### PR TITLE
fix: docs is_active column and selectWorkingDiff sql syntax

### DIFF
--- a/packages/sdk/src/diff/select-working-diff.ts
+++ b/packages/sdk/src/diff/select-working-diff.ts
@@ -200,11 +200,8 @@ export function selectWorkingDiff(args: {
 		]);
 
 	// CTEs for constants used across both UNION arms
-	const union = sql<DiffRow>`(
-        select * from (${base}) as w
-        union all
-        select * from (${unchanged}) as u
-    )`.as("diff");
+	const unionQuery = base.unionAll(unchanged);
+	const aliased = sql`(${unionQuery})`.as("diff");
 
 	return db
 		.with("wc", () => workingCommitIdQ as any)
@@ -225,7 +222,7 @@ export function selectWorkingDiff(args: {
 					.where("id", "=", sql`(select id from cc)` as any)
 					.select(["change_set_id"]) as any
 		)
-		.selectFrom(union) as unknown as SelectQueryBuilder<
+		.selectFrom(aliased) as unknown as SelectQueryBuilder<
 		LixDatabaseSchema & DiffDB,
 		"diff",
 		DiffRow

--- a/packages/website/content/docs/getting-started.md
+++ b/packages/website/content/docs/getting-started.md
@@ -146,9 +146,9 @@ Query the file's history using the `file_history` view. The `lixcol_root_commit_
 
 ```ts
 const activeVersion = await lix.db
-  .selectFrom("version")
-  .where("is_active", "=", true)
-  .select("commit_id")
+  .selectFrom("active_version")
+  .innerJoin("version", "active_version.version_id", "version.id")
+  .select("version.commit_id")
   .executeTakeFirstOrThrow();
 
 const history = await lix.db


### PR DESCRIPTION
## Summary

Fixes two bugs discovered when following the getting-started guide:

1. **Documentation bug**: The `getting-started.md` example used `.where("is_active", "=", true)` on the `version` table, but this column doesn't exist. The active version is tracked in a separate `active_version` table. Fixed by using proper join with `active_version` table.

2. **selectWorkingDiff SQL syntax error**: The function was incorrectly embedding Kysely query builders into a raw SQL template string, causing "near 'from': syntax error". Fixed by using Kysely's native `.unionAll()` method instead.

## Changes

- `packages/website/content/docs/getting-started.md`: Updated active version query to use `active_version` table join
- `packages/sdk/src/diff/select-working-diff.ts`: Replaced raw SQL union template with Kysely's `.unionAll()` method

## Testing

- All 9 `select-working-diff.test.ts` tests pass
- All 11 diff module tests pass