### PR TITLE
fix https://github.com/opral/lix/issues/382

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install @lix-js/sdk
 ```
 
 ```ts
-import { openLix } from "@lix-js/sdk";
+import { openLix, selectWorkingDiff } from "@lix-js/sdk";
 
 const lix = await openLix({
   environment: new InMemorySQLite()
@@ -47,7 +47,7 @@ const lix = await openLix({
 
 await lix.db.insertInto("file").values({ path: "/hello.txt", data: ... }).execute();
 
-const diff = selectWorkingDiff({ lix })
+const diff = await selectWorkingDiff({ lix }).selectAll().execute();
 ```
 
 ## Excel file example

--- a/blog/001-introducing-lix/index.md
+++ b/blog/001-introducing-lix/index.md
@@ -151,7 +151,7 @@ npm install @lix-js/sdk
 ```
 
 ```ts
-import { openLix } from "@lix-js/sdk";
+import { openLix, selectWorkingDiff } from "@lix-js/sdk";
 
 const lix = await openLix({
   environment: new InMemorySQLite()
@@ -159,7 +159,7 @@ const lix = await openLix({
 
 await lix.db.insertInto("file").values({ path: "/hello.txt", data: ... }).execute();
 
-const diff = selectWorkingDiff({ lix })
+const diff = await selectWorkingDiff({ lix }).selectAll().execute();
 ```
 
 ## What's next

--- a/packages/react-utils/README.md
+++ b/packages/react-utils/README.md
@@ -124,6 +124,7 @@ import { selectWorkingDiff } from "@lix-js/sdk";
 
 const rows = useQuery(({ lix }) =>
 	selectWorkingDiff({ lix })
+		.selectAll()
 		.where("diff.status", "!=", "unchanged")
 		.orderBy("diff.entity_id"),
 );

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -51,7 +51,7 @@ await lix.db
 	.execute();
 
 // 3) Query the changes
-const diff = await selectWorkingDiff({ lix }).execute();
+const diff = await selectWorkingDiff({ lix }).selectAll().execute();
 console.log(diff);
 ```
 

--- a/packages/sdk/src/diff/select-working-diff.ts
+++ b/packages/sdk/src/diff/select-working-diff.ts
@@ -34,6 +34,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  * @example
  * // Get all changes since the last checkpoint
  * const changes = await selectWorkingDiff({ lix })
+ *   .selectAll()
  *   .where('status', '!=', 'unchanged')
  *   .execute();
  *
@@ -42,6 +43,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  * @example
  * // Monitor changes to a specific file
  * const fileChanges = await selectWorkingDiff({ lix })
+ *   .selectAll()
  *   .where('file_id', '=', 'config.json')
  *   .where('status', '!=', 'unchanged')
  *   .orderBy('entity_id')
@@ -51,6 +53,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  * // Check if specific entities have changed since checkpoint
  * const entityIds = ['user-1', 'user-2', 'user-3'];
  * const entityChanges = await selectWorkingDiff({ lix })
+ *   .selectAll()
  *   .where('entity_id', 'in', entityIds)
  *   .where('status', '!=', 'unchanged')
  *   .execute();
@@ -58,6 +61,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  * @example
  * // Count changes by status
  * const allChanges = await selectWorkingDiff({ lix })
+ *   .selectAll()
  *   .where('status', '!=', 'unchanged')
  *   .execute();
  *

--- a/packages/website/content/docs/getting-started.md
+++ b/packages/website/content/docs/getting-started.md
@@ -42,7 +42,7 @@ await lix.db
 Lix tracks changes on the entity level. You can query the history of a specific entity, or the diff between two versions.
 
 ```ts
-const diff = await selectWorkingDiff({ lix }).execute();
+const diff = await selectWorkingDiff({ lix }).selectAll().execute();
 console.log(diff);
 ```
 
@@ -146,9 +146,9 @@ Query the file's history using the `file_history` view. The `lixcol_root_commit_
 
 ```ts
 const activeVersion = await lix.db
-  .selectFrom("version")
-  .where("is_active", "=", true)
-  .select("commit_id")
+  .selectFrom("active_version")
+  .innerJoin("version", "version.id", "active_version.version_id")
+  .select("version.commit_id as commit_id")
   .executeTakeFirstOrThrow();
 
 const history = await lix.db

--- a/packages/website/content/docs/react-integration.md
+++ b/packages/website/content/docs/react-integration.md
@@ -127,6 +127,7 @@ import { selectWorkingDiff } from "@lix-js/sdk";
 
 const rows = useQuery(({ lix }) =>
   selectWorkingDiff({ lix })
+    .selectAll()
     .where("diff.status", "!=", "unchanged")
     .orderBy("diff.entity_id"),
 );


### PR DESCRIPTION
closes https://github.com/opral/lix/issues/382

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns SDK, website, and README examples with current query API and corrects an active version query.
> 
> - Replace `selectWorkingDiff({ lix }).execute()` with `selectWorkingDiff({ lix }).selectAll().execute()` across READMEs, docs, and JSDoc
> - Update imports in examples to include `selectWorkingDiff`
> - Fix history example to read the active commit via `active_version` joined to `version` and alias `version.commit_id as commit_id`
> 
> No runtime code changes; only documentation and example updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 181a028c35ab473d27d71df5c20e2fa48ee90f25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->