### PR TITLE
add milestone 5-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -33,6 +44,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -90,6 +151,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -99,6 +166,21 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -129,6 +211,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -168,6 +256,52 @@ dependencies = [
  "num-traits",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "concurrent-queue"
@@ -270,6 +404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +448,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -358,6 +510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +597,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -567,6 +745,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +848,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -661,12 +869,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -677,8 +896,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -687,6 +906,36 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -698,8 +947,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -717,7 +966,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -731,18 +980,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -913,6 +1162,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +1190,36 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64 0.21.7",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "percent-encoding",
+ "regex",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -989,6 +1283,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "jsonschema",
  "paste",
  "postgresql_embedded",
  "serde",
@@ -1058,6 +1353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1397,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1444,27 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-format"
@@ -1142,6 +1497,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1531,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -1336,7 +1708,7 @@ dependencies = [
  "hex",
  "num-format",
  "regex-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -1391,6 +1763,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1542,10 +1920,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "reqwest"
@@ -1553,14 +1996,14 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -1572,7 +2015,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -1594,8 +2037,8 @@ checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
- "reqwest",
+ "http 1.4.0",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -1611,10 +2054,10 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.17",
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "parking_lot 0.11.2",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 1.0.69",
@@ -1632,9 +2075,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "getrandom 0.2.17",
- "http",
+ "http 1.4.0",
  "matchit",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "tracing",
 ]
@@ -1925,6 +2368,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -1993,7 +2446,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -2069,7 +2522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.10.0",
  "byteorder",
  "bytes",
@@ -2111,7 +2564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.10.0",
  "byteorder",
  "crc",
@@ -2196,6 +2649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2670,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -2230,6 +2695,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2303,6 +2789,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,7 +2855,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2398,7 +2914,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2413,8 +2929,8 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2528,6 +3044,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -3019,6 +3541,16 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -729,6 +749,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +988,7 @@ name = "lix_engine"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "paste",
  "postgresql_embedded",
  "serde",
@@ -951,6 +996,7 @@ dependencies = [
  "sqlparser",
  "sqlx",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1914,6 +1960,18 @@ checksum = "505aa16b045c4c1375bf5f125cce3813d0176325bfe9ffc4a903f423de7774ff"
 dependencies = [
  "log",
  "recursive",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2123,7 +2181,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2473,6 +2530,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "rand 0.9.2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,10 +2731,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -9,6 +9,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 sqlparser = { version = "0.60.0", features = ["visitor"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+jsonschema = "0.17"
 uuid = { version = "1", features = ["v7", "fast-rng", "std"] }
 
 [dev-dependencies]

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-sqlparser = "0.60.0"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+sqlparser = { version = "0.60.0", features = ["visitor"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v7", "fast-rng", "std"] }
 
 [dev-dependencies]
 postgresql_embedded = { version = "0.20", features = ["tokio"] }

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -3,14 +3,19 @@ use crate::schema_registry::register_schema;
 use crate::sql::{
     build_delete_followup_sql, build_update_followup_sql, preprocess_sql, PostprocessPlan,
 };
+use crate::validation::{validate_inserts, validate_updates, SchemaCache};
 use crate::{LixBackend, LixError, QueryResult, Value};
 
 pub struct Engine {
     backend: Box<dyn LixBackend + Send + Sync>,
+    schema_cache: SchemaCache,
 }
 
 pub fn boot(backend: Box<dyn LixBackend + Send + Sync>) -> Engine {
-    Engine { backend }
+    Engine {
+        backend,
+        schema_cache: SchemaCache::new(),
+    }
 }
 
 impl Engine {
@@ -20,6 +25,17 @@ impl Engine {
 
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<QueryResult, LixError> {
         let output = preprocess_sql(sql)?;
+        if !output.mutations.is_empty() {
+            validate_inserts(self.backend.as_ref(), &self.schema_cache, &output.mutations).await?;
+        }
+        if !output.update_validations.is_empty() {
+            validate_updates(
+                self.backend.as_ref(),
+                &self.schema_cache,
+                &output.update_validations,
+            )
+            .await?;
+        }
         for registration in output.registrations {
             register_schema(self.backend.as_ref(), &registration.schema_key).await?;
         }

--- a/packages/engine/src/functions/mod.rs
+++ b/packages/engine/src/functions/mod.rs
@@ -1,0 +1,2 @@
+pub mod timestamp;
+pub mod uuid_v7;

--- a/packages/engine/src/functions/timestamp.rs
+++ b/packages/engine/src/functions/timestamp.rs
@@ -1,0 +1,5 @@
+use chrono::SecondsFormat;
+
+pub fn timestamp() -> String {
+    chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}

--- a/packages/engine/src/functions/uuid_v7.rs
+++ b/packages/engine/src/functions/uuid_v7.rs
@@ -1,0 +1,5 @@
+use uuid::Uuid;
+
+pub fn uuid_v7() -> String {
+    Uuid::now_v7().to_string()
+}

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -2,6 +2,23 @@ use crate::LixBackend;
 use crate::LixError;
 
 const INIT_STATEMENTS: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS lix_internal_snapshot (\
+     id TEXT PRIMARY KEY,\
+     content TEXT\
+     )",
+    "INSERT INTO lix_internal_snapshot (id, content) VALUES ('no-content', NULL) \
+     ON CONFLICT (id) DO NOTHING",
+    "CREATE TABLE IF NOT EXISTS lix_internal_change (\
+     id TEXT PRIMARY KEY,\
+     entity_id TEXT NOT NULL,\
+     schema_key TEXT NOT NULL,\
+     schema_version TEXT NOT NULL,\
+     file_id TEXT NOT NULL,\
+     plugin_key TEXT NOT NULL,\
+     snapshot_id TEXT NOT NULL,\
+     metadata TEXT,\
+     created_at TEXT NOT NULL\
+     )",
     "CREATE TABLE IF NOT EXISTS lix_internal_state_materialized_v1_lix_stored_schema (\
      entity_id TEXT NOT NULL,\
      schema_key TEXT NOT NULL,\

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -22,6 +22,7 @@ const INIT_STATEMENTS: &[&str] = &[
     "CREATE TABLE IF NOT EXISTS lix_internal_state_materialized_v1_lix_stored_schema (\
      entity_id TEXT NOT NULL,\
      schema_key TEXT NOT NULL,\
+     schema_version TEXT NOT NULL,\
      file_id TEXT NOT NULL,\
      version_id TEXT NOT NULL,\
      plugin_key TEXT NOT NULL,\

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -37,7 +37,11 @@ const INIT_STATEMENTS: &[&str] = &[
      schema_key TEXT NOT NULL,\
      file_id TEXT NOT NULL,\
      version_id TEXT NOT NULL,\
+     plugin_key TEXT NOT NULL,\
      snapshot_content TEXT,\
+     schema_version TEXT NOT NULL,\
+     created_at TEXT NOT NULL,\
+     updated_at TEXT NOT NULL,\
      PRIMARY KEY (entity_id, schema_key, file_id, version_id)\
      )",
 ];

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod engine;
 mod error;
+mod functions;
 mod init;
 mod schema_registry;
 mod sql;

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -3,9 +3,16 @@ mod engine;
 mod error;
 mod functions;
 mod init;
+mod schema_definition;
 mod schema_registry;
 mod sql;
 mod types;
+mod validation;
+
+pub use schema_definition::{
+    lix_schema_definition, lix_schema_definition_json, validate_lix_schema,
+    validate_lix_schema_definition,
+};
 
 pub use backend::LixBackend;
 pub use engine::{boot, Engine};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -2,8 +2,8 @@ mod backend;
 mod engine;
 mod error;
 mod init;
-mod sql;
 mod schema_registry;
+mod sql;
 mod types;
 
 pub use backend::LixBackend;

--- a/packages/engine/src/schema_definition.json
+++ b/packages/engine/src/schema_definition.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Lix Schema Definition",
+  "description": "A JSON schema document that defines Lix schema documents, including custom x-lix-* metadata for identification and versioning.",
+  "allOf": [
+    {
+      "$ref": "http://json-schema.org/draft-07/schema#"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "x-lix-unique": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "format": "json-pointer",
+              "description": "JSON Pointer referencing a property"
+            }
+          }
+        },
+        "additionalProperties": {
+          "type": "boolean",
+          "const": false,
+          "description": "Objects describing Lix schemas must not allow arbitrary additional properties; set this explicitly to false."
+        },
+        "x-lix-primary-key": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "json-pointer",
+            "description": "JSON Pointer referencing a property that participates in the primary key."
+          }
+        },
+        "x-lix-foreign-keys": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "properties",
+              "references"
+            ],
+            "properties": {
+              "properties": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "format": "json-pointer",
+                  "description": "JSON Pointer referencing the local field."
+                },
+                "uniqueItems": true,
+                "description": "Local JSON-schema property names that participate in the FK"
+              },
+              "references": {
+                "type": "object",
+                "required": [
+                  "schemaKey",
+                  "properties"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "schemaKey": {
+                    "type": "string",
+                    "description": "The x-lix-key of the referenced schema"
+                  },
+                  "properties": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "format": "json-pointer",
+                      "description": "JSON Pointer referencing the remote field."
+                    },
+                    "uniqueItems": true,
+                    "description": "Remote property names (same length as local properties)"
+                  }
+                }
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "immediate",
+                  "materialized"
+                ],
+                "description": "Validation mode: immediate (default) or materialized (defer insert/update existence checks)"
+              },
+              "scope": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "version_id",
+                    "file_id"
+                  ]
+                },
+                "uniqueItems": true,
+                "description": "Implicit columns (version_id and/or file_id) used to scope the foreign key relationship"
+              }
+            }
+          }
+        },
+        "x-lix-key": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "The schema identifier. Must be snake_case (lowercase, underscores) to safely embed in SQL identifiers.",
+          "examples": [
+            "csv_plugin_cell"
+          ]
+        },
+        "x-lix-immutable": {
+          "type": "boolean",
+          "description": "When true, entities for this schema cannot be updated after creation."
+        },
+        "x-lix-override-lixcols": {
+          "type": "object",
+          "description": "Default metadata column values (such as lixcol_file_id). Does not affect JSON property defaults.",
+          "additionalProperties": {
+            "type": "string",
+            "format": "cel"
+          }
+        },
+        "x-lix-entity-views": {
+          "type": "array",
+          "description": "Restricts which SQL entity views (state/state_by_version/state_history) are generated. When omitted, all views are created.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "state",
+              "state_by_version",
+              "state_history"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "x-lix-version": {
+          "type": "string",
+          "pattern": "^[1-9]\\d*$",
+          "description": "Schema version identifier. Deliberately constrained to a monotonic integer (as a string) without leading zeros to keep translation rules open while avoiding future breaking changes.",
+          "examples": [
+            "1"
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "allOf": [
+              {
+                "$ref": "http://json-schema.org/draft-07/schema#"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "x-lix-default": {
+                    "type": "string",
+                    "format": "cel",
+                    "description": "CEL expression evaluated to produce the default value when the property is omitted."
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "x-lix-key",
+        "x-lix-version",
+        "additionalProperties"
+      ]
+    }
+  ]
+}

--- a/packages/engine/src/schema_definition.rs
+++ b/packages/engine/src/schema_definition.rs
@@ -1,0 +1,211 @@
+use jsonschema::JSONSchema;
+use serde_json::Value as JsonValue;
+use std::sync::OnceLock;
+
+use crate::LixError;
+
+static LIX_SCHEMA_DEFINITION: OnceLock<JsonValue> = OnceLock::new();
+static LIX_SCHEMA_VALIDATOR: OnceLock<Result<JSONSchema, LixError>> = OnceLock::new();
+
+pub fn lix_schema_definition() -> &'static JsonValue {
+    LIX_SCHEMA_DEFINITION.get_or_init(|| {
+        // NOTE: x-lix-version is intentionally constrained to a monotonic integer (as a string).
+        // This keeps translation rules open while avoiding a future breaking change when versioning
+        // semantics become concrete.
+        let raw = include_str!("schema_definition.json");
+        serde_json::from_str(raw).expect("schema_definition.json must be valid JSON")
+    })
+}
+
+pub fn lix_schema_definition_json() -> &'static str {
+    include_str!("schema_definition.json")
+}
+
+pub fn validate_lix_schema_definition(schema: &JsonValue) -> Result<(), LixError> {
+    let validator = lix_schema_validator()?;
+    if let Err(errors) = validator.validate(schema) {
+        let details = format_validation_errors(errors);
+        return Err(LixError {
+            message: format!("Invalid Lix schema definition: {details}"),
+        });
+    }
+
+    assert_primary_key_pointers(schema)?;
+    assert_unique_pointers(schema)?;
+
+    Ok(())
+}
+
+pub fn validate_lix_schema(schema: &JsonValue, data: &JsonValue) -> Result<(), LixError> {
+    validate_lix_schema_definition(schema)?;
+
+    let validator = compile_schema(schema)?;
+    if let Err(errors) = validator.validate(data) {
+        let details = format_validation_errors(errors);
+        return Err(LixError {
+            message: format!("Data validation failed: {details}"),
+        });
+    }
+
+    Ok(())
+}
+
+fn lix_schema_validator() -> Result<&'static JSONSchema, LixError> {
+    let result = LIX_SCHEMA_VALIDATOR.get_or_init(|| compile_schema(lix_schema_definition()));
+    match result {
+        Ok(schema) => Ok(schema),
+        Err(err) => Err(LixError {
+            message: err.message.clone(),
+        }),
+    }
+}
+
+fn compile_schema(schema: &JsonValue) -> Result<JSONSchema, LixError> {
+    let mut options = JSONSchema::options();
+    options.with_meta_schemas();
+    options.with_format("json-pointer", is_json_pointer);
+    options.with_format("cel", |_value| true);
+
+    options.compile(schema).map_err(|err| LixError {
+        message: format!("Failed to compile Lix schema definition: {err}"),
+    })
+}
+
+fn is_json_pointer(value: &str) -> bool {
+    parse_json_pointer(value).is_ok()
+}
+
+fn parse_json_pointer(pointer: &str) -> Result<Vec<String>, LixError> {
+    if pointer.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !pointer.starts_with('/') {
+        return Err(LixError {
+            message: "Invalid JSON pointer".to_string(),
+        });
+    }
+
+    let mut segments = Vec::new();
+    for raw in pointer[1..].split('/') {
+        segments.push(unescape_pointer_segment(raw)?);
+    }
+    Ok(segments)
+}
+
+fn unescape_pointer_segment(segment: &str) -> Result<String, LixError> {
+    let mut out = String::new();
+    let mut chars = segment.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '~' {
+            match chars.next() {
+                Some('0') => out.push('~'),
+                Some('1') => out.push('/'),
+                _ => {
+                    return Err(LixError {
+                        message: "Invalid JSON pointer".to_string(),
+                    })
+                }
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    Ok(out)
+}
+
+fn assert_primary_key_pointers(schema: &JsonValue) -> Result<(), LixError> {
+    let Some(primary_key) = schema
+        .get("x-lix-primary-key")
+        .and_then(|value| value.as_array())
+    else {
+        return Ok(());
+    };
+
+    for pointer in primary_key {
+        let Some(pointer) = pointer.as_str() else {
+            continue;
+        };
+        let segments = parse_json_pointer(pointer)?;
+        if segments.is_empty() || !schema_has_property(schema, &segments) {
+            return Err(LixError {
+                message: format!(
+                    "Invalid Lix schema definition: x-lix-primary-key references missing property \"{}\".",
+                    pointer
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn assert_unique_pointers(schema: &JsonValue) -> Result<(), LixError> {
+    let Some(unique_groups) = schema
+        .get("x-lix-unique")
+        .and_then(|value| value.as_array())
+    else {
+        return Ok(());
+    };
+
+    for group in unique_groups {
+        let Some(group) = group.as_array() else {
+            continue;
+        };
+        for pointer in group {
+            let Some(pointer) = pointer.as_str() else {
+                continue;
+            };
+            let segments = parse_json_pointer(pointer)?;
+            if segments.is_empty() || !schema_has_property(schema, &segments) {
+                return Err(LixError {
+                    message: format!(
+                        "Invalid Lix schema definition: x-lix-unique references missing property \"{}\".",
+                        pointer
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn schema_has_property(schema: &JsonValue, segments: &[String]) -> bool {
+    let mut node = schema;
+    for segment in segments {
+        let properties = match node.get("properties") {
+            Some(properties) => properties,
+            None => return false,
+        };
+        let properties = match properties.as_object() {
+            Some(properties) => properties,
+            None => return false,
+        };
+        let next = match properties.get(segment) {
+            Some(next) => next,
+            None => return false,
+        };
+        node = next;
+    }
+    true
+}
+
+fn format_validation_errors<'a>(
+    errors: impl Iterator<Item = jsonschema::ValidationError<'a>>,
+) -> String {
+    let mut parts = Vec::new();
+    for error in errors {
+        let path = error.instance_path.to_string();
+        let message = error.to_string();
+        if path.is_empty() {
+            parts.push(message);
+        } else {
+            parts.push(format!("{path} {message}"));
+        }
+    }
+    if parts.is_empty() {
+        "Unknown validation error".to_string()
+    } else {
+        parts.join("; ")
+    }
+}

--- a/packages/engine/src/schema_registry.rs
+++ b/packages/engine/src/schema_registry.rs
@@ -8,6 +8,7 @@ pub async fn register_schema(backend: &dyn LixBackend, schema_key: &str) -> Resu
         "CREATE TABLE IF NOT EXISTS {table} (\
          entity_id TEXT NOT NULL,\
          schema_key TEXT NOT NULL,\
+         schema_version TEXT NOT NULL,\
          file_id TEXT NOT NULL,\
          version_id TEXT NOT NULL,\
          plugin_key TEXT NOT NULL,\

--- a/packages/engine/src/sql/mod.rs
+++ b/packages/engine/src/sql/mod.rs
@@ -4,4 +4,6 @@ mod steps;
 mod types;
 
 pub use pipeline::preprocess_sql;
+pub use steps::vtable_write::{build_delete_followup_sql, build_update_followup_sql};
+pub use types::PostprocessPlan;
 pub use types::SchemaRegistration;

--- a/packages/engine/src/sql/mod.rs
+++ b/packages/engine/src/sql/mod.rs
@@ -7,3 +7,4 @@ pub use pipeline::preprocess_sql;
 pub use steps::vtable_write::{build_delete_followup_sql, build_update_followup_sql};
 pub use types::PostprocessPlan;
 pub use types::SchemaRegistration;
+pub use types::{MutationOperation, MutationRow, UpdateValidationPlan};

--- a/packages/engine/src/sql/pipeline.rs
+++ b/packages/engine/src/sql/pipeline.rs
@@ -15,6 +15,8 @@ pub fn preprocess_sql(sql: &str) -> Result<PreprocessOutput, LixError> {
     let mut registrations: Vec<SchemaRegistration> = Vec::new();
     let mut postprocess: Option<PostprocessPlan> = None;
     let mut rewritten = Vec::with_capacity(statements.len());
+    let mut mutations = Vec::new();
+    let mut update_validations = Vec::new();
     for statement in statements {
         let output = rewrite_statement(statement)?;
         registrations.extend(output.registrations);
@@ -26,6 +28,8 @@ pub fn preprocess_sql(sql: &str) -> Result<PreprocessOutput, LixError> {
             }
             postprocess = Some(plan);
         }
+        mutations.extend(output.mutations);
+        update_validations.extend(output.update_validations);
         for rewritten_statement in output.statements {
             rewritten.push(inline_lix_functions(rewritten_statement));
         }
@@ -47,5 +51,7 @@ pub fn preprocess_sql(sql: &str) -> Result<PreprocessOutput, LixError> {
         sql: normalized_sql,
         registrations,
         postprocess,
+        mutations,
+        update_validations,
     })
 }

--- a/packages/engine/src/sql/pipeline.rs
+++ b/packages/engine/src/sql/pipeline.rs
@@ -2,6 +2,7 @@ use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
 use crate::sql::route::rewrite_statement;
+use crate::sql::steps::inline_lix_functions::inline_lix_functions;
 use crate::sql::types::{PreprocessOutput, SchemaRegistration};
 use crate::LixError;
 
@@ -16,7 +17,9 @@ pub fn preprocess_sql(sql: &str) -> Result<PreprocessOutput, LixError> {
     for statement in statements {
         let output = rewrite_statement(statement)?;
         registrations.extend(output.registrations);
-        rewritten.push(output.statement);
+        for rewritten_statement in output.statements {
+            rewritten.push(inline_lix_functions(rewritten_statement));
+        }
     }
 
     let normalized_sql = rewritten

--- a/packages/engine/src/sql/route.rs
+++ b/packages/engine/src/sql/route.rs
@@ -1,7 +1,9 @@
 use sqlparser::ast::Statement;
 
 use crate::sql::steps::{stored_schema, vtable_read, vtable_write};
-use crate::sql::types::{PostprocessPlan, RewriteOutput, SchemaRegistration};
+use crate::sql::types::{
+    MutationRow, PostprocessPlan, RewriteOutput, SchemaRegistration, UpdateValidationPlan,
+};
 use crate::LixError;
 
 pub fn rewrite_statement(statement: Statement) -> Result<RewriteOutput, LixError> {
@@ -10,10 +12,13 @@ pub fn rewrite_statement(statement: Statement) -> Result<RewriteOutput, LixError
             let mut current = Statement::Insert(insert);
             let mut registrations: Vec<SchemaRegistration> = Vec::new();
             let mut statements: Vec<Statement> = Vec::new();
+            let mut mutations: Vec<MutationRow> = Vec::new();
+            let update_validations: Vec<UpdateValidationPlan> = Vec::new();
 
             if let Statement::Insert(inner) = &current {
                 if let Some(rewritten) = stored_schema::rewrite_insert(inner.clone())? {
                     registrations.push(rewritten.registration);
+                    mutations.push(rewritten.mutation);
                     current = rewritten.statement;
                 }
             }
@@ -21,6 +26,7 @@ pub fn rewrite_statement(statement: Statement) -> Result<RewriteOutput, LixError
                 if let Some(rewritten) = vtable_write::rewrite_insert(inner.clone())? {
                     registrations.extend(rewritten.registrations);
                     statements = rewritten.statements;
+                    mutations = rewritten.mutations;
                 }
             }
 
@@ -32,25 +38,33 @@ pub fn rewrite_statement(statement: Statement) -> Result<RewriteOutput, LixError
                 statements,
                 registrations,
                 postprocess: None,
+                mutations,
+                update_validations,
             })
         }
         Statement::Update(update) => {
             let rewritten = vtable_write::rewrite_update(update.clone())?;
             match rewritten {
-                Some(vtable_write::UpdateRewrite::Statement(statement)) => Ok(RewriteOutput {
-                    statements: vec![statement],
+                Some(vtable_write::UpdateRewrite::Statement(rewrite)) => Ok(RewriteOutput {
+                    statements: vec![rewrite.statement],
                     registrations: Vec::new(),
                     postprocess: None,
+                    mutations: Vec::new(),
+                    update_validations: rewrite.validation.into_iter().collect(),
                 }),
                 Some(vtable_write::UpdateRewrite::Planned(rewrite)) => Ok(RewriteOutput {
                     statements: vec![rewrite.statement],
                     registrations: Vec::new(),
                     postprocess: Some(PostprocessPlan::VtableUpdate(rewrite.plan)),
+                    mutations: Vec::new(),
+                    update_validations: rewrite.validation.into_iter().collect(),
                 }),
                 None => Ok(RewriteOutput {
                     statements: vec![Statement::Update(update)],
                     registrations: Vec::new(),
                     postprocess: None,
+                    mutations: Vec::new(),
+                    update_validations: Vec::new(),
                 }),
             }
         }
@@ -61,16 +75,22 @@ pub fn rewrite_statement(statement: Statement) -> Result<RewriteOutput, LixError
                     statements: vec![statement],
                     registrations: Vec::new(),
                     postprocess: None,
+                    mutations: Vec::new(),
+                    update_validations: Vec::new(),
                 }),
                 Some(vtable_write::DeleteRewrite::Planned(rewrite)) => Ok(RewriteOutput {
                     statements: vec![rewrite.statement],
                     registrations: Vec::new(),
                     postprocess: Some(PostprocessPlan::VtableDelete(rewrite.plan)),
+                    mutations: Vec::new(),
+                    update_validations: Vec::new(),
                 }),
                 None => Ok(RewriteOutput {
                     statements: vec![Statement::Delete(delete)],
                     registrations: Vec::new(),
                     postprocess: None,
+                    mutations: Vec::new(),
+                    update_validations: Vec::new(),
                 }),
             }
         }
@@ -80,11 +100,15 @@ pub fn rewrite_statement(statement: Statement) -> Result<RewriteOutput, LixError
                 .unwrap_or_else(|| Statement::Query(query))],
             registrations: Vec::new(),
             postprocess: None,
+            mutations: Vec::new(),
+            update_validations: Vec::new(),
         }),
         other => Ok(RewriteOutput {
             statements: vec![other],
             registrations: Vec::new(),
             postprocess: None,
+            mutations: Vec::new(),
+            update_validations: Vec::new(),
         }),
     }
 }

--- a/packages/engine/src/sql/steps/inline_lix_functions.rs
+++ b/packages/engine/src/sql/steps/inline_lix_functions.rs
@@ -1,0 +1,75 @@
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{
+    Expr, Function, FunctionArguments, ObjectName, ObjectNamePart, Statement, Value,
+};
+use sqlparser::ast::{VisitMut, VisitorMut};
+
+use crate::functions::timestamp::timestamp;
+use crate::functions::uuid_v7::uuid_v7;
+
+pub fn inline_lix_functions(mut statement: Statement) -> Statement {
+    let mut inliner = LixFunctionInliner;
+    let _ = statement.visit(&mut inliner);
+    statement
+}
+
+struct LixFunctionInliner;
+
+impl VisitorMut for LixFunctionInliner {
+    type Break = ();
+
+    fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        if let Expr::Function(function) = expr {
+            if function_is(function, "lix_uuid_v7") && function_args_empty(function) {
+                *expr = Expr::Value(Value::SingleQuotedString(uuid_v7()).into());
+            } else if function_is(function, "lix_timestamp") && function_args_empty(function) {
+                *expr = Expr::Value(Value::SingleQuotedString(timestamp()).into());
+            }
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+fn function_is(function: &Function, target: &str) -> bool {
+    object_name_matches(&function.name, target)
+}
+
+fn function_args_empty(function: &Function) -> bool {
+    match &function.args {
+        FunctionArguments::None => true,
+        FunctionArguments::List(list) => list.args.is_empty() && list.clauses.is_empty(),
+        FunctionArguments::Subquery(_) => false,
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inline_lix_functions;
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
+    #[test]
+    fn inlines_uuid_and_timestamp_calls() {
+        let sql = "INSERT INTO foo (id, created_at) VALUES (lix_uuid_v7(), lix_timestamp())";
+        let dialect = GenericDialect {};
+        let mut statements = Parser::parse_sql(&dialect, sql).expect("parse sql");
+        let statement = statements.remove(0);
+
+        let rewritten = inline_lix_functions(statement).to_string();
+
+        assert!(!rewritten.to_lowercase().contains("lix_uuid_v7"));
+        assert!(!rewritten.to_lowercase().contains("lix_timestamp"));
+        assert!(rewritten.contains("'"));
+        assert!(rewritten.contains("T"));
+        assert!(rewritten.contains("Z"));
+    }
+}

--- a/packages/engine/src/sql/steps/mod.rs
+++ b/packages/engine/src/sql/steps/mod.rs
@@ -1,2 +1,3 @@
-pub mod untracked;
 pub mod stored_schema;
+pub mod vtable_read;
+pub mod vtable_write;

--- a/packages/engine/src/sql/steps/mod.rs
+++ b/packages/engine/src/sql/steps/mod.rs
@@ -1,3 +1,4 @@
+pub mod inline_lix_functions;
 pub mod stored_schema;
 pub mod vtable_read;
 pub mod vtable_write;

--- a/packages/engine/src/sql/steps/stored_schema.rs
+++ b/packages/engine/src/sql/steps/stored_schema.rs
@@ -3,7 +3,7 @@ use sqlparser::ast::{
     Expr, Ident, Insert, ObjectName, ObjectNamePart, Statement, TableObject, Value, ValueWithSpan,
 };
 
-use crate::sql::SchemaRegistration;
+use crate::sql::{MutationOperation, MutationRow, SchemaRegistration};
 use crate::LixError;
 
 const STORED_SCHEMA_KEY: &str = "lix_stored_schema";
@@ -15,6 +15,7 @@ const ENGINE_PLUGIN_KEY: &str = "lix";
 pub struct StoredSchemaRewrite {
     pub statement: Statement,
     pub registration: SchemaRegistration,
+    pub mutation: MutationRow,
 }
 
 pub fn rewrite_insert(insert: Insert) -> Result<Option<StoredSchemaRewrite>, LixError> {
@@ -70,11 +71,15 @@ pub fn rewrite_insert(insert: Insert) -> Result<Option<StoredSchemaRewrite>, Lix
     let mut entity_id_value: Option<String> = None;
     let mut schema_key_value: Option<String> = None;
     let mut schema_version_value: Option<String> = None;
+    let mut snapshot_literal_value: Option<String> = None;
     for row in &rows {
         let snapshot_expr = row.get(snapshot_index).ok_or_else(|| LixError {
             message: "stored schema insert missing snapshot_content value".to_string(),
         })?;
         let literal = snapshot_literal(snapshot_expr)?;
+        if snapshot_literal_value.is_none() {
+            snapshot_literal_value = Some(literal.clone());
+        }
         let (schema_key, schema_version) = parse_schema_identity(&literal)?;
         let derived_id = format!("{}~{}", schema_key, schema_version);
         schema_key_value = Some(schema_key.clone());
@@ -100,6 +105,13 @@ pub fn rewrite_insert(insert: Insert) -> Result<Option<StoredSchemaRewrite>, Lix
     let schema_version_value = schema_version_value.ok_or_else(|| LixError {
         message: "stored schema insert requires schema version".to_string(),
     })?;
+    let snapshot_literal_value = snapshot_literal_value.ok_or_else(|| LixError {
+        message: "stored schema insert requires snapshot_content".to_string(),
+    })?;
+    let snapshot_value: JsonValue =
+        serde_json::from_str(&snapshot_literal_value).map_err(|err| LixError {
+            message: format!("stored schema snapshot_content must be valid JSON: {err}"),
+        })?;
 
     if let Some(entity_index) = find_column_index(&columns, "entity_id") {
         if !rows
@@ -158,6 +170,17 @@ pub fn rewrite_insert(insert: Insert) -> Result<Option<StoredSchemaRewrite>, Lix
         statement: Statement::Insert(rewritten),
         registration: SchemaRegistration {
             schema_key: schema_key_value,
+        },
+        mutation: MutationRow {
+            operation: MutationOperation::Insert,
+            entity_id,
+            schema_key: STORED_SCHEMA_KEY.to_string(),
+            schema_version: schema_version_value,
+            file_id: ENGINE_FILE_ID.to_string(),
+            version_id: GLOBAL_VERSION.to_string(),
+            plugin_key: ENGINE_PLUGIN_KEY.to_string(),
+            snapshot_content: Some(snapshot_value),
+            untracked: false,
         },
     }))
 }
@@ -267,27 +290,33 @@ fn parse_schema_identity(snapshot: &str) -> Result<(String, String), LixError> {
             message: "stored schema value.x-lix-version must be string".to_string(),
         })?;
 
-    ensure_semver(schema_version)?;
+    // Deliberately keep x-lix-version as a monotonic integer (string) so we can evolve
+    // translation rules later without locking into semver semantics.
+    ensure_monotonic_version(schema_version)?;
 
     Ok((schema_key.to_string(), schema_version.to_string()))
 }
 
-fn ensure_semver(version: &str) -> Result<(), LixError> {
-    let parts: Vec<&str> = version.split('.').collect();
-    if parts.len() != 3 {
+fn ensure_monotonic_version(version: &str) -> Result<(), LixError> {
+    if version.is_empty() {
         return Err(LixError {
-            message: "stored schema x-lix-version must be semver (major.minor.patch)".to_string(),
+            message: "stored schema x-lix-version must be a monotonic integer".to_string(),
         });
     }
-    if parts
-        .iter()
-        .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
-    {
-        return Ok(());
+    let mut chars = version.chars();
+    let Some(first) = chars.next() else {
+        return Err(LixError {
+            message: "stored schema x-lix-version must be a monotonic integer".to_string(),
+        });
+    };
+    if first == '0' || !first.is_ascii_digit() || !chars.all(|c| c.is_ascii_digit()) {
+        return Err(LixError {
+            message:
+                "stored schema x-lix-version must be a monotonic integer without leading zeros"
+                    .to_string(),
+        });
     }
-    Err(LixError {
-        message: "stored schema x-lix-version must be semver (major.minor.patch)".to_string(),
-    })
+    Ok(())
 }
 
 fn object_name_matches(name: &ObjectName, target: &str) -> bool {
@@ -346,7 +375,7 @@ mod tests {
 
     #[test]
     fn rewrite_stored_schema_insert_adds_overrides() {
-        let sql = r#"INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('lix_stored_schema', '{"value":{"x-lix-key":"mock_schema","x-lix-version":"1.0.0"}}')"#;
+        let sql = r#"INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('lix_stored_schema', '{"value":{"x-lix-key":"mock_schema","x-lix-version":"1"}}')"#;
         let insert = parse_insert(sql);
         let rewritten = rewrite_insert(insert)
             .expect("rewrite ok")
@@ -367,9 +396,9 @@ mod tests {
         let created_idx = column_index(&insert.columns, "created_at");
         let updated_idx = column_index(&insert.columns, "updated_at");
 
-        assert_eq!(expr_string(&row[entity_idx]), "mock_schema~1.0.0");
+        assert_eq!(expr_string(&row[entity_idx]), "mock_schema~1");
         assert_eq!(expr_string(&row[version_idx]), "global");
-        assert_eq!(expr_string(&row[schema_version_idx]), "1.0.0");
+        assert_eq!(expr_string(&row[schema_version_idx]), "1");
         assert_eq!(expr_string(&row[file_idx]), "lix");
         assert_eq!(expr_string(&row[plugin_idx]), "lix");
         assert_eq!(expr_string(&row[change_idx]), "schema");
@@ -383,16 +412,16 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_stored_schema_requires_semver() {
-        let sql = r#"INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('lix_stored_schema', '{"value":{"x-lix-key":"mock_schema","x-lix-version":"1.0"}}')"#;
+    fn rewrite_stored_schema_requires_monotonic_version() {
+        let sql = r#"INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('lix_stored_schema', '{"value":{"x-lix-key":"mock_schema","x-lix-version":"v1"}}')"#;
         let insert = parse_insert(sql);
         let err = rewrite_insert(insert).expect_err("expected error");
-        assert!(err.message.contains("semver"), "{:#?}", err);
+        assert!(err.message.contains("monotonic"), "{:#?}", err);
     }
 
     #[test]
     fn rewrite_ignores_other_schema_keys() {
-        let sql = r#"INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('other_schema', '{"value":{"x-lix-key":"mock_schema","x-lix-version":"1.0.0"}}')"#;
+        let sql = r#"INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('other_schema', '{"value":{"x-lix-key":"mock_schema","x-lix-version":"1"}}')"#;
         let insert = parse_insert(sql);
         let rewritten = rewrite_insert(insert).expect("rewrite ok");
         assert!(rewritten.is_none());

--- a/packages/engine/src/sql/steps/stored_schema.rs
+++ b/packages/engine/src/sql/steps/stored_schema.rs
@@ -102,7 +102,8 @@ pub fn rewrite_insert(insert: Insert) -> Result<Option<StoredSchemaRewrite>, Lix
             .all(|row| is_literal_equal(row.get(entity_index), &entity_id))
         {
             return Err(LixError {
-                message: "stored schema insert entity_id must match schema key + version".to_string(),
+                message: "stored schema insert entity_id must match schema key + version"
+                    .to_string(),
             });
         }
     } else {
@@ -267,7 +268,10 @@ fn ensure_semver(version: &str) -> Result<(), LixError> {
             message: "stored schema x-lix-version must be semver (major.minor.patch)".to_string(),
         });
     }
-    if parts.iter().all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit())) {
+    if parts
+        .iter()
+        .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+    {
         return Ok(());
     }
     Err(LixError {
@@ -286,9 +290,9 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlparser::ast::SetExpr;
     use sqlparser::dialect::GenericDialect;
     use sqlparser::parser::Parser;
-    use sqlparser::ast::SetExpr;
 
     fn parse_insert(sql: &str) -> Insert {
         let dialect = GenericDialect {};
@@ -333,7 +337,9 @@ mod tests {
     fn rewrite_stored_schema_insert_adds_overrides() {
         let sql = r#"INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('lix_stored_schema', '{"value":{"x-lix-key":"mock_schema","x-lix-version":"1.0.0"}}')"#;
         let insert = parse_insert(sql);
-        let rewritten = rewrite_insert(insert).expect("rewrite ok").expect("rewritten");
+        let rewritten = rewrite_insert(insert)
+            .expect("rewrite ok")
+            .expect("rewritten");
         let insert = match rewritten.statement {
             Statement::Insert(insert) => insert,
             _ => panic!("expected insert"),

--- a/packages/engine/src/sql/steps/vtable_read.rs
+++ b/packages/engine/src/sql/steps/vtable_read.rs
@@ -1,0 +1,799 @@
+use sqlparser::ast::{
+    BinaryOperator, Expr, Ident, ObjectName, Query, Select, SetExpr, Statement, TableAlias,
+    TableFactor, TableWithJoins, UnaryOperator, Value, ValueWithSpan,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::LixError;
+
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+const UNTRACKED_TABLE: &str = "lix_internal_state_untracked";
+const MATERIALIZED_PREFIX: &str = "lix_internal_state_materialized_v1_";
+
+pub fn rewrite_query(query: Query) -> Result<Option<Query>, LixError> {
+    let schema_keys = match extract_schema_keys_from_query(&query) {
+        Some(keys) => keys,
+        None => return Ok(None),
+    };
+    let pushdown_predicate = extract_pushdown_predicate(&query);
+
+    let mut changed = false;
+    let mut new_query = query.clone();
+    new_query.body = Box::new(rewrite_set_expr(
+        *query.body,
+        &schema_keys,
+        pushdown_predicate.as_ref(),
+        &mut changed,
+    )?);
+
+    if changed {
+        Ok(Some(new_query))
+    } else {
+        Ok(None)
+    }
+}
+
+fn rewrite_set_expr(
+    expr: SetExpr,
+    schema_keys: &[String],
+    pushdown_predicate: Option<&Expr>,
+    changed: &mut bool,
+) -> Result<SetExpr, LixError> {
+    Ok(match expr {
+        SetExpr::Select(select) => {
+            let mut select = *select;
+            rewrite_select(&mut select, schema_keys, pushdown_predicate, changed)?;
+            SetExpr::Select(Box::new(select))
+        }
+        SetExpr::Query(query) => {
+            let mut query = *query;
+            query.body = Box::new(rewrite_set_expr(
+                *query.body,
+                schema_keys,
+                pushdown_predicate,
+                changed,
+            )?);
+            SetExpr::Query(Box::new(query))
+        }
+        SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left,
+            right,
+        } => SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left: Box::new(rewrite_set_expr(
+                *left,
+                schema_keys,
+                pushdown_predicate,
+                changed,
+            )?),
+            right: Box::new(rewrite_set_expr(
+                *right,
+                schema_keys,
+                pushdown_predicate,
+                changed,
+            )?),
+        },
+        other => other,
+    })
+}
+
+fn rewrite_select(
+    select: &mut Select,
+    schema_keys: &[String],
+    pushdown_predicate: Option<&Expr>,
+    changed: &mut bool,
+) -> Result<(), LixError> {
+    for table in &mut select.from {
+        rewrite_table_with_joins(table, schema_keys, pushdown_predicate, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_with_joins(
+    table: &mut TableWithJoins,
+    schema_keys: &[String],
+    pushdown_predicate: Option<&Expr>,
+    changed: &mut bool,
+) -> Result<(), LixError> {
+    rewrite_table_factor(
+        &mut table.relation,
+        schema_keys,
+        pushdown_predicate,
+        changed,
+    )?;
+    for join in &mut table.joins {
+        rewrite_table_factor(&mut join.relation, schema_keys, pushdown_predicate, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_factor(
+    relation: &mut TableFactor,
+    schema_keys: &[String],
+    pushdown_predicate: Option<&Expr>,
+    changed: &mut bool,
+) -> Result<(), LixError> {
+    match relation {
+        TableFactor::Table { name, alias, .. } if object_name_matches(name, VTABLE_NAME) => {
+            let derived_query = build_untracked_union_query(schema_keys, pushdown_predicate)?;
+            let derived_alias = alias.clone().or_else(|| Some(default_vtable_alias()));
+            *relation = TableFactor::Derived {
+                lateral: false,
+                subquery: Box::new(derived_query),
+                alias: derived_alias,
+            };
+            *changed = true;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn build_untracked_union_query(
+    schema_keys: &[String],
+    pushdown_predicate: Option<&Expr>,
+) -> Result<Query, LixError> {
+    let dialect = GenericDialect {};
+    let schema_list = schema_keys
+        .iter()
+        .map(|key| format!("'{}'", escape_string_literal(key)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let predicate_sql = pushdown_predicate
+        .and_then(|expr| strip_qualifiers(expr.clone()))
+        .map(|expr| expr.to_string());
+    let untracked_where = match &predicate_sql {
+        Some(predicate) => format!("schema_key IN ({schema_list}) AND ({predicate})"),
+        None => format!("schema_key IN ({schema_list})"),
+    };
+
+    let mut union_parts = Vec::new();
+    union_parts.push(format!(
+        "SELECT entity_id, schema_key, file_id, version_id, snapshot_content, \
+                1 AS untracked, 1 AS priority \
+         FROM {untracked} \
+         WHERE {untracked_where}",
+        untracked = UNTRACKED_TABLE
+    ));
+
+    for key in schema_keys {
+        let materialized_table = format!("{MATERIALIZED_PREFIX}{key}");
+        let materialized_ident = quote_ident(&materialized_table);
+        let materialized_where = predicate_sql
+            .as_ref()
+            .map(|predicate| format!(" WHERE ({predicate})"))
+            .unwrap_or_default();
+        union_parts.push(format!(
+            "SELECT entity_id, schema_key, file_id, version_id, snapshot_content, \
+                    0 AS untracked, 2 AS priority \
+             FROM {materialized}{materialized_where}",
+            materialized = materialized_ident,
+            materialized_where = materialized_where
+        ));
+    }
+
+    let union_sql = union_parts.join(" UNION ALL ");
+
+    let sql = format!(
+        "SELECT entity_id, schema_key, file_id, version_id, snapshot_content, untracked \
+         FROM (\
+             SELECT entity_id, schema_key, file_id, version_id, snapshot_content, untracked, \
+                    ROW_NUMBER() OVER (PARTITION BY entity_id, schema_key, file_id, version_id ORDER BY priority) AS rn \
+             FROM ({union_sql}) AS lix_state_union\
+         ) AS lix_state_ranked \
+         WHERE rn = 1",
+    );
+
+    let mut statements = Parser::parse_sql(&dialect, &sql).map_err(|err| LixError {
+        message: err.to_string(),
+    })?;
+
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected single derived query statement".to_string(),
+        });
+    }
+
+    match statements.remove(0) {
+        Statement::Query(query) => Ok(*query),
+        _ => Err(LixError {
+            message: "derived query did not parse as SELECT".to_string(),
+        }),
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(|part| part.as_ident())
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn extract_schema_keys_from_query(query: &Query) -> Option<Vec<String>> {
+    extract_schema_keys_from_set_expr(&query.body)
+}
+
+fn extract_pushdown_predicate(query: &Query) -> Option<Expr> {
+    let select = match query.body.as_ref() {
+        SetExpr::Select(select) => select,
+        _ => return None,
+    };
+    let selection = select.selection.as_ref()?;
+    strip_qualifiers(selection.clone())
+}
+
+fn extract_schema_keys_from_set_expr(expr: &SetExpr) -> Option<Vec<String>> {
+    match expr {
+        SetExpr::Select(select) => extract_schema_keys_from_select(select),
+        SetExpr::Query(query) => extract_schema_keys_from_set_expr(&query.body),
+        SetExpr::SetOperation { left, right, .. } => extract_schema_keys_from_set_expr(left)
+            .or_else(|| extract_schema_keys_from_set_expr(right)),
+        _ => None,
+    }
+}
+
+fn extract_schema_keys_from_select(select: &Select) -> Option<Vec<String>> {
+    select
+        .selection
+        .as_ref()
+        .and_then(extract_schema_keys_from_expr)
+}
+
+fn extract_schema_keys_from_expr(expr: &Expr) -> Option<Vec<String>> {
+    match expr {
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            if expr_is_schema_key_column(left) {
+                return string_literal_value(right).map(|value| vec![value]);
+            }
+            if expr_is_schema_key_column(right) {
+                return string_literal_value(left).map(|value| vec![value]);
+            }
+            None
+        }
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::And,
+            right,
+        } => match (
+            extract_schema_keys_from_expr(left),
+            extract_schema_keys_from_expr(right),
+        ) {
+            (Some(left), Some(right)) => {
+                let intersection = intersect_strings(&left, &right);
+                if intersection.is_empty() {
+                    None
+                } else {
+                    Some(intersection)
+                }
+            }
+            (Some(keys), None) | (None, Some(keys)) => Some(keys),
+            (None, None) => None,
+        },
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Or,
+            right,
+        } => match (
+            extract_schema_keys_from_expr(left),
+            extract_schema_keys_from_expr(right),
+        ) {
+            (Some(left), Some(right)) => Some(union_strings(&left, &right)),
+            _ => None,
+        },
+        Expr::InList {
+            expr,
+            list,
+            negated: false,
+        } => {
+            if !expr_is_schema_key_column(expr) {
+                return None;
+            }
+            let mut values = Vec::with_capacity(list.len());
+            for item in list {
+                let value = string_literal_value(item)?;
+                values.push(value);
+            }
+            if values.is_empty() {
+                None
+            } else {
+                Some(dedup_strings(values))
+            }
+        }
+        Expr::Nested(inner) => extract_schema_keys_from_expr(inner),
+        _ => None,
+    }
+}
+
+fn expr_is_schema_key_column(expr: &Expr) -> bool {
+    match expr {
+        Expr::Identifier(ident) => ident.value.eq_ignore_ascii_case("schema_key"),
+        Expr::CompoundIdentifier(idents) => idents
+            .last()
+            .map(|ident| ident.value.eq_ignore_ascii_case("schema_key"))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+fn string_literal_value(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Value(ValueWithSpan {
+            value: Value::SingleQuotedString(value),
+            ..
+        }) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn strip_qualifiers(expr: Expr) -> Option<Expr> {
+    match expr {
+        Expr::Identifier(ident) => {
+            if is_pushdown_column(&ident) {
+                Some(Expr::Identifier(ident))
+            } else {
+                None
+            }
+        }
+        Expr::CompoundIdentifier(_) => None,
+        Expr::BinaryOp { left, op, right } => {
+            if !is_simple_binary_op(&op) {
+                return None;
+            }
+            let left = strip_qualifiers(*left)?;
+            let right = strip_qualifiers(*right)?;
+            Some(Expr::BinaryOp {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            })
+        }
+        Expr::Nested(inner) => strip_qualifiers(*inner).map(|inner| Expr::Nested(Box::new(inner))),
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } => {
+            let expr = strip_qualifiers(*expr)?;
+            let list = strip_in_list_values(list)?;
+            Some(Expr::InList {
+                expr: Box::new(expr),
+                list,
+                negated,
+            })
+        }
+        Expr::Between {
+            expr,
+            negated,
+            low,
+            high,
+        } => {
+            let expr = strip_qualifiers(*expr)?;
+            let low = strip_value_expr(*low)?;
+            let high = strip_value_expr(*high)?;
+            Some(Expr::Between {
+                expr: Box::new(expr),
+                negated,
+                low: Box::new(low),
+                high: Box::new(high),
+            })
+        }
+        Expr::IsNull(inner) => {
+            let inner = strip_qualifiers(*inner)?;
+            Some(Expr::IsNull(Box::new(inner)))
+        }
+        Expr::IsNotNull(inner) => {
+            let inner = strip_qualifiers(*inner)?;
+            Some(Expr::IsNotNull(Box::new(inner)))
+        }
+        Expr::UnaryOp {
+            op: UnaryOperator::Not,
+            expr,
+        } => {
+            let expr = strip_qualifiers(*expr)?;
+            Some(Expr::UnaryOp {
+                op: UnaryOperator::Not,
+                expr: Box::new(expr),
+            })
+        }
+        Expr::Like {
+            expr,
+            negated,
+            pattern,
+            escape_char,
+            any,
+        } => {
+            let expr = strip_qualifiers(*expr)?;
+            let pattern = strip_value_expr(*pattern)?;
+            Some(Expr::Like {
+                expr: Box::new(expr),
+                negated,
+                pattern: Box::new(pattern),
+                escape_char,
+                any,
+            })
+        }
+        Expr::ILike {
+            expr,
+            negated,
+            pattern,
+            escape_char,
+            any,
+        } => {
+            let expr = strip_qualifiers(*expr)?;
+            let pattern = strip_value_expr(*pattern)?;
+            Some(Expr::ILike {
+                expr: Box::new(expr),
+                negated,
+                pattern: Box::new(pattern),
+                escape_char,
+                any,
+            })
+        }
+        Expr::Value(_) => Some(expr),
+        _ => None,
+    }
+}
+
+fn strip_in_list_values(list: Vec<Expr>) -> Option<Vec<Expr>> {
+    let mut values = Vec::with_capacity(list.len());
+    for item in list {
+        let value = strip_value_expr(item)?;
+        values.push(value);
+    }
+    Some(values)
+}
+
+fn strip_value_expr(expr: Expr) -> Option<Expr> {
+    match expr {
+        Expr::Value(_) => Some(expr),
+        Expr::Nested(inner) => strip_value_expr(*inner).map(|inner| Expr::Nested(Box::new(inner))),
+        _ => None,
+    }
+}
+
+fn is_pushdown_column(ident: &Ident) -> bool {
+    let value = ident.value.to_ascii_lowercase();
+    matches!(
+        value.as_str(),
+        "entity_id" | "schema_key" | "file_id" | "version_id" | "snapshot_content"
+    )
+}
+
+fn is_simple_binary_op(op: &BinaryOperator) -> bool {
+    matches!(
+        op,
+        BinaryOperator::And
+            | BinaryOperator::Or
+            | BinaryOperator::Eq
+            | BinaryOperator::NotEq
+            | BinaryOperator::Lt
+            | BinaryOperator::LtEq
+            | BinaryOperator::Gt
+            | BinaryOperator::GtEq
+    )
+}
+
+fn dedup_strings(values: Vec<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    for value in values {
+        if !out.contains(&value) {
+            out.push(value);
+        }
+    }
+    out
+}
+
+fn union_strings(left: &[String], right: &[String]) -> Vec<String> {
+    let mut out = left.to_vec();
+    for value in right {
+        if !out.contains(value) {
+            out.push(value.clone());
+        }
+    }
+    out
+}
+
+fn intersect_strings(left: &[String], right: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    for value in left {
+        if right.contains(value) && !out.contains(value) {
+            out.push(value.clone());
+        }
+    }
+    out
+}
+
+fn default_vtable_alias() -> TableAlias {
+    TableAlias {
+        explicit: false,
+        name: Ident::new(VTABLE_NAME),
+        columns: Vec::new(),
+    }
+}
+
+fn escape_string_literal(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+fn quote_ident(value: &str) -> String {
+    let escaped = value.replace('"', "\"\"");
+    format!("\"{}\"", escaped)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sql::preprocess_sql;
+
+    fn compact_sql(sql: &str) -> String {
+        sql.chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    fn union_segment(sql: &str) -> &str {
+        let end = sql
+            .find(")ASlix_state_union")
+            .expect("union segment end not found");
+        let start = sql[..end]
+            .rfind("FROM(")
+            .expect("union segment start not found");
+        &sql[start + 5..end]
+    }
+
+    fn assert_branch_contains_all(sql: &str, table_marker: &str, needles: &[&str]) {
+        let union_sql = union_segment(sql);
+        let start = union_sql
+            .find(table_marker)
+            .or_else(|| union_sql.find(&table_marker.replace('"', "")))
+            .expect("table marker not found");
+        let slice = &union_sql[start..];
+        let end = slice.find("UNIONALL").unwrap_or(slice.len());
+        let branch = &slice[..end];
+        for needle in needles {
+            assert!(
+                branch.contains(needle),
+                "expected branch for {table_marker} to contain {needle}, got: {branch}"
+            );
+        }
+    }
+
+    fn assert_branch_not_contains(sql: &str, table_marker: &str, needle: &str) {
+        let union_sql = union_segment(sql);
+        let start = union_sql
+            .find(table_marker)
+            .or_else(|| union_sql.find(&table_marker.replace('"', "")))
+            .expect("table marker not found");
+        let slice = &union_sql[start..];
+        let end = slice.find("UNIONALL").unwrap_or(slice.len());
+        let branch = &slice[..end];
+        assert!(
+            !branch.contains(needle),
+            "expected branch for {table_marker} to not contain {needle}, got: {branch}"
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_predicates_for_schema_key_in() {
+        let sql = "SELECT * FROM lix_internal_state_vtable WHERE schema_key IN ('schema_a', 'schema_b') AND entity_id = 'entity-1'";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &[
+                "schema_keyIN('schema_a','schema_b')",
+                "entity_id='entity-1'",
+            ],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &[
+                "schema_keyIN('schema_a','schema_b')",
+                "entity_id='entity-1'",
+            ],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_b"#,
+            &[
+                "schema_keyIN('schema_a','schema_b')",
+                "entity_id='entity-1'",
+            ],
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_like_predicate() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key = 'schema_a' AND entity_id LIKE 'entity-%'";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &["schema_key='schema_a'", "entity_idLIKE'entity-%'"],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &["entity_idLIKE'entity-%'"],
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_or_predicate() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key IN ('schema_a', 'schema_b') \
+            AND (entity_id = 'entity-1' OR file_id = 'file-1')";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &[
+                "schema_keyIN('schema_a','schema_b')",
+                "entity_id='entity-1'ORfile_id='file-1'",
+            ],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &["entity_id='entity-1'ORfile_id='file-1'"],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_b"#,
+            &["entity_id='entity-1'ORfile_id='file-1'"],
+        );
+    }
+
+    #[test]
+    fn rewrite_skips_or_with_non_schema_predicate() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key = 'schema_a' OR entity_id = 'entity-1'";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert!(
+            !compact.contains("lix_internal_state_untracked"),
+            "expected no rewrite for OR with non-schema predicate, got: {compact}"
+        );
+    }
+
+    #[test]
+    fn rewrite_does_not_pushdown_qualified_identifiers() {
+        let sql = "SELECT * FROM lix_internal_state_vtable AS a \
+            WHERE a.schema_key = 'schema_a' AND a.entity_id = 'entity-1'";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &["schema_keyIN('schema_a')"],
+        );
+        assert_branch_not_contains(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            "entity_id='entity-1'",
+        );
+        assert_branch_not_contains(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            "entity_id='entity-1'",
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_comparison_predicates() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key = 'schema_a' AND file_id >= 'file-2' AND entity_id <> 'entity-1'";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &[
+                "schema_key='schema_a'",
+                "file_id>='file-2'",
+                "entity_id<>'entity-1'",
+            ],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &["file_id>='file-2'", "entity_id<>'entity-1'"],
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_not_in_predicate() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key = 'schema_a' AND entity_id NOT IN ('entity-1', 'entity-2')";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &[
+                "schema_key='schema_a'",
+                "entity_idNOTIN('entity-1','entity-2')",
+            ],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &["entity_idNOTIN('entity-1','entity-2')"],
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_is_null_predicate() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key = 'schema_a' AND snapshot_content IS NULL";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &["schema_key='schema_a'", "snapshot_contentISNULL"],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &["snapshot_contentISNULL"],
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_between_predicate() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key = 'schema_a' AND entity_id BETWEEN 'a' AND 'm'";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &["schema_key='schema_a'", "entity_idBETWEEN'a'AND'm'"],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &["entity_idBETWEEN'a'AND'm'"],
+        );
+    }
+
+    #[test]
+    fn rewrite_pushes_down_not_predicate() {
+        let sql = "SELECT * FROM lix_internal_state_vtable \
+            WHERE schema_key = 'schema_a' AND NOT (entity_id = 'entity-1')";
+        let output = preprocess_sql(sql).expect("preprocess_sql");
+        let compact = compact_sql(&output.sql);
+
+        assert_branch_contains_all(
+            &compact,
+            "FROMlix_internal_state_untracked",
+            &["schema_key='schema_a'", "NOT(entity_id='entity-1')"],
+        );
+        assert_branch_contains_all(
+            &compact,
+            r#"FROM"lix_internal_state_materialized_v1_schema_a"#,
+            &["NOT(entity_id='entity-1')"],
+        );
+    }
+}

--- a/packages/engine/src/sql/steps/vtable_write.rs
+++ b/packages/engine/src/sql/steps/vtable_write.rs
@@ -1,74 +1,109 @@
+use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{
     Assignment, AssignmentTarget, BinaryOperator, ConflictTarget, Delete, DoUpdate, Expr, Ident,
-    ObjectName, ObjectNamePart, OnConflict, OnConflictAction, OnInsert, SetExpr, Statement,
-    TableFactor, TableObject, TableWithJoins, Update, Value, ValueWithSpan,
+    ObjectName, ObjectNamePart, OnConflict, OnConflictAction, OnInsert, Query, SetExpr, Statement,
+    TableFactor, TableObject, TableWithJoins, Update, Value, ValueWithSpan, Values,
 };
 
+use crate::functions::timestamp::timestamp;
+use crate::functions::uuid_v7::uuid_v7;
+use crate::sql::SchemaRegistration;
 use crate::LixError;
 
 const VTABLE_NAME: &str = "lix_internal_state_vtable";
 const UNTRACKED_TABLE: &str = "lix_internal_state_untracked";
+const SNAPSHOT_TABLE: &str = "lix_internal_snapshot";
+const CHANGE_TABLE: &str = "lix_internal_change";
+const MATERIALIZED_PREFIX: &str = "lix_internal_state_materialized_v1_";
 
-pub fn rewrite_insert(insert: sqlparser::ast::Insert) -> Result<Option<Statement>, LixError> {
+pub struct VtableWriteRewrite {
+    pub statements: Vec<Statement>,
+    pub registrations: Vec<SchemaRegistration>,
+}
+
+pub fn rewrite_insert(
+    insert: sqlparser::ast::Insert,
+) -> Result<Option<VtableWriteRewrite>, LixError> {
     if !table_object_is_vtable(&insert.table) {
         return Ok(None);
     }
 
     if insert.on.is_some() {
-        return Ok(None);
+        return Err(LixError {
+            message: "vtable insert does not support ON CONFLICT".to_string(),
+        });
     }
 
     if insert.columns.is_empty() {
-        return Ok(None);
+        return Err(LixError {
+            message: "vtable insert requires explicit columns".to_string(),
+        });
     }
-
-    let untracked_index = find_column_index(&insert.columns, "untracked");
-    let untracked_index = match untracked_index {
-        Some(index) => index,
-        None => return Ok(None),
-    };
 
     let source = match &insert.source {
         Some(source) => source,
-        None => return Ok(None),
+        None => {
+            return Err(LixError {
+                message: "vtable insert requires a VALUES source".to_string(),
+            })
+        }
     };
 
     let values = match source.body.as_ref() {
         SetExpr::Values(values) => values,
-        _ => return Ok(None),
+        _ => {
+            return Err(LixError {
+                message: "vtable insert requires VALUES rows".to_string(),
+            })
+        }
     };
 
-    if !values.rows.iter().all(|row| {
-        row.get(untracked_index)
-            .map(is_untracked_true_literal)
-            .unwrap_or(false)
-    }) {
+    if values.rows.is_empty() {
         return Ok(None);
     }
 
-    let mut new_insert = insert.clone();
-    new_insert.table = TableObject::TableName(ObjectName(vec![ObjectNamePart::Identifier(
-        Ident::new(UNTRACKED_TABLE),
-    )]));
+    let untracked_index = find_column_index(&insert.columns, "untracked");
+    let mut tracked_rows = Vec::new();
+    let mut untracked_rows = Vec::new();
 
-    let mut new_columns = insert.columns.clone();
-    new_columns.remove(untracked_index);
-    new_insert.columns = new_columns;
+    for row in &values.rows {
+        let untracked_value = untracked_index.and_then(|idx| row.get(idx)).cloned();
 
-    let mut new_values = values.clone();
-    for row in &mut new_values.rows {
-        if row.len() > untracked_index {
-            row.remove(untracked_index);
+        let untracked = match untracked_value {
+            None => false,
+            Some(expr) if is_untracked_true_literal(&expr) => true,
+            Some(expr) if is_untracked_false_literal(&expr) => false,
+            Some(_) => {
+                return Err(LixError {
+                    message: "vtable insert requires literal untracked values".to_string(),
+                })
+            }
+        };
+
+        if untracked {
+            untracked_rows.push(row.clone());
+        } else {
+            tracked_rows.push(row.clone());
         }
     }
 
-    let mut new_query = (*source.clone()).clone();
-    new_query.body = Box::new(SetExpr::Values(new_values));
-    new_insert.source = Some(Box::new(new_query));
+    let mut statements: Vec<Statement> = Vec::new();
+    let mut registrations: Vec<SchemaRegistration> = Vec::new();
 
-    new_insert.on = Some(build_untracked_on_conflict());
+    if !tracked_rows.is_empty() {
+        let tracked = rewrite_tracked_rows(&insert, tracked_rows, &mut registrations)?;
+        statements.extend(tracked);
+    }
 
-    Ok(Some(Statement::Insert(new_insert)))
+    if !untracked_rows.is_empty() {
+        let untracked = build_untracked_insert(&insert, untracked_rows)?;
+        statements.push(untracked);
+    }
+
+    Ok(Some(VtableWriteRewrite {
+        statements,
+        registrations,
+    }))
 }
 
 pub fn rewrite_update(update: Update) -> Result<Option<Statement>, LixError> {
@@ -119,18 +154,381 @@ fn build_untracked_on_conflict() -> OnInsert {
             Ident::new("version_id"),
         ])),
         action: OnConflictAction::DoUpdate(DoUpdate {
-            assignments: vec![Assignment {
-                target: AssignmentTarget::ColumnName(ObjectName(vec![ObjectNamePart::Identifier(
-                    Ident::new("snapshot_content"),
-                )])),
-                value: Expr::CompoundIdentifier(vec![
-                    Ident::new("excluded"),
-                    Ident::new("snapshot_content"),
-                ]),
-            }],
+            assignments: vec![
+                Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident::new("snapshot_content")),
+                    ])),
+                    value: Expr::CompoundIdentifier(vec![
+                        Ident::new("excluded"),
+                        Ident::new("snapshot_content"),
+                    ]),
+                },
+                Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident::new("plugin_key")),
+                    ])),
+                    value: Expr::CompoundIdentifier(vec![
+                        Ident::new("excluded"),
+                        Ident::new("plugin_key"),
+                    ]),
+                },
+                Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident::new("schema_version")),
+                    ])),
+                    value: Expr::CompoundIdentifier(vec![
+                        Ident::new("excluded"),
+                        Ident::new("schema_version"),
+                    ]),
+                },
+                Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident::new("updated_at")),
+                    ])),
+                    value: Expr::CompoundIdentifier(vec![
+                        Ident::new("excluded"),
+                        Ident::new("updated_at"),
+                    ]),
+                },
+            ],
             selection: None,
         }),
     })
+}
+
+fn build_materialized_on_conflict() -> OnInsert {
+    OnInsert::OnConflict(OnConflict {
+        conflict_target: Some(ConflictTarget::Columns(vec![
+            Ident::new("entity_id"),
+            Ident::new("file_id"),
+            Ident::new("version_id"),
+        ])),
+        action: OnConflictAction::DoUpdate(DoUpdate {
+            assignments: vec![
+                Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident::new("snapshot_content")),
+                    ])),
+                    value: Expr::CompoundIdentifier(vec![
+                        Ident::new("excluded"),
+                        Ident::new("snapshot_content"),
+                    ]),
+                },
+                Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident::new("change_id")),
+                    ])),
+                    value: Expr::CompoundIdentifier(vec![
+                        Ident::new("excluded"),
+                        Ident::new("change_id"),
+                    ]),
+                },
+                Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident::new("updated_at")),
+                    ])),
+                    value: Expr::CompoundIdentifier(vec![
+                        Ident::new("excluded"),
+                        Ident::new("updated_at"),
+                    ]),
+                },
+            ],
+            selection: None,
+        }),
+    })
+}
+
+fn rewrite_tracked_rows(
+    insert: &sqlparser::ast::Insert,
+    rows: Vec<Vec<Expr>>,
+    registrations: &mut Vec<SchemaRegistration>,
+) -> Result<Vec<Statement>, LixError> {
+    let entity_idx = required_column_index(&insert.columns, "entity_id")?;
+    let schema_idx = required_column_index(&insert.columns, "schema_key")?;
+    let file_idx = required_column_index(&insert.columns, "file_id")?;
+    let version_idx = required_column_index(&insert.columns, "version_id")?;
+    let plugin_idx = required_column_index(&insert.columns, "plugin_key")?;
+    let schema_version_idx = required_column_index(&insert.columns, "schema_version")?;
+    let snapshot_idx = required_column_index(&insert.columns, "snapshot_content")?;
+    let metadata_idx = find_column_index(&insert.columns, "metadata");
+
+    let mut ensure_no_content = false;
+    let mut snapshot_rows = Vec::new();
+    let mut change_rows = Vec::new();
+    let mut materialized_by_schema: std::collections::BTreeMap<String, Vec<Vec<Expr>>> =
+        std::collections::BTreeMap::new();
+
+    for row in rows {
+        let schema_key_expr = row.get(schema_idx).ok_or_else(|| LixError {
+            message: "vtable insert missing schema_key".to_string(),
+        })?;
+        let schema_key = literal_string(schema_key_expr)?;
+
+        if !registrations.iter().any(|reg| reg.schema_key == schema_key) {
+            registrations.push(SchemaRegistration {
+                schema_key: schema_key.clone(),
+            });
+        }
+
+        let snapshot_content = row.get(snapshot_idx).cloned().unwrap_or_else(null_expr);
+        let snapshot_id = if is_null_literal(&snapshot_content) {
+            ensure_no_content = true;
+            "no-content".to_string()
+        } else {
+            let id = uuid_v7();
+            snapshot_rows.push(vec![string_expr(&id), snapshot_content.clone()]);
+            id
+        };
+
+        let change_id = uuid_v7();
+        let created_at = timestamp();
+        let updated_at = created_at.clone();
+
+        let metadata_expr = metadata_idx
+            .and_then(|idx| row.get(idx))
+            .cloned()
+            .unwrap_or_else(null_expr);
+
+        change_rows.push(vec![
+            string_expr(&change_id),
+            row.get(entity_idx).cloned().unwrap_or_else(null_expr),
+            row.get(schema_idx).cloned().unwrap_or_else(null_expr),
+            row.get(schema_version_idx)
+                .cloned()
+                .unwrap_or_else(null_expr),
+            row.get(file_idx).cloned().unwrap_or_else(null_expr),
+            row.get(plugin_idx).cloned().unwrap_or_else(null_expr),
+            string_expr(&snapshot_id),
+            metadata_expr,
+            string_expr(&created_at),
+        ]);
+
+        let materialized_row = vec![
+            row.get(entity_idx).cloned().unwrap_or_else(null_expr),
+            row.get(schema_idx).cloned().unwrap_or_else(null_expr),
+            row.get(file_idx).cloned().unwrap_or_else(null_expr),
+            row.get(version_idx).cloned().unwrap_or_else(null_expr),
+            row.get(plugin_idx).cloned().unwrap_or_else(null_expr),
+            snapshot_content,
+            string_expr(&change_id),
+            number_expr("0"),
+            string_expr(&created_at),
+            string_expr(&updated_at),
+        ];
+
+        materialized_by_schema
+            .entry(schema_key)
+            .or_default()
+            .push(materialized_row);
+    }
+
+    let mut statements = Vec::new();
+
+    if ensure_no_content {
+        statements.push(make_insert_statement(
+            SNAPSHOT_TABLE,
+            vec![Ident::new("id"), Ident::new("content")],
+            vec![vec![string_expr("no-content"), null_expr()]],
+            Some(build_snapshot_on_conflict()),
+        ));
+    }
+
+    if !snapshot_rows.is_empty() {
+        statements.push(make_insert_statement(
+            SNAPSHOT_TABLE,
+            vec![Ident::new("id"), Ident::new("content")],
+            snapshot_rows,
+            Some(build_snapshot_on_conflict()),
+        ));
+    }
+
+    if !change_rows.is_empty() {
+        statements.push(make_insert_statement(
+            CHANGE_TABLE,
+            vec![
+                Ident::new("id"),
+                Ident::new("entity_id"),
+                Ident::new("schema_key"),
+                Ident::new("schema_version"),
+                Ident::new("file_id"),
+                Ident::new("plugin_key"),
+                Ident::new("snapshot_id"),
+                Ident::new("metadata"),
+                Ident::new("created_at"),
+            ],
+            change_rows,
+            None,
+        ));
+    }
+
+    for (schema_key, rows) in materialized_by_schema {
+        let table_name = format!("{}{}", MATERIALIZED_PREFIX, schema_key);
+        statements.push(make_insert_statement(
+            &table_name,
+            vec![
+                Ident::new("entity_id"),
+                Ident::new("schema_key"),
+                Ident::new("file_id"),
+                Ident::new("version_id"),
+                Ident::new("plugin_key"),
+                Ident::new("snapshot_content"),
+                Ident::new("change_id"),
+                Ident::new("is_tombstone"),
+                Ident::new("created_at"),
+                Ident::new("updated_at"),
+            ],
+            rows,
+            Some(build_materialized_on_conflict()),
+        ));
+    }
+
+    Ok(statements)
+}
+
+fn build_snapshot_on_conflict() -> OnInsert {
+    OnInsert::OnConflict(OnConflict {
+        conflict_target: Some(ConflictTarget::Columns(vec![Ident::new("id")])),
+        action: OnConflictAction::DoNothing,
+    })
+}
+
+fn build_untracked_insert(
+    insert: &sqlparser::ast::Insert,
+    rows: Vec<Vec<Expr>>,
+) -> Result<Statement, LixError> {
+    let entity_idx = required_column_index(&insert.columns, "entity_id")?;
+    let schema_idx = required_column_index(&insert.columns, "schema_key")?;
+    let file_idx = required_column_index(&insert.columns, "file_id")?;
+    let version_idx = required_column_index(&insert.columns, "version_id")?;
+    let plugin_idx = required_column_index(&insert.columns, "plugin_key")?;
+    let snapshot_idx = required_column_index(&insert.columns, "snapshot_content")?;
+    let schema_version_idx = required_column_index(&insert.columns, "schema_version")?;
+
+    let mut mapped_rows = Vec::new();
+    for row in rows {
+        let now = timestamp();
+        mapped_rows.push(vec![
+            row.get(entity_idx).cloned().unwrap_or_else(null_expr),
+            row.get(schema_idx).cloned().unwrap_or_else(null_expr),
+            row.get(file_idx).cloned().unwrap_or_else(null_expr),
+            row.get(version_idx).cloned().unwrap_or_else(null_expr),
+            row.get(plugin_idx).cloned().unwrap_or_else(null_expr),
+            row.get(snapshot_idx).cloned().unwrap_or_else(null_expr),
+            row.get(schema_version_idx)
+                .cloned()
+                .unwrap_or_else(null_expr),
+            string_expr(&now),
+            string_expr(&now),
+        ]);
+    }
+
+    Ok(make_insert_statement(
+        UNTRACKED_TABLE,
+        vec![
+            Ident::new("entity_id"),
+            Ident::new("schema_key"),
+            Ident::new("file_id"),
+            Ident::new("version_id"),
+            Ident::new("plugin_key"),
+            Ident::new("snapshot_content"),
+            Ident::new("schema_version"),
+            Ident::new("created_at"),
+            Ident::new("updated_at"),
+        ],
+        mapped_rows,
+        Some(build_untracked_on_conflict()),
+    ))
+}
+
+fn make_insert_statement(
+    table: &str,
+    columns: Vec<Ident>,
+    rows: Vec<Vec<Expr>>,
+    on: Option<OnInsert>,
+) -> Statement {
+    let values = Values {
+        explicit_row: false,
+        value_keyword: false,
+        rows,
+    };
+    let query = Query {
+        with: None,
+        body: Box::new(SetExpr::Values(values)),
+        order_by: None,
+        limit_clause: None,
+        fetch: None,
+        locks: Vec::new(),
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+        pipe_operators: Vec::new(),
+    };
+
+    Statement::Insert(sqlparser::ast::Insert {
+        insert_token: AttachedToken::empty(),
+        or: None,
+        ignore: false,
+        into: true,
+        table: TableObject::TableName(ObjectName(vec![ObjectNamePart::Identifier(Ident::new(
+            table,
+        ))])),
+        table_alias: None,
+        columns,
+        overwrite: false,
+        source: Some(Box::new(query)),
+        assignments: Vec::new(),
+        partitioned: None,
+        after_columns: Vec::new(),
+        has_table_keyword: false,
+        on,
+        returning: None,
+        replace_into: false,
+        priority: None,
+        insert_alias: None,
+        settings: None,
+        format_clause: None,
+    })
+}
+
+fn required_column_index(columns: &[Ident], name: &str) -> Result<usize, LixError> {
+    find_column_index(columns, name).ok_or_else(|| LixError {
+        message: format!("vtable insert requires {name}"),
+    })
+}
+
+fn literal_string(expr: &Expr) -> Result<String, LixError> {
+    match expr {
+        Expr::Value(ValueWithSpan {
+            value: Value::SingleQuotedString(value),
+            ..
+        }) => Ok(value.clone()),
+        _ => Err(LixError {
+            message: "vtable insert requires literal schema_key".to_string(),
+        }),
+    }
+}
+
+fn string_expr(value: &str) -> Expr {
+    Expr::Value(Value::SingleQuotedString(value.to_string()).into())
+}
+
+fn number_expr(value: &str) -> Expr {
+    Expr::Value(Value::Number(value.to_string(), false).into())
+}
+
+fn null_expr() -> Expr {
+    Expr::Value(Value::Null.into())
+}
+
+fn is_null_literal(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Value(ValueWithSpan {
+            value: Value::Null,
+            ..
+        })
+    )
 }
 
 fn table_object_is_vtable(table: &TableObject) -> bool {
@@ -280,10 +678,173 @@ fn is_untracked_true_literal(expr: &Expr) -> bool {
     }
 }
 
+fn is_untracked_false_literal(expr: &Expr) -> bool {
+    match expr {
+        Expr::Value(ValueWithSpan {
+            value: Value::Number(value, _),
+            ..
+        }) => value == "0",
+        Expr::Value(ValueWithSpan {
+            value: Value::Boolean(value),
+            ..
+        }) => !*value,
+        _ => false,
+    }
+}
+
 fn object_name_matches(name: &ObjectName, target: &str) -> bool {
     name.0
         .last()
         .and_then(|part| part.as_ident())
         .map(|ident| ident.value.eq_ignore_ascii_case(target))
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_insert;
+    use sqlparser::ast::{
+        Expr, ObjectNamePart, SetExpr, Statement, TableObject, Value, ValueWithSpan,
+    };
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
+    #[test]
+    fn rewrite_tracked_insert_emits_snapshot_change_and_materialized() {
+        let sql = r#"INSERT INTO lix_internal_state_vtable
+            (entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version)
+            VALUES ('entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{"key":"value"}', '1')"#;
+        let mut statements = Parser::parse_sql(&GenericDialect {}, sql).expect("parse sql");
+        let statement = statements.remove(0);
+
+        let insert = match statement {
+            Statement::Insert(insert) => insert,
+            _ => panic!("expected insert"),
+        };
+
+        let rewrite = rewrite_insert(insert)
+            .expect("rewrite ok")
+            .expect("rewrite applied");
+
+        assert_eq!(rewrite.statements.len(), 3);
+
+        let snapshot_stmt = find_insert(&rewrite.statements, "lix_internal_snapshot");
+        let change_stmt = find_insert(&rewrite.statements, "lix_internal_change");
+        let materialized_stmt = find_insert(
+            &rewrite.statements,
+            "lix_internal_state_materialized_v1_test_schema",
+        );
+
+        let snapshot_id = extract_string_value(snapshot_stmt, "id");
+        let change_snapshot_id = extract_string_value(change_stmt, "snapshot_id");
+        assert_eq!(snapshot_id, change_snapshot_id);
+
+        let change_id = extract_string_value(change_stmt, "id");
+        let materialized_change_id = extract_string_value(materialized_stmt, "change_id");
+        assert_eq!(change_id, materialized_change_id);
+    }
+
+    #[test]
+    fn rewrite_tracked_insert_uses_no_content_snapshot() {
+        let sql = r#"INSERT INTO lix_internal_state_vtable
+            (entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version)
+            VALUES ('entity-1', 'test_schema', 'file-1', 'version-1', 'lix', NULL, '1')"#;
+        let mut statements = Parser::parse_sql(&GenericDialect {}, sql).expect("parse sql");
+        let statement = statements.remove(0);
+
+        let insert = match statement {
+            Statement::Insert(insert) => insert,
+            _ => panic!("expected insert"),
+        };
+
+        let rewrite = rewrite_insert(insert)
+            .expect("rewrite ok")
+            .expect("rewrite applied");
+
+        let change_stmt = find_insert(&rewrite.statements, "lix_internal_change");
+        let snapshot_id = extract_string_value(change_stmt, "snapshot_id");
+        assert_eq!(snapshot_id, "no-content");
+
+        let snapshot_stmt = find_insert(&rewrite.statements, "lix_internal_snapshot");
+        let ensured_id = extract_string_value(snapshot_stmt, "id");
+        assert_eq!(ensured_id, "no-content");
+    }
+
+    #[test]
+    fn rewrite_untracked_insert_routes_to_untracked_table() {
+        let sql = r#"INSERT INTO lix_internal_state_vtable
+            (entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, untracked)
+            VALUES ('entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{"key":"value"}', '1', 1)"#;
+        let mut statements = Parser::parse_sql(&GenericDialect {}, sql).expect("parse sql");
+        let statement = statements.remove(0);
+
+        let insert = match statement {
+            Statement::Insert(insert) => insert,
+            _ => panic!("expected insert"),
+        };
+
+        let rewrite = rewrite_insert(insert)
+            .expect("rewrite ok")
+            .expect("rewrite applied");
+
+        assert_eq!(rewrite.statements.len(), 1);
+        let stmt = &rewrite.statements[0];
+        assert_eq!(table_name(stmt), "lix_internal_state_untracked");
+    }
+
+    fn find_insert<'a>(statements: &'a [Statement], table: &str) -> &'a Statement {
+        statements
+            .iter()
+            .find(|stmt| table_name(stmt) == table)
+            .unwrap_or_else(|| panic!("missing insert into {table}"))
+    }
+
+    fn table_name(statement: &Statement) -> &str {
+        match statement {
+            Statement::Insert(insert) => match &insert.table {
+                TableObject::TableName(name) => name
+                    .0
+                    .last()
+                    .and_then(ObjectNamePart::as_ident)
+                    .map(|ident| ident.value.as_str())
+                    .expect("table name ident"),
+                _ => panic!("expected table name"),
+            },
+            _ => panic!("expected insert statement"),
+        }
+    }
+
+    fn extract_string_value(statement: &Statement, column: &str) -> String {
+        let (columns, rows) = insert_values(statement);
+        let idx = columns
+            .iter()
+            .position(|name| name.eq_ignore_ascii_case(column))
+            .expect("column present");
+        let expr = rows.get(0).and_then(|row| row.get(idx)).expect("row value");
+        match expr {
+            Expr::Value(ValueWithSpan {
+                value: Value::SingleQuotedString(value),
+                ..
+            }) => value.clone(),
+            _ => panic!("expected string literal"),
+        }
+    }
+
+    fn insert_values(statement: &Statement) -> (Vec<String>, Vec<Vec<Expr>>) {
+        match statement {
+            Statement::Insert(insert) => {
+                let columns = insert
+                    .columns
+                    .iter()
+                    .map(|ident| ident.value.clone())
+                    .collect::<Vec<_>>();
+                let rows = match insert.source.as_ref().expect("insert source").body.as_ref() {
+                    SetExpr::Values(values) => values.rows.clone(),
+                    _ => panic!("expected values"),
+                };
+                (columns, rows)
+            }
+            _ => panic!("expected insert"),
+        }
+    }
 }

--- a/packages/engine/src/sql/types.rs
+++ b/packages/engine/src/sql/types.rs
@@ -7,7 +7,7 @@ pub struct SchemaRegistration {
 
 #[derive(Debug, Clone)]
 pub struct RewriteOutput {
-    pub statement: Statement,
+    pub statements: Vec<Statement>,
     pub registrations: Vec<SchemaRegistration>,
 }
 

--- a/packages/engine/src/sql/types.rs
+++ b/packages/engine/src/sql/types.rs
@@ -1,3 +1,4 @@
+use serde_json::Value as JsonValue;
 use sqlparser::ast::Statement;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +16,34 @@ pub struct VtableDeletePlan {
     pub schema_key: String,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdateValidationPlan {
+    pub table: String,
+    pub where_clause: Option<String>,
+    pub snapshot_content: Option<JsonValue>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutationOperation {
+    Insert,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MutationRow {
+    pub operation: MutationOperation,
+    pub entity_id: String,
+    pub schema_key: String,
+    pub schema_version: String,
+    pub file_id: String,
+    pub version_id: String,
+    pub plugin_key: String,
+    pub snapshot_content: Option<JsonValue>,
+    pub untracked: bool,
+}
+
 #[derive(Debug, Clone)]
 pub enum PostprocessPlan {
     VtableUpdate(VtableUpdatePlan),
@@ -26,6 +55,8 @@ pub struct RewriteOutput {
     pub statements: Vec<Statement>,
     pub registrations: Vec<SchemaRegistration>,
     pub postprocess: Option<PostprocessPlan>,
+    pub mutations: Vec<MutationRow>,
+    pub update_validations: Vec<UpdateValidationPlan>,
 }
 
 #[derive(Debug, Clone)]
@@ -33,4 +64,6 @@ pub struct PreprocessOutput {
     pub sql: String,
     pub registrations: Vec<SchemaRegistration>,
     pub postprocess: Option<PostprocessPlan>,
+    pub mutations: Vec<MutationRow>,
+    pub update_validations: Vec<UpdateValidationPlan>,
 }

--- a/packages/engine/src/sql/types.rs
+++ b/packages/engine/src/sql/types.rs
@@ -5,14 +5,32 @@ pub struct SchemaRegistration {
     pub schema_key: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VtableUpdatePlan {
+    pub schema_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VtableDeletePlan {
+    pub schema_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum PostprocessPlan {
+    VtableUpdate(VtableUpdatePlan),
+    VtableDelete(VtableDeletePlan),
+}
+
 #[derive(Debug, Clone)]
 pub struct RewriteOutput {
     pub statements: Vec<Statement>,
     pub registrations: Vec<SchemaRegistration>,
+    pub postprocess: Option<PostprocessPlan>,
 }
 
 #[derive(Debug, Clone)]
 pub struct PreprocessOutput {
     pub sql: String,
     pub registrations: Vec<SchemaRegistration>,
+    pub postprocess: Option<PostprocessPlan>,
 }

--- a/packages/engine/src/validation.rs
+++ b/packages/engine/src/validation.rs
@@ -1,0 +1,447 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use jsonschema::JSONSchema;
+use serde_json::Value as JsonValue;
+
+use crate::sql::{MutationOperation, MutationRow, UpdateValidationPlan};
+use crate::validate_lix_schema_definition;
+use crate::{LixBackend, LixError, Value};
+
+const STORED_SCHEMA_TABLE: &str = "lix_internal_state_materialized_v1_lix_stored_schema";
+const STORED_SCHEMA_KEY: &str = "lix_stored_schema";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SchemaCacheKey {
+    schema_key: String,
+    schema_version: String,
+}
+
+#[derive(Debug, Default)]
+pub struct SchemaCache {
+    inner: RwLock<HashMap<SchemaCacheKey, Arc<JSONSchema>>>,
+}
+
+impl SchemaCache {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+pub async fn validate_inserts(
+    backend: &dyn LixBackend,
+    cache: &SchemaCache,
+    mutations: &[MutationRow],
+) -> Result<(), LixError> {
+    for row in mutations {
+        if row.operation != MutationOperation::Insert {
+            continue;
+        }
+
+        if row.schema_key == STORED_SCHEMA_KEY {
+            validate_stored_schema_insert(backend, row).await?;
+            continue;
+        }
+
+        let Some(snapshot) = row.snapshot_content.as_ref() else {
+            continue;
+        };
+
+        validate_snapshot_content(
+            backend,
+            cache,
+            &row.schema_key,
+            &row.schema_version,
+            snapshot,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+pub async fn validate_updates(
+    backend: &dyn LixBackend,
+    cache: &SchemaCache,
+    plans: &[UpdateValidationPlan],
+) -> Result<(), LixError> {
+    let mut definition_cache: HashMap<SchemaCacheKey, JsonValue> = HashMap::new();
+
+    for plan in plans {
+        let Some(snapshot) = plan.snapshot_content.as_ref() else {
+            // Even without snapshot_content changes we still enforce immutability.
+            let mut sql = format!(
+                "SELECT entity_id, file_id, version_id, plugin_key, schema_key, schema_version FROM {}",
+                plan.table
+            );
+            if let Some(where_clause) = &plan.where_clause {
+                sql.push_str(" WHERE ");
+                sql.push_str(where_clause);
+            }
+
+            let result = backend.execute(&sql, &[]).await?;
+            if result.rows.is_empty() {
+                continue;
+            }
+
+            for row in result.rows {
+                let schema_key = value_to_string(&row[4], "schema_key")?;
+                let schema_version = value_to_string(&row[5], "schema_version")?;
+
+                let key = SchemaCacheKey {
+                    schema_key: schema_key.clone(),
+                    schema_version: schema_version.clone(),
+                };
+                let schema = if let Some(schema) = definition_cache.get(&key) {
+                    schema.clone()
+                } else {
+                    let schema =
+                        load_schema_definition(backend, &schema_key, &schema_version).await?;
+                    definition_cache.insert(key.clone(), schema.clone());
+                    schema
+                };
+
+                if schema.get("x-lix-immutable").and_then(|v| v.as_bool()) == Some(true) {
+                    return Err(LixError {
+                        message: format!(
+                            "Schema '{}' is immutable and cannot be updated.",
+                            schema_key
+                        ),
+                    });
+                }
+            }
+
+            continue;
+        };
+
+        let mut sql = format!(
+            "SELECT entity_id, file_id, version_id, plugin_key, schema_key, schema_version FROM {}",
+            plan.table
+        );
+        if let Some(where_clause) = &plan.where_clause {
+            sql.push_str(" WHERE ");
+            sql.push_str(where_clause);
+        }
+
+        let result = backend.execute(&sql, &[]).await?;
+        if result.rows.is_empty() {
+            continue;
+        }
+
+        for row in result.rows {
+            let schema_key = value_to_string(&row[4], "schema_key")?;
+            let schema_version = value_to_string(&row[5], "schema_version")?;
+
+            let key = SchemaCacheKey {
+                schema_key: schema_key.clone(),
+                schema_version: schema_version.clone(),
+            };
+            let schema = if let Some(schema) = definition_cache.get(&key) {
+                schema.clone()
+            } else {
+                let schema = load_schema_definition(backend, &schema_key, &schema_version).await?;
+                definition_cache.insert(key.clone(), schema.clone());
+                schema
+            };
+
+            if schema.get("x-lix-immutable").and_then(|v| v.as_bool()) == Some(true) {
+                return Err(LixError {
+                    message: format!(
+                        "Schema '{}' is immutable and cannot be updated.",
+                        schema_key
+                    ),
+                });
+            }
+
+            if schema_key == STORED_SCHEMA_KEY {
+                continue;
+            }
+
+            validate_snapshot_content(backend, cache, &schema_key, &schema_version, snapshot)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn validate_snapshot_content(
+    backend: &dyn LixBackend,
+    cache: &SchemaCache,
+    schema_key: &str,
+    schema_version: &str,
+    snapshot: &JsonValue,
+) -> Result<(), LixError> {
+    let compiled = load_compiled_schema(backend, cache, schema_key, schema_version).await?;
+    let details = match compiled.validate(snapshot) {
+        Ok(()) => None,
+        Err(errors) => {
+            let mut parts = Vec::new();
+            for error in errors {
+                let path = error.instance_path.to_string();
+                let message = error.to_string();
+                if path.is_empty() {
+                    parts.push(message);
+                } else {
+                    parts.push(format!("{path} {message}"));
+                }
+            }
+            Some(parts.join("; "))
+        }
+    };
+
+    if let Some(details) = details {
+        return Err(LixError {
+            message: format!(
+                "snapshot_content does not match schema '{}' ({}): {details}",
+                schema_key, schema_version
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+async fn validate_stored_schema_insert(
+    backend: &dyn LixBackend,
+    row: &MutationRow,
+) -> Result<(), LixError> {
+    let snapshot = row.snapshot_content.as_ref().ok_or_else(|| LixError {
+        message: "stored schema insert requires snapshot_content".to_string(),
+    })?;
+    let schema_value = snapshot.get("value").ok_or_else(|| LixError {
+        message: "stored schema snapshot_content missing value".to_string(),
+    })?;
+
+    validate_lix_schema_definition(schema_value)?;
+    validate_foreign_key_reference_targets(backend, schema_value).await?;
+
+    Ok(())
+}
+
+async fn validate_foreign_key_reference_targets(
+    backend: &dyn LixBackend,
+    schema: &JsonValue,
+) -> Result<(), LixError> {
+    let Some(foreign_keys) = schema.get("x-lix-foreign-keys").and_then(|v| v.as_array()) else {
+        return Ok(());
+    };
+
+    for (index, foreign_key) in foreign_keys.iter().enumerate() {
+        let references = foreign_key
+            .get("references")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| LixError {
+                message: format!(
+                    "foreign key at index {index} missing references object in schema definition"
+                ),
+            })?;
+        let referenced_key = references
+            .get("schemaKey")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| LixError {
+                message: format!(
+                    "foreign key at index {index} references.schemaKey must be a string"
+                ),
+            })?;
+        let referenced_properties = references
+            .get("properties")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| LixError {
+                message: format!(
+                    "foreign key at index {index} references.properties must be an array"
+                ),
+            })?;
+
+        let referenced_properties: Vec<String> = referenced_properties
+            .iter()
+            .filter_map(|value| value.as_str())
+            .map(|value| value.to_string())
+            .collect();
+
+        let referenced_schema = load_latest_schema_definition(backend, referenced_key).await?;
+        let allowed_keys = collect_unique_key_groups(&referenced_schema);
+        if !allowed_keys
+            .iter()
+            .any(|group| group == &referenced_properties)
+        {
+            return Err(LixError {
+                message: format!(
+                    "foreign key at index {index} references properties that are not a primary key or unique key on schema '{}'",
+                    referenced_key
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_unique_key_groups(schema: &JsonValue) -> Vec<Vec<String>> {
+    let mut keys = Vec::new();
+    if let Some(primary) = schema
+        .get("x-lix-primary-key")
+        .and_then(|value| value.as_array())
+    {
+        let group: Vec<String> = primary
+            .iter()
+            .filter_map(|value| value.as_str())
+            .map(|value| value.to_string())
+            .collect();
+        if !group.is_empty() {
+            keys.push(group);
+        }
+    }
+    if let Some(unique_groups) = schema
+        .get("x-lix-unique")
+        .and_then(|value| value.as_array())
+    {
+        for group in unique_groups {
+            let Some(group_values) = group.as_array() else {
+                continue;
+            };
+            let group_values: Vec<String> = group_values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .map(|value| value.to_string())
+                .collect();
+            if !group_values.is_empty() {
+                keys.push(group_values);
+            }
+        }
+    }
+    keys
+}
+
+async fn load_compiled_schema(
+    backend: &dyn LixBackend,
+    cache: &SchemaCache,
+    schema_key: &str,
+    schema_version: &str,
+) -> Result<Arc<JSONSchema>, LixError> {
+    let key = SchemaCacheKey {
+        schema_key: schema_key.to_string(),
+        schema_version: schema_version.to_string(),
+    };
+
+    if let Some(existing) = cache.inner.read().unwrap().get(&key) {
+        return Ok(existing.clone());
+    }
+
+    let schema = load_schema_definition(backend, schema_key, schema_version).await?;
+    let compiled = JSONSchema::compile(&schema).map_err(|err| LixError {
+        message: format!(
+            "failed to compile schema '{}' ({}): {err}",
+            schema_key, schema_version
+        ),
+    })?;
+    let compiled = Arc::new(compiled);
+
+    cache.inner.write().unwrap().insert(key, compiled.clone());
+
+    Ok(compiled)
+}
+
+async fn load_schema_definition(
+    backend: &dyn LixBackend,
+    schema_key: &str,
+    schema_version: &str,
+) -> Result<JsonValue, LixError> {
+    let entity_id = format!("{}~{}", schema_key, schema_version);
+    let entity_id = escape_sql_string(&entity_id);
+
+    let sql = format!(
+        "SELECT snapshot_content FROM {table} \
+         WHERE entity_id = '{entity_id}' \
+           AND version_id = 'global' \
+           AND is_tombstone = 0 \
+           AND snapshot_content IS NOT NULL \
+         LIMIT 1",
+        table = STORED_SCHEMA_TABLE,
+        entity_id = entity_id,
+    );
+
+    let result = backend.execute(&sql, &[]).await?;
+    let row = result.rows.get(0).ok_or_else(|| LixError {
+        message: format!("schema '{}' ({}) is not stored", schema_key, schema_version),
+    })?;
+
+    let raw = match row.get(0) {
+        Some(Value::Text(text)) => text,
+        _ => {
+            return Err(LixError {
+                message: "stored schema row missing snapshot_content".to_string(),
+            })
+        }
+    };
+
+    let parsed: JsonValue = serde_json::from_str(raw).map_err(|err| LixError {
+        message: format!("stored schema snapshot_content invalid JSON: {err}"),
+    })?;
+
+    let schema = parsed.get("value").cloned().ok_or_else(|| LixError {
+        message: "stored schema snapshot_content missing value".to_string(),
+    })?;
+
+    Ok(schema)
+}
+
+async fn load_latest_schema_definition(
+    backend: &dyn LixBackend,
+    schema_key: &str,
+) -> Result<JsonValue, LixError> {
+    let prefix = format!("{schema_key}~");
+    let prefix_escaped = escape_sql_string(&prefix);
+    let prefix_len = prefix.len();
+    let sql = format!(
+        "SELECT snapshot_content \
+         FROM {table} \
+         WHERE substr(entity_id, 1, {prefix_len}) = '{prefix_escaped}' \
+           AND version_id = 'global' \
+           AND is_tombstone = 0 \
+           AND snapshot_content IS NOT NULL \
+         ORDER BY CAST(schema_version AS INTEGER) DESC \
+         LIMIT 1",
+        table = STORED_SCHEMA_TABLE,
+        prefix_len = prefix_len,
+        prefix_escaped = prefix_escaped,
+    );
+
+    let result = backend.execute(&sql, &[]).await?;
+    let row = result.rows.get(0).ok_or_else(|| LixError {
+        message: format!("schema '{}' is not stored", schema_key),
+    })?;
+
+    let raw = match row.get(0) {
+        Some(Value::Text(text)) => text,
+        _ => {
+            return Err(LixError {
+                message: "stored schema row missing snapshot_content".to_string(),
+            })
+        }
+    };
+
+    let parsed: JsonValue = serde_json::from_str(raw).map_err(|err| LixError {
+        message: format!("stored schema snapshot_content invalid JSON: {err}"),
+    })?;
+    let schema = parsed.get("value").cloned().ok_or_else(|| LixError {
+        message: "stored schema snapshot_content missing value".to_string(),
+    })?;
+
+    Ok(schema)
+}
+
+fn escape_sql_string(input: &str) -> String {
+    input.replace('\'', "''")
+}
+
+fn value_to_string(value: &Value, name: &str) -> Result<String, LixError> {
+    match value {
+        Value::Text(text) => Ok(text.clone()),
+        _ => Err(LixError {
+            message: format!("expected text value for {name}"),
+        }),
+    }
+}

--- a/packages/engine/tests/init.rs
+++ b/packages/engine/tests/init.rs
@@ -15,3 +15,56 @@ simulation_test!(init_creates_untracked_table, |sim| async move {
 
     sim.expect_deterministic(result.rows.clone());
 });
+
+simulation_test!(init_creates_snapshot_table, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    let result = engine
+        .execute("SELECT 1 FROM lix_internal_snapshot LIMIT 1", &[])
+        .await
+        .unwrap();
+
+    sim.expect_deterministic(result.rows.clone());
+});
+
+simulation_test!(init_creates_change_table, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    let result = engine
+        .execute("SELECT 1 FROM lix_internal_change LIMIT 1", &[])
+        .await
+        .unwrap();
+
+    sim.expect_deterministic(result.rows.clone());
+});
+
+simulation_test!(init_inserts_no_content_snapshot, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    let result = engine
+        .execute(
+            "SELECT content FROM lix_internal_snapshot WHERE id = 'no-content'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    sim.expect_deterministic(result.rows.clone());
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0], lix_engine::Value::Null);
+});

--- a/packages/engine/tests/schema_definition_validation.rs
+++ b/packages/engine/tests/schema_definition_validation.rs
@@ -1,0 +1,797 @@
+use lix_engine::{validate_lix_schema, validate_lix_schema_definition};
+use serde_json::json;
+
+#[test]
+fn validate_lix_schema_definition_passes_for_valid_schema() {
+    let valid_schema = json!({
+        "x-lix-key": "test_entity",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&valid_schema).is_ok());
+}
+
+#[test]
+fn validate_lix_schema_definition_throws_for_invalid_schema() {
+    let invalid_schema = json!({
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+
+    let err = validate_lix_schema_definition(&invalid_schema).unwrap_err();
+    assert!(err.to_string().contains("Invalid Lix schema definition"));
+}
+
+#[test]
+fn validate_lix_schema_validates_both_schema_and_data_successfully() {
+    let schema = json!({
+        "x-lix-key": "user",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+        },
+        "required": ["id", "name"],
+        "additionalProperties": false
+    });
+
+    let valid_data = json!({
+        "id": "123",
+        "name": "John Doe"
+    });
+
+    assert!(validate_lix_schema(&schema, &valid_data).is_ok());
+}
+
+#[test]
+fn validate_lix_schema_throws_when_schema_is_invalid() {
+    let invalid_schema = json!({
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+
+    let data = json!({ "id": "123" });
+
+    let err = validate_lix_schema(&invalid_schema, &data).unwrap_err();
+    assert!(err.to_string().contains("Invalid Lix schema definition"));
+}
+
+#[test]
+fn validate_lix_schema_throws_when_data_does_not_match_schema() {
+    let schema = json!({
+        "x-lix-key": "user",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+        },
+        "required": ["id", "name"],
+        "additionalProperties": false
+    });
+
+    let invalid_data = json!({ "id": "123" });
+
+    let err = validate_lix_schema(&schema, &invalid_data).unwrap_err();
+    assert!(err.to_string().contains("Data validation failed"));
+}
+
+#[test]
+fn validate_lix_schema_definition_rejects_when_additional_properties_missing() {
+    let schema = json!({
+        "x-lix-key": "user",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" }
+        },
+        "required": ["id"]
+    });
+
+    let err = validate_lix_schema_definition(&schema).unwrap_err();
+    assert!(err.to_string().contains("Invalid Lix schema definition"));
+}
+
+#[test]
+fn additional_properties_must_be_false() {
+    let schema_with_additional_props = json!({
+        "x-lix-key": "user",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+        },
+        "required": ["id", "name"],
+        "additionalProperties": true
+    });
+
+    assert!(validate_lix_schema_definition(&schema_with_additional_props).is_err());
+
+    let valid_schema = json!({
+        "x-lix-key": "user",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+        },
+        "required": ["id", "name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&valid_schema).is_ok());
+
+    let data = json!({
+        "id": "123",
+        "name": "John Doe",
+        "extraField": "not allowed"
+    });
+
+    let err = validate_lix_schema(&valid_schema, &data).unwrap_err();
+    assert!(err.to_string().contains("Data validation failed"));
+}
+
+#[test]
+fn validate_lix_schema_definition_rejects_missing_primary_key_properties() {
+    let schema = json!({
+        "x-lix-key": "missing_pk",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "value": { "type": "string" }
+        },
+        "required": ["value"],
+        "x-lix-primary-key": ["/entity_id"],
+        "additionalProperties": false
+    });
+
+    let err = validate_lix_schema_definition(&schema).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("x-lix-primary-key references missing property"));
+}
+
+#[test]
+fn validate_lix_schema_definition_rejects_missing_unique_constraint_properties() {
+    let schema = json!({
+        "x-lix-key": "missing_unique",
+        "x-lix-version": "1",
+        "type": "object",
+        "properties": {
+            "value": { "type": "string" }
+        },
+        "x-lix-unique": [["/entity_id", "/value"]],
+        "additionalProperties": false
+    });
+
+    let err = validate_lix_schema_definition(&schema).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("x-lix-unique references missing property"));
+}
+
+#[test]
+fn valid_schema() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-immutable": true,
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_immutable_accepts_boolean_values() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-immutable": false,
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_key_is_required() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": null,
+        "x-lix-version": "1",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_key_must_be_snake_case() {
+    let base_schema = json!({
+        "type": "object",
+        "x-lix-version": "1",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    let invalid_keys = [
+        "Invalid-Key!",
+        "also.invalid",
+        "123starts_with_number",
+        "contains space",
+        "camelCaseKey",
+        "UPPER_CASE",
+        "mixed-Case_Value",
+    ];
+    for key in invalid_keys {
+        let mut schema = base_schema.clone();
+        schema["x-lix-key"] = json!(key);
+        assert!(validate_lix_schema_definition(&schema).is_err());
+    }
+
+    let valid_keys = ["abc", "abc123", "abc_123", "a", "snake_case_key"];
+    for key in valid_keys {
+        let mut schema = base_schema.clone();
+        schema["x-lix-key"] = json!(key);
+        assert!(validate_lix_schema_definition(&schema).is_ok());
+    }
+}
+
+#[test]
+fn x_lix_unique_is_optional() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_unique_must_be_array_of_arrays_when_present() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-unique": [["/id"], ["/name", "/age"]],
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "age": { "type": "number" }
+        },
+        "required": ["id", "name", "age"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_unique_fails_with_invalid_structure() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-unique": ["/id", "/name"],
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+        },
+        "required": ["id", "name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_primary_key_must_include_at_least_one_unique_pointer() {
+    let base_schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "properties": {
+            "id": { "type": "string" }
+        },
+        "required": ["id"],
+        "additionalProperties": false
+    });
+
+    let mut empty_pk = base_schema.clone();
+    empty_pk["x-lix-primary-key"] = json!([]);
+    assert!(validate_lix_schema_definition(&empty_pk).is_err());
+
+    let mut duplicate_pk = base_schema.clone();
+    duplicate_pk["x-lix-primary-key"] = json!(["/id", "/id"]);
+    assert!(validate_lix_schema_definition(&duplicate_pk).is_err());
+
+    let mut valid_pk = base_schema.clone();
+    valid_pk["x-lix-primary-key"] = json!(["/id"]);
+    assert!(validate_lix_schema_definition(&valid_pk).is_ok());
+}
+
+#[test]
+fn x_lix_unique_groups_must_include_unique_pointers() {
+    let base_schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "properties": {
+            "id": { "type": "string" },
+            "email": { "type": "string" }
+        },
+        "required": ["id", "email"],
+        "additionalProperties": false
+    });
+
+    let mut empty_group = base_schema.clone();
+    empty_group["x-lix-unique"] = json!([[]]);
+    assert!(validate_lix_schema_definition(&empty_group).is_err());
+
+    let mut duplicate_pointers = base_schema.clone();
+    duplicate_pointers["x-lix-unique"] = json!([["/email", "/email"]]);
+    assert!(validate_lix_schema_definition(&duplicate_pointers).is_err());
+
+    let mut valid_unique = base_schema.clone();
+    valid_unique["x-lix-unique"] = json!([["/email"]]);
+    assert!(validate_lix_schema_definition(&valid_unique).is_ok());
+}
+
+#[test]
+fn x_lix_override_lixcols_rejects_complex_values() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-override-lixcols": {
+            "options": { "nested": true }
+        },
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_entity_views_accepts_known_view_names() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-entity-views": ["state", "state_by_version"],
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_entity_views_rejects_unknown_view_names() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-entity-views": ["state", "unknown"],
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_primary_key_is_optional() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_primary_key_must_be_array_of_strings_when_present() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-primary-key": ["/id", "/version"],
+        "properties": {
+            "id": { "type": "string" },
+            "version": { "type": "string" },
+            "name": { "type": "string" }
+        },
+        "required": ["id", "version", "name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_foreign_keys_is_optional() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "blog_post",
+        "x-lix-version": "1",
+        "properties": {
+            "id": { "type": "string" },
+            "author_id": { "type": "string" }
+        },
+        "required": ["id", "author_id"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_foreign_keys_with_valid_structure() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "blog_post",
+        "x-lix-version": "1",
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/author_id"],
+                "references": {
+                    "schemaKey": "user_profile",
+                    "properties": ["/id"]
+                }
+            },
+            {
+                "properties": ["/category_id"],
+                "references": {
+                    "schemaKey": "post_category",
+                    "properties": ["/id"]
+                }
+            }
+        ],
+        "properties": {
+            "id": { "type": "string" },
+            "author_id": { "type": "string" },
+            "category_id": { "type": "string" }
+        },
+        "required": ["id", "author_id", "category_id"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_foreign_keys_reject_duplicate_pointers() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "invalid_fk_duplicates",
+        "x-lix-version": "1",
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/local", "/local"],
+                "references": {
+                    "schemaKey": "remote_schema",
+                    "properties": ["/id", "/version"]
+                }
+            }
+        ],
+        "properties": {
+            "local": { "type": "string" }
+        },
+        "required": ["local"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_foreign_keys_fails_without_required_fields() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "blog_post",
+        "x-lix-version": "1",
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/author_id"]
+            }
+        ],
+        "properties": {
+            "id": { "type": "string" },
+            "author_id": { "type": "string" }
+        },
+        "required": ["id", "author_id"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_foreign_keys_rejects_schema_version() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "comment",
+        "x-lix-version": "1",
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/post_id"],
+                "references": {
+                    "schemaKey": "blog_post",
+                    "properties": ["/id"],
+                    "schemaVersion": "1"
+                }
+            }
+        ],
+        "properties": {
+            "id": { "type": "string" },
+            "post_id": { "type": "string" }
+        },
+        "required": ["id", "post_id"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_foreign_keys_supports_modes() {
+    let schema_materialized = json!({
+        "type": "object",
+        "x-lix-key": "child_entity",
+        "x-lix-version": "1",
+        "x-lix-primary-key": ["/id"],
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/parent_id"],
+                "references": { "schemaKey": "parent_entity", "properties": ["/id"] },
+                "mode": "materialized"
+            }
+        ],
+        "properties": {
+            "id": { "type": "string" },
+            "parent_id": { "type": "string" }
+        },
+        "required": ["id", "parent_id"],
+        "additionalProperties": false
+    });
+
+    let schema_immediate = json!({
+        "type": "object",
+        "x-lix-key": "comment",
+        "x-lix-version": "1",
+        "x-lix-primary-key": ["/id"],
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/post_id"],
+                "references": { "schemaKey": "post", "properties": ["/id"] },
+                "mode": "immediate"
+            }
+        ],
+        "properties": {
+            "id": { "type": "string" },
+            "post_id": { "type": "string" }
+        },
+        "required": ["id", "post_id"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema_materialized).is_ok());
+    assert!(validate_lix_schema_definition(&schema_immediate).is_ok());
+}
+
+#[test]
+fn x_lix_foreign_keys_fails_with_invalid_mode_value() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "child_entity",
+        "x-lix-version": "1",
+        "x-lix-primary-key": ["/id"],
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/parent_id"],
+                "references": { "schemaKey": "parent_entity", "properties": ["/id"] },
+                "mode": "deferred"
+            }
+        ],
+        "properties": {
+            "id": { "type": "string" },
+            "parent_id": { "type": "string" }
+        },
+        "required": ["id", "parent_id"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_foreign_keys_with_composite_key() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "entity_label",
+        "x-lix-version": "1",
+        "x-lix-foreign-keys": [
+            {
+                "properties": ["/entity_id", "/schema_key", "/file_id"],
+                "references": {
+                    "schemaKey": "state",
+                    "properties": ["/entity_id", "/schema_key", "/file_id"]
+                }
+            },
+            {
+                "properties": ["/label_id"],
+                "references": {
+                    "schemaKey": "lix_label",
+                    "properties": ["/id"]
+                }
+            }
+        ],
+        "properties": {
+            "entity_id": { "type": "string" },
+            "schema_key": { "type": "string" },
+            "file_id": { "type": "string" },
+            "label_id": { "type": "string" }
+        },
+        "required": ["entity_id", "schema_key", "file_id", "label_id"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_version_is_required() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-version": null,
+        "x-lix-key": "mock",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_version_must_be_monotonic_integer() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-version": "v1",
+        "x-lix-key": "mock",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_version_rejects_leading_zeros() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-version": "01",
+        "x-lix-key": "mock",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}
+
+#[test]
+fn x_lix_unique_is_optional_duplicate() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_unique_must_be_array_of_arrays_when_present_duplicate() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-unique": [["/id"], ["/name", "/age"]],
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "age": { "type": "number" }
+        },
+        "required": ["id", "name", "age"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_ok());
+}
+
+#[test]
+fn x_lix_unique_fails_with_invalid_structure_duplicate() {
+    let schema = json!({
+        "type": "object",
+        "x-lix-key": "mock",
+        "x-lix-version": "1",
+        "x-lix-unique": ["/id", "/name"],
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+        },
+        "required": ["id", "name"],
+        "additionalProperties": false
+    });
+
+    assert!(validate_lix_schema_definition(&schema).is_err());
+}

--- a/packages/engine/tests/snapshot_content_validation.rs
+++ b/packages/engine/tests/snapshot_content_validation.rs
@@ -1,0 +1,265 @@
+mod support;
+
+use lix_engine::Value;
+
+simulation_test!(allows_valid_snapshot, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    let result = engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"name\":\"Ada\"}', '1'\
+             )",
+                &[],
+            )
+            .await;
+
+    assert!(result.is_ok(), "{result:?}");
+
+    let stored = engine
+            .execute(
+                "SELECT snapshot_content FROM lix_internal_state_vtable \
+             WHERE schema_key = 'test_schema' AND entity_id = 'entity-1' AND file_id = 'file-1' AND version_id = 'version-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    assert_eq!(
+        stored.rows[0][0],
+        Value::Text("{\"name\":\"Ada\"}".to_string())
+    );
+});
+
+simulation_test!(rejects_invalid_snapshot, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    let result = engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"missing\":\"field\"}', '1'\
+             )",
+                &[],
+            )
+            .await;
+
+    let err = result.expect_err("expected validation error");
+    assert!(
+        err.to_string()
+            .contains("snapshot_content does not match schema 'test_schema' (1)"),
+        "unexpected error: {err}"
+    );
+});
+
+simulation_test!(requires_stored_schema, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    let result = engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'missing_schema', 'file-1', 'version-1', 'lix', '{\"name\":\"Ada\"}', '1'\
+             )",
+                &[],
+            )
+            .await;
+
+    let err = result.expect_err("expected validation error");
+    assert!(
+        err.to_string()
+            .contains("schema 'missing_schema' (1) is not stored"),
+        "unexpected error: {err}"
+    );
+});
+
+simulation_test!(rejects_invalid_update, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"name\":\"Ada\"}', '1'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    let result = engine
+            .execute(
+                "UPDATE lix_internal_state_vtable SET snapshot_content = '{\"missing\":\"field\"}' \
+             WHERE entity_id = 'entity-1' AND schema_key = 'test_schema' AND file_id = 'file-1' AND version_id = 'version-1'",
+                &[],
+            )
+            .await;
+
+    let err = result.expect_err("expected validation error");
+    assert!(
+        err.to_string()
+            .contains("snapshot_content does not match schema 'test_schema' (1)"),
+        "unexpected error: {err}"
+    );
+});
+
+simulation_test!(rejects_update_on_immutable_schema, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"immutable_schema\",\"x-lix-version\":\"1\",\"x-lix-immutable\":true,\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'immutable_schema', 'file-1', 'version-1', 'lix', '{\"name\":\"Ada\"}', '1'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    let result = engine
+            .execute(
+                "UPDATE lix_internal_state_vtable SET snapshot_content = '{\"name\":\"Grace\"}' \
+             WHERE entity_id = 'entity-1' AND schema_key = 'immutable_schema' AND file_id = 'file-1' AND version_id = 'version-1'",
+                &[],
+            )
+            .await;
+
+    let err = result.expect_err("expected immutability error");
+    assert!(
+        err.to_string()
+            .contains("Schema 'immutable_schema' is immutable and cannot be updated."),
+        "unexpected error: {err}"
+    );
+});
+
+simulation_test!(allows_delete_on_immutable_schema, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"immutable_schema\",\"x-lix-version\":\"1\",\"x-lix-immutable\":true,\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'immutable_schema', 'file-1', 'version-1', 'lix', '{\"name\":\"Ada\"}', '1'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+    let result = engine
+            .execute(
+                "DELETE FROM lix_internal_state_vtable \
+             WHERE entity_id = 'entity-1' AND schema_key = 'immutable_schema' AND file_id = 'file-1' AND version_id = 'version-1'",
+                &[],
+            )
+            .await;
+
+    assert!(result.is_ok(), "{result:?}");
+
+    let stored = engine
+        .execute(
+            "SELECT is_tombstone, snapshot_content \
+             FROM lix_internal_state_materialized_v1_immutable_schema \
+             WHERE entity_id = 'entity-1' AND file_id = 'file-1' AND version_id = 'version-1'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(stored.rows.len(), 1);
+    assert_eq!(stored.rows[0][0], Value::Integer(1));
+    assert_eq!(stored.rows[0][1], Value::Null);
+});

--- a/packages/engine/tests/stored_schema.rs
+++ b/packages/engine/tests/stored_schema.rs
@@ -16,7 +16,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -27,7 +27,7 @@ simulation_test!(
         .execute(
             "SELECT entity_id, schema_key, schema_version, version_id, file_id, plugin_key, change_id, is_tombstone, created_at, updated_at, snapshot_content \
              FROM lix_internal_state_materialized_v1_lix_stored_schema \
-             WHERE entity_id = 'test_schema~1.0.0'",
+             WHERE entity_id = 'test_schema~1'",
             &[],
         )
         .await
@@ -36,9 +36,9 @@ simulation_test!(
         sim.expect_deterministic(stored.rows.clone());
         assert_eq!(stored.rows.len(), 1);
         let row = &stored.rows[0];
-        assert_eq!(row[0], Value::Text("test_schema~1.0.0".to_string()));
+        assert_eq!(row[0], Value::Text("test_schema~1".to_string()));
         assert_eq!(row[1], Value::Text("lix_stored_schema".to_string()));
-        assert_eq!(row[2], Value::Text("1.0.0".to_string()));
+        assert_eq!(row[2], Value::Text("1".to_string()));
         assert_eq!(row[3], Value::Text("global".to_string()));
         assert_eq!(row[4], Value::Text("lix".to_string()));
         assert_eq!(row[5], Value::Text("lix".to_string()));
@@ -49,8 +49,7 @@ simulation_test!(
         assert_eq!(
             row[10],
             Value::Text(
-                "{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}"
-                    .to_string()
+                "{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}".to_string()
             )
         );
 
@@ -63,5 +62,56 @@ simulation_test!(
             .unwrap();
 
         assert_eq!(table_exists.rows[0][0], Value::Integer(0));
+    }
+);
+
+simulation_test!(
+    stored_schema_requires_foreign_key_targets_are_unique_or_primary,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"parent_schema\",\"x-lix-version\":\"1\",\"x-lix-primary-key\":[\"/id\"],\"x-lix-unique\":[[\"/slug\"]],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"slug\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"slug\",\"name\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let valid = engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"child_schema\",\"x-lix-version\":\"1\",\"x-lix-foreign-keys\":[{\"properties\":[\"/parent_id\"],\"references\":{\"schemaKey\":\"parent_schema\",\"properties\":[\"/id\"]}}],\"type\":\"object\",\"properties\":{\"parent_id\":{\"type\":\"string\"}},\"required\":[\"parent_id\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await;
+
+        assert!(valid.is_ok(), "{valid:?}");
+
+        let invalid = engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"bad_child\",\"x-lix-version\":\"1\",\"x-lix-foreign-keys\":[{\"properties\":[\"/parent_name\"],\"references\":{\"schemaKey\":\"parent_schema\",\"properties\":[\"/name\"]}}],\"type\":\"object\",\"properties\":{\"parent_name\":{\"type\":\"string\"}},\"required\":[\"parent_name\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await;
+
+        let err = invalid.expect_err("expected foreign key validation error");
+        assert!(
+            err.to_string().contains("not a primary key or unique key"),
+            "unexpected error: {err}"
+        );
     }
 );

--- a/packages/engine/tests/stored_schema.rs
+++ b/packages/engine/tests/stored_schema.rs
@@ -2,26 +2,28 @@ mod support;
 
 use lix_engine::Value;
 
-simulation_test!(stored_schema_registers_materialized_table, |sim| async move {
-    let engine = sim
-        .boot_simulated_engine()
-        .await
-        .expect("boot_simulated_engine should succeed");
+simulation_test!(
+    stored_schema_registers_materialized_table,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
 
-    engine.init().await.unwrap();
+        engine.init().await.unwrap();
 
-    engine
-        .execute(
-            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
              '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
              )",
-            &[],
-        )
-        .await
-        .unwrap();
+                &[],
+            )
+            .await
+            .unwrap();
 
-    let stored = engine
+        let stored = engine
         .execute(
             "SELECT entity_id, schema_key, version_id, file_id, plugin_key, change_id, is_tombstone, created_at, updated_at, snapshot_content \
              FROM lix_internal_state_materialized_v1_lix_stored_schema \
@@ -31,32 +33,34 @@ simulation_test!(stored_schema_registers_materialized_table, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(stored.rows.clone());
-    assert_eq!(stored.rows.len(), 1);
-    let row = &stored.rows[0];
-    assert_eq!(row[0], Value::Text("test_schema~1.0.0".to_string()));
-    assert_eq!(row[1], Value::Text("lix_stored_schema".to_string()));
-    assert_eq!(row[2], Value::Text("global".to_string()));
-    assert_eq!(row[3], Value::Text("lix".to_string()));
-    assert_eq!(row[4], Value::Text("lix".to_string()));
-    assert_eq!(row[5], Value::Text("schema".to_string()));
-    assert_eq!(row[6], Value::Integer(0));
-    assert_eq!(row[7], Value::Text("1970-01-01T00:00:00Z".to_string()));
-    assert_eq!(row[8], Value::Text("1970-01-01T00:00:00Z".to_string()));
-    assert_eq!(
-        row[9],
-        Value::Text(
-            "{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}".to_string()
-        )
-    );
+        sim.expect_deterministic(stored.rows.clone());
+        assert_eq!(stored.rows.len(), 1);
+        let row = &stored.rows[0];
+        assert_eq!(row[0], Value::Text("test_schema~1.0.0".to_string()));
+        assert_eq!(row[1], Value::Text("lix_stored_schema".to_string()));
+        assert_eq!(row[2], Value::Text("global".to_string()));
+        assert_eq!(row[3], Value::Text("lix".to_string()));
+        assert_eq!(row[4], Value::Text("lix".to_string()));
+        assert_eq!(row[5], Value::Text("schema".to_string()));
+        assert_eq!(row[6], Value::Integer(0));
+        assert_eq!(row[7], Value::Text("1970-01-01T00:00:00Z".to_string()));
+        assert_eq!(row[8], Value::Text("1970-01-01T00:00:00Z".to_string()));
+        assert_eq!(
+            row[9],
+            Value::Text(
+                "{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}"
+                    .to_string()
+            )
+        );
 
-    let table_exists = engine
-        .execute(
-            "SELECT COUNT(*) FROM lix_internal_state_materialized_v1_test_schema",
-            &[],
-        )
-        .await
-        .unwrap();
+        let table_exists = engine
+            .execute(
+                "SELECT COUNT(*) FROM lix_internal_state_materialized_v1_test_schema",
+                &[],
+            )
+            .await
+            .unwrap();
 
-    assert_eq!(table_exists.rows[0][0], Value::Integer(0));
-});
+        assert_eq!(table_exists.rows[0][0], Value::Integer(0));
+    }
+);

--- a/packages/engine/tests/stored_schema.rs
+++ b/packages/engine/tests/stored_schema.rs
@@ -25,7 +25,7 @@ simulation_test!(
 
         let stored = engine
         .execute(
-            "SELECT entity_id, schema_key, version_id, file_id, plugin_key, change_id, is_tombstone, created_at, updated_at, snapshot_content \
+            "SELECT entity_id, schema_key, schema_version, version_id, file_id, plugin_key, change_id, is_tombstone, created_at, updated_at, snapshot_content \
              FROM lix_internal_state_materialized_v1_lix_stored_schema \
              WHERE entity_id = 'test_schema~1.0.0'",
             &[],
@@ -38,15 +38,16 @@ simulation_test!(
         let row = &stored.rows[0];
         assert_eq!(row[0], Value::Text("test_schema~1.0.0".to_string()));
         assert_eq!(row[1], Value::Text("lix_stored_schema".to_string()));
-        assert_eq!(row[2], Value::Text("global".to_string()));
-        assert_eq!(row[3], Value::Text("lix".to_string()));
+        assert_eq!(row[2], Value::Text("1.0.0".to_string()));
+        assert_eq!(row[3], Value::Text("global".to_string()));
         assert_eq!(row[4], Value::Text("lix".to_string()));
-        assert_eq!(row[5], Value::Text("schema".to_string()));
-        assert_eq!(row[6], Value::Integer(0));
-        assert_eq!(row[7], Value::Text("1970-01-01T00:00:00Z".to_string()));
+        assert_eq!(row[5], Value::Text("lix".to_string()));
+        assert_eq!(row[6], Value::Text("schema".to_string()));
+        assert_eq!(row[7], Value::Integer(0));
         assert_eq!(row[8], Value::Text("1970-01-01T00:00:00Z".to_string()));
+        assert_eq!(row[9], Value::Text("1970-01-01T00:00:00Z".to_string()));
         assert_eq!(
-            row[9],
+            row[10],
             Value::Text(
                 "{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}"
                     .to_string()

--- a/packages/engine/tests/support/simulation_test.rs
+++ b/packages/engine/tests/support/simulation_test.rs
@@ -16,6 +16,7 @@ pub struct Simulation {
 pub struct SimulationArgs {
     backend_factory: Box<dyn Fn() -> Box<dyn LixBackend + Send + Sync> + Send + Sync>,
     setup: Option<Arc<dyn Fn() -> BoxFuture<'static, Result<(), LixError>> + Send + Sync>>,
+    #[allow(dead_code)]
     expect: ExpectDeterministic,
 }
 
@@ -44,6 +45,7 @@ impl SimulationArgs {
         })
     }
 
+    #[allow(dead_code)]
     pub fn expect_deterministic<T>(&self, actual: T)
     where
         T: PartialEq + std::fmt::Debug + Clone + Send + Sync + 'static,
@@ -58,6 +60,7 @@ struct ExpectDeterministic {
 }
 
 struct ExpectDeterministicState {
+    #[allow(dead_code)]
     expected_values: Vec<Box<dyn Any + Send + Sync>>,
     is_first: bool,
     call_index: usize,
@@ -83,6 +86,7 @@ impl ExpectDeterministic {
         state.call_index = 0;
     }
 
+    #[allow(dead_code)]
     fn expect_deterministic<T>(&self, actual: T)
     where
         T: PartialEq + std::fmt::Debug + Clone + Send + Sync + 'static,

--- a/packages/engine/tests/support/simulations/sqlite.rs
+++ b/packages/engine/tests/support/simulations/sqlite.rs
@@ -1,4 +1,4 @@
-use sqlx::{Row, SqlitePool};
+use sqlx::{Row, SqlitePool, ValueRef};
 use tokio::sync::OnceCell;
 
 use lix_engine::{LixBackend, LixError, QueryResult, Value};
@@ -94,6 +94,16 @@ fn bind_param_sqlite<'q>(
 }
 
 fn map_sqlite_value(row: &sqlx::sqlite::SqliteRow, index: usize) -> Result<Value, LixError> {
+    if row
+        .try_get_raw(index)
+        .map_err(|err| LixError {
+            message: err.to_string(),
+        })?
+        .is_null()
+    {
+        return Ok(Value::Null);
+    }
+
     if let Ok(value) = row.try_get::<i64, _>(index) {
         return Ok(Value::Integer(value));
     }

--- a/packages/engine/tests/vtable_read.rs
+++ b/packages/engine/tests/vtable_read.rs
@@ -28,9 +28,9 @@ simulation_test!(
         engine
         .execute(
             "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'test_schema', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
             &[],
         )
@@ -95,9 +95,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'test_schema', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -159,11 +159,11 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'schema_a', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              ), (\
-             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-3', 'schema_a', '1', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -172,9 +172,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-2', 'schema_b', '1', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -239,11 +239,11 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'schema_a', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              ), (\
-             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-3', 'schema_a', '1', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -252,9 +252,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-2', 'schema_b', '1', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -326,11 +326,11 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'schema_a', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              ), (\
-             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-3', 'schema_a', '1', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -339,9 +339,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-2', 'schema_b', '1', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -401,11 +401,11 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'schema_a', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              ), (\
-             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-3', 'schema_a', '1', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -414,9 +414,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-2', 'schema_b', '1', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -480,11 +480,11 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'schema_a', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              ), (\
-             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-3', 'schema_a', '1', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -493,9 +493,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-2', 'schema_b', '1', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -553,11 +553,11 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'schema_a', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              ), (\
-             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-3', 'schema_a', '1', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -566,9 +566,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-2', 'schema_b', '1', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
                 &[],
             )
@@ -618,9 +618,9 @@ simulation_test!(
         engine
         .execute(
             "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
              ) VALUES (\
-             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             'entity-1', 'test_schema', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
              )",
             &[],
         )

--- a/packages/engine/tests/vtable_read.rs
+++ b/packages/engine/tests/vtable_read.rs
@@ -40,10 +40,10 @@ simulation_test!(
         // Insert untracked row via vtable (should take priority).
         engine
             .execute(
-                "INSERT INTO lix_internal_state_vtable (\
-             entity_id, schema_key, file_id, version_id, snapshot_content, untracked\
+            "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, untracked\
              ) VALUES (\
-             'entity-1', 'test_schema', 'file-1', 'version-1', '{\"key\":\"untracked\"}', 1\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"untracked\"}', '1', 1\
              )",
                 &[],
             )
@@ -630,10 +630,10 @@ simulation_test!(
         // Insert untracked row via vtable.
         engine
             .execute(
-                "INSERT INTO lix_internal_state_vtable (\
-             entity_id, schema_key, file_id, version_id, snapshot_content, untracked\
+            "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, untracked\
              ) VALUES (\
-             'entity-1', 'test_schema', 'file-1', 'version-1', '{\"key\":\"untracked\"}', 1\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"untracked\"}', '1', 1\
              )",
                 &[],
             )

--- a/packages/engine/tests/vtable_read.rs
+++ b/packages/engine/tests/vtable_read.rs
@@ -17,7 +17,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -84,7 +84,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -138,7 +138,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -148,7 +148,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -219,7 +219,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -229,7 +229,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -306,7 +306,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -316,7 +316,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -381,7 +381,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -391,7 +391,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -460,7 +460,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -470,7 +470,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -533,7 +533,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -543,7 +543,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )
@@ -607,7 +607,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
              'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
              )",
                 &[],
             )

--- a/packages/engine/tests/vtable_read.rs
+++ b/packages/engine/tests/vtable_read.rs
@@ -1,0 +1,669 @@
+mod support;
+
+use lix_engine::Value;
+
+simulation_test!(
+    vtable_read_prioritizes_untracked_over_tracked,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        // Register schema so materialized table exists.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        // Insert tracked row directly into materialized table.
+        engine
+        .execute(
+            "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        // Insert untracked row via vtable (should take priority).
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, snapshot_content, untracked\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', '{\"key\":\"untracked\"}', 1\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let read = engine
+            .execute(
+                "SELECT snapshot_content, untracked FROM lix_internal_state_vtable \
+             WHERE schema_key = 'test_schema' AND entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(read.rows.clone());
+        assert_eq!(read.rows.len(), 1);
+        assert_eq!(
+            read.rows[0][0],
+            Value::Text("{\"key\":\"untracked\"}".to_string())
+        );
+        assert_eq!(read.rows[0][1], Value::Integer(1));
+    }
+);
+
+simulation_test!(
+    vtable_read_returns_tracked_when_no_untracked_exists,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        // Register schema so materialized table exists.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        // Insert tracked row directly into materialized table.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let read = engine
+            .execute(
+                "SELECT snapshot_content, untracked FROM lix_internal_state_vtable \
+             WHERE schema_key = 'test_schema' AND entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(read.rows.clone());
+        assert_eq!(read.rows.len(), 1);
+        assert_eq!(
+            read.rows[0][0],
+            Value::Text("{\"key\":\"tracked\"}".to_string())
+        );
+        assert_eq!(read.rows[0][1], Value::Integer(0));
+    }
+);
+
+simulation_test!(
+    vtable_read_schema_key_in_selects_multiple_materialized_tables,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        // Register schemas so materialized tables exist.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        // Insert tracked rows into both materialized tables.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             ), (\
+             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let read = engine
+            .execute(
+                "SELECT entity_id, schema_key, file_id FROM lix_internal_state_vtable \
+             WHERE schema_key IN ('schema_a', 'schema_b') \
+             ORDER BY entity_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(read.rows.clone());
+        assert_eq!(read.rows.len(), 3);
+        assert_eq!(read.rows[0][0], Value::Text("entity-1".to_string()));
+        assert_eq!(read.rows[0][1], Value::Text("schema_a".to_string()));
+        assert_eq!(read.rows[0][2], Value::Text("file-1".to_string()));
+        assert_eq!(read.rows[1][0], Value::Text("entity-2".to_string()));
+        assert_eq!(read.rows[1][1], Value::Text("schema_b".to_string()));
+        assert_eq!(read.rows[1][2], Value::Text("file-2".to_string()));
+        assert_eq!(read.rows[2][0], Value::Text("entity-3".to_string()));
+        assert_eq!(read.rows[2][1], Value::Text("schema_a".to_string()));
+        assert_eq!(read.rows[2][2], Value::Text("file-3".to_string()));
+    }
+);
+
+simulation_test!(
+    vtable_read_schema_key_in_single_filters_out_other,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             ), (\
+             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let schema_a_only = engine
+            .execute(
+                "SELECT entity_id, schema_key FROM lix_internal_state_vtable \
+             WHERE schema_key IN ('schema_a') \
+             ORDER BY entity_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(schema_a_only.rows.clone());
+        assert_eq!(schema_a_only.rows.len(), 2);
+        assert_eq!(
+            schema_a_only.rows[0][0],
+            Value::Text("entity-1".to_string())
+        );
+        assert_eq!(
+            schema_a_only.rows[0][1],
+            Value::Text("schema_a".to_string())
+        );
+        assert_eq!(
+            schema_a_only.rows[1][0],
+            Value::Text("entity-3".to_string())
+        );
+        assert_eq!(
+            schema_a_only.rows[1][1],
+            Value::Text("schema_a".to_string())
+        );
+    }
+);
+
+simulation_test!(
+    vtable_read_schema_key_equals_selects_single_table,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             ), (\
+             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let schema_a_eq = engine
+            .execute(
+                "SELECT entity_id, schema_key FROM lix_internal_state_vtable \
+             WHERE schema_key = 'schema_a' \
+             ORDER BY entity_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(schema_a_eq.rows.clone());
+        assert_eq!(schema_a_eq.rows.len(), 2);
+        assert_eq!(schema_a_eq.rows[0][0], Value::Text("entity-1".to_string()));
+        assert_eq!(schema_a_eq.rows[0][1], Value::Text("schema_a".to_string()));
+        assert_eq!(schema_a_eq.rows[1][0], Value::Text("entity-3".to_string()));
+        assert_eq!(schema_a_eq.rows[1][1], Value::Text("schema_a".to_string()));
+    }
+);
+
+simulation_test!(
+    vtable_read_filters_by_entity_id_with_schema_key,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             ), (\
+             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let entity_filter = engine
+            .execute(
+                "SELECT entity_id, schema_key, file_id FROM lix_internal_state_vtable \
+             WHERE schema_key = 'schema_b' AND entity_id = 'entity-2'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(entity_filter.rows.clone());
+        assert_eq!(entity_filter.rows.len(), 1);
+        assert_eq!(
+            entity_filter.rows[0][0],
+            Value::Text("entity-2".to_string())
+        );
+        assert_eq!(
+            entity_filter.rows[0][1],
+            Value::Text("schema_b".to_string())
+        );
+        assert_eq!(entity_filter.rows[0][2], Value::Text("file-2".to_string()));
+    }
+);
+
+simulation_test!(
+    vtable_read_filters_by_file_id_with_schema_key,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             ), (\
+             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let file_filter = engine
+            .execute(
+                "SELECT entity_id, schema_key, file_id FROM lix_internal_state_vtable \
+             WHERE schema_key = 'schema_a' AND file_id = 'file-3'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(file_filter.rows.clone());
+        assert_eq!(file_filter.rows.len(), 1);
+        assert_eq!(file_filter.rows[0][0], Value::Text("entity-3".to_string()));
+        assert_eq!(file_filter.rows[0][1], Value::Text("schema_a".to_string()));
+        assert_eq!(file_filter.rows[0][2], Value::Text("file-3".to_string()));
+    }
+);
+
+simulation_test!(
+    vtable_read_filters_by_multiple_predicates,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_a (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'schema_a', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             ), (\
+             'entity-3', 'schema_a', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}', 'change-3', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_schema_b (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-2', 'schema_b', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}', 'change-2', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let multi_filter = engine
+            .execute(
+                "SELECT entity_id, schema_key, file_id FROM lix_internal_state_vtable \
+             WHERE schema_key = 'schema_a' AND entity_id = 'entity-3' AND file_id = 'file-3'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(multi_filter.rows.clone());
+        assert_eq!(multi_filter.rows.len(), 1);
+        assert_eq!(multi_filter.rows[0][0], Value::Text("entity-3".to_string()));
+        assert_eq!(multi_filter.rows[0][1], Value::Text("schema_a".to_string()));
+        assert_eq!(multi_filter.rows[0][2], Value::Text("file-3".to_string()));
+    }
+);
+
+simulation_test!(
+    vtable_read_falls_back_to_tracked_after_untracked_deleted,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        // Register schema so materialized table exists.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        // Insert tracked row directly into materialized table.
+        engine
+        .execute(
+            "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        // Insert untracked row via vtable.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, snapshot_content, untracked\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', '{\"key\":\"untracked\"}', 1\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        // Delete untracked row.
+        engine
+        .execute(
+            "DELETE FROM lix_internal_state_vtable WHERE entity_id = 'entity-1' AND untracked = 1",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let read = engine
+            .execute(
+                "SELECT snapshot_content, untracked FROM lix_internal_state_vtable \
+             WHERE schema_key = 'test_schema' AND entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.expect_deterministic(read.rows.clone());
+        assert_eq!(read.rows.len(), 1);
+        assert_eq!(
+            read.rows[0][0],
+            Value::Text("{\"key\":\"tracked\"}".to_string())
+        );
+        assert_eq!(read.rows[0][1], Value::Integer(0));
+    }
+);

--- a/packages/engine/tests/vtable_write.rs
+++ b/packages/engine/tests/vtable_write.rs
@@ -12,16 +12,16 @@ simulation_test!(
 
         engine.init().await.unwrap();
 
-    engine
-        .execute(
-            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
-             'lix_stored_schema',\
-             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
-             )",
-            &[],
-        )
-        .await
-        .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+                 'lix_stored_schema',\
+                 '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
 
         engine
             .execute(
@@ -36,12 +36,12 @@ simulation_test!(
             .unwrap();
 
         let initial = engine
-        .execute(
-            "SELECT snapshot_content FROM lix_internal_state_untracked WHERE entity_id = 'entity-1'",
-            &[],
-        )
-        .await
-        .unwrap();
+            .execute(
+                "SELECT snapshot_content FROM lix_internal_state_untracked WHERE entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
 
         sim.expect_deterministic(initial.rows.clone());
         assert_eq!(initial.rows.len(), 1);
@@ -72,17 +72,17 @@ simulation_test!(
             Value::Text("{\"key\":\"updated\"}".to_string())
         );
 
-    engine
-        .execute(
-            "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
-             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
-             ) VALUES (\
-             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
-             )",
-            &[],
-        )
-        .await
-        .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
+                 entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+                 ) VALUES (\
+                 'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
 
         let read = engine
             .execute(
@@ -102,12 +102,12 @@ simulation_test!(
         assert_eq!(read.rows[0][1], Value::Integer(1));
 
         engine
-        .execute(
-            "DELETE FROM lix_internal_state_vtable WHERE entity_id = 'entity-1' AND untracked = 1",
-            &[],
-        )
-        .await
-        .unwrap();
+            .execute(
+                "DELETE FROM lix_internal_state_vtable WHERE entity_id = 'entity-1' AND untracked = 1",
+                &[],
+            )
+            .await
+            .unwrap();
 
         let remaining = engine
             .execute(

--- a/packages/engine/tests/vtable_write.rs
+++ b/packages/engine/tests/vtable_write.rs
@@ -75,9 +75,9 @@ simulation_test!(
         engine
             .execute(
                 "INSERT INTO lix_internal_state_materialized_v1_test_schema (\
-                 entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
+                 entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, created_at, updated_at\
                  ) VALUES (\
-                 'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
+                 'entity-1', 'test_schema', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', 'change-1', '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z'\
                  )",
                 &[],
             )
@@ -317,3 +317,416 @@ simulation_test!(tracked_state_change_id_matches_vtable, |sim| async move {
     assert_eq!(vtable.rows.len(), 1);
     assert_eq!(vtable.rows[0][0], Value::Text(change_id));
 });
+
+simulation_test!(tracked_update_creates_change_row, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', '1'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    engine
+        .execute(
+            "UPDATE lix_internal_state_vtable SET snapshot_content = '{\"key\":\"updated\"}' \
+             WHERE entity_id = 'entity-1' AND schema_key = 'test_schema' AND file_id = 'file-1' AND version_id = 'version-1'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let vtable = engine
+        .execute(
+            "SELECT change_id, snapshot_content FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_schema' AND entity_id = 'entity-1'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(vtable.rows.len(), 1);
+    assert_eq!(
+        vtable.rows[0][1],
+        Value::Text("{\"key\":\"updated\"}".to_string())
+    );
+
+    let change_id = match &vtable.rows[0][0] {
+        Value::Text(value) => value.clone(),
+        _ => panic!("expected change id"),
+    };
+
+    let change = engine
+        .execute(
+            &format!(
+                "SELECT snapshot_id FROM lix_internal_change WHERE id = '{}'",
+                change_id
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(change.rows.len(), 1);
+    let snapshot_id = match &change.rows[0][0] {
+        Value::Text(value) => value.clone(),
+        _ => panic!("expected snapshot id"),
+    };
+
+    let snapshot = engine
+        .execute(
+            &format!(
+                "SELECT content FROM lix_internal_snapshot WHERE id = '{}'",
+                snapshot_id
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.rows.len(), 1);
+    assert_eq!(
+        snapshot.rows[0][0],
+        Value::Text("{\"key\":\"updated\"}".to_string())
+    );
+});
+
+simulation_test!(
+    tracked_delete_creates_change_and_tombstone,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', '1'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        engine
+        .execute(
+            "DELETE FROM lix_internal_state_vtable \
+             WHERE entity_id = 'entity-1' AND schema_key = 'test_schema' AND file_id = 'file-1' AND version_id = 'version-1'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let materialized = engine
+            .execute(
+                "SELECT is_tombstone, snapshot_content, change_id \
+             FROM lix_internal_state_materialized_v1_test_schema \
+             WHERE entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(materialized.rows.len(), 1);
+        assert_eq!(materialized.rows[0][0], Value::Integer(1));
+        assert_eq!(materialized.rows[0][1], Value::Null);
+
+        let change_id = match &materialized.rows[0][2] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected change id"),
+        };
+
+        let change = engine
+            .execute(
+                &format!(
+                    "SELECT snapshot_id FROM lix_internal_change WHERE id = '{}'",
+                    change_id
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(change.rows.len(), 1);
+        assert_eq!(change.rows[0][0], Value::Text("no-content".to_string()));
+    }
+);
+
+simulation_test!(tracked_multi_row_insert_creates_changes, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine()
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"one\"}', '1'\
+             ), (\
+             'entity-2', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"two\"}', '1'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let changes = engine
+        .execute(
+            "SELECT id, entity_id, snapshot_id FROM lix_internal_change \
+             WHERE entity_id IN ('entity-1', 'entity-2')",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(changes.rows.len(), 2);
+
+    let mut change_map: std::collections::HashMap<String, (String, String)> =
+        std::collections::HashMap::new();
+    for row in changes.rows {
+        let change_id = match &row[0] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected change id"),
+        };
+        let entity_id = match &row[1] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected entity id"),
+        };
+        let snapshot_id = match &row[2] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected snapshot id"),
+        };
+        change_map.insert(entity_id, (change_id, snapshot_id));
+    }
+
+    let expected_content = [
+        ("entity-1", "{\"key\":\"one\"}"),
+        ("entity-2", "{\"key\":\"two\"}"),
+    ];
+
+    for (entity_id, content) in expected_content {
+        let snapshot_id = &change_map.get(entity_id).expect("missing change").1;
+        let snapshot = engine
+            .execute(
+                &format!(
+                    "SELECT content FROM lix_internal_snapshot WHERE id = '{}'",
+                    snapshot_id
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(snapshot.rows.len(), 1);
+        assert_eq!(snapshot.rows[0][0], Value::Text(content.to_string()));
+    }
+
+    let materialized = engine
+        .execute(
+            "SELECT entity_id, snapshot_content, change_id \
+             FROM lix_internal_state_materialized_v1_test_schema \
+             WHERE entity_id IN ('entity-1', 'entity-2')",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(materialized.rows.len(), 2);
+    for row in materialized.rows {
+        let entity_id = match &row[0] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected entity id"),
+        };
+        let snapshot_content = match &row[1] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected snapshot content"),
+        };
+        let change_id = match &row[2] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected change id"),
+        };
+        let (expected_change_id, _) = change_map.get(&entity_id).expect("missing change");
+        assert_eq!(&change_id, expected_change_id);
+        let expected = expected_content
+            .iter()
+            .find(|(id, _)| *id == entity_id)
+            .expect("missing expected")
+            .1;
+        assert_eq!(snapshot_content, expected);
+    }
+});
+
+simulation_test!(
+    tracked_update_null_uses_no_content_snapshot,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', '1'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        engine
+        .execute(
+            "UPDATE lix_internal_state_vtable SET snapshot_content = NULL \
+             WHERE entity_id = 'entity-1' AND schema_key = 'test_schema' AND file_id = 'file-1' AND version_id = 'version-1'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let vtable = engine
+            .execute(
+                "SELECT change_id, snapshot_content FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_schema' AND entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(vtable.rows.len(), 1);
+        assert_eq!(vtable.rows[0][1], Value::Null);
+
+        let change_id = match &vtable.rows[0][0] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected change id"),
+        };
+
+        let change = engine
+            .execute(
+                &format!(
+                    "SELECT snapshot_id FROM lix_internal_change WHERE id = '{}'",
+                    change_id
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(change.rows.len(), 1);
+        assert_eq!(change.rows[0][0], Value::Text("no-content".to_string()));
+    }
+);
+
+simulation_test!(
+    mixed_tracked_and_untracked_insert_splits_writes,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine()
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, untracked\
+             ) VALUES (\
+             'entity-1', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"tracked\"}', '1', 0\
+             ), (\
+             'entity-2', 'test_schema', 'file-1', 'version-1', 'lix', '{\"key\":\"untracked\"}', '1', 1\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let change_count = engine
+        .execute(
+            "SELECT COUNT(*) FROM lix_internal_change WHERE entity_id IN ('entity-1', 'entity-2')",
+            &[],
+        )
+        .await
+        .unwrap();
+        assert_eq!(change_count.rows[0][0], Value::Integer(1));
+
+        let tracked_change = engine
+            .execute(
+                "SELECT snapshot_id FROM lix_internal_change WHERE entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(tracked_change.rows.len(), 1);
+        let snapshot_id = match &tracked_change.rows[0][0] {
+            Value::Text(value) => value.clone(),
+            _ => panic!("expected snapshot id"),
+        };
+
+        let snapshot = engine
+            .execute(
+                &format!(
+                    "SELECT content FROM lix_internal_snapshot WHERE id = '{}'",
+                    snapshot_id
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(snapshot.rows.len(), 1);
+        assert_eq!(
+            snapshot.rows[0][0],
+            Value::Text("{\"key\":\"tracked\"}".to_string())
+        );
+
+        let tracked_materialized = engine
+            .execute(
+                "SELECT snapshot_content FROM lix_internal_state_materialized_v1_test_schema \
+             WHERE entity_id = 'entity-1'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(tracked_materialized.rows.len(), 1);
+        assert_eq!(
+            tracked_materialized.rows[0][0],
+            Value::Text("{\"key\":\"tracked\"}".to_string())
+        );
+
+        let untracked = engine
+            .execute(
+                "SELECT snapshot_content FROM lix_internal_state_untracked \
+             WHERE entity_id = 'entity-2'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(untracked.rows.len(), 1);
+        assert_eq!(
+            untracked.rows[0][0],
+            Value::Text("{\"key\":\"untracked\"}".to_string())
+        );
+    }
+);

--- a/packages/engine/tests/vtable_write.rs
+++ b/packages/engine/tests/vtable_write.rs
@@ -1,6 +1,20 @@
 mod support;
 
 use lix_engine::Value;
+use support::simulation_test::SimulationEngine;
+
+async fn register_test_schema(engine: &SimulationEngine) {
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+}
 
 simulation_test!(
     untracked_state_routes_to_untracked_table,
@@ -16,7 +30,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
                  'lix_stored_schema',\
-                 '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+                 '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
                  )",
                 &[],
             )
@@ -133,7 +147,7 @@ simulation_test!(untracked_state_change_id_is_untracked, |sim| async move {
         .execute(
             "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
                  'lix_stored_schema',\
-                 '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1.0.0\"}}'\
+                 '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
                  )",
             &[],
         )
@@ -174,6 +188,8 @@ simulation_test!(
             .expect("boot_simulated_engine should succeed");
 
         engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
 
         engine
             .execute(
@@ -246,6 +262,8 @@ simulation_test!(
 
         engine.init().await.unwrap();
 
+        register_test_schema(&engine).await;
+
         engine
             .execute(
                 "INSERT INTO lix_internal_state_vtable (\
@@ -278,6 +296,8 @@ simulation_test!(tracked_state_change_id_matches_vtable, |sim| async move {
         .expect("boot_simulated_engine should succeed");
 
     engine.init().await.unwrap();
+
+    register_test_schema(&engine).await;
 
     engine
             .execute(
@@ -325,6 +345,8 @@ simulation_test!(tracked_update_creates_change_row, |sim| async move {
         .expect("boot_simulated_engine should succeed");
 
     engine.init().await.unwrap();
+
+    register_test_schema(&engine).await;
 
     engine
         .execute(
@@ -412,6 +434,8 @@ simulation_test!(
 
         engine.init().await.unwrap();
 
+        register_test_schema(&engine).await;
+
         engine
         .execute(
             "INSERT INTO lix_internal_state_vtable (\
@@ -475,6 +499,8 @@ simulation_test!(tracked_multi_row_insert_creates_changes, |sim| async move {
         .expect("boot_simulated_engine should succeed");
 
     engine.init().await.unwrap();
+
+    register_test_schema(&engine).await;
 
     engine
         .execute(
@@ -585,6 +611,8 @@ simulation_test!(
 
         engine.init().await.unwrap();
 
+        register_test_schema(&engine).await;
+
         engine
         .execute(
             "INSERT INTO lix_internal_state_vtable (\
@@ -648,6 +676,8 @@ simulation_test!(
             .expect("boot_simulated_engine should succeed");
 
         engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
 
         engine
         .execute(

--- a/packages/rs-sdk/src/backend/sqlite.rs
+++ b/packages/rs-sdk/src/backend/sqlite.rs
@@ -24,6 +24,14 @@ impl LixBackend for SqliteBackend {
         let conn = self.conn.lock().map_err(|_| LixError {
             message: "sqlite mutex poisoned".to_string(),
         })?;
+
+        if params.is_empty() && sql.contains(';') {
+            conn.execute_batch(sql).map_err(|err| LixError {
+                message: err.to_string(),
+            })?;
+            return Ok(QueryResult { rows: Vec::new() });
+        }
+
         let mut stmt = conn.prepare(sql).map_err(|err| LixError {
             message: err.to_string(),
         })?;

--- a/plan.md
+++ b/plan.md
@@ -756,13 +756,14 @@ for row in &resolved_rows {
 
 ### Schema Storage
 
-Schemas are stored in `lix_internal_state_vtable` with `schema_key = 'lix_schema'`:
+Schemas are stored in `lix_internal_state_vtable` with `schema_key = 'lix_stored_schema'`:
 
 ```sql
 SELECT snapshot_content
 FROM lix_internal_state_vtable
-WHERE schema_key = 'lix_schema'
-  AND entity_id = 'lix_key_value'  -- the schema_key to validate against
+WHERE schema_key = 'lix_stored_schema'
+  AND json_extract(snapshot_content, '$.value."x-lix-key"') = 'lix_key_value'
+  AND version_id = 'global'
 ```
 
 The engine should cache compiled schemas in memory for performance.

--- a/plan.md
+++ b/plan.md
@@ -667,7 +667,7 @@ WHERE entity_id = 'entity-1' AND version_id = 'version-1';
 
 ## Milestone 7: In-Memory Row Representation
 
-Before rewriting queries, we need an in-memory representation of the rows being mutated. This enables validation, plugin callbacks, and correct SQL generation.
+We need an in-memory representation of the rows being mutated. This enables validation, plugin callbacks, and correct SQL generation.
 
 > **Note:** The row representation below is illustrative, not fixed. Flexibility is expected as implementation details emerge.
 

--- a/plan.md
+++ b/plan.md
@@ -376,12 +376,12 @@ Identity:
 
 Immutability:
 
-- `x-lix-immutable: true` is enforced for stored schemas.
+- `x-lix-immutable: true` enforcement is deferred to Milestone 13 (JSON Schema Validation).
 
 Semver:
 
-- `x-lix-version` must be `major.minor.patch` and comparisons must be semantic.
-- The engine should order versions by semver (not lexicographic string order).
+- `x-lix-version` must be `major.minor.patch` (format validation in this milestone).
+- Semver-aware ordering/comparisons are deferred to Milestone 13 (JSON Schema Validation) when schema loading/caching is implemented.
 
 ```sql
 -- Until entity views exist, insert directly into the vtable and set lixcols explicitly.
@@ -407,8 +407,8 @@ Lookup logic (current JS behavior):
 - **All schemas**: `SELECT snapshot_content, updated_at` where `schema_key = 'lix_stored_schema'`,
   `version_id = 'global'`, `snapshot_content IS NOT NULL`; parse `snapshot_content.value`.
 - **Single schema**: filter by `json_extract(snapshot_content, '$.value.\"x-lix-key\"') = <key>`
-  and pick the highest `x-lix-version` (should be semver-aware).
-- Cache per-engine; invalidate when a state commit touches `schema_key = 'lix_stored_schema'`.
+  and pick the highest `x-lix-version` (semver-aware selection is deferred to Milestone 13).
+- Schema cache/invalidation is deferred to Milestone 13.
 
 ### Schema Registration
 
@@ -442,10 +442,10 @@ fn register_schema(schema: &Schema, host: &impl HostBindings) -> Result<()> {
 
 1. Define materialized table schema with required columns
 2. Persist schema definitions into `lix_internal_state_vtable` via the `stored_schema` view (`schema_key = 'lix_stored_schema'`, `version_id = 'global'`)
-3. Enforce immutability and semver ordering for `x-lix-version`
-4. Implement `register_schema()` to create materialized tables dynamically
-5. Handle schema key sanitization for table names
-6. Create indexes for common query patterns (version_id, file_id)
+3. Implement `register_schema()` to create materialized tables dynamically
+
+Note: immutability enforcement and schema cache/invalidation are handled in Milestone 13.
+Semver ordering, schema key sanitization beyond identifier quoting, and indexes are handled in Milestone 14.
 
 ## Milestone 3: Rewriting `lix_internal_state_vtable` SELECT Queries
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core query rewriting/execution and introduces new persistence tables and validation logic, so failures could block writes or produce incorrect history/change tracking across schemas.
> 
> **Overview**
> The engine now **validates** vtable writes against stored JSON schemas and rejects invalid `snapshot_content` or updates to immutable schemas, using a new cached schema validator (`SchemaCache`) and a bundled JSON Schema definition for Lix schemas.
> 
> SQL preprocessing is expanded to rewrite `INSERT`/`UPDATE`/`DELETE` against `lix_internal_state_vtable` into tracked materialized/untracked writes, including creation of `lix_internal_snapshot` and `lix_internal_change` records and post-processing followups for update/delete to backfill `change_id` history.
> 
> Also adds inlined SQL functions `lix_uuid_v7()` and `lix_timestamp()` (replaced at preprocess time), introduces `schema_version` plumbing in internal tables/registrations, and updates stored-schema versioning rules to require a monotonic integer string (not semver).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50e06742577b3ff72f0f48e65912d7c8c6c7ac5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->