### PR TITLE
milestone 25

### DIFF
--- a/packages/engine/src/account/mod.rs
+++ b/packages/engine/src/account/mod.rs
@@ -1,0 +1,170 @@
+use serde_json::Value as JsonValue;
+use std::sync::OnceLock;
+
+use crate::builtin_schema::types::{LixAccount, LixActiveAccount};
+use crate::builtin_schema::{builtin_schema_definition, builtin_schema_json};
+use crate::LixError;
+
+pub(crate) const ACCOUNT_STORAGE_VERSION_ID: &str = "global";
+
+static ACCOUNT_SCHEMA_METADATA: OnceLock<SchemaMetadata> = OnceLock::new();
+static ACTIVE_ACCOUNT_SCHEMA_METADATA: OnceLock<SchemaMetadata> = OnceLock::new();
+
+struct SchemaMetadata {
+    schema_key: String,
+    schema_version: String,
+    file_id: String,
+    plugin_key: String,
+    storage_version_id: String,
+}
+
+#[allow(dead_code)]
+pub(crate) fn account_schema_definition() -> &'static JsonValue {
+    builtin_schema_definition("lix_account").expect("builtin schema 'lix_account' must exist")
+}
+
+#[allow(dead_code)]
+pub(crate) fn account_schema_definition_json() -> &'static str {
+    builtin_schema_json("lix_account").expect("builtin schema 'lix_account' must exist")
+}
+
+pub(crate) fn account_schema_key() -> &'static str {
+    &account_schema_metadata().schema_key
+}
+
+pub(crate) fn account_schema_version() -> &'static str {
+    &account_schema_metadata().schema_version
+}
+
+pub(crate) fn account_file_id() -> &'static str {
+    &account_schema_metadata().file_id
+}
+
+pub(crate) fn account_plugin_key() -> &'static str {
+    &account_schema_metadata().plugin_key
+}
+
+pub(crate) fn account_storage_version_id() -> &'static str {
+    &account_schema_metadata().storage_version_id
+}
+
+pub(crate) fn account_snapshot_content(id: &str, name: &str) -> String {
+    serde_json::to_string(&LixAccount {
+        id: id.to_string(),
+        name: name.to_string(),
+    })
+    .expect("lix_account snapshot serialization must succeed")
+}
+
+#[allow(dead_code)]
+pub(crate) fn active_account_schema_definition() -> &'static JsonValue {
+    builtin_schema_definition("lix_active_account")
+        .expect("builtin schema 'lix_active_account' must exist")
+}
+
+#[allow(dead_code)]
+pub(crate) fn active_account_schema_definition_json() -> &'static str {
+    builtin_schema_json("lix_active_account")
+        .expect("builtin schema 'lix_active_account' must exist")
+}
+
+pub(crate) fn active_account_schema_key() -> &'static str {
+    &active_account_schema_metadata().schema_key
+}
+
+pub(crate) fn active_account_schema_version() -> &'static str {
+    &active_account_schema_metadata().schema_version
+}
+
+pub(crate) fn active_account_file_id() -> &'static str {
+    &active_account_schema_metadata().file_id
+}
+
+pub(crate) fn active_account_plugin_key() -> &'static str {
+    &active_account_schema_metadata().plugin_key
+}
+
+pub(crate) fn active_account_storage_version_id() -> &'static str {
+    &active_account_schema_metadata().storage_version_id
+}
+
+pub(crate) fn active_account_snapshot_content(account_id: &str) -> String {
+    serde_json::to_string(&LixActiveAccount {
+        account_id: account_id.to_string(),
+    })
+    .expect("lix_active_account snapshot serialization must succeed")
+}
+
+pub(crate) fn parse_active_account_snapshot(snapshot_content: &str) -> Result<String, LixError> {
+    let parsed: LixActiveAccount =
+        serde_json::from_str(snapshot_content).map_err(|error| LixError {
+            message: format!("active account snapshot_content invalid JSON: {error}"),
+        })?;
+
+    if parsed.account_id.is_empty() {
+        return Err(LixError {
+            message: "active account id must not be empty".to_string(),
+        });
+    }
+
+    Ok(parsed.account_id)
+}
+
+fn account_schema_metadata() -> &'static SchemaMetadata {
+    ACCOUNT_SCHEMA_METADATA.get_or_init(|| parse_schema_metadata("lix_account"))
+}
+
+fn active_account_schema_metadata() -> &'static SchemaMetadata {
+    ACTIVE_ACCOUNT_SCHEMA_METADATA.get_or_init(|| parse_schema_metadata("lix_active_account"))
+}
+
+fn parse_schema_metadata(schema_key: &str) -> SchemaMetadata {
+    let schema = builtin_schema_definition(schema_key).unwrap_or_else(|| {
+        panic!("builtin schema '{schema_key}' must exist");
+    });
+    let parsed_schema_key = schema
+        .get("x-lix-key")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| panic!("builtin schema '{schema_key}' must define string x-lix-key"))
+        .to_string();
+    let schema_version = schema
+        .get("x-lix-version")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| panic!("builtin schema '{schema_key}' must define string x-lix-version"))
+        .to_string();
+    let overrides = schema
+        .get("x-lix-override-lixcols")
+        .and_then(JsonValue::as_object)
+        .unwrap_or_else(|| {
+            panic!("builtin schema '{schema_key}' must define object x-lix-override-lixcols")
+        });
+    let file_id_raw = overrides
+        .get("lixcol_file_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| {
+            panic!("builtin schema '{schema_key}' must define string lixcol_file_id")
+        });
+    let plugin_key_raw = overrides
+        .get("lixcol_plugin_key")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| {
+            panic!("builtin schema '{schema_key}' must define string lixcol_plugin_key")
+        });
+    let storage_version_id = overrides
+        .get("lixcol_version_id")
+        .and_then(JsonValue::as_str)
+        .map(decode_lixcol_literal)
+        .unwrap_or_else(|| ACCOUNT_STORAGE_VERSION_ID.to_string());
+
+    SchemaMetadata {
+        schema_key: parsed_schema_key,
+        schema_version,
+        file_id: decode_lixcol_literal(file_id_raw),
+        plugin_key: decode_lixcol_literal(plugin_key_raw),
+        storage_version_id,
+    }
+}
+
+fn decode_lixcol_literal(raw: &str) -> String {
+    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('"').to_string())
+}

--- a/packages/engine/src/account/mod.rs
+++ b/packages/engine/src/account/mod.rs
@@ -2,7 +2,9 @@ use serde_json::Value as JsonValue;
 use std::sync::OnceLock;
 
 use crate::builtin_schema::types::{LixAccount, LixActiveAccount};
-use crate::builtin_schema::{builtin_schema_definition, builtin_schema_json};
+use crate::builtin_schema::{
+    builtin_schema_definition, builtin_schema_json, decode_lixcol_literal,
+};
 use crate::LixError;
 
 pub(crate) const ACCOUNT_STORAGE_VERSION_ID: &str = "global";
@@ -163,8 +165,4 @@ fn parse_schema_metadata(schema_key: &str) -> SchemaMetadata {
         plugin_key: decode_lixcol_literal(plugin_key_raw),
         storage_version_id,
     }
-}
-
-fn decode_lixcol_literal(raw: &str) -> String {
-    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('"').to_string())
 }

--- a/packages/engine/src/backend.rs
+++ b/packages/engine/src/backend.rs
@@ -2,7 +2,15 @@ use async_trait::async_trait;
 
 use crate::{LixError, QueryResult, Value};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlDialect {
+    Sqlite,
+    Postgres,
+}
+
 #[async_trait(?Send)]
 pub trait LixBackend: Send + Sync {
+    fn dialect(&self) -> SqlDialect;
+
     async fn execute(&self, sql: &str, params: &[Value]) -> Result<QueryResult, LixError>;
 }

--- a/packages/engine/src/builtin_schema/lix_account.json
+++ b/packages/engine/src/builtin_schema/lix_account.json
@@ -1,0 +1,27 @@
+{
+  "x-lix-key": "lix_account",
+  "x-lix-version": "1",
+  "x-lix-primary-key": [
+    "/id"
+  ],
+  "x-lix-override-lixcols": {
+    "lixcol_file_id": "\"lix\"",
+    "lixcol_plugin_key": "\"lix\"",
+    "lixcol_version_id": "\"global\""
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "x-lix-default": "lix_uuid_v7()"
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/packages/engine/src/builtin_schema/lix_active_account.json
+++ b/packages/engine/src/builtin_schema/lix_active_account.json
@@ -1,27 +1,16 @@
 {
-  "x-lix-key": "lix_change_author",
+  "x-lix-key": "lix_active_account",
   "x-lix-version": "1",
   "x-lix-primary-key": [
-    "/change_id",
     "/account_id"
   ],
   "x-lix-override-lixcols": {
     "lixcol_file_id": "\"lix\"",
     "lixcol_plugin_key": "\"lix\"",
+    "lixcol_untracked": "1",
     "lixcol_version_id": "\"global\""
   },
   "x-lix-foreign-keys": [
-    {
-      "properties": [
-        "/change_id"
-      ],
-      "references": {
-        "schemaKey": "lix_change",
-        "properties": [
-          "/id"
-        ]
-      }
-    },
     {
       "properties": [
         "/account_id"
@@ -36,15 +25,11 @@
   ],
   "type": "object",
   "properties": {
-    "change_id": {
-      "type": "string"
-    },
     "account_id": {
       "type": "string"
     }
   },
   "required": [
-    "change_id",
     "account_id"
   ],
   "additionalProperties": false

--- a/packages/engine/src/builtin_schema/lix_active_version.json
+++ b/packages/engine/src/builtin_schema/lix_active_version.json
@@ -1,0 +1,27 @@
+{
+  "x-lix-key": "lix_active_version",
+  "x-lix-version": "1",
+  "x-lix-primary-key": [
+    "/id"
+  ],
+  "x-lix-override-lixcols": {
+    "lixcol_file_id": "\"lix\"",
+    "lixcol_plugin_key": "\"lix\"",
+    "lixcol_untracked": "1",
+    "lixcol_version_id": "\"global\""
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "version_id": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "version_id"
+  ],
+  "additionalProperties": false
+}

--- a/packages/engine/src/builtin_schema/lix_version_descriptor.json
+++ b/packages/engine/src/builtin_schema/lix_version_descriptor.json
@@ -1,0 +1,40 @@
+{
+  "x-lix-key": "lix_version_descriptor",
+  "x-lix-version": "1",
+  "x-lix-primary-key": [
+    "/id"
+  ],
+  "x-lix-override-lixcols": {
+    "lixcol_file_id": "\"lix\"",
+    "lixcol_plugin_key": "\"lix\""
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "x-lix-default": "lix_uuid_v7()"
+    },
+    "name": {
+      "type": "string"
+    },
+    "inherits_from_version_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "hidden": {
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": [
+    "id",
+    "name"
+  ],
+  "additionalProperties": false
+}

--- a/packages/engine/src/builtin_schema/lix_version_pointer.json
+++ b/packages/engine/src/builtin_schema/lix_version_pointer.json
@@ -1,5 +1,5 @@
 {
-  "x-lix-key": "lix_version_tip",
+  "x-lix-key": "lix_version_pointer",
   "x-lix-version": "1",
   "x-lix-primary-key": [
     "/id"

--- a/packages/engine/src/builtin_schema/mod.rs
+++ b/packages/engine/src/builtin_schema/mod.rs
@@ -147,6 +147,10 @@ pub(crate) fn builtin_schema_json(schema_key: &str) -> Option<&'static str> {
     }
 }
 
+pub(crate) fn decode_lixcol_literal(raw: &str) -> String {
+    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('"').to_string())
+}
+
 fn parse_builtin_schema(file_name: &str, raw_json: &str) -> JsonValue {
     serde_json::from_str(raw_json).unwrap_or_else(|error| {
         panic!("builtin schema file '{file_name}' must contain valid JSON: {error}")

--- a/packages/engine/src/builtin_schema/mod.rs
+++ b/packages/engine/src/builtin_schema/mod.rs
@@ -3,6 +3,8 @@ use std::sync::OnceLock;
 
 use crate::schema::lix_schema_definition;
 
+pub(crate) mod types;
+
 const LIX_STORED_SCHEMA_KEY: &str = "lix_stored_schema";
 const LIX_KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 const LIX_CHANGE_SCHEMA_KEY: &str = "lix_change";
@@ -10,7 +12,7 @@ const LIX_CHANGE_AUTHOR_SCHEMA_KEY: &str = "lix_change_author";
 const LIX_CHANGE_SET_SCHEMA_KEY: &str = "lix_change_set";
 const LIX_COMMIT_SCHEMA_KEY: &str = "lix_commit";
 const LIX_VERSION_DESCRIPTOR_SCHEMA_KEY: &str = "lix_version_descriptor";
-const LIX_VERSION_TIP_SCHEMA_KEY: &str = "lix_version_tip";
+const LIX_VERSION_POINTER_SCHEMA_KEY: &str = "lix_version_pointer";
 const LIX_ACTIVE_VERSION_SCHEMA_KEY: &str = "lix_active_version";
 const LIX_CHANGE_SET_ELEMENT_SCHEMA_KEY: &str = "lix_change_set_element";
 const LIX_COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
@@ -22,7 +24,7 @@ const LIX_CHANGE_AUTHOR_SCHEMA_JSON: &str = include_str!("lix_change_author.json
 const LIX_CHANGE_SET_SCHEMA_JSON: &str = include_str!("lix_change_set.json");
 const LIX_COMMIT_SCHEMA_JSON: &str = include_str!("lix_commit.json");
 const LIX_VERSION_DESCRIPTOR_SCHEMA_JSON: &str = include_str!("lix_version_descriptor.json");
-const LIX_VERSION_TIP_SCHEMA_JSON: &str = include_str!("lix_version_tip.json");
+const LIX_VERSION_POINTER_SCHEMA_JSON: &str = include_str!("lix_version_pointer.json");
 const LIX_ACTIVE_VERSION_SCHEMA_JSON: &str = include_str!("lix_active_version.json");
 const LIX_CHANGE_SET_ELEMENT_SCHEMA_JSON: &str = include_str!("lix_change_set_element.json");
 const LIX_COMMIT_EDGE_SCHEMA_JSON: &str = include_str!("lix_commit_edge.json");
@@ -34,7 +36,7 @@ static LIX_CHANGE_AUTHOR_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_SET_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_COMMIT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_VERSION_DESCRIPTOR_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
-static LIX_VERSION_TIP_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
+static LIX_VERSION_POINTER_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_ACTIVE_VERSION_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_SET_ELEMENT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_COMMIT_EDGE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
@@ -47,7 +49,7 @@ const BUILTIN_SCHEMA_KEYS: &[&str] = &[
     LIX_CHANGE_SET_SCHEMA_KEY,
     LIX_COMMIT_SCHEMA_KEY,
     LIX_VERSION_DESCRIPTOR_SCHEMA_KEY,
-    LIX_VERSION_TIP_SCHEMA_KEY,
+    LIX_VERSION_POINTER_SCHEMA_KEY,
     LIX_ACTIVE_VERSION_SCHEMA_KEY,
     LIX_CHANGE_SET_ELEMENT_SCHEMA_KEY,
     LIX_COMMIT_EDGE_SCHEMA_KEY,
@@ -89,8 +91,8 @@ pub(crate) fn builtin_schema_definition(schema_key: &str) -> Option<&'static Jso
                 )
             }))
         }
-        LIX_VERSION_TIP_SCHEMA_KEY => Some(LIX_VERSION_TIP_SCHEMA.get_or_init(|| {
-            parse_builtin_schema("lix_version_tip.json", LIX_VERSION_TIP_SCHEMA_JSON)
+        LIX_VERSION_POINTER_SCHEMA_KEY => Some(LIX_VERSION_POINTER_SCHEMA.get_or_init(|| {
+            parse_builtin_schema("lix_version_pointer.json", LIX_VERSION_POINTER_SCHEMA_JSON)
         })),
         LIX_ACTIVE_VERSION_SCHEMA_KEY => Some(LIX_ACTIVE_VERSION_SCHEMA.get_or_init(|| {
             parse_builtin_schema("lix_active_version.json", LIX_ACTIVE_VERSION_SCHEMA_JSON)
@@ -120,7 +122,7 @@ pub(crate) fn builtin_schema_json(schema_key: &str) -> Option<&'static str> {
         LIX_CHANGE_SET_SCHEMA_KEY => Some(LIX_CHANGE_SET_SCHEMA_JSON),
         LIX_COMMIT_SCHEMA_KEY => Some(LIX_COMMIT_SCHEMA_JSON),
         LIX_VERSION_DESCRIPTOR_SCHEMA_KEY => Some(LIX_VERSION_DESCRIPTOR_SCHEMA_JSON),
-        LIX_VERSION_TIP_SCHEMA_KEY => Some(LIX_VERSION_TIP_SCHEMA_JSON),
+        LIX_VERSION_POINTER_SCHEMA_KEY => Some(LIX_VERSION_POINTER_SCHEMA_JSON),
         LIX_ACTIVE_VERSION_SCHEMA_KEY => Some(LIX_ACTIVE_VERSION_SCHEMA_JSON),
         LIX_CHANGE_SET_ELEMENT_SCHEMA_KEY => Some(LIX_CHANGE_SET_ELEMENT_SCHEMA_JSON),
         LIX_COMMIT_EDGE_SCHEMA_KEY => Some(LIX_COMMIT_EDGE_SCHEMA_JSON),

--- a/packages/engine/src/builtin_schema/mod.rs
+++ b/packages/engine/src/builtin_schema/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod types;
 
 const LIX_STORED_SCHEMA_KEY: &str = "lix_stored_schema";
 const LIX_KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
+const LIX_ACCOUNT_SCHEMA_KEY: &str = "lix_account";
+const LIX_ACTIVE_ACCOUNT_SCHEMA_KEY: &str = "lix_active_account";
 const LIX_CHANGE_SCHEMA_KEY: &str = "lix_change";
 const LIX_CHANGE_AUTHOR_SCHEMA_KEY: &str = "lix_change_author";
 const LIX_CHANGE_SET_SCHEMA_KEY: &str = "lix_change_set";
@@ -19,6 +21,8 @@ const LIX_COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
 
 const LIX_STORED_SCHEMA_JSON: &str = include_str!("lix_stored_schema.json");
 const LIX_KEY_VALUE_SCHEMA_JSON: &str = include_str!("lix_key_value.json");
+const LIX_ACCOUNT_SCHEMA_JSON: &str = include_str!("lix_account.json");
+const LIX_ACTIVE_ACCOUNT_SCHEMA_JSON: &str = include_str!("lix_active_account.json");
 const LIX_CHANGE_SCHEMA_JSON: &str = include_str!("lix_change.json");
 const LIX_CHANGE_AUTHOR_SCHEMA_JSON: &str = include_str!("lix_change_author.json");
 const LIX_CHANGE_SET_SCHEMA_JSON: &str = include_str!("lix_change_set.json");
@@ -31,6 +35,8 @@ const LIX_COMMIT_EDGE_SCHEMA_JSON: &str = include_str!("lix_commit_edge.json");
 
 static LIX_STORED_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_KEY_VALUE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
+static LIX_ACCOUNT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
+static LIX_ACTIVE_ACCOUNT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_AUTHOR_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_SET_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
@@ -44,6 +50,8 @@ static LIX_COMMIT_EDGE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 const BUILTIN_SCHEMA_KEYS: &[&str] = &[
     LIX_STORED_SCHEMA_KEY,
     LIX_KEY_VALUE_SCHEMA_KEY,
+    LIX_ACCOUNT_SCHEMA_KEY,
+    LIX_ACTIVE_ACCOUNT_SCHEMA_KEY,
     LIX_CHANGE_SCHEMA_KEY,
     LIX_CHANGE_AUTHOR_SCHEMA_KEY,
     LIX_CHANGE_SET_SCHEMA_KEY,
@@ -69,6 +77,13 @@ pub(crate) fn builtin_schema_definition(schema_key: &str) -> Option<&'static Jso
                 parse_builtin_schema("lix_key_value.json", LIX_KEY_VALUE_SCHEMA_JSON)
             }))
         }
+        LIX_ACCOUNT_SCHEMA_KEY => Some(
+            LIX_ACCOUNT_SCHEMA
+                .get_or_init(|| parse_builtin_schema("lix_account.json", LIX_ACCOUNT_SCHEMA_JSON)),
+        ),
+        LIX_ACTIVE_ACCOUNT_SCHEMA_KEY => Some(LIX_ACTIVE_ACCOUNT_SCHEMA.get_or_init(|| {
+            parse_builtin_schema("lix_active_account.json", LIX_ACTIVE_ACCOUNT_SCHEMA_JSON)
+        })),
         LIX_CHANGE_SCHEMA_KEY => Some(
             LIX_CHANGE_SCHEMA
                 .get_or_init(|| parse_builtin_schema("lix_change.json", LIX_CHANGE_SCHEMA_JSON)),
@@ -117,6 +132,8 @@ pub(crate) fn builtin_schema_json(schema_key: &str) -> Option<&'static str> {
     match schema_key {
         LIX_STORED_SCHEMA_KEY => Some(LIX_STORED_SCHEMA_JSON),
         LIX_KEY_VALUE_SCHEMA_KEY => Some(LIX_KEY_VALUE_SCHEMA_JSON),
+        LIX_ACCOUNT_SCHEMA_KEY => Some(LIX_ACCOUNT_SCHEMA_JSON),
+        LIX_ACTIVE_ACCOUNT_SCHEMA_KEY => Some(LIX_ACTIVE_ACCOUNT_SCHEMA_JSON),
         LIX_CHANGE_SCHEMA_KEY => Some(LIX_CHANGE_SCHEMA_JSON),
         LIX_CHANGE_AUTHOR_SCHEMA_KEY => Some(LIX_CHANGE_AUTHOR_SCHEMA_JSON),
         LIX_CHANGE_SET_SCHEMA_KEY => Some(LIX_CHANGE_SET_SCHEMA_JSON),

--- a/packages/engine/src/builtin_schema/mod.rs
+++ b/packages/engine/src/builtin_schema/mod.rs
@@ -9,7 +9,9 @@ const LIX_CHANGE_SCHEMA_KEY: &str = "lix_change";
 const LIX_CHANGE_AUTHOR_SCHEMA_KEY: &str = "lix_change_author";
 const LIX_CHANGE_SET_SCHEMA_KEY: &str = "lix_change_set";
 const LIX_COMMIT_SCHEMA_KEY: &str = "lix_commit";
+const LIX_VERSION_DESCRIPTOR_SCHEMA_KEY: &str = "lix_version_descriptor";
 const LIX_VERSION_TIP_SCHEMA_KEY: &str = "lix_version_tip";
+const LIX_ACTIVE_VERSION_SCHEMA_KEY: &str = "lix_active_version";
 const LIX_CHANGE_SET_ELEMENT_SCHEMA_KEY: &str = "lix_change_set_element";
 const LIX_COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
 
@@ -19,7 +21,9 @@ const LIX_CHANGE_SCHEMA_JSON: &str = include_str!("lix_change.json");
 const LIX_CHANGE_AUTHOR_SCHEMA_JSON: &str = include_str!("lix_change_author.json");
 const LIX_CHANGE_SET_SCHEMA_JSON: &str = include_str!("lix_change_set.json");
 const LIX_COMMIT_SCHEMA_JSON: &str = include_str!("lix_commit.json");
+const LIX_VERSION_DESCRIPTOR_SCHEMA_JSON: &str = include_str!("lix_version_descriptor.json");
 const LIX_VERSION_TIP_SCHEMA_JSON: &str = include_str!("lix_version_tip.json");
+const LIX_ACTIVE_VERSION_SCHEMA_JSON: &str = include_str!("lix_active_version.json");
 const LIX_CHANGE_SET_ELEMENT_SCHEMA_JSON: &str = include_str!("lix_change_set_element.json");
 const LIX_COMMIT_EDGE_SCHEMA_JSON: &str = include_str!("lix_commit_edge.json");
 
@@ -29,7 +33,9 @@ static LIX_CHANGE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_AUTHOR_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_SET_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_COMMIT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
+static LIX_VERSION_DESCRIPTOR_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_VERSION_TIP_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
+static LIX_ACTIVE_VERSION_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_SET_ELEMENT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_COMMIT_EDGE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 
@@ -40,7 +46,9 @@ const BUILTIN_SCHEMA_KEYS: &[&str] = &[
     LIX_CHANGE_AUTHOR_SCHEMA_KEY,
     LIX_CHANGE_SET_SCHEMA_KEY,
     LIX_COMMIT_SCHEMA_KEY,
+    LIX_VERSION_DESCRIPTOR_SCHEMA_KEY,
     LIX_VERSION_TIP_SCHEMA_KEY,
+    LIX_ACTIVE_VERSION_SCHEMA_KEY,
     LIX_CHANGE_SET_ELEMENT_SCHEMA_KEY,
     LIX_COMMIT_EDGE_SCHEMA_KEY,
 ];
@@ -73,8 +81,19 @@ pub(crate) fn builtin_schema_definition(schema_key: &str) -> Option<&'static Jso
             LIX_COMMIT_SCHEMA
                 .get_or_init(|| parse_builtin_schema("lix_commit.json", LIX_COMMIT_SCHEMA_JSON)),
         ),
+        LIX_VERSION_DESCRIPTOR_SCHEMA_KEY => {
+            Some(LIX_VERSION_DESCRIPTOR_SCHEMA.get_or_init(|| {
+                parse_builtin_schema(
+                    "lix_version_descriptor.json",
+                    LIX_VERSION_DESCRIPTOR_SCHEMA_JSON,
+                )
+            }))
+        }
         LIX_VERSION_TIP_SCHEMA_KEY => Some(LIX_VERSION_TIP_SCHEMA.get_or_init(|| {
             parse_builtin_schema("lix_version_tip.json", LIX_VERSION_TIP_SCHEMA_JSON)
+        })),
+        LIX_ACTIVE_VERSION_SCHEMA_KEY => Some(LIX_ACTIVE_VERSION_SCHEMA.get_or_init(|| {
+            parse_builtin_schema("lix_active_version.json", LIX_ACTIVE_VERSION_SCHEMA_JSON)
         })),
         LIX_CHANGE_SET_ELEMENT_SCHEMA_KEY => {
             Some(LIX_CHANGE_SET_ELEMENT_SCHEMA.get_or_init(|| {
@@ -100,7 +119,9 @@ pub(crate) fn builtin_schema_json(schema_key: &str) -> Option<&'static str> {
         LIX_CHANGE_AUTHOR_SCHEMA_KEY => Some(LIX_CHANGE_AUTHOR_SCHEMA_JSON),
         LIX_CHANGE_SET_SCHEMA_KEY => Some(LIX_CHANGE_SET_SCHEMA_JSON),
         LIX_COMMIT_SCHEMA_KEY => Some(LIX_COMMIT_SCHEMA_JSON),
+        LIX_VERSION_DESCRIPTOR_SCHEMA_KEY => Some(LIX_VERSION_DESCRIPTOR_SCHEMA_JSON),
         LIX_VERSION_TIP_SCHEMA_KEY => Some(LIX_VERSION_TIP_SCHEMA_JSON),
+        LIX_ACTIVE_VERSION_SCHEMA_KEY => Some(LIX_ACTIVE_VERSION_SCHEMA_JSON),
         LIX_CHANGE_SET_ELEMENT_SCHEMA_KEY => Some(LIX_CHANGE_SET_ELEMENT_SCHEMA_JSON),
         LIX_COMMIT_EDGE_SCHEMA_KEY => Some(LIX_COMMIT_EDGE_SCHEMA_JSON),
         _ => None,

--- a/packages/engine/src/builtin_schema/types.rs
+++ b/packages/engine/src/builtin_schema/types.rs
@@ -1,4 +1,15 @@
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LixAccount {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LixActiveAccount {
+    pub account_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct LixActiveVersion {
     pub id: String,
     pub version_id: String,

--- a/packages/engine/src/builtin_schema/types.rs
+++ b/packages/engine/src/builtin_schema/types.rs
@@ -1,0 +1,45 @@
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LixActiveVersion {
+    pub id: String,
+    pub version_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LixCommit {
+    pub id: String,
+    #[serde(default)]
+    pub change_set_id: Option<String>,
+    #[serde(default)]
+    pub change_ids: Vec<String>,
+    #[serde(default)]
+    pub author_account_ids: Vec<String>,
+    #[serde(default)]
+    pub parent_commit_ids: Vec<String>,
+    #[serde(default)]
+    pub meta_change_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LixCommitEdge {
+    pub parent_id: String,
+    pub child_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LixVersionDescriptor {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub inherits_from_version_id: Option<String>,
+    #[serde(default)]
+    pub hidden: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LixVersionPointer {
+    pub id: String,
+    pub commit_id: String,
+    #[serde(default)]
+    pub working_commit_id: Option<String>,
+}

--- a/packages/engine/src/commit/generate_commit.rs
+++ b/packages/engine/src/commit/generate_commit.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::json;
 
-use crate::builtin_schema::builtin_schema_definition;
+use crate::builtin_schema::{builtin_schema_definition, decode_lixcol_literal};
 use crate::commit::types::{
     ChangeRow, DomainChangeInput, GenerateCommitArgs, GenerateCommitResult, MaterializedStateRow,
 };
@@ -514,10 +514,6 @@ fn builtin_schema_meta(schema_key: &str) -> Result<BuiltinSchemaMeta, LixError> 
         file_id: decode_lixcol_literal(file_id),
         plugin_key: decode_lixcol_literal(plugin_key),
     })
-}
-
-fn decode_lixcol_literal(raw: &str) -> String {
-    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('\"').to_string())
 }
 
 fn dedupe_ordered(values: &[String]) -> Vec<String> {

--- a/packages/engine/src/commit/generate_commit.rs
+++ b/packages/engine/src/commit/generate_commit.rs
@@ -10,7 +10,7 @@ use crate::LixError;
 
 const GLOBAL_VERSION: &str = "global";
 const COMMIT_SCHEMA_KEY: &str = "lix_commit";
-const VERSION_TIP_SCHEMA_KEY: &str = "lix_version_tip";
+const VERSION_POINTER_SCHEMA_KEY: &str = "lix_version_pointer";
 const CHANGE_SET_ELEMENT_SCHEMA_KEY: &str = "lix_change_set_element";
 const COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
 const CHANGE_AUTHOR_SCHEMA_KEY: &str = "lix_change_author";
@@ -64,7 +64,7 @@ where
     }
 
     let commit_schema = builtin_schema_meta(COMMIT_SCHEMA_KEY)?;
-    let version_tip_schema = builtin_schema_meta(VERSION_TIP_SCHEMA_KEY)?;
+    let version_pointer_schema = builtin_schema_meta(VERSION_POINTER_SCHEMA_KEY)?;
     let change_set_element_schema = builtin_schema_meta(CHANGE_SET_ELEMENT_SCHEMA_KEY)?;
     let commit_edge_schema = builtin_schema_meta(COMMIT_EDGE_SCHEMA_KEY)?;
     let change_author_schema = builtin_schema_meta(CHANGE_AUTHOR_SCHEMA_KEY)?;
@@ -114,16 +114,16 @@ where
             ),
         })?;
 
-        let version_tip_change_id = generate_uuid();
-        tip_change_id_by_version.insert(version_id.clone(), version_tip_change_id.clone());
+        let version_pointer_change_id = generate_uuid();
+        tip_change_id_by_version.insert(version_id.clone(), version_pointer_change_id.clone());
 
         meta_changes.push(ChangeRow {
-            id: version_tip_change_id,
+            id: version_pointer_change_id,
             entity_id: version_id.clone(),
-            schema_key: VERSION_TIP_SCHEMA_KEY.to_string(),
-            schema_version: version_tip_schema.schema_version.clone(),
-            file_id: version_tip_schema.file_id.clone(),
-            plugin_key: version_tip_schema.plugin_key.clone(),
+            schema_key: VERSION_POINTER_SCHEMA_KEY.to_string(),
+            schema_version: version_pointer_schema.schema_version.clone(),
+            file_id: version_pointer_schema.file_id.clone(),
+            plugin_key: version_pointer_schema.plugin_key.clone(),
             snapshot_content: Some(
                 json!({
                     "id": version_id,
@@ -357,7 +357,7 @@ where
         commit_snapshot_by_version.insert(version_id.clone(), commit_snapshot);
     }
 
-    // Materialize commit rows and version_tip rows so commit views can resolve immediately.
+    // Materialize commit rows and version_pointer rows so commit views can resolve immediately.
     for (version_id, meta) in &meta_by_version {
         let commit_snapshot = commit_snapshot_by_version
             .get(version_id)
@@ -396,10 +396,10 @@ where
         materialized_state.push(MaterializedStateRow {
             id: tip_id,
             entity_id: version_id.clone(),
-            schema_key: VERSION_TIP_SCHEMA_KEY.to_string(),
-            schema_version: version_tip_schema.schema_version.clone(),
-            file_id: version_tip_schema.file_id.clone(),
-            plugin_key: version_tip_schema.plugin_key.clone(),
+            schema_key: VERSION_POINTER_SCHEMA_KEY.to_string(),
+            schema_version: version_pointer_schema.schema_version.clone(),
+            file_id: version_pointer_schema.file_id.clone(),
+            plugin_key: version_pointer_schema.plugin_key.clone(),
             snapshot_content: Some(
                 json!({
                     "id": version_id,
@@ -622,7 +622,7 @@ mod tests {
             result
                 .changes
                 .iter()
-                .filter(|row| row.schema_key == "lix_version_tip")
+                .filter(|row| row.schema_key == "lix_version_pointer")
                 .count(),
             1
         );
@@ -667,7 +667,7 @@ mod tests {
         assert_eq!(materialized_counts.get("lix_change_author"), Some(&1));
         assert_eq!(materialized_counts.get("lix_change_set_element"), Some(&1));
         assert_eq!(materialized_counts.get("lix_commit"), Some(&1));
-        assert_eq!(materialized_counts.get("lix_version_tip"), Some(&1));
+        assert_eq!(materialized_counts.get("lix_version_pointer"), Some(&1));
         assert_eq!(materialized_counts.get("lix_commit_edge"), Some(&1));
         assert_eq!(result.materialized_state.len(), 6);
 
@@ -825,7 +825,7 @@ mod tests {
             result
                 .changes
                 .iter()
-                .filter(|row| row.schema_key == "lix_version_tip")
+                .filter(|row| row.schema_key == "lix_version_pointer")
                 .count(),
             2
         );
@@ -878,8 +878,8 @@ mod tests {
         let global_tip = result
             .materialized_state
             .iter()
-            .find(|row| row.schema_key == "lix_version_tip" && row.entity_id == "global")
-            .expect("global version_tip should exist");
+            .find(|row| row.schema_key == "lix_version_pointer" && row.entity_id == "global")
+            .expect("global version_pointer should exist");
         let global_tip_snapshot: serde_json::Value =
             serde_json::from_str(global_tip.snapshot_content.as_ref().unwrap()).unwrap();
         let global_commit_id = global_tip_snapshot["commit_id"]

--- a/packages/engine/src/default_values.rs
+++ b/packages/engine/src/default_values.rs
@@ -253,7 +253,7 @@ mod tests {
     use crate::cel::CelEvaluator;
     use crate::functions::{LixFunctionProvider, SharedFunctionProvider, SystemFunctionProvider};
     use crate::sql::parse_sql_statements;
-    use crate::{LixBackend, LixError, QueryResult, Value};
+    use crate::{LixBackend, LixError, QueryResult, SqlDialect, Value};
 
     use super::{apply_defaults_to_snapshot, apply_vtable_insert_defaults};
 
@@ -261,6 +261,10 @@ mod tests {
 
     #[async_trait::async_trait(?Send)]
     impl LixBackend for UnexpectedBackendCall {
+        fn dialect(&self) -> SqlDialect {
+            SqlDialect::Sqlite
+        }
+
         async fn execute(&self, _: &str, _: &[Value]) -> Result<QueryResult, LixError> {
             panic!("defaulting should resolve schema from pending in-request inserts")
         }

--- a/packages/engine/src/deterministic_mode/mod.rs
+++ b/packages/engine/src/deterministic_mode/mod.rs
@@ -7,7 +7,7 @@ use crate::key_value::{
     key_value_file_id, key_value_plugin_key, key_value_schema_key, key_value_schema_version,
     KEY_VALUE_GLOBAL_VERSION,
 };
-use crate::sql::{parse_sql_statements, preprocess_statements_with_provider};
+use crate::sql::{escape_sql_string, parse_sql_statements, preprocess_statements_with_provider};
 use crate::LixBackend;
 use crate::{LixError, Value};
 
@@ -197,10 +197,6 @@ fn value_to_string(value: &Value, name: &str) -> Result<String, LixError> {
             message: format!("expected text value for {name}"),
         }),
     }
-}
-
-fn escape_sql_string(input: &str) -> String {
-    input.replace('\'', "''")
 }
 
 fn is_missing_relation_error(err: &LixError) -> bool {

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -151,8 +151,13 @@ impl Engine {
             Some(PostprocessPlan::VtableUpdate(plan)) => {
                 let result = self.backend.execute(&output.sql, &output.params).await?;
                 let mut followup_functions = functions.clone();
-                let followup_sql =
-                    build_update_followup_sql(&plan, &result.rows, &mut followup_functions)?;
+                let followup_sql = build_update_followup_sql(
+                    self.backend.as_ref(),
+                    &plan,
+                    &result.rows,
+                    &mut followup_functions,
+                )
+                .await?;
                 if !followup_sql.is_empty() {
                     self.backend.execute(&followup_sql, &[]).await?;
                 }
@@ -161,8 +166,13 @@ impl Engine {
             Some(PostprocessPlan::VtableDelete(plan)) => {
                 let result = self.backend.execute(&output.sql, &output.params).await?;
                 let mut followup_functions = functions.clone();
-                let followup_sql =
-                    build_delete_followup_sql(&plan, &result.rows, &mut followup_functions)?;
+                let followup_sql = build_delete_followup_sql(
+                    self.backend.as_ref(),
+                    &plan,
+                    &result.rows,
+                    &mut followup_functions,
+                )
+                .await?;
                 if !followup_sql.is_empty() {
                     self.backend.execute(&followup_sql, &[]).await?;
                 }

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -14,12 +14,23 @@ use crate::key_value::{
 use crate::schema_registry::register_schema;
 use crate::sql::{
     build_delete_followup_sql, build_update_followup_sql, preprocess_sql_with_provider,
-    PostprocessPlan,
+    MutationRow, PostprocessPlan, UpdateValidationPlan,
 };
 use crate::validation::{validate_inserts, validate_updates, SchemaCache};
+use crate::version::{
+    active_version_file_id, active_version_plugin_key, active_version_schema_key,
+    active_version_schema_version, active_version_snapshot_content,
+    active_version_storage_version_id, parse_active_version_snapshot, version_descriptor_file_id,
+    version_descriptor_plugin_key, version_descriptor_schema_key,
+    version_descriptor_schema_version, version_descriptor_snapshot_content,
+    version_descriptor_storage_version_id, version_tip_file_id, version_tip_plugin_key,
+    version_tip_schema_key, version_tip_schema_version, version_tip_snapshot_content,
+    version_tip_storage_version_id, DEFAULT_ACTIVE_VERSION_NAME, GLOBAL_VERSION_ID,
+};
 use crate::{LixBackend, LixError, QueryResult, Value};
 use serde_json::Value as JsonValue;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
 
 const DETERMINISTIC_MODE_KEY: &str = "lix_deterministic_mode";
 
@@ -51,6 +62,7 @@ pub struct Engine {
     boot_key_values: Vec<BootKeyValue>,
     boot_deterministic_settings: Option<DeterministicSettings>,
     deterministic_boot_pending: AtomicBool,
+    active_version_id: RwLock<String>,
 }
 
 pub fn boot(args: BootArgs) -> Engine {
@@ -63,6 +75,7 @@ pub fn boot(args: BootArgs) -> Engine {
         boot_key_values: args.key_values,
         boot_deterministic_settings,
         deterministic_boot_pending: AtomicBool::new(deterministic_boot_pending),
+        active_version_id: RwLock::new(GLOBAL_VERSION_ID.to_string()),
     }
 }
 
@@ -72,11 +85,15 @@ impl Engine {
         let result = async {
             init_backend(self.backend.as_ref()).await?;
             self.ensure_builtin_schemas_installed().await?;
-            self.seed_boot_key_values().await
+            let default_active_version_id = self.seed_default_versions().await?;
+            self.seed_default_active_version(&default_active_version_id)
+                .await?;
+            self.seed_boot_key_values().await?;
+            self.load_and_cache_active_version().await
         }
         .await;
 
-        if clear_boot_pending {
+        if clear_boot_pending && result.is_ok() {
             self.deterministic_boot_pending
                 .store(false, Ordering::SeqCst);
         }
@@ -107,6 +124,10 @@ impl Engine {
             functions.clone(),
         )
         .await?;
+        let next_active_version_id_from_mutations =
+            active_version_from_mutations(&output.mutations)?;
+        let next_active_version_id_from_updates =
+            active_version_from_update_validations(&output.update_validations)?;
         if !output.mutations.is_empty() {
             validate_inserts(self.backend.as_ref(), &self.schema_cache, &output.mutations).await?;
         }
@@ -150,6 +171,12 @@ impl Engine {
             if sequence_end > sequence_start {
                 persist_sequence_highest(self.backend.as_ref(), sequence_end - 1).await?;
             }
+        }
+
+        if let Some(version_id) =
+            next_active_version_id_from_mutations.or(next_active_version_id_from_updates)
+        {
+            self.set_active_version_id(version_id);
         }
 
         Ok(result)
@@ -223,6 +250,328 @@ impl Engine {
 
         Ok(())
     }
+
+    async fn seed_default_versions(&self) -> Result<String, LixError> {
+        self.seed_materialized_version_descriptor(GLOBAL_VERSION_ID, GLOBAL_VERSION_ID, None)
+            .await?;
+        let main_version_id = match self
+            .find_version_id_by_name(DEFAULT_ACTIVE_VERSION_NAME)
+            .await?
+        {
+            Some(version_id) => version_id,
+            None => {
+                let generated_main_id = self.generate_runtime_uuid().await?;
+                self.seed_materialized_version_descriptor(
+                    &generated_main_id,
+                    DEFAULT_ACTIVE_VERSION_NAME,
+                    Some(GLOBAL_VERSION_ID),
+                )
+                .await?;
+                generated_main_id
+            }
+        };
+
+        let bootstrap_commit_id = self
+            .load_latest_commit_id()
+            .await?
+            .unwrap_or_else(|| GLOBAL_VERSION_ID.to_string());
+        self.seed_materialized_version_tip(GLOBAL_VERSION_ID, &bootstrap_commit_id)
+            .await?;
+        self.seed_materialized_version_tip(&main_version_id, &bootstrap_commit_id)
+            .await?;
+
+        Ok(main_version_id)
+    }
+
+    async fn seed_materialized_version_descriptor(
+        &self,
+        entity_id: &str,
+        name: &str,
+        inherits_from_version_id: Option<&str>,
+    ) -> Result<(), LixError> {
+        let table = format!(
+            "lix_internal_state_materialized_v1_{}",
+            version_descriptor_schema_key()
+        );
+        let check_sql = format!(
+            "SELECT 1 FROM {table} \
+             WHERE schema_key = '{schema_key}' \
+               AND entity_id = '{entity_id}' \
+               AND file_id = '{file_id}' \
+               AND version_id = '{version_id}' \
+               AND is_tombstone = 0 \
+               AND snapshot_content IS NOT NULL \
+             LIMIT 1",
+            table = table,
+            schema_key = escape_sql_string(version_descriptor_schema_key()),
+            entity_id = escape_sql_string(entity_id),
+            file_id = escape_sql_string(version_descriptor_file_id()),
+            version_id = escape_sql_string(version_descriptor_storage_version_id()),
+        );
+        let existing = self.backend.execute(&check_sql, &[]).await?;
+        if !existing.rows.is_empty() {
+            return Ok(());
+        }
+
+        let snapshot_content =
+            version_descriptor_snapshot_content(entity_id, name, inherits_from_version_id, false);
+        let insert_sql = format!(
+            "INSERT INTO {table} (\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, \
+             change_id, is_tombstone, created_at, updated_at\
+             ) VALUES (\
+             '{entity_id}', '{schema_key}', '{schema_version}', '{file_id}', '{version_id}', '{plugin_key}', '{snapshot_content}', \
+             'bootstrap', 0, '1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.000Z'\
+             ) \
+             ON CONFLICT (entity_id, file_id, version_id) DO NOTHING",
+            table = table,
+            entity_id = escape_sql_string(entity_id),
+            schema_key = escape_sql_string(version_descriptor_schema_key()),
+            schema_version = escape_sql_string(version_descriptor_schema_version()),
+            file_id = escape_sql_string(version_descriptor_file_id()),
+            version_id = escape_sql_string(version_descriptor_storage_version_id()),
+            plugin_key = escape_sql_string(version_descriptor_plugin_key()),
+            snapshot_content = escape_sql_string(&snapshot_content),
+        );
+        self.backend.execute(&insert_sql, &[]).await?;
+
+        Ok(())
+    }
+
+    async fn find_version_id_by_name(&self, name: &str) -> Result<Option<String>, LixError> {
+        let table = format!(
+            "lix_internal_state_materialized_v1_{}",
+            version_descriptor_schema_key()
+        );
+        let sql = format!(
+            "SELECT entity_id, snapshot_content \
+             FROM {table} \
+             WHERE schema_key = '{schema_key}' \
+               AND file_id = '{file_id}' \
+               AND version_id = '{version_id}' \
+               AND is_tombstone = 0 \
+               AND snapshot_content IS NOT NULL",
+            table = table,
+            schema_key = escape_sql_string(version_descriptor_schema_key()),
+            file_id = escape_sql_string(version_descriptor_file_id()),
+            version_id = escape_sql_string(version_descriptor_storage_version_id()),
+        );
+        let result = self.backend.execute(&sql, &[]).await?;
+
+        for row in result.rows {
+            if row.len() < 2 {
+                continue;
+            }
+            let entity_id = match &row[0] {
+                Value::Text(value) => value,
+                _ => continue,
+            };
+            let snapshot_content = match &row[1] {
+                Value::Text(value) => value,
+                _ => continue,
+            };
+            let snapshot: JsonValue =
+                serde_json::from_str(snapshot_content).map_err(|error| LixError {
+                    message: format!("version descriptor snapshot_content invalid JSON: {error}"),
+                })?;
+            let Some(snapshot_name) = snapshot.get("name").and_then(JsonValue::as_str) else {
+                continue;
+            };
+            if snapshot_name != name {
+                continue;
+            }
+            let snapshot_id = snapshot
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .filter(|value| !value.is_empty())
+                .unwrap_or(entity_id.as_str());
+            return Ok(Some(snapshot_id.to_string()));
+        }
+
+        Ok(None)
+    }
+
+    async fn seed_materialized_version_tip(
+        &self,
+        entity_id: &str,
+        commit_id: &str,
+    ) -> Result<(), LixError> {
+        let table = format!(
+            "lix_internal_state_materialized_v1_{}",
+            version_tip_schema_key()
+        );
+        let check_sql = format!(
+            "SELECT 1 FROM {table} \
+             WHERE schema_key = '{schema_key}' \
+               AND entity_id = '{entity_id}' \
+               AND file_id = '{file_id}' \
+               AND version_id = '{version_id}' \
+               AND is_tombstone = 0 \
+               AND snapshot_content IS NOT NULL \
+             LIMIT 1",
+            table = table,
+            schema_key = escape_sql_string(version_tip_schema_key()),
+            entity_id = escape_sql_string(entity_id),
+            file_id = escape_sql_string(version_tip_file_id()),
+            version_id = escape_sql_string(version_tip_storage_version_id()),
+        );
+        let existing = self.backend.execute(&check_sql, &[]).await?;
+        if !existing.rows.is_empty() {
+            return Ok(());
+        }
+
+        let snapshot_content = version_tip_snapshot_content(entity_id, commit_id, commit_id);
+        let insert_sql = format!(
+            "INSERT INTO {table} (\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, \
+             change_id, is_tombstone, created_at, updated_at\
+             ) VALUES (\
+             '{entity_id}', '{schema_key}', '{schema_version}', '{file_id}', '{version_id}', '{plugin_key}', '{snapshot_content}', \
+             'bootstrap', 0, '1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.000Z'\
+             ) \
+             ON CONFLICT (entity_id, file_id, version_id) DO NOTHING",
+            table = table,
+            entity_id = escape_sql_string(entity_id),
+            schema_key = escape_sql_string(version_tip_schema_key()),
+            schema_version = escape_sql_string(version_tip_schema_version()),
+            file_id = escape_sql_string(version_tip_file_id()),
+            version_id = escape_sql_string(version_tip_storage_version_id()),
+            plugin_key = escape_sql_string(version_tip_plugin_key()),
+            snapshot_content = escape_sql_string(&snapshot_content),
+        );
+        self.backend.execute(&insert_sql, &[]).await?;
+
+        Ok(())
+    }
+
+    async fn seed_default_active_version(&self, version_id: &str) -> Result<(), LixError> {
+        let check_sql = format!(
+            "SELECT 1 \
+             FROM lix_internal_state_untracked \
+             WHERE schema_key = '{schema_key}' \
+               AND file_id = '{file_id}' \
+               AND version_id = '{storage_version_id}' \
+               AND snapshot_content IS NOT NULL \
+             LIMIT 1",
+            schema_key = escape_sql_string(active_version_schema_key()),
+            file_id = escape_sql_string(active_version_file_id()),
+            storage_version_id = escape_sql_string(active_version_storage_version_id()),
+        );
+        let existing = self.backend.execute(&check_sql, &[]).await?;
+        if !existing.rows.is_empty() {
+            return Ok(());
+        }
+
+        let entity_id = self.generate_runtime_uuid().await?;
+        let snapshot_content = active_version_snapshot_content(&entity_id, version_id);
+        let insert_sql = format!(
+            "INSERT INTO lix_internal_state_untracked (\
+             entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, created_at, updated_at\
+             ) VALUES (\
+             '{entity_id}', '{schema_key}', '{file_id}', '{storage_version_id}', '{plugin_key}', '{snapshot_content}', '{schema_version}', '1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.000Z'\
+             )",
+            entity_id = escape_sql_string(&entity_id),
+            schema_key = escape_sql_string(active_version_schema_key()),
+            file_id = escape_sql_string(active_version_file_id()),
+            storage_version_id = escape_sql_string(active_version_storage_version_id()),
+            plugin_key = escape_sql_string(active_version_plugin_key()),
+            snapshot_content = escape_sql_string(&snapshot_content),
+            schema_version = escape_sql_string(active_version_schema_version()),
+        );
+        self.backend.execute(&insert_sql, &[]).await?;
+        Ok(())
+    }
+
+    async fn load_latest_commit_id(&self) -> Result<Option<String>, LixError> {
+        let result = self
+            .backend
+            .execute(
+                "SELECT entity_id \
+                 FROM lix_internal_change \
+                 WHERE schema_key = 'lix_commit' \
+                 ORDER BY created_at DESC, id DESC \
+                 LIMIT 1",
+                &[],
+            )
+            .await?;
+        let Some(row) = result.rows.first() else {
+            return Ok(None);
+        };
+        let Some(value) = row.first() else {
+            return Ok(None);
+        };
+        match value {
+            Value::Text(value) if !value.is_empty() => Ok(Some(value.clone())),
+            _ => Ok(None),
+        }
+    }
+
+    async fn generate_runtime_uuid(&self) -> Result<String, LixError> {
+        let result = self.execute("SELECT lix_uuid_v7()", &[]).await?;
+        let row = result.rows.first().ok_or_else(|| LixError {
+            message: "lix_uuid_v7 query returned no rows".to_string(),
+        })?;
+        let value = row.first().ok_or_else(|| LixError {
+            message: "lix_uuid_v7 query returned no columns".to_string(),
+        })?;
+        match value {
+            Value::Text(text) => Ok(text.clone()),
+            other => Err(LixError {
+                message: format!("lix_uuid_v7 query returned non-text value: {other:?}"),
+            }),
+        }
+    }
+
+    async fn load_and_cache_active_version(&self) -> Result<(), LixError> {
+        let result = self
+            .backend
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_internal_state_untracked \
+                 WHERE schema_key = $1 \
+                   AND file_id = $2 \
+                   AND version_id = $3 \
+                   AND snapshot_content IS NOT NULL \
+                 ORDER BY updated_at DESC \
+                 LIMIT 1",
+                &[
+                    Value::Text(active_version_schema_key().to_string()),
+                    Value::Text(active_version_file_id().to_string()),
+                    Value::Text(active_version_storage_version_id().to_string()),
+                ],
+            )
+            .await?;
+
+        if let Some(row) = result.rows.first() {
+            let snapshot_content = row.first().ok_or_else(|| LixError {
+                message: "active version query row is missing snapshot_content".to_string(),
+            })?;
+            let snapshot_content = match snapshot_content {
+                Value::Text(value) => value.as_str(),
+                other => {
+                    return Err(LixError {
+                        message: format!(
+                            "active version snapshot_content must be text, got {other:?}"
+                        ),
+                    })
+                }
+            };
+            let active_version_id = parse_active_version_snapshot(snapshot_content)?;
+            self.set_active_version_id(active_version_id);
+            return Ok(());
+        }
+
+        self.set_active_version_id(GLOBAL_VERSION_ID.to_string());
+        Ok(())
+    }
+
+    fn set_active_version_id(&self, version_id: String) {
+        let mut guard = self.active_version_id.write().unwrap();
+        if *guard == version_id {
+            return;
+        }
+        *guard = version_id;
+    }
 }
 
 fn builtin_schema_entity_id(schema: &JsonValue) -> Result<String, LixError> {
@@ -267,4 +616,71 @@ fn infer_boot_deterministic_settings(key_values: &[BootKeyValue]) -> Option<Dete
             timestamp_enabled,
         })
     })
+}
+
+fn active_version_from_mutations(mutations: &[MutationRow]) -> Result<Option<String>, LixError> {
+    for mutation in mutations.iter().rev() {
+        if !mutation.untracked {
+            continue;
+        }
+        if mutation.schema_key != active_version_schema_key()
+            || mutation.file_id != active_version_file_id()
+            || mutation.version_id != active_version_storage_version_id()
+        {
+            continue;
+        }
+
+        let snapshot = mutation.snapshot_content.as_ref().ok_or_else(|| LixError {
+            message: "active version mutation is missing snapshot_content".to_string(),
+        })?;
+        let snapshot_content = serde_json::to_string(snapshot).map_err(|error| LixError {
+            message: format!("active version mutation snapshot_content invalid JSON: {error}"),
+        })?;
+        return parse_active_version_snapshot(&snapshot_content).map(Some);
+    }
+
+    Ok(None)
+}
+
+fn active_version_from_update_validations(
+    plans: &[UpdateValidationPlan],
+) -> Result<Option<String>, LixError> {
+    for plan in plans.iter().rev() {
+        if !plan
+            .table
+            .eq_ignore_ascii_case("lix_internal_state_untracked")
+        {
+            continue;
+        }
+        if !where_clause_targets_active_version(plan.where_clause.as_deref()) {
+            continue;
+        }
+        let Some(snapshot) = plan.snapshot_content.as_ref() else {
+            continue;
+        };
+
+        let snapshot_content = serde_json::to_string(snapshot).map_err(|error| LixError {
+            message: format!("active version update snapshot_content invalid JSON: {error}"),
+        })?;
+        return parse_active_version_snapshot(&snapshot_content).map(Some);
+    }
+
+    Ok(None)
+}
+
+fn where_clause_targets_active_version(where_clause: Option<&str>) -> bool {
+    let Some(where_clause) = where_clause else {
+        return false;
+    };
+    let normalized: String = where_clause
+        .chars()
+        .filter(|character| !character.is_whitespace() && *character != '"')
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let schema_key_filter = format!("schema_key='{}'", active_version_schema_key());
+    normalized.contains(&schema_key_filter.to_ascii_lowercase())
+}
+
+fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
 }

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -23,8 +23,8 @@ use crate::materialization::{
 };
 use crate::schema_registry::register_schema;
 use crate::sql::{
-    build_delete_followup_sql, build_update_followup_sql, preprocess_sql_with_provider,
-    MutationRow, PostprocessPlan, UpdateValidationPlan,
+    build_delete_followup_sql, build_update_followup_sql, escape_sql_string,
+    preprocess_sql_with_provider, MutationRow, PostprocessPlan, UpdateValidationPlan,
 };
 use crate::validation::{validate_inserts, validate_updates, SchemaCache};
 use crate::version::{
@@ -805,8 +805,4 @@ fn where_clause_targets_active_version(where_clause: Option<&str>) -> bool {
         .to_ascii_lowercase();
     let schema_key_filter = format!("schema_key='{}'", active_version_schema_key());
     normalized.contains(&schema_key_filter.to_ascii_lowercase())
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
 }

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -27,6 +27,7 @@ const INIT_STATEMENTS: &[&str] = &[
      version_id TEXT NOT NULL,\
      plugin_key TEXT NOT NULL,\
      snapshot_content TEXT,\
+     inherited_from_version_id TEXT,\
      change_id TEXT NOT NULL,\
      is_tombstone INTEGER NOT NULL DEFAULT 0,\
      created_at TEXT NOT NULL,\

--- a/packages/engine/src/key_value/schema.rs
+++ b/packages/engine/src/key_value/schema.rs
@@ -1,7 +1,9 @@
 use serde_json::Value as JsonValue;
 use std::sync::OnceLock;
 
-use crate::builtin_schema::{builtin_schema_definition, builtin_schema_json};
+use crate::builtin_schema::{
+    builtin_schema_definition, builtin_schema_json, decode_lixcol_literal,
+};
 
 pub(crate) const KEY_VALUE_GLOBAL_VERSION: &str = "global";
 
@@ -72,8 +74,4 @@ fn key_value_schema_metadata() -> &'static KeyValueSchemaMetadata {
             plugin_key: decode_lixcol_literal(plugin_key_raw),
         }
     })
-}
-
-fn decode_lixcol_literal(raw: &str) -> String {
-    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('\"').to_string())
 }

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -10,6 +10,7 @@ mod functions;
 mod init;
 mod json_truthiness;
 mod key_value;
+mod materialization;
 mod schema;
 mod schema_registry;
 mod sql;
@@ -30,4 +31,12 @@ pub use commit::{
 };
 pub use engine::{boot, BootArgs, BootKeyValue, Engine};
 pub use error::LixError;
+pub use materialization::{
+    apply_materialization_plan, materialization_plan, materialize, InheritanceWinnerDebugRow,
+    LatestVisibleWinnerDebugRow, MaterializationApplyReport, MaterializationDebugMode,
+    MaterializationDebugTrace, MaterializationPlan, MaterializationReport, MaterializationRequest,
+    MaterializationScope, MaterializationWarning, MaterializationWrite, MaterializationWriteOp,
+    StageStat, TraversedCommitDebugRow, TraversedEdgeDebugRow, VersionAncestryDebugRow,
+    VersionPointerDebugRow,
+};
 pub use types::{QueryResult, Value};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -1,3 +1,4 @@
+mod account;
 mod backend;
 mod builtin_schema;
 mod cel;
@@ -29,7 +30,7 @@ pub use commit::{
     generate_commit, ChangeRow, DomainChangeInput, GenerateCommitArgs, GenerateCommitResult,
     MaterializedStateRow, VersionInfo, VersionSnapshot,
 };
-pub use engine::{boot, BootArgs, BootKeyValue, Engine};
+pub use engine::{boot, BootAccount, BootArgs, BootKeyValue, Engine};
 pub use error::LixError;
 pub use materialization::{
     apply_materialization_plan, materialization_plan, materialize, InheritanceWinnerDebugRow,

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -15,6 +15,7 @@ mod schema_registry;
 mod sql;
 mod types;
 mod validation;
+mod version;
 
 pub use schema::{
     lix_schema_definition, lix_schema_definition_json, validate_lix_schema,
@@ -22,6 +23,7 @@ pub use schema::{
 };
 
 pub use backend::LixBackend;
+pub use backend::SqlDialect;
 pub use commit::{
     generate_commit, ChangeRow, DomainChangeInput, GenerateCommitArgs, GenerateCommitResult,
     MaterializedStateRow, VersionInfo, VersionSnapshot,

--- a/packages/engine/src/materialization/apply.rs
+++ b/packages/engine/src/materialization/apply.rs
@@ -34,17 +34,23 @@ pub(crate) async fn apply_materialization_plan_internal(
             .as_ref()
             .map(|value| format!("'{}'", escape_sql_string(value)))
             .unwrap_or_else(|| "NULL".to_string());
+        let inherited_from_version_sql = write
+            .inherited_from_version_id
+            .as_ref()
+            .map(|value| format!("'{}'", escape_sql_string(value)))
+            .unwrap_or_else(|| "NULL".to_string());
 
         let sql = format!(
             "INSERT INTO {table} (\
-             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, is_tombstone, created_at, updated_at\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, inherited_from_version_id, change_id, is_tombstone, created_at, updated_at\
              ) VALUES (\
-             '{entity_id}', '{schema_key}', '{schema_version}', '{file_id}', '{version_id}', '{plugin_key}', {snapshot_content}, '{change_id}', {is_tombstone}, '{created_at}', '{updated_at}'\
+             '{entity_id}', '{schema_key}', '{schema_version}', '{file_id}', '{version_id}', '{plugin_key}', {snapshot_content}, {inherited_from_version_id}, '{change_id}', {is_tombstone}, '{created_at}', '{updated_at}'\
              ) ON CONFLICT (entity_id, file_id, version_id) DO UPDATE SET \
              schema_key = excluded.schema_key, \
              schema_version = excluded.schema_version, \
              plugin_key = excluded.plugin_key, \
              snapshot_content = excluded.snapshot_content, \
+             inherited_from_version_id = excluded.inherited_from_version_id, \
              change_id = excluded.change_id, \
              is_tombstone = excluded.is_tombstone, \
              created_at = excluded.created_at, \
@@ -57,6 +63,7 @@ pub(crate) async fn apply_materialization_plan_internal(
             version_id = escape_sql_string(&write.version_id),
             plugin_key = escape_sql_string(&write.plugin_key),
             snapshot_content = snapshot_sql,
+            inherited_from_version_id = inherited_from_version_sql,
             change_id = escape_sql_string(&write.change_id),
             is_tombstone = is_tombstone,
             created_at = escape_sql_string(&write.created_at),

--- a/packages/engine/src/materialization/apply.rs
+++ b/packages/engine/src/materialization/apply.rs
@@ -4,6 +4,7 @@ use crate::materialization::types::{
     MaterializationApplyReport, MaterializationPlan, MaterializationScope, MaterializationWriteOp,
 };
 use crate::schema_registry::register_schema;
+use crate::sql::escape_sql_string;
 use crate::{LixBackend, LixError, Value};
 
 pub(crate) async fn apply_materialization_plan_internal(
@@ -161,8 +162,4 @@ fn materialized_table_name(schema_key: &str) -> String {
 fn quote_ident(value: &str) -> String {
     let escaped = value.replace('"', "\"\"");
     format!("\"{escaped}\"")
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
 }

--- a/packages/engine/src/materialization/apply.rs
+++ b/packages/engine/src/materialization/apply.rs
@@ -1,0 +1,161 @@
+use std::collections::BTreeSet;
+
+use crate::materialization::types::{
+    MaterializationApplyReport, MaterializationPlan, MaterializationScope, MaterializationWriteOp,
+};
+use crate::schema_registry::register_schema;
+use crate::{LixBackend, LixError, Value};
+
+pub(crate) async fn apply_materialization_plan_internal(
+    backend: &dyn LixBackend,
+    plan: &MaterializationPlan,
+) -> Result<MaterializationApplyReport, LixError> {
+    let mut tables_touched = BTreeSet::new();
+    let target_versions = scope_versions(&plan.scope);
+
+    let mut schema_keys = BTreeSet::new();
+    for write in &plan.writes {
+        schema_keys.insert(write.schema_key.clone());
+    }
+
+    let rows_deleted =
+        clear_scope_rows(backend, &schema_keys, &target_versions, &mut tables_touched).await?;
+
+    for write in &plan.writes {
+        let table_name = materialized_table_name(&write.schema_key);
+        tables_touched.insert(table_name.clone());
+
+        let is_tombstone = match write.op {
+            MaterializationWriteOp::Upsert => 0,
+            MaterializationWriteOp::Tombstone => 1,
+        };
+        let snapshot_sql = write
+            .snapshot_content
+            .as_ref()
+            .map(|value| format!("'{}'", escape_sql_string(value)))
+            .unwrap_or_else(|| "NULL".to_string());
+
+        let sql = format!(
+            "INSERT INTO {table} (\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content, change_id, is_tombstone, created_at, updated_at\
+             ) VALUES (\
+             '{entity_id}', '{schema_key}', '{schema_version}', '{file_id}', '{version_id}', '{plugin_key}', {snapshot_content}, '{change_id}', {is_tombstone}, '{created_at}', '{updated_at}'\
+             ) ON CONFLICT (entity_id, file_id, version_id) DO UPDATE SET \
+             schema_key = excluded.schema_key, \
+             schema_version = excluded.schema_version, \
+             plugin_key = excluded.plugin_key, \
+             snapshot_content = excluded.snapshot_content, \
+             change_id = excluded.change_id, \
+             is_tombstone = excluded.is_tombstone, \
+             created_at = excluded.created_at, \
+             updated_at = excluded.updated_at",
+            table = quote_ident(&table_name),
+            entity_id = escape_sql_string(&write.entity_id),
+            schema_key = escape_sql_string(&write.schema_key),
+            schema_version = escape_sql_string(&write.schema_version),
+            file_id = escape_sql_string(&write.file_id),
+            version_id = escape_sql_string(&write.version_id),
+            plugin_key = escape_sql_string(&write.plugin_key),
+            snapshot_content = snapshot_sql,
+            change_id = escape_sql_string(&write.change_id),
+            is_tombstone = is_tombstone,
+            created_at = escape_sql_string(&write.created_at),
+            updated_at = escape_sql_string(&write.updated_at),
+        );
+
+        backend.execute(&sql, &[]).await?;
+    }
+
+    Ok(MaterializationApplyReport {
+        run_id: plan.run_id.clone(),
+        rows_written: plan.writes.len(),
+        rows_deleted,
+        tables_touched: tables_touched.into_iter().collect(),
+    })
+}
+
+async fn clear_scope_rows(
+    backend: &dyn LixBackend,
+    schema_keys: &BTreeSet<String>,
+    target_versions: &BTreeSet<String>,
+    tables_touched: &mut BTreeSet<String>,
+) -> Result<usize, LixError> {
+    if target_versions.is_empty() || schema_keys.is_empty() {
+        return Ok(0);
+    }
+
+    let in_list = in_clause_values(target_versions);
+    let mut rows_deleted = 0usize;
+
+    for schema_key in schema_keys {
+        register_schema(backend, schema_key).await?;
+        let table_name = materialized_table_name(schema_key);
+        tables_touched.insert(table_name.clone());
+
+        let count_sql = format!(
+            "SELECT COUNT(*) FROM {table_name} WHERE version_id IN ({in_list})",
+            table_name = quote_ident(&table_name),
+            in_list = in_list,
+        );
+        let count_result = backend.execute(&count_sql, &[]).await?;
+        rows_deleted += parse_count_result(&count_result.rows)?;
+
+        let delete_sql = format!(
+            "DELETE FROM {table_name} WHERE version_id IN ({in_list})",
+            table_name = quote_ident(&table_name),
+            in_list = in_list,
+        );
+        backend.execute(&delete_sql, &[]).await?;
+    }
+
+    Ok(rows_deleted)
+}
+
+fn parse_count_result(rows: &[Vec<Value>]) -> Result<usize, LixError> {
+    let Some(value) = rows.first().and_then(|row| row.first()) else {
+        return Err(LixError {
+            message: "materialization apply: count query returned no rows".to_string(),
+        });
+    };
+
+    match value {
+        Value::Integer(count) if *count >= 0 => Ok(*count as usize),
+        Value::Text(text) => text.parse::<usize>().map_err(|error| LixError {
+            message: format!(
+                "materialization apply: invalid count text '{}': {}",
+                text, error
+            ),
+        }),
+        _ => Err(LixError {
+            message: "materialization apply: count query returned non-integer value".to_string(),
+        }),
+    }
+}
+
+fn scope_versions(scope: &MaterializationScope) -> BTreeSet<String> {
+    match scope {
+        MaterializationScope::Full => BTreeSet::new(),
+        MaterializationScope::Versions(versions) => versions.clone(),
+    }
+}
+
+fn in_clause_values(values: &BTreeSet<String>) -> String {
+    values
+        .iter()
+        .map(|value| format!("'{}'", escape_sql_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn materialized_table_name(schema_key: &str) -> String {
+    format!("lix_internal_state_materialized_v1_{}", schema_key)
+}
+
+fn quote_ident(value: &str) -> String {
+    let escaped = value.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}

--- a/packages/engine/src/materialization/loader.rs
+++ b/packages/engine/src/materialization/loader.rs
@@ -1,0 +1,308 @@
+use std::collections::BTreeMap;
+
+use crate::builtin_schema::types::{
+    LixCommit, LixCommitEdge, LixVersionDescriptor, LixVersionPointer,
+};
+
+use crate::{LixBackend, LixError, Value};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ChangeRecord {
+    pub id: String,
+    pub entity_id: String,
+    pub schema_key: String,
+    pub schema_version: String,
+    pub file_id: String,
+    pub plugin_key: String,
+    pub snapshot_content: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CommitRecord {
+    pub id: String,
+    pub entity_id: String,
+    pub snapshot: LixCommit,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VersionPointerRecord {
+    pub id: String,
+    pub snapshot: LixVersionPointer,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VersionDescriptorRecord {
+    pub id: String,
+    pub entity_id: String,
+    pub snapshot: LixVersionDescriptor,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CommitEdgeRecord {
+    pub id: String,
+    pub snapshot: LixCommitEdge,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoadedData {
+    pub changes: BTreeMap<String, ChangeRecord>,
+    pub commits: BTreeMap<String, CommitRecord>,
+    pub version_pointers: Vec<VersionPointerRecord>,
+    pub version_descriptors: BTreeMap<String, VersionDescriptorRecord>,
+    pub commit_edges: Vec<CommitEdgeRecord>,
+}
+
+pub(crate) async fn load_data(backend: &dyn LixBackend) -> Result<LoadedData, LixError> {
+    let sql = "SELECT c.id, c.entity_id, c.schema_key, c.schema_version, c.file_id, c.plugin_key, s.content AS snapshot_content, c.created_at \
+               FROM lix_internal_change c \
+               LEFT JOIN lix_internal_snapshot s ON s.id = c.snapshot_id";
+    let result = backend.execute(sql, &[]).await?;
+
+    let mut changes = BTreeMap::new();
+    let mut commits = BTreeMap::new();
+    let mut version_pointers = Vec::new();
+    let mut version_descriptors = BTreeMap::new();
+    let mut commit_edges = Vec::new();
+
+    for row in result.rows {
+        let id = text_required(&row, 0, "id")?;
+        let entity_id = text_required(&row, 1, "entity_id")?;
+        let schema_key = text_required(&row, 2, "schema_key")?;
+        let schema_version = text_required(&row, 3, "schema_version")?;
+        let file_id = text_required(&row, 4, "file_id")?;
+        let plugin_key = text_required(&row, 5, "plugin_key")?;
+        let snapshot_content = text_optional(&row, 6, "snapshot_content")?;
+        let created_at = text_required(&row, 7, "created_at")?;
+
+        let change = ChangeRecord {
+            id: id.clone(),
+            entity_id: entity_id.clone(),
+            schema_key: schema_key.clone(),
+            schema_version: schema_version.clone(),
+            file_id: file_id.clone(),
+            plugin_key: plugin_key.clone(),
+            snapshot_content: snapshot_content.clone(),
+            created_at: created_at.clone(),
+        };
+
+        changes.insert(id.clone(), change.clone());
+
+        if schema_key == "lix_commit" {
+            if let Some(snapshot_raw) = snapshot_content {
+                if let Some(snapshot) = parse_commit_snapshot(&snapshot_raw)? {
+                    let candidate = CommitRecord {
+                        id: id.clone(),
+                        entity_id: entity_id.clone(),
+                        snapshot,
+                        created_at,
+                    };
+                    upsert_latest_by_entity(&mut commits, candidate, |record| {
+                        record.entity_id.clone()
+                    });
+                }
+            }
+            continue;
+        }
+
+        if schema_key == "lix_version_pointer" {
+            if let Some(snapshot_raw) = snapshot_content {
+                if let Some(snapshot) = parse_version_pointer_snapshot(&snapshot_raw)? {
+                    version_pointers.push(VersionPointerRecord {
+                        id,
+                        snapshot,
+                        created_at,
+                    });
+                }
+            }
+            continue;
+        }
+
+        if schema_key == "lix_version_descriptor" {
+            if let Some(snapshot_raw) = snapshot_content {
+                if let Some(snapshot) = parse_version_descriptor_snapshot(&snapshot_raw)? {
+                    let candidate = VersionDescriptorRecord {
+                        id: id.clone(),
+                        entity_id: entity_id.clone(),
+                        snapshot,
+                        created_at,
+                    };
+                    upsert_latest_by_entity(&mut version_descriptors, candidate, |record| {
+                        record.entity_id.clone()
+                    });
+                }
+            }
+            continue;
+        }
+
+        if schema_key == "lix_commit_edge" {
+            if let Some(snapshot_raw) = snapshot_content {
+                if let Some(snapshot) = parse_commit_edge_snapshot(&snapshot_raw)? {
+                    commit_edges.push(CommitEdgeRecord {
+                        id,
+                        snapshot,
+                        created_at,
+                    });
+                }
+            }
+        }
+    }
+
+    version_pointers.sort_by(|a, b| {
+        a.snapshot
+            .id
+            .cmp(&b.snapshot.id)
+            .then_with(|| a.snapshot.commit_id.cmp(&b.snapshot.commit_id))
+            .then_with(|| b.created_at.cmp(&a.created_at))
+            .then_with(|| b.id.cmp(&a.id))
+    });
+
+    commit_edges.sort_by(|a, b| {
+        a.snapshot
+            .parent_id
+            .cmp(&b.snapshot.parent_id)
+            .then_with(|| a.snapshot.child_id.cmp(&b.snapshot.child_id))
+            .then_with(|| b.created_at.cmp(&a.created_at))
+            .then_with(|| b.id.cmp(&a.id))
+    });
+
+    Ok(LoadedData {
+        changes,
+        commits,
+        version_pointers,
+        version_descriptors,
+        commit_edges,
+    })
+}
+
+fn upsert_latest_by_entity<T, F>(target: &mut BTreeMap<String, T>, candidate: T, key: F)
+where
+    T: Clone + HasOrder,
+    F: Fn(&T) -> String,
+{
+    let entity_key = key(&candidate);
+    match target.get(&entity_key) {
+        Some(existing) if !candidate.is_newer_than(existing) => {}
+        _ => {
+            target.insert(entity_key, candidate);
+        }
+    }
+}
+
+trait HasOrder {
+    fn created_at_value(&self) -> &str;
+    fn id_value(&self) -> &str;
+
+    fn is_newer_than(&self, other: &Self) -> bool {
+        self.created_at_value() > other.created_at_value()
+            || (self.created_at_value() == other.created_at_value()
+                && self.id_value() > other.id_value())
+    }
+}
+
+impl HasOrder for CommitRecord {
+    fn created_at_value(&self) -> &str {
+        &self.created_at
+    }
+
+    fn id_value(&self) -> &str {
+        &self.id
+    }
+}
+
+impl HasOrder for VersionDescriptorRecord {
+    fn created_at_value(&self) -> &str {
+        &self.created_at
+    }
+
+    fn id_value(&self) -> &str {
+        &self.id
+    }
+}
+
+fn parse_commit_snapshot(raw: &str) -> Result<Option<LixCommit>, LixError> {
+    let mut parsed: LixCommit = serde_json::from_str(raw).map_err(|error| LixError {
+        message: format!("materialization: invalid lix_commit snapshot JSON: {error}"),
+    })?;
+
+    if parsed.id.is_empty() {
+        return Ok(None);
+    }
+    parsed.change_ids.retain(|value| !value.is_empty());
+    parsed.parent_commit_ids.retain(|value| !value.is_empty());
+    parsed.author_account_ids.retain(|value| !value.is_empty());
+    parsed.meta_change_ids.retain(|value| !value.is_empty());
+    Ok(Some(parsed))
+}
+
+fn parse_version_pointer_snapshot(raw: &str) -> Result<Option<LixVersionPointer>, LixError> {
+    let parsed: LixVersionPointer = serde_json::from_str(raw).map_err(|error| LixError {
+        message: format!("materialization: invalid lix_version_pointer snapshot JSON: {error}"),
+    })?;
+
+    if parsed.id.is_empty() || parsed.commit_id.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(parsed))
+    }
+}
+
+fn parse_version_descriptor_snapshot(raw: &str) -> Result<Option<LixVersionDescriptor>, LixError> {
+    let parsed: LixVersionDescriptor = serde_json::from_str(raw).map_err(|error| LixError {
+        message: format!("materialization: invalid lix_version_descriptor snapshot JSON: {error}"),
+    })?;
+
+    if parsed.id.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(parsed))
+}
+
+fn parse_commit_edge_snapshot(raw: &str) -> Result<Option<LixCommitEdge>, LixError> {
+    let parsed: LixCommitEdge = serde_json::from_str(raw).map_err(|error| LixError {
+        message: format!("materialization: invalid lix_commit_edge snapshot JSON: {error}"),
+    })?;
+
+    if parsed.parent_id.is_empty() || parsed.child_id.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(parsed))
+    }
+}
+
+fn text_required(row: &[Value], index: usize, label: &str) -> Result<String, LixError> {
+    let Some(value) = row.get(index) else {
+        return Err(LixError {
+            message: format!("materialization: missing column '{label}' at index {index}"),
+        });
+    };
+    match value {
+        Value::Text(text) => Ok(text.clone()),
+        _ => Err(LixError {
+            message: format!(
+                "materialization: expected text for column '{label}' at index {index}"
+            ),
+        }),
+    }
+}
+
+fn text_optional(row: &[Value], index: usize, label: &str) -> Result<Option<String>, LixError> {
+    let Some(value) = row.get(index) else {
+        return Err(LixError {
+            message: format!("materialization: missing column '{label}' at index {index}"),
+        });
+    };
+    match value {
+        Value::Null => Ok(None),
+        Value::Text(text) => Ok(Some(text.clone())),
+        _ => Err(LixError {
+            message: format!(
+                "materialization: expected nullable text for column '{label}' at index {index}"
+            ),
+        }),
+    }
+}

--- a/packages/engine/src/materialization/mod.rs
+++ b/packages/engine/src/materialization/mod.rs
@@ -1,0 +1,37 @@
+mod apply;
+mod loader;
+mod plan;
+mod types;
+
+pub use types::{
+    InheritanceWinnerDebugRow, LatestVisibleWinnerDebugRow, MaterializationApplyReport,
+    MaterializationDebugMode, MaterializationDebugTrace, MaterializationPlan,
+    MaterializationReport, MaterializationRequest, MaterializationScope, MaterializationWarning,
+    MaterializationWrite, MaterializationWriteOp, StageStat, TraversedCommitDebugRow,
+    TraversedEdgeDebugRow, VersionAncestryDebugRow, VersionPointerDebugRow,
+};
+
+use crate::{LixBackend, LixError};
+
+pub async fn materialization_plan(
+    backend: &dyn LixBackend,
+    req: &MaterializationRequest,
+) -> Result<MaterializationPlan, LixError> {
+    plan::materialization_plan_internal(backend, req).await
+}
+
+pub async fn apply_materialization_plan(
+    backend: &dyn LixBackend,
+    plan: &MaterializationPlan,
+) -> Result<MaterializationApplyReport, LixError> {
+    apply::apply_materialization_plan_internal(backend, plan).await
+}
+
+pub async fn materialize(
+    backend: &dyn LixBackend,
+    req: &MaterializationRequest,
+) -> Result<MaterializationReport, LixError> {
+    let plan = materialization_plan(backend, req).await?;
+    let apply = apply_materialization_plan(backend, &plan).await?;
+    Ok(MaterializationReport { plan, apply })
+}

--- a/packages/engine/src/materialization/plan.rs
+++ b/packages/engine/src/materialization/plan.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use serde_json::json;
 
-use crate::builtin_schema::builtin_schema_definition;
 use crate::builtin_schema::types::LixVersionPointer;
+use crate::builtin_schema::{builtin_schema_definition, decode_lixcol_literal};
 use crate::materialization::loader::{load_data, ChangeRecord, LoadedData};
 use crate::materialization::types::{
     InheritanceWinnerDebugRow, LatestVisibleWinnerDebugRow, MaterializationDebugMode,
@@ -833,10 +833,6 @@ fn builtin_projection_schema_meta(schema_key: &str) -> BuiltinProjectionSchemaMe
         file_id: decode_lixcol_literal(file_id),
         plugin_key: decode_lixcol_literal(plugin_key),
     }
-}
-
-fn decode_lixcol_literal(raw: &str) -> String {
-    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('"').to_string())
 }
 
 fn resolve_target_versions(

--- a/packages/engine/src/materialization/plan.rs
+++ b/packages/engine/src/materialization/plan.rs
@@ -1,0 +1,1123 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use serde_json::json;
+
+use crate::builtin_schema::builtin_schema_definition;
+use crate::builtin_schema::types::LixVersionPointer;
+use crate::materialization::loader::{load_data, ChangeRecord, LoadedData};
+use crate::materialization::types::{
+    InheritanceWinnerDebugRow, LatestVisibleWinnerDebugRow, MaterializationDebugMode,
+    MaterializationDebugTrace, MaterializationPlan, MaterializationRequest, MaterializationScope,
+    MaterializationWarning, MaterializationWrite, MaterializationWriteOp, StageStat,
+    TraversedCommitDebugRow, TraversedEdgeDebugRow, VersionAncestryDebugRow,
+    VersionPointerDebugRow,
+};
+use crate::version::GLOBAL_VERSION_ID;
+use crate::{LixBackend, LixError};
+
+#[derive(Debug, Clone)]
+struct VisibleRow {
+    version_id: String,
+    commit_id: String,
+    change_id: String,
+    entity_id: String,
+    schema_key: String,
+    schema_version: String,
+    file_id: String,
+    plugin_key: String,
+    snapshot_content: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Clone)]
+struct FinalStateRow {
+    version_id: String,
+    inherited_from_version_id: Option<String>,
+    source: VisibleRow,
+}
+
+#[derive(Debug, Clone)]
+struct VisibleCandidate {
+    source_version_id: String,
+    depth: usize,
+    commit_id: String,
+    change: ChangeRecord,
+}
+
+#[derive(Debug, Clone)]
+struct ProjectionCandidate {
+    depth: usize,
+    row: VisibleRow,
+}
+
+#[derive(Debug, Clone)]
+struct BuiltinProjectionSchemaMeta {
+    schema_key: String,
+    schema_version: String,
+    file_id: String,
+    plugin_key: String,
+}
+
+#[derive(Debug, Clone)]
+struct VersionPointerSource {
+    change_id: String,
+    schema_version: String,
+    file_id: String,
+    plugin_key: String,
+    created_at: String,
+    working_commit_id: Option<String>,
+}
+
+pub(crate) async fn materialization_plan_internal(
+    backend: &dyn LixBackend,
+    req: &MaterializationRequest,
+) -> Result<MaterializationPlan, LixError> {
+    let data = load_data(backend).await?;
+    let mut stats = Vec::new();
+    let mut warnings = Vec::new();
+
+    let all_commit_edges = build_all_commit_edges(&data, &mut stats);
+    let version_pointers = build_version_pointers(&data, &all_commit_edges, &mut stats);
+    let commit_graph = build_commit_graph(&version_pointers, &all_commit_edges, &mut stats);
+
+    let latest_visible_state = build_latest_visible_state(
+        &data,
+        &commit_graph,
+        &version_pointers,
+        &mut warnings,
+        &mut stats,
+    );
+
+    let target_versions =
+        resolve_target_versions(req, &version_pointers, &data, &latest_visible_state);
+    let version_ancestry =
+        build_version_ancestry(&data, &target_versions, &mut warnings, &mut stats);
+    let final_state = build_final_state(
+        &latest_visible_state,
+        &version_ancestry,
+        &target_versions,
+        &mut stats,
+    );
+    let writes = build_writes(&final_state);
+
+    let debug = build_debug_trace(
+        req,
+        &version_pointers,
+        &commit_graph,
+        &all_commit_edges,
+        &version_ancestry,
+        &latest_visible_state,
+        &final_state,
+    );
+
+    Ok(MaterializationPlan {
+        run_id: format!("materialization::{:?}", req.scope),
+        scope: resolved_scope(req, target_versions),
+        stats,
+        writes,
+        warnings,
+        debug,
+    })
+}
+
+fn resolved_scope(
+    req: &MaterializationRequest,
+    target_versions: BTreeSet<String>,
+) -> MaterializationScope {
+    match &req.scope {
+        MaterializationScope::Full => MaterializationScope::Versions(target_versions),
+        MaterializationScope::Versions(_) => MaterializationScope::Versions(target_versions),
+    }
+}
+
+fn build_all_commit_edges(
+    data: &LoadedData,
+    stats: &mut Vec<StageStat>,
+) -> BTreeSet<(String, String)> {
+    let mut edges = BTreeSet::new();
+
+    for commit in data.commits.values() {
+        for parent_id in &commit.snapshot.parent_commit_ids {
+            if parent_id.is_empty() || commit.entity_id.is_empty() {
+                continue;
+            }
+            edges.insert((parent_id.clone(), commit.entity_id.clone()));
+        }
+    }
+
+    for edge in &data.commit_edges {
+        if edge.snapshot.parent_id.is_empty() || edge.snapshot.child_id.is_empty() {
+            continue;
+        }
+        edges.insert((
+            edge.snapshot.parent_id.clone(),
+            edge.snapshot.child_id.clone(),
+        ));
+    }
+
+    stats.push(StageStat {
+        stage: "all_commit_edges".to_string(),
+        input_rows: data.commits.len() + data.commit_edges.len(),
+        output_rows: edges.len(),
+    });
+
+    edges
+}
+
+fn build_version_pointers(
+    data: &LoadedData,
+    all_commit_edges: &BTreeSet<(String, String)>,
+    stats: &mut Vec<StageStat>,
+) -> BTreeMap<String, Vec<String>> {
+    let mut version_commits: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for tip in &data.version_pointers {
+        version_commits
+            .entry(tip.snapshot.id.clone())
+            .or_default()
+            .insert(tip.snapshot.commit_id.clone());
+    }
+
+    let mut tips = BTreeMap::new();
+    for (version_id, commits) in &version_commits {
+        let mut non_tips = BTreeSet::new();
+        for commit_id in commits {
+            let has_child_in_same_version = all_commit_edges
+                .iter()
+                .any(|(parent, child)| parent == commit_id && commits.contains(child));
+            if has_child_in_same_version {
+                non_tips.insert(commit_id.clone());
+            }
+        }
+
+        let mut tip_set: Vec<String> = commits
+            .iter()
+            .filter(|commit_id| !non_tips.contains(*commit_id))
+            .cloned()
+            .collect();
+        tip_set.sort();
+
+        if tip_set.is_empty() {
+            // Fallback to the latest observed commit for this version.
+            if let Some(last) = data
+                .version_pointers
+                .iter()
+                .filter(|tip| tip.snapshot.id == *version_id)
+                .max_by(|a, b| {
+                    a.created_at
+                        .cmp(&b.created_at)
+                        .then_with(|| a.id.cmp(&b.id))
+                })
+            {
+                tip_set.push(last.snapshot.commit_id.clone());
+            }
+        }
+
+        if !tip_set.is_empty() {
+            tips.insert(version_id.clone(), tip_set);
+        }
+    }
+
+    stats.push(StageStat {
+        stage: "version_pointers".to_string(),
+        input_rows: data.version_pointers.len(),
+        output_rows: tips.values().map(|rows| rows.len()).sum(),
+    });
+
+    tips
+}
+
+fn build_commit_graph(
+    version_pointers: &BTreeMap<String, Vec<String>>,
+    all_commit_edges: &BTreeSet<(String, String)>,
+    stats: &mut Vec<StageStat>,
+) -> BTreeMap<(String, String), usize> {
+    let mut parent_by_child: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (parent, child) in all_commit_edges {
+        parent_by_child
+            .entry(child.clone())
+            .or_default()
+            .push(parent.clone());
+    }
+    for parents in parent_by_child.values_mut() {
+        parents.sort();
+        parents.dedup();
+    }
+
+    let mut queue = VecDeque::new();
+    for (version_id, tips) in version_pointers {
+        for tip in tips {
+            queue.push_back((version_id.clone(), tip.clone(), 0usize));
+        }
+    }
+
+    let mut min_depth: BTreeMap<(String, String), usize> = BTreeMap::new();
+    while let Some((version_id, commit_id, depth)) = queue.pop_front() {
+        let key = (version_id.clone(), commit_id.clone());
+        if let Some(existing_depth) = min_depth.get(&key) {
+            if *existing_depth <= depth {
+                continue;
+            }
+        }
+        min_depth.insert(key, depth);
+
+        if let Some(parents) = parent_by_child.get(&commit_id) {
+            for parent_id in parents {
+                queue.push_back((version_id.clone(), parent_id.clone(), depth + 1));
+            }
+        }
+    }
+
+    stats.push(StageStat {
+        stage: "commit_graph".to_string(),
+        input_rows: version_pointers
+            .values()
+            .map(|rows| rows.len())
+            .sum::<usize>()
+            + all_commit_edges.len(),
+        output_rows: min_depth.len(),
+    });
+
+    min_depth
+}
+
+fn build_latest_visible_state(
+    data: &LoadedData,
+    commit_graph: &BTreeMap<(String, String), usize>,
+    version_pointers: &BTreeMap<String, Vec<String>>,
+    warnings: &mut Vec<MaterializationWarning>,
+    stats: &mut Vec<StageStat>,
+) -> Vec<VisibleRow> {
+    let mut candidates: BTreeMap<(String, String, String, String), Vec<VisibleCandidate>> =
+        BTreeMap::new();
+
+    for ((version_id, commit_id), depth) in commit_graph {
+        let Some(commit) = data.commits.get(commit_id) else {
+            warnings.push(MaterializationWarning {
+                code: "missing_commit_snapshot".to_string(),
+                message: format!(
+                    "commit_graph references commit '{}' for version '{}' but no lix_commit snapshot exists",
+                    commit_id, version_id
+                ),
+            });
+            continue;
+        };
+
+        for change_id in &commit.snapshot.change_ids {
+            let Some(change) = data.changes.get(change_id) else {
+                warnings.push(MaterializationWarning {
+                    code: "missing_change".to_string(),
+                    message: format!(
+                        "lix_commit '{}' references missing change '{}'",
+                        commit_id, change_id
+                    ),
+                });
+                continue;
+            };
+
+            if change.schema_key == "lix_version_descriptor"
+                || change.schema_key == "lix_version_pointer"
+            {
+                continue;
+            }
+
+            let key = (
+                version_id.clone(),
+                change.entity_id.clone(),
+                change.schema_key.clone(),
+                change.file_id.clone(),
+            );
+            candidates.entry(key).or_default().push(VisibleCandidate {
+                source_version_id: version_id.clone(),
+                depth: *depth,
+                commit_id: commit.entity_id.clone(),
+                change: change.clone(),
+            });
+        }
+    }
+
+    let mut winners = Vec::new();
+    for ((_version_id, _entity_id, _schema_key, _file_id), mut rows) in candidates {
+        rows.sort_by(|a, b| {
+            a.depth
+                .cmp(&b.depth)
+                .then_with(|| b.change.created_at.cmp(&a.change.created_at))
+                .then_with(|| b.change.id.cmp(&a.change.id))
+        });
+
+        let Some(winner) = rows.first() else {
+            continue;
+        };
+
+        let mut created_candidates = rows.clone();
+        created_candidates.sort_by(|a, b| {
+            b.depth
+                .cmp(&a.depth)
+                .then_with(|| a.change.created_at.cmp(&b.change.created_at))
+                .then_with(|| a.change.id.cmp(&b.change.id))
+        });
+        let created_at = created_candidates
+            .first()
+            .map(|row| row.change.created_at.clone())
+            .unwrap_or_else(|| winner.change.created_at.clone());
+
+        winners.push(VisibleRow {
+            version_id: winner.source_version_id.clone(),
+            commit_id: winner.commit_id.clone(),
+            change_id: winner.change.id.clone(),
+            entity_id: winner.change.entity_id.clone(),
+            schema_key: winner.change.schema_key.clone(),
+            schema_version: winner.change.schema_version.clone(),
+            file_id: winner.change.file_id.clone(),
+            plugin_key: winner.change.plugin_key.clone(),
+            snapshot_content: winner.change.snapshot_content.clone(),
+            created_at,
+            updated_at: winner.change.created_at.clone(),
+        });
+    }
+
+    winners.extend(build_global_projection_rows(
+        data,
+        commit_graph,
+        version_pointers,
+        warnings,
+    ));
+
+    winners.sort_by(|a, b| {
+        a.version_id
+            .cmp(&b.version_id)
+            .then_with(|| a.schema_key.cmp(&b.schema_key))
+            .then_with(|| a.file_id.cmp(&b.file_id))
+            .then_with(|| a.entity_id.cmp(&b.entity_id))
+            .then_with(|| a.change_id.cmp(&b.change_id))
+    });
+
+    stats.push(StageStat {
+        stage: "latest_visible_state".to_string(),
+        input_rows: commit_graph.len(),
+        output_rows: winners.len(),
+    });
+
+    winners
+}
+
+fn build_global_projection_rows(
+    data: &LoadedData,
+    commit_graph: &BTreeMap<(String, String), usize>,
+    version_pointers: &BTreeMap<String, Vec<String>>,
+    warnings: &mut Vec<MaterializationWarning>,
+) -> Vec<VisibleRow> {
+    let commit_schema = builtin_projection_schema_meta("lix_commit");
+    let version_pointer_schema = builtin_projection_schema_meta("lix_version_pointer");
+    let change_set_element_schema = builtin_projection_schema_meta("lix_change_set_element");
+    let commit_edge_schema = builtin_projection_schema_meta("lix_commit_edge");
+    let change_author_schema = builtin_projection_schema_meta("lix_change_author");
+    let commit_depths = min_depth_by_commit(commit_graph);
+
+    let mut candidates: BTreeMap<(String, String, String, String), Vec<ProjectionCandidate>> =
+        BTreeMap::new();
+
+    for (version_id, tip_commit_ids) in version_pointers {
+        for tip_commit_id in tip_commit_ids {
+            let source =
+                latest_version_pointer_source_for_tip(data, version_id, tip_commit_id, warnings);
+            let tip_depth = commit_depths
+                .get(tip_commit_id)
+                .copied()
+                .unwrap_or(usize::MAX / 4);
+            let fallback_created_at = data
+                .commits
+                .get(tip_commit_id)
+                .map(|commit| commit.created_at.clone())
+                .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+
+            let (change_id, schema_version, file_id, plugin_key, created_at, working_commit_id) =
+                match source {
+                    Some(source) => (
+                        source.change_id,
+                        source.schema_version,
+                        source.file_id,
+                        source.plugin_key,
+                        source.created_at,
+                        source
+                            .working_commit_id
+                            .filter(|value| !value.is_empty())
+                            .unwrap_or_else(|| tip_commit_id.clone()),
+                    ),
+                    None => (
+                        format!("syn~lix_version_pointer~{}~{}", version_id, tip_commit_id),
+                        version_pointer_schema.schema_version.clone(),
+                        version_pointer_schema.file_id.clone(),
+                        version_pointer_schema.plugin_key.clone(),
+                        fallback_created_at.clone(),
+                        tip_commit_id.clone(),
+                    ),
+                };
+
+            let row = VisibleRow {
+                version_id: GLOBAL_VERSION_ID.to_string(),
+                commit_id: tip_commit_id.clone(),
+                change_id,
+                entity_id: version_id.clone(),
+                schema_key: version_pointer_schema.schema_key.clone(),
+                schema_version,
+                file_id: file_id.clone(),
+                plugin_key,
+                snapshot_content: Some(
+                    json!({
+                        "id": version_id,
+                        "commit_id": tip_commit_id,
+                        "working_commit_id": working_commit_id,
+                    })
+                    .to_string(),
+                ),
+                created_at: created_at.clone(),
+                updated_at: created_at,
+            };
+            let key = (
+                row.version_id.clone(),
+                row.entity_id.clone(),
+                row.schema_key.clone(),
+                file_id,
+            );
+            candidates
+                .entry(key)
+                .or_default()
+                .push(ProjectionCandidate {
+                    depth: tip_depth,
+                    row,
+                });
+        }
+    }
+
+    for (commit_id, depth) in &commit_depths {
+        let Some(commit) = data.commits.get(commit_id) else {
+            warnings.push(MaterializationWarning {
+                code: "missing_commit_snapshot".to_string(),
+                message: format!(
+                    "commit_graph references commit '{}' but no lix_commit snapshot exists",
+                    commit_id
+                ),
+            });
+            continue;
+        };
+        let Some(commit_change) = data.changes.get(&commit.id) else {
+            warnings.push(MaterializationWarning {
+                code: "missing_commit_change".to_string(),
+                message: format!(
+                    "lix_commit '{}' references missing change row '{}'",
+                    commit.entity_id, commit.id
+                ),
+            });
+            continue;
+        };
+
+        let commit_row = VisibleRow {
+            version_id: GLOBAL_VERSION_ID.to_string(),
+            commit_id: commit.entity_id.clone(),
+            change_id: commit_change.id.clone(),
+            entity_id: commit.entity_id.clone(),
+            schema_key: commit_schema.schema_key.clone(),
+            schema_version: commit_change.schema_version.clone(),
+            file_id: commit_change.file_id.clone(),
+            plugin_key: commit_change.plugin_key.clone(),
+            snapshot_content: commit_change.snapshot_content.clone(),
+            created_at: commit_change.created_at.clone(),
+            updated_at: commit_change.created_at.clone(),
+        };
+        let commit_key = (
+            commit_row.version_id.clone(),
+            commit_row.entity_id.clone(),
+            commit_row.schema_key.clone(),
+            commit_row.file_id.clone(),
+        );
+        candidates
+            .entry(commit_key)
+            .or_default()
+            .push(ProjectionCandidate {
+                depth: *depth,
+                row: commit_row,
+            });
+
+        if let Some(change_set_id) = commit
+            .snapshot
+            .change_set_id
+            .as_ref()
+            .filter(|value| !value.is_empty())
+        {
+            for change_id in &commit.snapshot.change_ids {
+                let Some(change) = data.changes.get(change_id) else {
+                    warnings.push(MaterializationWarning {
+                        code: "missing_change".to_string(),
+                        message: format!(
+                            "lix_commit '{}' references missing change '{}'",
+                            commit_id, change_id
+                        ),
+                    });
+                    continue;
+                };
+
+                let cse_row = VisibleRow {
+                    version_id: GLOBAL_VERSION_ID.to_string(),
+                    commit_id: commit.entity_id.clone(),
+                    change_id: change.id.clone(),
+                    entity_id: format!("{}~{}", change_set_id, change.id),
+                    schema_key: change_set_element_schema.schema_key.clone(),
+                    schema_version: change_set_element_schema.schema_version.clone(),
+                    file_id: change_set_element_schema.file_id.clone(),
+                    plugin_key: change_set_element_schema.plugin_key.clone(),
+                    snapshot_content: Some(
+                        json!({
+                            "change_set_id": change_set_id,
+                            "change_id": change.id,
+                            "entity_id": change.entity_id,
+                            "schema_key": change.schema_key,
+                            "file_id": change.file_id,
+                        })
+                        .to_string(),
+                    ),
+                    created_at: change.created_at.clone(),
+                    updated_at: change.created_at.clone(),
+                };
+                let cse_key = (
+                    cse_row.version_id.clone(),
+                    cse_row.entity_id.clone(),
+                    cse_row.schema_key.clone(),
+                    cse_row.file_id.clone(),
+                );
+                candidates
+                    .entry(cse_key)
+                    .or_default()
+                    .push(ProjectionCandidate {
+                        depth: *depth,
+                        row: cse_row,
+                    });
+
+                for account_id in &commit.snapshot.author_account_ids {
+                    if account_id.is_empty() {
+                        continue;
+                    }
+                    let author_row = VisibleRow {
+                        version_id: GLOBAL_VERSION_ID.to_string(),
+                        commit_id: commit.entity_id.clone(),
+                        change_id: commit_change.id.clone(),
+                        entity_id: format!("{}~{}", change.id, account_id),
+                        schema_key: change_author_schema.schema_key.clone(),
+                        schema_version: change_author_schema.schema_version.clone(),
+                        file_id: change_author_schema.file_id.clone(),
+                        plugin_key: change_author_schema.plugin_key.clone(),
+                        snapshot_content: Some(
+                            json!({
+                                "change_id": change.id,
+                                "account_id": account_id,
+                            })
+                            .to_string(),
+                        ),
+                        created_at: commit_change.created_at.clone(),
+                        updated_at: commit_change.created_at.clone(),
+                    };
+                    let author_key = (
+                        author_row.version_id.clone(),
+                        author_row.entity_id.clone(),
+                        author_row.schema_key.clone(),
+                        author_row.file_id.clone(),
+                    );
+                    candidates
+                        .entry(author_key)
+                        .or_default()
+                        .push(ProjectionCandidate {
+                            depth: *depth,
+                            row: author_row,
+                        });
+                }
+            }
+        }
+
+        for parent_id in &commit.snapshot.parent_commit_ids {
+            if parent_id.is_empty() {
+                continue;
+            }
+            let edge_row = VisibleRow {
+                version_id: GLOBAL_VERSION_ID.to_string(),
+                commit_id: commit.entity_id.clone(),
+                change_id: commit_change.id.clone(),
+                entity_id: format!("{}~{}", parent_id, commit.entity_id),
+                schema_key: commit_edge_schema.schema_key.clone(),
+                schema_version: commit_edge_schema.schema_version.clone(),
+                file_id: commit_edge_schema.file_id.clone(),
+                plugin_key: commit_edge_schema.plugin_key.clone(),
+                snapshot_content: Some(
+                    json!({
+                        "parent_id": parent_id,
+                        "child_id": commit.entity_id,
+                    })
+                    .to_string(),
+                ),
+                created_at: commit_change.created_at.clone(),
+                updated_at: commit_change.created_at.clone(),
+            };
+            let edge_key = (
+                edge_row.version_id.clone(),
+                edge_row.entity_id.clone(),
+                edge_row.schema_key.clone(),
+                edge_row.file_id.clone(),
+            );
+            candidates
+                .entry(edge_key)
+                .or_default()
+                .push(ProjectionCandidate {
+                    depth: *depth,
+                    row: edge_row,
+                });
+        }
+    }
+
+    resolve_projection_candidates(candidates)
+}
+
+fn resolve_projection_candidates(
+    candidates: BTreeMap<(String, String, String, String), Vec<ProjectionCandidate>>,
+) -> Vec<VisibleRow> {
+    let mut rows = Vec::new();
+    for ((_version_id, _entity_id, _schema_key, _file_id), mut items) in candidates {
+        items.sort_by(|a, b| {
+            a.depth
+                .cmp(&b.depth)
+                .then_with(|| b.row.created_at.cmp(&a.row.created_at))
+                .then_with(|| b.row.change_id.cmp(&a.row.change_id))
+        });
+        if let Some(winner) = items.into_iter().next() {
+            rows.push(winner.row);
+        }
+    }
+    rows
+}
+
+fn min_depth_by_commit(
+    commit_graph: &BTreeMap<(String, String), usize>,
+) -> BTreeMap<String, usize> {
+    let mut min_depth = BTreeMap::new();
+    for ((_, commit_id), depth) in commit_graph {
+        min_depth
+            .entry(commit_id.clone())
+            .and_modify(|existing: &mut usize| {
+                if *depth < *existing {
+                    *existing = *depth;
+                }
+            })
+            .or_insert(*depth);
+    }
+    min_depth
+}
+
+fn latest_version_pointer_source_for_tip(
+    data: &LoadedData,
+    version_id: &str,
+    tip_commit_id: &str,
+    warnings: &mut Vec<MaterializationWarning>,
+) -> Option<VersionPointerSource> {
+    let mut best: Option<VersionPointerSource> = None;
+
+    for change in data.changes.values() {
+        if change.schema_key != "lix_version_pointer" || change.entity_id != version_id {
+            continue;
+        }
+        let Some(snapshot_content) = change.snapshot_content.as_deref() else {
+            continue;
+        };
+        let parsed: LixVersionPointer = match serde_json::from_str(snapshot_content) {
+            Ok(value) => value,
+            Err(error) => {
+                warnings.push(MaterializationWarning {
+                    code: "invalid_version_pointer_snapshot".to_string(),
+                    message: format!(
+                        "lix_version_pointer change '{}' has invalid snapshot JSON: {}",
+                        change.id, error
+                    ),
+                });
+                continue;
+            }
+        };
+        if parsed.commit_id != tip_commit_id {
+            continue;
+        }
+
+        let candidate = VersionPointerSource {
+            change_id: change.id.clone(),
+            schema_version: change.schema_version.clone(),
+            file_id: change.file_id.clone(),
+            plugin_key: change.plugin_key.clone(),
+            created_at: change.created_at.clone(),
+            working_commit_id: parsed.working_commit_id,
+        };
+
+        match &best {
+            Some(existing)
+                if existing.created_at > candidate.created_at
+                    || (existing.created_at == candidate.created_at
+                        && existing.change_id >= candidate.change_id) => {}
+            _ => best = Some(candidate),
+        }
+    }
+
+    best
+}
+
+fn builtin_projection_schema_meta(schema_key: &str) -> BuiltinProjectionSchemaMeta {
+    let schema = builtin_schema_definition(schema_key).unwrap_or_else(|| {
+        panic!("builtin schema '{}' must exist", schema_key);
+    });
+
+    let parsed_schema_key = schema
+        .get("x-lix-key")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("builtin schema '{}' must define x-lix-key", schema_key))
+        .to_string();
+    let schema_version = schema
+        .get("x-lix-version")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("builtin schema '{}' must define x-lix-version", schema_key))
+        .to_string();
+    let overrides = schema
+        .get("x-lix-override-lixcols")
+        .and_then(serde_json::Value::as_object)
+        .unwrap_or_else(|| {
+            panic!(
+                "builtin schema '{}' must define object x-lix-override-lixcols",
+                schema_key
+            )
+        });
+    let file_id = overrides
+        .get("lixcol_file_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| {
+            panic!(
+                "builtin schema '{}' must define string lixcol_file_id",
+                schema_key
+            )
+        });
+    let plugin_key = overrides
+        .get("lixcol_plugin_key")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| {
+            panic!(
+                "builtin schema '{}' must define string lixcol_plugin_key",
+                schema_key
+            )
+        });
+
+    BuiltinProjectionSchemaMeta {
+        schema_key: parsed_schema_key,
+        schema_version,
+        file_id: decode_lixcol_literal(file_id),
+        plugin_key: decode_lixcol_literal(plugin_key),
+    }
+}
+
+fn decode_lixcol_literal(raw: &str) -> String {
+    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('"').to_string())
+}
+
+fn resolve_target_versions(
+    req: &MaterializationRequest,
+    version_pointers: &BTreeMap<String, Vec<String>>,
+    data: &LoadedData,
+    latest_visible_state: &[VisibleRow],
+) -> BTreeSet<String> {
+    match &req.scope {
+        MaterializationScope::Versions(versions) => versions.clone(),
+        MaterializationScope::Full => {
+            let mut versions = BTreeSet::new();
+            for version_id in version_pointers.keys() {
+                versions.insert(version_id.clone());
+            }
+            for version_id in data.version_descriptors.keys() {
+                versions.insert(version_id.clone());
+            }
+            for row in latest_visible_state {
+                versions.insert(row.version_id.clone());
+            }
+            versions
+        }
+    }
+}
+
+fn build_version_ancestry(
+    data: &LoadedData,
+    target_versions: &BTreeSet<String>,
+    warnings: &mut Vec<MaterializationWarning>,
+    stats: &mut Vec<StageStat>,
+) -> BTreeMap<String, Vec<(String, usize)>> {
+    let mut ancestry: BTreeMap<String, Vec<(String, usize)>> = BTreeMap::new();
+
+    for version_id in target_versions {
+        let mut rows = Vec::new();
+        let mut seen = BTreeSet::new();
+        let mut current = version_id.clone();
+        let mut depth = 0usize;
+
+        loop {
+            if !seen.insert(current.clone()) {
+                warnings.push(MaterializationWarning {
+                    code: "version_inheritance_cycle".to_string(),
+                    message: format!(
+                        "cycle detected while resolving ancestry for version '{}'",
+                        version_id
+                    ),
+                });
+                break;
+            }
+
+            rows.push((current.clone(), depth));
+            let next = data
+                .version_descriptors
+                .get(&current)
+                .and_then(|descriptor| descriptor.snapshot.inherits_from_version_id.clone());
+
+            let Some(next) = next else {
+                break;
+            };
+
+            if depth >= 64 {
+                warnings.push(MaterializationWarning {
+                    code: "version_inheritance_depth_limit".to_string(),
+                    message: format!(
+                        "ancestry depth exceeded limit while resolving version '{}'",
+                        version_id
+                    ),
+                });
+                break;
+            }
+
+            current = next;
+            depth += 1;
+        }
+
+        ancestry.insert(version_id.clone(), rows);
+    }
+
+    stats.push(StageStat {
+        stage: "version_ancestry".to_string(),
+        input_rows: data.version_descriptors.len(),
+        output_rows: ancestry.values().map(|rows| rows.len()).sum(),
+    });
+
+    ancestry
+}
+
+fn build_final_state(
+    latest_visible_state: &[VisibleRow],
+    version_ancestry: &BTreeMap<String, Vec<(String, usize)>>,
+    target_versions: &BTreeSet<String>,
+    stats: &mut Vec<StageStat>,
+) -> Vec<FinalStateRow> {
+    let mut visible_by_version: BTreeMap<String, Vec<&VisibleRow>> = BTreeMap::new();
+    for row in latest_visible_state {
+        visible_by_version
+            .entry(row.version_id.clone())
+            .or_default()
+            .push(row);
+    }
+
+    let mut rows = Vec::new();
+    for version_id in target_versions {
+        let Some(ancestry) = version_ancestry.get(version_id) else {
+            continue;
+        };
+
+        let mut chosen: BTreeMap<(String, String, String), FinalStateRow> = BTreeMap::new();
+        for (ancestor_id, depth) in ancestry {
+            let Some(candidates) = visible_by_version.get(ancestor_id) else {
+                continue;
+            };
+
+            let mut sorted_candidates = candidates.clone();
+            sorted_candidates.sort_by(|a, b| {
+                a.schema_key
+                    .cmp(&b.schema_key)
+                    .then_with(|| a.file_id.cmp(&b.file_id))
+                    .then_with(|| a.entity_id.cmp(&b.entity_id))
+                    .then_with(|| a.change_id.cmp(&b.change_id))
+            });
+
+            for candidate in sorted_candidates {
+                let key = (
+                    candidate.entity_id.clone(),
+                    candidate.schema_key.clone(),
+                    candidate.file_id.clone(),
+                );
+                if chosen.contains_key(&key) {
+                    continue;
+                }
+                chosen.insert(
+                    key,
+                    FinalStateRow {
+                        version_id: version_id.clone(),
+                        inherited_from_version_id: if *depth == 0 {
+                            None
+                        } else {
+                            Some(ancestor_id.clone())
+                        },
+                        source: candidate.clone(),
+                    },
+                );
+            }
+        }
+
+        rows.extend(chosen.into_values());
+    }
+
+    rows.sort_by(|a, b| {
+        a.version_id
+            .cmp(&b.version_id)
+            .then_with(|| a.source.schema_key.cmp(&b.source.schema_key))
+            .then_with(|| a.source.file_id.cmp(&b.source.file_id))
+            .then_with(|| a.source.entity_id.cmp(&b.source.entity_id))
+            .then_with(|| a.source.change_id.cmp(&b.source.change_id))
+    });
+
+    stats.push(StageStat {
+        stage: "state_materializer".to_string(),
+        input_rows: latest_visible_state.len(),
+        output_rows: rows.len(),
+    });
+
+    rows
+}
+
+fn build_writes(final_state: &[FinalStateRow]) -> Vec<MaterializationWrite> {
+    let mut writes = Vec::new();
+    for row in final_state {
+        let op = if row.source.snapshot_content.is_some() {
+            MaterializationWriteOp::Upsert
+        } else {
+            MaterializationWriteOp::Tombstone
+        };
+        writes.push(MaterializationWrite {
+            schema_key: row.source.schema_key.clone(),
+            entity_id: row.source.entity_id.clone(),
+            file_id: row.source.file_id.clone(),
+            version_id: row.version_id.clone(),
+            op,
+            snapshot_content: row.source.snapshot_content.clone(),
+            schema_version: row.source.schema_version.clone(),
+            plugin_key: row.source.plugin_key.clone(),
+            change_id: row.source.change_id.clone(),
+            created_at: row.source.created_at.clone(),
+            updated_at: row.source.updated_at.clone(),
+        });
+    }
+
+    writes.sort_by(|a, b| {
+        a.schema_key
+            .cmp(&b.schema_key)
+            .then_with(|| a.version_id.cmp(&b.version_id))
+            .then_with(|| a.file_id.cmp(&b.file_id))
+            .then_with(|| a.entity_id.cmp(&b.entity_id))
+            .then_with(|| a.change_id.cmp(&b.change_id))
+    });
+
+    writes
+}
+
+fn build_debug_trace(
+    req: &MaterializationRequest,
+    version_pointers: &BTreeMap<String, Vec<String>>,
+    commit_graph: &BTreeMap<(String, String), usize>,
+    all_commit_edges: &BTreeSet<(String, String)>,
+    version_ancestry: &BTreeMap<String, Vec<(String, usize)>>,
+    latest_visible_state: &[VisibleRow],
+    final_state: &[FinalStateRow],
+) -> Option<MaterializationDebugTrace> {
+    if matches!(req.debug, MaterializationDebugMode::Off) {
+        return None;
+    }
+
+    let limit = req.debug_row_limit.max(1);
+
+    let mut tips_by_version = Vec::new();
+    for (version_id, tips) in version_pointers {
+        for tip in tips {
+            tips_by_version.push(VersionPointerDebugRow {
+                version_id: version_id.clone(),
+                tip_commit_id: tip.clone(),
+            });
+        }
+    }
+
+    let mut traversed_commits = Vec::new();
+    for ((version_id, commit_id), depth) in commit_graph {
+        traversed_commits.push(TraversedCommitDebugRow {
+            version_id: version_id.clone(),
+            commit_id: commit_id.clone(),
+            depth: *depth,
+        });
+    }
+
+    let mut traversed_edges = Vec::new();
+    for (parent_id, child_id) in all_commit_edges {
+        for (version_id, tips) in version_pointers {
+            if !tips.is_empty() {
+                traversed_edges.push(TraversedEdgeDebugRow {
+                    version_id: version_id.clone(),
+                    parent_id: parent_id.clone(),
+                    child_id: child_id.clone(),
+                });
+            }
+        }
+    }
+
+    let mut ancestry_rows = Vec::new();
+    for (version_id, rows) in version_ancestry {
+        for (ancestor_version_id, inheritance_depth) in rows {
+            ancestry_rows.push(VersionAncestryDebugRow {
+                version_id: version_id.clone(),
+                ancestor_version_id: ancestor_version_id.clone(),
+                inheritance_depth: *inheritance_depth,
+            });
+        }
+    }
+
+    let latest_visible_winners = if matches!(req.debug, MaterializationDebugMode::Full) {
+        latest_visible_state
+            .iter()
+            .map(|row| LatestVisibleWinnerDebugRow {
+                version_id: row.version_id.clone(),
+                entity_id: row.entity_id.clone(),
+                schema_key: row.schema_key.clone(),
+                file_id: row.file_id.clone(),
+                commit_id: row.commit_id.clone(),
+                change_id: row.change_id.clone(),
+            })
+            .take(limit)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let inheritance_winners = if matches!(req.debug, MaterializationDebugMode::Full) {
+        final_state
+            .iter()
+            .map(|row| InheritanceWinnerDebugRow {
+                version_id: row.version_id.clone(),
+                entity_id: row.source.entity_id.clone(),
+                schema_key: row.source.schema_key.clone(),
+                file_id: row.source.file_id.clone(),
+                inherited_from_version_id: row.inherited_from_version_id.clone(),
+                change_id: row.source.change_id.clone(),
+            })
+            .take(limit)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    Some(MaterializationDebugTrace {
+        tips_by_version: tips_by_version.into_iter().take(limit).collect(),
+        traversed_commits: traversed_commits.into_iter().take(limit).collect(),
+        traversed_edges: traversed_edges.into_iter().take(limit).collect(),
+        version_ancestry: ancestry_rows.into_iter().take(limit).collect(),
+        latest_visible_winners,
+        inheritance_winners,
+    })
+}

--- a/packages/engine/src/materialization/types.rs
+++ b/packages/engine/src/materialization/types.rs
@@ -1,0 +1,146 @@
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MaterializationScope {
+    Full,
+    Versions(BTreeSet<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MaterializationDebugMode {
+    Off,
+    Summary,
+    Full,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationRequest {
+    pub scope: MaterializationScope,
+    pub debug: MaterializationDebugMode,
+    pub debug_row_limit: usize,
+}
+
+impl Default for MaterializationRequest {
+    fn default() -> Self {
+        Self {
+            scope: MaterializationScope::Full,
+            debug: MaterializationDebugMode::Summary,
+            debug_row_limit: 1_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MaterializationWriteOp {
+    Upsert,
+    Tombstone,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationWrite {
+    pub schema_key: String,
+    pub entity_id: String,
+    pub file_id: String,
+    pub version_id: String,
+    pub op: MaterializationWriteOp,
+    pub snapshot_content: Option<String>,
+    pub schema_version: String,
+    pub plugin_key: String,
+    pub change_id: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StageStat {
+    pub stage: String,
+    pub input_rows: usize,
+    pub output_rows: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationWarning {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VersionPointerDebugRow {
+    pub version_id: String,
+    pub tip_commit_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TraversedCommitDebugRow {
+    pub version_id: String,
+    pub commit_id: String,
+    pub depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TraversedEdgeDebugRow {
+    pub version_id: String,
+    pub parent_id: String,
+    pub child_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VersionAncestryDebugRow {
+    pub version_id: String,
+    pub ancestor_version_id: String,
+    pub inheritance_depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LatestVisibleWinnerDebugRow {
+    pub version_id: String,
+    pub entity_id: String,
+    pub schema_key: String,
+    pub file_id: String,
+    pub commit_id: String,
+    pub change_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InheritanceWinnerDebugRow {
+    pub version_id: String,
+    pub entity_id: String,
+    pub schema_key: String,
+    pub file_id: String,
+    pub inherited_from_version_id: Option<String>,
+    pub change_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationDebugTrace {
+    pub tips_by_version: Vec<VersionPointerDebugRow>,
+    pub traversed_commits: Vec<TraversedCommitDebugRow>,
+    pub traversed_edges: Vec<TraversedEdgeDebugRow>,
+    pub version_ancestry: Vec<VersionAncestryDebugRow>,
+    pub latest_visible_winners: Vec<LatestVisibleWinnerDebugRow>,
+    pub inheritance_winners: Vec<InheritanceWinnerDebugRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationPlan {
+    pub run_id: String,
+    pub scope: MaterializationScope,
+    pub stats: Vec<StageStat>,
+    pub writes: Vec<MaterializationWrite>,
+    pub warnings: Vec<MaterializationWarning>,
+    pub debug: Option<MaterializationDebugTrace>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationApplyReport {
+    pub run_id: String,
+    pub rows_written: usize,
+    pub rows_deleted: usize,
+    pub tables_touched: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MaterializationReport {
+    pub plan: MaterializationPlan,
+    pub apply: MaterializationApplyReport,
+}

--- a/packages/engine/src/materialization/types.rs
+++ b/packages/engine/src/materialization/types.rs
@@ -42,6 +42,7 @@ pub struct MaterializationWrite {
     pub entity_id: String,
     pub file_id: String,
     pub version_id: String,
+    pub inherited_from_version_id: Option<String>,
     pub op: MaterializationWriteOp,
     pub snapshot_content: Option<String>,
     pub schema_version: String,

--- a/packages/engine/src/schema/overlay.rs
+++ b/packages/engine/src/schema/overlay.rs
@@ -94,7 +94,7 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::{json, Value as JsonValue};
 
-    use crate::{LixBackend, LixError, QueryResult, Value};
+    use crate::{LixBackend, LixError, QueryResult, SqlDialect, Value};
 
     use super::{OverlaySchemaProvider, SchemaKey, SchemaProvider, SqlStoredSchemaProvider};
 
@@ -137,6 +137,10 @@ mod tests {
 
     #[async_trait(?Send)]
     impl LixBackend for FakeBackend {
+        fn dialect(&self) -> SqlDialect {
+            SqlDialect::Sqlite
+        }
+
         async fn execute(&self, sql: &str, _: &[Value]) -> Result<QueryResult, LixError> {
             self.calls
                 .lock()

--- a/packages/engine/src/schema/provider.rs
+++ b/packages/engine/src/schema/provider.rs
@@ -153,7 +153,7 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::{json, Value as JsonValue};
 
-    use crate::{LixBackend, LixError, QueryResult, Value};
+    use crate::{LixBackend, LixError, QueryResult, SqlDialect, Value};
 
     use super::{SchemaKey, SchemaProvider, SqlStoredSchemaProvider};
 
@@ -196,6 +196,10 @@ mod tests {
 
     #[async_trait(?Send)]
     impl LixBackend for FakeBackend {
+        fn dialect(&self) -> SqlDialect {
+            SqlDialect::Sqlite
+        }
+
         async fn execute(&self, sql: &str, _: &[Value]) -> Result<QueryResult, LixError> {
             self.calls
                 .lock()

--- a/packages/engine/src/schema/provider.rs
+++ b/packages/engine/src/schema/provider.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 
+use crate::sql::escape_sql_string;
 use crate::{LixBackend, LixError, Value};
 
 use super::key::SchemaKey;
@@ -130,10 +131,6 @@ fn schema_from_snapshot_content(raw: &str) -> Result<JsonValue, LixError> {
     parsed.get("value").cloned().ok_or_else(|| LixError {
         message: "stored schema snapshot_content missing value".to_string(),
     })
-}
-
-fn escape_sql_string(input: &str) -> String {
-    input.replace('\'', "''")
 }
 
 fn value_to_string(value: &Value, name: &str) -> Result<String, LixError> {

--- a/packages/engine/src/schema_registry.rs
+++ b/packages/engine/src/schema_registry.rs
@@ -13,6 +13,7 @@ pub async fn register_schema(backend: &dyn LixBackend, schema_key: &str) -> Resu
          version_id TEXT NOT NULL,\
          plugin_key TEXT NOT NULL,\
          snapshot_content TEXT,\
+         inherited_from_version_id TEXT,\
          change_id TEXT NOT NULL,\
          is_tombstone INTEGER NOT NULL DEFAULT 0,\
          created_at TEXT NOT NULL,\

--- a/packages/engine/src/sql/escaping.rs
+++ b/packages/engine/src/sql/escaping.rs
@@ -1,0 +1,3 @@
+pub(crate) fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}

--- a/packages/engine/src/sql/lowering/json_fn.rs
+++ b/packages/engine/src/sql/lowering/json_fn.rs
@@ -1,0 +1,69 @@
+use sqlparser::ast::{
+    CastKind, DataType, Expr, Function, FunctionArg, FunctionArgExpr, FunctionArgumentList,
+    FunctionArguments, Ident, ObjectName, ObjectNamePart, Value as AstValue,
+};
+
+use crate::backend::SqlDialect;
+use crate::sql::lowering::logical_fn::LixJsonTextCall;
+
+pub(crate) fn lower_lix_json_text(call: &LixJsonTextCall, dialect: SqlDialect) -> Expr {
+    match dialect {
+        SqlDialect::Sqlite => lower_sqlite_json_text(call),
+        SqlDialect::Postgres => lower_postgres_json_text(call),
+    }
+}
+
+fn lower_sqlite_json_text(call: &LixJsonTextCall) -> Expr {
+    let mut json_path = "$".to_string();
+    for segment in &call.path {
+        json_path.push('.');
+        json_path.push('"');
+        json_path.push_str(&segment.replace('\\', "\\\\").replace('"', "\\\""));
+        json_path.push('"');
+    }
+    function_expr(
+        "json_extract",
+        vec![call.json_expr.clone(), string_literal_expr(json_path)],
+    )
+}
+
+fn lower_postgres_json_text(call: &LixJsonTextCall) -> Expr {
+    let mut args = Vec::with_capacity(call.path.len() + 1);
+    args.push(Expr::Cast {
+        kind: CastKind::Cast,
+        expr: Box::new(call.json_expr.clone()),
+        data_type: DataType::JSONB,
+        format: None,
+    });
+    args.extend(
+        call.path
+            .iter()
+            .map(|segment| string_literal_expr(segment.clone())),
+    );
+
+    function_expr("jsonb_extract_path_text", args)
+}
+
+fn function_expr(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::Function(Function {
+        name: ObjectName(vec![ObjectNamePart::Identifier(Ident::new(name))]),
+        uses_odbc_syntax: false,
+        parameters: FunctionArguments::None,
+        args: FunctionArguments::List(FunctionArgumentList {
+            duplicate_treatment: None,
+            args: args
+                .into_iter()
+                .map(|arg| FunctionArg::Unnamed(FunctionArgExpr::Expr(arg)))
+                .collect(),
+            clauses: Vec::new(),
+        }),
+        filter: None,
+        null_treatment: None,
+        over: None,
+        within_group: Vec::new(),
+    })
+}
+
+fn string_literal_expr(value: String) -> Expr {
+    Expr::Value(AstValue::SingleQuotedString(value).into())
+}

--- a/packages/engine/src/sql/lowering/logical_fn.rs
+++ b/packages/engine/src/sql/lowering/logical_fn.rs
@@ -1,0 +1,95 @@
+use sqlparser::ast::{
+    Expr, Function, FunctionArg, FunctionArgExpr, FunctionArguments, ObjectName, ObjectNamePart,
+    Value as AstValue, ValueWithSpan,
+};
+
+use crate::LixError;
+
+#[derive(Debug, Clone)]
+pub(crate) struct LixJsonTextCall {
+    pub(crate) json_expr: Expr,
+    pub(crate) path: Vec<String>,
+}
+
+pub(crate) fn parse_lix_json_text(
+    function: &Function,
+) -> Result<Option<LixJsonTextCall>, LixError> {
+    if !function_name_matches(&function.name, "lix_json_text") {
+        return Ok(None);
+    }
+
+    let args = match &function.args {
+        FunctionArguments::List(list) => {
+            if list.duplicate_treatment.is_some() || !list.clauses.is_empty() {
+                return Err(LixError {
+                    message: "lix_json_text() does not support DISTINCT/ALL/clauses".to_string(),
+                });
+            }
+            &list.args
+        }
+        _ => {
+            return Err(LixError {
+                message: "lix_json_text() requires a regular argument list".to_string(),
+            })
+        }
+    };
+
+    if args.len() < 2 {
+        return Err(LixError {
+            message: "lix_json_text() requires at least 2 arguments".to_string(),
+        });
+    }
+
+    let json_expr = function_arg_expr(&args[0])?;
+    let mut path = Vec::with_capacity(args.len() - 1);
+    for arg in &args[1..] {
+        let expr = function_arg_expr(arg)?;
+        let key = string_literal(&expr).ok_or_else(|| LixError {
+            message: "lix_json_text() path arguments must be single-quoted strings".to_string(),
+        })?;
+        if key.is_empty() {
+            return Err(LixError {
+                message: "lix_json_text() path segments must not be empty".to_string(),
+            });
+        }
+        path.push(key.to_string());
+    }
+
+    Ok(Some(LixJsonTextCall { json_expr, path }))
+}
+
+fn function_name_matches(name: &ObjectName, expected: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(expected))
+        .unwrap_or(false)
+}
+
+fn function_arg_expr(arg: &FunctionArg) -> Result<Expr, LixError> {
+    let inner = match arg {
+        FunctionArg::Unnamed(arg) => arg,
+        _ => {
+            return Err(LixError {
+                message: "lix_json_text() does not support named arguments".to_string(),
+            })
+        }
+    };
+
+    match inner {
+        FunctionArgExpr::Expr(expr) => Ok(expr.clone()),
+        _ => Err(LixError {
+            message: "lix_json_text() arguments must be SQL expressions".to_string(),
+        }),
+    }
+}
+
+fn string_literal(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Value(ValueWithSpan {
+            value: AstValue::SingleQuotedString(value),
+            ..
+        }) => Some(value.as_str()),
+        _ => None,
+    }
+}

--- a/packages/engine/src/sql/lowering/mod.rs
+++ b/packages/engine/src/sql/lowering/mod.rs
@@ -1,0 +1,115 @@
+mod json_fn;
+mod logical_fn;
+
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{Expr, Statement};
+use sqlparser::ast::{VisitMut, VisitorMut};
+
+use crate::backend::SqlDialect;
+use crate::LixError;
+
+use self::json_fn::lower_lix_json_text;
+use self::logical_fn::parse_lix_json_text;
+
+pub(crate) fn lower_statement(
+    statement: Statement,
+    dialect: SqlDialect,
+) -> Result<Statement, LixError> {
+    let mut statement = statement;
+    let mut lowerer = LogicalFunctionLowerer { dialect };
+    if let ControlFlow::Break(error) = statement.visit(&mut lowerer) {
+        return Err(error);
+    }
+    Ok(statement)
+}
+
+struct LogicalFunctionLowerer {
+    dialect: SqlDialect,
+}
+
+impl VisitorMut for LogicalFunctionLowerer {
+    type Break = LixError;
+
+    fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        let Expr::Function(function) = expr else {
+            return ControlFlow::Continue(());
+        };
+
+        let parsed = match parse_lix_json_text(function) {
+            Ok(parsed) => parsed,
+            Err(error) => return ControlFlow::Break(error),
+        };
+
+        let Some(call) = parsed else {
+            return ControlFlow::Continue(());
+        };
+
+        let lowered = lower_lix_json_text(&call, self.dialect);
+        *expr = lowered;
+        ControlFlow::Continue(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlparser::ast::{SetExpr, Statement};
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
+    use crate::backend::SqlDialect;
+
+    use super::lower_statement;
+
+    fn lower_query(sql: &str, dialect: SqlDialect) -> String {
+        let mut statements = Parser::parse_sql(&GenericDialect {}, sql).expect("parse SQL");
+        assert_eq!(statements.len(), 1);
+        let lowered = lower_statement(statements.remove(0), dialect).expect("lower statement");
+        lowered.to_string()
+    }
+
+    fn select_expr(sql: &str) -> String {
+        let mut statements = Parser::parse_sql(&GenericDialect {}, sql).expect("parse SQL");
+        let statement = statements.remove(0);
+        match statement {
+            Statement::Query(query) => match *query.body {
+                SetExpr::Select(select) => select.projection[0].to_string(),
+                _ => panic!("expected select"),
+            },
+            _ => panic!("expected query"),
+        }
+    }
+
+    #[test]
+    fn lowers_lix_json_text_to_sqlite_json_extract() {
+        let lowered = lower_query(
+            "SELECT lix_json_text(snapshot_content, 'id', 'commit_id') FROM foo",
+            SqlDialect::Sqlite,
+        );
+        let projection = select_expr(&lowered);
+        assert_eq!(
+            projection,
+            "json_extract(snapshot_content, '$.\"id\".\"commit_id\"')"
+        );
+    }
+
+    #[test]
+    fn lowers_lix_json_text_to_postgres_jsonb_extract_path_text() {
+        let lowered = lower_query(
+            "SELECT lix_json_text(snapshot_content, 'id', 'commit_id') FROM foo",
+            SqlDialect::Postgres,
+        );
+        let projection = select_expr(&lowered);
+        assert_eq!(
+            projection,
+            "jsonb_extract_path_text(CAST(snapshot_content AS JSONB), 'id', 'commit_id')"
+        );
+    }
+
+    #[test]
+    fn leaves_unrelated_functions_untouched() {
+        let lowered = lower_query("SELECT lix_uuid_v7() FROM foo", SqlDialect::Sqlite);
+        let projection = select_expr(&lowered);
+        assert_eq!(projection, "lix_uuid_v7()");
+    }
+}

--- a/packages/engine/src/sql/mod.rs
+++ b/packages/engine/src/sql/mod.rs
@@ -1,16 +1,19 @@
+mod lowering;
+mod params;
 mod pipeline;
 mod route;
 mod row_resolution;
 mod steps;
 mod types;
 
+pub(crate) use params::{bind_sql, bind_sql_with_state, PlaceholderState};
 #[allow(unused_imports)]
 pub use pipeline::{
     parse_sql_statements, preprocess_sql, preprocess_sql_rewrite_only,
     preprocess_sql_with_provider, preprocess_statements, preprocess_statements_with_provider,
 };
 pub(crate) use row_resolution::{
-    insert_values_rows_mut, materialize_vtable_insert_select_sources, resolve_expr_cell,
+    insert_values_rows_mut, materialize_vtable_insert_select_sources, resolve_expr_cell_with_state,
     resolve_insert_rows, ResolvedCell, RowSourceResolver,
 };
 pub use steps::vtable_write::{build_delete_followup_sql, build_update_followup_sql};

--- a/packages/engine/src/sql/mod.rs
+++ b/packages/engine/src/sql/mod.rs
@@ -1,3 +1,4 @@
+mod escaping;
 mod lowering;
 mod params;
 mod pipeline;
@@ -6,6 +7,7 @@ mod row_resolution;
 mod steps;
 mod types;
 
+pub(crate) use escaping::escape_sql_string;
 pub(crate) use params::{bind_sql, bind_sql_with_state, PlaceholderState};
 #[allow(unused_imports)]
 pub use pipeline::{

--- a/packages/engine/src/sql/params.rs
+++ b/packages/engine/src/sql/params.rs
@@ -1,0 +1,295 @@
+use std::collections::HashMap;
+
+use crate::backend::SqlDialect;
+use crate::{LixError, Value};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct PlaceholderState {
+    next_ordinal: usize,
+}
+
+impl PlaceholderState {
+    pub(crate) fn new() -> Self {
+        Self { next_ordinal: 0 }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BoundSql {
+    pub(crate) sql: String,
+    pub(crate) params: Vec<Value>,
+    pub(crate) state: PlaceholderState,
+}
+
+pub(crate) fn bind_sql(
+    sql: &str,
+    params: &[Value],
+    dialect: SqlDialect,
+) -> Result<BoundSql, LixError> {
+    bind_sql_with_state(sql, params, dialect, PlaceholderState::new())
+}
+
+pub(crate) fn bind_sql_with_state(
+    sql: &str,
+    params: &[Value],
+    dialect: SqlDialect,
+    mut state: PlaceholderState,
+) -> Result<BoundSql, LixError> {
+    let mut output = String::with_capacity(sql.len());
+    let mut used_source_indices = Vec::new();
+    let mut source_to_dense: HashMap<usize, usize> = HashMap::new();
+
+    let bytes = sql.as_bytes();
+    let mut index = 0usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+
+        if in_single_quote {
+            output.push(byte as char);
+            if byte == b'\'' {
+                if index + 1 < bytes.len() && bytes[index + 1] == b'\'' {
+                    output.push('\'');
+                    index += 2;
+                    continue;
+                }
+                in_single_quote = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if in_double_quote {
+            output.push(byte as char);
+            if byte == b'"' {
+                if index + 1 < bytes.len() && bytes[index + 1] == b'"' {
+                    output.push('"');
+                    index += 2;
+                    continue;
+                }
+                in_double_quote = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if byte == b'\'' {
+            in_single_quote = true;
+            output.push('\'');
+            index += 1;
+            continue;
+        }
+        if byte == b'"' {
+            in_double_quote = true;
+            output.push('"');
+            index += 1;
+            continue;
+        }
+
+        if byte == b'?' {
+            let start = index;
+            index += 1;
+            while index < bytes.len() && bytes[index].is_ascii_digit() {
+                index += 1;
+            }
+            let token = &sql[start..index];
+            let source_index = resolve_placeholder_index(token, params.len(), &mut state)?;
+            let dense_index = dense_index_for_source(
+                source_index,
+                &mut source_to_dense,
+                &mut used_source_indices,
+            );
+            output.push_str(&placeholder_for_dialect(dialect, dense_index + 1));
+            continue;
+        }
+
+        if byte == b'$' && index + 1 < bytes.len() && bytes[index + 1].is_ascii_digit() {
+            let start = index;
+            index += 1;
+            while index < bytes.len() && bytes[index].is_ascii_digit() {
+                index += 1;
+            }
+            let token = &sql[start..index];
+            let source_index = resolve_placeholder_index(token, params.len(), &mut state)?;
+            let dense_index = dense_index_for_source(
+                source_index,
+                &mut source_to_dense,
+                &mut used_source_indices,
+            );
+            output.push_str(&placeholder_for_dialect(dialect, dense_index + 1));
+            continue;
+        }
+
+        output.push(byte as char);
+        index += 1;
+    }
+
+    let bound_params = used_source_indices
+        .into_iter()
+        .map(|source_index| params[source_index].clone())
+        .collect();
+
+    Ok(BoundSql {
+        sql: output,
+        params: bound_params,
+        state,
+    })
+}
+
+pub(crate) fn resolve_placeholder_index(
+    token: &str,
+    params_len: usize,
+    state: &mut PlaceholderState,
+) -> Result<usize, LixError> {
+    let trimmed = token.trim();
+
+    let source_index = if trimmed.is_empty() || trimmed == "?" {
+        let source_index = state.next_ordinal;
+        state.next_ordinal += 1;
+        source_index
+    } else if let Some(numeric) = trimmed.strip_prefix('?') {
+        let parsed = parse_1_based_index(trimmed, numeric)?;
+        state.next_ordinal = state.next_ordinal.max(parsed);
+        parsed - 1
+    } else if let Some(numeric) = trimmed.strip_prefix('$') {
+        let parsed = parse_1_based_index(trimmed, numeric)?;
+        state.next_ordinal = state.next_ordinal.max(parsed);
+        parsed - 1
+    } else {
+        return Err(LixError {
+            message: format!("unsupported SQL placeholder format '{trimmed}'"),
+        });
+    };
+
+    if source_index >= params_len {
+        return Err(LixError {
+            message: format!(
+                "placeholder '{trimmed}' references parameter {} but only {} parameters were provided",
+                source_index + 1,
+                params_len
+            ),
+        });
+    }
+
+    Ok(source_index)
+}
+
+fn dense_index_for_source(
+    source_index: usize,
+    source_to_dense: &mut HashMap<usize, usize>,
+    used_source_indices: &mut Vec<usize>,
+) -> usize {
+    if let Some(existing) = source_to_dense.get(&source_index) {
+        return *existing;
+    }
+    let dense_index = used_source_indices.len();
+    used_source_indices.push(source_index);
+    source_to_dense.insert(source_index, dense_index);
+    dense_index
+}
+
+fn placeholder_for_dialect(dialect: SqlDialect, dense_index_1_based: usize) -> String {
+    match dialect {
+        SqlDialect::Sqlite => format!("?{dense_index_1_based}"),
+        SqlDialect::Postgres => format!("${dense_index_1_based}"),
+    }
+}
+
+fn parse_1_based_index(token: &str, numeric: &str) -> Result<usize, LixError> {
+    let parsed = numeric.parse::<usize>().map_err(|_| LixError {
+        message: format!("invalid SQL placeholder '{token}'"),
+    })?;
+    if parsed == 0 {
+        return Err(LixError {
+            message: format!("invalid SQL placeholder '{token}'"),
+        });
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::SqlDialect;
+    use crate::sql::params::{bind_sql, bind_sql_with_state};
+    use crate::Value;
+
+    #[test]
+    fn binds_sqlite_placeholders_with_dense_numbering() {
+        let bound = bind_sql(
+            "SELECT * FROM t WHERE a = ? OR b = ?3 OR c = ?",
+            &[
+                Value::Text("a".to_string()),
+                Value::Text("b".to_string()),
+                Value::Text("c".to_string()),
+                Value::Text("d".to_string()),
+            ],
+            SqlDialect::Sqlite,
+        )
+        .expect("bind should succeed");
+
+        assert_eq!(
+            bound.sql,
+            "SELECT * FROM t WHERE a = ?1 OR b = ?2 OR c = ?3"
+        );
+        assert_eq!(
+            bound.params,
+            vec![
+                Value::Text("a".to_string()),
+                Value::Text("c".to_string()),
+                Value::Text("d".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn binds_postgres_placeholders_and_reuses_explicit_indices() {
+        let bound = bind_sql(
+            "SELECT * FROM t WHERE a = $2 OR b = $2 OR c = $1",
+            &[Value::Integer(10), Value::Integer(20)],
+            SqlDialect::Postgres,
+        )
+        .expect("bind should succeed");
+
+        assert_eq!(
+            bound.sql,
+            "SELECT * FROM t WHERE a = $1 OR b = $1 OR c = $2"
+        );
+        assert_eq!(bound.params, vec![Value::Integer(20), Value::Integer(10)]);
+    }
+
+    #[test]
+    fn bind_with_state_respects_ordinal_progression() {
+        let first = bind_sql(
+            "SELECT ?",
+            &[Value::Integer(1), Value::Integer(2)],
+            SqlDialect::Sqlite,
+        )
+        .expect("bind first");
+        let second = bind_sql_with_state(
+            "SELECT ?",
+            &[Value::Integer(1), Value::Integer(2)],
+            SqlDialect::Sqlite,
+            first.state,
+        )
+        .expect("bind second");
+        assert_eq!(first.sql, "SELECT ?1");
+        assert_eq!(first.params, vec![Value::Integer(1)]);
+        assert_eq!(second.sql, "SELECT ?1");
+        assert_eq!(second.params, vec![Value::Integer(2)]);
+    }
+
+    #[test]
+    fn ignores_placeholders_inside_string_literals() {
+        let bound = bind_sql(
+            "SELECT '$1', \"?\", ? FROM t WHERE x = '$2'",
+            &[Value::Integer(5)],
+            SqlDialect::Postgres,
+        )
+        .expect("bind should succeed");
+
+        assert_eq!(bound.sql, "SELECT '$1', \"?\", $1 FROM t WHERE x = '$2'");
+        assert_eq!(bound.params, vec![Value::Integer(5)]);
+    }
+}

--- a/packages/engine/src/sql/pipeline.rs
+++ b/packages/engine/src/sql/pipeline.rs
@@ -2,9 +2,12 @@ use sqlparser::ast::{Expr, Insert, ObjectName, ObjectNamePart, Query, SetExpr, S
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
+use crate::backend::SqlDialect;
 use crate::cel::CelEvaluator;
 use crate::default_values::apply_vtable_insert_defaults;
 use crate::functions::{LixFunctionProvider, SharedFunctionProvider, SystemFunctionProvider};
+use crate::sql::bind_sql;
+use crate::sql::lowering::lower_statement;
 use crate::sql::materialize_vtable_insert_select_sources;
 use crate::sql::route::{rewrite_statement, rewrite_statement_with_backend};
 use crate::sql::steps::inline_lix_functions::inline_lix_functions_with_provider;
@@ -63,17 +66,8 @@ pub fn preprocess_statements_with_provider<P: LixFunctionProvider>(
         });
     }
 
-    let normalized_sql = rewritten
-        .iter()
-        .map(|statement| statement.to_string())
-        .collect::<Vec<_>>()
-        .join("; ");
-
-    let params = if sql_contains_placeholders(&normalized_sql) {
-        params.to_vec()
-    } else {
-        Vec::new()
-    };
+    let (normalized_sql, params) =
+        render_statements_with_params(&rewritten, params, SqlDialect::Sqlite)?;
 
     Ok(PreprocessOutput {
         sql: normalized_sql,
@@ -110,10 +104,8 @@ async fn preprocess_statements_with_provider_and_backend<P: LixFunctionProvider>
         mutations.extend(output.mutations);
         update_validations.extend(output.update_validations);
         for rewritten_statement in output.statements {
-            rewritten.push(inline_lix_functions_with_provider(
-                rewritten_statement,
-                provider,
-            ));
+            let inlined = inline_lix_functions_with_provider(rewritten_statement, provider);
+            rewritten.push(lower_statement(inlined, backend.dialect())?);
         }
     }
 
@@ -123,17 +115,8 @@ async fn preprocess_statements_with_provider_and_backend<P: LixFunctionProvider>
         });
     }
 
-    let normalized_sql = rewritten
-        .iter()
-        .map(|statement| statement.to_string())
-        .collect::<Vec<_>>()
-        .join("; ");
-
-    let params = if sql_contains_placeholders(&normalized_sql) {
-        params.to_vec()
-    } else {
-        Vec::new()
-    };
+    let (normalized_sql, params) =
+        render_statements_with_params(&rewritten, params, backend.dialect())?;
 
     Ok(PreprocessOutput {
         sql: normalized_sql,
@@ -187,49 +170,33 @@ pub fn preprocess_sql_rewrite_only(sql: &str) -> Result<PreprocessOutput, LixErr
     preprocess_statements(parse_sql_statements(sql)?, &[])
 }
 
-fn sql_contains_placeholders(sql: &str) -> bool {
-    let bytes = sql.as_bytes();
-    let mut i = 0usize;
-    let mut in_single_quoted = false;
+fn render_statements_with_params(
+    statements: &[Statement],
+    params: &[Value],
+    dialect: SqlDialect,
+) -> Result<(String, Vec<Value>), LixError> {
+    let mut rendered = Vec::with_capacity(statements.len());
+    let mut bound_params = Vec::new();
+    let mut statement_with_params_count = 0usize;
 
-    while i < bytes.len() {
-        let byte = bytes[i];
-        if in_single_quoted {
-            if byte == b'\'' {
-                if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
-                    i += 2;
-                    continue;
-                }
-                in_single_quoted = false;
-            }
-            i += 1;
-            continue;
+    for statement in statements {
+        let bound = bind_sql(&statement.to_string(), params, dialect)?;
+        let _placeholder_state = bound.state;
+        if !bound.params.is_empty() {
+            statement_with_params_count += 1;
+            bound_params = bound.params;
         }
-
-        if byte == b'\'' {
-            in_single_quoted = true;
-            i += 1;
-            continue;
-        }
-
-        if byte == b'?' {
-            return true;
-        }
-
-        if byte == b'$' {
-            let mut j = i + 1;
-            while j < bytes.len() && bytes[j].is_ascii_digit() {
-                j += 1;
-            }
-            if j > i + 1 {
-                return true;
-            }
-        }
-
-        i += 1;
+        rendered.push(bound.sql);
     }
 
-    false
+    if statement_with_params_count > 1 || (statement_with_params_count == 1 && statements.len() > 1)
+    {
+        return Err(LixError {
+            message: "multiple statements with placeholders are not supported".to_string(),
+        });
+    }
+
+    Ok((rendered.join("; "), bound_params))
 }
 
 fn coalesce_vtable_inserts_in_transactions(

--- a/packages/engine/src/sql/route.rs
+++ b/packages/engine/src/sql/route.rs
@@ -1,7 +1,10 @@
-use sqlparser::ast::Statement;
+use sqlparser::ast::{Insert, Statement};
 
 use crate::functions::LixFunctionProvider;
-use crate::sql::steps::{stored_schema, vtable_read, vtable_write};
+use crate::sql::steps::{
+    lix_active_version_view_read, lix_active_version_view_write, lix_version_view_read,
+    lix_version_view_write, stored_schema, vtable_read, vtable_write,
+};
 use crate::sql::types::{
     MutationRow, PostprocessPlan, RewriteOutput, SchemaRegistration, UpdateValidationPlan,
 };
@@ -14,6 +17,12 @@ pub fn rewrite_statement<P: LixFunctionProvider>(
 ) -> Result<RewriteOutput, LixError> {
     match statement {
         Statement::Insert(insert) => {
+            if let Some(version_inserts) =
+                lix_version_view_write::rewrite_insert(insert.clone(), params)?
+            {
+                return rewrite_vtable_inserts(version_inserts, params, functions);
+            }
+
             let mut current = Statement::Insert(insert);
             let mut registrations: Vec<SchemaRegistration> = Vec::new();
             let mut statements: Vec<Statement> = Vec::new();
@@ -101,15 +110,20 @@ pub fn rewrite_statement<P: LixFunctionProvider>(
                 }),
             }
         }
-        Statement::Query(query) => Ok(RewriteOutput {
-            statements: vec![vtable_read::rewrite_query(*query.clone())?
-                .map(|rewritten| Statement::Query(Box::new(rewritten)))
-                .unwrap_or_else(|| Statement::Query(query))],
-            registrations: Vec::new(),
-            postprocess: None,
-            mutations: Vec::new(),
-            update_validations: Vec::new(),
-        }),
+        Statement::Query(query) => {
+            let query = *query;
+            let query = lix_version_view_read::rewrite_query(query.clone())?.unwrap_or(query);
+            let query =
+                lix_active_version_view_read::rewrite_query(query.clone())?.unwrap_or(query);
+            let query = vtable_read::rewrite_query(query.clone())?.unwrap_or(query);
+            Ok(RewriteOutput {
+                statements: vec![Statement::Query(Box::new(query))],
+                registrations: Vec::new(),
+                postprocess: None,
+                mutations: Vec::new(),
+                update_validations: Vec::new(),
+            })
+        }
         other => Ok(RewriteOutput {
             statements: vec![other],
             registrations: Vec::new(),
@@ -128,6 +142,19 @@ pub async fn rewrite_statement_with_backend<P: LixFunctionProvider>(
 ) -> Result<RewriteOutput, LixError> {
     match statement {
         Statement::Insert(insert) => {
+            if let Some(version_inserts) =
+                lix_version_view_write::rewrite_insert_with_backend(backend, insert.clone(), params)
+                    .await?
+            {
+                return rewrite_vtable_inserts_with_backend(
+                    backend,
+                    version_inserts,
+                    params,
+                    functions,
+                )
+                .await;
+            }
+
             let mut current = Statement::Insert(insert);
             let mut registrations: Vec<SchemaRegistration> = Vec::new();
             let mut statements: Vec<Statement> = Vec::new();
@@ -168,6 +195,116 @@ pub async fn rewrite_statement_with_backend<P: LixFunctionProvider>(
                 update_validations,
             })
         }
+        Statement::Update(update) => {
+            if let Some(active_version_inserts) =
+                lix_active_version_view_write::rewrite_update_with_backend(
+                    backend,
+                    update.clone(),
+                    params,
+                )
+                .await?
+            {
+                return rewrite_vtable_inserts_with_backend(
+                    backend,
+                    active_version_inserts,
+                    params,
+                    functions,
+                )
+                .await;
+            }
+
+            if let Some(version_inserts) =
+                lix_version_view_write::rewrite_update_with_backend(backend, update.clone(), params)
+                    .await?
+            {
+                return rewrite_vtable_inserts_with_backend(
+                    backend,
+                    version_inserts,
+                    params,
+                    functions,
+                )
+                .await;
+            }
+
+            rewrite_statement(Statement::Update(update), params, functions)
+        }
+        Statement::Delete(delete) => {
+            if let Some(version_inserts) =
+                lix_version_view_write::rewrite_delete_with_backend(backend, delete.clone(), params)
+                    .await?
+            {
+                return rewrite_vtable_inserts_with_backend(
+                    backend,
+                    version_inserts,
+                    params,
+                    functions,
+                )
+                .await;
+            }
+
+            rewrite_statement(Statement::Delete(delete), params, functions)
+        }
         other => rewrite_statement(other, params, functions),
     }
+}
+
+fn rewrite_vtable_inserts<P: LixFunctionProvider>(
+    inserts: Vec<Insert>,
+    params: &[Value],
+    functions: &mut P,
+) -> Result<RewriteOutput, LixError> {
+    let mut statements = Vec::new();
+    let mut registrations = Vec::new();
+    let mut mutations = Vec::new();
+
+    for insert in inserts {
+        let Some(rewritten) = vtable_write::rewrite_insert(insert, params, functions)? else {
+            return Err(LixError {
+                message: "lix_version rewrite expected vtable insert rewrite".to_string(),
+            });
+        };
+        statements.extend(rewritten.statements);
+        registrations.extend(rewritten.registrations);
+        mutations.extend(rewritten.mutations);
+    }
+
+    Ok(RewriteOutput {
+        statements,
+        registrations,
+        postprocess: None,
+        mutations,
+        update_validations: Vec::new(),
+    })
+}
+
+async fn rewrite_vtable_inserts_with_backend<P: LixFunctionProvider>(
+    backend: &dyn LixBackend,
+    inserts: Vec<Insert>,
+    params: &[Value],
+    functions: &mut P,
+) -> Result<RewriteOutput, LixError> {
+    let mut statements = Vec::new();
+    let mut registrations = Vec::new();
+    let mut mutations = Vec::new();
+
+    for insert in inserts {
+        let Some(rewritten) =
+            vtable_write::rewrite_insert_with_backend(backend, insert, params, functions).await?
+        else {
+            return Err(LixError {
+                message: "lix_version rewrite expected backend vtable insert rewrite".to_string(),
+            });
+        };
+        statements.extend(rewritten.statements);
+        registrations.extend(rewritten.registrations);
+        mutations.extend(rewritten.mutations);
+    }
+
+    Ok(RewriteOutput {
+        statements,
+        registrations,
+        postprocess: None,
+        mutations,
+        update_validations: Vec::new(),
+    })
 }

--- a/packages/engine/src/sql/steps/lix_active_account_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_active_account_view_read.rs
@@ -1,0 +1,195 @@
+use sqlparser::ast::{
+    Ident, ObjectName, ObjectNamePart, Query, Select, SetExpr, Statement, TableAlias, TableFactor,
+    TableWithJoins,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::account::{
+    active_account_file_id, active_account_schema_key, active_account_storage_version_id,
+};
+use crate::LixError;
+
+const LIX_ACTIVE_ACCOUNT_VIEW_NAME: &str = "lix_active_account";
+
+pub fn rewrite_query(query: Query) -> Result<Option<Query>, LixError> {
+    if !top_level_select_targets_lix_active_account(&query) {
+        return Ok(None);
+    }
+
+    let mut changed = false;
+    let mut new_query = query.clone();
+    new_query.body = Box::new(rewrite_set_expr(*query.body, &mut changed)?);
+
+    if changed {
+        Ok(Some(new_query))
+    } else {
+        Ok(None)
+    }
+}
+
+fn top_level_select_targets_lix_active_account(query: &Query) -> bool {
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return false;
+    };
+    select
+        .from
+        .iter()
+        .any(table_with_joins_targets_lix_active_account)
+}
+
+fn table_with_joins_targets_lix_active_account(table: &TableWithJoins) -> bool {
+    table_factor_is_lix_active_account(&table.relation)
+        || table
+            .joins
+            .iter()
+            .any(|join| table_factor_is_lix_active_account(&join.relation))
+}
+
+fn table_factor_is_lix_active_account(relation: &TableFactor) -> bool {
+    matches!(
+        relation,
+        TableFactor::Table { name, .. } if object_name_matches(name, LIX_ACTIVE_ACCOUNT_VIEW_NAME)
+    )
+}
+
+fn rewrite_set_expr(expr: SetExpr, changed: &mut bool) -> Result<SetExpr, LixError> {
+    Ok(match expr {
+        SetExpr::Select(select) => {
+            let mut select = *select;
+            rewrite_select(&mut select, changed)?;
+            SetExpr::Select(Box::new(select))
+        }
+        SetExpr::Query(query) => {
+            let mut query = *query;
+            query.body = Box::new(rewrite_set_expr(*query.body, changed)?);
+            SetExpr::Query(Box::new(query))
+        }
+        SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left,
+            right,
+        } => SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left: Box::new(rewrite_set_expr(*left, changed)?),
+            right: Box::new(rewrite_set_expr(*right, changed)?),
+        },
+        other => other,
+    })
+}
+
+fn rewrite_select(select: &mut Select, changed: &mut bool) -> Result<(), LixError> {
+    for table in &mut select.from {
+        rewrite_table_with_joins(table, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_with_joins(
+    table: &mut TableWithJoins,
+    changed: &mut bool,
+) -> Result<(), LixError> {
+    rewrite_table_factor(&mut table.relation, changed)?;
+    for join in &mut table.joins {
+        rewrite_table_factor(&mut join.relation, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_factor(relation: &mut TableFactor, changed: &mut bool) -> Result<(), LixError> {
+    match relation {
+        TableFactor::Table { name, alias, .. }
+            if object_name_matches(name, LIX_ACTIVE_ACCOUNT_VIEW_NAME) =>
+        {
+            let derived_query = build_lix_active_account_view_query()?;
+            let derived_alias = alias
+                .clone()
+                .or_else(|| Some(default_lix_active_account_alias()));
+            *relation = TableFactor::Derived {
+                lateral: false,
+                subquery: Box::new(derived_query),
+                alias: derived_alias,
+            };
+            *changed = true;
+        }
+        TableFactor::Derived { subquery, .. } => {
+            if let Some(rewritten) = rewrite_query((**subquery).clone())? {
+                *subquery = Box::new(rewritten);
+                *changed = true;
+            }
+        }
+        TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => {
+            rewrite_table_with_joins(table_with_joins, changed)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn build_lix_active_account_view_query() -> Result<Query, LixError> {
+    let sql = format!(
+        "SELECT \
+             lix_json_text(snapshot_content, 'account_id') AS account_id, \
+             schema_key, \
+             file_id, \
+             version_id AS lixcol_version_id, \
+             plugin_key, \
+             schema_version, \
+             untracked, \
+             created_at, \
+             updated_at, \
+             change_id AS lixcol_change_id \
+         FROM lix_internal_state_vtable \
+         WHERE schema_key = '{schema_key}' \
+           AND file_id = '{file_id}' \
+           AND version_id = '{storage_version_id}' \
+           AND untracked = 1 \
+           AND snapshot_content IS NOT NULL",
+        schema_key = escape_sql_string(active_account_schema_key()),
+        file_id = escape_sql_string(active_account_file_id()),
+        storage_version_id = escape_sql_string(active_account_storage_version_id()),
+    );
+    parse_single_query(&sql)
+}
+
+fn default_lix_active_account_alias() -> TableAlias {
+    TableAlias {
+        explicit: false,
+        name: Ident::new(LIX_ACTIVE_ACCOUNT_VIEW_NAME),
+        columns: Vec::new(),
+    }
+}
+
+fn parse_single_query(sql: &str) -> Result<Query, LixError> {
+    let mut statements = Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| LixError {
+        message: error.to_string(),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected a single SELECT statement".to_string(),
+        });
+    }
+    let statement = statements.remove(0);
+    match statement {
+        Statement::Query(query) => Ok(*query),
+        _ => Err(LixError {
+            message: "expected SELECT statement".to_string(),
+        }),
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}

--- a/packages/engine/src/sql/steps/lix_active_account_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_active_account_view_read.rs
@@ -8,6 +8,7 @@ use sqlparser::parser::Parser;
 use crate::account::{
     active_account_file_id, active_account_schema_key, active_account_storage_version_id,
 };
+use crate::sql::escape_sql_string;
 use crate::LixError;
 
 const LIX_ACTIVE_ACCOUNT_VIEW_NAME: &str = "lix_active_account";
@@ -188,8 +189,4 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
         .and_then(ObjectNamePart::as_ident)
         .map(|ident| ident.value.eq_ignore_ascii_case(target))
         .unwrap_or(false)
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
 }

--- a/packages/engine/src/sql/steps/lix_active_account_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_active_account_view_write.rs
@@ -13,7 +13,7 @@ use crate::account::{
 };
 use crate::sql::lowering::lower_statement;
 use crate::sql::steps::{lix_active_account_view_read, vtable_read};
-use crate::sql::{bind_sql_with_state, resolve_insert_rows, PlaceholderState};
+use crate::sql::{bind_sql_with_state, escape_sql_string, resolve_insert_rows, PlaceholderState};
 use crate::{LixBackend, LixError, Value as EngineValue};
 
 const LIX_ACTIVE_ACCOUNT_VIEW_NAME: &str = "lix_active_account";
@@ -307,8 +307,4 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
         .and_then(ObjectNamePart::as_ident)
         .map(|ident| ident.value.eq_ignore_ascii_case(target))
         .unwrap_or(false)
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
 }

--- a/packages/engine/src/sql/steps/lix_active_account_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_active_account_view_write.rs
@@ -1,0 +1,314 @@
+use serde_json::Value as JsonValue;
+use sqlparser::ast::{
+    Delete, Expr, Insert, ObjectName, ObjectNamePart, Statement, TableFactor, TableObject,
+    TableWithJoins,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::account::{
+    active_account_file_id, active_account_plugin_key, active_account_schema_key,
+    active_account_schema_version, active_account_snapshot_content,
+    active_account_storage_version_id,
+};
+use crate::sql::lowering::lower_statement;
+use crate::sql::steps::{lix_active_account_view_read, vtable_read};
+use crate::sql::{bind_sql_with_state, resolve_insert_rows, PlaceholderState};
+use crate::{LixBackend, LixError, Value as EngineValue};
+
+const LIX_ACTIVE_ACCOUNT_VIEW_NAME: &str = "lix_active_account";
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+
+#[derive(Debug, Clone)]
+struct InsertRow {
+    entity_id: String,
+    snapshot_content: JsonValue,
+}
+
+pub fn rewrite_insert(
+    insert: Insert,
+    params: &[EngineValue],
+) -> Result<Option<Vec<Insert>>, LixError> {
+    if !table_object_is_lix_active_account(&insert.table) {
+        return Ok(None);
+    }
+    if insert.on.is_some() {
+        return Err(LixError {
+            message: "lix_active_account insert does not support ON CONFLICT".to_string(),
+        });
+    }
+    if insert.columns.is_empty() {
+        return Err(LixError {
+            message: "lix_active_account insert requires explicit columns".to_string(),
+        });
+    }
+
+    let resolved_rows = resolve_insert_rows(&insert, params)?.ok_or_else(|| LixError {
+        message: "lix_active_account insert requires VALUES rows".to_string(),
+    })?;
+    let mut rows = Vec::with_capacity(resolved_rows.len());
+    for resolved_row in resolved_rows {
+        let mut account_id: Option<String> = None;
+
+        for (index, column) in insert.columns.iter().enumerate() {
+            let value = resolved_row
+                .get(index)
+                .and_then(|cell| cell.value.as_ref())
+                .ok_or_else(|| LixError {
+                    message: format!(
+                        "lix_active_account insert '{}' must be literal or parameter",
+                        column.value
+                    ),
+                })?;
+            match column.value.to_ascii_lowercase().as_str() {
+                "account_id" => account_id = Some(value_required_string(value, "account_id")?),
+                other => {
+                    return Err(LixError {
+                        message: format!(
+                            "lix_active_account insert does not support column '{other}'"
+                        ),
+                    })
+                }
+            }
+        }
+
+        let account_id = account_id.ok_or_else(|| LixError {
+            message: "lix_active_account insert requires column 'account_id'".to_string(),
+        })?;
+        if account_id.is_empty() {
+            return Err(LixError {
+                message: "lix_active_account insert requires non-empty account_id".to_string(),
+            });
+        }
+
+        rows.push(InsertRow {
+            entity_id: account_id.clone(),
+            snapshot_content: serde_json::from_str::<JsonValue>(&active_account_snapshot_content(
+                &account_id,
+            ))
+            .map_err(|error| LixError {
+                message: format!("failed to encode active account snapshot: {error}"),
+            })?,
+        });
+    }
+
+    Ok(Some(vec![build_vtable_insert(rows)?]))
+}
+
+pub async fn rewrite_delete_with_backend(
+    backend: &dyn LixBackend,
+    delete: Delete,
+    params: &[EngineValue],
+) -> Result<Option<Statement>, LixError> {
+    if !delete_from_is_lix_active_account(&delete) {
+        return Ok(None);
+    }
+    if delete.using.is_some() {
+        return Err(LixError {
+            message: "lix_active_account delete does not support USING".to_string(),
+        });
+    }
+    if delete.returning.is_some() {
+        return Err(LixError {
+            message: "lix_active_account delete does not support RETURNING".to_string(),
+        });
+    }
+    if !delete.order_by.is_empty() || delete.limit.is_some() {
+        return Err(LixError {
+            message: "lix_active_account delete does not support LIMIT or ORDER BY".to_string(),
+        });
+    }
+
+    let entity_ids =
+        query_entity_ids_for_delete(backend, delete.selection.as_ref(), params).await?;
+    if entity_ids.is_empty() {
+        return Ok(Some(build_noop_delete()?));
+    }
+
+    Ok(Some(build_vtable_delete(entity_ids)?))
+}
+
+fn value_required_string(value: &EngineValue, field: &str) -> Result<String, LixError> {
+    match value {
+        EngineValue::Text(text) => Ok(text.clone()),
+        EngineValue::Null => Err(LixError {
+            message: format!("lix_active_account field '{field}' cannot be NULL"),
+        }),
+        _ => Err(LixError {
+            message: format!("lix_active_account field '{field}' must be a string"),
+        }),
+    }
+}
+
+async fn query_entity_ids_for_delete(
+    backend: &dyn LixBackend,
+    selection: Option<&Expr>,
+    params: &[EngineValue],
+) -> Result<Vec<String>, LixError> {
+    let mut sql = "SELECT account_id FROM lix_active_account".to_string();
+    if let Some(selection) = selection {
+        sql.push_str(" WHERE ");
+        sql.push_str(&selection.to_string());
+    }
+
+    let mut statements = Parser::parse_sql(&GenericDialect {}, &sql).map_err(|error| LixError {
+        message: format!("failed to parse lix_active_account row loader query: {error}"),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected a single SELECT statement while querying lix_active_account rows"
+                .to_string(),
+        });
+    }
+    let statement = statements.remove(0);
+    let Statement::Query(query) = statement else {
+        return Err(LixError {
+            message: "lix_active_account row loader query must be SELECT".to_string(),
+        });
+    };
+
+    let query = *query;
+    let query = lix_active_account_view_read::rewrite_query(query.clone())?.unwrap_or(query);
+    let query = vtable_read::rewrite_query(query.clone())?.unwrap_or(query);
+    let lowered = lower_statement(Statement::Query(Box::new(query)), backend.dialect())?;
+    let Statement::Query(lowered_query) = lowered else {
+        return Err(LixError {
+            message: "lix_active_account row loader rewrite expected query statement".to_string(),
+        });
+    };
+    let bound = bind_sql_with_state(
+        &lowered_query.to_string(),
+        params,
+        backend.dialect(),
+        PlaceholderState::new(),
+    )?;
+    let result = backend.execute(&bound.sql, &bound.params).await?;
+
+    let mut entity_ids = Vec::with_capacity(result.rows.len());
+    for row in result.rows {
+        if row.len() != 1 {
+            return Err(LixError {
+                message: "lix_active_account rewrite expected 1 column from row loader query"
+                    .to_string(),
+            });
+        }
+        entity_ids.push(value_required_string(&row[0], "account_id")?);
+    }
+    Ok(entity_ids)
+}
+
+fn build_vtable_insert(rows: Vec<InsertRow>) -> Result<Insert, LixError> {
+    let values = rows
+        .iter()
+        .map(|row| {
+            format!(
+                "('{entity_id}', '{schema_key}', '{file_id}', '{version_id}', '{plugin_key}', '{snapshot_content}', '{schema_version}', 1)",
+                entity_id = escape_sql_string(&row.entity_id),
+                schema_key = escape_sql_string(active_account_schema_key()),
+                file_id = escape_sql_string(active_account_file_id()),
+                version_id = escape_sql_string(active_account_storage_version_id()),
+                plugin_key = escape_sql_string(active_account_plugin_key()),
+                snapshot_content = escape_sql_string(&row.snapshot_content.to_string()),
+                schema_version = escape_sql_string(active_account_schema_version()),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "INSERT INTO {vtable} \
+         (entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, untracked) \
+         VALUES {values}",
+        vtable = VTABLE_NAME,
+        values = values,
+    );
+    parse_insert(
+        &sql,
+        "lix_active_account rewrite expected generated INSERT statement",
+    )
+}
+
+fn build_vtable_delete(entity_ids: Vec<String>) -> Result<Statement, LixError> {
+    let in_values = entity_ids
+        .iter()
+        .map(|entity_id| format!("'{}'", escape_sql_string(entity_id)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "DELETE FROM {vtable} \
+         WHERE schema_key = '{schema_key}' \
+           AND file_id = '{file_id}' \
+           AND version_id = '{version_id}' \
+           AND untracked = 1 \
+           AND entity_id IN ({in_values})",
+        vtable = VTABLE_NAME,
+        schema_key = escape_sql_string(active_account_schema_key()),
+        file_id = escape_sql_string(active_account_file_id()),
+        version_id = escape_sql_string(active_account_storage_version_id()),
+    );
+    parse_statement(
+        &sql,
+        "lix_active_account rewrite expected generated DELETE statement",
+    )
+}
+
+fn build_noop_delete() -> Result<Statement, LixError> {
+    parse_statement(
+        &format!("DELETE FROM {VTABLE_NAME} WHERE 1 = 0"),
+        "lix_active_account rewrite expected generated no-op DELETE statement",
+    )
+}
+
+fn parse_insert(sql: &str, error_message: &str) -> Result<Insert, LixError> {
+    let statement = parse_statement(sql, error_message)?;
+    match statement {
+        Statement::Insert(insert) => Ok(insert),
+        _ => Err(LixError {
+            message: error_message.to_string(),
+        }),
+    }
+}
+
+fn parse_statement(sql: &str, error_message: &str) -> Result<Statement, LixError> {
+    let mut statements = Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| LixError {
+        message: format!("failed to build lix_active_account rewrite statement: {error}"),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: error_message.to_string(),
+        });
+    }
+    Ok(statements.remove(0))
+}
+
+fn table_object_is_lix_active_account(table: &TableObject) -> bool {
+    matches!(table, TableObject::TableName(name) if object_name_matches(name, LIX_ACTIVE_ACCOUNT_VIEW_NAME))
+}
+
+fn delete_from_is_lix_active_account(delete: &Delete) -> bool {
+    match &delete.from {
+        sqlparser::ast::FromTable::WithFromKeyword(tables)
+        | sqlparser::ast::FromTable::WithoutKeyword(tables) => {
+            tables.len() == 1 && table_with_joins_is_lix_active_account(&tables[0])
+        }
+    }
+}
+
+fn table_with_joins_is_lix_active_account(table: &TableWithJoins) -> bool {
+    table.joins.is_empty()
+        && matches!(
+            &table.relation,
+            TableFactor::Table { name, .. } if object_name_matches(name, LIX_ACTIVE_ACCOUNT_VIEW_NAME)
+        )
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}

--- a/packages/engine/src/sql/steps/lix_active_version_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_active_version_view_read.rs
@@ -1,0 +1,195 @@
+use sqlparser::ast::{
+    Ident, ObjectName, ObjectNamePart, Query, Select, SetExpr, Statement, TableAlias, TableFactor,
+    TableWithJoins,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::version::{
+    active_version_file_id, active_version_schema_key, active_version_storage_version_id,
+};
+use crate::LixError;
+
+const LIX_ACTIVE_VERSION_VIEW_NAME: &str = "lix_active_version";
+
+pub fn rewrite_query(query: Query) -> Result<Option<Query>, LixError> {
+    if !top_level_select_targets_lix_active_version(&query) {
+        return Ok(None);
+    }
+
+    let mut changed = false;
+    let mut new_query = query.clone();
+    new_query.body = Box::new(rewrite_set_expr(*query.body, &mut changed)?);
+
+    if changed {
+        Ok(Some(new_query))
+    } else {
+        Ok(None)
+    }
+}
+
+fn top_level_select_targets_lix_active_version(query: &Query) -> bool {
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return false;
+    };
+    select
+        .from
+        .iter()
+        .any(table_with_joins_targets_lix_active_version)
+}
+
+fn table_with_joins_targets_lix_active_version(table: &TableWithJoins) -> bool {
+    table_factor_is_lix_active_version(&table.relation)
+        || table
+            .joins
+            .iter()
+            .any(|join| table_factor_is_lix_active_version(&join.relation))
+}
+
+fn table_factor_is_lix_active_version(relation: &TableFactor) -> bool {
+    matches!(
+        relation,
+        TableFactor::Table { name, .. } if object_name_matches(name, LIX_ACTIVE_VERSION_VIEW_NAME)
+    )
+}
+
+fn rewrite_set_expr(expr: SetExpr, changed: &mut bool) -> Result<SetExpr, LixError> {
+    Ok(match expr {
+        SetExpr::Select(select) => {
+            let mut select = *select;
+            rewrite_select(&mut select, changed)?;
+            SetExpr::Select(Box::new(select))
+        }
+        SetExpr::Query(query) => {
+            let mut query = *query;
+            query.body = Box::new(rewrite_set_expr(*query.body, changed)?);
+            SetExpr::Query(Box::new(query))
+        }
+        SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left,
+            right,
+        } => SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left: Box::new(rewrite_set_expr(*left, changed)?),
+            right: Box::new(rewrite_set_expr(*right, changed)?),
+        },
+        other => other,
+    })
+}
+
+fn rewrite_select(select: &mut Select, changed: &mut bool) -> Result<(), LixError> {
+    for table in &mut select.from {
+        rewrite_table_with_joins(table, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_with_joins(
+    table: &mut TableWithJoins,
+    changed: &mut bool,
+) -> Result<(), LixError> {
+    rewrite_table_factor(&mut table.relation, changed)?;
+    for join in &mut table.joins {
+        rewrite_table_factor(&mut join.relation, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_factor(relation: &mut TableFactor, changed: &mut bool) -> Result<(), LixError> {
+    match relation {
+        TableFactor::Table { name, alias, .. }
+            if object_name_matches(name, LIX_ACTIVE_VERSION_VIEW_NAME) =>
+        {
+            let derived_query = build_lix_active_version_view_query()?;
+            let derived_alias = alias
+                .clone()
+                .or_else(|| Some(default_lix_active_version_alias()));
+            *relation = TableFactor::Derived {
+                lateral: false,
+                subquery: Box::new(derived_query),
+                alias: derived_alias,
+            };
+            *changed = true;
+        }
+        TableFactor::Derived { subquery, .. } => {
+            if let Some(rewritten) = rewrite_query((**subquery).clone())? {
+                *subquery = Box::new(rewritten);
+                *changed = true;
+            }
+        }
+        TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => {
+            rewrite_table_with_joins(table_with_joins, changed)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn build_lix_active_version_view_query() -> Result<Query, LixError> {
+    let sql = format!(
+        "SELECT \
+             entity_id AS id, \
+             lix_json_text(snapshot_content, 'version_id') AS version_id, \
+             schema_key, \
+             file_id, \
+             version_id AS lixcol_version_id, \
+             schema_version, \
+             untracked, \
+             created_at, \
+             updated_at, \
+             change_id \
+         FROM lix_internal_state_vtable \
+         WHERE schema_key = '{schema_key}' \
+           AND file_id = '{file_id}' \
+           AND version_id = '{storage_version_id}' \
+           AND untracked = 1 \
+           AND snapshot_content IS NOT NULL",
+        schema_key = escape_sql_string(active_version_schema_key()),
+        file_id = escape_sql_string(active_version_file_id()),
+        storage_version_id = escape_sql_string(active_version_storage_version_id()),
+    );
+    parse_single_query(&sql)
+}
+
+fn default_lix_active_version_alias() -> TableAlias {
+    TableAlias {
+        explicit: false,
+        name: Ident::new(LIX_ACTIVE_VERSION_VIEW_NAME),
+        columns: Vec::new(),
+    }
+}
+
+fn parse_single_query(sql: &str) -> Result<Query, LixError> {
+    let mut statements = Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| LixError {
+        message: error.to_string(),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected a single SELECT statement".to_string(),
+        });
+    }
+    let statement = statements.remove(0);
+    match statement {
+        Statement::Query(query) => Ok(*query),
+        _ => Err(LixError {
+            message: "expected SELECT statement".to_string(),
+        }),
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}

--- a/packages/engine/src/sql/steps/lix_active_version_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_active_version_view_read.rs
@@ -5,6 +5,7 @@ use sqlparser::ast::{
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
+use crate::sql::escape_sql_string;
 use crate::version::{
     active_version_file_id, active_version_schema_key, active_version_storage_version_id,
 };
@@ -188,8 +189,4 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
         .and_then(ObjectNamePart::as_ident)
         .map(|ident| ident.value.eq_ignore_ascii_case(target))
         .unwrap_or(false)
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
 }

--- a/packages/engine/src/sql/steps/lix_active_version_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_active_version_view_write.rs
@@ -1,0 +1,314 @@
+use serde_json::Value as JsonValue;
+use sqlparser::ast::{
+    Assignment, AssignmentTarget, Expr, Insert, ObjectName, ObjectNamePart, Statement, TableFactor,
+    TableWithJoins, Update,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::sql::lowering::lower_statement;
+use crate::sql::steps::{lix_active_version_view_read, vtable_read};
+use crate::sql::{bind_sql_with_state, resolve_expr_cell_with_state, PlaceholderState};
+use crate::version::{
+    active_version_file_id, active_version_plugin_key, active_version_schema_key,
+    active_version_schema_version, active_version_snapshot_content,
+    active_version_storage_version_id,
+};
+use crate::{LixBackend, LixError, Value as EngineValue};
+
+const LIX_ACTIVE_VERSION_VIEW_NAME: &str = "lix_active_version";
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+const VERSION_DESCRIPTOR_TABLE: &str = "lix_internal_state_materialized_v1_lix_version_descriptor";
+
+#[derive(Debug, Clone)]
+struct ActiveVersionRow {
+    id: String,
+}
+
+#[derive(Debug, Clone)]
+struct UpdateAssignments {
+    version_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct InsertSnapshotRow {
+    entity_id: String,
+    snapshot_content: JsonValue,
+}
+
+pub async fn rewrite_update_with_backend(
+    backend: &dyn LixBackend,
+    update: Update,
+    params: &[EngineValue],
+) -> Result<Option<Vec<Insert>>, LixError> {
+    if !table_with_joins_is_lix_active_version(&update.table) {
+        return Ok(None);
+    }
+    if update.from.is_some() {
+        return Err(LixError {
+            message: "lix_active_version update does not support FROM".to_string(),
+        });
+    }
+    if update.returning.is_some() {
+        return Err(LixError {
+            message: "lix_active_version update does not support RETURNING".to_string(),
+        });
+    }
+
+    let mut placeholder_state = PlaceholderState::new();
+    let assignments =
+        parse_update_assignments(&update.assignments, params, &mut placeholder_state)?;
+    ensure_version_descriptor_exists(backend, &assignments.version_id).await?;
+
+    let existing_rows = query_lix_active_version_rows(
+        backend,
+        update.selection.as_ref(),
+        params,
+        placeholder_state,
+    )
+    .await?;
+    if existing_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let insert_rows = existing_rows
+        .into_iter()
+        .map(|row| {
+            let snapshot_content = serde_json::from_str::<JsonValue>(
+                &active_version_snapshot_content(&row.id, &assignments.version_id),
+            )
+            .map_err(|error| LixError {
+                message: format!("failed to encode active version snapshot: {error}"),
+            })?;
+            Ok(InsertSnapshotRow {
+                entity_id: row.id,
+                snapshot_content,
+            })
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+
+    Ok(Some(vec![build_vtable_insert(insert_rows)?]))
+}
+
+fn parse_update_assignments(
+    assignments: &[Assignment],
+    params: &[EngineValue],
+    placeholder_state: &mut PlaceholderState,
+) -> Result<UpdateAssignments, LixError> {
+    let mut version_id: Option<String> = None;
+    for assignment in assignments {
+        let column = assignment_target_column(&assignment.target).ok_or_else(|| LixError {
+            message: "lix_active_version update requires single-column assignments".to_string(),
+        })?;
+        let resolved = resolve_expr_cell_with_state(&assignment.value, params, placeholder_state)?;
+        let value = resolved.value.as_ref().ok_or_else(|| LixError {
+            message: format!(
+                "lix_active_version update assignment for '{column}' must be literal or parameter"
+            ),
+        })?;
+        match column.as_str() {
+            "id" => {
+                return Err(LixError {
+                    message: "lix_active_version update cannot modify id".to_string(),
+                })
+            }
+            "version_id" => {
+                let next_value = value_required_string(value, "version_id")?;
+                if next_value.is_empty() {
+                    return Err(LixError {
+                        message: "lix_active_version update cannot set empty version_id"
+                            .to_string(),
+                    });
+                }
+                version_id = Some(next_value);
+            }
+            _ => {
+                return Err(LixError {
+                    message: format!(
+                        "lix_active_version update does not support column '{column}'"
+                    ),
+                })
+            }
+        }
+    }
+
+    let version_id = version_id.ok_or_else(|| LixError {
+        message: "lix_active_version update must set version_id".to_string(),
+    })?;
+
+    Ok(UpdateAssignments { version_id })
+}
+
+fn value_required_string(value: &EngineValue, field: &str) -> Result<String, LixError> {
+    match value {
+        EngineValue::Text(text) => Ok(text.clone()),
+        EngineValue::Null => Err(LixError {
+            message: format!("lix_active_version field '{field}' cannot be NULL"),
+        }),
+        _ => Err(LixError {
+            message: format!("lix_active_version field '{field}' must be a string"),
+        }),
+    }
+}
+
+async fn ensure_version_descriptor_exists(
+    backend: &dyn LixBackend,
+    version_id: &str,
+) -> Result<(), LixError> {
+    let result = backend
+        .execute(
+            &format!(
+                "SELECT 1 \
+                 FROM {table} \
+                 WHERE entity_id = $1 \
+                   AND is_tombstone = 0 \
+                   AND snapshot_content IS NOT NULL \
+                 LIMIT 1",
+                table = VERSION_DESCRIPTOR_TABLE,
+            ),
+            &[EngineValue::Text(version_id.to_string())],
+        )
+        .await?;
+
+    if result.rows.is_empty() {
+        return Err(LixError {
+            message: format!(
+                "Foreign key constraint violation: lix_active_version.version_id '{}' references missing lix_version_descriptor.id",
+                version_id
+            ),
+        });
+    }
+    Ok(())
+}
+
+async fn query_lix_active_version_rows(
+    backend: &dyn LixBackend,
+    selection: Option<&Expr>,
+    params: &[EngineValue],
+    placeholder_state: PlaceholderState,
+) -> Result<Vec<ActiveVersionRow>, LixError> {
+    let mut sql = "SELECT id FROM lix_active_version".to_string();
+    if let Some(selection) = selection {
+        sql.push_str(" WHERE ");
+        sql.push_str(&selection.to_string());
+    }
+
+    let mut statements = Parser::parse_sql(&GenericDialect {}, &sql).map_err(|error| LixError {
+        message: format!("failed to parse lix_active_version row loader query: {error}"),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected a single SELECT statement while querying lix_active_version rows"
+                .to_string(),
+        });
+    }
+    let statement = statements.remove(0);
+    let Statement::Query(query) = statement else {
+        return Err(LixError {
+            message: "lix_active_version row loader query must be SELECT".to_string(),
+        });
+    };
+
+    let query = *query;
+    let query = lix_active_version_view_read::rewrite_query(query.clone())?.unwrap_or(query);
+    let query = vtable_read::rewrite_query(query.clone())?.unwrap_or(query);
+    let lowered = lower_statement(Statement::Query(Box::new(query)), backend.dialect())?;
+    let Statement::Query(lowered_query) = lowered else {
+        return Err(LixError {
+            message: "lix_active_version row loader rewrite expected query statement".to_string(),
+        });
+    };
+    let bound = bind_sql_with_state(
+        &lowered_query.to_string(),
+        params,
+        backend.dialect(),
+        placeholder_state,
+    )?;
+    let result = backend.execute(&bound.sql, &bound.params).await?;
+
+    let mut rows = Vec::with_capacity(result.rows.len());
+    for row in result.rows {
+        if row.len() != 1 {
+            return Err(LixError {
+                message: "lix_active_version rewrite expected 1 column from row loader query"
+                    .to_string(),
+            });
+        }
+        rows.push(ActiveVersionRow {
+            id: value_required_string(&row[0], "id")?,
+        });
+    }
+    Ok(rows)
+}
+
+fn build_vtable_insert(rows: Vec<InsertSnapshotRow>) -> Result<Insert, LixError> {
+    let values = rows
+        .iter()
+        .map(|row| {
+            format!(
+                "('{entity_id}', '{schema_key}', '{file_id}', '{storage_version_id}', '{plugin_key}', '{snapshot_content}', '{schema_version}', 1)",
+                entity_id = escape_sql_string(&row.entity_id),
+                schema_key = escape_sql_string(active_version_schema_key()),
+                file_id = escape_sql_string(active_version_file_id()),
+                storage_version_id = escape_sql_string(active_version_storage_version_id()),
+                plugin_key = escape_sql_string(active_version_plugin_key()),
+                snapshot_content = escape_sql_string(&row.snapshot_content.to_string()),
+                schema_version = escape_sql_string(active_version_schema_version()),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "INSERT INTO {vtable} \
+         (entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, untracked) \
+         VALUES {values}",
+        vtable = VTABLE_NAME,
+        values = values,
+    );
+    let mut statements = Parser::parse_sql(&GenericDialect {}, &sql).map_err(|error| LixError {
+        message: format!("failed to build vtable insert for lix_active_version rewrite: {error}"),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "lix_active_version rewrite expected one INSERT statement".to_string(),
+        });
+    }
+    let statement = statements.remove(0);
+    match statement {
+        Statement::Insert(insert) => Ok(insert),
+        _ => Err(LixError {
+            message: "lix_active_version rewrite expected generated INSERT statement".to_string(),
+        }),
+    }
+}
+
+fn assignment_target_column(target: &AssignmentTarget) -> Option<String> {
+    match target {
+        AssignmentTarget::ColumnName(name) => name
+            .0
+            .last()
+            .and_then(ObjectNamePart::as_ident)
+            .map(|ident| ident.value.to_ascii_lowercase()),
+        AssignmentTarget::Tuple(_) => None,
+    }
+}
+
+fn table_with_joins_is_lix_active_version(table: &TableWithJoins) -> bool {
+    table.joins.is_empty()
+        && matches!(
+            &table.relation,
+            TableFactor::Table { name, .. } if object_name_matches(name, LIX_ACTIVE_VERSION_VIEW_NAME)
+        )
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}

--- a/packages/engine/src/sql/steps/lix_active_version_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_active_version_view_write.rs
@@ -8,7 +8,9 @@ use sqlparser::parser::Parser;
 
 use crate::sql::lowering::lower_statement;
 use crate::sql::steps::{lix_active_version_view_read, vtable_read};
-use crate::sql::{bind_sql_with_state, resolve_expr_cell_with_state, PlaceholderState};
+use crate::sql::{
+    bind_sql_with_state, escape_sql_string, resolve_expr_cell_with_state, PlaceholderState,
+};
 use crate::version::{
     active_version_file_id, active_version_plugin_key, active_version_schema_key,
     active_version_schema_version, active_version_snapshot_content,
@@ -307,8 +309,4 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
         .and_then(ObjectNamePart::as_ident)
         .map(|ident| ident.value.eq_ignore_ascii_case(target))
         .unwrap_or(false)
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
 }

--- a/packages/engine/src/sql/steps/lix_state_by_version_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_state_by_version_view_read.rs
@@ -1,0 +1,150 @@
+use sqlparser::ast::{
+    BinaryOperator, Expr, Ident, ObjectName, ObjectNamePart, Query, Select, SetExpr, TableFactor,
+    TableWithJoins,
+};
+
+use crate::LixError;
+
+const LIX_STATE_BY_VERSION_VIEW_NAME: &str = "lix_state_by_version";
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+
+pub fn rewrite_query(query: Query) -> Result<Option<Query>, LixError> {
+    if !top_level_select_targets_lix_state_by_version(&query) {
+        return Ok(None);
+    }
+
+    let mut changed = false;
+    let mut new_query = query.clone();
+    new_query.body = Box::new(rewrite_set_expr(*query.body, &mut changed)?);
+
+    if changed {
+        Ok(Some(new_query))
+    } else {
+        Ok(None)
+    }
+}
+
+fn top_level_select_targets_lix_state_by_version(query: &Query) -> bool {
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return false;
+    };
+    select
+        .from
+        .iter()
+        .any(table_with_joins_targets_lix_state_by_version)
+}
+
+fn table_with_joins_targets_lix_state_by_version(table: &TableWithJoins) -> bool {
+    table_factor_is_lix_state_by_version(&table.relation)
+        || table
+            .joins
+            .iter()
+            .any(|join| table_factor_is_lix_state_by_version(&join.relation))
+}
+
+fn table_factor_is_lix_state_by_version(relation: &TableFactor) -> bool {
+    matches!(
+        relation,
+        TableFactor::Table { name, .. } if object_name_matches(name, LIX_STATE_BY_VERSION_VIEW_NAME)
+    )
+}
+
+fn rewrite_set_expr(expr: SetExpr, changed: &mut bool) -> Result<SetExpr, LixError> {
+    Ok(match expr {
+        SetExpr::Select(select) => {
+            let mut select = *select;
+            rewrite_select(&mut select, changed)?;
+            SetExpr::Select(Box::new(select))
+        }
+        SetExpr::Query(query) => {
+            let mut query = *query;
+            query.body = Box::new(rewrite_set_expr(*query.body, changed)?);
+            SetExpr::Query(Box::new(query))
+        }
+        SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left,
+            right,
+        } => SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left: Box::new(rewrite_set_expr(*left, changed)?),
+            right: Box::new(rewrite_set_expr(*right, changed)?),
+        },
+        other => other,
+    })
+}
+
+fn rewrite_select(select: &mut Select, changed: &mut bool) -> Result<(), LixError> {
+    let mut has_state_target = false;
+    for table in &mut select.from {
+        if rewrite_table_with_joins(table, changed)? {
+            has_state_target = true;
+        }
+    }
+
+    if !has_state_target {
+        return Ok(());
+    }
+
+    let visible_predicate = snapshot_not_null_predicate_expr();
+    select.selection = Some(match select.selection.take() {
+        Some(existing) => Expr::BinaryOp {
+            left: Box::new(existing),
+            op: BinaryOperator::And,
+            right: Box::new(visible_predicate),
+        },
+        None => visible_predicate,
+    });
+    *changed = true;
+    Ok(())
+}
+
+fn rewrite_table_with_joins(
+    table: &mut TableWithJoins,
+    changed: &mut bool,
+) -> Result<bool, LixError> {
+    let mut rewrote_target = rewrite_table_factor(&mut table.relation, changed)?;
+    for join in &mut table.joins {
+        if rewrite_table_factor(&mut join.relation, changed)? {
+            rewrote_target = true;
+        }
+    }
+    Ok(rewrote_target)
+}
+
+fn rewrite_table_factor(relation: &mut TableFactor, changed: &mut bool) -> Result<bool, LixError> {
+    match relation {
+        TableFactor::Table { name, .. }
+            if object_name_matches(name, LIX_STATE_BY_VERSION_VIEW_NAME) =>
+        {
+            *name = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(VTABLE_NAME))]);
+            *changed = true;
+            Ok(true)
+        }
+        TableFactor::Derived { subquery, .. } => {
+            if let Some(rewritten) = rewrite_query((**subquery).clone())? {
+                *subquery = Box::new(rewritten);
+                *changed = true;
+            }
+            Ok(false)
+        }
+        TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => rewrite_table_with_joins(table_with_joins, changed),
+        _ => Ok(false),
+    }
+}
+
+fn snapshot_not_null_predicate_expr() -> Expr {
+    Expr::IsNotNull(Box::new(Expr::Identifier(Ident::new("snapshot_content"))))
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}

--- a/packages/engine/src/sql/steps/lix_state_by_version_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_state_by_version_view_write.rs
@@ -1,0 +1,220 @@
+use sqlparser::ast::{
+    AssignmentTarget, BinaryOperator, Delete, Expr, FromTable, Ident, Insert, ObjectName,
+    ObjectNamePart, TableFactor, TableObject, TableWithJoins, Update,
+};
+
+use crate::LixError;
+
+const LIX_STATE_BY_VERSION_VIEW_NAME: &str = "lix_state_by_version";
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+
+pub fn rewrite_insert(mut insert: Insert) -> Result<Option<Insert>, LixError> {
+    if !table_object_is_lix_state_by_version(&insert.table) {
+        return Ok(None);
+    }
+    if insert.on.is_some() {
+        return Err(LixError {
+            message: "lix_state_by_version insert does not support ON CONFLICT".to_string(),
+        });
+    }
+    if insert.columns.is_empty() {
+        return Err(LixError {
+            message: "lix_state_by_version insert requires explicit columns".to_string(),
+        });
+    }
+    if insert.columns.iter().any(|column| {
+        column
+            .value
+            .eq_ignore_ascii_case("inherited_from_version_id")
+    }) {
+        return Err(LixError {
+            message:
+                "lix_state_by_version insert cannot set inherited_from_version_id; it is computed"
+                    .to_string(),
+        });
+    }
+    if !insert
+        .columns
+        .iter()
+        .any(|column| column.value.eq_ignore_ascii_case("version_id"))
+    {
+        return Err(LixError {
+            message: "lix_state_by_version insert requires version_id".to_string(),
+        });
+    }
+
+    insert.table = TableObject::TableName(ObjectName(vec![ObjectNamePart::Identifier(
+        Ident::new(VTABLE_NAME),
+    )]));
+    Ok(Some(insert))
+}
+
+pub fn rewrite_update(mut update: Update) -> Result<Option<Update>, LixError> {
+    if !table_with_joins_is_lix_state_by_version(&update.table) {
+        return Ok(None);
+    }
+    if update.assignments.iter().any(|assignment| {
+        assignment_target_is_column(&assignment.target, "inherited_from_version_id")
+    }) {
+        return Err(LixError {
+            message:
+                "lix_state_by_version update cannot set inherited_from_version_id; it is computed"
+                    .to_string(),
+        });
+    }
+
+    let Some(existing_selection) = update.selection.take() else {
+        return Err(LixError {
+            message: "lix_state_by_version update requires a version_id predicate".to_string(),
+        });
+    };
+    if !contains_column_reference(&existing_selection, "version_id") {
+        return Err(LixError {
+            message: "lix_state_by_version update requires a version_id predicate".to_string(),
+        });
+    }
+
+    replace_table_with_vtable(&mut update.table)?;
+    update.selection = Some(Expr::BinaryOp {
+        left: Box::new(existing_selection),
+        op: BinaryOperator::And,
+        right: Box::new(snapshot_not_null_predicate_expr()),
+    });
+    Ok(Some(update))
+}
+
+pub fn rewrite_delete(mut delete: Delete) -> Result<Option<Delete>, LixError> {
+    if !delete_from_is_lix_state_by_version(&delete) {
+        return Ok(None);
+    }
+
+    let Some(existing_selection) = delete.selection.take() else {
+        return Err(LixError {
+            message: "lix_state_by_version delete requires a version_id predicate".to_string(),
+        });
+    };
+    if !contains_column_reference(&existing_selection, "version_id") {
+        return Err(LixError {
+            message: "lix_state_by_version delete requires a version_id predicate".to_string(),
+        });
+    }
+
+    replace_delete_from_vtable(&mut delete)?;
+    delete.selection = Some(Expr::BinaryOp {
+        left: Box::new(existing_selection),
+        op: BinaryOperator::And,
+        right: Box::new(snapshot_not_null_predicate_expr()),
+    });
+    Ok(Some(delete))
+}
+
+fn snapshot_not_null_predicate_expr() -> Expr {
+    Expr::IsNotNull(Box::new(Expr::Identifier(Ident::new("snapshot_content"))))
+}
+
+fn table_object_is_lix_state_by_version(table: &TableObject) -> bool {
+    match table {
+        TableObject::TableName(name) => object_name_matches(name, LIX_STATE_BY_VERSION_VIEW_NAME),
+        _ => false,
+    }
+}
+
+fn table_with_joins_is_lix_state_by_version(table: &TableWithJoins) -> bool {
+    table.joins.is_empty()
+        && matches!(
+            &table.relation,
+            TableFactor::Table { name, .. } if object_name_matches(name, LIX_STATE_BY_VERSION_VIEW_NAME)
+        )
+}
+
+fn delete_from_is_lix_state_by_version(delete: &Delete) -> bool {
+    match &delete.from {
+        FromTable::WithFromKeyword(tables) | FromTable::WithoutKeyword(tables) => {
+            tables.len() == 1 && table_with_joins_is_lix_state_by_version(&tables[0])
+        }
+    }
+}
+
+fn replace_table_with_vtable(table: &mut TableWithJoins) -> Result<(), LixError> {
+    if !table.joins.is_empty() {
+        return Err(LixError {
+            message: "lix_state_by_version mutation does not support JOIN targets".to_string(),
+        });
+    }
+    match &mut table.relation {
+        TableFactor::Table { name, .. } => {
+            *name = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(VTABLE_NAME))]);
+            Ok(())
+        }
+        _ => Err(LixError {
+            message: "lix_state_by_version mutation requires table target".to_string(),
+        }),
+    }
+}
+
+fn replace_delete_from_vtable(delete: &mut Delete) -> Result<(), LixError> {
+    let tables = match &mut delete.from {
+        FromTable::WithFromKeyword(tables) | FromTable::WithoutKeyword(tables) => tables,
+    };
+    let Some(table) = tables.first_mut() else {
+        return Err(LixError {
+            message: "lix_state_by_version delete requires table target".to_string(),
+        });
+    };
+    replace_table_with_vtable(table)
+}
+
+fn assignment_target_is_column(target: &AssignmentTarget, name: &str) -> bool {
+    match target {
+        AssignmentTarget::ColumnName(object_name) => object_name
+            .0
+            .last()
+            .and_then(ObjectNamePart::as_ident)
+            .map(|ident| ident.value.eq_ignore_ascii_case(name))
+            .unwrap_or(false),
+        AssignmentTarget::Tuple(_) => false,
+    }
+}
+
+fn contains_column_reference(expr: &Expr, column: &str) -> bool {
+    match expr {
+        Expr::Identifier(ident) => ident.value.eq_ignore_ascii_case(column),
+        Expr::CompoundIdentifier(idents) => idents
+            .last()
+            .map(|ident| ident.value.eq_ignore_ascii_case(column))
+            .unwrap_or(false),
+        Expr::BinaryOp { left, right, .. } => {
+            contains_column_reference(left, column) || contains_column_reference(right, column)
+        }
+        Expr::UnaryOp { expr, .. } => contains_column_reference(expr, column),
+        Expr::Nested(inner) => contains_column_reference(inner, column),
+        Expr::InList { expr, list, .. } => {
+            contains_column_reference(expr, column)
+                || list
+                    .iter()
+                    .any(|item| contains_column_reference(item, column))
+        }
+        Expr::Between {
+            expr, low, high, ..
+        } => {
+            contains_column_reference(expr, column)
+                || contains_column_reference(low, column)
+                || contains_column_reference(high, column)
+        }
+        Expr::Like { expr, pattern, .. } | Expr::ILike { expr, pattern, .. } => {
+            contains_column_reference(expr, column) || contains_column_reference(pattern, column)
+        }
+        Expr::IsNull(inner) | Expr::IsNotNull(inner) => contains_column_reference(inner, column),
+        Expr::Cast { expr, .. } => contains_column_reference(expr, column),
+        Expr::Function(_) => false,
+        _ => false,
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}

--- a/packages/engine/src/sql/steps/lix_state_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_state_view_read.rs
@@ -1,18 +1,18 @@
 use sqlparser::ast::{
-    BinaryOperator, Expr, Ident, ObjectName, ObjectNamePart, Query, Select, SetExpr, Statement,
-    TableFactor, TableWithJoins,
+    Ident, ObjectName, ObjectNamePart, Query, Select, SetExpr, Statement, TableAlias, TableFactor,
+    TableWithJoins,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
 use crate::version::{
     active_version_file_id, active_version_schema_key, active_version_storage_version_id,
+    version_descriptor_file_id, version_descriptor_schema_key,
+    version_descriptor_storage_version_id,
 };
 use crate::LixError;
 
 const LIX_STATE_VIEW_NAME: &str = "lix_state";
-const VTABLE_NAME: &str = "lix_internal_state_vtable";
-const UNTRACKED_TABLE: &str = "lix_internal_state_untracked";
 
 pub fn rewrite_query(query: Query) -> Result<Option<Query>, LixError> {
     if !top_level_select_targets_lix_state(&query) {
@@ -80,111 +80,162 @@ fn rewrite_set_expr(expr: SetExpr, changed: &mut bool) -> Result<SetExpr, LixErr
 }
 
 fn rewrite_select(select: &mut Select, changed: &mut bool) -> Result<(), LixError> {
-    let mut has_state_target = false;
     for table in &mut select.from {
-        if rewrite_table_with_joins(table, changed)? {
-            has_state_target = true;
-        }
+        rewrite_table_with_joins(table, changed)?;
     }
-
-    if !has_state_target {
-        return Ok(());
-    }
-
-    let version_predicate = active_version_predicate_expr()?;
-    select.selection = Some(match select.selection.take() {
-        Some(existing) => Expr::BinaryOp {
-            left: Box::new(existing),
-            op: BinaryOperator::And,
-            right: Box::new(version_predicate),
-        },
-        None => version_predicate,
-    });
-    *changed = true;
-
     Ok(())
 }
 
 fn rewrite_table_with_joins(
     table: &mut TableWithJoins,
     changed: &mut bool,
-) -> Result<bool, LixError> {
-    let mut rewrote_state_target = rewrite_table_factor(&mut table.relation, changed)?;
+) -> Result<(), LixError> {
+    rewrite_table_factor(&mut table.relation, changed)?;
     for join in &mut table.joins {
-        if rewrite_table_factor(&mut join.relation, changed)? {
-            rewrote_state_target = true;
-        }
+        rewrite_table_factor(&mut join.relation, changed)?;
     }
-    Ok(rewrote_state_target)
+    Ok(())
 }
 
-fn rewrite_table_factor(relation: &mut TableFactor, changed: &mut bool) -> Result<bool, LixError> {
+fn rewrite_table_factor(relation: &mut TableFactor, changed: &mut bool) -> Result<(), LixError> {
     match relation {
-        TableFactor::Table { name, .. } if object_name_matches(name, LIX_STATE_VIEW_NAME) => {
-            *name = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(VTABLE_NAME))]);
+        TableFactor::Table { name, alias, .. }
+            if object_name_matches(name, LIX_STATE_VIEW_NAME) =>
+        {
+            let derived_query = build_lix_state_view_query()?;
+            let derived_alias = alias.clone().or_else(|| Some(default_lix_state_alias()));
+            *relation = TableFactor::Derived {
+                lateral: false,
+                subquery: Box::new(derived_query),
+                alias: derived_alias,
+            };
             *changed = true;
-            Ok(true)
         }
         TableFactor::Derived { subquery, .. } => {
             if let Some(rewritten) = rewrite_query((**subquery).clone())? {
                 *subquery = Box::new(rewritten);
                 *changed = true;
             }
-            Ok(false)
         }
         TableFactor::NestedJoin {
             table_with_joins, ..
-        } => rewrite_table_with_joins(table_with_joins, changed),
-        _ => Ok(false),
+        } => {
+            rewrite_table_with_joins(table_with_joins, changed)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn build_lix_state_view_query() -> Result<Query, LixError> {
+    let descriptor_table = quote_ident(&format!(
+        "lix_internal_state_materialized_v1_{}",
+        version_descriptor_schema_key()
+    ));
+    let sql = format!(
+        "SELECT \
+             ranked.entity_id AS entity_id, \
+             ranked.schema_key AS schema_key, \
+             ranked.file_id AS file_id, \
+             ranked.version_id AS version_id, \
+             ranked.plugin_key AS plugin_key, \
+             ranked.snapshot_content AS snapshot_content, \
+             ranked.schema_version AS schema_version, \
+             ranked.created_at AS created_at, \
+             ranked.updated_at AS updated_at, \
+             ranked.inherited_from_version_id AS inherited_from_version_id, \
+             ranked.change_id AS change_id, \
+             ranked.untracked AS untracked \
+         FROM ( \
+           WITH RECURSIVE active_version AS ( \
+             SELECT lix_json_text(snapshot_content, 'version_id') AS version_id \
+             FROM lix_internal_state_untracked \
+             WHERE schema_key = '{active_schema_key}' \
+               AND file_id = '{active_file_id}' \
+               AND version_id = '{active_storage_version_id}' \
+               AND snapshot_content IS NOT NULL \
+             ORDER BY updated_at DESC \
+             LIMIT 1 \
+           ), \
+           version_chain(version_id, depth) AS ( \
+             SELECT version_id, 0 AS depth \
+             FROM active_version \
+             UNION ALL \
+             SELECT \
+               lix_json_text(vd.snapshot_content, 'inherits_from_version_id') AS version_id, \
+               vc.depth + 1 AS depth \
+             FROM version_chain vc \
+             JOIN {descriptor_table} vd \
+               ON lix_json_text(vd.snapshot_content, 'id') = vc.version_id \
+             WHERE vd.schema_key = '{descriptor_schema_key}' \
+               AND vd.file_id = '{descriptor_file_id}' \
+               AND vd.version_id = '{descriptor_storage_version_id}' \
+               AND vd.is_tombstone = 0 \
+               AND vd.snapshot_content IS NOT NULL \
+               AND lix_json_text(vd.snapshot_content, 'inherits_from_version_id') IS NOT NULL \
+               AND vc.depth < 64 \
+           ) \
+           SELECT \
+             s.entity_id AS entity_id, \
+             s.schema_key AS schema_key, \
+             s.file_id AS file_id, \
+             av.version_id AS version_id, \
+             s.plugin_key AS plugin_key, \
+             s.snapshot_content AS snapshot_content, \
+             s.schema_version AS schema_version, \
+             s.created_at AS created_at, \
+             s.updated_at AS updated_at, \
+             CASE \
+               WHEN vc.depth = 0 THEN NULL \
+               ELSE s.version_id \
+             END AS inherited_from_version_id, \
+             s.change_id AS change_id, \
+             s.untracked AS untracked, \
+             ROW_NUMBER() OVER ( \
+               PARTITION BY s.entity_id, s.schema_key, s.file_id \
+               ORDER BY vc.depth ASC \
+             ) AS rn \
+           FROM lix_internal_state_vtable s \
+           JOIN version_chain vc \
+             ON vc.version_id = s.version_id \
+           CROSS JOIN active_version av \
+         ) AS ranked \
+         WHERE ranked.rn = 1 \
+           AND ranked.snapshot_content IS NOT NULL",
+        active_schema_key = escape_sql_string(active_version_schema_key()),
+        active_file_id = escape_sql_string(active_version_file_id()),
+        active_storage_version_id = escape_sql_string(active_version_storage_version_id()),
+        descriptor_schema_key = escape_sql_string(version_descriptor_schema_key()),
+        descriptor_file_id = escape_sql_string(version_descriptor_file_id()),
+        descriptor_storage_version_id = escape_sql_string(version_descriptor_storage_version_id()),
+    );
+    parse_single_query(&sql)
+}
+
+fn default_lix_state_alias() -> TableAlias {
+    TableAlias {
+        explicit: false,
+        name: Ident::new(LIX_STATE_VIEW_NAME),
+        columns: Vec::new(),
     }
 }
 
-fn active_version_predicate_expr() -> Result<Expr, LixError> {
-    let sql = format!(
-        "version_id = (\
-         SELECT lix_json_text(snapshot_content, 'version_id') \
-         FROM {untracked_table} \
-         WHERE schema_key = '{schema_key}' \
-           AND file_id = '{file_id}' \
-           AND version_id = '{storage_version_id}' \
-           AND snapshot_content IS NOT NULL \
-         LIMIT 1\
-         )",
-        untracked_table = UNTRACKED_TABLE,
-        schema_key = escape_sql_string(active_version_schema_key()),
-        file_id = escape_sql_string(active_version_file_id()),
-        storage_version_id = escape_sql_string(active_version_storage_version_id()),
-    );
-    parse_predicate_expr(&sql)
-}
-
-fn parse_predicate_expr(predicate_sql: &str) -> Result<Expr, LixError> {
-    let sql = format!("SELECT 1 WHERE {predicate_sql}");
-    let mut statements = Parser::parse_sql(&GenericDialect {}, &sql).map_err(|error| LixError {
-        message: format!("failed to parse predicate expression: {error}"),
+fn parse_single_query(sql: &str) -> Result<Query, LixError> {
+    let mut statements = Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| LixError {
+        message: error.to_string(),
     })?;
     if statements.len() != 1 {
         return Err(LixError {
-            message: "expected a single predicate expression statement".to_string(),
+            message: "expected a single SELECT statement".to_string(),
         });
     }
-
     let statement = statements.remove(0);
-    let Statement::Query(query) = statement else {
-        return Err(LixError {
-            message: "predicate expression did not parse as SELECT".to_string(),
-        });
-    };
-
-    let SetExpr::Select(select) = query.body.as_ref() else {
-        return Err(LixError {
-            message: "predicate expression did not parse as SELECT body".to_string(),
-        });
-    };
-
-    select.selection.as_ref().cloned().ok_or_else(|| LixError {
-        message: "predicate expression is missing WHERE clause".to_string(),
-    })
+    match statement {
+        Statement::Query(query) => Ok(*query),
+        _ => Err(LixError {
+            message: "expected SELECT statement".to_string(),
+        }),
+    }
 }
 
 fn object_name_matches(name: &ObjectName, target: &str) -> bool {
@@ -197,4 +248,9 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
 
 fn escape_sql_string(value: &str) -> String {
     value.replace('\'', "''")
+}
+
+fn quote_ident(value: &str) -> String {
+    let escaped = value.replace('"', "\"\"");
+    format!("\"{escaped}\"")
 }

--- a/packages/engine/src/sql/steps/lix_state_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_state_view_read.rs
@@ -5,6 +5,7 @@ use sqlparser::ast::{
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
+use crate::sql::escape_sql_string;
 use crate::version::{
     active_version_file_id, active_version_schema_key, active_version_storage_version_id,
     version_descriptor_file_id, version_descriptor_schema_key,
@@ -245,10 +246,6 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
         .and_then(ObjectNamePart::as_ident)
         .map(|ident| ident.value.eq_ignore_ascii_case(target))
         .unwrap_or(false)
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
 }
 
 fn quote_ident(value: &str) -> String {

--- a/packages/engine/src/sql/steps/lix_state_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_state_view_read.rs
@@ -1,0 +1,200 @@
+use sqlparser::ast::{
+    BinaryOperator, Expr, Ident, ObjectName, ObjectNamePart, Query, Select, SetExpr, Statement,
+    TableFactor, TableWithJoins,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::version::{
+    active_version_file_id, active_version_schema_key, active_version_storage_version_id,
+};
+use crate::LixError;
+
+const LIX_STATE_VIEW_NAME: &str = "lix_state";
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+const UNTRACKED_TABLE: &str = "lix_internal_state_untracked";
+
+pub fn rewrite_query(query: Query) -> Result<Option<Query>, LixError> {
+    if !top_level_select_targets_lix_state(&query) {
+        return Ok(None);
+    }
+
+    let mut changed = false;
+    let mut new_query = query.clone();
+    new_query.body = Box::new(rewrite_set_expr(*query.body, &mut changed)?);
+
+    if changed {
+        Ok(Some(new_query))
+    } else {
+        Ok(None)
+    }
+}
+
+fn top_level_select_targets_lix_state(query: &Query) -> bool {
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return false;
+    };
+    select.from.iter().any(table_with_joins_targets_lix_state)
+}
+
+fn table_with_joins_targets_lix_state(table: &TableWithJoins) -> bool {
+    table_factor_is_lix_state(&table.relation)
+        || table
+            .joins
+            .iter()
+            .any(|join| table_factor_is_lix_state(&join.relation))
+}
+
+fn table_factor_is_lix_state(relation: &TableFactor) -> bool {
+    matches!(
+        relation,
+        TableFactor::Table { name, .. } if object_name_matches(name, LIX_STATE_VIEW_NAME)
+    )
+}
+
+fn rewrite_set_expr(expr: SetExpr, changed: &mut bool) -> Result<SetExpr, LixError> {
+    Ok(match expr {
+        SetExpr::Select(select) => {
+            let mut select = *select;
+            rewrite_select(&mut select, changed)?;
+            SetExpr::Select(Box::new(select))
+        }
+        SetExpr::Query(query) => {
+            let mut query = *query;
+            query.body = Box::new(rewrite_set_expr(*query.body, changed)?);
+            SetExpr::Query(Box::new(query))
+        }
+        SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left,
+            right,
+        } => SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left: Box::new(rewrite_set_expr(*left, changed)?),
+            right: Box::new(rewrite_set_expr(*right, changed)?),
+        },
+        other => other,
+    })
+}
+
+fn rewrite_select(select: &mut Select, changed: &mut bool) -> Result<(), LixError> {
+    let mut has_state_target = false;
+    for table in &mut select.from {
+        if rewrite_table_with_joins(table, changed)? {
+            has_state_target = true;
+        }
+    }
+
+    if !has_state_target {
+        return Ok(());
+    }
+
+    let version_predicate = active_version_predicate_expr()?;
+    select.selection = Some(match select.selection.take() {
+        Some(existing) => Expr::BinaryOp {
+            left: Box::new(existing),
+            op: BinaryOperator::And,
+            right: Box::new(version_predicate),
+        },
+        None => version_predicate,
+    });
+    *changed = true;
+
+    Ok(())
+}
+
+fn rewrite_table_with_joins(
+    table: &mut TableWithJoins,
+    changed: &mut bool,
+) -> Result<bool, LixError> {
+    let mut rewrote_state_target = rewrite_table_factor(&mut table.relation, changed)?;
+    for join in &mut table.joins {
+        if rewrite_table_factor(&mut join.relation, changed)? {
+            rewrote_state_target = true;
+        }
+    }
+    Ok(rewrote_state_target)
+}
+
+fn rewrite_table_factor(relation: &mut TableFactor, changed: &mut bool) -> Result<bool, LixError> {
+    match relation {
+        TableFactor::Table { name, .. } if object_name_matches(name, LIX_STATE_VIEW_NAME) => {
+            *name = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(VTABLE_NAME))]);
+            *changed = true;
+            Ok(true)
+        }
+        TableFactor::Derived { subquery, .. } => {
+            if let Some(rewritten) = rewrite_query((**subquery).clone())? {
+                *subquery = Box::new(rewritten);
+                *changed = true;
+            }
+            Ok(false)
+        }
+        TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => rewrite_table_with_joins(table_with_joins, changed),
+        _ => Ok(false),
+    }
+}
+
+fn active_version_predicate_expr() -> Result<Expr, LixError> {
+    let sql = format!(
+        "version_id = (\
+         SELECT lix_json_text(snapshot_content, 'version_id') \
+         FROM {untracked_table} \
+         WHERE schema_key = '{schema_key}' \
+           AND file_id = '{file_id}' \
+           AND version_id = '{storage_version_id}' \
+           AND snapshot_content IS NOT NULL \
+         LIMIT 1\
+         )",
+        untracked_table = UNTRACKED_TABLE,
+        schema_key = escape_sql_string(active_version_schema_key()),
+        file_id = escape_sql_string(active_version_file_id()),
+        storage_version_id = escape_sql_string(active_version_storage_version_id()),
+    );
+    parse_predicate_expr(&sql)
+}
+
+fn parse_predicate_expr(predicate_sql: &str) -> Result<Expr, LixError> {
+    let sql = format!("SELECT 1 WHERE {predicate_sql}");
+    let mut statements = Parser::parse_sql(&GenericDialect {}, &sql).map_err(|error| LixError {
+        message: format!("failed to parse predicate expression: {error}"),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected a single predicate expression statement".to_string(),
+        });
+    }
+
+    let statement = statements.remove(0);
+    let Statement::Query(query) = statement else {
+        return Err(LixError {
+            message: "predicate expression did not parse as SELECT".to_string(),
+        });
+    };
+
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return Err(LixError {
+            message: "predicate expression did not parse as SELECT body".to_string(),
+        });
+    };
+
+    select.selection.as_ref().cloned().ok_or_else(|| LixError {
+        message: "predicate expression is missing WHERE clause".to_string(),
+    })
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn escape_sql_string(value: &str) -> String {
+    value.replace('\'', "''")
+}

--- a/packages/engine/src/sql/steps/lix_state_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_state_view_read.rs
@@ -186,6 +186,7 @@ fn build_lix_state_view_query() -> Result<Query, LixError> {
              s.created_at AS created_at, \
              s.updated_at AS updated_at, \
              CASE \
+               WHEN s.inherited_from_version_id IS NOT NULL THEN s.inherited_from_version_id \
                WHEN vc.depth = 0 THEN NULL \
                ELSE s.version_id \
              END AS inherited_from_version_id, \

--- a/packages/engine/src/sql/steps/lix_state_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_state_view_write.rs
@@ -1,0 +1,323 @@
+use sqlparser::ast::{
+    AssignmentTarget, BinaryOperator, Delete, Expr, FromTable, Ident, Insert, ObjectName,
+    ObjectNamePart, SetExpr, TableFactor, TableObject, TableWithJoins, Update, Value,
+};
+
+use crate::version::{
+    active_version_file_id, active_version_schema_key, active_version_storage_version_id,
+    parse_active_version_snapshot,
+};
+use crate::{LixBackend, LixError, Value as EngineValue};
+
+const LIX_STATE_VIEW_NAME: &str = "lix_state";
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+const UNTRACKED_TABLE: &str = "lix_internal_state_untracked";
+
+pub async fn rewrite_insert_with_backend(
+    backend: &dyn LixBackend,
+    mut insert: Insert,
+) -> Result<Option<Insert>, LixError> {
+    if !table_object_is_lix_state(&insert.table) {
+        return Ok(None);
+    }
+    if insert.on.is_some() {
+        return Err(LixError {
+            message: "lix_state insert does not support ON CONFLICT".to_string(),
+        });
+    }
+    if insert.columns.is_empty() {
+        return Err(LixError {
+            message: "lix_state insert requires explicit columns".to_string(),
+        });
+    }
+    if insert
+        .columns
+        .iter()
+        .any(|column| column.value.eq_ignore_ascii_case("version_id"))
+    {
+        return Err(LixError {
+            message:
+                "lix_state insert cannot set version_id; active version is resolved automatically"
+                    .to_string(),
+        });
+    }
+
+    let active_version_id = load_active_version_id(backend).await?;
+    let expected_columns = insert.columns.len();
+    let source = insert.source.as_mut().ok_or_else(|| LixError {
+        message: "lix_state insert requires VALUES rows".to_string(),
+    })?;
+    let SetExpr::Values(values) = source.body.as_mut() else {
+        return Err(LixError {
+            message: "lix_state insert requires VALUES rows".to_string(),
+        });
+    };
+
+    for row in &mut values.rows {
+        if row.len() != expected_columns {
+            return Err(LixError {
+                message: "lix_state insert row length does not match column count".to_string(),
+            });
+        }
+        row.push(Expr::Value(
+            sqlparser::ast::Value::SingleQuotedString(active_version_id.clone()).into(),
+        ));
+    }
+
+    insert.columns.push(Ident::new("version_id"));
+    insert.table = TableObject::TableName(ObjectName(vec![ObjectNamePart::Identifier(
+        Ident::new(VTABLE_NAME),
+    )]));
+    Ok(Some(insert))
+}
+
+pub async fn rewrite_update_with_backend(
+    backend: &dyn LixBackend,
+    mut update: Update,
+    params: &[EngineValue],
+) -> Result<Option<Update>, LixError> {
+    if !table_with_joins_is_lix_state(&update.table) {
+        return Ok(None);
+    }
+    if update
+        .assignments
+        .iter()
+        .any(|assignment| assignment_target_is_column(&assignment.target, "version_id"))
+    {
+        return Err(LixError {
+            message:
+                "lix_state update cannot set version_id; active version is resolved automatically"
+                    .to_string(),
+        });
+    }
+
+    let active_version_id = load_active_version_id(backend).await?;
+    let has_untracked_predicate = update
+        .selection
+        .as_ref()
+        .map(|selection| contains_column_reference(selection, "untracked"))
+        .unwrap_or(false);
+    replace_table_with_vtable(&mut update.table)?;
+    let mut selection = match update.selection.take() {
+        Some(existing) => Expr::BinaryOp {
+            left: Box::new(existing),
+            op: BinaryOperator::And,
+            right: Box::new(version_predicate_expr(&active_version_id)),
+        },
+        None => version_predicate_expr(&active_version_id),
+    };
+
+    if !has_untracked_predicate && matches_untracked_rows(backend, &selection, params).await? {
+        selection = Expr::BinaryOp {
+            left: Box::new(selection),
+            op: BinaryOperator::And,
+            right: Box::new(untracked_true_predicate_expr()),
+        };
+    }
+
+    update.selection = Some(selection);
+    Ok(Some(update))
+}
+
+async fn matches_untracked_rows(
+    backend: &dyn LixBackend,
+    selection: &Expr,
+    params: &[EngineValue],
+) -> Result<bool, LixError> {
+    let sql = format!(
+        "SELECT 1 \
+         FROM {untracked_table} \
+         WHERE ({selection}) \
+         LIMIT 1",
+        untracked_table = UNTRACKED_TABLE,
+        selection = selection,
+    );
+    let result = backend.execute(&sql, params).await?;
+    Ok(!result.rows.is_empty())
+}
+
+fn contains_column_reference(expr: &Expr, column: &str) -> bool {
+    match expr {
+        Expr::Identifier(ident) => ident.value.eq_ignore_ascii_case(column),
+        Expr::CompoundIdentifier(idents) => idents
+            .last()
+            .map(|ident| ident.value.eq_ignore_ascii_case(column))
+            .unwrap_or(false),
+        Expr::BinaryOp { left, right, .. } => {
+            contains_column_reference(left, column) || contains_column_reference(right, column)
+        }
+        Expr::UnaryOp { expr, .. } => contains_column_reference(expr, column),
+        Expr::Nested(inner) => contains_column_reference(inner, column),
+        Expr::InList { expr, list, .. } => {
+            contains_column_reference(expr, column)
+                || list
+                    .iter()
+                    .any(|item| contains_column_reference(item, column))
+        }
+        Expr::Between {
+            expr, low, high, ..
+        } => {
+            contains_column_reference(expr, column)
+                || contains_column_reference(low, column)
+                || contains_column_reference(high, column)
+        }
+        Expr::Like { expr, pattern, .. } | Expr::ILike { expr, pattern, .. } => {
+            contains_column_reference(expr, column) || contains_column_reference(pattern, column)
+        }
+        Expr::IsNull(inner) | Expr::IsNotNull(inner) => contains_column_reference(inner, column),
+        Expr::Cast { expr, .. } => contains_column_reference(expr, column),
+        Expr::Function(_) => false,
+        _ => false,
+    }
+}
+
+fn untracked_true_predicate_expr() -> Expr {
+    Expr::BinaryOp {
+        left: Box::new(Expr::Identifier(Ident::new("untracked"))),
+        op: BinaryOperator::Eq,
+        right: Box::new(Expr::Value(Value::Number("1".to_string(), false).into())),
+    }
+}
+
+pub async fn rewrite_delete_with_backend(
+    backend: &dyn LixBackend,
+    mut delete: Delete,
+) -> Result<Option<Delete>, LixError> {
+    if !delete_from_is_lix_state(&delete) {
+        return Ok(None);
+    }
+
+    let active_version_id = load_active_version_id(backend).await?;
+    replace_delete_from_vtable(&mut delete)?;
+    delete.selection = Some(match delete.selection.take() {
+        Some(existing) => Expr::BinaryOp {
+            left: Box::new(existing),
+            op: BinaryOperator::And,
+            right: Box::new(version_predicate_expr(&active_version_id)),
+        },
+        None => version_predicate_expr(&active_version_id),
+    });
+    Ok(Some(delete))
+}
+
+async fn load_active_version_id(backend: &dyn LixBackend) -> Result<String, LixError> {
+    let sql = format!(
+        "SELECT snapshot_content \
+         FROM {untracked_table} \
+         WHERE schema_key = $1 \
+           AND file_id = $2 \
+           AND version_id = $3 \
+           AND snapshot_content IS NOT NULL \
+         ORDER BY updated_at DESC \
+         LIMIT 1",
+        untracked_table = UNTRACKED_TABLE,
+    );
+    let result = backend
+        .execute(
+            &sql,
+            &[
+                EngineValue::Text(active_version_schema_key().to_string()),
+                EngineValue::Text(active_version_file_id().to_string()),
+                EngineValue::Text(active_version_storage_version_id().to_string()),
+            ],
+        )
+        .await?;
+
+    let row = result.rows.first().ok_or_else(|| LixError {
+        message: "lix_state write requires an active version".to_string(),
+    })?;
+    let snapshot_content = row.first().ok_or_else(|| LixError {
+        message: "active version query row is missing snapshot_content".to_string(),
+    })?;
+    let snapshot_content = match snapshot_content {
+        EngineValue::Text(value) => value.as_str(),
+        other => {
+            return Err(LixError {
+                message: format!("active version snapshot_content must be text, got {other:?}"),
+            })
+        }
+    };
+    parse_active_version_snapshot(snapshot_content)
+}
+
+fn table_object_is_lix_state(table: &TableObject) -> bool {
+    match table {
+        TableObject::TableName(name) => object_name_matches(name, LIX_STATE_VIEW_NAME),
+        _ => false,
+    }
+}
+
+fn table_with_joins_is_lix_state(table: &TableWithJoins) -> bool {
+    table.joins.is_empty()
+        && matches!(
+            &table.relation,
+            TableFactor::Table { name, .. } if object_name_matches(name, LIX_STATE_VIEW_NAME)
+        )
+}
+
+fn delete_from_is_lix_state(delete: &Delete) -> bool {
+    match &delete.from {
+        FromTable::WithFromKeyword(tables) | FromTable::WithoutKeyword(tables) => {
+            tables.len() == 1 && table_with_joins_is_lix_state(&tables[0])
+        }
+    }
+}
+
+fn replace_table_with_vtable(table: &mut TableWithJoins) -> Result<(), LixError> {
+    if !table.joins.is_empty() {
+        return Err(LixError {
+            message: "lix_state update does not support JOIN targets".to_string(),
+        });
+    }
+    match &mut table.relation {
+        TableFactor::Table { name, .. } => {
+            *name = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(VTABLE_NAME))]);
+            Ok(())
+        }
+        _ => Err(LixError {
+            message: "lix_state update requires table target".to_string(),
+        }),
+    }
+}
+
+fn replace_delete_from_vtable(delete: &mut Delete) -> Result<(), LixError> {
+    let tables = match &mut delete.from {
+        FromTable::WithFromKeyword(tables) | FromTable::WithoutKeyword(tables) => tables,
+    };
+    let Some(table) = tables.first_mut() else {
+        return Err(LixError {
+            message: "lix_state delete requires table target".to_string(),
+        });
+    };
+    replace_table_with_vtable(table)
+}
+
+fn version_predicate_expr(version_id: &str) -> Expr {
+    Expr::BinaryOp {
+        left: Box::new(Expr::Identifier(Ident::new("version_id"))),
+        op: BinaryOperator::Eq,
+        right: Box::new(Expr::Value(
+            Value::SingleQuotedString(version_id.to_string()).into(),
+        )),
+    }
+}
+
+fn assignment_target_is_column(target: &AssignmentTarget, name: &str) -> bool {
+    match target {
+        AssignmentTarget::ColumnName(object_name) => object_name
+            .0
+            .last()
+            .and_then(ObjectNamePart::as_ident)
+            .map(|ident| ident.value.eq_ignore_ascii_case(name))
+            .unwrap_or(false),
+        AssignmentTarget::Tuple(_) => false,
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}

--- a/packages/engine/src/sql/steps/lix_version_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_version_view_read.rs
@@ -142,7 +142,7 @@ fn build_lix_version_view_query() -> Result<Query, LixError> {
                    lix_json_text(snapshot_content, 'commit_id') AS commit_id, \
                    lix_json_text(snapshot_content, 'working_commit_id') AS working_commit_id \
                  FROM lix_internal_state_vtable \
-                 WHERE schema_key = 'lix_version_tip' \
+                 WHERE schema_key = 'lix_version_pointer' \
                    AND version_id = 'global' \
                    AND snapshot_content IS NOT NULL \
                ) AS t \

--- a/packages/engine/src/sql/steps/lix_version_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_version_view_read.rs
@@ -1,0 +1,183 @@
+use sqlparser::ast::{
+    Ident, ObjectName, Query, Select, SetExpr, Statement, TableAlias, TableFactor, TableWithJoins,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+
+use crate::LixError;
+
+const LIX_VERSION_VIEW_NAME: &str = "lix_version";
+
+pub fn rewrite_query(query: Query) -> Result<Option<Query>, LixError> {
+    let mut changed = false;
+    let mut new_query = query.clone();
+    new_query.body = Box::new(rewrite_set_expr(*query.body, &mut changed)?);
+
+    if changed {
+        Ok(Some(new_query))
+    } else {
+        Ok(None)
+    }
+}
+
+fn rewrite_set_expr(expr: SetExpr, changed: &mut bool) -> Result<SetExpr, LixError> {
+    Ok(match expr {
+        SetExpr::Select(select) => {
+            let mut select = *select;
+            rewrite_select(&mut select, changed)?;
+            SetExpr::Select(Box::new(select))
+        }
+        SetExpr::Query(query) => {
+            let mut query = *query;
+            query.body = Box::new(rewrite_set_expr(*query.body, changed)?);
+            SetExpr::Query(Box::new(query))
+        }
+        SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left,
+            right,
+        } => SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left: Box::new(rewrite_set_expr(*left, changed)?),
+            right: Box::new(rewrite_set_expr(*right, changed)?),
+        },
+        other => other,
+    })
+}
+
+fn rewrite_select(select: &mut Select, changed: &mut bool) -> Result<(), LixError> {
+    for table in &mut select.from {
+        rewrite_table_with_joins(table, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_with_joins(
+    table: &mut TableWithJoins,
+    changed: &mut bool,
+) -> Result<(), LixError> {
+    rewrite_table_factor(&mut table.relation, changed)?;
+    for join in &mut table.joins {
+        rewrite_table_factor(&mut join.relation, changed)?;
+    }
+    Ok(())
+}
+
+fn rewrite_table_factor(relation: &mut TableFactor, changed: &mut bool) -> Result<(), LixError> {
+    match relation {
+        TableFactor::Table { name, alias, .. }
+            if object_name_matches(name, LIX_VERSION_VIEW_NAME) =>
+        {
+            let derived_query = build_lix_version_view_query()?;
+            let derived_alias = alias.clone().or_else(|| Some(default_lix_version_alias()));
+            *relation = TableFactor::Derived {
+                lateral: false,
+                subquery: Box::new(derived_query),
+                alias: derived_alias,
+            };
+            *changed = true;
+        }
+        TableFactor::Derived { subquery, .. } => {
+            if let Some(rewritten) = rewrite_query((**subquery).clone())? {
+                *subquery = Box::new(rewritten);
+                *changed = true;
+            }
+        }
+        TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => {
+            rewrite_table_with_joins(table_with_joins, changed)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn build_lix_version_view_query() -> Result<Query, LixError> {
+    let dialect = GenericDialect {};
+    let sql = "SELECT \
+                 d.id AS id, \
+                 d.name AS name, \
+                 d.inherits_from_version_id AS inherits_from_version_id, \
+                 d.hidden AS hidden, \
+                 t.commit_id AS commit_id, \
+                 t.working_commit_id AS working_commit_id, \
+                 d.entity_id AS entity_id, \
+                 'lix_version' AS schema_key, \
+                 d.file_id AS file_id, \
+                 d.version_id AS version_id, \
+                 'lix' AS plugin_key, \
+                 d.schema_version AS schema_version, \
+                 COALESCE(t.change_id, d.change_id) AS change_id, \
+                 COALESCE(d.created_at, t.created_at) AS created_at, \
+                 COALESCE(t.updated_at, d.updated_at) AS updated_at, \
+                 0 AS untracked \
+               FROM ( \
+                 SELECT \
+                   entity_id, \
+                   file_id, \
+                   version_id, \
+                   schema_version, \
+                   change_id, \
+                   created_at, \
+                   updated_at, \
+                   lix_json_text(snapshot_content, 'id') AS id, \
+                   lix_json_text(snapshot_content, 'name') AS name, \
+                   lix_json_text(snapshot_content, 'inherits_from_version_id') AS inherits_from_version_id, \
+                   lix_json_text(snapshot_content, 'hidden') AS hidden \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'lix_version_descriptor' \
+                   AND version_id = 'global' \
+                   AND snapshot_content IS NOT NULL \
+               ) AS d \
+               LEFT JOIN ( \
+                 SELECT \
+                   entity_id, \
+                   change_id, \
+                   created_at, \
+                   updated_at, \
+                   lix_json_text(snapshot_content, 'id') AS id, \
+                   lix_json_text(snapshot_content, 'commit_id') AS commit_id, \
+                   lix_json_text(snapshot_content, 'working_commit_id') AS working_commit_id \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'lix_version_tip' \
+                   AND version_id = 'global' \
+                   AND snapshot_content IS NOT NULL \
+               ) AS t \
+                 ON t.id = d.id";
+
+    let mut statements = Parser::parse_sql(&dialect, sql).map_err(|err| LixError {
+        message: err.to_string(),
+    })?;
+
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected single derived query statement".to_string(),
+        });
+    }
+
+    match statements.remove(0) {
+        Statement::Query(query) => Ok(*query),
+        _ => Err(LixError {
+            message: "derived query did not parse as SELECT".to_string(),
+        }),
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(|part| part.as_ident())
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn default_lix_version_alias() -> TableAlias {
+    TableAlias {
+        explicit: false,
+        name: Ident::new(LIX_VERSION_VIEW_NAME),
+        columns: Vec::new(),
+    }
+}

--- a/packages/engine/src/sql/steps/lix_version_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_version_view_write.rs
@@ -10,7 +10,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use crate::sql::lowering::lower_statement;
 use crate::sql::steps::{lix_version_view_read, vtable_read};
 use crate::sql::{
-    bind_sql_with_state, resolve_expr_cell_with_state, PlaceholderState, RowSourceResolver,
+    bind_sql_with_state, escape_sql_string, resolve_expr_cell_with_state, PlaceholderState,
+    RowSourceResolver,
 };
 use crate::version::{
     version_descriptor_file_id, version_descriptor_plugin_key, version_descriptor_schema_key,
@@ -871,8 +872,4 @@ fn object_name_matches(name: &ObjectName, target: &str) -> bool {
         .and_then(ObjectNamePart::as_ident)
         .map(|ident| ident.value.eq_ignore_ascii_case(target))
         .unwrap_or(false)
-}
-
-fn escape_sql_string(input: &str) -> String {
-    input.replace('\'', "''")
 }

--- a/packages/engine/src/sql/steps/lix_version_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_version_view_write.rs
@@ -191,13 +191,17 @@ pub async fn rewrite_update_with_backend(
                     message: "lix_version update cannot set empty commit_id".to_string(),
                 });
             }
-            let next_working_commit_id = assignment_values.working_commit_id.clone().ok_or_else(
-                || LixError {
+            let next_working_commit_id =
+                assignment_values
+                    .working_commit_id
+                    .clone()
+                    .ok_or_else(|| {
+                        LixError {
                     message:
                         "lix_version update must set both commit_id and working_commit_id together"
                             .to_string(),
-                },
-            )?;
+                }
+                    })?;
             if next_working_commit_id.is_empty() {
                 return Err(LixError {
                     message: "lix_version update cannot set empty working_commit_id".to_string(),

--- a/packages/engine/src/sql/steps/lix_version_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_version_view_write.rs
@@ -1,0 +1,874 @@
+use serde_json::Value as JsonValue;
+use sqlparser::ast::{
+    Assignment, AssignmentTarget, Delete, Expr, FromTable, Ident, Insert, ObjectName,
+    ObjectNamePart, Statement, TableFactor, TableObject, TableWithJoins, Update,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use crate::sql::lowering::lower_statement;
+use crate::sql::steps::{lix_version_view_read, vtable_read};
+use crate::sql::{
+    bind_sql_with_state, resolve_expr_cell_with_state, PlaceholderState, RowSourceResolver,
+};
+use crate::version::{
+    version_descriptor_file_id, version_descriptor_plugin_key, version_descriptor_schema_key,
+    version_descriptor_schema_version, version_descriptor_snapshot_content,
+    version_descriptor_storage_version_id, version_tip_file_id, version_tip_plugin_key,
+    version_tip_schema_key, version_tip_schema_version, version_tip_snapshot_content,
+    version_tip_storage_version_id,
+};
+use crate::{LixBackend, LixError, Value as EngineValue};
+
+const LIX_VERSION_VIEW_NAME: &str = "lix_version";
+const VTABLE_NAME: &str = "lix_internal_state_vtable";
+const VERSION_TIP_TABLE: &str = "lix_internal_state_materialized_v1_lix_version_tip";
+
+pub fn rewrite_insert(
+    insert: Insert,
+    params: &[EngineValue],
+) -> Result<Option<Vec<Insert>>, LixError> {
+    if !table_object_is_lix_version(&insert.table) {
+        return Ok(None);
+    }
+    if insert.columns.is_empty() {
+        return Err(LixError {
+            message: "lix_version insert requires explicit columns".to_string(),
+        });
+    }
+    if insert.on.is_some() {
+        return Err(LixError {
+            message: "lix_version insert does not support ON CONFLICT".to_string(),
+        });
+    }
+
+    let field_map = insert_field_map(&insert.columns)?;
+    let rows_source =
+        RowSourceResolver::new(params).resolve_insert_required(&insert, "lix_version insert")?;
+    let parsed_rows = parse_insert_rows(
+        &field_map,
+        rows_source.rows,
+        rows_source.resolved_rows,
+        "lix_version insert",
+    )?;
+    let descriptor_rows = parsed_rows
+        .iter()
+        .map(|row| row.descriptor_row.clone())
+        .collect::<Vec<_>>();
+    let tip_rows = parsed_rows
+        .iter()
+        .map(|row| row.tip_row.clone())
+        .collect::<Vec<_>>();
+
+    Ok(Some(build_vtable_inserts(descriptor_rows, tip_rows)?))
+}
+
+pub async fn rewrite_insert_with_backend(
+    backend: &dyn LixBackend,
+    insert: Insert,
+    params: &[EngineValue],
+) -> Result<Option<Vec<Insert>>, LixError> {
+    if !table_object_is_lix_version(&insert.table) {
+        return Ok(None);
+    }
+    if insert.columns.is_empty() {
+        return Err(LixError {
+            message: "lix_version insert requires explicit columns".to_string(),
+        });
+    }
+    if insert.on.is_some() {
+        return Err(LixError {
+            message: "lix_version insert does not support ON CONFLICT".to_string(),
+        });
+    }
+
+    let field_map = insert_field_map(&insert.columns)?;
+    let rows_source =
+        RowSourceResolver::new(params).resolve_insert_required(&insert, "lix_version insert")?;
+    let parsed_rows = parse_insert_rows(
+        &field_map,
+        rows_source.rows,
+        rows_source.resolved_rows,
+        "lix_version insert",
+    )?;
+    validate_tip_working_commit_uniqueness(backend, &parsed_rows).await?;
+
+    let descriptor_rows = parsed_rows
+        .iter()
+        .map(|row| row.descriptor_row.clone())
+        .collect::<Vec<_>>();
+    let tip_rows = parsed_rows
+        .iter()
+        .map(|row| row.tip_row.clone())
+        .collect::<Vec<_>>();
+    Ok(Some(build_vtable_inserts(descriptor_rows, tip_rows)?))
+}
+
+pub async fn rewrite_update_with_backend(
+    backend: &dyn LixBackend,
+    update: Update,
+    params: &[EngineValue],
+) -> Result<Option<Vec<Insert>>, LixError> {
+    if !table_with_joins_is_lix_version(&update.table) {
+        return Ok(None);
+    }
+    if update.from.is_some() {
+        return Err(LixError {
+            message: "lix_version update does not support FROM".to_string(),
+        });
+    }
+    if update.returning.is_some() {
+        return Err(LixError {
+            message: "lix_version update does not support RETURNING".to_string(),
+        });
+    }
+    let mut placeholder_state = PlaceholderState::new();
+    let assignment_values =
+        parse_update_assignments(&update.assignments, params, &mut placeholder_state)?;
+    if !assignment_values.touches_descriptor() && !assignment_values.touches_tip() {
+        return Err(LixError {
+            message: "lix_version update must set at least one supported column".to_string(),
+        });
+    }
+
+    let existing_rows = query_lix_version_rows(
+        backend,
+        update.selection.as_ref(),
+        params,
+        placeholder_state,
+    )
+    .await?;
+    if existing_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let mut descriptor_rows = Vec::new();
+    let mut tip_rows = Vec::new();
+    for existing in existing_rows {
+        if assignment_values.touches_descriptor() {
+            let next_name = assignment_values
+                .name
+                .as_ref()
+                .cloned()
+                .unwrap_or(existing.name.clone());
+            if next_name.is_empty() {
+                return Err(LixError {
+                    message: "lix_version update cannot set empty name".to_string(),
+                });
+            }
+            let next_inherits = assignment_values
+                .inherits_from_version_id
+                .clone()
+                .unwrap_or(existing.inherits_from_version_id.clone());
+            let next_hidden = assignment_values.hidden.unwrap_or(existing.hidden);
+            let snapshot = serde_json::from_str::<JsonValue>(&version_descriptor_snapshot_content(
+                &existing.id,
+                &next_name,
+                next_inherits.as_deref(),
+                next_hidden,
+            ))
+            .map_err(|error| LixError {
+                message: format!("failed to encode updated version descriptor snapshot: {error}"),
+            })?;
+            descriptor_rows.push(InsertSnapshotRow {
+                entity_id: existing.id.clone(),
+                snapshot_content: Some(snapshot),
+            });
+        }
+
+        if assignment_values.touches_tip() {
+            let next_commit_id = assignment_values
+                .commit_id
+                .clone()
+                .ok_or_else(|| LixError {
+                    message:
+                        "lix_version update must set both commit_id and working_commit_id together"
+                            .to_string(),
+                })?;
+            if next_commit_id.is_empty() {
+                return Err(LixError {
+                    message: "lix_version update cannot set empty commit_id".to_string(),
+                });
+            }
+            let next_working_commit_id = assignment_values.working_commit_id.clone().ok_or_else(
+                || LixError {
+                    message:
+                        "lix_version update must set both commit_id and working_commit_id together"
+                            .to_string(),
+                },
+            )?;
+            if next_working_commit_id.is_empty() {
+                return Err(LixError {
+                    message: "lix_version update cannot set empty working_commit_id".to_string(),
+                });
+            }
+            let snapshot = serde_json::from_str::<JsonValue>(&version_tip_snapshot_content(
+                &existing.id,
+                &next_commit_id,
+                &next_working_commit_id,
+            ))
+            .map_err(|error| LixError {
+                message: format!("failed to encode updated version tip snapshot: {error}"),
+            })?;
+            tip_rows.push(InsertSnapshotRow {
+                entity_id: existing.id,
+                snapshot_content: Some(snapshot),
+            });
+        }
+    }
+
+    Ok(Some(build_vtable_inserts(descriptor_rows, tip_rows)?))
+}
+
+pub async fn rewrite_delete_with_backend(
+    backend: &dyn LixBackend,
+    delete: Delete,
+    params: &[EngineValue],
+) -> Result<Option<Vec<Insert>>, LixError> {
+    if !delete_from_is_lix_version(&delete) {
+        return Ok(None);
+    }
+    if delete.using.is_some() {
+        return Err(LixError {
+            message: "lix_version delete does not support USING".to_string(),
+        });
+    }
+    if delete.returning.is_some() {
+        return Err(LixError {
+            message: "lix_version delete does not support RETURNING".to_string(),
+        });
+    }
+    if delete.limit.is_some() || !delete.order_by.is_empty() {
+        return Err(LixError {
+            message: "lix_version delete does not support LIMIT or ORDER BY".to_string(),
+        });
+    }
+
+    let existing_rows = query_lix_version_rows(
+        backend,
+        delete.selection.as_ref(),
+        params,
+        PlaceholderState::new(),
+    )
+    .await?;
+    if existing_rows.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let mut descriptor_rows = Vec::new();
+    let mut tip_rows = Vec::new();
+    for row in existing_rows {
+        descriptor_rows.push(InsertSnapshotRow {
+            entity_id: row.id.clone(),
+            snapshot_content: None,
+        });
+        tip_rows.push(InsertSnapshotRow {
+            entity_id: row.id,
+            snapshot_content: None,
+        });
+    }
+
+    Ok(Some(build_vtable_inserts(descriptor_rows, tip_rows)?))
+}
+
+#[derive(Debug, Clone)]
+struct InsertSnapshotRow {
+    entity_id: String,
+    snapshot_content: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone)]
+struct VersionRow {
+    id: String,
+    name: String,
+    inherits_from_version_id: Option<String>,
+    hidden: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct VersionAssignments {
+    name: Option<String>,
+    inherits_from_version_id: Option<Option<String>>,
+    hidden: Option<bool>,
+    commit_id: Option<String>,
+    working_commit_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedInsertRow {
+    entity_id: String,
+    working_commit_id: String,
+    descriptor_row: InsertSnapshotRow,
+    tip_row: InsertSnapshotRow,
+}
+
+impl VersionAssignments {
+    fn touches_descriptor(&self) -> bool {
+        self.name.is_some() || self.inherits_from_version_id.is_some() || self.hidden.is_some()
+    }
+
+    fn touches_tip(&self) -> bool {
+        self.commit_id.is_some() || self.working_commit_id.is_some()
+    }
+}
+
+fn parse_update_assignments(
+    assignments: &[Assignment],
+    params: &[EngineValue],
+    placeholder_state: &mut PlaceholderState,
+) -> Result<VersionAssignments, LixError> {
+    let mut parsed = VersionAssignments::default();
+    for assignment in assignments {
+        let column = assignment_target_column(&assignment.target).ok_or_else(|| LixError {
+            message: "lix_version update requires single-column assignments".to_string(),
+        })?;
+        let resolved = resolve_expr_cell_with_state(&assignment.value, params, placeholder_state)?;
+        let value = resolved.value.ok_or_else(|| LixError {
+            message: format!(
+                "lix_version update assignment for '{column}' must be literal or parameter"
+            ),
+        })?;
+
+        match column.as_str() {
+            "id" => {
+                return Err(LixError {
+                    message: "lix_version update cannot modify id".to_string(),
+                });
+            }
+            "name" => {
+                parsed.name = Some(value_required_string(&value, "name")?);
+            }
+            "inherits_from_version_id" => {
+                parsed.inherits_from_version_id =
+                    Some(value_optional_string(&value, "inherits_from_version_id")?);
+            }
+            "hidden" => {
+                parsed.hidden = Some(value_bool(&value, "hidden")?);
+            }
+            "commit_id" => {
+                parsed.commit_id = Some(value_required_string(&value, "commit_id")?);
+            }
+            "working_commit_id" => {
+                parsed.working_commit_id =
+                    Some(value_required_string(&value, "working_commit_id")?);
+            }
+            _ => {
+                return Err(LixError {
+                    message: format!("lix_version update does not support column '{column}'"),
+                });
+            }
+        }
+    }
+
+    if parsed.commit_id.is_some() ^ parsed.working_commit_id.is_some() {
+        return Err(LixError {
+            message: "lix_version update must set both commit_id and working_commit_id together"
+                .to_string(),
+        });
+    }
+
+    Ok(parsed)
+}
+
+fn parse_insert_rows(
+    field_map: &BTreeMap<String, usize>,
+    rows: Vec<Vec<Expr>>,
+    resolved_rows: Vec<Vec<crate::sql::ResolvedCell>>,
+    operation_name: &str,
+) -> Result<Vec<ParsedInsertRow>, LixError> {
+    let mut parsed_rows = Vec::new();
+    for (row, resolved_row) in rows.iter().zip(resolved_rows.iter()) {
+        let id = field_required_string(field_map.get("id"), resolved_row, row, "id")?;
+        let name = field_required_string(field_map.get("name"), resolved_row, row, "name")?;
+        let inherits_from_version_id = field_optional_string(
+            field_map.get("inherits_from_version_id"),
+            resolved_row,
+            row,
+            "inherits_from_version_id",
+        )?;
+        let hidden = field_optional_bool(field_map.get("hidden"), resolved_row, row, "hidden")?
+            .unwrap_or(false);
+
+        let commit_id =
+            field_required_string(field_map.get("commit_id"), resolved_row, row, "commit_id")?;
+        let working_commit_id = field_required_string(
+            field_map.get("working_commit_id"),
+            resolved_row,
+            row,
+            "working_commit_id",
+        )?;
+
+        if id.is_empty() {
+            return Err(LixError {
+                message: format!("{operation_name} field 'id' cannot be empty"),
+            });
+        }
+        if commit_id.is_empty() {
+            return Err(LixError {
+                message: format!("{operation_name} field 'commit_id' cannot be empty"),
+            });
+        }
+        if working_commit_id.is_empty() {
+            return Err(LixError {
+                message: format!("{operation_name} field 'working_commit_id' cannot be empty"),
+            });
+        }
+
+        let descriptor_snapshot =
+            serde_json::from_str::<JsonValue>(&version_descriptor_snapshot_content(
+                &id,
+                &name,
+                inherits_from_version_id.as_deref(),
+                hidden,
+            ))
+            .map_err(|error| LixError {
+                message: format!("failed to encode version descriptor snapshot: {error}"),
+            })?;
+        let tip_snapshot = serde_json::from_str::<JsonValue>(&version_tip_snapshot_content(
+            &id,
+            &commit_id,
+            &working_commit_id,
+        ))
+        .map_err(|error| LixError {
+            message: format!("failed to encode version tip snapshot: {error}"),
+        })?;
+
+        parsed_rows.push(ParsedInsertRow {
+            entity_id: id.clone(),
+            working_commit_id,
+            descriptor_row: InsertSnapshotRow {
+                entity_id: id.clone(),
+                snapshot_content: Some(descriptor_snapshot),
+            },
+            tip_row: InsertSnapshotRow {
+                entity_id: id,
+                snapshot_content: Some(tip_snapshot),
+            },
+        });
+    }
+    Ok(parsed_rows)
+}
+
+async fn validate_tip_working_commit_uniqueness(
+    backend: &dyn LixBackend,
+    parsed_rows: &[ParsedInsertRow],
+) -> Result<(), LixError> {
+    let mut incoming_working_to_entity = HashMap::<String, String>::new();
+    for row in parsed_rows {
+        if let Some(existing_entity_id) =
+            incoming_working_to_entity.insert(row.working_commit_id.clone(), row.entity_id.clone())
+        {
+            if existing_entity_id != row.entity_id {
+                return Err(LixError {
+                    message: format!(
+                        "Unique constraint violation: working_commit_id '{}' already used by version '{}'",
+                        row.working_commit_id, existing_entity_id
+                    ),
+                });
+            }
+        }
+    }
+
+    if incoming_working_to_entity.is_empty() {
+        return Ok(());
+    }
+
+    let result = backend
+        .execute(
+            &format!(
+                "SELECT entity_id, snapshot_content \
+                 FROM {table_name} \
+                 WHERE schema_key = $1 \
+                   AND version_id = $2 \
+                   AND is_tombstone = 0 \
+                   AND snapshot_content IS NOT NULL",
+                table_name = VERSION_TIP_TABLE
+            ),
+            &[
+                EngineValue::Text(version_tip_schema_key().to_string()),
+                EngineValue::Text(version_tip_storage_version_id().to_string()),
+            ],
+        )
+        .await?;
+
+    let mut seen = HashSet::<String>::new();
+    for row in result.rows {
+        if row.len() < 2 {
+            continue;
+        }
+        let entity_id = match &row[0] {
+            EngineValue::Text(value) => value,
+            _ => continue,
+        };
+        let snapshot_content = match &row[1] {
+            EngineValue::Text(value) => value,
+            _ => continue,
+        };
+        let snapshot: JsonValue = match serde_json::from_str(snapshot_content) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let Some(working_commit_id) = snapshot
+            .get("working_commit_id")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        if !seen.insert(working_commit_id.clone()) {
+            // Keep behavior stable when prior data already violates uniqueness.
+            continue;
+        }
+        if let Some(incoming_entity_id) = incoming_working_to_entity.get(&working_commit_id) {
+            if incoming_entity_id != entity_id {
+                return Err(LixError {
+                    message: format!(
+                        "Unique constraint violation: working_commit_id '{}' already used by version '{}'",
+                        working_commit_id, entity_id
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn query_lix_version_rows(
+    backend: &dyn LixBackend,
+    selection: Option<&Expr>,
+    params: &[EngineValue],
+    placeholder_state: PlaceholderState,
+) -> Result<Vec<VersionRow>, LixError> {
+    let where_sql = selection
+        .map(|expr| format!(" WHERE {expr}"))
+        .unwrap_or_default();
+    let sql = format!(
+        "SELECT \
+         id, name, inherits_from_version_id, hidden, commit_id, working_commit_id \
+         FROM {view}{where_sql}",
+        view = LIX_VERSION_VIEW_NAME
+    );
+
+    let mut statements = Parser::parse_sql(&GenericDialect {}, &sql).map_err(|error| LixError {
+        message: error.to_string(),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "expected a single SELECT statement while querying lix_version rows"
+                .to_string(),
+        });
+    }
+    let Statement::Query(query) = statements.remove(0) else {
+        return Err(LixError {
+            message: "version row loader query must be SELECT".to_string(),
+        });
+    };
+
+    let query = *query;
+    let query = lix_version_view_read::rewrite_query(query.clone())?.unwrap_or(query);
+    let query = vtable_read::rewrite_query(query.clone())?.unwrap_or(query);
+    let lowered = lower_statement(Statement::Query(Box::new(query)), backend.dialect())?;
+    let bound = bind_sql_with_state(
+        &lowered.to_string(),
+        params,
+        backend.dialect(),
+        placeholder_state,
+    )?;
+    let result = backend.execute(&bound.sql, &bound.params).await?;
+
+    let mut rows = Vec::new();
+    for row in result.rows {
+        if row.len() < 6 {
+            return Err(LixError {
+                message: "lix_version rewrite expected 6 columns from row loader query".to_string(),
+            });
+        }
+        let id = value_required_string(&row[0], "id")?;
+        let name = value_required_string(&row[1], "name")?;
+        let inherits_from_version_id = value_optional_string(&row[2], "inherits_from_version_id")?;
+        let hidden = value_bool(&row[3], "hidden")?;
+        let _commit_id = value_required_string(&row[4], "commit_id")?;
+        let _working_commit_id = value_required_string(&row[5], "working_commit_id")?;
+
+        rows.push(VersionRow {
+            id,
+            name,
+            inherits_from_version_id,
+            hidden,
+        });
+    }
+
+    Ok(rows)
+}
+
+fn build_vtable_inserts(
+    descriptor_rows: Vec<InsertSnapshotRow>,
+    tip_rows: Vec<InsertSnapshotRow>,
+) -> Result<Vec<Insert>, LixError> {
+    let mut inserts = Vec::new();
+    if !descriptor_rows.is_empty() {
+        inserts.push(build_vtable_insert_for_schema(
+            version_descriptor_schema_key(),
+            version_descriptor_file_id(),
+            version_descriptor_storage_version_id(),
+            version_descriptor_plugin_key(),
+            version_descriptor_schema_version(),
+            &descriptor_rows,
+        )?);
+    }
+    if !tip_rows.is_empty() {
+        inserts.push(build_vtable_insert_for_schema(
+            version_tip_schema_key(),
+            version_tip_file_id(),
+            version_tip_storage_version_id(),
+            version_tip_plugin_key(),
+            version_tip_schema_version(),
+            &tip_rows,
+        )?);
+    }
+    Ok(inserts)
+}
+
+fn build_vtable_insert_for_schema(
+    schema_key: &str,
+    file_id: &str,
+    version_id: &str,
+    plugin_key: &str,
+    schema_version: &str,
+    rows: &[InsertSnapshotRow],
+) -> Result<Insert, LixError> {
+    let values_sql = rows
+        .iter()
+        .map(|row| {
+            let snapshot_sql = row
+                .snapshot_content
+                .as_ref()
+                .map(|value| format!("'{}'", escape_sql_string(&value.to_string())))
+                .unwrap_or_else(|| "NULL".to_string());
+            format!(
+                "('{entity_id}', '{schema_key}', '{file_id}', '{version_id}', '{plugin_key}', {snapshot}, '{schema_version}')",
+                entity_id = escape_sql_string(&row.entity_id),
+                schema_key = escape_sql_string(schema_key),
+                file_id = escape_sql_string(file_id),
+                version_id = escape_sql_string(version_id),
+                plugin_key = escape_sql_string(plugin_key),
+                snapshot = snapshot_sql,
+                schema_version = escape_sql_string(schema_version),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let sql = format!(
+        "INSERT INTO {vtable} (\
+         entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+         ) VALUES {values}",
+        vtable = VTABLE_NAME,
+        values = values_sql
+    );
+
+    let mut statements = Parser::parse_sql(&GenericDialect {}, &sql).map_err(|error| LixError {
+        message: error.to_string(),
+    })?;
+    if statements.len() != 1 {
+        return Err(LixError {
+            message: "failed to build vtable insert for lix_version rewrite".to_string(),
+        });
+    }
+    let Statement::Insert(insert) = statements.remove(0) else {
+        return Err(LixError {
+            message: "lix_version rewrite expected generated INSERT statement".to_string(),
+        });
+    };
+
+    Ok(insert)
+}
+
+fn insert_field_map(columns: &[Ident]) -> Result<BTreeMap<String, usize>, LixError> {
+    let allowed: BTreeSet<&str> = BTreeSet::from([
+        "id",
+        "name",
+        "inherits_from_version_id",
+        "hidden",
+        "commit_id",
+        "working_commit_id",
+    ]);
+    let mut map = BTreeMap::new();
+    for (index, column) in columns.iter().enumerate() {
+        let key = column.value.to_ascii_lowercase();
+        if !allowed.contains(key.as_str()) {
+            return Err(LixError {
+                message: format!(
+                    "lix_version insert does not support column '{}'",
+                    column.value
+                ),
+            });
+        }
+        if map.insert(key.clone(), index).is_some() {
+            return Err(LixError {
+                message: format!("lix_version insert duplicated column '{}'", column.value),
+            });
+        }
+    }
+    Ok(map)
+}
+
+fn field_required_string(
+    index: Option<&usize>,
+    resolved_row: &[crate::sql::ResolvedCell],
+    original_row: &[Expr],
+    field: &str,
+) -> Result<String, LixError> {
+    let Some(index) = index else {
+        return Err(LixError {
+            message: format!("lix_version insert requires column '{field}'"),
+        });
+    };
+    let value = resolved_row
+        .get(*index)
+        .and_then(|cell| cell.value.as_ref())
+        .ok_or_else(|| LixError {
+            message: format!("lix_version insert '{field}' must be literal or parameter"),
+        })?;
+    value_required_string(value, field).map_err(|error| {
+        if matches!(original_row.get(*index), Some(Expr::Value(_))) {
+            error
+        } else {
+            LixError {
+                message: format!("lix_version insert '{field}' must be literal or parameter"),
+            }
+        }
+    })
+}
+
+fn field_optional_string(
+    index: Option<&usize>,
+    resolved_row: &[crate::sql::ResolvedCell],
+    _original_row: &[Expr],
+    field: &str,
+) -> Result<Option<String>, LixError> {
+    let Some(index) = index else {
+        return Ok(None);
+    };
+    let value = resolved_row
+        .get(*index)
+        .and_then(|cell| cell.value.as_ref())
+        .ok_or_else(|| LixError {
+            message: format!("lix_version insert '{field}' must be literal or parameter"),
+        })?;
+    value_optional_string(value, field)
+}
+
+fn field_optional_bool(
+    index: Option<&usize>,
+    resolved_row: &[crate::sql::ResolvedCell],
+    _original_row: &[Expr],
+    field: &str,
+) -> Result<Option<bool>, LixError> {
+    let Some(index) = index else {
+        return Ok(None);
+    };
+    let value = resolved_row
+        .get(*index)
+        .and_then(|cell| cell.value.as_ref())
+        .ok_or_else(|| LixError {
+            message: format!("lix_version insert '{field}' must be literal or parameter"),
+        })?;
+    Ok(Some(value_bool(value, field)?))
+}
+
+fn value_required_string(value: &EngineValue, field: &str) -> Result<String, LixError> {
+    match value {
+        EngineValue::Text(text) => Ok(text.clone()),
+        EngineValue::Null => Err(LixError {
+            message: format!("lix_version field '{field}' cannot be NULL"),
+        }),
+        _ => Err(LixError {
+            message: format!("lix_version field '{field}' must be a string"),
+        }),
+    }
+}
+
+fn value_optional_string(value: &EngineValue, field: &str) -> Result<Option<String>, LixError> {
+    match value {
+        EngineValue::Text(text) => Ok(Some(text.clone())),
+        EngineValue::Null => Ok(None),
+        _ => Err(LixError {
+            message: format!("lix_version field '{field}' must be a string or NULL"),
+        }),
+    }
+}
+
+fn value_bool(value: &EngineValue, field: &str) -> Result<bool, LixError> {
+    match value {
+        EngineValue::Integer(number) => Ok(*number != 0),
+        EngineValue::Real(number) => Ok(*number != 0.0),
+        EngineValue::Text(text) => {
+            let normalized = text.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "1" | "true" => Ok(true),
+                "0" | "false" => Ok(false),
+                _ => Err(LixError {
+                    message: format!(
+                        "lix_version field '{field}' must be boolean-compatible, got '{text}'"
+                    ),
+                }),
+            }
+        }
+        EngineValue::Null => Ok(false),
+        _ => Err(LixError {
+            message: format!("lix_version field '{field}' must be boolean-compatible"),
+        }),
+    }
+}
+
+fn assignment_target_column(target: &AssignmentTarget) -> Option<String> {
+    match target {
+        AssignmentTarget::ColumnName(name) => name
+            .0
+            .last()
+            .and_then(ObjectNamePart::as_ident)
+            .map(|ident| ident.value.to_ascii_lowercase()),
+        AssignmentTarget::Tuple(_) => None,
+    }
+}
+
+fn table_object_is_lix_version(table: &TableObject) -> bool {
+    match table {
+        TableObject::TableName(name) => object_name_matches(name, LIX_VERSION_VIEW_NAME),
+        _ => false,
+    }
+}
+
+fn table_with_joins_is_lix_version(table: &TableWithJoins) -> bool {
+    table.joins.is_empty()
+        && matches!(
+            &table.relation,
+            TableFactor::Table { name, .. } if object_name_matches(name, LIX_VERSION_VIEW_NAME)
+        )
+}
+
+fn delete_from_is_lix_version(delete: &Delete) -> bool {
+    match &delete.from {
+        FromTable::WithFromKeyword(tables) | FromTable::WithoutKeyword(tables) => {
+            if tables.len() != 1 {
+                return false;
+            }
+            table_with_joins_is_lix_version(&tables[0])
+        }
+    }
+}
+
+fn object_name_matches(name: &ObjectName, target: &str) -> bool {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.eq_ignore_ascii_case(target))
+        .unwrap_or(false)
+}
+
+fn escape_sql_string(input: &str) -> String {
+    input.replace('\'', "''")
+}

--- a/packages/engine/src/sql/steps/mod.rs
+++ b/packages/engine/src/sql/steps/mod.rs
@@ -1,4 +1,6 @@
 pub mod inline_lix_functions;
+pub mod lix_active_account_view_read;
+pub mod lix_active_account_view_write;
 pub mod lix_active_version_view_read;
 pub mod lix_active_version_view_write;
 pub mod lix_state_by_version_view_read;

--- a/packages/engine/src/sql/steps/mod.rs
+++ b/packages/engine/src/sql/steps/mod.rs
@@ -1,4 +1,8 @@
 pub mod inline_lix_functions;
+pub mod lix_active_version_view_read;
+pub mod lix_active_version_view_write;
+pub mod lix_version_view_read;
+pub mod lix_version_view_write;
 pub mod stored_schema;
 pub mod vtable_read;
 pub mod vtable_write;

--- a/packages/engine/src/sql/steps/mod.rs
+++ b/packages/engine/src/sql/steps/mod.rs
@@ -1,6 +1,8 @@
 pub mod inline_lix_functions;
 pub mod lix_active_version_view_read;
 pub mod lix_active_version_view_write;
+pub mod lix_state_by_version_view_read;
+pub mod lix_state_by_version_view_write;
 pub mod lix_state_view_read;
 pub mod lix_state_view_write;
 pub mod lix_version_view_read;

--- a/packages/engine/src/sql/steps/mod.rs
+++ b/packages/engine/src/sql/steps/mod.rs
@@ -1,6 +1,8 @@
 pub mod inline_lix_functions;
 pub mod lix_active_version_view_read;
 pub mod lix_active_version_view_write;
+pub mod lix_state_view_read;
+pub mod lix_state_view_write;
 pub mod lix_version_view_read;
 pub mod lix_version_view_write;
 pub mod stored_schema;

--- a/packages/engine/src/sql/steps/vtable_read.rs
+++ b/packages/engine/src/sql/steps/vtable_read.rs
@@ -234,7 +234,7 @@ fn build_untracked_union_query(
             .unwrap_or_default();
         union_parts.push(format!(
             "SELECT entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, \
-                    created_at, updated_at, NULL AS inherited_from_version_id, change_id, 0 AS untracked, 2 AS priority \
+                    created_at, updated_at, inherited_from_version_id, change_id, 0 AS untracked, 2 AS priority \
              FROM {materialized}{materialized_where}",
             materialized = materialized_ident,
             materialized_where = materialized_where

--- a/packages/engine/src/sql/steps/vtable_write.rs
+++ b/packages/engine/src/sql/steps/vtable_write.rs
@@ -22,7 +22,10 @@ use crate::sql::types::{
     MutationOperation, MutationRow, UpdateValidationPlan, VtableDeletePlan, VtableUpdatePlan,
 };
 use crate::sql::SchemaRegistration;
-use crate::sql::{resolve_expr_cell_with_state, PlaceholderState, ResolvedCell, RowSourceResolver};
+use crate::sql::{
+    escape_sql_string, resolve_expr_cell_with_state, PlaceholderState, ResolvedCell,
+    RowSourceResolver,
+};
 use crate::Value as EngineValue;
 use crate::{LixBackend, LixError};
 
@@ -1478,10 +1481,6 @@ fn value_to_string(value: &EngineValue, name: &str) -> Result<String, LixError> 
             message: format!("vtable update expected text for {name}"),
         }),
     }
-}
-
-fn escape_sql_string(input: &str) -> String {
-    input.replace('\'', "''")
 }
 
 fn is_missing_relation_error(err: &LixError) -> bool {

--- a/packages/engine/src/version/mod.rs
+++ b/packages/engine/src/version/mod.rs
@@ -2,7 +2,9 @@ use serde_json::Value as JsonValue;
 use std::sync::OnceLock;
 
 use crate::builtin_schema::types::{LixActiveVersion, LixVersionDescriptor, LixVersionPointer};
-use crate::builtin_schema::{builtin_schema_definition, builtin_schema_json};
+use crate::builtin_schema::{
+    builtin_schema_definition, builtin_schema_json, decode_lixcol_literal,
+};
 use crate::LixError;
 
 pub(crate) const GLOBAL_VERSION_ID: &str = "global";
@@ -201,8 +203,4 @@ fn parse_schema_metadata(schema_key: &str) -> SchemaMetadata {
         plugin_key: decode_lixcol_literal(plugin_key_raw),
         storage_version_id,
     }
-}
-
-fn decode_lixcol_literal(raw: &str) -> String {
-    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('"').to_string())
 }

--- a/packages/engine/src/version/mod.rs
+++ b/packages/engine/src/version/mod.rs
@@ -1,0 +1,213 @@
+use serde_json::Value as JsonValue;
+use std::sync::OnceLock;
+
+use crate::builtin_schema::{builtin_schema_definition, builtin_schema_json};
+use crate::LixError;
+
+pub(crate) const GLOBAL_VERSION_ID: &str = "global";
+pub(crate) const DEFAULT_ACTIVE_VERSION_NAME: &str = "main";
+
+static ACTIVE_VERSION_SCHEMA_METADATA: OnceLock<SchemaMetadata> = OnceLock::new();
+static VERSION_DESCRIPTOR_SCHEMA_METADATA: OnceLock<SchemaMetadata> = OnceLock::new();
+static VERSION_TIP_SCHEMA_METADATA: OnceLock<SchemaMetadata> = OnceLock::new();
+
+struct SchemaMetadata {
+    schema_key: String,
+    schema_version: String,
+    file_id: String,
+    plugin_key: String,
+    storage_version_id: String,
+}
+
+#[allow(dead_code)]
+pub(crate) fn active_version_schema_definition() -> &'static JsonValue {
+    builtin_schema_definition("lix_active_version")
+        .expect("builtin schema 'lix_active_version' must exist")
+}
+
+#[allow(dead_code)]
+pub(crate) fn active_version_schema_definition_json() -> &'static str {
+    builtin_schema_json("lix_active_version")
+        .expect("builtin schema 'lix_active_version' must exist")
+}
+
+pub(crate) fn active_version_schema_key() -> &'static str {
+    &active_version_schema_metadata().schema_key
+}
+
+pub(crate) fn active_version_schema_version() -> &'static str {
+    &active_version_schema_metadata().schema_version
+}
+
+pub(crate) fn active_version_file_id() -> &'static str {
+    &active_version_schema_metadata().file_id
+}
+
+pub(crate) fn active_version_plugin_key() -> &'static str {
+    &active_version_schema_metadata().plugin_key
+}
+
+pub(crate) fn active_version_storage_version_id() -> &'static str {
+    &active_version_schema_metadata().storage_version_id
+}
+
+pub(crate) fn active_version_snapshot_content(entity_id: &str, version_id: &str) -> String {
+    serde_json::json!({
+        "id": entity_id,
+        "version_id": version_id,
+    })
+    .to_string()
+}
+
+pub(crate) fn parse_active_version_snapshot(snapshot_content: &str) -> Result<String, LixError> {
+    let parsed: JsonValue = serde_json::from_str(snapshot_content).map_err(|error| LixError {
+        message: format!("active version snapshot_content invalid JSON: {error}"),
+    })?;
+
+    let value = parsed
+        .get("version_id")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| LixError {
+            message: "active version snapshot_content must contain string version_id".to_string(),
+        })?;
+
+    if value.is_empty() {
+        return Err(LixError {
+            message: "active version must not be empty".to_string(),
+        });
+    }
+
+    Ok(value.to_string())
+}
+
+pub(crate) fn version_descriptor_schema_key() -> &'static str {
+    &version_descriptor_schema_metadata().schema_key
+}
+
+pub(crate) fn version_descriptor_schema_version() -> &'static str {
+    &version_descriptor_schema_metadata().schema_version
+}
+
+pub(crate) fn version_descriptor_file_id() -> &'static str {
+    &version_descriptor_schema_metadata().file_id
+}
+
+pub(crate) fn version_descriptor_plugin_key() -> &'static str {
+    &version_descriptor_schema_metadata().plugin_key
+}
+
+pub(crate) fn version_descriptor_storage_version_id() -> &'static str {
+    &version_descriptor_schema_metadata().storage_version_id
+}
+
+pub(crate) fn version_descriptor_snapshot_content(
+    id: &str,
+    name: &str,
+    inherits_from_version_id: Option<&str>,
+    hidden: bool,
+) -> String {
+    serde_json::json!({
+        "id": id,
+        "name": name,
+        "inherits_from_version_id": inherits_from_version_id,
+        "hidden": hidden,
+    })
+    .to_string()
+}
+
+pub(crate) fn version_tip_schema_key() -> &'static str {
+    &version_tip_schema_metadata().schema_key
+}
+
+pub(crate) fn version_tip_schema_version() -> &'static str {
+    &version_tip_schema_metadata().schema_version
+}
+
+pub(crate) fn version_tip_file_id() -> &'static str {
+    &version_tip_schema_metadata().file_id
+}
+
+pub(crate) fn version_tip_plugin_key() -> &'static str {
+    &version_tip_schema_metadata().plugin_key
+}
+
+pub(crate) fn version_tip_storage_version_id() -> &'static str {
+    &version_tip_schema_metadata().storage_version_id
+}
+
+pub(crate) fn version_tip_snapshot_content(
+    id: &str,
+    commit_id: &str,
+    working_commit_id: &str,
+) -> String {
+    serde_json::json!({
+        "id": id,
+        "commit_id": commit_id,
+        "working_commit_id": working_commit_id,
+    })
+    .to_string()
+}
+
+fn active_version_schema_metadata() -> &'static SchemaMetadata {
+    ACTIVE_VERSION_SCHEMA_METADATA.get_or_init(|| parse_schema_metadata("lix_active_version"))
+}
+
+fn version_descriptor_schema_metadata() -> &'static SchemaMetadata {
+    VERSION_DESCRIPTOR_SCHEMA_METADATA
+        .get_or_init(|| parse_schema_metadata("lix_version_descriptor"))
+}
+
+fn version_tip_schema_metadata() -> &'static SchemaMetadata {
+    VERSION_TIP_SCHEMA_METADATA.get_or_init(|| parse_schema_metadata("lix_version_tip"))
+}
+
+fn parse_schema_metadata(schema_key: &str) -> SchemaMetadata {
+    let schema = builtin_schema_definition(schema_key).unwrap_or_else(|| {
+        panic!("builtin schema '{schema_key}' must exist");
+    });
+    let parsed_schema_key = schema
+        .get("x-lix-key")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| panic!("builtin schema '{schema_key}' must define string x-lix-key"))
+        .to_string();
+    let schema_version = schema
+        .get("x-lix-version")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| panic!("builtin schema '{schema_key}' must define string x-lix-version"))
+        .to_string();
+    let overrides = schema
+        .get("x-lix-override-lixcols")
+        .and_then(JsonValue::as_object)
+        .unwrap_or_else(|| {
+            panic!("builtin schema '{schema_key}' must define object x-lix-override-lixcols")
+        });
+    let file_id_raw = overrides
+        .get("lixcol_file_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| {
+            panic!("builtin schema '{schema_key}' must define string lixcol_file_id")
+        });
+    let plugin_key_raw = overrides
+        .get("lixcol_plugin_key")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| {
+            panic!("builtin schema '{schema_key}' must define string lixcol_plugin_key")
+        });
+    let storage_version_id = overrides
+        .get("lixcol_version_id")
+        .and_then(JsonValue::as_str)
+        .map(decode_lixcol_literal)
+        .unwrap_or_else(|| GLOBAL_VERSION_ID.to_string());
+
+    SchemaMetadata {
+        schema_key: parsed_schema_key,
+        schema_version,
+        file_id: decode_lixcol_literal(file_id_raw),
+        plugin_key: decode_lixcol_literal(plugin_key_raw),
+        storage_version_id,
+    }
+}
+
+fn decode_lixcol_literal(raw: &str) -> String {
+    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.trim_matches('"').to_string())
+}

--- a/packages/engine/tests/active_version.rs
+++ b/packages/engine/tests/active_version.rs
@@ -1,0 +1,309 @@
+mod support;
+
+use lix_engine::{BootKeyValue, Value};
+use support::simulation_test::{
+    default_simulations, run_simulation_test, SimulationArgs, SimulationBootArgs,
+};
+
+fn parse_snapshot(value: &Value) -> serde_json::Value {
+    let text = match value {
+        Value::Text(value) => value,
+        other => panic!("expected text snapshot_content, got {other:?}"),
+    };
+    serde_json::from_str(text).expect("snapshot_content should be valid JSON")
+}
+
+async fn read_active_version_value(engine: &support::simulation_test::SimulationEngine) -> String {
+    let row = engine
+        .execute(
+            "SELECT snapshot_content \
+             FROM lix_internal_state_vtable \
+             WHERE schema_key = 'lix_active_version' \
+               AND file_id = 'lix' \
+               AND version_id = 'global' \
+               AND untracked = 1 \
+             ORDER BY updated_at DESC \
+             LIMIT 1",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(row.rows.len(), 1);
+    let snapshot = parse_snapshot(&row.rows[0][0]);
+    snapshot["version_id"]
+        .as_str()
+        .expect("active version value should be a string")
+        .to_string()
+}
+
+async fn read_active_version_view_row(
+    engine: &support::simulation_test::SimulationEngine,
+) -> (String, String) {
+    let result = engine
+        .execute("SELECT id, version_id FROM lix_active_version", &[])
+        .await
+        .unwrap();
+    assert_eq!(result.rows.len(), 1);
+    let id = match &result.rows[0][0] {
+        Value::Text(value) => value.clone(),
+        other => panic!("expected text id, got {other:?}"),
+    };
+    let version_id = match &result.rows[0][1] {
+        Value::Text(value) => value.clone(),
+        other => panic!("expected text version_id, got {other:?}"),
+    };
+    (id, version_id)
+}
+
+fn deterministic_boot_args() -> SimulationBootArgs {
+    SimulationBootArgs {
+        key_values: vec![BootKeyValue {
+            key: "lix_deterministic_mode".to_string(),
+            value: serde_json::json!({ "enabled": true }),
+            version_id: None,
+        }],
+    }
+}
+
+async fn run_init_seeds_default_active_version_deterministic(sim: SimulationArgs) {
+    let engine = sim
+        .boot_simulated_engine(Some(deterministic_boot_args()))
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    let row = engine
+        .execute(
+            "SELECT entity_id, snapshot_content, untracked \
+             FROM lix_internal_state_vtable \
+             WHERE schema_key = 'lix_active_version' \
+               AND file_id = 'lix' \
+               AND version_id = 'global' \
+               AND untracked = 1 \
+             ORDER BY updated_at DESC \
+             LIMIT 1",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(row.rows.len(), 1);
+    let entity_id = match &row.rows[0][0] {
+        Value::Text(value) => value,
+        other => panic!("expected text entity_id, got {other:?}"),
+    };
+    let snapshot = parse_snapshot(&row.rows[0][1]);
+    assert_eq!(snapshot["id"], entity_id.as_str());
+    let active_version_id = snapshot["version_id"]
+        .as_str()
+        .expect("active version snapshot should include string version_id");
+    assert!(!active_version_id.is_empty());
+    assert_eq!(row.rows[0][2], Value::Integer(1));
+
+    sim.assert_deterministic(entity_id.to_string());
+    sim.assert_deterministic(active_version_id.to_string());
+
+    let version = engine
+        .execute(
+            "SELECT name FROM lix_version WHERE id = $1",
+            &[Value::Text(active_version_id.to_string())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(version.rows.len(), 1);
+    assert_eq!(version.rows[0][0], Value::Text("main".to_string()));
+}
+
+#[tokio::test]
+async fn init_seeds_default_active_version_is_deterministic_across_backends() {
+    run_simulation_test(
+        default_simulations(),
+        run_init_seeds_default_active_version_deterministic,
+    )
+    .await;
+}
+
+simulation_test!(init_seeds_default_active_version, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine(None)
+        .await
+        .expect("boot_simulated_engine should succeed");
+
+    engine.init().await.unwrap();
+
+    let row = engine
+        .execute(
+            "SELECT entity_id, snapshot_content, untracked \
+             FROM lix_internal_state_vtable \
+             WHERE schema_key = 'lix_active_version' \
+               AND file_id = 'lix' \
+               AND version_id = 'global' \
+               AND untracked = 1 \
+             ORDER BY updated_at DESC \
+             LIMIT 1",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(row.rows.len(), 1);
+    let entity_id = match &row.rows[0][0] {
+        Value::Text(value) => value,
+        other => panic!("expected text entity_id, got {other:?}"),
+    };
+    let snapshot = parse_snapshot(&row.rows[0][1]);
+    assert_eq!(snapshot["id"], entity_id.as_str());
+    let active_version_id = snapshot["version_id"]
+        .as_str()
+        .expect("active version snapshot should include string version_id");
+    assert!(!active_version_id.is_empty());
+    assert_eq!(row.rows[0][2], Value::Integer(1));
+
+    let version = engine
+        .execute(
+            "SELECT name FROM lix_version WHERE id = $1",
+            &[Value::Text(active_version_id.to_string())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(version.rows.len(), 1);
+    assert_eq!(version.rows[0][0], Value::Text("main".to_string()));
+});
+
+simulation_test!(
+    active_version_view_select_reads_seeded_row,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let (id, version_id) = read_active_version_view_row(&engine).await;
+        assert!(!id.is_empty());
+        assert!(!version_id.is_empty());
+    }
+);
+
+simulation_test!(
+    active_version_view_update_switches_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let (before_id, _) = read_active_version_view_row(&engine).await;
+
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = $1",
+                &[Value::Text("global".to_string())],
+            )
+            .await
+            .unwrap();
+
+        let (after_id, after_version_id) = read_active_version_view_row(&engine).await;
+        assert_eq!(after_id, before_id);
+        assert_eq!(after_version_id, "global");
+    }
+);
+
+simulation_test!(
+    active_version_view_update_rejects_missing_version_fk,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let error = engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version_nonexistent'",
+                &[],
+            )
+            .await
+            .expect_err("missing version_id should violate active version FK");
+        assert!(
+            error.message.contains("Foreign key constraint violation"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+);
+
+simulation_test!(
+    active_version_view_update_allows_existing_version_fk,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute("UPDATE lix_active_version SET version_id = 'global'", &[])
+            .await
+            .unwrap();
+
+        let (_, version_id) = read_active_version_view_row(&engine).await;
+        assert_eq!(version_id, "global");
+    }
+);
+
+simulation_test!(
+    active_version_can_be_switched_via_vtable_update,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+        engine
+            .execute(
+                "UPDATE lix_internal_state_vtable \
+                 SET snapshot_content = '{\"id\":\"preserved\",\"version_id\":\"version-a\"}' \
+                 WHERE untracked = 1 \
+                   AND schema_key = 'lix_active_version' \
+                   AND file_id = 'lix' \
+                   AND version_id = 'global'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(read_active_version_value(&engine).await, "version-a");
+    }
+);
+
+simulation_test!(
+    active_version_can_be_updated_multiple_times_via_vtable_update,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "UPDATE lix_internal_state_vtable \
+                 SET snapshot_content = '{\"id\":\"preserved\",\"version_id\":\"version-b\"}' \
+                 WHERE untracked = 1 \
+                   AND schema_key = 'lix_active_version' \
+                   AND file_id = 'lix' \
+                   AND version_id = 'global'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(read_active_version_value(&engine).await, "version-b");
+    }
+);

--- a/packages/engine/tests/active_version.rs
+++ b/packages/engine/tests/active_version.rs
@@ -63,6 +63,7 @@ fn deterministic_boot_args() -> SimulationBootArgs {
             value: serde_json::json!({ "enabled": true }),
             version_id: None,
         }],
+        active_account: None,
     }
 }
 

--- a/packages/engine/tests/cel_default_values.rs
+++ b/packages/engine/tests/cel_default_values.rs
@@ -362,7 +362,7 @@ async fn run_insert_applies_uuid_function_default(sim: SimulationArgs) {
 
     let snapshot = text_to_json(&row.rows[0][0]);
     let token = snapshot["token"].as_str().expect("token to be string");
-    sim.expect_deterministic(token.to_string());
+    sim.assert_deterministic(token.to_string());
     assert_eq!(token, deterministic_uuid(0));
     Uuid::parse_str(token).expect("token to be valid UUID");
 }
@@ -411,7 +411,7 @@ async fn run_insert_applies_timestamp_function_default(sim: SimulationArgs) {
     let created_at = snapshot["created_at"]
         .as_str()
         .expect("created_at to be string");
-    sim.expect_deterministic(created_at.to_string());
+    sim.assert_deterministic(created_at.to_string());
     assert_eq!(created_at, "1970-01-01T00:00:00.000Z");
     DateTime::parse_from_rfc3339(created_at).expect("created_at to be strict RFC3339");
     assert!(created_at.ends_with('Z'));

--- a/packages/engine/tests/commit.rs
+++ b/packages/engine/tests/commit.rs
@@ -59,13 +59,13 @@ fn as_i64(value: &Value) -> i64 {
     }
 }
 
-async fn read_version_tip_commit_id(engine: &SimulationEngine, version_id: &str) -> String {
+async fn read_version_pointer_commit_id(engine: &SimulationEngine, version_id: &str) -> String {
     let result = engine
         .execute(
             &format!(
                 "SELECT snapshot_content \
                  FROM lix_internal_state_vtable \
-                 WHERE schema_key = 'lix_version_tip' \
+                 WHERE schema_key = 'lix_version_pointer' \
                    AND entity_id = '{}' \
                  LIMIT 1",
                 version_id
@@ -157,7 +157,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        let previous_commit_id = read_version_tip_commit_id(&engine, "global").await;
+        let previous_commit_id = read_version_pointer_commit_id(&engine, "global").await;
 
         engine
             .execute(
@@ -171,7 +171,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        let new_commit_id = read_version_tip_commit_id(&engine, "global").await;
+        let new_commit_id = read_version_pointer_commit_id(&engine, "global").await;
         assert_ne!(new_commit_id, previous_commit_id);
 
         let domain_change = engine
@@ -253,7 +253,7 @@ simulation_test!(
             .execute(
                 "SELECT snapshot_id \
                  FROM lix_internal_change \
-                 WHERE schema_key IN ('test_schema', 'lix_commit', 'lix_version_tip')",
+                 WHERE schema_key IN ('test_schema', 'lix_commit', 'lix_version_pointer')",
                 &[],
             )
             .await
@@ -291,7 +291,7 @@ simulation_test!(
             .execute(
                 "SELECT COUNT(*) \
                  FROM lix_internal_change \
-                 WHERE schema_key IN ('test_schema', 'lix_commit', 'lix_version_tip', 'lix_change_set_element', 'lix_commit_edge')",
+                 WHERE schema_key IN ('test_schema', 'lix_commit', 'lix_version_pointer', 'lix_change_set_element', 'lix_commit_edge')",
                 &[],
             )
             .await
@@ -314,7 +314,7 @@ simulation_test!(
             .execute(
                 "SELECT COUNT(*) \
                  FROM lix_internal_change \
-                 WHERE schema_key IN ('test_schema', 'lix_commit', 'lix_version_tip', 'lix_change_set_element', 'lix_commit_edge')",
+                 WHERE schema_key IN ('test_schema', 'lix_commit', 'lix_version_pointer', 'lix_change_set_element', 'lix_commit_edge')",
                 &[],
             )
             .await

--- a/packages/engine/tests/deterministic_mode.rs
+++ b/packages/engine/tests/deterministic_mode.rs
@@ -67,6 +67,7 @@ simulation_test!(
                     value: serde_json::json!({ "enabled": true }),
                     version_id: None,
                 }],
+                ..Default::default()
             }))
             .await
             .expect("boot_simulated_engine should succeed");
@@ -94,8 +95,8 @@ simulation_test!(
             Value::Text(value) => value,
             other => panic!("expected text updated_at, got {other:?}"),
         };
-        sim.expect_deterministic(created_at.to_string());
-        sim.expect_deterministic(updated_at.to_string());
+        sim.assert_deterministic(created_at.to_string());
+        sim.assert_deterministic(updated_at.to_string());
         assert!(created_at.starts_with("1970-01-01T00:00:00."));
         assert!(created_at.ends_with('Z'));
         assert_eq!(created_at, updated_at);

--- a/packages/engine/tests/execute.rs
+++ b/packages/engine/tests/execute.rs
@@ -8,7 +8,7 @@ simulation_test!(select_works, |sim| async move {
         .await
         .expect("boot_simulated_engine should succeed");
     let result = engine.execute("SELECT 1 + 1", &[]).await.unwrap();
-    sim.expect_deterministic(result.rows.clone());
+    sim.assert_deterministic(result.rows.clone());
     assert_eq!(result.rows.len(), 1);
     assert_eq!(result.rows[0][0], Value::Integer(2));
 });

--- a/packages/engine/tests/init.rs
+++ b/packages/engine/tests/init.rs
@@ -14,7 +14,7 @@ simulation_test!(init_creates_untracked_table, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(result.rows.clone());
+    sim.assert_deterministic(result.rows.clone());
 });
 
 simulation_test!(init_creates_snapshot_table, |sim| async move {
@@ -30,7 +30,7 @@ simulation_test!(init_creates_snapshot_table, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(result.rows.clone());
+    sim.assert_deterministic(result.rows.clone());
 });
 
 simulation_test!(init_creates_change_table, |sim| async move {
@@ -46,7 +46,7 @@ simulation_test!(init_creates_change_table, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(result.rows.clone());
+    sim.assert_deterministic(result.rows.clone());
 });
 
 simulation_test!(init_inserts_no_content_snapshot, |sim| async move {
@@ -65,7 +65,7 @@ simulation_test!(init_inserts_no_content_snapshot, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(result.rows.clone());
+    sim.assert_deterministic(result.rows.clone());
     assert_eq!(result.rows.len(), 1);
     assert_eq!(result.rows[0][0], lix_engine::Value::Null);
 });
@@ -90,7 +90,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(result.rows.clone());
+        sim.assert_deterministic(result.rows.clone());
     }
 );
 
@@ -116,7 +116,7 @@ simulation_test!(init_seeds_key_value_schema_definition, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(result.rows.clone());
+    sim.assert_deterministic(result.rows.clone());
     assert_eq!(result.rows.len(), 1);
     assert_eq!(
         result.rows[0][0],
@@ -164,7 +164,7 @@ simulation_test!(init_seeds_builtin_schema_definitions, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(result.rows.clone());
+    sim.assert_deterministic(result.rows.clone());
     assert_eq!(result.rows.len(), 9);
 
     let mut seen_schema_keys = BTreeSet::new();

--- a/packages/engine/tests/init.rs
+++ b/packages/engine/tests/init.rs
@@ -151,7 +151,7 @@ simulation_test!(init_seeds_builtin_schema_definitions, |sim| async move {
                'lix_change_author~1', \
                'lix_change_set~1', \
                'lix_commit~1', \
-               'lix_version_tip~1', \
+               'lix_version_pointer~1', \
                'lix_change_set_element~1', \
                'lix_commit_edge~1'\
              ) \
@@ -213,7 +213,7 @@ simulation_test!(init_seeds_builtin_schema_definitions, |sim| async move {
             "lix_commit_edge".to_string(),
             "lix_key_value".to_string(),
             "lix_stored_schema".to_string(),
-            "lix_version_tip".to_string(),
+            "lix_version_pointer".to_string(),
         ])
     );
 });

--- a/packages/engine/tests/key_value.rs
+++ b/packages/engine/tests/key_value.rs
@@ -37,7 +37,7 @@ simulation_test!(key_value_crud_is_handled_through_vtable, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(after_insert.rows.clone());
+    sim.assert_deterministic(after_insert.rows.clone());
     assert_eq!(after_insert.rows.len(), 1);
     assert_eq!(
         after_insert.rows[0][0],
@@ -65,7 +65,7 @@ simulation_test!(key_value_crud_is_handled_through_vtable, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(after_update.rows.clone());
+    sim.assert_deterministic(after_update.rows.clone());
     assert_eq!(after_update.rows.len(), 1);
     assert_eq!(
         after_update.rows[0][0],
@@ -93,7 +93,7 @@ simulation_test!(key_value_crud_is_handled_through_vtable, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(after_delete.rows.clone());
+    sim.assert_deterministic(after_delete.rows.clone());
     assert_eq!(after_delete.rows.len(), 0);
 });
 
@@ -133,7 +133,7 @@ simulation_test!(key_value_allows_arbitrary_json_values, |sim| async move {
         .await
         .unwrap();
 
-    sim.expect_deterministic(rows.rows.clone());
+    sim.assert_deterministic(rows.rows.clone());
     assert_eq!(rows.rows.len(), 6);
 
     let actual_by_id: HashMap<String, String> = rows
@@ -209,7 +209,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(rows.rows.clone());
+        sim.assert_deterministic(rows.rows.clone());
         assert_eq!(rows.rows.len(), 2);
 
         let number_row = &rows.rows[0];

--- a/packages/engine/tests/materialization.rs
+++ b/packages/engine/tests/materialization.rs
@@ -1,0 +1,189 @@
+mod support;
+
+use std::collections::BTreeSet;
+
+use lix_engine::{
+    BootKeyValue, MaterializationDebugMode, MaterializationRequest, MaterializationScope, Value,
+};
+
+async fn register_test_schema(engine: &support::simulation_test::SimulationEngine) {
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"materialization_test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false}}'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+}
+
+async fn main_version_id(engine: &support::simulation_test::SimulationEngine) -> String {
+    let rows = engine
+        .execute(
+            "SELECT id FROM lix_version WHERE name = 'main' LIMIT 1",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows.rows.len(), 1);
+    match &rows.rows[0][0] {
+        Value::Text(value) => value.clone(),
+        other => panic!("expected main version id text, got {other:?}"),
+    }
+}
+
+simulation_test!(
+    materialization_plan_exposes_debug_trace_and_is_deterministic,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(Some(support::simulation_test::SimulationBootArgs {
+                key_values: vec![BootKeyValue {
+                    key: "lix_deterministic_mode".to_string(),
+                    value: serde_json::json!({ "enabled": true }),
+                    version_id: None,
+                }],
+            }))
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        let main_version_id = main_version_id(&engine).await;
+
+        engine
+            .execute(
+                &format!(
+                    "INSERT INTO lix_state_by_version (\
+                     entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+                     ) VALUES (\
+                     'entity-1', 'materialization_test_schema', 'file-1', '{}', 'lix', '{{\"value\":\"A\"}}', '1'\
+                     )",
+                    main_version_id
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let plan = engine
+            .materialization_plan(&MaterializationRequest {
+                scope: MaterializationScope::Full,
+                debug: MaterializationDebugMode::Full,
+                debug_row_limit: 256,
+            })
+            .await
+            .unwrap();
+
+        assert!(!plan.writes.is_empty(), "expected materialization writes");
+        let schema_keys: BTreeSet<String> = plan
+            .writes
+            .iter()
+            .map(|write| write.schema_key.clone())
+            .collect();
+        assert!(schema_keys.contains("lix_commit"));
+        assert!(schema_keys.contains("lix_version_pointer"));
+        assert!(schema_keys.contains("lix_change_set_element"));
+        assert!(schema_keys.contains("lix_commit_edge"));
+
+        let debug = plan.debug.as_ref().expect("expected debug trace");
+        assert!(!debug.tips_by_version.is_empty(), "expected version tips");
+        assert!(
+            !debug.traversed_commits.is_empty(),
+            "expected traversed commits"
+        );
+
+        let deterministic_payload = serde_json::to_string(&plan).unwrap();
+        sim.assert_deterministic(deterministic_payload);
+    }
+);
+
+simulation_test!(apply_materialization_plan_upserts_rows, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine(Some(support::simulation_test::SimulationBootArgs {
+            key_values: vec![BootKeyValue {
+                key: "lix_deterministic_mode".to_string(),
+                value: serde_json::json!({ "enabled": true }),
+                version_id: None,
+            }],
+        }))
+        .await
+        .expect("boot_simulated_engine should succeed");
+    engine.init().await.unwrap();
+
+    register_test_schema(&engine).await;
+    let main_version_id = main_version_id(&engine).await;
+
+    engine
+            .execute(
+                &format!(
+                    "INSERT INTO lix_state_by_version (\
+                     entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+                     ) VALUES (\
+                     'entity-2', 'materialization_test_schema', 'file-1', '{}', 'lix', '{{\"value\":\"B\"}}', '1'\
+                     )",
+                    main_version_id
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+
+    let plan = engine
+        .materialization_plan(&MaterializationRequest {
+            scope: MaterializationScope::Full,
+            debug: MaterializationDebugMode::Summary,
+            debug_row_limit: 128,
+        })
+        .await
+        .unwrap();
+
+    let first_report = engine.apply_materialization_plan(&plan).await.unwrap();
+
+    assert_eq!(first_report.rows_written, plan.writes.len());
+    assert!(first_report.rows_written > 0);
+    sim.assert_deterministic(first_report.rows_written as i64);
+
+    let next_plan = engine
+        .materialization_plan(&MaterializationRequest {
+            scope: MaterializationScope::Full,
+            debug: MaterializationDebugMode::Summary,
+            debug_row_limit: 128,
+        })
+        .await
+        .unwrap();
+    let report = engine.apply_materialization_plan(&next_plan).await.unwrap();
+    assert!(report.rows_deleted > 0);
+    assert!(report.rows_written > 0);
+    sim.assert_deterministic(vec![report.rows_written as i64, report.rows_deleted as i64]);
+
+    let rows = engine
+        .execute(
+            &format!(
+                "SELECT snapshot_content, change_id \
+                     FROM lix_internal_state_vtable \
+                     WHERE schema_key = 'materialization_test_schema' \
+                       AND entity_id = 'entity-2' \
+                       AND version_id = '{}' \
+                       AND snapshot_content IS NOT NULL \
+                     LIMIT 1",
+                main_version_id
+            ),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rows.rows.len(), 1);
+    match &rows.rows[0][0] {
+        Value::Text(text) => assert_eq!(text, "{\"value\":\"B\"}"),
+        other => panic!("expected text snapshot_content, got {other:?}"),
+    }
+    match &rows.rows[0][1] {
+        Value::Text(text) => assert!(!text.is_empty()),
+        other => panic!("expected text change_id, got {other:?}"),
+    }
+
+    sim.assert_deterministic(rows.rows.clone());
+});

--- a/packages/engine/tests/materialization.rs
+++ b/packages/engine/tests/materialization.rs
@@ -44,6 +44,7 @@ simulation_test!(
                     value: serde_json::json!({ "enabled": true }),
                     version_id: None,
                 }],
+                active_account: None,
             }))
             .await
             .expect("boot_simulated_engine should succeed");
@@ -107,6 +108,7 @@ simulation_test!(apply_materialization_plan_upserts_rows, |sim| async move {
                 value: serde_json::json!({ "enabled": true }),
                 version_id: None,
             }],
+            active_account: None,
         }))
         .await
         .expect("boot_simulated_engine should succeed");

--- a/packages/engine/tests/state_by_version_view.rs
+++ b/packages/engine/tests/state_by_version_view.rs
@@ -1,0 +1,514 @@
+mod support;
+
+use lix_engine::Value;
+
+fn assert_text(value: &Value, expected: &str) {
+    match value {
+        Value::Text(actual) => assert_eq!(actual, expected),
+        other => panic!("expected text value '{expected}', got {other:?}"),
+    }
+}
+
+async fn register_test_schema(engine: &support::simulation_test::SimulationEngine) {
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_state_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false}}'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_version(engine: &support::simulation_test::SimulationEngine, version_id: &str) {
+    let sql = format!(
+        "INSERT INTO lix_version (\
+         id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+         ) VALUES (\
+         '{version_id}', '{version_id}', 'global', 0, 'commit-{version_id}', 'working-{version_id}'\
+         )",
+    );
+    engine.execute(&sql, &[]).await.unwrap();
+}
+
+async fn insert_state_row(
+    engine: &support::simulation_test::SimulationEngine,
+    entity_id: &str,
+    version_id: &str,
+    snapshot_content: &str,
+) {
+    let sql = format!(
+        "INSERT INTO lix_internal_state_vtable (\
+         entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+         ) VALUES (\
+         '{entity_id}', 'test_state_schema', 'test-file', '{version_id}', 'lix', '{snapshot_content}', '1'\
+         )",
+        entity_id = entity_id,
+        version_id = version_id,
+        snapshot_content = snapshot_content.replace('\'', "''"),
+    );
+    engine.execute(&sql, &[]).await.unwrap();
+}
+
+// TODO(parity): Legacy SDK currently resolves inherited rows in state_by_version reads.
+// This test suite covers milestone 20-23 explicit-version behavior only.
+
+simulation_test!(
+    lix_state_by_version_select_scopes_to_version_predicate,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        insert_state_row(&engine, "entity-sel", "version-a", "{\"value\":\"A\"}").await;
+        insert_state_row(&engine, "entity-sel", "version-b", "{\"value\":\"B\"}").await;
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id, version_id, snapshot_content \
+                 FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-sel' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "entity-sel");
+        assert_text(&rows.rows[0][1], "version-a");
+        assert_text(&rows.rows[0][2], "{\"value\":\"A\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_select_hides_tracked_tombstones,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+
+        engine
+            .execute(
+                "INSERT INTO lix_state_by_version (\
+                 entity_id, schema_key, file_id, version_id, plugin_key, schema_version, snapshot_content\
+                 ) VALUES (\
+                 'entity-tomb', 'test_state_schema', 'test-file', 'version-a', 'lix', '1', '{\"value\":\"live\"}'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "DELETE FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-tomb' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id \
+                 FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-tomb' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert!(rows.rows.is_empty());
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_insert_routes_to_vtable,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+
+        engine
+            .execute(
+                "INSERT INTO lix_state_by_version (\
+                 entity_id, schema_key, file_id, version_id, plugin_key, schema_version, snapshot_content\
+                 ) VALUES (\
+                 'entity-ins', 'test_state_schema', 'test-file', 'version-a', 'lix', '1', '{\"value\":\"inserted\"}'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-ins' \
+                   AND file_id = 'test-file'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "version-a");
+        assert_text(&rows.rows[0][1], "{\"value\":\"inserted\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_insert_supports_placeholders,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+
+        engine
+            .execute(
+                "INSERT INTO lix_state_by_version (\
+                 entity_id, schema_key, file_id, version_id, plugin_key, schema_version, snapshot_content\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    Value::Text("entity-ins-p".to_string()),
+                    Value::Text("test_state_schema".to_string()),
+                    Value::Text("test-file".to_string()),
+                    Value::Text("version-a".to_string()),
+                    Value::Text("lix".to_string()),
+                    Value::Text("1".to_string()),
+                    Value::Text("{\"value\":\"inserted-p\"}".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-ins-p' \
+                   AND file_id = 'test-file'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "version-a");
+        assert_text(&rows.rows[0][1], "{\"value\":\"inserted-p\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_insert_requires_version_id,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+
+        let err = engine
+            .execute(
+                "INSERT INTO lix_state_by_version (\
+                 entity_id, schema_key, file_id, plugin_key, schema_version, snapshot_content\
+                 ) VALUES (\
+                 'entity-ins-err', 'test_state_schema', 'test-file', 'lix', '1', '{\"value\":\"x\"}'\
+                 )",
+                &[],
+            )
+            .await
+            .expect_err("insert without version_id should fail");
+
+        assert!(
+            err.message
+                .contains("lix_state_by_version insert requires version_id"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_update_routes_to_explicit_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        insert_state_row(&engine, "entity-upd", "version-a", "{\"value\":\"A\"}").await;
+        insert_state_row(&engine, "entity-upd", "version-b", "{\"value\":\"B\"}").await;
+
+        engine
+            .execute(
+                "UPDATE lix_state_by_version \
+                 SET snapshot_content = '{\"value\":\"A-updated\"}' \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-upd' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-upd' \
+                   AND file_id = 'test-file' \
+                 ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 2);
+        assert_text(&rows.rows[0][0], "version-a");
+        assert_text(&rows.rows[0][1], "{\"value\":\"A-updated\"}");
+        assert_text(&rows.rows[1][0], "version-b");
+        assert_text(&rows.rows[1][1], "{\"value\":\"B\"}");
+    }
+);
+
+// TODO(parity): Legacy SDK supports broader placeholder forms in UPDATE assignments.
+// Rust vtable UPDATE currently requires snapshot_content as a direct literal/parameter expression.
+
+simulation_test!(
+    lix_state_by_version_update_requires_version_id_predicate,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_state_row(
+            &engine,
+            "entity-upd-err",
+            "version-a",
+            "{\"value\":\"before\"}",
+        )
+        .await;
+
+        let err = engine
+            .execute(
+                "UPDATE lix_state_by_version \
+                 SET snapshot_content = '{\"value\":\"after\"}' \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-upd-err' \
+                   AND file_id = 'test-file'",
+                &[],
+            )
+            .await
+            .expect_err("update without version predicate should fail");
+
+        assert!(
+            err.message
+                .contains("lix_state_by_version update requires a version_id predicate"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_delete_routes_to_explicit_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        insert_state_row(&engine, "entity-del", "version-a", "{\"value\":\"A\"}").await;
+        insert_state_row(&engine, "entity-del", "version-b", "{\"value\":\"B\"}").await;
+
+        engine
+            .execute(
+                "DELETE FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-del' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let materialized = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-del' \
+                   AND file_id = 'test-file' \
+                 ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(materialized.rows.clone());
+        assert_eq!(materialized.rows.len(), 2);
+        assert_text(&materialized.rows[0][0], "version-a");
+        assert_eq!(materialized.rows[0][1], Value::Null);
+        assert_text(&materialized.rows[1][0], "version-b");
+        assert_text(&materialized.rows[1][1], "{\"value\":\"B\"}");
+
+        let visible = engine
+            .execute(
+                "SELECT version_id \
+                 FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-del' \
+                   AND file_id = 'test-file' \
+                 ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(visible.rows.clone());
+        assert_eq!(visible.rows.len(), 1);
+        assert_text(&visible.rows[0][0], "version-b");
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_delete_supports_placeholders,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_state_row(&engine, "entity-del-p", "version-a", "{\"value\":\"A\"}").await;
+
+        engine
+            .execute(
+                "DELETE FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = $1 \
+                   AND file_id = $2 \
+                   AND version_id = $3",
+                &[
+                    Value::Text("entity-del-p".to_string()),
+                    Value::Text("test-file".to_string()),
+                    Value::Text("version-a".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id \
+                 FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-del-p' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert!(rows.rows.is_empty());
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_delete_requires_version_id_predicate,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_state_row(
+            &engine,
+            "entity-del-err",
+            "version-a",
+            "{\"value\":\"before\"}",
+        )
+        .await;
+
+        let err = engine
+            .execute(
+                "DELETE FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-del-err' \
+                   AND file_id = 'test-file'",
+                &[],
+            )
+            .await
+            .expect_err("delete without version predicate should fail");
+
+        assert!(
+            err.message
+                .contains("lix_state_by_version delete requires a version_id predicate"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+);

--- a/packages/engine/tests/state_inheritance.rs
+++ b/packages/engine/tests/state_inheritance.rs
@@ -1,0 +1,270 @@
+mod support;
+
+use lix_engine::Value;
+
+fn assert_text(value: &Value, expected: &str) {
+    match value {
+        Value::Text(actual) => assert_eq!(actual, expected),
+        other => panic!("expected text value '{expected}', got {other:?}"),
+    }
+}
+
+async fn register_test_schema(engine: &support::simulation_test::SimulationEngine) {
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_state_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false}}'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_version(engine: &support::simulation_test::SimulationEngine, version_id: &str) {
+    let sql = format!(
+        "INSERT INTO lix_version (\
+         id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+         ) VALUES (\
+         '{version_id}', '{version_id}', 'global', 0, 'commit-{version_id}', 'working-{version_id}'\
+         )",
+    );
+    engine.execute(&sql, &[]).await.unwrap();
+}
+
+async fn insert_state_row(
+    engine: &support::simulation_test::SimulationEngine,
+    entity_id: &str,
+    version_id: &str,
+    snapshot_content: &str,
+) {
+    let sql = format!(
+        "INSERT INTO lix_internal_state_vtable (\
+         entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+         ) VALUES (\
+         '{entity_id}', 'test_state_schema', 'test-file', '{version_id}', 'lix', '{snapshot_content}', '1'\
+         )",
+        entity_id = entity_id,
+        version_id = version_id,
+        snapshot_content = snapshot_content.replace('\'', "''"),
+    );
+    engine.execute(&sql, &[]).await.unwrap();
+}
+
+// TODO(parity): Legacy SDK also resolves inheritance on state_by_version.
+// Current milestone follows plan.md scope: inheritance is applied on lix_state reads.
+
+simulation_test!(
+    lix_state_select_inherits_from_parent_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-child").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-child'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(
+            &engine,
+            "entity-inherited",
+            "global",
+            "{\"value\":\"global\"}",
+        )
+        .await;
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id, version_id, inherited_from_version_id, snapshot_content \
+             FROM lix_state \
+             WHERE schema_key = 'test_state_schema' \
+               AND entity_id = 'entity-inherited'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "entity-inherited");
+        assert_text(&rows.rows[0][1], "version-child");
+        assert_text(&rows.rows[0][2], "global");
+        assert_text(&rows.rows[0][3], "{\"value\":\"global\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_select_prefers_child_row_over_parent,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-child").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-child'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(
+            &engine,
+            "entity-override",
+            "global",
+            "{\"value\":\"global\"}",
+        )
+        .await;
+        insert_state_row(
+            &engine,
+            "entity-override",
+            "version-child",
+            "{\"value\":\"child\"}",
+        )
+        .await;
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, inherited_from_version_id, snapshot_content \
+             FROM lix_state \
+             WHERE schema_key = 'test_state_schema' \
+               AND entity_id = 'entity-override'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "version-child");
+        assert_eq!(rows.rows[0][1], Value::Null);
+        assert_text(&rows.rows[0][2], "{\"value\":\"child\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_select_child_tombstone_hides_parent_row,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-child").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-child'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(&engine, "entity-tomb", "global", "{\"value\":\"global\"}").await;
+        insert_state_row(
+            &engine,
+            "entity-tomb",
+            "version-child",
+            "{\"value\":\"child\"}",
+        )
+        .await;
+
+        engine
+            .execute(
+                "DELETE FROM lix_state_by_version \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-tomb' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-child'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-tomb'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert!(rows.rows.is_empty());
+    }
+);
+
+simulation_test!(
+    lix_state_delete_with_inherited_null_filter_deletes_only_local_rows,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-child").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-child'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(&engine, "entity-global", "global", "{\"value\":\"global\"}").await;
+        insert_state_row(
+            &engine,
+            "entity-local",
+            "version-child",
+            "{\"value\":\"local\"}",
+        )
+        .await;
+
+        engine
+            .execute(
+                "DELETE FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id LIKE 'entity-%' \
+                   AND inherited_from_version_id IS NULL",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id, inherited_from_version_id, snapshot_content \
+                 FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' \
+                 ORDER BY entity_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "entity-global");
+        assert_text(&rows.rows[0][1], "global");
+        assert_text(&rows.rows[0][2], "{\"value\":\"global\"}");
+    }
+);

--- a/packages/engine/tests/state_view.rs
+++ b/packages/engine/tests/state_view.rs
@@ -1,0 +1,862 @@
+mod support;
+
+use lix_engine::Value;
+
+fn assert_text(value: &Value, expected: &str) {
+    match value {
+        Value::Text(actual) => assert_eq!(actual, expected),
+        other => panic!("expected text value '{expected}', got {other:?}"),
+    }
+}
+
+async fn register_test_schema(engine: &support::simulation_test::SimulationEngine) {
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_state_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false}}'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_version(engine: &support::simulation_test::SimulationEngine, version_id: &str) {
+    let sql = format!(
+        "INSERT INTO lix_version (\
+         id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+         ) VALUES (\
+         '{version_id}', '{version_id}', 'global', 0, 'commit-{version_id}', 'working-{version_id}'\
+         )",
+    );
+    engine.execute(&sql, &[]).await.unwrap();
+}
+
+async fn insert_state_row(
+    engine: &support::simulation_test::SimulationEngine,
+    entity_id: &str,
+    version_id: &str,
+    snapshot_content: &str,
+    untracked: bool,
+) {
+    let sql = format!(
+        "INSERT INTO lix_internal_state_vtable (\
+         entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version, untracked\
+         ) VALUES (\
+         '{entity_id}', 'test_state_schema', 'test-file', '{version_id}', 'lix', '{snapshot_content}', '1', {untracked}\
+         )",
+        entity_id = entity_id,
+        version_id = version_id,
+        snapshot_content = snapshot_content.replace('\'', "''"),
+        untracked = if untracked { 1 } else { 0 },
+    );
+    engine.execute(&sql, &[]).await.unwrap();
+}
+
+simulation_test!(
+    lix_state_select_scopes_to_active_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(&engine, "entity-a", "version-a", "{\"value\":\"A\"}", false).await;
+        insert_state_row(&engine, "entity-b", "version-b", "{\"value\":\"B\"}", false).await;
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id, snapshot_content \
+                 FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' \
+                 ORDER BY entity_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "entity-a");
+        assert_text(&rows.rows[0][1], "{\"value\":\"A\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_select_switches_with_active_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        insert_state_row(&engine, "entity-a", "version-a", "{\"value\":\"A\"}", false).await;
+        insert_state_row(&engine, "entity-b", "version-b", "{\"value\":\"B\"}", false).await;
+
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+        let first = engine
+            .execute(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'test_state_schema'",
+                &[],
+            )
+            .await
+            .unwrap();
+        sim.assert_deterministic(first.rows.clone());
+        assert_eq!(first.rows.len(), 1);
+        assert_text(&first.rows[0][0], "entity-a");
+
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-b'",
+                &[],
+            )
+            .await
+            .unwrap();
+        let second = engine
+            .execute(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'test_state_schema'",
+                &[],
+            )
+            .await
+            .unwrap();
+        sim.assert_deterministic(second.rows.clone());
+        assert_eq!(second.rows.len(), 1);
+        assert_text(&second.rows[0][0], "entity-b");
+    }
+);
+
+simulation_test!(
+    lix_state_select_prioritizes_untracked_in_active_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(
+            &engine,
+            "entity-x",
+            "version-a",
+            "{\"value\":\"tracked\"}",
+            false,
+        )
+        .await;
+        insert_state_row(
+            &engine,
+            "entity-x",
+            "version-a",
+            "{\"value\":\"untracked\"}",
+            true,
+        )
+        .await;
+
+        let rows = engine
+            .execute(
+                "SELECT snapshot_content, untracked \
+                 FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' AND entity_id = 'entity-x'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "{\"value\":\"untracked\"}");
+        assert_eq!(rows.rows[0][1], Value::Integer(1));
+    }
+);
+
+simulation_test!(
+    lix_state_select_without_schema_key_filter,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(&engine, "entity-a", "version-a", "{\"value\":\"A\"}", false).await;
+        insert_state_row(&engine, "entity-b", "version-b", "{\"value\":\"B\"}", false).await;
+
+        let rows = engine
+            .execute(
+                "SELECT entity_id, schema_key \
+                 FROM lix_state \
+                 WHERE file_id = 'test-file' \
+                 ORDER BY entity_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "entity-a");
+        assert_text(&rows.rows[0][1], "test_state_schema");
+    }
+);
+
+simulation_test!(
+    lix_state_select_reflects_untracked_entity_after_vtable_update,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(
+            &engine,
+            "untracked-entity",
+            "version-a",
+            "{\"value\":\"initial\"}",
+            true,
+        )
+        .await;
+
+        engine
+            .execute(
+                "UPDATE lix_internal_state_vtable \
+                 SET snapshot_content = '{\"value\":\"updated\"}' \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'untracked-entity' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a' \
+                   AND untracked = 1",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let updated = engine
+            .execute(
+                "SELECT snapshot_content, untracked \
+                 FROM lix_state \
+                 WHERE entity_id = 'untracked-entity'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(updated.rows.clone());
+        assert_eq!(updated.rows.len(), 1);
+        assert_text(&updated.rows[0][0], "{\"value\":\"updated\"}");
+        assert_eq!(updated.rows[0][1], Value::Integer(1));
+    }
+);
+
+simulation_test!(
+    lix_state_insert_routes_to_active_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_state (\
+             entity_id, file_id, schema_key, plugin_key, schema_version, snapshot_content\
+             ) VALUES (\
+             'entity-0', 'file-0', 'test_state_schema', 'lix', '1', '{\"value\":\"A\"}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let first = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+             FROM lix_internal_state_vtable \
+             WHERE schema_key = 'test_state_schema' \
+               AND entity_id = 'entity-0' \
+               AND file_id = 'file-0' \
+             ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+        sim.assert_deterministic(first.rows.clone());
+        assert_eq!(first.rows.len(), 1);
+        assert_text(&first.rows[0][0], "version-a");
+        assert_text(&first.rows[0][1], "{\"value\":\"A\"}");
+
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-b'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_state (\
+             entity_id, file_id, schema_key, plugin_key, schema_version, snapshot_content\
+             ) VALUES (\
+             'entity-0', 'file-0', 'test_state_schema', 'lix', '1', '{\"value\":\"B\"}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let second = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+             FROM lix_internal_state_vtable \
+             WHERE schema_key = 'test_state_schema' \
+               AND entity_id = 'entity-0' \
+               AND file_id = 'file-0' \
+             ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+        sim.assert_deterministic(second.rows.clone());
+        assert_eq!(second.rows.len(), 2);
+        assert_text(&second.rows[0][0], "version-a");
+        assert_text(&second.rows[0][1], "{\"value\":\"A\"}");
+        assert_text(&second.rows[1][0], "version-b");
+        assert_text(&second.rows[1][1], "{\"value\":\"B\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_insert_routes_to_active_version_with_placeholders,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, file_id, schema_key, plugin_key, schema_version, snapshot_content\
+                 ) VALUES ($1, $2, $3, $4, $5, $6)",
+                &[
+                    Value::Text("entity-p".to_string()),
+                    Value::Text("file-p".to_string()),
+                    Value::Text("test_state_schema".to_string()),
+                    Value::Text("lix".to_string()),
+                    Value::Text("1".to_string()),
+                    Value::Text("{\"value\":\"P\"}".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-p' \
+                   AND file_id = 'file-p'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "version-a");
+        assert_text(&rows.rows[0][1], "{\"value\":\"P\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_insert_rejects_explicit_version_id_column,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let error = engine
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, file_id, schema_key, version_id, plugin_key, schema_version, snapshot_content\
+                 ) VALUES (\
+                 'entity-x', 'file-x', 'test_state_schema', 'version-b', 'lix', '1', '{\"value\":\"x\"}'\
+                 )",
+                &[],
+            )
+            .await
+            .expect_err("lix_state insert with version_id should fail");
+
+        assert!(
+            error
+                .message
+                .contains("lix_state insert cannot set version_id"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+);
+
+simulation_test!(
+    lix_state_update_routes_to_active_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        insert_state_row(
+            &engine,
+            "entity-u",
+            "version-a",
+            "{\"value\":\"A-initial\"}",
+            false,
+        )
+        .await;
+        insert_state_row(
+            &engine,
+            "entity-u",
+            "version-b",
+            "{\"value\":\"B-initial\"}",
+            false,
+        )
+        .await;
+
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "UPDATE lix_state \
+                 SET snapshot_content = '{\"value\":\"A-updated\"}' \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-u' \
+                   AND file_id = 'test-file'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-u' \
+                   AND file_id = 'test-file' \
+                 ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 2);
+        assert_text(&rows.rows[0][0], "version-a");
+        assert_text(&rows.rows[0][1], "{\"value\":\"A-updated\"}");
+        assert_text(&rows.rows[1][0], "version-b");
+        assert_text(&rows.rows[1][1], "{\"value\":\"B-initial\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_update_allows_untracked_without_untracked_predicate,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(
+            &engine,
+            "untracked-entity-u",
+            "version-a",
+            "{\"value\":\"initial\"}",
+            true,
+        )
+        .await;
+
+        engine
+            .execute(
+                "UPDATE lix_state \
+                 SET snapshot_content = '{\"value\":\"updated\"}' \
+                 WHERE entity_id = 'untracked-entity-u'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT snapshot_content, untracked \
+                 FROM lix_state \
+                 WHERE entity_id = 'untracked-entity-u'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "{\"value\":\"updated\"}");
+        assert_eq!(rows.rows[0][1], Value::Integer(1));
+    }
+);
+
+simulation_test!(
+    lix_state_update_rejects_explicit_version_id_assignment,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_state_row(
+            &engine,
+            "entity-ver",
+            "version-a",
+            "{\"value\":\"before\"}",
+            false,
+        )
+        .await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let error = engine
+            .execute(
+                "UPDATE lix_state \
+                 SET version_id = 'version-b' \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-ver'",
+                &[],
+            )
+            .await
+            .expect_err("lix_state update with version_id assignment should fail");
+        assert!(
+            error
+                .message
+                .contains("lix_state update cannot set version_id"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+);
+
+simulation_test!(
+    lix_state_delete_routes_to_active_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        insert_state_row(
+            &engine,
+            "entity-d",
+            "version-a",
+            "{\"value\":\"A-initial\"}",
+            false,
+        )
+        .await;
+        insert_state_row(
+            &engine,
+            "entity-d",
+            "version-b",
+            "{\"value\":\"B-initial\"}",
+            false,
+        )
+        .await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "DELETE FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-d' \
+                   AND file_id = 'test-file'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-d' \
+                   AND file_id = 'test-file' \
+                 ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 2);
+        assert_text(&rows.rows[0][0], "version-a");
+        assert_eq!(rows.rows[0][1], Value::Null);
+        assert_text(&rows.rows[1][0], "version-b");
+        assert_text(&rows.rows[1][1], "{\"value\":\"B-initial\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_delete_allows_untracked_with_untracked_predicate,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        insert_state_row(
+            &engine,
+            "untracked-entity-d",
+            "version-a",
+            "{\"value\":\"A-untracked\"}",
+            true,
+        )
+        .await;
+        insert_state_row(
+            &engine,
+            "untracked-entity-d",
+            "version-b",
+            "{\"value\":\"B-untracked\"}",
+            true,
+        )
+        .await;
+
+        engine
+            .execute(
+                "DELETE FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'untracked-entity-d' \
+                   AND file_id = 'test-file' \
+                   AND untracked = 1",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content, untracked \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'untracked-entity-d' \
+                   AND file_id = 'test-file' \
+                 ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "version-b");
+        assert_text(&rows.rows[0][1], "{\"value\":\"B-untracked\"}");
+        assert_eq!(rows.rows[0][2], Value::Integer(1));
+    }
+);
+
+simulation_test!(
+    lix_state_delete_is_scoped_to_active_version_even_with_explicit_version_predicate,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_version(&engine, "version-b").await;
+        insert_state_row(&engine, "entity-s", "version-a", "{\"value\":\"A\"}", false).await;
+        insert_state_row(&engine, "entity-s", "version-b", "{\"value\":\"B\"}", false).await;
+        engine
+            .execute(
+                "UPDATE lix_active_version SET version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "DELETE FROM lix_state \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-s' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-b'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT version_id, snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-s' \
+                   AND file_id = 'test-file' \
+                 ORDER BY version_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 2);
+        assert_text(&rows.rows[0][0], "version-a");
+        assert_text(&rows.rows[0][1], "{\"value\":\"A\"}");
+        assert_text(&rows.rows[1][0], "version-b");
+        assert_text(&rows.rows[1][1], "{\"value\":\"B\"}");
+    }
+);

--- a/packages/engine/tests/stored_schema.rs
+++ b/packages/engine/tests/stored_schema.rs
@@ -34,7 +34,7 @@ simulation_test!(
         .await
         .unwrap();
 
-        sim.expect_deterministic(stored.rows.clone());
+        sim.assert_deterministic(stored.rows.clone());
         assert_eq!(stored.rows.len(), 1);
         let row = &stored.rows[0];
         assert_eq!(row[0], Value::Text("test_schema~1".to_string()));

--- a/packages/engine/tests/support/mod.rs
+++ b/packages/engine/tests/support/mod.rs
@@ -4,78 +4,46 @@ pub mod simulations;
 #[macro_export]
 macro_rules! simulation_test {
     ($name:ident, |$sim:ident| $body:expr) => {
+        $crate::simulation_test!(
+            $name,
+            simulations = [sqlite, postgres, materialization],
+            |$sim| $body
+        );
+    };
+    ($name:ident, simulations = [$($simulation:ident),+ $(,)?], |$sim:ident| $body:expr) => {
         paste::paste! {
-            #[test]
-            fn [<$name _sqlite>]() {
-                std::thread::Builder::new()
-                    .name(concat!(stringify!($name), "_sqlite").to_string())
-                    .stack_size(8 * 1024 * 1024)
-                    .spawn(|| {
-                        let runtime = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .expect("failed to build tokio runtime");
-                        runtime.block_on(async {
-                            $crate::support::simulation_test::run_single_simulation_test(
-                                "sqlite",
-                                concat!(module_path!(), "::", stringify!($name)),
-                                |$sim| $body,
-                            )
-                            .await;
-                        });
-                    })
-                    .expect("failed to spawn sqlite test thread")
-                    .join()
-                    .expect("sqlite simulation test thread panicked");
-            }
-
-            #[test]
-            fn [<$name _postgres>]() {
-                std::thread::Builder::new()
-                    .name(concat!(stringify!($name), "_postgres").to_string())
-                    .stack_size(8 * 1024 * 1024)
-                    .spawn(|| {
-                        let runtime = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .expect("failed to build tokio runtime");
-                        runtime.block_on(async {
-                            $crate::support::simulation_test::run_single_simulation_test(
-                                "postgres",
-                                concat!(module_path!(), "::", stringify!($name)),
-                                |$sim| $body,
-                            )
-                            .await;
-                        });
-                    })
-                    .expect("failed to spawn postgres test thread")
-                    .join()
-                    .expect("postgres simulation test thread panicked");
-            }
-
-            #[test]
-            fn [<$name _materialization>]() {
-                std::thread::Builder::new()
-                    .name(concat!(stringify!($name), "_materialization").to_string())
-                    .stack_size(8 * 1024 * 1024)
-                    .spawn(|| {
-                        let runtime = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .expect("failed to build tokio runtime");
-                        runtime.block_on(async {
-                            $crate::support::simulation_test::run_single_simulation_test(
-                                "materialization",
-                                concat!(module_path!(), "::", stringify!($name)),
-                                |$sim| $body,
-                            )
-                            .await;
-                        });
-                    })
-                    .expect("failed to spawn materialization test thread")
-                    .join()
-                    .expect("materialization simulation test thread panicked");
-            }
+            $(
+                #[test]
+                fn [<$name _ $simulation>]() {
+                    std::thread::Builder::new()
+                        .name(concat!(stringify!($name), "_", stringify!($simulation)).to_string())
+                        .stack_size(8 * 1024 * 1024)
+                        .spawn(|| {
+                            let runtime = tokio::runtime::Builder::new_current_thread()
+                                .enable_all()
+                                .build()
+                                .expect("failed to build tokio runtime");
+                            runtime.block_on(async {
+                                $crate::support::simulation_test::run_single_simulation_test(
+                                    stringify!($simulation),
+                                    concat!(module_path!(), "::", stringify!($name)),
+                                    |$sim| $body,
+                                )
+                                .await;
+                            });
+                        })
+                        .expect(concat!(
+                            "failed to spawn ",
+                            stringify!($simulation),
+                            " test thread"
+                        ))
+                        .join()
+                        .expect(concat!(
+                            stringify!($simulation),
+                            " simulation test thread panicked"
+                        ));
+                }
+            )+
         }
     };
 }

--- a/packages/engine/tests/support/mod.rs
+++ b/packages/engine/tests/support/mod.rs
@@ -3,25 +3,55 @@ pub mod simulations;
 
 #[macro_export]
 macro_rules! simulation_test {
-	($name:ident, |$sim:ident| $body:expr) => {
-		paste::paste! {
-			#[tokio::test]
-			async fn [<$name _sqlite>]() {
-				let $sim = $crate::support::simulation_test::default_simulations()
-					.into_iter()
-					.find(|sim| sim.name == "sqlite")
-					.expect("sqlite simulation missing");
-				$crate::support::simulation_test::run_simulation_test(vec![$sim], |$sim| $body).await;
-			}
+    ($name:ident, |$sim:ident| $body:expr) => {
+        paste::paste! {
+            #[test]
+            fn [<$name _sqlite>]() {
+                std::thread::Builder::new()
+                    .name(concat!(stringify!($name), "_sqlite").to_string())
+                    .stack_size(8 * 1024 * 1024)
+                    .spawn(|| {
+                        let runtime = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .expect("failed to build tokio runtime");
+                        runtime.block_on(async {
+                            $crate::support::simulation_test::run_single_simulation_test(
+                                "sqlite",
+                                concat!(module_path!(), "::", stringify!($name)),
+                                |$sim| $body,
+                            )
+                            .await;
+                        });
+                    })
+                    .expect("failed to spawn sqlite test thread")
+                    .join()
+                    .expect("sqlite simulation test thread panicked");
+            }
 
-			#[tokio::test]
-			async fn [<$name _postgres>]() {
-				let $sim = $crate::support::simulation_test::default_simulations()
-					.into_iter()
-					.find(|sim| sim.name == "postgres")
-					.expect("postgres simulation missing");
-				$crate::support::simulation_test::run_simulation_test(vec![$sim], |$sim| $body).await;
-			}
-		}
-	};
+            #[test]
+            fn [<$name _postgres>]() {
+                std::thread::Builder::new()
+                    .name(concat!(stringify!($name), "_postgres").to_string())
+                    .stack_size(8 * 1024 * 1024)
+                    .spawn(|| {
+                        let runtime = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .expect("failed to build tokio runtime");
+                        runtime.block_on(async {
+                            $crate::support::simulation_test::run_single_simulation_test(
+                                "postgres",
+                                concat!(module_path!(), "::", stringify!($name)),
+                                |$sim| $body,
+                            )
+                            .await;
+                        });
+                    })
+                    .expect("failed to spawn postgres test thread")
+                    .join()
+                    .expect("postgres simulation test thread panicked");
+            }
+        }
+    };
 }

--- a/packages/engine/tests/support/simulation_test.rs
+++ b/packages/engine/tests/support/simulation_test.rs
@@ -1,7 +1,11 @@
+#![allow(dead_code)]
+
 use std::any::Any;
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use lix_engine::{boot, BootArgs, BootKeyValue, Engine, LixBackend, LixError, QueryResult, Value};
 
@@ -16,7 +20,6 @@ pub struct Simulation {
 pub struct SimulationArgs {
     backend_factory: Box<dyn Fn() -> Box<dyn LixBackend + Send + Sync> + Send + Sync>,
     setup: Option<Arc<dyn Fn() -> BoxFuture<'static, Result<(), LixError>> + Send + Sync>>,
-    #[allow(dead_code)]
     expect: ExpectDeterministic,
 }
 
@@ -57,31 +60,36 @@ impl SimulationArgs {
         })
     }
 
-    #[allow(dead_code)]
-    pub fn expect_deterministic<T>(&self, actual: T)
+    pub fn assert_deterministic<T>(&self, actual: T)
     where
         T: PartialEq + std::fmt::Debug + Clone + Send + Sync + 'static,
     {
-        self.expect.expect_deterministic(actual);
+        self.expect.assert_deterministic(actual);
     }
 }
 
 #[derive(Clone)]
-struct ExpectDeterministic {
-    inner: Arc<Mutex<ExpectDeterministicState>>,
+enum ExpectDeterministic {
+    Local(LocalExpectDeterministic),
+    Shared(SharedExpectDeterministic),
 }
 
-struct ExpectDeterministicState {
+#[derive(Clone)]
+struct LocalExpectDeterministic {
+    inner: Arc<Mutex<LocalExpectDeterministicState>>,
+}
+
+struct LocalExpectDeterministicState {
     #[allow(dead_code)]
     expected_values: Vec<Box<dyn Any + Send + Sync>>,
     is_first: bool,
     call_index: usize,
 }
 
-impl ExpectDeterministic {
+impl LocalExpectDeterministic {
     fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(ExpectDeterministicState {
+            inner: Arc::new(Mutex::new(LocalExpectDeterministicState {
                 expected_values: Vec::new(),
                 is_first: true,
                 call_index: 0,
@@ -99,7 +107,7 @@ impl ExpectDeterministic {
     }
 
     #[allow(dead_code)]
-    fn expect_deterministic<T>(&self, actual: T)
+    fn assert_deterministic<T>(&self, actual: T)
     where
         T: PartialEq + std::fmt::Debug + Clone + Send + Sync + 'static,
     {
@@ -134,6 +142,313 @@ impl ExpectDeterministic {
     }
 }
 
+#[derive(Clone)]
+struct SharedExpectDeterministic {
+    run: Arc<SharedDeterministicRun>,
+}
+
+struct SharedDeterministicRun {
+    backend_name: String,
+    case_id: String,
+    call_index: Mutex<usize>,
+    state: Arc<SharedDeterministicCase>,
+    is_baseline: bool,
+}
+
+struct SharedDeterministicCase {
+    state: Mutex<SharedDeterministicCaseState>,
+    condvar: Condvar,
+}
+
+struct SharedDeterministicCaseState {
+    baseline_backend: Option<String>,
+    baseline_finished: bool,
+    baseline_failed: bool,
+    baseline_call_count: Option<usize>,
+    expected_values: Vec<Box<dyn Any + Send + Sync>>,
+    role_by_backend: HashMap<String, bool>,
+}
+
+struct SharedDeterministicRunGuard {
+    run: Arc<SharedDeterministicRun>,
+}
+
+impl SharedDeterministicRun {
+    fn next_index(&self) -> usize {
+        let mut idx = self
+            .call_index
+            .lock()
+            .expect("deterministic run call_index mutex poisoned");
+        let current = *idx;
+        *idx += 1;
+        current
+    }
+
+    fn call_count(&self) -> usize {
+        *self
+            .call_index
+            .lock()
+            .expect("deterministic run call_index mutex poisoned")
+    }
+
+    fn assert_deterministic<T>(&self, actual: T)
+    where
+        T: PartialEq + std::fmt::Debug + Clone + Send + Sync + 'static,
+    {
+        let idx = self.next_index();
+        if self.is_baseline {
+            let mut state = self
+                .state
+                .state
+                .lock()
+                .expect("shared deterministic mutex poisoned");
+            state.expected_values.push(Box::new(actual));
+            self.state.condvar.notify_all();
+            return;
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(120);
+        let mut state = self
+            .state
+            .state
+            .lock()
+            .expect("shared deterministic mutex poisoned");
+        loop {
+            if idx < state.expected_values.len() {
+                break;
+            }
+
+            if state.baseline_finished {
+                if state.baseline_failed {
+                    panic!(
+                        "SIMULATION DETERMINISM VIOLATION\n\nCase `{}` baseline backend `{}` failed; cannot compare call #{} for backend `{}`",
+                        self.case_id,
+                        state
+                            .baseline_backend
+                            .as_deref()
+                            .unwrap_or("<unknown>"),
+                        idx,
+                        self.backend_name
+                    );
+                }
+                panic!(
+                    "SIMULATION DETERMINISM VIOLATION\n\nCase `{}` backend `{}` called assert_deterministic one extra time at call #{}",
+                    self.case_id,
+                    self.backend_name,
+                    idx
+                );
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                panic!(
+                    "SIMULATION DETERMINISM VIOLATION\n\nTimed out waiting for baseline values in case `{}` (backend `{}`, call #{})",
+                    self.case_id,
+                    self.backend_name,
+                    idx
+                );
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let (next_state, _) = self
+                .state
+                .condvar
+                .wait_timeout(state, remaining)
+                .expect("shared deterministic condvar wait poisoned");
+            state = next_state;
+        }
+
+        let expected_any = state
+            .expected_values
+            .get(idx)
+            .expect("expected deterministic value missing");
+        let expected = expected_any
+            .downcast_ref::<T>()
+            .expect("expect_deterministic type mismatch across simulations");
+        if &actual != expected {
+            panic!(
+                "SIMULATION DETERMINISM VIOLATION\n\nCase `{}` call #{} differs for backend `{}`\nactual: {:?}\nexpected: {:?}",
+                self.case_id,
+                idx,
+                self.backend_name,
+                actual,
+                expected
+            );
+        }
+    }
+
+    fn finish(&self, success: bool) -> Result<(), String> {
+        if self.is_baseline {
+            let mut state = self
+                .state
+                .state
+                .lock()
+                .expect("shared deterministic mutex poisoned");
+            state.baseline_finished = true;
+            state.baseline_failed = !success;
+            state.baseline_call_count = Some(self.call_count());
+            self.state.condvar.notify_all();
+            return Ok(());
+        }
+
+        if !success {
+            return Ok(());
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(120);
+        let mut state = self
+            .state
+            .state
+            .lock()
+            .expect("shared deterministic mutex poisoned");
+        while !state.baseline_finished {
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(format!(
+                    "SIMULATION DETERMINISM VIOLATION\n\nTimed out waiting for baseline completion in case `{}` for backend `{}`",
+                    self.case_id, self.backend_name
+                ));
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let (next_state, _) = self
+                .state
+                .condvar
+                .wait_timeout(state, remaining)
+                .expect("shared deterministic condvar wait poisoned");
+            state = next_state;
+        }
+
+        if state.baseline_failed {
+            return Err(format!(
+                "SIMULATION DETERMINISM VIOLATION\n\nCase `{}` baseline backend `{}` failed; cannot validate backend `{}`",
+                self.case_id,
+                state
+                    .baseline_backend
+                    .as_deref()
+                    .unwrap_or("<unknown>"),
+                self.backend_name
+            ));
+        }
+
+        let expected_calls = state
+            .baseline_call_count
+            .unwrap_or(state.expected_values.len());
+        let actual_calls = self.call_count();
+        if actual_calls != expected_calls {
+            return Err(format!(
+                "SIMULATION DETERMINISM VIOLATION\n\nCase `{}` backend `{}` called assert_deterministic {} times but baseline expected {}",
+                self.case_id, self.backend_name, actual_calls, expected_calls
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SharedDeterministicRunGuard {
+    fn drop(&mut self) {
+        let success = !std::thread::panicking();
+        if let Err(message) = self.run.finish(success) {
+            if success {
+                panic!("{message}");
+            }
+        }
+    }
+}
+
+impl SharedExpectDeterministic {
+    fn new(case_id: &str, backend_name: &str) -> (Self, SharedDeterministicRunGuard) {
+        static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<SharedDeterministicCase>>>> =
+            OnceLock::new();
+        let registry = REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
+
+        let case = {
+            let mut lock = registry
+                .lock()
+                .expect("shared deterministic registry mutex poisoned");
+            lock.entry(case_id.to_string())
+                .or_insert_with(|| {
+                    Arc::new(SharedDeterministicCase {
+                        state: Mutex::new(SharedDeterministicCaseState {
+                            baseline_backend: None,
+                            baseline_finished: false,
+                            baseline_failed: false,
+                            baseline_call_count: None,
+                            expected_values: Vec::new(),
+                            role_by_backend: HashMap::new(),
+                        }),
+                        condvar: Condvar::new(),
+                    })
+                })
+                .clone()
+        };
+
+        let is_baseline = {
+            let mut state = case
+                .state
+                .lock()
+                .expect("shared deterministic mutex poisoned");
+            if let Some(existing) = state.role_by_backend.get(backend_name) {
+                *existing
+            } else if state.baseline_backend.is_none() {
+                state.baseline_backend = Some(backend_name.to_string());
+                state.role_by_backend.insert(backend_name.to_string(), true);
+                true
+            } else {
+                state
+                    .role_by_backend
+                    .insert(backend_name.to_string(), false);
+                false
+            }
+        };
+
+        let run = Arc::new(SharedDeterministicRun {
+            backend_name: backend_name.to_string(),
+            case_id: case_id.to_string(),
+            call_index: Mutex::new(0),
+            state: case,
+            is_baseline,
+        });
+        let guard = SharedDeterministicRunGuard { run: run.clone() };
+        (Self { run }, guard)
+    }
+
+    fn assert_deterministic<T>(&self, actual: T)
+    where
+        T: PartialEq + std::fmt::Debug + Clone + Send + Sync + 'static,
+    {
+        self.run.assert_deterministic(actual);
+    }
+}
+
+impl ExpectDeterministic {
+    fn new_local() -> Self {
+        Self::Local(LocalExpectDeterministic::new())
+    }
+
+    fn new_shared(case_id: &str, backend_name: &str) -> (Self, SharedDeterministicRunGuard) {
+        let (expect, guard) = SharedExpectDeterministic::new(case_id, backend_name);
+        (Self::Shared(expect), guard)
+    }
+
+    fn start_simulation(&self, is_first: bool) {
+        match self {
+            Self::Local(local) => local.start_simulation(is_first),
+            Self::Shared(_) => {
+                panic!("start_simulation is only valid for local deterministic mode")
+            }
+        }
+    }
+
+    fn assert_deterministic<T>(&self, actual: T)
+    where
+        T: PartialEq + std::fmt::Debug + Clone + Send + Sync + 'static,
+    {
+        match self {
+            Self::Local(local) => local.assert_deterministic(actual),
+            Self::Shared(shared) => shared.assert_deterministic(actual),
+        }
+    }
+}
+
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 pub async fn run_simulation_test<F, Fut>(simulations: Vec<Simulation>, test_fn: F)
@@ -141,7 +456,7 @@ where
     F: Fn(SimulationArgs) -> Fut,
     Fut: Future<Output = ()>,
 {
-    let deterministic = ExpectDeterministic::new();
+    let deterministic = ExpectDeterministic::new_local();
 
     for (index, simulation) in simulations.into_iter().enumerate() {
         deterministic.start_simulation(index == 0);
@@ -150,8 +465,26 @@ where
             setup: simulation.setup,
             expect: deterministic.clone(),
         };
-        test_fn(args).await;
+        Box::pin(test_fn(args)).await;
     }
+}
+
+pub async fn run_single_simulation_test<F, Fut>(simulation_name: &str, case_id: &str, test_fn: F)
+where
+    F: Fn(SimulationArgs) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let simulation = default_simulations_impl()
+        .into_iter()
+        .find(|sim| sim.name == simulation_name)
+        .unwrap_or_else(|| panic!("{} simulation missing", simulation_name));
+    let (deterministic, _guard) = ExpectDeterministic::new_shared(case_id, simulation.name);
+    let args = SimulationArgs {
+        backend_factory: simulation.backend_factory,
+        setup: simulation.setup,
+        expect: deterministic,
+    };
+    Box::pin(test_fn(args)).await;
 }
 
 pub fn default_simulations() -> Vec<Simulation> {

--- a/packages/engine/tests/support/simulation_test.rs
+++ b/packages/engine/tests/support/simulation_test.rs
@@ -7,7 +7,10 @@ use std::pin::Pin;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use lix_engine::{boot, BootArgs, BootKeyValue, Engine, LixBackend, LixError, QueryResult, Value};
+use lix_engine::{
+    boot, BootArgs, BootKeyValue, Engine, LixBackend, LixError, MaterializationApplyReport,
+    MaterializationPlan, MaterializationReport, MaterializationRequest, QueryResult, Value,
+};
 
 use super::simulations::default_simulations as default_simulations_impl;
 
@@ -40,6 +43,27 @@ impl SimulationEngine {
 
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<QueryResult, LixError> {
         self.engine.execute(sql, params).await
+    }
+
+    pub async fn materialization_plan(
+        &self,
+        req: &MaterializationRequest,
+    ) -> Result<MaterializationPlan, LixError> {
+        self.engine.materialization_plan(req).await
+    }
+
+    pub async fn apply_materialization_plan(
+        &self,
+        plan: &MaterializationPlan,
+    ) -> Result<MaterializationApplyReport, LixError> {
+        self.engine.apply_materialization_plan(plan).await
+    }
+
+    pub async fn materialize(
+        &self,
+        req: &MaterializationRequest,
+    ) -> Result<MaterializationReport, LixError> {
+        self.engine.materialize(req).await
     }
 }
 

--- a/packages/engine/tests/support/simulation_test.rs
+++ b/packages/engine/tests/support/simulation_test.rs
@@ -9,9 +9,9 @@ use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use lix_engine::{
-    boot, BootArgs, BootKeyValue, Engine, LixBackend, LixError, MaterializationApplyReport,
-    MaterializationDebugMode, MaterializationPlan, MaterializationReport, MaterializationRequest,
-    MaterializationScope, QueryResult, Value,
+    boot, BootAccount, BootArgs, BootKeyValue, Engine, LixBackend, LixError,
+    MaterializationApplyReport, MaterializationDebugMode, MaterializationPlan,
+    MaterializationReport, MaterializationRequest, MaterializationScope, QueryResult, Value,
 };
 use tokio::sync::Mutex as TokioMutex;
 
@@ -40,6 +40,7 @@ pub struct SimulationArgs {
 #[derive(Default)]
 pub struct SimulationBootArgs {
     pub key_values: Vec<BootKeyValue>,
+    pub active_account: Option<BootAccount>,
 }
 
 pub struct SimulationEngine {
@@ -144,6 +145,7 @@ impl SimulationArgs {
             engine: boot(BootArgs {
                 backend: (self.backend_factory)(),
                 key_values: args.key_values,
+                active_account: args.active_account,
             }),
             behavior: self.behavior,
             rematerialization_pending: AtomicBool::new(false),

--- a/packages/engine/tests/support/simulations/materialization.rs
+++ b/packages/engine/tests/support/simulations/materialization.rs
@@ -1,0 +1,8 @@
+use crate::support::simulation_test::Simulation;
+
+pub fn materialization_simulation() -> Simulation {
+    let mut simulation = super::sqlite::sqlite_simulation();
+    simulation.name = "materialization";
+    simulation.behavior = crate::support::simulation_test::SimulationBehavior::Rematerialization;
+    simulation
+}

--- a/packages/engine/tests/support/simulations/mod.rs
+++ b/packages/engine/tests/support/simulations/mod.rs
@@ -1,11 +1,17 @@
+mod materialization;
 mod postgres;
 mod sqlite;
 
+pub use materialization::materialization_simulation;
 pub use postgres::postgres_simulation;
 pub use sqlite::sqlite_simulation;
 
 use crate::support::simulation_test::Simulation;
 
 pub fn default_simulations() -> Vec<Simulation> {
-    vec![sqlite_simulation(), postgres_simulation()]
+    vec![
+        sqlite_simulation(),
+        postgres_simulation(),
+        materialization_simulation(),
+    ]
 }

--- a/packages/engine/tests/support/simulations/postgres.rs
+++ b/packages/engine/tests/support/simulations/postgres.rs
@@ -7,7 +7,7 @@ use tokio::sync::{Mutex as TokioMutex, OnceCell};
 
 use lix_engine::{LixBackend, LixError, QueryResult, SqlDialect, Value};
 
-use crate::support::simulation_test::Simulation;
+use crate::support::simulation_test::{Simulation, SimulationBehavior};
 
 static POSTGRES: OnceCell<Arc<PostgresInstance>> = OnceCell::const_new();
 static DB_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -92,6 +92,7 @@ pub fn postgres_simulation() -> Simulation {
                 Ok(())
             })
         })),
+        behavior: SimulationBehavior::Base,
         backend_factory: Box::new(move || {
             let url = connection_string
                 .lock()

--- a/packages/engine/tests/support/simulations/postgres.rs
+++ b/packages/engine/tests/support/simulations/postgres.rs
@@ -5,7 +5,7 @@ use postgresql_embedded::{PostgreSQL, Status};
 use sqlx::{Executor, PgPool, Row, ValueRef};
 use tokio::sync::{Mutex as TokioMutex, OnceCell};
 
-use lix_engine::{LixBackend, LixError, QueryResult, Value};
+use lix_engine::{LixBackend, LixError, QueryResult, SqlDialect, Value};
 
 use crate::support::simulation_test::Simulation;
 
@@ -137,6 +137,10 @@ impl PostgresBackend {
 
 #[async_trait::async_trait(?Send)]
 impl LixBackend for PostgresBackend {
+    fn dialect(&self) -> SqlDialect {
+        SqlDialect::Postgres
+    }
+
     async fn execute(&self, sql: &str, params: &[Value]) -> Result<QueryResult, LixError> {
         let pool = self.pool().await?;
 

--- a/packages/engine/tests/support/simulations/sqlite.rs
+++ b/packages/engine/tests/support/simulations/sqlite.rs
@@ -1,7 +1,7 @@
 use sqlx::{Executor, Row, SqlitePool, ValueRef};
 use tokio::sync::OnceCell;
 
-use lix_engine::{LixBackend, LixError, QueryResult, Value};
+use lix_engine::{LixBackend, LixError, QueryResult, SqlDialect, Value};
 
 use crate::support::simulation_test::Simulation;
 
@@ -55,6 +55,10 @@ impl SqliteBackend {
 
 #[async_trait::async_trait(?Send)]
 impl LixBackend for SqliteBackend {
+    fn dialect(&self) -> SqlDialect {
+        SqlDialect::Sqlite
+    }
+
     async fn execute(&self, sql: &str, params: &[Value]) -> Result<QueryResult, LixError> {
         let pool = self.pool().await?;
 

--- a/packages/engine/tests/support/simulations/sqlite.rs
+++ b/packages/engine/tests/support/simulations/sqlite.rs
@@ -3,12 +3,13 @@ use tokio::sync::OnceCell;
 
 use lix_engine::{LixBackend, LixError, QueryResult, SqlDialect, Value};
 
-use crate::support::simulation_test::Simulation;
+use crate::support::simulation_test::{Simulation, SimulationBehavior};
 
 pub fn sqlite_simulation() -> Simulation {
     Simulation {
         name: "sqlite",
         setup: None,
+        behavior: SimulationBehavior::Base,
         backend_factory: Box::new(|| {
             Box::new(SqliteBackend::new(SqliteConfig {
                 filename: ":memory:".to_string(),

--- a/packages/engine/tests/version_view.rs
+++ b/packages/engine/tests/version_view.rs
@@ -45,6 +45,7 @@ fn deterministic_boot_args() -> SimulationBootArgs {
             value: serde_json::json!({ "enabled": true }),
             version_id: None,
         }],
+        active_account: None,
     }
 }
 

--- a/packages/engine/tests/version_view.rs
+++ b/packages/engine/tests/version_view.rs
@@ -1,0 +1,741 @@
+mod support;
+
+use lix_engine::{BootKeyValue, Value};
+use support::simulation_test::{
+    default_simulations, run_simulation_test, SimulationArgs, SimulationBootArgs,
+};
+
+fn assert_text(value: &Value, expected: &str) {
+    match value {
+        Value::Text(actual) => assert_eq!(actual, expected),
+        other => panic!("expected text value '{expected}', got {other:?}"),
+    }
+}
+
+fn assert_non_empty_text(value: &Value) {
+    match value {
+        Value::Text(actual) => assert!(
+            !actual.is_empty(),
+            "expected non-empty text value, got empty string"
+        ),
+        other => panic!("expected text value, got {other:?}"),
+    }
+}
+
+fn assert_bool(value: &Value, expected: bool) {
+    match value {
+        Value::Integer(actual) => assert_eq!(*actual != 0, expected),
+        Value::Text(actual) => {
+            let normalized = actual.trim().to_ascii_lowercase();
+            let parsed = match normalized.as_str() {
+                "1" | "true" => true,
+                "0" | "false" => false,
+                _ => panic!("expected boolean-compatible text, got '{actual}'"),
+            };
+            assert_eq!(parsed, expected);
+        }
+        other => panic!("expected boolean-compatible value, got {other:?}"),
+    }
+}
+
+fn deterministic_boot_args() -> SimulationBootArgs {
+    SimulationBootArgs {
+        key_values: vec![BootKeyValue {
+            key: "lix_deterministic_mode".to_string(),
+            value: serde_json::json!({ "enabled": true }),
+            version_id: None,
+        }],
+    }
+}
+
+async fn register_test_state_schema(engine: &support::simulation_test::SimulationEngine) {
+    engine
+        .execute(
+            "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"test_schema\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+}
+
+async fn run_lix_version_seeded_main_id_deterministic(sim: SimulationArgs) {
+    let engine = sim
+        .boot_simulated_engine(Some(deterministic_boot_args()))
+        .await
+        .expect("boot_simulated_engine should succeed");
+    engine.init().await.unwrap();
+
+    let result = engine
+        .execute(
+            "SELECT id, name, inherits_from_version_id \
+             FROM lix_version \
+             WHERE name = 'main'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows.len(), 1);
+    let row = &result.rows[0];
+    let id = match &row[0] {
+        Value::Text(value) => value.clone(),
+        other => panic!("expected text id, got {other:?}"),
+    };
+    assert!(!id.is_empty());
+    assert_ne!(id, "main");
+    sim.assert_deterministic(id);
+    assert_text(&row[1], "main");
+    assert_text(&row[2], "global");
+}
+
+#[tokio::test]
+async fn lix_version_seeded_main_id_is_deterministic_across_backends() {
+    run_simulation_test(
+        default_simulations(),
+        run_lix_version_seeded_main_id_deterministic,
+    )
+    .await;
+}
+
+simulation_test!(
+    lix_version_select_reads_seeded_global_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let result = engine
+            .execute(
+                "SELECT \
+                 id, name, inherits_from_version_id, commit_id, working_commit_id, \
+                 schema_key, file_id, version_id, plugin_key, schema_version, untracked \
+                 FROM lix_version \
+                 WHERE id = 'global'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 1);
+        let row = &result.rows[0];
+        assert_text(&row[0], "global");
+        assert_text(&row[1], "global");
+        assert_eq!(row[2], Value::Null);
+        assert_non_empty_text(&row[3]);
+        assert_non_empty_text(&row[4]);
+        assert_text(&row[5], "lix_version");
+        assert_text(&row[6], "lix");
+        assert_text(&row[7], "global");
+        assert_text(&row[8], "lix");
+        assert_text(&row[9], "1");
+        assert_eq!(row[10], Value::Integer(0));
+    }
+);
+
+simulation_test!(
+    lix_version_select_reads_seeded_main_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let result = engine
+            .execute(
+                "SELECT \
+                 id, name, inherits_from_version_id \
+                 FROM lix_version \
+                 WHERE name = 'main'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 1);
+        let row = &result.rows[0];
+        assert_non_empty_text(&row[0]);
+        assert_ne!(row[0], Value::Text("main".to_string()));
+        assert_text(&row[1], "main");
+        assert_text(&row[2], "global");
+    }
+);
+
+simulation_test!(
+    lix_version_insert_routes_to_descriptor_and_tip,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+             id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+             ) VALUES (\
+             'version-a', 'Version A', NULL, 0, 'commit-a', 'working-a'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let result = engine
+            .execute(
+                "SELECT \
+             id, name, inherits_from_version_id, hidden, commit_id, working_commit_id \
+             FROM lix_version \
+             WHERE id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 1);
+        let row = &result.rows[0];
+        assert_text(&row[0], "version-a");
+        assert_text(&row[1], "Version A");
+        assert_eq!(row[2], Value::Null);
+        assert_bool(&row[3], false);
+        assert_text(&row[4], "commit-a");
+        assert_text(&row[5], "working-a");
+
+        let vtable_rows = engine
+            .execute(
+                "SELECT schema_key \
+             FROM lix_internal_state_vtable \
+             WHERE entity_id = 'version-a' \
+               AND schema_key IN ('lix_version_descriptor', 'lix_version_tip') \
+             ORDER BY schema_key",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(vtable_rows.rows.len(), 2);
+        assert_text(&vtable_rows.rows[0][0], "lix_version_descriptor");
+        assert_text(&vtable_rows.rows[1][0], "lix_version_tip");
+    }
+);
+
+simulation_test!(
+    lix_version_insert_requires_explicit_tip_columns,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let error = engine
+            .execute(
+                "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id\
+                 ) VALUES (\
+                 'version-missing-tip', 'Version Missing Tip', NULL, 0, 'commit-missing-tip'\
+                 )",
+                &[],
+            )
+            .await
+            .expect_err("insert should require working_commit_id");
+
+        assert!(
+            error
+                .message
+                .contains("lix_version insert requires column 'working_commit_id'"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+);
+
+simulation_test!(
+    lix_version_update_routes_to_descriptor_and_tip,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+             id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+             ) VALUES (\
+             'version-b', 'Version B', NULL, 0, 'commit-b', 'working-b'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+        .execute(
+            "UPDATE lix_version \
+             SET name = 'Version B2', hidden = 1, commit_id = 'commit-b2', working_commit_id = 'working-b2' \
+             WHERE id = 'version-b'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let result = engine
+            .execute(
+                "SELECT \
+             id, name, hidden, commit_id, working_commit_id \
+             FROM lix_version \
+             WHERE id = 'version-b'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 1);
+        let row = &result.rows[0];
+        assert_text(&row[0], "version-b");
+        assert_text(&row[1], "Version B2");
+        assert_bool(&row[2], true);
+        assert_text(&row[3], "commit-b2");
+        assert_text(&row[4], "working-b2");
+    }
+);
+
+simulation_test!(
+    lix_version_update_tip_requires_both_commit_and_working_commit,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+             id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+             ) VALUES (\
+             'version-tip-contract', 'Version Tip Contract', NULL, 0, 'commit-tip-0', 'working-tip-0'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let error = engine
+            .execute(
+                "UPDATE lix_version \
+                 SET commit_id = 'commit-tip-1' \
+                 WHERE id = 'version-tip-contract'",
+                &[],
+            )
+            .await
+            .expect_err("tip update should require both commit fields");
+
+        assert!(
+            error
+                .message
+                .contains("must set both commit_id and working_commit_id together"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+);
+
+simulation_test!(lix_version_update_supports_placeholders, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine(None)
+        .await
+        .expect("boot_simulated_engine should succeed");
+    engine.init().await.unwrap();
+
+    engine
+        .execute(
+            "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+                 ) VALUES (\
+                 'version-ph', 'Version PH', NULL, 0, 'commit-ph', 'working-ph'\
+                 )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    engine
+        .execute(
+            "UPDATE lix_version \
+                 SET name = ?, commit_id = ?, working_commit_id = ? \
+                 WHERE id = ?",
+            &[
+                Value::Text("Version PH2".to_string()),
+                Value::Text("commit-ph2".to_string()),
+                Value::Text("working-ph2".to_string()),
+                Value::Text("version-ph".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let result = engine
+        .execute(
+            "SELECT id, name, commit_id, working_commit_id \
+                 FROM lix_version \
+                 WHERE id = 'version-ph'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows.len(), 1);
+    let row = &result.rows[0];
+    assert_text(&row[0], "version-ph");
+    assert_text(&row[1], "Version PH2");
+    assert_text(&row[2], "commit-ph2");
+    assert_text(&row[3], "working-ph2");
+});
+
+simulation_test!(lix_version_delete_routes_to_tombstones, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine(None)
+        .await
+        .expect("boot_simulated_engine should succeed");
+    engine.init().await.unwrap();
+
+    engine
+        .execute(
+            "INSERT INTO lix_version (\
+             id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+             ) VALUES (\
+             'version-c', 'Version C', NULL, 0, 'commit-c', 'working-c'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    engine
+        .execute("DELETE FROM lix_version WHERE id = 'version-c'", &[])
+        .await
+        .unwrap();
+
+    let version_rows = engine
+        .execute("SELECT id FROM lix_version WHERE id = 'version-c'", &[])
+        .await
+        .unwrap();
+    assert_eq!(version_rows.rows.len(), 0);
+
+    let deleted_rows = engine
+        .execute(
+            "SELECT schema_key, snapshot_content \
+             FROM lix_internal_state_vtable \
+             WHERE entity_id = 'version-c' \
+               AND schema_key IN ('lix_version_descriptor', 'lix_version_tip') \
+             ORDER BY schema_key",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(deleted_rows.rows.len(), 2);
+    assert_text(&deleted_rows.rows[0][0], "lix_version_descriptor");
+    assert_eq!(deleted_rows.rows[0][1], Value::Null);
+    assert_text(&deleted_rows.rows[1][0], "lix_version_tip");
+    assert_eq!(deleted_rows.rows[1][1], Value::Null);
+});
+
+simulation_test!(lix_version_delete_supports_placeholders, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine(None)
+        .await
+        .expect("boot_simulated_engine should succeed");
+    engine.init().await.unwrap();
+
+    engine
+        .execute(
+            "INSERT INTO lix_version (\
+             id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+             ) VALUES (\
+             'version-pd', 'Version PD', NULL, 0, 'commit-pd', 'working-pd'\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    engine
+        .execute(
+            "DELETE FROM lix_version WHERE id = ?",
+            &[Value::Text("version-pd".to_string())],
+        )
+        .await
+        .unwrap();
+
+    let result = engine
+        .execute("SELECT id FROM lix_version WHERE id = 'version-pd'", &[])
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows.len(), 0);
+});
+
+simulation_test!(
+    lix_version_direct_mutation_does_not_duplicate_entries,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+                 ) VALUES (\
+                 'version-direct', 'version-direct', NULL, 0, 'commit-direct', 'working-direct'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let before_version = engine
+            .execute(
+                "SELECT id, name, commit_id, working_commit_id \
+                 FROM lix_version \
+                 WHERE id = 'version-direct'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(before_version.rows.len(), 1);
+
+        let global_before = engine
+            .execute("SELECT commit_id FROM lix_version WHERE id = 'global'", &[])
+            .await
+            .unwrap();
+        assert_eq!(global_before.rows.len(), 1);
+        let global_before_commit = match &global_before.rows[0][0] {
+            Value::Text(value) => value.clone(),
+            other => panic!("expected text commit_id, got {other:?}"),
+        };
+
+        engine
+            .execute(
+                "UPDATE lix_version SET name = 'version-direct-renamed' WHERE id = 'version-direct'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let after_version = engine
+            .execute(
+                "SELECT id, name, commit_id, working_commit_id \
+                 FROM lix_version \
+                 WHERE id = 'version-direct'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(after_version.rows.len(), 1);
+        assert_text(&after_version.rows[0][0], "version-direct");
+        assert_text(&after_version.rows[0][1], "version-direct-renamed");
+        assert_eq!(after_version.rows[0][2], before_version.rows[0][2]);
+        assert_eq!(after_version.rows[0][3], before_version.rows[0][3]);
+
+        let global_after = engine
+            .execute("SELECT commit_id FROM lix_version WHERE id = 'global'", &[])
+            .await
+            .unwrap();
+        assert_eq!(global_after.rows.len(), 1);
+        let global_after_commit = match &global_after.rows[0][0] {
+            Value::Text(value) => value.clone(),
+            other => panic!("expected text commit_id, got {other:?}"),
+        };
+        assert_ne!(global_after_commit, global_before_commit);
+    }
+);
+
+simulation_test!(
+    lix_version_state_mutation_does_not_duplicate_entries,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+                 ) VALUES (\
+                 'version-state', 'version-state', NULL, 0, 'commit-state', 'working-state'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+        register_test_state_schema(&engine).await;
+
+        let before_version = engine
+            .execute(
+                "SELECT id, name, commit_id, working_commit_id \
+                 FROM lix_version \
+                 WHERE id = 'version-state'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(before_version.rows.len(), 1);
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+                 entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+                 ) VALUES (\
+                 'state-entity-1', 'test_schema', 'file-state', 'version-state', 'lix', '{\"key\":\"value\"}', '1'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let after_version = engine
+            .execute(
+                "SELECT id, name, commit_id, working_commit_id \
+                 FROM lix_version \
+                 WHERE id = 'version-state'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(after_version.rows.len(), 1);
+        assert_text(&after_version.rows[0][0], "version-state");
+        assert_text(&after_version.rows[0][1], "version-state");
+        assert_ne!(after_version.rows[0][2], before_version.rows[0][2]);
+        assert_eq!(after_version.rows[0][3], before_version.rows[0][3]);
+    }
+);
+
+simulation_test!(
+    lix_version_enforces_unique_working_commit_id_on_insert,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+                 ) VALUES (\
+                 'v-unique-1', 'v-unique-1', NULL, 0, 'commit-unique-1', 'working-unique-1'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let duplicate_error = engine
+            .execute(
+                "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+                 ) VALUES (\
+                 'v-unique-2', 'v-unique-2', NULL, 0, 'commit-unique-2', 'working-unique-1'\
+                 )",
+                &[],
+            )
+            .await
+            .expect_err("duplicate working_commit_id should fail");
+        assert!(
+            duplicate_error
+                .message
+                .contains("Unique constraint violation"),
+            "unexpected error message: {}",
+            duplicate_error.message
+        );
+        assert!(
+            duplicate_error.message.contains("working_commit_id"),
+            "unexpected error message: {}",
+            duplicate_error.message
+        );
+        assert!(
+            duplicate_error.message.contains("working-unique-1"),
+            "unexpected error message: {}",
+            duplicate_error.message
+        );
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+                 ) VALUES (\
+                 'v-unique-3', 'v-unique-3', NULL, 0, 'commit-unique-3', 'working-unique-3'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let versions = engine
+            .execute(
+                "SELECT id \
+                 FROM lix_version \
+                 WHERE id IN ('v-unique-1', 'v-unique-2', 'v-unique-3') \
+                 ORDER BY id",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(versions.rows.len(), 2);
+        assert_text(&versions.rows[0][0], "v-unique-1");
+        assert_text(&versions.rows[1][0], "v-unique-3");
+    }
+);
+
+simulation_test!(
+    lix_version_insert_commit_id_fk_is_lenient_materialized_mode,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_version (\
+                 id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+                 ) VALUES (\
+                 'v-lenient', 'v-lenient', NULL, 0, 'does_not_exist', 'working-lenient'\
+                 )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let inserted = engine
+            .execute(
+                "SELECT id, commit_id, working_commit_id \
+                 FROM lix_version \
+                 WHERE id = 'v-lenient'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(inserted.rows.len(), 1);
+        assert_text(&inserted.rows[0][0], "v-lenient");
+        assert_text(&inserted.rows[0][1], "does_not_exist");
+        assert_text(&inserted.rows[0][2], "working-lenient");
+    }
+);

--- a/packages/engine/tests/version_view.rs
+++ b/packages/engine/tests/version_view.rs
@@ -212,7 +212,7 @@ simulation_test!(
                 "SELECT schema_key \
              FROM lix_internal_state_vtable \
              WHERE entity_id = 'version-a' \
-               AND schema_key IN ('lix_version_descriptor', 'lix_version_tip') \
+               AND schema_key IN ('lix_version_descriptor', 'lix_version_pointer') \
              ORDER BY schema_key",
                 &[],
             )
@@ -221,7 +221,7 @@ simulation_test!(
 
         assert_eq!(vtable_rows.rows.len(), 2);
         assert_text(&vtable_rows.rows[0][0], "lix_version_descriptor");
-        assert_text(&vtable_rows.rows[1][0], "lix_version_tip");
+        assert_text(&vtable_rows.rows[1][0], "lix_version_pointer");
     }
 );
 
@@ -436,7 +436,7 @@ simulation_test!(lix_version_delete_routes_to_tombstones, |sim| async move {
             "SELECT schema_key, snapshot_content \
              FROM lix_internal_state_vtable \
              WHERE entity_id = 'version-c' \
-               AND schema_key IN ('lix_version_descriptor', 'lix_version_tip') \
+               AND schema_key IN ('lix_version_descriptor', 'lix_version_pointer') \
              ORDER BY schema_key",
             &[],
         )
@@ -446,7 +446,7 @@ simulation_test!(lix_version_delete_routes_to_tombstones, |sim| async move {
     assert_eq!(deleted_rows.rows.len(), 2);
     assert_text(&deleted_rows.rows[0][0], "lix_version_descriptor");
     assert_eq!(deleted_rows.rows[0][1], Value::Null);
-    assert_text(&deleted_rows.rows[1][0], "lix_version_tip");
+    assert_text(&deleted_rows.rows[1][0], "lix_version_pointer");
     assert_eq!(deleted_rows.rows[1][1], Value::Null);
 });
 

--- a/packages/engine/tests/vtable_read.rs
+++ b/packages/engine/tests/vtable_read.rs
@@ -206,6 +206,87 @@ simulation_test!(
 );
 
 simulation_test!(
+    vtable_read_without_schema_key_selects_multiple_materialized_tables,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+
+        engine.init().await.unwrap();
+
+        // Register schemas so materialized tables exist.
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_a\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES (\
+             'lix_stored_schema',\
+             '{\"value\":{\"x-lix-key\":\"schema_b\",\"x-lix-version\":\"1\",\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\"}},\"required\":[\"key\"],\"additionalProperties\":false}}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content\
+             ) VALUES (\
+             'entity-1', 'schema_a', '1', 'file-1', 'version-1', 'lix', '{\"key\":\"a1\"}'\
+             ), (\
+             'entity-3', 'schema_a', '1', 'file-3', 'version-1', 'lix', '{\"key\":\"a2\"}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+        engine
+            .execute(
+                "INSERT INTO lix_internal_state_vtable (\
+             entity_id, schema_key, schema_version, file_id, version_id, plugin_key, snapshot_content\
+             ) VALUES (\
+             'entity-2', 'schema_b', '1', 'file-2', 'version-1', 'lix', '{\"key\":\"b1\"}'\
+             )",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let read = engine
+            .execute(
+                "SELECT entity_id, schema_key, file_id FROM lix_internal_state_vtable \
+             WHERE file_id IN ('file-1', 'file-2', 'file-3') \
+             ORDER BY entity_id",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(read.rows.clone());
+        assert_eq!(read.rows.len(), 3);
+        assert_eq!(read.rows[0][0], Value::Text("entity-1".to_string()));
+        assert_eq!(read.rows[0][1], Value::Text("schema_a".to_string()));
+        assert_eq!(read.rows[0][2], Value::Text("file-1".to_string()));
+        assert_eq!(read.rows[1][0], Value::Text("entity-2".to_string()));
+        assert_eq!(read.rows[1][1], Value::Text("schema_b".to_string()));
+        assert_eq!(read.rows[1][2], Value::Text("file-2".to_string()));
+        assert_eq!(read.rows[2][0], Value::Text("entity-3".to_string()));
+        assert_eq!(read.rows[2][1], Value::Text("schema_a".to_string()));
+        assert_eq!(read.rows[2][2], Value::Text("file-3".to_string()));
+    }
+);
+
+simulation_test!(
     vtable_read_schema_key_in_single_filters_out_other,
     |sim| async move {
         let engine = sim

--- a/packages/engine/tests/vtable_read.rs
+++ b/packages/engine/tests/vtable_read.rs
@@ -59,7 +59,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(read.rows.clone());
+        sim.assert_deterministic(read.rows.clone());
         assert_eq!(read.rows.len(), 1);
         assert_eq!(
             read.rows[0][0],
@@ -113,7 +113,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(read.rows.clone());
+        sim.assert_deterministic(read.rows.clone());
         assert_eq!(read.rows.len(), 1);
         assert_eq!(
             read.rows[0][0],
@@ -191,7 +191,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(read.rows.clone());
+        sim.assert_deterministic(read.rows.clone());
         assert_eq!(read.rows.len(), 3);
         assert_eq!(read.rows[0][0], Value::Text("entity-1".to_string()));
         assert_eq!(read.rows[0][1], Value::Text("schema_a".to_string()));
@@ -271,7 +271,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(schema_a_only.rows.clone());
+        sim.assert_deterministic(schema_a_only.rows.clone());
         assert_eq!(schema_a_only.rows.len(), 2);
         assert_eq!(
             schema_a_only.rows[0][0],
@@ -358,7 +358,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(schema_a_eq.rows.clone());
+        sim.assert_deterministic(schema_a_eq.rows.clone());
         assert_eq!(schema_a_eq.rows.len(), 2);
         assert_eq!(schema_a_eq.rows[0][0], Value::Text("entity-1".to_string()));
         assert_eq!(schema_a_eq.rows[0][1], Value::Text("schema_a".to_string()));
@@ -432,7 +432,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(entity_filter.rows.clone());
+        sim.assert_deterministic(entity_filter.rows.clone());
         assert_eq!(entity_filter.rows.len(), 1);
         assert_eq!(
             entity_filter.rows[0][0],
@@ -511,7 +511,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(file_filter.rows.clone());
+        sim.assert_deterministic(file_filter.rows.clone());
         assert_eq!(file_filter.rows.len(), 1);
         assert_eq!(file_filter.rows[0][0], Value::Text("entity-3".to_string()));
         assert_eq!(file_filter.rows[0][1], Value::Text("schema_a".to_string()));
@@ -584,7 +584,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(multi_filter.rows.clone());
+        sim.assert_deterministic(multi_filter.rows.clone());
         assert_eq!(multi_filter.rows.len(), 1);
         assert_eq!(multi_filter.rows[0][0], Value::Text("entity-3".to_string()));
         assert_eq!(multi_filter.rows[0][1], Value::Text("schema_a".to_string()));
@@ -658,7 +658,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(read.rows.clone());
+        sim.assert_deterministic(read.rows.clone());
         assert_eq!(read.rows.len(), 1);
         assert_eq!(
             read.rows[0][0],

--- a/packages/engine/tests/vtable_write.rs
+++ b/packages/engine/tests/vtable_write.rs
@@ -57,7 +57,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(initial.rows.clone());
+        sim.assert_deterministic(initial.rows.clone());
         assert_eq!(initial.rows.len(), 1);
         assert_eq!(
             initial.rows[0][0],
@@ -107,7 +107,7 @@ simulation_test!(
             .await
             .unwrap();
 
-        sim.expect_deterministic(read.rows.clone());
+        sim.assert_deterministic(read.rows.clone());
         assert_eq!(read.rows.len(), 1);
         assert_eq!(
             read.rows[0][0],

--- a/plan.md
+++ b/plan.md
@@ -1029,56 +1029,9 @@ host.execute(&sql)?;
 4. Generate `lix_change_set_element` rows for domain changes
 5. Return both raw changes and materialized state for cache insertion
 
-## Milestone 14: State Materialization
-
-The materialization logic computes the correct state from the commit graph and change history. This is critical for ensuring reads return the correct data based on version inheritance and commit ancestry.
-
-See the current JS implementation: [materialize-state.ts](https://github.com/opral/monorepo/blob/2413bafee26554208ec674e2a52306fcf4b77bc4/packages/lix/sdk/src/state/materialize-state.ts)
-
-### Materialization Views
-
-The JS implementation creates a chain of SQL views:
-
-```
-lix_internal_materialization_all_commit_edges
-    │
-    ▼
-lix_internal_materialization_version_tips
-    │
-    ▼
-lix_internal_materialization_commit_graph
-    │
-    ▼
-lix_internal_materialization_latest_visible_state
-    │
-    ├─────────────────────────────────┐
-    ▼                                 ▼
-lix_internal_materialization_     lix_internal_state_materializer
-version_ancestry                      (final output)
-```
-
-| View                   | Purpose                                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `all_commit_edges`     | Union of edges from commit.parent_commit_ids and lix_commit_edge rows                                |
-| `version_tips`         | Current tip commit per version                                                                       |
-| `commit_graph`         | Recursive DAG traversal with depth from tips                                                         |
-| `latest_visible_state` | Explodes commit.change_ids, joins with change table, deduplicates by (version, entity, schema, file) |
-| `version_ancestry`     | Recursive inheritance chain per version                                                              |
-| `state_materializer`   | Final state with inheritance resolution                                                              |
-
-### Correctness Assurance
-
-After Milestone 13, we should have tests that verify:
-
-1. State reads match the JS implementation for the same change history
-2. Version inheritance correctly resolves parent → child state visibility
-3. Tombstones (deletions) are correctly handled
-4. Commit graph traversal handles merge commits (multiple parents)
-5. Cache tables are populated correctly from materialized state
-
 # Versions
 
-## Milestone 15: Active Version
+## Milestone 14: Active Version
 
 The active version determines which version context is used for state operations. It is stored in the untracked table since it's local-only state that shouldn't be synced.
 
@@ -1115,7 +1068,7 @@ WHERE entity_id = 'lix_active_version' AND schema_key = 'lix_key_value'
 3. Provide API to switch active version
 4. Update cached value when active version changes
 
-## Milestone 16: Version View (version_descriptor + version_tip)
+## Milestone 15: Version View (version_descriptor + version_tip)
 
 The `version` view combines `lix_version_descriptor` and `lix_version_tip` to provide a unified view of versions with their current tip commits.
 
@@ -1156,7 +1109,242 @@ WHERE json_extract(vd.snapshot_content, '$.id') = 'version-1'
 3. Project relevant fields from snapshot_content
 4. Handle INSERT/UPDATE/DELETE by routing to appropriate underlying schema
 
-## Milestone 17: Version Inheritance in SELECT Rewriting
+## Milestone 16: `lix_state` SELECT Rewriting
+
+The `lix_state` view provides state for the "current" version (typically the active version in the session). It wraps `lix_state_by_version` with implicit version resolution.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+SELECT * FROM lix_state
+WHERE schema_key = 'lix_key_value'
+```
+
+**Rewritten query:**
+
+```sql
+-- First resolve current version from session/context
+-- Then rewrite as lix_state_by_version with that version_id
+SELECT * FROM (
+  -- Same as lix_state_by_version rewriting with version_id = <current_version>
+  ...
+) WHERE rn = 1 AND is_tombstone = 0
+```
+
+### Tasks
+
+1. Parse SELECT statements targeting `lix_state`
+2. Resolve current version from engine context
+3. Delegate to `lix_state_by_version` SELECT rewriting with resolved version
+4. Handle cases where no version is active
+
+## Milestone 17: `lix_state` INSERT Rewriting
+
+INSERT operations on `lix_state` write to the current version.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+INSERT INTO lix_state (entity_id, schema_key, snapshot_content)
+VALUES ('entity-1', 'lix_key_value', '{"key": "foo"}')
+```
+
+**Rewritten query:**
+
+```sql
+-- Resolve current version, then delegate to lix_state_by_version INSERT
+```
+
+### Tasks
+
+1. Parse INSERT statements targeting `lix_state`
+2. Resolve current version from engine context
+3. Delegate to `lix_state_by_version` INSERT rewriting with resolved version
+
+## Milestone 18: `lix_state` UPDATE Rewriting
+
+UPDATE operations on `lix_state` modify state for the current version.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+UPDATE lix_state
+SET snapshot_content = '{"key": "updated"}'
+WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
+```
+
+**Rewritten query:**
+
+```sql
+-- Resolve current version, then delegate to lix_state_by_version UPDATE
+```
+
+### Tasks
+
+1. Parse UPDATE statements targeting `lix_state`
+2. Resolve current version from engine context
+3. Delegate to `lix_state_by_version` UPDATE rewriting with resolved version
+
+## Milestone 19: `lix_state` DELETE Rewriting
+
+DELETE operations on `lix_state` create tombstones for the current version.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+DELETE FROM lix_state
+WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
+```
+
+**Rewritten query:**
+
+```sql
+-- Resolve current version, then delegate to lix_state_by_version DELETE
+```
+
+### Tasks
+
+1. Parse DELETE statements targeting `lix_state`
+2. Resolve current version from engine context
+3. Delegate to `lix_state_by_version` DELETE rewriting (tombstone creation)
+
+## Milestone 20: `lix_state_by_version` SELECT Rewriting
+
+The `lix_state_by_version` view provides state scoped to a specific version. It builds on the vtable rewriting by adding version-specific filtering.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+SELECT * FROM lix_state_by_version
+WHERE schema_key = 'lix_key_value' AND version_id = 'version-1'
+```
+
+**Rewritten query:**
+
+```sql
+SELECT
+  entity_id,
+  schema_key,
+  file_id,
+  version_id,
+  snapshot_content,
+  change_id
+FROM (
+  SELECT *, ROW_NUMBER() OVER (
+    PARTITION BY entity_id, file_id
+    ORDER BY priority
+  ) AS rn
+  FROM (
+    -- Priority 1: Untracked
+    SELECT *, 1 AS priority FROM lix_internal_state_untracked
+    WHERE schema_key = 'lix_key_value' AND version_id = 'version-1'
+
+    UNION ALL
+
+    -- Priority 2: Materialized
+    SELECT *, 2 AS priority FROM lix_internal_state_materialized_v1_lix_key_value
+    WHERE version_id = 'version-1'
+  )
+) WHERE rn = 1 AND is_tombstone = 0
+```
+
+### Tasks
+
+1. Parse SELECT statements targeting `lix_state_by_version`
+2. Extract `version_id` from WHERE clause
+3. Apply version filtering to both untracked and materialized tables
+4. Filter out tombstones by default
+
+## Milestone 21: `lix_state_by_version` INSERT Rewriting
+
+INSERT operations on `lix_state_by_version` write to the underlying vtable with explicit version scoping.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+INSERT INTO lix_state_by_version (entity_id, schema_key, version_id, snapshot_content)
+VALUES ('entity-1', 'lix_key_value', 'version-1', '{"key": "foo"}')
+```
+
+**Rewritten query:**
+
+```sql
+-- Delegates to lix_internal_state_vtable INSERT rewriting (Milestone 4)
+-- with version_id explicitly set
+```
+
+### Tasks
+
+1. Parse INSERT statements targeting `lix_state_by_version`
+2. Validate `version_id` is provided
+3. Delegate to vtable INSERT rewriting with version context
+
+## Milestone 22: `lix_state_by_version` UPDATE Rewriting
+
+UPDATE operations on `lix_state_by_version` modify state for a specific version.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+UPDATE lix_state_by_version
+SET snapshot_content = '{"key": "updated"}'
+WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value' AND version_id = 'version-1'
+```
+
+**Rewritten query:**
+
+```sql
+-- Delegates to lix_internal_state_vtable UPDATE rewriting (Milestone 5)
+-- with version_id explicitly set
+```
+
+### Tasks
+
+1. Parse UPDATE statements targeting `lix_state_by_version`
+2. Extract `version_id` from WHERE clause
+3. Delegate to vtable UPDATE rewriting with version context
+
+## Milestone 23: `lix_state_by_version` DELETE Rewriting
+
+DELETE operations on `lix_state_by_version` create tombstones for the specified version.
+
+### Query Rewriting Example
+
+**Input query:**
+
+```sql
+DELETE FROM lix_state_by_version
+WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value' AND version_id = 'version-1'
+```
+
+**Rewritten query:**
+
+```sql
+-- Delegates to lix_internal_state_vtable DELETE rewriting (Milestone 6)
+-- Creates tombstone for the specific version
+```
+
+### Tasks
+
+1. Parse DELETE statements targeting `lix_state_by_version`
+2. Extract `version_id` from WHERE clause
+3. Delegate to vtable DELETE rewriting (tombstone creation)
+
+## Milestone 24: Version Inheritance in SELECT Rewriting
 
 State queries must respect version inheritance. When querying state for a version, if an entity doesn't exist in that version, the query should fall back to parent versions.
 
@@ -1168,14 +1356,14 @@ version-child (active)
             └── version-grandparent
 ```
 
-When querying `state` for `version-child`, if an entity exists in `version-parent` but not `version-child`, it should be visible.
+When querying `lix_state` for `version-child`, if an entity exists in `version-parent` but not `version-child`, it should be visible.
 
 ### Query Rewriting Example
 
 **Input query:**
 
 ```sql
-SELECT * FROM state
+SELECT * FROM lix_state
 WHERE schema_key = 'lix_key_value'
 ```
 
@@ -1222,8 +1410,8 @@ SELECT * FROM (
 - Version inheritance is resolved via recursive CTE
 - Closer versions (lower depth) take priority
 - Tombstones in child versions hide parent state
-- `state_by_version` does NOT use inheritance (explicit version only)
-- `state` uses inheritance based on active version
+- `lix_state_by_version` does NOT use inheritance (explicit version only)
+- `lix_state` uses inheritance based on active version
 
 ### Tasks
 
@@ -1231,9 +1419,58 @@ SELECT * FROM (
 2. Join state queries with version chain
 3. Prioritize by inheritance depth (closer = higher priority)
 4. Handle tombstones correctly (child tombstone hides parent state)
-5. Apply inheritance only to `state` view, not `state_by_version`
+5. Apply inheritance only to `lix_state` view, not `lix_state_by_version`
 
-## Milestone 18: Active Account and Change Author
+## Milestone 25: State Materialization
+
+The materialization logic computes the correct state from the commit graph and change history. This is critical for ensuring reads return the correct data based on version inheritance and commit ancestry.
+
+See the current JS implementation: [materialize-state.ts](https://github.com/opral/monorepo/blob/2413bafee26554208ec674e2a52306fcf4b77bc4/packages/lix/sdk/src/state/materialize-state.ts)
+
+### Materialization Views
+
+The JS implementation creates a chain of SQL views:
+
+```
+lix_internal_materialization_all_commit_edges
+    │
+    ▼
+lix_internal_materialization_version_tips
+    │
+    ▼
+lix_internal_materialization_commit_graph
+    │
+    ▼
+lix_internal_materialization_latest_visible_state
+    │
+    ├─────────────────────────────────┐
+    ▼                                 ▼
+lix_internal_materialization_     lix_internal_state_materializer
+version_ancestry                      (final output)
+```
+
+| View                   | Purpose                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `all_commit_edges`     | Union of edges from commit.parent_commit_ids and lix_commit_edge rows                                |
+| `version_tips`         | Current tip commit per version                                                                       |
+| `commit_graph`         | Recursive DAG traversal with depth from tips                                                         |
+| `latest_visible_state` | Explodes commit.change_ids, joins with change table, deduplicates by (version, entity, schema, file) |
+| `version_ancestry`     | Recursive inheritance chain per version                                                              |
+| `state_materializer`   | Final state with inheritance resolution                                                              |
+
+### Correctness Assurance
+
+After Milestone 13, we should have tests that verify:
+
+1. State reads match the JS implementation for the same change history
+2. Version inheritance correctly resolves parent → child state visibility
+3. Tombstones (deletions) are correctly handled
+4. Commit graph traversal handles merge commits (multiple parents)
+5. Cache tables are populated correctly from materialized state
+
+# Accounts
+
+## Milestone 26: Active Account and Change Author
 
 The active account determines which account context is used for change attribution. Like active version, it is stored in the untracked table. When changes are created, the engine generates change author records linking changes to accounts.
 
@@ -1317,253 +1554,18 @@ VALUES (
 
 # State Views
 
-## Milestone 19: `state_by_version` SELECT Rewriting
+## Milestone 27: `lix_state_history` SELECT Rewriting (Read-Only)
 
-The `state_by_version` view provides state scoped to a specific version. It builds on the vtable rewriting by adding version-specific filtering.
+The `lix_state_history` view provides the full history of state changes across all versions. Unlike `lix_state` and `lix_state_by_version`, it does not deduplicate by entity—it returns all historical records.
 
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-SELECT * FROM state_by_version
-WHERE schema_key = 'lix_key_value' AND version_id = 'version-1'
-```
-
-**Rewritten query:**
-
-```sql
-SELECT
-  entity_id,
-  schema_key,
-  file_id,
-  version_id,
-  snapshot_content,
-  change_id
-FROM (
-  SELECT *, ROW_NUMBER() OVER (
-    PARTITION BY entity_id, file_id
-    ORDER BY priority
-  ) AS rn
-  FROM (
-    -- Priority 1: Untracked
-    SELECT *, 1 AS priority FROM lix_internal_state_untracked
-    WHERE schema_key = 'lix_key_value' AND version_id = 'version-1'
-
-    UNION ALL
-
-    -- Priority 2: Materialized
-    SELECT *, 2 AS priority FROM lix_internal_state_materialized_v1_lix_key_value
-    WHERE version_id = 'version-1'
-  )
-) WHERE rn = 1 AND is_tombstone = 0
-```
-
-### Tasks
-
-1. Parse SELECT statements targeting `state_by_version`
-2. Extract `version_id` from WHERE clause
-3. Apply version filtering to both untracked and materialized tables
-4. Filter out tombstones by default
-
-## Milestone 20: `state_by_version` INSERT Rewriting
-
-INSERT operations on `state_by_version` write to the underlying vtable with explicit version scoping.
+> **Note:** `lix_state_history` is read-only. INSERT/UPDATE/DELETE are not supported.
 
 ### Query Rewriting Example
 
 **Input query:**
 
 ```sql
-INSERT INTO state_by_version (entity_id, schema_key, version_id, snapshot_content)
-VALUES ('entity-1', 'lix_key_value', 'version-1', '{"key": "foo"}')
-```
-
-**Rewritten query:**
-
-```sql
--- Delegates to lix_internal_state_vtable INSERT rewriting (Milestone 4)
--- with version_id explicitly set
-```
-
-### Tasks
-
-1. Parse INSERT statements targeting `state_by_version`
-2. Validate `version_id` is provided
-3. Delegate to vtable INSERT rewriting with version context
-
-## Milestone 21: `state_by_version` UPDATE Rewriting
-
-UPDATE operations on `state_by_version` modify state for a specific version.
-
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-UPDATE state_by_version
-SET snapshot_content = '{"key": "updated"}'
-WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value' AND version_id = 'version-1'
-```
-
-**Rewritten query:**
-
-```sql
--- Delegates to lix_internal_state_vtable UPDATE rewriting (Milestone 5)
--- with version_id explicitly set
-```
-
-### Tasks
-
-1. Parse UPDATE statements targeting `state_by_version`
-2. Extract `version_id` from WHERE clause
-3. Delegate to vtable UPDATE rewriting with version context
-
-## Milestone 22: `state_by_version` DELETE Rewriting
-
-DELETE operations on `state_by_version` create tombstones for the specified version.
-
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-DELETE FROM state_by_version
-WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value' AND version_id = 'version-1'
-```
-
-**Rewritten query:**
-
-```sql
--- Delegates to lix_internal_state_vtable DELETE rewriting (Milestone 6)
--- Creates tombstone for the specific version
-```
-
-### Tasks
-
-1. Parse DELETE statements targeting `state_by_version`
-2. Extract `version_id` from WHERE clause
-3. Delegate to vtable DELETE rewriting (tombstone creation)
-
-## Milestone 23: `state` SELECT Rewriting
-
-The `state` view provides state for the "current" version (typically the active version in the session). It wraps `state_by_version` with implicit version resolution.
-
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-SELECT * FROM state
-WHERE schema_key = 'lix_key_value'
-```
-
-**Rewritten query:**
-
-```sql
--- First resolve current version from session/context
--- Then rewrite as state_by_version with that version_id
-SELECT * FROM (
-  -- Same as state_by_version rewriting with version_id = <current_version>
-  ...
-) WHERE rn = 1 AND is_tombstone = 0
-```
-
-### Tasks
-
-1. Parse SELECT statements targeting `state`
-2. Resolve current version from engine context
-3. Delegate to `state_by_version` SELECT rewriting with resolved version
-4. Handle cases where no version is active
-
-## Milestone 24: `state` INSERT Rewriting
-
-INSERT operations on `state` write to the current version.
-
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-INSERT INTO state (entity_id, schema_key, snapshot_content)
-VALUES ('entity-1', 'lix_key_value', '{"key": "foo"}')
-```
-
-**Rewritten query:**
-
-```sql
--- Resolve current version, then delegate to state_by_version INSERT
-```
-
-### Tasks
-
-1. Parse INSERT statements targeting `state`
-2. Resolve current version from engine context
-3. Delegate to `state_by_version` INSERT rewriting with resolved version
-
-## Milestone 25: `state` UPDATE Rewriting
-
-UPDATE operations on `state` modify state for the current version.
-
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-UPDATE state
-SET snapshot_content = '{"key": "updated"}'
-WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
-```
-
-**Rewritten query:**
-
-```sql
--- Resolve current version, then delegate to state_by_version UPDATE
-```
-
-### Tasks
-
-1. Parse UPDATE statements targeting `state`
-2. Resolve current version from engine context
-3. Delegate to `state_by_version` UPDATE rewriting with resolved version
-
-## Milestone 26: `state` DELETE Rewriting
-
-DELETE operations on `state` create tombstones for the current version.
-
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-DELETE FROM state
-WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
-```
-
-**Rewritten query:**
-
-```sql
--- Resolve current version, then delegate to state_by_version DELETE
-```
-
-### Tasks
-
-1. Parse DELETE statements targeting `state`
-2. Resolve current version from engine context
-3. Delegate to `state_by_version` DELETE rewriting (tombstone creation)
-
-## Milestone 27: `state_history` SELECT Rewriting (Read-Only)
-
-The `state_history` view provides the full history of state changes across all versions. Unlike `state` and `state_by_version`, it does not deduplicate by entity—it returns all historical records.
-
-> **Note:** `state_history` is read-only. INSERT/UPDATE/DELETE are not supported.
-
-### Query Rewriting Example
-
-**Input query:**
-
-```sql
-SELECT * FROM state_history
+SELECT * FROM lix_state_history
 WHERE schema_key = 'lix_key_value' AND entity_id = 'entity-1'
 ```
 
@@ -1586,7 +1588,7 @@ ORDER BY c.created_at DESC
 
 ### Tasks
 
-1. Parse SELECT statements targeting `state_history`
+1. Parse SELECT statements targeting `lix_state_history`
 2. Rewrite to query `lix_internal_change` joined with `lix_internal_snapshot`
 3. Include all historical records (no deduplication)
 4. Order by creation time
@@ -1598,7 +1600,7 @@ ORDER BY c.created_at DESC
 
 ## Milestone 28: `entity_by_version` SELECT Rewriting
 
-The `entity_by_version` view is a layer on top of `state_by_version` that filters by `entity_id`. It returns state for a specific entity in a specific version.
+The `entity_by_version` view is a layer on top of `lix_state_by_version` that filters by `entity_id`. It returns state for a specific entity in a specific version.
 
 ### Query Rewriting Example
 
@@ -1612,10 +1614,10 @@ WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value' AND version_id = '
 **Rewritten query:**
 
 ```sql
--- Delegates to state_by_version SELECT rewriting (Milestone 19)
+-- Delegates to lix_state_by_version SELECT rewriting (Milestone 20)
 -- with entity_id filter applied
 SELECT * FROM (
-  -- state_by_version rewriting...
+  -- lix_state_by_version rewriting...
 ) WHERE entity_id = 'entity-1'
 ```
 
@@ -1623,11 +1625,11 @@ SELECT * FROM (
 
 1. Parse SELECT statements targeting `entity_by_version`
 2. Extract `entity_id` from WHERE clause (required)
-3. Delegate to `state_by_version` SELECT rewriting with entity_id filter
+3. Delegate to `lix_state_by_version` SELECT rewriting with entity_id filter
 
 ## Milestone 29: `entity_by_version` INSERT Rewriting
 
-INSERT operations on `entity_by_version` delegate to `state_by_version` INSERT.
+INSERT operations on `entity_by_version` delegate to `lix_state_by_version` INSERT.
 
 ### Query Rewriting Example
 
@@ -1641,18 +1643,18 @@ VALUES ('entity-1', 'lix_key_value', 'version-1', '{"key": "foo"}')
 **Rewritten query:**
 
 ```sql
--- Delegates to state_by_version INSERT rewriting (Milestone 20)
+-- Delegates to lix_state_by_version INSERT rewriting (Milestone 21)
 ```
 
 ### Tasks
 
 1. Parse INSERT statements targeting `entity_by_version`
 2. Validate `entity_id` and `version_id` are provided
-3. Delegate to `state_by_version` INSERT rewriting
+3. Delegate to `lix_state_by_version` INSERT rewriting
 
 ## Milestone 30: `entity_by_version` UPDATE Rewriting
 
-UPDATE operations on `entity_by_version` delegate to `state_by_version` UPDATE.
+UPDATE operations on `entity_by_version` delegate to `lix_state_by_version` UPDATE.
 
 ### Query Rewriting Example
 
@@ -1667,18 +1669,18 @@ WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value' AND version_id = '
 **Rewritten query:**
 
 ```sql
--- Delegates to state_by_version UPDATE rewriting (Milestone 21)
+-- Delegates to lix_state_by_version UPDATE rewriting (Milestone 22)
 ```
 
 ### Tasks
 
 1. Parse UPDATE statements targeting `entity_by_version`
 2. Extract `entity_id` and `version_id` from WHERE clause
-3. Delegate to `state_by_version` UPDATE rewriting
+3. Delegate to `lix_state_by_version` UPDATE rewriting
 
 ## Milestone 31: `entity_by_version` DELETE Rewriting
 
-DELETE operations on `entity_by_version` delegate to `state_by_version` DELETE.
+DELETE operations on `entity_by_version` delegate to `lix_state_by_version` DELETE.
 
 ### Query Rewriting Example
 
@@ -1692,18 +1694,18 @@ WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value' AND version_id = '
 **Rewritten query:**
 
 ```sql
--- Delegates to state_by_version DELETE rewriting (Milestone 22)
+-- Delegates to lix_state_by_version DELETE rewriting (Milestone 23)
 ```
 
 ### Tasks
 
 1. Parse DELETE statements targeting `entity_by_version`
 2. Extract `entity_id` and `version_id` from WHERE clause
-3. Delegate to `state_by_version` DELETE rewriting
+3. Delegate to `lix_state_by_version` DELETE rewriting
 
 ## Milestone 32: `entity` SELECT Rewriting
 
-The `entity` view is a layer on top of `state` that filters by `entity_id`. It returns state for a specific entity in the current version.
+The `entity` view is a layer on top of `lix_state` that filters by `entity_id`. It returns state for a specific entity in the current version.
 
 ### Query Rewriting Example
 
@@ -1717,10 +1719,10 @@ WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
 **Rewritten query:**
 
 ```sql
--- Delegates to state SELECT rewriting (Milestone 23)
+-- Delegates to lix_state SELECT rewriting (Milestone 16)
 -- with entity_id filter applied
 SELECT * FROM (
-  -- state rewriting...
+  -- lix_state rewriting...
 ) WHERE entity_id = 'entity-1'
 ```
 
@@ -1728,11 +1730,11 @@ SELECT * FROM (
 
 1. Parse SELECT statements targeting `entity`
 2. Extract `entity_id` from WHERE clause (required)
-3. Delegate to `state` SELECT rewriting with entity_id filter
+3. Delegate to `lix_state` SELECT rewriting with entity_id filter
 
 ## Milestone 33: `entity` INSERT Rewriting
 
-INSERT operations on `entity` delegate to `state` INSERT.
+INSERT operations on `entity` delegate to `lix_state` INSERT.
 
 ### Query Rewriting Example
 
@@ -1746,18 +1748,18 @@ VALUES ('entity-1', 'lix_key_value', '{"key": "foo"}')
 **Rewritten query:**
 
 ```sql
--- Delegates to state INSERT rewriting (Milestone 24)
+-- Delegates to lix_state INSERT rewriting (Milestone 17)
 ```
 
 ### Tasks
 
 1. Parse INSERT statements targeting `entity`
 2. Validate `entity_id` is provided
-3. Delegate to `state` INSERT rewriting
+3. Delegate to `lix_state` INSERT rewriting
 
 ## Milestone 34: `entity` UPDATE Rewriting
 
-UPDATE operations on `entity` delegate to `state` UPDATE.
+UPDATE operations on `entity` delegate to `lix_state` UPDATE.
 
 ### Query Rewriting Example
 
@@ -1772,18 +1774,18 @@ WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
 **Rewritten query:**
 
 ```sql
--- Delegates to state UPDATE rewriting (Milestone 25)
+-- Delegates to lix_state UPDATE rewriting (Milestone 18)
 ```
 
 ### Tasks
 
 1. Parse UPDATE statements targeting `entity`
 2. Extract `entity_id` from WHERE clause
-3. Delegate to `state` UPDATE rewriting
+3. Delegate to `lix_state` UPDATE rewriting
 
 ## Milestone 35: `entity` DELETE Rewriting
 
-DELETE operations on `entity` delegate to `state` DELETE.
+DELETE operations on `entity` delegate to `lix_state` DELETE.
 
 ### Query Rewriting Example
 
@@ -1797,18 +1799,18 @@ WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
 **Rewritten query:**
 
 ```sql
--- Delegates to state DELETE rewriting (Milestone 26)
+-- Delegates to lix_state DELETE rewriting (Milestone 19)
 ```
 
 ### Tasks
 
 1. Parse DELETE statements targeting `entity`
 2. Extract `entity_id` from WHERE clause
-3. Delegate to `state` DELETE rewriting
+3. Delegate to `lix_state` DELETE rewriting
 
 ## Milestone 36: `entity_history` SELECT Rewriting (Read-Only)
 
-The `entity_history` view is a layer on top of `state_history` that filters by `entity_id`. It returns all historical records for a specific entity.
+The `entity_history` view is a layer on top of `lix_state_history` that filters by `entity_id`. It returns all historical records for a specific entity.
 
 > **Note:** `entity_history` is read-only. INSERT/UPDATE/DELETE are not supported.
 
@@ -1824,10 +1826,10 @@ WHERE entity_id = 'entity-1' AND schema_key = 'lix_key_value'
 **Rewritten query:**
 
 ```sql
--- Delegates to state_history SELECT rewriting (Milestone 27)
+-- Delegates to lix_state_history SELECT rewriting (Milestone 27)
 -- with entity_id filter applied
 SELECT * FROM (
-  -- state_history rewriting...
+  -- lix_state_history rewriting...
 ) WHERE entity_id = 'entity-1'
 ```
 
@@ -1835,7 +1837,7 @@ SELECT * FROM (
 
 1. Parse SELECT statements targeting `entity_history`
 2. Extract `entity_id` from WHERE clause (required)
-3. Delegate to `state_history` SELECT rewriting with entity_id filter
+3. Delegate to `lix_state_history` SELECT rewriting with entity_id filter
 4. Reject INSERT/UPDATE/DELETE with clear error message
 
 ---
@@ -2077,7 +2079,7 @@ fn materialize_file_data(file_id: &str, version_id: &str, host: &impl HostBindin
 
     // 3. Query entities for this file
     let entities = host.execute(
-        "SELECT * FROM state_by_version WHERE plugin_key = ? AND file_id = ? AND version_id = ?",
+        "SELECT * FROM lix_state_by_version WHERE plugin_key = ? AND file_id = ? AND version_id = ?",
         &[&plugin.key, file_id, version_id]
     )?;
 


### PR DESCRIPTION
Introduce SQL backend support for SQLite and PostgreSQL, refactor backend structures, and implement a simulation testing framework. Enhance schema handling with new built-in definitions and validation processes. Add functionality for account management, including LixAccount and LixActiveAccount schemas, and improve error handling and testing for various operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core SQL preprocessing/execution paths and adds a new materialization write path that mutates internal materialized tables, increasing risk of query rewrite/binding regressions and state correctness issues across dialects.
> 
> **Overview**
> Adds new built-in schemas and supporting code for **accounts and version metadata**: `lix_account`, `lix_active_account`, `lix_active_version`, `lix_version_descriptor`, and renames `lix_version_tip` to `lix_version_pointer` (updating commit generation and schema registry accordingly).
> 
> Introduces a **materialization subsystem** (`materialization_plan`/`apply_materialization_plan`/`materialize`) that loads change/commit/version graphs, computes latest-visible state with inheritance, and writes results into `lix_internal_state_materialized_v1_*` tables (including a new `inherited_from_version_id` column).
> 
> Refactors SQL execution to be **dialect-aware** by adding `SqlDialect` to `LixBackend`, adding logical function lowering (`lix_json_text`   `json_extract`/`jsonb_extract_path_text`), and adding placeholder binding/normalization across `?`/`$n` styles with stricter multi-statement placeholder handling.
> 
> Extends `Engine` boot/init and routing to seed default versions/pointers, optionally seed an active account, track active version in-memory based on untracked mutations/updates, and expose materialization APIs; updates follow-up vtable write SQL generation to require backend context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a138172c1edb8d5fadcb83429f9a1e6008bc0567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->