### PR TITLE
Fix canonical URLs pointing to redirects

### DIFF
--- a/packages/website/src/components/header.tsx
+++ b/packages/website/src/components/header.tsx
@@ -120,9 +120,9 @@ export const MenuIcon = ({ className = "" }) => (
 );
 
 const navLinks = [
-  { href: "/docs/what-is-lix", label: "Docs" },
-  { href: "/plugins", label: "Plugins" },
-  { href: "/blog", label: "Blog" },
+  { href: "/docs/what-is-lix", label: "Docs", activePrefix: "/docs" },
+  { href: "/plugins", label: "Plugins", activePrefix: "/plugins" },
+  { href: "/blog", label: "Blog", activePrefix: "/blog" },
 ];
 
 const socialLinks = [
@@ -159,10 +159,11 @@ export function Header() {
     return count.toString();
   };
 
-  const isActive = (href: string) =>
-    href === "/"
-      ? pathname === "/"
-      : pathname === href || pathname.startsWith(`${href.replace(/\/$/, "")}/`);
+  const isActive = (href: string, activePrefix?: string) => {
+    const normalized = (activePrefix ?? href).replace(/\/$/, "");
+    if (normalized === "/") return pathname === "/";
+    return pathname === normalized || pathname.startsWith(`${normalized}/`);
+  };
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur">
@@ -177,18 +178,18 @@ export function Header() {
         </Link>
         <div className="flex items-center gap-6">
           <nav className="hidden items-center gap-4 text-sm font-medium text-gray-700 sm:flex">
-            {navLinks.map(({ href, label }) => (
+            {navLinks.map(({ href, label, activePrefix }) => (
               <Link
                 key={href + label}
                 to={href}
                 className={
-                  isActive(href)
+                  isActive(href, activePrefix)
                     ? href.startsWith("/plugins")
                       ? "px-2 py-1 text-[#0891B2] hover:text-[#0692B6]"
                       : "px-2 py-1 text-[#0891B2]"
                     : "px-2 py-1 transition-colors hover:text-[#0692B6]"
                 }
-                aria-current={isActive(href) ? "page" : undefined}
+                aria-current={isActive(href, activePrefix) ? "page" : undefined}
               >
                 {label}
               </Link>

--- a/packages/website/src/components/header.tsx
+++ b/packages/website/src/components/header.tsx
@@ -160,7 +160,9 @@ export function Header() {
   };
 
   const isActive = (href: string, activePrefix?: string) => {
-    const normalized = (activePrefix ?? href).replace(/\/$/, "");
+    const candidate = activePrefix ?? href;
+    const normalized =
+      candidate === "/" ? "/" : candidate.replace(/\/$/, "");
     if (normalized === "/") return pathname === "/";
     return pathname === normalized || pathname.startsWith(`${normalized}/`);
   };

--- a/packages/website/src/components/header.tsx
+++ b/packages/website/src/components/header.tsx
@@ -120,9 +120,9 @@ export const MenuIcon = ({ className = "" }) => (
 );
 
 const navLinks = [
-  { href: "/docs", label: "Docs" },
-  { href: "/plugins/", label: "Plugins" },
-  { href: "/blog/", label: "Blog" },
+  { href: "/docs/what-is-lix", label: "Docs" },
+  { href: "/plugins", label: "Plugins" },
+  { href: "/blog", label: "Blog" },
 ];
 
 const socialLinks = [

--- a/packages/website/src/components/landing-page.tsx
+++ b/packages/website/src/components/landing-page.tsx
@@ -231,15 +231,16 @@ function LandingPage({ readmeHtml }: { readmeHtml?: string }) {
   };
 
   const navLinks = [
-    { href: docsPath, label: "Docs" },
-    { href: "/plugins", label: "Plugins" },
-    { href: "/blog", label: "Blog" },
+    { href: docsPath, label: "Docs", activePrefix: "/docs" },
+    { href: "/plugins", label: "Plugins", activePrefix: "/plugins" },
+    { href: "/blog", label: "Blog", activePrefix: "/blog" },
   ];
 
-  const isActive = (href: string) =>
-    href === "/"
-      ? pathname === "/"
-      : pathname === href || pathname.startsWith(`${href.replace(/\/$/, "")}/`);
+  const isActive = (href: string, activePrefix?: string) => {
+    const normalized = (activePrefix ?? href).replace(/\/$/, "");
+    if (normalized === "/") return pathname === "/";
+    return pathname === normalized || pathname.startsWith(`${normalized}/`);
+  };
 
   const socialLinks = [
     {
@@ -270,18 +271,20 @@ function LandingPage({ readmeHtml }: { readmeHtml?: string }) {
           </a>
           <div className="flex items-center gap-6">
             <nav className="hidden items-center gap-4 text-sm font-medium text-gray-700 sm:flex">
-              {navLinks.map(({ href, label }) => (
+              {navLinks.map(({ href, label, activePrefix }) => (
                 <a
                   key={href}
                   href={href}
                   className={
-                    isActive(href)
+                    isActive(href, activePrefix)
                       ? href.startsWith("/plugins")
                         ? "px-2 py-1 text-[#0891B2] hover:text-[#0692B6]"
                         : "px-2 py-1 text-[#0891B2]"
                       : "px-2 py-1 transition-colors hover:text-[#0692B6]"
                   }
-                  aria-current={isActive(href) ? "page" : undefined}
+                  aria-current={
+                    isActive(href, activePrefix) ? "page" : undefined
+                  }
                 >
                   {label}
                 </a>

--- a/packages/website/src/components/landing-page.tsx
+++ b/packages/website/src/components/landing-page.tsx
@@ -217,7 +217,7 @@ const GoIcon = ({ className = "" }) => (
  * <LandingPage />
  */
 function LandingPage({ readmeHtml }: { readmeHtml?: string }) {
-  const docsPath = "/docs";
+  const docsPath = "/docs/what-is-lix";
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
@@ -232,8 +232,8 @@ function LandingPage({ readmeHtml }: { readmeHtml?: string }) {
 
   const navLinks = [
     { href: docsPath, label: "Docs" },
-    { href: "/plugins/", label: "Plugins" },
-    { href: "/blog/", label: "Blog" },
+    { href: "/plugins", label: "Plugins" },
+    { href: "/blog", label: "Blog" },
   ];
 
   const isActive = (href: string) =>

--- a/packages/website/src/components/landing-page.tsx
+++ b/packages/website/src/components/landing-page.tsx
@@ -237,7 +237,9 @@ function LandingPage({ readmeHtml }: { readmeHtml?: string }) {
   ];
 
   const isActive = (href: string, activePrefix?: string) => {
-    const normalized = (activePrefix ?? href).replace(/\/$/, "");
+    const candidate = activePrefix ?? href;
+    const normalized =
+      candidate === "/" ? "/" : candidate.replace(/\/$/, "");
     if (normalized === "/") return pathname === "/";
     return pathname === normalized || pathname.startsWith(`${normalized}/`);
   };

--- a/packages/website/src/lib/seo.test.ts
+++ b/packages/website/src/lib/seo.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { buildCanonicalUrl } from "./seo";
+
+describe("buildCanonicalUrl", () => {
+  test("keeps the site root canonical without changing it", () => {
+    expect(buildCanonicalUrl("/")).toBe("https://lix.dev");
+  });
+
+  test("normalizes route paths to no-trailing-slash canonicals", () => {
+    expect(buildCanonicalUrl("/blog")).toBe("https://lix.dev/blog");
+    expect(buildCanonicalUrl("docs/what-is-lix")).toBe(
+      "https://lix.dev/docs/what-is-lix",
+    );
+    expect(buildCanonicalUrl("/rfc/002-rewrite-in-rust/")).toBe(
+      "https://lix.dev/rfc/002-rewrite-in-rust",
+    );
+  });
+
+  test("keeps file-like paths canonicalized without extra slash", () => {
+    expect(buildCanonicalUrl("/lix-features.svg")).toBe(
+      "https://lix.dev/lix-features.svg",
+    );
+  });
+});

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -82,7 +82,6 @@ const config = defineConfig(({ mode, command }) => {
           autoSubfolderIndex: true,
           autoStaticPathsDiscovery: true,
           crawlLinks: true,
-          filter: (page) => page.path === "/" || !page.path.endsWith("/"),
           concurrency: 8,
           retryCount: 2,
           retryDelay: 1000,

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -82,6 +82,7 @@ const config = defineConfig(({ mode, command }) => {
           autoSubfolderIndex: true,
           autoStaticPathsDiscovery: true,
           crawlLinks: true,
+          filter: (page) => page.path === "/" || !page.path.endsWith("/"),
           concurrency: 8,
           retryCount: 2,
           retryDelay: 1000,

--- a/packages/website/wrangler.json
+++ b/packages/website/wrangler.json
@@ -3,6 +3,7 @@
   "name": "lix-website",
   "compatibility_date": "2025-11-23",
   "assets": {
-    "directory": "./dist/client"
+    "directory": "./dist/client",
+    "html_handling": "drop-trailing-slash"
   }
 }


### PR DESCRIPTION
Summary
- update canonical handling and navigation links so they point to the final URLs (no trailing slash) instead of redirecting
- adjust sitemap/indexing metadata so submitted URLs are permanent rather than temporary redirects

Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily URL/SEO and navigation tweaks plus a Cloudflare static-site setting; low risk but could affect routing/SEO if canonical or trailing-slash behavior is unexpectedly relied on.
> 
> **Overview**
> Updates header and landing-page navigation to link to the *final* docs entry point (`/docs/what-is-lix`) and removes trailing slashes from `Docs`/`Plugins`/`Blog` URLs while preserving active-state highlighting via an `activePrefix`.
> 
> Adds coverage for `buildCanonicalUrl` to ensure consistent no-trailing-slash canonicals (including root and asset paths), and configures Cloudflare Wrangler assets to `drop-trailing-slash` for HTML handling to reduce redirect-based canonicals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b019599f9a97ca6db77b354f8ae439af498e3edd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->