### PR TITLE
Git-replay-benchs

### DIFF
--- a/@optimization.md
+++ b/@optimization.md
@@ -1,0 +1,11 @@
+# Optimization Notebook
+
+## Baseline (current)
+Hypothesis: Establish stable baseline before applying pipeline optimizations.
+Implementation: Run `BENCH_REPLAY_COMMITS=25 pnpm --filter nextjs-replay-bench run bench` and capture throughput + phase breakdown.
+Result: Replay duration `15950.20ms`, commit throughput `1.32 commits/s`, execute phase `15298.06ms`.
+
+## optimize 1: strict-id fast path for mutation rewrite prefetch
+Hypothesis: `mutation.file_ids_matching_update` spends most time expanding `lix_file_by_version`; exact `WHERE id = ...` updates can fetch `id/untracked` directly from `lix_state_by_version` with pushdown.
+Implementation: Add a strict predicate parser for `id`/`version_id` equality and route those updates to a direct `lix_state_by_version` query. Fall back to previous path for all other predicates.
+Result: Replay duration `9827.51ms` (from `15950.20ms`, `-38.4%`), commit throughput `2.14 commits/s` (from `1.32`, `+62.1%`). `cargo test -p lix_engine mutation_rewrite` passed.

--- a/@optimization.md
+++ b/@optimization.md
@@ -34,3 +34,8 @@ Result: Replay duration `2908.15ms` (from `3349.14ms`, `-13.2%`; from original b
 Hypothesis: detect pipeline still spends significant time loading existing plugin entities from DB even though `plugin_text_lines` already emits full add/remove diff.
 Implementation: For `plugin_text_lines`, bypass the `load_existing_plugin_entities` reconciliation path in detect (keep fallback path for other plugins).
 Result: Replay duration `1990.29ms` (from `2908.15ms`, `-31.6%`; from original baseline `15950.20ms`, `-87.5%`). `cargo test -p lix_engine plugin_install` passed.
+
+## optimize 7: use release wasm artifact for text-lines plugin in benchmark
+Hypothesis: first detect call is dominated by JCO transpiling a large debug wasm artifact (~7.1MB); loading release wasm (~238KB) should significantly reduce one-time component init cost.
+Implementation: Update replay benchmark plugin loader/build to prefer `target/wasm32-wasip2/release/plugin_text_lines.wasm` and build with `cargo build --release` fallback.
+Result: Replay duration `1590.48ms` (from `1990.29ms`, `-20.1%`; from original baseline `15950.20ms`, `-90.0%`), crossing the 10x target on this 25-commit run.

--- a/@optimization.md
+++ b/@optimization.md
@@ -9,3 +9,8 @@ Result: Replay duration `15950.20ms`, commit throughput `1.32 commits/s`, execut
 Hypothesis: `mutation.file_ids_matching_update` spends most time expanding `lix_file_by_version`; exact `WHERE id = ...` updates can fetch `id/untracked` directly from `lix_state_by_version` with pushdown.
 Implementation: Add a strict predicate parser for `id`/`version_id` equality and route those updates to a direct `lix_state_by_version` query. Fall back to previous path for all other predicates.
 Result: Replay duration `9827.51ms` (from `15950.20ms`, `-38.4%`), commit throughput `2.14 commits/s` (from `1.32`, `+62.1%`). `cargo test -p lix_engine mutation_rewrite` passed.
+
+## optimize 2: pending update prefetch cache fast path
+Hypothesis: `pending.collect_update_writes` still dominates after optimize 1 because it expands `lix_file_by_version` for each id-scoped update; using file path/data caches should bypass that expansion for common replay updates.
+Implementation: Add exact-id fast path in `pending_file_writes` that reads before-path from `lix_internal_file_path_cache` and before-data from `lix_internal_file_data_cache`. Populate/maintain path cache in engine postprocess and invalidate on deletes.
+Result: Replay duration `3349.14ms` (from `9827.51ms`, `-65.9%`; from original baseline `15950.20ms`, `-79.0%`). Commit throughput `6.27 commits/s` (`+193%` vs optimize 1). `cargo test -p lix_engine pending_file_writes` passed.

--- a/@optimization.md
+++ b/@optimization.md
@@ -29,3 +29,8 @@ Result: Replay duration `3284.56ms` (worse than optimize 3 by `+1.0%`). Reverted
 Hypothesis: plugin instance reuse only within a single `execute` still re-initializes component instances across statements/commits; promoting cache to engine lifecycle should reduce per-statement fixed cost.
 Implementation: Add engine-owned plugin component cache keyed by plugin key, reuse across detect calls, clear cache when plugin SQL invalidates installed plugin cache.
 Result: Replay duration `2908.15ms` (from `3349.14ms`, `-13.2%`; from original baseline `15950.20ms`, `-81.8%`), confirmed across repeated run (`2918.10ms`).
+
+## optimize 6: skip existing-entity reconciliation for text-lines detect
+Hypothesis: detect pipeline still spends significant time loading existing plugin entities from DB even though `plugin_text_lines` already emits full add/remove diff.
+Implementation: For `plugin_text_lines`, bypass the `load_existing_plugin_entities` reconciliation path in detect (keep fallback path for other plugins).
+Result: Replay duration `1990.29ms` (from `2908.15ms`, `-31.6%`; from original baseline `15950.20ms`, `-87.5%`). `cargo test -p lix_engine plugin_install` passed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,32 +671,6 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
@@ -706,7 +680,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.8.2",
+ "criterion-plot",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -718,16 +692,6 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1318,12 +1282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,32 +1602,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "iso8601"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
  "nom 8.0.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1844,7 +1782,7 @@ dependencies = [
  "async-trait",
  "cel",
  "chrono",
- "criterion 0.8.2",
+ "criterion",
  "futures-util",
  "jsonschema",
  "paste",
@@ -1868,9 +1806,6 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "lix_engine",
- "plugin_json_v2",
- "serde",
- "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -2361,12 +2296,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "plugin_json_v2"
+name = "plugin_text_lines"
 version = "0.1.0"
 dependencies = [
- "criterion 0.5.1",
  "serde",
  "serde_json",
+ "sha1",
  "wit-bindgen 0.40.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "lix_engine",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ resolver = "2"
 members = [
   "packages/engine",
   "packages/js-sdk",
+  "packages/plugin-text-lines",
   "packages/rs-sdk",
 ]

--- a/optimizations2.md
+++ b/optimizations2.md
@@ -1,0 +1,46 @@
+# Optimization Notebook v2
+
+## Benchmark Target
+
+- Scenario: `packages/nextjs-replay-bench` (`BENCH_REPLAY_COMMITS=500`, `BENCH_REPLAY_WARMUP_COMMITS=5`, `BENCH_REPLAY_FIRST_PARENT=0`)
+- Goal: remove multi-second replay stalls while preserving engine semantics.
+
+## Baseline (before optimize 1)
+
+| Metric | Value |
+| --- | --- |
+| Replay duration (measured) | `49,545.83ms` |
+| Commit throughput | `9.47 commits/s` |
+| Execute phase | `42,331.42ms` (`85.4%`) |
+| Max statement latency | `5,246.03ms` |
+| Dominant outlier | `DELETE FROM lix_file WHERE id IN (...)` triggering `pending.collect_delete_targets.id_projection` |
+
+## Optimize 1: exact delete-target predicate pushdown
+
+**Hypothesis**  
+Simple id-scoped deletes should not prefetch via full `lix_state_by_version` expansion.  
+If we resolve exact `(file_id, version_id)` targets from the SQL predicate itself, we can skip the pathological scan.
+
+**Implementation**  
+- Added exact delete target extraction in `pending_file_writes` for:
+  - `id = ...`
+  - `id IN (...)`
+  - optional `version_id` / `lixcol_version_id` exact constraints
+  - conjunctions via `AND`
+- Applied as an early fast path in `collect_delete_targets(...)`.
+- Kept fallback to the existing generic prefetch path when predicates are not exact.
+- Added unit tests for active-version, explicit-version, and non-exact predicate cases.
+
+**Result**
+
+| Metric | Before | After | Delta |
+| --- | --- | --- | --- |
+| Replay duration (measured) | `49,545.83ms` | `19,784.81ms` | `-60.1%` |
+| Commit throughput | `9.47 commits/s` | `23.71 commits/s` | `+150.4%` |
+| Execute phase | `42,331.42ms` | `12,586.99ms` | `-70.3%` |
+| Max statement latency | `5,246.03ms` | `310.45ms` | `-94.1%` |
+
+**Validation**
+- `cargo test -p lix_engine pending_file_writes`
+- `cargo test -p lix_engine --test commit`
+

--- a/optimizations2.md
+++ b/optimizations2.md
@@ -7,13 +7,13 @@
 
 ## Baseline (before optimize 1)
 
-| Metric | Value |
-| --- | --- |
-| Replay duration (measured) | `49,545.83ms` |
-| Commit throughput | `9.47 commits/s` |
-| Execute phase | `42,331.42ms` (`85.4%`) |
-| Max statement latency | `5,246.03ms` |
-| Dominant outlier | `DELETE FROM lix_file WHERE id IN (...)` triggering `pending.collect_delete_targets.id_projection` |
+| Metric                     | Value                                                                                              |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| Replay duration (measured) | `49,545.83ms`                                                                                      |
+| Commit throughput          | `9.47 commits/s`                                                                                   |
+| Execute phase              | `42,331.42ms` (`85.4%`)                                                                            |
+| Max statement latency      | `5,246.03ms`                                                                                       |
+| Dominant outlier           | `DELETE FROM lix_file WHERE id IN (...)` triggering `pending.collect_delete_targets.id_projection` |
 
 ## Optimize 1: exact delete-target predicate pushdown
 
@@ -21,7 +21,8 @@
 Simple id-scoped deletes should not prefetch via full `lix_state_by_version` expansion.  
 If we resolve exact `(file_id, version_id)` targets from the SQL predicate itself, we can skip the pathological scan.
 
-**Implementation**  
+**Implementation**
+
 - Added exact delete target extraction in `pending_file_writes` for:
   - `id = ...`
   - `id IN (...)`
@@ -33,14 +34,15 @@ If we resolve exact `(file_id, version_id)` targets from the SQL predicate itsel
 
 **Result**
 
-| Metric | Before | After | Delta |
-| --- | --- | --- | --- |
-| Replay duration (measured) | `49,545.83ms` | `19,784.81ms` | `-60.1%` |
-| Commit throughput | `9.47 commits/s` | `23.71 commits/s` | `+150.4%` |
-| Execute phase | `42,331.42ms` | `12,586.99ms` | `-70.3%` |
-| Max statement latency | `5,246.03ms` | `310.45ms` | `-94.1%` |
+| Metric                     | Before           | After             | Delta     |
+| -------------------------- | ---------------- | ----------------- | --------- |
+| Replay duration (measured) | `49,545.83ms`    | `19,784.81ms`     | `-60.1%`  |
+| Commit throughput          | `9.47 commits/s` | `23.71 commits/s` | `+150.4%` |
+| Execute phase              | `42,331.42ms`    | `12,586.99ms`     | `-70.3%`  |
+| Max statement latency      | `5,246.03ms`     | `310.45ms`        | `-94.1%`  |
 
 **Validation**
+
 - `cargo test -p lix_engine pending_file_writes`
 - `cargo test -p lix_engine --test commit`
 
@@ -49,7 +51,8 @@ If we resolve exact `(file_id, version_id)` targets from the SQL predicate itsel
 **Hypothesis**  
 `mutation.file_ids_matching_update.fast_id` still queried `lix_state_by_version` for exact `(version_id, file_id)` update predicates, paying unnecessary planner/view expansion cost per update.
 
-**Implementation**  
+**Implementation**
+
 - Added a direct exact lookup path in `mutation_rewrite`:
   - first checks `lix_internal_state_untracked` for `(schema_key='lix_file_descriptor', version_id, entity_id)`
   - then checks `lix_internal_state_materialized_v1_lix_file_descriptor` for the same key (non-tombstone)
@@ -58,14 +61,15 @@ If we resolve exact `(file_id, version_id)` targets from the SQL predicate itsel
 
 **Result**
 
-| Metric | Before | After | Delta |
-| --- | --- | --- | --- |
-| Replay duration (measured) | `19,784.81ms` | `14,191.52ms` | `-28.3%` |
-| Commit throughput | `23.71 commits/s` | `33.05 commits/s` | `+39.4%` |
-| Execute phase | `12,586.99ms` | `7,074.07ms` | `-43.8%` |
-| Max statement latency | `59.73ms` | `52.72ms` | `-11.7%` |
+| Metric                     | Before            | After             | Delta    |
+| -------------------------- | ----------------- | ----------------- | -------- |
+| Replay duration (measured) | `19,784.81ms`     | `14,191.52ms`     | `-28.3%` |
+| Commit throughput          | `23.71 commits/s` | `33.05 commits/s` | `+39.4%` |
+| Execute phase              | `12,586.99ms`     | `7,074.07ms`      | `-43.8%` |
+| Max statement latency      | `59.73ms`         | `52.72ms`         | `-11.7%` |
 
 **Validation**
+
 - `cargo test -p lix_engine mutation_rewrite`
 - `cargo test -p lix_engine --test commit`
 
@@ -76,3 +80,27 @@ If we resolve exact `(file_id, version_id)` targets from the SQL predicate itsel
   - `readPatchSetMs`: `7,073.03ms` (49.8%)
 - Slowest SQL statements are now ~`50ms` large write payloads, with previous multi-second outliers eliminated.
 - Profiling indicates no remaining single engine rewrite hotspot large enough to plausibly yield another >10% overall reduction without changing higher-level replay strategy (for example batching mode or git patch-read pipeline changes).
+
+## Optimize 3 (attempt): temp-table set-based cache flush/invalidation
+
+**Hypothesis**  
+Replacing per-row cache upserts/deletes with temp-table bulk load + set-based `INSERT ... SELECT` / `DELETE ... EXISTS` should reduce transaction overhead in replay commits.
+
+**Implementation**  
+- Added SQLite transaction-path temp tables for:
+  - pending file data cache updates
+  - pending file path cache updates
+  - file cache invalidation targets
+- Replaced row-by-row operations with set-based operations when batch size crosses a threshold.
+
+**Benchmark comparison (same config as above)**
+
+| Metric | Before | After | Delta |
+| --- | --- | --- | --- |
+| Replay duration (measured) | `14,165.04ms` | `14,438.95ms` (run 1) | `+1.9%` |
+| Replay duration (measured) | `14,165.04ms` | `14,112.03ms` (run 2) | `-0.4%` |
+| Commit throughput | `33.11 commits/s` | `32.48` to `33.23 commits/s` | noise |
+
+**Result**  
+- No reliable >10% improvement on this replay path.
+- The run remains dominated by a near 50/50 split between execute and patch-read, and this cache flush path does not move total runtime materially in current execution mode.

--- a/packages/engine/benches/support/test_json_plugin.rs
+++ b/packages/engine/benches/support/test_json_plugin.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lix_engine::{LixError, WasmLimits, WasmModuleInstance, WasmRuntime};
+use lix_engine::{LixError, WasmComponentInstance, WasmLimits, WasmRuntime};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use std::sync::Arc;
@@ -51,11 +51,11 @@ struct WirePluginEntityChange {
 
 #[async_trait(?Send)]
 impl WasmRuntime for BenchJsonPluginRuntime {
-    async fn instantiate(
+    async fn init_component(
         &self,
         bytes: Vec<u8>,
         _limits: WasmLimits,
-    ) -> Result<Arc<dyn WasmModuleInstance>, LixError> {
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
         if bytes.is_empty() {
             return Err(LixError {
                 message: "benchmark runtime received empty wasm bytes".to_string(),
@@ -66,7 +66,7 @@ impl WasmRuntime for BenchJsonPluginRuntime {
 }
 
 #[async_trait(?Send)]
-impl WasmModuleInstance for BenchJsonPluginInstance {
+impl WasmComponentInstance for BenchJsonPluginInstance {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
         match export {
             "detect-changes" | "api#detect-changes" => detect_changes(input),

--- a/packages/engine/benches/support/test_json_plugin.rs
+++ b/packages/engine/benches/support/test_json_plugin.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lix_engine::{LixError, LoadWasmComponentRequest, WasmInstance, WasmRuntime};
+use lix_engine::{LixError, WasmLimits, WasmModuleInstance, WasmRuntime};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use std::sync::Arc;
@@ -51,13 +51,14 @@ struct WirePluginEntityChange {
 
 #[async_trait(?Send)]
 impl WasmRuntime for BenchJsonPluginRuntime {
-    async fn load_component(
+    async fn instantiate(
         &self,
-        request: LoadWasmComponentRequest,
-    ) -> Result<Arc<dyn WasmInstance>, LixError> {
-        if request.key != "test_json_plugin" {
+        bytes: Vec<u8>,
+        _limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmModuleInstance>, LixError> {
+        if bytes.is_empty() {
             return Err(LixError {
-                message: format!("unsupported benchmark plugin key '{}'", request.key),
+                message: "benchmark runtime received empty wasm bytes".to_string(),
             });
         }
         Ok(Arc::new(BenchJsonPluginInstance))
@@ -65,7 +66,7 @@ impl WasmRuntime for BenchJsonPluginRuntime {
 }
 
 #[async_trait(?Send)]
-impl WasmInstance for BenchJsonPluginInstance {
+impl WasmModuleInstance for BenchJsonPluginInstance {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
         match export {
             "detect-changes" | "api#detect-changes" => detect_changes(input),

--- a/packages/engine/src/backend.rs
+++ b/packages/engine/src/backend.rs
@@ -20,10 +20,7 @@ pub trait LixBackend: Send + Sync {
     ///
     /// Implementations should write a valid SQLite3 database image (for example `.lix`)
     /// to `writer` in one or more chunks.
-    async fn export_snapshot(
-        &self,
-        _writer: &mut dyn SnapshotChunkWriter,
-    ) -> Result<(), LixError> {
+    async fn export_snapshot(&self, _writer: &mut dyn SnapshotChunkWriter) -> Result<(), LixError> {
         Err(LixError {
             message: "export_snapshot is not supported by this backend".to_string(),
         })

--- a/packages/engine/src/backend.rs
+++ b/packages/engine/src/backend.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::{LixError, QueryResult, Value};
+use crate::{LixError, QueryResult, SnapshotChunkReader, SnapshotChunkWriter, Value};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqlDialect {
@@ -15,6 +15,29 @@ pub trait LixBackend: Send + Sync {
     async fn execute(&self, sql: &str, params: &[Value]) -> Result<QueryResult, LixError>;
 
     async fn begin_transaction(&self) -> Result<Box<dyn LixTransaction + '_>, LixError>;
+
+    /// Exports the current Lix database snapshot as a SQLite database file payload.
+    ///
+    /// Implementations should write a valid SQLite3 database image (for example `.lix`)
+    /// to `writer` in one or more chunks.
+    async fn export_snapshot(
+        &self,
+        _writer: &mut dyn SnapshotChunkWriter,
+    ) -> Result<(), LixError> {
+        Err(LixError {
+            message: "export_snapshot is not supported by this backend".to_string(),
+        })
+    }
+
+    /// Restores backend state from a SQLite database file payload stream.
+    async fn restore_from_snapshot(
+        &self,
+        _reader: &mut dyn SnapshotChunkReader,
+    ) -> Result<(), LixError> {
+        Err(LixError {
+            message: "restore_from_snapshot is not supported by this backend".to_string(),
+        })
+    }
 }
 
 #[async_trait(?Send)]

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -27,7 +27,7 @@ use crate::plugin::types::{InstalledPlugin, PluginManifest};
 use crate::schema_registry::{register_schema, register_schema_sql_statements};
 use crate::sql::{
     bind_sql_with_state, build_delete_followup_sql, build_update_followup_sql, escape_sql_string,
-    expr_references_column_name, parse_sql_statements,
+    expr_references_column_name, parse_sql_statements, preprocess_sql,
     preprocess_sql_with_provider_and_detected_file_domain_changes, ColumnReferenceOptions,
     DetectedFileDomainChange, MutationOperation, MutationRow, PlaceholderState, PostprocessPlan,
     UpdateValidationPlan,
@@ -44,12 +44,12 @@ use crate::version::{
     version_pointer_storage_version_id, DEFAULT_ACTIVE_VERSION_NAME, GLOBAL_VERSION_ID,
 };
 use crate::WasmRuntime;
-use crate::{LixBackend, LixError, LixTransaction, QueryResult, Value};
+use crate::{LixBackend, LixError, LixTransaction, QueryResult, SqlDialect, Value};
 use futures_util::FutureExt;
 use serde_json::Value as JsonValue;
 use sqlparser::ast::{
-    BinaryOperator, Expr, FromTable, ObjectName, ObjectNamePart, Query, Select, SetExpr, Statement,
-    TableFactor, TableObject, TableWithJoins, Update, UpdateTableFromKind,
+    AssignmentTarget, BinaryOperator, Expr, FromTable, ObjectName, ObjectNamePart, Query, Select,
+    SetExpr, Statement, TableFactor, TableObject, TableWithJoins, Update, UpdateTableFromKind,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
@@ -139,6 +139,8 @@ impl<'a> EngineTransaction<'a> {
                 params,
                 &self.options,
                 &mut self.active_version_id,
+                None,
+                false,
             )
             .await?;
         if self.active_version_id != previous_active_version_id {
@@ -193,6 +195,15 @@ struct CollectedExecutionSideEffects {
     detected_file_domain_changes_by_statement: Vec<Vec<DetectedFileDomainChange>>,
     detected_file_domain_changes: Vec<DetectedFileDomainChange>,
     untracked_filesystem_update_domain_changes: Vec<DetectedFileDomainChange>,
+}
+
+#[derive(Default)]
+struct DeferredTransactionSideEffects {
+    pending_file_writes: Vec<crate::filesystem::pending_file_writes::PendingFileWrite>,
+    pending_file_delete_targets: BTreeSet<(String, String)>,
+    detected_file_domain_changes: Vec<DetectedFileDomainChange>,
+    untracked_filesystem_update_domain_changes: Vec<DetectedFileDomainChange>,
+    file_cache_invalidation_targets: BTreeSet<(String, String)>,
 }
 
 // SAFETY: `TransactionBackendAdapter` is only used inside a single async execution flow.
@@ -319,6 +330,12 @@ impl Engine {
         params: &[Value],
         options: ExecuteOptions,
     ) -> Result<QueryResult, LixError> {
+        if let Some(statements) = extract_explicit_transaction_script(sql, params)? {
+            return self
+                .execute_transaction_script_with_options(statements, options)
+                .await;
+        }
+
         let active_version_id = self.active_version_id.read().unwrap().clone();
         let writer_key = options.writer_key.as_deref();
         self.maybe_materialize_reads_with_backend(self.backend.as_ref(), sql, &active_version_id)
@@ -337,6 +354,7 @@ impl Engine {
                 params,
                 &active_version_id,
                 writer_key,
+                true,
                 true,
             )
             .await?;
@@ -534,7 +552,11 @@ impl Engine {
         }
         self.persist_pending_file_data_updates(&pending_file_writes)
             .await?;
+        self.persist_pending_file_path_updates(&pending_file_writes)
+            .await?;
         self.invalidate_file_data_cache_entries(&file_cache_invalidation_targets)
+            .await?;
+        self.invalidate_file_path_cache_entries(&file_cache_invalidation_targets)
             .await?;
         if self.wasm_runtime.is_some() {
             self.refresh_file_data_for_versions(file_cache_refresh_targets)
@@ -545,6 +567,128 @@ impl Engine {
         }
 
         Ok(result)
+    }
+
+    async fn execute_transaction_script_with_options(
+        &self,
+        statements: Vec<Statement>,
+        options: ExecuteOptions,
+    ) -> Result<QueryResult, LixError> {
+        let mut transaction = self.backend.begin_transaction().await?;
+        let mut last_result = QueryResult { rows: Vec::new() };
+        let mut active_version_id = self.active_version_id.read().unwrap().clone();
+        let mut active_version_changed = false;
+        let mut installed_plugins_cache_invalidation_pending = false;
+        let coalesced_statements =
+            coalesce_lix_file_transaction_statements(&statements, Some(transaction.dialect()));
+        let can_defer_side_effects = self.wasm_runtime.is_none() && coalesced_statements.is_some();
+        let mut deferred_side_effects = if can_defer_side_effects {
+            let original_sql = statements
+                .iter()
+                .map(Statement::to_string)
+                .collect::<Vec<_>>()
+                .join(";\n");
+            let CollectedExecutionSideEffects {
+                pending_file_writes,
+                pending_file_delete_targets,
+                detected_file_domain_changes: filesystem_tracked_domain_changes,
+                untracked_filesystem_update_domain_changes,
+                ..
+            } = {
+                let backend = TransactionBackendAdapter::new(transaction.as_mut());
+                self.collect_execution_side_effects_with_backend(
+                    &backend,
+                    &original_sql,
+                    &[],
+                    &active_version_id,
+                    options.writer_key.as_deref(),
+                    false,
+                    false,
+                )
+                .await?
+            };
+            Some(DeferredTransactionSideEffects {
+                pending_file_writes,
+                pending_file_delete_targets: pending_file_delete_targets.clone(),
+                detected_file_domain_changes: filesystem_tracked_domain_changes,
+                untracked_filesystem_update_domain_changes,
+                file_cache_invalidation_targets: pending_file_delete_targets,
+            })
+        } else {
+            None
+        };
+        let sql_statements = statements
+            .into_iter()
+            .map(|statement| statement.to_string())
+            .collect::<Vec<_>>();
+        let skip_statement_side_effect_collection = deferred_side_effects.is_some();
+
+        for sql in sql_statements {
+            let previous_active_version_id = active_version_id.clone();
+            let result = if skip_statement_side_effect_collection {
+                self.execute_with_options_in_transaction(
+                    transaction.as_mut(),
+                    &sql,
+                    &[],
+                    &options,
+                    &mut active_version_id,
+                    deferred_side_effects.as_mut(),
+                    true,
+                )
+                .await
+            } else {
+                self.execute_with_options_in_transaction(
+                    transaction.as_mut(),
+                    &sql,
+                    &[],
+                    &options,
+                    &mut active_version_id,
+                    None,
+                    false,
+                )
+                .await
+            };
+
+            match result {
+                Ok(query_result) => {
+                    last_result = query_result;
+                }
+                Err(error) => {
+                    let _ = transaction.rollback().await;
+                    return Err(error);
+                }
+            }
+
+            if active_version_id != previous_active_version_id {
+                active_version_changed = true;
+            }
+            if should_invalidate_installed_plugins_cache_for_sql(&sql) {
+                installed_plugins_cache_invalidation_pending = true;
+            }
+        }
+
+        if let Some(side_effects) = deferred_side_effects.as_mut() {
+            if let Err(error) = self
+                .flush_deferred_transaction_side_effects_in_transaction(
+                    transaction.as_mut(),
+                    side_effects,
+                    options.writer_key.as_deref(),
+                )
+                .await
+            {
+                let _ = transaction.rollback().await;
+                return Err(error);
+            }
+        }
+
+        transaction.commit().await?;
+        if active_version_changed {
+            self.set_active_version_id(active_version_id);
+        }
+        if installed_plugins_cache_invalidation_pending {
+            self.invalidate_installed_plugins_cache()?;
+        }
+        Ok(last_result)
     }
 
     async fn begin_transaction_with_options(
@@ -593,8 +737,11 @@ impl Engine {
         params: &[Value],
         options: &ExecuteOptions,
         active_version_id: &mut String,
+        deferred_side_effects: Option<&mut DeferredTransactionSideEffects>,
+        skip_side_effect_collection: bool,
     ) -> Result<QueryResult, LixError> {
         let writer_key = options.writer_key.as_deref();
+        let defer_side_effects = deferred_side_effects.is_some();
         let should_refresh_file_cache = should_refresh_file_cache_for_sql(sql);
         let (
             pending_file_writes,
@@ -615,16 +762,26 @@ impl Engine {
                 detected_file_domain_changes_by_statement,
                 detected_file_domain_changes,
                 untracked_filesystem_update_domain_changes,
-            } = self
-                .collect_execution_side_effects_with_backend(
+            } = if skip_side_effect_collection {
+                CollectedExecutionSideEffects {
+                    pending_file_writes: Vec::new(),
+                    pending_file_delete_targets: BTreeSet::new(),
+                    detected_file_domain_changes_by_statement: vec![Vec::new(); 1],
+                    detected_file_domain_changes: Vec::new(),
+                    untracked_filesystem_update_domain_changes: Vec::new(),
+                }
+            } else {
+                self.collect_execution_side_effects_with_backend(
                     &backend,
                     sql,
                     params,
                     active_version_id,
                     writer_key,
                     false,
+                    !defer_side_effects,
                 )
-                .await?;
+                .await?
+            };
             let (settings, sequence_start, functions) = self
                 .prepare_runtime_functions_with_backend(&backend)
                 .await?;
@@ -794,27 +951,55 @@ impl Engine {
         file_cache_invalidation_targets.extend(descriptor_cache_eviction_targets);
         file_cache_invalidation_targets.extend(pending_file_delete_targets);
 
-        if !plugin_changes_committed && !detected_file_domain_changes.is_empty() {
-            self.persist_detected_file_domain_changes_in_transaction(
+        if let Some(deferred) = deferred_side_effects {
+            deferred.pending_file_writes.extend(pending_file_writes);
+            deferred
+                .file_cache_invalidation_targets
+                .extend(file_cache_invalidation_targets.iter().cloned());
+            if !plugin_changes_committed {
+                deferred
+                    .detected_file_domain_changes
+                    .extend(detected_file_domain_changes);
+            }
+            deferred
+                .untracked_filesystem_update_domain_changes
+                .extend(untracked_filesystem_update_domain_changes);
+        } else {
+            if !plugin_changes_committed && !detected_file_domain_changes.is_empty() {
+                self.persist_detected_file_domain_changes_in_transaction(
+                    transaction,
+                    &detected_file_domain_changes,
+                )
+                .await?;
+            }
+            if !untracked_filesystem_update_domain_changes.is_empty() {
+                self.persist_untracked_file_domain_changes_in_transaction(
+                    transaction,
+                    &untracked_filesystem_update_domain_changes,
+                )
+                .await?;
+            }
+            self.persist_pending_file_data_updates_in_transaction(
                 transaction,
-                &detected_file_domain_changes,
+                &pending_file_writes,
+            )
+            .await?;
+            self.persist_pending_file_path_updates_in_transaction(
+                transaction,
+                &pending_file_writes,
+            )
+            .await?;
+            self.invalidate_file_data_cache_entries_in_transaction(
+                transaction,
+                &file_cache_invalidation_targets,
+            )
+            .await?;
+            self.invalidate_file_path_cache_entries_in_transaction(
+                transaction,
+                &file_cache_invalidation_targets,
             )
             .await?;
         }
-        if !untracked_filesystem_update_domain_changes.is_empty() {
-            self.persist_untracked_file_domain_changes_in_transaction(
-                transaction,
-                &untracked_filesystem_update_domain_changes,
-            )
-            .await?;
-        }
-        self.persist_pending_file_data_updates_in_transaction(transaction, &pending_file_writes)
-            .await?;
-        self.invalidate_file_data_cache_entries_in_transaction(
-            transaction,
-            &file_cache_invalidation_targets,
-        )
-        .await?;
         self.persist_runtime_sequence_with_backend(
             &TransactionBackendAdapter::new(transaction),
             settings,
@@ -939,6 +1124,7 @@ impl Engine {
         active_version_id: &str,
         writer_key: Option<&str>,
         allow_plugin_cache: bool,
+        detect_plugin_file_changes: bool,
     ) -> Result<CollectedExecutionSideEffects, LixError> {
         let pending_file_write_collection =
             crate::filesystem::pending_file_writes::collect_pending_file_writes(
@@ -967,13 +1153,16 @@ impl Engine {
                 message: format!("pending file delete collection failed: {}", error.message),
             })?;
 
-        let detected_file_changes_by_statement = self
-            .detect_file_changes_for_pending_writes_by_statement_with_backend(
+        let detected_file_changes_by_statement = if detect_plugin_file_changes {
+            self.detect_file_changes_for_pending_writes_by_statement_with_backend(
                 backend,
                 &pending_file_writes_by_statement,
                 allow_plugin_cache,
             )
-            .await?;
+            .await?
+        } else {
+            vec![Vec::new(); pending_file_writes_by_statement.len()]
+        };
         let mut detected_file_domain_changes_by_statement = detected_file_changes_by_statement
             .into_iter()
             .map(|changes| {
@@ -1027,6 +1216,83 @@ impl Engine {
             detected_file_domain_changes,
             untracked_filesystem_update_domain_changes,
         })
+    }
+
+    async fn flush_deferred_transaction_side_effects_in_transaction(
+        &self,
+        transaction: &mut dyn LixTransaction,
+        side_effects: &mut DeferredTransactionSideEffects,
+        writer_key: Option<&str>,
+    ) -> Result<(), LixError> {
+        let collapsed_writes =
+            collapse_pending_file_writes_for_transaction(&side_effects.pending_file_writes);
+        side_effects.pending_file_writes = collapsed_writes;
+
+        let mut detected_file_domain_changes =
+            std::mem::take(&mut side_effects.detected_file_domain_changes);
+        if !side_effects.pending_file_writes.is_empty() {
+            let detected_by_statement = {
+                let backend = TransactionBackendAdapter::new(transaction);
+                self.detect_file_changes_for_pending_writes_by_statement_with_backend(
+                    &backend,
+                    &[side_effects.pending_file_writes.clone()],
+                    false,
+                )
+                .await?
+            };
+            if let Some(detected) = detected_by_statement.into_iter().next() {
+                detected_file_domain_changes.extend(
+                    detected_file_domain_changes_from_detected_file_changes(&detected, writer_key),
+                );
+            }
+        }
+        detected_file_domain_changes =
+            dedupe_detected_file_domain_changes(&detected_file_domain_changes);
+        let untracked_filesystem_update_domain_changes = dedupe_detected_file_domain_changes(
+            &std::mem::take(&mut side_effects.untracked_filesystem_update_domain_changes),
+        );
+        side_effects
+            .file_cache_invalidation_targets
+            .extend(std::mem::take(
+                &mut side_effects.pending_file_delete_targets,
+            ));
+
+        if !detected_file_domain_changes.is_empty() {
+            self.persist_detected_file_domain_changes_in_transaction(
+                transaction,
+                &detected_file_domain_changes,
+            )
+            .await?;
+        }
+        if !untracked_filesystem_update_domain_changes.is_empty() {
+            self.persist_untracked_file_domain_changes_in_transaction(
+                transaction,
+                &untracked_filesystem_update_domain_changes,
+            )
+            .await?;
+        }
+        self.persist_pending_file_data_updates_in_transaction(
+            transaction,
+            &side_effects.pending_file_writes,
+        )
+        .await?;
+        self.persist_pending_file_path_updates_in_transaction(
+            transaction,
+            &side_effects.pending_file_writes,
+        )
+        .await?;
+        self.invalidate_file_data_cache_entries_in_transaction(
+            transaction,
+            &side_effects.file_cache_invalidation_targets,
+        )
+        .await?;
+        self.invalidate_file_path_cache_entries_in_transaction(
+            transaction,
+            &side_effects.file_cache_invalidation_targets,
+        )
+        .await?;
+
+        Ok(())
     }
 
     async fn prepare_runtime_functions_with_backend(
@@ -1744,7 +2010,9 @@ impl Engine {
              ) VALUES {}",
             rows.join(", ")
         );
-        transaction.execute(&sql, &params).await?;
+        let backend = TransactionBackendAdapter::new(transaction);
+        let output = preprocess_sql(&backend, &self.cel_evaluator, &sql, &params).await?;
+        backend.execute(&output.sql, &output.params).await?;
 
         Ok(())
     }
@@ -1811,6 +2079,87 @@ impl Engine {
                 .await?;
         }
 
+        Ok(())
+    }
+
+    async fn persist_pending_file_path_updates(
+        &self,
+        writes: &[crate::filesystem::pending_file_writes::PendingFileWrite],
+    ) -> Result<(), LixError> {
+        let mut latest_by_key: BTreeMap<(String, String), usize> = BTreeMap::new();
+        for (index, write) in writes.iter().enumerate() {
+            latest_by_key.insert((write.file_id.clone(), write.version_id.clone()), index);
+        }
+
+        for index in latest_by_key.into_values() {
+            let write = &writes[index];
+            let Some((name, extension)) = file_name_and_extension_from_path(&write.path) else {
+                continue;
+            };
+            self.backend
+                .execute(
+                    "INSERT INTO lix_internal_file_path_cache \
+                     (file_id, version_id, directory_id, name, extension, path) \
+                     VALUES ($1, $2, NULL, $3, $4, $5) \
+                     ON CONFLICT (file_id, version_id) DO UPDATE SET \
+                     directory_id = EXCLUDED.directory_id, \
+                     name = EXCLUDED.name, \
+                     extension = EXCLUDED.extension, \
+                     path = EXCLUDED.path",
+                    &[
+                        Value::Text(write.file_id.clone()),
+                        Value::Text(write.version_id.clone()),
+                        Value::Text(name),
+                        match extension {
+                            Some(value) => Value::Text(value),
+                            None => Value::Null,
+                        },
+                        Value::Text(write.path.clone()),
+                    ],
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn persist_pending_file_path_updates_in_transaction(
+        &self,
+        transaction: &mut dyn LixTransaction,
+        writes: &[crate::filesystem::pending_file_writes::PendingFileWrite],
+    ) -> Result<(), LixError> {
+        let mut latest_by_key: BTreeMap<(String, String), usize> = BTreeMap::new();
+        for (index, write) in writes.iter().enumerate() {
+            latest_by_key.insert((write.file_id.clone(), write.version_id.clone()), index);
+        }
+
+        for index in latest_by_key.into_values() {
+            let write = &writes[index];
+            let Some((name, extension)) = file_name_and_extension_from_path(&write.path) else {
+                continue;
+            };
+            transaction
+                .execute(
+                    "INSERT INTO lix_internal_file_path_cache \
+                     (file_id, version_id, directory_id, name, extension, path) \
+                     VALUES ($1, $2, NULL, $3, $4, $5) \
+                     ON CONFLICT (file_id, version_id) DO UPDATE SET \
+                     directory_id = EXCLUDED.directory_id, \
+                     name = EXCLUDED.name, \
+                     extension = EXCLUDED.extension, \
+                     path = EXCLUDED.path",
+                    &[
+                        Value::Text(write.file_id.clone()),
+                        Value::Text(write.version_id.clone()),
+                        Value::Text(name),
+                        match extension {
+                            Some(value) => Value::Text(value),
+                            None => Value::Null,
+                        },
+                        Value::Text(write.path.clone()),
+                    ],
+                )
+                .await?;
+        }
         Ok(())
     }
 
@@ -1891,6 +2240,83 @@ impl Engine {
         Ok(())
     }
 
+    async fn invalidate_file_path_cache_entries(
+        &self,
+        targets: &BTreeSet<(String, String)>,
+    ) -> Result<(), LixError> {
+        if targets.is_empty() {
+            return Ok(());
+        }
+
+        const PAIRS_PER_CHUNK: usize = 200;
+        let keys = targets.iter().cloned().collect::<Vec<_>>();
+
+        for chunk in keys.chunks(PAIRS_PER_CHUNK) {
+            let mut params = Vec::with_capacity(chunk.len() * 2);
+            let mut predicates = Vec::with_capacity(chunk.len());
+            for (index, (file_id, version_id)) in chunk.iter().enumerate() {
+                let file_param = index * 2 + 1;
+                let version_param = file_param + 1;
+                predicates.push(format!(
+                    "(file_id = ${file_param} AND version_id = ${version_param})"
+                ));
+                params.push(Value::Text(file_id.clone()));
+                params.push(Value::Text(version_id.clone()));
+            }
+
+            self.backend
+                .execute(
+                    &format!(
+                        "DELETE FROM lix_internal_file_path_cache \
+                         WHERE {}",
+                        predicates.join(" OR ")
+                    ),
+                    &params,
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn invalidate_file_path_cache_entries_in_transaction(
+        &self,
+        transaction: &mut dyn LixTransaction,
+        targets: &BTreeSet<(String, String)>,
+    ) -> Result<(), LixError> {
+        if targets.is_empty() {
+            return Ok(());
+        }
+
+        const PAIRS_PER_CHUNK: usize = 200;
+        let keys = targets.iter().cloned().collect::<Vec<_>>();
+
+        for chunk in keys.chunks(PAIRS_PER_CHUNK) {
+            let mut params = Vec::with_capacity(chunk.len() * 2);
+            let mut predicates = Vec::with_capacity(chunk.len());
+            for (index, (file_id, version_id)) in chunk.iter().enumerate() {
+                let file_param = index * 2 + 1;
+                let version_param = file_param + 1;
+                predicates.push(format!(
+                    "(file_id = ${file_param} AND version_id = ${version_param})"
+                ));
+                params.push(Value::Text(file_id.clone()));
+                params.push(Value::Text(version_id.clone()));
+            }
+
+            transaction
+                .execute(
+                    &format!(
+                        "DELETE FROM lix_internal_file_path_cache \
+                         WHERE {}",
+                        predicates.join(" OR ")
+                    ),
+                    &params,
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
     async fn refresh_file_data_for_versions(
         &self,
         targets: BTreeSet<(String, String)>,
@@ -1952,6 +2378,8 @@ impl Engine {
                 params,
                 options,
                 active_version_id,
+                None,
+                false,
             ))
             .await?;
         }
@@ -1983,6 +2411,401 @@ fn should_sequentialize_postprocess_multi_statement(
                 | Statement::Rollback { .. }
         )
     })
+}
+
+fn file_name_and_extension_from_path(path: &str) -> Option<(String, Option<String>)> {
+    let trimmed = path.trim_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let file_name = trimmed.rsplit('/').next()?;
+    if file_name.is_empty() {
+        return None;
+    }
+    let last_dot = file_name.rfind('.');
+    let (name, extension) = match last_dot {
+        Some(index) if index > 0 => {
+            let name = file_name[..index].to_string();
+            let extension = file_name[index + 1..].to_string();
+            let extension = if extension.is_empty() {
+                None
+            } else {
+                Some(extension)
+            };
+            (name, extension)
+        }
+        _ => (file_name.to_string(), None),
+    };
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, extension))
+}
+
+fn extract_explicit_transaction_script(
+    sql: &str,
+    params: &[Value],
+) -> Result<Option<Vec<Statement>>, LixError> {
+    if !params.is_empty() {
+        return Ok(None);
+    }
+
+    let statements = parse_sql_statements(sql)?;
+    if statements.len() < 2 {
+        return Ok(None);
+    }
+
+    let first_is_begin = matches!(statements.first(), Some(Statement::StartTransaction { .. }));
+    let last_is_commit = matches!(statements.last(), Some(Statement::Commit { .. }));
+    if !first_is_begin || !last_is_commit {
+        return Ok(None);
+    }
+
+    let middle = &statements[1..statements.len() - 1];
+    if middle.iter().any(|statement| {
+        matches!(
+            statement,
+            Statement::StartTransaction { .. }
+                | Statement::Commit { .. }
+                | Statement::Rollback { .. }
+        )
+    }) {
+        return Err(LixError {
+            message:
+                "nested transaction statements are not supported inside BEGIN ... COMMIT scripts"
+                    .to_string(),
+        });
+    }
+
+    Ok(Some(middle.to_vec()))
+}
+
+#[derive(Debug, Clone)]
+struct LixFileWriteRow {
+    id: String,
+    path_sql: String,
+    data_sql: String,
+}
+
+fn coalesce_lix_file_transaction_statements(
+    statements: &[Statement],
+    dialect: Option<SqlDialect>,
+) -> Option<Vec<String>> {
+    if statements.is_empty() {
+        return Some(Vec::new());
+    }
+    if !matches!(dialect, Some(SqlDialect::Sqlite)) {
+        return None;
+    }
+
+    let mut delete_ids = Vec::new();
+    let mut insert_rows = Vec::new();
+    let mut update_rows = Vec::new();
+    let mut seen_ids = BTreeSet::new();
+    let mut saw_update = false;
+
+    for statement in statements {
+        if let Some(ids) = parse_lix_file_delete_ids(statement) {
+            if saw_update {
+                return None;
+            }
+            for id in ids {
+                if !seen_ids.insert(id.clone()) {
+                    return None;
+                }
+                delete_ids.push(id);
+            }
+            continue;
+        }
+        if let Some(rows) = parse_lix_file_insert_rows(statement) {
+            if saw_update {
+                return None;
+            }
+            for row in rows {
+                if !seen_ids.insert(row.id.clone()) {
+                    return None;
+                }
+                insert_rows.push(row);
+            }
+            continue;
+        }
+        if let Some(row) = parse_lix_file_update_row(statement) {
+            if !seen_ids.insert(row.id.clone()) {
+                return None;
+            }
+            saw_update = true;
+            update_rows.push(row);
+            continue;
+        }
+        return None;
+    }
+
+    let mut rewritten = Vec::new();
+
+    if !delete_ids.is_empty() {
+        let id_list = delete_ids
+            .iter()
+            .map(|id| format!("'{}'", escape_sql_string(id)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        rewritten.push(format!("DELETE FROM lix_file WHERE id IN ({id_list})"));
+    }
+
+    if !insert_rows.is_empty() {
+        let values = insert_rows
+            .iter()
+            .map(|row| {
+                format!(
+                    "('{}', {}, {})",
+                    escape_sql_string(&row.id),
+                    row.path_sql,
+                    row.data_sql
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        rewritten.push(format!(
+            "INSERT INTO lix_file (id, path, data) VALUES {values}"
+        ));
+    }
+
+    if !update_rows.is_empty() {
+        let path_cases = update_rows
+            .iter()
+            .map(|row| {
+                format!(
+                    "WHEN '{}' THEN {}",
+                    escape_sql_string(&row.id),
+                    row.path_sql
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let data_cases = update_rows
+            .iter()
+            .map(|row| {
+                format!(
+                    "WHEN '{}' THEN {}",
+                    escape_sql_string(&row.id),
+                    row.data_sql
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let id_list = update_rows
+            .iter()
+            .map(|row| format!("'{}'", escape_sql_string(&row.id)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        rewritten.push(format!(
+            "UPDATE lix_file \
+             SET path = CASE id {path_cases} ELSE path END, \
+                 data = CASE id {data_cases} ELSE data END \
+             WHERE id IN ({id_list})"
+        ));
+    }
+
+    Some(rewritten)
+}
+
+fn parse_lix_file_insert_rows(statement: &Statement) -> Option<Vec<LixFileWriteRow>> {
+    let Statement::Insert(insert) = statement else {
+        return None;
+    };
+    if !table_object_targets_table_name(&insert.table, "lix_file") {
+        return None;
+    }
+    if insert.columns.is_empty() {
+        return None;
+    }
+    if !insert.assignments.is_empty() || insert.on.is_some() || insert.returning.is_some() {
+        return None;
+    }
+    let source = insert.source.as_deref()?;
+    let SetExpr::Values(values) = source.body.as_ref() else {
+        return None;
+    };
+
+    let id_index = insert
+        .columns
+        .iter()
+        .position(|column| column.value.eq_ignore_ascii_case("id"))?;
+    let path_index = insert
+        .columns
+        .iter()
+        .position(|column| column.value.eq_ignore_ascii_case("path"))?;
+    let data_index = insert
+        .columns
+        .iter()
+        .position(|column| column.value.eq_ignore_ascii_case("data"))?;
+
+    let mut rows = Vec::with_capacity(values.rows.len());
+    for row in &values.rows {
+        let id = expr_as_string_literal(row.get(id_index)?)?;
+        let path_sql = row.get(path_index)?.to_string();
+        let data_sql = row.get(data_index)?.to_string();
+        rows.push(LixFileWriteRow {
+            id,
+            path_sql,
+            data_sql,
+        });
+    }
+    Some(rows)
+}
+
+fn parse_lix_file_update_row(statement: &Statement) -> Option<LixFileWriteRow> {
+    let Statement::Update(update) = statement else {
+        return None;
+    };
+    if !table_with_joins_targets_table_name(&update.table, "lix_file") {
+        return None;
+    }
+    if update.from.is_some() || update.returning.is_some() || update.limit.is_some() {
+        return None;
+    }
+
+    let mut path_sql = None;
+    let mut data_sql = None;
+    for assignment in &update.assignments {
+        let AssignmentTarget::ColumnName(target) = &assignment.target else {
+            return None;
+        };
+        let column = object_name_last_ident_value(target)?;
+        if column.eq_ignore_ascii_case("path") {
+            path_sql = Some(assignment.value.to_string());
+        } else if column.eq_ignore_ascii_case("data") {
+            data_sql = Some(assignment.value.to_string());
+        } else {
+            return None;
+        }
+    }
+
+    let id = parse_id_eq_selection(update.selection.as_ref()?)?;
+    Some(LixFileWriteRow {
+        id,
+        path_sql: path_sql?,
+        data_sql: data_sql?,
+    })
+}
+
+fn parse_lix_file_delete_ids(statement: &Statement) -> Option<Vec<String>> {
+    let Statement::Delete(delete) = statement else {
+        return None;
+    };
+    if !delete.tables.is_empty()
+        || delete.using.is_some()
+        || delete.returning.is_some()
+        || !delete.order_by.is_empty()
+        || delete.limit.is_some()
+    {
+        return None;
+    }
+
+    let from = match &delete.from {
+        FromTable::WithFromKeyword(from) | FromTable::WithoutKeyword(from) => from,
+    };
+    if from.len() != 1 || !table_with_joins_targets_table_name(&from[0], "lix_file") {
+        return None;
+    }
+
+    parse_id_selection(delete.selection.as_ref()?)
+}
+
+fn parse_id_selection(selection: &Expr) -> Option<Vec<String>> {
+    match selection {
+        Expr::InList {
+            expr,
+            list,
+            negated: false,
+        } if expr_is_column_name(expr, "id") => list.iter().map(expr_as_string_literal).collect(),
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            if expr_is_column_name(left, "id") {
+                return Some(vec![expr_as_string_literal(right)?]);
+            }
+            if expr_is_column_name(right, "id") {
+                return Some(vec![expr_as_string_literal(left)?]);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn parse_id_eq_selection(selection: &Expr) -> Option<String> {
+    let ids = parse_id_selection(selection)?;
+    if ids.len() == 1 {
+        return ids.into_iter().next();
+    }
+    None
+}
+
+fn expr_as_string_literal(expr: &Expr) -> Option<String> {
+    let Expr::Value(value) = expr else {
+        return None;
+    };
+    match &value.value {
+        sqlparser::ast::Value::SingleQuotedString(text)
+        | sqlparser::ast::Value::DoubleQuotedString(text)
+        | sqlparser::ast::Value::NationalStringLiteral(text)
+        | sqlparser::ast::Value::EscapedStringLiteral(text)
+        | sqlparser::ast::Value::UnicodeStringLiteral(text) => Some(text.clone()),
+        _ => None,
+    }
+}
+
+fn expr_is_column_name(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::Identifier(ident) => ident.value.eq_ignore_ascii_case(name),
+        Expr::CompoundIdentifier(parts) => parts
+            .last()
+            .is_some_and(|ident| ident.value.eq_ignore_ascii_case(name)),
+        Expr::Nested(inner) => expr_is_column_name(inner, name),
+        _ => false,
+    }
+}
+
+fn object_name_last_ident_value(name: &ObjectName) -> Option<&str> {
+    name.0
+        .last()
+        .and_then(ObjectNamePart::as_ident)
+        .map(|ident| ident.value.as_str())
+}
+
+fn collapse_pending_file_writes_for_transaction(
+    writes: &[crate::filesystem::pending_file_writes::PendingFileWrite],
+) -> Vec<crate::filesystem::pending_file_writes::PendingFileWrite> {
+    let mut collapsed =
+        Vec::<crate::filesystem::pending_file_writes::PendingFileWrite>::with_capacity(
+            writes.len(),
+        );
+    let mut index_by_key = BTreeMap::<(String, String), usize>::new();
+
+    for write in writes {
+        let key = (write.file_id.clone(), write.version_id.clone());
+        if let Some(index) = index_by_key.get(&key).copied() {
+            let existing = &mut collapsed[index];
+            existing.path = write.path.clone();
+            existing.after_data = write.after_data.clone();
+            existing.data_is_authoritative =
+                existing.data_is_authoritative || write.data_is_authoritative;
+            if existing.before_path.is_none() {
+                existing.before_path = write.before_path.clone();
+            }
+            if existing.before_data.is_none() {
+                existing.before_data = write.before_data.clone();
+            }
+            continue;
+        }
+
+        index_by_key.insert(key, collapsed.len());
+        collapsed.push(write.clone());
+    }
+
+    collapsed
 }
 
 fn direct_state_file_cache_refresh_targets(
@@ -3059,10 +3882,10 @@ fn intersect_strings(left: &[String], right: &[String]) -> Vec<String> {
 mod tests {
     use super::{
         active_version_from_update_validations, active_version_schema_key,
-        advance_placeholder_state_for_statement, boot,
+        advance_placeholder_state_for_statement, boot, coalesce_lix_file_transaction_statements,
         detected_file_domain_changes_from_detected_file_changes,
-        detected_file_domain_changes_with_writer_key, file_descriptor_cache_eviction_targets,
-        file_history_read_materialization_required_for_sql,
+        detected_file_domain_changes_with_writer_key, extract_explicit_transaction_script,
+        file_descriptor_cache_eviction_targets, file_history_read_materialization_required_for_sql,
         file_read_materialization_scope_for_sql, should_invalidate_installed_plugins_cache_for_sql,
         should_refresh_file_cache_for_sql, BootArgs, ExecuteOptions, FileReadMaterializationScope,
     };
@@ -3599,6 +4422,58 @@ mod tests {
 
         assert_eq!(targets.len(), 1);
         assert!(targets.contains(&("file-a".to_string(), "version-a".to_string())));
+    }
+
+    #[test]
+    fn extract_explicit_transaction_script_parses_begin_commit_wrapper() {
+        let parsed = extract_explicit_transaction_script(
+            "BEGIN; INSERT INTO lix_file (id, path, data) VALUES ('f1', '/a', x'01'); COMMIT;",
+            &[],
+        )
+        .expect("parse transaction script");
+
+        let statements = parsed.expect("expected explicit transaction script");
+        assert_eq!(statements.len(), 1);
+        assert!(matches!(statements[0], Statement::Insert(_)));
+    }
+
+    #[test]
+    fn coalesce_lix_file_transaction_statements_rewrites_replay_shape() {
+        let statements = parse_sql_statements(
+            "DELETE FROM lix_file WHERE id IN ('d1');\
+             INSERT INTO lix_file (id, path, data) VALUES ('i1', '/inserted.txt', x'01');\
+             UPDATE lix_file SET path = '/updated-a.txt', data = x'0A' WHERE id = 'u1';\
+             UPDATE lix_file SET path = '/updated-b.txt', data = x'0B' WHERE id = 'u2';",
+        )
+        .expect("parse");
+
+        let rewritten =
+            coalesce_lix_file_transaction_statements(&statements, Some(SqlDialect::Sqlite))
+                .expect("expected coalesced rewrite");
+
+        assert_eq!(rewritten.len(), 3);
+        assert!(rewritten[0].starts_with("DELETE FROM lix_file WHERE id IN ('d1')"));
+        assert!(rewritten[1].starts_with("INSERT INTO lix_file (id, path, data) VALUES "));
+        assert!(rewritten[1].contains("('i1', '/inserted.txt', X'01')"));
+        assert!(rewritten[2].starts_with("UPDATE lix_file SET path = CASE id "));
+        assert!(rewritten[2].contains("WHEN 'u1' THEN '/updated-a.txt'"));
+        assert!(rewritten[2].contains("WHEN 'u2' THEN '/updated-b.txt'"));
+        assert!(rewritten[2].contains("WHEN 'u1' THEN X'0A'"));
+        assert!(rewritten[2].contains("WHEN 'u2' THEN X'0B'"));
+        assert!(rewritten[2].contains("WHERE id IN ('u1', 'u2')"));
+    }
+
+    #[test]
+    fn coalesce_lix_file_transaction_statements_returns_none_for_duplicate_ids() {
+        let statements = parse_sql_statements(
+            "UPDATE lix_file SET path = '/updated-a.txt', data = x'0A' WHERE id = 'u1';\
+             UPDATE lix_file SET path = '/updated-b.txt', data = x'0B' WHERE id = 'u1';",
+        )
+        .expect("parse");
+
+        let rewritten =
+            coalesce_lix_file_transaction_statements(&statements, Some(SqlDialect::Sqlite));
+        assert!(rewritten.is_none());
     }
 
     fn parse_update_where_clause(sql: &str) -> Expr {

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -845,6 +845,21 @@ impl Engine {
         Ok(())
     }
 
+    /// Exports a portable snapshot as SQLite3 file bytes written via chunk stream.
+    pub async fn export_snapshot(
+        &self,
+        writer: &mut dyn crate::SnapshotChunkWriter,
+    ) -> Result<(), LixError> {
+        self.backend.export_snapshot(writer).await
+    }
+
+    pub async fn restore_from_snapshot(
+        &self,
+        reader: &mut dyn crate::SnapshotChunkReader,
+    ) -> Result<(), LixError> {
+        self.backend.restore_from_snapshot(reader).await
+    }
+
     pub async fn materialization_plan(
         &self,
         req: &MaterializationRequest,

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -48,4 +48,4 @@ pub use materialization::{
     VersionPointerDebugRow,
 };
 pub use types::{QueryResult, Value};
-pub use wasm_runtime::{LoadWasmComponentRequest, WasmInstance, WasmLimits, WasmRuntime};
+pub use wasm_runtime::{WasmLimits, WasmModuleInstance, WasmRuntime};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -16,6 +16,7 @@ mod materialization;
 mod plugin;
 mod schema;
 mod schema_registry;
+mod snapshot;
 mod sql;
 mod types;
 mod validation;
@@ -47,5 +48,6 @@ pub use materialization::{
     StageStat, TraversedCommitDebugRow, TraversedEdgeDebugRow, VersionAncestryDebugRow,
     VersionPointerDebugRow,
 };
+pub use snapshot::{SnapshotChunkReader, SnapshotChunkWriter};
 pub use types::{QueryResult, Value};
 pub use wasm_runtime::{WasmLimits, WasmComponentInstance, WasmRuntime};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -48,4 +48,4 @@ pub use materialization::{
     VersionPointerDebugRow,
 };
 pub use types::{QueryResult, Value};
-pub use wasm_runtime::{WasmLimits, WasmModuleInstance, WasmRuntime};
+pub use wasm_runtime::{WasmLimits, WasmComponentInstance, WasmRuntime};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -50,4 +50,4 @@ pub use materialization::{
 };
 pub use snapshot::{SnapshotChunkReader, SnapshotChunkWriter};
 pub use types::{QueryResult, Value};
-pub use wasm_runtime::{WasmLimits, WasmComponentInstance, WasmRuntime};
+pub use wasm_runtime::{WasmComponentInstance, WasmLimits, WasmRuntime};

--- a/packages/engine/src/plugin/runtime.rs
+++ b/packages/engine/src/plugin/runtime.rs
@@ -136,7 +136,7 @@ pub(crate) async fn detect_file_changes_with_plugins(
             != plugin.key.as_str();
 
         let instance = runtime
-            .instantiate(plugin.wasm.clone(), WasmLimits::default())
+            .init_component(plugin.wasm.clone(), WasmLimits::default())
             .await?;
 
         let mut before_data = if plugin_changed || !has_before_context {
@@ -334,7 +334,7 @@ pub(crate) async fn materialize_file_data_with_plugins(
             .push(write);
     }
 
-    let mut loaded_instances: BTreeMap<String, std::sync::Arc<dyn crate::WasmModuleInstance>> =
+    let mut loaded_instances: BTreeMap<String, std::sync::Arc<dyn crate::WasmComponentInstance>> =
         BTreeMap::new();
 
     for descriptor in descriptors.values() {
@@ -403,7 +403,7 @@ pub(crate) async fn materialize_file_data_with_plugins(
             existing.clone()
         } else {
             let loaded = runtime
-                .instantiate(plugin.wasm.clone(), WasmLimits::default())
+                .init_component(plugin.wasm.clone(), WasmLimits::default())
                 .await?;
             loaded_instances.insert(plugin.key.clone(), loaded.clone());
             loaded
@@ -436,7 +436,7 @@ pub(crate) async fn materialize_missing_file_data_with_plugins(
         return Ok(());
     }
 
-    let mut loaded_instances: BTreeMap<String, std::sync::Arc<dyn crate::WasmModuleInstance>> =
+    let mut loaded_instances: BTreeMap<String, std::sync::Arc<dyn crate::WasmComponentInstance>> =
         BTreeMap::new();
 
     for descriptor in descriptors.values() {
@@ -473,7 +473,7 @@ pub(crate) async fn materialize_missing_file_data_with_plugins(
             existing.clone()
         } else {
             let loaded = runtime
-                .instantiate(plugin.wasm.clone(), WasmLimits::default())
+                .init_component(plugin.wasm.clone(), WasmLimits::default())
                 .await?;
             loaded_instances.insert(plugin.key.clone(), loaded.clone());
             loaded
@@ -505,7 +505,7 @@ pub(crate) async fn materialize_missing_file_history_data_with_plugins(
         return Ok(());
     }
 
-    let mut loaded_instances: BTreeMap<String, std::sync::Arc<dyn crate::WasmModuleInstance>> =
+    let mut loaded_instances: BTreeMap<String, std::sync::Arc<dyn crate::WasmComponentInstance>> =
         BTreeMap::new();
 
     for descriptor in descriptors.values() {
@@ -544,7 +544,7 @@ pub(crate) async fn materialize_missing_file_history_data_with_plugins(
             existing.clone()
         } else {
             let loaded = runtime
-                .instantiate(plugin.wasm.clone(), WasmLimits::default())
+                .init_component(plugin.wasm.clone(), WasmLimits::default())
                 .await?;
             loaded_instances.insert(plugin.key.clone(), loaded.clone());
             loaded
@@ -610,7 +610,7 @@ fn glob_matches_extension(glob: &str, extension: Option<&str>) -> bool {
 }
 
 async fn call_apply_changes(
-    instance: &dyn crate::WasmModuleInstance,
+    instance: &dyn crate::WasmComponentInstance,
     payload: &[u8],
 ) -> Result<Vec<u8>, LixError> {
     let mut errors = Vec::new();
@@ -630,7 +630,7 @@ async fn call_apply_changes(
 }
 
 async fn call_detect_changes(
-    instance: &dyn crate::WasmModuleInstance,
+    instance: &dyn crate::WasmComponentInstance,
     payload: &[u8],
 ) -> Result<Vec<u8>, LixError> {
     let mut errors = Vec::new();
@@ -651,7 +651,7 @@ async fn call_detect_changes(
 
 async fn reconstruct_before_file_data_from_state(
     backend: &dyn LixBackend,
-    instance: &dyn crate::WasmModuleInstance,
+    instance: &dyn crate::WasmComponentInstance,
     plugin: &InstalledPlugin,
     file_id: &str,
     version_id: &str,

--- a/packages/engine/src/snapshot.rs
+++ b/packages/engine/src/snapshot.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+use crate::LixError;
+
+#[async_trait(?Send)]
+pub trait SnapshotChunkReader: Send {
+    async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, LixError>;
+}
+
+#[async_trait(?Send)]
+pub trait SnapshotChunkWriter: Send {
+    async fn write_chunk(&mut self, chunk: &[u8]) -> Result<(), LixError>;
+
+    async fn finish(&mut self) -> Result<(), LixError> {
+        Ok(())
+    }
+}

--- a/packages/engine/src/sql/mod.rs
+++ b/packages/engine/src/sql/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use ast_utils::{default_alias, object_name_matches, parse_single_quer
 pub(crate) use escaping::escape_sql_string;
 pub(crate) use lowering::lower_statement;
 pub(crate) use params::{bind_sql, bind_sql_with_state, PlaceholderState};
+pub(crate) use pipeline::coalesce_vtable_inserts_in_statement_list;
 #[allow(unused_imports)]
 pub use pipeline::{
     parse_sql_statements, preprocess_sql, preprocess_sql_rewrite_only,

--- a/packages/engine/src/wasm_runtime.rs
+++ b/packages/engine/src/wasm_runtime.rs
@@ -4,14 +4,6 @@ use async_trait::async_trait;
 
 use crate::LixError;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LoadWasmComponentRequest {
-    pub key: String,
-    pub bytes: Vec<u8>,
-    pub world: String,
-    pub limits: WasmLimits,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WasmLimits {
     pub max_memory_bytes: u64,
@@ -31,13 +23,18 @@ impl Default for WasmLimits {
 
 #[async_trait(?Send)]
 pub trait WasmRuntime: Send + Sync {
-    async fn load_component(
+    async fn instantiate(
         &self,
-        request: LoadWasmComponentRequest,
-    ) -> Result<Arc<dyn WasmInstance>, LixError>;
+        bytes: Vec<u8>,
+        limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmModuleInstance>, LixError>;
 }
 
 #[async_trait(?Send)]
-pub trait WasmInstance: Send + Sync {
+pub trait WasmModuleInstance: Send + Sync {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError>;
+
+    async fn close(&self) -> Result<(), LixError> {
+        Ok(())
+    }
 }

--- a/packages/engine/src/wasm_runtime.rs
+++ b/packages/engine/src/wasm_runtime.rs
@@ -23,15 +23,15 @@ impl Default for WasmLimits {
 
 #[async_trait(?Send)]
 pub trait WasmRuntime: Send + Sync {
-    async fn instantiate(
+    async fn init_component(
         &self,
         bytes: Vec<u8>,
         limits: WasmLimits,
-    ) -> Result<Arc<dyn WasmModuleInstance>, LixError>;
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError>;
 }
 
 #[async_trait(?Send)]
-pub trait WasmModuleInstance: Send + Sync {
+pub trait WasmComponentInstance: Send + Sync {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError>;
 
     async fn close(&self) -> Result<(), LixError> {

--- a/packages/engine/tests/file_materialization.rs
+++ b/packages/engine/tests/file_materialization.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, OnceLock};
 
 use lix_engine::{
     LixError, MaterializationDebugMode, MaterializationRequest, MaterializationScope, Value,
-    WasmLimits, WasmComponentInstance, WasmRuntime,
+    WasmComponentInstance, WasmLimits, WasmRuntime,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;

--- a/packages/engine/tests/file_materialization.rs
+++ b/packages/engine/tests/file_materialization.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, OnceLock};
 
 use lix_engine::{
     LixError, MaterializationDebugMode, MaterializationRequest, MaterializationScope, Value,
-    WasmLimits, WasmModuleInstance, WasmRuntime,
+    WasmLimits, WasmComponentInstance, WasmRuntime,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -70,17 +70,17 @@ struct BeforeAwareInstance;
 
 #[async_trait(?Send)]
 impl WasmRuntime for PathEchoRuntime {
-    async fn instantiate(
+    async fn init_component(
         &self,
         _bytes: Vec<u8>,
         _limits: WasmLimits,
-    ) -> Result<Arc<dyn WasmModuleInstance>, LixError> {
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
         Ok(Arc::new(PathEchoInstance))
     }
 }
 
 #[async_trait(?Send)]
-impl WasmModuleInstance for PathEchoInstance {
+impl WasmComponentInstance for PathEchoInstance {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
         match export {
             "detect-changes" | "api#detect-changes" => {
@@ -127,17 +127,17 @@ impl WasmModuleInstance for PathEchoInstance {
 
 #[async_trait(?Send)]
 impl WasmRuntime for BeforeAwareRuntime {
-    async fn instantiate(
+    async fn init_component(
         &self,
         _bytes: Vec<u8>,
         _limits: WasmLimits,
-    ) -> Result<Arc<dyn WasmModuleInstance>, LixError> {
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
         Ok(Arc::new(BeforeAwareInstance))
     }
 }
 
 #[async_trait(?Send)]
-impl WasmModuleInstance for BeforeAwareInstance {
+impl WasmComponentInstance for BeforeAwareInstance {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
         match export {
             "detect-changes" | "api#detect-changes" => {

--- a/packages/engine/tests/file_materialization.rs
+++ b/packages/engine/tests/file_materialization.rs
@@ -7,8 +7,8 @@ use std::process::Command;
 use std::sync::{Arc, OnceLock};
 
 use lix_engine::{
-    LixError, LoadWasmComponentRequest, MaterializationDebugMode, MaterializationRequest,
-    MaterializationScope, Value, WasmInstance, WasmRuntime,
+    LixError, MaterializationDebugMode, MaterializationRequest, MaterializationScope, Value,
+    WasmLimits, WasmModuleInstance, WasmRuntime,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -70,16 +70,17 @@ struct BeforeAwareInstance;
 
 #[async_trait(?Send)]
 impl WasmRuntime for PathEchoRuntime {
-    async fn load_component(
+    async fn instantiate(
         &self,
-        _request: LoadWasmComponentRequest,
-    ) -> Result<Arc<dyn WasmInstance>, LixError> {
+        _bytes: Vec<u8>,
+        _limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmModuleInstance>, LixError> {
         Ok(Arc::new(PathEchoInstance))
     }
 }
 
 #[async_trait(?Send)]
-impl WasmInstance for PathEchoInstance {
+impl WasmModuleInstance for PathEchoInstance {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
         match export {
             "detect-changes" | "api#detect-changes" => {
@@ -126,16 +127,17 @@ impl WasmInstance for PathEchoInstance {
 
 #[async_trait(?Send)]
 impl WasmRuntime for BeforeAwareRuntime {
-    async fn load_component(
+    async fn instantiate(
         &self,
-        _request: LoadWasmComponentRequest,
-    ) -> Result<Arc<dyn WasmInstance>, LixError> {
+        _bytes: Vec<u8>,
+        _limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmModuleInstance>, LixError> {
         Ok(Arc::new(BeforeAwareInstance))
     }
 }
 
 #[async_trait(?Send)]
-impl WasmInstance for BeforeAwareInstance {
+impl WasmModuleInstance for BeforeAwareInstance {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
         match export {
             "detect-changes" | "api#detect-changes" => {

--- a/packages/engine/tests/support/wasmtime_runtime.rs
+++ b/packages/engine/tests/support/wasmtime_runtime.rs
@@ -5,7 +5,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use lix_engine::{LixError, WasmLimits, WasmComponentInstance, WasmRuntime};
+use lix_engine::{LixError, WasmComponentInstance, WasmLimits, WasmRuntime};
 use wasmtime::component::{Component, Linker, ResourceTable};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{IoView, WasiCtx, WasiCtxBuilder, WasiView};

--- a/packages/engine/tests/support/wasmtime_runtime.rs
+++ b/packages/engine/tests/support/wasmtime_runtime.rs
@@ -5,7 +5,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use lix_engine::{LixError, WasmLimits, WasmModuleInstance, WasmRuntime};
+use lix_engine::{LixError, WasmLimits, WasmComponentInstance, WasmRuntime};
 use wasmtime::component::{Component, Linker, ResourceTable};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{IoView, WasiCtx, WasiCtxBuilder, WasiView};
@@ -114,11 +114,11 @@ impl WasiView for WasiState {
 
 #[async_trait(?Send)]
 impl WasmRuntime for TestWasmtimeRuntime {
-    async fn instantiate(
+    async fn init_component(
         &self,
         bytes: Vec<u8>,
         _limits: WasmLimits,
-    ) -> Result<Arc<dyn WasmModuleInstance>, LixError> {
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
         let cache_key = ComponentCacheKey::from_bytes(&bytes);
 
         if let Some(component) = self
@@ -160,7 +160,7 @@ impl WasmRuntime for TestWasmtimeRuntime {
 }
 
 #[async_trait(?Send)]
-impl WasmModuleInstance for TestWasmtimeInstance {
+impl WasmComponentInstance for TestWasmtimeInstance {
     async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
         let mut store = Store::new(
             &self.engine,

--- a/packages/js-benchmarks/README.md
+++ b/packages/js-benchmarks/README.md
@@ -68,8 +68,7 @@ The JSON benchmark installs:
 - legacy JS plugin (`@lix-js/plugin-json`) in old SDK
 - wasm JSON plugin (`plugin-json-v2`) in new `js-sdk`
 
-The new `js-sdk` benchmark path provides `wasmRuntime` to `openLix(...)` so plugin execution runs during inserts.
-That runtime (`src/wasm-runtime-node.mjs`) transpiles installed wasm components with `@bytecodealliance/jco`
-and executes them with Node WebAssembly + WASI preview2 shims.
+The new `js-sdk` benchmark path uses `openLix()` with the SDK-selected runtime. In Node, `js-sdk`
+loads its built-in component runtime and executes installed wasm plugins during inserts.
 
 Set `BENCH_REQUIRE_PLUGIN_EXEC=1` to fail the run when plugin rows are zero.

--- a/packages/js-benchmarks/README.md
+++ b/packages/js-benchmarks/README.md
@@ -68,6 +68,8 @@ The JSON benchmark installs:
 - legacy JS plugin (`@lix-js/plugin-json`) in old SDK
 - wasm JSON plugin (`plugin-json-v2`) in new `js-sdk`
 
-If new runtime plugin execution is unavailable, the benchmark prints a warning and reports `plugin rows/file (new): 0.0`.
+The new `js-sdk` benchmark path provides `wasmRuntime` to `openLix(...)` so plugin execution runs during inserts.
+That runtime (`src/wasm-runtime-node.mjs`) transpiles installed wasm components with `@bytecodealliance/jco`
+and executes them with Node WebAssembly + WASI preview2 shims.
 
 Set `BENCH_REQUIRE_PLUGIN_EXEC=1` to fail the run when plugin rows are zero.

--- a/packages/js-benchmarks/package.json
+++ b/packages/js-benchmarks/package.json
@@ -21,9 +21,5 @@
     "@lix-js/plugin-json": "workspace:*",
     "@lix-js/sdk": "workspace:*",
     "js-sdk": "workspace:*"
-  },
-  "devDependencies": {
-    "@bytecodealliance/jco": "^1.17.0",
-    "@bytecodealliance/preview2-shim": "^0.17.8"
   }
 }

--- a/packages/js-benchmarks/package.json
+++ b/packages/js-benchmarks/package.json
@@ -21,5 +21,9 @@
     "@lix-js/plugin-json": "workspace:*",
     "@lix-js/sdk": "workspace:*",
     "js-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@bytecodealliance/jco": "^1.17.0",
+    "@bytecodealliance/preview2-shim": "^0.17.8"
   }
 }

--- a/packages/js-benchmarks/src/json-insert-breakdown.bench.mjs
+++ b/packages/js-benchmarks/src/json-insert-breakdown.bench.mjs
@@ -4,7 +4,6 @@ import { fileURLToPath } from "node:url";
 import { performance } from "node:perf_hooks";
 import { spawn } from "node:child_process";
 import { openLix as openNewLix } from "js-sdk";
-import { createBenchWasmRuntime } from "./wasm-runtime-node.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR = join(__dirname, "..", "results");
@@ -84,7 +83,7 @@ async function main() {
 }
 
 async function runScenario(scenario, wasmBytes) {
-  const lix = await openNewLix({ wasmRuntime: createBenchWasmRuntime() });
+  const lix = await openNewLix();
   try {
     if (scenario.installPlugin) {
       await lix.installPlugin({ manifestJson: MANIFEST, wasmBytes });

--- a/packages/js-benchmarks/src/json-insert-breakdown.bench.mjs
+++ b/packages/js-benchmarks/src/json-insert-breakdown.bench.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { performance } from "node:perf_hooks";
 import { spawn } from "node:child_process";
 import { openLix as openNewLix } from "js-sdk";
+import { createBenchWasmRuntime } from "./wasm-runtime-node.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR = join(__dirname, "..", "results");
@@ -83,7 +84,7 @@ async function main() {
 }
 
 async function runScenario(scenario, wasmBytes) {
-  const lix = await openNewLix();
+  const lix = await openNewLix({ wasmRuntime: createBenchWasmRuntime() });
   try {
     if (scenario.installPlugin) {
       await lix.installPlugin({ manifestJson: MANIFEST, wasmBytes });
@@ -133,7 +134,7 @@ async function runScenario(scenario, wasmBytes) {
       fileRowsTotal: scalarToNumber(fileRowsResult.rows?.[0]?.[0], "file rows total"),
     };
   } finally {
-    // js-sdk currently does not expose close().
+    await lix.close();
   }
 }
 

--- a/packages/js-benchmarks/src/json-insert-breakdown.bench.mjs
+++ b/packages/js-benchmarks/src/json-insert-breakdown.bench.mjs
@@ -83,7 +83,15 @@ async function main() {
 }
 
 async function runScenario(scenario, wasmBytes) {
-  const lix = await openNewLix();
+  const lix = await openNewLix({
+    keyValues: [
+      {
+        key: "lix_deterministic_mode",
+        value: { enabled: true },
+        lixcol_version_id: "global",
+      },
+    ],
+  });
   try {
     if (scenario.installPlugin) {
       await lix.installPlugin({ manifestJson: MANIFEST, wasmBytes });

--- a/packages/js-benchmarks/src/json-insert.bench.mjs
+++ b/packages/js-benchmarks/src/json-insert.bench.mjs
@@ -6,7 +6,6 @@ import { spawn } from "node:child_process";
 import { openLix as openOldLix } from "@lix-js/sdk";
 import { plugin as legacyJsonPlugin } from "@lix-js/plugin-json";
 import { openLix as openNewLix } from "js-sdk";
-import { createBenchWasmRuntime } from "./wasm-runtime-node.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR = join(__dirname, "..", "results");
@@ -133,7 +132,7 @@ async function setupOldAdapter() {
 }
 
 async function setupNewAdapter() {
-  const lix = await openNewLix({ wasmRuntime: createBenchWasmRuntime() });
+  const lix = await openNewLix();
   const wasmBytes = await loadPluginJsonV2WasmBytes();
 
   await lix.installPlugin({

--- a/packages/js-benchmarks/src/json-insert.bench.mjs
+++ b/packages/js-benchmarks/src/json-insert.bench.mjs
@@ -132,7 +132,15 @@ async function setupOldAdapter() {
 }
 
 async function setupNewAdapter() {
-  const lix = await openNewLix();
+  const lix = await openNewLix({
+    keyValues: [
+      {
+        key: "lix_deterministic_mode",
+        value: { enabled: true },
+        lixcol_version_id: "global",
+      },
+    ],
+  });
   const wasmBytes = await loadPluginJsonV2WasmBytes();
 
   await lix.installPlugin({

--- a/packages/js-benchmarks/src/state-insert.bench.mjs
+++ b/packages/js-benchmarks/src/state-insert.bench.mjs
@@ -156,12 +156,15 @@ async function setupOldAdapter() {
 }
 
 async function setupNewAdapter() {
-  const lix = await openNewLix();
-
-  await lix.execute(
-    "INSERT INTO lix_key_value (key, value) VALUES (?, ?)",
-    ["lix_deterministic_mode", "{\"enabled\":true}"],
-  );
+  const lix = await openNewLix({
+    keyValues: [
+      {
+        key: "lix_deterministic_mode",
+        value: { enabled: true },
+        lixcol_version_id: "global",
+      },
+    ],
+  });
 
   await lix.execute(
     "INSERT INTO lix_internal_state_vtable (schema_key, snapshot_content) VALUES ('lix_stored_schema', ?)",
@@ -191,7 +194,7 @@ async function setupNewAdapter() {
       });
     },
     async close() {
-      // js-sdk currently does not expose close().
+      await lix.close();
     },
   };
 }

--- a/packages/js-benchmarks/src/wasm-runtime-node.mjs
+++ b/packages/js-benchmarks/src/wasm-runtime-node.mjs
@@ -1,0 +1,221 @@
+import { createHash } from "node:crypto";
+import { transpile as transpileComponent } from "@bytecodealliance/jco";
+import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
+
+const COMPONENT_API_KEY = "lix:plugin/api@0.1.0";
+const DETECT_EXPORTS = new Set(["detect-changes", "api#detect-changes"]);
+const APPLY_EXPORTS = new Set(["apply-changes", "api#apply-changes"]);
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+const wasiImports = new WASIShim({
+  sandbox: {
+    preopens: {},
+    env: {},
+    args: ["lix-plugin"],
+    enableNetwork: false,
+  },
+}).getImportObject();
+
+const transpiledCache = new Map();
+
+function toUint8Array(value) {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (Array.isArray(value)) {
+    return Uint8Array.from(value);
+  }
+  return new Uint8Array();
+}
+
+function decodeJsonBytes(input) {
+  const decoded = textDecoder.decode(toUint8Array(input));
+  return JSON.parse(decoded);
+}
+
+function encodeJsonBytes(value) {
+  return textEncoder.encode(JSON.stringify(value));
+}
+
+function normalizeWireFile(file) {
+  return {
+    id: String(file?.id ?? ""),
+    path: String(file?.path ?? ""),
+    data: toUint8Array(file?.data),
+  };
+}
+
+function normalizeWireEntityChange(change) {
+  const snapshot =
+    change?.snapshotContent !== undefined
+      ? change.snapshotContent
+      : change?.snapshot_content;
+
+  return {
+    entity_id: String(change?.entityId ?? change?.entity_id ?? ""),
+    schema_key: String(change?.schemaKey ?? change?.schema_key ?? ""),
+    schema_version: String(change?.schemaVersion ?? change?.schema_version ?? ""),
+    snapshot_content: snapshot === undefined ? null : snapshot,
+  };
+}
+
+function toPluginEntityChange(change) {
+  const normalized = {
+    entityId: String(change?.entity_id ?? change?.entityId ?? ""),
+    schemaKey: String(change?.schema_key ?? change?.schemaKey ?? ""),
+    schemaVersion: String(change?.schema_version ?? change?.schemaVersion ?? ""),
+  };
+
+  const snapshot =
+    change?.snapshot_content !== undefined
+      ? change.snapshot_content
+      : change?.snapshotContent;
+  if (snapshot !== null && snapshot !== undefined) {
+    normalized.snapshotContent = String(snapshot);
+  }
+
+  return normalized;
+}
+
+function hashComponentBytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function toDataUrl(bytes) {
+  return `data:text/javascript;base64,${Buffer.from(bytes).toString("base64")}`;
+}
+
+function readTranspiledFile(files, suffix) {
+  const entry = Object.entries(files).find(([name]) => name.endsWith(suffix));
+  if (!entry) {
+    throw new Error(`transpile output missing '${suffix}' file`);
+  }
+  return entry;
+}
+
+function resolveComponentApi(exportsObject) {
+  if (exportsObject && typeof exportsObject.api === "object") {
+    return exportsObject.api;
+  }
+  if (
+    exportsObject &&
+    typeof exportsObject[COMPONENT_API_KEY] === "object"
+  ) {
+    return exportsObject[COMPONENT_API_KEY];
+  }
+  if (
+    exportsObject &&
+    typeof exportsObject.detectChanges === "function" &&
+    typeof exportsObject.applyChanges === "function"
+  ) {
+    return exportsObject;
+  }
+
+  const keys = exportsObject && typeof exportsObject === "object"
+    ? Object.keys(exportsObject)
+    : [];
+  throw new Error(
+    `transpiled component did not expose plugin api '${COMPONENT_API_KEY}' (exports: ${keys.join(", ")})`,
+  );
+}
+
+async function prepareTranspiledComponent(wasmBytes) {
+  const hash = hashComponentBytes(wasmBytes);
+  let pending = transpiledCache.get(hash);
+  if (!pending) {
+    pending = (async () => {
+      const name = `plugin_${hash.slice(0, 12)}`;
+      const transpiled = await transpileComponent(wasmBytes, {
+        name,
+        instantiation: "async",
+      });
+
+      const [jsFileName, jsSourceBytes] = readTranspiledFile(transpiled.files, ".js");
+      const jsModule = await import(toDataUrl(jsSourceBytes));
+      if (typeof jsModule.instantiate !== "function") {
+        throw new Error(`transpiled module '${jsFileName}' is missing instantiate()`);
+      }
+
+      const coreModulePromises = new Map(
+        Object.entries(transpiled.files)
+          .filter(([fileName]) => fileName.endsWith(".wasm"))
+          .map(([fileName, fileBytes]) => [
+            fileName,
+            WebAssembly.compile(toUint8Array(fileBytes)),
+          ]),
+      );
+
+      return {
+        instantiate: jsModule.instantiate,
+        coreModulePromises,
+      };
+    })();
+    transpiledCache.set(hash, pending);
+  }
+
+  return await pending;
+}
+
+function createModuleInstance(componentApi) {
+  return {
+    async call(exportName, input) {
+      if (DETECT_EXPORTS.has(exportName)) {
+        const request = decodeJsonBytes(input);
+        const before = request.before
+          ? normalizeWireFile(request.before)
+          : undefined;
+        const after = normalizeWireFile(request.after);
+        const rawChanges = await componentApi.detectChanges(before, after);
+        const normalized = Array.isArray(rawChanges)
+          ? rawChanges.map(normalizeWireEntityChange)
+          : [];
+        return encodeJsonBytes(normalized);
+      }
+
+      if (APPLY_EXPORTS.has(exportName)) {
+        const request = decodeJsonBytes(input);
+        const file = normalizeWireFile(request.file);
+        const changes = Array.isArray(request.changes)
+          ? request.changes.map(toPluginEntityChange)
+          : [];
+        const outputBytes = await componentApi.applyChanges(file, changes);
+        return toUint8Array(outputBytes);
+      }
+
+      throw new Error(`unsupported export '${exportName}'`);
+    },
+    async close() {
+      // no-op
+    },
+  };
+}
+
+export function createBenchWasmRuntime() {
+  return {
+    async initComponent(bytes) {
+      const wasmBytes = toUint8Array(bytes);
+      if (wasmBytes.byteLength === 0) {
+        throw new Error("wasmRuntime.initComponent received empty bytes");
+      }
+
+      const compiled = await prepareTranspiledComponent(wasmBytes);
+      const exportsObject = await compiled.instantiate(
+        async (coreFileName) => {
+          const coreModulePromise = compiled.coreModulePromises.get(coreFileName);
+          if (!coreModulePromise) {
+            throw new Error(`transpiled component requested unknown core module '${coreFileName}'`);
+          }
+          return await coreModulePromise;
+        },
+        wasiImports,
+      );
+
+      const componentApi = resolveComponentApi(exportsObject);
+      return createModuleInstance(componentApi);
+    },
+  };
+}

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -9,11 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 lix_engine = { path = "../engine" }
-plugin_json_v2 = { path = "../plugin-json-v2" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 async-trait = "0.1"
 getrandom = { version = "0.3", features = ["wasm_js"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -14,3 +14,4 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 async-trait = "0.1"
 getrandom = { version = "0.3", features = ["wasm_js"] }
+serde_json = "1"

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -20,6 +20,8 @@
     "test:watch": "node ./scripts/build.js && vitest"
   },
   "dependencies": {
+    "@bytecodealliance/jco": "^1.17.0",
+    "@bytecodealliance/preview2-shim": "^0.17.8",
     "@sqlite.org/sqlite-wasm": "^3.50.4-build1"
   },
   "devDependencies": {

--- a/packages/js-sdk/src/backend/wasm-sqlite.ts
+++ b/packages/js-sdk/src/backend/wasm-sqlite.ts
@@ -110,6 +110,10 @@ export async function createWasmSqliteBackend(): Promise<LixBackend> {
       runQuery("BEGIN", []);
       return createTransaction();
     },
+    async exportSnapshot(): Promise<Uint8Array> {
+      ensureBackendOpen();
+      return db.sqlite3.capi.sqlite3_js_db_export(db, "main");
+    },
     async close(): Promise<void> {
       if (backendClosed) {
         return;

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -6,8 +6,5 @@ export type {
   LixSqlDialect,
   LixTransaction,
   LixValueLike,
-  LixWasmLimits,
-  LixWasmComponentInstance,
-  LixWasmRuntime,
 } from "./types.js";
 export { QueryResult, Value } from "./engine-wasm/index.js";

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -6,5 +6,8 @@ export type {
   LixSqlDialect,
   LixTransaction,
   LixValueLike,
+  LixWasmLimits,
+  LixWasmModuleInstance,
+  LixWasmRuntime,
 } from "./types.js";
 export { QueryResult, Value } from "./engine-wasm/index.js";

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -7,7 +7,7 @@ export type {
   LixTransaction,
   LixValueLike,
   LixWasmLimits,
-  LixWasmModuleInstance,
+  LixWasmComponentInstance,
   LixWasmRuntime,
 } from "./types.js";
 export { QueryResult, Value } from "./engine-wasm/index.js";

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -50,6 +50,15 @@ test("installPlugin stores plugin metadata", async () => {
   await lix.close();
 });
 
+test("exportSnapshot returns sqlite bytes", async () => {
+  const lix = await openLix();
+  await lix.execute("INSERT INTO lix_file (id, path, data) VALUES ('f1', '/a.txt', x'01')", []);
+  const snapshot = await lix.exportSnapshot();
+  expect(snapshot).toBeInstanceOf(Uint8Array);
+  expect(snapshot.byteLength).toBeGreaterThan(0);
+  await lix.close();
+});
+
 test("close is idempotent and blocks further API calls", async () => {
   const lix = await openLix();
   await lix.close();

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -59,6 +59,29 @@ test("exportSnapshot returns sqlite bytes", async () => {
   await lix.close();
 });
 
+test("openLix seeds keyValues at startup", async () => {
+  const lix = await openLix({
+    keyValues: [
+      {
+        key: "lix_deterministic_mode",
+        value: { enabled: true },
+        lixcol_version_id: "global",
+      },
+    ],
+  });
+  const result = await lix.execute(
+    "SELECT value FROM lix_key_value \
+     WHERE key = 'lix_deterministic_mode' LIMIT 1",
+    [],
+  );
+  expect(result.rows.length).toBe(1);
+  expect(result.rows[0][0]).toEqual({
+    kind: "Text",
+    value: JSON.stringify({ enabled: true }),
+  });
+  await lix.close();
+});
+
 test("close is idempotent and blocks further API calls", async () => {
   const lix = await openLix();
   await lix.close();

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -5,7 +5,7 @@ import init, {
   resolveEngineWasmModuleOrPath,
 } from "./engine-wasm/index.js";
 import { createWasmSqliteBackend } from "./backend/wasm-sqlite.js";
-import type { LixBackend } from "./types.js";
+import type { LixBackend, LixWasmRuntime } from "./types.js";
 
 export type {
   LixBackend,
@@ -13,6 +13,9 @@ export type {
   LixSqlDialect,
   LixTransaction,
   LixValueLike,
+  LixWasmLimits,
+  LixWasmModuleInstance,
+  LixWasmRuntime,
 } from "./types.js";
 export { QueryResult, Value } from "./engine-wasm/index.js";
 
@@ -56,11 +59,12 @@ async function ensureWasmReady(): Promise<void> {
 export async function openLix(
   args: {
     backend?: LixBackend;
+    wasmRuntime?: LixWasmRuntime;
   } = {},
 ): Promise<Lix> {
   await ensureWasmReady();
   const backend = args.backend ?? (await createWasmSqliteBackend());
-  const wasmLix = await openLixWasm(backend);
+  const wasmLix = await openLixWasm(backend, args.wasmRuntime);
   let closed = false;
 
   const ensureOpen = (methodName: string): void => {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -35,6 +35,14 @@ export type InstallPluginOptions = {
   wasmBytes: Uint8Array | ArrayBuffer;
 };
 
+export type OpenLixKeyValue = {
+  key: string;
+  value: unknown;
+  versionId?: string;
+  version_id?: string;
+  lixcol_version_id?: string;
+};
+
 export type Lix = {
   execute(sql: string, params?: ReadonlyArray<unknown>): Promise<QueryResult>;
   createVersion(args?: CreateVersionOptions): Promise<CreateVersionResult>;
@@ -60,11 +68,16 @@ async function ensureWasmReady(): Promise<void> {
 export async function openLix(
   args: {
     backend?: LixBackend;
+    keyValues?: ReadonlyArray<OpenLixKeyValue>;
   } = {},
 ): Promise<Lix> {
   await ensureWasmReady();
   const backend = args.backend ?? (await createWasmSqliteBackend());
-  const wasmLix = await openLixWasm(backend, await getDefaultWasmRuntime());
+  const wasmLix = await openLixWasm(
+    backend,
+    await getDefaultWasmRuntime(),
+    args.keyValues ? [...args.keyValues] : undefined,
+  );
   let closed = false;
 
   const ensureOpen = (methodName: string): void => {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -14,7 +14,7 @@ export type {
   LixTransaction,
   LixValueLike,
   LixWasmLimits,
-  LixWasmModuleInstance,
+  LixWasmComponentInstance,
   LixWasmRuntime,
 } from "./types.js";
 export { QueryResult, Value } from "./engine-wasm/index.js";

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -1,8 +1,5 @@
 import type {
   LixBackend as WasmLixBackend,
-  LixWasmLimits,
-  LixWasmComponentInstance,
-  LixWasmRuntime,
   LixQueryResultLike,
   LixSqlDialect,
   LixTransaction,
@@ -18,7 +15,4 @@ export type {
   LixSqlDialect,
   LixTransaction,
   LixValueLike,
-  LixWasmLimits,
-  LixWasmComponentInstance,
-  LixWasmRuntime,
 };

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -1,7 +1,7 @@
 import type {
   LixBackend as WasmLixBackend,
   LixWasmLimits,
-  LixWasmModuleInstance,
+  LixWasmComponentInstance,
   LixWasmRuntime,
   LixQueryResultLike,
   LixSqlDialect,
@@ -19,6 +19,6 @@ export type {
   LixTransaction,
   LixValueLike,
   LixWasmLimits,
-  LixWasmModuleInstance,
+  LixWasmComponentInstance,
   LixWasmRuntime,
 };

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -1,5 +1,8 @@
 import type {
   LixBackend as WasmLixBackend,
+  LixWasmLimits,
+  LixWasmModuleInstance,
+  LixWasmRuntime,
   LixQueryResultLike,
   LixSqlDialect,
   LixTransaction,
@@ -10,4 +13,12 @@ export type LixBackend = WasmLixBackend & {
   close?: () => Promise<void> | void;
 };
 
-export type { LixQueryResultLike, LixSqlDialect, LixTransaction, LixValueLike };
+export type {
+  LixQueryResultLike,
+  LixSqlDialect,
+  LixTransaction,
+  LixValueLike,
+  LixWasmLimits,
+  LixWasmModuleInstance,
+  LixWasmRuntime,
+};

--- a/packages/js-sdk/src/wasm-runtime/node.js
+++ b/packages/js-sdk/src/wasm-runtime/node.js
@@ -194,7 +194,7 @@ function createModuleInstance(componentApi) {
   };
 }
 
-export function createBenchWasmRuntime() {
+export function createNodeWasmRuntime() {
   return {
     async initComponent(bytes) {
       const wasmBytes = toUint8Array(bytes);

--- a/packages/js-sdk/wasm-bindgen.rs
+++ b/packages/js-sdk/wasm-bindgen.rs
@@ -189,7 +189,8 @@ export type LixBootKeyValue = {
             }
 
             let key = read_required_string_property(&entry, "key", "openLix keyValues entry")?;
-            let value = Reflect::get(&entry, &JsValue::from_str("value")).map_err(js_to_lix_error)?;
+            let value =
+                Reflect::get(&entry, &JsValue::from_str("value")).map_err(js_to_lix_error)?;
             let value = js_to_json_value(value, &format!("openLix keyValues[{key}].value"))?;
 
             let version_id = read_optional_string_property(&entry, "versionId")?
@@ -221,7 +222,10 @@ export type LixBootKeyValue = {
         Ok(text)
     }
 
-    fn read_optional_string_property(object: &JsValue, key: &str) -> Result<Option<String>, LixError> {
+    fn read_optional_string_property(
+        object: &JsValue,
+        key: &str,
+    ) -> Result<Option<String>, LixError> {
         let value = Reflect::get(object, &JsValue::from_str(key)).map_err(js_to_lix_error)?;
         if value.is_null() || value.is_undefined() {
             return Ok(None);
@@ -289,8 +293,7 @@ export type LixBootKeyValue = {
             let resolved = JsBackend::await_if_promise(result).await?;
             if resolved.is_null() || resolved.is_undefined() {
                 return Err(LixError {
-                    message: "wasmRuntime.initComponent returned no component instance"
-                        .to_string(),
+                    message: "wasmRuntime.initComponent returned no component instance".to_string(),
                 });
             }
 
@@ -308,15 +311,18 @@ export type LixBootKeyValue = {
             let input_arg = Uint8Array::new_with_length(input.len() as u32);
             input_arg.copy_from(input);
             let result = call_method
-                .call2(&self.component, &JsValue::from_str(export), &input_arg.into())
+                .call2(
+                    &self.component,
+                    &JsValue::from_str(export),
+                    &input_arg.into(),
+                )
                 .map_err(js_to_lix_error)?;
             let resolved = JsBackend::await_if_promise(result).await?;
             js_bytes_from_value(resolved, "wasmComponentInstance.call result")
         }
 
         async fn close(&self) -> Result<(), LixError> {
-            let Some(close_method) =
-                JsBackend::get_optional_method(&self.component, "close")?
+            let Some(close_method) = JsBackend::get_optional_method(&self.component, "close")?
             else {
                 return Ok(());
             };
@@ -516,12 +522,10 @@ export type LixBootKeyValue = {
             &self,
             writer: &mut dyn SnapshotChunkWriter,
         ) -> Result<(), LixError> {
-            let export_snapshot =
-                Self::get_optional_method(&self.backend, "exportSnapshot")?
-                    .ok_or_else(|| LixError {
-                        message: "backend.exportSnapshot is required for export_snapshot"
-                            .to_string(),
-                    })?;
+            let export_snapshot = Self::get_optional_method(&self.backend, "exportSnapshot")?
+                .ok_or_else(|| LixError {
+                    message: "backend.exportSnapshot is required for export_snapshot".to_string(),
+                })?;
             let result = export_snapshot
                 .call0(&self.backend)
                 .map_err(js_to_lix_error)?;

--- a/packages/nextjs-replay-bench/.gitignore
+++ b/packages/nextjs-replay-bench/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/packages/nextjs-replay-bench/README.md
+++ b/packages/nextjs-replay-bench/README.md
@@ -14,6 +14,7 @@ Warm vs cold quick commands:
 pnpm -C packages/nextjs-replay-bench bench:25        # warm (5 warmup + 25 measured)
 pnpm -C packages/nextjs-replay-bench bench:25:cold   # cold (0 warmup + 25 measured)
 pnpm -C packages/nextjs-replay-bench bench:git-files:100   # git file-write + git commit baseline
+pnpm -C packages/nextjs-replay-bench bench:parity:25   # replay + git-vs-lix state parity checks
 ```
 
 ## Useful env vars
@@ -28,6 +29,10 @@ pnpm -C packages/nextjs-replay-bench bench:git-files:100   # git file-write + gi
 - `BENCH_REPLAY_EXPORT_SNAPSHOT` set to `1` to export a sqlite snapshot artifact
 - `BENCH_REPLAY_SNAPSHOT_PATH` custom output path for snapshot artifact (`.lix` recommended)
 - `BENCH_REPLAY_PROGRESS_EVERY` progress cadence (default: `25`)
+- `BENCH_PARITY_EVERY` run full git-vs-lix parity every N replayed commits (default: `1`)
+- `BENCH_PARITY_FAIL_FAST` stop on first mismatch (`1`/`0`, default: `1`)
+- `BENCH_PARITY_MAX_MISMATCH_SAMPLES` max example paths captured per mismatch bucket (default: `20`)
+- `BENCH_PARITY_REPORT_PATH` custom output path for parity report
 - `BENCH_GIT_FILES_REPORT_PATH` custom output path for git file-replay report
 - `BENCH_GIT_FILES_DISABLE_MAINTENANCE` disable git auto maintenance/gc in target replay repo (default: `1`)
 - `BENCH_GIT_TRACE2_PERF` set to `1` to enable git Trace2 performance logging for the git baseline replay
@@ -42,4 +47,5 @@ Output report:
 
 - `packages/nextjs-replay-bench/results/nextjs-replay.bench.json`
 - `packages/nextjs-replay-bench/results/nextjs-replay.git-files.bench.json`
+- `packages/nextjs-replay-bench/results/nextjs-replay.parity.json`
 - `packages/nextjs-replay-bench/results/nextjs-replay.snapshot.lix` (when snapshot export enabled)

--- a/packages/nextjs-replay-bench/README.md
+++ b/packages/nextjs-replay-bench/README.md
@@ -8,16 +8,30 @@ One-off benchmark package to replay linear git history into `js-sdk`/engine.
 pnpm --filter nextjs-replay-bench run bench:1000
 ```
 
+Warm vs cold quick commands:
+
+```bash
+pnpm -C packages/nextjs-replay-bench bench:25        # warm (5 warmup + 25 measured)
+pnpm -C packages/nextjs-replay-bench bench:25:cold   # cold (0 warmup + 25 measured)
+```
+
 ## Useful env vars
 
 - `BENCH_REPLAY_REPO_PATH` path to an existing git clone (skip clone)
 - `BENCH_REPLAY_REPO_URL` remote clone URL (default: `https://github.com/vercel/next.js.git`)
-- `BENCH_REPLAY_COMMITS` number of commits to replay (default: `1000`)
-- `BENCH_REPLAY_FETCH` set to `0` to skip `git fetch`
+- `BENCH_REPLAY_REF` git ref to replay from (default: `HEAD`)
+- `BENCH_REPLAY_COMMITS` number of measured commits to replay (default: `1000`)
+- `BENCH_REPLAY_WARMUP_COMMITS` number of warmup commits to replay first (excluded from measured stats, default: `0`)
+- `BENCH_REPLAY_FETCH` set to `1` to fetch remote updates (default: `0`)
 - `BENCH_REPLAY_INSTALL_TEXT_LINES_PLUGIN` set to `0` to disable plugin install
 - `BENCH_REPLAY_EXPORT_SNAPSHOT` set to `1` to export a sqlite snapshot artifact
 - `BENCH_REPLAY_SNAPSHOT_PATH` custom output path for snapshot artifact (`.lix` recommended)
 - `BENCH_REPLAY_PROGRESS_EVERY` progress cadence (default: `25`)
+
+Determinism:
+
+- replay always opens `openLix({ keyValues: [{ key: "lix_deterministic_mode", value: { enabled: true }, lixcol_version_id: "global" }] })`
+- for fully reproducible commit sets across machines, pin `BENCH_REPLAY_REF` to a commit SHA
 
 Output report:
 

--- a/packages/nextjs-replay-bench/README.md
+++ b/packages/nextjs-replay-bench/README.md
@@ -13,6 +13,7 @@ Warm vs cold quick commands:
 ```bash
 pnpm -C packages/nextjs-replay-bench bench:25        # warm (5 warmup + 25 measured)
 pnpm -C packages/nextjs-replay-bench bench:25:cold   # cold (0 warmup + 25 measured)
+pnpm -C packages/nextjs-replay-bench bench:git-files:100   # git file-write + git commit baseline
 ```
 
 ## Useful env vars
@@ -21,12 +22,13 @@ pnpm -C packages/nextjs-replay-bench bench:25:cold   # cold (0 warmup + 25 measu
 - `BENCH_REPLAY_REPO_URL` remote clone URL (default: `https://github.com/vercel/next.js.git`)
 - `BENCH_REPLAY_REF` git ref to replay from (default: `HEAD`)
 - `BENCH_REPLAY_COMMITS` number of measured commits to replay (default: `1000`)
-- `BENCH_REPLAY_WARMUP_COMMITS` number of warmup commits to replay first (excluded from measured stats, default: `0`)
+- `BENCH_REPLAY_WARMUP_COMMITS` number of warmup commits to replay first (excluded from measured stats, default: `5`)
 - `BENCH_REPLAY_FETCH` set to `1` to fetch remote updates (default: `0`)
 - `BENCH_REPLAY_INSTALL_TEXT_LINES_PLUGIN` set to `0` to disable plugin install
 - `BENCH_REPLAY_EXPORT_SNAPSHOT` set to `1` to export a sqlite snapshot artifact
 - `BENCH_REPLAY_SNAPSHOT_PATH` custom output path for snapshot artifact (`.lix` recommended)
 - `BENCH_REPLAY_PROGRESS_EVERY` progress cadence (default: `25`)
+- `BENCH_GIT_FILES_REPORT_PATH` custom output path for git file-replay report
 
 Determinism:
 
@@ -36,4 +38,5 @@ Determinism:
 Output report:
 
 - `packages/nextjs-replay-bench/results/nextjs-replay.bench.json`
+- `packages/nextjs-replay-bench/results/nextjs-replay.git-files.bench.json`
 - `packages/nextjs-replay-bench/results/nextjs-replay.snapshot.lix` (when snapshot export enabled)

--- a/packages/nextjs-replay-bench/README.md
+++ b/packages/nextjs-replay-bench/README.md
@@ -15,8 +15,11 @@ pnpm --filter nextjs-replay-bench run bench:1000
 - `BENCH_REPLAY_COMMITS` number of commits to replay (default: `1000`)
 - `BENCH_REPLAY_FETCH` set to `0` to skip `git fetch`
 - `BENCH_REPLAY_INSTALL_TEXT_LINES_PLUGIN` set to `0` to disable plugin install
+- `BENCH_REPLAY_EXPORT_SNAPSHOT` set to `1` to export a sqlite snapshot artifact
+- `BENCH_REPLAY_SNAPSHOT_PATH` custom output path for snapshot artifact (`.lix` recommended)
 - `BENCH_REPLAY_PROGRESS_EVERY` progress cadence (default: `25`)
 
 Output report:
 
 - `packages/nextjs-replay-bench/results/nextjs-replay.bench.json`
+- `packages/nextjs-replay-bench/results/nextjs-replay.snapshot.lix` (when snapshot export enabled)

--- a/packages/nextjs-replay-bench/README.md
+++ b/packages/nextjs-replay-bench/README.md
@@ -1,0 +1,22 @@
+# nextjs-replay-bench
+
+One-off benchmark package to replay linear git history into `js-sdk`/engine.
+
+## Run
+
+```bash
+pnpm --filter nextjs-replay-bench run bench:1000
+```
+
+## Useful env vars
+
+- `BENCH_REPLAY_REPO_PATH` path to an existing git clone (skip clone)
+- `BENCH_REPLAY_REPO_URL` remote clone URL (default: `https://github.com/vercel/next.js.git`)
+- `BENCH_REPLAY_COMMITS` number of commits to replay (default: `1000`)
+- `BENCH_REPLAY_FETCH` set to `0` to skip `git fetch`
+- `BENCH_REPLAY_INSTALL_TEXT_LINES_PLUGIN` set to `0` to disable plugin install
+- `BENCH_REPLAY_PROGRESS_EVERY` progress cadence (default: `25`)
+
+Output report:
+
+- `packages/nextjs-replay-bench/results/nextjs-replay.bench.json`

--- a/packages/nextjs-replay-bench/README.md
+++ b/packages/nextjs-replay-bench/README.md
@@ -29,6 +29,9 @@ pnpm -C packages/nextjs-replay-bench bench:git-files:100   # git file-write + gi
 - `BENCH_REPLAY_SNAPSHOT_PATH` custom output path for snapshot artifact (`.lix` recommended)
 - `BENCH_REPLAY_PROGRESS_EVERY` progress cadence (default: `25`)
 - `BENCH_GIT_FILES_REPORT_PATH` custom output path for git file-replay report
+- `BENCH_GIT_FILES_DISABLE_MAINTENANCE` disable git auto maintenance/gc in target replay repo (default: `1`)
+- `BENCH_GIT_TRACE2_PERF` set to `1` to enable git Trace2 performance logging for the git baseline replay
+- `BENCH_GIT_TRACE2_PERF_PATH` output path for trace2 log (default: `packages/nextjs-replay-bench/results/nextjs-replay.git-files.trace2.perf.log`)
 
 Determinism:
 

--- a/packages/nextjs-replay-bench/package.json
+++ b/packages/nextjs-replay-bench/package.json
@@ -7,11 +7,15 @@
   "scripts": {
     "bench": "pnpm --filter js-sdk run build && pnpm --filter js-sdk run build:dist && pnpm run bench:run",
     "bench:run": "node ./src/replay.bench.js",
+    "bench:git-files": "node ./src/git-files.bench.js",
     "bench:profile-slowest": "node ./src/profile-slowest-commit.js",
     "bench:25:cold": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=0 pnpm run bench",
     "bench:25": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
     "bench:100": "BENCH_REPLAY_COMMITS=100 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
-    "bench:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench"
+    "bench:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
+    "bench:git-files:25": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files",
+    "bench:git-files:100": "BENCH_REPLAY_COMMITS=100 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files",
+    "bench:git-files:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files"
   },
   "dependencies": {
     "js-sdk": "workspace:*"

--- a/packages/nextjs-replay-bench/package.json
+++ b/packages/nextjs-replay-bench/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nextjs-replay-bench",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Replay benchmark for linear git history into js-sdk/engine",
+  "scripts": {
+    "bench": "pnpm --filter js-sdk run build && pnpm --filter js-sdk run build:dist && pnpm run bench:run",
+    "bench:run": "node ./src/replay.bench.js",
+    "bench:quick": "BENCH_REPLAY_COMMITS=100 pnpm run bench",
+    "bench:1000": "BENCH_REPLAY_COMMITS=1000 pnpm run bench"
+  },
+  "dependencies": {
+    "js-sdk": "workspace:*"
+  }
+}

--- a/packages/nextjs-replay-bench/package.json
+++ b/packages/nextjs-replay-bench/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "bench": "pnpm --filter js-sdk run build && pnpm --filter js-sdk run build:dist && pnpm run bench:run",
     "bench:run": "node ./src/replay.bench.js",
-    "bench:quick": "BENCH_REPLAY_COMMITS=100 pnpm run bench",
+    "bench:25": "BENCH_REPLAY_COMMITS=25 pnpm run bench",
+    "bench:100": "BENCH_REPLAY_COMMITS=100 pnpm run bench",
     "bench:1000": "BENCH_REPLAY_COMMITS=1000 pnpm run bench"
   },
   "dependencies": {

--- a/packages/nextjs-replay-bench/package.json
+++ b/packages/nextjs-replay-bench/package.json
@@ -12,6 +12,7 @@
     "bench:25:cold": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=0 pnpm run bench",
     "bench:25": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
     "bench:100": "BENCH_REPLAY_COMMITS=100 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
+    "bench:500": "BENCH_REPLAY_COMMITS=500 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
     "bench:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
     "bench:git-files:25": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files",
     "bench:git-files:100": "BENCH_REPLAY_COMMITS=100 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files",

--- a/packages/nextjs-replay-bench/package.json
+++ b/packages/nextjs-replay-bench/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "bench": "pnpm --filter js-sdk run build && pnpm --filter js-sdk run build:dist && pnpm run bench:run",
     "bench:run": "node ./src/replay.bench.js",
+    "bench:parity": "pnpm --filter js-sdk run build && pnpm --filter js-sdk run build:dist && node ./src/state-parity.js",
     "bench:git-files": "node ./src/git-files.bench.js",
     "bench:profile-slowest": "node ./src/profile-slowest-commit.js",
     "bench:25:cold": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=0 pnpm run bench",
@@ -16,7 +17,8 @@
     "bench:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
     "bench:git-files:25": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files",
     "bench:git-files:100": "BENCH_REPLAY_COMMITS=100 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files",
-    "bench:git-files:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files"
+    "bench:git-files:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench:git-files",
+    "bench:parity:25": "BENCH_REPLAY_COMMITS=25 BENCH_PARITY_EVERY=1 pnpm run bench:parity"
   },
   "dependencies": {
     "js-sdk": "workspace:*"

--- a/packages/nextjs-replay-bench/package.json
+++ b/packages/nextjs-replay-bench/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "bench": "pnpm --filter js-sdk run build && pnpm --filter js-sdk run build:dist && pnpm run bench:run",
     "bench:run": "node ./src/replay.bench.js",
-    "bench:25": "BENCH_REPLAY_COMMITS=25 pnpm run bench",
+    "bench:profile-slowest": "node ./src/profile-slowest-commit.js",
+    "bench:25:cold": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=0 pnpm run bench",
+    "bench:25": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
     "bench:100": "BENCH_REPLAY_COMMITS=100 pnpm run bench",
     "bench:1000": "BENCH_REPLAY_COMMITS=1000 pnpm run bench"
   },

--- a/packages/nextjs-replay-bench/package.json
+++ b/packages/nextjs-replay-bench/package.json
@@ -10,8 +10,8 @@
     "bench:profile-slowest": "node ./src/profile-slowest-commit.js",
     "bench:25:cold": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=0 pnpm run bench",
     "bench:25": "BENCH_REPLAY_COMMITS=25 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
-    "bench:100": "BENCH_REPLAY_COMMITS=100 pnpm run bench",
-    "bench:1000": "BENCH_REPLAY_COMMITS=1000 pnpm run bench"
+    "bench:100": "BENCH_REPLAY_COMMITS=100 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench",
+    "bench:1000": "BENCH_REPLAY_COMMITS=1000 BENCH_REPLAY_WARMUP_COMMITS=5 pnpm run bench"
   },
   "dependencies": {
     "js-sdk": "workspace:*"

--- a/packages/nextjs-replay-bench/src/apply-to-lix.js
+++ b/packages/nextjs-replay-bench/src/apply-to-lix.js
@@ -1,0 +1,245 @@
+import { createHash } from "node:crypto";
+
+export function createReplayState() {
+  return {
+    pathToFileId: new Map(),
+    knownFileIds: new Set(),
+  };
+}
+
+export function prepareCommitChanges(state, changes, blobByOid) {
+  const deleteIds = new Set();
+  const insertsById = new Map();
+  const updatesById = new Map();
+  const statusCounts = new Map();
+  let blobBytes = 0;
+
+  for (const change of changes) {
+    const status = normalizeStatus(change.status);
+    statusCounts.set(status, (statusCounts.get(status) ?? 0) + 1);
+
+    if (status === "D") {
+      const id = resolveDeleteId(state, change);
+      if (id) {
+        deleteIds.add(id);
+        insertsById.delete(id);
+        updatesById.delete(id);
+      }
+      continue;
+    }
+
+    if (!change.newPath) {
+      continue;
+    }
+
+    const writeTarget = resolveWriteTarget(state, change, status);
+    const bytes = blobByOid.get(change.newOid);
+    if (!bytes) {
+      throw new Error(
+        `missing blob for ${change.newOid} while applying ${status} ${change.newPath}`,
+      );
+    }
+
+    blobBytes += bytes.byteLength;
+    const write = {
+      id: writeTarget.id,
+      path: toLixPath(change.newPath),
+      data: bytes,
+    };
+
+    if (deleteIds.has(write.id)) {
+      deleteIds.delete(write.id);
+    }
+
+    if (writeTarget.isInsert) {
+      insertsById.set(write.id, write);
+      updatesById.delete(write.id);
+      state.knownFileIds.add(write.id);
+      continue;
+    }
+
+    if (insertsById.has(write.id)) {
+      insertsById.set(write.id, write);
+      continue;
+    }
+
+    updatesById.set(write.id, write);
+  }
+
+  return {
+    deletes: [...deleteIds],
+    inserts: [...insertsById.values()],
+    updates: [...updatesById.values()],
+    statusCounts,
+    blobBytes,
+  };
+}
+
+export function buildReplayCommitStatements(batch, options = {}) {
+  const maxInsertRows = positiveOrDefault(options.maxInsertRows, 200);
+  const maxInsertSqlChars = positiveOrDefault(options.maxInsertSqlChars, 1_500_000);
+
+  if (batch.deletes.length === 0 && batch.inserts.length === 0 && batch.updates.length === 0) {
+    return [];
+  }
+
+  const statements = [];
+
+  for (const deleteChunk of chunkArray(batch.deletes, 500)) {
+    if (deleteChunk.length === 0) {
+      continue;
+    }
+    statements.push(
+      `DELETE FROM lix_file WHERE id IN (${deleteChunk.map(sqlText).join(", ")})`,
+    );
+  }
+
+  appendInsertStatements(statements, batch.inserts, {
+    maxInsertRows,
+    maxInsertSqlChars,
+  });
+
+  appendUpdateStatements(statements, batch.updates, {
+    maxInsertRows,
+    maxInsertSqlChars,
+  });
+
+  return statements;
+}
+
+function appendInsertStatements(statements, rows, options) {
+  if (rows.length === 0) {
+    return;
+  }
+
+  const { maxInsertRows, maxInsertSqlChars } = options;
+  const prefix = "INSERT INTO lix_file (id, path, data) VALUES ";
+
+  let chunk = [];
+  let chunkChars = 0;
+
+  const flush = () => {
+    if (chunk.length === 0) {
+      return;
+    }
+    statements.push(`${prefix}${chunk.join(", ")}`);
+    chunk = [];
+    chunkChars = 0;
+  };
+
+  for (const row of rows) {
+    const rowLiteral = `(${sqlText(row.id)}, ${sqlText(row.path)}, ${sqlBlob(row.data)})`;
+    const wouldOverflowChars =
+      chunk.length > 0 && prefix.length + chunkChars + rowLiteral.length + 2 > maxInsertSqlChars;
+    const wouldOverflowRows = chunk.length >= maxInsertRows;
+
+    if (wouldOverflowChars || wouldOverflowRows) {
+      flush();
+    }
+
+    chunk.push(rowLiteral);
+    chunkChars += rowLiteral.length + 2;
+  }
+
+  flush();
+}
+
+function appendUpdateStatements(statements, rows, options) {
+  if (rows.length === 0) {
+    return;
+  }
+  const _ = options;
+  for (const row of rows) {
+    statements.push(
+      `UPDATE lix_file SET path = ${sqlText(row.path)}, data = ${sqlBlob(row.data)} WHERE id = ${sqlText(row.id)}`,
+    );
+  }
+}
+
+function normalizeStatus(value) {
+  if (!value || typeof value !== "string") {
+    return "M";
+  }
+  return value[0].toUpperCase();
+}
+
+function resolveDeleteId(state, change) {
+  if (!change.oldPath) {
+    return null;
+  }
+  const id = state.pathToFileId.get(change.oldPath);
+  if (!id) {
+    return null;
+  }
+  state.pathToFileId.delete(change.oldPath);
+  state.knownFileIds.delete(id);
+  return id;
+}
+
+function resolveWriteTarget(state, change, status) {
+  if (!change.newPath) {
+    throw new Error("resolveWriteTarget requires newPath");
+  }
+
+  if (status === "R" && change.oldPath) {
+    const fromPath = change.oldPath;
+    const existingId = state.pathToFileId.get(fromPath);
+    if (existingId) {
+      state.pathToFileId.delete(fromPath);
+      state.pathToFileId.set(change.newPath, existingId);
+      return { id: existingId, isInsert: false };
+    }
+  }
+
+  const current = state.pathToFileId.get(change.newPath);
+  if (current) {
+    return { id: current, isInsert: false };
+  }
+
+  const generated = stableFileId(change.newPath);
+  state.pathToFileId.set(change.newPath, generated);
+  return {
+    id: generated,
+    isInsert: !state.knownFileIds.has(generated),
+  };
+}
+
+function stableFileId(path) {
+  const digest = createHash("sha1").update(path).digest("hex");
+  return `git-replay-${digest.slice(0, 24)}`;
+}
+
+function toLixPath(path) {
+  const normalized = String(path).replace(/\\/g, "/");
+  if (normalized.startsWith("/")) {
+    return normalized;
+  }
+  return `/${normalized}`;
+}
+
+function chunkArray(values, size) {
+  if (values.length === 0) {
+    return [];
+  }
+  const chunks = [];
+  for (let i = 0; i < values.length; i += size) {
+    chunks.push(values.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function sqlText(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function sqlBlob(bytes) {
+  return `x'${Buffer.from(bytes).toString("hex")}'`;
+}
+
+function positiveOrDefault(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}

--- a/packages/nextjs-replay-bench/src/git-files.bench.js
+++ b/packages/nextjs-replay-bench/src/git-files.bench.js
@@ -1,0 +1,516 @@
+import { mkdtemp, mkdir, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { spawn } from "node:child_process";
+import { ensureGitRepo, listLinearCommits, readCommitPatchSet } from "./git-history.js";
+import { printProgress, summarizeSamples } from "./report.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT_DIR = join(__dirname, "..", "results");
+const OUTPUT_PATH = join(OUTPUT_DIR, "nextjs-replay.git-files.bench.json");
+const DEFAULT_CACHE_DIR = join(__dirname, "..", ".cache", "nextjs-replay");
+
+const CONFIG = {
+  repoUrl: process.env.BENCH_REPLAY_REPO_URL ?? "https://github.com/vercel/next.js.git",
+  repoPath: process.env.BENCH_REPLAY_REPO_PATH ?? "",
+  repoRef: process.env.BENCH_REPLAY_REF ?? "HEAD",
+  cacheDir: process.env.BENCH_REPLAY_CACHE_DIR ?? DEFAULT_CACHE_DIR,
+  commitLimit: parseEnvInt("BENCH_REPLAY_COMMITS", 1000),
+  warmupCommitCount: parseEnvNonNegativeInt("BENCH_REPLAY_WARMUP_COMMITS", 5),
+  firstParent: parseEnvBool("BENCH_REPLAY_FIRST_PARENT", true),
+  syncRemote: parseEnvBool("BENCH_REPLAY_FETCH", false),
+  progressEvery: parseEnvInt("BENCH_REPLAY_PROGRESS_EVERY", 25),
+  showProgress: parseEnvBool("BENCH_REPLAY_PROGRESS", true),
+  reportPath: process.env.BENCH_GIT_FILES_REPORT_PATH ?? OUTPUT_PATH,
+};
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  const benchmarkStarted = performance.now();
+
+  const repoSetupStarted = performance.now();
+  const sourceRepo = await ensureGitRepo({
+    repoPath: CONFIG.repoPath || undefined,
+    repoUrl: CONFIG.repoUrl,
+    cacheDir: CONFIG.cacheDir,
+    defaultDirName: "next.js",
+    syncRemote: CONFIG.syncRemote,
+    ref: CONFIG.repoRef,
+  });
+  const repoSetupMs = performance.now() - repoSetupStarted;
+
+  const commitDiscoveryStarted = performance.now();
+  const totalRequestedCommits = CONFIG.commitLimit + CONFIG.warmupCommitCount;
+  const commits = await listLinearCommits(sourceRepo.repoPath, {
+    ref: CONFIG.repoRef,
+    maxCount: totalRequestedCommits,
+    firstParent: CONFIG.firstParent,
+  });
+  const commitDiscoveryMs = performance.now() - commitDiscoveryStarted;
+
+  if (commits.length === 0) {
+    throw new Error(`no commits found at ${sourceRepo.repoPath} (${CONFIG.repoRef})`);
+  }
+
+  const warmupCommitCount = Math.min(CONFIG.warmupCommitCount, commits.length);
+  const measuredCommits = commits.slice(warmupCommitCount);
+  if (measuredCommits.length === 0) {
+    throw new Error(
+      `warmup consumed all discovered commits (warmup=${warmupCommitCount}, discovered=${commits.length})`,
+    );
+  }
+
+  const tempRoot = await mkdtemp(join(tmpdir(), "nextjs-git-files-replay-"));
+  const gitRepoPath = join(tempRoot, "repo");
+  await mkdir(gitRepoPath, { recursive: true });
+  await runCommand("git", ["init", "-q"], { cwd: gitRepoPath });
+  await runCommand("git", ["config", "user.email", "bench@example.com"], { cwd: gitRepoPath });
+  await runCommand("git", ["config", "user.name", "nextjs-replay-bench"], { cwd: gitRepoPath });
+
+  if (CONFIG.showProgress) {
+    console.log(
+      `[progress] replaying ${commits.length} commits (warmup=${warmupCommitCount}, measured=${measuredCommits.length}) from ${sourceRepo.repoPath} (${sourceRepo.source})`,
+    );
+  }
+
+  const phaseTotalsMs = {
+    readPatchSetMs: 0,
+    applyFilesMs: 0,
+    gitStageCommitMs: 0,
+  };
+  const commitDurations = [];
+  const slowestCommits = [];
+
+  let warmupApplied = 0;
+  let warmupNoop = 0;
+  let measuredApplied = 0;
+  let measuredNoop = 0;
+  let totalChangedPaths = 0;
+  let warmupChangedPaths = 0;
+  let totalBlobBytes = 0;
+
+  const loopStarted = performance.now();
+  let measuredStarted = warmupCommitCount === 0 ? loopStarted : null;
+  let warmupMs = 0;
+
+  for (let index = 0; index < commits.length; index++) {
+    if (index === warmupCommitCount && measuredStarted === null) {
+      warmupMs = performance.now() - loopStarted;
+      measuredStarted = performance.now();
+    }
+    const isWarmup = index < warmupCommitCount;
+    const commitSha = commits[index];
+
+    const readPatchSetStarted = performance.now();
+    const patchSet = await readCommitPatchSet(sourceRepo.repoPath, commitSha);
+    const readPatchSetMs = performance.now() - readPatchSetStarted;
+    if (!isWarmup) {
+      phaseTotalsMs.readPatchSetMs += readPatchSetMs;
+    }
+
+    if (!isWarmup) {
+      totalChangedPaths += patchSet.changes.length;
+    } else {
+      warmupChangedPaths += patchSet.changes.length;
+    }
+
+    if (patchSet.changes.length === 0) {
+      if (isWarmup) {
+        warmupNoop += 1;
+      } else {
+        measuredNoop += 1;
+      }
+      printMaybeProgress({
+        commitSha,
+        commitIndex: index,
+        commits,
+        warmupCommitCount,
+        warmupChangedPaths,
+        measuredChangedPaths: totalChangedPaths,
+        warmupApplied,
+        warmupNoop,
+        measuredApplied,
+        measuredNoop,
+        benchmarkStarted,
+      });
+      continue;
+    }
+
+    const commitStarted = performance.now();
+
+    const applyFilesStarted = performance.now();
+    const appliedBlobBytes = await applyPatchSetToRepo(gitRepoPath, patchSet);
+    const applyFilesMs = performance.now() - applyFilesStarted;
+
+    const gitStageCommitStarted = performance.now();
+    await runCommand("git", ["add", "-A"], { cwd: gitRepoPath });
+    await runCommand(
+      "git",
+      ["commit", "-q", "--allow-empty", "-m", `replay ${commitSha.slice(0, 12)}`],
+      { cwd: gitRepoPath },
+    );
+    const gitStageCommitMs = performance.now() - gitStageCommitStarted;
+
+    const commitTotalMs = performance.now() - commitStarted;
+
+    if (isWarmup) {
+      warmupApplied += 1;
+    } else {
+      measuredApplied += 1;
+      totalBlobBytes += appliedBlobBytes;
+      phaseTotalsMs.applyFilesMs += applyFilesMs;
+      phaseTotalsMs.gitStageCommitMs += gitStageCommitMs;
+      commitDurations.push(commitTotalMs);
+      pushSlowCommit(slowestCommits, {
+        commitSha,
+        durationMs: commitTotalMs,
+        changedPaths: patchSet.changes.length,
+      });
+    }
+
+    printMaybeProgress({
+      commitSha,
+      commitIndex: index,
+      commits,
+      warmupCommitCount,
+      warmupChangedPaths,
+      measuredChangedPaths: totalChangedPaths,
+      warmupApplied,
+      warmupNoop,
+      measuredApplied,
+      measuredNoop,
+      benchmarkStarted,
+    });
+  }
+
+  if (measuredStarted === null) {
+    throw new Error("internal error: measured replay did not start");
+  }
+  const measuredMs = performance.now() - measuredStarted;
+  const overallMs = performance.now() - benchmarkStarted;
+
+  const commitSummary = summarizeSamples(commitDurations);
+  const phaseBreakdown = [
+    { phase: "readPatchSetMs", totalMs: phaseTotalsMs.readPatchSetMs },
+    { phase: "applyFilesMs", totalMs: phaseTotalsMs.applyFilesMs },
+    { phase: "gitStageCommitMs", totalMs: phaseTotalsMs.gitStageCommitMs },
+  ].map((entry) => ({
+    ...entry,
+    sharePct: measuredMs > 0 ? (entry.totalMs / measuredMs) * 100 : 0,
+  }));
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    startedAt,
+    kind: "git-files-replay",
+    config: { ...CONFIG },
+    sourceRepo: {
+      path: sourceRepo.repoPath,
+      source: sourceRepo.source,
+      ref: CONFIG.repoRef,
+    },
+    targetRepo: {
+      path: gitRepoPath,
+      kind: "fresh-git-working-tree",
+    },
+    commitTotals: {
+      requested: totalRequestedCommits,
+      discovered: commits.length,
+      measuredDiscovered: measuredCommits.length,
+      warmupRequested: CONFIG.warmupCommitCount,
+      warmupUsed: warmupCommitCount,
+      warmupApplied,
+      warmupNoop,
+      applied: measuredApplied,
+      noop: measuredNoop,
+    },
+    io: {
+      changedPaths: totalChangedPaths,
+      blobBytes: totalBlobBytes,
+    },
+    timings: {
+      measuredMs,
+      overallMs,
+      warmupMs,
+      setup: {
+        repoSetupMs,
+        commitDiscoveryMs,
+      },
+      phases: phaseTotalsMs,
+      phaseBreakdown,
+      commit: commitSummary,
+    },
+    throughput: {
+      commitsPerSecond: measuredMs > 0 ? (CONFIG.commitLimit / measuredMs) * 1000 : 0,
+      changedPathsPerSecond: measuredMs > 0 ? (totalChangedPaths / measuredMs) * 1000 : 0,
+      blobMegabytesPerSecond:
+        measuredMs > 0 ? ((totalBlobBytes / (1024 * 1024)) / measuredMs) * 1000 : 0,
+    },
+    slowestCommits,
+  };
+
+  await mkdir(dirname(CONFIG.reportPath), { recursive: true });
+  await writeFile(CONFIG.reportPath, JSON.stringify(report, null, 2), "utf8");
+
+  printSummary(report);
+  console.log("");
+  console.log(`Wrote git file-replay benchmark report: ${CONFIG.reportPath}`);
+}
+
+async function applyPatchSetToRepo(repoPath, patchSet) {
+  let blobBytes = 0;
+
+  for (const change of patchSet.changes) {
+    const status = normalizeStatus(change.status);
+    const oldPath = toRepoPath(repoPath, change.oldPath);
+    const newPath = toRepoPath(repoPath, change.newPath);
+
+    if (status === "D") {
+      if (oldPath) {
+        await safeDeleteFile(oldPath);
+      }
+      continue;
+    }
+
+    if (status === "R" && oldPath && newPath && oldPath !== newPath) {
+      await safeDeleteFile(oldPath);
+    }
+
+    if (!newPath || !change.newOid || change.newOid === "0000000000000000000000000000000000000000") {
+      if (oldPath && status !== "C") {
+        await safeDeleteFile(oldPath);
+      }
+      continue;
+    }
+
+    const bytes = patchSet.blobByOid.get(change.newOid);
+    if (!bytes) {
+      throw new Error(
+        `missing blob for ${change.newOid} while applying ${status} ${change.newPath ?? "<none>"}`,
+      );
+    }
+    blobBytes += bytes.byteLength;
+
+    await mkdir(dirname(newPath), { recursive: true });
+    await writeFile(newPath, bytes);
+  }
+
+  return blobBytes;
+}
+
+function toRepoPath(repoPath, rawPath) {
+  if (!rawPath) {
+    return null;
+  }
+  const normalized = String(rawPath).replace(/\\/g, "/");
+  if (normalized.includes("\0")) {
+    throw new Error(`path contains NUL byte: ${rawPath}`);
+  }
+  const trimmed = normalized.startsWith("/") ? normalized.slice(1) : normalized;
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const absolute = resolve(repoPath, trimmed);
+  const allowedPrefix = repoPath.endsWith(sep) ? repoPath : `${repoPath}${sep}`;
+  if (absolute !== repoPath && !absolute.startsWith(allowedPrefix)) {
+    throw new Error(`path escapes target repo: ${rawPath}`);
+  }
+  return absolute;
+}
+
+async function safeDeleteFile(path) {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function normalizeStatus(value) {
+  if (!value || typeof value !== "string") {
+    return "M";
+  }
+  return value[0].toUpperCase();
+}
+
+function printMaybeProgress(state) {
+  if (!CONFIG.showProgress) {
+    return;
+  }
+
+  const {
+    commitSha,
+    commitIndex,
+    commits,
+    warmupCommitCount,
+    warmupChangedPaths,
+    measuredChangedPaths,
+    warmupApplied,
+    warmupNoop,
+    measuredApplied,
+    measuredNoop,
+    benchmarkStarted,
+  } = state;
+
+  const isWarmup = commitIndex < warmupCommitCount;
+  const phaseIndex = isWarmup ? commitIndex + 1 : commitIndex - warmupCommitCount + 1;
+  const phaseTotal = isWarmup ? warmupCommitCount : commits.length - warmupCommitCount;
+  if (phaseTotal <= 0) {
+    return;
+  }
+  if (
+    phaseIndex !== 1 &&
+    phaseIndex % CONFIG.progressEvery !== 0 &&
+    phaseIndex !== phaseTotal
+  ) {
+    return;
+  }
+
+  printProgress({
+    label: isWarmup ? "warmup" : "measure",
+    index: phaseIndex,
+    total: phaseTotal,
+    commitSha,
+    elapsedMs: performance.now() - benchmarkStarted,
+    changedPaths: isWarmup ? warmupChangedPaths : measuredChangedPaths,
+    commitsApplied: isWarmup ? warmupApplied : measuredApplied,
+    commitsNoop: isWarmup ? warmupNoop : measuredNoop,
+  });
+}
+
+function printSummary(report) {
+  console.log("");
+  console.log("Git File-Replay Benchmark");
+  console.log(`Commits requested (measured): ${report.config.commitLimit}`);
+  console.log(`Commits requested (warmup): ${report.commitTotals.warmupRequested}`);
+  console.log(`Commits used (warmup): ${report.commitTotals.warmupUsed}`);
+  console.log(`Commits discovered (total): ${report.commitTotals.discovered}`);
+  console.log(`Commits discovered (measured): ${report.commitTotals.measuredDiscovered}`);
+  console.log(`Warmup applied: ${report.commitTotals.warmupApplied}`);
+  console.log(`Warmup skipped (no file changes): ${report.commitTotals.warmupNoop}`);
+  console.log(`Commits applied (measured): ${report.commitTotals.applied}`);
+  console.log(`Commits skipped (measured, no file changes): ${report.commitTotals.noop}`);
+  console.log(`Warmup duration: ${formatMs(report.timings.warmupMs ?? 0)}`);
+  console.log(`Replay duration (measured): ${formatMs(report.timings.measuredMs)}`);
+  console.log(`Replay duration (overall): ${formatMs(report.timings.overallMs)}`);
+
+  console.log("");
+  console.log(`Commit throughput: ${report.throughput.commitsPerSecond.toFixed(2)} commits/s`);
+  console.log(`Changed paths/sec: ${report.throughput.changedPathsPerSecond.toFixed(2)}`);
+  console.log(`Blob ingest MB/s: ${report.throughput.blobMegabytesPerSecond.toFixed(2)}`);
+
+  console.log("");
+  console.log("Commit execution latency");
+  console.log(`  mean: ${formatMs(report.timings.commit.meanMs)}`);
+  console.log(`  p50:  ${formatMs(report.timings.commit.p50Ms)}`);
+  console.log(`  p95:  ${formatMs(report.timings.commit.p95Ms)}`);
+  console.log(`  max:  ${formatMs(report.timings.commit.maxMs)}`);
+
+  console.log("");
+  console.log("Replay phase breakdown");
+  for (const phase of report.timings.phaseBreakdown) {
+    const label = String(phase.phase).padEnd(21, " ");
+    console.log(`  ${label} ${formatMs(phase.totalMs)} (${Number(phase.sharePct).toFixed(1)}%)`);
+  }
+
+  console.log("");
+  console.log("Setup timing");
+  console.log(`  repo setup: ${formatMs(report.timings.setup.repoSetupMs)}`);
+  console.log(`  commit discovery: ${formatMs(report.timings.setup.commitDiscoveryMs)}`);
+
+  if (Array.isArray(report.slowestCommits) && report.slowestCommits.length > 0) {
+    console.log("");
+    console.log("Slowest commits");
+    for (const row of report.slowestCommits.slice(0, 5)) {
+      console.log(
+        `  ${formatMs(Number(row.durationMs ?? 0))} commit=${String(row.commitSha).slice(0, 12)} changed_paths=${Number(row.changedPaths ?? 0)}`,
+      );
+    }
+  }
+
+  console.log("");
+  console.log(`Target git repo: ${report.targetRepo.path}`);
+}
+
+function formatMs(value) {
+  return `${Number(value).toFixed(2)}ms`;
+}
+
+function parseEnvInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function parseEnvNonNegativeInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function parseEnvBool(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "no") {
+    return false;
+  }
+  return fallback;
+}
+
+function pushSlowCommit(slowest, row) {
+  slowest.push(row);
+  slowest.sort((left, right) => right.durationMs - left.durationMs);
+  if (slowest.length > 20) {
+    slowest.length = 20;
+  }
+}
+
+async function runCommand(command, args, options = {}) {
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    child.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+    child.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+    child.on("error", rejectPromise);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolvePromise(Buffer.concat(stdoutChunks).toString("utf8"));
+        return;
+      }
+      rejectPromise(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${code}:\n${Buffer.concat(stderrChunks).toString("utf8")}`,
+        ),
+      );
+    });
+    child.stdin.end();
+  });
+}
+
+main().catch((error) => {
+  console.error("Git file-replay benchmark failed:");
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/nextjs-replay-bench/src/git-history.js
+++ b/packages/nextjs-replay-bench/src/git-history.js
@@ -1,0 +1,261 @@
+import { mkdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+
+export const NULL_OID = "0000000000000000000000000000000000000000";
+
+export async function ensureGitRepo(options) {
+  const {
+    repoPath,
+    repoUrl,
+    cacheDir,
+    defaultDirName,
+    syncRemote,
+    ref,
+  } = options;
+
+  if (repoPath) {
+    await assertGitRepo(repoPath);
+    if (syncRemote) {
+      await runGit(repoPath, ["fetch", "--tags", "origin"]);
+    }
+    return { repoPath, source: "explicit-path", ref: ref ?? "HEAD" };
+  }
+
+  if (!repoUrl) {
+    throw new Error("repoUrl is required when BENCH_REPLAY_REPO_PATH is not set");
+  }
+
+  const targetPath = join(cacheDir, defaultDirName ?? "repo");
+  await mkdir(cacheDir, { recursive: true });
+
+  const hasRepo = await isGitRepo(targetPath);
+  if (!hasRepo) {
+    await runCommand("git", [
+      "clone",
+      "--filter=blob:none",
+      "--no-checkout",
+      repoUrl,
+      targetPath,
+    ]);
+  } else if (syncRemote) {
+    await runGit(targetPath, ["fetch", "--tags", "origin"]);
+  }
+
+  return { repoPath: targetPath, source: hasRepo ? "cache" : "clone", ref: ref ?? "HEAD" };
+}
+
+export async function listLinearCommits(repoPath, { ref = "HEAD", maxCount, firstParent = true }) {
+  const args = ["rev-list", "--reverse"];
+  if (firstParent) {
+    args.push("--first-parent");
+  }
+  if (maxCount && maxCount > 0) {
+    args.push(`--max-count=${maxCount}`);
+  }
+  args.push(ref);
+
+  const stdout = await runGit(repoPath, args);
+  return stdout
+    .toString("utf8")
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export async function readCommitPatchSet(repoPath, commitSha) {
+  const raw = await runGit(repoPath, [
+    "diff-tree",
+    "--root",
+    "--raw",
+    "-r",
+    "-z",
+    "--find-renames",
+    "--no-commit-id",
+    commitSha,
+  ]);
+
+  const changes = parseRawDiffTree(raw);
+  const wantedBlobIds = new Set();
+  for (const change of changes) {
+    if (!change.newPath) {
+      continue;
+    }
+    if (change.newOid && change.newOid !== NULL_OID) {
+      wantedBlobIds.add(change.newOid);
+    }
+  }
+
+  const blobByOid = await readBlobs(repoPath, [...wantedBlobIds]);
+  return { changes, blobByOid };
+}
+
+function parseRawDiffTree(rawBuffer) {
+  if (rawBuffer.length === 0) {
+    return [];
+  }
+
+  const tokens = rawBuffer.toString("utf8").split("\0");
+  if (tokens[tokens.length - 1] === "") {
+    tokens.pop();
+  }
+
+  const changes = [];
+  let index = 0;
+
+  while (index < tokens.length) {
+    const headerToken = tokens[index++];
+    if (!headerToken || !headerToken.startsWith(":")) {
+      continue;
+    }
+
+    const fields = headerToken.slice(1).split(" ");
+    if (fields.length < 5) {
+      continue;
+    }
+
+    const [oldMode, newMode, oldOid, newOid, statusToken] = fields;
+    const status = statusToken[0] ?? "M";
+    const firstPath = tokens[index++] ?? "";
+
+    if (status === "R" || status === "C") {
+      const secondPath = tokens[index++] ?? "";
+      changes.push({
+        status,
+        oldMode,
+        newMode,
+        oldOid,
+        newOid,
+        oldPath: firstPath,
+        newPath: secondPath,
+      });
+      continue;
+    }
+
+    changes.push({
+      status,
+      oldMode,
+      newMode,
+      oldOid,
+      newOid,
+      oldPath: status === "A" ? null : firstPath,
+      newPath: status === "D" ? null : firstPath,
+    });
+  }
+
+  return changes;
+}
+
+async function readBlobs(repoPath, blobIds) {
+  if (blobIds.length === 0) {
+    return new Map();
+  }
+
+  const requestBody = Buffer.from(`${blobIds.join("\n")}\n`, "utf8");
+  const stdout = await runGit(repoPath, ["cat-file", "--batch"], {
+    stdin: requestBody,
+  });
+
+  const blobs = new Map();
+  let offset = 0;
+
+  while (offset < stdout.length) {
+    const lineEnd = stdout.indexOf(0x0a, offset);
+    if (lineEnd < 0) {
+      break;
+    }
+
+    const header = stdout.toString("utf8", offset, lineEnd).trim();
+    offset = lineEnd + 1;
+
+    if (!header) {
+      continue;
+    }
+
+    const [oid, type, sizeToken] = header.split(" ");
+    if (type === "missing") {
+      blobs.set(oid, null);
+      continue;
+    }
+
+    const size = Number.parseInt(sizeToken, 10);
+    if (!Number.isFinite(size) || size < 0) {
+      throw new Error(`invalid cat-file size '${sizeToken}' for ${oid}`);
+    }
+
+    const dataStart = offset;
+    const dataEnd = dataStart + size;
+    if (dataEnd > stdout.length) {
+      throw new Error(`cat-file output truncated while reading ${oid}`);
+    }
+
+    blobs.set(oid, Uint8Array.from(stdout.subarray(dataStart, dataEnd)));
+    offset = dataEnd;
+    if (offset < stdout.length && stdout[offset] === 0x0a) {
+      offset += 1;
+    }
+  }
+
+  return blobs;
+}
+
+async function assertGitRepo(repoPath) {
+  if (!(await isGitRepo(repoPath))) {
+    throw new Error(`not a git repository: ${repoPath}`);
+  }
+}
+
+async function isGitRepo(repoPath) {
+  try {
+    const stats = await stat(join(repoPath, ".git"));
+    return stats.isDirectory() || stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function runGit(repoPath, args, options = {}) {
+  return await runCommand("git", ["-C", repoPath, ...args], options);
+}
+
+async function runCommand(command, args, options = {}) {
+  const { stdin } = options;
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    child.stdout.on("data", (chunk) => {
+      stdoutChunks.push(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderrChunks.push(chunk);
+    });
+
+    child.on("error", reject);
+
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdoutChunks));
+        return;
+      }
+
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${code}:\n${stderr}`,
+        ),
+      );
+    });
+
+    if (stdin) {
+      child.stdin.write(stdin);
+    }
+    child.stdin.end();
+  });
+}

--- a/packages/nextjs-replay-bench/src/git-history.js
+++ b/packages/nextjs-replay-bench/src/git-history.js
@@ -50,17 +50,18 @@ export async function listLinearCommits(repoPath, { ref = "HEAD", maxCount, firs
   if (firstParent) {
     args.push("--first-parent");
   }
-  if (maxCount && maxCount > 0) {
-    args.push(`--max-count=${maxCount}`);
-  }
   args.push(ref);
 
   const stdout = await runGit(repoPath, args);
-  return stdout
+  const commits = stdout
     .toString("utf8")
     .split("\n")
     .map((entry) => entry.trim())
     .filter(Boolean);
+  if (maxCount && maxCount > 0) {
+    return commits.slice(0, maxCount);
+  }
+  return commits;
 }
 
 export async function readCommitPatchSet(repoPath, commitSha) {

--- a/packages/nextjs-replay-bench/src/profile-slowest-commit.js
+++ b/packages/nextjs-replay-bench/src/profile-slowest-commit.js
@@ -1,0 +1,728 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { openLix, createWasmSqliteBackend } from "js-sdk";
+import {
+  ensureGitRepo,
+  listLinearCommits,
+  readCommitPatchSet,
+} from "./git-history.js";
+import {
+  createReplayState,
+  prepareCommitChanges,
+  buildReplayCommitStatements,
+} from "./apply-to-lix.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+const RESULTS_DIR = join(__dirname, "..", "results");
+const DEFAULT_REPORT_PATH = join(RESULTS_DIR, "nextjs-replay.bench.json");
+const DEFAULT_OUTPUT_PATH = join(RESULTS_DIR, "nextjs-replay.slowest-commit.explain.txt");
+
+const TEXT_LINES_MANIFEST = {
+  key: "plugin_text_lines",
+  runtime: "wasm-component-v1",
+  api_version: "0.1.0",
+  detect_changes_glob: "**/*",
+  entry: "plugin.wasm",
+};
+
+async function main() {
+  const reportPath = process.env.BENCH_REPLAY_REPORT_PATH ?? DEFAULT_REPORT_PATH;
+  const outputPath = process.env.BENCH_REPLAY_EXPLAIN_OUTPUT ?? DEFAULT_OUTPUT_PATH;
+  const report = JSON.parse(await readFile(reportPath, "utf8"));
+
+  const targetCommit =
+    process.env.BENCH_REPLAY_TARGET_COMMIT ??
+    report?.slowestCommits?.[0]?.commitSha;
+  if (!targetCommit) {
+    throw new Error("failed to resolve target commit (BENCH_REPLAY_TARGET_COMMIT or slowestCommits[0])");
+  }
+
+  const config = report.config ?? {};
+  const replayConfig = {
+    repoUrl: process.env.BENCH_REPLAY_REPO_URL ?? config.repoUrl ?? "https://github.com/vercel/next.js.git",
+    repoPath: process.env.BENCH_REPLAY_REPO_PATH ?? report?.repo?.path ?? "",
+    repoRef: process.env.BENCH_REPLAY_REF ?? report?.repo?.ref ?? "HEAD",
+    cacheDir: process.env.BENCH_REPLAY_CACHE_DIR ?? config.cacheDir,
+    commitLimit: parseEnvInt(
+      "BENCH_REPLAY_COMMITS",
+      Number(config.commitLimit ?? report?.commitTotals?.discovered ?? 1000),
+    ),
+    firstParent: parseEnvBool("BENCH_REPLAY_FIRST_PARENT", config.firstParent ?? true),
+    syncRemote: parseEnvBool("BENCH_REPLAY_FETCH", false),
+    installTextLinesPlugin: parseEnvBool(
+      "BENCH_REPLAY_INSTALL_TEXT_LINES_PLUGIN",
+      config.installTextLinesPlugin ?? true,
+    ),
+    maxInsertRows: parseEnvInt("BENCH_REPLAY_MAX_INSERT_ROWS", Number(config.maxInsertRows ?? 200)),
+    maxInsertSqlChars: parseEnvInt(
+      "BENCH_REPLAY_MAX_INSERT_SQL_CHARS",
+      Number(config.maxInsertSqlChars ?? 1_500_000),
+    ),
+    progressEvery: parseEnvInt("BENCH_REPLAY_PROGRESS_EVERY", 25),
+  };
+
+  const repo = await ensureGitRepo({
+    repoPath: replayConfig.repoPath || undefined,
+    repoUrl: replayConfig.repoUrl,
+    cacheDir: replayConfig.cacheDir,
+    defaultDirName: "next.js",
+    syncRemote: replayConfig.syncRemote,
+    ref: replayConfig.repoRef,
+  });
+
+  const commits = await listLinearCommits(repo.repoPath, {
+    ref: replayConfig.repoRef,
+    maxCount: replayConfig.commitLimit,
+    firstParent: replayConfig.firstParent,
+  });
+  const targetIndex = commits.findIndex((commit) => commit === targetCommit);
+  if (targetIndex < 0) {
+    throw new Error(
+      `target commit ${targetCommit} not found in first ${commits.length} commits of ${replayConfig.repoRef}`,
+    );
+  }
+
+  console.log(
+    `[profile] target commit ${targetCommit.slice(0, 12)} at index ${targetIndex + 1}/${commits.length}`,
+  );
+  console.log("[profile] opening lix and replaying history up to target commit");
+
+  const baseBackend = await createWasmSqliteBackend();
+  const tracedBackend = createTracingBackend(baseBackend);
+  const lix = await openLix({
+    backend: tracedBackend.backend,
+    keyValues: [{
+      key: "lix_deterministic_mode",
+      value: { enabled: true },
+      lixcol_version_id: "global",
+    }],
+  });
+
+  try {
+    if (replayConfig.installTextLinesPlugin) {
+      const wasmBytes = await loadTextLinesPluginWasmBytes();
+      await lix.installPlugin({
+        manifestJson: TEXT_LINES_MANIFEST,
+        wasmBytes,
+      });
+    }
+
+    const state = createReplayState();
+    const replayStarted = performance.now();
+    let profile = null;
+
+    for (let index = 0; index <= targetIndex; index++) {
+      const commitSha = commits[index];
+      const patchSet = await readCommitPatchSet(repo.repoPath, commitSha);
+      const prepared = prepareCommitChanges(state, patchSet.changes, patchSet.blobByOid);
+      const statements = buildReplayCommitStatements(prepared, {
+        maxInsertRows: replayConfig.maxInsertRows,
+        maxInsertSqlChars: replayConfig.maxInsertSqlChars,
+      });
+
+      if (index < targetIndex) {
+        for (const sql of statements) {
+          await lix.execute(sql, []);
+        }
+      } else {
+        console.log(
+          `[profile] profiling target commit with ${statements.length} statement(s), changed_paths=${patchSet.changes.length}`,
+        );
+        profile = await profileCommitStatements(
+          lix,
+          tracedBackend,
+          commitSha,
+          patchSet.changes.length,
+          prepared,
+          statements,
+        );
+      }
+
+      if ((index + 1) % replayConfig.progressEvery === 0 || index === targetIndex) {
+        const elapsedMs = performance.now() - replayStarted;
+        console.log(
+          `[profile] replay progress ${index + 1}/${targetIndex + 1} (${(((index + 1) / (targetIndex + 1)) * 100).toFixed(1)}%) elapsed=${(elapsedMs / 1000).toFixed(1)}s`,
+        );
+      }
+    }
+
+    if (!profile) {
+      throw new Error("internal error: target profile not collected");
+    }
+
+    const reportText = formatExplainReport({
+      reportPath,
+      outputPath,
+      repo,
+      replayConfig,
+      targetIndex,
+      totalCommits: commits.length,
+      profile,
+    });
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, reportText, "utf8");
+    console.log(`[profile] wrote explain report: ${outputPath}`);
+  } finally {
+    await lix.close();
+  }
+}
+
+async function profileCommitStatements(
+  lix,
+  tracedBackend,
+  commitSha,
+  changedPaths,
+  prepared,
+  statements,
+) {
+  const statementProfiles = [];
+  let commitTotalMs = 0;
+  const traceStart = tracedBackend.trace.length;
+
+  for (let index = 0; index < statements.length; index++) {
+    const sql = statements[index];
+    const started = performance.now();
+    await lix.execute(sql, []);
+    const durationMs = performance.now() - started;
+    commitTotalMs += durationMs;
+
+    statementProfiles.push({
+      statementIndex: index,
+      durationMs,
+      sqlChars: sql.length,
+      sql: sanitizeSqlForReport(sql),
+    });
+  }
+
+  const rawTrace = tracedBackend.trace.slice(traceStart);
+  const rawTraceByKind = summarizeRawTraceByKind(rawTrace);
+  const rawTraceTemplates = summarizeRawTraceTemplates(rawTrace);
+  const rawTraceSummaries = summarizeRawTraceExact(rawTrace);
+  const explainPlans = await collectExplainPlansForRawTrace(tracedBackend, rawTraceSummaries);
+
+  const sorted = [...statementProfiles].sort((a, b) => b.durationMs - a.durationMs);
+  return {
+    commitSha,
+    changedPaths,
+    inserts: prepared.inserts.length,
+    updates: prepared.updates.length,
+    deletes: prepared.deletes.length,
+    statementCount: statements.length,
+    commitTotalMs,
+    slowestStatements: sorted.slice(0, 10),
+    statements: statementProfiles,
+    rawTraceTotalCount: rawTrace.length,
+    rawTraceByKind,
+    rawTraceTemplates,
+    rawTraceSummaries,
+    rawExplainPlans: explainPlans,
+  };
+}
+
+function formatExplainReport(payload) {
+  const {
+    reportPath,
+    repo,
+    replayConfig,
+    targetIndex,
+    totalCommits,
+    profile,
+  } = payload;
+  const lines = [];
+  lines.push("Next.js Replay Slowest-Commit Explain Report");
+  lines.push("");
+  lines.push(`source_report: ${reportPath}`);
+  lines.push(`repo_path: ${repo.repoPath}`);
+  lines.push(`repo_source: ${repo.source}`);
+  lines.push(`repo_ref: ${replayConfig.repoRef}`);
+  lines.push(`target_commit: ${profile.commitSha}`);
+  lines.push(`target_position: ${targetIndex + 1}/${totalCommits}`);
+  lines.push(`changed_paths: ${profile.changedPaths}`);
+  lines.push(`writes: inserts=${profile.inserts} updates=${profile.updates} deletes=${profile.deletes}`);
+  lines.push(`statement_count: ${profile.statementCount}`);
+  lines.push(`commit_total_ms: ${profile.commitTotalMs.toFixed(3)}`);
+  lines.push(`raw_backend_statement_count: ${profile.rawTraceTotalCount}`);
+  lines.push("");
+  lines.push("Top statements by execution time");
+  for (const stmt of profile.slowestStatements) {
+    lines.push(
+      `- stmt=${stmt.statementIndex} duration_ms=${stmt.durationMs.toFixed(3)} sql_chars=${stmt.sqlChars}`,
+    );
+  }
+  lines.push("");
+
+  lines.push("Raw backend trace by kind");
+  for (const item of profile.rawTraceByKind) {
+    lines.push(
+      `- kind=${item.kind} count=${item.count} total_ms=${item.totalMs.toFixed(3)} avg_ms=${(item.totalMs / Math.max(item.count, 1)).toFixed(3)}`,
+    );
+  }
+  lines.push("");
+
+  lines.push("Top raw SQL templates by total time");
+  for (const item of profile.rawTraceTemplates) {
+    lines.push(
+      `- template=${item.templateDigest} count=${item.count} total_ms=${item.totalMs.toFixed(3)} max_ms=${item.maxMs.toFixed(3)} avg_ms=${(item.totalMs / Math.max(item.count, 1)).toFixed(3)}`,
+    );
+    lines.push(`  preview: ${compactSqlPreview(item.sampleSql)}`);
+  }
+  lines.push("");
+
+  for (const stmt of profile.statements) {
+    lines.push("--------------------------------------------------------------------------------");
+    lines.push(`statement_index: ${stmt.statementIndex}`);
+    lines.push(`duration_ms: ${stmt.durationMs.toFixed(3)}`);
+    lines.push(`sql_chars: ${stmt.sqlChars}`);
+    lines.push("");
+    lines.push("SQL");
+    lines.push(stmt.sql);
+    lines.push("");
+  }
+
+  lines.push("================================================================================");
+  lines.push("Top Raw Backend Statements");
+  for (const item of profile.rawTraceSummaries) {
+    const digest = digestSql(item.sql);
+    lines.push(
+      `- digest=${digest} count=${item.count} total_ms=${item.totalMs.toFixed(3)} max_ms=${item.maxMs.toFixed(3)} avg_ms=${(item.totalMs / Math.max(item.count, 1)).toFixed(3)} kind=${item.kind}`,
+    );
+    lines.push(`  sql_preview: ${compactSqlPreview(item.sql)}`);
+  }
+  lines.push("");
+
+  lines.push("================================================================================");
+  lines.push("EXPLAIN QUERY PLAN (Raw Backend SQL)");
+  for (const plan of profile.rawExplainPlans) {
+    const digest = digestSql(plan.sql);
+    lines.push("--------------------------------------------------------------------------------");
+    lines.push(`digest: ${digest}`);
+    lines.push(`kind: ${plan.kind}`);
+    lines.push(`count: ${plan.count}`);
+    lines.push(`total_ms: ${plan.totalMs.toFixed(3)}`);
+    lines.push(`max_ms: ${plan.maxMs.toFixed(3)}`);
+    lines.push(`avg_ms: ${(plan.totalMs / Math.max(plan.count, 1)).toFixed(3)}`);
+    lines.push("SQL");
+    lines.push(compactSqlPreview(plan.sql, 1200));
+    lines.push("EXPLAIN");
+    if (plan.error) {
+      lines.push(`ERROR: ${plan.error}`);
+    } else if (plan.rows.length === 0) {
+      lines.push("(no rows)");
+    } else {
+      const explainCounts = summarizeExplainRows(plan.rows);
+      lines.push(
+        `summary: scan=${explainCounts.scan} search=${explainCounts.search} temp_btree=${explainCounts.tempBtree} materialize=${explainCounts.materialize} coroutine=${explainCounts.coroutine}`,
+      );
+      for (const row of plan.rows) {
+        lines.push(`- ${row.join(" | ")}`);
+      }
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function sanitizeSqlForReport(sql) {
+  const withoutBlobs = String(sql).replace(/x'([0-9a-fA-F]+)'/g, (_match, hex) => {
+    const bytes = Math.floor(hex.length / 2);
+    return `x'<blob:${bytes} bytes>'`;
+  });
+  return withoutBlobs;
+}
+
+function compactSqlPreview(sql, maxChars = 320) {
+  const normalized = sanitizeSqlForReport(sql).replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxChars)}... [${normalized.length} chars]`;
+}
+
+function digestSql(sql) {
+  return createHash("sha1")
+    .update(String(sql))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+function createTracingBackend(baseBackend) {
+  const trace = [];
+  let capture = true;
+
+  const withTrace = async (kind, sql, params, fn) => {
+    const started = performance.now();
+    try {
+      const result = await fn();
+      if (capture) {
+        trace.push({
+          kind,
+          sql: String(sql),
+          params: [...params],
+          durationMs: performance.now() - started,
+          error: null,
+        });
+      }
+      return result;
+    } catch (error) {
+      if (capture) {
+        trace.push({
+          kind,
+          sql: String(sql),
+          params: [...params],
+          durationMs: performance.now() - started,
+          error: firstErrorLine(error),
+        });
+      }
+      throw error;
+    }
+  };
+
+  const backend = {
+    dialect: baseBackend.dialect,
+    async execute(sql, params) {
+      return await withTrace("backend", sql, params, () => baseBackend.execute(sql, params));
+    },
+    async beginTransaction() {
+      const tx = await baseBackend.beginTransaction();
+      return {
+        dialect: tx.dialect,
+        async execute(sql, params) {
+          return await withTrace("tx", sql, params, () => tx.execute(sql, params));
+        },
+        async commit() {
+          return await withTrace("tx-commit", "COMMIT", [], () => tx.commit());
+        },
+        async rollback() {
+          return await withTrace("tx-rollback", "ROLLBACK", [], () => tx.rollback());
+        },
+      };
+    },
+    async exportSnapshot() {
+      return await baseBackend.exportSnapshot();
+    },
+    async close() {
+      if (typeof baseBackend.close === "function") {
+        await baseBackend.close();
+      }
+    },
+  };
+
+  return {
+    backend,
+    trace,
+    setCapture(next) {
+      capture = next;
+    },
+    async executeRaw(sql, params = []) {
+      return await baseBackend.execute(sql, params);
+    },
+  };
+}
+
+function summarizeRawTraceExact(rawTrace) {
+  const grouped = new Map();
+  for (const item of rawTrace) {
+    if (item.error) {
+      continue;
+    }
+    const normalizedSql = item.sql.trim();
+    if (!normalizedSql) {
+      continue;
+    }
+    const key = `${item.kind}::${normalizedSql}`;
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.totalMs += item.durationMs;
+      existing.maxMs = Math.max(existing.maxMs, item.durationMs);
+      continue;
+    }
+    grouped.set(key, {
+      kind: item.kind,
+      sql: normalizedSql,
+      params: item.params,
+      count: 1,
+      totalMs: item.durationMs,
+      maxMs: item.durationMs,
+    });
+  }
+
+  return [...grouped.values()]
+    .filter((item) => explainableSql(item.sql))
+    .sort((a, b) => b.totalMs - a.totalMs)
+    .slice(0, 20);
+}
+
+function summarizeRawTraceByKind(rawTrace) {
+  const grouped = new Map();
+  for (const item of rawTrace) {
+    if (item.error) {
+      continue;
+    }
+    const existing = grouped.get(item.kind);
+    if (existing) {
+      existing.count += 1;
+      existing.totalMs += item.durationMs;
+      continue;
+    }
+    grouped.set(item.kind, {
+      kind: item.kind,
+      count: 1,
+      totalMs: item.durationMs,
+    });
+  }
+  return [...grouped.values()].sort((a, b) => b.totalMs - a.totalMs);
+}
+
+function summarizeRawTraceTemplates(rawTrace) {
+  const grouped = new Map();
+  for (const item of rawTrace) {
+    if (item.error) {
+      continue;
+    }
+    const sql = item.sql.trim();
+    if (!sql || !explainableSql(sql)) {
+      continue;
+    }
+    const templateKey = `${item.kind}::${normalizeSqlTemplate(sql)}`;
+    const existing = grouped.get(templateKey);
+    if (existing) {
+      existing.count += 1;
+      existing.totalMs += item.durationMs;
+      existing.maxMs = Math.max(existing.maxMs, item.durationMs);
+      continue;
+    }
+    grouped.set(templateKey, {
+      kind: item.kind,
+      templateDigest: digestSql(templateKey),
+      sampleSql: sql,
+      count: 1,
+      totalMs: item.durationMs,
+      maxMs: item.durationMs,
+    });
+  }
+  return [...grouped.values()]
+    .sort((a, b) => b.totalMs - a.totalMs)
+    .slice(0, 20);
+}
+
+function normalizeSqlTemplate(sql) {
+  return String(sql)
+    .replace(/x'([0-9a-fA-F]+)'/g, "x'<blob>'")
+    .replace(/'([^']|'')*'/g, "'?'")
+    .replace(/\b\d+\b/g, "?")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function collectExplainPlansForRawTrace(tracedBackend, summaries) {
+  const plans = [];
+  for (const item of summaries) {
+    const explainSql = `EXPLAIN QUERY PLAN ${item.sql}`;
+    let rows = [];
+    let error = null;
+    tracedBackend.setCapture(false);
+    try {
+      const explainResult = await tracedBackend.executeRaw(explainSql, item.params);
+      rows = (explainResult?.rows ?? []).map((row) => row.map(scalarToText));
+    } catch (cause) {
+      error = firstErrorLine(cause);
+    } finally {
+      tracedBackend.setCapture(true);
+    }
+
+    plans.push({
+      kind: item.kind,
+      sql: item.sql,
+      count: item.count,
+      totalMs: item.totalMs,
+      maxMs: item.maxMs,
+      rows,
+      error,
+    });
+  }
+  return plans;
+}
+
+function summarizeExplainRows(rows) {
+  const summary = {
+    scan: 0,
+    search: 0,
+    tempBtree: 0,
+    materialize: 0,
+    coroutine: 0,
+  };
+  for (const row of rows) {
+    const detail = String(row?.[3] ?? "").toUpperCase();
+    if (detail.includes("SCAN ")) {
+      summary.scan += 1;
+    }
+    if (detail.includes("SEARCH ")) {
+      summary.search += 1;
+    }
+    if (detail.includes("USE TEMP B-TREE")) {
+      summary.tempBtree += 1;
+    }
+    if (detail.includes("MATERIALIZE ")) {
+      summary.materialize += 1;
+    }
+    if (detail.includes("CO-ROUTINE")) {
+      summary.coroutine += 1;
+    }
+  }
+  return summary;
+}
+
+function explainableSql(sql) {
+  const upper = String(sql).trim().toUpperCase();
+  return (
+    upper.startsWith("SELECT ") ||
+    upper.startsWith("INSERT ") ||
+    upper.startsWith("UPDATE ") ||
+    upper.startsWith("DELETE ")
+  );
+}
+
+function firstErrorLine(error) {
+  return String(error?.message ?? error).split("\n")[0];
+}
+
+function scalarToText(value) {
+  if (value === null || value === undefined) {
+    return "NULL";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (typeof value === "object" && value && "kind" in value) {
+    return String(value.value);
+  }
+  return JSON.stringify(value);
+}
+
+async function loadTextLinesPluginWasmBytes() {
+  const packageDebugPath = join(
+    REPO_ROOT,
+    "packages",
+    "plugin-text-lines",
+    "target",
+    "wasm32-wasip2",
+    "debug",
+    "plugin_text_lines.wasm",
+  );
+  const workspaceDebugPath = join(
+    REPO_ROOT,
+    "target",
+    "wasm32-wasip2",
+    "debug",
+    "plugin_text_lines.wasm",
+  );
+
+  try {
+    return await readFile(packageDebugPath);
+  } catch {
+    try {
+      return await readFile(workspaceDebugPath);
+    } catch {
+      await ensureTextLinesPluginWasmBuilt();
+      try {
+        return await readFile(packageDebugPath);
+      } catch {
+        return await readFile(workspaceDebugPath);
+      }
+    }
+  }
+}
+
+async function ensureTextLinesPluginWasmBuilt() {
+  const manifestPath = join(REPO_ROOT, "packages", "plugin-text-lines", "Cargo.toml");
+  try {
+    await runCommand("cargo", [
+      "build",
+      "--manifest-path",
+      manifestPath,
+      "--target",
+      "wasm32-wasip2",
+    ]);
+  } catch (error) {
+    const message = String(error?.message ?? error);
+    if (
+      message.includes("wasm32-wasip2") &&
+      (message.includes("can't find crate for `core`") ||
+        message.includes("target may not be installed"))
+    ) {
+      await runCommand("rustup", ["target", "add", "wasm32-wasip2"]);
+      await runCommand("cargo", [
+        "build",
+        "--manifest-path",
+        manifestPath,
+        "--target",
+        "wasm32-wasip2",
+      ]);
+      return;
+    }
+    throw error;
+  }
+}
+
+function parseEnvInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got '${raw}'`);
+  }
+  return parsed;
+}
+
+function parseEnvBool(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  if (["1", "true", "yes", "on"].includes(raw.toLowerCase())) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(raw.toLowerCase())) {
+    return false;
+  }
+  throw new Error(`${name} must be boolean-like (0/1/true/false), got '${raw}'`);
+}
+
+async function runCommand(command, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const stderr = [];
+
+    child.stderr.on("data", (chunk) => {
+      stderr.push(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} failed with exit code ${code}:\n${Buffer.concat(stderr).toString("utf8")}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+main().catch((error) => {
+  console.error("Slowest commit profile failed:");
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/nextjs-replay-bench/src/profile-slowest-commit.js
+++ b/packages/nextjs-replay-bench/src/profile-slowest-commit.js
@@ -126,8 +126,8 @@ async function main() {
       });
 
       if (index < targetIndex) {
-        for (const sql of statements) {
-          await lix.execute(sql, []);
+        for (const statement of statements) {
+          await lix.execute(statement.sql, statement.params ?? []);
         }
       } else {
         console.log(
@@ -185,9 +185,11 @@ async function profileCommitStatements(
   const traceStart = tracedBackend.trace.length;
 
   for (let index = 0; index < statements.length; index++) {
-    const sql = statements[index];
+    const statement = statements[index];
+    const sql = statement.sql;
+    const params = statement.params ?? [];
     const started = performance.now();
-    await lix.execute(sql, []);
+    await lix.execute(sql, params);
     const durationMs = performance.now() - started;
     commitTotalMs += durationMs;
 

--- a/packages/nextjs-replay-bench/src/replay.bench.js
+++ b/packages/nextjs-replay-bench/src/replay.bench.js
@@ -28,7 +28,7 @@ const CONFIG = {
   repoRef: process.env.BENCH_REPLAY_REF ?? "HEAD",
   cacheDir: process.env.BENCH_REPLAY_CACHE_DIR ?? DEFAULT_CACHE_DIR,
   commitLimit: parseEnvInt("BENCH_REPLAY_COMMITS", 1000),
-  warmupCommitCount: parseEnvNonNegativeInt("BENCH_REPLAY_WARMUP_COMMITS", 0),
+  warmupCommitCount: parseEnvNonNegativeInt("BENCH_REPLAY_WARMUP_COMMITS", 5),
   firstParent: parseEnvBool("BENCH_REPLAY_FIRST_PARENT", true),
   syncRemote: parseEnvBool("BENCH_REPLAY_FETCH", false),
   progressEvery: parseEnvInt("BENCH_REPLAY_PROGRESS_EVERY", 25),

--- a/packages/nextjs-replay-bench/src/replay.bench.js
+++ b/packages/nextjs-replay-bench/src/replay.bench.js
@@ -1,0 +1,433 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { spawn } from "node:child_process";
+import { openLix } from "js-sdk";
+import {
+  ensureGitRepo,
+  listLinearCommits,
+  readCommitPatchSet,
+} from "./git-history.js";
+import {
+  createReplayState,
+  prepareCommitChanges,
+  buildReplayCommitStatements,
+} from "./apply-to-lix.js";
+import { printProgress, printSummary, summarizeSamples } from "./report.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+const OUTPUT_DIR = join(__dirname, "..", "results");
+const OUTPUT_PATH = join(OUTPUT_DIR, "nextjs-replay.bench.json");
+const DEFAULT_CACHE_DIR = join(__dirname, "..", ".cache", "nextjs-replay");
+
+const CONFIG = {
+  repoUrl: process.env.BENCH_REPLAY_REPO_URL ?? "https://github.com/vercel/next.js.git",
+  repoPath: process.env.BENCH_REPLAY_REPO_PATH ?? "",
+  repoRef: process.env.BENCH_REPLAY_REF ?? "HEAD",
+  cacheDir: process.env.BENCH_REPLAY_CACHE_DIR ?? DEFAULT_CACHE_DIR,
+  commitLimit: parseEnvInt("BENCH_REPLAY_COMMITS", 1000),
+  firstParent: parseEnvBool("BENCH_REPLAY_FIRST_PARENT", true),
+  syncRemote: parseEnvBool("BENCH_REPLAY_FETCH", true),
+  progressEvery: parseEnvInt("BENCH_REPLAY_PROGRESS_EVERY", 25),
+  showProgress: parseEnvBool("BENCH_REPLAY_PROGRESS", true),
+  installTextLinesPlugin: parseEnvBool("BENCH_REPLAY_INSTALL_TEXT_LINES_PLUGIN", true),
+  maxInsertRows: parseEnvInt("BENCH_REPLAY_MAX_INSERT_ROWS", 200),
+  maxInsertSqlChars: parseEnvInt("BENCH_REPLAY_MAX_INSERT_SQL_CHARS", 1_500_000),
+};
+
+const TEXT_LINES_MANIFEST = {
+  key: "plugin_text_lines",
+  runtime: "wasm-component-v1",
+  api_version: "0.1.0",
+  detect_changes_glob: "**/*",
+  entry: "plugin.wasm",
+};
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  const replayStarted = performance.now();
+
+  const repo = await ensureGitRepo({
+    repoPath: CONFIG.repoPath || undefined,
+    repoUrl: CONFIG.repoUrl,
+    cacheDir: CONFIG.cacheDir,
+    defaultDirName: "next.js",
+    syncRemote: CONFIG.syncRemote,
+    ref: CONFIG.repoRef,
+  });
+
+  const commits = await listLinearCommits(repo.repoPath, {
+    ref: CONFIG.repoRef,
+    maxCount: CONFIG.commitLimit,
+    firstParent: CONFIG.firstParent,
+  });
+
+  if (commits.length === 0) {
+    throw new Error(`no commits found at ${repo.repoPath} (${CONFIG.repoRef})`);
+  }
+
+  if (CONFIG.showProgress) {
+    console.log(
+      `[progress] replaying ${commits.length} commits from ${repo.repoPath} (${repo.source})`,
+    );
+  }
+
+  const lix = await openLix();
+
+  try {
+    if (CONFIG.installTextLinesPlugin) {
+      const pluginWasmBytes = await loadTextLinesPluginWasmBytes(CONFIG.showProgress);
+      await lix.installPlugin({
+        manifestJson: TEXT_LINES_MANIFEST,
+        wasmBytes: pluginWasmBytes,
+      });
+    }
+
+    const state = createReplayState();
+    const commitDurations = [];
+    const slowCommits = [];
+
+    let commitsApplied = 0;
+    let commitsNoop = 0;
+    let totalChangedPaths = 0;
+    let totalBlobBytes = 0;
+    let totalSqlChars = 0;
+    let totalEngineStatements = 0;
+    let totalInserts = 0;
+    let totalUpdates = 0;
+    let totalDeletes = 0;
+
+    for (let index = 0; index < commits.length; index++) {
+      const commitSha = commits[index];
+      const patchSet = await readCommitPatchSet(repo.repoPath, commitSha);
+      const prepared = prepareCommitChanges(state, patchSet.changes, patchSet.blobByOid);
+
+      totalChangedPaths += patchSet.changes.length;
+      totalBlobBytes += prepared.blobBytes;
+      totalInserts += prepared.inserts.length;
+      totalUpdates += prepared.updates.length;
+      totalDeletes += prepared.deletes.length;
+
+      const statements = buildReplayCommitStatements(prepared, {
+        maxInsertRows: CONFIG.maxInsertRows,
+        maxInsertSqlChars: CONFIG.maxInsertSqlChars,
+      });
+
+      if (statements.length === 0) {
+        commitsNoop += 1;
+      } else {
+        const commitStarted = performance.now();
+        try {
+          await executeStatements(lix, statements);
+        } catch (error) {
+          throw new Error(
+            `failed while replaying commit ${commitSha}: ${String(error?.message ?? error)}`,
+          );
+        }
+        const commitMs = performance.now() - commitStarted;
+
+        commitsApplied += 1;
+        commitDurations.push(commitMs);
+        totalSqlChars += statementChars(statements);
+        totalEngineStatements += statements.length;
+        pushSlowCommit(slowCommits, {
+          commitSha,
+          durationMs: commitMs,
+          changedPaths: patchSet.changes.length,
+          inserts: prepared.inserts.length,
+          updates: prepared.updates.length,
+          deletes: prepared.deletes.length,
+        });
+      }
+
+      if (
+        CONFIG.showProgress &&
+        (index === 0 || (index + 1) % CONFIG.progressEvery === 0 || index + 1 === commits.length)
+      ) {
+        printProgress({
+          index: index + 1,
+          total: commits.length,
+          commitSha,
+          elapsedMs: performance.now() - replayStarted,
+          changedPaths: totalChangedPaths,
+          commitsApplied,
+          commitsNoop,
+        });
+      }
+    }
+
+    const replayMs = performance.now() - replayStarted;
+    const storage = await collectStorageCounters(lix);
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      startedAt,
+      config: {
+        ...CONFIG,
+      },
+      repo: {
+        path: repo.repoPath,
+        source: repo.source,
+        ref: CONFIG.repoRef,
+      },
+      commitTotals: {
+        discovered: commits.length,
+        applied: commitsApplied,
+        noop: commitsNoop,
+      },
+      io: {
+        changedPaths: totalChangedPaths,
+        blobBytes: totalBlobBytes,
+        sqlChars: totalSqlChars,
+        engineStatements: totalEngineStatements,
+        inserts: totalInserts,
+        updates: totalUpdates,
+        deletes: totalDeletes,
+      },
+      timings: {
+        replayMs,
+        commit: summarizeSamples(commitDurations),
+      },
+      throughput: {
+        commitsPerSecond: commitsApplied / Math.max(replayMs / 1000, 0.001),
+        changedPathsPerSecond: totalChangedPaths / Math.max(replayMs / 1000, 0.001),
+        blobMegabytesPerSecond: totalBlobBytes / 1024 / 1024 / Math.max(replayMs / 1000, 0.001),
+      },
+      storage,
+      slowestCommits: slowCommits,
+    };
+
+    await mkdir(OUTPUT_DIR, { recursive: true });
+    await writeFile(OUTPUT_PATH, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+    printSummary(report);
+    console.log(`\nWrote benchmark report: ${OUTPUT_PATH}`);
+  } finally {
+    await lix.close();
+  }
+}
+
+function pushSlowCommit(store, candidate) {
+  store.push(candidate);
+  store.sort((left, right) => right.durationMs - left.durationMs);
+  if (store.length > 20) {
+    store.length = 20;
+  }
+}
+
+async function collectStorageCounters(lix) {
+  const fileRows = await queryScalarNumber(lix, "SELECT COUNT(*) FROM lix_file", "lix_file count");
+  const internalChangeRows = await queryScalarNumber(
+    lix,
+    "SELECT COUNT(*) FROM lix_internal_change",
+    "lix_internal_change count",
+  );
+  const internalSnapshotRows = await queryScalarNumber(
+    lix,
+    "SELECT COUNT(*) FROM lix_internal_snapshot",
+    "lix_internal_snapshot count",
+  );
+
+  const schemaCountResult = await lix.execute(
+    "SELECT schema_key, COUNT(*) AS row_count FROM lix_internal_change GROUP BY schema_key ORDER BY row_count DESC LIMIT 20",
+    [],
+  );
+
+  const topSchemaCounts = (schemaCountResult.rows ?? []).map((row) => ({
+    schemaKey: scalarToString(row?.[0], "schema_key"),
+    rowCount: scalarToNumber(row?.[1], "row_count"),
+  }));
+
+  return {
+    fileRows,
+    internalChangeRows,
+    internalSnapshotRows,
+    topSchemaCounts,
+  };
+}
+
+async function executeStatements(lix, statements) {
+  for (const sql of statements) {
+    await lix.execute(sql, []);
+  }
+}
+
+function statementChars(statements) {
+  return statements.reduce((total, sql) => total + sql.length, 0);
+}
+
+async function loadTextLinesPluginWasmBytes(showProgress) {
+  const packageDebugPath = join(
+    REPO_ROOT,
+    "packages",
+    "plugin-text-lines",
+    "target",
+    "wasm32-wasip2",
+    "debug",
+    "plugin_text_lines.wasm",
+  );
+  const workspaceDebugPath = join(
+    REPO_ROOT,
+    "target",
+    "wasm32-wasip2",
+    "debug",
+    "plugin_text_lines.wasm",
+  );
+
+  try {
+    return await readFile(packageDebugPath);
+  } catch {
+    try {
+      return await readFile(workspaceDebugPath);
+    } catch {
+      await ensureTextLinesPluginWasmBuilt(showProgress);
+      try {
+        return await readFile(packageDebugPath);
+      } catch {
+        return await readFile(workspaceDebugPath);
+      }
+    }
+  }
+}
+
+async function ensureTextLinesPluginWasmBuilt(showProgress) {
+  const manifestPath = join(REPO_ROOT, "packages", "plugin-text-lines", "Cargo.toml");
+
+  if (showProgress) {
+    console.log("[progress] building plugin-text-lines wasm (wasm32-wasip2)");
+  }
+
+  try {
+    await runCommand("cargo", [
+      "build",
+      "--manifest-path",
+      manifestPath,
+      "--target",
+      "wasm32-wasip2",
+    ]);
+  } catch (error) {
+    const message = String(error?.message ?? error);
+    if (
+      message.includes("wasm32-wasip2") &&
+      (message.includes("can't find crate for `core`") ||
+        message.includes("target may not be installed"))
+    ) {
+      await runCommand("rustup", ["target", "add", "wasm32-wasip2"]);
+      await runCommand("cargo", [
+        "build",
+        "--manifest-path",
+        manifestPath,
+        "--target",
+        "wasm32-wasip2",
+      ]);
+      return;
+    }
+    throw error;
+  }
+
+  if (showProgress) {
+    console.log("[progress] plugin-text-lines wasm build done");
+  }
+}
+
+async function queryScalarNumber(lix, sql, context) {
+  const result = await lix.execute(sql, []);
+  return scalarToNumber(result.rows?.[0]?.[0], context);
+}
+
+function scalarToNumber(value, context) {
+  if (value === null || value === undefined) {
+    throw new Error(`missing scalar for ${context}`);
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    return Number(value);
+  }
+  if (typeof value === "object") {
+    if (value.kind === "Integer" || value.kind === "Real" || value.kind === "Text") {
+      return Number(value.value);
+    }
+  }
+  throw new Error(`unsupported scalar value for ${context}: ${JSON.stringify(value)}`);
+}
+
+function scalarToString(value, context) {
+  if (value === null || value === undefined) {
+    throw new Error(`missing scalar for ${context}`);
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (typeof value === "object") {
+    if (value.kind === "Text" || value.kind === "Integer" || value.kind === "Real") {
+      return String(value.value);
+    }
+  }
+  throw new Error(`unsupported text scalar for ${context}: ${JSON.stringify(value)}`);
+}
+
+function parseEnvInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got '${raw}'`);
+  }
+  return parsed;
+}
+
+function parseEnvBool(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  if (["1", "true", "yes", "on"].includes(raw.toLowerCase())) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(raw.toLowerCase())) {
+    return false;
+  }
+  throw new Error(`${name} must be boolean-like (0/1/true/false), got '${raw}'`);
+}
+
+async function runCommand(command, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const stderr = [];
+
+    child.stderr.on("data", (chunk) => {
+      stderr.push(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} failed with exit code ${code}:\n${Buffer.concat(stderr).toString("utf8")}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+main().catch((error) => {
+  console.error("Benchmark run failed:");
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/nextjs-replay-bench/src/report.js
+++ b/packages/nextjs-replay-bench/src/report.js
@@ -1,0 +1,111 @@
+export function summarizeSamples(samples) {
+  if (samples.length === 0) {
+    return {
+      count: 0,
+      meanMs: 0,
+      minMs: 0,
+      maxMs: 0,
+      p50Ms: 0,
+      p95Ms: 0,
+    };
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const meanMs = samples.reduce((sum, value) => sum + value, 0) / samples.length;
+
+  return {
+    count: samples.length,
+    meanMs,
+    minMs: sorted[0],
+    maxMs: sorted[sorted.length - 1],
+    p50Ms: percentile(sorted, 0.5),
+    p95Ms: percentile(sorted, 0.95),
+  };
+}
+
+export function printProgress(state) {
+  const {
+    index,
+    total,
+    commitSha,
+    elapsedMs,
+    changedPaths,
+    commitsApplied,
+    commitsNoop,
+  } = state;
+  const pct = ((index / total) * 100).toFixed(1);
+  const elapsedSec = (elapsedMs / 1000).toFixed(1);
+
+  console.log(
+    color(
+      `[progress] ${index}/${total} (${pct}%) commit=${commitSha.slice(0, 12)} changed_paths=${changedPaths} applied=${commitsApplied} noop=${commitsNoop} elapsed=${elapsedSec}s`,
+      "dim",
+    ),
+  );
+}
+
+export function printSummary(report) {
+  console.log("");
+  console.log(color("Next.js Replay Benchmark", "bold"));
+  console.log(color(`Commits requested: ${report.config.commitLimit}`, "dim"));
+  console.log(color(`Commits discovered: ${report.commitTotals.discovered}`, "dim"));
+  console.log(color(`Commits applied: ${report.commitTotals.applied}`, "dim"));
+  console.log(color(`Commits skipped (no file changes): ${report.commitTotals.noop}`, "dim"));
+  console.log(color(`Replay duration: ${formatMs(report.timings.replayMs)}`, "dim"));
+
+  console.log("");
+  console.log(`Commit throughput: ${report.throughput.commitsPerSecond.toFixed(2)} commits/s`);
+  console.log(`Changed paths/sec: ${report.throughput.changedPathsPerSecond.toFixed(2)}`);
+  console.log(`Blob ingest MB/s: ${report.throughput.blobMegabytesPerSecond.toFixed(2)}`);
+
+  console.log("");
+  console.log("Commit execution latency");
+  console.log(`  mean: ${formatMs(report.timings.commit.meanMs)}`);
+  console.log(`  p50:  ${formatMs(report.timings.commit.p50Ms)}`);
+  console.log(`  p95:  ${formatMs(report.timings.commit.p95Ms)}`);
+  console.log(`  max:  ${formatMs(report.timings.commit.maxMs)}`);
+
+  console.log("");
+  console.log("Storage counters");
+  console.log(`  lix_file rows: ${report.storage.fileRows}`);
+  console.log(`  internal changes: ${report.storage.internalChangeRows}`);
+  console.log(`  internal snapshots: ${report.storage.internalSnapshotRows}`);
+
+  if (report.storage.topSchemaCounts.length > 0) {
+    console.log("");
+    console.log("Top schema change counts");
+    for (const row of report.storage.topSchemaCounts) {
+      console.log(`  ${String(row.schemaKey).padEnd(28, " ")} ${row.rowCount}`);
+    }
+  }
+}
+
+function percentile(sorted, ratio) {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor(sorted.length * ratio)));
+  return sorted[idx];
+}
+
+function formatMs(value) {
+  return `${value.toFixed(2)}ms`;
+}
+
+const ANSI = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+};
+
+function color(text, style) {
+  const supportsColor = !process.env.NO_COLOR && Boolean(process.stdout?.isTTY);
+  if (!supportsColor) {
+    return text;
+  }
+  const code = ANSI[style];
+  if (!code) {
+    return text;
+  }
+  return `${code}${text}${ANSI.reset}`;
+}

--- a/packages/nextjs-replay-bench/src/state-parity.js
+++ b/packages/nextjs-replay-bench/src/state-parity.js
@@ -1,0 +1,601 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { spawn } from "node:child_process";
+import { openLix, Value } from "js-sdk";
+import {
+  ensureGitRepo,
+  listLinearCommits,
+  readCommitPatchSet,
+} from "./git-history.js";
+import {
+  createReplayState,
+  prepareCommitChanges,
+  buildReplayCommitStatements,
+} from "./apply-to-lix.js";
+import { printProgress } from "./report.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+const OUTPUT_DIR = join(__dirname, "..", "results");
+const DEFAULT_OUTPUT_PATH = join(OUTPUT_DIR, "nextjs-replay.parity.json");
+const DEFAULT_CACHE_DIR = join(__dirname, "..", ".cache", "nextjs-replay");
+
+const CONFIG = {
+  repoUrl: process.env.BENCH_REPLAY_REPO_URL ?? "https://github.com/vercel/next.js.git",
+  repoPath: process.env.BENCH_REPLAY_REPO_PATH ?? "",
+  repoRef: process.env.BENCH_REPLAY_REF ?? "HEAD",
+  cacheDir: process.env.BENCH_REPLAY_CACHE_DIR ?? DEFAULT_CACHE_DIR,
+  commitLimit: parseEnvInt("BENCH_REPLAY_COMMITS", 100),
+  firstParent: parseEnvBool("BENCH_REPLAY_FIRST_PARENT", true),
+  syncRemote: parseEnvBool("BENCH_REPLAY_FETCH", false),
+  progressEvery: parseEnvInt("BENCH_REPLAY_PROGRESS_EVERY", 25),
+  showProgress: parseEnvBool("BENCH_REPLAY_PROGRESS", true),
+  installTextLinesPlugin: parseEnvBool("BENCH_REPLAY_INSTALL_TEXT_LINES_PLUGIN", true),
+  maxInsertRows: parseEnvInt("BENCH_REPLAY_MAX_INSERT_ROWS", 200),
+  maxInsertSqlChars: parseEnvInt("BENCH_REPLAY_MAX_INSERT_SQL_CHARS", 1_500_000),
+  parityEveryCommits: parseEnvInt("BENCH_PARITY_EVERY", 1),
+  maxMismatchSamples: parseEnvInt("BENCH_PARITY_MAX_MISMATCH_SAMPLES", 20),
+  failFastOnMismatch: parseEnvBool("BENCH_PARITY_FAIL_FAST", true),
+  outputPath: process.env.BENCH_PARITY_REPORT_PATH ?? DEFAULT_OUTPUT_PATH,
+};
+
+const TEXT_LINES_MANIFEST = {
+  key: "plugin_text_lines",
+  runtime: "wasm-component-v1",
+  api_version: "0.1.0",
+  detect_changes_glob: "**/*",
+  entry: "plugin.wasm",
+};
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  const runStarted = performance.now();
+
+  const repoSetupStarted = performance.now();
+  const repo = await ensureGitRepo({
+    repoPath: CONFIG.repoPath || undefined,
+    repoUrl: CONFIG.repoUrl,
+    cacheDir: CONFIG.cacheDir,
+    defaultDirName: "next.js",
+    syncRemote: CONFIG.syncRemote,
+    ref: CONFIG.repoRef,
+  });
+  const repoSetupMs = performance.now() - repoSetupStarted;
+
+  const commitDiscoveryStarted = performance.now();
+  const commits = await listLinearCommits(repo.repoPath, {
+    ref: CONFIG.repoRef,
+    maxCount: CONFIG.commitLimit,
+    firstParent: CONFIG.firstParent,
+  });
+  const commitDiscoveryMs = performance.now() - commitDiscoveryStarted;
+
+  if (commits.length === 0) {
+    throw new Error(`no commits found at ${repo.repoPath} (${CONFIG.repoRef})`);
+  }
+
+  const objectFormat = await readGitObjectFormat(repo.repoPath);
+
+  if (CONFIG.showProgress) {
+    console.log(
+      `[progress] replaying ${commits.length} commits with parity checks (every=${CONFIG.parityEveryCommits}) from ${repo.repoPath} (${repo.source})`,
+    );
+  }
+
+  const lixOpenStarted = performance.now();
+  const lix = await openLix({
+    keyValues: [{
+      key: "lix_deterministic_mode",
+      value: { enabled: true },
+      lixcol_version_id: "global",
+    }],
+  });
+  const lixOpenMs = performance.now() - lixOpenStarted;
+
+  try {
+    let pluginInstallMs = 0;
+    if (CONFIG.installTextLinesPlugin) {
+      const pluginWasmBytes = await loadTextLinesPluginWasmBytes();
+      const installStarted = performance.now();
+      await lix.installPlugin({
+        manifestJson: TEXT_LINES_MANIFEST,
+        wasmBytes: pluginWasmBytes,
+      });
+      pluginInstallMs = performance.now() - installStarted;
+    }
+
+    const state = createReplayState();
+
+    let commitsApplied = 0;
+    let commitsNoop = 0;
+    let totalChangedPaths = 0;
+    let parityChecks = 0;
+    let parityFailures = 0;
+    let firstFailure = null;
+
+    const parityResults = [];
+    const applyDurations = [];
+    const parityDurations = [];
+
+    for (let index = 0; index < commits.length; index++) {
+      const commitSha = commits[index];
+      const patchSet = await readCommitPatchSet(repo.repoPath, commitSha);
+      totalChangedPaths += patchSet.changes.length;
+
+      const prepared = prepareCommitChanges(state, patchSet.changes, patchSet.blobByOid);
+      const statements = buildReplayCommitStatements(prepared, {
+        maxInsertRows: CONFIG.maxInsertRows,
+        maxInsertSqlChars: CONFIG.maxInsertSqlChars,
+      });
+
+      const applyStarted = performance.now();
+      if (statements.length === 0) {
+        commitsNoop += 1;
+      } else {
+        await executeStatements(lix, statements);
+        commitsApplied += 1;
+      }
+      applyDurations.push(performance.now() - applyStarted);
+
+      const shouldVerify =
+        CONFIG.parityEveryCommits <= 1 ||
+        index === commits.length - 1 ||
+        (index + 1) % CONFIG.parityEveryCommits === 0;
+
+      if (shouldVerify) {
+        const parityStarted = performance.now();
+        const parity = await checkCommitParity({
+          repoPath: repo.repoPath,
+          commitSha,
+          lix,
+          objectFormat,
+          maxMismatchSamples: CONFIG.maxMismatchSamples,
+        });
+        parity.totalMs = performance.now() - parityStarted;
+
+        parityChecks += 1;
+        parityDurations.push(parity.totalMs);
+        parityResults.push(parity);
+
+        if (!parity.ok) {
+          parityFailures += 1;
+          if (!firstFailure) {
+            firstFailure = parity;
+          }
+          if (CONFIG.failFastOnMismatch) {
+            break;
+          }
+        }
+      }
+
+      if (
+        CONFIG.showProgress &&
+        (index === 0 || (index + 1) % CONFIG.progressEvery === 0 || index + 1 === commits.length)
+      ) {
+        printProgress({
+          label: "measure",
+          index: index + 1,
+          total: commits.length,
+          commitSha,
+          elapsedMs: performance.now() - runStarted,
+          changedPaths: totalChangedPaths,
+          commitsApplied,
+          commitsNoop,
+        });
+      }
+    }
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      startedAt,
+      kind: "state-parity",
+      config: { ...CONFIG },
+      repo: {
+        path: repo.repoPath,
+        source: repo.source,
+        ref: CONFIG.repoRef,
+      },
+      commitTotals: {
+        requested: CONFIG.commitLimit,
+        discovered: commits.length,
+        applied: commitsApplied,
+        noop: commitsNoop,
+        changedPaths: totalChangedPaths,
+      },
+      parity: {
+        objectFormat,
+        checks: parityChecks,
+        failures: parityFailures,
+        pass: parityFailures === 0,
+        firstFailure,
+      },
+      timings: {
+        totalMs: performance.now() - runStarted,
+        setup: {
+          repoSetupMs,
+          commitDiscoveryMs,
+          lixOpenMs,
+          pluginInstallMs,
+        },
+        apply: summarizeSamples(applyDurations),
+        parity: summarizeSamples(parityDurations),
+      },
+      checks: parityResults,
+    };
+
+    await mkdir(dirname(CONFIG.outputPath), { recursive: true });
+    await writeFile(CONFIG.outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+    printParitySummary(report);
+    console.log(`\nWrote parity report: ${CONFIG.outputPath}`);
+
+    if (parityFailures > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await lix.close();
+  }
+}
+
+async function executeStatements(lix, statements) {
+  for (const statement of statements) {
+    await lix.execute(statement.sql, statement.params ?? []);
+  }
+}
+
+async function checkCommitParity(args) {
+  const { repoPath, commitSha, lix, objectFormat, maxMismatchSamples } = args;
+
+  const gitTreeStarted = performance.now();
+  const gitPathToOid = await readGitTreePathToBlobOid(repoPath, commitSha);
+  const gitTreeMs = performance.now() - gitTreeStarted;
+
+  const lixReadStarted = performance.now();
+  const lixPathToOid = await readLixPathToBlobOid(lix, objectFormat);
+  const lixReadMs = performance.now() - lixReadStarted;
+
+  const compareStarted = performance.now();
+  const missingInLix = [];
+  const extraInLix = [];
+  const contentMismatches = [];
+
+  for (const [path, gitOid] of gitPathToOid) {
+    const lixOid = lixPathToOid.get(path);
+    if (!lixOid) {
+      if (missingInLix.length < maxMismatchSamples) {
+        missingInLix.push({ path, gitOid });
+      }
+      continue;
+    }
+    if (lixOid !== gitOid) {
+      if (contentMismatches.length < maxMismatchSamples) {
+        contentMismatches.push({ path, gitOid, lixOid });
+      }
+    }
+  }
+
+  for (const [path, lixOid] of lixPathToOid) {
+    if (!gitPathToOid.has(path) && extraInLix.length < maxMismatchSamples) {
+      extraInLix.push({ path, lixOid });
+    }
+  }
+
+  const compareMs = performance.now() - compareStarted;
+
+  const missingCount = gitPathToOid.size - intersectSize(gitPathToOid, lixPathToOid);
+  const extraCount = lixPathToOid.size - intersectSize(lixPathToOid, gitPathToOid);
+  const mismatchCount = countMismatches(gitPathToOid, lixPathToOid);
+
+  return {
+    commitSha,
+    ok: missingCount === 0 && extraCount === 0 && mismatchCount === 0,
+    gitFileCount: gitPathToOid.size,
+    lixFileCount: lixPathToOid.size,
+    missingInLixCount: missingCount,
+    extraInLixCount: extraCount,
+    contentMismatchCount: mismatchCount,
+    missingInLix,
+    extraInLix,
+    contentMismatches,
+    timings: {
+      gitTreeMs,
+      lixReadMs,
+      compareMs,
+    },
+  };
+}
+
+async function readGitTreePathToBlobOid(repoPath, commitSha) {
+  const raw = await runGit(repoPath, ["ls-tree", "-r", "-z", "--full-tree", commitSha]);
+  const tokens = raw.toString("utf8").split("\0");
+  if (tokens[tokens.length - 1] === "") {
+    tokens.pop();
+  }
+
+  const pathToOid = new Map();
+  for (const token of tokens) {
+    if (!token) {
+      continue;
+    }
+
+    const tabIndex = token.indexOf("\t");
+    if (tabIndex < 0) {
+      continue;
+    }
+
+    const meta = token.slice(0, tabIndex);
+    const path = token.slice(tabIndex + 1);
+    const fields = meta.split(" ");
+    if (fields.length < 3) {
+      continue;
+    }
+
+    const type = fields[1];
+    const oid = fields[2];
+    if (type !== "blob") {
+      continue;
+    }
+    pathToOid.set(path, oid);
+  }
+
+  return pathToOid;
+}
+
+async function readLixPathToBlobOid(lix, objectFormat) {
+  const result = await lix.execute("SELECT path, data FROM lix_file ORDER BY path", []);
+  const rows = Array.isArray(result?.rows) ? result.rows : [];
+
+  const pathToOid = new Map();
+  for (const row of rows) {
+    if (!Array.isArray(row) || row.length < 2) {
+      continue;
+    }
+
+    const encodedPath = readTextCell(row[0], "lix_file.path");
+    const path = decodeLixPath(encodedPath);
+    const bytes = readBlobCell(row[1], "lix_file.data");
+    const oid = gitBlobOid(bytes, objectFormat);
+    pathToOid.set(path, oid);
+  }
+
+  return pathToOid;
+}
+
+function decodeLixPath(encodedPath) {
+  const normalized = String(encodedPath);
+  const withoutLeadingSlash = normalized.startsWith("/")
+    ? normalized.slice(1)
+    : normalized;
+
+  if (withoutLeadingSlash.length === 0) {
+    return "";
+  }
+
+  return withoutLeadingSlash
+    .split("/")
+    .map((segment) => decodeURIComponent(segment))
+    .join("/");
+}
+
+function readTextCell(cell, label) {
+  const text = Value.from(cell).asText();
+  if (text === undefined) {
+    throw new Error(`${label} is not a text value`);
+  }
+  return text;
+}
+
+function readBlobCell(cell, label) {
+  const parsed = Value.from(cell);
+  const blob = parsed.asBlob();
+  if (blob instanceof Uint8Array) {
+    return blob;
+  }
+  const text = parsed.asText();
+  if (text !== undefined) {
+    return new TextEncoder().encode(text);
+  }
+  throw new Error(`${label} is not a blob value`);
+}
+
+function gitBlobOid(bytes, objectFormat) {
+  const header = Buffer.from(`blob ${bytes.byteLength}\0`, "utf8");
+  const digest = createHash(objectFormat).update(header).update(bytes).digest("hex");
+  return digest;
+}
+
+function intersectSize(left, right) {
+  let matches = 0;
+  for (const key of left.keys()) {
+    if (right.has(key)) {
+      matches += 1;
+    }
+  }
+  return matches;
+}
+
+function countMismatches(gitPathToOid, lixPathToOid) {
+  let mismatches = 0;
+  for (const [path, gitOid] of gitPathToOid) {
+    const lixOid = lixPathToOid.get(path);
+    if (lixOid !== undefined && lixOid !== gitOid) {
+      mismatches += 1;
+    }
+  }
+  return mismatches;
+}
+
+async function readGitObjectFormat(repoPath) {
+  const raw = await runGit(repoPath, ["rev-parse", "--show-object-format"]);
+  const format = raw.toString("utf8").trim().toLowerCase();
+  if (format !== "sha1" && format !== "sha256") {
+    throw new Error(`unsupported git object format: ${format}`);
+  }
+  return format;
+}
+
+function summarizeSamples(samples) {
+  if (samples.length === 0) {
+    return {
+      count: 0,
+      meanMs: 0,
+      p50Ms: 0,
+      p95Ms: 0,
+      maxMs: 0,
+    };
+  }
+
+  const sorted = [...samples].sort((left, right) => left - right);
+  const meanMs = samples.reduce((sum, value) => sum + value, 0) / samples.length;
+
+  return {
+    count: sorted.length,
+    meanMs,
+    p50Ms: percentile(sorted, 0.5),
+    p95Ms: percentile(sorted, 0.95),
+    maxMs: sorted[sorted.length - 1],
+  };
+}
+
+function percentile(sorted, ratio) {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const index = Math.min(sorted.length - 1, Math.floor(sorted.length * ratio));
+  return sorted[index];
+}
+
+function printParitySummary(report) {
+  console.log("");
+  console.log("Next.js Replay State Parity");
+  console.log(`Commits requested: ${report.config.commitLimit}`);
+  console.log(`Commits discovered: ${report.commitTotals.discovered}`);
+  console.log(`Commits applied: ${report.commitTotals.applied}`);
+  console.log(`Commits skipped (no file changes): ${report.commitTotals.noop}`);
+  console.log(`Parity checks: ${report.parity.checks}`);
+  console.log(`Parity failures: ${report.parity.failures}`);
+  console.log(`Object format: ${report.parity.objectFormat}`);
+
+  console.log("");
+  console.log("Timing");
+  console.log(`  total: ${formatMs(report.timings.totalMs)}`);
+  console.log(`  apply mean: ${formatMs(report.timings.apply.meanMs)}`);
+  console.log(`  parity mean: ${formatMs(report.timings.parity.meanMs)}`);
+
+  if (report.parity.firstFailure) {
+    const first = report.parity.firstFailure;
+    console.log("");
+    console.log(`First mismatch commit: ${String(first.commitSha).slice(0, 12)}`);
+    console.log(`  missing in lix: ${first.missingInLixCount}`);
+    console.log(`  extra in lix: ${first.extraInLixCount}`);
+    console.log(`  content mismatches: ${first.contentMismatchCount}`);
+  }
+}
+
+function formatMs(value) {
+  return `${Number(value).toFixed(2)}ms`;
+}
+
+function parseEnvInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function parseEnvBool(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "no") {
+    return false;
+  }
+  return fallback;
+}
+
+async function loadTextLinesPluginWasmBytes() {
+  const packageReleasePath = join(
+    REPO_ROOT,
+    "packages",
+    "plugin-text-lines",
+    "target",
+    "wasm32-wasip2",
+    "release",
+    "plugin_text_lines.wasm",
+  );
+  const workspaceReleasePath = join(
+    REPO_ROOT,
+    "target",
+    "wasm32-wasip2",
+    "release",
+    "plugin_text_lines.wasm",
+  );
+
+  try {
+    return new Uint8Array(await readFile(packageReleasePath));
+  } catch {
+    return new Uint8Array(await readFile(workspaceReleasePath));
+  }
+}
+
+async function runGit(repoPath, args, options = {}) {
+  return await runCommand("git", ["-C", repoPath, ...args], options);
+}
+
+async function runCommand(command, args, options = {}) {
+  const { stdin } = options;
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    child.stdout.on("data", (chunk) => {
+      stdoutChunks.push(chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderrChunks.push(chunk);
+    });
+
+    child.on("error", reject);
+
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdoutChunks));
+        return;
+      }
+
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${code}:\n${stderr}`,
+        ),
+      );
+    });
+
+    if (stdin) {
+      child.stdin.write(stdin);
+    }
+    child.stdin.end();
+  });
+}
+
+main().catch((error) => {
+  console.error("State parity run failed:");
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/plugin-text-lines/Cargo.toml
+++ b/packages/plugin-text-lines/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "plugin_text_lines"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha1 = "0.10"
+wit-bindgen = "0.40"

--- a/packages/plugin-text-lines/README.md
+++ b/packages/plugin-text-lines/README.md
@@ -1,0 +1,12 @@
+# plugin-text-lines
+
+Rust/WASM component plugin that models files as line entities for the Lix engine.
+
+- Uses `packages/engine/wit/lix-plugin.wit`.
+- `detect-changes` emits:
+  - `text_line` rows for inserted/deleted lines (order-preserving line matching, Git-style)
+  - one `text_document` row with ordered `line_ids`
+- `apply-changes` rebuilds exact bytes from the latest projection.
+
+This plugin is byte-safe (works with non-UTF-8 files) by storing line content as hex in
+snapshot payloads.

--- a/packages/plugin-text-lines/src/lib.rs
+++ b/packages/plugin-text-lines/src/lib.rs
@@ -1,0 +1,553 @@
+use crate::exports::lix::plugin::api::{EntityChange, File, Guest, PluginError};
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+wit_bindgen::generate!({
+    path: "../engine/wit",
+    world: "plugin",
+});
+
+pub const LINE_SCHEMA_KEY: &str = "text_line";
+pub const DOCUMENT_SCHEMA_KEY: &str = "text_document";
+pub const SCHEMA_VERSION: &str = "1";
+pub const DOCUMENT_ENTITY_ID: &str = "__document__";
+
+pub use crate::exports::lix::plugin::api::{
+    EntityChange as PluginEntityChange, File as PluginFile, PluginError as PluginApiError,
+};
+
+struct TextLinesPlugin;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum LineEnding {
+    None,
+    Lf,
+    Crlf,
+}
+
+impl LineEnding {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "",
+            Self::Lf => "\n",
+            Self::Crlf => "\r\n",
+        }
+    }
+
+    fn from_str(value: &str) -> Result<Self, PluginError> {
+        match value {
+            "" => Ok(Self::None),
+            "\n" => Ok(Self::Lf),
+            "\r\n" => Ok(Self::Crlf),
+            _ => Err(PluginError::InvalidInput(format!(
+                "unsupported line ending '{value}', expected one of '', '\\n', '\\r\\n'"
+            ))),
+        }
+    }
+
+    fn marker_byte(self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::Lf => 1,
+            Self::Crlf => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedLine {
+    entity_id: String,
+    content: Vec<u8>,
+    ending: LineEnding,
+}
+
+#[derive(Debug, Serialize)]
+struct DocumentSnapshot<'a> {
+    line_ids: &'a [String],
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DocumentSnapshotOwned {
+    line_ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LineSnapshot<'a> {
+    content_hex: &'a str,
+    ending: &'a str,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LineSnapshotOwned {
+    content_hex: String,
+    ending: String,
+}
+
+impl Guest for TextLinesPlugin {
+    fn detect_changes(before: Option<File>, after: File) -> Result<Vec<EntityChange>, PluginError> {
+        if let Some(previous) = before.as_ref() {
+            if previous.data == after.data {
+                return Ok(Vec::new());
+            }
+        }
+
+        let before_lines = before
+            .as_ref()
+            .map(|file| parse_lines_with_ids(&file.data))
+            .unwrap_or_default();
+        let after_lines = if before.is_some() {
+            parse_after_lines_with_git_matching(&before_lines, &after.data)
+        } else {
+            parse_lines_with_ids(&after.data)
+        };
+
+        let before_ids = before_lines
+            .iter()
+            .map(|line| line.entity_id.clone())
+            .collect::<Vec<_>>();
+        let after_ids = after_lines
+            .iter()
+            .map(|line| line.entity_id.clone())
+            .collect::<Vec<_>>();
+
+        let before_id_set = before_ids.iter().cloned().collect::<BTreeSet<_>>();
+        let after_id_set = after_ids.iter().cloned().collect::<BTreeSet<_>>();
+        let mut changes = Vec::new();
+
+        if before.is_some() {
+            for removed in before_lines
+                .iter()
+                .filter(|line| !after_id_set.contains(&line.entity_id))
+                .map(|line| line.entity_id.clone())
+                .collect::<BTreeSet<_>>()
+            {
+                changes.push(EntityChange {
+                    entity_id: removed,
+                    schema_key: LINE_SCHEMA_KEY.to_string(),
+                    schema_version: SCHEMA_VERSION.to_string(),
+                    snapshot_content: None,
+                });
+            }
+        }
+
+        for line in &after_lines {
+            if before_id_set.contains(&line.entity_id) {
+                continue;
+            }
+            changes.push(EntityChange {
+                entity_id: line.entity_id.clone(),
+                schema_key: LINE_SCHEMA_KEY.to_string(),
+                schema_version: SCHEMA_VERSION.to_string(),
+                snapshot_content: Some(serialize_line_snapshot(line)?),
+            });
+        }
+
+        if before.is_none() || before_ids != after_ids {
+            let snapshot = serde_json::to_string(&DocumentSnapshot {
+                line_ids: &after_ids,
+            })
+            .map_err(|error| {
+                PluginError::Internal(format!("failed to encode document snapshot: {error}"))
+            })?;
+            changes.push(EntityChange {
+                entity_id: DOCUMENT_ENTITY_ID.to_string(),
+                schema_key: DOCUMENT_SCHEMA_KEY.to_string(),
+                schema_version: SCHEMA_VERSION.to_string(),
+                snapshot_content: Some(snapshot),
+            });
+        }
+
+        Ok(changes)
+    }
+
+    fn apply_changes(_file: File, changes: Vec<EntityChange>) -> Result<Vec<u8>, PluginError> {
+        let mut document_snapshot: Option<DocumentSnapshotOwned> = None;
+        let mut document_tombstoned = false;
+        let mut line_by_id = BTreeMap::<String, ParsedLine>::new();
+
+        for change in changes {
+            if change.schema_key == LINE_SCHEMA_KEY {
+                validate_schema_version(&change.schema_version, LINE_SCHEMA_KEY)?;
+
+                match change.snapshot_content {
+                    Some(snapshot_raw) => {
+                        let snapshot = parse_line_snapshot(&snapshot_raw, &change.entity_id)?;
+                        let replaced = line_by_id.insert(
+                            change.entity_id.clone(),
+                            ParsedLine {
+                                entity_id: change.entity_id,
+                                content: snapshot.content,
+                                ending: snapshot.ending,
+                            },
+                        );
+                        if replaced.is_some() {
+                            return Err(PluginError::InvalidInput(
+                                "duplicate text_line snapshot in apply_changes input".to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        line_by_id.remove(&change.entity_id);
+                    }
+                }
+                continue;
+            }
+
+            if change.schema_key == DOCUMENT_SCHEMA_KEY {
+                validate_schema_version(&change.schema_version, DOCUMENT_SCHEMA_KEY)?;
+                if change.entity_id != DOCUMENT_ENTITY_ID {
+                    return Err(PluginError::InvalidInput(format!(
+                        "document snapshot entity_id must be '{DOCUMENT_ENTITY_ID}', got '{}'",
+                        change.entity_id
+                    )));
+                }
+
+                match change.snapshot_content {
+                    Some(snapshot_raw) => {
+                        if document_snapshot.is_some() || document_tombstoned {
+                            return Err(PluginError::InvalidInput(
+                                "duplicate text_document snapshot in apply_changes input"
+                                    .to_string(),
+                            ));
+                        }
+                        let parsed = parse_document_snapshot(&snapshot_raw)?;
+                        document_snapshot = Some(parsed);
+                    }
+                    None => {
+                        if document_snapshot.is_some() || document_tombstoned {
+                            return Err(PluginError::InvalidInput(
+                                "duplicate text_document snapshot in apply_changes input"
+                                    .to_string(),
+                            ));
+                        }
+                        document_tombstoned = true;
+                    }
+                }
+            }
+        }
+
+        if document_tombstoned {
+            return Ok(Vec::new());
+        }
+
+        let document_snapshot = document_snapshot.ok_or_else(|| {
+            PluginError::InvalidInput(
+                "missing text_document snapshot; apply_changes requires full latest projection"
+                    .to_string(),
+            )
+        })?;
+
+        let mut output = Vec::new();
+        for line_id in document_snapshot.line_ids {
+            let Some(line) = line_by_id.get(&line_id) else {
+                return Err(PluginError::InvalidInput(format!(
+                    "document references missing text_line entity_id '{line_id}'"
+                )));
+            };
+            output.extend_from_slice(&line.content);
+            output.extend_from_slice(line.ending.as_str().as_bytes());
+        }
+
+        Ok(output)
+    }
+}
+
+fn validate_schema_version(value: &str, schema_key: &str) -> Result<(), PluginError> {
+    if value == SCHEMA_VERSION {
+        return Ok(());
+    }
+    Err(PluginError::InvalidInput(format!(
+        "unsupported schema_version '{value}' for schema_key '{schema_key}', expected '{SCHEMA_VERSION}'"
+    )))
+}
+
+fn parse_document_snapshot(raw: &str) -> Result<DocumentSnapshotOwned, PluginError> {
+    let parsed: DocumentSnapshotOwned = serde_json::from_str(raw).map_err(|error| {
+        PluginError::InvalidInput(format!("invalid text_document snapshot_content: {error}"))
+    })?;
+
+    let mut seen = BTreeSet::new();
+    for line_id in &parsed.line_ids {
+        if line_id.is_empty() {
+            return Err(PluginError::InvalidInput(
+                "text_document.line_ids must not contain empty ids".to_string(),
+            ));
+        }
+        if !seen.insert(line_id.clone()) {
+            return Err(PluginError::InvalidInput(format!(
+                "text_document.line_ids contains duplicate id '{line_id}'"
+            )));
+        }
+    }
+
+    Ok(parsed)
+}
+
+fn parse_line_snapshot(raw: &str, entity_id: &str) -> Result<ParsedLine, PluginError> {
+    let parsed: LineSnapshotOwned = serde_json::from_str(raw).map_err(|error| {
+        PluginError::InvalidInput(format!(
+            "invalid text_line snapshot_content for entity_id '{entity_id}': {error}"
+        ))
+    })?;
+
+    let content = hex_to_bytes(&parsed.content_hex).map_err(|error| {
+        PluginError::InvalidInput(format!(
+            "invalid text_line.content_hex for entity_id '{entity_id}': {error}"
+        ))
+    })?;
+    let ending = LineEnding::from_str(&parsed.ending)?;
+
+    Ok(ParsedLine {
+        entity_id: entity_id.to_string(),
+        content,
+        ending,
+    })
+}
+
+fn serialize_line_snapshot(line: &ParsedLine) -> Result<String, PluginError> {
+    let content_hex = bytes_to_hex(&line.content);
+    serde_json::to_string(&LineSnapshot {
+        content_hex: &content_hex,
+        ending: line.ending.as_str(),
+    })
+    .map_err(|error| PluginError::Internal(format!("failed to encode text_line snapshot: {error}")))
+}
+
+fn parse_lines_with_ids(data: &[u8]) -> Vec<ParsedLine> {
+    parse_lines_with_ids_from_split(split_lines(data))
+}
+
+fn parse_lines_with_ids_from_split(split: Vec<(Vec<u8>, LineEnding)>) -> Vec<ParsedLine> {
+    let mut occurrence_by_key = HashMap::<Vec<u8>, u32>::new();
+    let mut lines = Vec::with_capacity(split.len());
+
+    for (content, ending) in split {
+        let key = line_key_bytes(&content, ending);
+        let occurrence = occurrence_by_key.entry(key.clone()).or_insert(0);
+        let entity_id = format!("line:{}:{}", sha1_hex(&key), occurrence);
+        *occurrence += 1;
+
+        lines.push(ParsedLine {
+            entity_id,
+            content,
+            ending,
+        });
+    }
+
+    lines
+}
+
+fn parse_after_lines_with_git_matching(
+    before_lines: &[ParsedLine],
+    after_data: &[u8],
+) -> Vec<ParsedLine> {
+    let after_split = split_lines(after_data);
+    let canonical_after_lines = parse_lines_with_ids_from_split(after_split.clone());
+
+    let before_keys = before_lines
+        .iter()
+        .map(|line| line_key_bytes(&line.content, line.ending))
+        .collect::<Vec<_>>();
+    let after_keys = after_split
+        .iter()
+        .map(|(content, ending)| line_key_bytes(content, *ending))
+        .collect::<Vec<_>>();
+    let lcs_pairs = longest_common_subsequence_pairs(&before_keys, &after_keys);
+
+    let mut matched_after_to_before = HashMap::<usize, usize>::new();
+    for (before_index, after_index) in lcs_pairs {
+        matched_after_to_before.insert(after_index, before_index);
+    }
+
+    let mut used_ids = before_lines
+        .iter()
+        .map(|line| line.entity_id.clone())
+        .collect::<BTreeSet<_>>();
+    let mut after_lines = Vec::with_capacity(after_split.len());
+
+    for (after_index, (content, ending)) in after_split.into_iter().enumerate() {
+        let entity_id = if let Some(before_index) = matched_after_to_before.get(&after_index) {
+            before_lines[*before_index].entity_id.clone()
+        } else {
+            allocate_inserted_line_id(&canonical_after_lines[after_index].entity_id, &used_ids)
+        };
+        used_ids.insert(entity_id.clone());
+
+        after_lines.push(ParsedLine {
+            entity_id,
+            content,
+            ending,
+        });
+    }
+
+    after_lines
+}
+
+fn allocate_inserted_line_id(base: &str, used_ids: &BTreeSet<String>) -> String {
+    if !used_ids.contains(base) {
+        return base.to_string();
+    }
+
+    let mut suffix = 0u32;
+    loop {
+        let candidate = format!("{base}:ins:{suffix}");
+        if !used_ids.contains(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+fn longest_common_subsequence_pairs(
+    before_keys: &[Vec<u8>],
+    after_keys: &[Vec<u8>],
+) -> Vec<(usize, usize)> {
+    let before_len = before_keys.len();
+    let after_len = after_keys.len();
+    if before_len == 0 || after_len == 0 {
+        return Vec::new();
+    }
+
+    let mut lengths = vec![vec![0u32; after_len + 1]; before_len + 1];
+    for before_index in (0..before_len).rev() {
+        for after_index in (0..after_len).rev() {
+            lengths[before_index][after_index] = if before_keys[before_index]
+                == after_keys[after_index]
+            {
+                lengths[before_index + 1][after_index + 1] + 1
+            } else {
+                lengths[before_index + 1][after_index].max(lengths[before_index][after_index + 1])
+            };
+        }
+    }
+
+    let mut pairs = Vec::new();
+    let mut before_index = 0usize;
+    let mut after_index = 0usize;
+
+    while before_index < before_len && after_index < after_len {
+        if before_keys[before_index] == after_keys[after_index] {
+            pairs.push((before_index, after_index));
+            before_index += 1;
+            after_index += 1;
+            continue;
+        }
+
+        if lengths[before_index + 1][after_index] >= lengths[before_index][after_index + 1] {
+            before_index += 1;
+        } else {
+            after_index += 1;
+        }
+    }
+
+    pairs
+}
+
+fn split_lines(data: &[u8]) -> Vec<(Vec<u8>, LineEnding)> {
+    if data.is_empty() {
+        return Vec::new();
+    }
+
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+
+    for index in 0..data.len() {
+        if data[index] != b'\n' {
+            continue;
+        }
+
+        if index > start && data[index - 1] == b'\r' {
+            lines.push((data[start..index - 1].to_vec(), LineEnding::Crlf));
+        } else {
+            lines.push((data[start..index].to_vec(), LineEnding::Lf));
+        }
+        start = index + 1;
+    }
+
+    if start < data.len() {
+        lines.push((data[start..].to_vec(), LineEnding::None));
+    }
+
+    lines
+}
+
+fn line_key_bytes(content: &[u8], ending: LineEnding) -> Vec<u8> {
+    let mut key = Vec::with_capacity(content.len() + 2);
+    key.extend_from_slice(content);
+    key.push(0xff);
+    key.push(ending.marker_byte());
+    key
+}
+
+fn sha1_hex(bytes: &[u8]) -> String {
+    let digest = Sha1::digest(bytes);
+    bytes_to_hex(&digest)
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(hex_char(byte >> 4));
+        output.push(hex_char(byte & 0x0f));
+    }
+    output
+}
+
+fn hex_char(value: u8) -> char {
+    match value {
+        0..=9 => (b'0' + value) as char,
+        10..=15 => (b'a' + (value - 10)) as char,
+        _ => '?',
+    }
+}
+
+fn hex_to_bytes(raw: &str) -> Result<Vec<u8>, String> {
+    if raw.len() % 2 != 0 {
+        return Err("expected even-length hex string".to_string());
+    }
+
+    let mut out = Vec::with_capacity(raw.len() / 2);
+    let bytes = raw.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let high = from_hex_nibble(bytes[index]).ok_or_else(|| {
+            format!(
+                "invalid hex character '{}' at index {}",
+                bytes[index] as char, index
+            )
+        })?;
+        let low = from_hex_nibble(bytes[index + 1]).ok_or_else(|| {
+            format!(
+                "invalid hex character '{}' at index {}",
+                bytes[index + 1] as char,
+                index + 1
+            )
+        })?;
+        out.push((high << 4) | low);
+        index += 2;
+    }
+
+    Ok(out)
+}
+
+fn from_hex_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+pub fn detect_changes(before: Option<File>, after: File) -> Result<Vec<EntityChange>, PluginError> {
+    <TextLinesPlugin as Guest>::detect_changes(before, after)
+}
+
+pub fn apply_changes(file: File, changes: Vec<EntityChange>) -> Result<Vec<u8>, PluginError> {
+    <TextLinesPlugin as Guest>::apply_changes(file, changes)
+}
+
+export!(TextLinesPlugin);

--- a/packages/plugin-text-lines/tests/apply_changes.rs
+++ b/packages/plugin-text-lines/tests/apply_changes.rs
@@ -1,0 +1,77 @@
+mod common;
+
+use common::{file_from_bytes, parse_document_snapshot};
+use plugin_text_lines::{
+    apply_changes, detect_changes, PluginApiError, PluginEntityChange, DOCUMENT_SCHEMA_KEY,
+    LINE_SCHEMA_KEY,
+};
+
+#[test]
+fn applies_full_projection_and_reconstructs_bytes() {
+    let expected = b"line 1\nline 2\r\nline 3";
+    let after = file_from_bytes("f1", "/doc.txt", expected);
+
+    let changes = detect_changes(None, after).expect("detect_changes should succeed");
+    let output = apply_changes(file_from_bytes("f1", "/doc.txt", b""), changes)
+        .expect("apply_changes should succeed");
+
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn supports_binary_bytes() {
+    let expected = vec![0xff, b'\n', 0x00, b'\r', b'\n', 0x7f];
+    let after = file_from_bytes("f1", "/bin.dat", &expected);
+
+    let changes = detect_changes(None, after).expect("detect_changes should succeed");
+    let output = apply_changes(file_from_bytes("f1", "/bin.dat", b""), changes)
+        .expect("apply_changes should succeed");
+
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn rejects_missing_document_snapshot() {
+    let changes = vec![PluginEntityChange {
+        entity_id: "line:abc:0".to_string(),
+        schema_key: LINE_SCHEMA_KEY.to_string(),
+        schema_version: "1".to_string(),
+        snapshot_content: Some(r#"{"content_hex":"61","ending":"\n"}"#.to_string()),
+    }];
+
+    let error = apply_changes(file_from_bytes("f1", "/doc.txt", b""), changes)
+        .expect_err("apply_changes should fail");
+
+    match error {
+        PluginApiError::InvalidInput(message) => {
+            assert!(message.contains("missing text_document snapshot"));
+        }
+        PluginApiError::Internal(message) => {
+            panic!("expected InvalidInput, got Internal({message})");
+        }
+    }
+}
+
+#[test]
+fn document_order_drives_output_order() {
+    let after = file_from_bytes("f1", "/doc.txt", b"a\nb\n");
+    let mut changes = detect_changes(None, after).expect("detect_changes should succeed");
+
+    let document_index = changes
+        .iter()
+        .position(|change| change.schema_key == DOCUMENT_SCHEMA_KEY)
+        .expect("document row should exist");
+    let mut doc = parse_document_snapshot(&changes[document_index]);
+    doc.line_ids.reverse();
+    changes[document_index].snapshot_content = Some(
+        serde_json::json!({
+            "line_ids": doc.line_ids,
+        })
+        .to_string(),
+    );
+
+    let output = apply_changes(file_from_bytes("f1", "/doc.txt", b""), changes)
+        .expect("apply_changes should succeed");
+
+    assert_eq!(output, b"b\na\n");
+}

--- a/packages/plugin-text-lines/tests/common/mod.rs
+++ b/packages/plugin-text-lines/tests/common/mod.rs
@@ -1,0 +1,39 @@
+#![allow(dead_code)]
+
+use plugin_text_lines::{PluginEntityChange, PluginFile};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct LineSnapshot {
+    pub content_hex: String,
+    pub ending: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DocumentSnapshot {
+    pub line_ids: Vec<String>,
+}
+
+pub fn file_from_bytes(id: &str, path: &str, data: &[u8]) -> PluginFile {
+    PluginFile {
+        id: id.to_string(),
+        path: path.to_string(),
+        data: data.to_vec(),
+    }
+}
+
+pub fn parse_line_snapshot(change: &PluginEntityChange) -> LineSnapshot {
+    let raw = change
+        .snapshot_content
+        .as_ref()
+        .expect("line snapshot should exist");
+    serde_json::from_str(raw).expect("line snapshot should parse")
+}
+
+pub fn parse_document_snapshot(change: &PluginEntityChange) -> DocumentSnapshot {
+    let raw = change
+        .snapshot_content
+        .as_ref()
+        .expect("document snapshot should exist");
+    serde_json::from_str(raw).expect("document snapshot should parse")
+}

--- a/packages/plugin-text-lines/tests/detect_changes.rs
+++ b/packages/plugin-text-lines/tests/detect_changes.rs
@@ -1,0 +1,113 @@
+mod common;
+
+use common::{file_from_bytes, parse_document_snapshot};
+use plugin_text_lines::{
+    detect_changes, DOCUMENT_ENTITY_ID, DOCUMENT_SCHEMA_KEY, LINE_SCHEMA_KEY, SCHEMA_VERSION,
+};
+
+#[test]
+fn creation_returns_full_projection() {
+    let after = file_from_bytes("f1", "/doc.txt", b"a\nb\n");
+
+    let changes = detect_changes(None, after).expect("detect_changes should succeed");
+
+    let line_changes = changes
+        .iter()
+        .filter(|change| change.schema_key == LINE_SCHEMA_KEY)
+        .collect::<Vec<_>>();
+    assert_eq!(line_changes.len(), 2);
+    assert!(line_changes
+        .iter()
+        .all(|change| change.schema_version == SCHEMA_VERSION));
+    assert!(line_changes
+        .iter()
+        .all(|change| change.snapshot_content.is_some()));
+
+    let document_change = changes
+        .iter()
+        .find(|change| change.schema_key == DOCUMENT_SCHEMA_KEY)
+        .expect("document snapshot should exist");
+    assert_eq!(document_change.entity_id, DOCUMENT_ENTITY_ID);
+    let doc = parse_document_snapshot(document_change);
+    assert_eq!(doc.line_ids.len(), 2);
+}
+
+#[test]
+fn insertion_in_middle_emits_inserted_line_and_document_change() {
+    let before = file_from_bytes("f1", "/doc.txt", b"a\nb\n");
+    let after = file_from_bytes("f1", "/doc.txt", b"a\nx\nb\n");
+
+    let changes = detect_changes(Some(before), after).expect("detect_changes should succeed");
+
+    let line_inserts = changes
+        .iter()
+        .filter(|change| change.schema_key == LINE_SCHEMA_KEY)
+        .filter(|change| change.snapshot_content.is_some())
+        .collect::<Vec<_>>();
+    let line_tombstones = changes
+        .iter()
+        .filter(|change| change.schema_key == LINE_SCHEMA_KEY)
+        .filter(|change| change.snapshot_content.is_none())
+        .collect::<Vec<_>>();
+
+    assert_eq!(line_inserts.len(), 1);
+    assert_eq!(line_tombstones.len(), 0);
+    assert!(changes
+        .iter()
+        .any(|change| change.schema_key == DOCUMENT_SCHEMA_KEY));
+}
+
+#[test]
+fn deletion_emits_line_tombstone_and_document_change() {
+    let before = file_from_bytes("f1", "/doc.txt", b"a\nb\n");
+    let after = file_from_bytes("f1", "/doc.txt", b"a\n");
+
+    let changes = detect_changes(Some(before), after).expect("detect_changes should succeed");
+
+    let line_tombstones = changes
+        .iter()
+        .filter(|change| change.schema_key == LINE_SCHEMA_KEY)
+        .filter(|change| change.snapshot_content.is_none())
+        .collect::<Vec<_>>();
+
+    assert_eq!(line_tombstones.len(), 1);
+    assert!(changes
+        .iter()
+        .any(|change| change.schema_key == DOCUMENT_SCHEMA_KEY));
+}
+
+#[test]
+fn unchanged_file_returns_no_changes() {
+    let before = file_from_bytes("f1", "/doc.txt", b"unchanged\n");
+    let after = file_from_bytes("f1", "/doc.txt", b"unchanged\n");
+
+    let changes = detect_changes(Some(before), after).expect("detect_changes should succeed");
+
+    assert!(changes.is_empty());
+}
+
+#[test]
+fn line_reorder_emits_delete_and_insert() {
+    let before = file_from_bytes("f1", "/doc.txt", b"a\nb\n");
+    let after = file_from_bytes("f1", "/doc.txt", b"b\na\n");
+
+    let changes = detect_changes(Some(before), after).expect("detect_changes should succeed");
+
+    let line_inserts = changes
+        .iter()
+        .filter(|change| change.schema_key == LINE_SCHEMA_KEY)
+        .filter(|change| change.snapshot_content.is_some())
+        .collect::<Vec<_>>();
+    let line_tombstones = changes
+        .iter()
+        .filter(|change| change.schema_key == LINE_SCHEMA_KEY)
+        .filter(|change| change.snapshot_content.is_none())
+        .collect::<Vec<_>>();
+
+    assert_eq!(line_inserts.len(), 1);
+    assert_eq!(line_tombstones.len(), 1);
+    assert_ne!(line_inserts[0].entity_id, line_tombstones[0].entity_id);
+    assert!(changes
+        .iter()
+        .any(|change| change.schema_key == DOCUMENT_SCHEMA_KEY));
+}

--- a/packages/plugin-text-lines/tests/roundtrip.rs
+++ b/packages/plugin-text-lines/tests/roundtrip.rs
@@ -1,0 +1,29 @@
+mod common;
+
+use common::file_from_bytes;
+use plugin_text_lines::{apply_changes, detect_changes};
+
+#[test]
+fn detect_then_apply_roundtrips_exact_bytes() {
+    let payload = b"first line\nsecond line\r\nthird line\n";
+    let file = file_from_bytes("f1", "/doc.txt", payload);
+
+    let changes = detect_changes(None, file).expect("detect_changes should succeed");
+    let reconstructed = apply_changes(file_from_bytes("f1", "/doc.txt", b""), changes)
+        .expect("apply_changes should succeed");
+
+    assert_eq!(reconstructed, payload);
+}
+
+#[test]
+fn update_roundtrip_preserves_exact_target_bytes() {
+    let before = file_from_bytes("f1", "/doc.txt", b"a\nb\nc\n");
+    let after_payload = b"a\nx\nc\n";
+    let after = file_from_bytes("f1", "/doc.txt", after_payload);
+
+    let changes = detect_changes(Some(before), after).expect("detect_changes should succeed");
+    let reconstructed = apply_changes(file_from_bytes("f1", "/doc.txt", b""), changes)
+        .expect("apply_changes should succeed");
+
+    assert_eq!(reconstructed, after_payload);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,16 +151,15 @@ importers:
       js-sdk:
         specifier: workspace:*
         version: link:../js-sdk
-    devDependencies:
+
+  packages/js-sdk:
+    dependencies:
       '@bytecodealliance/jco':
         specifier: ^1.17.0
         version: 1.17.0
       '@bytecodealliance/preview2-shim':
         specifier: ^0.17.8
         version: 0.17.8
-
-  packages/js-sdk:
-    dependencies:
       '@sqlite.org/sqlite-wasm':
         specifier: ^3.50.4-build1
         version: 3.50.4-build1
@@ -171,6 +170,12 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
+  packages/nextjs-replay-bench:
+    dependencies:
+      js-sdk:
+        specifier: workspace:*
+        version: link:../js-sdk
 
   packages/plugin-csv:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,13 @@ importers:
       js-sdk:
         specifier: workspace:*
         version: link:../js-sdk
+    devDependencies:
+      '@bytecodealliance/jco':
+        specifier: ^1.17.0
+        version: 1.17.0
+      '@bytecodealliance/preview2-shim':
+        specifier: ^0.17.8
+        version: 0.17.8
 
   packages/js-sdk:
     dependencies:
@@ -785,6 +792,58 @@ packages:
 
   '@bundled-es-modules/tough-cookie@0.1.6':
     resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
+
+  '@bytecodealliance/componentize-js@0.19.3':
+    resolution: {integrity: sha512-ju7Y4WeF0B9uMkSPHJgmT6ouEfSwbe9M1uR/YOnYZjBpxJjH9qzxIkJg/kf8NycVDyFJ2/lscmJ1E1uPiDQVRQ==}
+    hasBin: true
+
+  '@bytecodealliance/jco@1.17.0':
+    resolution: {integrity: sha512-+8cLL6p++K+KKJiG+xqRDyKcjoWvAB1cwH+diIvuUf8O0AEN+QfzW7GdZJ0zzvfpCfGYX+uO7ylmPFvn+pWxCA==}
+    hasBin: true
+
+  '@bytecodealliance/preview2-shim@0.17.8':
+    resolution: {integrity: sha512-wS5kg8u0KCML1UeHQPJ1IuOI24x/XLentCzsqPER1+gDNC5Cz2hG4G2blLOZap+3CEGhIhnJ9mmZYj6a2W0Lww==}
+
+  '@bytecodealliance/wizer-darwin-arm64@10.0.0':
+    resolution: {integrity: sha512-dhZTWel+xccGTKSJtI9A7oM4yyP20FWflsT+AoqkOqkCY7kCNrj4tmMtZ6GXZFRDkrPY5+EnOh62sfShEibAMA==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@bytecodealliance/wizer-darwin-x64@10.0.0':
+    resolution: {integrity: sha512-r/LUIZw6Q3Hf4htd46mD+EBxfwjBkxVIrTM1r+B2pTCddoBYQnKVdVsI4UFyy7NoBxzEg8F8BwmTNoSLmFRjpw==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@bytecodealliance/wizer-linux-arm64@10.0.0':
+    resolution: {integrity: sha512-pGSfFWXzeTqHm6z1PtVaEn+7Fm3QGC8YnHrzBV4sQDVS3N1NwmuHZAc8kslmlFPNdu61ycEvdOsSgCny8JPQvg==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@bytecodealliance/wizer-linux-s390x@10.0.0':
+    resolution: {integrity: sha512-O8vHxRTAdb1lUnVXMIMTcp/9q4pq1D4iIKigJCipg2JN15taV9uFAWh0fO88wylXwuSlO7dOE1AwQl54fMKXQg==}
+    cpu: [s390x]
+    os: [linux]
+    hasBin: true
+
+  '@bytecodealliance/wizer-linux-x64@10.0.0':
+    resolution: {integrity: sha512-fJtM1sy43FBMnp+xpapFX6U1YdTBKA/1T4CYfG/qeE8jn0SXk2EuiYoY/EnC2uyNy9hjTrvfdYO5n4MXW0EIdQ==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@bytecodealliance/wizer-win32-x64@10.0.0':
+    resolution: {integrity: sha512-55BPLfGT7iT7gH5M69NpTM16QknJZ7OxJ0z73VOEoeGA9CT8QPKMRzFKsPIvLs+W8G28fdudFA94nElrdkp3Kg==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@bytecodealliance/wizer@10.0.0':
+    resolution: {integrity: sha512-ziWmovyu1jQl9TsKlfC2bwuUZwxVPFHlX4fOqTzxhgS76jITIo45nzODEwPgU+jjmOr8F3YX2V2wAChC5NKujg==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   '@changesets/apply-release-plan@7.0.13':
     resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
@@ -1661,6 +1720,9 @@ packages:
     resolution: {integrity: sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==}
     engines: {node: '>=18'}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
@@ -1841,9 +1903,101 @@ packages:
     resolution: {integrity: sha512-pZDiecYrpSxw7miv4ZSufCRB9sqFMXRa0Rf+LQcoEEh0VOBI6beOmvB+iXmWJ7vxMQINuS7yfsvm5ZyrTm/W5A==}
     engines: {node: '>=20'}
 
+  '@oxc-parser/binding-android-arm64@0.76.0':
+    resolution: {integrity: sha512-1XJW/16CDmF5bHE7LAyPPmEEVnxSadDgdJz+xiLqBrmC4lfAeuAfRw3HlOygcPGr+AJsbD4Z5sFJMkwjbSZlQg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.76.0':
+    resolution: {integrity: sha512-yoQwSom8xsB+JdGsPUU0xxmxLKiF2kdlrK7I56WtGKZilixuBf/TmOwNYJYLRWkBoW5l2/pDZOhBm2luwmLiLw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.76.0':
+    resolution: {integrity: sha512-uRIopPLvr3pf2Xj7f5LKyCuqzIU6zOS+zEIR8UDYhcgJyZHnvBkfrYnfcztyIcrGdQehrFUi3uplmI09E7RdiQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.76.0':
+    resolution: {integrity: sha512-a0EOFvnOd2FqmDSvH6uWLROSlU6KV/JDKbsYDA/zRLyKcG6HCsmFnPsp8iV7/xr9WMbNgyJi6R5IMpePQlUq7Q==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.76.0':
+    resolution: {integrity: sha512-ikRYDHL3fOdZwfJKmcdqjlLgkeNZ3Ez0qM8wAev5zlHZ+lY/Ig7qG5SCqPlvuTu+nNQ6zrFFaKvvt69EBKXU/g==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.76.0':
+    resolution: {integrity: sha512-dtRv5J5MRCLR7x39K8ufIIW4svIc7gYFUaI0YFXmmeOBhK/K2t/CkguPnDroKtsmXIPHDRtmJ1JJYzNcgJl6Wg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.76.0':
+    resolution: {integrity: sha512-IE4iiiggFH2snagQxHrY5bv6dDpRMMat+vdlMN/ibonA65eOmRLp8VLTXnDiNrcla/itJ1L9qGABHNKU+SnE8g==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.76.0':
+    resolution: {integrity: sha512-wi9zQPMDHrBuRuT7Iurfidc9qlZh7cKa5vfYzOWNBCaqJdgxmNOFzvYen02wVUxSWGKhpiPHxrPX0jdRyJ8Npg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.76.0':
+    resolution: {integrity: sha512-0tqqu1pqPee2lLGY8vtYlX1L415fFn89e0a3yp4q5N9f03j1rRs0R31qesTm3bt/UK8HYjECZ+56FCVPs2MEMQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.76.0':
+    resolution: {integrity: sha512-y36Hh1a5TA+oIGtlc8lT7N9vdHXBlhBetQJW0p457KbiVQ7jF7AZkaPWhESkjHWAsTVKD2OjCa9ZqfaqhSI0FQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.76.0':
+    resolution: {integrity: sha512-7/acaG9htovp3gp/J0kHgbItQTuHctl+rbqPPqZ9DRBYTz8iV8kv3QN8t8Or8i/hOmOjfZp9McDoSU1duoR4/A==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.76.0':
+    resolution: {integrity: sha512-AxFt0reY6Q2rfudABmMTFGR8tFFr58NlH2rRBQgcj+F+iEwgJ+jMwAPhXd2y1I2zaI8GspuahedUYQinqxWqjA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-wasm32-wasi@0.76.0':
+    resolution: {integrity: sha512-wHdkHdhf6AWBoO8vs5cpoR6zEFY1rB+fXWtq6j/xb9j/lu1evlujRVMkh8IM/M/pOUIrNkna3nzST/mRImiveQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.76.0':
+    resolution: {integrity: sha512-G7ZlEWcb2hNwCK3qalzqJoyB6HaTigQ/GEa7CU8sAJ/WwMdG/NnPqiC9IqpEAEy1ARSo4XMALfKbKNuqbSs5mg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.76.0':
+    resolution: {integrity: sha512-0jLzzmnu8/mqNhKBnNS2lFUbPEzRdj5ReiZwHGHpjma0+ullmmwP2AqSEqx3ssHDK9CpcEMdKOK2LsbCfhHKIA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/runtime@0.87.0':
     resolution: {integrity: sha512-ky2Hqi2q/uGX36UfY79zxMbUqiNIl1RyKKVJfFenG70lbn+/fcaKBVTbhmUwn8a2wPyv2gNtDQxuDytbKX9giQ==}
     engines: {node: '>=6.9.0'}
+
+  '@oxc-project/types@0.76.0':
+    resolution: {integrity: sha512-CH3THIrSViKal8yV/Wh3FK0pFhp40nzW1MUDCik9fNuid2D/7JJXKJnfFOAvMxInGXDlvmgT6ACAzrl47TqzkQ==}
 
   '@oxc-project/types@0.87.0':
     resolution: {integrity: sha512-ipZFWVGE9fADBVXXWJWY/cxpysc41Gt5upKDeb32F6WMgFyO7XETUMVq8UuREKCih+Km5E6p2VhEvf6Fuhey6g==}
@@ -3765,6 +3919,10 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  binaryen@123.0.0:
+    resolution: {integrity: sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw==}
+    hasBin: true
+
   birpc@2.7.0:
     resolution: {integrity: sha512-tub/wFGH49vNCm0xraykcY3TcRgX/3JsALYq/Lwrtti+bTyFHkCUAWF5wgYoie8P41wYwig2mIKiqoocr1EkEQ==}
 
@@ -3914,6 +4072,10 @@ packages:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-spinners@2.6.1:
     resolution: {integrity: sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==}
     engines: {node: '>=6'}
@@ -3964,6 +4126,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -4425,6 +4591,9 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -4813,6 +4982,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -5161,6 +5334,10 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -5198,6 +5375,14 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -5518,6 +5703,10 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
   loglevel-plugin-prefix@0.8.4:
     resolution: {integrity: sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==}
 
@@ -5757,6 +5946,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -5808,6 +6001,11 @@ packages:
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5923,6 +6121,10 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -5947,6 +6149,10 @@ packages:
     resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}
     engines: {node: '>=10'}
 
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
+
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
@@ -5955,6 +6161,10 @@ packages:
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
+  oxc-parser@0.76.0:
+    resolution: {integrity: sha512-l98B2e9evuhES7zN99rb1QGhbzx25829TJFaKi2j0ib3/K/G5z1FdGYz6HZkrU3U8jdH7v2FC8mX1j2l9JrOUg==}
+    engines: {node: '>=20.0.0'}
 
   oxlint@1.26.0:
     resolution: {integrity: sha512-KRpL+SMi07JQyggv5ldIF+wt2pnrKm8NLW0B+8bK+0HZsLmH9/qGA+qMWie5Vf7lnlMBllJmsuzHaKFEGY3rIA==}
@@ -6402,6 +6612,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -6778,6 +6992,10 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
@@ -6799,6 +7017,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -8044,6 +8266,52 @@ snapshots:
       tough-cookie: 4.1.4
     optional: true
 
+  '@bytecodealliance/componentize-js@0.19.3':
+    dependencies:
+      '@bytecodealliance/jco': 1.17.0
+      '@bytecodealliance/wizer': 10.0.0
+      es-module-lexer: 1.7.0
+      oxc-parser: 0.76.0
+
+  '@bytecodealliance/jco@1.17.0':
+    dependencies:
+      '@bytecodealliance/componentize-js': 0.19.3
+      '@bytecodealliance/preview2-shim': 0.17.8
+      binaryen: 123.0.0
+      commander: 14.0.3
+      mkdirp: 3.0.1
+      ora: 8.2.0
+      terser: 5.36.0
+
+  '@bytecodealliance/preview2-shim@0.17.8': {}
+
+  '@bytecodealliance/wizer-darwin-arm64@10.0.0':
+    optional: true
+
+  '@bytecodealliance/wizer-darwin-x64@10.0.0':
+    optional: true
+
+  '@bytecodealliance/wizer-linux-arm64@10.0.0':
+    optional: true
+
+  '@bytecodealliance/wizer-linux-s390x@10.0.0':
+    optional: true
+
+  '@bytecodealliance/wizer-linux-x64@10.0.0':
+    optional: true
+
+  '@bytecodealliance/wizer-win32-x64@10.0.0':
+    optional: true
+
+  '@bytecodealliance/wizer@10.0.0':
+    optionalDependencies:
+      '@bytecodealliance/wizer-darwin-arm64': 10.0.0
+      '@bytecodealliance/wizer-darwin-x64': 10.0.0
+      '@bytecodealliance/wizer-linux-arm64': 10.0.0
+      '@bytecodealliance/wizer-linux-s390x': 10.0.0
+      '@bytecodealliance/wizer-linux-x64': 10.0.0
+      '@bytecodealliance/wizer-win32-x64': 10.0.0
+
   '@changesets/apply-release-plan@7.0.13':
     dependencies:
       '@changesets/config': 3.1.1
@@ -8775,7 +9043,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -8922,6 +9189,13 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.5.0
+      '@emnapi/runtime': 1.5.0
+      '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@napi-rs/wasm-runtime@0.2.4':
@@ -9116,7 +9390,56 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.40
 
+  '@oxc-parser/binding-android-arm64@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.76.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.76.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.76.0':
+    optional: true
+
   '@oxc-project/runtime@0.87.0': {}
+
+  '@oxc-project/types@0.76.0': {}
 
   '@oxc-project/types@0.87.0': {}
 
@@ -11454,6 +11777,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  binaryen@123.0.0: {}
+
   birpc@2.7.0: {}
 
   bl@4.1.0:
@@ -11504,8 +11829,7 @@ snapshots:
   buffer-crc32@1.0.0:
     optional: true
 
-  buffer-from@1.1.2:
-    optional: true
+  buffer-from@1.1.2: {}
 
   buffer@5.7.1:
     dependencies:
@@ -11551,8 +11875,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2:
-    optional: true
+  chalk@5.6.2: {}
 
   change-case@5.4.4: {}
 
@@ -11628,6 +11951,10 @@ snapshots:
     dependencies:
       restore-cursor: 3.1.0
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-spinners@2.6.1: {}
 
   cli-spinners@2.9.2: {}
@@ -11672,8 +11999,9 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
-  commander@2.20.3:
-    optional: true
+  commander@14.0.3: {}
+
+  commander@2.20.3: {}
 
   commander@7.2.0: {}
 
@@ -12137,6 +12465,8 @@ snapshots:
 
   electron-to-chromium@1.5.267:
     optional: true
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -12634,6 +12964,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.4.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -13077,6 +13409,8 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-interactive@2.0.0: {}
+
   is-node-process@1.2.0:
     optional: true
 
@@ -13100,6 +13434,10 @@ snapshots:
       better-path-resolve: 1.0.0
 
   is-unicode-supported@0.1.0: {}
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-windows@1.0.2: {}
 
@@ -13440,6 +13778,11 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   loglevel-plugin-prefix@0.8.4:
     optional: true
@@ -13884,6 +14227,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-function@5.0.1: {}
+
   mimic-response@3.1.0: {}
 
   min-document@2.19.0:
@@ -13944,6 +14289,8 @@ snapshots:
       yallist: 4.0.0
 
   mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   mlly@1.8.0:
     dependencies:
@@ -14160,6 +14507,10 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@4.3.3:
@@ -14204,12 +14555,44 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+
   orderedmap@2.1.1: {}
 
   outdent@0.5.0: {}
 
   outvariant@1.4.3:
     optional: true
+
+  oxc-parser@0.76.0:
+    dependencies:
+      '@oxc-project/types': 0.76.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm64': 0.76.0
+      '@oxc-parser/binding-darwin-arm64': 0.76.0
+      '@oxc-parser/binding-darwin-x64': 0.76.0
+      '@oxc-parser/binding-freebsd-x64': 0.76.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.76.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.76.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.76.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.76.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.76.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.76.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.76.0
+      '@oxc-parser/binding-linux-x64-musl': 0.76.0
+      '@oxc-parser/binding-wasm32-wasi': 0.76.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.76.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.76.0
 
   oxlint@1.26.0:
     optionalDependencies:
@@ -14771,6 +15154,11 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   reusify@1.0.4: {}
 
   rgb2hex@0.2.5:
@@ -15197,7 +15585,6 @@ snapshots:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    optional: true
 
   source-map@0.6.1: {}
 
@@ -15232,6 +15619,8 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  stdin-discarder@0.2.2: {}
+
   stoppable@1.1.0: {}
 
   streamx@2.23.0:
@@ -15258,6 +15647,12 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
 
   string_decoder@1.1.1:
@@ -15377,7 +15772,6 @@ snapshots:
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    optional: true
 
   test-exclude@7.0.1:
     dependencies:

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,15 @@
+## Prompt
+
+Our goal now is to replay a large git repository in the new lix packages/engine via the js sdk packages/js-sdk. Ignore the legacy codebase packages/sdk. 
+
+The goal is to identify performance optimization opportunities:
+
+- Queries that are slow
+- Storage costs
+- Other bottlenecks
+
+The repository is going to https://github.com/vercel/next.js as real world example.
+
+Replay refers to taking each git commit and "replay" it in lix. The real repo has 32,xxx commits. We expect to see 32,xxx commits in lix as well.
+
+We only care about linear history for now. Replay the 30k commits and then benchmark.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core engine execution/transaction flow, SQL rewrite/prefetch logic, and plugin runtime instantiation, which could subtly affect correctness or cache invalidation despite added tests/benches.
> 
> **Overview**
> Significantly reduces replay overhead by adding **exact-id fast paths** for `lix_file` UPDATE/DELETE prefetch (including id-only projections for deletes) and by maintaining/invalidating a new `lix_internal_file_path_cache` alongside existing data caches.
> 
> Adds an **engine-lifetime WASM plugin component cache** and updates the WASM runtime API to `init_component`/`WasmComponentInstance`; also skips DB reconciliation for `plugin_text_lines` detects that already emit full diffs.
> 
> Introduces a SQLite-only optimization for explicit `BEGIN ... COMMIT` scripts that **coalesces replay-shaped `lix_file` statements** and can defer/flush file side-effects at transaction end; adds snapshot import/export plumbing (`SnapshotChunkReader`/`Writer`) and minor SQL pipeline improvements (heap-pin large rewrite future, vtable insert coalescing, bounded iterative writer-key routing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b627b419620c1a6bd32478ede59356499154194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->