### PR TITLE
fix(engine): parse CAST(? AS TEXT) snapshot_content updates for validation

### DIFF
--- a/packages/engine/tests/state_by_version_view.rs
+++ b/packages/engine/tests/state_by_version_view.rs
@@ -486,8 +486,113 @@ simulation_test!(
     }
 );
 
-// TODO(parity): Legacy SDK supports broader placeholder forms in UPDATE assignments.
-// Rust vtable UPDATE currently requires snapshot_content as a direct literal/parameter expression.
+simulation_test!(
+    lix_state_by_version_update_supports_cast_placeholder_snapshot_content,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_state_row(
+            &engine,
+            "entity-upd-cast",
+            "version-a",
+            "{\"value\":\"before\"}",
+        )
+        .await;
+
+        engine
+            .execute(
+                "UPDATE lix_state_by_version \
+                 SET snapshot_content = CAST(? AS TEXT) \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-upd-cast' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[Value::Text("{\"value\":\"after\"}".to_string())],
+            )
+            .await
+            .unwrap();
+
+        let rows = engine
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-upd-cast' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "{\"value\":\"after\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_by_version_update_cast_placeholder_requires_valid_json,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        register_test_schema(&engine).await;
+        insert_version(&engine, "version-a").await;
+        insert_state_row(
+            &engine,
+            "entity-upd-cast-invalid",
+            "version-a",
+            "{\"value\":\"before\"}",
+        )
+        .await;
+
+        let err = engine
+            .execute(
+                "UPDATE lix_state_by_version \
+                 SET snapshot_content = CAST(? AS TEXT) \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-upd-cast-invalid' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[Value::Text("not-json".to_string())],
+            )
+            .await
+            .expect_err("invalid JSON should fail");
+
+        assert!(
+            err.message.contains("snapshot_content invalid JSON"),
+            "unexpected error: {}",
+            err.message
+        );
+
+        let rows = engine
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_internal_state_vtable \
+                 WHERE schema_key = 'test_state_schema' \
+                   AND entity_id = 'entity-upd-cast-invalid' \
+                   AND file_id = 'test-file' \
+                   AND version_id = 'version-a'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        sim.assert_deterministic(rows.rows.clone());
+        assert_eq!(rows.rows.len(), 1);
+        assert_text(&rows.rows[0][0], "{\"value\":\"before\"}");
+    }
+);
 
 simulation_test!(
     lix_state_by_version_update_requires_version_id_predicate,

--- a/prompt.md
+++ b/prompt.md
@@ -11,8 +11,8 @@ Workflow:
 3. Fix the bug.
 4. Run the engine tests to ensure that the bug is fixed and that no other tests are broken.
 5. Commit, push and open a pull request against the `next` branch. Use the github access token provided in the .env file.
-6. Wait for Cursor Bugbot CI/CD check to finish (you can poll every 2 minutes). Read the comments. Either fix them or reply why the comment is wrong.
-7. Create a new branch from the existing branch (stacked PRs) for the next bug and repeat the process.
+6. Wait for Cursor Bugbot CI/CD check to finish (you can poll every 2 minutes). Read the comments of cursor bugbot. Either fix them or reply why the comment is wrong.
+7. Once all bugs that cursor bug bot has found are fixed, and all comments are resolved, create a new branch from the existing branch (stacked PRs) for the next bug and repeat the process.
 
 Tips:
 

--- a/prompt.md
+++ b/prompt.md
@@ -2,14 +2,14 @@ Your job is to be a Q&A engineer.
 
 The codebase is packages/engine and the packages/js-sdk.
 
-Run in a loop at least 8 hours (until I terminate the process) to find bugs in the codebase and fix them.
+Run in a loop until I terminate the process to find bugs in the codebase and fix them.
 
 Workflow:
 
 1. Identify bugs.
 2. Add a regression test that fails because of the bug.
 3. Fix the bug.
-4. Run the engine tests to ensure that the bug is fixed and that no other tests are broken.
+4. Run scoped tests first, then full engine + js-sdk tests to ensure that the bug is fixed and that no other tests are broken.
 5. Commit, push and open a pull request against the `next` branch. Use the github access token provided in the .env file.
 6. Wait for Cursor Bugbot CI/CD check to finish (you can poll every 2 minutes). Read the comments of cursor bugbot. Either fix them or reply why the comment is wrong.
 7. Once all bugs that cursor bug bot has found are fixed, and all comments are resolved, create a new branch from the existing branch (stacked PRs) for the next bug and repeat the process.

--- a/prompt.md
+++ b/prompt.md
@@ -2,7 +2,7 @@ Your job is to be a Q&A engineer.
 
 The codebase is packages/engine and the packages/js-sdk.
 
-Run in a loop until I terminate the process to find bugs in the codebase and fix them.
+Run in a loop until I terminate the process to find bugs in the codebase and fix them. NEVER STOP. 
 
 Workflow:
 
@@ -11,8 +11,9 @@ Workflow:
 3. Fix the bug.
 4. Run scoped tests first, then full engine + js-sdk tests to ensure that the bug is fixed and that no other tests are broken.
 5. Commit, push and open a pull request against the `next` branch. Use the github access token provided in the .env file.
-6. Wait for Cursor Bugbot CI/CD check to finish (you can poll every 2 minutes). Read the comments of cursor bugbot. Either fix them or reply why the comment is wrong.
+6. Wait for Cursor Bugbot CI/CD check to finish (you can poll the comments every 2 minutes). Read the comments of cursor bugbot. Either fix them or reply why the comment is wrong.
 7. Once all bugs that cursor bug bot has found are fixed, and all comments are resolved, create a new branch from the existing branch (stacked PRs) for the next bug and repeat the process.
+8. REPEAT. NEVER STOP.
 
 Tips:
 

--- a/prompt.md
+++ b/prompt.md
@@ -1,15 +1,21 @@
-## Prompt
+Your job is to be a Q&A engineer.
 
-Our goal now is to replay a large git repository in the new lix packages/engine via the js sdk packages/js-sdk. Ignore the legacy codebase packages/sdk. 
+The codebase is packages/engine and the packages/js-sdk.
 
-The goal is to identify performance optimization opportunities:
+Run in a loop at least 8 hours (until I terminate the process) to find bugs in the codebase and fix them.
 
-- Queries that are slow
-- Storage costs
-- Other bottlenecks
+Workflow:
 
-The repository is going to https://github.com/vercel/next.js as real world example.
+1. Identify bugs.
+2. Add a regression test that fails because of the bug.
+3. Fix the bug.
+4. Run the engine tests to ensure that the bug is fixed and that no other tests are broken.
+5. Open a pull request against the `next` branch. Use the github access token provided in the .env file.
+6. Wait for Cursor Bugbot CI/CD check to finish. Read the comments. Either fix them or reply why the comment is wrong.
+7. Create a new branch from the existing branch (stacked PRs) for the next bug and repeat the process.
 
-Replay refers to taking each git commit and "replay" it in lix. The real repo has 32,xxx commits. We expect to see 32,xxx commits in lix as well.
+Tips:
 
-We only care about linear history for now. Replay the 30k commits and then benchmark.
+- It's crucial that you stack the PRs to avoid merge conflicts.
+- Focus on one bug at a time.
+- Before or right after compacting the conversation, read this prompt.md file again to refresh your memory on the workflow and tips.

--- a/prompt.md
+++ b/prompt.md
@@ -19,3 +19,4 @@ Tips:
 - It's crucial that you stack the PRs to avoid merge conflicts.
 - Focus on one bug at a time.
 - Before or right after compacting the conversation, read this prompt.md file again to refresh your memory on the workflow and tips.
+- you can use the git parity tests in packages/next-js-replay-bench to find state divergance bugs.

--- a/prompt.md
+++ b/prompt.md
@@ -11,7 +11,7 @@ Workflow:
 3. Fix the bug.
 4. Run the engine tests to ensure that the bug is fixed and that no other tests are broken.
 5. Commit, push and open a pull request against the `next` branch. Use the github access token provided in the .env file.
-6. Wait for Cursor Bugbot CI/CD check to finish. Read the comments. Either fix them or reply why the comment is wrong.
+6. Wait for Cursor Bugbot CI/CD check to finish (you can poll every 2 minutes). Read the comments. Either fix them or reply why the comment is wrong.
 7. Create a new branch from the existing branch (stacked PRs) for the next bug and repeat the process.
 
 Tips:

--- a/prompt.md
+++ b/prompt.md
@@ -10,7 +10,7 @@ Workflow:
 2. Add a regression test that fails because of the bug.
 3. Fix the bug.
 4. Run the engine tests to ensure that the bug is fixed and that no other tests are broken.
-5. Open a pull request against the `next` branch. Use the github access token provided in the .env file.
+5. Commit, push and open a pull request against the `next` branch. Use the github access token provided in the .env file.
 6. Wait for Cursor Bugbot CI/CD check to finish. Read the comments. Either fix them or reply why the comment is wrong.
 7. Create a new branch from the existing branch (stacked PRs) for the next bug and repeat the process.
 


### PR DESCRIPTION
## Summary
- fix vtable UPDATE snapshot extraction so `snapshot_content = CAST(? AS TEXT)` and nested cast/paren wrappers are treated like direct placeholder assignments
- reject unsupported `snapshot_content` assignment expressions instead of silently skipping validation extraction
- add regression tests for `lix_state_by_version` updates that use cast-wrapped placeholders:
  - valid JSON payload updates successfully
  - invalid JSON payload is rejected and original snapshot remains unchanged

## Validation
- `cargo fmt --all`
- `cargo test -p lix_engine cast_placeholder`
- `pnpm --filter js-sdk test`
- `cargo test -p lix_engine` *(fails on an existing baseline issue: stack overflow in `filesystem::pending_file_writes::tests::exact_update_fast_path_falls_back_when_data_cache_misses`)*

I confirmed the stack-overflow failure is pre-existing on `origin/bug-fix-1` by running the same test in a clean detached worktree at commit `003b22a1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQL update validation/placeholder binding logic; mistakes could cause incorrect parameter indexing or reject/accept invalid updates, but scope is limited and covered by new regression tests.
> 
> **Overview**
> Fixes vtable UPDATE validation extraction so `snapshot_content = CAST(? AS TEXT)` (and nested cast/paren wrappers) is treated like a direct placeholder/literal, and **now errors** when `snapshot_content` uses an unsupported expression instead of silently skipping validation.
> 
> Also ensures placeholder binding state advances for non-`snapshot_content` assignments encountered before the snapshot assignment, preventing later placeholders from being mis-indexed. Adds regression coverage in `state_by_version_view` for cast-wrapped placeholder updates (valid JSON succeeds; invalid JSON fails without changing stored snapshot) plus a unit test for the placeholder-state advancement case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48f4702245b8ce74d70937cb6f6e9f4056198271. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->