### PR TITLE
Add-observe-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ name = "lix_engine_wasm_bindgen"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures-util",
  "getrandom 0.3.4",
  "js-sys",
  "lix_engine",

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -13,6 +13,7 @@ mod init;
 mod json_truthiness;
 mod key_value;
 mod materialization;
+mod observe;
 mod plugin;
 mod schema;
 mod schema_registry;
@@ -49,6 +50,7 @@ pub use materialization::{
     StageStat, TraversedCommitDebugRow, TraversedEdgeDebugRow, VersionAncestryDebugRow,
     VersionPointerDebugRow,
 };
+pub use observe::{observe_owned, ObserveEvent, ObserveEvents, ObserveEventsOwned, ObserveQuery};
 pub use snapshot::{SnapshotChunkReader, SnapshotChunkWriter};
 pub use state_commit_events::{
     StateCommitEventBatch, StateCommitEventChange, StateCommitEventFilter,

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -18,6 +18,7 @@ mod schema;
 mod schema_registry;
 mod snapshot;
 mod sql;
+mod state_commit_events;
 mod types;
 mod validation;
 mod version;
@@ -49,5 +50,9 @@ pub use materialization::{
     VersionPointerDebugRow,
 };
 pub use snapshot::{SnapshotChunkReader, SnapshotChunkWriter};
+pub use state_commit_events::{
+    StateCommitEventBatch, StateCommitEventChange, StateCommitEventFilter,
+    StateCommitEventOperation, StateCommitEvents,
+};
 pub use types::{QueryResult, Value};
 pub use wasm_runtime::{WasmComponentInstance, WasmLimits, WasmRuntime};

--- a/packages/engine/src/observe.rs
+++ b/packages/engine/src/observe.rs
@@ -1,0 +1,669 @@
+use crate::engine::{Engine, ExecuteOptions};
+use crate::sql::{bind_sql_with_state, parse_sql_statements, PlaceholderState};
+use crate::state_commit_events::{StateCommitEventFilter, StateCommitEvents};
+use crate::{LixError, QueryResult, SqlDialect, Value};
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::{
+    BinaryOperator, Expr, ObjectNamePart, Query, Statement, TableFactor, UnaryOperator,
+    Value as SqlValue,
+};
+use sqlparser::ast::{Visit, Visitor};
+use std::collections::BTreeSet;
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ObserveQuery {
+    pub sql: String,
+    pub params: Vec<Value>,
+}
+
+impl ObserveQuery {
+    pub fn new(sql: impl Into<String>, params: Vec<Value>) -> Self {
+        Self {
+            sql: sql.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ObserveEvent {
+    pub sequence: u64,
+    pub rows: QueryResult,
+    pub state_commit_sequence: Option<u64>,
+}
+
+pub struct ObserveEvents<'a> {
+    engine: &'a Engine,
+    state: ObserveState,
+}
+
+pub struct ObserveEventsOwned {
+    engine: Arc<Engine>,
+    state: ObserveState,
+}
+
+struct ObserveState {
+    query: ObserveQuery,
+    state_commits: StateCommitEvents,
+    last_result: Option<QueryResult>,
+    emitted_initial: bool,
+    next_sequence: u64,
+    closed: bool,
+}
+
+impl ObserveEvents<'_> {
+    pub async fn next(&mut self) -> Result<Option<ObserveEvent>, LixError> {
+        if self.state.closed {
+            return Ok(None);
+        }
+
+        if !self.state.emitted_initial {
+            self.state.emitted_initial = true;
+            let rows = self
+                .engine
+                .execute(
+                    &self.state.query.sql,
+                    &self.state.query.params,
+                    ExecuteOptions::default(),
+                )
+                .await?;
+            self.state.last_result = Some(rows.clone());
+            return Ok(Some(self.state.make_event(rows, None)));
+        }
+
+        loop {
+            let Some(batch) = self.state.state_commits.next().await else {
+                self.state.closed = true;
+                return Ok(None);
+            };
+
+            let rows = self
+                .engine
+                .execute(
+                    &self.state.query.sql,
+                    &self.state.query.params,
+                    ExecuteOptions::default(),
+                )
+                .await?;
+
+            if self
+                .state
+                .last_result
+                .as_ref()
+                .is_some_and(|previous| *previous == rows)
+            {
+                continue;
+            }
+
+            self.state.last_result = Some(rows.clone());
+            return Ok(Some(self.state.make_event(rows, Some(batch.sequence))));
+        }
+    }
+
+    pub fn close(&mut self) {
+        self.state.close();
+    }
+}
+
+impl Drop for ObserveEvents<'_> {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl ObserveEventsOwned {
+    pub async fn next(&mut self) -> Result<Option<ObserveEvent>, LixError> {
+        if self.state.closed {
+            return Ok(None);
+        }
+
+        if !self.state.emitted_initial {
+            self.state.emitted_initial = true;
+            let rows = self
+                .engine
+                .execute(
+                    &self.state.query.sql,
+                    &self.state.query.params,
+                    ExecuteOptions::default(),
+                )
+                .await?;
+            self.state.last_result = Some(rows.clone());
+            return Ok(Some(self.state.make_event(rows, None)));
+        }
+
+        loop {
+            let Some(batch) = self.state.state_commits.next().await else {
+                self.state.closed = true;
+                return Ok(None);
+            };
+
+            let rows = self
+                .engine
+                .execute(
+                    &self.state.query.sql,
+                    &self.state.query.params,
+                    ExecuteOptions::default(),
+                )
+                .await?;
+
+            if self
+                .state
+                .last_result
+                .as_ref()
+                .is_some_and(|previous| *previous == rows)
+            {
+                continue;
+            }
+
+            self.state.last_result = Some(rows.clone());
+            return Ok(Some(self.state.make_event(rows, Some(batch.sequence))));
+        }
+    }
+
+    pub fn close(&mut self) {
+        self.state.close();
+    }
+}
+
+impl Drop for ObserveEventsOwned {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl ObserveState {
+    fn make_event(
+        &mut self,
+        rows: QueryResult,
+        state_commit_sequence: Option<u64>,
+    ) -> ObserveEvent {
+        let sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        ObserveEvent {
+            sequence,
+            rows,
+            state_commit_sequence,
+        }
+    }
+
+    fn close(&mut self) {
+        if self.closed {
+            return;
+        }
+        self.closed = true;
+        self.state_commits.close();
+    }
+}
+
+impl Engine {
+    pub fn observe(&self, query: ObserveQuery) -> Result<ObserveEvents<'_>, LixError> {
+        let state = build_observe_state(self, query)?;
+        Ok(ObserveEvents {
+            engine: self,
+            state,
+        })
+    }
+}
+
+pub fn observe_owned(
+    engine: Arc<Engine>,
+    query: ObserveQuery,
+) -> Result<ObserveEventsOwned, LixError> {
+    let state = build_observe_state(engine.as_ref(), query)?;
+    Ok(ObserveEventsOwned { engine, state })
+}
+
+fn build_observe_state(engine: &Engine, query: ObserveQuery) -> Result<ObserveState, LixError> {
+    let statements = parse_sql_statements(&query.sql)?;
+    if statements.is_empty()
+        || !statements
+            .iter()
+            .all(|statement| matches!(statement, Statement::Query(_)))
+    {
+        return Err(LixError {
+            message: "observe requires one or more SELECT statements".to_string(),
+        });
+    }
+
+    let filter = derive_state_commit_event_filter(&statements, &query.params)?;
+    let state_commits = engine.state_commit_events(filter);
+
+    Ok(ObserveState {
+        query,
+        state_commits,
+        last_result: None,
+        emitted_initial: false,
+        next_sequence: 0,
+        closed: false,
+    })
+}
+
+#[derive(Default)]
+struct DerivedObserveFilter {
+    relations: BTreeSet<String>,
+    schema_keys: BTreeSet<String>,
+    entity_ids: BTreeSet<String>,
+    file_ids: BTreeSet<String>,
+    version_ids: BTreeSet<String>,
+}
+
+fn derive_state_commit_event_filter(
+    statements: &[Statement],
+    params: &[Value],
+) -> Result<StateCommitEventFilter, LixError> {
+    let mut derived = DerivedObserveFilter::default();
+    let mut placeholder_state = PlaceholderState::new();
+    // One conjunctive filter cannot represent OR across independent statements.
+    let mut allow_literal_filters = statements.len() == 1;
+
+    for statement in statements {
+        let statement_sql = statement.to_string();
+        let bound = bind_sql_with_state(
+            &statement_sql,
+            params,
+            SqlDialect::Sqlite,
+            placeholder_state,
+        )?;
+        placeholder_state = bound.state;
+
+        let mut rebound_statements = parse_sql_statements(&bound.sql)?;
+        if rebound_statements.len() != 1 {
+            continue;
+        }
+        let rebound_statement = rebound_statements.remove(0);
+        let Statement::Query(query) = rebound_statement else {
+            continue;
+        };
+
+        collect_relation_names_from_query(&query, &mut derived.relations);
+        if allow_literal_filters {
+            let representable =
+                collect_literal_filters_from_query(&query, &bound.params, &mut derived);
+            if !representable {
+                allow_literal_filters = false;
+                derived.schema_keys.clear();
+                derived.entity_ids.clear();
+                derived.file_ids.clear();
+                derived.version_ids.clear();
+            }
+        }
+    }
+
+    Ok(state_commit_filter_from_derived(derived))
+}
+
+fn state_commit_filter_from_derived(derived: DerivedObserveFilter) -> StateCommitEventFilter {
+    let mut schema_keys = BTreeSet::new();
+    let mut uses_dynamic_state_relations = false;
+
+    for relation in &derived.relations {
+        match relation.as_str() {
+            "state"
+            | "state_by_version"
+            | "state_history"
+            | "lix_state"
+            | "lix_state_by_version"
+            | "lix_state_history"
+            | "lix_internal_state_vtable"
+            | "lix_internal_state_untracked" => {
+                uses_dynamic_state_relations = true;
+            }
+            "file"
+            | "file_by_version"
+            | "file_history"
+            | "lix_file"
+            | "lix_file_by_version"
+            | "lix_file_history" => {
+                schema_keys.insert("lix_file_descriptor".to_string());
+            }
+            "directory"
+            | "directory_by_version"
+            | "directory_history"
+            | "lix_directory"
+            | "lix_directory_by_version"
+            | "lix_directory_history" => {
+                schema_keys.insert("lix_directory_descriptor".to_string());
+            }
+            "version" | "version_by_version" | "lix_version" | "lix_version_by_version" => {
+                schema_keys.insert("lix_version_descriptor".to_string());
+                schema_keys.insert("lix_version_tip".to_string());
+            }
+            "active_version" | "lix_active_version" => {
+                schema_keys.insert("lix_active_version".to_string());
+            }
+            "active_account" | "lix_active_account" => {
+                schema_keys.insert("lix_active_account".to_string());
+            }
+            "change" => {
+                schema_keys.insert("lix_change".to_string());
+            }
+            _ => {
+                if relation.starts_with("lix_") && !relation.starts_with("lix_internal_") {
+                    schema_keys.insert(relation.clone());
+                }
+            }
+        }
+    }
+
+    if uses_dynamic_state_relations {
+        schema_keys.extend(derived.schema_keys);
+    }
+
+    StateCommitEventFilter {
+        schema_keys: schema_keys.into_iter().collect(),
+        entity_ids: derived.entity_ids.into_iter().collect(),
+        file_ids: derived.file_ids.into_iter().collect(),
+        version_ids: derived.version_ids.into_iter().collect(),
+        ..StateCommitEventFilter::default()
+    }
+}
+
+fn collect_relation_names_from_query(query: &Query, relation_names: &mut BTreeSet<String>) {
+    struct Collector<'a> {
+        relation_names: &'a mut BTreeSet<String>,
+    }
+
+    impl Visitor for Collector<'_> {
+        type Break = ();
+
+        fn pre_visit_table_factor(
+            &mut self,
+            table_factor: &TableFactor,
+        ) -> ControlFlow<Self::Break> {
+            if let TableFactor::Table { name, .. } = table_factor {
+                if let Some(identifier) = name.0.last().and_then(ObjectNamePart::as_ident) {
+                    self.relation_names
+                        .insert(identifier.value.to_ascii_lowercase());
+                }
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    let mut collector = Collector { relation_names };
+    let _ = query.visit(&mut collector);
+}
+
+fn collect_literal_filters_from_query(
+    query: &Query,
+    params: &[Value],
+    out: &mut DerivedObserveFilter,
+) -> bool {
+    struct Collector<'a> {
+        params: &'a [Value],
+        out: &'a mut DerivedObserveFilter,
+        representable: bool,
+    }
+
+    impl Visitor for Collector<'_> {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expr: &Expr) -> ControlFlow<Self::Break> {
+            if expr_is_non_representable_for_commit_filter(expr) {
+                self.representable = false;
+                return ControlFlow::Break(());
+            }
+            collect_literal_filters_from_expr(expr, self.params, self.out);
+            ControlFlow::Continue(())
+        }
+    }
+
+    let mut collector = Collector {
+        params,
+        out,
+        representable: true,
+    };
+    let _ = query.visit(&mut collector);
+    collector.representable
+}
+
+fn expr_is_non_representable_for_commit_filter(expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryOp { left, op, right } => {
+            matches!(op, BinaryOperator::Or | BinaryOperator::Xor)
+                && (expr_contains_filter_column(left) || expr_contains_filter_column(right))
+        }
+        Expr::UnaryOp {
+            op: UnaryOperator::Not,
+            expr,
+        } => expr_contains_filter_column(expr),
+        Expr::InList {
+            expr,
+            negated: true,
+            ..
+        } => expr_contains_filter_column(expr),
+        _ => false,
+    }
+}
+
+fn expr_contains_filter_column(expr: &Expr) -> bool {
+    struct Collector {
+        found: bool,
+    }
+
+    impl Visitor for Collector {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expr: &Expr) -> ControlFlow<Self::Break> {
+            if extract_filter_column(expr).is_some() {
+                self.found = true;
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(())
+        }
+    }
+
+    let mut collector = Collector { found: false };
+    let _ = expr.visit(&mut collector);
+    collector.found
+}
+
+fn collect_literal_filters_from_expr(
+    expr: &Expr,
+    params: &[Value],
+    out: &mut DerivedObserveFilter,
+) {
+    match expr {
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            if let Some(column) = extract_filter_column(left) {
+                if let Some(value) = extract_filter_literal(right, params) {
+                    add_filter_literal(out, column, value);
+                }
+            }
+            if let Some(column) = extract_filter_column(right) {
+                if let Some(value) = extract_filter_literal(left, params) {
+                    add_filter_literal(out, column, value);
+                }
+            }
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated: false,
+        } => {
+            if let Some(column) = extract_filter_column(expr) {
+                for item in list {
+                    if let Some(value) = extract_filter_literal(item, params) {
+                        add_filter_literal(out, column, value);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FilterColumn {
+    SchemaKey,
+    EntityId,
+    FileId,
+    VersionId,
+}
+
+fn extract_filter_column(expr: &Expr) -> Option<FilterColumn> {
+    let column = match expr {
+        Expr::Identifier(identifier) => Some(identifier.value.as_str()),
+        Expr::CompoundIdentifier(identifiers) => identifiers
+            .last()
+            .map(|identifier| identifier.value.as_str()),
+        Expr::Nested(inner) => return extract_filter_column(inner),
+        _ => None,
+    }?;
+
+    match column.to_ascii_lowercase().as_str() {
+        "schema_key" => Some(FilterColumn::SchemaKey),
+        "entity_id" => Some(FilterColumn::EntityId),
+        "file_id" => Some(FilterColumn::FileId),
+        "version_id" | "lixcol_version_id" => Some(FilterColumn::VersionId),
+        _ => None,
+    }
+}
+
+fn extract_filter_literal(expr: &Expr, params: &[Value]) -> Option<String> {
+    match expr {
+        Expr::Value(value) => extract_sql_value_literal(&value.value, params),
+        Expr::Nested(inner) => extract_filter_literal(inner, params),
+        _ => None,
+    }
+}
+
+fn extract_sql_value_literal(value: &SqlValue, params: &[Value]) -> Option<String> {
+    if let Some(literal) = value.clone().into_string() {
+        return Some(literal);
+    }
+
+    if let SqlValue::Placeholder(token) = value {
+        return extract_placeholder_literal(token, params);
+    }
+
+    None
+}
+
+fn extract_placeholder_literal(token: &str, params: &[Value]) -> Option<String> {
+    let trimmed = token.trim();
+    let numeric = if let Some(rest) = trimmed.strip_prefix('?') {
+        rest
+    } else if let Some(rest) = trimmed.strip_prefix('$') {
+        rest
+    } else {
+        return None;
+    };
+    let index = numeric.parse::<usize>().ok()?;
+    if index == 0 {
+        return None;
+    }
+    value_to_filter_literal(params.get(index - 1)?)
+}
+
+fn value_to_filter_literal(value: &Value) -> Option<String> {
+    match value {
+        Value::Text(text) => Some(text.clone()),
+        Value::Integer(number) => Some(number.to_string()),
+        Value::Real(number) => Some(number.to_string()),
+        Value::Null | Value::Blob(_) => None,
+    }
+}
+
+fn add_filter_literal(out: &mut DerivedObserveFilter, column: FilterColumn, value: String) {
+    match column {
+        FilterColumn::SchemaKey => {
+            out.schema_keys.insert(value);
+        }
+        FilterColumn::EntityId => {
+            out.entity_ids.insert(value);
+        }
+        FilterColumn::FileId => {
+            out.file_ids.insert(value);
+        }
+        FilterColumn::VersionId => {
+            out.version_ids.insert(value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{derive_state_commit_event_filter, parse_sql_statements};
+    use crate::Value;
+
+    #[test]
+    fn derive_filter_extracts_schema_entity_and_version_literals() {
+        let statements = parse_sql_statements(
+            "SELECT entity_id FROM lix_state \
+             WHERE schema_key = $1 AND entity_id IN ($2, 'entity-b') AND version_id = 'v-1'",
+        )
+        .expect("parse sql");
+
+        let filter = derive_state_commit_event_filter(
+            &statements,
+            &[
+                Value::Text("lix_key_value".to_string()),
+                Value::Text("entity-a".to_string()),
+            ],
+        )
+        .expect("derive filter");
+
+        assert_eq!(filter.schema_keys, vec!["lix_key_value".to_string()]);
+        assert_eq!(
+            filter.entity_ids,
+            vec!["entity-a".to_string(), "entity-b".to_string()]
+        );
+        assert_eq!(filter.version_ids, vec!["v-1".to_string()]);
+    }
+
+    #[test]
+    fn derive_filter_maps_file_reads_to_file_descriptor_schema() {
+        let statements =
+            parse_sql_statements("SELECT id, path FROM lix_file WHERE path = '/docs/a.md'")
+                .expect("parse sql");
+
+        let filter = derive_state_commit_event_filter(&statements, &[]).expect("derive filter");
+        assert_eq!(filter.schema_keys, vec!["lix_file_descriptor".to_string()]);
+    }
+
+    #[test]
+    fn derive_filter_maps_direct_schema_view_reads() {
+        let statements =
+            parse_sql_statements("SELECT entity_id FROM lix_key_value LIMIT 1").expect("parse sql");
+
+        let filter = derive_state_commit_event_filter(&statements, &[]).expect("derive filter");
+        assert_eq!(filter.schema_keys, vec!["lix_key_value".to_string()]);
+    }
+
+    #[test]
+    fn derive_filter_falls_back_for_or_across_tracked_columns() {
+        let statements = parse_sql_statements(
+            "SELECT entity_id FROM lix_state \
+             WHERE schema_key = 'a' OR entity_id = 'b'",
+        )
+        .expect("parse sql");
+
+        let filter = derive_state_commit_event_filter(&statements, &[]).expect("derive filter");
+        assert!(filter.schema_keys.is_empty());
+        assert!(filter.entity_ids.is_empty());
+        assert!(filter.file_ids.is_empty());
+        assert!(filter.version_ids.is_empty());
+    }
+
+    #[test]
+    fn derive_filter_falls_back_for_multiple_statements() {
+        let statements = parse_sql_statements(
+            "SELECT entity_id FROM lix_state WHERE schema_key = 'a'; \
+             SELECT entity_id FROM lix_state WHERE entity_id = 'b'",
+        )
+        .expect("parse sql");
+
+        let filter = derive_state_commit_event_filter(&statements, &[]).expect("derive filter");
+        assert!(filter.schema_keys.is_empty());
+        assert!(filter.entity_ids.is_empty());
+        assert!(filter.file_ids.is_empty());
+        assert!(filter.version_ids.is_empty());
+    }
+}

--- a/packages/engine/src/state_commit_events.rs
+++ b/packages/engine/src/state_commit_events.rs
@@ -1,0 +1,447 @@
+use crate::sql::{MutationOperation, MutationRow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+const MAX_PENDING_BATCHES_PER_LISTENER: usize = 256;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StateCommitEventFilter {
+    pub schema_keys: Vec<String>,
+    pub entity_ids: Vec<String>,
+    pub file_ids: Vec<String>,
+    pub version_ids: Vec<String>,
+    pub writer_keys: Vec<String>,
+    pub exclude_writer_keys: Vec<String>,
+    pub include_untracked: bool,
+}
+
+impl Default for StateCommitEventFilter {
+    fn default() -> Self {
+        Self {
+            schema_keys: Vec::new(),
+            entity_ids: Vec::new(),
+            file_ids: Vec::new(),
+            version_ids: Vec::new(),
+            writer_keys: Vec::new(),
+            exclude_writer_keys: Vec::new(),
+            include_untracked: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum StateCommitEventOperation {
+    Insert,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StateCommitEventChange {
+    pub operation: StateCommitEventOperation,
+    pub entity_id: String,
+    pub schema_key: String,
+    pub schema_version: String,
+    pub file_id: String,
+    pub version_id: String,
+    pub plugin_key: String,
+    pub snapshot_content: Option<JsonValue>,
+    pub untracked: bool,
+    pub writer_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StateCommitEventBatch {
+    pub sequence: u64,
+    pub changes: Vec<StateCommitEventChange>,
+}
+
+pub struct StateCommitEvents {
+    listener_id: u64,
+    queue: Arc<Mutex<VecDeque<StateCommitEventBatch>>>,
+    bus: Arc<StateCommitEventBus>,
+    closed: AtomicBool,
+}
+
+impl StateCommitEvents {
+    pub fn try_next(&self) -> Option<StateCommitEventBatch> {
+        let mut queue = self.queue.lock().unwrap();
+        queue.pop_front()
+    }
+
+    pub fn close(&self) {
+        if self.closed.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        self.bus.unsubscribe(self.listener_id);
+    }
+}
+
+impl Drop for StateCommitEvents {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct StateCommitEventBus {
+    inner: Mutex<StateCommitEventBusInner>,
+}
+
+impl StateCommitEventBus {
+    pub(crate) fn subscribe(self: &Arc<Self>, filter: StateCommitEventFilter) -> StateCommitEvents {
+        let compiled_filter = CompiledStateCommitEventFilter::new(filter);
+        let queue = Arc::new(Mutex::new(VecDeque::new()));
+
+        let mut inner = self.inner.lock().unwrap();
+        let listener_id = inner.next_listener_id;
+        inner.next_listener_id = inner.next_listener_id.saturating_add(1);
+
+        let listener_entry = ListenerEntry {
+            filter: compiled_filter.clone(),
+            queue: Arc::clone(&queue),
+        };
+        inner.listeners.insert(listener_id, listener_entry);
+
+        if compiled_filter.is_wildcard_listener() {
+            inner.wildcard_listeners.insert(listener_id);
+        }
+        index_listener(
+            &mut inner.by_schema_key,
+            &compiled_filter.schema_keys,
+            listener_id,
+        );
+        index_listener(
+            &mut inner.by_entity_id,
+            &compiled_filter.entity_ids,
+            listener_id,
+        );
+        index_listener(
+            &mut inner.by_file_id,
+            &compiled_filter.file_ids,
+            listener_id,
+        );
+        index_listener(
+            &mut inner.by_version_id,
+            &compiled_filter.version_ids,
+            listener_id,
+        );
+        index_listener(
+            &mut inner.by_writer_key,
+            &compiled_filter.writer_keys,
+            listener_id,
+        );
+
+        StateCommitEvents {
+            listener_id,
+            queue,
+            bus: Arc::clone(self),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn emit(&self, changes: Vec<StateCommitEventChange>) {
+        if changes.is_empty() {
+            return;
+        }
+
+        let (batch, candidate_listeners) = {
+            let mut inner = self.inner.lock().unwrap();
+            let touched = TouchedFields::from_changes(&changes);
+
+            let mut candidate_ids: HashSet<u64> = HashSet::new();
+            candidate_ids.extend(inner.wildcard_listeners.iter().copied());
+            extend_candidates(
+                &mut candidate_ids,
+                &inner.by_schema_key,
+                touched.schema_keys.iter(),
+            );
+            extend_candidates(
+                &mut candidate_ids,
+                &inner.by_entity_id,
+                touched.entity_ids.iter(),
+            );
+            extend_candidates(
+                &mut candidate_ids,
+                &inner.by_file_id,
+                touched.file_ids.iter(),
+            );
+            extend_candidates(
+                &mut candidate_ids,
+                &inner.by_version_id,
+                touched.version_ids.iter(),
+            );
+            extend_candidates(
+                &mut candidate_ids,
+                &inner.by_writer_key,
+                touched.writer_keys.iter(),
+            );
+
+            if candidate_ids.is_empty() {
+                return;
+            }
+
+            let sequence = inner.next_sequence;
+            inner.next_sequence = inner.next_sequence.saturating_add(1);
+            let batch = StateCommitEventBatch { sequence, changes };
+
+            let listeners = candidate_ids
+                .into_iter()
+                .filter_map(|listener_id| inner.listeners.get(&listener_id).cloned())
+                .collect::<Vec<_>>();
+
+            (batch, listeners)
+        };
+
+        for listener in candidate_listeners {
+            if !listener.filter.matches_batch(&batch) {
+                continue;
+            }
+            enqueue_batch(&listener.queue, batch.clone());
+        }
+    }
+
+    fn unsubscribe(&self, listener_id: u64) {
+        let mut inner = self.inner.lock().unwrap();
+        let Some(listener) = inner.listeners.remove(&listener_id) else {
+            return;
+        };
+
+        inner.wildcard_listeners.remove(&listener_id);
+        unindex_listener(
+            &mut inner.by_schema_key,
+            &listener.filter.schema_keys,
+            listener_id,
+        );
+        unindex_listener(
+            &mut inner.by_entity_id,
+            &listener.filter.entity_ids,
+            listener_id,
+        );
+        unindex_listener(
+            &mut inner.by_file_id,
+            &listener.filter.file_ids,
+            listener_id,
+        );
+        unindex_listener(
+            &mut inner.by_version_id,
+            &listener.filter.version_ids,
+            listener_id,
+        );
+        unindex_listener(
+            &mut inner.by_writer_key,
+            &listener.filter.writer_keys,
+            listener_id,
+        );
+    }
+}
+
+#[derive(Default)]
+struct StateCommitEventBusInner {
+    next_listener_id: u64,
+    next_sequence: u64,
+    listeners: HashMap<u64, ListenerEntry>,
+    wildcard_listeners: HashSet<u64>,
+    by_schema_key: HashMap<String, HashSet<u64>>,
+    by_entity_id: HashMap<String, HashSet<u64>>,
+    by_file_id: HashMap<String, HashSet<u64>>,
+    by_version_id: HashMap<String, HashSet<u64>>,
+    by_writer_key: HashMap<String, HashSet<u64>>,
+}
+
+#[derive(Clone)]
+struct ListenerEntry {
+    filter: CompiledStateCommitEventFilter,
+    queue: Arc<Mutex<VecDeque<StateCommitEventBatch>>>,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledStateCommitEventFilter {
+    schema_keys: HashSet<String>,
+    entity_ids: HashSet<String>,
+    file_ids: HashSet<String>,
+    version_ids: HashSet<String>,
+    writer_keys: HashSet<String>,
+    exclude_writer_keys: HashSet<String>,
+    include_untracked: bool,
+}
+
+impl CompiledStateCommitEventFilter {
+    fn new(filter: StateCommitEventFilter) -> Self {
+        Self {
+            schema_keys: normalize_filter_values(filter.schema_keys),
+            entity_ids: normalize_filter_values(filter.entity_ids),
+            file_ids: normalize_filter_values(filter.file_ids),
+            version_ids: normalize_filter_values(filter.version_ids),
+            writer_keys: normalize_filter_values(filter.writer_keys),
+            exclude_writer_keys: normalize_filter_values(filter.exclude_writer_keys),
+            include_untracked: filter.include_untracked,
+        }
+    }
+
+    fn is_wildcard_listener(&self) -> bool {
+        self.schema_keys.is_empty()
+            && self.entity_ids.is_empty()
+            && self.file_ids.is_empty()
+            && self.version_ids.is_empty()
+            && self.writer_keys.is_empty()
+    }
+
+    fn matches_batch(&self, batch: &StateCommitEventBatch) -> bool {
+        batch
+            .changes
+            .iter()
+            .any(|change| self.matches_change(change))
+    }
+
+    fn matches_change(&self, change: &StateCommitEventChange) -> bool {
+        if !self.include_untracked && change.untracked {
+            return false;
+        }
+        if !self.schema_keys.is_empty() && !self.schema_keys.contains(&change.schema_key) {
+            return false;
+        }
+        if !self.entity_ids.is_empty() && !self.entity_ids.contains(&change.entity_id) {
+            return false;
+        }
+        if !self.file_ids.is_empty() && !self.file_ids.contains(&change.file_id) {
+            return false;
+        }
+        if !self.version_ids.is_empty() && !self.version_ids.contains(&change.version_id) {
+            return false;
+        }
+        if !self.writer_keys.is_empty() {
+            let Some(writer_key) = change.writer_key.as_ref() else {
+                return false;
+            };
+            if !self.writer_keys.contains(writer_key) {
+                return false;
+            }
+        }
+        if let Some(writer_key) = change.writer_key.as_ref() {
+            if self.exclude_writer_keys.contains(writer_key) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[derive(Default)]
+struct TouchedFields {
+    schema_keys: HashSet<String>,
+    entity_ids: HashSet<String>,
+    file_ids: HashSet<String>,
+    version_ids: HashSet<String>,
+    writer_keys: HashSet<String>,
+}
+
+impl TouchedFields {
+    fn from_changes(changes: &[StateCommitEventChange]) -> Self {
+        let mut touched = Self::default();
+        for change in changes {
+            touched.schema_keys.insert(change.schema_key.clone());
+            touched.entity_ids.insert(change.entity_id.clone());
+            touched.file_ids.insert(change.file_id.clone());
+            touched.version_ids.insert(change.version_id.clone());
+            if let Some(writer_key) = change.writer_key.as_ref() {
+                touched.writer_keys.insert(writer_key.clone());
+            }
+        }
+        touched
+    }
+}
+
+fn normalize_filter_values(values: Vec<String>) -> HashSet<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn index_listener(
+    index: &mut HashMap<String, HashSet<u64>>,
+    keys: &HashSet<String>,
+    listener_id: u64,
+) {
+    for key in keys {
+        index
+            .entry(key.clone())
+            .or_insert_with(HashSet::new)
+            .insert(listener_id);
+    }
+}
+
+fn unindex_listener(
+    index: &mut HashMap<String, HashSet<u64>>,
+    keys: &HashSet<String>,
+    listener_id: u64,
+) {
+    for key in keys {
+        if let Some(ids) = index.get_mut(key) {
+            ids.remove(&listener_id);
+            if ids.is_empty() {
+                index.remove(key);
+            }
+        }
+    }
+}
+
+fn extend_candidates<'a>(
+    candidates: &mut HashSet<u64>,
+    index: &HashMap<String, HashSet<u64>>,
+    keys: impl Iterator<Item = &'a String>,
+) {
+    for key in keys {
+        if let Some(listener_ids) = index.get(key) {
+            candidates.extend(listener_ids.iter().copied());
+        }
+    }
+}
+
+fn enqueue_batch(queue: &Mutex<VecDeque<StateCommitEventBatch>>, batch: StateCommitEventBatch) {
+    let mut queue = queue.lock().unwrap();
+    if queue.len() >= MAX_PENDING_BATCHES_PER_LISTENER {
+        queue.pop_front();
+    }
+    queue.push_back(batch);
+}
+
+pub(crate) fn state_commit_event_changes_from_mutations(
+    mutations: &[MutationRow],
+    writer_key: Option<&str>,
+) -> Vec<StateCommitEventChange> {
+    if mutations.is_empty() {
+        return Vec::new();
+    }
+
+    let writer_key = writer_key.map(str::to_string);
+
+    mutations
+        .iter()
+        .map(|mutation| StateCommitEventChange {
+            operation: map_mutation_operation(&mutation.operation),
+            entity_id: mutation.entity_id.clone(),
+            schema_key: mutation.schema_key.clone(),
+            schema_version: mutation.schema_version.clone(),
+            file_id: mutation.file_id.clone(),
+            version_id: mutation.version_id.clone(),
+            plugin_key: mutation.plugin_key.clone(),
+            snapshot_content: mutation.snapshot_content.clone(),
+            untracked: mutation.untracked,
+            writer_key: writer_key.clone(),
+        })
+        .collect()
+}
+
+fn map_mutation_operation(operation: &MutationOperation) -> StateCommitEventOperation {
+    match operation {
+        MutationOperation::Insert => StateCommitEventOperation::Insert,
+        MutationOperation::Update => StateCommitEventOperation::Update,
+        MutationOperation::Delete => StateCommitEventOperation::Delete,
+    }
+}

--- a/packages/engine/tests/observe.rs
+++ b/packages/engine/tests/observe.rs
@@ -1,0 +1,317 @@
+mod support;
+
+use lix_engine::{ObserveQuery, Value};
+
+fn insert_key_value_sql(key: &str, value_json: &str) -> String {
+    format!(
+        "INSERT INTO lix_internal_state_vtable (\
+         entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+         ) VALUES (\
+         '{key}', 'lix_key_value', 'lix', 'global', 'lix', '{{\"key\":\"{key}\",\"value\":{value_json}}}', '1'\
+         )"
+    )
+}
+
+fn update_key_value_sql(key: &str, value_json: &str) -> String {
+    format!(
+        "UPDATE lix_internal_state_vtable \
+         SET snapshot_content = '{{\"key\":\"{key}\",\"value\":{value_json}}}' \
+         WHERE entity_id = '{key}' \
+           AND schema_key = 'lix_key_value' \
+           AND file_id = 'lix' \
+           AND version_id = 'global'"
+    )
+}
+
+simulation_test!(
+    observe_emits_initial_and_followup_rows,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let mut observed = engine
+            .raw_engine()
+            .observe(ObserveQuery::new(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'lix_key_value' AND entity_id = ?1",
+                vec![Value::Text("observe-key".to_string())],
+            ))
+            .expect("observe should succeed");
+
+        let initial = observed
+            .next()
+            .await
+            .expect("initial observe poll should succeed")
+            .expect("initial observe event should exist");
+        assert_eq!(initial.sequence, 0);
+        assert!(initial.rows.rows.is_empty());
+        assert_eq!(initial.state_commit_sequence, None);
+
+        engine
+            .execute(&insert_key_value_sql("observe-key", "\"v0\""), &[])
+            .await
+            .unwrap();
+
+        let update = observed
+            .next()
+            .await
+            .expect("follow-up observe poll should succeed")
+            .expect("follow-up observe event should exist");
+        assert_eq!(update.sequence, 1);
+        assert!(update.state_commit_sequence.is_some());
+        assert_eq!(update.rows.rows.len(), 1);
+        assert_eq!(
+            update.rows.rows[0][0],
+            Value::Text("observe-key".to_string())
+        );
+
+        observed.close();
+        let closed = observed
+            .next()
+            .await
+            .expect("observe poll after close should succeed");
+        assert!(closed.is_none());
+    }
+);
+
+simulation_test!(
+    observe_supports_multiple_subscribers,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let mut observed_a = engine
+            .raw_engine()
+            .observe(ObserveQuery::new(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'lix_key_value' AND entity_id = ?1 \
+                 ORDER BY entity_id",
+                vec![Value::Text("observe-multi".to_string())],
+            ))
+            .expect("observe should succeed");
+        let mut observed_b = engine
+            .raw_engine()
+            .observe(ObserveQuery::new(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'lix_key_value' AND entity_id = ?1 \
+                 ORDER BY entity_id",
+                vec![Value::Text("observe-multi".to_string())],
+            ))
+            .expect("observe should succeed");
+
+        let initial_a = observed_a.next().await.unwrap().unwrap();
+        let initial_b = observed_b.next().await.unwrap().unwrap();
+        assert!(initial_a.rows.rows.is_empty());
+        assert!(initial_b.rows.rows.is_empty());
+
+        engine
+            .execute(&insert_key_value_sql("observe-multi", "\"v0\""), &[])
+            .await
+            .unwrap();
+
+        let update_a = observed_a.next().await.unwrap().unwrap();
+        let update_b = observed_b.next().await.unwrap().unwrap();
+
+        assert_eq!(update_a.sequence, 1);
+        assert_eq!(update_b.sequence, 1);
+        assert_eq!(update_a.rows.rows.len(), 1);
+        assert_eq!(update_b.rows.rows.len(), 1);
+        assert_eq!(
+            update_a.rows.rows[0][0],
+            Value::Text("observe-multi".to_string())
+        );
+        assert_eq!(
+            update_b.rows.rows[0][0],
+            Value::Text("observe-multi".to_string())
+        );
+    }
+);
+
+simulation_test!(
+    observe_skips_unrelated_commits_until_result_changes,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let mut observed = engine
+            .raw_engine()
+            .observe(ObserveQuery::new(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'lix_key_value' AND entity_id = ?1 \
+                 ORDER BY entity_id",
+                vec![Value::Text("observe-target".to_string())],
+            ))
+            .expect("observe should succeed");
+
+        let initial = observed.next().await.unwrap().unwrap();
+        assert_eq!(initial.sequence, 0);
+        assert!(initial.rows.rows.is_empty());
+
+        engine
+            .execute(&insert_key_value_sql("observe-unrelated", "\"v0\""), &[])
+            .await
+            .unwrap();
+        engine
+            .execute(&insert_key_value_sql("observe-target", "\"v1\""), &[])
+            .await
+            .unwrap();
+
+        let update = observed.next().await.unwrap().unwrap();
+        assert_eq!(update.sequence, 1);
+        assert_eq!(update.rows.rows.len(), 1);
+        assert_eq!(
+            update.rows.rows[0][0],
+            Value::Text("observe-target".to_string())
+        );
+    }
+);
+
+simulation_test!(
+    observe_dedups_noop_result_reexecutions,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        engine
+            .execute(&insert_key_value_sql("observe-dedup", "\"v0\""), &[])
+            .await
+            .unwrap();
+
+        let mut observed = engine
+            .raw_engine()
+            .observe(ObserveQuery::new(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'lix_key_value' \
+                 ORDER BY entity_id",
+                vec![],
+            ))
+            .expect("observe should succeed");
+
+        let initial = observed.next().await.unwrap().unwrap();
+        assert_eq!(initial.sequence, 0);
+        assert_eq!(initial.rows.rows.len(), 1);
+
+        engine
+            .execute(&update_key_value_sql("observe-dedup", "\"v1\""), &[])
+            .await
+            .unwrap();
+        engine
+            .execute(&insert_key_value_sql("observe-dedup-2", "\"v0\""), &[])
+            .await
+            .unwrap();
+
+        let next = observed.next().await.unwrap().unwrap();
+        assert_eq!(next.sequence, 1);
+        assert_eq!(next.rows.rows.len(), 2);
+        assert_eq!(
+            next.rows.rows[0][0],
+            Value::Text("observe-dedup".to_string())
+        );
+        assert_eq!(
+            next.rows.rows[1][0],
+            Value::Text("observe-dedup-2".to_string())
+        );
+    }
+);
+
+simulation_test!(
+    observe_preserves_commit_order_across_multiple_updates,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let mut observed = engine
+            .raw_engine()
+            .observe(ObserveQuery::new(
+                "SELECT entity_id \
+                 FROM lix_state \
+                 WHERE schema_key = 'lix_key_value' \
+                 ORDER BY entity_id",
+                vec![],
+            ))
+            .expect("observe should succeed");
+
+        let initial = observed.next().await.unwrap().unwrap();
+        assert_eq!(initial.sequence, 0);
+        assert!(initial.rows.rows.is_empty());
+
+        engine
+            .execute(&insert_key_value_sql("observe-order-a", "\"v0\""), &[])
+            .await
+            .unwrap();
+
+        let first = observed.next().await.unwrap().unwrap();
+        assert_eq!(first.sequence, 1);
+        assert_eq!(first.rows.rows.len(), 1);
+
+        engine
+            .execute(&insert_key_value_sql("observe-order-b", "\"v0\""), &[])
+            .await
+            .unwrap();
+
+        let second = observed.next().await.unwrap().unwrap();
+        assert_eq!(second.sequence, 2);
+        assert_eq!(second.rows.rows.len(), 2);
+        assert!(
+            first
+                .state_commit_sequence
+                .zip(second.state_commit_sequence)
+                .is_some_and(|(left, right)| right > left),
+            "expected monotonic state commit sequence order"
+        );
+    }
+);
+
+simulation_test!(
+    observe_rejects_non_query_sql,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let result = engine.raw_engine().observe(ObserveQuery::new(
+            "UPDATE lix_state SET schema_version = '1' WHERE 1 = 0",
+            vec![],
+        ));
+
+        let error = match result {
+            Ok(_) => panic!("observe should reject non-query SQL"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .message
+                .contains("observe requires one or more SELECT statements"),
+            "unexpected error message: {}",
+            error.message
+        );
+    }
+);

--- a/packages/engine/tests/state_commit_events.rs
+++ b/packages/engine/tests/state_commit_events.rs
@@ -1,0 +1,161 @@
+mod support;
+
+use lix_engine::{ExecuteOptions, LixError, StateCommitEventFilter};
+
+fn insert_key_value_sql(key: &str, value_json: &str) -> String {
+    format!(
+        "INSERT INTO lix_internal_state_vtable (\
+         entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version\
+         ) VALUES (\
+         '{key}', 'lix_key_value', 'lix', 'global', 'lix', '{{\"key\":\"{key}\",\"value\":{value_json}}}', '1'\
+         )"
+    )
+}
+
+simulation_test!(
+    state_commit_events_emits_matching_batches,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let events = engine
+            .raw_engine()
+            .state_commit_events(StateCommitEventFilter {
+                schema_keys: vec!["lix_key_value".to_string()],
+                ..StateCommitEventFilter::default()
+            });
+
+        engine
+            .execute(
+                &insert_key_value_sql("state-commit-events-a", "\"v0\""),
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let batch = events
+            .try_next()
+            .expect("expected a state commit event batch");
+        assert!(
+            batch
+                .changes
+                .iter()
+                .any(|change| change.schema_key == "lix_key_value"
+                    && change.entity_id == "state-commit-events-a"),
+            "expected key_value mutation in batch: {:?}",
+            batch.changes
+        );
+        assert!(
+            events.try_next().is_none(),
+            "expected a single batch for one execute() call"
+        );
+    }
+);
+
+simulation_test!(
+    state_commit_events_respects_excluded_writer_keys,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let events = engine
+            .raw_engine()
+            .state_commit_events(StateCommitEventFilter {
+                schema_keys: vec!["lix_key_value".to_string()],
+                exclude_writer_keys: vec!["ui-writer".to_string()],
+                ..StateCommitEventFilter::default()
+            });
+
+        engine
+            .execute_with_options(
+                &insert_key_value_sql("state-commit-events-b", "\"v0\""),
+                &[],
+                ExecuteOptions {
+                    writer_key: Some("ui-writer".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            events.try_next().is_none(),
+            "excluded writer should not receive events"
+        );
+
+        engine
+            .execute(
+                &insert_key_value_sql("state-commit-events-c", "\"v0\""),
+                &[],
+            )
+            .await
+            .unwrap();
+        let batch = events
+            .try_next()
+            .expect("expected event batch from non-excluded writer");
+        assert!(batch.changes.iter().any(|change| {
+            change.schema_key == "lix_key_value" && change.entity_id == "state-commit-events-c"
+        }));
+    }
+);
+
+simulation_test!(
+    state_commit_events_aggregates_changes_per_transaction_commit,
+    simulations = [sqlite, postgres],
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.unwrap();
+
+        let events = engine
+            .raw_engine()
+            .state_commit_events(StateCommitEventFilter {
+                schema_keys: vec!["lix_key_value".to_string()],
+                ..StateCommitEventFilter::default()
+            });
+
+        engine
+            .raw_engine()
+            .transaction(ExecuteOptions::default(), |tx| {
+                Box::pin(async move {
+                    tx.execute(
+                        &insert_key_value_sql("state-commit-events-d", "\"v0\""),
+                        &[],
+                    )
+                    .await?;
+                    tx.execute(
+                        &insert_key_value_sql("state-commit-events-e", "\"v0\""),
+                        &[],
+                    )
+                    .await?;
+                    Ok::<(), LixError>(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let batch = events
+            .try_next()
+            .expect("expected a single batched event on transaction commit");
+        assert!(batch
+            .changes
+            .iter()
+            .any(|change| change.entity_id == "state-commit-events-d"));
+        assert!(batch
+            .changes
+            .iter()
+            .any(|change| change.entity_id == "state-commit-events-e"));
+        assert!(
+            events.try_next().is_none(),
+            "transaction commit should emit one batch"
+        );
+    }
+);

--- a/packages/engine/tests/support/mod.rs
+++ b/packages/engine/tests/support/mod.rs
@@ -16,33 +16,69 @@ macro_rules! simulation_test {
             $(
                 #[test]
                 fn [<$name _ $simulation>]() {
-                    std::thread::Builder::new()
-                        .name(concat!(stringify!($name), "_", stringify!($simulation)).to_string())
+                    let simulation_name = stringify!($simulation);
+                    let case_id = concat!(module_path!(), "::", stringify!($name));
+                    let timeout_secs = std::env::var("LIX_SIMULATION_TEST_TIMEOUT_SECS")
+                        .ok()
+                        .and_then(|raw| raw.parse::<u64>().ok())
+                        .unwrap_or(120);
+                    let simulation_name_for_thread = simulation_name;
+                    let case_id_for_thread = case_id;
+                    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+                    let thread = std::thread::Builder::new()
+                        .name(format!("{}_{}", stringify!($name), simulation_name))
                         .stack_size(8 * 1024 * 1024)
-                        .spawn(|| {
-                            let runtime = tokio::runtime::Builder::new_current_thread()
-                                .enable_all()
-                                .build()
-                                .expect("failed to build tokio runtime");
-                            runtime.block_on(async {
-                                $crate::support::simulation_test::run_single_simulation_test(
-                                    stringify!($simulation),
-                                    concat!(module_path!(), "::", stringify!($name)),
-                                    |$sim| $body,
-                                )
-                                .await;
-                            });
+                        .spawn(move || {
+                            let run_result =
+                                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                    let runtime = tokio::runtime::Builder::new_current_thread()
+                                        .enable_all()
+                                        .build()
+                                        .expect("failed to build tokio runtime");
+                                    runtime.block_on(async {
+                                        $crate::support::simulation_test::run_single_simulation_test(
+                                            simulation_name_for_thread,
+                                            case_id_for_thread,
+                                            |$sim| $body,
+                                        )
+                                        .await;
+                                    });
+                                }));
+                            let _ = result_tx.send(run_result);
                         })
                         .expect(concat!(
                             "failed to spawn ",
                             stringify!($simulation),
                             " test thread"
-                        ))
-                        .join()
-                        .expect(concat!(
-                            stringify!($simulation),
-                            " simulation test thread panicked"
                         ));
+
+                    match result_rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
+                        Ok(Ok(())) => {
+                            thread.join().expect(concat!(
+                                stringify!($simulation),
+                                " simulation test thread panicked"
+                            ));
+                        }
+                        Ok(Err(payload)) => {
+                            let _ = thread.join();
+                            std::panic::resume_unwind(payload);
+                        }
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                            panic!(
+                                "simulation test timed out after {}s (simulation={}, case={})",
+                                timeout_secs, simulation_name, case_id
+                            );
+                        }
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                            if let Err(payload) = thread.join() {
+                                std::panic::resume_unwind(payload);
+                            }
+                            panic!(
+                                "simulation test thread exited without reporting result (simulation={}, case={})",
+                                simulation_name, case_id
+                            );
+                        }
+                    }
                 }
             )+
         }

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -15,3 +15,4 @@ js-sys = "0.3"
 async-trait = "0.1"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 serde_json = "1"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }

--- a/packages/text-plugin/benches/apply_changes.rs
+++ b/packages/text-plugin/benches/apply_changes.rs
@@ -2,8 +2,8 @@ mod common;
 
 use common::{apply_scenarios, file_from_bytes};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
-use text_plugin::apply_changes;
 use std::time::Duration;
+use text_plugin::apply_changes;
 
 fn bench_apply_changes(c: &mut Criterion) {
     let scenarios = apply_scenarios();
@@ -22,8 +22,8 @@ fn bench_apply_changes(c: &mut Criterion) {
                     )
                 },
                 |(base, changes)| {
-                    let reconstructed =
-                        apply_changes(base, changes).expect("apply_changes benchmark should succeed");
+                    let reconstructed = apply_changes(base, changes)
+                        .expect("apply_changes benchmark should succeed");
                     black_box(reconstructed);
                 },
                 BatchSize::SmallInput,

--- a/packages/text-plugin/benches/detect_changes.rs
+++ b/packages/text-plugin/benches/detect_changes.rs
@@ -2,8 +2,8 @@ mod common;
 
 use common::{detect_scenarios, file_from_bytes};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
-use text_plugin::detect_changes;
 use std::time::Duration;
+use text_plugin::detect_changes;
 
 fn bench_detect_changes(c: &mut Criterion) {
     let scenarios = detect_scenarios();

--- a/packages/text-plugin/src/lib.rs
+++ b/packages/text-plugin/src/lib.rs
@@ -399,7 +399,10 @@ fn parse_after_lines_with_histogram_matching(
     after_lines
 }
 
-fn compute_histogram_line_matching_pairs(before_data: &[u8], after_data: &[u8]) -> Vec<(usize, usize)> {
+fn compute_histogram_line_matching_pairs(
+    before_data: &[u8],
+    after_data: &[u8],
+) -> Vec<(usize, usize)> {
     let input = InternedInput::new(before_data, after_data);
     let mut diff = Diff::compute(Algorithm::Histogram, &input);
     diff.postprocess_lines(&input);
@@ -513,7 +516,9 @@ fn parse_line_ending_literal(value: &str) -> Result<LineEnding, String> {
         "" => Ok(LineEnding::None),
         "\\n" => Ok(LineEnding::Lf),
         "\\r\\n" => Ok(LineEnding::Crlf),
-        _ => Err("unsupported ending literal; expected \"\", \"\\\\n\", or \"\\\\r\\\\n\"".to_string()),
+        _ => Err(
+            "unsupported ending literal; expected \"\", \"\\\\n\", or \"\\\\r\\\\n\"".to_string(),
+        ),
     }
 }
 
@@ -561,8 +566,9 @@ pub fn line_schema_json() -> &'static str {
 }
 
 pub fn line_schema_definition() -> &'static Value {
-    LINE_SCHEMA
-        .get_or_init(|| serde_json::from_str(LINE_SCHEMA_JSON).expect("text line schema must parse"))
+    LINE_SCHEMA.get_or_init(|| {
+        serde_json::from_str(LINE_SCHEMA_JSON).expect("text line schema must parse")
+    })
 }
 
 pub fn document_schema_json() -> &'static str {

--- a/packages/text-plugin/tests/common/mod.rs
+++ b/packages/text-plugin/tests/common/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use text_plugin::{PluginEntityChange, PluginFile};
 use serde::Deserialize;
+use text_plugin::{PluginEntityChange, PluginFile};
 
 #[derive(Debug, Deserialize)]
 pub struct LineSnapshot {

--- a/packages/text-plugin/tests/roundtrip.rs
+++ b/packages/text-plugin/tests/roundtrip.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use common::file_from_bytes;
-use text_plugin::{apply_changes, detect_changes, PluginEntityChange};
 use std::collections::BTreeMap;
+use text_plugin::{apply_changes, detect_changes, PluginEntityChange};
 
 #[test]
 fn detect_then_apply_roundtrips_exact_bytes() {
@@ -50,9 +50,7 @@ fn projected_change_log_reconstructs_from_empty_base() {
     assert_eq!(reconstructed, after_payload);
 }
 
-fn collapse_to_latest_projection(
-    batches: [Vec<PluginEntityChange>; 2],
-) -> Vec<PluginEntityChange> {
+fn collapse_to_latest_projection(batches: [Vec<PluginEntityChange>; 2]) -> Vec<PluginEntityChange> {
     let mut latest = BTreeMap::<(String, String), PluginEntityChange>::new();
     for batch in batches {
         for change in batch {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core execution/transaction paths to collect and emit mutation-derived events, which could impact performance or ordering if incorrect. New async event/observe streams add concurrency and lifecycle edge cases (backpressure, close/abort) to validate.
> 
> **Overview**
> Adds an in-process **state commit event** system to `lix_engine`: executions now derive `StateCommitEventChange`s from mutations and emit them as a single batch on successful `execute()`/transaction commit, with subscribers able to filter by schema/entity/file/version and writer key.
> 
> Builds on that with a new `observe` API that accepts SELECT-only queries, derives an event filter from the query AST/params, and streams updated query results only when they change. The JS SDK/WASM bindings expose `stateCommitEvents()` and `observe()` (with proper close/abort semantics) and add integration tests for both features, plus a small simulation-test harness timeout improvement and minor formatting tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85690acac0ccd37a605d0df7a9fe1d752624b59a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->