### PR TITLE
Refactor state commit events to state commit stream

### DIFF
--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -19,7 +19,7 @@ mod schema;
 mod schema_registry;
 mod snapshot;
 mod sql;
-mod state_commit_events;
+mod state_commit_stream;
 mod types;
 mod validation;
 mod version;
@@ -52,9 +52,9 @@ pub use materialization::{
 };
 pub use observe::{observe_owned, ObserveEvent, ObserveEvents, ObserveEventsOwned, ObserveQuery};
 pub use snapshot::{SnapshotChunkReader, SnapshotChunkWriter};
-pub use state_commit_events::{
-    StateCommitEventBatch, StateCommitEventChange, StateCommitEventFilter,
-    StateCommitEventOperation, StateCommitEvents,
+pub use state_commit_stream::{
+    StateCommitStream, StateCommitStreamBatch, StateCommitStreamChange, StateCommitStreamFilter,
+    StateCommitStreamOperation,
 };
 pub use types::{QueryResult, Value};
 pub use wasm_runtime::{WasmComponentInstance, WasmLimits, WasmRuntime};

--- a/packages/engine/tests/state_commit_stream.rs
+++ b/packages/engine/tests/state_commit_stream.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use lix_engine::{ExecuteOptions, LixError, StateCommitEventFilter};
+use lix_engine::{ExecuteOptions, LixError, StateCommitStreamFilter};
 
 fn insert_key_value_sql(key: &str, value_json: &str) -> String {
     format!(
@@ -13,7 +13,7 @@ fn insert_key_value_sql(key: &str, value_json: &str) -> String {
 }
 
 simulation_test!(
-    state_commit_events_emits_matching_batches,
+    state_commit_stream_emits_matching_batches,
     simulations = [sqlite, postgres],
     |sim| async move {
         let engine = sim
@@ -24,9 +24,9 @@ simulation_test!(
 
         let events = engine
             .raw_engine()
-            .state_commit_events(StateCommitEventFilter {
+            .state_commit_stream(StateCommitStreamFilter {
                 schema_keys: vec!["lix_key_value".to_string()],
-                ..StateCommitEventFilter::default()
+                ..StateCommitStreamFilter::default()
             });
 
         engine
@@ -57,7 +57,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    state_commit_events_respects_excluded_writer_keys,
+    state_commit_stream_respects_excluded_writer_keys,
     simulations = [sqlite, postgres],
     |sim| async move {
         let engine = sim
@@ -68,10 +68,10 @@ simulation_test!(
 
         let events = engine
             .raw_engine()
-            .state_commit_events(StateCommitEventFilter {
+            .state_commit_stream(StateCommitStreamFilter {
                 schema_keys: vec!["lix_key_value".to_string()],
                 exclude_writer_keys: vec!["ui-writer".to_string()],
-                ..StateCommitEventFilter::default()
+                ..StateCommitStreamFilter::default()
             });
 
         engine
@@ -106,7 +106,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    state_commit_events_aggregates_changes_per_transaction_commit,
+    state_commit_stream_aggregates_changes_per_transaction_commit,
     simulations = [sqlite, postgres],
     |sim| async move {
         let engine = sim
@@ -117,9 +117,9 @@ simulation_test!(
 
         let events = engine
             .raw_engine()
-            .state_commit_events(StateCommitEventFilter {
+            .state_commit_stream(StateCommitStreamFilter {
                 schema_keys: vec!["lix_key_value".to_string()],
-                ..StateCommitEventFilter::default()
+                ..StateCommitStreamFilter::default()
             });
 
         engine

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -92,9 +92,9 @@ test("close is idempotent and blocks further API calls", async () => {
   await expect(lix.switchVersion("v1")).rejects.toThrow("lix is closed");
 });
 
-test("stateCommitEvents emits filtered commit events", async () => {
+test("stateCommitStream emits filtered commit batches", async () => {
   const lix = await openLix();
-  const events = lix.stateCommitEvents({ schemaKeys: ["lix_key_value"] });
+  const events = lix.stateCommitStream({ schemaKeys: ["lix_key_value"] });
 
   await lix.execute(
     "INSERT INTO lix_internal_state_vtable (\

--- a/packages/js-sdk/wasm-bindgen.rs
+++ b/packages/js-sdk/wasm-bindgen.rs
@@ -7,10 +7,10 @@ mod wasm {
         boot, observe_owned, BootArgs, BootKeyValue, ExecuteOptions, LixBackend, LixError,
         LixTransaction, ObserveEvent as EngineObserveEvent,
         ObserveEventsOwned as EngineObserveEvents, ObserveQuery as EngineObserveQuery,
-        QueryResult as EngineQueryResult, SnapshotChunkWriter, SqlDialect, StateCommitEventBatch,
-        StateCommitEventChange, StateCommitEventFilter, StateCommitEventOperation,
-        StateCommitEvents as EngineStateCommitEvents, Value as EngineValue, WasmComponentInstance,
-        WasmLimits, WasmRuntime,
+        QueryResult as EngineQueryResult, SnapshotChunkWriter, SqlDialect,
+        StateCommitStream as EngineStateCommitStream, StateCommitStreamBatch,
+        StateCommitStreamChange, StateCommitStreamFilter, StateCommitStreamOperation,
+        Value as EngineValue, WasmComponentInstance, WasmLimits, WasmRuntime,
     };
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
@@ -83,7 +83,7 @@ export type LixBootKeyValue = {
   lixcol_version_id?: string;
 };
 
-export type StateCommitEventFilter = {
+export type StateCommitStreamFilter = {
   schemaKeys?: string[];
   entityIds?: string[];
   fileIds?: string[];
@@ -93,10 +93,10 @@ export type StateCommitEventFilter = {
   includeUntracked?: boolean;
 };
 
-export type StateCommitEventOperation = "Insert" | "Update" | "Delete";
+export type StateCommitStreamOperation = "Insert" | "Update" | "Delete";
 
-export type StateCommitEventChange = {
-  operation: StateCommitEventOperation;
+export type StateCommitStreamChange = {
+  operation: StateCommitStreamOperation;
   entityId: string;
   schemaKey: string;
   schemaVersion: string;
@@ -108,13 +108,13 @@ export type StateCommitEventChange = {
   writerKey: string | null;
 };
 
-export type StateCommitEventBatch = {
+export type StateCommitStreamBatch = {
   sequence: number;
-  changes: StateCommitEventChange[];
+  changes: StateCommitStreamChange[];
 };
 
-export type LixStateCommitEvents = {
-  tryNext(): StateCommitEventBatch | undefined;
+export type LixStateCommitStream = {
+  tryNext(): StateCommitStreamBatch | undefined;
   close(): void;
 };
 
@@ -148,9 +148,9 @@ export type LixObserveEvents = {
         engine: Arc<lix_engine::Engine>,
     }
 
-    #[wasm_bindgen(js_name = StateCommitEvents)]
-    pub struct JsStateCommitEvents {
-        inner: std::sync::Mutex<Option<EngineStateCommitEvents>>,
+    #[wasm_bindgen(js_name = StateCommitStream)]
+    pub struct JsStateCommitStream {
+        inner: std::sync::Mutex<Option<EngineStateCommitStream>>,
     }
 
     #[wasm_bindgen(js_name = ObserveEvents)]
@@ -201,11 +201,11 @@ export type LixObserveEvents = {
             Ok(Uint8Array::from(writer.bytes.as_slice()))
         }
 
-        #[wasm_bindgen(js_name = stateCommitEvents)]
-        pub fn state_commit_events(&self, filter: JsValue) -> Result<JsStateCommitEvents, JsValue> {
-            let filter = parse_state_commit_event_filter(filter).map_err(js_error)?;
-            let events = self.engine.state_commit_events(filter);
-            Ok(JsStateCommitEvents {
+        #[wasm_bindgen(js_name = stateCommitStream)]
+        pub fn state_commit_stream(&self, filter: JsValue) -> Result<JsStateCommitStream, JsValue> {
+            let filter = parse_state_commit_stream_filter(filter).map_err(js_error)?;
+            let events = self.engine.state_commit_stream(filter);
+            Ok(JsStateCommitStream {
                 inner: std::sync::Mutex::new(Some(events)),
             })
         }
@@ -222,20 +222,20 @@ export type LixObserveEvents = {
         }
     }
 
-    #[wasm_bindgen(js_class = StateCommitEvents)]
-    impl JsStateCommitEvents {
+    #[wasm_bindgen(js_class = StateCommitStream)]
+    impl JsStateCommitStream {
         #[wasm_bindgen(js_name = tryNext)]
         pub fn try_next(&self) -> Result<JsValue, JsValue> {
             let guard = self.inner.lock().map_err(|_| {
                 js_error(LixError {
-                    message: "state commit events lock poisoned".to_string(),
+                    message: "state commit stream lock poisoned".to_string(),
                 })
             })?;
             let Some(events) = guard.as_ref() else {
                 return Ok(JsValue::UNDEFINED);
             };
             match events.try_next() {
-                Some(batch) => Ok(state_commit_event_batch_to_js(batch).into()),
+                Some(batch) => Ok(state_commit_stream_batch_to_js(batch).into()),
                 None => Ok(JsValue::UNDEFINED),
             }
         }
@@ -244,7 +244,7 @@ export type LixObserveEvents = {
         pub fn close(&self) -> Result<(), JsValue> {
             let mut guard = self.inner.lock().map_err(|_| {
                 js_error(LixError {
-                    message: "state commit events lock poisoned".to_string(),
+                    message: "state commit stream lock poisoned".to_string(),
                 })
             })?;
             if let Some(events) = guard.take() {
@@ -443,17 +443,19 @@ export type LixObserveEvents = {
         Ok(parsed)
     }
 
-    fn parse_state_commit_event_filter(input: JsValue) -> Result<StateCommitEventFilter, LixError> {
+    fn parse_state_commit_stream_filter(
+        input: JsValue,
+    ) -> Result<StateCommitStreamFilter, LixError> {
         if input.is_null() || input.is_undefined() {
-            return Ok(StateCommitEventFilter::default());
+            return Ok(StateCommitStreamFilter::default());
         }
         if !input.is_object() {
             return Err(LixError {
-                message: "stateCommitEvents filter must be an object".to_string(),
+                message: "stateCommitStream filter must be an object".to_string(),
             });
         }
 
-        Ok(StateCommitEventFilter {
+        Ok(StateCommitStreamFilter {
             schema_keys: read_optional_string_array_property(&input, "schemaKeys")?
                 .unwrap_or_default(),
             entity_ids: read_optional_string_array_property(&input, "entityIds")?
@@ -504,14 +506,14 @@ export type LixObserveEvents = {
         }
         if !Array::is_array(&value) {
             return Err(LixError {
-                message: format!("stateCommitEvents filter '{key}' must be an array of strings"),
+                message: format!("stateCommitStream filter '{key}' must be an array of strings"),
             });
         }
         let values = Array::from(&value);
         let mut out = Vec::with_capacity(values.length() as usize);
         for item in values.iter() {
             let text = item.as_string().ok_or_else(|| LixError {
-                message: format!("stateCommitEvents filter '{key}' must be an array of strings"),
+                message: format!("stateCommitStream filter '{key}' must be an array of strings"),
             })?;
             if !text.trim().is_empty() {
                 out.push(text);
@@ -528,12 +530,12 @@ export type LixObserveEvents = {
         value
             .as_bool()
             .ok_or_else(|| LixError {
-                message: format!("stateCommitEvents filter '{key}' must be a boolean"),
+                message: format!("stateCommitStream filter '{key}' must be a boolean"),
             })
             .map(Some)
     }
 
-    fn state_commit_event_batch_to_js(batch: StateCommitEventBatch) -> Object {
+    fn state_commit_stream_batch_to_js(batch: StateCommitStreamBatch) -> Object {
         let object = Object::new();
         let _ = Reflect::set(
             &object,
@@ -542,21 +544,21 @@ export type LixObserveEvents = {
         );
         let changes = Array::new();
         for change in batch.changes {
-            changes.push(&state_commit_event_change_to_js(change).into());
+            changes.push(&state_commit_stream_change_to_js(change).into());
         }
         let _ = Reflect::set(&object, &JsValue::from_str("changes"), &changes);
         object
     }
 
-    fn state_commit_event_change_to_js(change: StateCommitEventChange) -> Object {
+    fn state_commit_stream_change_to_js(change: StateCommitStreamChange) -> Object {
         let object = Object::new();
         let _ = Reflect::set(
             &object,
             &JsValue::from_str("operation"),
             &JsValue::from_str(match change.operation {
-                StateCommitEventOperation::Insert => "Insert",
-                StateCommitEventOperation::Update => "Update",
-                StateCommitEventOperation::Delete => "Delete",
+                StateCommitStreamOperation::Insert => "Insert",
+                StateCommitStreamOperation::Update => "Update",
+                StateCommitStreamOperation::Delete => "Delete",
             }),
         );
         let _ = Reflect::set(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad API rename across Rust/wasm/JS is prone to breaking downstream callers and bindings despite being mostly mechanical. The `observe` error-handling change alters runtime behavior and could affect client retry/close semantics.
> 
> **Overview**
> Renames the engine’s state-commit notification API from `state_commit_events` to `state_commit_stream` across Rust core, observer integration, WASM bindings, and the JS SDK, including all public types (`*Filter`, `*Batch`, `*Change`, `*Operation`) and internal buses/queues.
> 
> Updates transaction/execution paths to accumulate and emit `StateCommitStreamChange` batches on commit, adjusts tests accordingly, and improves JS/WASM `observe().next()` behavior so transient query errors reject but keep the stream usable for subsequent updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 686efb89e0b1d0998e4c7d47fff3b1c3e84a5e4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->