### PR TITLE
engine: add timestamp shuffle functionality and corresponding tests

### DIFF
--- a/packages/engine/src/boot.rs
+++ b/packages/engine/src/boot.rs
@@ -70,10 +70,15 @@ pub(crate) fn infer_boot_deterministic_settings(
         }
         let uuid_v7_enabled = !object.get("uuid_v7").map(loosely_false).unwrap_or(false);
         let timestamp_enabled = !object.get("timestamp").map(loosely_false).unwrap_or(false);
+        let timestamp_shuffle_enabled = object
+            .get("timestamp_shuffle")
+            .map(loosely_true)
+            .unwrap_or(false);
         Some(DeterministicSettings {
             enabled,
             uuid_v7_enabled,
             timestamp_enabled,
+            timestamp_shuffle_enabled,
         })
     })
 }

--- a/packages/engine/src/sql/steps/lix_state_history_view_read.rs
+++ b/packages/engine/src/sql/steps/lix_state_history_view_read.rs
@@ -213,16 +213,13 @@ fn take_history_pushdown_predicates(
         let blocked_by_cross_bucket =
             part.has_bare_placeholder && has_cross_bucket_bare_placeholders;
         match part.extracted {
-            Some(ExtractedPredicate::Push(bucket, sql))
-                if !blocked_by_cross_bucket =>
+            Some(ExtractedPredicate::Push(bucket, sql)) if !blocked_by_cross_bucket => match bucket
             {
-                match bucket {
-                    HistoryPushdownBucket::Change => pushdown.change_predicates.push(sql),
-                    HistoryPushdownBucket::Requested => pushdown.requested_predicates.push(sql),
-                    HistoryPushdownBucket::Cse => pushdown.cse_predicates.push(sql),
-                    HistoryPushdownBucket::Remaining => remaining.push(part.predicate),
-                }
-            }
+                HistoryPushdownBucket::Change => pushdown.change_predicates.push(sql),
+                HistoryPushdownBucket::Requested => pushdown.requested_predicates.push(sql),
+                HistoryPushdownBucket::Cse => pushdown.cse_predicates.push(sql),
+                HistoryPushdownBucket::Remaining => remaining.push(part.predicate),
+            },
             Some(ExtractedPredicate::Push(HistoryPushdownBucket::Requested, _))
                 if blocked_by_cross_bucket =>
             {

--- a/packages/engine/tests/support/simulations/mod.rs
+++ b/packages/engine/tests/support/simulations/mod.rs
@@ -1,10 +1,12 @@
 mod materialization;
 mod postgres;
 mod sqlite;
+mod timestamp_shuffle;
 
 pub use materialization::materialization_simulation;
 pub use postgres::postgres_simulation;
 pub use sqlite::sqlite_simulation;
+pub use timestamp_shuffle::timestamp_shuffle_simulation;
 
 use crate::support::simulation_test::Simulation;
 
@@ -13,5 +15,6 @@ pub fn default_simulations() -> Vec<Simulation> {
         sqlite_simulation(),
         postgres_simulation(),
         materialization_simulation(),
+        timestamp_shuffle_simulation(),
     ]
 }

--- a/packages/engine/tests/support/simulations/timestamp_shuffle.rs
+++ b/packages/engine/tests/support/simulations/timestamp_shuffle.rs
@@ -1,0 +1,8 @@
+use crate::support::simulation_test::Simulation;
+
+pub fn timestamp_shuffle_simulation() -> Simulation {
+    let mut simulation = super::sqlite::sqlite_simulation();
+    simulation.name = "timestamp_shuffle";
+    simulation.behavior = crate::support::simulation_test::SimulationBehavior::TimestampShuffle;
+    simulation
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deterministic timestamp generation semantics behind a new config flag; risk is mainly around unexpected ordering assumptions in deterministic/test modes rather than production behavior.
> 
> **Overview**
> Adds an opt-in `timestamp_shuffle` flag to deterministic mode settings (boot key-values + persisted settings) that **scrambles deterministic `lix_timestamp()` millisecond values** via a fixed shuffle function while still consuming the same sequence counter.
> 
> Extends the test simulation harness with a new `TimestampShuffle` behavior and `timestamp_shuffle` simulation, updates materialization determinism tests to run under it (including scrubbing timestamp fields from serialized plans), and adds a dedicated test asserting shuffled timestamps can be non-monotonic. Includes a small refactor in `lix_state_history_view_read` predicate pushdown match formatting with no behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b976b5c93c232772b147ea7b15e9f2641abf6eae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->