### PR TITLE
Add executeTransaction API and stabilize transaction-script binding

### DIFF
--- a/packages/engine/src/execute/entry.rs
+++ b/packages/engine/src/execute/entry.rs
@@ -87,7 +87,7 @@ impl Engine {
             extract_explicit_transaction_script_from_statements(&parsed_statements, params)?
         {
             return self
-                .execute_transaction_script_with_options(statements, options)
+                .execute_transaction_script_with_options(statements, params, options)
                 .await;
         }
 
@@ -179,7 +179,7 @@ impl Engine {
                 self.backend.as_ref(),
                 &self.schema_cache,
                 &output.update_validations,
-                &output.params,
+                params,
             )
             .await?;
         }

--- a/packages/engine/src/execute/in_transaction.rs
+++ b/packages/engine/src/execute/in_transaction.rs
@@ -114,7 +114,7 @@ impl Engine {
                     &backend,
                     &self.schema_cache,
                     &output.update_validations,
-                    &output.params,
+                    params,
                 )
                 .await?;
             }

--- a/packages/engine/src/sql/mod.rs
+++ b/packages/engine/src/sql/mod.rs
@@ -34,7 +34,9 @@ pub(crate) use ast_utils::{
 };
 pub(crate) use escaping::escape_sql_string;
 pub(crate) use lowering::lower_statement;
-pub(crate) use params::{bind_sql, bind_sql_with_state, PlaceholderState};
+pub(crate) use params::{
+    bind_sql, bind_sql_with_state, bind_sql_with_state_and_appended_params, PlaceholderState,
+};
 pub(crate) use pipeline::coalesce_vtable_inserts_in_statement_list;
 #[allow(unused_imports)]
 pub use pipeline::{

--- a/packages/engine/src/sql/rewrite.rs
+++ b/packages/engine/src/sql/rewrite.rs
@@ -20,9 +20,7 @@ pub(crate) fn extract_explicit_transaction_script_from_statements(
     statements: &[Statement],
     params: &[Value],
 ) -> Result<Option<Vec<Statement>>, LixError> {
-    if !params.is_empty() {
-        return Ok(None);
-    }
+    let _ = params;
     if statements.len() < 2 {
         return Ok(None);
     }

--- a/packages/engine/src/sql/steps/lix_state_view_write.rs
+++ b/packages/engine/src/sql/steps/lix_state_view_write.rs
@@ -4,6 +4,7 @@ use sqlparser::ast::{
 };
 
 use crate::sql::object_name_matches;
+use crate::sql::bind_sql;
 use crate::version::{
     active_version_file_id, active_version_schema_key, active_version_storage_version_id,
     parse_active_version_snapshot,
@@ -138,7 +139,8 @@ async fn matches_untracked_rows(
         untracked_table = UNTRACKED_TABLE,
         selection = selection,
     );
-    let result = backend.execute(&sql, params).await?;
+    let bound = bind_sql(&sql, params, backend.dialect())?;
+    let result = backend.execute(&bound.sql, &bound.params).await?;
     Ok(!result.rows.is_empty())
 }
 


### PR DESCRIPTION
Introduce an API for executing batched SQL statements in a single transaction. Stabilize the binding of transaction-script placeholders to ensure consistent behavior during execution. Update related components to support these enhancements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SQL placeholder binding and multi-statement transaction execution paths; mistakes could cause incorrect parameter mapping or runtime failures across dialects, though coverage is improved with new integration tests.
> 
> **Overview**
> Adds a new `executeTransaction` API to the JS SDK/wasm bindings that accepts an array of `{ sql, params }` statements and executes them as a single `BEGIN … COMMIT` script.
> 
> Stabilizes parameter binding for multi-statement transaction scripts in the engine by binding placeholders per-statement (tracking placeholder state across statements) and supporting “base + appended” param sources to avoid param fanout/duplication; explicit `BEGIN/COMMIT` scripts are now eligible even when parameters are provided.
> 
> Updates VSCode docs replay to use parameterized statements and execute them via `executeTransaction` instead of issuing each statement individually, and adds regression tests for large parameterized scripts and correct placeholder resolution across statements (SQLite/Postgres).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77460426fa38dd70b7e08d2866335de674e702e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->