### PR TITLE
Remove AI control workflow section from blog post

### DIFF
--- a/blog/002-modeling-a-company-as-a-repository/index.md
+++ b/blog/002-modeling-a-company-as-a-repository/index.md
@@ -1,45 +1,49 @@
 ---
-date: "2026-02-17"
-og:description: "The filesystem is the best interface for agent context, but most company data lives in binary formats. Lix bridges that gap by mapping binary files to structured, editable schemas."
+date: "2026-02-23"
+og:description: "Modeling a company as a filesystem is promising for AI agents, but binary files break the model. Lix turns binary formats into structured data agents can read and write."
 og:image: "./cover.jpg"
-og:image:alt: "Abstract illustration for Modeling a Company as a Repository"
+og:image:alt: "Abstract illustration for Your Company should be a Repository for AI agents"
 ---
 
-# Modeling a Company as a Repository
+# Your Company should be a Repository for AI agents
 
-The idea of modeling a company as a filesystem is gaining traction. [Eli Mernit](https://x.com/mernit/status/2021324284875153544) makes the case that agents should access company data the same way developers access code: through files. [Anvisha Pai](https://x.com/anvishapai/status/2022062725354967551) points out the limitation: most company data is in binary formats that agents cannot read or edit.
+The idea of modeling a company as a filesystem for maximum agent efficiency is gaining traction on X (Twitter).
 
-What if a system could map those files into a structure agents can understand? That is what we have been building with [Lix](https://github.com/opral/lix).
+For example, [Eli Mernit](https://x.com/mernit/status/2021324284875153544) wrote that agents get better context if a company is modeled as files ("Your company is a filesystem").
+
+The problem is modeling a company as filesystem doesn't work today because most files are binary formats that agents can't work with effectively. [Anvisha Pai](https://x.com/anvishapai/status/2022062725354967551) pointed that out in her response post "Your company is not a filesystem".
+
+But, what if a system exists that turns binary files into structured data agents can read and write to?
 
 ![Twitter discussion between Eli Mernit and Anvisha](./twitter-discussion-cards.png)
 
 ## The case for the filesystem
 
-The "company as a filesystem" framing is compelling for two reasons:
+The "company as a filesystem because of agents" argument is compelling for two reasons:
 
-1. **Agents get full context.**
-   When company data lives in files, agents can inspect and reason across systems without brittle app integrations.
+1. Agents get full context. When company data lives in files, agents can inspect and reason across systems without brittle app integrations.
 
-2. **Files have no API bottlenecks.**
-   Tools like Codex and Claude Code feel powerful because they can use direct filesystem primitives (`grep`, shell commands, scripts) instead of being constrained by narrow third-party APIs.
+2. No third party API restrictions. Tools like Codex and Claude Code feel powerful because they can use direct filesystem primitives (`grep`, shell commands, scripts) instead of being constrained by third-party APIs.
 
 ![Example structure for modeling a company as a filesystem](./mernit-filesystem-example.jpg)
 
 ## But the filesystem is not enough
 
-A plain filesystem alone does not solve the whole problem.
+A plain filesystem alone doesn't let agents work effectively:
 
-1. **Most file formats are not agent-friendly.**
-   Documents, spreadsheets, presentations, and many business artifacts are binary formats. Agents can parse some formats, but there is no universal semantic model and no reliable round-trip editing path across all of them.
+1. Most file formats are not agent-friendly. Documents, spreadsheets, presentations, etc. are binary formats. Agents can parse some formats, but there is no universal semantic layer that enables round-trip editing.
 
-2. **Some work cannot be flattened to text without loss.**
-   Visual and structural media (for example CAD, PCB, or layered design files) lose critical information when reduced to text. That makes review and verification harder, which is exactly where human control matters most.
+2. Many files cannot be converted into text. A common workaround is to convert binary files to text. But, visual and structural media (for example CAD, PCB, or layered design files) lose critical information when reduced to text. That makes review and verification harder, the real bottleneck with the uprising of AI agents.
 
 ![Visual formats are not fully representable as plain text](./anvisha-visual-formats.jpg)
 
-## We need a system that understands binary files
+## A system that understands binary files
 
-If files are the best interface for context, and most company work is in binary formats, we need a system that maps those formats into structured data an agent can read and write.
+A system that turns binary files into structured data agents can read and write to would enable modeling a company as filesystem.
+
+The implementation can be simple. Parse binary files into their schemas. After all, most binary files are structured data under the hood.
+
+For example, a docx file is a collection of paragraphs, tables, images, etc. All of those can be expressed as JSON that an agent can understand.
 
 ```text
   ┌─────────────────┐         ┌───────────────────────┐
@@ -63,20 +67,14 @@ If files are the best interface for context, and most company work is in binary 
                                └──────────────┘
 ```
 
-That gives agents one interface across text and binary data, without lossy conversions.
-
 ## Lix is that system
 
-I have been building a universal version control system called **Lix**.
+A system that turns binary files into structured JSON agents can understand already exists; it's called **Lix**.
 
-It is "universal" because it parses files into schemas and tracks semantic changes at that schema level. The same mechanism can expose binary formats to agents in a structured, controllable way.
+Lix is a "universal" version control system. "Universal" because it can track changes in binary files by parsing files into JSON schemas. Otherwise, tracking changes in those binary files would not be possible. Lix also solves the problem of opaque binary files agents are now running into.
+
+Lix is in alpha, but you can already check out the repository on GitHub.
 
 [Lix on GitHub](https://github.com/opral/lix)
 
 ![Lix GitHub repository screenshot](./lix-github.jpg)
-
-This also addresses a second company-level AI problem: control.
-
-Every agent action is versioned. You can diff changes, review them, gate approvals, and run experiments in branches before merging. It is the proven software workflow (branch, diff, review, merge), applied to all company artifacts, not only source code.
-
-![Version-controlled workflow for agent changes](./version-control-workflow.jpg)


### PR DESCRIPTION
### Motivation
- Remove the closing AI-control paragraph and image from the Lix blog post to address the inline comment and align the post's messaging.

### Description
- Deleted the sentence "This also addresses company-level AI control needs.", the paragraph beginning "Every agent action is versioned...", and the `version-control-workflow.jpg` image reference from `blog/002-modeling-a-company-as-a-repository/index.md` and committed the change.

### Testing
- Ran `pnpm exec prettier --write blog/002-modeling-a-company-as-a-repository/index.md` and `pnpm exec prettier --check blog/002-modeling-a-company-as-a-repository/index.md`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca2649e108326956d26796a4d3a0e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a single blog post (copy/metadata and removed section/image reference) with no runtime or behavioral impact.
> 
> **Overview**
> Updates the `blog/002-modeling-a-company-as-a-repository` post’s metadata and headline (new date, revised OG description/alt text, retitled to target AI agents) and rewrites the intro/body copy to more directly frame the “company as filesystem” argument and the binary-file limitation.
> 
> Removes the closing AI-control/versioning workflow section, including the associated paragraph content and `version-control-workflow.jpg` image reference, and tweaks the `Lix` section wording (including an alpha mention) to focus on binary-to-structured-JSON capabilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f66474cbfff0bafb9d158b177eca592b901b477. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->