### PR TITLE
feat(engine): add create/switch version APIs and expose via sdk

### DIFF
--- a/packages/engine/src/api.rs
+++ b/packages/engine/src/api.rs
@@ -1,7 +1,7 @@
-use super::super::*;
-use super::execution::{apply_effects_post_commit, apply_effects_tx, run, shared_path};
-use super::planning::parse::parse_sql;
-use super::planning::script::extract_explicit_transaction_script_from_statements;
+use super::sql::execution::{apply_effects_post_commit, apply_effects_tx, run, shared_path};
+use super::sql::planning::parse::parse_sql;
+use super::sql::planning::script::extract_explicit_transaction_script_from_statements;
+use super::*;
 
 impl Engine {
     pub fn wasm_runtime(&self) -> Arc<dyn WasmRuntime> {
@@ -175,6 +175,17 @@ impl Engine {
 
     pub async fn create_checkpoint(&self) -> Result<crate::CreateCheckpointResult, LixError> {
         crate::checkpoint::create_checkpoint(self).await
+    }
+
+    pub async fn create_version(
+        &self,
+        options: crate::CreateVersionOptions,
+    ) -> Result<crate::CreateVersionResult, LixError> {
+        crate::version::create_version(self, options).await
+    }
+
+    pub async fn switch_version(&self, version_id: String) -> Result<(), LixError> {
+        crate::version::switch_version(self, version_id).await
     }
 
     /// Exports a portable snapshot as SQLite3 file bytes written via chunk stream.

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -47,6 +47,8 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;
 
+#[path = "api.rs"]
+mod api;
 #[path = "init/active_version.rs"]
 mod init_active_version;
 #[path = "init/bootstrap.rs"]

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -61,4 +61,5 @@ pub use state_commit_stream::{
     StateCommitStreamOperation,
 };
 pub use types::{QueryResult, Value};
+pub use version::{CreateVersionOptions, CreateVersionResult};
 pub use wasm_runtime::{NoopWasmRuntime, WasmComponentInstance, WasmLimits, WasmRuntime};

--- a/packages/engine/src/sql/mod.rs
+++ b/packages/engine/src/sql/mod.rs
@@ -1,4 +1,3 @@
-pub(crate) mod api;
 pub(crate) mod ast;
 pub(crate) mod contracts;
 pub(crate) mod execution;

--- a/packages/engine/src/version/create_version.rs
+++ b/packages/engine/src/version/create_version.rs
@@ -5,6 +5,7 @@ pub struct CreateVersionOptions {
     pub id: Option<String>,
     pub name: Option<String>,
     pub inherits_from_version_id: Option<String>,
+    #[serde(default)]
     pub hidden: bool,
 }
 
@@ -246,4 +247,17 @@ fn normalize_parent_commit_ids(
     parent_commit_ids.sort();
     parent_commit_ids.dedup();
     parent_commit_ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CreateVersionOptions;
+
+    #[test]
+    fn create_version_options_deserialize_defaults_hidden() {
+        let options: CreateVersionOptions =
+            serde_json::from_str(r#"{"id":"test-version"}"#).expect("deserialization should work");
+        assert_eq!(options.id.as_deref(), Some("test-version"));
+        assert!(!options.hidden);
+    }
 }

--- a/packages/engine/src/version/create_version.rs
+++ b/packages/engine/src/version/create_version.rs
@@ -1,0 +1,123 @@
+use crate::{Engine, EngineTransaction, ExecuteOptions, LixError, QueryResult, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+pub struct CreateVersionOptions {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub inherits_from_version_id: Option<String>,
+    pub hidden: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CreateVersionResult {
+    pub id: String,
+    pub name: String,
+    pub inherits_from_version_id: String,
+}
+
+pub async fn create_version(
+    engine: &Engine,
+    options: CreateVersionOptions,
+) -> Result<CreateVersionResult, LixError> {
+    engine
+        .transaction(ExecuteOptions::default(), |tx| {
+            Box::pin(async move { create_version_in_transaction(tx, options).await })
+        })
+        .await
+}
+
+async fn create_version_in_transaction(
+    tx: &mut EngineTransaction<'_>,
+    options: CreateVersionOptions,
+) -> Result<CreateVersionResult, LixError> {
+    let active_version = tx
+        .execute(
+            "SELECT av.version_id, v.commit_id \
+             FROM lix_active_version av \
+             JOIN lix_version v ON v.id = av.version_id \
+             ORDER BY av.id \
+             LIMIT 1",
+            &[],
+        )
+        .await?;
+    let row = first_row(&active_version, "active version row")?;
+    let active_version_id = text_at(row, 0, "active_version.version_id")?;
+    let active_commit_id = text_at(row, 1, "lix_version.commit_id")?;
+
+    let id =
+        normalize_optional_non_empty_text(options.id, "id")?.unwrap_or(generate_uuid(tx).await?);
+    let name = normalize_optional_non_empty_text(options.name, "name")?.unwrap_or(id.clone());
+    let inherits_from_version_id = normalize_optional_non_empty_text(
+        options.inherits_from_version_id,
+        "inherits_from_version_id",
+    )?
+    .unwrap_or(active_version_id);
+    let hidden = if options.hidden { 1 } else { 0 };
+    let working_commit_id = generate_uuid(tx).await?;
+
+    tx.execute(
+        "INSERT INTO lix_version (\
+         id, name, inherits_from_version_id, hidden, commit_id, working_commit_id\
+         ) VALUES ($1, $2, $3, $4, $5, $6)",
+        &[
+            Value::Text(id.clone()),
+            Value::Text(name.clone()),
+            Value::Text(inherits_from_version_id.clone()),
+            Value::Integer(hidden),
+            Value::Text(active_commit_id),
+            Value::Text(working_commit_id),
+        ],
+    )
+    .await?;
+
+    Ok(CreateVersionResult {
+        id,
+        name,
+        inherits_from_version_id,
+    })
+}
+
+async fn generate_uuid(tx: &mut EngineTransaction<'_>) -> Result<String, LixError> {
+    let generated = tx.execute("SELECT lix_uuid_v7()", &[]).await?;
+    let row = first_row(&generated, "generated uuid")?;
+    text_at(row, 0, "lix_uuid_v7()")
+}
+
+fn first_row<'a>(result: &'a QueryResult, context: &str) -> Result<&'a [Value], LixError> {
+    result
+        .rows
+        .first()
+        .map(std::vec::Vec::as_slice)
+        .ok_or_else(|| LixError {
+            message: format!("missing {context}"),
+        })
+}
+
+fn text_at(row: &[Value], index: usize, field: &str) -> Result<String, LixError> {
+    match row.get(index) {
+        Some(Value::Text(value)) if !value.is_empty() => Ok(value.clone()),
+        Some(Value::Text(_)) => Err(LixError {
+            message: format!("{field} is empty"),
+        }),
+        Some(Value::Integer(value)) => Ok(value.to_string()),
+        Some(other) => Err(LixError {
+            message: format!("expected text-like value for {field}, got {other:?}"),
+        }),
+        None => Err(LixError {
+            message: format!("missing {field}"),
+        }),
+    }
+}
+
+fn normalize_optional_non_empty_text(
+    value: Option<String>,
+    field: &str,
+) -> Result<Option<String>, LixError> {
+    match value {
+        Some(value) if value.trim().is_empty() => Err(LixError {
+            message: format!("{field} must be a non-empty string when provided"),
+        }),
+        Some(value) => Ok(Some(value)),
+        None => Ok(None),
+    }
+}

--- a/packages/engine/src/version/mod.rs
+++ b/packages/engine/src/version/mod.rs
@@ -7,6 +7,12 @@ use crate::builtin_schema::{
 };
 use crate::LixError;
 
+mod create_version;
+mod switch_version;
+
+pub use create_version::{create_version, CreateVersionOptions, CreateVersionResult};
+pub use switch_version::switch_version;
+
 pub(crate) const GLOBAL_VERSION_ID: &str = "global";
 pub(crate) const DEFAULT_ACTIVE_VERSION_NAME: &str = "main";
 

--- a/packages/engine/src/version/switch_version.rs
+++ b/packages/engine/src/version/switch_version.rs
@@ -1,0 +1,50 @@
+use crate::{Engine, EngineTransaction, ExecuteOptions, LixError, Value};
+
+pub async fn switch_version(engine: &Engine, version_id: String) -> Result<(), LixError> {
+    if version_id.trim().is_empty() {
+        return Err(LixError {
+            message: "version_id must be a non-empty string".to_string(),
+        });
+    }
+
+    engine
+        .transaction(ExecuteOptions::default(), move |tx| {
+            let version_id = version_id.clone();
+            Box::pin(async move { switch_version_in_transaction(tx, version_id).await })
+        })
+        .await
+}
+
+async fn switch_version_in_transaction(
+    tx: &mut EngineTransaction<'_>,
+    version_id: String,
+) -> Result<(), LixError> {
+    ensure_version_exists(tx, &version_id).await?;
+    tx.execute(
+        "UPDATE lix_active_version SET version_id = $1",
+        &[Value::Text(version_id)],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn ensure_version_exists(
+    tx: &mut EngineTransaction<'_>,
+    version_id: &str,
+) -> Result<(), LixError> {
+    let result = tx
+        .execute(
+            "SELECT 1 \
+             FROM lix_version \
+             WHERE id = $1 \
+             LIMIT 1",
+            &[Value::Text(version_id.to_string())],
+        )
+        .await?;
+    if result.rows.is_empty() {
+        return Err(LixError {
+            message: format!("version '{version_id}' does not exist"),
+        });
+    }
+    Ok(())
+}

--- a/packages/engine/tests/version_api.rs
+++ b/packages/engine/tests/version_api.rs
@@ -1,0 +1,150 @@
+mod support;
+
+use lix_engine::{CreateVersionOptions, Value};
+
+fn value_as_text(value: &Value) -> String {
+    match value {
+        Value::Text(value) => value.clone(),
+        Value::Integer(value) => value.to_string(),
+        other => panic!("expected text-like value, got {other:?}"),
+    }
+}
+
+fn value_as_bool(value: &Value) -> bool {
+    match value {
+        Value::Integer(value) => *value != 0,
+        Value::Text(value) => matches!(value.as_str(), "1" | "true" | "TRUE"),
+        other => panic!("expected boolean-compatible value, got {other:?}"),
+    }
+}
+
+simulation_test!(create_version_defaults_to_active_parent, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine_deterministic()
+        .await
+        .expect("boot_simulated_engine_deterministic should succeed");
+    engine.init().await.expect("init should succeed");
+
+    let active_before = engine
+        .execute(
+            "SELECT av.version_id, v.commit_id \
+             FROM lix_active_version av \
+             JOIN lix_version v ON v.id = av.version_id \
+             ORDER BY av.id \
+             LIMIT 1",
+            &[],
+        )
+        .await
+        .expect("active version query should succeed");
+    let active_version_id = value_as_text(&active_before.rows[0][0]);
+    let active_commit_id = value_as_text(&active_before.rows[0][1]);
+
+    let created = engine
+        .create_version(CreateVersionOptions::default())
+        .await
+        .expect("create_version should succeed");
+
+    assert!(!created.id.is_empty());
+    assert_eq!(created.name, created.id);
+    assert_eq!(created.inherits_from_version_id, active_version_id);
+
+    let created_row = engine
+        .execute(
+            "SELECT id, name, inherits_from_version_id, hidden, commit_id, working_commit_id \
+             FROM lix_version \
+             WHERE id = $1",
+            &[Value::Text(created.id.clone())],
+        )
+        .await
+        .expect("created version query should succeed");
+    assert_eq!(created_row.rows.len(), 1);
+    let row = &created_row.rows[0];
+    assert_eq!(value_as_text(&row[0]), created.id);
+    assert_eq!(value_as_text(&row[1]), created.name);
+    assert_eq!(value_as_text(&row[2]), created.inherits_from_version_id);
+    assert!(!value_as_bool(&row[3]));
+    assert_eq!(value_as_text(&row[4]), active_commit_id);
+    assert!(!value_as_text(&row[5]).is_empty());
+
+    let active_after = engine
+        .execute(
+            "SELECT version_id FROM lix_active_version ORDER BY id LIMIT 1",
+            &[],
+        )
+        .await
+        .expect("active version query after create should succeed");
+    assert_eq!(value_as_text(&active_after.rows[0][0]), active_version_id);
+});
+
+simulation_test!(
+    create_version_with_options_and_switch_version,
+    |sim| async move {
+        let engine = sim
+            .boot_simulated_engine(None)
+            .await
+            .expect("boot_simulated_engine should succeed");
+        engine.init().await.expect("init should succeed");
+
+        let created = engine
+            .create_version(CreateVersionOptions {
+                id: Some("branch-alpha".to_string()),
+                name: Some("Branch Alpha".to_string()),
+                inherits_from_version_id: Some("global".to_string()),
+                hidden: true,
+            })
+            .await
+            .expect("create_version should succeed");
+        assert_eq!(created.id, "branch-alpha");
+        assert_eq!(created.name, "Branch Alpha");
+        assert_eq!(created.inherits_from_version_id, "global");
+
+        let created_row = engine
+            .execute(
+                "SELECT id, name, inherits_from_version_id, hidden \
+                 FROM lix_version \
+                 WHERE id = 'branch-alpha'",
+                &[],
+            )
+            .await
+            .expect("created version query should succeed");
+        assert_eq!(created_row.rows.len(), 1);
+        let row = &created_row.rows[0];
+        assert_eq!(value_as_text(&row[0]), "branch-alpha");
+        assert_eq!(value_as_text(&row[1]), "Branch Alpha");
+        assert_eq!(value_as_text(&row[2]), "global");
+        assert!(value_as_bool(&row[3]));
+
+        engine
+            .switch_version("branch-alpha".to_string())
+            .await
+            .expect("switch_version should succeed");
+        let active = engine
+            .execute(
+                "SELECT version_id FROM lix_active_version ORDER BY id LIMIT 1",
+                &[],
+            )
+            .await
+            .expect("active version query should succeed");
+        assert_eq!(value_as_text(&active.rows[0][0]), "branch-alpha");
+    }
+);
+
+simulation_test!(switch_version_rejects_invalid_inputs, |sim| async move {
+    let engine = sim
+        .boot_simulated_engine(None)
+        .await
+        .expect("boot_simulated_engine should succeed");
+    engine.init().await.expect("init should succeed");
+
+    let empty = engine
+        .switch_version("".to_string())
+        .await
+        .expect_err("empty version id should fail");
+    assert!(empty.message.contains("non-empty"));
+
+    let missing = engine
+        .switch_version("missing-version-id".to_string())
+        .await
+        .expect_err("unknown version id should fail");
+    assert!(missing.message.contains("does not exist"));
+});

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -35,6 +35,37 @@ test("createVersion + switchVersion use the JS API surface", async () => {
   await lix.close();
 });
 
+test("createVersion forwards inheritsFromVersionId and hidden options", async () => {
+  const lix = await openLix();
+
+  const created = await lix.createVersion({
+    id: "branch-options",
+    name: "Branch Options",
+    inheritsFromVersionId: "global",
+    hidden: true,
+  });
+  expect(created).toEqual({
+    id: "branch-options",
+    name: "Branch Options",
+    inheritsFromVersionId: "global",
+  });
+
+  const row = await lix.execute(
+    "SELECT id, name, inherits_from_version_id, hidden \
+     FROM lix_version \
+     WHERE id = ? \
+     LIMIT 1",
+    ["branch-options"],
+  );
+  expect(row.rows.length).toBe(1);
+  expect(row.rows[0][0]).toEqual({ kind: "Text", value: "branch-options" });
+  expect(row.rows[0][1]).toEqual({ kind: "Text", value: "Branch Options" });
+  expect(row.rows[0][2]).toEqual({ kind: "Text", value: "global" });
+  expect(row.rows[0][3]).toEqual({ kind: "Integer", value: 1 });
+
+  await lix.close();
+});
+
 test("createCheckpoint returns checkpoint metadata and rotates working pointer", async () => {
   const lix = await openLix();
   await lix.execute("INSERT INTO lix_key_value (key, value) VALUES (?1, ?2)", [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches version/commit graph persistence and active-version switching, which can affect data lineage and runtime behavior if invariants are wrong, but changes are localized and covered by new tests.
> 
> **Overview**
> Adds first-class version management to the Rust engine: new `Engine::create_version` creates a version (with optional id/name/parent/hidden) plus a fresh working commit/changeset and updates commit edge/ancestry records; new `Engine::switch_version` validates the target exists then updates `lix_active_version`.
> 
> Exposes these APIs through the wasm boundary and JS SDK by replacing the SDK’s previous direct-SQL `createVersion`/`switchVersion` implementations with calls to wasm exports, adding option/result type bindings and input parsing, and adding new engine + JS tests covering option forwarding and validation errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c1d57372a58dc7133f8edbf27049a7b59e3644a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added version creation capability with configurable options (custom ID, name, inheritance from existing versions, and hidden flag).
  * Added version switching functionality to change the active version.
  * Both features are now available through the Rust engine API and JavaScript SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->