### PR TITLE
Add April 2026 update

### DIFF
--- a/blog/005-april-2026-update/cover.svg
+++ b/blog/005-april-2026-update/cover.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#ffffff"/>
+
+  <g transform="translate(60, 50) scale(2.8)">
+    <path d="M14.7618 5.74842L16.9208 9.85984L22.3675 0.358398H25.7133L19.0723 11.6284L22.5712 17.5085H19.2407L16.9208 13.443L14.6393 17.5085H11.2705L14.7618 11.6284L11.393 5.74842H14.7618Z" fill="#08B5D6"/>
+    <path d="M6.16211 17.5081V5.74805H9.42368V17.5081H6.16211Z" fill="#08B5D6"/>
+    <path d="M3.52112 0.393555V17.6416H0.287109V0.393555H3.52112Z" fill="#08B5D6"/>
+    <path d="M6.21582 0.393555H14.8399V3.08856H6.21582V0.393555Z" fill="#08B5D6"/>
+  </g>
+
+  <text x="150" y="92" font-family="'Courier New', 'Courier', monospace" font-size="56" font-weight="bold" fill="#111111">Owning the storage model</text>
+  <text x="150" y="124" font-family="'Courier New', 'Courier', monospace" font-size="24" fill="#666666">SQL stays · DataFusion plans · backends plug in below</text>
+
+  <rect x="40" y="150" width="1120" height="430" fill="#1a1a2e" stroke="#111111" stroke-width="3"/>
+  <rect x="40" y="150" width="1120" height="50" fill="#f0f0f0" stroke="#111111" stroke-width="3"/>
+  <circle cx="80" cy="175" r="8" fill="#111111"/>
+  <circle cx="108" cy="175" r="8" fill="#111111"/>
+  <circle cx="136" cy="175" r="8" fill="#111111"/>
+
+  <text x="80" y="245" font-family="'Courier New', 'Courier', monospace" font-size="30" fill="#c0c0d0">SQL query</text>
+  <text x="95" y="285" font-family="'Courier New', 'Courier', monospace" font-size="30" fill="#666688">↓</text>
+  <text x="80" y="325" font-family="'Courier New', 'Courier', monospace" font-size="30" fill="#c0c0d0">DataFusion ........ query planner / executor</text>
+  <text x="95" y="365" font-family="'Courier New', 'Courier', monospace" font-size="30" fill="#666688">↓</text>
+
+  <rect x="70" y="390" width="1000" height="62" fill="#08B5D6"/>
+  <text x="95" y="430" font-family="'Courier New', 'Courier', monospace" font-size="30" font-weight="bold" fill="#111111">Lix-owned layer ... state · versions · history · merge</text>
+
+  <text x="95" y="485" font-family="'Courier New', 'Courier', monospace" font-size="30" fill="#666688">↓</text>
+  <text x="80" y="525" font-family="'Courier New', 'Courier', monospace" font-size="30" fill="#c0c0d0">SQLite · RocksDB · S3/R2 · OPFS</text>
+  <text x="80" y="560" font-family="'Courier New', 'Courier', monospace" font-size="22" fill="#666688">physical persistence is swappable</text>
+
+  <text x="60" y="615" font-family="'Courier New', 'Courier', monospace" font-size="20" fill="#666666">MVP flow runs on the new path · v0.6 targeted for May</text>
+</svg>

--- a/blog/005-april-2026-update/index.md
+++ b/blog/005-april-2026-update/index.md
@@ -1,0 +1,196 @@
+---
+date: "2026-05-11"
+og:description: "The new DataFusion path runs the core Lix MVP flow. April did not hit the 10k inserts target, but it clarified why Lix needs control from incoming query down to storage."
+og:image: "./cover.svg"
+og:image:alt: "Lix April 2026 Update cover showing DataFusion planning queries, Lix owning the storage abstraction, and SQLite, RocksDB, S3/R2, and OPFS as backends"
+---
+
+# April 2026 Update: Adopting DataFusion
+
+![Lix April 2026 Update](./cover.svg)
+
+**TL;DR**
+
+- The new DataFusion path runs the core MVP flow and is published as [`@lix-js/sdk@0.6.0-preview.2`](https://www.npmjs.com/package/@lix-js/sdk/v/0.6.0-preview.2).
+- April goal was 10k semantic inserts under 100ms. We did not hit it.
+- The benchmark exposed that SQLite gives too little control over Lix's versioned storage model to keep improving incrementally.
+- Decision: move query execution to DataFusion while keeping SQLite as a possible physical storage backend.
+- May goal: turn the preview into `v0.6`: CRUD with branching and merging on the optimized semantic write path that the file API will use next.
+
+Lix is an embeddable version control system for apps and agents that need branching, merging, and history for structured data and files.
+
+## What works now
+
+The important April result is that the core API works on the new path.
+
+The shape is the MVP API:
+
+```ts
+import { openLix } from "@lix-js/sdk";
+import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
+
+const lix = await openLix({
+  backend: createBetterSqlite3Backend({ path: "app.lix" }),
+  // Later: swap this for a RocksDB/S3/OPFS backend
+  // without changing the Lix API below.
+});
+
+await lix.createVersion({ name: "draft" });
+
+await lix.execute("INSERT INTO markdown_paragraph (id, text) VALUES ($1, $2)", [
+  "paragraph_1",
+  "Ship CRUD MVP",
+]);
+
+await lix.switchVersion({ name: "main" });
+
+await lix.mergeVersion({ source: "draft" });
+```
+
+The exact API names might still change. The important part is that the flow works:
+
+- open a Lix
+- create a version
+- write entities with CRUD operations
+- switch versions
+- merge a version
+
+That is the product surface for the MVP.
+
+Files are not in the `v0.6` MVP on purpose.
+
+A file write fans out into entity writes. A Word document, JSON file, or spreadsheet save can become thousands of inserts. That means the file API can only be as fast as the entity layer underneath it. The 10k inserts benchmark measures that layer.
+
+Most apps and agents should write entities directly anyway. They should update a paragraph, cell, or property, not re-serialize a whole document. The file API comes after CRUD because it is built on the same semantic write path.
+
+The first preview is published on npm:
+
+```bash
+npm install @lix-js/sdk@0.6.0-preview.2
+```
+
+[`@lix-js/sdk@0.6.0-preview.2`](https://www.npmjs.com/package/@lix-js/sdk/v/0.6.0-preview.2) is not the final `v0.6` MVP yet. It is the preview that proves the new path can be installed and tested.
+
+## April goal
+
+[Last month](/blog/march-2026-update) we found the next bottleneck: semantic writes.
+
+The blob path was already fast. The semantic path was not. Writing one file can fan out into thousands of entities, and the April goal was to get **10k entity inserts under 100ms**.
+
+The number is not random. A semantic file is not one row:
+
+- a Word document becomes paragraphs, tables, comments, images, and relationships
+- a JSON file becomes hundreds or thousands of properties
+- a spreadsheet becomes cells, formulas, sheets, and metadata
+
+10k inserts is the first useful proxy for "real file, real structure." 100ms is the interaction budget. Below that, the write still feels instant. Above that, Lix becomes something users and agents wait on.
+
+We did not hit the benchmark in April.
+
+We are not publishing a final April number because the benchmark target moved to the new DataFusion path. Optimizing the old SQLite-centered path further would measure the architecture we are replacing.
+
+The problem was not one slow query. The SQLite-centered path kept pushing Lix concepts like version roots, inherited rows, tombstones, and file projections into SQLite tables and views. Each optimization fixed one path, but the next feature needed another translation layer.
+
+## Finding: too little control
+
+The recurring problem has been architecture confidence. Lix should ship an MVP and improve from there. But that only works if the architecture can be improved incrementally.
+
+In February, we wrote that the Rust rewrite gave Lix control over the query planner. That wording was too broad. Lix controlled the query before SQLite saw it. Lix could parse and rewrite SQL, batch operations, and avoid many vtable callbacks.
+
+April showed that this is not enough.
+
+SQLite still owns the final query planner and storage model. Lix can rewrite queries before SQLite sees them, but the result still has to fit into SQLite tables, indexes, views, and vtables.
+
+The 10k inserts work made the missing control clear. Lix needs control from the incoming query all the way down to raw storage. Every write touches current state, history, branch visibility, file projections, and later merge inputs. Those choices depend on the physical shape of the data.
+
+```plain
+  February / March architecture
+
+  ┌───────────┐
+  │ SQL query │
+  └─────┬─────┘
+        │
+        ▼
+  ┌────────────────────────┐
+  │ Lix SQL parser/rewrite │  ← Lix controls this
+  └─────┬──────────────────┘
+        │
+        ▼
+  ┌──────────────────────┐
+  │ SQLite query planner │  ← SQLite still controls this
+  └─────┬────────────────┘
+        │
+        ▼
+  ┌───────────────────────────────┐
+  │ SQLite tables/views/vtables   │  ← Lix concepts squeezed here
+  └─────┬─────────────────────────┘
+        │
+        ▼
+  ┌────────────────┐
+  │ SQLite storage │
+  └────────────────┘
+```
+
+## Decision: adopt DataFusion
+
+DataFusion is an Apache Arrow SQL query engine. It gives Lix SQL parsing, planning, and execution while letting Lix provide the logic underneath.
+
+The decision is not "SQLite bad, custom database good." Reusing a query engine is still the right idea. The mistake would be building one from scratch when DataFusion exists.
+
+That is the control Lix needs: from incoming query, through `lix_state`, versions, history, branch visibility, merge inputs, and file projections, down to the raw storage backend.
+
+SQLite does not go away. It can still be the physical storage backend. The change is that SQLite no longer defines the query and storage shape of Lix state.
+
+```plain
+  DataFusion-centered architecture
+
+  ┌───────────┐
+  │ SQL query │
+  └─────┬─────┘
+        │
+        ▼
+  ┌─────────────────────────┐
+  │ DataFusion query engine │  ← Lix controls query execution
+  └─────┬───────────────────┘
+        │
+        ▼
+  ┌──────────────────────────────────┐
+  │ Lix logic + storage abstraction  │  ← Lix controls this
+  └─────┬────────────────────────────┘
+        │
+        ▼
+  ┌──────────────────────────────────┐
+  │ SQLite · RocksDB · S3/R2 · OPFS  │  ← physical storage
+  └──────────────────────────────────┘
+```
+
+Lix does not need to invent physical storage. Existing systems should still handle durability, transactions, files, pages, object storage, and the other hard parts of persistence. The prolly-tree direction from March is now part of this storage abstraction work: make branching cheap by sharing unchanged state, while keeping CRUD operations fast enough for the MVP.
+
+This also changes the portability story. Earlier posts framed portability as "any SQL database." With DataFusion, portability moves one layer down: any backend that can satisfy Lix's storage abstraction. Postgres can still be a backend later, but not because Lix delegates SQL execution to Postgres.
+
+## What happened to March's goals
+
+March had three April goals:
+
+1. 10k entity inserts under 100ms
+2. prolly trees for cheap branching
+3. workload testing with the semantic layer on
+
+The first goal moved to May on the DataFusion path. Prolly trees moved into the broader physical storage abstraction work. The semantic workload replay should happen after the `v0.6` path is fast enough to be the path we intend to ship.
+
+## What's next in May
+
+May goal: turn the preview into the Lix `v0.6` MVP.
+
+The acceptance criteria:
+
+1. CRUD operations work through the new DataFusion path.
+2. Branching and merging work on that path.
+3. 10k semantic inserts are under 100ms.
+4. The Lix physical storage abstraction is no more than 1.5x slower than a direct SQLite storage + query baseline for the same workload.
+
+The 1.5x number is the guardrail for the storage abstraction. It is not the final product latency target. It checks that the abstraction itself is not the bottleneck. If storage is close to SQLite's baseline, Lix can ship the MVP and keep optimizing query/runtime logic above it incrementally.
+
+Files follow after CRUD because file writes fan out into the same entity writes.
+
+Everything else is secondary.

--- a/blog/table_of_contents.json
+++ b/blog/table_of_contents.json
@@ -1,5 +1,10 @@
 [
   {
+    "path": "./005-april-2026-update/index.md",
+    "slug": "april-2026-update",
+    "authors": ["samuelstroschein"]
+  },
+  {
     "path": "./004-march-2026-update/index.md",
     "slug": "march-2026-update",
     "authors": ["samuelstroschein"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: content-only changes adding a new blog post, cover image, and table-of-contents entry with no runtime code impact.
> 
> **Overview**
> Adds a new **April 2026 Update** blog post describing the shift to a DataFusion-centered execution path and the current `@lix-js/sdk@0.6.0-preview.2` MVP status, including updated goals for `v0.6`.
> 
> Includes a new `cover.svg` for the post and registers the post in `blog/table_of_contents.json` so it appears in the blog index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a85b1738a6f250ce882fccf42d4c9fe1968dd7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->