### PR TITLE
Expose transaction handles in SDKs

### DIFF
--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -55,7 +55,7 @@ pub use session::{
     CreateVersionOptions, CreateVersionReceipt, MergeChangeStats, MergeConflict,
     MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, MergeVersionOptions,
     MergeVersionOutcome, MergeVersionPreview, MergeVersionPreviewOptions, MergeVersionReceipt,
-    SessionContext, SwitchVersionOptions, SwitchVersionReceipt,
+    SessionContext, SessionTransaction, SwitchVersionOptions, SwitchVersionReceipt,
 };
 pub use session::{ExecuteResult, Row, RowRef, TryFromValue};
 

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -25,6 +25,8 @@ use crate::version::{
 use crate::GLOBAL_VERSION_ID;
 use crate::{LixError, NullableKeyFilter};
 
+use super::transaction::transaction_state_error;
+
 pub(crate) const WORKSPACE_VERSION_KEY: &str = "lix_workspace_version_id";
 
 #[derive(Clone)]
@@ -54,6 +56,7 @@ pub struct SessionContext {
     pub(super) version_ctx: Arc<VersionContext>,
     pub(super) catalog_context: Arc<CatalogContext>,
     closed: Arc<AtomicBool>,
+    active_transaction: Arc<AtomicBool>,
 }
 
 impl SessionContext {
@@ -124,6 +127,7 @@ impl SessionContext {
             version_ctx,
             catalog_context,
             Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
         )
     }
 
@@ -137,6 +141,7 @@ impl SessionContext {
         version_ctx: Arc<VersionContext>,
         catalog_context: Arc<CatalogContext>,
         closed: Arc<AtomicBool>,
+        active_transaction: Arc<AtomicBool>,
     ) -> Self {
         Self {
             mode,
@@ -148,6 +153,7 @@ impl SessionContext {
             version_ctx,
             catalog_context,
             closed,
+            active_transaction,
         }
     }
 
@@ -164,6 +170,10 @@ impl SessionContext {
 
     pub(crate) fn closed_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.closed)
+    }
+
+    pub(crate) fn active_transaction_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.active_transaction)
     }
 
     pub(crate) fn ensure_open(&self) -> Result<(), LixError> {
@@ -277,6 +287,11 @@ impl SessionContext {
         ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
     {
         self.ensure_open()?;
+        if self.active_transaction.load(Ordering::SeqCst) {
+            return Err(transaction_state_error(
+                "Lix handle has an active transaction; use the transaction handle for writes until it is committed or rolled back",
+            ));
+        }
         let opened = open_transaction(
             &self.mode,
             self.storage.clone(),

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -287,11 +287,7 @@ impl SessionContext {
         ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
     {
         self.ensure_open()?;
-        if self.active_transaction.load(Ordering::SeqCst) {
-            return Err(transaction_state_error(
-                "Lix handle has an active transaction; use the transaction handle for writes until it is committed or rolled back",
-            ));
-        }
+        let _write_guard = self.reserve_write_transaction()?;
         let opened = open_transaction(
             &self.mode,
             self.storage.clone(),
@@ -317,11 +313,34 @@ impl SessionContext {
             }
         }
     }
+
+    pub(super) fn reserve_write_transaction(&self) -> Result<SessionWriteGuard, LixError> {
+        let active_transaction = self.active_transaction_flag();
+        if active_transaction
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(transaction_state_error(
+                "Lix handle has an active transaction; use the transaction handle for writes until it is committed or rolled back",
+            ));
+        }
+        Ok(SessionWriteGuard { active_transaction })
+    }
 }
 
 fn closed_error() -> LixError {
     LixError::new(LixError::CODE_CLOSED, "Lix handle is closed")
         .with_hint("Open a new Lix handle before calling this method.")
+}
+
+pub(super) struct SessionWriteGuard {
+    active_transaction: Arc<AtomicBool>,
+}
+
+impl Drop for SessionWriteGuard {
+    fn drop(&mut self) {
+        self.active_transaction.store(false, Ordering::SeqCst);
+    }
 }
 
 /// Read-only SQL execution context derived from a session.

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -38,13 +38,10 @@ pub(crate) enum SessionMode {
 /// Session-context state for engine execution.
 ///
 /// A session context pins the active version selector and shared execution
-/// services. Each call to `execute(...)` projects this state into a read-only
-/// SQL context or a transaction-owned write context.
-///
-/// Write transaction invariant: any engine operation that may write must enter
-/// through `SessionContext::with_write_transaction`. Reads that influence writes
-/// are only available from that transaction capability, not from session-level
-/// helpers.
+/// services. Parent-handle `execute(...)` runs as an implicit single-statement
+/// transaction. Explicit transactions hold the session execution lease until
+/// commit or rollback, so all SQL during that window must run through the
+/// transaction handle.
 #[derive(Clone)]
 pub struct SessionContext {
     pub(super) mode: SessionMode,
@@ -287,7 +284,16 @@ impl SessionContext {
         ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
     {
         self.ensure_open()?;
-        let _write_guard = self.reserve_write_transaction()?;
+        let _transaction_guard = self.reserve_session_transaction()?;
+        self.with_write_transaction_reserved(f).await
+    }
+
+    pub(crate) async fn with_write_transaction_reserved<T, F>(&self, f: F) -> Result<T, LixError>
+    where
+        F: for<'tx> FnOnce(
+            &'tx mut Transaction,
+        ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
+    {
         let opened = open_transaction(
             &self.mode,
             self.storage.clone(),
@@ -314,17 +320,17 @@ impl SessionContext {
         }
     }
 
-    pub(super) fn reserve_write_transaction(&self) -> Result<SessionWriteGuard, LixError> {
+    pub(super) fn reserve_session_transaction(&self) -> Result<SessionTransactionGuard, LixError> {
         let active_transaction = self.active_transaction_flag();
         if active_transaction
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
             .is_err()
         {
             return Err(transaction_state_error(
-                "Lix handle has an active transaction; use the transaction handle for writes until it is committed or rolled back",
+                "Lix handle has an active transaction; use the transaction handle for reads and writes until it is committed or rolled back",
             ));
         }
-        Ok(SessionWriteGuard { active_transaction })
+        Ok(SessionTransactionGuard { active_transaction })
     }
 }
 
@@ -333,11 +339,11 @@ fn closed_error() -> LixError {
         .with_hint("Open a new Lix handle before calling this method.")
 }
 
-pub(super) struct SessionWriteGuard {
+pub(super) struct SessionTransactionGuard {
     active_transaction: Arc<AtomicBool>,
 }
 
-impl Drop for SessionWriteGuard {
+impl Drop for SessionTransactionGuard {
     fn drop(&mut self) {
         self.active_transaction.store(false, Ordering::SeqCst);
     }

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -297,13 +297,14 @@ impl SessionContext {
     /// catalog inspection. Lix owns transaction boundaries for each statement.
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {
         self.ensure_open()?;
+        let _transaction_guard = self.reserve_session_transaction()?;
         let kind = sql2::classify_statement(sql)?;
         if kind == sql2::SqlStatementKind::Write {
             let sql = sql.to_string();
             let sql_for_error = sql.clone();
             let params = params.to_vec();
             return self
-                .with_write_transaction(|transaction| {
+                .with_write_transaction_reserved(|transaction| {
                     Box::pin(async move {
                         // Re-plan against the transaction-backed write
                         // session so provider hooks read and stage through the
@@ -316,6 +317,12 @@ impl SessionContext {
                 })
                 .await
                 .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
+        }
+        if kind == sql2::SqlStatementKind::Other {
+            return Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "SQL statement is not supported by Lix SQL",
+            ));
         }
 
         let read_scope = StorageReadScope::new(self.storage.begin_read_transaction().await?);
@@ -379,7 +386,6 @@ impl SessionContext {
         if writes.is_empty() {
             return Ok(());
         }
-        let _write_guard = self.reserve_write_transaction()?;
         let mut transaction = self.storage.begin_write_transaction().await?;
         writes.apply(&mut transaction.as_mut()).await?;
         transaction.commit().await

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -6,6 +6,7 @@ use crate::storage::{StorageReadScope, StorageWriteSet};
 use crate::{LixError, LixNotice, SqlQueryResult, Value};
 
 use super::context::{SessionContext, SessionSqlExecutionContext};
+use super::transaction::SessionTransaction;
 
 /// Result of executing one SQL statement through engine.
 ///
@@ -381,6 +382,51 @@ impl SessionContext {
         }
         transaction.commit().await
     }
+}
+
+impl SessionTransaction {
+    /// Executes one SQL statement inside this transaction.
+    ///
+    /// Write statements are staged until `commit()`. Read statements use the
+    /// transaction overlay, so they can observe writes staged by earlier calls
+    /// on this transaction handle.
+    pub async fn execute(
+        &mut self,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<ExecuteResult, LixError> {
+        let kind = sql2::classify_statement(sql)?;
+        let transaction = self.transaction_mut()?;
+        match kind {
+            sql2::SqlStatementKind::Write => execute_transaction_write(transaction, sql, params)
+                .await
+                .map_err(|error| normalize_sql_surface_error(error, sql)),
+            sql2::SqlStatementKind::Read => {
+                let plan = sql2::create_transaction_read_logical_plan(transaction, sql)
+                    .await
+                    .map_err(|error| normalize_sql_surface_error(error, sql))?;
+                let result = sql2::execute_logical_plan(plan, params)
+                    .await
+                    .map_err(|error| normalize_sql_surface_error(error, sql))?;
+                Ok(ExecuteResult::from_sql_query_result(result))
+            }
+            sql2::SqlStatementKind::Other => Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "SQL statement is not supported by Lix SQL",
+            )),
+        }
+    }
+}
+
+async fn execute_transaction_write(
+    transaction: &mut crate::transaction::Transaction,
+    sql: &str,
+    params: &[Value],
+) -> Result<ExecuteResult, LixError> {
+    let tx_plan = sql2::create_write_logical_plan(transaction, sql).await?;
+    let result = sql2::execute_logical_plan(tx_plan, params).await?;
+    let affected_rows = affected_rows_from_query_result(result)?;
+    Ok(ExecuteResult::from_rows_affected(affected_rows))
 }
 
 fn normalize_sql_surface_error(error: LixError, sql: &str) -> LixError {

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -372,14 +372,16 @@ impl SessionContext {
         &self,
         runtime_functions: &FunctionContext,
     ) -> Result<(), LixError> {
-        let mut transaction = self.storage.begin_write_transaction().await?;
         let mut writes = StorageWriteSet::new();
         runtime_functions
             .stage_persist_if_needed(&mut writes)
             .await?;
-        if !writes.is_empty() {
-            writes.apply(&mut transaction.as_mut()).await?;
+        if writes.is_empty() {
+            return Ok(());
         }
+        let _write_guard = self.reserve_write_transaction()?;
+        let mut transaction = self.storage.begin_write_transaction().await?;
+        writes.apply(&mut transaction.as_mut()).await?;
         transaction.commit().await
     }
 }

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -14,6 +14,7 @@ mod merge;
 #[cfg(feature = "storage-benches")]
 pub mod optimization9_sql2_bench;
 mod switch_version;
+mod transaction;
 
 pub use context::SessionContext;
 pub(crate) use context::{SessionMode, WORKSPACE_VERSION_KEY};
@@ -25,3 +26,4 @@ pub use merge::{
     MergeVersionReceipt,
 };
 pub use switch_version::{SwitchVersionOptions, SwitchVersionReceipt};
+pub use transaction::SessionTransaction;

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -1,11 +1,9 @@
 //! Engine session boundary.
 //!
-//! Transaction invariant:
-//! any engine operation that may write must enter through
-//! `SessionContext::with_write_transaction`. Reads that influence writes are
-//! only available from the transaction capability. Session APIs must not
-//! open `Transaction` directly or use session-level read helpers inside write
-//! flows.
+//! Transaction invariant: a session has one execution lease. Parent-handle
+//! calls use it for implicit single-statement execution; explicit transactions
+//! hold it until commit or rollback. Session APIs must not open `Transaction`
+//! directly or use session-level read helpers inside write flows.
 
 mod context;
 mod create_version;

--- a/packages/engine/src/session/switch_version.rs
+++ b/packages/engine/src/session/switch_version.rs
@@ -75,6 +75,7 @@ impl SessionContext {
             Arc::clone(&self.version_ctx),
             Arc::clone(&self.catalog_context),
             self.closed_flag(),
+            self.active_transaction_flag(),
         );
         Ok((
             session,

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -11,7 +11,6 @@ pub struct SessionTransaction {
     pub(super) transaction: Option<Transaction>,
     pub(super) runtime_functions: FunctionContext,
     _transaction_guard: SessionTransactionGuard,
-    closed: bool,
 }
 
 impl SessionContext {
@@ -39,16 +38,12 @@ impl SessionContext {
             transaction: Some(opened.transaction),
             runtime_functions: opened.runtime_functions,
             _transaction_guard: transaction_guard,
-            closed: false,
         })
     }
 }
 
 impl SessionTransaction {
     pub(super) fn transaction_mut(&mut self) -> Result<&mut Transaction, LixError> {
-        if self.closed {
-            return Err(transaction_state_error("Lix transaction is closed"));
-        }
         self.transaction
             .as_mut()
             .ok_or_else(|| transaction_state_error("Lix transaction is closed"))
@@ -59,7 +54,6 @@ impl SessionTransaction {
             .transaction
             .take()
             .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
-        self.closed = true;
         let result = transaction
             .commit(&self.runtime_functions)
             .await
@@ -72,7 +66,6 @@ impl SessionTransaction {
             .transaction
             .take()
             .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
-        self.closed = true;
         let result = transaction.rollback().await;
         result
     }

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -1,31 +1,23 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::functions::FunctionContext;
 use crate::transaction::{open_transaction, Transaction};
 use crate::LixError;
 
+use super::context::SessionWriteGuard;
 use super::SessionContext;
 
 pub struct SessionTransaction {
     pub(super) transaction: Option<Transaction>,
     pub(super) runtime_functions: FunctionContext,
-    active_transaction: Arc<AtomicBool>,
+    _write_guard: SessionWriteGuard,
     closed: bool,
 }
 
 impl SessionContext {
     pub async fn begin_transaction(&self) -> Result<SessionTransaction, LixError> {
         self.ensure_open()?;
-        let active_transaction = self.active_transaction_flag();
-        if active_transaction
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            return Err(transaction_state_error(
-                "Lix handle already has an active transaction",
-            ));
-        }
+        let write_guard = self.reserve_write_transaction()?;
         let opened = match open_transaction(
             &self.mode,
             self.storage.clone(),
@@ -40,14 +32,13 @@ impl SessionContext {
         {
             Ok(opened) => opened,
             Err(error) => {
-                active_transaction.store(false, Ordering::SeqCst);
                 return Err(error);
             }
         };
         Ok(SessionTransaction {
             transaction: Some(opened.transaction),
             runtime_functions: opened.runtime_functions,
-            active_transaction,
+            _write_guard: write_guard,
             closed: false,
         })
     }
@@ -73,7 +64,6 @@ impl SessionTransaction {
             .commit(&self.runtime_functions)
             .await
             .map(|_| ());
-        self.active_transaction.store(false, Ordering::SeqCst);
         result
     }
 
@@ -84,14 +74,7 @@ impl SessionTransaction {
             .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
         self.closed = true;
         let result = transaction.rollback().await;
-        self.active_transaction.store(false, Ordering::SeqCst);
         result
-    }
-}
-
-impl Drop for SessionTransaction {
-    fn drop(&mut self) {
-        self.active_transaction.store(false, Ordering::SeqCst);
     }
 }
 

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -4,20 +4,20 @@ use crate::functions::FunctionContext;
 use crate::transaction::{open_transaction, Transaction};
 use crate::LixError;
 
-use super::context::SessionWriteGuard;
+use super::context::SessionTransactionGuard;
 use super::SessionContext;
 
 pub struct SessionTransaction {
     pub(super) transaction: Option<Transaction>,
     pub(super) runtime_functions: FunctionContext,
-    _write_guard: SessionWriteGuard,
+    _transaction_guard: SessionTransactionGuard,
     closed: bool,
 }
 
 impl SessionContext {
     pub async fn begin_transaction(&self) -> Result<SessionTransaction, LixError> {
         self.ensure_open()?;
-        let write_guard = self.reserve_write_transaction()?;
+        let transaction_guard = self.reserve_session_transaction()?;
         let opened = match open_transaction(
             &self.mode,
             self.storage.clone(),
@@ -38,7 +38,7 @@ impl SessionContext {
         Ok(SessionTransaction {
             transaction: Some(opened.transaction),
             runtime_functions: opened.runtime_functions,
-            _write_guard: write_guard,
+            _transaction_guard: transaction_guard,
             closed: false,
         })
     }

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -1,0 +1,100 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use crate::functions::FunctionContext;
+use crate::transaction::{open_transaction, Transaction};
+use crate::LixError;
+
+use super::SessionContext;
+
+pub struct SessionTransaction {
+    pub(super) transaction: Option<Transaction>,
+    pub(super) runtime_functions: FunctionContext,
+    active_transaction: Arc<AtomicBool>,
+    closed: bool,
+}
+
+impl SessionContext {
+    pub async fn begin_transaction(&self) -> Result<SessionTransaction, LixError> {
+        self.ensure_open()?;
+        let active_transaction = self.active_transaction_flag();
+        if active_transaction
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(transaction_state_error(
+                "Lix handle already has an active transaction",
+            ));
+        }
+        let opened = match open_transaction(
+            &self.mode,
+            self.storage.clone(),
+            Arc::clone(&self.live_state),
+            Arc::clone(&self.tracked_state),
+            Arc::clone(&self.binary_cas),
+            Arc::clone(&self.commit_store),
+            Arc::clone(&self.version_ctx),
+            Arc::clone(&self.catalog_context),
+        )
+        .await
+        {
+            Ok(opened) => opened,
+            Err(error) => {
+                active_transaction.store(false, Ordering::SeqCst);
+                return Err(error);
+            }
+        };
+        Ok(SessionTransaction {
+            transaction: Some(opened.transaction),
+            runtime_functions: opened.runtime_functions,
+            active_transaction,
+            closed: false,
+        })
+    }
+}
+
+impl SessionTransaction {
+    pub(super) fn transaction_mut(&mut self) -> Result<&mut Transaction, LixError> {
+        if self.closed {
+            return Err(transaction_state_error("Lix transaction is closed"));
+        }
+        self.transaction
+            .as_mut()
+            .ok_or_else(|| transaction_state_error("Lix transaction is closed"))
+    }
+
+    pub async fn commit(mut self) -> Result<(), LixError> {
+        let transaction = self
+            .transaction
+            .take()
+            .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
+        self.closed = true;
+        let result = transaction
+            .commit(&self.runtime_functions)
+            .await
+            .map(|_| ());
+        self.active_transaction.store(false, Ordering::SeqCst);
+        result
+    }
+
+    pub async fn rollback(mut self) -> Result<(), LixError> {
+        let transaction = self
+            .transaction
+            .take()
+            .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
+        self.closed = true;
+        let result = transaction.rollback().await;
+        self.active_transaction.store(false, Ordering::SeqCst);
+        result
+    }
+}
+
+impl Drop for SessionTransaction {
+    fn drop(&mut self) {
+        self.active_transaction.store(false, Ordering::SeqCst);
+    }
+}
+
+pub(crate) fn transaction_state_error(message: impl Into<String>) -> LixError {
+    LixError::new("LIX_INVALID_TRANSACTION_STATE", message)
+}

--- a/packages/engine/src/sql2/execute.rs
+++ b/packages/engine/src/sql2/execute.rs
@@ -111,6 +111,33 @@ pub(crate) async fn create_write_logical_plan(
     })
 }
 
+pub(crate) async fn create_transaction_read_logical_plan(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    sql: &str,
+) -> Result<SqlLogicalPlan, LixError> {
+    super::validate_supported_statement_ast(sql)?;
+    super::udfs::validate_public_udf_calls(sql)?;
+    validate_public_read_sql_surface(sql)?;
+    let session = build_write_session(ctx).await?;
+    let plan = session
+        .state()
+        .create_logical_plan(sql)
+        .await
+        .map_err(datafusion_error_to_lix_error)?;
+    validate_supported_logical_plan(&plan)?;
+    validate_json_predicates_in_logical_plan(&plan)?;
+    let kind = classify_logical_plan(&plan);
+    let notices = history_filter_notices(&plan);
+
+    Ok(SqlLogicalPlan {
+        session,
+        plan,
+        kind,
+        notices,
+        strict_binary_params: BTreeSet::new(),
+    })
+}
+
 fn validate_public_read_sql_surface(sql: &str) -> Result<(), LixError> {
     let normalized = sql.to_ascii_lowercase();
     if normalized.contains("lower(path)") {

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -41,6 +41,6 @@ pub(crate) use context::{
 };
 #[allow(unused_imports)]
 pub(crate) use execute::{
-    create_logical_plan, create_write_logical_plan, execute_logical_plan, execute_sql,
-    SqlLogicalPlan,
+    create_logical_plan, create_transaction_read_logical_plan, create_write_logical_plan,
+    execute_logical_plan, execute_sql, SqlLogicalPlan,
 };

--- a/packages/engine/tests/transaction.rs
+++ b/packages/engine/tests/transaction.rs
@@ -135,6 +135,60 @@ async fn rebuild_tracked_state_rolls_back_read_and_write_transactions_on_failure
 }
 
 #[tokio::test]
+async fn active_transaction_blocks_session_read_and_allows_transaction_read() {
+    let backend = RecordingBackend::new();
+    let _receipt = Engine::initialize(Box::new(backend.clone()))
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(Box::new(backend))
+        .await
+        .expect("initialized backend should create an engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_global, lixcol_untracked) \
+             VALUES ('lix_deterministic_mode', \
+             lix_json('{\"enabled\":true}'), true, true)",
+            &[],
+        )
+        .await
+        .expect("deterministic mode insert should succeed");
+
+    let mut tx = session
+        .begin_transaction()
+        .await
+        .expect("transaction should begin");
+
+    let error = session
+        .execute("SELECT lix_uuid_v7()", &[])
+        .await
+        .expect_err("session read should be blocked while transaction is active");
+    assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+
+    let result = tx
+        .execute("SELECT lix_uuid_v7()", &[])
+        .await
+        .expect("deterministic transaction read should succeed");
+    assert_eq!(
+        result
+            .rows()
+            .first()
+            .expect("read should return a row")
+            .get::<String>("lix_uuid_v7()")
+            .expect("uuid should be returned as text"),
+        "01920000-0000-7000-8000-000000000000",
+    );
+
+    tx.rollback()
+        .await
+        .expect("transaction rollback should succeed");
+}
+
+#[tokio::test]
 async fn begin_transaction_cannot_race_with_opening_session_write() {
     let backend = BlockingBeginWriteBackend::new();
     let gate = backend.gate();

--- a/packages/engine/tests/transaction.rs
+++ b/packages/engine/tests/transaction.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
 
 use async_trait::async_trait;
 use lix_engine::{
@@ -133,11 +134,166 @@ async fn rebuild_tracked_state_rolls_back_read_and_write_transactions_on_failure
     assert_eq!(delta.write_committed, 0, "failed rebuild must not commit");
 }
 
+#[tokio::test]
+async fn begin_transaction_cannot_race_with_opening_session_write() {
+    let backend = BlockingBeginWriteBackend::new();
+    let gate = backend.gate();
+    let _receipt = Engine::initialize(Box::new(backend.clone()))
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(Box::new(backend))
+        .await
+        .expect("initialized backend should create an engine");
+    let session = Arc::new(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open"),
+    );
+
+    gate.block_next_write();
+    let writer_session = Arc::clone(&session);
+    let writer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move {
+            writer_session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ('racing-session-write', 'value')",
+                    &[],
+                )
+                .await
+        })
+    });
+
+    gate.wait_until_blocked();
+    let error = match session.begin_transaction().await {
+        Ok(_) => panic!("explicit transaction should not race past a session write reservation"),
+        Err(error) => error,
+    };
+    assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+
+    gate.release();
+    writer
+        .join()
+        .expect("writer thread should not panic")
+        .expect("session write should complete after release");
+
+    let result = session
+        .execute(
+            "SELECT key FROM lix_key_value WHERE key = 'racing-session-write'",
+            &[],
+        )
+        .await
+        .expect("session write should be committed");
+    assert_eq!(result.len(), 1);
+}
+
 #[derive(Clone, Default)]
 struct RecordingBackend {
     data: Arc<Mutex<KvMap>>,
     stats: Arc<TransactionStats>,
     fail_read_namespace: Arc<Mutex<Option<String>>>,
+}
+
+#[derive(Clone)]
+struct BlockingBeginWriteBackend {
+    inner: RecordingBackend,
+    gate: BlockingBeginWriteGate,
+}
+
+impl BlockingBeginWriteBackend {
+    fn new() -> Self {
+        Self {
+            inner: RecordingBackend::new(),
+            gate: BlockingBeginWriteGate::new(),
+        }
+    }
+
+    fn gate(&self) -> BlockingBeginWriteGate {
+        self.gate.clone()
+    }
+}
+
+#[async_trait]
+impl Backend for BlockingBeginWriteBackend {
+    async fn begin_read_transaction(
+        &self,
+    ) -> Result<Box<dyn BackendReadTransaction + Send + Sync + 'static>, LixError> {
+        self.inner.begin_read_transaction().await
+    }
+
+    async fn begin_write_transaction(
+        &self,
+    ) -> Result<Box<dyn BackendWriteTransaction + Send + Sync + 'static>, LixError> {
+        self.gate.maybe_block();
+        self.inner.begin_write_transaction().await
+    }
+}
+
+#[derive(Clone)]
+struct BlockingBeginWriteGate {
+    state: Arc<(Mutex<BlockingBeginWriteState>, Condvar)>,
+}
+
+impl BlockingBeginWriteGate {
+    fn new() -> Self {
+        Self {
+            state: Arc::new((
+                Mutex::new(BlockingBeginWriteState::default()),
+                Condvar::new(),
+            )),
+        }
+    }
+
+    fn block_next_write(&self) {
+        let (lock, _) = &*self.state;
+        let mut state = lock.lock().expect("blocking gate lock should be available");
+        state.block_next = true;
+        state.blocked = false;
+        state.released = false;
+    }
+
+    fn maybe_block(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock.lock().expect("blocking gate lock should be available");
+        if !state.block_next {
+            return;
+        }
+        state.block_next = false;
+        state.blocked = true;
+        condvar.notify_all();
+        while !state.released {
+            state = condvar
+                .wait(state)
+                .expect("blocking gate lock should be available after wait");
+        }
+    }
+
+    fn wait_until_blocked(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock.lock().expect("blocking gate lock should be available");
+        while !state.blocked {
+            state = condvar
+                .wait(state)
+                .expect("blocking gate lock should be available after wait");
+        }
+    }
+
+    fn release(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock.lock().expect("blocking gate lock should be available");
+        state.released = true;
+        condvar.notify_all();
+    }
+}
+
+#[derive(Default)]
+struct BlockingBeginWriteState {
+    block_next: bool,
+    blocked: bool,
+    released: bool,
 }
 
 impl RecordingBackend {

--- a/packages/js-sdk/SKILL.md
+++ b/packages/js-sdk/SKILL.md
@@ -62,7 +62,7 @@ Do not use this skill for raw SQLite access, private engine/wasm internals, SDK 
 - Use `lix_json($1)` when inserting JSON text into JSON-typed columns.
 - Use scalar SQL functions `SELECT lix_uuid_v7()` and `SELECT lix_timestamp()` when consumer code needs Lix-generated UUID v7 ids or ISO timestamps. Do not call them as table functions with `SELECT * FROM ...`.
 - Use `beginTransaction()` for batch writes. One `lix.execute()` write is one transaction and therefore one commit.
-- Do not write through the parent `lix` handle while a transaction is active; use the transaction handle until `commit()` or `rollback()`.
+- Do not call `execute()` through the parent `lix` handle while a transaction is active; use the transaction handle for reads and writes until `commit()` or `rollback()`.
 - Use stable, namespaced, lowercase schema keys like `acme_section`, not generic names like `task`.
 - Always include `x-lix-primary-key` and `additionalProperties: false` on app schemas.
 - Use version names from the user's vocabulary, such as `"Marketing edit"` or `"Q3 pricing draft"`.
@@ -237,7 +237,7 @@ Transaction rules:
 - `commit()` makes the whole transaction durable as one commit.
 - `rollback()` drops the staged writes.
 - After `commit()` or `rollback()`, the transaction handle is closed and cannot be reused.
-- A Lix handle allows one active transaction at a time. While it is active, keep writes on `tx`; ordinary `lix.execute()` writes are rejected until the transaction closes.
+- A Lix handle allows one active transaction at a time. While it is active, use `tx.execute()` for reads and writes; parent-handle `lix.execute()` is rejected until the transaction closes.
 - Do not use a callback-style transaction helper. The JS SDK mirrors the Rust SDK shape: explicitly `beginTransaction()`, then `commit()` or `rollback()`.
 
 ## Registering Schemas
@@ -491,7 +491,7 @@ Other UDFs, such as `lix_json_get`, `lix_uuid_v7`, `lix_text_encode`, and `lix_e
 | Use `$1`, `$2`, `$3` placeholders. | Bare `?` placeholders. |
 | Use `lix_json($1)` for JSON parameters. | Inlining stringified JSON directly into SQL. |
 | Use `beginTransaction()` for imports and batch writes that should be one commit. | Loops of standalone `lix.execute()` writes for bulk imports. |
-| Use the transaction handle for writes until it commits or rolls back. | Mixing parent-handle writes into an active transaction. |
+| Use the transaction handle for reads and writes until it commits or rolls back. | Calling parent-handle `execute()` during an active transaction. |
 | Use `_by_version` for cross-version reads/writes. | Switching versions just to render a side-by-side view. |
 | Name versions in user vocabulary. | User-facing words like branch, branch-1, or generic Draft. |
 | Model collaborative data as small rows. | One giant row when multiple reviewers edit different parts. |

--- a/packages/js-sdk/SKILL.md
+++ b/packages/js-sdk/SKILL.md
@@ -13,6 +13,7 @@ Current `@lix-js/sdk` capabilities:
 
 - Register JSON schemas as tracked entity tables.
 - Read and write entities through generated SQL tables.
+- Group related writes in explicit transactions so they commit once.
 - Create named versions of state and write/read across versions.
 - Merge one version into the active version.
 - Query `lix_change` for history, audit, activity feeds, and undo-style features.
@@ -34,6 +35,7 @@ Use this skill when you need to write or debug consumer code using `@lix-js/sdk`
 - Opening a persistent `.lix` file.
 - Registering schemas.
 - Writing and reading generated SQL entity tables.
+- Grouping imports, migrations, and batch writes into one transaction.
 - Reading `execute()` results.
 - Creating, switching, previewing, and merging versions.
 - Querying history through `lix_change`.
@@ -47,9 +49,10 @@ Do not use this skill for raw SQLite access, private engine/wasm internals, SDK 
 2. Open with `createBetterSqlite3Backend({ path })`; do not open `.lix` with raw SQLite.
 3. Register a schema with `x-lix-key`, `x-lix-primary-key`, and `additionalProperties: false`.
 4. Write rows through the generated table named by `x-lix-key`.
-5. Use `<schema>_by_version` plus `lixcol_version_id` for side-by-side version reads/writes.
-6. Query `lix_change` for audit/history instead of hand-rolling audit tables.
-7. Wrap `mergeVersion()` in `try/catch` whenever conflicts are possible.
+5. Use `beginTransaction()` for imports, migrations, and multi-row writes that should be one commit.
+6. Use `<schema>_by_version` plus `lixcol_version_id` for side-by-side version reads/writes.
+7. Query `lix_change` for audit/history instead of hand-rolling audit tables.
+8. Wrap `mergeVersion()` in `try/catch` whenever conflicts are possible.
 
 ## Core Rules
 
@@ -58,6 +61,8 @@ Do not use this skill for raw SQLite access, private engine/wasm internals, SDK 
 - Use numbered SQL placeholders: `$1`, `$2`, `$3`; bare `?` is rejected.
 - Use `lix_json($1)` when inserting JSON text into JSON-typed columns.
 - Use scalar SQL functions `SELECT lix_uuid_v7()` and `SELECT lix_timestamp()` when consumer code needs Lix-generated UUID v7 ids or ISO timestamps. Do not call them as table functions with `SELECT * FROM ...`.
+- Use `beginTransaction()` for batch writes. One `lix.execute()` write is one transaction and therefore one commit.
+- Do not write through the parent `lix` handle while a transaction is active; use the transaction handle until `commit()` or `rollback()`.
 - Use stable, namespaced, lowercase schema keys like `acme_section`, not generic names like `task`.
 - Always include `x-lix-primary-key` and `additionalProperties: false` on app schemas.
 - Use version names from the user's vocabulary, such as `"Marketing edit"` or `"Q3 pricing draft"`.
@@ -202,6 +207,38 @@ for (const row of r.rows) {
 Accessors return `undefined` when the cell kind does not match. Branch on `value.kind` if a column can hold multiple types. Public kind strings are `"null"`, `"boolean"`, `"integer"`, `"real"`, `"text"`, `"json"`, and `"blob"`.
 
 `Row` also has convenience methods when native JS values are enough: `get(name)`, `tryGet(name)`, `getAt(index)`, `toObject()`, and `toValueMap()`.
+
+## Transactions
+
+Use `beginTransaction()` whenever several writes belong to one logical operation: CSV imports, seed scripts, migrations, bulk updates, or multi-table changes. A write through `lix.execute()` opens and commits its own transaction, so thousands of separate `execute()` writes become thousands of commits. A transaction handle stages those writes and commits them together.
+
+```ts
+const tx = await lix.beginTransaction();
+
+try {
+  for (const note of notes) {
+    await tx.execute(
+      "INSERT INTO acme_note (id, title, done) VALUES ($1, $2, $3)",
+      [note.id, note.title, false],
+    );
+  }
+
+  await tx.commit();
+} catch (error) {
+  await tx.rollback();
+  throw error;
+}
+```
+
+Transaction rules:
+
+- `tx.execute()` has the same result shape as `lix.execute()`.
+- Writes are visible to later reads on the same transaction before commit.
+- `commit()` makes the whole transaction durable as one commit.
+- `rollback()` drops the staged writes.
+- After `commit()` or `rollback()`, the transaction handle is closed and cannot be reused.
+- A Lix handle allows one active transaction at a time. While it is active, keep writes on `tx`; ordinary `lix.execute()` writes are rejected until the transaction closes.
+- Do not use a callback-style transaction helper. The JS SDK mirrors the Rust SDK shape: explicitly `beginTransaction()`, then `commit()` or `rollback()`.
 
 ## Registering Schemas
 
@@ -453,6 +490,8 @@ Other UDFs, such as `lix_json_get`, `lix_uuid_v7`, `lix_text_encode`, and `lix_e
 | Use public imports from `@lix-js/sdk` and `@lix-js/sdk/sqlite`. | Importing `engine-wasm` or private internals. |
 | Use `$1`, `$2`, `$3` placeholders. | Bare `?` placeholders. |
 | Use `lix_json($1)` for JSON parameters. | Inlining stringified JSON directly into SQL. |
+| Use `beginTransaction()` for imports and batch writes that should be one commit. | Loops of standalone `lix.execute()` writes for bulk imports. |
+| Use the transaction handle for writes until it commits or rolls back. | Mixing parent-handle writes into an active transaction. |
 | Use `_by_version` for cross-version reads/writes. | Switching versions just to render a side-by-side view. |
 | Name versions in user vocabulary. | User-facing words like branch, branch-1, or generic Draft. |
 | Model collaborative data as small rows. | One giant row when multiple reviewers edit different parts. |

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -262,11 +262,15 @@ test("beginTransaction blocks session writes on the same handle", async () => {
 	await lix.close();
 });
 
-test("beginTransaction allows session reads on the same handle", async () => {
+test("beginTransaction blocks session reads on the same handle", async () => {
 	const lix = await openLix();
 	const tx = await lix.beginTransaction();
 
-	const result = await lix.execute("SELECT 1 AS ok");
+	await expect(lix.execute("SELECT 1 AS ok")).rejects.toMatchObject({
+		code: "LIX_INVALID_TRANSACTION_STATE",
+	});
+
+	const result = await tx.execute("SELECT 1 AS ok");
 	expect(result.rows[0]?.get("ok")).toBe(1);
 
 	await tx.rollback();

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -168,6 +168,111 @@ test("execute supports UNION ALL without trapping wasm", async () => {
 	await lix.close();
 });
 
+test("beginTransaction commits multiple statements together", async () => {
+	const lix = await openLix();
+	await registerCrmTaskSchema(lix);
+
+	const tx = await lix.beginTransaction();
+	await tx.execute(
+		"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+		["tx-task-1", "First", false, JSON.stringify({ batch: 1 })],
+	);
+	await tx.execute(
+		"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+		["tx-task-2", "Second", true, JSON.stringify({ batch: 1 })],
+	);
+
+	const staged = await tx.execute(
+		"SELECT id FROM crm_task WHERE id IN ($1, $2) ORDER BY id",
+		["tx-task-1", "tx-task-2"],
+	);
+	expect(staged.rows.map((row) => row.get("id"))).toEqual([
+		"tx-task-1",
+		"tx-task-2",
+	]);
+
+	await tx.commit();
+
+	const committed = await lix.execute(
+		"SELECT id FROM crm_task WHERE id IN ($1, $2) ORDER BY id",
+		["tx-task-1", "tx-task-2"],
+	);
+	expect(committed.rows.map((row) => row.get("id"))).toEqual([
+		"tx-task-1",
+		"tx-task-2",
+	]);
+	await expect(tx.execute("SELECT 1")).rejects.toMatchObject({
+		code: "LIX_INVALID_TRANSACTION_STATE",
+	});
+
+	await lix.close();
+});
+
+test("beginTransaction rollback discards writes and closes handle", async () => {
+	const lix = await openLix();
+	await registerCrmTaskSchema(lix);
+
+	const tx = await lix.beginTransaction();
+	await tx.execute(
+		"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+		["rolled-back-task", "Rollback", false, JSON.stringify({ batch: 1 })],
+	);
+	await tx.rollback();
+
+	const result = await lix.execute("SELECT id FROM crm_task WHERE id = $1", [
+		"rolled-back-task",
+	]);
+	expect(result.rows).toHaveLength(0);
+	await expect(tx.rollback()).rejects.toMatchObject({
+		code: "LIX_INVALID_TRANSACTION_STATE",
+	});
+
+	await lix.close();
+});
+
+test("beginTransaction blocks session writes on the same handle", async () => {
+	const lix = await openLix();
+	await registerCrmTaskSchema(lix);
+
+	const tx = await lix.beginTransaction();
+	await tx.execute(
+		"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+		["tx-only-task", "Inside tx", false, JSON.stringify({ batch: 1 })],
+	);
+
+	await expect(
+		lix.execute(
+			"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+			["outside-task", "Outside tx", false, JSON.stringify({ batch: 1 })],
+		),
+	).rejects.toMatchObject({
+		code: "LIX_INVALID_TRANSACTION_STATE",
+	});
+
+	await tx.commit();
+
+	const committed = await lix.execute(
+		"SELECT id FROM crm_task WHERE id IN ($1, $2) ORDER BY id",
+		["outside-task", "tx-only-task"],
+	);
+	expect(committed.rows.map((row) => row.get("id"))).toEqual([
+		"tx-only-task",
+	]);
+
+	await lix.close();
+});
+
+test("beginTransaction allows session reads on the same handle", async () => {
+	const lix = await openLix();
+	const tx = await lix.beginTransaction();
+
+	const result = await lix.execute("SELECT 1 AS ok");
+	expect(result.rows[0]?.get("ok")).toBe(1);
+
+	await tx.rollback();
+	await lix.close();
+});
+
 test("unsupported UNION DISTINCT returns a JS error without trapping wasm", async () => {
 	const { stdout } = await execFileAsync(
 		process.execPath,

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -315,6 +315,7 @@ export type Lix = {
 		sql: string,
 		params?: ReadonlyArray<LixRuntimeValue>,
 	): Promise<ExecuteResult>;
+	beginTransaction(): Promise<LixTransaction>;
 	activeVersionId(): Promise<string>;
 	createVersion(options: CreateVersionOptions): Promise<CreateVersionResult>;
 	switchVersion(options: SwitchVersionOptions): Promise<SwitchVersionResult>;
@@ -323,6 +324,15 @@ export type Lix = {
 	): Promise<MergeVersionPreviewResult>;
 	mergeVersion(options: MergeVersionOptions): Promise<MergeVersionResult>;
 	close(): Promise<void>;
+};
+
+export type LixTransaction = {
+	execute(
+		sql: string,
+		params?: ReadonlyArray<LixRuntimeValue>,
+	): Promise<ExecuteResult>;
+	commit(): Promise<void>;
+	rollback(): Promise<void>;
 };
 
 let wasmReady: Promise<void> | null = null;
@@ -340,6 +350,7 @@ type WasmLix = {
 	 * SQL contract.
 	 */
 	execute(sql: string, params: unknown[]): Promise<WasmExecuteResult>;
+	beginTransaction(): Promise<WasmLixTransaction>;
 	activeVersionId(): Promise<string>;
 	createVersion(options: CreateVersionOptions): Promise<CreateVersionResult>;
 	switchVersion(options: SwitchVersionOptions): Promise<SwitchVersionResult>;
@@ -348,6 +359,12 @@ type WasmLix = {
 	): Promise<MergeVersionPreviewResult>;
 	mergeVersion(options: MergeVersionOptions): Promise<MergeVersionResult>;
 	close(): Promise<void>;
+};
+
+type WasmLixTransaction = {
+	execute(sql: string, params: unknown[]): Promise<WasmExecuteResult>;
+	commit(): Promise<void>;
+	rollback(): Promise<void>;
 };
 
 async function ensureWasmReady(): Promise<void> {
@@ -418,6 +435,13 @@ function createLixHandle(wasmLix: WasmLix): Lix {
 			return normalizeExecuteResult(result);
 		},
 
+		async beginTransaction(): Promise<LixTransaction> {
+			const wasmTransaction = await runQueued(() =>
+				wasmLix.beginTransaction(),
+			);
+			return createLixTransactionHandle(wasmTransaction, runQueued);
+		},
+
 		async activeVersionId(): Promise<string> {
 			return await runQueued(() => wasmLix.activeVersionId());
 		},
@@ -446,6 +470,56 @@ function createLixHandle(wasmLix: WasmLix): Lix {
 
 		async close(): Promise<void> {
 			await runQueued(() => wasmLix.close());
+		},
+	};
+}
+
+function createLixTransactionHandle(
+	wasmTransaction: WasmLixTransaction,
+	runQueued: <T>(operation: () => Promise<T>) => Promise<T>,
+): LixTransaction {
+	let closed = false;
+	const ensureOpen = () => {
+		if (closed) {
+			throw createLixError(
+				"LIX_INVALID_TRANSACTION_STATE",
+				"Lix transaction is closed",
+			);
+		}
+	};
+
+	return {
+		async execute(
+			sql: string,
+			params: ReadonlyArray<LixRuntimeValue> = [],
+		): Promise<ExecuteResult> {
+			ensureOpen();
+			validateExecuteArguments(sql, params);
+			const values = params.map((param, index) =>
+				valueFromExecuteParam(param, index),
+			);
+			const result = await runQueued(() =>
+				wasmTransaction.execute(sql, values),
+			);
+			return normalizeExecuteResult(result);
+		},
+
+		async commit(): Promise<void> {
+			ensureOpen();
+			try {
+				await runQueued(() => wasmTransaction.commit());
+			} finally {
+				closed = true;
+			}
+		},
+
+		async rollback(): Promise<void> {
+			ensureOpen();
+			try {
+				await runQueued(() => wasmTransaction.rollback());
+			} finally {
+				closed = true;
+			}
 		},
 	};
 }

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -309,7 +309,8 @@ export type Lix = {
 	 * This is not SQLite SQL. Use the DataFusion SQL dialect; positional
 	 * placeholders are `$1`, `$2`, and so on. SQLite-specific catalog tables and
 	 * transaction statements such as `sqlite_master`, `BEGIN`, and `COMMIT` are
-	 * not available. Use `information_schema` for catalog inspection.
+	 * not available. Use `information_schema` for catalog inspection. While a
+	 * transaction is active, call `execute()` on the transaction handle instead.
 	 */
 	execute(
 		sql: string,

--- a/packages/js-sdk/wasm-bindgen.rs
+++ b/packages/js-sdk/wasm-bindgen.rs
@@ -8,8 +8,8 @@ mod wasm {
         BackendKvScanRequest, BackendKvValueBatch, BackendKvValueGroup, BackendKvValuePage,
         BackendKvWriteBatch, BackendKvWriteStats, BackendReadTransaction, BackendWriteTransaction,
         BytePageBuilder, CreateVersionOptions, ExecuteResult, Lix as RsLix, LixError,
-        MergeVersionOptions, MergeVersionPreviewOptions, OpenLixOptions, SwitchVersionOptions,
-        Value,
+        LixTransaction as RsLixTransaction, MergeVersionOptions, MergeVersionPreviewOptions,
+        OpenLixOptions, SwitchVersionOptions, Value,
     };
     use serde::Serialize;
     use serde_json::json;
@@ -229,6 +229,11 @@ export type MergeConflictSide = {
     }
 
     #[wasm_bindgen]
+    pub struct LixTransaction {
+        inner: Option<RsLixTransaction>,
+    }
+
+    #[wasm_bindgen]
     impl Lix {
         /// Executes one DataFusion SQL statement against this Lix session.
         ///
@@ -256,6 +261,12 @@ export type MergeConflictSide = {
                 .map_err(js_error)?;
             let result = self.inner.execute(&sql, &values).await.map_err(js_error)?;
             execute_result_to_js(result).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = beginTransaction)]
+        pub async fn begin_transaction(&self) -> Result<LixTransaction, JsValue> {
+            let inner = self.inner.begin_transaction().await.map_err(js_error)?;
+            Ok(LixTransaction { inner: Some(inner) })
         }
 
         #[wasm_bindgen(js_name = activeVersionId)]
@@ -350,6 +361,55 @@ export type MergeConflictSide = {
         #[wasm_bindgen(js_name = close)]
         pub async fn close(&self) -> Result<(), JsValue> {
             self.inner.close().await.map_err(js_error)
+        }
+    }
+
+    #[wasm_bindgen]
+    impl LixTransaction {
+        #[wasm_bindgen(js_name = execute)]
+        pub async fn execute(&mut self, sql: JsValue, params: JsValue) -> Result<JsValue, JsValue> {
+            let sql = sql
+                .as_string()
+                .ok_or_else(|| invalid_argument_error("execute", "sql", "string", &sql))
+                .map_err(js_error)?;
+            if !Array::is_array(&params) {
+                return Err(js_error(invalid_argument_error(
+                    "execute", "params", "array", &params,
+                )));
+            }
+            let params = Array::from(&params);
+            let values = params
+                .iter()
+                .map(value_from_js)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(js_error)?;
+            let inner = self
+                .inner
+                .as_mut()
+                .ok_or_else(transaction_closed_error)
+                .map_err(js_error)?;
+            let result = inner.execute(&sql, &values).await.map_err(js_error)?;
+            execute_result_to_js(result).map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = commit)]
+        pub async fn commit(&mut self) -> Result<(), JsValue> {
+            let inner = self
+                .inner
+                .take()
+                .ok_or_else(transaction_closed_error)
+                .map_err(js_error)?;
+            inner.commit().await.map_err(js_error)
+        }
+
+        #[wasm_bindgen(js_name = rollback)]
+        pub async fn rollback(&mut self) -> Result<(), JsValue> {
+            let inner = self
+                .inner
+                .take()
+                .ok_or_else(transaction_closed_error)
+                .map_err(js_error)?;
+            inner.rollback().await.map_err(js_error)
         }
     }
 
@@ -1319,6 +1379,10 @@ export type MergeConflictSide = {
 
     fn js_sdk_error(message: impl Into<String>) -> LixError {
         LixError::new("LIX_ERROR_JS_SDK", message.into())
+    }
+
+    fn transaction_closed_error() -> LixError {
+        LixError::new("LIX_INVALID_TRANSACTION_STATE", "Lix transaction is closed")
     }
 
     fn js_error(error: LixError) -> JsValue {

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -7,7 +7,7 @@
 mod in_memory_backend;
 mod lix;
 
-pub use lix::{open_lix, Lix, OpenLixOptions};
+pub use lix::{open_lix, Lix, LixTransaction, OpenLixOptions};
 pub use lix_engine::{
     Backend, BackendKvEntryPage, BackendKvExistsBatch, BackendKvExistsGroup, BackendKvGetGroup,
     BackendKvGetRequest, BackendKvKeyPage, BackendKvScanRange, BackendKvScanRequest,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -54,6 +54,8 @@ impl Lix {
     /// and transaction statements such as `sqlite_master`, `BEGIN`, and
     /// `COMMIT` are not part of this contract; use `information_schema` for
     /// catalog inspection. Lix owns transaction boundaries for each statement.
+    /// While a transaction is active, call `execute()` on the transaction
+    /// handle instead.
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {
         self.session.execute(sql, params).await
     }
@@ -111,6 +113,10 @@ pub struct LixTransaction {
 }
 
 impl LixTransaction {
+    /// Executes one SQL statement inside this transaction.
+    ///
+    /// Writes are staged until `commit()`. Reads use the transaction overlay,
+    /// so they can observe writes staged by earlier calls on this handle.
     pub async fn execute(
         &mut self,
         sql: &str,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -58,6 +58,12 @@ impl Lix {
         self.session.execute(sql, params).await
     }
 
+    pub async fn begin_transaction(&self) -> Result<LixTransaction, LixError> {
+        Ok(LixTransaction {
+            inner: self.session.begin_transaction().await?,
+        })
+    }
+
     pub async fn active_version_id(&self) -> Result<String, LixError> {
         self.session.active_version_id().await
     }
@@ -97,6 +103,28 @@ impl Lix {
             self.backend.close().await?;
         }
         Ok(())
+    }
+}
+
+pub struct LixTransaction {
+    inner: lix_engine::SessionTransaction,
+}
+
+impl LixTransaction {
+    pub async fn execute(
+        &mut self,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<ExecuteResult, LixError> {
+        self.inner.execute(sql, params).await
+    }
+
+    pub async fn commit(self) -> Result<(), LixError> {
+        self.inner.commit().await
+    }
+
+    pub async fn rollback(self) -> Result<(), LixError> {
+        self.inner.rollback().await
     }
 }
 

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -222,6 +222,145 @@ async fn failed_write_validation_does_not_poison_backend_transaction() {
     lix.close().await.unwrap();
 }
 
+#[tokio::test]
+async fn transaction_commits_multiple_statements_together() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    register_crm_task_schema(&lix).await;
+
+    let mut tx = lix.begin_transaction().await.unwrap();
+    tx.execute(
+        "INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+        &[
+            Value::Text("tx-task-1".to_string()),
+            Value::Text("First".to_string()),
+            Value::Boolean(false),
+            Value::Text(r#"{"batch":1}"#.to_string()),
+        ],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+        &[
+            Value::Text("tx-task-2".to_string()),
+            Value::Text("Second".to_string()),
+            Value::Boolean(true),
+            Value::Text(r#"{"batch":1}"#.to_string()),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let staged = tx
+        .execute(
+            "SELECT id FROM crm_task WHERE id IN ($1, $2) ORDER BY id",
+            &[
+                Value::Text("tx-task-1".to_string()),
+                Value::Text("tx-task-2".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(staged.len(), 2);
+
+    tx.commit().await.unwrap();
+
+    let committed = lix
+        .execute(
+            "SELECT id FROM crm_task WHERE id IN ($1, $2) ORDER BY id",
+            &[
+                Value::Text("tx-task-1".to_string()),
+                Value::Text("tx-task-2".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(committed.len(), 2);
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_rollback_discards_staged_writes() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    register_crm_task_schema(&lix).await;
+
+    let mut tx = lix.begin_transaction().await.unwrap();
+    tx.execute(
+        "INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+        &[
+            Value::Text("rolled-back-task".to_string()),
+            Value::Text("Rollback".to_string()),
+            Value::Boolean(false),
+            Value::Text(r#"{"batch":1}"#.to_string()),
+        ],
+    )
+    .await
+    .unwrap();
+    tx.rollback().await.unwrap();
+
+    let result = lix
+        .execute(
+            "SELECT id FROM crm_task WHERE id = $1",
+            &[Value::Text("rolled-back-task".to_string())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.len(), 0);
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn transaction_blocks_session_writes_on_same_handle() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    register_crm_task_schema(&lix).await;
+
+    let mut tx = lix.begin_transaction().await.unwrap();
+    tx.execute(
+        "INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+        &[
+            Value::Text("tx-only-task".to_string()),
+            Value::Text("Inside tx".to_string()),
+            Value::Boolean(false),
+            Value::Text(r#"{"batch":1}"#.to_string()),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let error = lix
+        .execute(
+            "INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+            &[
+                Value::Text("outside-task".to_string()),
+                Value::Text("Outside tx".to_string()),
+                Value::Boolean(false),
+                Value::Text(r#"{"batch":1}"#.to_string()),
+            ],
+        )
+        .await
+        .expect_err("session writes should be blocked while explicit transaction is active");
+    assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+
+    tx.commit().await.unwrap();
+
+    let committed = lix
+        .execute(
+            "SELECT id FROM crm_task WHERE id IN ($1, $2) ORDER BY id",
+            &[
+                Value::Text("outside-task".to_string()),
+                Value::Text("tx-only-task".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(committed.len(), 1);
+    assert_eq!(
+        committed.rows()[0].values(),
+        &[Value::Text("tx-only-task".to_string())]
+    );
+    lix.close().await.unwrap();
+}
+
 async fn register_crm_task_schema(lix: &lix_rs_sdk::Lix) {
     let schema = r#"{
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -310,7 +310,7 @@ async fn transaction_rollback_discards_staged_writes() {
 }
 
 #[tokio::test]
-async fn transaction_blocks_session_writes_on_same_handle() {
+async fn transaction_blocks_session_execute_on_same_handle() {
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
     register_crm_task_schema(&lix).await;
 
@@ -340,6 +340,18 @@ async fn transaction_blocks_session_writes_on_same_handle() {
         .await
         .expect_err("session writes should be blocked while explicit transaction is active");
     assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+
+    let error = lix
+        .execute("SELECT 1 AS ok", &[])
+        .await
+        .expect_err("session reads should be blocked while explicit transaction is active");
+    assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+
+    let tx_read = tx
+        .execute("SELECT 1 AS ok", &[])
+        .await
+        .expect("transaction reads should remain available");
+    assert_eq!(tx_read.rows()[0].get::<i64>("ok").unwrap(), 1);
 
     tx.commit().await.unwrap();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds explicit transaction handles and enforces a single active execution lease per session, which changes how reads/writes are routed and could surface new transaction-state errors in existing call patterns.
> 
> **Overview**
> Adds an explicit `begin_transaction()`/`beginTransaction()` API that returns a transaction handle supporting `execute`, `commit`, and `rollback`, letting multiple statements commit as a single unit and allowing reads to see staged writes before commit.
> 
> Enforces a **single active transaction/execute lease per session** via an `active_transaction` guard: while a transaction is open, parent-handle `execute()` (reads *and* writes) is rejected with `LIX_INVALID_TRANSACTION_STATE`, and session write helpers are refactored to reserve this lease.
> 
> Extends SQL planning to support transaction-scoped reads (`create_transaction_read_logical_plan`) and adds Rust/JS/WASM bindings, docs, and tests covering commit/rollback behavior and blocking/race scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72801736363c5e5ae23307bd108462a336d2fe95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->