### PR TITLE
Remove accidental Claude worktree submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ examples/sveltekit/package-lock.json
 .env*
 .dev.vars
 .nx
+.claude/
 
 # Benchmark reports and scratch databases
 benchmarks/engine2-json-pointer/output*/

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -11,14 +11,10 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@cloudflare/vite-plugin": "^1.36.0",
-    "@lix-js/plugin-json": "1.0.1",
     "@opral/markdown-wc": "0.9.0",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-router": "^1.169.2",
     "@tanstack/react-start": "^1.167.64",
-    "@tanstack/router-plugin": "^1.167.34",
-    "lucide-react": "^0.544.0",
     "posthog-js": "^1.321.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -26,21 +22,15 @@
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.2.0",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitest/browser": "^4.1.5",
-    "@vitest/coverage-v8": "^4.1.5",
-    "jsdom": "^27.0.0",
     "prettier": "^3.6.0",
     "typescript": "^5.7.2",
     "vite": "^8.0.10",
     "vite-plugin-static-copy": "^4.1.0",
     "vitest": "^4.1.5",
-    "web-vitals": "^5.1.0",
     "wrangler": "^4.88.0"
   }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.36.0",
     "@lix-js/plugin-json": "1.0.1",
-    "@lix-js/sdk": "workspace:*",
     "@opral/markdown-wc": "0.9.0",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-router": "^1.169.2",

--- a/packages/website/src/types/lix-js-plugin-json.d.ts
+++ b/packages/website/src/types/lix-js-plugin-json.d.ts
@@ -1,1 +1,0 @@
-declare module "@lix-js/plugin-json";

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig, loadEnv, type Plugin } from "vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import { pluginReadmeSync } from "./scripts/plugin-readme-sync";
 import { githubStarsPlugin } from "./src/ssg/github-stars-plugin";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import path from "path";
@@ -102,7 +101,6 @@ const config = defineConfig(({ mode, command }) => {
     plugins: [
       command === "serve" && blogAssetsPlugin(),
       command === "serve" && docsContentWatchPlugin(),
-      pluginReadmeSync(),
       githubStarsPlugin({
         token: githubToken,
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,12 +99,6 @@ importers:
 
   packages/website:
     dependencies:
-      '@cloudflare/vite-plugin':
-        specifier: ^1.36.0
-        version: 1.36.0(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(workerd@1.20260504.1)(wrangler@4.88.0)
-      '@lix-js/plugin-json':
-        specifier: 1.0.1
-        version: 1.0.1(tslib@2.8.1)
       '@opral/markdown-wc':
         specifier: 0.9.0
         version: 0.9.0
@@ -117,12 +111,6 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.167.64
         version: 1.167.64(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(webpack@5.99.9(esbuild@0.27.3))
-      '@tanstack/router-plugin':
-        specifier: ^1.167.34
-        version: 1.167.34(@tanstack/react-router@1.169.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(webpack@5.99.9(esbuild@0.27.3))
-      lucide-react:
-        specifier: ^0.544.0
-        version: 0.544.0(react@19.2.0)
       posthog-js:
         specifier: ^1.321.2
         version: 1.321.2
@@ -139,12 +127,6 @@ importers:
         specifier: ^4.2.4
         version: 4.2.4
     devDependencies:
-      '@testing-library/dom':
-        specifier: ^10.4.0
-        version: 10.4.1
-      '@testing-library/react':
-        specifier: ^16.2.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/node':
         specifier: ^22.10.2
         version: 22.15.33
@@ -157,15 +139,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
-      '@vitest/browser':
-        specifier: ^4.1.5
-        version: 4.1.5(msw@2.10.2(@types/node@22.15.33)(typescript@5.8.3))(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@4.1.5)
-      '@vitest/coverage-v8':
-        specifier: ^4.1.5
-        version: 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
-      jsdom:
-        specifier: ^27.0.0
-        version: 27.3.0(postcss@8.5.14)
       prettier:
         specifier: ^3.6.0
         version: 3.6.2
@@ -181,9 +154,6 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.15.33)(@vitest/coverage-v8@4.1.5)(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.14))(msw@2.10.2(@types/node@22.15.33)(typescript@5.8.3))(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
-      web-vitals:
-        specifier: ^5.1.0
-        version: 5.1.0
       wrangler:
         specifier: ^4.88.0
         version: 4.88.0
@@ -415,12 +385,6 @@ packages:
     peerDependenciesMeta:
       workerd:
         optional: true
-
-  '@cloudflare/vite-plugin@1.36.0':
-    resolution: {integrity: sha512-Rkfa3wAbJ1lqCquWX453x4YlngO+OjNmCQvjb4D5JyMW7KprX6fEJE1NQ06giJDonEz0306EASELF93pRADibA==}
-    peerDependencies:
-      vite: ^6.1.0 || ^7.0.0 || ^8.0.0
-      wrangler: ^4.88.0
 
   '@cloudflare/workerd-darwin-64@1.20260504.1':
     resolution: {integrity: sha512-IOMjYoftNRXabFt+QzY2Bo2mR2TNl8xsGvE0HnQ+K0S2c61VOUGUkr9gpJjnwrJ65yA9Qed4xfg0RRqXHO+nfA==}
@@ -1052,49 +1016,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@jsonjoy.com/buffers@17.63.0':
-    resolution: {integrity: sha512-IZB5WQRVNPEbuqouOQxZHl59AL6/ff+gmM20+xAx4SRX6DjZnQAxs03pQ2J6g5ssN+pzmShrBuGeksjlcZ3HCw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/codegen@17.63.0':
-    resolution: {integrity: sha512-vQ18JiRQ8YfZQwzwCQs88rR5eGuy6AFfu+anz9RTvHQs9L4AE8dGA/mLzu6teh6CiSQTo2TNOQbqRh4Vy+7LEQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pointer@17.63.0':
-    resolution: {integrity: sha512-wAW7rQsGW2zWtE+77cXU8lXsoXYCKa9eHptK3a2CCoNTm5YpPA3dev6LuEyaTDYKdF4DTjtwREv2PpjJidHE5w==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/util@17.63.0':
-    resolution: {integrity: sha512-AhpTIOFvuixKwem4d+ey4In78KJLCrDIUyp0IQ8xgpbs0IjNPTTfT3nXXbYMgJGxjegmqa9otl9nqbCvxOaiXw==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@lix-js/plugin-json@1.0.1':
-    resolution: {integrity: sha512-pCqzG08D8jLtVy8RnITPZIy92XNlRAJWLrlRrzh3ttwS/PWM/iXiOPPuzvb23MoFhYxerzJ8uDGXhEXfVagY2w==}
-
-  '@lix-js/sdk@0.5.1':
-    resolution: {integrity: sha512-FiDGp6BznOLdzNOCUC5OvTJ6KfdKGk8wd5edD1dhU46quS4vi4EkHjS/N+12PSpCfl/p3wBWSQD6vzvZcIHTFg==}
-    engines: {node: '>=22'}
-
-  '@lix-js/server-protocol-schema@0.1.1':
-    resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
-
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
-
-  '@marcbachmann/cel-js@2.5.2':
-    resolution: {integrity: sha512-QnvFBFQ+2T8gX4H4pmcgIfs3gXwfhRjv7hYoRRDLwKeXxgPEZ+zvExe1pGtPs8xPWHu4ng0CmllNpVHWi4kB9A==}
-    engines: {node: '>=20.19.0'}
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
@@ -1281,10 +1207,6 @@ packages:
     peerDependenciesMeta:
       '@tiptap/core':
         optional: true
-
-  '@opral/zettel-ast@0.1.0':
-    resolution: {integrity: sha512-pZDiecYrpSxw7miv4ZSufCRB9sqFMXRa0Rf+LQcoEEh0VOBI6beOmvB+iXmWJ7vxMQINuS7yfsvm5ZyrTm/W5A==}
-    engines: {node: '>=20'}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -1627,10 +1549,6 @@ packages:
 
   '@speed-highlight/core@1.2.12':
     resolution: {integrity: sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==}
-
-  '@sqlite.org/sqlite-wasm@3.50.4-build1':
-    resolution: {integrity: sha512-Qig2Wso7gPkU1PtXwFzndh+CTRzrIFxVGqv6eCetjU7YqxlHItj+GvQYwYTppCRgAPawtRN/4AJcEgB9xDHGug==}
-    hasBin: true
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -2348,9 +2266,6 @@ packages:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
       ajv: ^8.8.2
-
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -3277,9 +3192,6 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.0.3:
-    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
-
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
@@ -3994,11 +3906,6 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
-
-  lucide-react@0.544.0:
-    resolution: {integrity: sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -5662,9 +5569,6 @@ packages:
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
-  web-vitals@5.1.0:
-    resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
-
   webdriver@9.2.0:
     resolution: {integrity: sha512-UrhuHSLq4m3OgncvX75vShfl5w3gmjAy8LvLb6/L6V+a+xcqMRelFx/DQ72Mr84F4m8Li6wjtebrOH1t9V/uOQ==}
     engines: {node: '>=18.20.0'}
@@ -5868,7 +5772,8 @@ packages:
 
 snapshots:
 
-  '@acemir/cssom@0.9.28': {}
+  '@acemir/cssom@0.9.28':
+    optional: true
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -5897,6 +5802,7 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 11.2.4
+    optional: true
 
   '@asamuzakjp/dom-selector@6.7.6':
     dependencies:
@@ -5905,8 +5811,10 @@ snapshots:
       css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.4
+    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9': {}
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5990,6 +5898,7 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+    optional: true
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -6030,10 +5939,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+    optional: true
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@blazediff/core@1.9.1': {}
+  '@blazediff/core@1.9.1':
+    optional: true
 
   '@braintree/sanitize-url@7.1.1': {}
 
@@ -6225,19 +6136,6 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260504.1
 
-  '@cloudflare/vite-plugin@1.36.0(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(workerd@1.20260504.1)(wrangler@4.88.0)':
-    dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260504.1)
-      miniflare: 4.20260504.0
-      unenv: 2.0.0-rc.24
-      vite: 8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
-      wrangler: 4.88.0
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - workerd
-
   '@cloudflare/workerd-darwin-64@1.20260504.1':
     optional: true
 
@@ -6278,6 +6176,7 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.14)':
     dependencies:
       postcss: 8.5.14
+    optional: true
 
   '@csstools/css-tokenizer@3.0.4': {}
 
@@ -6698,45 +6597,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jsonjoy.com/buffers@17.63.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/codegen@17.63.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pointer@17.63.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/util': 17.63.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/util@17.63.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 17.63.0(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 17.63.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@lix-js/plugin-json@1.0.1(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/json-pointer': 17.63.0(tslib@2.8.1)
-      '@lix-js/sdk': 0.5.1
-    transitivePeerDependencies:
-      - tslib
-
-  '@lix-js/sdk@0.5.1':
-    dependencies:
-      '@lix-js/server-protocol-schema': 0.1.1
-      '@marcbachmann/cel-js': 2.5.2
-      '@opral/zettel-ast': 0.1.0
-      '@sqlite.org/sqlite-wasm': 3.50.4-build1
-      ajv: 8.17.1
-      chevrotain: 11.0.3
-      kysely: 0.28.7
-      uuid: 11.1.0
-
-  '@lix-js/server-protocol-schema@0.1.1': {}
-
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -6752,8 +6612,6 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-
-  '@marcbachmann/cel-js@2.5.2': {}
 
   '@mermaid-js/parser@0.6.3':
     dependencies:
@@ -6957,10 +6815,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opral/zettel-ast@0.1.0':
-    dependencies:
-      '@sinclair/typebox': 0.34.40
-
   '@oxc-project/types@0.127.0': {}
 
   '@oxlint/darwin-arm64@1.26.0':
@@ -6990,7 +6844,8 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@polka/url@1.0.0-next.29': {}
+  '@polka/url@1.0.0-next.29':
+    optional: true
 
   '@poppinss/colors@4.1.5':
     dependencies:
@@ -7213,8 +7068,6 @@ snapshots:
   '@sindresorhus/is@7.1.1': {}
 
   '@speed-highlight/core@1.2.12': {}
-
-  '@sqlite.org/sqlite-wasm@3.50.4-build1': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -7821,6 +7674,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)':
     dependencies:
@@ -7858,6 +7712,7 @@ snapshots:
       vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.15.33)(@vitest/coverage-v8@4.1.5)(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.14))(msw@2.10.2(@types/node@22.15.33)(typescript@5.8.3))(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
     optionalDependencies:
       '@vitest/browser': 4.1.5(msw@2.10.2(@types/node@22.15.33)(typescript@5.8.3))(vite@8.0.10(@types/node@22.15.33)(esbuild@0.27.3)(jiti@2.6.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@4.1.5)
+    optional: true
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -8194,13 +8049,6 @@ snapshots:
       fast-deep-equal: 3.1.3
     optional: true
 
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.0.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -8292,6 +8140,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+    optional: true
 
   async@3.2.6:
     optional: true
@@ -8380,6 +8229,7 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
 
   binary-extensions@2.3.0: {}
 
@@ -8673,6 +8523,7 @@ snapshots:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
+    optional: true
 
   css-value@0.0.1:
     optional: true
@@ -8691,6 +8542,7 @@ snapshots:
       css-tree: 3.1.0
     transitivePeerDependencies:
       - postcss
+    optional: true
 
   csstype@3.2.3: {}
 
@@ -8893,6 +8745,7 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
+    optional: true
 
   dayjs@1.11.19: {}
 
@@ -9216,7 +9069,8 @@ snapshots:
   fast-deep-equal@2.0.1:
     optional: true
 
-  fast-deep-equal@3.1.3: {}
+  fast-deep-equal@3.1.3:
+    optional: true
 
   fast-fifo@1.3.2:
     optional: true
@@ -9228,8 +9082,6 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
-
-  fast-uri@3.0.3: {}
 
   fast-uri@3.1.2:
     optional: true
@@ -9803,7 +9655,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  js-tokens@10.0.0: {}
+  js-tokens@10.0.0:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -9865,13 +9718,14 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.20.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
       - postcss
       - supports-color
       - utf-8-validate
+    optional: true
 
   jsesc@3.1.0: {}
 
@@ -9883,7 +9737,8 @@ snapshots:
       '@babel/runtime': 7.28.4
       ts-algebra: 2.0.0
 
-  json-schema-traverse@1.0.0: {}
+  json-schema-traverse@1.0.0:
+    optional: true
 
   json5@2.2.3: {}
 
@@ -10050,7 +9905,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.4: {}
+  lru-cache@11.2.4:
+    optional: true
 
   lru-cache@5.1.1:
     dependencies:
@@ -10058,10 +9914,6 @@ snapshots:
 
   lru-cache@7.18.3:
     optional: true
-
-  lucide-react@0.544.0(react@19.2.0):
-    dependencies:
-      react: 19.2.0
 
   lz-string@1.5.0: {}
 
@@ -10084,6 +9936,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
+    optional: true
 
   make-dir@4.0.0:
     dependencies:
@@ -10220,7 +10073,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.12.2: {}
+  mdn-data@2.12.2:
+    optional: true
 
   merge-stream@2.0.0:
     optional: true
@@ -10526,7 +10380,8 @@ snapshots:
 
   mri@1.2.0: {}
 
-  mrmime@2.0.1: {}
+  mrmime@2.0.1:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -10836,6 +10691,7 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
+    optional: true
 
   path-data-parser@0.1.0: {}
 
@@ -10891,7 +10747,8 @@ snapshots:
       fsevents: 2.3.2
     optional: true
 
-  pngjs@7.0.0: {}
+  pngjs@7.0.0:
+    optional: true
 
   points-on-curve@0.2.0: {}
 
@@ -11208,7 +11065,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2: {}
+  require-from-string@2.0.2:
+    optional: true
 
   requires-port@1.0.0:
     optional: true
@@ -11499,6 +11357,7 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+    optional: true
 
   slash@3.0.0: {}
 
@@ -11775,7 +11634,8 @@ snapshots:
 
   tldts-core@6.1.52: {}
 
-  tldts-core@7.0.19: {}
+  tldts-core@7.0.19:
+    optional: true
 
   tldts@6.1.52:
     dependencies:
@@ -11784,6 +11644,7 @@ snapshots:
   tldts@7.0.19:
     dependencies:
       tldts-core: 7.0.19
+    optional: true
 
   tmp@0.2.5: {}
 
@@ -11791,7 +11652,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  totalist@3.0.1: {}
+  totalist@3.0.1:
+    optional: true
 
   tough-cookie@4.1.4:
     dependencies:
@@ -11808,6 +11670,7 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.19
+    optional: true
 
   tr46@5.1.1:
     dependencies:
@@ -11816,6 +11679,7 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -12258,8 +12122,6 @@ snapshots:
 
   web-vitals@4.2.4: {}
 
-  web-vitals@5.1.0: {}
-
   webdriver@9.2.0:
     dependencies:
       '@types/node': 20.19.39
@@ -12320,7 +12182,8 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webidl-conversions@8.0.0: {}
+  webidl-conversions@8.0.0:
+    optional: true
 
   webpack-sources@3.4.1:
     optional: true
@@ -12377,6 +12240,7 @@ snapshots:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.0
+    optional: true
 
   which@2.0.2:
     dependencies:
@@ -12441,7 +12305,8 @@ snapshots:
 
   ws@8.18.3: {}
 
-  ws@8.20.0: {}
+  ws@8.20.0:
+    optional: true
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       '@lix-js/plugin-json':
         specifier: 1.0.1
         version: 1.0.1(tslib@2.8.1)
-      '@lix-js/sdk':
-        specifier: workspace:*
-        version: link:../js-sdk
       '@opral/markdown-wc':
         specifier: 0.9.0
         version: 0.9.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the website build/tooling by removing the `pluginReadmeSync` Vite plugin and several dependencies, which could affect content generation or CI if any were implicitly relied on.
> 
> **Overview**
> Simplifies the `packages/website` build setup by removing `pluginReadmeSync()` from `vite.config.ts` and dropping several website dependencies/devDependencies (including `@lix-js/*`, `@cloudflare/vite-plugin`, `lucide-react`, and browser testing deps).
> 
> Cleans up related type stubs (`lix-js-plugin-json.d.ts`) and updates the lockfile accordingly, and ignores the local `.claude/` directory in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb30027a96218587ac5c8c9a857672ecbe0381d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->