### PR TITLE
feat(engine): support anonymous SQL placeholders

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -22,7 +22,7 @@ Returns a `Lix` with the following methods.
 lix.execute(sql: string, params?: LixRuntimeValue[]): Promise<ExecuteResult>;
 ```
 
-Run one DataFusion SQL statement. Use numbered placeholders (`$1`, `$2`); bare `?` is rejected. Use `lix_json($1)` when binding a JSON-typed parameter.
+Run one DataFusion SQL statement. Use anonymous placeholders (`?`) or numbered placeholders (`$1`, `$2`); do not mix both styles in one statement. Use `lix_json(?)` or `lix_json($1)` when binding a JSON-typed parameter.
 
 ```ts
 type ExecuteResult = {
@@ -53,14 +53,14 @@ class Row {
 
 Use `value(name)` for a `Value` with typed accessors:
 
-| Method | Returns | For |
-| --- | --- | --- |
-| `asText()` | `string \| undefined` | text columns |
-| `asBoolean()` | `boolean \| undefined` | booleans |
-| `asInteger()` | `number \| undefined` | integers |
-| `asReal()` | `number \| undefined` | decimals |
-| `asJson()` | `JsonValue \| undefined` | JSON / objects / arrays |
-| `asBlob()` | `Uint8Array \| undefined` | bytes |
+| Method        | Returns                   | For                     |
+| ------------- | ------------------------- | ----------------------- |
+| `asText()`    | `string \| undefined`     | text columns            |
+| `asBoolean()` | `boolean \| undefined`    | booleans                |
+| `asInteger()` | `number \| undefined`     | integers                |
+| `asReal()`    | `number \| undefined`     | decimals                |
+| `asJson()`    | `JsonValue \| undefined`  | JSON / objects / arrays |
+| `asBlob()`    | `Uint8Array \| undefined` | bytes                   |
 
 Accessors return `undefined` when the cell kind doesn't match. Branch on `value.kind` (`"null" | "boolean" | "integer" | "real" | "text" | "json" | "blob"`) for polymorphic columns.
 
@@ -138,14 +138,14 @@ Always close in scripts and tests.
 
 ## Built-in tables
 
-| Table | Purpose |
-| --- | --- |
-| `lix_registered_schema` | App schemas (and built-ins). Insert into `value` to register. See [Schemas](./schemas.md). |
-| `lix_change` | Immutable global change journal. Columns: `id`, `entity_id`, `schema_key`, `schema_version`, `file_id`, `metadata`, `snapshot_content`, `created_at`. No version filter; `lix_change` is global. |
-| `lix_state` / `lix_state_by_version` / `lix_state_history` | Schema-agnostic JSON state. Active version, cross-version, and time-travel respectively. See [SQL Surfaces](./surfaces.md). |
-| `lix_version` | Writable version surface: `id`, `name`, `hidden`, `commit_id`. |
-| `lix_file` / `lix_file_by_version` / `lix_file_history` | Versioned files (with `data` bytes), cross-version reads/writes, and history. |
-| `lix_directory` / `lix_directory_by_version` / `lix_directory_history` | Directory tree, cross-version, and history. |
+| Table                                                                  | Purpose                                                                                                                                                                                          |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `lix_registered_schema`                                                | App schemas (and built-ins). Insert into `value` to register. See [Schemas](./schemas.md).                                                                                                       |
+| `lix_change`                                                           | Immutable global change journal. Columns: `id`, `entity_id`, `schema_key`, `schema_version`, `file_id`, `metadata`, `snapshot_content`, `created_at`. No version filter; `lix_change` is global. |
+| `lix_state` / `lix_state_by_version` / `lix_state_history`             | Schema-agnostic JSON state. Active version, cross-version, and time-travel respectively. See [SQL Surfaces](./surfaces.md).                                                                      |
+| `lix_version`                                                          | Writable version surface: `id`, `name`, `hidden`, `commit_id`.                                                                                                                                   |
+| `lix_file` / `lix_file_by_version` / `lix_file_history`                | Versioned files (with `data` bytes), cross-version reads/writes, and history.                                                                                                                    |
+| `lix_directory` / `lix_directory_by_version` / `lix_directory_history` | Directory tree, cross-version, and history.                                                                                                                                                      |
 
 Every registered schema `X` produces three typed surfaces:
 
@@ -157,17 +157,17 @@ For the full grid of state / per-entity / file / directory surfaces and how they
 
 ## Built-in SQL functions
 
-| Function | What it does |
-| --- | --- |
-| `lix_active_version_commit_id()` | Commit id at the active version's tip. Use to scope `_history` queries (the planner rejects subqueries on `start_commit_id`). |
-| `lix_json(text)` | Parse JSON text into a JSON-typed value. Use when binding JSON parameters. |
-| `lix_json_get(json, path...)` | Project a JSON-typed value out of a JSON column. |
-| `lix_json_get_text(json, path...)` | Project a value out of a JSON column as text. |
-| `lix_uuid_v7()` | Generate a UUIDv7 string. |
-| `lix_timestamp()` | Current ISO-8601 timestamp string. |
-| `lix_text_decode(blob[, encoding])` | Decode a `BLOB` to text (default `utf-8`). |
-| `lix_text_encode(text[, encoding])` | Encode text to a `BLOB`. |
-| `lix_empty_blob()` | Zero-byte `BLOB` literal. |
+| Function                            | What it does                                                                                                                  |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `lix_active_version_commit_id()`    | Commit id at the active version's tip. Use to scope `_history` queries (the planner rejects subqueries on `start_commit_id`). |
+| `lix_json(text)`                    | Parse JSON text into a JSON-typed value. Use when binding JSON parameters.                                                    |
+| `lix_json_get(json, path...)`       | Project a JSON-typed value out of a JSON column.                                                                              |
+| `lix_json_get_text(json, path...)`  | Project a value out of a JSON column as text.                                                                                 |
+| `lix_uuid_v7()`                     | Generate a UUIDv7 string.                                                                                                     |
+| `lix_timestamp()`                   | Current ISO-8601 timestamp string.                                                                                            |
+| `lix_text_decode(blob[, encoding])` | Decode a `BLOB` to text (default `utf-8`).                                                                                    |
+| `lix_text_encode(text[, encoding])` | Encode text to a `BLOB`.                                                                                                      |
+| `lix_empty_blob()`                  | Zero-byte `BLOB` literal.                                                                                                     |
 
 See [SQL Functions](./sql-functions.md) for examples and signatures.
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -291,17 +291,17 @@ impl SessionContext {
     /// Executes one DataFusion SQL statement against this Lix session.
     ///
     /// The SQL dialect is DataFusion SQL, not SQLite SQL. Positional
-    /// placeholders use `$1`, `$2`, and so on. SQLite-specific catalog tables
+    /// placeholders use `?` or `$1`, `$2`, and so on. SQLite-specific catalog tables
     /// and transaction statements such as `sqlite_master`, `BEGIN`, and
     /// `COMMIT` are not part of this contract; use `information_schema` for
     /// catalog inspection. Lix owns transaction boundaries for each statement.
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {
         self.ensure_open()?;
         let _transaction_guard = self.reserve_session_transaction()?;
-        let kind = sql2::classify_statement(sql)?;
+        let statement = sql2::parse_statement(sql)?;
+        let kind = sql2::classify_datafusion_statement(&statement);
         if kind == sql2::SqlStatementKind::Write {
-            let sql = sql.to_string();
-            let sql_for_error = sql.clone();
+            let sql_for_error = sql.to_string();
             let params = params.to_vec();
             return self
                 .with_write_transaction_reserved(|transaction| {
@@ -309,7 +309,9 @@ impl SessionContext {
                         // Re-plan against the transaction-backed write
                         // session so provider hooks read and stage through the
                         // transaction-owned SQL write context.
-                        let tx_plan = sql2::create_write_logical_plan(transaction, &sql).await?;
+                        let tx_plan =
+                            sql2::create_write_logical_plan_from_parsed(transaction, statement)
+                                .await?;
                         let result = sql2::execute_logical_plan(tx_plan, &params).await?;
                         let affected_rows = affected_rows_from_query_result(result)?;
                         Ok(ExecuteResult::from_rows_affected(affected_rows))
@@ -348,7 +350,7 @@ impl SessionContext {
                 functions: functions.clone(),
             };
 
-            let plan = sql2::create_logical_plan(&ctx, sql).await?;
+            let plan = sql2::create_logical_plan_from_parsed(&ctx, sql, statement).await?;
             let result = sql2::execute_logical_plan(plan, params).await?;
             drop(ctx);
             drop(live_state);
@@ -403,16 +405,23 @@ impl SessionTransaction {
         sql: &str,
         params: &[Value],
     ) -> Result<ExecuteResult, LixError> {
-        let kind = sql2::classify_statement(sql)?;
+        let statement = sql2::parse_statement(sql)?;
+        let kind = sql2::classify_datafusion_statement(&statement);
         let transaction = self.transaction_mut()?;
         match kind {
-            sql2::SqlStatementKind::Write => execute_transaction_write(transaction, sql, params)
-                .await
-                .map_err(|error| normalize_sql_surface_error(error, sql)),
-            sql2::SqlStatementKind::Read => {
-                let plan = sql2::create_transaction_read_logical_plan(transaction, sql)
+            sql2::SqlStatementKind::Write => {
+                execute_transaction_write(transaction, statement, params)
                     .await
-                    .map_err(|error| normalize_sql_surface_error(error, sql))?;
+                    .map_err(|error| normalize_sql_surface_error(error, sql))
+            }
+            sql2::SqlStatementKind::Read => {
+                let plan = sql2::create_transaction_read_logical_plan_from_parsed(
+                    transaction,
+                    sql,
+                    statement,
+                )
+                .await
+                .map_err(|error| normalize_sql_surface_error(error, sql))?;
                 let result = sql2::execute_logical_plan(plan, params)
                     .await
                     .map_err(|error| normalize_sql_surface_error(error, sql))?;
@@ -428,10 +437,10 @@ impl SessionTransaction {
 
 async fn execute_transaction_write(
     transaction: &mut crate::transaction::Transaction,
-    sql: &str,
+    statement: datafusion::sql::parser::Statement,
     params: &[Value],
 ) -> Result<ExecuteResult, LixError> {
-    let tx_plan = sql2::create_write_logical_plan(transaction, sql).await?;
+    let tx_plan = sql2::create_write_logical_plan_from_parsed(transaction, statement).await?;
     let result = sql2::execute_logical_plan(tx_plan, params).await?;
     let affected_rows = affected_rows_from_query_result(result)?;
     Ok(ExecuteResult::from_rows_affected(affected_rows))

--- a/packages/engine/src/sql2/classify.rs
+++ b/packages/engine/src/sql2/classify.rs
@@ -3,8 +3,6 @@ use datafusion::sql::sqlparser::ast::{
     FromTable, ObjectName, Query, SetExpr, Statement as SqlStatement, TableFactor, TableObject,
     TableWithJoins,
 };
-use datafusion::sql::sqlparser::dialect::GenericDialect;
-use datafusion::sql::sqlparser::parser::Parser;
 
 use crate::LixError;
 
@@ -15,35 +13,31 @@ pub(crate) enum SqlStatementKind {
     Other,
 }
 
-pub(crate) fn classify_statement(sql: &str) -> Result<SqlStatementKind, LixError> {
-    let statements = parse_sql_statements(sql)?;
-    let [statement] = statements.as_slice() else {
-        return Ok(SqlStatementKind::Other);
-    };
-    Ok(classify_ast_statement(statement))
-}
-
-pub(crate) fn validate_supported_statement_ast(sql: &str) -> Result<(), LixError> {
-    let statements = parse_sql_statements(sql)?;
-    let [statement] = statements.as_slice() else {
-        return Err(unsupported_sql_error(
-            "Lix SQL only supports one statement per execute() call",
-        ));
-    };
-    validate_supported_ast_statement(statement)
-}
-
 pub(crate) fn validate_supported_datafusion_statement_ast(
     statement: &DataFusionStatement,
 ) -> Result<(), LixError> {
     match statement {
         DataFusionStatement::Statement(statement) => validate_supported_ast_statement(statement),
         DataFusionStatement::Explain(explain) => {
+            if classify_datafusion_statement(explain.statement.as_ref()) == SqlStatementKind::Write
+            {
+                return Err(unsupported_sql_error(
+                    "EXPLAIN of write statements is not supported by Lix SQL",
+                ));
+            }
             validate_supported_datafusion_statement_ast(explain.statement.as_ref())
         }
         _ => Err(unsupported_sql_error(format!(
             "SQL statement is not supported by Lix SQL: {statement}"
         ))),
+    }
+}
+
+pub(crate) fn classify_datafusion_statement(statement: &DataFusionStatement) -> SqlStatementKind {
+    match statement {
+        DataFusionStatement::Statement(statement) => classify_ast_statement(statement),
+        DataFusionStatement::Explain(_) => SqlStatementKind::Read,
+        _ => SqlStatementKind::Other,
     }
 }
 
@@ -53,15 +47,6 @@ pub(crate) fn datafusion_statement_dml_target_table_names(
     let mut targets = Vec::new();
     collect_datafusion_statement_dml_target_table_names(statement, &mut targets);
     targets
-}
-
-fn parse_sql_statements(sql: &str) -> Result<Vec<SqlStatement>, LixError> {
-    Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| {
-        LixError::new(
-            LixError::CODE_PARSE_ERROR,
-            format!("sql2 SQL parse error: {error}"),
-        )
-    })
 }
 
 fn collect_datafusion_statement_dml_target_table_names(
@@ -133,7 +118,7 @@ fn classify_ast_statement(statement: &SqlStatement) -> SqlStatementKind {
             SqlStatementKind::Write
         }
         SqlStatement::Query(_) => SqlStatementKind::Read,
-        SqlStatement::Explain { statement, .. } => classify_ast_statement(statement.as_ref()),
+        SqlStatement::Explain { .. } => SqlStatementKind::Read,
         _ => SqlStatementKind::Other,
     }
 }
@@ -142,7 +127,14 @@ fn validate_supported_ast_statement(statement: &SqlStatement) -> Result<(), LixE
     match statement {
         SqlStatement::Query(query) => validate_supported_query(query),
         SqlStatement::Insert(_) | SqlStatement::Update(_) | SqlStatement::Delete(_) => Ok(()),
-        SqlStatement::Explain { statement, .. } => validate_supported_ast_statement(statement),
+        SqlStatement::Explain { statement, .. } => {
+            if classify_ast_statement(statement.as_ref()) == SqlStatementKind::Write {
+                return Err(unsupported_sql_error(
+                    "EXPLAIN of write statements is not supported by Lix SQL",
+                ));
+            }
+            validate_supported_ast_statement(statement)
+        }
         _ => Err(unsupported_sql_error(format!(
             "SQL statement is not supported by Lix SQL: {statement}"
         ))),

--- a/packages/engine/src/sql2/error.rs
+++ b/packages/engine/src/sql2/error.rs
@@ -59,7 +59,7 @@ fn classify_datafusion_error(error: &DataFusionError) -> LixError {
 
     if looks_like_unsupported_dialect(&lower) {
         return LixError::new(LixError::CODE_DIALECT_UNSUPPORTED, message)
-            .with_hint("Lix SQL uses DataFusion syntax. Use lix_json_get(...) or lix_json_get_text(...) for JSON access, and numbered placeholders like $1, $2, ...");
+            .with_hint("Lix SQL uses DataFusion syntax. Use lix_json_get(...) or lix_json_get_text(...) for JSON access, and placeholders like ?, ? or $1, $2, ...");
     }
 
     if looks_like_unsupported_runtime_plan(&lower) {
@@ -76,9 +76,8 @@ fn classify_datafusion_error(error: &DataFusionError) -> LixError {
         || lower.contains("placeholder")
         || lower.contains("bind")
     {
-        return LixError::new(LixError::CODE_PARSE_ERROR, message).with_hint(
-            "Use numbered placeholders like $1, $2, ...; '?' placeholders are not supported.",
-        );
+        return LixError::new(LixError::CODE_PARSE_ERROR, message)
+            .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...");
     }
 
     if lower.contains("requires start_commit_id")

--- a/packages/engine/src/sql2/execute.rs
+++ b/packages/engine/src/sql2/execute.rs
@@ -4,7 +4,9 @@ use datafusion::common::metadata::{FieldMetadata, ScalarAndMetadata};
 use datafusion::common::{ParamValues, ScalarValue};
 use datafusion::logical_expr::{Expr, LogicalPlan, WriteOp};
 use datafusion::prelude::SessionContext;
-use datafusion::sql::parser::Statement as DataFusionStatement;
+use datafusion::sql::parser::{DFParserBuilder, Statement as DataFusionStatement};
+use datafusion::sql::sqlparser::dialect::GenericDialect;
+use datafusion::sql::sqlparser::tokenizer::{Token, Tokenizer};
 use serde_json::{json, Value as JsonValue};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
@@ -13,7 +15,7 @@ use crate::{LixError, LixNotice, SqlQueryResult, Value};
 
 use super::predicate_typecheck::validate_json_predicate_expr_with_dfschema;
 use super::result_metadata::{field_is_json, LIX_VALUE_TYPE_JSON, LIX_VALUE_TYPE_METADATA_KEY};
-use super::session::{build_read_session, build_write_session, new_sql_session_context};
+use super::session::{build_read_session, build_write_session};
 use super::write_normalization::{
     is_binary_type, lix_file_data_type_lix_error, logical_expr_is_binary_or_null,
 };
@@ -60,15 +62,24 @@ pub(crate) async fn create_logical_plan(
     ctx: &dyn SqlExecutionContext,
     sql: &str,
 ) -> Result<SqlLogicalPlan, LixError> {
-    super::validate_supported_statement_ast(sql)?;
-    super::udfs::validate_public_udf_calls(sql)?;
+    let statement = parse_statement(sql)?;
+    create_logical_plan_from_parsed(ctx, sql, statement).await
+}
+
+pub(crate) fn parse_statement(sql: &str) -> Result<DataFusionStatement, LixError> {
+    parse_datafusion_statement(sql)
+}
+
+pub(crate) async fn create_logical_plan_from_parsed(
+    ctx: &dyn SqlExecutionContext,
+    sql: &str,
+    statement: DataFusionStatement,
+) -> Result<SqlLogicalPlan, LixError> {
     validate_public_read_sql_surface(sql)?;
+    super::validate_supported_datafusion_statement_ast(&statement)?;
+    super::udfs::validate_public_udf_calls_in_datafusion_statement(&statement)?;
     let session = build_read_session(ctx).await?;
-    let plan = session
-        .state()
-        .create_logical_plan(sql)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
+    let plan = create_logical_plan_from_statement(&session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
     let kind = classify_logical_plan(&plan);
@@ -88,10 +99,17 @@ pub(crate) async fn create_write_logical_plan(
     ctx: &mut dyn SqlWriteExecutionContext,
     sql: &str,
 ) -> Result<SqlLogicalPlan, LixError> {
-    super::udfs::validate_public_udf_calls(sql)?;
+    let statement = parse_statement(sql)?;
+    create_write_logical_plan_from_parsed(ctx, statement).await
+}
+
+pub(crate) async fn create_write_logical_plan_from_parsed(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    statement: DataFusionStatement,
+) -> Result<SqlLogicalPlan, LixError> {
+    super::udfs::validate_public_udf_calls_in_datafusion_statement(&statement)?;
     let visible_schemas = ctx.list_visible_schemas()?;
-    super::public_bind::validate_public_dml_sql(sql, &visible_schemas)?;
-    let statement = parse_datafusion_statement(sql)?;
+    super::public_bind::validate_public_dml_statement(&statement, &visible_schemas)?;
     super::validate_supported_datafusion_statement_ast(&statement)?;
     reject_read_only_history_view_dml_from_statement(&statement, &visible_schemas)?;
     let session = build_write_session(ctx).await?;
@@ -111,19 +129,16 @@ pub(crate) async fn create_write_logical_plan(
     })
 }
 
-pub(crate) async fn create_transaction_read_logical_plan(
+pub(crate) async fn create_transaction_read_logical_plan_from_parsed(
     ctx: &mut dyn SqlWriteExecutionContext,
     sql: &str,
+    statement: DataFusionStatement,
 ) -> Result<SqlLogicalPlan, LixError> {
-    super::validate_supported_statement_ast(sql)?;
-    super::udfs::validate_public_udf_calls(sql)?;
     validate_public_read_sql_surface(sql)?;
+    super::validate_supported_datafusion_statement_ast(&statement)?;
+    super::udfs::validate_public_udf_calls_in_datafusion_statement(&statement)?;
     let session = build_write_session(ctx).await?;
-    let plan = session
-        .state()
-        .create_logical_plan(sql)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
+    let plan = create_logical_plan_from_statement(&session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
     let kind = classify_logical_plan(&plan);
@@ -158,12 +173,64 @@ fn validate_public_read_sql_surface(sql: &str) -> Result<(), LixError> {
 }
 
 fn parse_datafusion_statement(sql: &str) -> Result<DataFusionStatement, LixError> {
-    let session = new_sql_session_context();
-    let dialect = session.state().config_options().sql_parser.dialect;
-    session
-        .state()
-        .sql_to_statement(sql, &dialect)
-        .map_err(datafusion_error_to_lix_error)
+    let dialect = GenericDialect {};
+    let mut next_index = 1usize;
+    let mut has_anonymous = false;
+    let mut explicit_placeholders = Vec::new();
+
+    let mut tokens = Vec::new();
+    Tokenizer::new(&dialect, sql)
+        .tokenize_with_location_into_buf_with_mapper(&mut tokens, |mut token_span| {
+            if let Token::Placeholder(placeholder) = &token_span.token {
+                if placeholder == "?" {
+                    has_anonymous = true;
+                    token_span.token = Token::Placeholder(format!("${next_index}"));
+                    next_index += 1;
+                } else {
+                    explicit_placeholders.push(placeholder.clone());
+                }
+            }
+            token_span
+        })
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_PARSE_ERROR,
+                format!("sql2 SQL tokenize error: {error}"),
+            )
+        })?;
+
+    if has_anonymous && !explicit_placeholders.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_PARSE_ERROR,
+            "SQL mixes anonymous and explicit parameter placeholders",
+        )
+        .with_hint("Use either anonymous placeholders like ?, ? or numbered placeholders like $1, $2, but not both.")
+        .with_details(json!({
+            "operation": "execute",
+            "explicit_placeholders": explicit_placeholders,
+        })));
+    }
+
+    let mut statements = DFParserBuilder::new(tokens)
+        .with_dialect(&dialect)
+        .build()
+        .map_err(datafusion_error_to_lix_error)?
+        .parse_statements()
+        .map_err(datafusion_error_to_lix_error)?;
+
+    if statements.len() > 1 {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "Lix SQL only supports one statement per execute() call",
+        ));
+    }
+
+    statements.pop_front().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_PARSE_ERROR,
+            "sql2 DataFusion error: No SQL statements were provided in the query string",
+        )
+    })
 }
 
 async fn create_logical_plan_from_statement(
@@ -294,7 +361,7 @@ fn placeholder_index(id: &str) -> Result<usize, LixError> {
                 LixError::CODE_PARSE_ERROR,
                 format!("unsupported SQL parameter placeholder '{id}'"),
             )
-            .with_hint("Use numbered placeholders like $1, $2, ...")
+            .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...")
         })
 }
 
@@ -389,7 +456,7 @@ fn expected_positional_parameter_count(
                 LixError::CODE_PARSE_ERROR,
                 format!("unsupported SQL parameter placeholder '{name}'"),
             )
-            .with_hint("Use numbered placeholders like $1, $2, ...")
+            .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...")
             .with_details(json!({
                 "operation": "execute",
                 "placeholder": name,
@@ -400,7 +467,7 @@ fn expected_positional_parameter_count(
                 LixError::CODE_PARSE_ERROR,
                 "SQL parameter placeholders are 1-indexed",
             )
-            .with_hint("Use numbered placeholders like $1, $2, ...")
+            .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...")
             .with_details(json!({
                 "operation": "execute",
                 "placeholder": name,
@@ -1897,7 +1964,6 @@ mod tests {
             "DELETE FROM lix_state_history",
             "DELETE FROM LIX_STATE_HISTORY",
             "DELETE FROM main.LIX_STATE_HISTORY",
-            "EXPLAIN DELETE FROM lix_state_history",
         ] {
             let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
             let live_state = Arc::new(DummyLiveStateReader);

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -30,9 +30,8 @@ mod version_scope;
 mod write_normalization;
 
 pub(crate) use classify::{
-    classify_statement, datafusion_statement_dml_target_table_names,
-    validate_supported_datafusion_statement_ast, validate_supported_statement_ast,
-    SqlStatementKind,
+    classify_datafusion_statement, datafusion_statement_dml_target_table_names,
+    validate_supported_datafusion_statement_ast, SqlStatementKind,
 };
 pub(crate) use context::{
     CommitStoreQuerySource, SqlCommitStoreQuerySource, SqlExecutionContext, SqlJsonReader,
@@ -41,6 +40,8 @@ pub(crate) use context::{
 };
 #[allow(unused_imports)]
 pub(crate) use execute::{
-    create_logical_plan, create_transaction_read_logical_plan, create_write_logical_plan,
-    execute_logical_plan, execute_sql, SqlLogicalPlan,
+    create_logical_plan, create_logical_plan_from_parsed,
+    create_transaction_read_logical_plan_from_parsed, create_write_logical_plan,
+    create_write_logical_plan_from_parsed, execute_logical_plan, execute_sql, parse_statement,
+    SqlLogicalPlan,
 };

--- a/packages/engine/src/sql2/public_bind/dml.rs
+++ b/packages/engine/src/sql2/public_bind/dml.rs
@@ -1,10 +1,9 @@
 use datafusion::logical_expr::{LogicalPlan, WriteOp};
+use datafusion::sql::parser::Statement as DataFusionStatement;
 use datafusion::sql::sqlparser::ast::{
     Assignment, AssignmentTarget, Delete, FromTable, ObjectName, Statement, TableFactor,
     TableObject, TableWithJoins, Update,
 };
-use datafusion::sql::sqlparser::dialect::GenericDialect;
-use datafusion::sql::sqlparser::parser::Parser;
 use serde_json::Value as JsonValue;
 
 use crate::LixError;
@@ -30,18 +29,25 @@ impl DmlOperation {
     }
 }
 
-pub(crate) fn validate_sql(sql: &str, visible_schemas: &[JsonValue]) -> Result<(), LixError> {
-    let statements = Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| {
-        LixError::new(
-            LixError::CODE_PARSE_ERROR,
-            format!("sql2 SQL parse error: {error}"),
-        )
-    })?;
-    let [statement] = statements.as_slice() else {
-        return Ok(());
-    };
+pub(crate) fn validate_datafusion_statement(
+    statement: &DataFusionStatement,
+    visible_schemas: &[JsonValue],
+) -> Result<(), LixError> {
     let contracts = PublicTableContracts::new(visible_schemas)?;
-    validate_statement(statement, &contracts)
+    validate_datafusion_statement_with_contracts(statement, &contracts)
+}
+
+fn validate_datafusion_statement_with_contracts(
+    statement: &DataFusionStatement,
+    contracts: &PublicTableContracts,
+) -> Result<(), LixError> {
+    match statement {
+        DataFusionStatement::Statement(statement) => validate_statement(statement, contracts),
+        DataFusionStatement::Explain(explain) => {
+            validate_datafusion_statement_with_contracts(explain.statement.as_ref(), contracts)
+        }
+        _ => Ok(()),
+    }
 }
 
 pub(crate) fn validate_plan(

--- a/packages/engine/src/sql2/public_bind/mod.rs
+++ b/packages/engine/src/sql2/public_bind/mod.rs
@@ -4,17 +4,18 @@ mod dml;
 mod table;
 
 use datafusion::logical_expr::LogicalPlan;
+use datafusion::sql::parser::Statement as DataFusionStatement;
 use serde_json::Value as JsonValue;
 
 use crate::LixError;
 
 pub(crate) use dml::DmlOperation;
 
-pub(crate) fn validate_public_dml_sql(
-    sql: &str,
+pub(crate) fn validate_public_dml_statement(
+    statement: &DataFusionStatement,
     visible_schemas: &[JsonValue],
 ) -> Result<(), LixError> {
-    dml::validate_sql(sql, visible_schemas)
+    dml::validate_datafusion_statement(statement, visible_schemas)
 }
 
 pub(crate) fn validate_public_dml_plan(

--- a/packages/engine/src/sql2/udfs/mod.rs
+++ b/packages/engine/src/sql2/udfs/mod.rs
@@ -15,7 +15,7 @@ use datafusion::logical_expr::ScalarUDF;
 
 use crate::functions::FunctionProviderHandle;
 
-pub(crate) use public_call::validate_public_udf_calls;
+pub(crate) use public_call::validate_public_udf_calls_in_datafusion_statement;
 
 #[cfg(test)]
 pub(crate) fn system_sql2_function_provider() -> FunctionProviderHandle {

--- a/packages/engine/src/sql2/udfs/public_call.rs
+++ b/packages/engine/src/sql2/udfs/public_call.rs
@@ -1,14 +1,18 @@
 use std::ops::ControlFlow;
 
+use datafusion::sql::parser::Statement as DataFusionStatement;
 use datafusion::sql::sqlparser::ast::{
     Expr, Function, FunctionArg, FunctionArgExpr, FunctionArguments, ObjectNamePart, Statement,
     Value, Visit, Visitor,
 };
+#[cfg(test)]
 use datafusion::sql::sqlparser::dialect::GenericDialect;
+#[cfg(test)]
 use datafusion::sql::sqlparser::parser::Parser;
 
 use crate::LixError;
 
+#[cfg(test)]
 pub(crate) fn validate_public_udf_calls(sql: &str) -> Result<(), LixError> {
     let statements = Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| {
         LixError::new(
@@ -63,6 +67,29 @@ fn validate_public_function_call(function: &Function) -> Result<(), LixError> {
         "lix_text_encode" | "lix_text_decode" => {
             expect_arity_range(name, arity, 1, 2)?;
             validate_literal_utf8_encoding(name, &function.args)
+        }
+        _ => Ok(()),
+    }
+}
+
+pub(crate) fn validate_public_udf_calls_in_datafusion_statement(
+    statement: &DataFusionStatement,
+) -> Result<(), LixError> {
+    let mut visitor = PublicUdfCallVisitor;
+    visit_datafusion_statement(statement, &mut visitor)
+}
+
+fn visit_datafusion_statement(
+    statement: &DataFusionStatement,
+    visitor: &mut PublicUdfCallVisitor,
+) -> Result<(), LixError> {
+    match statement {
+        DataFusionStatement::Statement(statement) => match statement.visit(visitor) {
+            ControlFlow::Continue(()) => Ok(()),
+            ControlFlow::Break(error) => Err(*error),
+        },
+        DataFusionStatement::Explain(explain) => {
+            visit_datafusion_statement(explain.statement.as_ref(), visitor)
         }
         _ => Ok(()),
     }

--- a/packages/engine/tests/sql/errors.rs
+++ b/packages/engine/tests/sql/errors.rs
@@ -59,7 +59,149 @@ simulation_test!(
     }
 );
 
-simulation_test!(sql_question_mark_placeholder_has_hint, |sim| async move {
+simulation_test!(
+    sql_question_mark_placeholders_bind_positionally,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("main session should open");
+
+        let result = session
+            .execute(
+                "SELECT * FROM lix_file WHERE id = ?",
+                &[Value::Text("missing-file".to_string())],
+            )
+            .await
+            .expect("anonymous placeholder should still bind when no rows match");
+        assert_eq!(result.len(), 0);
+
+        let result = session
+            .execute(
+                "SELECT '?' AS literal, ? AS first, ? AS second",
+                &[Value::Integer(10), Value::Text("second".to_string())],
+            )
+            .await
+            .expect("anonymous placeholders should bind left to right");
+        let row = result.rows().first().expect("query should return one row");
+        assert_eq!(
+            row.values(),
+            &[
+                Value::Text("?".to_string()),
+                Value::Integer(10),
+                Value::Text("second".to_string()),
+            ]
+        );
+
+        let result = session
+            .execute(
+                "SELECT 'it''s ?' AS escaped_literal, ? AS bound_value -- ? in comment\n",
+                &[Value::Integer(42)],
+            )
+            .await
+            .expect("normalization should preserve escaped literals and comments");
+        let row = result.rows().first().expect("query should return one row");
+        assert_eq!(
+            row.values(),
+            &[Value::Text("it's ?".to_string()), Value::Integer(42)]
+        );
+
+        let error = session
+            .execute("SELECT ? AS missing_param", &[])
+            .await
+            .expect_err("anonymous placeholder without a value should fail");
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+    }
+);
+
+simulation_test!(
+    sql_mixed_anonymous_and_explicit_placeholders_are_rejected,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let error = session
+            .execute(
+                "SELECT ? AS anonymous_value, $2 AS numbered_value",
+                &[Value::Integer(1), Value::Integer(2)],
+            )
+            .await
+            .expect_err("mixed placeholder styles should fail");
+
+        assert_eq!(error.code, LixError::CODE_PARSE_ERROR);
+        assert!(
+            error.hint().is_some_and(|hint| hint.contains("not both")),
+            "expected mixed-placeholder hint: {error}"
+        );
+    }
+);
+
+simulation_test!(
+    sql_transaction_execute_accepts_anonymous_placeholders,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+
+        let result = transaction
+            .execute(
+                "SELECT ? AS first, ? AS second",
+                &[Value::Integer(1), Value::Text("two".to_string())],
+            )
+            .await
+            .expect("anonymous parameter read in transaction should succeed");
+        assert_eq!(
+            result.rows()[0].values(),
+            &[Value::Integer(1), Value::Text("two".to_string())]
+        );
+
+        transaction
+            .execute(
+                "INSERT INTO lix_file (id, path) VALUES (?, ?)",
+                &[
+                    Value::Text("anonymous-transaction-file".to_string()),
+                    Value::Text("/anonymous-transaction.txt".to_string()),
+                ],
+            )
+            .await
+            .expect("anonymous parameter write in transaction should succeed");
+
+        transaction
+            .commit()
+            .await
+            .expect("transaction commit should succeed");
+
+        let result = session
+            .execute(
+                "SELECT path FROM lix_file WHERE id = ?",
+                &[Value::Text("anonymous-transaction-file".to_string())],
+            )
+            .await
+            .expect("committed anonymous parameter write should be visible");
+        assert_eq!(
+            result.rows()[0].values(),
+            &[Value::Text("/anonymous-transaction.txt".to_string())]
+        );
+    }
+);
+
+simulation_test!(sql_explain_is_read_shaped, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
@@ -69,16 +211,24 @@ simulation_test!(sql_question_mark_placeholder_has_hint, |sim| async move {
         &engine,
     );
 
-    let error = session
-        .execute("SELECT * FROM lix_file WHERE id = ?", &[])
+    let result = session
+        .execute("EXPLAIN SELECT ? AS explained_value", &[Value::Integer(1)])
         .await
-        .expect_err("question mark placeholders should fail");
+        .expect("EXPLAIN SELECT should return explain rows");
+    assert!(!result.columns().is_empty());
+    assert!(!result.rows().is_empty());
 
-    assert_eq!(error.code, LixError::CODE_PARSE_ERROR);
-    assert!(
-        error.hint().is_some_and(|hint| hint.contains("$1")),
-        "expected placeholder hint: {error}"
-    );
+    let error = session
+        .execute(
+            "EXPLAIN INSERT INTO lix_file (id, path) VALUES (?, ?)",
+            &[
+                Value::Text("explained-write".to_string()),
+                Value::Text("/explained-write.txt".to_string()),
+            ],
+        )
+        .await
+        .expect_err("EXPLAIN of write statements should not route through write execution");
+    assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
 });
 
 simulation_test!(sql_json_function_miss_has_lix_udf_hint, |sim| async move {

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -746,6 +746,75 @@ simulation_test!(
     }
 );
 
+simulation_test!(
+    lix_file_insert_accepts_anonymous_path_and_data_parameters,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let insert_result = session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES (?, ?, ?)",
+                &[
+                    Value::Text("anonymous-param-file".to_string()),
+                    Value::Text("/anonymous-param.bin".to_string()),
+                    Value::Blob(b"anonymous".to_vec()),
+                ],
+            )
+            .await
+            .expect("anonymous parameter insert should succeed");
+        assert_eq!(insert_result.rows_affected(), 1);
+
+        let result = session
+            .execute(
+                "SELECT path, data FROM lix_file WHERE id = ?",
+                &[Value::Text("anonymous-param-file".to_string())],
+            )
+            .await
+            .expect("anonymous parameter read should succeed");
+        assert_rows_eq(
+            result,
+            vec![vec![
+                Value::Text("/anonymous-param.bin".to_string()),
+                Value::Blob(b"anonymous".to_vec()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_anonymous_data_parameter_keeps_strict_blob_validation,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let error = session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES (?, ?, ?)",
+                &[
+                    Value::Text("anonymous-text-data-file".to_string()),
+                    Value::Text("/anonymous-text-data.bin".to_string()),
+                    Value::Text("not binary".to_string()),
+                ],
+            )
+            .await
+            .expect_err("anonymous non-binary data parameter should be rejected");
+        assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
+    }
+);
+
 simulation_test!(lix_file_insert_accepts_empty_blob_data, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(

--- a/packages/engine/tests/support/simulation_test/engine/simulation.rs
+++ b/packages/engine/tests/support/simulation_test/engine/simulation.rs
@@ -2,7 +2,7 @@ use lix_engine::{Backend, LixError, Value};
 use lix_engine::{
     CreateVersionOptions, CreateVersionReceipt, Engine, ExecuteResult, InitReceipt,
     MergeVersionOptions, MergeVersionPreview, MergeVersionPreviewOptions, MergeVersionReceipt,
-    SessionContext, SwitchVersionOptions, SwitchVersionReceipt,
+    SessionContext, SessionTransaction, SwitchVersionOptions, SwitchVersionReceipt,
 };
 
 use super::expect_same::SimulationAssertions;
@@ -120,24 +120,38 @@ impl SimSession {
     }
 
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {
-        match classify_statement(sql) {
-            StatementKind::Read => {
-                let active_version_id = self.session.active_version_id().await?;
-                self.sim
-                    .rebuild_tracked_state
-                    .before_read(&self.engine, &active_version_id)
-                    .await?;
-                self.session.execute(sql, params).await
-            }
-            StatementKind::Write => {
-                let result = self.session.execute(sql, params).await;
-                if result.is_ok() {
-                    self.sim.rebuild_tracked_state.after_successful_write();
-                }
-                result
-            }
-            StatementKind::Utility => self.session.execute(sql, params).await,
+        let statement_kind = classify_statement(sql);
+        if statement_kind == StatementKind::Read {
+            let active_version_id = self.session.active_version_id().await?;
+            self.sim
+                .rebuild_tracked_state
+                .before_read(&self.engine, &active_version_id)
+                .await?;
         }
+
+        let result = self.session.execute(sql, params).await;
+        if let Ok(result) = &result {
+            if statement_kind == StatementKind::Write || execute_result_looks_like_write(result) {
+                self.sim.rebuild_tracked_state.after_successful_write();
+            }
+        }
+        result
+    }
+
+    pub async fn begin_transaction(&self) -> Result<SimTransaction, LixError> {
+        let active_version_id = self.session.active_version_id().await?;
+        self.sim
+            .rebuild_tracked_state
+            .before_read(&self.engine, &active_version_id)
+            .await?;
+        let transaction = self.session.begin_transaction().await?;
+        Ok(SimTransaction {
+            sim: self.sim.clone(),
+            engine: self.engine.clone(),
+            session: self.session.clone(),
+            transaction,
+            saw_write: false,
+        })
     }
 
     pub async fn create_version(
@@ -185,6 +199,57 @@ impl SimSession {
     }
 }
 
+/// Transaction wrapper that injects simulation behavior around normal execution.
+#[allow(dead_code)]
+pub struct SimTransaction {
+    sim: Simulation,
+    engine: Engine,
+    session: SessionContext,
+    transaction: SessionTransaction,
+    saw_write: bool,
+}
+
+#[allow(dead_code)]
+impl SimTransaction {
+    pub async fn execute(
+        &mut self,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<ExecuteResult, LixError> {
+        let statement_kind = classify_statement(sql);
+        match statement_kind {
+            StatementKind::Read => {
+                let active_version_id = self.session.active_version_id().await?;
+                self.sim
+                    .rebuild_tracked_state
+                    .before_read(&self.engine, &active_version_id)
+                    .await?;
+            }
+            StatementKind::Write => {}
+            StatementKind::Utility => {}
+        }
+        let result = self.transaction.execute(sql, params).await;
+        if let Ok(result) = &result {
+            if statement_kind == StatementKind::Write || execute_result_looks_like_write(result) {
+                self.saw_write = true;
+            }
+        }
+        result
+    }
+
+    pub async fn commit(self) -> Result<(), LixError> {
+        let result = self.transaction.commit().await;
+        if result.is_ok() && self.saw_write {
+            self.sim.rebuild_tracked_state.after_successful_write();
+        }
+        result
+    }
+
+    pub async fn rollback(self) -> Result<(), LixError> {
+        self.transaction.rollback().await
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StatementKind {
     Read,
@@ -193,17 +258,88 @@ enum StatementKind {
 }
 
 fn classify_statement(sql: &str) -> StatementKind {
-    let keyword = sql
-        .trim_start()
-        .split(|ch: char| ch.is_whitespace() || ch == '(')
-        .next()
-        .unwrap_or("")
-        .to_ascii_uppercase();
+    let sql = skip_leading_sql_trivia(sql);
+    if let Some(inner) = sql.strip_prefix('(') {
+        return classify_statement(inner);
+    }
+
+    let (keyword, _rest) = first_keyword_and_rest(sql);
     match keyword.as_str() {
-        "SELECT" | "WITH" => StatementKind::Read,
+        "SELECT" | "WITH" | "VALUES" | "FROM" | "TABLE" => StatementKind::Read,
         "INSERT" | "UPDATE" | "DELETE" => StatementKind::Write,
+        "EXPLAIN" => StatementKind::Read,
         _ => StatementKind::Utility,
     }
+}
+
+fn first_keyword_and_rest(sql: &str) -> (String, &str) {
+    let sql = skip_leading_sql_trivia(sql);
+    let end_index = sql
+        .char_indices()
+        .find_map(|(index, ch)| {
+            if !(ch.is_ascii_alphanumeric() || ch == '_') {
+                Some(index)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(sql.len());
+    (sql[..end_index].to_ascii_uppercase(), &sql[end_index..])
+}
+
+fn skip_leading_sql_trivia(mut sql: &str) -> &str {
+    loop {
+        let trimmed = sql.trim_start();
+        if trimmed.len() != sql.len() {
+            sql = trimmed;
+            continue;
+        }
+
+        if let Some(comment_body) = sql.strip_prefix("--") {
+            let Some(newline_index) = comment_body.find('\n') else {
+                return "";
+            };
+            sql = &comment_body[newline_index + 1..];
+            continue;
+        }
+
+        if let Some(comment_body) = sql.strip_prefix("/*") {
+            let Some(end_index) = end_of_nested_block_comment(comment_body) else {
+                return "";
+            };
+            sql = &comment_body[end_index..];
+            continue;
+        }
+
+        return sql;
+    }
+}
+
+fn end_of_nested_block_comment(comment_body: &str) -> Option<usize> {
+    let mut depth = 1usize;
+    let mut index = 0usize;
+    while index < comment_body.len() {
+        let rest = &comment_body[index..];
+        if rest.starts_with("/*") {
+            depth += 1;
+            index += 2;
+            continue;
+        }
+        if rest.starts_with("*/") {
+            depth -= 1;
+            index += 2;
+            if depth == 0 {
+                return Some(index);
+            }
+            continue;
+        }
+        index += rest.chars().next().map(char::len_utf8).unwrap_or_default();
+    }
+    None
+}
+
+fn execute_result_looks_like_write(result: &ExecuteResult) -> bool {
+    result.columns().is_empty() && result.rows().is_empty()
 }
 
 #[cfg(test)]
@@ -218,6 +354,18 @@ mod tests {
             StatementKind::Read
         );
         assert_eq!(
+            classify_statement("-- leading comment\nSELECT 1"),
+            StatementKind::Read
+        );
+        assert_eq!(
+            classify_statement("/* leading block */ INSERT INTO t VALUES (1)"),
+            StatementKind::Write
+        );
+        assert_eq!(
+            classify_statement("/* outer /* inner */ outer */ SELECT 1"),
+            StatementKind::Read
+        );
+        assert_eq!(
             classify_statement("INSERT INTO t VALUES (1)"),
             StatementKind::Write
         );
@@ -226,9 +374,41 @@ mod tests {
             StatementKind::Write
         );
         assert_eq!(classify_statement("DELETE FROM t"), StatementKind::Write);
+        assert_eq!(classify_statement("EXPLAIN SELECT 1"), StatementKind::Read);
         assert_eq!(
-            classify_statement("EXPLAIN SELECT 1"),
-            StatementKind::Utility
+            classify_statement("EXPLAIN ANALYZE INSERT INTO t VALUES (1)"),
+            StatementKind::Read
         );
+        assert_eq!(
+            classify_statement("EXPLAIN FORMAT INDENT SELECT 1"),
+            StatementKind::Read
+        );
+        assert_eq!(
+            classify_statement("EXPLAIN FORMAT 'INDENT' SELECT 1"),
+            StatementKind::Read
+        );
+        assert_eq!(
+            classify_statement("EXPLAIN FORMAT \"INDENT\" SELECT 1"),
+            StatementKind::Read
+        );
+        assert_eq!(
+            classify_statement("SELECT/* comment */ 1"),
+            StatementKind::Read
+        );
+        assert_eq!(
+            classify_statement("EXPLAIN/* comment */ SELECT 1"),
+            StatementKind::Read
+        );
+        assert_eq!(
+            classify_statement("EXPLAIN (SELECT 1)"),
+            StatementKind::Read
+        );
+        assert_eq!(classify_statement("VALUES (1), (2)"), StatementKind::Read);
+        assert_eq!(
+            classify_statement("FROM lix_file SELECT id"),
+            StatementKind::Read
+        );
+        assert_eq!(classify_statement("(SELECT 1)"), StatementKind::Read);
+        assert_eq!(classify_statement("((SELECT 1))"), StatementKind::Read);
     }
 }

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -307,7 +307,7 @@ export type Lix = {
 	 * Executes one DataFusion SQL statement against this Lix session.
 	 *
 	 * This is not SQLite SQL. Use the DataFusion SQL dialect; positional
-	 * placeholders are `$1`, `$2`, and so on. SQLite-specific catalog tables and
+	 * placeholders are `?` or `$1`, `$2`, and so on. SQLite-specific catalog tables and
 	 * transaction statements such as `sqlite_master`, `BEGIN`, and `COMMIT` are
 	 * not available. Use `information_schema` for catalog inspection. While a
 	 * transaction is active, call `execute()` on the transaction handle instead.

--- a/packages/js-sdk/wasm-bindgen.rs
+++ b/packages/js-sdk/wasm-bindgen.rs
@@ -238,7 +238,7 @@ export type MergeConflictSide = {
         /// Executes one DataFusion SQL statement against this Lix session.
         ///
         /// The SQL dialect is DataFusion SQL, not SQLite SQL. Positional
-        /// placeholders use `$1`, `$2`, and so on. SQLite-specific catalog
+        /// placeholders use `?` or `$1`, `$2`, and so on. SQLite-specific catalog
         /// tables and transaction statements such as `sqlite_master`, `BEGIN`,
         /// and `COMMIT` are not part of this contract; use
         /// `information_schema` for catalog inspection.

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -50,7 +50,7 @@ impl Lix {
     /// Executes one DataFusion SQL statement against this Lix session.
     ///
     /// The SQL dialect is DataFusion SQL, not SQLite SQL. Positional
-    /// placeholders use `$1`, `$2`, and so on. SQLite-specific catalog tables
+    /// placeholders use `?` or `$1`, `$2`, and so on. SQLite-specific catalog tables
     /// and transaction statements such as `sqlite_master`, `BEGIN`, and
     /// `COMMIT` are not part of this contract; use `information_schema` for
     /// catalog inspection. Lix owns transaction boundaries for each statement.


### PR DESCRIPTION
Closes https://github.com/opral/lix/issues/437

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQL parsing/binding behavior in the core execution path by accepting `?` placeholders (and rewriting them), which could affect parameter ordering and error handling across reads/writes/transactions. Adds new EXPLAIN classification rules and validation, so planner/execution routing behavior may change for some statements.
> 
> **Overview**
> Lix SQL now supports anonymous `?` placeholders by tokenizing SQL and rewriting `?` into `$n` parameters (left-to-right), while **rejecting mixed `?` and `$n` styles** with a parse error and hint.
> 
> Execution/planning is refactored to parse once (`parse_statement`) and pass a parsed DataFusion statement through read/write/transaction planning, including updating statement classification and public DML/UDF validation to operate on parsed statements.
> 
> `EXPLAIN` is treated as read-shaped, but `EXPLAIN` of write statements is explicitly rejected; docs/SDK comments and tests are updated to reflect the new placeholder behavior and add coverage for binding, mixing rejection, transactions, and `lix_file` blob strictness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29727078656fa4f064d0c01478f97cb3abe5bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->