### PR TITLE
Faster transactions

### DIFF
--- a/packages/engine/benches/transaction/main.rs
+++ b/packages/engine/benches/transaction/main.rs
@@ -4,7 +4,8 @@ use lix_engine::storage_bench::{self, TransactionAccountingReport};
 use lix_engine::{
     Backend, BackendKvEntryPage, BackendKvExistsBatch, BackendKvGetRequest, BackendKvKeyPage,
     BackendKvScanRequest, BackendKvValueBatch, BackendKvValuePage, BackendKvWriteBatch,
-    BackendKvWriteStats, BackendReadTransaction, BackendWriteTransaction, LixError,
+    BackendKvWriteStats, BackendReadTransaction, BackendWriteTransaction, Engine, LixError,
+    SessionContext, Value,
 };
 use std::collections::{BTreeMap, HashSet};
 use std::sync::OnceLock;
@@ -22,6 +23,7 @@ const LARGE_ENTITY_ROWS: usize = 1_000;
 const UPDATE_ROWS_SMALL: usize = 1;
 const UPDATE_ROWS_BATCH: usize = 100;
 const SCALING_ROWS: &[usize] = &[1_000, 2_000, 5_000, 10_000, 20_000];
+const TRANSACTION_LOGIC_ROWS: &[usize] = &[250, 500, 1_000, 2_000];
 
 fn transaction_benches(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -645,6 +647,133 @@ fn transaction_benches(c: &mut Criterion) {
 
     io_group.finish();
 
+    let mut logic_group = c.benchmark_group("transaction_logic");
+    for &rows in TRANSACTION_LOGIC_ROWS {
+        let label = row_count_label(rows);
+
+        logic_group.bench_function(
+            format!("stage_rows_batch_no_payload/{label}"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        runtime
+                            .block_on(
+                                storage_bench::prepare_transaction_commit_entities_no_payload(
+                                    BenchBackend::new(),
+                                    rows,
+                                ),
+                            )
+                            .unwrap_or_else(|error| {
+                                panic!(
+                                    "prepare transaction_logic/stage_rows_batch_no_payload/{label}: {error}"
+                                )
+                            })
+                    },
+                    |fixture| {
+                        stage_only(
+                            &runtime,
+                            fixture,
+                            "transaction_logic/stage_rows_batch_no_payload",
+                        )
+                    },
+                    BatchSize::LargeInput,
+                )
+            },
+        );
+
+        logic_group.bench_function(
+            format!("stage_rows_individual_no_payload/{label}"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        runtime
+                            .block_on(
+                                storage_bench::prepare_transaction_commit_entities_no_payload(
+                                    BenchBackend::new(),
+                                    rows,
+                                ),
+                            )
+                            .unwrap_or_else(|error| {
+                                panic!(
+                                    "prepare transaction_logic/stage_rows_individual_no_payload/{label}: {error}"
+                                )
+                            })
+                    },
+                    |fixture| {
+                        stage_rows_individually(
+                            &runtime,
+                            fixture,
+                            "transaction_logic/stage_rows_individual_no_payload",
+                        )
+                    },
+                    BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+    logic_group.finish();
+
+    let mut sql_group = c.benchmark_group("transaction_sql_fast_path");
+    for &rows in TRANSACTION_LOGIC_ROWS {
+        let label = row_count_label(rows);
+
+        sql_group.bench_function(format!("insert_values_batch_no_payload/{label}"), |b| {
+            b.iter_batched(
+                || {
+                    runtime
+                        .block_on(prepare_sql_fast_path_fixture(rows))
+                        .unwrap_or_else(|error| {
+                            panic!(
+                                "prepare transaction_sql_fast_path/insert_values_batch_no_payload/{label}: {error}"
+                            )
+                        })
+                },
+                |fixture| {
+                    black_box(
+                        runtime
+                            .block_on(sql_fast_path_insert_batch(fixture))
+                            .unwrap_or_else(|error| {
+                                panic!(
+                                    "transaction_sql_fast_path/insert_values_batch_no_payload/{label}: {error}"
+                                )
+                            }),
+                    )
+                },
+                BatchSize::LargeInput,
+            )
+        });
+
+        sql_group.bench_function(
+            format!("insert_values_individual_no_payload/{label}"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        runtime
+                            .block_on(prepare_sql_fast_path_fixture(rows))
+                            .unwrap_or_else(|error| {
+                                panic!(
+                                    "prepare transaction_sql_fast_path/insert_values_individual_no_payload/{label}: {error}"
+                                )
+                            })
+                    },
+                    |fixture| {
+                        black_box(
+                            runtime
+                                .block_on(sql_fast_path_insert_individual(fixture))
+                                .unwrap_or_else(|error| {
+                                    panic!(
+                                        "transaction_sql_fast_path/insert_values_individual_no_payload/{label}: {error}"
+                                    )
+                                }),
+                        )
+                    },
+                    BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+    sql_group.finish();
+
     let mut scaling_group = c.benchmark_group("transaction_scaling");
     for &rows in SCALING_ROWS {
         let label = row_count_label(rows);
@@ -844,6 +973,98 @@ fn stage_only(
             .block_on(storage_bench::transaction_stage_only_prepared(&fixture))
             .unwrap_or_else(|error| panic!("{label} succeeds: {error}")),
     )
+}
+
+fn stage_rows_individually(
+    runtime: &Runtime,
+    fixture: storage_bench::TransactionBenchFixture,
+    label: &str,
+) -> storage_bench::StorageBenchReport {
+    black_box(
+        runtime
+            .block_on(storage_bench::transaction_stage_rows_individually_prepared(
+                &fixture,
+            ))
+            .unwrap_or_else(|error| panic!("{label} succeeds: {error}")),
+    )
+}
+
+struct SqlFastPathFixture {
+    session: SessionContext,
+    batch_sql: String,
+    row_params: Vec<[Value; 2]>,
+}
+
+async fn prepare_sql_fast_path_fixture(rows: usize) -> Result<SqlFastPathFixture, LixError> {
+    let backend = backend::BenchBackend::default();
+    Engine::initialize(Box::new(backend.clone())).await?;
+    let engine = Engine::new(Box::new(backend)).await?;
+    let session = engine.open_workspace_session().await?;
+    register_sql_fast_path_schema(&session).await?;
+    let batch_sql = sql_fast_path_batch_insert_sql(rows);
+    let row_params = (0..rows)
+        .map(|index| {
+            [
+                Value::Text(format!("entity-{index:06}")),
+                Value::Text(format!("value-{index:06}")),
+            ]
+        })
+        .collect();
+    Ok(SqlFastPathFixture {
+        session,
+        batch_sql,
+        row_params,
+    })
+}
+
+async fn register_sql_fast_path_schema(session: &SessionContext) -> Result<(), LixError> {
+    let schema = r#"{
+        "x-lix-key": "bench_fast_path",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "value": { "type": "string" }
+        },
+        "required": ["id", "value"],
+        "additionalProperties": false
+    }"#;
+    let sql = format!(
+        "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json('{}'), false, false)",
+        schema.replace('\'', "''")
+    );
+    let affected = session.execute(&sql, &[]).await?.rows_affected();
+    assert_eq!(affected, 1);
+    Ok(())
+}
+
+async fn sql_fast_path_insert_batch(fixture: SqlFastPathFixture) -> Result<usize, LixError> {
+    let mut tx = fixture.session.begin_transaction().await?;
+    let affected = tx.execute(&fixture.batch_sql, &[]).await?.rows_affected() as usize;
+    tx.rollback().await?;
+    Ok(affected)
+}
+
+async fn sql_fast_path_insert_individual(fixture: SqlFastPathFixture) -> Result<usize, LixError> {
+    let mut tx = fixture.session.begin_transaction().await?;
+    let sql = "INSERT INTO bench_fast_path (id, value) VALUES (?, ?)";
+    let mut affected = 0usize;
+    for params in &fixture.row_params {
+        affected += tx.execute(sql, params.as_slice()).await?.rows_affected() as usize;
+    }
+    tx.rollback().await?;
+    Ok(affected)
+}
+
+fn sql_fast_path_batch_insert_sql(rows: usize) -> String {
+    let mut sql = String::from("INSERT INTO bench_fast_path (id, value) VALUES ");
+    for index in 0..rows {
+        if index > 0 {
+            sql.push(',');
+        }
+        sql.push_str(&format!("('entity-{index:06}', 'value-{index:06}')"));
+    }
+    sql
 }
 
 fn commit_only(

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -77,6 +77,9 @@ where
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        if request.filter.no_match {
+            return Ok(Vec::new());
+        }
         let mut store = self.store.lock().await;
         let scope = scan_scope(&mut *store, &self.untracked_state, request).await?;
         let derived_rows =

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -2,7 +2,7 @@ mod context;
 mod overlay;
 mod reader;
 mod types;
-mod visibility;
+pub(crate) mod visibility;
 
 #[allow(unused_imports)]
 pub(crate) use context::{LiveStateContext, LiveStateStoreReader};

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -150,6 +150,8 @@ pub(crate) struct LiveStateFilter {
     pub(crate) constraints: Vec<ScanConstraint>,
     #[serde(default)]
     pub(crate) include_tombstones: bool,
+    #[serde(default)]
+    pub(crate) no_match: bool,
 }
 
 impl From<LiveStateFilter> for UntrackedStateFilter {

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -309,6 +309,11 @@ impl SessionContext {
                         // Re-plan against the transaction-backed write
                         // session so provider hooks read and stage through the
                         // transaction-owned SQL write context.
+                        if let Some(affected_rows) =
+                            sql2::try_execute_simple_write(transaction, &statement, &params).await?
+                        {
+                            return Ok(ExecuteResult::from_rows_affected(affected_rows));
+                        }
                         let tx_plan =
                             sql2::create_write_logical_plan_from_parsed(transaction, statement)
                                 .await?;
@@ -440,6 +445,11 @@ async fn execute_transaction_write(
     statement: datafusion::sql::parser::Statement,
     params: &[Value],
 ) -> Result<ExecuteResult, LixError> {
+    if let Some(affected_rows) =
+        sql2::try_execute_simple_write(transaction, &statement, params).await?
+    {
+        return Ok(ExecuteResult::from_rows_affected(affected_rows));
+    }
     let tx_plan = sql2::create_write_logical_plan_from_parsed(transaction, statement).await?;
     let result = sql2::execute_logical_plan(tx_plan, params).await?;
     let affected_rows = affected_rows_from_query_result(result)?;

--- a/packages/engine/src/sql2/entity_provider.rs
+++ b/packages/engine/src/sql2/entity_provider.rs
@@ -2274,7 +2274,7 @@ fn projected_schema(schema: &SchemaRef, projection: Option<&Vec<usize>>) -> Resu
     Ok(Arc::new(schema.project(projection)?))
 }
 
-fn derive_entity_surface_spec_from_schema(
+pub(super) fn derive_entity_surface_spec_from_schema(
     schema: &JsonValue,
 ) -> std::result::Result<EntitySurfaceSpec, LixError> {
     let schema_key = schema

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -24,6 +24,7 @@ mod record_batch;
 mod result_metadata;
 mod runtime;
 mod session;
+mod simple_dml;
 mod udfs;
 mod version_provider;
 mod version_scope;
@@ -45,3 +46,4 @@ pub(crate) use execute::{
     create_write_logical_plan_from_parsed, execute_logical_plan, execute_sql, parse_statement,
     SqlLogicalPlan,
 };
+pub(crate) use simple_dml::try_execute_simple_write;

--- a/packages/engine/src/sql2/simple_dml.rs
+++ b/packages/engine/src/sql2/simple_dml.rs
@@ -261,12 +261,13 @@ async fn try_execute_update(
             spec,
             version_binding,
         } => {
+            let require_version_filter = version_binding.is_none();
             let filter = match simple_entity_filter(
                 update.selection,
                 &mut decoder,
                 &spec,
                 version_binding.as_deref(),
-                false,
+                require_version_filter,
             ) {
                 Ok(filter) => filter,
                 Err(error) if is_fast_path_miss(&error) => return Ok(None),
@@ -745,7 +746,11 @@ fn live_lix_state_write_row(
         change_id: None,
         commit_id: None,
         untracked: row.untracked,
-        version_id: row.version_id.clone(),
+        version_id: if row.global {
+            GLOBAL_VERSION_ID.to_string()
+        } else {
+            row.version_id.clone()
+        },
     })
 }
 
@@ -770,7 +775,11 @@ fn live_entity_write_row(
         change_id: None,
         commit_id: None,
         untracked: row.untracked,
-        version_id: row.version_id.clone(),
+        version_id: if row.global {
+            GLOBAL_VERSION_ID.to_string()
+        } else {
+            row.version_id.clone()
+        },
     })
 }
 
@@ -864,7 +873,15 @@ fn simple_assignments(
                 "simple DML fast path does not support dynamic assignment targets",
             ));
         };
-        result.insert(column, decoder.expr_value(&assignment.value)?);
+        if result
+            .insert(column.clone(), decoder.expr_value(&assignment.value)?)
+            .is_some()
+        {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                format!("simple DML assigns column '{column}' more than once"),
+            ));
+        }
     }
     Ok(result)
 }
@@ -1002,7 +1019,12 @@ fn apply_column_values(
                 filter.no_match = true;
             }
         }
-        "version_id" | "lixcol_version_id" if allow_version_filter => {
+        "version_id" if spec.is_none() && allow_version_filter => {
+            if merge_string_filter(&mut filter.version_ids, string_values(values, &column)?)? {
+                filter.no_match = true;
+            }
+        }
+        "lixcol_version_id" if allow_version_filter => {
             if merge_string_filter(&mut filter.version_ids, string_values(values, &column)?)? {
                 filter.no_match = true;
             }
@@ -1093,6 +1115,15 @@ fn row_cells(
             ),
         ));
     }
+    let mut seen = std::collections::BTreeSet::new();
+    for column in columns {
+        if !seen.insert(column) {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                format!("INSERT target column '{column}' is specified more than once"),
+            ));
+        }
+    }
     columns
         .iter()
         .zip(values)
@@ -1105,7 +1136,7 @@ fn simple_dml_target(
     active_version_id: &str,
     visible_schemas: &[JsonValue],
 ) -> Result<Option<SimpleDmlTarget>, LixError> {
-    let Some(target_name) = object_name_leaf(target_name) else {
+    let Some(target_name) = object_name_unqualified(target_name) else {
         return Ok(None);
     };
     if target_name == "lix_state" {
@@ -1433,6 +1464,13 @@ fn object_name_leaf(name: &ObjectName) -> Option<String> {
             ident.value.to_ascii_lowercase()
         }
     })
+}
+
+fn object_name_unqualified(name: &ObjectName) -> Option<String> {
+    if name.0.len() != 1 {
+        return None;
+    }
+    object_name_leaf(name)
 }
 
 fn ident_name(ident: &Ident) -> String {

--- a/packages/engine/src/sql2/simple_dml.rs
+++ b/packages/engine/src/sql2/simple_dml.rs
@@ -1,0 +1,1471 @@
+use datafusion::sql::parser::Statement as DataFusionStatement;
+use datafusion::sql::sqlparser::ast::{
+    Assignment, AssignmentTarget, BinaryOperator, Delete, Expr, Ident, Insert, ObjectName, Query,
+    SetExpr, Statement, TableFactor, TableObject, TableWithJoins, Update, Value as SqlValue,
+};
+use serde_json::Value as JsonValue;
+
+use crate::entity_identity::EntityIdentity;
+use crate::live_state::{LiveStateFilter, LiveStateScanRequest, MaterializedLiveStateRow};
+use crate::sql2::entity_provider::{
+    derive_entity_surface_spec_from_schema, EntityColumnType, EntitySurfaceSpec,
+};
+use crate::sql2::read_only::{reject_read_only_entity_surface, reject_read_only_stage_rows};
+use crate::sql2::version_scope::resolve_write_version_scope;
+use crate::transaction::types::{
+    TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteRow,
+};
+use crate::{parse_row_metadata_value, LixError, Value, GLOBAL_VERSION_ID};
+
+use super::SqlWriteExecutionContext;
+
+enum SimpleDml<'ast> {
+    Insert(SimpleInsert<'ast>),
+    Update(SimpleUpdate<'ast>),
+    Delete(SimpleDelete<'ast>),
+}
+
+struct SimpleInsert<'ast> {
+    target: SimpleDmlTarget,
+    columns: Vec<String>,
+    value_rows: &'ast [Vec<Expr>],
+}
+
+struct SimpleUpdate<'ast> {
+    target: SimpleDmlTarget,
+    assignments: &'ast [Assignment],
+    selection: &'ast Expr,
+}
+
+struct SimpleDelete<'ast> {
+    target: SimpleDmlTarget,
+    selection: &'ast Expr,
+}
+
+enum SimpleDmlTarget {
+    LixState {
+        active_version_id: String,
+    },
+    Entity {
+        spec: EntitySurfaceSpec,
+        version_binding: Option<String>,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum SimpleDmlAction {
+    Insert,
+    Dml,
+}
+
+impl SimpleDmlAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Insert => "INSERT",
+            Self::Dml => "DML",
+        }
+    }
+}
+
+pub(crate) async fn try_execute_simple_write(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Result<Option<u64>, LixError> {
+    let DataFusionStatement::Statement(statement) = statement else {
+        return Ok(None);
+    };
+
+    let visible_schemas = ctx.list_visible_schemas()?;
+    super::public_bind::validate_public_dml_statement(
+        &DataFusionStatement::Statement(statement.clone()),
+        &visible_schemas,
+    )?;
+
+    match classify_simple_dml(
+        statement.as_ref(),
+        ctx.active_version_id(),
+        &visible_schemas,
+    )? {
+        Some(SimpleDml::Insert(insert)) => try_execute_insert(ctx, insert, params).await,
+        Some(SimpleDml::Update(update)) => try_execute_update(ctx, update, params).await,
+        Some(SimpleDml::Delete(delete)) => try_execute_delete(ctx, delete, params).await,
+        None => Ok(None),
+    }
+}
+
+fn classify_simple_dml<'ast>(
+    statement: &'ast Statement,
+    active_version_id: &str,
+    visible_schemas: &[JsonValue],
+) -> Result<Option<SimpleDml<'ast>>, LixError> {
+    match statement {
+        Statement::Insert(insert) => {
+            classify_simple_insert(insert, active_version_id, visible_schemas)
+                .map(|insert| insert.map(SimpleDml::Insert))
+        }
+        Statement::Update(update) => {
+            classify_simple_update(update, active_version_id, visible_schemas)
+                .map(|update| update.map(SimpleDml::Update))
+        }
+        Statement::Delete(delete) => {
+            classify_simple_delete(delete, active_version_id, visible_schemas)
+                .map(|delete| delete.map(SimpleDml::Delete))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn classify_simple_insert<'ast>(
+    insert: &'ast Insert,
+    active_version_id: &str,
+    visible_schemas: &[JsonValue],
+) -> Result<Option<SimpleInsert<'ast>>, LixError> {
+    if insert.columns.is_empty()
+        || insert.overwrite
+        || insert.source.is_none()
+        || !insert.assignments.is_empty()
+        || insert.on.is_some()
+        || insert.returning.is_some()
+        || insert.replace_into
+    {
+        return Ok(None);
+    }
+    let target = match &insert.table {
+        TableObject::TableName(name) => {
+            simple_dml_target(name, active_version_id, visible_schemas)?
+        }
+        _ => None,
+    };
+    let Some(target) = target else {
+        return Ok(None);
+    };
+
+    let Some(source) = &insert.source else {
+        return Ok(None);
+    };
+    let Some(value_rows) = query_values(source) else {
+        return Ok(None);
+    };
+    Ok(Some(SimpleInsert {
+        target,
+        columns: insert.columns.iter().map(ident_name).collect(),
+        value_rows,
+    }))
+}
+
+async fn try_execute_insert(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    insert: SimpleInsert<'_>,
+    params: &[Value],
+) -> Result<Option<u64>, LixError> {
+    let mut decoder = ParamDecoder::new(params);
+    let rows = match insert.target {
+        SimpleDmlTarget::LixState { active_version_id } => match decode_lix_state_insert(
+            &active_version_id,
+            &insert.columns,
+            insert.value_rows,
+            &mut decoder,
+        ) {
+            Ok(rows) => rows,
+            Err(error) if is_fast_path_miss(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        },
+        SimpleDmlTarget::Entity {
+            spec,
+            version_binding,
+        } => match decode_entity_insert(
+            &spec,
+            version_binding.as_deref(),
+            &insert.columns,
+            insert.value_rows,
+            &mut decoder,
+        ) {
+            Ok(rows) => rows,
+            Err(error) if is_fast_path_miss(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        },
+    };
+    decoder.validate_count()?;
+
+    let count = u64::try_from(rows.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            "simple INSERT row count overflow".to_string(),
+        )
+    })?;
+    reject_read_only_stage_rows(&rows, "INSERT into lix_state").map_err(datafusion_to_lix_error)?;
+    ctx.stage_write(TransactionWrite::Rows {
+        mode: TransactionWriteMode::Insert,
+        rows,
+    })
+    .await?;
+    Ok(Some(count))
+}
+
+fn classify_simple_update<'ast>(
+    update: &'ast Update,
+    active_version_id: &str,
+    visible_schemas: &[JsonValue],
+) -> Result<Option<SimpleUpdate<'ast>>, LixError> {
+    if update.from.is_some()
+        || update.returning.is_some()
+        || update.or.is_some()
+        || update.limit.is_some()
+        || !update.table.joins.is_empty()
+    {
+        return Ok(None);
+    }
+    let Some(target) = simple_update_target(&update.table, active_version_id, visible_schemas)?
+    else {
+        return Ok(None);
+    };
+    let Some(selection) = &update.selection else {
+        return Ok(None);
+    };
+    Ok(Some(SimpleUpdate {
+        target,
+        assignments: &update.assignments,
+        selection,
+    }))
+}
+
+async fn try_execute_update(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    update: SimpleUpdate<'_>,
+    params: &[Value],
+) -> Result<Option<u64>, LixError> {
+    let mut decoder = ParamDecoder::new(params);
+    let assignments = match simple_assignments(update.assignments, &mut decoder) {
+        Ok(assignments) => assignments,
+        Err(error) if is_fast_path_miss(&error) => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    match update.target {
+        SimpleDmlTarget::LixState { active_version_id } => {
+            let filter = match simple_lix_state_filter(
+                update.selection,
+                &mut decoder,
+                Some(active_version_id.as_str()),
+            ) {
+                Ok(filter) => filter,
+                Err(error) if is_fast_path_miss(&error) => return Ok(None),
+                Err(error) => return Err(error),
+            };
+            decoder.validate_count()?;
+            return execute_lix_state_update(ctx, filter, assignments)
+                .await
+                .map(Some);
+        }
+        SimpleDmlTarget::Entity {
+            spec,
+            version_binding,
+        } => {
+            let filter = match simple_entity_filter(
+                update.selection,
+                &mut decoder,
+                &spec,
+                version_binding.as_deref(),
+            ) {
+                Ok(filter) => filter,
+                Err(error) if is_fast_path_miss(&error) => return Ok(None),
+                Err(error) => return Err(error),
+            };
+            decoder.validate_count()?;
+            return execute_entity_update(ctx, &spec, filter, assignments)
+                .await
+                .map(Some);
+        }
+    }
+}
+
+fn classify_simple_delete<'ast>(
+    delete: &'ast Delete,
+    active_version_id: &str,
+    visible_schemas: &[JsonValue],
+) -> Result<Option<SimpleDelete<'ast>>, LixError> {
+    if !delete.tables.is_empty()
+        || delete.using.is_some()
+        || delete.returning.is_some()
+        || !delete.order_by.is_empty()
+        || delete.limit.is_some()
+    {
+        return Ok(None);
+    }
+    let Some(target) = simple_delete_target(delete, active_version_id, visible_schemas)? else {
+        return Ok(None);
+    };
+    let Some(selection) = &delete.selection else {
+        return Ok(None);
+    };
+    Ok(Some(SimpleDelete { target, selection }))
+}
+
+async fn try_execute_delete(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    delete: SimpleDelete<'_>,
+    params: &[Value],
+) -> Result<Option<u64>, LixError> {
+    match delete.target {
+        SimpleDmlTarget::LixState { active_version_id } => {
+            let mut decoder = ParamDecoder::new(params);
+            let filter = match simple_lix_state_filter(
+                delete.selection,
+                &mut decoder,
+                Some(active_version_id.as_str()),
+            ) {
+                Ok(filter) => filter,
+                Err(error) if is_fast_path_miss(&error) => return Ok(None),
+                Err(error) => return Err(error),
+            };
+            decoder.validate_count()?;
+            return execute_lix_state_delete(ctx, filter).await.map(Some);
+        }
+        SimpleDmlTarget::Entity {
+            spec,
+            version_binding,
+        } => {
+            let mut decoder = ParamDecoder::new(params);
+            let filter = match simple_entity_filter(
+                delete.selection,
+                &mut decoder,
+                &spec,
+                version_binding.as_deref(),
+            ) {
+                Ok(filter) => filter,
+                Err(error) if is_fast_path_miss(&error) => return Ok(None),
+                Err(error) => return Err(error),
+            };
+            decoder.validate_count()?;
+            return execute_entity_delete(ctx, &spec, filter).await.map(Some);
+        }
+    }
+}
+
+fn query_values(query: &Query) -> Option<&[Vec<Expr>]> {
+    if query.with.is_some()
+        || query.order_by.is_some()
+        || query.limit_clause.is_some()
+        || !query.locks.is_empty()
+        || query.fetch.is_some()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return None;
+    }
+    match query.body.as_ref() {
+        SetExpr::Values(values) => Some(values.rows.as_slice()),
+        _ => None,
+    }
+}
+
+fn decode_lix_state_insert(
+    active_version_id: &str,
+    columns: &[String],
+    value_rows: &[Vec<Expr>],
+    decoder: &mut ParamDecoder<'_>,
+) -> Result<Vec<TransactionWriteRow>, LixError> {
+    value_rows
+        .iter()
+        .map(|values| {
+            let cells = row_cells(columns, values, decoder)?;
+            let global = optional_bool(&cells, "global", "INSERT into lix_state")?.unwrap_or(false);
+            let version_id = optional_string(&cells, "version_id", "INSERT into lix_state")?
+                .unwrap_or_else(|| {
+                    if global {
+                        GLOBAL_VERSION_ID.to_string()
+                    } else {
+                        active_version_id.to_string()
+                    }
+                });
+            let entity_id = required_string(&cells, "entity_id", "INSERT into lix_state")?;
+            Ok(TransactionWriteRow {
+                entity_id: Some(EntityIdentity::from_json_array_text(&entity_id).map_err(
+                    |error| {
+                        LixError::new(
+                            LixError::CODE_INVALID_PARAM,
+                            format!("lix_state INSERT has invalid entity_id: {error}"),
+                        )
+                    },
+                )?),
+                schema_key: required_string(&cells, "schema_key", "INSERT into lix_state")?,
+                file_id: optional_string(&cells, "file_id", "INSERT into lix_state")?,
+                snapshot: optional_json(&cells, "snapshot_content", "lix_state")?,
+                metadata: optional_metadata(&cells, "metadata", "lix_state")?,
+                origin: None,
+                created_at: optional_string(&cells, "created_at", "INSERT into lix_state")?,
+                updated_at: optional_string(&cells, "updated_at", "INSERT into lix_state")?,
+                global,
+                change_id: optional_string(&cells, "change_id", "INSERT into lix_state")?,
+                commit_id: optional_string(&cells, "commit_id", "INSERT into lix_state")?,
+                untracked: optional_bool(&cells, "untracked", "INSERT into lix_state")?
+                    .unwrap_or(false),
+                version_id,
+            })
+        })
+        .collect()
+}
+
+fn decode_entity_insert(
+    spec: &EntitySurfaceSpec,
+    version_binding: Option<&str>,
+    columns: &[String],
+    value_rows: &[Vec<Expr>],
+    decoder: &mut ParamDecoder<'_>,
+) -> Result<Vec<TransactionWriteRow>, LixError> {
+    value_rows
+        .iter()
+        .map(|values| {
+            let cells = row_cells(columns, values, decoder)?;
+            let scope = resolve_write_version_scope(
+                optional_bool(&cells, "lixcol_global", "INSERT into entity surface")?,
+                optional_string(&cells, "lixcol_version_id", "INSERT into entity surface")?,
+                version_binding,
+                &format!("INSERT into {}_by_version", spec.schema_key),
+                &spec.schema_key,
+            )
+            .map_err(datafusion_to_lix_error)?;
+
+            if let Some(schema_key) =
+                optional_string(&cells, "lixcol_schema_key", "INSERT into entity surface")?
+            {
+                if schema_key != spec.schema_key {
+                    return Err(LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!(
+                            "INSERT into entity surface '{}' cannot set lixcol_schema_key to '{}'",
+                            spec.schema_key, schema_key
+                        ),
+                    ));
+                }
+            }
+            reject_present_entity_insert_field(&cells, "lixcol_snapshot_content")?;
+            reject_present_entity_insert_field(&cells, "lixcol_created_at")?;
+            reject_present_entity_insert_field(&cells, "lixcol_updated_at")?;
+            reject_present_entity_insert_field(&cells, "lixcol_change_id")?;
+            reject_present_entity_insert_field(&cells, "lixcol_commit_id")?;
+
+            let explicit_entity_id =
+                optional_string(&cells, "lixcol_entity_id", "INSERT into entity surface")?;
+            let entity_id = if spec.primary_key_paths.is_empty() {
+                let entity_id = explicit_entity_id.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!(
+                            "INSERT into entity surface '{}' requires lixcol_entity_id because the schema has no x-lix-primary-key",
+                            spec.schema_key
+                        ),
+                    )
+                })?;
+                Some(entity_identity(
+                    &entity_id,
+                    &spec.schema_key,
+                    SimpleDmlAction::Insert,
+                )?)
+            } else {
+                explicit_entity_id
+                    .map(|entity_id| {
+                        entity_identity(&entity_id, &spec.schema_key, SimpleDmlAction::Insert)
+                    })
+                    .transpose()?
+            };
+
+            let mut snapshot = serde_json::Map::new();
+            for column in &spec.columns {
+                let Some(value) = cells.get(&column.name) else {
+                    continue;
+                };
+                snapshot.insert(
+                    column.name.clone(),
+                    entity_json_value(value, column.column_type)?,
+                );
+            }
+
+            Ok(TransactionWriteRow {
+                entity_id,
+                schema_key: spec.schema_key.clone(),
+                file_id: optional_string(&cells, "lixcol_file_id", "INSERT into entity surface")?,
+                snapshot: Some(TransactionJson::from_value(
+                    JsonValue::Object(snapshot),
+                    &format!("{} insert snapshot_content", spec.schema_key),
+                )?),
+                metadata: optional_metadata(&cells, "lixcol_metadata", &spec.schema_key)?,
+                origin: None,
+                created_at: None,
+                updated_at: None,
+                global: scope.global,
+                change_id: None,
+                commit_id: None,
+                untracked: optional_bool(&cells, "lixcol_untracked", "INSERT into entity surface")?
+                    .unwrap_or(false),
+                version_id: scope.version_id,
+            })
+        })
+        .collect()
+}
+
+async fn execute_lix_state_delete(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    filter: LiveStateFilter,
+) -> Result<u64, LixError> {
+    let rows = ctx
+        .scan_live_state(&LiveStateScanRequest {
+            filter,
+            projection: Default::default(),
+            limit: None,
+        })
+        .await?;
+    let write_rows = rows
+        .iter()
+        .map(|row| live_lix_state_write_row(row, None, live_metadata(row, "lix_state")?))
+        .collect::<Result<Vec<_>, _>>()?;
+    let count = u64::try_from(write_rows.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            "simple DELETE row count overflow".to_string(),
+        )
+    })?;
+    if count > 0 {
+        reject_read_only_stage_rows(&write_rows, "DELETE FROM lix_state")
+            .map_err(datafusion_to_lix_error)?;
+        ctx.stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows: write_rows,
+        })
+        .await?;
+    }
+    Ok(count)
+}
+
+async fn execute_lix_state_update(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    filter: LiveStateFilter,
+    assignments: std::collections::BTreeMap<String, Value>,
+) -> Result<u64, LixError> {
+    if assignments
+        .keys()
+        .any(|column| !matches!(column.as_str(), "snapshot_content" | "metadata"))
+    {
+        return Err(LixError::new(
+            LixError::CODE_READ_ONLY,
+            "UPDATE lix_state can only stage snapshot_content and metadata",
+        ));
+    }
+    let rows = ctx
+        .scan_live_state(&LiveStateScanRequest {
+            filter,
+            projection: Default::default(),
+            limit: None,
+        })
+        .await?;
+    let write_rows = rows
+        .iter()
+        .map(|row| {
+            let snapshot = if assignments.contains_key("snapshot_content") {
+                assigned_optional_json(&assignments, "snapshot_content", "lix_state")?
+            } else {
+                live_snapshot(row, "lix_state")?
+            };
+            let metadata = if assignments.contains_key("metadata") {
+                assigned_optional_metadata(&assignments, "metadata", "lix_state")?
+            } else {
+                live_metadata(row, "lix_state")?
+            };
+            live_lix_state_write_row(row, snapshot, metadata)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let count = u64::try_from(write_rows.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            "simple UPDATE row count overflow".to_string(),
+        )
+    })?;
+    if count > 0 {
+        reject_read_only_stage_rows(&write_rows, "UPDATE lix_state")
+            .map_err(datafusion_to_lix_error)?;
+        ctx.stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows: write_rows,
+        })
+        .await?;
+    }
+    Ok(count)
+}
+
+async fn execute_entity_delete(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    spec: &EntitySurfaceSpec,
+    filter: LiveStateFilter,
+) -> Result<u64, LixError> {
+    let rows = ctx
+        .scan_live_state(&LiveStateScanRequest {
+            filter,
+            projection: Default::default(),
+            limit: None,
+        })
+        .await?;
+    let write_rows = rows
+        .iter()
+        .map(|row| live_entity_write_row(spec, row, None, live_metadata(row, &spec.schema_key)?))
+        .collect::<Result<Vec<_>, _>>()?;
+    let count = u64::try_from(write_rows.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            "simple DELETE row count overflow".to_string(),
+        )
+    })?;
+    if count > 0 {
+        ctx.stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows: write_rows,
+        })
+        .await?;
+    }
+    Ok(count)
+}
+
+async fn execute_entity_update(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    spec: &EntitySurfaceSpec,
+    filter: LiveStateFilter,
+    assignments: std::collections::BTreeMap<String, Value>,
+) -> Result<u64, LixError> {
+    if assignments.keys().any(|column| {
+        column != "lixcol_metadata" && !spec.columns.iter().any(|field| field.name == *column)
+    }) {
+        return Err(LixError::new(
+            LixError::CODE_READ_ONLY,
+            format!(
+                "UPDATE entity surface '{}' can only stage visible columns and lixcol_metadata",
+                spec.schema_key
+            ),
+        ));
+    }
+    let rows = ctx
+        .scan_live_state(&LiveStateScanRequest {
+            filter,
+            projection: Default::default(),
+            limit: None,
+        })
+        .await?;
+    let write_rows = rows
+        .iter()
+        .map(|row| {
+            let mut snapshot = existing_snapshot(row, &spec.schema_key)?;
+            for column in &spec.columns {
+                let Some(value) = assignments.get(&column.name) else {
+                    continue;
+                };
+                snapshot.insert(
+                    column.name.clone(),
+                    entity_json_value(value, column.column_type)?,
+                );
+            }
+            let metadata = if assignments.contains_key("lixcol_metadata") {
+                assigned_optional_metadata(&assignments, "lixcol_metadata", &spec.schema_key)?
+            } else {
+                live_metadata(row, &spec.schema_key)?
+            };
+            live_entity_write_row(spec, row, Some(JsonValue::Object(snapshot)), metadata)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let count = u64::try_from(write_rows.len()).map_err(|_| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            "simple UPDATE row count overflow".to_string(),
+        )
+    })?;
+    if count > 0 {
+        ctx.stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows: write_rows,
+        })
+        .await?;
+    }
+    Ok(count)
+}
+
+fn live_lix_state_write_row(
+    row: &MaterializedLiveStateRow,
+    snapshot: Option<TransactionJson>,
+    metadata: Option<TransactionJson>,
+) -> Result<TransactionWriteRow, LixError> {
+    Ok(TransactionWriteRow {
+        entity_id: Some(row.entity_id.clone()),
+        schema_key: row.schema_key.clone(),
+        file_id: row.file_id.clone(),
+        snapshot,
+        metadata,
+        origin: None,
+        created_at: None,
+        updated_at: None,
+        global: row.global,
+        change_id: None,
+        commit_id: None,
+        untracked: row.untracked,
+        version_id: row.version_id.clone(),
+    })
+}
+
+fn live_entity_write_row(
+    spec: &EntitySurfaceSpec,
+    row: &MaterializedLiveStateRow,
+    snapshot: Option<JsonValue>,
+    metadata: Option<TransactionJson>,
+) -> Result<TransactionWriteRow, LixError> {
+    Ok(TransactionWriteRow {
+        entity_id: Some(row.entity_id.clone()),
+        schema_key: spec.schema_key.clone(),
+        file_id: row.file_id.clone(),
+        snapshot: snapshot
+            .map(|value| TransactionJson::from_value(value, &format!("{} update", spec.schema_key)))
+            .transpose()?,
+        metadata,
+        origin: None,
+        created_at: None,
+        updated_at: None,
+        global: row.global,
+        change_id: None,
+        commit_id: None,
+        untracked: row.untracked,
+        version_id: row.version_id.clone(),
+    })
+}
+
+fn live_metadata(
+    row: &MaterializedLiveStateRow,
+    context: &str,
+) -> Result<Option<TransactionJson>, LixError> {
+    row.metadata
+        .as_ref()
+        .map(|value| {
+            parse_row_metadata_value(value, context)
+                .and_then(|value| TransactionJson::from_value(value, context))
+        })
+        .transpose()
+}
+
+fn live_snapshot(
+    row: &MaterializedLiveStateRow,
+    context: &str,
+) -> Result<Option<TransactionJson>, LixError> {
+    row.snapshot_content
+        .as_ref()
+        .map(|value| {
+            serde_json::from_str::<JsonValue>(value)
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!("{context} expected valid snapshot JSON: {error}"),
+                    )
+                })
+                .and_then(|value| TransactionJson::from_value(value, context))
+        })
+        .transpose()
+}
+
+fn existing_snapshot(
+    row: &MaterializedLiveStateRow,
+    schema_key: &str,
+) -> Result<serde_json::Map<String, JsonValue>, LixError> {
+    let snapshot = row.snapshot_content.as_ref().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!("UPDATE entity surface '{schema_key}' requires existing snapshot_content"),
+        )
+    })?;
+    match serde_json::from_str::<JsonValue>(snapshot).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!("UPDATE entity surface '{schema_key}' expected valid snapshot JSON: {error}"),
+        )
+    })? {
+        JsonValue::Object(object) => Ok(object),
+        other => Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!("UPDATE entity surface '{schema_key}' expected object snapshot, got {other}"),
+        )),
+    }
+}
+
+fn assigned_optional_json(
+    assignments: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+    context: &str,
+) -> Result<Option<TransactionJson>, LixError> {
+    optional_json(assignments, column, context)
+}
+
+fn assigned_optional_metadata(
+    assignments: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+    context: &str,
+) -> Result<Option<TransactionJson>, LixError> {
+    optional_metadata(assignments, column, context)
+}
+
+fn simple_assignments(
+    assignments: &[datafusion::sql::sqlparser::ast::Assignment],
+    decoder: &mut ParamDecoder<'_>,
+) -> Result<std::collections::BTreeMap<String, Value>, LixError> {
+    let mut result = std::collections::BTreeMap::new();
+    for assignment in assignments {
+        let AssignmentTarget::ColumnName(name) = &assignment.target else {
+            return Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "simple DML fast path does not support tuple assignments",
+            ));
+        };
+        let Some(column) = object_name_leaf(name) else {
+            return Ok(std::collections::BTreeMap::new());
+        };
+        result.insert(column, decoder.expr_value(&assignment.value)?);
+    }
+    Ok(result)
+}
+
+fn simple_lix_state_filter(
+    expr: &Expr,
+    decoder: &mut ParamDecoder<'_>,
+    active_version_id: Option<&str>,
+) -> Result<LiveStateFilter, LixError> {
+    let mut filter = LiveStateFilter {
+        version_ids: active_version_id
+            .map(|version_id| vec![version_id.to_string()])
+            .unwrap_or_default(),
+        ..LiveStateFilter::default()
+    };
+    apply_simple_filter(expr, decoder, &mut filter, None)?;
+    if filter.schema_keys.is_empty() && filter.entity_ids.is_empty() && filter.file_ids.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "simple lix_state DML requires an identity predicate",
+        ));
+    }
+    Ok(filter)
+}
+
+fn simple_entity_filter(
+    expr: &Expr,
+    decoder: &mut ParamDecoder<'_>,
+    spec: &EntitySurfaceSpec,
+    active_version_id: Option<&str>,
+) -> Result<LiveStateFilter, LixError> {
+    let mut filter = LiveStateFilter {
+        schema_keys: vec![spec.schema_key.clone()],
+        version_ids: active_version_id
+            .map(|version_id| vec![version_id.to_string()])
+            .unwrap_or_default(),
+        ..LiveStateFilter::default()
+    };
+    apply_simple_filter(expr, decoder, &mut filter, Some(spec))?;
+    if filter.entity_ids.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "simple entity DML requires a lixcol_entity_id predicate",
+        ));
+    }
+    Ok(filter)
+}
+
+fn apply_simple_filter(
+    expr: &Expr,
+    decoder: &mut ParamDecoder<'_>,
+    filter: &mut LiveStateFilter,
+    spec: Option<&EntitySurfaceSpec>,
+) -> Result<(), LixError> {
+    match expr {
+        Expr::BinaryOp { left, op, right } if *op == BinaryOperator::And => {
+            apply_simple_filter(left, decoder, filter, spec)?;
+            apply_simple_filter(right, decoder, filter, spec)
+        }
+        Expr::BinaryOp { left, op, right } if *op == BinaryOperator::Eq => {
+            let right_values = [right.as_ref()];
+            let left_values = [left.as_ref()];
+            apply_column_values(left, &right_values, decoder, filter, spec)
+                .or_else(|_| apply_column_values(right, &left_values, decoder, filter, spec))
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } if !negated => {
+            let values = list.iter().collect::<Vec<_>>();
+            apply_column_values(expr, &values, decoder, filter, spec)
+        }
+        _ => Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "simple DML fast path only supports equality and IN predicates",
+        )),
+    }
+}
+
+fn apply_column_values(
+    column_expr: &Expr,
+    value_exprs: &[&Expr],
+    decoder: &mut ParamDecoder<'_>,
+    filter: &mut LiveStateFilter,
+    spec: Option<&EntitySurfaceSpec>,
+) -> Result<(), LixError> {
+    let column = column_name(column_expr).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "simple DML predicate must compare a column to literals or params",
+        )
+    })?;
+    let values = value_exprs
+        .iter()
+        .map(|expr| decoder.expr_value(expr))
+        .collect::<Result<Vec<_>, _>>()?;
+    match column.as_str() {
+        "schema_key" if spec.is_none() => {
+            filter.schema_keys = string_values(values, "schema_key")?;
+        }
+        "version_id" | "lixcol_version_id" => {
+            filter.version_ids = string_values(values, &column)?;
+        }
+        "entity_id" | "lixcol_entity_id" => {
+            filter.entity_ids = string_values(values, &column)?
+                .into_iter()
+                .map(|value| {
+                    entity_identity(
+                        &value,
+                        spec.map_or("lix_state", |spec| &spec.schema_key),
+                        SimpleDmlAction::Dml,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+        }
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "simple DML fast path only supports identity predicates",
+            ))
+        }
+    }
+    Ok(())
+}
+
+fn string_values(values: Vec<Value>, column: &str) -> Result<Vec<String>, LixError> {
+    values
+        .into_iter()
+        .map(|value| match value {
+            Value::Text(value) => Ok(value),
+            other => Err(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!("predicate column '{column}' expected text, got {other:?}"),
+            )),
+        })
+        .collect()
+}
+
+fn row_cells(
+    columns: &[String],
+    values: &[Expr],
+    decoder: &mut ParamDecoder<'_>,
+) -> Result<std::collections::BTreeMap<String, Value>, LixError> {
+    if columns.len() != values.len() {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!(
+                "INSERT expected {} value(s), got {}",
+                columns.len(),
+                values.len()
+            ),
+        ));
+    }
+    columns
+        .iter()
+        .zip(values)
+        .map(|(column, value)| Ok((column.clone(), decoder.expr_value(value)?)))
+        .collect()
+}
+
+fn simple_dml_target(
+    target_name: &ObjectName,
+    active_version_id: &str,
+    visible_schemas: &[JsonValue],
+) -> Result<Option<SimpleDmlTarget>, LixError> {
+    let Some(target_name) = object_name_leaf(target_name) else {
+        return Ok(None);
+    };
+    if target_name == "lix_state" {
+        return Ok(Some(SimpleDmlTarget::LixState {
+            active_version_id: active_version_id.to_string(),
+        }));
+    }
+    for schema in visible_schemas {
+        let Ok(spec) = derive_entity_surface_spec_from_schema(schema) else {
+            continue;
+        };
+        if target_name == spec.schema_key {
+            if reject_read_only_entity_surface(&spec.schema_key, "DML").is_err() {
+                return Ok(None);
+            }
+            return Ok(Some(SimpleDmlTarget::Entity {
+                spec,
+                version_binding: Some(active_version_id.to_string()),
+            }));
+        }
+        if target_name == format!("{}_by_version", spec.schema_key) {
+            if reject_read_only_entity_surface(&spec.schema_key, "DML").is_err() {
+                return Ok(None);
+            }
+            return Ok(Some(SimpleDmlTarget::Entity {
+                spec,
+                version_binding: None,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+fn simple_update_target(
+    update_table: &TableWithJoins,
+    active_version_id: &str,
+    visible_schemas: &[JsonValue],
+) -> Result<Option<SimpleDmlTarget>, LixError> {
+    let TableFactor::Table { name, .. } = &update_table.relation else {
+        return Ok(None);
+    };
+    simple_dml_target(name, active_version_id, visible_schemas)
+}
+
+fn simple_delete_target(
+    delete: &Delete,
+    active_version_id: &str,
+    visible_schemas: &[JsonValue],
+) -> Result<Option<SimpleDmlTarget>, LixError> {
+    let tables = match &delete.from {
+        datafusion::sql::sqlparser::ast::FromTable::WithFromKeyword(tables)
+        | datafusion::sql::sqlparser::ast::FromTable::WithoutKeyword(tables) => tables,
+    };
+    if tables.len() != 1 {
+        return Ok(None);
+    }
+    simple_update_target(&tables[0], active_version_id, visible_schemas)
+}
+
+fn column_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Identifier(ident) => Some(ident_name(ident)),
+        Expr::CompoundIdentifier(parts) => parts.last().map(ident_name),
+        _ => None,
+    }
+}
+
+fn optional_string(
+    cells: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+    context: &str,
+) -> Result<Option<String>, LixError> {
+    match cells.get(column) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Text(value)) => Ok(Some(value.clone())),
+        Some(other) => Err(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            format!("{context} expected text-compatible column '{column}', got {other:?}"),
+        )),
+    }
+}
+
+fn required_string(
+    cells: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+    context: &str,
+) -> Result<String, LixError> {
+    optional_string(cells, column, context)?.ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!("{context} requires non-null text column '{column}'"),
+        )
+    })
+}
+
+fn optional_bool(
+    cells: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+    context: &str,
+) -> Result<Option<bool>, LixError> {
+    match cells.get(column) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Boolean(value)) => Ok(Some(*value)),
+        Some(other) => Err(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            format!("{context} expected boolean column '{column}', got {other:?}"),
+        )),
+    }
+}
+
+fn optional_json(
+    cells: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+    context: &str,
+) -> Result<Option<TransactionJson>, LixError> {
+    optional_string(cells, column, context)?
+        .map(|value| {
+            serde_json::from_str::<JsonValue>(&value)
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!("{context} expected valid JSON in column '{column}': {error}"),
+                    )
+                })
+                .and_then(|value| TransactionJson::from_value(value, context))
+        })
+        .transpose()
+}
+
+fn optional_metadata(
+    cells: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+    context: &str,
+) -> Result<Option<TransactionJson>, LixError> {
+    optional_string(cells, column, context)?
+        .map(|value| {
+            parse_row_metadata_value(&value, context)
+                .and_then(|value| TransactionJson::from_value(value, context))
+        })
+        .transpose()
+}
+
+fn reject_present_entity_insert_field(
+    cells: &std::collections::BTreeMap<String, Value>,
+    column: &str,
+) -> Result<(), LixError> {
+    if cells
+        .get(column)
+        .is_some_and(|value| !matches!(value, Value::Null))
+    {
+        return Err(LixError::new(
+            LixError::CODE_READ_ONLY,
+            format!("INSERT into entity surface cannot stage read-only column '{column}'"),
+        ));
+    }
+    Ok(())
+}
+
+fn entity_json_value(value: &Value, column_type: EntityColumnType) -> Result<JsonValue, LixError> {
+    match value {
+        Value::Null => Ok(JsonValue::Null),
+        Value::Boolean(value) => Ok(JsonValue::Bool(*value)),
+        Value::Integer(value) => Ok(JsonValue::from(*value)),
+        Value::Real(value) => serde_json::Number::from_f64(*value)
+            .map(JsonValue::Number)
+            .ok_or_else(|| LixError::new(LixError::CODE_TYPE_MISMATCH, "invalid JSON number")),
+        Value::Text(value) => match column_type {
+            EntityColumnType::Json => Ok(
+                serde_json::from_str(value).unwrap_or_else(|_| JsonValue::String(value.clone()))
+            ),
+            EntityColumnType::Integer => {
+                value.parse::<i64>().map(JsonValue::from).map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_TYPE_MISMATCH,
+                        format!("entity integer column expected integer text: {error}"),
+                    )
+                })
+            }
+            EntityColumnType::Number => value
+                .parse::<f64>()
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_TYPE_MISMATCH,
+                        format!("entity number column expected number text: {error}"),
+                    )
+                })
+                .and_then(|value| {
+                    serde_json::Number::from_f64(value)
+                        .map(JsonValue::Number)
+                        .ok_or_else(|| {
+                            LixError::new(LixError::CODE_TYPE_MISMATCH, "invalid JSON number")
+                        })
+                }),
+            EntityColumnType::Boolean => {
+                value.parse::<bool>().map(JsonValue::from).map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_TYPE_MISMATCH,
+                        format!("entity boolean column expected boolean text: {error}"),
+                    )
+                })
+            }
+            EntityColumnType::String => Ok(JsonValue::String(value.clone())),
+        },
+        Value::Json(value) => Ok(value.clone()),
+        Value::Blob(_) => Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "entity JSON columns cannot store blob values directly",
+        )),
+    }
+}
+
+fn entity_identity(
+    value: &str,
+    schema_key: &str,
+    action: SimpleDmlAction,
+) -> Result<EntityIdentity, LixError> {
+    EntityIdentity::from_json_array_text(value).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!(
+                "{} entity surface '{schema_key}' has invalid lixcol_entity_id: {error}",
+                action.as_str()
+            ),
+        )
+    })
+}
+
+struct ParamDecoder<'a> {
+    params: &'a [Value],
+    max_placeholder: usize,
+}
+
+impl<'a> ParamDecoder<'a> {
+    fn new(params: &'a [Value]) -> Self {
+        Self {
+            params,
+            max_placeholder: 0,
+        }
+    }
+
+    fn expr_value(&mut self, expr: &Expr) -> Result<Value, LixError> {
+        match expr {
+            Expr::Value(value) => self.sql_value(&value.value),
+            Expr::Nested(expr) => self.expr_value(expr),
+            _ => Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "simple DML fast path only supports literal values and bound parameters",
+            )),
+        }
+    }
+
+    fn sql_value(&mut self, value: &SqlValue) -> Result<Value, LixError> {
+        Ok(match value {
+            SqlValue::Null => Value::Null,
+            SqlValue::Boolean(value) => Value::Boolean(*value),
+            SqlValue::Number(raw, _) => raw
+                .parse::<i64>()
+                .map(Value::Integer)
+                .or_else(|_| raw.parse::<f64>().map(Value::Real))
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!("invalid numeric SQL literal '{raw}': {error}"),
+                    )
+                })?,
+            SqlValue::Placeholder(name) => {
+                let index = placeholder_index(name)?;
+                self.max_placeholder = self.max_placeholder.max(index);
+                self.params.get(index - 1).cloned().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        format!("SQL expected at least {index} parameter(s)"),
+                    )
+                })?
+            }
+            SqlValue::SingleQuotedString(value)
+            | SqlValue::DoubleQuotedString(value)
+            | SqlValue::TripleSingleQuotedString(value)
+            | SqlValue::TripleDoubleQuotedString(value)
+            | SqlValue::EscapedStringLiteral(value)
+            | SqlValue::UnicodeStringLiteral(value)
+            | SqlValue::NationalStringLiteral(value) => Value::Text(value.clone()),
+            SqlValue::HexStringLiteral(value) => Value::Text(value.clone()),
+            _ => {
+                return Err(LixError::new(
+                    LixError::CODE_UNSUPPORTED_SQL,
+                    "simple DML fast path only supports scalar SQL literals",
+                ))
+            }
+        })
+    }
+
+    fn validate_count(&self) -> Result<(), LixError> {
+        if self.params.len() == self.max_placeholder {
+            return Ok(());
+        }
+        Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!(
+                "SQL expected {} parameter(s), but {} parameter(s) were provided",
+                self.max_placeholder,
+                self.params.len()
+            ),
+        ))
+    }
+}
+
+fn placeholder_index(id: &str) -> Result<usize, LixError> {
+    id.strip_prefix('$')
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .filter(|index| *index > 0)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_PARSE_ERROR,
+                format!("unsupported SQL parameter placeholder '{id}'"),
+            )
+        })
+}
+
+fn object_name_leaf(name: &ObjectName) -> Option<String> {
+    name.0.last().and_then(|part| part.as_ident()).map(|ident| {
+        if ident.quote_style.is_some() {
+            ident.value.clone()
+        } else {
+            ident.value.to_ascii_lowercase()
+        }
+    })
+}
+
+fn ident_name(ident: &Ident) -> String {
+    if ident.quote_style.is_some() {
+        ident.value.clone()
+    } else {
+        ident.value.to_ascii_lowercase()
+    }
+}
+
+fn datafusion_to_lix_error(error: datafusion::error::DataFusionError) -> LixError {
+    super::error::datafusion_error_to_lix_error(error)
+}
+
+fn is_fast_path_miss(error: &LixError) -> bool {
+    error.code == LixError::CODE_UNSUPPORTED_SQL
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use crate::binary_cas::{BlobBytesBatch, BlobHash};
+    use crate::functions::{
+        FunctionProvider, FunctionProviderHandle, SharedFunctionProvider, SystemFunctionProvider,
+    };
+    use crate::live_state::{LiveStateScanRequest, MaterializedLiveStateRow};
+    use crate::transaction::types::{TransactionWriteOutcome, TransactionWriteRow};
+
+    use super::*;
+
+    struct CapturingWriteContext {
+        staged: Arc<Mutex<Vec<TransactionWriteRow>>>,
+        schemas: Vec<JsonValue>,
+    }
+
+    #[async_trait]
+    impl SqlWriteExecutionContext for CapturingWriteContext {
+        fn active_version_id(&self) -> &str {
+            "version-main"
+        }
+
+        fn functions(&self) -> FunctionProviderHandle {
+            SharedFunctionProvider::new(
+                Box::new(SystemFunctionProvider) as Box<dyn FunctionProvider + Send>
+            )
+        }
+
+        fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
+            Ok(self.schemas.clone())
+        }
+
+        async fn load_bytes_many(
+            &mut self,
+            _hashes: &[BlobHash],
+        ) -> Result<BlobBytesBatch, LixError> {
+            Ok(BlobBytesBatch::new(Vec::new()))
+        }
+
+        async fn scan_live_state(
+            &mut self,
+            _request: &LiveStateScanRequest,
+        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            Ok(Vec::new())
+        }
+
+        async fn load_version_head(
+            &mut self,
+            _version_id: &str,
+        ) -> Result<Option<String>, LixError> {
+            Ok(Some("commit-main".to_string()))
+        }
+
+        async fn stage_write(
+            &mut self,
+            write: TransactionWrite,
+        ) -> Result<TransactionWriteOutcome, LixError> {
+            let TransactionWrite::Rows { rows, .. } = write else {
+                return Ok(TransactionWriteOutcome { count: 0 });
+            };
+            let count = rows.len() as u64;
+            self.staged.lock().expect("staged rows lock").extend(rows);
+            Ok(TransactionWriteOutcome { count })
+        }
+    }
+
+    #[tokio::test]
+    async fn simple_entity_insert_stages_rows_without_datafusion_plan() {
+        let staged = Arc::new(Mutex::new(Vec::new()));
+        let mut ctx = CapturingWriteContext {
+            staged: Arc::clone(&staged),
+            schemas: vec![test_schema()],
+        };
+        let statement =
+            super::super::parse_statement("INSERT INTO test_schema (id, value) VALUES (?, ?)")
+                .expect("statement should parse");
+
+        let count = try_execute_simple_write(
+            &mut ctx,
+            &statement,
+            &[
+                Value::Text("entity-1".to_string()),
+                Value::Text("hello".to_string()),
+            ],
+        )
+        .await
+        .expect("simple write should execute");
+
+        assert_eq!(count, Some(1));
+        let rows = staged.lock().expect("staged rows lock");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].schema_key, "test_schema");
+        assert_eq!(rows[0].version_id, "version-main");
+        assert_eq!(
+            rows[0].snapshot.as_ref().unwrap().value(),
+            &json!({"id": "entity-1", "value": "hello"})
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_select_falls_back_to_datafusion() {
+        let staged = Arc::new(Mutex::new(Vec::new()));
+        let mut ctx = CapturingWriteContext {
+            staged: Arc::clone(&staged),
+            schemas: vec![test_schema()],
+        };
+        let statement =
+            super::super::parse_statement("INSERT INTO test_schema (id) SELECT 'entity-1'")
+                .expect("statement should parse");
+
+        let count = try_execute_simple_write(&mut ctx, &statement, &[])
+            .await
+            .expect("fallback should not error");
+
+        assert_eq!(count, None);
+        assert!(staged.lock().expect("staged rows lock").is_empty());
+    }
+
+    fn test_schema() -> JsonValue {
+        json!({
+            "x-lix-key": "test_schema",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "value": { "type": "string" }
+            }
+        })
+    }
+}

--- a/packages/engine/src/sql2/simple_dml.rs
+++ b/packages/engine/src/sql2/simple_dml.rs
@@ -819,7 +819,10 @@ fn simple_assignments(
             ));
         };
         let Some(column) = object_name_leaf(name) else {
-            return Ok(std::collections::BTreeMap::new());
+            return Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "simple DML fast path does not support dynamic assignment targets",
+            ));
         };
         result.insert(column, decoder.expr_value(&assignment.value)?);
     }
@@ -1455,6 +1458,32 @@ mod tests {
 
         assert_eq!(count, None);
         assert!(staged.lock().expect("staged rows lock").is_empty());
+    }
+
+    #[test]
+    fn dynamic_assignment_target_is_fast_path_miss() {
+        let assignment = Assignment {
+            target: AssignmentTarget::ColumnName(ObjectName(vec![
+                datafusion::sql::sqlparser::ast::ObjectNamePart::Function(
+                    datafusion::sql::sqlparser::ast::ObjectNamePartFunction {
+                        name: Ident::new("IDENTIFIER"),
+                        args: vec![datafusion::sql::sqlparser::ast::FunctionArg::Unnamed(
+                            datafusion::sql::sqlparser::ast::FunctionArgExpr::Expr(Expr::Value(
+                                SqlValue::SingleQuotedString("value".to_string()).into(),
+                            )),
+                        )],
+                    },
+                ),
+            ])),
+            value: Expr::Value(SqlValue::Placeholder("$1".to_string()).into()),
+        };
+        let params = [Value::Text("second".to_string())];
+        let mut decoder = ParamDecoder::new(&params);
+
+        let error = simple_assignments(&[assignment], &mut decoder)
+            .expect_err("dynamic assignment target should miss fast path");
+
+        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
     }
 
     fn test_schema() -> JsonValue {

--- a/packages/engine/src/sql2/simple_dml.rs
+++ b/packages/engine/src/sql2/simple_dml.rs
@@ -266,6 +266,7 @@ async fn try_execute_update(
                 &mut decoder,
                 &spec,
                 version_binding.as_deref(),
+                false,
             ) {
                 Ok(filter) => filter,
                 Err(error) if is_fast_path_miss(&error) => return Ok(None),
@@ -325,12 +326,14 @@ async fn try_execute_delete(
             spec,
             version_binding,
         } => {
+            let require_version_filter = version_binding.is_none();
             let mut decoder = ParamDecoder::new(params);
             let filter = match simple_entity_filter(
                 delete.selection,
                 &mut decoder,
                 &spec,
                 version_binding.as_deref(),
+                require_version_filter,
             ) {
                 Ok(filter) => filter,
                 Err(error) if is_fast_path_miss(&error) => return Ok(None),
@@ -415,6 +418,7 @@ fn decode_entity_insert(
     value_rows: &[Vec<Expr>],
     decoder: &mut ParamDecoder<'_>,
 ) -> Result<Vec<TransactionWriteRow>, LixError> {
+    validate_entity_insert_columns(spec, version_binding, columns)?;
     value_rows
         .iter()
         .map(|values| {
@@ -504,6 +508,42 @@ fn decode_entity_insert(
             })
         })
         .collect()
+}
+
+fn validate_entity_insert_columns(
+    spec: &EntitySurfaceSpec,
+    version_binding: Option<&str>,
+    columns: &[String],
+) -> Result<(), LixError> {
+    for column in columns {
+        let is_visible_column = spec.columns.iter().any(|field| field.name == *column);
+        let is_public_system_column = matches!(
+            column.as_str(),
+            "lixcol_entity_id"
+                | "lixcol_schema_key"
+                | "lixcol_file_id"
+                | "lixcol_snapshot_content"
+                | "lixcol_metadata"
+                | "lixcol_created_at"
+                | "lixcol_updated_at"
+                | "lixcol_global"
+                | "lixcol_change_id"
+                | "lixcol_commit_id"
+                | "lixcol_untracked"
+        );
+        let is_by_version_column = column == "lixcol_version_id" && version_binding.is_none();
+        if is_visible_column || is_public_system_column || is_by_version_column {
+            continue;
+        }
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            format!(
+                "simple DML fast path does not support INSERT column '{column}' for entity surface '{}'",
+                spec.schema_key
+            ),
+        ));
+    }
+    Ok(())
 }
 
 async fn execute_lix_state_delete(
@@ -840,7 +880,7 @@ fn simple_lix_state_filter(
             .unwrap_or_default(),
         ..LiveStateFilter::default()
     };
-    apply_simple_filter(expr, decoder, &mut filter, None)?;
+    apply_simple_filter(expr, decoder, &mut filter, None, true)?;
     if filter.schema_keys.is_empty() && filter.entity_ids.is_empty() && filter.file_ids.is_empty() {
         return Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
@@ -855,6 +895,7 @@ fn simple_entity_filter(
     decoder: &mut ParamDecoder<'_>,
     spec: &EntitySurfaceSpec,
     active_version_id: Option<&str>,
+    require_version_filter: bool,
 ) -> Result<LiveStateFilter, LixError> {
     let mut filter = LiveStateFilter {
         schema_keys: vec![spec.schema_key.clone()],
@@ -863,11 +904,23 @@ fn simple_entity_filter(
             .unwrap_or_default(),
         ..LiveStateFilter::default()
     };
-    apply_simple_filter(expr, decoder, &mut filter, Some(spec))?;
+    apply_simple_filter(
+        expr,
+        decoder,
+        &mut filter,
+        Some(spec),
+        active_version_id.is_none(),
+    )?;
     if filter.entity_ids.is_empty() {
         return Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
             "simple entity DML requires a lixcol_entity_id predicate",
+        ));
+    }
+    if require_version_filter && filter.version_ids.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "simple entity DML requires a lixcol_version_id predicate",
         ));
     }
     Ok(filter)
@@ -878,17 +931,34 @@ fn apply_simple_filter(
     decoder: &mut ParamDecoder<'_>,
     filter: &mut LiveStateFilter,
     spec: Option<&EntitySurfaceSpec>,
+    allow_version_filter: bool,
 ) -> Result<(), LixError> {
     match expr {
         Expr::BinaryOp { left, op, right } if *op == BinaryOperator::And => {
-            apply_simple_filter(left, decoder, filter, spec)?;
-            apply_simple_filter(right, decoder, filter, spec)
+            apply_simple_filter(left, decoder, filter, spec, allow_version_filter)?;
+            apply_simple_filter(right, decoder, filter, spec, allow_version_filter)
         }
         Expr::BinaryOp { left, op, right } if *op == BinaryOperator::Eq => {
             let right_values = [right.as_ref()];
             let left_values = [left.as_ref()];
-            apply_column_values(left, &right_values, decoder, filter, spec)
-                .or_else(|_| apply_column_values(right, &left_values, decoder, filter, spec))
+            apply_column_values(
+                left,
+                &right_values,
+                decoder,
+                filter,
+                spec,
+                allow_version_filter,
+            )
+            .or_else(|_| {
+                apply_column_values(
+                    right,
+                    &left_values,
+                    decoder,
+                    filter,
+                    spec,
+                    allow_version_filter,
+                )
+            })
         }
         Expr::InList {
             expr,
@@ -896,7 +966,7 @@ fn apply_simple_filter(
             negated,
         } if !negated => {
             let values = list.iter().collect::<Vec<_>>();
-            apply_column_values(expr, &values, decoder, filter, spec)
+            apply_column_values(expr, &values, decoder, filter, spec, allow_version_filter)
         }
         _ => Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
@@ -911,6 +981,7 @@ fn apply_column_values(
     decoder: &mut ParamDecoder<'_>,
     filter: &mut LiveStateFilter,
     spec: Option<&EntitySurfaceSpec>,
+    allow_version_filter: bool,
 ) -> Result<(), LixError> {
     let column = column_name(column_expr).ok_or_else(|| {
         LixError::new(
@@ -924,13 +995,20 @@ fn apply_column_values(
         .collect::<Result<Vec<_>, _>>()?;
     match column.as_str() {
         "schema_key" if spec.is_none() => {
-            filter.schema_keys = string_values(values, "schema_key")?;
+            if merge_string_filter(
+                &mut filter.schema_keys,
+                string_values(values, "schema_key")?,
+            )? {
+                filter.no_match = true;
+            }
         }
-        "version_id" | "lixcol_version_id" => {
-            filter.version_ids = string_values(values, &column)?;
+        "version_id" | "lixcol_version_id" if allow_version_filter => {
+            if merge_string_filter(&mut filter.version_ids, string_values(values, &column)?)? {
+                filter.no_match = true;
+            }
         }
         "entity_id" | "lixcol_entity_id" => {
-            filter.entity_ids = string_values(values, &column)?
+            let entity_ids = string_values(values, &column)?
                 .into_iter()
                 .map(|value| {
                     entity_identity(
@@ -940,6 +1018,9 @@ fn apply_column_values(
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()?;
+            if merge_entity_filter(&mut filter.entity_ids, entity_ids)? {
+                filter.no_match = true;
+            }
         }
         _ => {
             return Err(LixError::new(
@@ -949,6 +1030,39 @@ fn apply_column_values(
         }
     }
     Ok(())
+}
+
+fn merge_string_filter(target: &mut Vec<String>, values: Vec<String>) -> Result<bool, LixError> {
+    if values.is_empty() {
+        return Ok(true);
+    }
+    if target.is_empty() {
+        *target = values;
+        return Ok(false);
+    }
+    target.retain(|value| values.contains(value));
+    if target.is_empty() {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn merge_entity_filter(
+    target: &mut Vec<EntityIdentity>,
+    values: Vec<EntityIdentity>,
+) -> Result<bool, LixError> {
+    if values.is_empty() {
+        return Ok(true);
+    }
+    if target.is_empty() {
+        *target = values;
+        return Ok(false);
+    }
+    target.retain(|value| values.contains(value));
+    if target.is_empty() {
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 fn string_values(values: Vec<Value>, column: &str) -> Result<Vec<String>, LixError> {

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -489,6 +489,41 @@ pub async fn transaction_stage_only_prepared(
     })
 }
 
+pub async fn transaction_stage_rows_individually_prepared(
+    fixture: &TransactionBenchFixture,
+) -> Result<StorageBenchReport, LixError> {
+    let opened = open_transaction(
+        &SessionMode::Pinned {
+            version_id: crate::GLOBAL_VERSION_ID.to_string(),
+        },
+        fixture.storage.clone(),
+        Arc::clone(&fixture.live_state),
+        Arc::clone(&fixture.tracked_state),
+        Arc::clone(&fixture.binary_cas),
+        Arc::clone(&fixture.commit_store),
+        Arc::clone(&fixture.version_ctx),
+        Arc::clone(&fixture.catalog_context),
+    )
+    .await?;
+    let mut transaction = opened.transaction;
+    let started_at = Instant::now();
+    for row in &fixture.rows {
+        transaction
+            .stage_write(TransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: vec![row.clone()],
+            })
+            .await?;
+    }
+    let elapsed = started_at.elapsed();
+    transaction.rollback().await?;
+    Ok(StorageBenchReport {
+        measured_rows: fixture.rows.len(),
+        verified_rows: fixture.rows.len(),
+        elapsed,
+    })
+}
+
 pub async fn prepare_transaction_commit_only(
     fixture: TransactionBenchFixture,
 ) -> Result<TransactionCommitOnlyFixture, LixError> {
@@ -575,9 +610,25 @@ async fn prepare_transaction_fixture(
         crate::commit_graph::CommitGraphContext::new(),
     ));
     let binary_cas = Arc::new(BinaryCasContext::new());
-    let version_ctx = Arc::new(VersionContext::new(untracked_state));
+    let version_ctx = Arc::new(VersionContext::new(Arc::clone(&untracked_state)));
     let catalog_context = Arc::new(CatalogContext::new());
-    seed_transaction_visible_schema_rows(storage.clone()).await?;
+    crate::init::initialize(
+        storage.clone(),
+        commit_store.as_ref(),
+        tracked_state.as_ref(),
+        untracked_state.as_ref(),
+    )
+    .await?;
+    seed_transaction_bench_schema_row(
+        storage.clone(),
+        Arc::clone(&live_state),
+        Arc::clone(&tracked_state),
+        Arc::clone(&binary_cas),
+        Arc::clone(&commit_store),
+        Arc::clone(&version_ctx),
+        Arc::clone(&catalog_context),
+    )
+    .await?;
     Ok(TransactionBenchFixture {
         storage,
         live_state,
@@ -590,36 +641,55 @@ async fn prepare_transaction_fixture(
     })
 }
 
-async fn seed_transaction_visible_schema_rows(storage: StorageContext) -> Result<(), LixError> {
-    let mut writes = StorageWriteSet::new();
-    let rows = crate::schema::seed_schema_definitions()
-        .into_iter()
-        .cloned()
-        .chain(std::iter::once(transaction_entity_schema_definition()))
-        .map(|schema| {
-            let key = crate::schema::schema_key_from_definition(&schema)
-                .expect("seed schema key should derive");
-            let snapshot_content = serde_json::json!({ "value": schema }).to_string();
-            Ok(crate::untracked_state::UntrackedStateRow {
-                entity_id: crate::schema::registered_schema_entity_id(&key.schema_key)
-                    .expect("registered schema identity should derive"),
+async fn seed_transaction_bench_schema_row(
+    storage: StorageContext,
+    live_state: Arc<LiveStateContext>,
+    tracked_state: Arc<TrackedStateContext>,
+    binary_cas: Arc<BinaryCasContext>,
+    commit_store: Arc<CommitStoreContext>,
+    version_ctx: Arc<VersionContext>,
+    catalog_context: Arc<CatalogContext>,
+) -> Result<(), LixError> {
+    let schema = transaction_entity_schema_definition();
+    let key = crate::schema::schema_key_from_definition(&schema)?;
+    let opened = open_transaction(
+        &SessionMode::Pinned {
+            version_id: crate::GLOBAL_VERSION_ID.to_string(),
+        },
+        storage,
+        live_state,
+        tracked_state,
+        binary_cas,
+        commit_store,
+        version_ctx,
+        catalog_context,
+    )
+    .await?;
+    let mut transaction = opened.transaction;
+    transaction
+        .stage_write(TransactionWrite::Rows {
+            mode: TransactionWriteMode::Replace,
+            rows: vec![TransactionWriteRow {
+                entity_id: Some(crate::schema::registered_schema_entity_id(&key.schema_key)?),
                 schema_key: "lix_registered_schema".to_string(),
                 file_id: None,
-                version_id: crate::GLOBAL_VERSION_ID.to_string(),
-                snapshot_content: Some(snapshot_content),
+                snapshot: Some(TransactionJson::from_value_unchecked(
+                    serde_json::json!({ "value": schema }),
+                )),
                 metadata: None,
-                created_at: "1970-01-01T00:00:00.000Z".to_string(),
-                updated_at: "1970-01-01T00:00:00.000Z".to_string(),
+                origin: None,
+                created_at: None,
+                updated_at: None,
                 global: true,
-            })
+                change_id: None,
+                commit_id: None,
+                untracked: false,
+                version_id: crate::GLOBAL_VERSION_ID.to_string(),
+            }],
         })
-        .collect::<Result<Vec<_>, LixError>>()?;
-    let mut transaction = storage.begin_write_transaction().await?;
-    UntrackedStateContext::new()
-        .writer(&mut writes)
-        .stage_rows(rows.iter().map(|row| row.as_ref()))?;
-    writes.apply(&mut transaction.as_mut()).await?;
-    transaction.commit().await
+        .await?;
+    transaction.commit(&opened.runtime_functions).await?;
+    Ok(())
 }
 
 fn transaction_entity_schema_definition() -> serde_json::Value {

--- a/packages/engine/src/transaction/live_state_overlay.rs
+++ b/packages/engine/src/transaction/live_state_overlay.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeSet;
-
+use crate::live_state::visibility;
 use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{LiveStateReader, LiveStateScanRequest};
-use crate::transaction::staging::{PreparedStateRowIdentity, PreparedStateRowOverlay};
+use crate::transaction::staging::PreparedStateRowOverlay;
 use crate::LixError;
 
 pub(crate) async fn overlay_scan_rows(
@@ -11,22 +10,13 @@ pub(crate) async fn overlay_scan_rows(
     request: &LiveStateScanRequest,
 ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
     let staged_parts = staged.scan_parts(request)?;
-    let hidden_identities = staged_parts.hidden_identities;
-    let mut rows = staged_parts.rows;
-    let mut visible_identities = rows
-        .iter()
-        .map(PreparedStateRowIdentity::from)
-        .collect::<BTreeSet<_>>();
-
-    for row in base.scan_rows(request).await? {
-        let identity = PreparedStateRowIdentity::from(&row);
-        if hidden_identities.contains(&identity) {
-            continue;
-        }
-        if visible_identities.insert(identity) {
-            rows.push(row);
-        }
-    }
+    let mut rows = base.scan_rows(request).await?;
+    rows.extend(staged_parts.rows);
+    rows = visibility::resolve_scan_rows(
+        rows,
+        &request.filter.version_ids,
+        request.filter.include_tombstones,
+    );
 
     if let Some(limit) = request.limit {
         rows.truncate(limit);

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -430,19 +430,8 @@ impl TransactionWriteBuffer {
 
     /// Builds the transaction-local read overlay from currently staged writes.
     pub(crate) fn staging_overlay(self: &Arc<Self>) -> Result<PreparedStateRowOverlay, LixError> {
-        let by_identity_guard = self.by_identity.lock().map_err(|_| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "failed to acquire transaction staged identity index lock",
-            )
-        })?;
-        let slots = by_identity_guard
-            .iter()
-            .map(|(identity, slot)| (identity.clone(), *slot))
-            .collect();
         Ok(PreparedStateRowOverlay {
             staged_writes: Arc::clone(self),
-            slots,
         })
     }
 
@@ -593,7 +582,6 @@ impl TransactionWriteBuffer {
 /// Read overlay derived from staged transaction writes.
 pub(crate) struct PreparedStateRowOverlay {
     staged_writes: Arc<TransactionWriteBuffer>,
-    slots: BTreeMap<PreparedStateRowIdentity, RowSlot>,
 }
 
 pub(crate) struct StagedScanParts {
@@ -631,10 +619,16 @@ impl PreparedStateRowOverlay {
                 "failed to acquire transaction staged adopted writes lock",
             )
         })?;
+        let by_identity_guard = self.staged_writes.by_identity.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged identity index lock",
+            )
+        })?;
 
         let mut rows = Vec::new();
         let mut hidden_identities = BTreeSet::new();
-        for (identity, slot) in &self.slots {
+        for (identity, slot) in by_identity_guard.iter() {
             match *slot {
                 RowSlot::State(index) => {
                     let Some(row) = rows_guard.get(index).and_then(Option::as_ref) else {
@@ -699,16 +693,13 @@ impl PreparedStateRowOverlay {
 
     #[cfg(test)]
     fn load_state_slot(&self, identity: &PreparedStateRowIdentity) -> Option<PreparedStateRow> {
-        let Some(RowSlot::State(index)) = self.slots.get(identity).copied() else {
+        let rows_guard = self.staged_writes.rows.lock().ok()?;
+        let _adopted_guard = self.staged_writes.adopted_rows.lock().ok()?;
+        let by_identity_guard = self.staged_writes.by_identity.lock().ok()?;
+        let Some(RowSlot::State(index)) = by_identity_guard.get(identity).copied() else {
             return None;
         };
-        self.staged_writes
-            .rows
-            .lock()
-            .ok()?
-            .get(index)?
-            .as_ref()
-            .cloned()
+        rows_guard.get(index)?.as_ref().cloned()
     }
 
     #[cfg(test)]
@@ -716,16 +707,13 @@ impl PreparedStateRowOverlay {
         &self,
         identity: &PreparedStateRowIdentity,
     ) -> Option<PreparedAdoptedStateRow> {
-        let Some(RowSlot::Adopted(index)) = self.slots.get(identity).copied() else {
+        let _rows_guard = self.staged_writes.rows.lock().ok()?;
+        let adopted_guard = self.staged_writes.adopted_rows.lock().ok()?;
+        let by_identity_guard = self.staged_writes.by_identity.lock().ok()?;
+        let Some(RowSlot::Adopted(index)) = by_identity_guard.get(identity).copied() else {
             return None;
         };
-        self.staged_writes
-            .adopted_rows
-            .lock()
-            .ok()?
-            .get(index)?
-            .as_ref()
-            .cloned()
+        adopted_guard.get(index)?.as_ref().cloned()
     }
 }
 

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -607,6 +607,13 @@ impl PreparedStateRowOverlay {
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<StagedScanParts, LixError> {
+        if request.filter.no_match {
+            return Ok(StagedScanParts {
+                rows: Vec::new(),
+                hidden_identities: BTreeSet::new(),
+            });
+        }
+
         let rows_guard = self.staged_writes.rows.lock().map_err(|_| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 
 use crate::catalog::SchemaPlanId;
@@ -586,7 +586,6 @@ pub(crate) struct PreparedStateRowOverlay {
 
 pub(crate) struct StagedScanParts {
     pub(crate) rows: Vec<MaterializedLiveStateRow>,
-    pub(crate) hidden_identities: BTreeSet<PreparedStateRowIdentity>,
 }
 
 impl PreparedStateRowOverlay {
@@ -596,7 +595,11 @@ impl PreparedStateRowOverlay {
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        Ok(self.scan_parts(request)?.rows)
+        Ok(crate::live_state::visibility::resolve_scan_rows(
+            self.scan_parts(request)?.rows,
+            &request.filter.version_ids,
+            request.filter.include_tombstones,
+        ))
     }
 
     /// Returns staged rows and base-row identities hidden by staged rows in one pass.
@@ -608,10 +611,7 @@ impl PreparedStateRowOverlay {
         request: &LiveStateScanRequest,
     ) -> Result<StagedScanParts, LixError> {
         if request.filter.no_match {
-            return Ok(StagedScanParts {
-                rows: Vec::new(),
-                hidden_identities: BTreeSet::new(),
-            });
+            return Ok(StagedScanParts { rows: Vec::new() });
         }
 
         let rows_guard = self.staged_writes.rows.lock().map_err(|_| {
@@ -634,8 +634,7 @@ impl PreparedStateRowOverlay {
         })?;
 
         let mut rows = Vec::new();
-        let mut hidden_identities = BTreeSet::new();
-        for (identity, slot) in by_identity_guard.iter() {
+        for slot in by_identity_guard.values() {
             match *slot {
                 RowSlot::State(index) => {
                     let Some(row) = rows_guard.get(index).and_then(Option::as_ref) else {
@@ -644,10 +643,7 @@ impl PreparedStateRowOverlay {
                     if !staged_row_identity_matches_scan(row, request) {
                         continue;
                     }
-                    hidden_identities.insert(identity.clone());
-                    if row.snapshot.is_some() || request.filter.include_tombstones {
-                        rows.push(MaterializedLiveStateRow::from(row));
-                    }
+                    rows.push(MaterializedLiveStateRow::from(row));
                 }
                 RowSlot::Adopted(index) => {
                     let Some(row) = adopted_guard.get(index).and_then(Option::as_ref) else {
@@ -656,17 +652,11 @@ impl PreparedStateRowOverlay {
                     if !adopted_row_identity_matches_scan(row, request) {
                         continue;
                     }
-                    hidden_identities.insert(identity.clone());
-                    if row.snapshot.is_some() || request.filter.include_tombstones {
-                        rows.push(MaterializedLiveStateRow::from(row));
-                    }
+                    rows.push(MaterializedLiveStateRow::from(row));
                 }
             }
         }
-        Ok(StagedScanParts {
-            rows,
-            hidden_identities,
-        })
+        Ok(StagedScanParts { rows })
     }
 
     /// Returns a staged exact-row answer, if this transaction has one.
@@ -1037,9 +1027,7 @@ fn adopted_row_identity_matches_scan(
     {
         return false;
     }
-    if !request.filter.version_ids.is_empty()
-        && !request.filter.version_ids.contains(&row.version_id)
-    {
+    if !staged_version_matches_scan(&row.version_id, request) {
         return false;
     }
     if request.filter.untracked == Some(true) {
@@ -1061,9 +1049,7 @@ fn staged_row_identity_matches_scan(
     {
         return false;
     }
-    if !request.filter.version_ids.is_empty()
-        && !request.filter.version_ids.contains(&row.version_id)
-    {
+    if !staged_version_matches_scan(&row.version_id, request) {
         return false;
     }
     if request
@@ -1084,6 +1070,21 @@ fn nullable_key_matches_filters(
         || filters
             .iter()
             .any(|filter| nullable_key_matches_filter(value, filter))
+}
+
+fn staged_version_matches_scan(version_id: &str, request: &LiveStateScanRequest) -> bool {
+    request.filter.version_ids.is_empty()
+        || request
+            .filter
+            .version_ids
+            .iter()
+            .any(|requested| requested == version_id)
+        || (version_id == GLOBAL_VERSION_ID
+            && request
+                .filter
+                .version_ids
+                .iter()
+                .any(|requested| requested != GLOBAL_VERSION_ID))
 }
 
 fn nullable_key_matches_filter(value: &Option<String>, filter: &NullableKeyFilter<String>) -> bool {

--- a/packages/engine/tests/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/sql/lix_registered_schema.rs
@@ -1318,6 +1318,93 @@ simulation_test!(
 );
 
 simulation_test!(
+    typed_entity_insert_rejects_duplicate_columns,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"engine_duplicate_insert_column_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+
+        let error = session
+            .execute(
+                "INSERT INTO engine_duplicate_insert_column_schema \
+                 (id, name, name, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'before', 'after', false, false)",
+                &[],
+            )
+            .await
+            .expect_err("typed entity insert should not accept duplicate columns");
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+
+        let result = session
+            .execute("SELECT id FROM engine_duplicate_insert_column_schema", &[])
+            .await
+            .expect("select should succeed");
+        assert_rows_eq(result, Vec::<Vec<Value>>::new());
+    }
+);
+
+simulation_test!(
+    typed_entity_insert_rejects_unresolved_qualified_table,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"engine_qualified_insert_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+
+        session
+            .execute(
+                "INSERT INTO bogus.engine_qualified_insert_schema \
+                 (id, name, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'wrong', false, false)",
+                &[],
+            )
+            .await
+            .expect_err("qualified unresolved table should fall back to normal planning");
+
+        let result = session
+            .execute("SELECT id FROM engine_qualified_insert_schema", &[])
+            .await
+            .expect("select should succeed");
+        assert_rows_eq(result, Vec::<Vec<Value>>::new());
+    }
+);
+
+simulation_test!(
     typed_entity_base_insert_cannot_override_active_version_filter,
     |sim| async move {
         let engine = sim.boot_engine().await;
@@ -1466,6 +1553,271 @@ simulation_test!(
                 ],
             ],
         );
+    }
+);
+
+simulation_test!(
+    typed_entity_by_version_update_requires_explicit_version_filter,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_version_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"engine_by_version_update_scope_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("registered schema insert should succeed");
+
+        main.create_version(CreateVersionOptions {
+            id: Some("by-version-update-draft".to_string()),
+            name: "By-version Update Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft version should be created after schema registration");
+
+        main.execute(
+            "INSERT INTO engine_by_version_update_scope_schema \
+             (id, name, lixcol_global, lixcol_untracked) \
+             VALUES ('row-1', 'main', false, false)",
+            &[],
+        )
+        .await
+        .expect("main entity insert should succeed");
+
+        let draft = sim.wrap_session(
+            engine
+                .open_session("by-version-update-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+        draft
+            .execute(
+                "INSERT INTO engine_by_version_update_scope_schema \
+                 (id, name, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'draft', false, false)",
+                &[],
+            )
+            .await
+            .expect("draft entity insert should succeed");
+
+        main.execute(
+            "UPDATE engine_by_version_update_scope_schema_by_version \
+             SET name = 'updated-all' \
+             WHERE lixcol_entity_id = '[\"row-1\"]'",
+            &[],
+        )
+        .await
+        .expect_err("_by_version update should not update all versions without a version filter");
+
+        let result = main
+            .execute(
+                &format!(
+                    "SELECT name, lixcol_version_id \
+                 FROM engine_by_version_update_scope_schema_by_version \
+                 WHERE lixcol_entity_id = lix_json('[\"row-1\"]') \
+                   AND lixcol_version_id IN ('{}', 'by-version-update-draft') \
+                 ORDER BY name",
+                    sim.main_version_id()
+                ),
+                &[],
+            )
+            .await
+            .expect("by-version query should succeed");
+        assert_rows_eq(
+            result,
+            vec![
+                vec![
+                    Value::Text("draft".to_string()),
+                    Value::Text("by-version-update-draft".to_string()),
+                ],
+                vec![
+                    Value::Text("main".to_string()),
+                    Value::Text(sim.main_version_id().to_string()),
+                ],
+            ],
+        );
+    }
+);
+
+simulation_test!(
+    typed_entity_by_version_dml_rejects_version_id_alias,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_version_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"engine_by_version_alias_scope_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("registered schema insert should succeed");
+
+        main.create_version(CreateVersionOptions {
+            id: Some("by-version-alias-draft".to_string()),
+            name: "By-version Alias Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft version should be created after schema registration");
+
+        main.execute(
+            "INSERT INTO engine_by_version_alias_scope_schema \
+             (id, name, lixcol_global, lixcol_untracked) \
+             VALUES ('row-1', 'main', false, false)",
+            &[],
+        )
+        .await
+        .expect("main entity insert should succeed");
+
+        let draft = sim.wrap_session(
+            engine
+                .open_session("by-version-alias-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+        draft
+            .execute(
+                "INSERT INTO engine_by_version_alias_scope_schema \
+                 (id, name, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'draft', false, false)",
+                &[],
+            )
+            .await
+            .expect("draft entity insert should succeed");
+
+        let update_error = main
+            .execute(
+                "UPDATE engine_by_version_alias_scope_schema_by_version \
+                 SET name = 'updated-via-alias' \
+                 WHERE lixcol_entity_id = '[\"row-1\"]' \
+                   AND version_id = 'by-version-alias-draft'",
+                &[],
+            )
+            .await
+            .expect_err("_by_version update should not accept version_id alias");
+        assert_eq!(update_error.code, LixError::CODE_COLUMN_NOT_FOUND);
+
+        let delete_error = main
+            .execute(
+                "DELETE FROM engine_by_version_alias_scope_schema_by_version \
+                 WHERE lixcol_entity_id = '[\"row-1\"]' \
+                   AND version_id = 'by-version-alias-draft'",
+                &[],
+            )
+            .await
+            .expect_err("_by_version delete should not accept version_id alias");
+        assert_eq!(delete_error.code, LixError::CODE_COLUMN_NOT_FOUND);
+
+        let result = main
+            .execute(
+                &format!(
+                    "SELECT name, lixcol_version_id \
+                 FROM engine_by_version_alias_scope_schema_by_version \
+                 WHERE lixcol_entity_id = lix_json('[\"row-1\"]') \
+                   AND lixcol_version_id IN ('{}', 'by-version-alias-draft') \
+                 ORDER BY name",
+                    sim.main_version_id()
+                ),
+                &[],
+            )
+            .await
+            .expect("by-version query should succeed");
+        assert_rows_eq(
+            result,
+            vec![
+                vec![
+                    Value::Text("draft".to_string()),
+                    Value::Text("by-version-alias-draft".to_string()),
+                ],
+                vec![
+                    Value::Text("main".to_string()),
+                    Value::Text(sim.main_version_id().to_string()),
+                ],
+            ],
+        );
+    }
+);
+
+simulation_test!(
+    typed_entity_update_rejects_duplicate_assignments,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"engine_duplicate_update_assignment_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+
+        session
+            .execute(
+                "INSERT INTO engine_duplicate_update_assignment_schema \
+                 (id, name, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'before', false, false)",
+                &[],
+            )
+            .await
+            .expect("entity insert should succeed");
+
+        let error = session
+            .execute(
+                "UPDATE engine_duplicate_update_assignment_schema \
+                 SET name = 'first', name = 'second' \
+                 WHERE id = 'row-1'",
+                &[],
+            )
+            .await
+            .expect_err("typed entity update should not accept duplicate assignments");
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+
+        let result = session
+            .execute(
+                "SELECT name FROM engine_duplicate_update_assignment_schema WHERE id = 'row-1'",
+                &[],
+            )
+            .await
+            .expect("select should succeed");
+        assert_rows_eq(result, vec![vec![Value::Text("before".to_string())]]);
     }
 );
 

--- a/packages/engine/tests/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/sql/lix_registered_schema.rs
@@ -1141,6 +1141,335 @@ simulation_test!(
 );
 
 simulation_test!(
+    typed_entity_base_update_cannot_override_active_version_filter,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_version_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"engine_base_version_filter_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("registered schema insert should succeed");
+
+        main.create_version(CreateVersionOptions {
+            id: Some("base-filter-draft".to_string()),
+            name: "Base Filter Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft version should be created after schema registration");
+
+        let draft = sim.wrap_session(
+            engine
+                .open_session("base-filter-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+
+        draft
+            .execute(
+                "INSERT INTO engine_base_version_filter_schema \
+                 (id, name, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'draft', false, false)",
+                &[],
+            )
+            .await
+            .expect("draft entity insert should succeed");
+
+        let error = main
+            .execute(
+                "UPDATE engine_base_version_filter_schema \
+                 SET name = 'main-updated-draft' \
+                 WHERE lixcol_entity_id = '[\"row-1\"]' \
+                   AND lixcol_version_id = 'base-filter-draft'",
+                &[],
+            )
+            .await
+            .expect_err("base entity table should not expose lixcol_version_id");
+        assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
+
+        let result = main
+            .execute(
+                "SELECT name \
+                 FROM engine_base_version_filter_schema_by_version \
+                 WHERE lixcol_entity_id = lix_json('[\"row-1\"]') \
+                   AND lixcol_version_id = 'base-filter-draft'",
+                &[],
+            )
+            .await
+            .expect("by-version query should succeed");
+        assert_rows_eq(result, vec![vec![Value::Text("draft".to_string())]]);
+    }
+);
+
+simulation_test!(
+    typed_entity_base_insert_cannot_override_active_version_scope,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_version_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"engine_base_insert_version_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("registered schema insert should succeed");
+
+        main.create_version(CreateVersionOptions {
+            id: Some("base-insert-draft".to_string()),
+            name: "Base Insert Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft version should be created after schema registration");
+
+        let error = main
+            .execute(
+                "INSERT INTO engine_base_insert_version_schema \
+                 (id, name, lixcol_version_id, lixcol_untracked) \
+                 VALUES ('row-1', 'draft', 'base-insert-draft', false)",
+                &[],
+            )
+            .await
+            .expect_err("base entity table should not expose lixcol_version_id");
+        assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
+
+        let result = main
+            .execute(
+                "SELECT name \
+                 FROM engine_base_insert_version_schema_by_version \
+                 WHERE lixcol_entity_id = lix_json('[\"row-1\"]') \
+                   AND lixcol_version_id = 'base-insert-draft'",
+                &[],
+            )
+            .await
+            .expect("by-version query should succeed");
+        assert_rows_eq(result, vec![]);
+    }
+);
+
+simulation_test!(
+    typed_entity_insert_rejects_unknown_column,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"engine_unknown_insert_column_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+
+        let error = session
+            .execute(
+                "INSERT INTO engine_unknown_insert_column_schema \
+                 (id, name, missing_column, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'before', 'ignored-before-fix', false, false)",
+                &[],
+            )
+            .await
+            .expect_err("typed entity insert should not ignore unknown columns");
+        assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
+
+        let result = session
+            .execute("SELECT id FROM engine_unknown_insert_column_schema", &[])
+            .await
+            .expect("select should succeed");
+        assert_rows_eq(result, Vec::<Vec<Value>>::new());
+    }
+);
+
+simulation_test!(
+    typed_entity_base_insert_cannot_override_active_version_filter,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_version_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"engine_base_version_insert_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("registered schema insert should succeed");
+
+        main.create_version(CreateVersionOptions {
+            id: Some("base-insert-draft".to_string()),
+            name: "Base Insert Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft version should be created after schema registration");
+
+        let error = main
+            .execute(
+                "INSERT INTO engine_base_version_insert_schema \
+                 (id, name, lixcol_version_id, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'draft-via-main', 'base-insert-draft', false, false)",
+                &[],
+            )
+            .await
+            .expect_err("base entity table should not expose lixcol_version_id");
+        assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
+
+        let result = main
+            .execute(
+                "SELECT id \
+                 FROM engine_base_version_insert_schema_by_version \
+                 WHERE lixcol_version_id = 'base-insert-draft'",
+                &[],
+            )
+            .await
+            .expect("by-version query should succeed");
+        assert_rows_eq(result, Vec::<Vec<Value>>::new());
+    }
+);
+
+simulation_test!(
+    typed_entity_by_version_delete_requires_explicit_version_filter,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_version_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"engine_by_version_delete_scope_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("registered schema insert should succeed");
+
+        main.create_version(CreateVersionOptions {
+            id: Some("by-version-delete-draft".to_string()),
+            name: "By-version Delete Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft version should be created after schema registration");
+
+        main.execute(
+            "INSERT INTO engine_by_version_delete_scope_schema \
+             (id, name, lixcol_global, lixcol_untracked) \
+             VALUES ('row-1', 'main', false, false)",
+            &[],
+        )
+        .await
+        .expect("main entity insert should succeed");
+
+        let draft = sim.wrap_session(
+            engine
+                .open_session("by-version-delete-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+        draft
+            .execute(
+                "INSERT INTO engine_by_version_delete_scope_schema \
+                 (id, name, lixcol_global, lixcol_untracked) \
+                 VALUES ('row-1', 'draft', false, false)",
+                &[],
+            )
+            .await
+            .expect("draft entity insert should succeed");
+
+        main.execute(
+            "DELETE FROM engine_by_version_delete_scope_schema_by_version \
+             WHERE lixcol_entity_id = '[\"row-1\"]'",
+            &[],
+        )
+        .await
+        .expect_err("_by_version delete should not delete all versions without a version filter");
+
+        let result = main
+            .execute(
+                &format!(
+                    "SELECT name, lixcol_version_id \
+                 FROM engine_by_version_delete_scope_schema_by_version \
+                 WHERE lixcol_entity_id = lix_json('[\"row-1\"]') \
+                   AND lixcol_version_id IN ('{}', 'by-version-delete-draft') \
+                 ORDER BY name",
+                    sim.main_version_id()
+                ),
+                &[],
+            )
+            .await
+            .expect("by-version query should succeed");
+        assert_rows_eq(
+            result,
+            vec![
+                vec![
+                    Value::Text("draft".to_string()),
+                    Value::Text("by-version-delete-draft".to_string()),
+                ],
+                vec![
+                    Value::Text("main".to_string()),
+                    Value::Text(sim.main_version_id().to_string()),
+                ],
+            ],
+        );
+    }
+);
+
+simulation_test!(
     typed_entity_update_preserves_absent_optional_non_nullable_fields,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/engine/tests/sql/lix_state.rs
+++ b/packages/engine/tests/sql/lix_state.rs
@@ -247,6 +247,128 @@ simulation_test!(
 );
 
 simulation_test!(
+    lix_state_transaction_insert_global_row_is_visible_before_commit,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+
+        transaction
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, schema_key, file_id, snapshot_content, global, untracked\
+                 ) VALUES (\
+                 '[\"state-tx-global\"]', 'lix_key_value', NULL, '{\"key\":\"state-tx-global\",\"value\":\"global\"}', true, false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("transactional global lix_state insert should succeed");
+
+        let result = transaction
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_state \
+                 WHERE entity_id = lix_json('[\"state-tx-global\"]') AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("transactional active read should succeed");
+        assert_single_text(result, "{\"key\":\"state-tx-global\",\"value\":\"global\"}");
+
+        let result = transaction
+            .execute(
+                "UPDATE lix_state \
+                 SET snapshot_content = '{\"key\":\"state-tx-global\",\"value\":\"updated\"}' \
+                 WHERE entity_id = '[\"state-tx-global\"]' AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("transactional active update should see staged global row");
+        assert_eq!(result.rows_affected(), 1);
+
+        let result = transaction
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_state \
+                 WHERE entity_id = lix_json('[\"state-tx-global\"]') AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("transactional active read after update should succeed");
+        assert_single_text(
+            result,
+            "{\"key\":\"state-tx-global\",\"value\":\"updated\"}",
+        );
+    }
+);
+
+simulation_test!(
+    lix_state_transaction_global_row_does_not_override_active_row,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, schema_key, file_id, snapshot_content, global, untracked\
+                 ) VALUES (\
+                 '[\"state-tx-global-shadowed\"]', 'lix_key_value', NULL, '{\"key\":\"state-tx-global-shadowed\",\"value\":\"active\"}', false, false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("active lix_state insert should succeed");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, schema_key, file_id, snapshot_content, global, untracked\
+                 ) VALUES (\
+                 '[\"state-tx-global-shadowed\"]', 'lix_key_value', NULL, '{\"key\":\"state-tx-global-shadowed\",\"value\":\"global\"}', true, false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("transactional global lix_state insert should succeed");
+
+        let result = transaction
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_state \
+                 WHERE entity_id = lix_json('[\"state-tx-global-shadowed\"]') AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("transactional active read should succeed");
+        assert_single_text(
+            result,
+            "{\"key\":\"state-tx-global-shadowed\",\"value\":\"active\"}",
+        );
+    }
+);
+
+simulation_test!(
     lix_state_global_rows_are_visible_through_version_overlay,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/engine/tests/sql/lix_state.rs
+++ b/packages/engine/tests/sql/lix_state.rs
@@ -91,6 +91,162 @@ simulation_test!(lix_state_delete_hides_row, |sim| async move {
 });
 
 simulation_test!(
+    lix_state_update_intersects_repeated_identity_predicates,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, schema_key, file_id, snapshot_content, global, untracked\
+                 ) VALUES \
+                 ('[\"state-repeat-a\"]', 'lix_key_value', NULL, '{\"key\":\"state-repeat-a\",\"value\":\"a\"}', false, false), \
+                 ('[\"state-repeat-b\"]', 'lix_key_value', NULL, '{\"key\":\"state-repeat-b\",\"value\":\"b\"}', false, false)",
+                &[],
+            )
+            .await
+            .expect("lix_state insert should succeed");
+
+        let result = session
+            .execute(
+                "UPDATE lix_state \
+                 SET snapshot_content = '{\"key\":\"state-repeat-b\",\"value\":\"wrong\"}' \
+                 WHERE entity_id = '[\"state-repeat-a\"]' \
+                   AND schema_key = 'lix_key_value' \
+                   AND entity_id = '[\"state-repeat-b\"]'",
+                &[],
+            )
+            .await
+            .expect("contradictory lix_state update should succeed with zero rows");
+        assert_eq!(result.rows_affected(), 0);
+
+        let result = session
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_state \
+                 WHERE entity_id = lix_json('[\"state-repeat-b\"]') AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("lix_state read should succeed");
+        assert_single_text(result, "{\"key\":\"state-repeat-b\",\"value\":\"b\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_update_intersects_repeated_identity_predicates_in_transaction,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+
+        transaction
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, schema_key, file_id, snapshot_content, global, untracked\
+                 ) VALUES \
+                 ('[\"state-tx-repeat-a\"]', 'lix_key_value', NULL, '{\"key\":\"state-tx-repeat-a\",\"value\":\"a\"}', false, false), \
+                 ('[\"state-tx-repeat-b\"]', 'lix_key_value', NULL, '{\"key\":\"state-tx-repeat-b\",\"value\":\"b\"}', false, false)",
+                &[],
+            )
+            .await
+            .expect("transactional lix_state insert should succeed");
+
+        let result = transaction
+            .execute(
+                "UPDATE lix_state \
+                 SET snapshot_content = '{\"key\":\"state-tx-repeat-b\",\"value\":\"wrong\"}' \
+                 WHERE entity_id = '[\"state-tx-repeat-a\"]' \
+                   AND schema_key = 'lix_key_value' \
+                   AND entity_id = '[\"state-tx-repeat-b\"]'",
+                &[],
+            )
+            .await
+            .expect("contradictory transactional update should succeed with zero rows");
+        assert_eq!(result.rows_affected(), 0);
+
+        let result = transaction
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_state \
+                 WHERE entity_id = lix_json('[\"state-tx-repeat-b\"]') AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("transactional lix_state read should succeed");
+        assert_single_text(result, "{\"key\":\"state-tx-repeat-b\",\"value\":\"b\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_delete_intersects_repeated_identity_predicates,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_state (\
+                 entity_id, schema_key, file_id, snapshot_content, global, untracked\
+                 ) VALUES \
+                 ('[\"state-delete-repeat-a\"]', 'lix_key_value', NULL, '{\"key\":\"state-delete-repeat-a\",\"value\":\"a\"}', false, false), \
+                 ('[\"state-delete-repeat-b\"]', 'lix_key_value', NULL, '{\"key\":\"state-delete-repeat-b\",\"value\":\"b\"}', false, false)",
+                &[],
+            )
+            .await
+            .expect("lix_state insert should succeed");
+
+        let result = session
+            .execute(
+                "DELETE FROM lix_state \
+                 WHERE entity_id = '[\"state-delete-repeat-a\"]' \
+                   AND schema_key = 'lix_key_value' \
+                   AND entity_id = '[\"state-delete-repeat-b\"]'",
+                &[],
+            )
+            .await
+            .expect("contradictory lix_state delete should succeed with zero rows");
+        assert_eq!(result.rows_affected(), 0);
+
+        let result = session
+            .execute(
+                "SELECT snapshot_content \
+                 FROM lix_state \
+                 WHERE entity_id = lix_json('[\"state-delete-repeat-b\"]') AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("lix_state read should succeed");
+        assert_single_text(
+            result,
+            "{\"key\":\"state-delete-repeat-b\",\"value\":\"b\"}",
+        );
+    }
+);
+
+simulation_test!(
     lix_state_global_rows_are_visible_through_version_overlay,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes SQL write execution and transaction scan visibility semantics; mistakes could cause incorrect row targeting or version/global row visibility in reads/writes, though the fast path is gated to a narrow subset with fallback to existing planning.
> 
> **Overview**
> **Speeds up common write paths** by adding a `sql2::try_execute_simple_write` fast path for simple `INSERT`/`UPDATE`/`DELETE` against `lix_state` and entity surfaces, staging rows directly when statements match a restricted pattern (VALUES-only inserts, simple assignments, and `=`/`IN` identity predicates), otherwise falling back to the existing DataFusion planning/execution.
> 
> **Adjusts live-state scan behavior** by introducing a `no_match` flag on `LiveStateFilter` (early-returning empty scans) and centralizing version/global row and tombstone visibility via `live_state::visibility::resolve_scan_rows`, simplifying the transaction overlay logic.
> 
> Adds/updates benchmarks and tests to cover the new fast-path behavior, version-scope restrictions, duplicate/unknown column handling, and repeated/contradictory identity predicates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416fcf1cf68b0a70452f7256097e75ad02d9451d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->