### PR TITLE
agent-1: harden changelog codec corruption checks

### DIFF
--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -1718,14 +1718,20 @@ impl BenchPayloadShape {
     fn inline_payloads(self, index: usize) -> Vec<SegmentInlinePayload> {
         match self {
             Self::None | Self::ExternalRefsOnly => Vec::new(),
-            Self::SmallInline => vec![SegmentInlinePayload {
-                json_ref: json_ref(index, 1),
-                bytes: payload_bytes(index, 64),
-            }],
-            Self::LargeInline => vec![SegmentInlinePayload {
-                json_ref: json_ref(index, 1),
-                bytes: payload_bytes(index, 8 * 1024),
-            }],
+            Self::SmallInline => {
+                let bytes = payload_bytes(index, 64);
+                vec![SegmentInlinePayload {
+                    json_ref: JsonRef::for_content(&bytes),
+                    bytes,
+                }]
+            }
+            Self::LargeInline => {
+                let bytes = payload_bytes(index, 8 * 1024);
+                vec![SegmentInlinePayload {
+                    json_ref: JsonRef::for_content(&bytes),
+                    bytes,
+                }]
+            }
         }
     }
 }

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -13,14 +13,14 @@ use super::codec::{
 };
 use super::context::ChangelogContext;
 use super::segment::{
-    canonicalize_segment, directory_change_location, directory_commit_location,
-    validate_change_checksum, validate_commit_checksum, validate_segment_shape,
-    DecodedSegmentIndex,
+    DecodedSegmentIndex, canonicalize_segment, directory_change_location,
+    directory_commit_location, validate_change_checksum, validate_commit_checksum,
+    validate_segment_shape,
 };
 use super::store::{
+    BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE, SEGMENT_SPACE,
     by_change_key, by_change_membership_commit_id_from_key, by_change_membership_key,
-    by_change_membership_prefix, by_commit_key, segment_key, segment_value, BY_CHANGE_INDEX_SPACE,
-    BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE, SEGMENT_SPACE,
+    by_change_membership_prefix, by_commit_key, segment_key, segment_value,
 };
 use super::types::{
     ChangeLoadRequest, ChangeProjection, ChangeVisibilityMode, CommitLoadRequest, CommitProjection,

--- a/packages/engine/src/changelog/by_change_index.rs
+++ b/packages/engine/src/changelog/by_change_index.rs
@@ -1,6 +1,7 @@
 //! Rebuildable by_change index behavior.
 
 use super::segment::directory_change_location;
+use super::truth::SegmentTruthSnapshot;
 use super::types::{ByChangeEntry, Segment};
 use crate::LixError;
 use std::collections::HashSet;
@@ -25,6 +26,16 @@ pub(super) fn by_change_entries_for_segments(
         }
     }
     Ok(entries)
+}
+
+pub(super) fn by_change_entries_for_truth(truth: &SegmentTruthSnapshot) -> Vec<ByChangeEntry> {
+    truth
+        .changes_in_segment_order()
+        .map(|(change_id, location, _)| ByChangeEntry {
+            change_id: change_id.to_string(),
+            location: location.clone(),
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/packages/engine/src/changelog/by_change_membership_index.rs
+++ b/packages/engine/src/changelog/by_change_membership_index.rs
@@ -1,5 +1,6 @@
 //! Rebuildable by_change_membership index behavior.
 
+use super::truth::SegmentTruthSnapshot;
 use super::types::{CommitId, Segment};
 
 pub(super) struct ByChangeMembershipEntry {
@@ -21,6 +22,21 @@ pub(super) fn by_change_membership_entries_for_segments(
                     commit_id: commit.header.id.clone(),
                 });
             }
+        }
+    }
+    entries
+}
+
+pub(super) fn by_change_membership_entries_for_truth(
+    truth: &SegmentTruthSnapshot,
+) -> Vec<ByChangeMembershipEntry> {
+    let mut entries = Vec::new();
+    for (commit_id, _, commit) in truth.commits_in_segment_order() {
+        for membership in &commit.body.membership {
+            entries.push(ByChangeMembershipEntry {
+                change_id: membership.member_change_id.clone(),
+                commit_id: commit_id.to_string(),
+            });
         }
     }
     entries

--- a/packages/engine/src/changelog/by_commit_index.rs
+++ b/packages/engine/src/changelog/by_commit_index.rs
@@ -35,8 +35,15 @@ pub(super) fn by_commit_entries_for_segments(
 ) -> Result<Vec<ByCommitEntry>, LixError> {
     let generations = rebuilt_commit_generations(segments)?;
     let mut entries = Vec::new();
+    let mut seen = HashSet::new();
     for segment in segments {
         for commit in &segment.commits {
+            if !seen.insert(commit.header.id.as_str()) {
+                return Err(LixError::unknown(format!(
+                    "changelog index rebuild found duplicate commit '{}'",
+                    commit.header.id
+                )));
+            }
             entries.push(ByCommitEntry {
                 commit_id: commit.header.id.clone(),
                 location: directory_commit_location(segment, &commit.header.id)?,

--- a/packages/engine/src/changelog/by_commit_index.rs
+++ b/packages/engine/src/changelog/by_commit_index.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::segment::directory_commit_location;
+use super::truth::SegmentTruthSnapshot;
 use super::types::{ByCommitEntry, Segment};
 use crate::LixError;
 
@@ -56,6 +57,26 @@ pub(super) fn by_commit_entries_for_segments(
                 })?,
             });
         }
+    }
+    Ok(entries)
+}
+
+pub(super) fn by_commit_entries_for_truth(
+    truth: &SegmentTruthSnapshot,
+) -> Result<Vec<ByCommitEntry>, LixError> {
+    let generations = rebuilt_commit_generations_for_truth(truth)?;
+    let mut entries = Vec::new();
+    for (commit_id, location, commit) in truth.commits_in_segment_order() {
+        entries.push(ByCommitEntry {
+            commit_id: commit_id.to_string(),
+            location: location.clone(),
+            parent_commit_ids: commit.header.parent_commit_ids.clone(),
+            generation: *generations.get(commit_id).ok_or_else(|| {
+                LixError::unknown(format!(
+                    "changelog index rebuild did not compute generation for commit '{commit_id}'"
+                ))
+            })?,
+        });
     }
     Ok(entries)
 }
@@ -155,6 +176,33 @@ fn rebuilt_commit_generations(segments: &[Segment]) -> Result<HashMap<String, u6
             }
         }
     }
+
+    let mut generations = HashMap::new();
+    let mut visiting = HashSet::new();
+    for commit_id in parents_by_commit.keys() {
+        let generation = rebuilt_commit_generation(
+            commit_id,
+            &parents_by_commit,
+            &mut generations,
+            &mut visiting,
+        )?;
+        generations.insert(commit_id.clone(), generation);
+    }
+    Ok(generations)
+}
+
+fn rebuilt_commit_generations_for_truth(
+    truth: &SegmentTruthSnapshot,
+) -> Result<HashMap<String, u64>, LixError> {
+    let parents_by_commit = truth
+        .commits_in_segment_order()
+        .map(|(commit_id, _, commit)| {
+            (
+                commit_id.to_string(),
+                commit.header.parent_commit_ids.clone(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     let mut generations = HashMap::new();
     let mut visiting = HashSet::new();

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -8,11 +8,27 @@ use super::types::{
 use crate::common::{CanonicalSchemaKey, EntityId, FileId, LixError};
 use crate::entity_identity::EntityIdentity;
 use crate::json_store::JsonRef;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 
 const SEGMENT_MAGIC: &[u8; 5] = b"LXSG1";
 const COMMIT_VISIBILITY_MAGIC: &[u8; 5] = b"LXCV1";
 const BY_COMMIT_MAGIC: &[u8; 5] = b"LXBC1";
 const BY_CHANGE_MAGIC: &[u8; 5] = b"LXBG1";
+const SEGMENT_FORMAT_VERSION: u32 = 1;
+const MIN_STRING_BYTES: usize = 4;
+const MIN_LOCATION_BYTES: usize = MIN_STRING_BYTES + 8 + 8 + MIN_STRING_BYTES;
+const MIN_DIRECTORY_ENTRY_BYTES: usize = MIN_STRING_BYTES + MIN_LOCATION_BYTES;
+const MIN_MEMBERSHIP_RECORD_BYTES: usize = MIN_STRING_BYTES + 1 + 1;
+const MIN_STATE_ROW_IDENTITY_ENTRY_BYTES: usize =
+    MIN_STRING_BYTES + MIN_STRING_BYTES + MIN_STRING_BYTES + MIN_STRING_BYTES;
+const MIN_MEMBERSHIP_ORDINAL_BYTES: usize = MIN_STRING_BYTES + 4;
+const MIN_INLINE_PAYLOAD_BYTES: usize = 32 + 4;
+const MIN_PAYLOAD_LOCATION_BYTES: usize = 32 + 8 + 8;
+const MIN_COMMIT_OBJECT_BYTES: usize =
+    MIN_STRING_BYTES + 4 + MIN_STRING_BYTES + 4 + MIN_STRING_BYTES + 4 + MIN_STRING_BYTES;
+const MIN_CHANGE_OBJECT_BYTES: usize =
+    MIN_STRING_BYTES + 1 + 4 + MIN_STRING_BYTES + 1 + 1 + 1 + MIN_STRING_BYTES + 4 + 4;
 
 pub(crate) fn encode_segment(segment: &Segment) -> Result<Vec<u8>, LixError> {
     Ok(encode_segment_with_object_locations(segment)?.bytes)
@@ -73,26 +89,455 @@ pub(crate) fn decode_segment(bytes: &[u8]) -> Result<Segment, LixError> {
     let mut cursor = ByteCursor::new(bytes);
     cursor.expect_magic(SEGMENT_MAGIC, "segment")?;
     let header = cursor.read_segment_header("header")?;
-    let directory = cursor.read_segment_directory("directory")?;
+    let directory = cursor.read_segment_directory(
+        "directory",
+        header.commit_count as usize,
+        header.change_count as usize,
+    )?;
     let commit_len = cursor.read_len("commits")?;
     cursor.ensure_len_fits_remaining(commit_len, "commits")?;
+    cursor.ensure_counted_records_fit_remaining(commit_len, MIN_COMMIT_OBJECT_BYTES, "commits")?;
+    validate_count_matches_usize("commit_count", header.commit_count, commit_len, "commits")?;
     let mut commits = Vec::with_capacity(commit_len);
     for index in 0..commit_len {
         commits.push(cursor.read_segment_commit(&format!("commits[{index}]"))?);
     }
     let change_len = cursor.read_len("changes")?;
     cursor.ensure_len_fits_remaining(change_len, "changes")?;
+    cursor.ensure_counted_records_fit_remaining(change_len, MIN_CHANGE_OBJECT_BYTES, "changes")?;
+    validate_count_matches_usize("change_count", header.change_count, change_len, "changes")?;
     let mut changes = Vec::with_capacity(change_len);
+    let mut remaining_payload_count = header.payload_count as usize;
     for index in 0..change_len {
-        changes.push(cursor.read_segment_change(&format!("changes[{index}]"))?);
+        changes.push(cursor.read_segment_change(
+            &format!("changes[{index}]"),
+            Some(&mut remaining_payload_count),
+        )?);
     }
     cursor.expect_end("segment")?;
-    Ok(Segment {
+    validate_count_matches_usize(
+        "payload_count",
+        header.payload_count,
+        header.payload_count as usize - remaining_payload_count,
+        "inline payloads",
+    )?;
+    validate_segment_header_object_counts(
+        header.commit_count,
+        header.change_count,
+        header.payload_count,
+        commits.len(),
+        changes.as_slice(),
+    )?;
+    let commit_memberships = commits
+        .iter()
+        .map(|commit| {
+            commit
+                .body
+                .membership
+                .iter()
+                .map(|membership| CommitMembershipDescriptor {
+                    member_change_id: Cow::Owned(membership.member_change_id.clone()),
+                    role: membership.role,
+                    source_parent_ordinal: membership.source_parent_ordinal,
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    validate_segment_commit_state_row_identities(
+        commits
+            .iter()
+            .zip(commit_memberships.iter())
+            .map(|(commit, memberships)| {
+                (
+                    commit.header.id.as_str(),
+                    memberships.as_slice(),
+                    commit.directory.state_row_identities.as_slice(),
+                )
+            }),
+        changes.iter().map(|change| {
+            Ok((
+                change.id.as_str(),
+                ChangeValidationDescriptor {
+                    state_row_identity: state_row_identity_for_change(change)?,
+                    authored_commit_id: change.authored_commit_id.as_deref(),
+                },
+            ))
+        }),
+    )?;
+    let (commit_slices, change_slices) = read_segment_object_slices_view(bytes)?;
+    validate_segment_directory_object_slices_owned(
+        &header.segment_id,
+        &directory,
+        &commit_slices,
+        &change_slices,
+    )?;
+    let segment = Segment {
         header,
         directory,
         commits,
         changes,
-    })
+    };
+    Ok(segment)
+}
+
+fn validate_commit_checksum(commit: &SegmentCommit) -> Result<(), LixError> {
+    let canonical = checksum_commit(commit)?;
+    if commit.checksum != canonical {
+        return Err(LixError::unknown(format!(
+            "changelog commit '{}' checksum '{}' does not match canonical checksum '{}'",
+            commit.header.id, commit.checksum, canonical
+        )));
+    }
+    Ok(())
+}
+
+fn validate_segment_view_checksum(
+    bytes: &[u8],
+    header: &SegmentHeaderView<'_>,
+    directory_changes: &[SegmentDirectoryEntryRef<'_>],
+    commits: &[SegmentCommitSliceRead<'_>],
+    changes: &[SegmentChangeSliceRead<'_>],
+) -> Result<(), LixError> {
+    if header.byte_count != bytes.len() as u64 {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{}' byte_count {} does not match encoded length {}",
+            header.segment_id,
+            header.byte_count,
+            bytes.len()
+        )));
+    }
+    let change_checksums = changes
+        .iter()
+        .map(|change| (change.slice.id, change.checksum.as_str()))
+        .collect::<HashMap<_, _>>();
+    for entry in directory_changes {
+        let Some(canonical) = change_checksums.get(entry.id) else {
+            continue;
+        };
+        if entry.location.checksum != *canonical {
+            return Err(LixError::unknown(format!(
+                "changelog change '{}' locator checksum '{}' does not match canonical checksum '{}'",
+                entry.id, entry.location.checksum, canonical
+            )));
+        }
+    }
+    let canonical = checksum_segment_from_view(header, commits, changes)?;
+    if header.checksum != canonical {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{}' checksum '{}' does not match canonical checksum '{}'",
+            header.segment_id, header.checksum, canonical
+        )));
+    }
+    Ok(())
+}
+
+fn checksum_segment_from_view(
+    header: &SegmentHeaderView<'_>,
+    commits: &[SegmentCommitSliceRead<'_>],
+    changes: &[SegmentChangeSliceRead<'_>],
+) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "segment");
+    hash_field(&mut hasher, "segment_id", header.segment_id);
+    hash_field(
+        &mut hasher,
+        "format_version",
+        &header.format_version.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "commit_count",
+        &header.commit_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "change_count",
+        &header.change_count.to_string(),
+    );
+    hash_field(&mut hasher, "byte_count", &header.byte_count.to_string());
+    hash_field(
+        &mut hasher,
+        "payload_count",
+        &header.payload_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "commits", commits.len());
+    for commit in commits {
+        hash_part(&mut hasher, "commit");
+        hash_field(&mut hasher, "id", commit.slice.id);
+        hash_field(&mut hasher, "checksum", &commit.checksum);
+    }
+    hash_list_len(&mut hasher, "changes", changes.len());
+    for change in changes {
+        hash_part(&mut hasher, "change");
+        hash_field(&mut hasher, "id", change.slice.id);
+        hash_field(&mut hasher, "checksum", &change.checksum);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn checksum_segment(segment: &Segment) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "segment");
+    hash_field(&mut hasher, "segment_id", &segment.header.segment_id);
+    hash_field(
+        &mut hasher,
+        "format_version",
+        &segment.header.format_version.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "commit_count",
+        &segment.header.commit_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "change_count",
+        &segment.header.change_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "byte_count",
+        &segment.header.byte_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "payload_count",
+        &segment.header.payload_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "commits", segment.commits.len());
+    for commit in &segment.commits {
+        hash_part(&mut hasher, "commit");
+        hash_field(&mut hasher, "id", &commit.header.id);
+        hash_field(&mut hasher, "checksum", &commit.checksum);
+    }
+    hash_list_len(&mut hasher, "changes", segment.changes.len());
+    for change in &segment.changes {
+        hash_part(&mut hasher, "change");
+        hash_field(&mut hasher, "id", &change.id);
+        hash_field(&mut hasher, "checksum", &checksum_change(change)?);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn checksum_commit(commit: &SegmentCommit) -> Result<String, LixError> {
+    let memberships = commit
+        .body
+        .membership
+        .iter()
+        .map(|membership| CommitMembershipDescriptor {
+            member_change_id: Cow::Owned(membership.member_change_id.clone()),
+            role: membership.role,
+            source_parent_ordinal: membership.source_parent_ordinal,
+        })
+        .collect::<Vec<_>>();
+    checksum_commit_parts(
+        &commit.header.id,
+        commit.header.parent_commit_ids.iter().map(String::as_str),
+        &commit.header.derivable_change_id,
+        commit.header.author_account_ids.iter().map(String::as_str),
+        &commit.header.created_at,
+        commit.header.membership_count,
+        &memberships,
+        &commit.directory,
+    )
+}
+
+fn checksum_commit_parts<'a>(
+    id: &str,
+    parent_commit_ids: impl Iterator<Item = &'a str>,
+    derivable_change_id: &str,
+    author_account_ids: impl Iterator<Item = &'a str>,
+    created_at: &str,
+    membership_count: u32,
+    memberships: &[CommitMembershipDescriptor<'_>],
+    directory: &SegmentCommitDirectory,
+) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "commit");
+    hash_field(&mut hasher, "id", id);
+    let parent_commit_ids = parent_commit_ids.collect::<Vec<_>>();
+    hash_list_len(&mut hasher, "parent_commit_ids", parent_commit_ids.len());
+    for parent in parent_commit_ids {
+        hash_field(&mut hasher, "parent_commit_id", parent);
+    }
+    hash_field(&mut hasher, "derivable_change_id", derivable_change_id);
+    let author_account_ids = author_account_ids.collect::<Vec<_>>();
+    hash_list_len(&mut hasher, "author_account_ids", author_account_ids.len());
+    for account_id in author_account_ids {
+        hash_field(&mut hasher, "author_account_id", account_id);
+    }
+    hash_field(&mut hasher, "created_at", created_at);
+    hash_field(
+        &mut hasher,
+        "membership_count",
+        &membership_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "memberships", memberships.len());
+    for membership in memberships {
+        hash_part(&mut hasher, "membership");
+        hash_field(
+            &mut hasher,
+            "member_change_id",
+            &membership.member_change_id,
+        );
+        hash_field(
+            &mut hasher,
+            "role",
+            match membership.role {
+                MembershipRole::Authored => "authored",
+                MembershipRole::Adopted => "adopted",
+            },
+        );
+        hash_field(
+            &mut hasher,
+            "source_parent_ordinal",
+            &membership
+                .source_parent_ordinal
+                .map(|ordinal| ordinal.to_string())
+                .unwrap_or_default(),
+        );
+    }
+    hash_list_len(
+        &mut hasher,
+        "state_row_identities",
+        directory.state_row_identities.len(),
+    );
+    for (identity, change_id) in &directory.state_row_identities {
+        hash_part(&mut hasher, "state_row_identity");
+        hash_field(&mut hasher, "schema_key", identity.schema_key.as_str());
+        hash_field(&mut hasher, "file_id", identity.file_id.as_str());
+        hash_field(&mut hasher, "entity_id", identity.entity_id.as_str());
+        hash_field(&mut hasher, "change_id", change_id);
+    }
+    hash_list_len(
+        &mut hasher,
+        "membership_ordinals",
+        directory.membership_ordinals.len(),
+    );
+    for (change_id, ordinal) in &directory.membership_ordinals {
+        hash_part(&mut hasher, "membership_ordinal");
+        hash_field(&mut hasher, "change_id", change_id);
+        hash_field(&mut hasher, "ordinal", &ordinal.to_string());
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn checksum_change(change: &SegmentChange) -> Result<String, LixError> {
+    checksum_change_parts(
+        &change.id,
+        change.authored_commit_id.as_deref(),
+        &change.entity_id,
+        &change.schema_key,
+        change.file_id.as_deref(),
+        change.snapshot_ref.as_ref(),
+        change.metadata_ref.as_ref(),
+        &change.created_at,
+        &change
+            .inline_payloads
+            .iter()
+            .map(|payload| SegmentInlinePayloadRef {
+                json_ref: payload.json_ref.clone(),
+                bytes: payload.bytes.as_slice(),
+            })
+            .collect::<Vec<_>>(),
+        &change.directory,
+    )
+}
+
+fn checksum_change_parts(
+    id: &str,
+    authored_commit_id: Option<&str>,
+    entity_id: &EntityIdentity,
+    schema_key: &str,
+    file_id: Option<&str>,
+    snapshot_ref: Option<&JsonRef>,
+    metadata_ref: Option<&JsonRef>,
+    created_at: &str,
+    inline_payloads: &[SegmentInlinePayloadRef<'_>],
+    directory: &SegmentChangeDirectory,
+) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "change");
+    hash_field(&mut hasher, "id", id);
+    hash_optional_str(&mut hasher, "authored_commit_id", authored_commit_id);
+    hash_list_len(&mut hasher, "entity_id", entity_id.parts.len());
+    for part in &entity_id.parts {
+        hash_field(&mut hasher, "entity_id_part", part);
+    }
+    hash_field(&mut hasher, "schema_key", schema_key);
+    hash_optional_str(&mut hasher, "file_id", file_id);
+    hash_optional_json_ref(&mut hasher, "snapshot_ref", snapshot_ref);
+    hash_optional_json_ref(&mut hasher, "metadata_ref", metadata_ref);
+    hash_field(&mut hasher, "created_at", created_at);
+    hash_list_len(&mut hasher, "inline_payloads", inline_payloads.len());
+    for payload in inline_payloads {
+        hash_part(&mut hasher, "inline_payload");
+        hash_json_ref(&mut hasher, "json_ref", &payload.json_ref);
+        hash_bytes_field(&mut hasher, "bytes", payload.bytes);
+    }
+    hash_list_len(&mut hasher, "directory_payloads", directory.payloads.len());
+    for payload_location in &directory.payloads {
+        hash_part(&mut hasher, "payload_location");
+        hash_json_ref(&mut hasher, "json_ref", &payload_location.json_ref);
+        hash_field(&mut hasher, "offset", &payload_location.offset.to_string());
+        hash_field(&mut hasher, "len", &payload_location.len.to_string());
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn hash_part(hasher: &mut blake3::Hasher, value: &str) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn hash_field(hasher: &mut blake3::Hasher, field: &str, value: &str) {
+    hash_part(hasher, field);
+    hash_part(hasher, value);
+}
+
+fn hash_list_len(hasher: &mut blake3::Hasher, field: &str, len: usize) {
+    hash_part(hasher, field);
+    hasher.update(&(len as u64).to_le_bytes());
+}
+
+fn hash_bytes_part(hasher: &mut blake3::Hasher, value: &[u8]) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn hash_bytes_field(hasher: &mut blake3::Hasher, field: &str, value: &[u8]) {
+    hash_part(hasher, field);
+    hash_bytes_part(hasher, value);
+}
+
+fn hash_optional_str(hasher: &mut blake3::Hasher, field: &str, value: Option<&str>) {
+    hash_part(hasher, field);
+    match value {
+        Some(value) => {
+            hash_part(hasher, "some");
+            hash_part(hasher, value);
+        }
+        None => hash_part(hasher, "none"),
+    }
+}
+
+fn hash_optional_json_ref(hasher: &mut blake3::Hasher, field: &str, value: Option<&JsonRef>) {
+    hash_part(hasher, field);
+    match value {
+        Some(value) => {
+            hash_part(hasher, "some");
+            hash_json_ref(hasher, "json_ref", value);
+        }
+        None => hash_part(hasher, "none"),
+    }
+}
+
+fn hash_json_ref(hasher: &mut blake3::Hasher, field: &str, value: &JsonRef) {
+    hash_bytes_field(hasher, field, value.as_hash_bytes());
+}
+
+fn empty_checksum() -> String {
+    "0".repeat(64)
 }
 
 pub(crate) fn decode_segment_commit(bytes: &[u8]) -> Result<SegmentCommit, LixError> {
@@ -104,29 +549,159 @@ pub(crate) fn decode_segment_commit(bytes: &[u8]) -> Result<SegmentCommit, LixEr
 
 pub(crate) fn segment_commit_membership_contains_any(
     bytes: &[u8],
+    expected_commit_id: &str,
+    expected_checksum: &str,
     requested_change_ids: &std::collections::HashSet<String>,
 ) -> Result<Vec<String>, LixError> {
     let mut cursor = ByteCursor::new(bytes);
-    cursor.skip_commit_header_fast()?;
-    cursor.read_matching_membership_change_ids(requested_change_ids)
+    let id = cursor.read_string_ref_fast()?;
+    if id != expected_commit_id {
+        return Err(LixError::unknown(format!(
+            "changelog commit locator for '{expected_commit_id}' decoded commit '{id}'"
+        )));
+    }
+    let parent_commit_ids = cursor.read_strings_fast_refs()?;
+    let parent_count = parent_commit_ids.len();
+    let derivable_change_id = cursor.read_string_ref_fast()?;
+    let author_account_ids = cursor.read_strings_fast_refs()?;
+    let created_at = cursor.read_string_ref_fast()?;
+    let membership_count = cursor.read_u32_fast()? as usize;
+    let (matches, memberships) =
+        cursor.read_matching_membership_change_ids(membership_count, requested_change_ids)?;
+    let directory =
+        cursor.read_segment_commit_directory_fast_validated(id, parent_count, &memberships)?;
+    let checksum = cursor.read_string_ref_fast()?;
+    if checksum != expected_checksum {
+        return Err(LixError::unknown(format!(
+            "changelog commit '{id}' locator checksum '{expected_checksum}' does not match encoded checksum '{checksum}'"
+        )));
+    }
+    cursor.expect_end("commit")?;
+    let canonical = checksum_commit_parts(
+        id,
+        parent_commit_ids.iter().copied(),
+        derivable_change_id,
+        author_account_ids.iter().copied(),
+        created_at,
+        membership_count as u32,
+        &memberships,
+        &directory,
+    )?;
+    if checksum != canonical {
+        return Err(LixError::unknown(format!(
+            "changelog commit '{id}' checksum '{checksum}' does not match canonical checksum '{canonical}'"
+        )));
+    }
+    Ok(matches)
 }
 
 pub(crate) fn decode_segment_change(bytes: &[u8]) -> Result<SegmentChange, LixError> {
     let mut cursor = ByteCursor::new(bytes);
-    let change = cursor.read_segment_change("change")?;
+    let change = cursor.read_segment_change("change", None)?;
     cursor.expect_end("change")?;
+    state_row_identity_for_change(&change)?;
     Ok(change)
 }
 
 pub(crate) fn view_segment(bytes: &[u8]) -> Result<SegmentView<'_>, LixError> {
+    let cursor = read_segment_header_and_directory_view(bytes, false)?;
+    let header = cursor.header;
+    let directory_commits = cursor.directory_commits;
+    let directory_changes = cursor.directory_changes;
+    let mut object_cursor = cursor.cursor.clone();
+    let objects = read_segment_object_slices_for_header_fast(&mut object_cursor, &header)?;
+    let commit_slices = objects.commit_slices();
+    let change_slices = objects.change_slices();
+    validate_segment_directory_object_slices_ref(
+        header.segment_id,
+        &directory_commits,
+        &directory_changes,
+        &commit_slices,
+        &change_slices,
+    )?;
+    validate_segment_view_checksum(
+        bytes,
+        &header,
+        &directory_changes,
+        &objects.commits,
+        &objects.changes,
+    )?;
+    let object_bytes = cursor.cursor.remaining_bytes();
+
+    Ok(segment_view_from_parts(
+        bytes,
+        header,
+        directory_commits,
+        directory_changes,
+        object_bytes,
+    ))
+}
+
+pub(crate) fn view_segment_directory(bytes: &[u8]) -> Result<SegmentView<'_>, LixError> {
+    let cursor = read_segment_header_and_directory_view(bytes, true)?;
+    let object_bytes = cursor.cursor.remaining_bytes();
+
+    Ok(segment_view_from_parts(
+        bytes,
+        cursor.header,
+        cursor.directory_commits,
+        cursor.directory_changes,
+        object_bytes,
+    ))
+}
+
+struct SegmentDirectoryViewRead<'a> {
+    cursor: ByteCursor<'a>,
+    header: SegmentHeaderView<'a>,
+    directory_commits: Vec<SegmentDirectoryEntryRef<'a>>,
+    directory_changes: Vec<SegmentDirectoryEntryRef<'a>>,
+}
+
+fn read_segment_header_and_directory_view(
+    bytes: &[u8],
+    validate_encoded_bounds: bool,
+) -> Result<SegmentDirectoryViewRead<'_>, LixError> {
     let mut cursor = ByteCursor::new(bytes);
     cursor.expect_magic(SEGMENT_MAGIC, "segment")?;
     let header = cursor.read_segment_header_view_fast()?;
-    let directory_commits = cursor.read_segment_directory_commit_views_fast()?;
-    let directory_changes = cursor.read_segment_directory_change_views_fast()?;
-    let object_bytes = cursor.remaining_bytes();
+    let directory_commits =
+        cursor.read_segment_directory_commit_views_fast(header.commit_count as usize)?;
+    let directory_changes =
+        cursor.read_segment_directory_change_views_fast(header.change_count as usize)?;
+    if validate_encoded_bounds && header.byte_count != bytes.len() as u64 {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{}' byte_count {} does not match encoded length {}",
+            header.segment_id,
+            header.byte_count,
+            bytes.len()
+        )));
+    }
+    if validate_encoded_bounds {
+        validate_directory_locations_are_in_bounds(
+            header.segment_id,
+            bytes.len() as u64,
+            directory_commits
+                .iter()
+                .chain(directory_changes.iter())
+                .copied(),
+        )?;
+    }
+    Ok(SegmentDirectoryViewRead {
+        cursor,
+        header,
+        directory_commits,
+        directory_changes,
+    })
+}
 
-    Ok(SegmentView {
+fn segment_view_from_parts<'a>(
+    bytes: &'a [u8],
+    header: SegmentHeaderView<'a>,
+    directory_commits: Vec<SegmentDirectoryEntryRef<'a>>,
+    directory_changes: Vec<SegmentDirectoryEntryRef<'a>>,
+    object_bytes: &'a [u8],
+) -> SegmentView<'a> {
+    SegmentView {
         bytes,
         segment_id: header.segment_id,
         format_version: header.format_version,
@@ -138,20 +713,534 @@ pub(crate) fn view_segment(bytes: &[u8]) -> Result<SegmentView<'_>, LixError> {
         directory_commits,
         directory_changes,
         object_bytes,
-    })
+    }
+}
+
+fn validate_directory_locations_are_in_bounds<'a>(
+    segment_id: &str,
+    byte_count: u64,
+    entries: impl Iterator<Item = SegmentDirectoryEntryRef<'a>>,
+) -> Result<(), LixError> {
+    let mut seen = HashSet::new();
+    for entry in entries {
+        let location = entry.location;
+        if location.segment_id != segment_id {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' directory locator for '{}' points to segment '{}'",
+                entry.id, location.segment_id
+            )));
+        }
+        if !seen.insert(entry.id) {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' contains duplicate directory locator for '{}'",
+                entry.id
+            )));
+        }
+        let end = location.offset.checked_add(location.len).ok_or_else(|| {
+            LixError::unknown(format!(
+                "changelog segment '{segment_id}' directory locator for '{}' overflows",
+                entry.id
+            ))
+        })?;
+        if end > byte_count {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' directory locator for '{}' is outside segment byte range",
+                entry.id
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn view_segment_object_slices(
     bytes: &[u8],
 ) -> Result<(Vec<SegmentObjectSlice<'_>>, Vec<SegmentObjectSlice<'_>>), LixError> {
+    read_segment_object_slices_view(bytes)
+}
+
+pub(crate) fn view_segment_object_ranges(
+    bytes: &[u8],
+) -> Result<(Vec<SegmentObjectSlice<'_>>, Vec<SegmentObjectSlice<'_>>), LixError> {
+    let cursor = read_segment_header_and_directory_view(bytes, true)?;
+    let header = cursor.header;
+    let directory_commits = cursor.directory_commits;
+    let directory_changes = cursor.directory_changes;
+    let mut object_cursor = cursor.cursor.clone();
+
+    let commit_len = object_cursor.read_len("commits")?;
+    object_cursor.ensure_len_fits_remaining(commit_len, "commits")?;
+    object_cursor.ensure_counted_records_fit_remaining(
+        commit_len,
+        MIN_COMMIT_OBJECT_BYTES,
+        "commits",
+    )?;
+    validate_count_matches_usize("commit_count", header.commit_count, commit_len, "commits")?;
+    let mut commits = Vec::with_capacity(commit_len);
+    for index in 0..commit_len {
+        commits.push(object_cursor.read_segment_commit_slice(&format!("commits[{index}]"))?);
+    }
+
+    let change_len = object_cursor.read_len("changes")?;
+    object_cursor.ensure_len_fits_remaining(change_len, "changes")?;
+    object_cursor.ensure_counted_records_fit_remaining(
+        change_len,
+        MIN_CHANGE_OBJECT_BYTES,
+        "changes",
+    )?;
+    validate_count_matches_usize("change_count", header.change_count, change_len, "changes")?;
+    let mut changes = Vec::with_capacity(change_len);
+    for index in 0..change_len {
+        changes.push(object_cursor.read_segment_change_slice(&format!("changes[{index}]"))?);
+    }
+
+    object_cursor.expect_end("segment")?;
+    validate_segment_directory_object_slices_ref(
+        header.segment_id,
+        &directory_commits,
+        &directory_changes,
+        &commits,
+        &changes,
+    )?;
+    Ok((commits, changes))
+}
+
+fn read_segment_object_slices_view(
+    bytes: &[u8],
+) -> Result<(Vec<SegmentObjectSlice<'_>>, Vec<SegmentObjectSlice<'_>>), LixError> {
     let mut cursor = ByteCursor::new(bytes);
     cursor.expect_magic(SEGMENT_MAGIC, "segment")?;
-    let _ = cursor.read_segment_header_view_fast()?;
-    let _ = cursor.read_segment_directory_commit_views_fast()?;
-    let _ = cursor.read_segment_directory_change_views_fast()?;
+    let header = cursor.read_segment_header_view_fast()?;
+    let _directory_commits =
+        cursor.read_segment_directory_commit_views_fast(header.commit_count as usize)?;
+    let _directory_changes =
+        cursor.read_segment_directory_change_views_fast(header.change_count as usize)?;
 
+    let objects = read_segment_object_slices_for_header_fast(&mut cursor, &header)?;
+    let commits = objects.commit_slices();
+    let changes = objects.change_slices();
+    validate_segment_directory_object_slices_ref(
+        header.segment_id,
+        &_directory_commits,
+        &_directory_changes,
+        &commits,
+        &changes,
+    )?;
+    validate_segment_view_checksum(
+        bytes,
+        &header,
+        &_directory_changes,
+        &objects.commits,
+        &objects.changes,
+    )?;
+    Ok((commits, changes))
+}
+
+#[derive(Clone)]
+struct PayloadDescriptor {
+    json_ref: JsonRef,
+    len: u64,
+}
+
+struct SegmentInlinePayloadRef<'a> {
+    json_ref: JsonRef,
+    bytes: &'a [u8],
+}
+
+#[derive(Clone)]
+struct CommitMembershipDescriptor<'a> {
+    member_change_id: Cow<'a, str>,
+    role: MembershipRole,
+    source_parent_ordinal: Option<u32>,
+}
+
+struct SegmentCommitSliceRead<'a> {
+    slice: SegmentObjectSlice<'a>,
+    memberships: Vec<CommitMembershipDescriptor<'a>>,
+    state_row_identities: Vec<(StateRowIdentity, String)>,
+    checksum: String,
+}
+
+struct SegmentChangeSliceRead<'a> {
+    slice: SegmentObjectSlice<'a>,
+    state_row_identity: StateRowIdentity,
+    authored_commit_id: Option<&'a str>,
+    checksum: String,
+}
+
+struct SegmentObjectSliceRead<'a> {
+    commits: Vec<SegmentCommitSliceRead<'a>>,
+    changes: Vec<SegmentChangeSliceRead<'a>>,
+}
+
+impl<'a> SegmentObjectSliceRead<'a> {
+    fn commit_slices(&self) -> Vec<SegmentObjectSlice<'a>> {
+        self.commits.iter().map(|commit| commit.slice).collect()
+    }
+
+    fn change_slices(&self) -> Vec<SegmentObjectSlice<'a>> {
+        self.changes.iter().map(|change| change.slice).collect()
+    }
+}
+
+fn validate_segment_header_object_counts(
+    header_commit_count: u32,
+    header_change_count: u32,
+    header_payload_count: u32,
+    commit_count: usize,
+    changes: &[SegmentChange],
+) -> Result<(), LixError> {
+    validate_count_matches_usize("commit_count", header_commit_count, commit_count, "commits")?;
+    validate_count_matches_usize(
+        "change_count",
+        header_change_count,
+        changes.len(),
+        "changes",
+    )?;
+    let payload_count = changes.iter().try_fold(0_usize, |count, change| {
+        count
+            .checked_add(change.inline_payloads.len())
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "failed to decode changelog segment: inline payload count overflows",
+                )
+            })
+    })?;
+    validate_count_matches_usize(
+        "payload_count",
+        header_payload_count,
+        payload_count,
+        "inline payloads",
+    )
+}
+
+fn validate_change_payload_directory(
+    change_id: &str,
+    inline_payloads: &[SegmentInlinePayload],
+    directory: &SegmentChangeDirectory,
+) -> Result<(), LixError> {
+    validate_count_matches_usize(
+        "payload_count",
+        inline_payloads.len() as u32,
+        directory.payloads.len(),
+        "change directory payloads",
+    )?;
+    let inline_payloads = inline_payloads
+        .iter()
+        .map(|payload| PayloadDescriptor {
+            json_ref: payload.json_ref.clone(),
+            len: payload.bytes.len() as u64,
+        })
+        .collect::<Vec<_>>();
+    validate_payload_descriptors_against_directory(change_id, &inline_payloads, directory)
+}
+
+fn validate_payload_descriptors_against_directory(
+    change_id: &str,
+    inline_payloads: &[PayloadDescriptor],
+    directory: &SegmentChangeDirectory,
+) -> Result<(), LixError> {
+    let mut inline_by_ref = HashMap::with_capacity(inline_payloads.len());
+    for (ordinal, payload) in inline_payloads.iter().enumerate() {
+        if inline_by_ref
+            .insert(
+                payload.json_ref.as_hash_bytes(),
+                (ordinal as u64, payload.len),
+            )
+            .is_some()
+        {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' contains duplicate inline payload ref"
+            )));
+        }
+    }
+
+    let mut directory_payload_refs = HashSet::with_capacity(directory.payloads.len());
+    for location in &directory.payloads {
+        let json_ref = location.json_ref.as_hash_bytes();
+        if !directory_payload_refs.insert(json_ref) {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' contains duplicate payload directory entry"
+            )));
+        }
+        let Some((ordinal, len)) = inline_by_ref.get(&json_ref) else {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' payload directory references unknown inline payload"
+            )));
+        };
+        if location.offset != *ordinal || location.len != *len {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' payload directory entry does not match inline payload"
+            )));
+        }
+    }
+
+    if directory_payload_refs.len() != inline_by_ref.len() {
+        return Err(LixError::unknown(format!(
+            "changelog change '{change_id}' is missing payload directory entry"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_inline_payload_ref(
+    change_id: &str,
+    json_ref: &JsonRef,
+    bytes: &[u8],
+) -> Result<(), LixError> {
+    let actual = JsonRef::for_content(bytes);
+    if json_ref != &actual {
+        return Err(LixError::unknown(format!(
+            "changelog change '{change_id}' inline payload ref '{}' does not match payload bytes '{}'",
+            json_ref.to_hex(),
+            actual.to_hex()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_commit_object_consistency(
+    header: &CommitHeader,
+    body: &CommitBody,
+    directory: &SegmentCommitDirectory,
+) -> Result<(), LixError> {
+    let memberships = body
+        .membership
+        .iter()
+        .map(|membership| CommitMembershipDescriptor {
+            member_change_id: Cow::Owned(membership.member_change_id.clone()),
+            role: membership.role,
+            source_parent_ordinal: membership.source_parent_ordinal,
+        })
+        .collect::<Vec<_>>();
+    validate_commit_membership_descriptors(
+        &header.id,
+        header.parent_commit_ids.len(),
+        &memberships,
+    )?;
+    validate_commit_directory_descriptors(
+        &header.id,
+        &memberships,
+        directory
+            .state_row_identities
+            .iter()
+            .map(|(identity, change_id)| (identity, change_id.as_str())),
+        directory
+            .membership_ordinals
+            .iter()
+            .map(|(change_id, ordinal)| (change_id.as_str(), *ordinal)),
+    )
+}
+
+fn validate_commit_membership_descriptors(
+    commit_id: &str,
+    parent_count: usize,
+    memberships: &[CommitMembershipDescriptor<'_>],
+) -> Result<(), LixError> {
+    let mut member_ids = HashSet::with_capacity(memberships.len());
+    for membership in memberships {
+        match membership.role {
+            MembershipRole::Authored => {
+                if membership.source_parent_ordinal.is_some() {
+                    return Err(LixError::unknown(format!(
+                        "changelog commit '{commit_id}' authored membership change '{}' must not record a source_parent_ordinal",
+                        membership.member_change_id
+                    )));
+                }
+            }
+            MembershipRole::Adopted => {
+                let Some(source_parent_ordinal) = membership.source_parent_ordinal else {
+                    return Err(LixError::unknown(format!(
+                        "changelog commit '{commit_id}' adopted membership change '{}' is missing source_parent_ordinal",
+                        membership.member_change_id
+                    )));
+                };
+                if source_parent_ordinal as usize >= parent_count {
+                    return Err(LixError::unknown(format!(
+                        "changelog commit '{commit_id}' adopted membership change '{}' source_parent_ordinal {} is out of bounds for {} parents",
+                        membership.member_change_id, source_parent_ordinal, parent_count
+                    )));
+                }
+            }
+        }
+        if !member_ids.insert(membership.member_change_id.as_ref()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate membership change '{}'",
+                membership.member_change_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_commit_directory_descriptors<'a>(
+    commit_id: &str,
+    memberships: &[CommitMembershipDescriptor<'_>],
+    state_row_identities: impl Iterator<Item = (&'a StateRowIdentity, &'a str)>,
+    membership_ordinals: impl Iterator<Item = (&'a str, u32)>,
+) -> Result<(), LixError> {
+    let member_ids = memberships
+        .iter()
+        .map(|membership| membership.member_change_id.as_ref())
+        .collect::<HashSet<_>>();
+
+    let mut ordinal_ids = HashSet::with_capacity(memberships.len());
+    let membership_ordinals_by_id = memberships
+        .iter()
+        .enumerate()
+        .map(|(ordinal, membership)| (membership.member_change_id.as_ref(), ordinal))
+        .collect::<HashMap<_, _>>();
+    for (change_id, ordinal) in membership_ordinals {
+        if !ordinal_ids.insert(change_id) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate membership ordinal for change '{change_id}'"
+            )));
+        }
+        let Some(expected_ordinal) = membership_ordinals_by_id.get(change_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' membership ordinal references non-member change '{change_id}'"
+            )));
+        };
+        if ordinal as usize != *expected_ordinal {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' membership ordinal for change '{change_id}' is {ordinal}, expected {expected_ordinal}"
+            )));
+        }
+    }
+    for membership in memberships {
+        if !ordinal_ids.contains(membership.member_change_id.as_ref()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' is missing membership ordinal for change '{}'",
+                membership.member_change_id
+            )));
+        }
+    }
+
+    let mut identities = HashSet::new();
+    let mut directory_change_ids = HashSet::with_capacity(memberships.len());
+    for (identity, change_id) in state_row_identities {
+        if !identities.insert(identity) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate StateRowIdentity winner"
+            )));
+        }
+        if !directory_change_ids.insert(change_id) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate StateRowIdentity winner for change '{change_id}'"
+            )));
+        }
+        if !member_ids.contains(change_id) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' StateRowIdentity winner references non-member change '{change_id}'"
+            )));
+        }
+    }
+    for membership in memberships {
+        if !directory_change_ids.contains(membership.member_change_id.as_ref()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' membership change '{}' is missing from SegmentCommitDirectory",
+                membership.member_change_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_segment_commit_state_row_identities<'a>(
+    commits: impl Iterator<
+        Item = (
+            &'a str,
+            &'a [CommitMembershipDescriptor<'a>],
+            &'a [(StateRowIdentity, String)],
+        ),
+    >,
+    changes: impl Iterator<Item = Result<(&'a str, ChangeValidationDescriptor<'a>), LixError>>,
+) -> Result<(), LixError> {
+    let mut changes_by_id = HashMap::new();
+    for change in changes {
+        let (change_id, descriptor) = change?;
+        changes_by_id.insert(change_id, descriptor);
+    }
+    for (commit_id, memberships, state_row_identities) in commits {
+        let memberships_by_id = memberships
+            .iter()
+            .map(|membership| (membership.member_change_id.as_ref(), membership.role))
+            .collect::<HashMap<_, _>>();
+        for membership in memberships {
+            let Some(change) = changes_by_id.get(membership.member_change_id.as_ref()) else {
+                continue;
+            };
+            match membership.role {
+                MembershipRole::Authored => {
+                    if change.authored_commit_id != Some(commit_id) {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{commit_id}' authored membership change '{}' has mismatched authored_commit_id",
+                            membership.member_change_id
+                        )));
+                    }
+                }
+                MembershipRole::Adopted => {
+                    if change.authored_commit_id == Some(commit_id) {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{commit_id}' adopted membership change '{}' must not be authored by the same commit",
+                            membership.member_change_id
+                        )));
+                    }
+                }
+            }
+        }
+        for (identity, change_id) in state_row_identities {
+            let Some(change) = changes_by_id.get(change_id.as_str()) else {
+                if memberships_by_id.get(change_id.as_str()) == Some(&MembershipRole::Adopted) {
+                    continue;
+                }
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' StateRowIdentity winner references missing authored change '{change_id}'"
+                )));
+            };
+            if change.state_row_identity != *identity {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' StateRowIdentity winner for change '{change_id}' does not match changelog.change"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+struct ChangeValidationDescriptor<'a> {
+    state_row_identity: StateRowIdentity,
+    authored_commit_id: Option<&'a str>,
+}
+
+fn state_row_identity_for_change(change: &SegmentChange) -> Result<StateRowIdentity, LixError> {
+    state_row_identity_for_change_fields(
+        &change.schema_key,
+        change.file_id.as_deref(),
+        &change.entity_id,
+    )
+}
+
+fn state_row_identity_for_change_fields(
+    schema_key: &str,
+    file_id: Option<&str>,
+    entity_id: &EntityIdentity,
+) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(schema_key.to_string())?,
+        file_id: FileId::new(file_id.unwrap_or("__global__").to_string())?,
+        entity_id: EntityId::new(entity_id.as_json_array_text()?)?,
+    })
+}
+
+fn read_segment_object_slices_for_header_fast<'a>(
+    cursor: &mut ByteCursor<'a>,
+    header: &SegmentHeaderView<'_>,
+) -> Result<SegmentObjectSliceRead<'a>, LixError> {
     let commit_len = cursor.read_len_fast()?;
     cursor.ensure_len_fits_remaining_fast(commit_len)?;
+    cursor.ensure_counted_records_fit_remaining_fast(commit_len, MIN_COMMIT_OBJECT_BYTES)?;
+    validate_count_matches_usize("commit_count", header.commit_count, commit_len, "commits")?;
     let mut commits = Vec::with_capacity(commit_len);
     for _ in 0..commit_len {
         commits.push(cursor.read_segment_commit_slice_fast()?);
@@ -159,13 +1248,215 @@ pub(crate) fn view_segment_object_slices(
 
     let change_len = cursor.read_len_fast()?;
     cursor.ensure_len_fits_remaining_fast(change_len)?;
+    cursor.ensure_counted_records_fit_remaining_fast(change_len, MIN_CHANGE_OBJECT_BYTES)?;
+    validate_count_matches_usize("change_count", header.change_count, change_len, "changes")?;
     let mut changes = Vec::with_capacity(change_len);
+    let mut payload_count = 0_usize;
+    let mut remaining_payload_count = header.payload_count as usize;
     for _ in 0..change_len {
-        changes.push(cursor.read_segment_change_slice_fast()?);
+        let (change, change_payload_count) =
+            cursor.read_segment_change_slice_with_count_fast(Some(remaining_payload_count))?;
+        remaining_payload_count = remaining_payload_count
+            .checked_sub(change_payload_count)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "failed to decode changelog segment: inline payload count exceeds header payload_count",
+                )
+            })?;
+        payload_count = payload_count
+            .checked_add(change_payload_count)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "failed to decode changelog segment: inline payload count overflows",
+                )
+            })?;
+        changes.push(change);
     }
 
     cursor.expect_end("segment")?;
-    Ok((commits, changes))
+    validate_count_matches_usize(
+        "payload_count",
+        header.payload_count,
+        payload_count,
+        "inline payloads",
+    )?;
+    validate_segment_commit_state_row_identities(
+        commits.iter().map(|commit| {
+            (
+                commit.slice.id,
+                commit.memberships.as_slice(),
+                commit.state_row_identities.as_slice(),
+            )
+        }),
+        changes.iter().map(|change| {
+            Ok((
+                change.slice.id,
+                ChangeValidationDescriptor {
+                    state_row_identity: change.state_row_identity.clone(),
+                    authored_commit_id: change.authored_commit_id,
+                },
+            ))
+        }),
+    )?;
+    Ok(SegmentObjectSliceRead { commits, changes })
+}
+
+fn validate_segment_directory_object_slices_owned(
+    segment_id: &str,
+    directory: &SegmentDirectory,
+    commit_slices: &[SegmentObjectSlice<'_>],
+    change_slices: &[SegmentObjectSlice<'_>],
+) -> Result<(), LixError> {
+    let commits = directory
+        .commits
+        .iter()
+        .map(|(id, location)| (id.as_str(), location.as_ref()));
+    let changes = directory
+        .changes
+        .iter()
+        .map(|(id, location)| (id.as_str(), location.as_ref()));
+    validate_segment_directory_object_slices(
+        segment_id,
+        commits,
+        changes,
+        commit_slices,
+        change_slices,
+    )
+}
+
+fn validate_segment_directory_object_slices_ref(
+    segment_id: &str,
+    directory_commits: &[SegmentDirectoryEntryRef<'_>],
+    directory_changes: &[SegmentDirectoryEntryRef<'_>],
+    commit_slices: &[SegmentObjectSlice<'_>],
+    change_slices: &[SegmentObjectSlice<'_>],
+) -> Result<(), LixError> {
+    validate_segment_directory_object_slices(
+        segment_id,
+        directory_commits
+            .iter()
+            .map(|entry| (entry.id, entry.location)),
+        directory_changes
+            .iter()
+            .map(|entry| (entry.id, entry.location)),
+        commit_slices,
+        change_slices,
+    )
+}
+
+fn validate_segment_directory_object_slices<'a>(
+    segment_id: &str,
+    directory_commits: impl Iterator<Item = (&'a str, SegmentObjectLocationRef<'a>)>,
+    directory_changes: impl Iterator<Item = (&'a str, SegmentObjectLocationRef<'a>)>,
+    commit_slices: &[SegmentObjectSlice<'_>],
+    change_slices: &[SegmentObjectSlice<'_>],
+) -> Result<(), LixError> {
+    validate_directory_entries_against_slices(
+        segment_id,
+        "commit",
+        directory_commits,
+        commit_slices,
+        true,
+    )?;
+    validate_directory_entries_against_slices(
+        segment_id,
+        "change",
+        directory_changes,
+        change_slices,
+        false,
+    )
+}
+
+fn validate_directory_entries_against_slices<'a>(
+    segment_id: &str,
+    kind: &str,
+    entries: impl Iterator<Item = (&'a str, SegmentObjectLocationRef<'a>)>,
+    slices: &[SegmentObjectSlice<'_>],
+    validate_encoded_checksum: bool,
+) -> Result<(), LixError> {
+    let mut seen = HashSet::with_capacity(slices.len());
+    let mut entry_count = 0_usize;
+    for (index, (id, location)) in entries.enumerate() {
+        entry_count += 1;
+        if location.segment_id != segment_id {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' {kind} '{id}' locator points to segment '{}'",
+                location.segment_id
+            )));
+        }
+        let Some(slice) = slices.get(index) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' contains extra {kind} directory entry '{id}'"
+            )));
+        };
+        if id != slice.id {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' {kind} directory order does not match encoded object order"
+            )));
+        }
+        if !seen.insert(id) {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' contains duplicate {kind} directory entry '{id}'"
+            )));
+        }
+        if location.offset != slice.offset || location.len != slice.len {
+            return Err(LixError::unknown(format!(
+                "changelog {kind} '{id}' locator offset/len does not match encoded byte range"
+            )));
+        }
+        if validate_encoded_checksum {
+            if let Some(encoded_checksum) = slice.encoded_checksum {
+                if location.checksum != encoded_checksum {
+                    return Err(LixError::unknown(format!(
+                        "changelog {kind} '{id}' locator checksum does not match encoded object checksum"
+                    )));
+                }
+            }
+        }
+    }
+    if entry_count != slices.len() {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{segment_id}' {kind} directory count does not match encoded object count"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_segment_format_version(format_version: u32, field: &str) -> Result<(), LixError> {
+    if format_version != SEGMENT_FORMAT_VERSION {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "failed to decode changelog segment: {field} format_version {format_version} is not supported"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_count_matches_usize(
+    header_field: &str,
+    header_count: u32,
+    actual_count: usize,
+    actual_field: &str,
+) -> Result<(), LixError> {
+    let actual_count = u32::try_from(actual_count).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to decode changelog segment: {actual_field} count exceeds u32"),
+        )
+    })?;
+    if header_count != actual_count {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "failed to decode changelog segment: header {header_field} {header_count} does not match {actual_count} {actual_field}"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn encode_commit_visibility(visibility: &CommitVisibility) -> Result<Vec<u8>, LixError> {
@@ -516,6 +1807,7 @@ fn write_strings<'a>(
     Ok(())
 }
 
+#[derive(Clone)]
 struct ByteCursor<'a> {
     bytes: &'a [u8],
     offset: usize,
@@ -580,7 +1872,7 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn read_segment_header(&mut self, field: &str) -> Result<SegmentHeader, LixError> {
-        Ok(SegmentHeader {
+        let header = SegmentHeader {
             segment_id: self.read_string(&format!("{field}.segment_id"))?,
             format_version: self.read_u32(&format!("{field}.format_version"))?,
             commit_count: self.read_u32(&format!("{field}.commit_count"))?,
@@ -588,11 +1880,13 @@ impl<'a> ByteCursor<'a> {
             byte_count: self.read_u64(&format!("{field}.byte_count"))?,
             payload_count: self.read_u32(&format!("{field}.payload_count"))?,
             checksum: self.read_string(&format!("{field}.checksum"))?,
-        })
+        };
+        validate_segment_format_version(header.format_version, field)?;
+        Ok(header)
     }
 
     fn read_segment_header_view(&mut self, field: &str) -> Result<SegmentHeaderView<'a>, LixError> {
-        Ok(SegmentHeaderView {
+        let header = SegmentHeaderView {
             segment_id: self.read_string_ref(&format!("{field}.segment_id"))?,
             format_version: self.read_u32(&format!("{field}.format_version"))?,
             commit_count: self.read_u32(&format!("{field}.commit_count"))?,
@@ -600,11 +1894,13 @@ impl<'a> ByteCursor<'a> {
             byte_count: self.read_u64(&format!("{field}.byte_count"))?,
             payload_count: self.read_u32(&format!("{field}.payload_count"))?,
             checksum: self.read_string_ref(&format!("{field}.checksum"))?,
-        })
+        };
+        validate_segment_format_version(header.format_version, field)?;
+        Ok(header)
     }
 
     fn read_segment_header_view_fast(&mut self) -> Result<SegmentHeaderView<'a>, LixError> {
-        Ok(SegmentHeaderView {
+        let header = SegmentHeaderView {
             segment_id: self.read_string_ref_fast()?,
             format_version: self.read_u32_fast()?,
             commit_count: self.read_u32_fast()?,
@@ -612,12 +1908,30 @@ impl<'a> ByteCursor<'a> {
             byte_count: self.read_u64_fast()?,
             payload_count: self.read_u32_fast()?,
             checksum: self.read_string_ref_fast()?,
-        })
+        };
+        validate_segment_format_version(header.format_version, "header")?;
+        Ok(header)
     }
 
-    fn read_segment_directory(&mut self, field: &str) -> Result<SegmentDirectory, LixError> {
+    fn read_segment_directory(
+        &mut self,
+        field: &str,
+        expected_commit_count: usize,
+        expected_change_count: usize,
+    ) -> Result<SegmentDirectory, LixError> {
         let commit_len = self.read_len(&format!("{field}.commits"))?;
         self.ensure_len_fits_remaining(commit_len, &format!("{field}.commits"))?;
+        self.ensure_counted_records_fit_remaining(
+            commit_len,
+            MIN_DIRECTORY_ENTRY_BYTES,
+            &format!("{field}.commits"),
+        )?;
+        validate_count_matches_usize(
+            "commit_count",
+            expected_commit_count as u32,
+            commit_len,
+            "directory commits",
+        )?;
         let mut commits = Vec::with_capacity(commit_len);
         for index in 0..commit_len {
             let commit_id = self.read_string(&format!("{field}.commits[{index}].commit_id"))?;
@@ -627,6 +1941,17 @@ impl<'a> ByteCursor<'a> {
 
         let change_len = self.read_len(&format!("{field}.changes"))?;
         self.ensure_len_fits_remaining(change_len, &format!("{field}.changes"))?;
+        self.ensure_counted_records_fit_remaining(
+            change_len,
+            MIN_DIRECTORY_ENTRY_BYTES,
+            &format!("{field}.changes"),
+        )?;
+        validate_count_matches_usize(
+            "change_count",
+            expected_change_count as u32,
+            change_len,
+            "directory changes",
+        )?;
         let mut changes = Vec::with_capacity(change_len);
         for index in 0..change_len {
             let change_id = self.read_string(&format!("{field}.changes[{index}].change_id"))?;
@@ -643,6 +1968,7 @@ impl<'a> ByteCursor<'a> {
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_DIRECTORY_ENTRY_BYTES, field)?;
         let mut commits = Vec::with_capacity(len);
         for index in 0..len {
             let id = self.read_string_ref(&format!("{field}[{index}].commit_id"))?;
@@ -654,9 +1980,17 @@ impl<'a> ByteCursor<'a> {
 
     fn read_segment_directory_commit_views_fast(
         &mut self,
+        expected_len: usize,
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_DIRECTORY_ENTRY_BYTES)?;
+        validate_count_matches_usize(
+            "commit_count",
+            expected_len as u32,
+            len,
+            "directory commits",
+        )?;
         let mut commits = Vec::with_capacity(len);
         for _ in 0..len {
             let id = self.read_string_ref_fast()?;
@@ -672,6 +2006,7 @@ impl<'a> ByteCursor<'a> {
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_DIRECTORY_ENTRY_BYTES, field)?;
         let mut changes = Vec::with_capacity(len);
         for index in 0..len {
             let id = self.read_string_ref(&format!("{field}[{index}].change_id"))?;
@@ -683,9 +2018,17 @@ impl<'a> ByteCursor<'a> {
 
     fn read_segment_directory_change_views_fast(
         &mut self,
+        expected_len: usize,
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_DIRECTORY_ENTRY_BYTES)?;
+        validate_count_matches_usize(
+            "change_count",
+            expected_len as u32,
+            len,
+            "directory changes",
+        )?;
         let mut changes = Vec::with_capacity(len);
         for _ in 0..len {
             let id = self.read_string_ref_fast()?;
@@ -696,12 +2039,19 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn read_segment_commit(&mut self, field: &str) -> Result<SegmentCommit, LixError> {
-        Ok(SegmentCommit {
-            header: self.read_commit_header(&format!("{field}.header"))?,
-            body: self.read_commit_body(&format!("{field}.body"))?,
-            directory: self.read_segment_commit_directory(&format!("{field}.directory"))?,
+        let header = self.read_commit_header(&format!("{field}.header"))?;
+        let body =
+            self.read_commit_body(&format!("{field}.body"), header.membership_count as usize)?;
+        let directory = self.read_segment_commit_directory(&format!("{field}.directory"))?;
+        validate_commit_object_consistency(&header, &body, &directory)?;
+        let commit = SegmentCommit {
+            header,
+            body,
+            directory,
             checksum: self.read_string(&format!("{field}.checksum"))?,
-        })
+        };
+        validate_commit_checksum(&commit)?;
+        Ok(commit)
     }
 
     fn read_segment_commit_slice(
@@ -714,8 +2064,8 @@ impl<'a> ByteCursor<'a> {
         self.skip_string(&format!("{field}.header.derivable_change_id"))?;
         self.skip_strings(&format!("{field}.header.author_account_ids"))?;
         self.skip_string(&format!("{field}.header.created_at"))?;
-        self.skip_u32(&format!("{field}.header.membership_count"))?;
-        self.skip_commit_body(&format!("{field}.body"))?;
+        let membership_count = self.read_u32(&format!("{field}.header.membership_count"))?;
+        self.skip_commit_body(&format!("{field}.body"), membership_count as usize)?;
         self.skip_segment_commit_directory(&format!("{field}.directory"))?;
         let checksum = self.read_string_ref(&format!("{field}.checksum"))?;
         let end = self.offset;
@@ -728,24 +2078,46 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
-    fn read_segment_commit_slice_fast(&mut self) -> Result<SegmentObjectSlice<'a>, LixError> {
+    fn read_segment_commit_slice_fast(&mut self) -> Result<SegmentCommitSliceRead<'a>, LixError> {
         let start = self.offset;
         let id = self.read_string_ref_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_u32_fast()?;
-        self.skip_commit_body_fast()?;
-        self.skip_segment_commit_directory_fast()?;
+        let parent_commit_ids = self.read_strings_fast_owned()?;
+        let parent_count = parent_commit_ids.len();
+        let derivable_change_id = self.read_string_ref_fast()?;
+        let author_account_ids = self.read_strings_fast_owned()?;
+        let created_at = self.read_string_ref_fast()?;
+        let membership_count = self.read_u32_fast()? as usize;
+        let memberships = self.read_commit_body_descriptors_fast(membership_count)?;
+        let directory =
+            self.read_segment_commit_directory_fast_validated(id, parent_count, &memberships)?;
         let checksum = self.read_string_ref_fast()?;
-        let end = self.offset;
-        Ok(SegmentObjectSlice {
+        let canonical = checksum_commit_parts(
             id,
-            offset: start as u64,
-            len: (end - start) as u64,
-            encoded_checksum: Some(checksum),
-            bytes: &self.bytes[start..end],
+            parent_commit_ids.iter().map(String::as_str),
+            derivable_change_id,
+            author_account_ids.iter().map(String::as_str),
+            created_at,
+            membership_count as u32,
+            &memberships,
+            &directory,
+        )?;
+        if checksum != canonical {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{id}' checksum '{checksum}' does not match canonical checksum '{canonical}'"
+            )));
+        }
+        let end = self.offset;
+        Ok(SegmentCommitSliceRead {
+            slice: SegmentObjectSlice {
+                id,
+                offset: start as u64,
+                len: (end - start) as u64,
+                encoded_checksum: Some(checksum),
+                bytes: &self.bytes[start..end],
+            },
+            memberships,
+            state_row_identities: directory.state_row_identities,
+            checksum: canonical,
         })
     }
 
@@ -760,23 +2132,67 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
-    fn skip_commit_header_fast(&mut self) -> Result<(), LixError> {
+    fn read_commit_header_fast(&mut self) -> Result<CommitHeaderView<'a>, LixError> {
+        let id = self.read_string_ref_fast()?;
+        let parent_count = self.read_strings_fast_owned()?.len();
         self.skip_string_fast()?;
-        self.skip_strings_fast()?;
+        self.read_strings_fast_owned()?;
         self.skip_string_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_u32_fast()
+        let membership_count = self.read_u32_fast()?;
+        Ok(CommitHeaderView {
+            id,
+            parent_count,
+            membership_count,
+        })
     }
 
-    fn read_commit_body(&mut self, field: &str) -> Result<CommitBody, LixError> {
+    fn read_commit_body(
+        &mut self,
+        field: &str,
+        expected_membership_count: usize,
+    ) -> Result<CommitBody, LixError> {
         let len = self.read_len(&format!("{field}.membership"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.membership"))?;
+        self.ensure_counted_records_fit_remaining(
+            len,
+            MIN_MEMBERSHIP_RECORD_BYTES,
+            &format!("{field}.membership"),
+        )?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
         let mut membership = Vec::with_capacity(len);
         for index in 0..len {
             membership.push(self.read_membership_record(&format!("{field}.membership[{index}]"))?);
         }
         Ok(CommitBody { membership })
+    }
+
+    fn read_commit_body_descriptors_fast(
+        &mut self,
+        expected_membership_count: usize,
+    ) -> Result<Vec<CommitMembershipDescriptor<'a>>, LixError> {
+        let len = self.read_len_fast()?;
+        self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_MEMBERSHIP_RECORD_BYTES)?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
+        let mut memberships = Vec::with_capacity(len);
+        for _ in 0..len {
+            memberships.push(CommitMembershipDescriptor {
+                member_change_id: Cow::Borrowed(self.read_string_ref_fast()?),
+                role: self.read_membership_role_fast()?,
+                source_parent_ordinal: self.read_optional_u32_fast()?,
+            });
+        }
+        Ok(memberships)
     }
 
     fn read_membership_record(&mut self, field: &str) -> Result<MembershipRecord, LixError> {
@@ -790,20 +2206,34 @@ impl<'a> ByteCursor<'a> {
 
     fn read_matching_membership_change_ids(
         &mut self,
+        expected_membership_count: usize,
         requested_change_ids: &std::collections::HashSet<String>,
-    ) -> Result<Vec<String>, LixError> {
+    ) -> Result<(Vec<String>, Vec<CommitMembershipDescriptor<'a>>), LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_MEMBERSHIP_RECORD_BYTES)?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
         let mut matches = Vec::new();
+        let mut memberships = Vec::with_capacity(len);
         for _ in 0..len {
             let member_change_id = self.read_string_ref_fast()?;
             if requested_change_ids.contains(member_change_id) {
                 matches.push(member_change_id.to_string());
             }
-            self.skip_u8_fast()?;
-            self.skip_optional_u32_fast()?;
+            let role = self.read_membership_role_fast()?;
+            let source_parent_ordinal = self.read_optional_u32_fast()?;
+            memberships.push(CommitMembershipDescriptor {
+                member_change_id: Cow::Borrowed(member_change_id),
+                role,
+                source_parent_ordinal,
+            });
         }
-        Ok(matches)
+        Ok((matches, memberships))
     }
 
     fn read_segment_commit_directory(
@@ -812,6 +2242,11 @@ impl<'a> ByteCursor<'a> {
     ) -> Result<SegmentCommitDirectory, LixError> {
         let identity_len = self.read_len(&format!("{field}.state_row_identities"))?;
         self.ensure_len_fits_remaining(identity_len, &format!("{field}.state_row_identities"))?;
+        self.ensure_counted_records_fit_remaining(
+            identity_len,
+            MIN_STATE_ROW_IDENTITY_ENTRY_BYTES,
+            &format!("{field}.state_row_identities"),
+        )?;
         let mut state_row_identities = Vec::with_capacity(identity_len);
         for index in 0..identity_len {
             let identity = self.read_state_row_identity(&format!(
@@ -824,6 +2259,11 @@ impl<'a> ByteCursor<'a> {
 
         let ordinal_len = self.read_len(&format!("{field}.membership_ordinals"))?;
         self.ensure_len_fits_remaining(ordinal_len, &format!("{field}.membership_ordinals"))?;
+        self.ensure_counted_records_fit_remaining(
+            ordinal_len,
+            MIN_MEMBERSHIP_ORDINAL_BYTES,
+            &format!("{field}.membership_ordinals"),
+        )?;
         let mut membership_ordinals = Vec::with_capacity(ordinal_len);
         for index in 0..ordinal_len {
             let change_id =
@@ -839,7 +2279,11 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
-    fn read_segment_change(&mut self, field: &str) -> Result<SegmentChange, LixError> {
+    fn read_segment_change(
+        &mut self,
+        field: &str,
+        payload_budget: Option<&mut usize>,
+    ) -> Result<SegmentChange, LixError> {
         let id = self.read_string(&format!("{field}.id"))?;
         let authored_commit_id =
             self.read_optional_string(&format!("{field}.authored_commit_id"))?;
@@ -852,14 +2296,44 @@ impl<'a> ByteCursor<'a> {
 
         let payload_len = self.read_len(&format!("{field}.inline_payloads"))?;
         self.ensure_len_fits_remaining(payload_len, &format!("{field}.inline_payloads"))?;
+        self.ensure_counted_records_fit_remaining(
+            payload_len,
+            MIN_INLINE_PAYLOAD_BYTES,
+            &format!("{field}.inline_payloads"),
+        )?;
+        if let Some(payload_budget) = payload_budget {
+            *payload_budget = payload_budget.checked_sub(payload_len).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "failed to decode changelog {field}.inline_payloads: declared inline payload count exceeds header payload_count"
+                    ),
+                )
+            })?;
+        }
         let mut inline_payloads = Vec::with_capacity(payload_len);
+        let mut payload_descriptors = Vec::with_capacity(payload_len);
         for index in 0..payload_len {
-            inline_payloads.push(
-                self.read_segment_inline_payload(&format!("{field}.inline_payloads[{index}]"))?,
-            );
+            let payload =
+                self.read_segment_inline_payload_ref(&format!("{field}.inline_payloads[{index}]"))?;
+            validate_inline_payload_ref(&id, &payload.json_ref, payload.bytes)?;
+            payload_descriptors.push(PayloadDescriptor {
+                json_ref: payload.json_ref.clone(),
+                len: payload.bytes.len() as u64,
+            });
+            inline_payloads.push(payload);
         }
 
-        let directory = self.read_segment_change_directory(&format!("{field}.directory"))?;
+        let directory =
+            self.read_segment_change_directory(&format!("{field}.directory"), payload_len)?;
+        validate_payload_descriptors_against_directory(&id, &payload_descriptors, &directory)?;
+        let inline_payloads = inline_payloads
+            .into_iter()
+            .map(|payload| SegmentInlinePayload {
+                json_ref: payload.json_ref,
+                bytes: payload.bytes.to_vec(),
+            })
+            .collect();
 
         Ok(SegmentChange {
             id,
@@ -882,14 +2356,14 @@ impl<'a> ByteCursor<'a> {
         let start = self.offset;
         let id = self.read_string_ref(&format!("{field}.id"))?;
         self.skip_optional_string(&format!("{field}.authored_commit_id"))?;
-        self.skip_string(&format!("{field}.entity_id"))?;
+        self.read_entity_identity(&format!("{field}.entity_id"))?;
         self.skip_string(&format!("{field}.schema_key"))?;
         self.skip_optional_string(&format!("{field}.file_id"))?;
         self.skip_optional_json_ref(&format!("{field}.snapshot_ref"))?;
         self.skip_optional_json_ref(&format!("{field}.metadata_ref"))?;
         self.skip_string(&format!("{field}.created_at"))?;
-        self.skip_segment_inline_payloads(&format!("{field}.inline_payloads"))?;
-        self.skip_segment_change_directory(&format!("{field}.directory"))?;
+        let payloads = self.skip_segment_inline_payloads(&format!("{field}.inline_payloads"))?;
+        self.skip_segment_change_directory(&format!("{field}.directory"), id, &payloads)?;
         let end = self.offset;
         Ok(SegmentObjectSlice {
             id,
@@ -901,47 +2375,99 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn read_segment_change_slice_fast(&mut self) -> Result<SegmentObjectSlice<'a>, LixError> {
+        self.read_segment_change_slice_with_count_fast(None)
+            .map(|(change, _)| change.slice)
+    }
+
+    fn read_segment_change_slice_with_count_fast(
+        &mut self,
+        payload_budget: Option<usize>,
+    ) -> Result<(SegmentChangeSliceRead<'a>, usize), LixError> {
         let start = self.offset;
         let id = self.read_string_ref_fast()?;
-        self.skip_optional_string_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_optional_string_fast()?;
-        self.skip_optional_json_ref_fast()?;
-        self.skip_optional_json_ref_fast()?;
-        self.skip_string_fast()?;
-        self.skip_segment_inline_payloads_fast()?;
-        self.skip_segment_change_directory_fast()?;
-        let end = self.offset;
-        Ok(SegmentObjectSlice {
+        let authored_commit_id = self.read_optional_string_ref_fast()?;
+        let entity_id = self.read_entity_identity_fast()?;
+        let schema_key = self.read_string_ref_fast()?;
+        let file_id = self.read_optional_string_ref_fast()?;
+        let snapshot_ref = self.read_optional_json_ref_fast()?;
+        let metadata_ref = self.read_optional_json_ref_fast()?;
+        let created_at = self.read_string_ref_fast()?;
+        let payloads = self.read_segment_inline_payloads_fast(payload_budget)?;
+        for payload in &payloads {
+            validate_inline_payload_ref(id, &payload.json_ref, payload.bytes)?;
+        }
+        let payload_descriptors = payloads
+            .iter()
+            .map(|payload| PayloadDescriptor {
+                json_ref: payload.json_ref.clone(),
+                len: payload.bytes.len() as u64,
+            })
+            .collect::<Vec<_>>();
+        let directory = self.read_segment_change_directory_fast(id, &payload_descriptors)?;
+        let checksum = checksum_change_parts(
             id,
-            offset: start as u64,
-            len: (end - start) as u64,
-            encoded_checksum: None,
-            bytes: &self.bytes[start..end],
-        })
+            authored_commit_id,
+            &entity_id,
+            schema_key,
+            file_id,
+            snapshot_ref.as_ref(),
+            metadata_ref.as_ref(),
+            created_at,
+            &payloads,
+            &directory,
+        )?;
+        let end = self.offset;
+        Ok((
+            SegmentChangeSliceRead {
+                slice: SegmentObjectSlice {
+                    id,
+                    offset: start as u64,
+                    len: (end - start) as u64,
+                    encoded_checksum: None,
+                    bytes: &self.bytes[start..end],
+                },
+                state_row_identity: state_row_identity_for_change_fields(
+                    schema_key, file_id, &entity_id,
+                )?,
+                authored_commit_id,
+                checksum,
+            },
+            payloads.len(),
+        ))
     }
 
     fn remaining_bytes(&self) -> &'a [u8] {
         &self.bytes[self.offset..]
     }
 
-    fn read_segment_inline_payload(
+    fn read_segment_inline_payload_ref(
         &mut self,
         field: &str,
-    ) -> Result<SegmentInlinePayload, LixError> {
-        Ok(SegmentInlinePayload {
+    ) -> Result<SegmentInlinePayloadRef<'a>, LixError> {
+        Ok(SegmentInlinePayloadRef {
             json_ref: self.read_json_ref(&format!("{field}.json_ref"))?,
-            bytes: self.read_byte_vec(&format!("{field}.bytes"))?,
+            bytes: self.read_byte_vec_ref(&format!("{field}.bytes"))?,
         })
     }
 
     fn read_segment_change_directory(
         &mut self,
         field: &str,
+        expected_payload_count: usize,
     ) -> Result<SegmentChangeDirectory, LixError> {
         let len = self.read_len(&format!("{field}.payloads"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.payloads"))?;
+        self.ensure_counted_records_fit_remaining(
+            len,
+            MIN_PAYLOAD_LOCATION_BYTES,
+            &format!("{field}.payloads"),
+        )?;
+        validate_count_matches_usize(
+            "payload_count",
+            expected_payload_count as u32,
+            len,
+            "change directory payloads",
+        )?;
         let mut payloads = Vec::with_capacity(len);
         for index in 0..len {
             payloads.push(self.read_payload_location(&format!("{field}.payloads[{index}]"))?);
@@ -965,6 +2491,35 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
+    fn read_state_row_identity_fast(&mut self) -> Result<StateRowIdentity, LixError> {
+        let schema_key = self.read_string_ref_fast()?;
+        let schema_key = CanonicalSchemaKey::new(schema_key.to_string()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog state row identity schema_key: {error}"),
+            )
+        })?;
+        let file_id = self.read_string_ref_fast()?;
+        let file_id = FileId::new(file_id.to_string()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog state row identity file_id: {error}"),
+            )
+        })?;
+        let entity_id = self.read_string_ref_fast()?;
+        let entity_id = EntityId::new(entity_id.to_string()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog state row identity entity_id: {error}"),
+            )
+        })?;
+        Ok(StateRowIdentity {
+            schema_key,
+            file_id,
+            entity_id,
+        })
+    }
+
     fn read_entity_identity(&mut self, field: &str) -> Result<EntityIdentity, LixError> {
         let parts = self.read_strings_fast_owned().map_err(|error| {
             LixError::new(
@@ -982,6 +2537,18 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
+    fn read_entity_identity_fast(&mut self) -> Result<EntityIdentity, LixError> {
+        let parts = self.read_strings_fast_owned()?;
+        EntityIdentity::from_parts(parts).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "failed to decode changelog entity_id: invalid entity identity parts: {error}"
+                ),
+            )
+        })
+    }
+
     fn read_membership_role(&mut self, field: &str) -> Result<MembershipRole, LixError> {
         match self.read_u8(field)? {
             0 => Ok(MembershipRole::Authored),
@@ -993,9 +2560,18 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
+    fn read_membership_role_fast(&mut self) -> Result<MembershipRole, LixError> {
+        match self.read_u8_fast()? {
+            0 => Ok(MembershipRole::Authored),
+            1 => Ok(MembershipRole::Adopted),
+            _ => Err(self.fast_error("invalid membership role")),
+        }
+    }
+
     fn read_strings(&mut self, field: &str) -> Result<Vec<String>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_STRING_BYTES, field)?;
         let mut out = Vec::with_capacity(len);
         for index in 0..len {
             out.push(self.read_string(&format!("{field}[{index}]"))?);
@@ -1006,6 +2582,7 @@ impl<'a> ByteCursor<'a> {
     fn read_strings_fast_owned(&mut self) -> Result<Vec<String>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_STRING_BYTES)?;
         let mut out = Vec::with_capacity(len);
         for _ in 0..len {
             out.push(self.read_string_fast_owned()?);
@@ -1013,9 +2590,21 @@ impl<'a> ByteCursor<'a> {
         Ok(out)
     }
 
+    fn read_strings_fast_refs(&mut self) -> Result<Vec<&'a str>, LixError> {
+        let len = self.read_len_fast()?;
+        self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_STRING_BYTES)?;
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            out.push(self.read_string_ref_fast()?);
+        }
+        Ok(out)
+    }
+
     fn skip_strings(&mut self, field: &str) -> Result<(), LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_STRING_BYTES, field)?;
         for index in 0..len {
             self.skip_string(&format!("{field}[{index}]"))?;
         }
@@ -1025,6 +2614,7 @@ impl<'a> ByteCursor<'a> {
     fn skip_strings_fast(&mut self) -> Result<(), LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_STRING_BYTES)?;
         for _ in 0..len {
             self.skip_string_fast()?;
         }
@@ -1082,19 +2672,13 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn skip_string(&mut self, field: &str) -> Result<(), LixError> {
-        let len = self.read_u32(&format!("{field}.len"))?;
-        let len = usize::try_from(len).map_err(|_| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("failed to decode changelog {field}: length exceeds usize"),
-            )
-        })?;
-        self.skip_bytes(len, field)
+        let _ = self.read_string_ref(field)?;
+        Ok(())
     }
 
     fn skip_string_fast(&mut self) -> Result<(), LixError> {
-        let len = self.read_len_fast()?;
-        self.skip_bytes_fast(len)
+        let _ = self.read_string_ref_fast()?;
+        Ok(())
     }
 
     fn read_optional_string(&mut self, field: &str) -> Result<Option<String>, LixError> {
@@ -1121,6 +2705,14 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
+    fn read_optional_string_ref_fast(&mut self) -> Result<Option<&'a str>, LixError> {
+        if self.read_bool_fast()? {
+            Ok(Some(self.read_string_ref_fast()?))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn read_optional_u32(&mut self, field: &str) -> Result<Option<u32>, LixError> {
         if self.read_bool(&format!("{field}.present"))? {
             Ok(Some(self.read_u32(field)?))
@@ -1134,6 +2726,14 @@ impl<'a> ByteCursor<'a> {
             self.skip_u32(field)
         } else {
             Ok(())
+        }
+    }
+
+    fn read_optional_u32_fast(&mut self) -> Result<Option<u32>, LixError> {
+        if self.read_bool_fast()? {
+            Ok(Some(self.read_u32_fast()?))
+        } else {
+            Ok(None)
         }
     }
 
@@ -1169,6 +2769,14 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
+    fn read_optional_json_ref_fast(&mut self) -> Result<Option<JsonRef>, LixError> {
+        if self.read_bool_fast()? {
+            Ok(Some(JsonRef::from_hash_bytes(self.read_fixed_hash_fast()?)))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn read_json_ref(&mut self, field: &str) -> Result<JsonRef, LixError> {
         let bytes = self.read_bytes(32, field)?;
         let mut hash = [0_u8; 32];
@@ -1176,27 +2784,56 @@ impl<'a> ByteCursor<'a> {
         Ok(JsonRef::from_hash_bytes(hash))
     }
 
+    fn read_fixed_hash_fast(&mut self) -> Result<[u8; 32], LixError> {
+        let bytes = self.read_bytes_fast(32)?;
+        let mut hash = [0_u8; 32];
+        hash.copy_from_slice(bytes);
+        Ok(hash)
+    }
+
     fn read_byte_vec(&mut self, field: &str) -> Result<Vec<u8>, LixError> {
         let len = self.read_len(field)?;
         Ok(self.read_bytes(len, field)?.to_vec())
     }
 
-    fn skip_byte_vec(&mut self, field: &str) -> Result<(), LixError> {
+    fn read_byte_vec_ref(&mut self, field: &str) -> Result<&'a [u8], LixError> {
         let len = self.read_len(field)?;
-        self.skip_bytes(len, field)
+        self.read_bytes(len, field)
     }
 
-    fn skip_byte_vec_fast(&mut self) -> Result<(), LixError> {
+    fn read_byte_vec_ref_fast(&mut self) -> Result<&'a [u8], LixError> {
         let len = self.read_len_fast()?;
-        self.skip_bytes_fast(len)
+        self.read_bytes_fast(len)
     }
 
-    fn skip_commit_body(&mut self, field: &str) -> Result<(), LixError> {
+    fn skip_byte_vec(&mut self, field: &str) -> Result<usize, LixError> {
+        let len = self.read_len(field)?;
+        self.skip_bytes(len, field)?;
+        Ok(len)
+    }
+
+    fn skip_byte_vec_fast(&mut self) -> Result<usize, LixError> {
+        let len = self.read_len_fast()?;
+        self.skip_bytes_fast(len)?;
+        Ok(len)
+    }
+
+    fn skip_commit_body(
+        &mut self,
+        field: &str,
+        expected_membership_count: usize,
+    ) -> Result<(), LixError> {
         let len = self.read_len(&format!("{field}.membership"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.membership"))?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
         for index in 0..len {
             self.skip_string(&format!("{field}.membership[{index}].member_change_id"))?;
-            self.skip_u8(&format!("{field}.membership[{index}].role"))?;
+            self.read_membership_role(&format!("{field}.membership[{index}].role"))?;
             self.skip_optional_u32(&format!(
                 "{field}.membership[{index}].source_parent_ordinal"
             ))?;
@@ -1204,20 +2841,19 @@ impl<'a> ByteCursor<'a> {
         Ok(())
     }
 
-    fn skip_commit_body_fast(&mut self) -> Result<(), LixError> {
-        let len = self.read_len_fast()?;
-        self.ensure_len_fits_remaining_fast(len)?;
-        for _ in 0..len {
-            self.skip_string_fast()?;
-            self.skip_u8_fast()?;
-            self.skip_optional_u32_fast()?;
-        }
+    fn skip_commit_body_fast(&mut self, expected_membership_count: usize) -> Result<(), LixError> {
+        let _ = self.read_commit_body_descriptors_fast(expected_membership_count)?;
         Ok(())
     }
 
     fn skip_segment_commit_directory(&mut self, field: &str) -> Result<(), LixError> {
         let identity_len = self.read_len(&format!("{field}.state_row_identities"))?;
         self.ensure_len_fits_remaining(identity_len, &format!("{field}.state_row_identities"))?;
+        self.ensure_counted_records_fit_remaining(
+            identity_len,
+            MIN_STATE_ROW_IDENTITY_ENTRY_BYTES,
+            &format!("{field}.state_row_identities"),
+        )?;
         for index in 0..identity_len {
             self.skip_string(&format!(
                 "{field}.state_row_identities[{index}].state_row_identity.schema_key"
@@ -1233,6 +2869,11 @@ impl<'a> ByteCursor<'a> {
 
         let ordinal_len = self.read_len(&format!("{field}.membership_ordinals"))?;
         self.ensure_len_fits_remaining(ordinal_len, &format!("{field}.membership_ordinals"))?;
+        self.ensure_counted_records_fit_remaining(
+            ordinal_len,
+            MIN_MEMBERSHIP_ORDINAL_BYTES,
+            &format!("{field}.membership_ordinals"),
+        )?;
         for index in 0..ordinal_len {
             self.skip_string(&format!("{field}.membership_ordinals[{index}].change_id"))?;
             self.skip_u32(&format!("{field}.membership_ordinals[{index}].ordinal"))?;
@@ -1241,64 +2882,157 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn skip_segment_commit_directory_fast(&mut self) -> Result<(), LixError> {
+        let _ = self.read_segment_commit_directory_fast()?;
+        Ok(())
+    }
+
+    fn read_segment_commit_directory_fast(&mut self) -> Result<SegmentCommitDirectory, LixError> {
         let identity_len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(identity_len)?;
+        self.ensure_counted_records_fit_remaining_fast(
+            identity_len,
+            MIN_STATE_ROW_IDENTITY_ENTRY_BYTES,
+        )?;
+        let mut state_row_identities = Vec::with_capacity(identity_len);
         for _ in 0..identity_len {
-            self.skip_string_fast()?;
-            self.skip_string_fast()?;
-            self.skip_string_fast()?;
-            self.skip_string_fast()?;
+            let identity = self.read_state_row_identity_fast()?;
+            let change_id = self.read_string_ref_fast()?.to_string();
+            state_row_identities.push((identity, change_id));
         }
 
         let ordinal_len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(ordinal_len)?;
+        self.ensure_counted_records_fit_remaining_fast(ordinal_len, MIN_MEMBERSHIP_ORDINAL_BYTES)?;
+        let mut membership_ordinals = Vec::with_capacity(ordinal_len);
         for _ in 0..ordinal_len {
-            self.skip_string_fast()?;
-            self.skip_u32_fast()?;
+            let change_id = self.read_string_ref_fast()?.to_string();
+            let ordinal = self.read_u32_fast()?;
+            membership_ordinals.push((change_id, ordinal));
         }
-        Ok(())
+        Ok(SegmentCommitDirectory {
+            state_row_identities,
+            membership_ordinals,
+        })
     }
 
-    fn skip_segment_inline_payloads(&mut self, field: &str) -> Result<(), LixError> {
+    fn read_segment_commit_directory_fast_validated(
+        &mut self,
+        commit_id: &str,
+        parent_count: usize,
+        memberships: &[CommitMembershipDescriptor<'_>],
+    ) -> Result<SegmentCommitDirectory, LixError> {
+        validate_commit_membership_descriptors(commit_id, parent_count, memberships)?;
+        let directory = self.read_segment_commit_directory_fast()?;
+        validate_commit_directory_descriptors(
+            commit_id,
+            memberships,
+            directory
+                .state_row_identities
+                .iter()
+                .map(|(identity, change_id)| (identity, change_id.as_str())),
+            directory
+                .membership_ordinals
+                .iter()
+                .map(|(change_id, ordinal)| (change_id.as_str(), *ordinal)),
+        )?;
+        Ok(directory)
+    }
+
+    fn skip_segment_inline_payloads(
+        &mut self,
+        field: &str,
+    ) -> Result<Vec<PayloadDescriptor>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_INLINE_PAYLOAD_BYTES, field)?;
+        let mut payloads = Vec::with_capacity(len);
         for index in 0..len {
-            self.skip_bytes(32, &format!("{field}[{index}].json_ref"))?;
-            self.skip_byte_vec(&format!("{field}[{index}].bytes"))?;
+            let json_ref = self.read_json_ref(&format!("{field}[{index}].json_ref"))?;
+            let bytes_len = self.skip_byte_vec(&format!("{field}[{index}].bytes"))?;
+            payloads.push(PayloadDescriptor {
+                json_ref,
+                len: bytes_len as u64,
+            });
         }
-        Ok(())
+        Ok(payloads)
     }
 
-    fn skip_segment_inline_payloads_fast(&mut self) -> Result<(), LixError> {
+    fn read_segment_inline_payloads_fast(
+        &mut self,
+        payload_budget: Option<usize>,
+    ) -> Result<Vec<SegmentInlinePayloadRef<'a>>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
-        for _ in 0..len {
-            self.skip_bytes_fast(32)?;
-            self.skip_byte_vec_fast()?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_INLINE_PAYLOAD_BYTES)?;
+        if payload_budget.is_some_and(|budget| len > budget) {
+            return Err(
+                self.fast_error("declared inline payload count exceeds header payload_count")
+            );
         }
-        Ok(())
+        let mut payloads = Vec::with_capacity(len);
+        for _ in 0..len {
+            let json_ref = JsonRef::from_hash_bytes(self.read_fixed_hash_fast()?);
+            let bytes = self.read_byte_vec_ref_fast()?;
+            payloads.push(SegmentInlinePayloadRef { json_ref, bytes });
+        }
+        Ok(payloads)
     }
 
-    fn skip_segment_change_directory(&mut self, field: &str) -> Result<(), LixError> {
+    fn skip_segment_change_directory(
+        &mut self,
+        field: &str,
+        change_id: &str,
+        inline_payloads: &[PayloadDescriptor],
+    ) -> Result<(), LixError> {
         let len = self.read_len(&format!("{field}.payloads"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.payloads"))?;
+        self.ensure_counted_records_fit_remaining(
+            len,
+            MIN_PAYLOAD_LOCATION_BYTES,
+            &format!("{field}.payloads"),
+        )?;
+        validate_count_matches_usize(
+            "payload_count",
+            inline_payloads.len() as u32,
+            len,
+            "change directory payloads",
+        )?;
+        let mut payloads = Vec::with_capacity(len);
         for index in 0..len {
-            self.skip_bytes(32, &format!("{field}.payloads[{index}].json_ref"))?;
-            self.skip_u64(&format!("{field}.payloads[{index}].offset"))?;
-            self.skip_u64(&format!("{field}.payloads[{index}].len"))?;
+            payloads.push(self.read_payload_location(&format!("{field}.payloads[{index}]"))?);
         }
-        Ok(())
+        validate_payload_descriptors_against_directory(
+            change_id,
+            inline_payloads,
+            &SegmentChangeDirectory { payloads },
+        )
     }
 
-    fn skip_segment_change_directory_fast(&mut self) -> Result<(), LixError> {
+    fn read_segment_change_directory_fast(
+        &mut self,
+        change_id: &str,
+        inline_payloads: &[PayloadDescriptor],
+    ) -> Result<SegmentChangeDirectory, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_PAYLOAD_LOCATION_BYTES)?;
+        validate_count_matches_usize(
+            "payload_count",
+            inline_payloads.len() as u32,
+            len,
+            "change directory payloads",
+        )?;
+        let mut payloads = Vec::with_capacity(len);
         for _ in 0..len {
-            self.skip_bytes_fast(32)?;
-            self.skip_u64_fast()?;
-            self.skip_u64_fast()?;
+            payloads.push(SegmentPayloadLocation {
+                json_ref: JsonRef::from_hash_bytes(self.read_fixed_hash_fast()?),
+                offset: self.read_u64_fast()?,
+                len: self.read_u64_fast()?,
+            });
         }
-        Ok(())
+        let directory = SegmentChangeDirectory { payloads };
+        validate_payload_descriptors_against_directory(change_id, inline_payloads, &directory)?;
+        Ok(directory)
     }
 
     fn read_len(&mut self, field: &str) -> Result<usize, LixError> {
@@ -1330,6 +3064,43 @@ impl<'a> ByteCursor<'a> {
             return Ok(());
         }
         Err(self.fast_error("declared length exceeds remaining bytes"))
+    }
+
+    fn ensure_counted_records_fit_remaining(
+        &self,
+        len: usize,
+        min_record_bytes: usize,
+        field: &str,
+    ) -> Result<(), LixError> {
+        let min_bytes = len.checked_mul(min_record_bytes).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog {field}: declared count byte size overflows"),
+            )
+        })?;
+        if min_bytes <= self.bytes.len().saturating_sub(self.offset) {
+            return Ok(());
+        }
+        Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "failed to decode changelog {field}: declared count exceeds remaining bytes for minimum record size"
+            ),
+        ))
+    }
+
+    fn ensure_counted_records_fit_remaining_fast(
+        &self,
+        len: usize,
+        min_record_bytes: usize,
+    ) -> Result<(), LixError> {
+        let min_bytes = len
+            .checked_mul(min_record_bytes)
+            .ok_or_else(|| self.fast_error("declared count byte size overflows"))?;
+        if min_bytes <= self.bytes.len().saturating_sub(self.offset) {
+            return Ok(());
+        }
+        Err(self.fast_error("declared count exceeds remaining bytes for minimum record size"))
     }
 
     fn read_bool(&mut self, field: &str) -> Result<bool, LixError> {
@@ -1483,6 +3254,12 @@ struct SegmentHeaderView<'a> {
     checksum: &'a str,
 }
 
+struct CommitHeaderView<'a> {
+    id: &'a str,
+    parent_count: usize,
+    membership_count: u32,
+}
+
 fn changelog_codec_not_implemented(message: impl Into<String>) -> LixError {
     LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
 }
@@ -1493,76 +3270,7 @@ mod tests {
 
     #[test]
     fn segment_roundtrips() {
-        let state_row_identity = StateRowIdentity {
-            schema_key: CanonicalSchemaKey::new("message").unwrap(),
-            file_id: FileId::new("file-1").unwrap(),
-            entity_id: EntityId::new("entity-1").unwrap(),
-        };
-        let snapshot_ref = JsonRef::from_hash_bytes([1; 32]);
-        let metadata_ref = JsonRef::from_hash_bytes([2; 32]);
-        let payload_ref = JsonRef::from_hash_bytes([3; 32]);
-
-        let segment = Segment {
-            header: SegmentHeader {
-                segment_id: "segment-1".to_string(),
-                format_version: 1,
-                commit_count: 1,
-                change_count: 1,
-                byte_count: 123,
-                payload_count: 1,
-                checksum: "segment-checksum".to_string(),
-            },
-            directory: SegmentDirectory {
-                commits: vec![("commit-1".to_string(), location("segment-1", 10, 20, "c"))],
-                changes: vec![("change-1".to_string(), location("segment-1", 30, 40, "ch"))],
-            },
-            commits: vec![SegmentCommit {
-                header: CommitHeader {
-                    id: "commit-1".to_string(),
-                    parent_commit_ids: vec!["parent-1".to_string()],
-                    derivable_change_id: "commit-change-1".to_string(),
-                    author_account_ids: vec!["account-1".to_string()],
-                    created_at: "2026-05-12T00:00:00Z".to_string(),
-                    membership_count: 1,
-                },
-                body: CommitBody {
-                    membership: vec![MembershipRecord {
-                        member_change_id: "change-1".to_string(),
-                        role: MembershipRole::Authored,
-                        source_parent_ordinal: Some(0),
-                    }],
-                },
-                directory: SegmentCommitDirectory {
-                    state_row_identities: vec![(
-                        state_row_identity.clone(),
-                        "change-1".to_string(),
-                    )],
-                    membership_ordinals: vec![("change-1".to_string(), 0)],
-                },
-                checksum: "commit-checksum".to_string(),
-            }],
-            changes: vec![SegmentChange {
-                id: "change-1".to_string(),
-                authored_commit_id: Some("commit-1".to_string()),
-                entity_id: EntityIdentity::single("entity-1"),
-                schema_key: "message".to_string(),
-                file_id: Some("file-1".to_string()),
-                snapshot_ref: Some(snapshot_ref),
-                metadata_ref: Some(metadata_ref),
-                created_at: "2026-05-12T00:00:00Z".to_string(),
-                inline_payloads: vec![SegmentInlinePayload {
-                    json_ref: payload_ref,
-                    bytes: br#"{"hello":"world"}"#.to_vec(),
-                }],
-                directory: SegmentChangeDirectory {
-                    payloads: vec![SegmentPayloadLocation {
-                        json_ref: payload_ref,
-                        offset: 0,
-                        len: 17,
-                    }],
-                },
-            }],
-        };
+        let segment = sample_segment();
 
         assert_eq!(
             decode_segment(&encode_segment(&segment).unwrap()).unwrap(),
@@ -1642,7 +3350,7 @@ mod tests {
             &SegmentHeader {
                 segment_id: "segment-1".to_string(),
                 format_version: 1,
-                commit_count: u32::MAX,
+                commit_count: 0,
                 change_count: 0,
                 byte_count: 0,
                 payload_count: 0,
@@ -1661,6 +3369,1504 @@ mod tests {
                 .contains("declared length exceeds remaining bytes"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn segment_decode_rejects_header_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.commit_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("header count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 2 does not match 1 directory commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_object_count_mismatch_before_allocating_objects() {
+        let bytes = segment_bytes_with_empty_object_lists(sample_segment());
+
+        let error = decode_segment(&bytes).expect_err("object count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 1 does not match 0 commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_directory_count_before_allocating() {
+        let bytes = segment_bytes_with_directory_lengths(sample_segment(), 1, 1_000);
+
+        let error = decode_segment(&bytes).expect_err("impossible directory count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_header_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.change_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("header count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header change_count 2 does not match 1 directory changes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_unsupported_format_version() {
+        let mut segment = sample_segment();
+        segment.header.format_version = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("unsupported format version should reject");
+
+        assert!(
+            error.message.contains("format_version 2 is not supported"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_unsupported_format_version() {
+        let mut segment = sample_segment();
+        segment.header.format_version = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("unsupported format version should reject");
+
+        assert!(
+            error.message.contains("format_version 2 is not supported"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_header_byte_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.byte_count += 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("byte count mismatch should reject");
+
+        assert!(
+            error.message.contains("byte_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_header_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("header checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_header_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("header checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_header_directory_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.change_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("directory count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header change_count 2 does not match 1 directory changes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_directory_locator_offset_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.commits[0].1.offset += 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("directory locator mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("locator offset/len does not match encoded byte range"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_directory_locator_offset_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.commits[0].1.offset += 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("directory locator mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("locator offset/len does not match encoded byte range"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_directory_order_mismatch() {
+        let mut segment = sample_segment_with_two_changes();
+        apply_sample_encoded_locations(&mut segment);
+        segment.directory.changes.swap(0, 1);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("directory order mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("directory order does not match encoded object order"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_directory_view_rejects_duplicate_change_ids_with_different_locations() {
+        let mut segment = sample_segment_with_two_changes();
+        segment.directory.changes[1].0 = segment.directory.changes[0].0.clone();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_directory(&bytes).expect_err("duplicate directory id should reject");
+
+        assert!(
+            error.message.contains("duplicate directory locator"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_directory_order_mismatch() {
+        let mut segment = sample_segment_with_two_changes();
+        apply_sample_encoded_locations(&mut segment);
+        segment.directory.changes.swap(0, 1);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("directory order mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("directory order does not match encoded object order"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_locator_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.changes[0].1.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("change locator checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("locator checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_inline_payload_ref_mismatch() {
+        let mut segment = sample_segment();
+        let bogus_ref = JsonRef::from_hash_bytes([9; 32]);
+        segment.changes[0].inline_payloads[0].json_ref = bogus_ref;
+        segment.changes[0].directory.payloads[0].json_ref = bogus_ref;
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("inline payload hash mismatch should reject");
+
+        assert!(
+            error.message.contains("does not match payload bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_inline_payload_ref_mismatch() {
+        let mut segment = sample_segment();
+        let bogus_ref = JsonRef::from_hash_bytes([9; 32]);
+        segment.changes[0].inline_payloads[0].json_ref = bogus_ref;
+        segment.changes[0].directory.payloads[0].json_ref = bogus_ref;
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("inline payload hash mismatch should reject");
+
+        assert!(
+            error.message.contains("does not match payload bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_change_locator_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.changes[0].1.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("change locator checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("locator checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_object_count_mismatch() {
+        let bytes = segment_bytes_with_empty_object_lists(sample_segment());
+
+        let error = view_segment(&bytes).expect_err("object count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 1 does not match 0 commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_object_count_mismatch() {
+        let bytes = segment_bytes_with_empty_object_lists(sample_segment());
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("object count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 1 does not match 0 commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("payload count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 2 does not match 1 inline payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("payload count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 2 does not match 1 inline payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("payload count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 2 does not match 1 inline payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_inline_payloads_exceeding_header_payload_count_before_allocating() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 0;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("payload budget overrun should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared inline payload count exceeds header payload_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_inline_payloads_exceeding_header_payload_count_before_scanning() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 0;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("payload budget overrun should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared inline payload count exceeds header payload_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_inline_payloads_exceeding_header_payload_count_before_scanning(
+    ) {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 0;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("payload budget overrun should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared inline payload count exceeds header payload_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_inline_payload_count_before_allocating() {
+        let bytes = segment_change_bytes_with_inline_payload_len(sample_segment(), 1_000);
+
+        let error =
+            decode_segment(&bytes).expect_err("impossible inline payload count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_impossible_inline_payload_count_before_allocating() {
+        let bytes = segment_change_bytes_with_inline_payload_len(sample_segment(), 1_000);
+
+        let error =
+            view_segment(&bytes).expect_err("impossible inline payload count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_string_list_count_before_allocating() {
+        let bytes = commit_bytes_with_parent_count(sample_segment(), 1_000);
+
+        let error = decode_segment(&bytes).expect_err("impossible string list count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_impossible_string_list_count_before_allocating() {
+        let bytes = commit_bytes_with_parent_count(sample_segment(), 1_000);
+
+        let error = view_segment(&bytes).expect_err("impossible string list count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_top_level_commit_count_before_allocating() {
+        let bytes = segment_bytes_with_object_lengths(sample_segment(), 1_000, 0);
+
+        let error = decode_segment(&bytes).expect_err("impossible commit count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_impossible_top_level_commit_count_before_allocating() {
+        let bytes = segment_bytes_with_object_lengths(sample_segment(), 1_000, 0);
+
+        let error = view_segment(&bytes).expect_err("impossible commit count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_directory_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0]
+            .directory
+            .payloads
+            .push(SegmentPayloadLocation {
+                json_ref: JsonRef::from_hash_bytes([9; 32]),
+                offset: 1,
+                len: 0,
+            });
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("change directory count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 1 does not match 2 change directory payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_change_decode_rejects_change_directory_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0]
+            .directory
+            .payloads
+            .push(SegmentPayloadLocation {
+                json_ref: JsonRef::from_hash_bytes([9; 32]),
+                offset: 1,
+                len: 0,
+            });
+        let mut bytes = Vec::new();
+        write_segment_change(&mut bytes, &segment.changes[0]).unwrap();
+
+        let error = decode_segment_change(&bytes)
+            .expect_err("change directory count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 1 does not match 2 change directory payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes)
+            .expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment_object_slices(&bytes)
+            .expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_change_decode_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let mut bytes = Vec::new();
+        write_segment_change(&mut bytes, &segment.changes[0]).unwrap();
+
+        let error = decode_segment_change(&bytes)
+            .expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_directory_payload_offset_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].offset = 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes)
+            .expect_err("change directory payload offset mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_commit_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_commit_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_commit_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment_object_slices(&bytes)
+            .expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_invalid_membership_role() {
+        let bytes = segment_bytes_with_membership_role(sample_segment(), 9);
+
+        let error = view_segment(&bytes).expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_invalid_utf8_in_skipped_commit_string() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.created_at = "commit-created".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = segment_bytes_with_invalid_string_content(segment, "commit-created");
+
+        let error = view_segment(&bytes).expect_err("invalid UTF-8 should reject");
+
+        assert!(
+            error.message.contains("invalid UTF-8"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_invalid_utf8_in_skipped_change_string() {
+        let mut segment = sample_segment();
+        segment.changes[0].created_at = "change-created".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = segment_bytes_with_invalid_string_content(segment, "change-created");
+
+        let error = view_segment(&bytes).expect_err("invalid UTF-8 should reject");
+
+        assert!(
+            error.message.contains("invalid UTF-8"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_empty_change_entity_identity_part() {
+        let mut segment = sample_segment();
+        segment.changes[0].entity_id = EntityIdentity {
+            parts: vec![String::new()],
+        };
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("empty entity identity should reject");
+
+        assert!(
+            error.message.contains("invalid entity identity parts"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_empty_state_row_identity() {
+        let bytes = segment_bytes_with_empty_state_row_entity_id(sample_segment());
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("empty state-row identity should reject");
+
+        assert!(
+            error.message.contains("entity_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_state_row_identity_change_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.state_row_identities[0]
+            .0
+            .schema_key = CanonicalSchemaKey::new("other").unwrap();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("state-row identity mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner for change 'change-1' does not match"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_state_row_identity_change_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.state_row_identities[0]
+            .0
+            .schema_key = CanonicalSchemaKey::new("other").unwrap();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("state-row identity mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner for change 'change-1' does not match"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_authored_state_row_identity_missing_change() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].member_change_id = "missing-change".to_string();
+        segment.commits[0].directory.state_row_identities[0].1 = "missing-change".to_string();
+        segment.commits[0].directory.membership_ordinals[0].0 = "missing-change".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("missing authored change object should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner references missing authored change"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_authored_state_row_identity_missing_change() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].member_change_id = "missing-change".to_string();
+        segment.commits[0].directory.state_row_identities[0].1 = "missing-change".to_string();
+        segment.commits[0].directory.membership_ordinals[0].0 = "missing-change".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("missing authored change object should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner references missing authored change"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_authored_membership_commit_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].authored_commit_id = Some("other-commit".to_string());
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("authored commit ownership mismatch should reject");
+
+        assert!(
+            error.message.contains("mismatched authored_commit_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_authored_membership_commit_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].authored_commit_id = Some("other-commit".to_string());
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("authored commit ownership mismatch should reject");
+
+        assert!(
+            error.message.contains("mismatched authored_commit_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_adopted_membership_authored_by_same_commit() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("self-authored adopted membership should reject");
+
+        assert!(
+            error
+                .message
+                .contains("must not be authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_adopted_membership_authored_by_same_commit() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("self-authored adopted membership should reject");
+
+        assert!(
+            error
+                .message
+                .contains("must not be authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_checksum_distinguishes_list_boundaries() {
+        let segment = sample_segment();
+        let mut left = segment.commits[0].clone();
+        left.header.parent_commit_ids = vec!["a".to_string(), "b".to_string()];
+        left.header.derivable_change_id = "c".to_string();
+        left.header.author_account_ids = vec!["d".to_string()];
+
+        let mut right = segment.commits[0].clone();
+        right.header.parent_commit_ids = vec!["a".to_string()];
+        right.header.derivable_change_id = "b".to_string();
+        right.header.author_account_ids = vec!["c".to_string(), "d".to_string()];
+
+        assert_ne!(
+            checksum_commit(&left).unwrap(),
+            checksum_commit(&right).unwrap()
+        );
+    }
+
+    #[test]
+    fn change_checksum_distinguishes_entity_schema_boundaries() {
+        let segment = sample_segment();
+        let mut left = segment.changes[0].clone();
+        left.entity_id = EntityIdentity {
+            parts: vec!["a".to_string(), "b".to_string()],
+        };
+        left.schema_key = "c".to_string();
+        left.file_id = Some("d".to_string());
+
+        let mut right = segment.changes[0].clone();
+        right.entity_id = EntityIdentity {
+            parts: vec!["a".to_string()],
+        };
+        right.schema_key = "b".to_string();
+        right.file_id = Some("c".to_string());
+
+        assert_ne!(
+            checksum_change(&left).unwrap(),
+            checksum_change(&right).unwrap()
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_invalid_membership_role() {
+        let bytes = segment_bytes_with_membership_role(sample_segment(), 9);
+
+        let error = decode_segment(&bytes).expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_commit_decode_rejects_invalid_membership_role() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+        let role_offset = find_membership_role_offset(&bytes, "change-1");
+        bytes[role_offset] = 9;
+
+        let error = decode_segment_commit(&bytes).expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_invalid_membership_role() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].role = MembershipRole::Authored;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+        let role_offset = find_membership_role_offset(&bytes, "change-1");
+        bytes[role_offset] = 9;
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_wrong_expected_commit_id() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "other-commit",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("wrong expected commit id should reject");
+
+        assert!(
+            error.message.contains("decoded commit 'commit-1'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_membership_ordinal_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.membership_ordinals[0].1 = 7;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("membership ordinal mismatch should reject");
+
+        assert!(
+            error.message.contains("membership ordinal"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_commit_decode_rejects_membership_ordinal_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.membership_ordinals[0].1 = 7;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error =
+            decode_segment_commit(&bytes).expect_err("membership ordinal mismatch should reject");
+
+        assert!(
+            error.message.contains("membership ordinal"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_commit_decode_rejects_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].checksum = empty_checksum();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error =
+            decode_segment_commit(&bytes).expect_err("commit checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_locator_checksum_mismatch() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            "wrong-checksum",
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("locator checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("locator checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].checksum = empty_checksum();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("commit checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_truncated_commit_after_body() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_commit_header(&mut bytes, &segment.commits[0].header).unwrap();
+        write_commit_body(&mut bytes, &segment.commits[0].body).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("truncated commit should reject");
+
+        assert!(
+            error.message.contains("truncated bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn segment_bytes_with_empty_object_lists(segment: Segment) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, 0, "commits").unwrap();
+        write_len(&mut bytes, 0, "changes").unwrap();
+        bytes
+    }
+
+    fn segment_bytes_with_directory_lengths(
+        segment: Segment,
+        commit_len: usize,
+        change_len: usize,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_len(&mut bytes, commit_len, "directory commits").unwrap();
+        write_len(&mut bytes, change_len, "directory changes").unwrap();
+        write_len(&mut bytes, 0, "commits").unwrap();
+        write_len(&mut bytes, 0, "changes").unwrap();
+        bytes
+    }
+
+    fn segment_bytes_with_object_lengths(
+        segment: Segment,
+        commit_len: usize,
+        change_len: usize,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, commit_len, "commits").unwrap();
+        write_len(&mut bytes, change_len, "changes").unwrap();
+        bytes.resize(bytes.len() + commit_len + change_len, 0);
+        bytes
+    }
+
+    fn segment_change_bytes_with_inline_payload_len(
+        segment: Segment,
+        payload_len: usize,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, segment.commits.len(), "commits").unwrap();
+        for commit in &segment.commits {
+            write_segment_commit(&mut bytes, commit).unwrap();
+        }
+        write_len(&mut bytes, segment.changes.len(), "changes").unwrap();
+        let change = &segment.changes[0];
+        write_str(&mut bytes, &change.id).unwrap();
+        write_optional_str(&mut bytes, change.authored_commit_id.as_deref()).unwrap();
+        write_entity_identity(&mut bytes, &change.entity_id).unwrap();
+        write_str(&mut bytes, &change.schema_key).unwrap();
+        write_optional_str(&mut bytes, change.file_id.as_deref()).unwrap();
+        write_optional_json_ref(&mut bytes, change.snapshot_ref.as_ref());
+        write_optional_json_ref(&mut bytes, change.metadata_ref.as_ref());
+        write_str(&mut bytes, &change.created_at).unwrap();
+        write_len(&mut bytes, payload_len, "inline payloads").unwrap();
+        bytes.resize(bytes.len() + payload_len, 0);
+        bytes
+    }
+
+    fn commit_bytes_with_parent_count(segment: Segment, parent_count: usize) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, segment.commits.len(), "commits").unwrap();
+        let commit = &segment.commits[0];
+        write_str(&mut bytes, &commit.header.id).unwrap();
+        write_len(&mut bytes, parent_count, "parent commits").unwrap();
+        bytes.resize(bytes.len() + parent_count, 0);
+        bytes
+    }
+
+    fn segment_bytes_with_membership_role(segment: Segment, role: u8) -> Vec<u8> {
+        let mut bytes = encode_segment(&segment).unwrap();
+        let role_offset = find_membership_role_offset(&bytes, "change-1");
+        bytes[role_offset] = role;
+        bytes
+    }
+
+    fn segment_bytes_with_invalid_string_content(segment: Segment, value: &str) -> Vec<u8> {
+        let mut bytes = encode_segment(&segment).unwrap();
+        let mut pattern = Vec::new();
+        append_test_string(&mut pattern, value);
+        let offset = bytes
+            .windows(pattern.len())
+            .position(|window| window == pattern.as_slice())
+            .expect("test string should exist");
+        bytes[offset + 4] = 0xff;
+        bytes
+    }
+
+    fn segment_bytes_with_empty_state_row_entity_id(segment: Segment) -> Vec<u8> {
+        let mut bytes = encode_segment(&segment).unwrap();
+        let entity_len_offset = find_state_row_entity_id_len_offset(&bytes);
+        let entity = EntityIdentity::single("entity-1")
+            .as_json_array_text()
+            .unwrap();
+        let entity_len = entity.len();
+        bytes[entity_len_offset..entity_len_offset + 4].copy_from_slice(&0_u32.to_le_bytes());
+        bytes.drain(entity_len_offset + 4..entity_len_offset + 4 + entity_len);
+        bytes
+    }
+
+    fn find_state_row_entity_id_len_offset(bytes: &[u8]) -> usize {
+        let mut pattern = Vec::new();
+        append_test_string(&mut pattern, "message");
+        append_test_string(&mut pattern, "file-1");
+        let entity_len_offset = pattern.len();
+        append_test_string(
+            &mut pattern,
+            &EntityIdentity::single("entity-1")
+                .as_json_array_text()
+                .unwrap(),
+        );
+        append_test_string(&mut pattern, "change-1");
+        bytes
+            .windows(pattern.len())
+            .position(|window| window == pattern.as_slice())
+            .map(|offset| offset + entity_len_offset)
+            .expect("state-row identity should exist")
+    }
+
+    fn append_test_string(bytes: &mut Vec<u8>, value: &str) {
+        bytes.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(value.as_bytes());
+    }
+
+    fn find_membership_role_offset(bytes: &[u8], member_change_id: &str) -> usize {
+        let needle_len = (member_change_id.len() as u32).to_le_bytes();
+        let needle = member_change_id.as_bytes();
+        bytes
+            .windows(4 + needle.len())
+            .enumerate()
+            .find_map(|(offset, window)| {
+                if &window[..4] != needle_len.as_slice() || &window[4..] != needle {
+                    return None;
+                }
+                let role_offset = offset + 4 + needle.len();
+                let expected_after_role = [0, 0];
+                (bytes.get(role_offset..role_offset + expected_after_role.len())
+                    == Some(expected_after_role.as_slice()))
+                .then_some(role_offset)
+            })
+            .expect("membership record should exist")
+    }
+
+    fn sample_segment() -> Segment {
+        let entity_identity = EntityIdentity::single("entity-1");
+        let state_row_identity = StateRowIdentity {
+            schema_key: CanonicalSchemaKey::new("message").unwrap(),
+            file_id: FileId::new("file-1").unwrap(),
+            entity_id: EntityId::new(entity_identity.as_json_array_text().unwrap()).unwrap(),
+        };
+        let snapshot_ref = JsonRef::from_hash_bytes([1; 32]);
+        let metadata_ref = JsonRef::from_hash_bytes([2; 32]);
+        let payload_bytes = br#"{"hello":"world"}"#.to_vec();
+        let payload_ref = JsonRef::for_content(&payload_bytes);
+
+        let mut segment = Segment {
+            header: SegmentHeader {
+                segment_id: "segment-1".to_string(),
+                format_version: 1,
+                commit_count: 1,
+                change_count: 1,
+                byte_count: 123,
+                payload_count: 1,
+                checksum: "segment-checksum".to_string(),
+            },
+            directory: SegmentDirectory {
+                commits: vec![(
+                    "commit-1".to_string(),
+                    location("segment-1", 10, 20, "commit-checksum"),
+                )],
+                changes: vec![(
+                    "change-1".to_string(),
+                    location("segment-1", 30, 40, "change-checksum"),
+                )],
+            },
+            commits: vec![SegmentCommit {
+                header: CommitHeader {
+                    id: "commit-1".to_string(),
+                    parent_commit_ids: vec!["parent-1".to_string()],
+                    derivable_change_id: "commit-change-1".to_string(),
+                    author_account_ids: vec!["account-1".to_string()],
+                    created_at: "2026-05-12T00:00:00Z".to_string(),
+                    membership_count: 1,
+                },
+                body: CommitBody {
+                    membership: vec![MembershipRecord {
+                        member_change_id: "change-1".to_string(),
+                        role: MembershipRole::Authored,
+                        source_parent_ordinal: None,
+                    }],
+                },
+                directory: SegmentCommitDirectory {
+                    state_row_identities: vec![(state_row_identity, "change-1".to_string())],
+                    membership_ordinals: vec![("change-1".to_string(), 0)],
+                },
+                checksum: "commit-checksum".to_string(),
+            }],
+            changes: vec![SegmentChange {
+                id: "change-1".to_string(),
+                authored_commit_id: Some("commit-1".to_string()),
+                entity_id: entity_identity,
+                schema_key: "message".to_string(),
+                file_id: Some("file-1".to_string()),
+                snapshot_ref: Some(snapshot_ref),
+                metadata_ref: Some(metadata_ref),
+                created_at: "2026-05-12T00:00:00Z".to_string(),
+                inline_payloads: vec![SegmentInlinePayload {
+                    json_ref: payload_ref,
+                    bytes: payload_bytes,
+                }],
+                directory: SegmentChangeDirectory {
+                    payloads: vec![SegmentPayloadLocation {
+                        json_ref: payload_ref,
+                        offset: 0,
+                        len: 17,
+                    }],
+                },
+            }],
+        };
+        apply_sample_encoded_locations(&mut segment);
+        segment
+    }
+
+    fn sample_segment_with_two_changes() -> Segment {
+        let mut segment = sample_segment();
+        let entity_identity = EntityIdentity::single("entity-2");
+        let state_row_identity = StateRowIdentity {
+            schema_key: CanonicalSchemaKey::new("message").unwrap(),
+            file_id: FileId::new("file-1").unwrap(),
+            entity_id: EntityId::new(entity_identity.as_json_array_text().unwrap()).unwrap(),
+        };
+        let payload_bytes = br#"{"goodbye":"world"}"#.to_vec();
+        let payload_ref = JsonRef::for_content(&payload_bytes);
+        segment.commits[0].header.membership_count = 2;
+        segment.commits[0].body.membership.push(MembershipRecord {
+            member_change_id: "change-2".to_string(),
+            role: MembershipRole::Authored,
+            source_parent_ordinal: None,
+        });
+        segment.commits[0]
+            .directory
+            .state_row_identities
+            .push((state_row_identity, "change-2".to_string()));
+        segment.commits[0]
+            .directory
+            .membership_ordinals
+            .push(("change-2".to_string(), 1));
+        segment.changes.push(SegmentChange {
+            id: "change-2".to_string(),
+            authored_commit_id: Some("commit-1".to_string()),
+            entity_id: entity_identity,
+            schema_key: "message".to_string(),
+            file_id: Some("file-1".to_string()),
+            snapshot_ref: None,
+            metadata_ref: None,
+            created_at: "2026-05-12T00:00:01Z".to_string(),
+            inline_payloads: vec![SegmentInlinePayload {
+                json_ref: payload_ref,
+                bytes: payload_bytes,
+            }],
+            directory: SegmentChangeDirectory {
+                payloads: vec![SegmentPayloadLocation {
+                    json_ref: payload_ref,
+                    offset: 0,
+                    len: 19,
+                }],
+            },
+        });
+        segment.header.change_count = 2;
+        segment.header.payload_count = 2;
+        segment.directory.changes.push((
+            "change-2".to_string(),
+            location("segment-1", 0, 0, "change-checksum-2"),
+        ));
+        apply_sample_encoded_locations(&mut segment);
+        segment
+    }
+
+    fn apply_sample_encoded_locations(segment: &mut Segment) {
+        for commit in &mut segment.commits {
+            commit.checksum = checksum_commit(commit).unwrap();
+        }
+        let change_checksums = segment
+            .changes
+            .iter()
+            .map(|change| (change.id.clone(), checksum_change(change).unwrap()))
+            .collect::<HashMap<_, _>>();
+        for (change_id, location) in &mut segment.directory.changes {
+            location.checksum = change_checksums
+                .get(change_id)
+                .expect("change checksum should exist")
+                .clone();
+        }
+        for (commit_id, location) in &mut segment.directory.commits {
+            location.checksum = segment
+                .commits
+                .iter()
+                .find(|commit| commit.header.id == *commit_id)
+                .expect("commit checksum should exist")
+                .checksum
+                .clone();
+        }
+        segment.header.byte_count = 0;
+        segment.header.checksum = empty_checksum();
+        let encoded = encode_segment_with_object_locations(segment).unwrap();
+        for (id, location) in &mut segment.directory.commits {
+            let object = encoded
+                .commits
+                .iter()
+                .find(|object| object.id == *id)
+                .expect("commit location should exist");
+            location.offset = object.offset;
+            location.len = object.len;
+        }
+        for (id, location) in &mut segment.directory.changes {
+            let object = encoded
+                .changes
+                .iter()
+                .find(|object| object.id == *id)
+                .expect("change location should exist");
+            location.offset = object.offset;
+            location.len = object.len;
+        }
+        segment.header.byte_count = encode_segment(segment).unwrap().len() as u64;
+        segment.header.checksum = checksum_segment(segment).unwrap();
     }
 
     fn location(segment_id: &str, offset: u64, len: u64, checksum: &str) -> SegmentObjectLocation {

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -94,6 +94,7 @@ pub(crate) fn decode_segment(bytes: &[u8]) -> Result<Segment, LixError> {
         header.commit_count as usize,
         header.change_count as usize,
     )?;
+    let mut object_slice_cursor = cursor.clone();
     let commit_len = cursor.read_len("commits")?;
     cursor.ensure_len_fits_remaining(commit_len, "commits")?;
     cursor.ensure_counted_records_fit_remaining(commit_len, MIN_COMMIT_OBJECT_BYTES, "commits")?;
@@ -164,12 +165,39 @@ pub(crate) fn decode_segment(bytes: &[u8]) -> Result<Segment, LixError> {
             ))
         }),
     )?;
-    let (commit_slices, change_slices) = read_segment_object_slices_view(bytes)?;
+    let header_view = SegmentHeaderView {
+        segment_id: &header.segment_id,
+        format_version: header.format_version,
+        commit_count: header.commit_count,
+        change_count: header.change_count,
+        byte_count: header.byte_count,
+        payload_count: header.payload_count,
+        checksum: &header.checksum,
+    };
+    let object_slices =
+        read_segment_object_slices_for_header_fast(&mut object_slice_cursor, &header_view)?;
+    let commit_slices = object_slices.commit_slices();
+    let change_slices = object_slices.change_slices();
     validate_segment_directory_object_slices_owned(
         &header.segment_id,
         &directory,
         &commit_slices,
         &change_slices,
+    )?;
+    let directory_change_refs = directory
+        .changes
+        .iter()
+        .map(|(id, location)| SegmentDirectoryEntryRef {
+            id,
+            location: location.as_ref(),
+        })
+        .collect::<Vec<_>>();
+    validate_segment_view_checksum(
+        bytes,
+        &header_view,
+        &directory_change_refs,
+        &object_slices.commits,
+        &object_slices.changes,
     )?;
     let segment = Segment {
         header,
@@ -680,10 +708,14 @@ fn read_segment_header_and_directory_view(
         validate_directory_locations_are_in_bounds(
             header.segment_id,
             bytes.len() as u64,
-            directory_commits
-                .iter()
-                .chain(directory_changes.iter())
-                .copied(),
+            "commit",
+            directory_commits.iter().copied(),
+        )?;
+        validate_directory_locations_are_in_bounds(
+            header.segment_id,
+            bytes.len() as u64,
+            "change",
+            directory_changes.iter().copied(),
         )?;
     }
     Ok(SegmentDirectoryViewRead {
@@ -719,6 +751,7 @@ fn segment_view_from_parts<'a>(
 fn validate_directory_locations_are_in_bounds<'a>(
     segment_id: &str,
     byte_count: u64,
+    kind: &str,
     entries: impl Iterator<Item = SegmentDirectoryEntryRef<'a>>,
 ) -> Result<(), LixError> {
     let mut seen = HashSet::new();
@@ -732,7 +765,7 @@ fn validate_directory_locations_are_in_bounds<'a>(
         }
         if !seen.insert(entry.id) {
             return Err(LixError::unknown(format!(
-                "changelog segment '{segment_id}' contains duplicate directory locator for '{}'",
+                "changelog segment '{segment_id}' contains duplicate {kind} directory locator for '{}'",
                 entry.id
             )));
         }
@@ -912,27 +945,6 @@ fn validate_segment_header_object_counts(
         payload_count,
         "inline payloads",
     )
-}
-
-fn validate_change_payload_directory(
-    change_id: &str,
-    inline_payloads: &[SegmentInlinePayload],
-    directory: &SegmentChangeDirectory,
-) -> Result<(), LixError> {
-    validate_count_matches_usize(
-        "payload_count",
-        inline_payloads.len() as u32,
-        directory.payloads.len(),
-        "change directory payloads",
-    )?;
-    let inline_payloads = inline_payloads
-        .iter()
-        .map(|payload| PayloadDescriptor {
-            json_ref: payload.json_ref.clone(),
-            len: payload.bytes.len() as u64,
-        })
-        .collect::<Vec<_>>();
-    validate_payload_descriptors_against_directory(change_id, &inline_payloads, directory)
 }
 
 fn validate_payload_descriptors_against_directory(
@@ -2132,20 +2144,6 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
-    fn read_commit_header_fast(&mut self) -> Result<CommitHeaderView<'a>, LixError> {
-        let id = self.read_string_ref_fast()?;
-        let parent_count = self.read_strings_fast_owned()?.len();
-        self.skip_string_fast()?;
-        self.read_strings_fast_owned()?;
-        self.skip_string_fast()?;
-        let membership_count = self.read_u32_fast()?;
-        Ok(CommitHeaderView {
-            id,
-            parent_count,
-            membership_count,
-        })
-    }
-
     fn read_commit_body(
         &mut self,
         field: &str,
@@ -3254,12 +3252,6 @@ struct SegmentHeaderView<'a> {
     checksum: &'a str,
 }
 
-struct CommitHeaderView<'a> {
-    id: &'a str,
-    parent_count: usize,
-    membership_count: u32,
-}
-
 fn changelog_codec_not_implemented(message: impl Into<String>) -> LixError {
     LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
 }
@@ -3285,6 +3277,25 @@ mod tests {
         assert_eq!(view.directory_commits[0].id, "commit-1");
         assert_eq!(view.directory_changes[0].id, "change-1");
         assert!(!view.object_bytes.is_empty());
+    }
+
+    #[test]
+    fn directory_view_allows_same_commit_and_change_id() {
+        let mut segment = sample_segment();
+        segment.changes[0].id = "commit-1".to_string();
+        segment.changes[0].authored_commit_id = Some("commit-1".to_string());
+        segment.commits[0].body.membership[0].member_change_id = "commit-1".to_string();
+        segment.commits[0].directory.state_row_identities[0].1 = "commit-1".to_string();
+        segment.commits[0].directory.membership_ordinals[0].0 = "commit-1".to_string();
+        segment.directory.changes[0].0 = "commit-1".to_string();
+        apply_sample_encoded_locations(&mut segment);
+
+        let encoded = encode_segment(&segment).unwrap();
+        let view = view_segment_directory(&encoded)
+            .expect("commit and change ids should be separate directory namespaces");
+
+        assert_eq!(view.directory_commits[0].id, "commit-1");
+        assert_eq!(view.directory_changes[0].id, "commit-1");
     }
 
     #[test]
@@ -3578,7 +3589,7 @@ mod tests {
             view_segment_directory(&bytes).expect_err("duplicate directory id should reject");
 
         assert!(
-            error.message.contains("duplicate directory locator"),
+            error.message.contains("duplicate change directory locator"),
             "unexpected error: {error}"
         );
     }
@@ -3775,8 +3786,8 @@ mod tests {
     }
 
     #[test]
-    fn segment_object_slices_rejects_inline_payloads_exceeding_header_payload_count_before_scanning(
-    ) {
+    fn segment_object_slices_rejects_inline_payloads_exceeding_header_payload_count_before_scanning()
+     {
         let mut segment = sample_segment();
         segment.header.payload_count = 0;
         let bytes = encode_segment(&segment).unwrap();

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -3627,6 +3627,27 @@ mod tests {
     }
 
     #[test]
+    fn segment_decode_rejects_mutated_object_body_with_stale_checksums() {
+        let mut segment = sample_segment();
+        let encoded = encode_segment(&segment).unwrap();
+        segment.changes[0].created_at = "2026-05-12T00:00:01Z".to_string();
+        let stale_bytes = encode_segment(&segment).unwrap();
+        assert_eq!(
+            encoded.len(),
+            stale_bytes.len(),
+            "test mutation should preserve encoded layout"
+        );
+
+        let error = decode_segment(&stale_bytes)
+            .expect_err("mutated body with stale checksums must reject");
+
+        assert!(
+            error.message.contains("canonical checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn segment_decode_rejects_inline_payload_ref_mismatch() {
         let mut segment = sample_segment();
         let bogus_ref = JsonRef::from_hash_bytes([9; 32]);

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -25,7 +25,11 @@ use super::store::{
     commit_visibility_key, commit_visibility_value, segment_key, segment_value,
     visible_change_proof_key, visible_change_proof_value,
 };
-use super::truth::{SegmentTruthSnapshot, load_segment_truth_index};
+use super::truth::{
+    SegmentTruthSnapshot, find_change_by_exhaustive_segment_scan,
+    find_changes_by_exhaustive_segment_scan, find_commit_by_exhaustive_segment_scan,
+    find_commits_by_exhaustive_segment_scan, load_segment_truth_index,
+};
 use crate::LixError;
 use crate::changelog::{
     ByChangeEntry, ByCommitEntry, Change, ChangeLoadBatch, ChangeLoadEntry, ChangeLoadRequest,
@@ -404,6 +408,9 @@ where
         commit_ids: &[String],
         projection: CommitProjection,
     ) -> Result<Vec<Option<CommitLoadEntry>>, LixError> {
+        if commit_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let visibilities = self.load_commit_visibility_many(commit_ids).await?;
         let mut segment_ids = Vec::new();
         for visibility in visibilities.iter().flatten() {
@@ -440,7 +447,20 @@ where
         commit_ids: &[String],
         projection: CommitProjection,
     ) -> Result<Vec<Option<CommitLoadEntry>>, LixError> {
+        if commit_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let by_commit_entries = self.load_by_commit_many(commit_ids).await?;
+        let missing_commit_ids = commit_ids
+            .iter()
+            .zip(by_commit_entries.iter())
+            .filter_map(|(commit_id, entry)| entry.is_none().then_some(commit_id.as_str()))
+            .collect::<Vec<_>>();
+        let truth_commits = if missing_commit_ids.is_empty() {
+            HashMap::new()
+        } else {
+            find_commits_by_exhaustive_segment_scan(&mut self.store, &missing_commit_ids).await?
+        };
         let mut segment_ids = Vec::new();
         for entry in by_commit_entries.iter().flatten() {
             push_unique(&mut segment_ids, entry.location.segment_id.clone());
@@ -449,7 +469,11 @@ where
         let mut entries = Vec::with_capacity(commit_ids.len());
         for (commit_id, by_commit) in commit_ids.iter().zip(by_commit_entries.iter()) {
             let Some(by_commit) = by_commit else {
-                entries.push(None);
+                entries.push(
+                    truth_commits
+                        .get(commit_id)
+                        .map(|(_, commit)| project_segment_commit(commit, projection)),
+                );
                 continue;
             };
             if by_commit.commit_id != *commit_id {
@@ -465,6 +489,7 @@ where
                 )));
             };
             let commit = segment.load_commit(&by_commit.location, commit_id)?;
+            validate_commit_checksum(&by_commit.location.checksum, commit_id, &commit)?;
             entries.push(Some(project_segment_commit(&commit, projection)));
         }
         Ok(entries)
@@ -492,7 +517,20 @@ where
         change_ids: &[String],
         projection: ChangeProjection,
     ) -> Result<Vec<Option<ChangeLoadEntry>>, LixError> {
+        if change_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let by_change_entries = self.load_by_change_many(change_ids).await?;
+        let missing_change_ids = change_ids
+            .iter()
+            .zip(by_change_entries.iter())
+            .filter_map(|(change_id, entry)| entry.is_none().then_some(change_id.as_str()))
+            .collect::<Vec<_>>();
+        let truth_changes = if missing_change_ids.is_empty() {
+            HashMap::new()
+        } else {
+            find_changes_by_exhaustive_segment_scan(&mut self.store, &missing_change_ids).await?
+        };
         let mut segment_ids = Vec::new();
         for entry in by_change_entries.iter().flatten() {
             push_unique(&mut segment_ids, entry.location.segment_id.clone());
@@ -501,7 +539,9 @@ where
         let mut entries = Vec::with_capacity(change_ids.len());
         for (change_id, by_change) in change_ids.iter().zip(by_change_entries.iter()) {
             let Some(by_change) = by_change else {
-                entries.push(None);
+                entries.push(truth_changes.get(change_id).map(|(location, change)| {
+                    project_change_with_location(location.clone(), change, projection)
+                }));
                 continue;
             };
             if by_change.change_id != *change_id {
@@ -539,6 +579,9 @@ where
         change_ids: &[String],
         projection: ChangeProjection,
     ) -> Result<Vec<Option<ChangeLoadEntry>>, LixError> {
+        if change_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let by_change_entries = self.load_by_change_many(change_ids).await?;
         let mut segment_ids = Vec::new();
         for entry in by_change_entries.iter().flatten() {
@@ -546,6 +589,20 @@ where
         }
         let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
         let visible_change_ids = self.prove_visible_changes(change_ids).await?;
+        let missing_visible_change_ids = change_ids
+            .iter()
+            .zip(by_change_entries.iter())
+            .filter_map(|(change_id, entry)| {
+                (entry.is_none() && visible_change_ids.contains(change_id))
+                    .then_some(change_id.as_str())
+            })
+            .collect::<Vec<_>>();
+        let truth_changes = if missing_visible_change_ids.is_empty() {
+            HashMap::new()
+        } else {
+            find_changes_by_exhaustive_segment_scan(&mut self.store, &missing_visible_change_ids)
+                .await?
+        };
         let mut entries = Vec::with_capacity(change_ids.len());
         for (change_id, by_change) in change_ids.iter().zip(by_change_entries.iter()) {
             if !visible_change_ids.contains(change_id) {
@@ -577,7 +634,9 @@ where
                     )));
                 }
             } else {
-                self.find_segment_change(change_id).await?
+                truth_changes
+                    .get(change_id)
+                    .map(|(location, change)| (location.clone(), change.clone()))
             };
             let Some((location, change)) = physical else {
                 return Err(LixError::unknown(format!(
@@ -1053,44 +1112,6 @@ where
         Ok(Some(project_segment_commit(commit, projection)))
     }
 
-    async fn load_physical_commit_entry(
-        &mut self,
-        commit_id: &str,
-        projection: CommitProjection,
-    ) -> Result<Option<CommitLoadEntry>, LixError> {
-        let Some(entry) = self.load_by_commit(commit_id).await? else {
-            return Ok(None);
-        };
-        let Some(segment) = self.load_segment(&entry.location.segment_id).await? else {
-            return Err(LixError::unknown(format!(
-                "changelog by_commit entry for '{commit_id}' points to missing segment '{}'",
-                entry.location.segment_id
-            )));
-        };
-        let Some(commit) = segment_commit(&segment, commit_id) else {
-            return Err(LixError::unknown(format!(
-                "changelog by_commit entry for '{commit_id}' points to segment '{}' without that commit",
-                segment.header.segment_id
-            )));
-        };
-        validate_commit_location(&entry.location, &segment, commit_id)?;
-        Ok(Some(project_segment_commit(commit, projection)))
-    }
-
-    async fn load_physical_change_entry(
-        &mut self,
-        change_id: &str,
-        projection: ChangeProjection,
-    ) -> Result<Option<ChangeLoadEntry>, LixError> {
-        let Some((location, change)) = self.load_physical_segment_change(change_id).await? else {
-            return Ok(None);
-        };
-        if projection == ChangeProjection::PhysicalLocation {
-            return Ok(Some(ChangeLoadEntry::PhysicalLocation(location)));
-        }
-        Ok(Some(project_segment_change(&change, projection)))
-    }
-
     async fn load_visible_change_entry(
         &mut self,
         change_id: &str,
@@ -1153,20 +1174,24 @@ where
         if expected_locations.is_empty() {
             return Ok(());
         }
-        let mut seen = HashSet::new();
-        for segment in self.scan_all_segments().await? {
-            for commit_id in expected_locations.keys() {
-                let Some(commit) = segment_commit(&segment, commit_id) else {
-                    continue;
-                };
-                let location = directory_commit_location(&segment, commit_id)?;
-                validate_commit_checksum(&location.checksum, commit_id, commit)?;
-                let expected_location = &expected_locations[commit_id];
-                if &location != expected_location || !seen.insert(commit_id.clone()) {
-                    return Err(LixError::unknown(format!(
-                        "changelog commit '{commit_id}' appears in multiple segments"
-                    )));
-                }
+        let found = find_commits_by_exhaustive_segment_scan(
+            &mut self.store,
+            &expected_locations
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+        for (commit_id, expected_location) in expected_locations {
+            let Some((location, _)) = found.get(commit_id) else {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' is missing from segment truth"
+                )));
+            };
+            if location != expected_location {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' appears in multiple segments"
+                )));
             }
         }
         Ok(())
@@ -1182,7 +1207,7 @@ where
                     .await?;
                 Ok(Some(found))
             }
-            Ok(None) => self.scan_segments_for_change(change_id).await,
+            Ok(None) => find_change_by_exhaustive_segment_scan(&mut self.store, change_id).await,
             Err(error) => Err(error),
         }
     }
@@ -1206,66 +1231,27 @@ where
         if expected_locations.is_empty() {
             return Ok(());
         }
-        let mut seen = HashSet::new();
-        for segment in self.scan_all_segments().await? {
-            for change_id in expected_locations.keys() {
-                let Some(change) = segment_change(&segment, change_id) else {
-                    continue;
-                };
-                let location = directory_change_location(&segment, change_id)?;
-                validate_change_checksum(&location.checksum, change_id, change)?;
-                let expected_location = &expected_locations[change_id];
-                if &location != expected_location || !seen.insert(change_id.clone()) {
-                    return Err(LixError::unknown(format!(
-                        "changelog change '{change_id}' appears in multiple segments"
-                    )));
-                }
+        let found = find_changes_by_exhaustive_segment_scan(
+            &mut self.store,
+            &expected_locations
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+        for (change_id, expected_location) in expected_locations {
+            let Some((location, _)) = found.get(change_id) else {
+                return Err(LixError::unknown(format!(
+                    "changelog change '{change_id}' is missing from segment truth"
+                )));
+            };
+            if location != expected_location {
+                return Err(LixError::unknown(format!(
+                    "changelog change '{change_id}' appears in multiple segments"
+                )));
             }
         }
         Ok(())
-    }
-
-    async fn scan_segments_for_change(
-        &mut self,
-        change_id: &str,
-    ) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError> {
-        let mut found = None::<(SegmentObjectLocation, SegmentChange)>;
-        let mut after = None;
-        loop {
-            let page = self
-                .store
-                .changelog_scan(
-                    SEGMENT_SPACE,
-                    Vec::new(),
-                    after,
-                    64,
-                    StorageCoreProjection::FullValue,
-                )
-                .await?;
-            for index in 0..page.len() {
-                let Some(bytes) = page.value(index) else {
-                    continue;
-                };
-                let segment = decode_segment(bytes)?;
-                validate_segment_shape(&segment)?;
-                if let Some(change) = segment_change(&segment, change_id) {
-                    let location = directory_change_location(&segment, change_id)?;
-                    validate_change_checksum(&location.checksum, change_id, change)?;
-                    if let Some((existing, _)) = &found {
-                        return Err(LixError::unknown(format!(
-                            "changelog change '{change_id}' appears in multiple segments: '{}' and '{}'",
-                            existing.segment_id, location.segment_id
-                        )));
-                    }
-                    found = Some((location, change.clone()));
-                }
-            }
-            let Some(next_after) = page.resume_after else {
-                break;
-            };
-            after = Some(next_after);
-        }
-        Ok(found)
     }
 
     async fn visible_membership_contains_change(
@@ -1599,8 +1585,31 @@ where
         let location = if let Some(location) = self.staged_commits.get(commit_id).cloned() {
             location
         } else {
-            self.load_stored_commit_location_from_segment_truth(commit_id)
-                .await?
+            let truth_location = self
+                .load_stored_commit_location_from_segment_truth(commit_id)
+                .await?;
+            if let Some(entry) = get_one(
+                &mut *self.store,
+                BY_COMMIT_INDEX_SPACE,
+                by_commit_key(commit_id),
+            )
+            .await?
+            .map(|bytes| decode_by_commit_entry(&bytes))
+            .transpose()?
+            {
+                if entry.commit_id != commit_id {
+                    return Err(LixError::unknown(format!(
+                        "by_commit key for '{commit_id}' contains commit_id '{}'",
+                        entry.commit_id
+                    )));
+                }
+                if entry.location != truth_location {
+                    return Err(LixError::unknown(format!(
+                        "by_commit entry for '{commit_id}' does not match segment truth"
+                    )));
+                }
+            }
+            truth_location
         };
         self.stage_publish_commit_at_location(commit_id, location)
             .await
@@ -1610,45 +1619,14 @@ where
         &mut self,
         commit_id: &str,
     ) -> Result<SegmentObjectLocation, LixError> {
-        let mut after = None;
-        let mut found = None::<SegmentObjectLocation>;
-        loop {
-            let page = self
-                .store
-                .changelog_scan(
-                    SEGMENT_SPACE,
-                    Vec::new(),
-                    after,
-                    64,
-                    StorageCoreProjection::FullValue,
-                )
-                .await?;
-            for index in 0..page.len() {
-                let Some(bytes) = page.value(index) else {
-                    continue;
-                };
-                let segment = DecodedSegmentIndex::decode(bytes)?;
-                let Some(location) = segment.commit_location(commit_id) else {
-                    continue;
-                };
-                if let Some(existing) = &found {
-                    return Err(LixError::unknown(format!(
-                        "cannot publish changelog commit '{commit_id}' because multiple segments contain it: '{}' and '{}'",
-                        existing.segment_id, location.segment_id
-                    )));
-                }
-                found = Some(location.clone());
-            }
-            let Some(next_after) = page.resume_after else {
-                break;
-            };
-            after = Some(next_after);
-        }
-        found.ok_or_else(|| {
-            LixError::unknown(format!(
-                "cannot publish changelog commit '{commit_id}' because no segment contains it"
-            ))
-        })
+        find_commit_by_exhaustive_segment_scan(&mut *self.store, commit_id)
+            .await?
+            .map(|(location, _)| location)
+            .ok_or_else(|| {
+                LixError::unknown(format!(
+                    "cannot publish changelog commit '{commit_id}' because no segment contains it"
+                ))
+            })
     }
 
     pub(crate) async fn stage_publish_commit_at_location(
@@ -2226,7 +2204,11 @@ where
         .map(|bytes| decode_by_commit_entry(&bytes))
         .transpose()?
         else {
-            return self.scan_segments_for_commit(commit_id).await;
+            return Ok(
+                find_commit_by_exhaustive_segment_scan(&mut *self.store, commit_id)
+                    .await?
+                    .map(|(_, commit)| commit),
+            );
         };
         if entry.commit_id != commit_id {
             return Err(LixError::unknown(format!(
@@ -2245,30 +2227,19 @@ where
         };
         let commit = segment.load_commit(&entry.location, commit_id)?;
         validate_commit_checksum(&entry.location.checksum, commit_id, &commit)?;
-        self.ensure_unique_stored_commit(commit_id, &entry.location)
-            .await?;
-        Ok(Some(commit))
-    }
-
-    async fn ensure_unique_stored_commit(
-        &mut self,
-        commit_id: &str,
-        expected_location: &SegmentObjectLocation,
-    ) -> Result<(), LixError> {
-        for segment in self.scan_all_segments().await? {
-            let Some(commit) = segment_commit(&segment, commit_id) else {
-                continue;
-            };
-            let location = directory_commit_location(&segment, commit_id)?;
-            validate_commit_checksum(&location.checksum, commit_id, commit)?;
-            if &location != expected_location {
-                return Err(LixError::unknown(format!(
-                    "changelog commit '{commit_id}' appears in multiple segments: '{}' and '{}'",
-                    expected_location.segment_id, location.segment_id
-                )));
-            }
+        let Some((truth_location, _)) =
+            find_commit_by_exhaustive_segment_scan(&mut *self.store, commit_id).await?
+        else {
+            return Err(LixError::unknown(format!(
+                "by_commit entry for '{commit_id}' points to object missing from segment truth"
+            )));
+        };
+        if truth_location != entry.location {
+            return Err(LixError::unknown(format!(
+                "by_commit entry for '{commit_id}' does not match segment truth"
+            )));
         }
-        Ok(())
+        Ok(Some(commit))
     }
 
     async fn load_segment_byte_index_for_writer(
@@ -2280,28 +2251,6 @@ where
             return Ok(None);
         };
         Ok(Some(SegmentByteIndex::decode(bytes)?))
-    }
-
-    async fn scan_segments_for_commit(
-        &mut self,
-        commit_id: &str,
-    ) -> Result<Option<SegmentCommit>, LixError> {
-        let mut found = None::<(String, SegmentCommit)>;
-        for segment in self.scan_all_segments().await? {
-            let Some(commit) = segment_commit(&segment, commit_id) else {
-                continue;
-            };
-            let location = directory_commit_location(&segment, commit_id)?;
-            validate_commit_checksum(&location.checksum, commit_id, commit)?;
-            if let Some((existing_segment_id, _)) = &found {
-                return Err(LixError::unknown(format!(
-                    "changelog commit '{commit_id}' appears in multiple segments: '{}' and '{}'",
-                    existing_segment_id, segment.header.segment_id
-                )));
-            }
-            found = Some((segment.header.segment_id.clone(), commit.clone()));
-        }
-        Ok(found.map(|(_, commit)| commit))
     }
 
     async fn resolve_publish_changes(
@@ -3130,7 +3079,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_commits_physical_only_returns_none_when_locator_index_is_missing_for_existing_commit()
+    async fn load_commits_physical_only_falls_back_when_locator_index_is_missing_for_existing_commit()
      {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
@@ -3160,7 +3109,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(batch.entries, vec![None]);
+        assert!(matches!(
+            batch.entries.as_slice(),
+            [Some(CommitLoadEntry::Header(_))]
+        ));
     }
 
     #[tokio::test]
@@ -3320,7 +3272,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_changes_physical_only_returns_none_when_locator_index_is_missing_for_existing_change()
+    async fn load_changes_physical_only_falls_back_when_locator_index_is_missing_for_existing_change()
      {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
@@ -3329,7 +3281,7 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
+            writer.stage_segment(segment.clone()).await.unwrap();
         }
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
@@ -3350,7 +3302,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(batch.entries, vec![None]);
+        assert_eq!(
+            batch.entries,
+            vec![Some(ChangeLoadEntry::Segment(segment.changes[0].clone()))]
+        );
     }
 
     #[tokio::test]
@@ -4521,7 +4476,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stage_publish_commit_ignores_stale_by_commit_locator() {
+    async fn stage_publish_commit_rejects_stale_by_commit_locator() {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
 
@@ -4553,19 +4508,14 @@ mod tests {
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();
         let mut writer = context.writer(&mut *transaction, &mut writes);
-        writer.stage_publish_commit("commit-1").await.unwrap();
-        writes.apply(&mut *transaction).await.unwrap();
-        transaction.commit().await.unwrap();
-
-        let result = read_test_value_groups(
-            &storage,
-            vec![(
-                COMMIT_VISIBILITY_SPACE,
-                vec![commit_visibility_key("commit-1")],
-            )],
+        let error = writer
+            .stage_publish_commit("commit-1")
+            .await
+            .expect_err("stale by_commit locator must fail closed");
+        assert!(
+            error.message.contains("does not match segment truth"),
+            "unexpected error: {error}"
         );
-        let visibility = decode_commit_visibility(result[0][0].as_deref().unwrap()).unwrap();
-        assert_eq!(visibility.location.segment_id, "segment-1");
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -425,8 +425,6 @@ where
             };
             let commit = segment.load_commit(&visibility.location, commit_id)?;
             validate_commit_checksum(&visibility.checksum, commit_id, &commit)?;
-            self.ensure_unique_stored_commit(commit_id, &visibility.location)
-                .await?;
             entries.push(Some(project_segment_commit(&commit, projection)));
         }
         Ok(entries)
@@ -443,16 +441,6 @@ where
             push_unique(&mut segment_ids, entry.location.segment_id.clone());
         }
         let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
-        let expected_locations = commit_ids
-            .iter()
-            .zip(by_commit_entries.iter())
-            .filter_map(|(commit_id, entry)| {
-                let entry = entry.as_ref()?;
-                (entry.commit_id == *commit_id).then(|| (commit_id.clone(), entry.location.clone()))
-            })
-            .collect::<HashMap<_, _>>();
-        self.ensure_unique_stored_commits(&expected_locations)
-            .await?;
         let mut entries = Vec::with_capacity(commit_ids.len());
         for (commit_id, by_commit) in commit_ids.iter().zip(by_commit_entries.iter()) {
             let Some(by_commit) = by_commit else {
@@ -505,16 +493,6 @@ where
             push_unique(&mut segment_ids, entry.location.segment_id.clone());
         }
         let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
-        let expected_locations = change_ids
-            .iter()
-            .zip(by_change_entries.iter())
-            .filter_map(|(change_id, entry)| {
-                let entry = entry.as_ref()?;
-                (entry.change_id == *change_id).then(|| (change_id.clone(), entry.location.clone()))
-            })
-            .collect::<HashMap<_, _>>();
-        self.ensure_unique_stored_changes(&expected_locations)
-            .await?;
         let mut entries = Vec::with_capacity(change_ids.len());
         for (change_id, by_change) in change_ids.iter().zip(by_change_entries.iter()) {
             let Some(by_change) = by_change else {
@@ -564,17 +542,6 @@ where
         }
         let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
         let visible_change_ids = self.prove_visible_changes(change_ids).await?;
-        let expected_locations = change_ids
-            .iter()
-            .zip(by_change_entries.iter())
-            .filter(|(change_id, _)| visible_change_ids.contains(*change_id))
-            .filter_map(|(change_id, entry)| {
-                let entry = entry.as_ref()?;
-                (entry.change_id == *change_id).then(|| (change_id.clone(), entry.location.clone()))
-            })
-            .collect::<HashMap<_, _>>();
-        self.ensure_unique_stored_changes(&expected_locations)
-            .await?;
         let mut entries = Vec::with_capacity(change_ids.len());
         for (change_id, by_change) in change_ids.iter().zip(by_change_entries.iter()) {
             if !visible_change_ids.contains(change_id) {
@@ -733,7 +700,11 @@ where
         .await?;
         values
             .into_iter()
-            .map(|value| Ok(value.and_then(|bytes| decode_commit_visibility(&bytes).ok())))
+            .map(|value| {
+                value
+                    .map(|bytes| decode_commit_visibility(&bytes))
+                    .transpose()
+            })
             .collect()
     }
 
@@ -3715,7 +3686,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_changes_visible_recovers_from_corrupt_visible_change_proof() {
+    async fn load_changes_visible_rejects_corrupt_visible_change_proof() {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
 
@@ -3740,18 +3711,20 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut reader = context.reader(storage);
-        let batch = reader
+        let error = reader
             .load_changes(ChangeLoadRequest {
                 change_ids: &["change-1".to_string()],
                 projection: ChangeProjection::Segment,
                 visibility: ChangeVisibilityMode::RequireReachableFromVisibleCommit,
             })
             .await
-            .expect("corrupt visible proof should fall back to membership/visibility scans");
+            .expect_err("corrupt visible proof should fail closed");
 
-        assert_eq!(
-            batch.entries,
-            vec![Some(ChangeLoadEntry::Segment(segment.changes[0].clone()))]
+        assert!(
+            error
+                .to_string()
+                .contains("failed to decode changelog commit visibility"),
+            "unexpected error: {error}"
         );
     }
 
@@ -4264,77 +4237,6 @@ mod tests {
             .find_segment_change("change-1")
             .await
             .expect_err("duplicate primary change must reject despite by_change index");
-
-        assert!(
-            error.message.contains("appears in multiple"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn load_changes_physical_rejects_duplicate_primary_change_even_when_by_change_exists() {
-        let (context, storage) = changelog_test_context();
-
-        let mut transaction = storage.begin_write_transaction().await.unwrap();
-        let mut writes = StorageWriteSet::new();
-        {
-            let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(test_segment()).await.unwrap();
-        }
-        writes.apply(&mut *transaction).await.unwrap();
-        transaction.commit().await.unwrap();
-
-        let mut duplicate = test_segment();
-        duplicate.header.segment_id = "segment-2".to_string();
-        duplicate.commits[0].header.id = "commit-2".to_string();
-        duplicate.commits[0].header.derivable_change_id = "derived-change-2".to_string();
-        duplicate.changes[0].authored_commit_id = Some("commit-2".to_string());
-        let duplicate = canonicalize_segment(duplicate).unwrap();
-        write_raw_segment(&storage, &duplicate).await;
-
-        let mut reader = context.reader(storage);
-        let error = reader
-            .load_changes(ChangeLoadRequest {
-                change_ids: &["change-1".to_string()],
-                projection: ChangeProjection::Segment,
-                visibility: ChangeVisibilityMode::PhysicalOnly,
-            })
-            .await
-            .expect_err("batch physical read must reject duplicate primary change");
-
-        assert!(
-            error.message.contains("appears in multiple"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn load_commits_physical_rejects_duplicate_primary_commit_even_when_by_commit_exists() {
-        let (context, storage) = changelog_test_context();
-
-        let mut transaction = storage.begin_write_transaction().await.unwrap();
-        let mut writes = StorageWriteSet::new();
-        {
-            let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(test_segment()).await.unwrap();
-        }
-        writes.apply(&mut *transaction).await.unwrap();
-        transaction.commit().await.unwrap();
-
-        let mut duplicate = test_segment();
-        duplicate.header.segment_id = "segment-2".to_string();
-        let duplicate = canonicalize_segment(duplicate).unwrap();
-        write_raw_segment(&storage, &duplicate).await;
-
-        let mut reader = context.reader(storage);
-        let error = reader
-            .load_commits(CommitLoadRequest {
-                commit_ids: &["commit-1".to_string()],
-                projection: CommitProjection::Header,
-                visibility: CommitVisibilityMode::PhysicalOnly,
-            })
-            .await
-            .expect_err("batch physical read must reject duplicate primary commit");
 
         assert!(
             error.message.contains("appears in multiple"),

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -8,24 +8,20 @@ use super::by_change_index::by_change_entries_for_segments;
 use super::by_change_membership_index::by_change_membership_entries_for_segments;
 use super::by_commit_index::{by_commit_entries_for_segment, by_commit_entries_for_segments};
 use super::segment::{
-    canonicalize_segment, directory_change_location, directory_commit_location, segment_change,
-    segment_commit, validate_change_checksum, validate_change_location, validate_commit_checksum,
-    validate_commit_location, validate_segment_shape, validate_stage_segment_shape,
-    DecodedSegmentIndex,
+    DecodedSegmentIndex, canonicalize_segment, directory_change_location,
+    directory_commit_location, segment_change, segment_commit, validate_change_checksum,
+    validate_change_location, validate_commit_checksum, validate_commit_location,
+    validate_segment_shape, validate_stage_segment_shape,
 };
 use super::store::{
-    by_change_index_value, by_change_key, by_change_membership_commit_id_from_key,
-    by_change_membership_index_value, by_change_membership_key, by_change_membership_prefix,
-    by_commit_index_value, by_commit_key, commit_visibility_key, commit_visibility_value,
-    segment_key, segment_value, visible_change_proof_key, visible_change_proof_value,
     BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE,
-    COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
+    COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE, by_change_index_value,
+    by_change_key, by_change_membership_commit_id_from_key, by_change_membership_index_value,
+    by_change_membership_key, by_change_membership_prefix, by_commit_index_value, by_commit_key,
+    commit_visibility_key, commit_visibility_value, segment_key, segment_value,
+    visible_change_proof_key, visible_change_proof_value,
 };
-use crate::changelog::{
-    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
-    decode_segment_change, decode_segment_commit, segment_commit_membership_contains_any,
-    view_segment_directory,
-};
+use crate::LixError;
 use crate::changelog::{
     ByChangeEntry, ByCommitEntry, Change, ChangeLoadBatch, ChangeLoadEntry, ChangeLoadRequest,
     ChangeProjection, ChangeVisibilityMode, CommitLoadBatch, CommitLoadEntry, CommitLoadRequest,
@@ -33,13 +29,17 @@ use crate::changelog::{
     RebuildIndexStats, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation,
     SegmentStageReport, StateRowIdentity,
 };
+use crate::changelog::{
+    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
+    decode_segment_change, decode_segment_commit, segment_commit_membership_contains_any,
+    view_segment_directory,
+};
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::storage::{
     PointReadPlan, ScanPlan, StorageBackend, StorageContext, StorageCoreProjection,
     StorageGetOptions, StorageKey, StorageKeyRange, StoragePrefix, StorageProjectedValue,
     StorageRead, StorageReadOptions, StorageScanOptions, StorageSpace, StorageWriteSet,
 };
-use crate::LixError;
 
 /// Factory for changelog readers and writers.
 ///
@@ -2165,15 +2165,22 @@ where
         &mut self,
         commit_id: &str,
     ) -> Result<Option<SegmentCommit>, LixError> {
+        let mut found = None::<(String, SegmentCommit)>;
         for segment in self.scan_all_segments().await? {
             let Some(commit) = segment_commit(&segment, commit_id) else {
                 continue;
             };
             let location = directory_commit_location(&segment, commit_id)?;
             validate_commit_checksum(&location.checksum, commit_id, commit)?;
-            return Ok(Some(commit.clone()));
+            if let Some((existing_segment_id, _)) = &found {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' appears in multiple segments: '{}' and '{}'",
+                    existing_segment_id, segment.header.segment_id
+                )));
+            }
+            found = Some((segment.header.segment_id.clone(), commit.clone()));
         }
-        Ok(None)
+        Ok(found.map(|(_, commit)| commit))
     }
 
     async fn resolve_publish_changes(
@@ -2790,9 +2797,9 @@ where
 mod tests {
     use crate::changelog::test_support::*;
     use crate::changelog::{
-        decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
         CommitBody, CommitHeader, MembershipRecord, MembershipRole, SegmentCommit,
-        SegmentCommitDirectory,
+        SegmentCommitDirectory, decode_by_change_entry, decode_by_commit_entry,
+        decode_commit_visibility, decode_segment,
     };
     use crate::entity_identity::EntityIdentity;
     use crate::storage::StorageWriteSet;
@@ -3064,8 +3071,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_commits_physical_only_returns_none_when_locator_index_is_missing_for_existing_commit(
-    ) {
+    async fn load_commits_physical_only_returns_none_when_locator_index_is_missing_for_existing_commit()
+     {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
 
@@ -3125,6 +3132,45 @@ mod tests {
             error
                 .to_string()
                 .contains("failed to decode changelog by_commit entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_segment_commit_rejects_duplicate_commit_id_during_fallback_scan() {
+        let (context, storage) = changelog_test_context();
+        let segment_1 = test_segment();
+        let mut segment_2 = test_segment();
+        segment_2.header.segment_id = "segment-2".to_string();
+        let segment_2 = canonicalize_segment(segment_2).unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            SEGMENT_SPACE,
+            segment_key("segment-1"),
+            segment_value(&segment_1).unwrap(),
+        );
+        writes.put(
+            SEGMENT_SPACE,
+            segment_key("segment-2"),
+            segment_value(&segment_2).unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .find_segment_commit("commit-1")
+                .await
+                .expect_err("fallback scan should reject duplicate commit ids")
+        };
+
+        assert!(
+            error.to_string().contains("appears in multiple segments"),
             "unexpected error: {error}"
         );
     }
@@ -3215,8 +3261,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_changes_physical_only_returns_none_when_locator_index_is_missing_for_existing_change(
-    ) {
+    async fn load_changes_physical_only_returns_none_when_locator_index_is_missing_for_existing_change()
+     {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
 
@@ -4578,8 +4624,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stage_publish_commit_accepts_adopted_membership_reachable_through_source_parent_history(
-    ) {
+    async fn stage_publish_commit_accepts_adopted_membership_reachable_through_source_parent_history()
+     {
         let (context, storage) = changelog_test_context();
         let mut segment = two_commit_segment();
         segment.commits.push(SegmentCommit {

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -24,7 +24,7 @@ use super::store::{
 use crate::changelog::{
     decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
     decode_segment_change, decode_segment_commit, segment_commit_membership_contains_any,
-    view_segment,
+    view_segment_directory,
 };
 use crate::changelog::{
     ByChangeEntry, ByCommitEntry, Change, ChangeLoadBatch, ChangeLoadEntry, ChangeLoadRequest,
@@ -192,7 +192,7 @@ struct SegmentByteIndex {
 
 impl SegmentByteIndex {
     fn decode(bytes: Vec<u8>) -> Result<Self, LixError> {
-        let view = view_segment(&bytes)?;
+        let view = view_segment_directory(&bytes)?;
         let segment_id = view.segment_id.to_string();
         let commit_locations = view
             .directory_commits
@@ -256,6 +256,7 @@ impl SegmentByteIndex {
                 commit.header.id
             )));
         }
+        validate_commit_checksum(&location.checksum, commit_id, &commit)?;
         Ok(commit)
     }
 
@@ -277,7 +278,12 @@ impl SegmentByteIndex {
             )));
         }
         let bytes = self.object_bytes(location, "commit", commit_id)?;
-        segment_commit_membership_contains_any(bytes, requested_change_ids)
+        segment_commit_membership_contains_any(
+            bytes,
+            commit_id,
+            &location.checksum,
+            requested_change_ids,
+        )
     }
 
     fn load_change(
@@ -349,6 +355,12 @@ impl SegmentByteIndex {
             ))
         })
     }
+}
+
+#[derive(Default)]
+struct SourceParentFacts {
+    reachable_memberships: HashSet<String>,
+    first_parent_winners: HashMap<StateRowIdentity, String>,
 }
 
 impl<S> ChangelogStoreReader<S>
@@ -500,7 +512,8 @@ where
                 )));
             };
             if projection == ChangeProjection::PhysicalLocation {
-                segment.validate_change_location(&by_change.location, change_id)?;
+                let change = segment.load_change(&by_change.location, change_id)?;
+                validate_change_checksum(&by_change.location.checksum, change_id, &change)?;
                 entries.push(Some(ChangeLoadEntry::PhysicalLocation(
                     by_change.location.clone(),
                 )));
@@ -544,7 +557,8 @@ where
                 }
                 if let Some(segment) = segments.get(&by_change.location.segment_id) {
                     if projection == ChangeProjection::PhysicalLocation {
-                        segment.validate_change_location(&by_change.location, change_id)?;
+                        let change = segment.load_change(&by_change.location, change_id)?;
+                        validate_change_checksum(&by_change.location.checksum, change_id, &change)?;
                         entries.push(Some(ChangeLoadEntry::PhysicalLocation(
                             by_change.location.clone(),
                         )));
@@ -1340,6 +1354,8 @@ where
     ) -> Result<SegmentStageReport, LixError> {
         let segment = canonicalize_segment(segment)?;
         validate_stage_segment_shape(&segment)?;
+        self.validate_stage_adopted_membership_provenance(&segment)
+            .await?;
         self.reject_duplicate_logical_ids(&segment).await?;
         let segment_id = segment.header.segment_id.clone();
         let report = SegmentStageReport {
@@ -1644,6 +1660,7 @@ where
             .map(|membership| membership.member_change_id.clone())
             .collect::<HashSet<_>>();
         let changes = self.resolve_publish_changes(&member_change_ids).await?;
+        let mut source_parent_facts = HashMap::<String, SourceParentFacts>::new();
 
         for membership in &commit.body.membership {
             let Some(change) = changes.get(&membership.member_change_id) else {
@@ -1683,9 +1700,16 @@ where
                             commit.header.id, membership.member_change_id, source_parent_ordinal
                         )));
                     };
-                    if !self
-                        .commit_history_contains_membership(parent_id, &membership.member_change_id)
-                        .await?
+                    if !source_parent_facts.contains_key(parent_id) {
+                        let facts = self.source_parent_facts(parent_id).await?;
+                        source_parent_facts.insert(parent_id.clone(), facts);
+                    }
+                    let facts = source_parent_facts
+                        .get(parent_id)
+                        .expect("source parent facts should be cached");
+                    if !facts
+                        .reachable_memberships
+                        .contains(&membership.member_change_id)
                     {
                         return Err(LixError::unknown(format!(
                             "cannot publish changelog commit '{}' because adopted membership change '{}' is not reachable from source parent '{}'",
@@ -1693,13 +1717,8 @@ where
                         )));
                     }
                     let identity = state_row_identity_for_change(change)?;
-                    if !self
-                        .commit_history_projects_state_row(
-                            parent_id,
-                            &identity,
-                            &membership.member_change_id,
-                        )
-                        .await?
+                    if facts.first_parent_winners.get(&identity)
+                        != Some(&membership.member_change_id)
                     {
                         return Err(LixError::unknown(format!(
                             "cannot publish changelog commit '{}' because adopted membership change '{}' is not the source parent '{}' winner for {:?}",
@@ -1728,11 +1747,111 @@ where
         Ok(())
     }
 
-    async fn commit_history_contains_membership(
+    async fn validate_stage_adopted_membership_provenance(
+        &mut self,
+        segment: &Segment,
+    ) -> Result<(), LixError> {
+        let adopted_change_ids = segment
+            .commits
+            .iter()
+            .flat_map(|commit| {
+                commit
+                    .body
+                    .membership
+                    .iter()
+                    .filter(|membership| membership.role == MembershipRole::Adopted)
+                    .map(|membership| membership.member_change_id.clone())
+            })
+            .collect::<HashSet<_>>();
+        if adopted_change_ids.is_empty() {
+            return Ok(());
+        }
+
+        let mut changes = segment
+            .changes
+            .iter()
+            .filter(|change| adopted_change_ids.contains(&change.id))
+            .map(|change| (change.id.clone(), change.clone()))
+            .collect::<HashMap<_, _>>();
+        let missing = adopted_change_ids
+            .difference(&changes.keys().cloned().collect::<HashSet<_>>())
+            .cloned()
+            .collect::<HashSet<_>>();
+        if !missing.is_empty() {
+            changes.extend(self.resolve_publish_changes(&missing).await?);
+        }
+
+        let mut source_parent_facts = HashMap::<String, SourceParentFacts>::new();
+
+        for commit in &segment.commits {
+            for membership in &commit.body.membership {
+                if membership.role != MembershipRole::Adopted {
+                    continue;
+                }
+                let source_parent_ordinal =
+                    membership.source_parent_ordinal.ok_or_else(|| {
+                        LixError::unknown(format!(
+                            "cannot stage changelog commit '{}' because adopted membership change '{}' is missing source_parent_ordinal",
+                            commit.header.id, membership.member_change_id
+                        ))
+                    })?;
+                let parent_id = commit
+                    .header
+                    .parent_commit_ids
+                    .get(source_parent_ordinal as usize)
+                    .ok_or_else(|| {
+                        LixError::unknown(format!(
+                            "cannot stage changelog commit '{}' because adopted membership change '{}' source_parent_ordinal {} is out of bounds",
+                            commit.header.id, membership.member_change_id, source_parent_ordinal
+                        ))
+                    })?;
+                let Some(change) = changes.get(&membership.member_change_id) else {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' has no changelog.change",
+                        commit.header.id, membership.member_change_id
+                    )));
+                };
+                if change.authored_commit_id.as_deref() == Some(commit.header.id.as_str()) {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' is authored by the same commit",
+                        commit.header.id, membership.member_change_id
+                    )));
+                }
+                if !source_parent_facts.contains_key(parent_id) {
+                    let facts = self
+                        .source_parent_facts_in_segment(parent_id, segment)
+                        .await?;
+                    source_parent_facts.insert(parent_id.clone(), facts);
+                }
+                let facts = source_parent_facts
+                    .get(parent_id)
+                    .expect("source parent facts should be cached");
+                if !facts
+                    .reachable_memberships
+                    .contains(&membership.member_change_id)
+                {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' is not reachable from source parent '{}'",
+                        commit.header.id, membership.member_change_id, parent_id
+                    )));
+                }
+                let identity = state_row_identity_for_change(change)?;
+                if facts.first_parent_winners.get(&identity) != Some(&membership.member_change_id) {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' is not the source parent '{}' winner for {:?}",
+                        commit.header.id, membership.member_change_id, parent_id, identity
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn source_parent_facts(
         &mut self,
         root_commit_id: &str,
-        change_id: &str,
-    ) -> Result<bool, LixError> {
+    ) -> Result<SourceParentFacts, LixError> {
+        let mut facts = SourceParentFacts::default();
         let mut stack = vec![root_commit_id.to_string()];
         let mut visited = HashSet::new();
         while let Some(commit_id) = stack.pop() {
@@ -1740,6 +1859,132 @@ where
                 continue;
             }
             let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
+                continue;
+            };
+            facts.reachable_memberships.extend(
+                commit
+                    .body
+                    .membership
+                    .iter()
+                    .map(|membership| membership.member_change_id.clone()),
+            );
+            stack.extend(commit.header.parent_commit_ids);
+        }
+
+        let mut next_commit_id = Some(root_commit_id.to_string());
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = next_commit_id.take() {
+            if !visited.insert(commit_id.clone()) {
+                return Err(LixError::unknown(format!(
+                    "cannot resolve source parent facts because first-parent history contains parent cycle at commit '{commit_id}'"
+                )));
+            }
+            let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
+                break;
+            };
+            for (identity, change_id) in &commit.directory.state_row_identities {
+                facts
+                    .first_parent_winners
+                    .entry(identity.clone())
+                    .or_insert_with(|| change_id.clone());
+            }
+            next_commit_id = commit.header.parent_commit_ids.first().cloned();
+        }
+        Ok(facts)
+    }
+
+    async fn source_parent_facts_in_segment(
+        &mut self,
+        root_commit_id: &str,
+        segment: &Segment,
+    ) -> Result<SourceParentFacts, LixError> {
+        let mut facts = SourceParentFacts::default();
+        let mut stack = vec![root_commit_id.to_string()];
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = stack.pop() {
+            if !visited.insert(commit_id.clone()) {
+                continue;
+            }
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, Some(segment))
+                .await?
+            else {
+                continue;
+            };
+            facts.reachable_memberships.extend(
+                commit
+                    .body
+                    .membership
+                    .iter()
+                    .map(|membership| membership.member_change_id.clone()),
+            );
+            stack.extend(commit.header.parent_commit_ids);
+        }
+
+        let mut next_commit_id = Some(root_commit_id.to_string());
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = next_commit_id.take() {
+            if !visited.insert(commit_id.clone()) {
+                return Err(LixError::unknown(format!(
+                    "cannot resolve source parent facts because first-parent history contains parent cycle at commit '{commit_id}'"
+                )));
+            }
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, Some(segment))
+                .await?
+            else {
+                break;
+            };
+            for (identity, change_id) in &commit.directory.state_row_identities {
+                facts
+                    .first_parent_winners
+                    .entry(identity.clone())
+                    .or_insert_with(|| change_id.clone());
+            }
+            next_commit_id = commit.header.parent_commit_ids.first().cloned();
+        }
+        Ok(facts)
+    }
+
+    async fn commit_history_contains_membership(
+        &mut self,
+        root_commit_id: &str,
+        change_id: &str,
+    ) -> Result<bool, LixError> {
+        self.commit_history_contains_membership_with_loader(root_commit_id, change_id, None)
+            .await
+    }
+
+    async fn commit_history_contains_membership_in_segment(
+        &mut self,
+        root_commit_id: &str,
+        change_id: &str,
+        segment: &Segment,
+    ) -> Result<bool, LixError> {
+        self.commit_history_contains_membership_with_loader(
+            root_commit_id,
+            change_id,
+            Some(segment),
+        )
+        .await
+    }
+
+    async fn commit_history_contains_membership_with_loader(
+        &mut self,
+        root_commit_id: &str,
+        change_id: &str,
+        segment: Option<&Segment>,
+    ) -> Result<bool, LixError> {
+        let mut stack = vec![root_commit_id.to_string()];
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = stack.pop() {
+            if !visited.insert(commit_id.clone()) {
+                continue;
+            }
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, segment)
+                .await?
+            else {
                 continue;
             };
             if commit
@@ -1761,6 +2006,38 @@ where
         identity: &StateRowIdentity,
         change_id: &str,
     ) -> Result<bool, LixError> {
+        self.commit_history_projects_state_row_with_loader(
+            root_commit_id,
+            identity,
+            change_id,
+            None,
+        )
+        .await
+    }
+
+    async fn commit_history_projects_state_row_in_segment(
+        &mut self,
+        root_commit_id: &str,
+        identity: &StateRowIdentity,
+        change_id: &str,
+        segment: &Segment,
+    ) -> Result<bool, LixError> {
+        self.commit_history_projects_state_row_with_loader(
+            root_commit_id,
+            identity,
+            change_id,
+            Some(segment),
+        )
+        .await
+    }
+
+    async fn commit_history_projects_state_row_with_loader(
+        &mut self,
+        root_commit_id: &str,
+        identity: &StateRowIdentity,
+        change_id: &str,
+        segment: Option<&Segment>,
+    ) -> Result<bool, LixError> {
         let mut next_commit_id = Some(root_commit_id.to_string());
         let mut visited = HashSet::new();
         while let Some(commit_id) = next_commit_id.take() {
@@ -1770,7 +2047,10 @@ where
                     identity, commit_id
                 )));
             }
-            let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, segment)
+                .await?
+            else {
                 return Ok(false);
             };
             if let Some((_, winner_change_id)) = commit
@@ -1784,6 +2064,25 @@ where
             next_commit_id = commit.header.parent_commit_ids.first().cloned();
         }
         Ok(false)
+    }
+
+    async fn load_published_staged_or_segment_commit(
+        &mut self,
+        commit_id: &str,
+        segment: Option<&Segment>,
+    ) -> Result<Option<SegmentCommit>, LixError> {
+        if let Some(commit) = segment.and_then(|segment| {
+            segment
+                .commits
+                .iter()
+                .find(|commit| commit.header.id == commit_id)
+        }) {
+            return Ok(Some(commit.clone()));
+        }
+        if let Some(commit) = self.load_published_or_staged_commit(commit_id).await? {
+            return Ok(Some(commit));
+        }
+        self.find_segment_commit(commit_id).await
     }
 
     async fn load_published_or_staged_commit(
@@ -1810,6 +2109,71 @@ where
         self.load_publish_commit(commit_id, &visibility.location)
             .await
             .map(Some)
+    }
+
+    async fn find_segment_commit(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<Option<SegmentCommit>, LixError> {
+        let Some(entry) = get_one(
+            &mut *self.store,
+            BY_COMMIT_INDEX_SPACE,
+            by_commit_key(commit_id),
+        )
+        .await?
+        .map(|bytes| decode_by_commit_entry(&bytes))
+        .transpose()?
+        else {
+            return self.scan_segments_for_commit(commit_id).await;
+        };
+        if entry.commit_id != commit_id {
+            return Err(LixError::unknown(format!(
+                "by_commit key for '{commit_id}' contains commit_id '{}'",
+                entry.commit_id
+            )));
+        }
+        let Some(segment) = self
+            .load_segment_byte_index_for_writer(&entry.location.segment_id)
+            .await?
+        else {
+            return self.scan_segments_for_commit(commit_id).await;
+        };
+        match segment.load_commit(&entry.location, commit_id) {
+            Ok(commit) => {
+                if validate_commit_checksum(&entry.location.checksum, commit_id, &commit).is_ok() {
+                    Ok(Some(commit))
+                } else {
+                    self.scan_segments_for_commit(commit_id).await
+                }
+            }
+            Err(_) => self.scan_segments_for_commit(commit_id).await,
+        }
+    }
+
+    async fn load_segment_byte_index_for_writer(
+        &mut self,
+        segment_id: &str,
+    ) -> Result<Option<SegmentByteIndex>, LixError> {
+        let Some(bytes) = get_one(&mut *self.store, SEGMENT_SPACE, segment_key(segment_id)).await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(SegmentByteIndex::decode(bytes)?))
+    }
+
+    async fn scan_segments_for_commit(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<Option<SegmentCommit>, LixError> {
+        for segment in self.scan_all_segments().await? {
+            let Some(commit) = segment_commit(&segment, commit_id) else {
+                continue;
+            };
+            let location = directory_commit_location(&segment, commit_id)?;
+            validate_commit_checksum(&location.checksum, commit_id, commit)?;
+            return Ok(Some(commit.clone()));
+        }
+        Ok(None)
     }
 
     async fn resolve_publish_changes(
@@ -3654,6 +4018,7 @@ mod tests {
         duplicate.header.segment_id = "segment-2".to_string();
         duplicate.commits[0].header.id = "commit-2".to_string();
         duplicate.commits[0].header.derivable_change_id = "derived-change-2".to_string();
+        duplicate.changes[0].authored_commit_id = Some("commit-2".to_string());
         let duplicate = canonicalize_segment(duplicate).unwrap();
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();
@@ -3996,15 +4361,16 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
             writer
-                .stage_publish_commit("commit-1")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove membership changes exist")
+                .expect_err("staging must prove membership changes exist")
         };
 
         assert!(
-            error.message.contains("no changelog.change exists"),
+            error
+                .message
+                .contains("authored membership references missing change 'change-1'"),
             "unexpected error: {error}"
         );
     }
@@ -4020,11 +4386,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
             writer
-                .stage_publish_commit("commit-1")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove StateRowIdentity matches the change")
+                .expect_err("staging must prove StateRowIdentity matches the change")
         };
 
         assert!(
@@ -4045,20 +4410,141 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
             writer
-                .stage_publish_commit("commit-2")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove authored membership owns its change")
+                .expect_err("staging must prove authored membership owns its change")
         };
 
         assert!(
-            error
-                .message
-                .contains("authored membership change 'change-1' belongs to"),
+            error.message.contains(
+                "authored membership change 'change-1' has mismatched authored_commit_id"
+            ),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn stage_segment_rejects_cross_segment_adopted_membership_authored_by_same_commit() {
+        let (context, storage) = changelog_test_context();
+        let mut change_segment = test_segment();
+        change_segment.header.segment_id = "change-segment".to_string();
+        change_segment.commits.clear();
+        change_segment.directory.commits.clear();
+        change_segment.changes[0].authored_commit_id = Some("commit-2".to_string());
+        let change_segment = canonicalize_segment(change_segment).unwrap();
+
+        let mut adopt_segment = test_segment();
+        adopt_segment.header.segment_id = "adopt-segment".to_string();
+        adopt_segment.changes.clear();
+        adopt_segment.directory.changes.clear();
+        adopt_segment.commits[0].header.id = "commit-2".to_string();
+        adopt_segment.commits[0].header.parent_commit_ids = vec!["missing-parent".to_string()];
+        adopt_segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        adopt_segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(change_segment).await.unwrap();
+            writer
+                .stage_segment(adopt_segment)
+                .await
+                .expect_err("staging must reject self-authored adopted membership")
+        };
+
+        assert!(
+            error.message.contains("is authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage_segment_accepts_adopted_membership_from_unpublished_stored_parent() {
+        let (context, storage) = changelog_test_context();
+        let parent_segment = test_segment();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(parent_segment).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut adopt_segment = test_segment();
+        adopt_segment.header.segment_id = "adopt-segment".to_string();
+        adopt_segment.changes.clear();
+        adopt_segment.directory.changes.clear();
+        adopt_segment.commits[0].header.id = "commit-2".to_string();
+        adopt_segment.commits[0].header.parent_commit_ids = vec!["commit-1".to_string()];
+        adopt_segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        adopt_segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(adopt_segment).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn stage_segment_accepts_adopted_membership_from_physical_parent_when_by_commit_is_stale()
+    {
+        let (context, storage) = changelog_test_context();
+        let parent_segment = test_segment();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(parent_segment).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            BY_COMMIT_INDEX_SPACE,
+            by_commit_key("commit-1"),
+            by_commit_index_value(&ByCommitEntry {
+                commit_id: "commit-1".to_string(),
+                location: SegmentObjectLocation {
+                    segment_id: "missing-segment".to_string(),
+                    offset: 0,
+                    len: 0,
+                    checksum: "stale-checksum".to_string(),
+                },
+                parent_commit_ids: Vec::new(),
+                generation: 0,
+            })
+            .unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut adopt_segment = test_segment();
+        adopt_segment.header.segment_id = "adopt-segment".to_string();
+        adopt_segment.changes.clear();
+        adopt_segment.directory.changes.clear();
+        adopt_segment.commits[0].header.id = "commit-2".to_string();
+        adopt_segment.commits[0].header.parent_commit_ids = vec!["commit-1".to_string()];
+        adopt_segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        adopt_segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(adopt_segment).await.unwrap();
+        }
     }
 
     #[tokio::test]
@@ -4189,16 +4675,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
             writer
-                .stage_publish_commit("commit-other-parent")
+                .stage_segment(segment)
                 .await
-                .unwrap();
-            writer
-                .stage_publish_commit("commit-3")
-                .await
-                .expect_err("publication must prove adopted change reaches through source parent")
+                .expect_err("staging must prove adopted change reaches through source parent")
         };
 
         assert!(
@@ -4278,13 +4758,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
-            writer.stage_publish_commit("commit-2").await.unwrap();
             writer
-                .stage_publish_commit("commit-3")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove adopted change is the source winner")
+                .expect_err("staging must prove adopted change is the source winner")
         };
 
         assert!(
@@ -4423,15 +4900,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
-            writer.stage_publish_commit("target-commit").await.unwrap();
-            writer.stage_publish_commit("source-commit").await.unwrap();
-            writer.stage_publish_commit("merge-parent").await.unwrap();
             writer
-                .stage_publish_commit("adopting-commit")
+                .stage_segment(segment)
                 .await
-                .expect_err("source parent winner must use first-parent projection")
+                .expect_err("staging source parent winner must use first-parent projection")
         };
 
         assert!(
@@ -4584,7 +5056,10 @@ mod tests {
             error.message.contains("without that change")
                 || error
                     .message
-                    .contains("locator does not match segment directory"),
+                    .contains("locator does not match segment directory")
+                || error
+                    .message
+                    .contains("references missing authored change 'change-1'"),
             "unexpected error: {error}"
         );
     }
@@ -4605,7 +5080,7 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut corrupted = segment;
-        corrupted.changes[0].schema_key = "messagb".to_string();
+        corrupted.changes[0].created_at = "2026-05-12T00:00:01Z".to_string();
         write_raw_segment(&storage, &corrupted).await;
 
         let mut reader = context.reader(storage);

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -4,9 +4,13 @@ use std::ops::Bound;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use super::by_change_index::by_change_entries_for_segments;
-use super::by_change_membership_index::by_change_membership_entries_for_segments;
-use super::by_commit_index::{by_commit_entries_for_segment, by_commit_entries_for_segments};
+use super::by_change_index::{by_change_entries_for_segments, by_change_entries_for_truth};
+use super::by_change_membership_index::{
+    by_change_membership_entries_for_segments, by_change_membership_entries_for_truth,
+};
+use super::by_commit_index::{
+    by_commit_entries_for_segment, by_commit_entries_for_segments, by_commit_entries_for_truth,
+};
 use super::segment::{
     DecodedSegmentIndex, canonicalize_segment, directory_change_location,
     directory_commit_location, segment_change, segment_commit, validate_change_checksum,
@@ -21,6 +25,7 @@ use super::store::{
     commit_visibility_key, commit_visibility_value, segment_key, segment_value,
     visible_change_proof_key, visible_change_proof_value,
 };
+use super::truth::{SegmentTruthSnapshot, load_segment_truth_index};
 use crate::LixError;
 use crate::changelog::{
     ByChangeEntry, ByCommitEntry, Change, ChangeLoadBatch, ChangeLoadEntry, ChangeLoadRequest,
@@ -2417,34 +2422,40 @@ where
     pub(crate) async fn rebuild_mandatory_indexes(
         &mut self,
     ) -> Result<RebuildIndexStats, LixError> {
-        let segments = self.scan_all_segments().await?;
+        let truth = load_segment_truth_index(&mut *self.store).await?;
         let stats = self
-            .stage_by_commit_index_rebuild(&segments)
+            .stage_by_commit_index_rebuild_from_truth(&truth)
             .await?
-            .combine(self.stage_by_change_index_rebuild(&segments).await?)
             .combine(
-                self.stage_by_change_membership_index_rebuild(&segments)
+                self.stage_by_change_index_rebuild_from_truth(&truth)
                     .await?,
             )
-            .combine(self.stage_visible_change_proof_rebuild(&segments).await?);
+            .combine(
+                self.stage_by_change_membership_index_rebuild_from_truth(&truth)
+                    .await?,
+            )
+            .combine(
+                self.stage_visible_change_proof_rebuild_from_truth(&truth)
+                    .await?,
+            );
         Ok(stats)
     }
 
     pub(crate) async fn rebuild_by_commit_index(&mut self) -> Result<RebuildIndexStats, LixError> {
-        let segments = self.scan_all_segments().await?;
-        self.stage_by_commit_index_rebuild(&segments).await
+        let truth = load_segment_truth_index(&mut *self.store).await?;
+        self.stage_by_commit_index_rebuild_from_truth(&truth).await
     }
 
     pub(crate) async fn rebuild_by_change_index(&mut self) -> Result<RebuildIndexStats, LixError> {
-        let segments = self.scan_all_segments().await?;
-        self.stage_by_change_index_rebuild(&segments).await
+        let truth = load_segment_truth_index(&mut *self.store).await?;
+        self.stage_by_change_index_rebuild_from_truth(&truth).await
     }
 
     pub(crate) async fn rebuild_by_change_membership_index(
         &mut self,
     ) -> Result<RebuildIndexStats, LixError> {
-        let segments = self.scan_all_segments().await?;
-        self.stage_by_change_membership_index_rebuild(&segments)
+        let truth = load_segment_truth_index(&mut *self.store).await?;
+        self.stage_by_change_membership_index_rebuild_from_truth(&truth)
             .await
     }
 
@@ -2478,11 +2489,11 @@ where
         Ok(segments)
     }
 
-    async fn stage_by_commit_index_rebuild(
+    async fn stage_by_commit_index_rebuild_from_truth(
         &mut self,
-        segments: &[Segment],
+        truth: &SegmentTruthSnapshot,
     ) -> Result<RebuildIndexStats, LixError> {
-        let entries = by_commit_entries_for_segments(segments)?;
+        let entries = by_commit_entries_for_truth(truth)?;
         let mut expected_rows = HashMap::new();
         for entry in &entries {
             expected_rows.insert(
@@ -2502,11 +2513,11 @@ where
         Ok(stats)
     }
 
-    async fn stage_by_change_index_rebuild(
+    async fn stage_by_change_index_rebuild_from_truth(
         &mut self,
-        segments: &[Segment],
+        truth: &SegmentTruthSnapshot,
     ) -> Result<RebuildIndexStats, LixError> {
-        let entries = by_change_entries_for_segments(segments)?;
+        let entries = by_change_entries_for_truth(truth);
         let mut expected_rows = HashMap::new();
         for entry in &entries {
             expected_rows.insert(
@@ -2518,11 +2529,11 @@ where
             .await
     }
 
-    async fn stage_by_change_membership_index_rebuild(
+    async fn stage_by_change_membership_index_rebuild_from_truth(
         &mut self,
-        segments: &[Segment],
+        truth: &SegmentTruthSnapshot,
     ) -> Result<RebuildIndexStats, LixError> {
-        let entries = by_change_membership_entries_for_segments(segments);
+        let entries = by_change_membership_entries_for_truth(truth);
         let mut expected_rows = HashMap::new();
         for entry in &entries {
             expected_rows.insert(
@@ -2534,24 +2545,31 @@ where
             .await
     }
 
-    async fn stage_visible_change_proof_rebuild(
+    async fn stage_visible_change_proof_rebuild_from_truth(
         &mut self,
-        segments: &[Segment],
+        truth: &SegmentTruthSnapshot,
     ) -> Result<RebuildIndexStats, LixError> {
-        let mut segments_by_id = HashMap::new();
-        for segment in segments {
-            segments_by_id.insert(segment.header.segment_id.as_str(), segment);
-        }
-
+        let retained_segments = truth.segment_ids.iter().collect::<HashSet<_>>();
         let mut expected_rows = HashMap::new();
         for visibility in self.scan_commit_visibilities().await? {
-            let Some(segment) = segments_by_id.get(visibility.location.segment_id.as_str()) else {
-                continue;
+            if !retained_segments.contains(&visibility.location.segment_id) {
+                return Err(LixError::unknown(format!(
+                    "changelog commit_visibility for '{}' points to missing segment '{}'",
+                    visibility.commit_id, visibility.location.segment_id
+                )));
+            }
+            let Some((truth_location, commit)) = truth.commits.get(&visibility.commit_id) else {
+                return Err(LixError::unknown(format!(
+                    "changelog commit_visibility for '{}' points to segment '{}' without that commit",
+                    visibility.commit_id, visibility.location.segment_id
+                )));
             };
-            let Some(commit) = segment_commit(segment, &visibility.commit_id) else {
-                continue;
-            };
-            validate_commit_location(&visibility.location, segment, &visibility.commit_id)?;
+            if truth_location != &visibility.location {
+                return Err(LixError::unknown(format!(
+                    "changelog commit_visibility for '{}' locator does not match segment truth",
+                    visibility.commit_id
+                )));
+            }
             validate_commit_checksum(&visibility.checksum, &visibility.commit_id, commit)?;
             for membership in &commit.body.membership {
                 expected_rows.insert(
@@ -4460,7 +4478,7 @@ mod tests {
         };
 
         assert!(
-            error.message.contains("duplicate commit 'commit-1'"),
+            error.message.contains("duplicate commit id 'commit-1'"),
             "unexpected error: {error}"
         );
     }

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -512,8 +512,7 @@ where
                 )));
             };
             if projection == ChangeProjection::PhysicalLocation {
-                let change = segment.load_change(&by_change.location, change_id)?;
-                validate_change_checksum(&by_change.location.checksum, change_id, &change)?;
+                segment.validate_change_location(&by_change.location, change_id)?;
                 entries.push(Some(ChangeLoadEntry::PhysicalLocation(
                     by_change.location.clone(),
                 )));
@@ -557,8 +556,7 @@ where
                 }
                 if let Some(segment) = segments.get(&by_change.location.segment_id) {
                     if projection == ChangeProjection::PhysicalLocation {
-                        let change = segment.load_change(&by_change.location, change_id)?;
-                        validate_change_checksum(&by_change.location.checksum, change_id, &change)?;
+                        segment.validate_change_location(&by_change.location, change_id)?;
                         entries.push(Some(ChangeLoadEntry::PhysicalLocation(
                             by_change.location.clone(),
                         )));
@@ -700,11 +698,7 @@ where
         .await?;
         values
             .into_iter()
-            .map(|value| {
-                value
-                    .map(|bytes| decode_commit_visibility(&bytes))
-                    .transpose()
-            })
+            .map(|value| Ok(value.and_then(|bytes| decode_commit_visibility(&bytes).ok())))
             .collect()
     }
 
@@ -2420,10 +2414,6 @@ where
         super::gc::collect_garbage(&mut *self.store, self.writes, roots).await
     }
 
-    pub(crate) async fn stage_gc_sweep(&mut self, plan: &GcPlan) -> Result<(), LixError> {
-        super::gc::stage_gc_sweep(self.writes, plan)
-    }
-
     pub(crate) async fn rebuild_mandatory_indexes(
         &mut self,
     ) -> Result<RebuildIndexStats, LixError> {
@@ -3686,7 +3676,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_changes_visible_rejects_corrupt_visible_change_proof() {
+    async fn load_changes_visible_recovers_from_corrupt_visible_change_proof() {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
 
@@ -3711,20 +3701,18 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut reader = context.reader(storage);
-        let error = reader
+        let batch = reader
             .load_changes(ChangeLoadRequest {
                 change_ids: &["change-1".to_string()],
                 projection: ChangeProjection::Segment,
                 visibility: ChangeVisibilityMode::RequireReachableFromVisibleCommit,
             })
             .await
-            .expect_err("corrupt visible proof should fail closed");
+            .expect("corrupt visible proof should fall back to membership/visibility truth");
 
-        assert!(
-            error
-                .to_string()
-                .contains("failed to decode changelog commit visibility"),
-            "unexpected error: {error}"
+        assert_eq!(
+            batch.entries,
+            vec![Some(ChangeLoadEntry::Segment(segment.changes[0].clone()))]
         );
     }
 

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -11,6 +11,7 @@ use super::by_change_membership_index::{
 use super::by_commit_index::{
     by_commit_entries_for_segment, by_commit_entries_for_segments, by_commit_entries_for_truth,
 };
+use super::graph::{CommitGraphLoader, SourceParentFacts};
 use super::segment::{
     DecodedSegmentIndex, canonicalize_segment, directory_change_location,
     directory_commit_location, segment_change, segment_commit, validate_change_checksum,
@@ -365,12 +366,6 @@ impl SegmentByteIndex {
             ))
         })
     }
-}
-
-#[derive(Default)]
-struct SourceParentFacts {
-    reachable_memberships: HashSet<String>,
-    first_parent_winners: HashMap<StateRowIdentity, String>,
 }
 
 impl<S> ChangelogStoreReader<S>
@@ -1423,6 +1418,39 @@ pub(crate) struct ChangelogStoreWriter<'a, S: ?Sized> {
     staged_visible_change_proofs: HashSet<String>,
 }
 
+struct ChangelogCommitGraphLoader<'writer, 'store, S: ?Sized> {
+    writer: &'writer mut ChangelogStoreWriter<'store, S>,
+    segment_commits: Option<&'writer HashMap<String, SegmentCommit>>,
+    allow_segment_truth_fallback: bool,
+}
+
+#[async_trait(?Send)]
+impl<S> CommitGraphLoader for ChangelogCommitGraphLoader<'_, '_, S>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    async fn load_commit(&mut self, commit_id: &str) -> Result<Option<SegmentCommit>, LixError> {
+        if let Some(commit) = self
+            .segment_commits
+            .and_then(|commits| commits.get(commit_id))
+        {
+            return Ok(Some(commit.clone()));
+        }
+        if let Some(commit) = self
+            .writer
+            .load_published_or_staged_commit(commit_id)
+            .await?
+        {
+            return Ok(Some(commit));
+        }
+        if self.allow_segment_truth_fallback {
+            self.writer.find_segment_commit(commit_id).await
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 impl<S> ChangelogStoreWriter<'_, S>
 where
     S: ChangelogStorageRead + ?Sized,
@@ -1881,46 +1909,12 @@ where
         &mut self,
         root_commit_id: &str,
     ) -> Result<SourceParentFacts, LixError> {
-        let mut facts = SourceParentFacts::default();
-        let mut stack = vec![root_commit_id.to_string()];
-        let mut visited = HashSet::new();
-        while let Some(commit_id) = stack.pop() {
-            if !visited.insert(commit_id.clone()) {
-                continue;
-            }
-            let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
-                continue;
-            };
-            facts.reachable_memberships.extend(
-                commit
-                    .body
-                    .membership
-                    .iter()
-                    .map(|membership| membership.member_change_id.clone()),
-            );
-            stack.extend(commit.header.parent_commit_ids);
-        }
-
-        let mut next_commit_id = Some(root_commit_id.to_string());
-        let mut visited = HashSet::new();
-        while let Some(commit_id) = next_commit_id.take() {
-            if !visited.insert(commit_id.clone()) {
-                return Err(LixError::unknown(format!(
-                    "cannot resolve source parent facts because first-parent history contains parent cycle at commit '{commit_id}'"
-                )));
-            }
-            let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
-                break;
-            };
-            for (identity, change_id) in &commit.directory.state_row_identities {
-                facts
-                    .first_parent_winners
-                    .entry(identity.clone())
-                    .or_insert_with(|| change_id.clone());
-            }
-            next_commit_id = commit.header.parent_commit_ids.first().cloned();
-        }
-        Ok(facts)
+        let mut loader = ChangelogCommitGraphLoader {
+            writer: self,
+            segment_commits: None,
+            allow_segment_truth_fallback: false,
+        };
+        super::graph::source_parent_facts(&mut loader, root_commit_id).await
     }
 
     async fn source_parent_facts_in_segment(
@@ -1928,52 +1922,12 @@ where
         root_commit_id: &str,
         segment_commits: &HashMap<String, SegmentCommit>,
     ) -> Result<SourceParentFacts, LixError> {
-        let mut facts = SourceParentFacts::default();
-        let mut stack = vec![root_commit_id.to_string()];
-        let mut visited = HashSet::new();
-        while let Some(commit_id) = stack.pop() {
-            if !visited.insert(commit_id.clone()) {
-                continue;
-            }
-            let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, Some(segment_commits))
-                .await?
-            else {
-                continue;
-            };
-            facts.reachable_memberships.extend(
-                commit
-                    .body
-                    .membership
-                    .iter()
-                    .map(|membership| membership.member_change_id.clone()),
-            );
-            stack.extend(commit.header.parent_commit_ids);
-        }
-
-        let mut next_commit_id = Some(root_commit_id.to_string());
-        let mut visited = HashSet::new();
-        while let Some(commit_id) = next_commit_id.take() {
-            if !visited.insert(commit_id.clone()) {
-                return Err(LixError::unknown(format!(
-                    "cannot resolve source parent facts because first-parent history contains parent cycle at commit '{commit_id}'"
-                )));
-            }
-            let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, Some(segment_commits))
-                .await?
-            else {
-                break;
-            };
-            for (identity, change_id) in &commit.directory.state_row_identities {
-                facts
-                    .first_parent_winners
-                    .entry(identity.clone())
-                    .or_insert_with(|| change_id.clone());
-            }
-            next_commit_id = commit.header.parent_commit_ids.first().cloned();
-        }
-        Ok(facts)
+        let mut loader = ChangelogCommitGraphLoader {
+            writer: self,
+            segment_commits: Some(segment_commits),
+            allow_segment_truth_fallback: true,
+        };
+        super::graph::source_parent_facts(&mut loader, root_commit_id).await
     }
 
     async fn commit_history_contains_membership(
@@ -1981,7 +1935,12 @@ where
         root_commit_id: &str,
         change_id: &str,
     ) -> Result<bool, LixError> {
-        self.commit_history_contains_membership_with_loader(root_commit_id, change_id, None)
+        let mut loader = ChangelogCommitGraphLoader {
+            writer: self,
+            segment_commits: None,
+            allow_segment_truth_fallback: true,
+        };
+        super::graph::commit_history_contains_membership(&mut loader, root_commit_id, change_id)
             .await
     }
 
@@ -1996,43 +1955,13 @@ where
             .iter()
             .map(|commit| (commit.header.id.clone(), commit.clone()))
             .collect::<HashMap<_, _>>();
-        self.commit_history_contains_membership_with_loader(
-            root_commit_id,
-            change_id,
-            Some(&segment_commits),
-        )
-        .await
-    }
-
-    async fn commit_history_contains_membership_with_loader(
-        &mut self,
-        root_commit_id: &str,
-        change_id: &str,
-        segment_commits: Option<&HashMap<String, SegmentCommit>>,
-    ) -> Result<bool, LixError> {
-        let mut stack = vec![root_commit_id.to_string()];
-        let mut visited = HashSet::new();
-        while let Some(commit_id) = stack.pop() {
-            if !visited.insert(commit_id.clone()) {
-                continue;
-            }
-            let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, segment_commits)
-                .await?
-            else {
-                continue;
-            };
-            if commit
-                .body
-                .membership
-                .iter()
-                .any(|membership| membership.member_change_id == change_id)
-            {
-                return Ok(true);
-            }
-            stack.extend(commit.header.parent_commit_ids);
-        }
-        Ok(false)
+        let mut loader = ChangelogCommitGraphLoader {
+            writer: self,
+            segment_commits: Some(&segment_commits),
+            allow_segment_truth_fallback: true,
+        };
+        super::graph::commit_history_contains_membership(&mut loader, root_commit_id, change_id)
+            .await
     }
 
     async fn commit_history_projects_state_row(
@@ -2041,11 +1970,16 @@ where
         identity: &StateRowIdentity,
         change_id: &str,
     ) -> Result<bool, LixError> {
-        self.commit_history_projects_state_row_with_loader(
+        let mut loader = ChangelogCommitGraphLoader {
+            writer: self,
+            segment_commits: None,
+            allow_segment_truth_fallback: true,
+        };
+        super::graph::commit_history_projects_state_row(
+            &mut loader,
             root_commit_id,
             identity,
             change_id,
-            None,
         )
         .await
     }
@@ -2062,62 +1996,18 @@ where
             .iter()
             .map(|commit| (commit.header.id.clone(), commit.clone()))
             .collect::<HashMap<_, _>>();
-        self.commit_history_projects_state_row_with_loader(
+        let mut loader = ChangelogCommitGraphLoader {
+            writer: self,
+            segment_commits: Some(&segment_commits),
+            allow_segment_truth_fallback: true,
+        };
+        super::graph::commit_history_projects_state_row(
+            &mut loader,
             root_commit_id,
             identity,
             change_id,
-            Some(&segment_commits),
         )
         .await
-    }
-
-    async fn commit_history_projects_state_row_with_loader(
-        &mut self,
-        root_commit_id: &str,
-        identity: &StateRowIdentity,
-        change_id: &str,
-        segment_commits: Option<&HashMap<String, SegmentCommit>>,
-    ) -> Result<bool, LixError> {
-        let mut next_commit_id = Some(root_commit_id.to_string());
-        let mut visited = HashSet::new();
-        while let Some(commit_id) = next_commit_id.take() {
-            if !visited.insert(commit_id.clone()) {
-                return Err(LixError::unknown(format!(
-                    "cannot resolve StateRowIdentity winner for {:?} because first-parent history contains cycle at commit '{}'",
-                    identity, commit_id
-                )));
-            }
-            let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, segment_commits)
-                .await?
-            else {
-                return Ok(false);
-            };
-            if let Some((_, winner_change_id)) = commit
-                .directory
-                .state_row_identities
-                .iter()
-                .find(|(candidate, _)| candidate == identity)
-            {
-                return Ok(winner_change_id == change_id);
-            }
-            next_commit_id = commit.header.parent_commit_ids.first().cloned();
-        }
-        Ok(false)
-    }
-
-    async fn load_published_staged_or_segment_commit(
-        &mut self,
-        commit_id: &str,
-        segment_commits: Option<&HashMap<String, SegmentCommit>>,
-    ) -> Result<Option<SegmentCommit>, LixError> {
-        if let Some(commit) = segment_commits.and_then(|commits| commits.get(commit_id)) {
-            return Ok(Some(commit.clone()));
-        }
-        if let Some(commit) = self.load_published_or_staged_commit(commit_id).await? {
-            return Ok(Some(commit));
-        }
-        self.find_segment_commit(commit_id).await
     }
 
     async fn load_published_or_staged_commit(

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -425,6 +425,8 @@ where
             };
             let commit = segment.load_commit(&visibility.location, commit_id)?;
             validate_commit_checksum(&visibility.checksum, commit_id, &commit)?;
+            self.ensure_unique_stored_commit(commit_id, &visibility.location)
+                .await?;
             entries.push(Some(project_segment_commit(&commit, projection)));
         }
         Ok(entries)
@@ -441,6 +443,16 @@ where
             push_unique(&mut segment_ids, entry.location.segment_id.clone());
         }
         let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
+        let expected_locations = commit_ids
+            .iter()
+            .zip(by_commit_entries.iter())
+            .filter_map(|(commit_id, entry)| {
+                let entry = entry.as_ref()?;
+                (entry.commit_id == *commit_id).then(|| (commit_id.clone(), entry.location.clone()))
+            })
+            .collect::<HashMap<_, _>>();
+        self.ensure_unique_stored_commits(&expected_locations)
+            .await?;
         let mut entries = Vec::with_capacity(commit_ids.len());
         for (commit_id, by_commit) in commit_ids.iter().zip(by_commit_entries.iter()) {
             let Some(by_commit) = by_commit else {
@@ -493,6 +505,16 @@ where
             push_unique(&mut segment_ids, entry.location.segment_id.clone());
         }
         let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
+        let expected_locations = change_ids
+            .iter()
+            .zip(by_change_entries.iter())
+            .filter_map(|(change_id, entry)| {
+                let entry = entry.as_ref()?;
+                (entry.change_id == *change_id).then(|| (change_id.clone(), entry.location.clone()))
+            })
+            .collect::<HashMap<_, _>>();
+        self.ensure_unique_stored_changes(&expected_locations)
+            .await?;
         let mut entries = Vec::with_capacity(change_ids.len());
         for (change_id, by_change) in change_ids.iter().zip(by_change_entries.iter()) {
             let Some(by_change) = by_change else {
@@ -542,6 +564,17 @@ where
         }
         let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
         let visible_change_ids = self.prove_visible_changes(change_ids).await?;
+        let expected_locations = change_ids
+            .iter()
+            .zip(by_change_entries.iter())
+            .filter(|(change_id, _)| visible_change_ids.contains(*change_id))
+            .filter_map(|(change_id, entry)| {
+                let entry = entry.as_ref()?;
+                (entry.change_id == *change_id).then(|| (change_id.clone(), entry.location.clone()))
+            })
+            .collect::<HashMap<_, _>>();
+        self.ensure_unique_stored_changes(&expected_locations)
+            .await?;
         let mut entries = Vec::with_capacity(change_ids.len());
         for (change_id, by_change) in change_ids.iter().zip(by_change_entries.iter()) {
             if !visible_change_ids.contains(change_id) {
@@ -700,11 +733,7 @@ where
         .await?;
         values
             .into_iter()
-            .map(|value| {
-                value
-                    .map(|bytes| decode_commit_visibility(&bytes))
-                    .transpose()
-            })
+            .map(|value| Ok(value.and_then(|bytes| decode_commit_visibility(&bytes).ok())))
             .collect()
     }
 
@@ -1135,6 +1164,44 @@ where
         Ok(Some((entry.location, change.clone())))
     }
 
+    async fn ensure_unique_stored_commit(
+        &mut self,
+        commit_id: &str,
+        expected_location: &SegmentObjectLocation,
+    ) -> Result<(), LixError> {
+        self.ensure_unique_stored_commits(&HashMap::from([(
+            commit_id.to_string(),
+            expected_location.clone(),
+        )]))
+        .await
+    }
+
+    async fn ensure_unique_stored_commits(
+        &mut self,
+        expected_locations: &HashMap<String, SegmentObjectLocation>,
+    ) -> Result<(), LixError> {
+        if expected_locations.is_empty() {
+            return Ok(());
+        }
+        let mut seen = HashSet::new();
+        for segment in self.scan_all_segments().await? {
+            for commit_id in expected_locations.keys() {
+                let Some(commit) = segment_commit(&segment, commit_id) else {
+                    continue;
+                };
+                let location = directory_commit_location(&segment, commit_id)?;
+                validate_commit_checksum(&location.checksum, commit_id, commit)?;
+                let expected_location = &expected_locations[commit_id];
+                if &location != expected_location || !seen.insert(commit_id.clone()) {
+                    return Err(LixError::unknown(format!(
+                        "changelog commit '{commit_id}' appears in multiple segments"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn find_segment_change(
         &mut self,
         change_id: &str,
@@ -1155,17 +1222,34 @@ where
         change_id: &str,
         expected_location: &SegmentObjectLocation,
     ) -> Result<(), LixError> {
+        self.ensure_unique_stored_changes(&HashMap::from([(
+            change_id.to_string(),
+            expected_location.clone(),
+        )]))
+        .await
+    }
+
+    async fn ensure_unique_stored_changes(
+        &mut self,
+        expected_locations: &HashMap<String, SegmentObjectLocation>,
+    ) -> Result<(), LixError> {
+        if expected_locations.is_empty() {
+            return Ok(());
+        }
+        let mut seen = HashSet::new();
         for segment in self.scan_all_segments().await? {
-            let Some(change) = segment_change(&segment, change_id) else {
-                continue;
-            };
-            let location = directory_change_location(&segment, change_id)?;
-            validate_change_checksum(&location.checksum, change_id, change)?;
-            if &location != expected_location {
-                return Err(LixError::unknown(format!(
-                    "changelog change '{change_id}' appears in multiple segments: '{}' and '{}'",
-                    expected_location.segment_id, location.segment_id
-                )));
+            for change_id in expected_locations.keys() {
+                let Some(change) = segment_change(&segment, change_id) else {
+                    continue;
+                };
+                let location = directory_change_location(&segment, change_id)?;
+                validate_change_checksum(&location.checksum, change_id, change)?;
+                let expected_location = &expected_locations[change_id];
+                if &location != expected_location || !seen.insert(change_id.clone()) {
+                    return Err(LixError::unknown(format!(
+                        "changelog change '{change_id}' appears in multiple segments"
+                    )));
+                }
             }
         }
         Ok(())
@@ -2191,7 +2275,30 @@ where
         };
         let commit = segment.load_commit(&entry.location, commit_id)?;
         validate_commit_checksum(&entry.location.checksum, commit_id, &commit)?;
+        self.ensure_unique_stored_commit(commit_id, &entry.location)
+            .await?;
         Ok(Some(commit))
+    }
+
+    async fn ensure_unique_stored_commit(
+        &mut self,
+        commit_id: &str,
+        expected_location: &SegmentObjectLocation,
+    ) -> Result<(), LixError> {
+        for segment in self.scan_all_segments().await? {
+            let Some(commit) = segment_commit(&segment, commit_id) else {
+                continue;
+            };
+            let location = directory_commit_location(&segment, commit_id)?;
+            validate_commit_checksum(&location.checksum, commit_id, commit)?;
+            if &location != expected_location {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' appears in multiple segments: '{}' and '{}'",
+                    expected_location.segment_id, location.segment_id
+                )));
+            }
+        }
+        Ok(())
     }
 
     async fn load_segment_byte_index_for_writer(
@@ -2245,12 +2352,9 @@ where
             }
         }
 
-        let remaining = change_ids
-            .difference(&found.keys().cloned().collect::<HashSet<_>>())
-            .cloned()
-            .collect::<Vec<_>>();
-        if !remaining.is_empty() {
-            self.resolve_publish_changes_by_segment_scan(&remaining, &mut found)
+        if !change_ids.is_empty() {
+            let requested = change_ids.iter().cloned().collect::<Vec<_>>();
+            self.resolve_publish_changes_by_segment_scan(&requested, &mut found)
                 .await?;
         }
 
@@ -3611,6 +3715,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_changes_visible_recovers_from_corrupt_visible_change_proof() {
+        let (context, storage) = changelog_test_context();
+        let segment = test_segment();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(segment.clone()).await.unwrap();
+            writer.stage_publish_commit("commit-1").await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-1"),
+            b"not a commit visibility".to_vec(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage);
+        let batch = reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &["change-1".to_string()],
+                projection: ChangeProjection::Segment,
+                visibility: ChangeVisibilityMode::RequireReachableFromVisibleCommit,
+            })
+            .await
+            .expect("corrupt visible proof should fall back to membership/visibility scans");
+
+        assert_eq!(
+            batch.entries,
+            vec![Some(ChangeLoadEntry::Segment(segment.changes[0].clone()))]
+        );
+    }
+
+    #[tokio::test]
     async fn rebuild_mandatory_indexes_repairs_deleted_locator_indexes() {
         let (context, storage) = changelog_test_context();
         let segment = test_segment();
@@ -4127,6 +4272,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_changes_physical_rejects_duplicate_primary_change_even_when_by_change_exists() {
+        let (context, storage) = changelog_test_context();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(test_segment()).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut duplicate = test_segment();
+        duplicate.header.segment_id = "segment-2".to_string();
+        duplicate.commits[0].header.id = "commit-2".to_string();
+        duplicate.commits[0].header.derivable_change_id = "derived-change-2".to_string();
+        duplicate.changes[0].authored_commit_id = Some("commit-2".to_string());
+        let duplicate = canonicalize_segment(duplicate).unwrap();
+        write_raw_segment(&storage, &duplicate).await;
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &["change-1".to_string()],
+                projection: ChangeProjection::Segment,
+                visibility: ChangeVisibilityMode::PhysicalOnly,
+            })
+            .await
+            .expect_err("batch physical read must reject duplicate primary change");
+
+        assert!(
+            error.message.contains("appears in multiple"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_commits_physical_rejects_duplicate_primary_commit_even_when_by_commit_exists() {
+        let (context, storage) = changelog_test_context();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(test_segment()).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut duplicate = test_segment();
+        duplicate.header.segment_id = "segment-2".to_string();
+        let duplicate = canonicalize_segment(duplicate).unwrap();
+        write_raw_segment(&storage, &duplicate).await;
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .load_commits(CommitLoadRequest {
+                commit_ids: &["commit-1".to_string()],
+                projection: CommitProjection::Header,
+                visibility: CommitVisibilityMode::PhysicalOnly,
+            })
+            .await
+            .expect_err("batch physical read must reject duplicate primary commit");
+
+        assert!(
+            error.message.contains("appears in multiple"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn stage_segment_computes_by_commit_generations_from_parent_edges() {
         let (context, storage) = changelog_test_context();
         let segment = two_commit_segment();
@@ -4328,6 +4544,33 @@ mod tests {
 
         assert!(
             error.to_string().contains("parent cycle"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_by_commit_index_rejects_duplicate_stored_commit_ids() {
+        let (context, storage) = changelog_test_context();
+        let segment_1 = test_segment();
+        let mut segment_2 = test_segment();
+        segment_2.header.segment_id = "segment-2".to_string();
+        let segment_2 = canonicalize_segment(segment_2).unwrap();
+
+        write_raw_segment(&storage, &segment_1).await;
+        write_raw_segment(&storage, &segment_2).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .rebuild_by_commit_index()
+                .await
+                .expect_err("duplicate stored commit ids should abort rebuild")
+        };
+
+        assert!(
+            error.message.contains("duplicate commit 'commit-1'"),
             "unexpected error: {error}"
         );
     }

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -32,7 +32,7 @@ use crate::changelog::{
 use crate::changelog::{
     decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
     decode_segment_change, decode_segment_commit, segment_commit_membership_contains_any,
-    view_segment_directory,
+    view_segment,
 };
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::storage::{
@@ -192,7 +192,7 @@ struct SegmentByteIndex {
 
 impl SegmentByteIndex {
     fn decode(bytes: Vec<u8>) -> Result<Self, LixError> {
-        let view = view_segment_directory(&bytes)?;
+        let view = view_segment(&bytes)?;
         let segment_id = view.segment_id.to_string();
         let commit_locations = view
             .directory_commits
@@ -967,10 +967,16 @@ where
                 continue;
             };
             let Some(segment) = segments.get(&visibility.location.segment_id) else {
-                continue;
+                return Err(LixError::unknown(format!(
+                    "visible changelog commit '{}' points to missing segment '{}'",
+                    visibility.commit_id, visibility.location.segment_id
+                )));
             };
             if visibility.checksum != visibility.location.checksum {
-                continue;
+                return Err(LixError::unknown(format!(
+                    "visible changelog commit '{}' checksum '{}' does not match locator checksum '{}'",
+                    visibility.commit_id, visibility.checksum, visibility.location.checksum
+                )));
             }
             for change_id in segment.prove_commit_membership(
                 &visibility.location,
@@ -1134,16 +1140,42 @@ where
         change_id: &str,
     ) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError> {
         match self.load_physical_segment_change(change_id).await {
-            Ok(Some(found)) => Ok(Some(found)),
+            Ok(Some(found)) => {
+                self.ensure_unique_stored_change(change_id, &found.0)
+                    .await?;
+                Ok(Some(found))
+            }
             Ok(None) => self.scan_segments_for_change(change_id).await,
             Err(error) => Err(error),
         }
+    }
+
+    async fn ensure_unique_stored_change(
+        &mut self,
+        change_id: &str,
+        expected_location: &SegmentObjectLocation,
+    ) -> Result<(), LixError> {
+        for segment in self.scan_all_segments().await? {
+            let Some(change) = segment_change(&segment, change_id) else {
+                continue;
+            };
+            let location = directory_change_location(&segment, change_id)?;
+            validate_change_checksum(&location.checksum, change_id, change)?;
+            if &location != expected_location {
+                return Err(LixError::unknown(format!(
+                    "changelog change '{change_id}' appears in multiple segments: '{}' and '{}'",
+                    expected_location.segment_id, location.segment_id
+                )));
+            }
+        }
+        Ok(())
     }
 
     async fn scan_segments_for_change(
         &mut self,
         change_id: &str,
     ) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError> {
+        let mut found = None::<(SegmentObjectLocation, SegmentChange)>;
         let mut after = None;
         loop {
             let page = self
@@ -1165,7 +1197,13 @@ where
                 if let Some(change) = segment_change(&segment, change_id) {
                     let location = directory_change_location(&segment, change_id)?;
                     validate_change_checksum(&location.checksum, change_id, change)?;
-                    return Ok(Some((location, change.clone())));
+                    if let Some((existing, _)) = &found {
+                        return Err(LixError::unknown(format!(
+                            "changelog change '{change_id}' appears in multiple segments: '{}' and '{}'",
+                            existing.segment_id, location.segment_id
+                        )));
+                    }
+                    found = Some((location, change.clone()));
                 }
             }
             let Some(next_after) = page.resume_after else {
@@ -1173,7 +1211,7 @@ where
             };
             after = Some(next_after);
         }
-        Ok(None)
+        Ok(found)
     }
 
     async fn visible_membership_contains_change(
@@ -1781,6 +1819,11 @@ where
             changes.extend(self.resolve_publish_changes(&missing).await?);
         }
 
+        let segment_commits = segment
+            .commits
+            .iter()
+            .map(|commit| (commit.header.id.clone(), commit.clone()))
+            .collect::<HashMap<_, _>>();
         let mut source_parent_facts = HashMap::<String, SourceParentFacts>::new();
 
         for commit in &segment.commits {
@@ -1819,7 +1862,7 @@ where
                 }
                 if !source_parent_facts.contains_key(parent_id) {
                     let facts = self
-                        .source_parent_facts_in_segment(parent_id, segment)
+                        .source_parent_facts_in_segment(parent_id, &segment_commits)
                         .await?;
                     source_parent_facts.insert(parent_id.clone(), facts);
                 }
@@ -1896,7 +1939,7 @@ where
     async fn source_parent_facts_in_segment(
         &mut self,
         root_commit_id: &str,
-        segment: &Segment,
+        segment_commits: &HashMap<String, SegmentCommit>,
     ) -> Result<SourceParentFacts, LixError> {
         let mut facts = SourceParentFacts::default();
         let mut stack = vec![root_commit_id.to_string()];
@@ -1906,7 +1949,7 @@ where
                 continue;
             }
             let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, Some(segment))
+                .load_published_staged_or_segment_commit(&commit_id, Some(segment_commits))
                 .await?
             else {
                 continue;
@@ -1930,7 +1973,7 @@ where
                 )));
             }
             let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, Some(segment))
+                .load_published_staged_or_segment_commit(&commit_id, Some(segment_commits))
                 .await?
             else {
                 break;
@@ -1961,10 +2004,15 @@ where
         change_id: &str,
         segment: &Segment,
     ) -> Result<bool, LixError> {
+        let segment_commits = segment
+            .commits
+            .iter()
+            .map(|commit| (commit.header.id.clone(), commit.clone()))
+            .collect::<HashMap<_, _>>();
         self.commit_history_contains_membership_with_loader(
             root_commit_id,
             change_id,
-            Some(segment),
+            Some(&segment_commits),
         )
         .await
     }
@@ -1973,7 +2021,7 @@ where
         &mut self,
         root_commit_id: &str,
         change_id: &str,
-        segment: Option<&Segment>,
+        segment_commits: Option<&HashMap<String, SegmentCommit>>,
     ) -> Result<bool, LixError> {
         let mut stack = vec![root_commit_id.to_string()];
         let mut visited = HashSet::new();
@@ -1982,7 +2030,7 @@ where
                 continue;
             }
             let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, segment)
+                .load_published_staged_or_segment_commit(&commit_id, segment_commits)
                 .await?
             else {
                 continue;
@@ -2022,11 +2070,16 @@ where
         change_id: &str,
         segment: &Segment,
     ) -> Result<bool, LixError> {
+        let segment_commits = segment
+            .commits
+            .iter()
+            .map(|commit| (commit.header.id.clone(), commit.clone()))
+            .collect::<HashMap<_, _>>();
         self.commit_history_projects_state_row_with_loader(
             root_commit_id,
             identity,
             change_id,
-            Some(segment),
+            Some(&segment_commits),
         )
         .await
     }
@@ -2036,7 +2089,7 @@ where
         root_commit_id: &str,
         identity: &StateRowIdentity,
         change_id: &str,
-        segment: Option<&Segment>,
+        segment_commits: Option<&HashMap<String, SegmentCommit>>,
     ) -> Result<bool, LixError> {
         let mut next_commit_id = Some(root_commit_id.to_string());
         let mut visited = HashSet::new();
@@ -2048,7 +2101,7 @@ where
                 )));
             }
             let Some(commit) = self
-                .load_published_staged_or_segment_commit(&commit_id, segment)
+                .load_published_staged_or_segment_commit(&commit_id, segment_commits)
                 .await?
             else {
                 return Ok(false);
@@ -2069,14 +2122,9 @@ where
     async fn load_published_staged_or_segment_commit(
         &mut self,
         commit_id: &str,
-        segment: Option<&Segment>,
+        segment_commits: Option<&HashMap<String, SegmentCommit>>,
     ) -> Result<Option<SegmentCommit>, LixError> {
-        if let Some(commit) = segment.and_then(|segment| {
-            segment
-                .commits
-                .iter()
-                .find(|commit| commit.header.id == commit_id)
-        }) {
+        if let Some(commit) = segment_commits.and_then(|commits| commits.get(commit_id)) {
             return Ok(Some(commit.clone()));
         }
         if let Some(commit) = self.load_published_or_staged_commit(commit_id).await? {
@@ -2136,18 +2184,14 @@ where
             .load_segment_byte_index_for_writer(&entry.location.segment_id)
             .await?
         else {
-            return self.scan_segments_for_commit(commit_id).await;
+            return Err(LixError::unknown(format!(
+                "by_commit entry for '{commit_id}' points to missing segment '{}'",
+                entry.location.segment_id
+            )));
         };
-        match segment.load_commit(&entry.location, commit_id) {
-            Ok(commit) => {
-                if validate_commit_checksum(&entry.location.checksum, commit_id, &commit).is_ok() {
-                    Ok(Some(commit))
-                } else {
-                    self.scan_segments_for_commit(commit_id).await
-                }
-            }
-            Err(_) => self.scan_segments_for_commit(commit_id).await,
-        }
+        let commit = segment.load_commit(&entry.location, commit_id)?;
+        validate_commit_checksum(&entry.location.checksum, commit_id, &commit)?;
+        Ok(Some(commit))
     }
 
     async fn load_segment_byte_index_for_writer(
@@ -2201,15 +2245,10 @@ where
             }
         }
 
-        let mut remaining = change_ids
+        let remaining = change_ids
             .difference(&found.keys().cloned().collect::<HashSet<_>>())
             .cloned()
             .collect::<Vec<_>>();
-        if !remaining.is_empty() {
-            self.resolve_publish_changes_from_by_change(&remaining, &mut found)
-                .await?;
-            remaining.retain(|change_id| !found.contains_key(change_id));
-        }
         if !remaining.is_empty() {
             self.resolve_publish_changes_by_segment_scan(&remaining, &mut found)
                 .await?;
@@ -2223,69 +2262,6 @@ where
             }
         }
         Ok(found)
-    }
-
-    async fn resolve_publish_changes_from_by_change(
-        &mut self,
-        change_ids: &[String],
-        found: &mut HashMap<String, SegmentChange>,
-    ) -> Result<(), LixError> {
-        let values = get_many(
-            &mut *self.store,
-            BY_CHANGE_INDEX_SPACE,
-            change_ids
-                .iter()
-                .map(|change_id| by_change_key(change_id))
-                .collect(),
-        )
-        .await?;
-        let mut entries = Vec::new();
-        let mut segment_ids = Vec::new();
-        for (change_id, value) in change_ids.iter().zip(values.into_iter()) {
-            let Some(bytes) = value else {
-                continue;
-            };
-            let entry = decode_by_change_entry(&bytes)?;
-            if entry.change_id != *change_id {
-                return Err(LixError::unknown(format!(
-                    "by_change key for '{change_id}' contains change_id '{}'",
-                    entry.change_id
-                )));
-            }
-            push_unique(&mut segment_ids, entry.location.segment_id.clone());
-            entries.push(entry);
-        }
-
-        let segment_values = get_many(
-            &mut *self.store,
-            SEGMENT_SPACE,
-            segment_ids
-                .iter()
-                .map(|segment_id| segment_key(segment_id))
-                .collect(),
-        )
-        .await?;
-        let mut segments = HashMap::new();
-        for (segment_id, value) in segment_ids.iter().zip(segment_values.into_iter()) {
-            if let Some(bytes) = value {
-                segments.insert(segment_id.clone(), SegmentByteIndex::decode(bytes)?);
-            }
-        }
-
-        for entry in entries {
-            let Some(segment) = segments.get(&entry.location.segment_id) else {
-                continue;
-            };
-            let change = segment.load_change(&entry.location, &entry.change_id)?;
-            validate_change_checksum(&entry.location.checksum, &entry.change_id, &change)?;
-            if found.insert(entry.change_id.clone(), change).is_some() {
-                return Err(LixError::unknown(format!(
-                    "cannot publish changelog change '{}' because it appears in multiple staged/stored segments",
-                    entry.change_id
-                )));
-            }
-        }
-        Ok(())
     }
 
     async fn resolve_publish_changes_by_segment_scan(
@@ -4081,6 +4057,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_publish_changes_rejects_duplicate_stored_change_even_when_by_change_exists() {
+        let (context, storage) = changelog_test_context();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(test_segment()).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut duplicate = test_segment();
+        duplicate.header.segment_id = "segment-2".to_string();
+        duplicate.commits[0].header.id = "commit-2".to_string();
+        duplicate.commits[0].header.derivable_change_id = "derived-change-2".to_string();
+        duplicate.changes[0].authored_commit_id = Some("commit-2".to_string());
+        let duplicate = canonicalize_segment(duplicate).unwrap();
+        write_raw_segment(&storage, &duplicate).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .resolve_publish_changes(&HashSet::from(["change-1".to_string()]))
+                .await
+                .expect_err("primary duplicate change must reject despite by_change index")
+        };
+
+        assert!(
+            error.message.contains("appears in multiple"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_segment_change_rejects_duplicate_primary_change_even_when_by_change_exists() {
+        let (context, storage) = changelog_test_context();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(test_segment()).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut duplicate = test_segment();
+        duplicate.header.segment_id = "segment-2".to_string();
+        duplicate.commits[0].header.id = "commit-2".to_string();
+        duplicate.commits[0].header.derivable_change_id = "derived-change-2".to_string();
+        duplicate.changes[0].authored_commit_id = Some("commit-2".to_string());
+        let duplicate = canonicalize_segment(duplicate).unwrap();
+        write_raw_segment(&storage, &duplicate).await;
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .find_segment_change("change-1")
+            .await
+            .expect_err("duplicate primary change must reject despite by_change index");
+
+        assert!(
+            error.message.contains("appears in multiple"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn stage_segment_computes_by_commit_generations_from_parent_edges() {
         let (context, storage) = changelog_test_context();
         let segment = two_commit_segment();
@@ -4540,8 +4586,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stage_segment_accepts_adopted_membership_from_physical_parent_when_by_commit_is_stale()
-    {
+    async fn stage_segment_rejects_adopted_membership_when_by_commit_is_corrupt() {
         let (context, storage) = changelog_test_context();
         let parent_segment = test_segment();
 
@@ -4587,10 +4632,20 @@ mod tests {
 
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();
-        {
+        let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(adopt_segment).await.unwrap();
-        }
+            writer
+                .stage_segment(adopt_segment)
+                .await
+                .expect_err("present corrupt by_commit row should fail closed")
+        };
+
+        assert!(
+            error
+                .message
+                .contains("points to missing segment 'missing-segment'"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -29,6 +29,7 @@ use super::truth::{
     SegmentTruthSnapshot, find_change_by_exhaustive_segment_scan,
     find_changes_by_exhaustive_segment_scan, find_commit_by_exhaustive_segment_scan,
     find_commits_by_exhaustive_segment_scan, load_segment_truth_index,
+    validate_segment_truth_overlay,
 };
 use crate::LixError;
 use crate::changelog::{
@@ -1484,58 +1485,12 @@ where
     }
 
     async fn reject_duplicate_logical_ids(&mut self, segment: &Segment) -> Result<(), LixError> {
-        let commit_ids = segment
-            .commits
-            .iter()
-            .map(|commit| commit.header.id.as_str())
-            .collect::<HashSet<_>>();
-        let change_ids = segment
-            .changes
-            .iter()
-            .map(|change| change.id.as_str())
-            .collect::<HashSet<_>>();
-
-        for commit in &segment.commits {
-            if self.staged_commits.contains_key(&commit.header.id) {
-                return Err(LixError::unknown(format!(
-                    "changelog commit '{}' already exists in another segment",
-                    commit.header.id
-                )));
-            }
-        }
-        for change in &segment.changes {
-            if self.staged_changes.contains(&change.id) {
-                return Err(LixError::unknown(format!(
-                    "changelog change '{}' already exists in another segment",
-                    change.id
-                )));
-            }
-        }
-
-        for existing_segment in self.scan_all_segments().await? {
-            if existing_segment.header.segment_id == segment.header.segment_id {
-                return Err(LixError::unknown(format!(
-                    "changelog segment '{}' already exists",
-                    segment.header.segment_id
-                )));
-            }
-            for commit in &existing_segment.commits {
-                if commit_ids.contains(commit.header.id.as_str()) {
-                    return Err(LixError::unknown(format!(
-                        "changelog commit '{}' already exists in another segment",
-                        commit.header.id
-                    )));
-                }
-            }
-            for change in &existing_segment.changes {
-                if change_ids.contains(change.id.as_str()) {
-                    return Err(LixError::unknown(format!(
-                        "changelog change '{}' already exists in another segment",
-                        change.id
-                    )));
-                }
-            }
-        }
+        let stored = load_segment_truth_index(&mut *self.store).await?;
+        let staged = self
+            .staged_segments
+            .values()
+            .chain(std::iter::once(segment));
+        validate_segment_truth_overlay(&stored, staged)?;
         Ok(())
     }
 

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use super::context::ChangelogStorageRead;
-use super::segment::{validate_change_checksum, validate_commit_checksum, validate_segment_shape};
+use super::segment::{
+    directory_change_location, directory_commit_location, validate_change_checksum,
+    validate_commit_checksum, validate_segment_shape,
+};
 use super::store::{
     BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE,
     COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE, by_change_index_value,
@@ -11,13 +14,12 @@ use super::store::{
 };
 use super::types::{
     ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRoot, GcSweepSet,
-    MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation,
-    SegmentObjectLocationRef, StateRowIdentity,
+    MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation, StateRowIdentity,
 };
 use crate::LixError;
 use crate::changelog::{
-    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
-    decode_segment_change, decode_segment_commit, view_segment_directory,
+    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility,
+    decode_empty_index_value, decode_segment,
 };
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::json_store::{self, JsonRef};
@@ -27,16 +29,13 @@ pub(super) async fn plan_gc<S>(store: &mut S, roots: &[GcRoot]) -> Result<GcPlan
 where
     S: ChangelogStorageRead + ?Sized,
 {
-    let all_segment_ids = scan_segment_ids(store).await?;
+    let truth = load_segment_truth_index(store).await?;
     let all_commit_visibility = scan_utf8_keys(store, COMMIT_VISIBILITY_SPACE).await?;
     let all_by_commit = scan_utf8_keys(store, BY_COMMIT_INDEX_SPACE).await?;
     let all_by_change = scan_utf8_keys(store, BY_CHANGE_INDEX_SPACE).await?;
-    let all_by_change_membership = scan_by_change_membership_keys(store).await?;
+    let all_by_change_membership = scan_by_change_membership_entries(store).await?;
     let all_visible_change_proof = scan_utf8_keys(store, VISIBLE_CHANGE_PROOF_SPACE).await?;
     let all_json_payloads = scan_json_payload_keys(store).await?;
-    if roots.is_empty() {
-        validate_all_segments(store).await?;
-    }
 
     let mut live = GcLiveSet::default();
     let mut pending_commits = Vec::new();
@@ -44,7 +43,6 @@ where
         pending_commits.push(gc_root_commit_id(root).to_string());
     }
 
-    let mut segment_bytes = HashMap::<String, Vec<u8>>::new();
     let mut commit_index: HashMap<String, (SegmentObjectLocation, SegmentCommit)> = HashMap::new();
     let mut change_index: HashMap<String, (SegmentObjectLocation, SegmentChange)> = HashMap::new();
     let mut source_parent_facts = HashMap::<String, GcSourceParentFacts>::new();
@@ -54,9 +52,7 @@ where
         if live.commits.contains(&commit_id) {
             continue;
         }
-        let Some((commit_location, commit)) =
-            load_gc_commit(store, &all_segment_ids, &mut segment_bytes, &commit_id).await?
-        else {
+        let Some((commit_location, commit)) = truth.commits.get(&commit_id).cloned() else {
             return Err(LixError::unknown(format!(
                 "changelog GC root/ancestor commit '{commit_id}' was not found in changelog segments"
             )));
@@ -81,9 +77,7 @@ where
 
         for membership in &commit.body.membership {
             let change_id = &membership.member_change_id;
-            let Some((change_location, change)) =
-                load_gc_change(store, &all_segment_ids, &mut segment_bytes, change_id).await?
-            else {
+            let Some((change_location, change)) = truth.changes.get(change_id).cloned() else {
                 return Err(LixError::unknown(format!(
                     "changelog GC live commit '{}' references missing change '{}'",
                     commit.header.id, change_id
@@ -114,7 +108,6 @@ where
             &mut checked_commits,
         )?;
     }
-    validate_live_segments(&segment_bytes, &live.segments)?;
     validate_gc_adopted_memberships(&commit_index, &change_index, &mut source_parent_facts)?;
 
     let live_commits: HashSet<_> = live.commits.iter().cloned().collect();
@@ -187,8 +180,21 @@ where
         }
     }
 
+    for membership in &live_memberships {
+        let Some(value) = all_by_change_membership.get(membership) else {
+            continue;
+        };
+        decode_empty_index_value(value).map_err(|error| {
+            LixError::unknown(format!(
+                "changelog GC live by_change_membership entry for change '{}' commit '{}' is corrupt: {error}",
+                membership.0, membership.1
+            ))
+        })?;
+    }
+
     let sweep = GcSweepSet {
-        segments: all_segment_ids
+        segments: truth
+            .segment_ids
             .into_iter()
             .filter(|segment_id| !live.segments.contains(segment_id))
             .collect(),
@@ -209,8 +215,9 @@ where
             .filter(|change_id| !live_changes.contains(change_id))
             .collect(),
         by_change_membership: all_by_change_membership
-            .into_iter()
-            .filter(|membership| !live_memberships.contains(membership))
+            .keys()
+            .filter(|membership| !live_memberships.contains(*membership))
+            .cloned()
             .collect(),
         visible_change_proof: all_visible_change_proof
             .into_iter()
@@ -242,6 +249,94 @@ where
         roots: roots.to_vec(),
         live,
         sweep,
+    })
+}
+
+struct SegmentTruthIndex {
+    segment_ids: Vec<String>,
+    commits: HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    changes: HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+}
+
+async fn load_segment_truth_index<S>(store: &mut S) -> Result<SegmentTruthIndex, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut after = None;
+    let mut segment_ids = Vec::new();
+    let mut commits = HashMap::new();
+    let mut changes = HashMap::new();
+    loop {
+        let page = store
+            .changelog_scan(
+                SEGMENT_SPACE,
+                Vec::new(),
+                after,
+                64,
+                StorageCoreProjection::FullValue,
+            )
+            .await?;
+        for index in 0..page.len() {
+            let Some(key) = page.key(index) else {
+                continue;
+            };
+            let segment_id = std::str::from_utf8(key)
+                .map_err(|error| {
+                    LixError::unknown(format!(
+                        "changelog GC found invalid UTF-8 segment key: {error}"
+                    ))
+                })?
+                .to_string();
+            let Some(bytes) = page.value(index) else {
+                return Err(LixError::unknown(format!(
+                    "changelog GC segment '{segment_id}' scan returned key without value"
+                )));
+            };
+            let segment = decode_segment(bytes)?;
+            validate_segment_shape(&segment)?;
+            if segment.header.segment_id != segment_id {
+                return Err(LixError::unknown(format!(
+                    "changelog GC segment key '{segment_id}' contains segment '{}'",
+                    segment.header.segment_id
+                )));
+            }
+            push_unique(&mut segment_ids, segment_id);
+            for commit in &segment.commits {
+                let location = directory_commit_location(&segment, &commit.header.id)?;
+                validate_commit_checksum(&location.checksum, &commit.header.id, commit)?;
+                if commits
+                    .insert(commit.header.id.clone(), (location, commit.clone()))
+                    .is_some()
+                {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC found duplicate commit id '{}'",
+                        commit.header.id
+                    )));
+                }
+            }
+            for change in &segment.changes {
+                let location = directory_change_location(&segment, &change.id)?;
+                validate_change_checksum(&location.checksum, &change.id, change)?;
+                if changes
+                    .insert(change.id.clone(), (location, change.clone()))
+                    .is_some()
+                {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC found duplicate change id '{}'",
+                        change.id
+                    )));
+                }
+            }
+        }
+        let Some(next_after) = page.resume_after else {
+            break;
+        };
+        after = Some(next_after);
+    }
+    Ok(SegmentTruthIndex {
+        segment_ids,
+        commits,
+        changes,
     })
 }
 
@@ -382,364 +477,6 @@ pub(super) fn stage_gc_sweep(writes: &mut StorageWriteSet, plan: &GcPlan) -> Res
     Ok(())
 }
 
-async fn scan_segment_ids<S>(store: &mut S) -> Result<Vec<String>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let mut after = None;
-    let mut segment_ids = Vec::new();
-    loop {
-        let page = store
-            .changelog_scan(
-                SEGMENT_SPACE,
-                Vec::new(),
-                after,
-                64,
-                StorageCoreProjection::KeyOnly,
-            )
-            .await?;
-        for key in &page.keys {
-            let segment_id = std::str::from_utf8(key)
-                .map_err(|error| {
-                    LixError::unknown(format!(
-                        "changelog GC found invalid UTF-8 segment key: {error}"
-                    ))
-                })?
-                .to_string();
-            if !segment_ids.iter().any(|existing| existing == &segment_id) {
-                segment_ids.push(segment_id);
-            }
-        }
-        let Some(next_after) = page.resume_after else {
-            break;
-        };
-        after = Some(next_after);
-    }
-    Ok(segment_ids)
-}
-
-async fn validate_all_segments<S>(store: &mut S) -> Result<(), LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let mut after = None;
-    loop {
-        let page = store
-            .changelog_scan(
-                SEGMENT_SPACE,
-                Vec::new(),
-                after,
-                64,
-                StorageCoreProjection::FullValue,
-            )
-            .await?;
-        for index in 0..page.len() {
-            let Some(bytes) = page.value(index) else {
-                continue;
-            };
-            let segment = decode_segment(bytes)?;
-            validate_segment_shape(&segment)?;
-        }
-        let Some(next_after) = page.resume_after else {
-            break;
-        };
-        after = Some(next_after);
-    }
-    Ok(())
-}
-
-fn validate_live_segments(
-    segment_bytes: &HashMap<String, Vec<u8>>,
-    live_segment_ids: &[String],
-) -> Result<(), LixError> {
-    for segment_id in live_segment_ids {
-        let Some(bytes) = segment_bytes.get(segment_id) else {
-            return Err(LixError::unknown(format!(
-                "changelog GC live segment '{segment_id}' was not loaded"
-            )));
-        };
-        let segment = decode_segment(bytes)?;
-        validate_segment_shape(&segment)?;
-    }
-    Ok(())
-}
-
-async fn load_gc_commit<S>(
-    store: &mut S,
-    all_segment_ids: &[String],
-    segment_bytes: &mut HashMap<String, Vec<u8>>,
-    commit_id: &str,
-) -> Result<Option<(SegmentObjectLocation, SegmentCommit)>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    scan_segments_for_commit(store, all_segment_ids, segment_bytes, commit_id).await
-}
-
-async fn load_gc_change<S>(
-    store: &mut S,
-    all_segment_ids: &[String],
-    segment_bytes: &mut HashMap<String, Vec<u8>>,
-    change_id: &str,
-) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    scan_segments_for_change(store, all_segment_ids, segment_bytes, change_id).await
-}
-
-async fn load_by_commit_entry<S>(
-    store: &mut S,
-    commit_id: &str,
-) -> Result<Option<ByCommitEntry>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let Some(bytes) = store
-        .changelog_get_many(BY_COMMIT_INDEX_SPACE, vec![by_commit_key(commit_id)])
-        .await?
-        .into_iter()
-        .next()
-        .flatten()
-    else {
-        return Ok(None);
-    };
-    let entry = decode_by_commit_entry(&bytes)?;
-    if entry.commit_id != commit_id {
-        return Err(LixError::unknown(format!(
-            "by_commit key for '{commit_id}' contains commit_id '{}'",
-            entry.commit_id
-        )));
-    }
-    Ok(Some(entry))
-}
-
-async fn load_by_change_entry<S>(
-    store: &mut S,
-    change_id: &str,
-) -> Result<Option<ByChangeEntry>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let Some(bytes) = store
-        .changelog_get_many(BY_CHANGE_INDEX_SPACE, vec![by_change_key(change_id)])
-        .await?
-        .into_iter()
-        .next()
-        .flatten()
-    else {
-        return Ok(None);
-    };
-    let entry = decode_by_change_entry(&bytes)?;
-    if entry.change_id != change_id {
-        return Err(LixError::unknown(format!(
-            "by_change key for '{change_id}' contains change_id '{}'",
-            entry.change_id
-        )));
-    }
-    Ok(Some(entry))
-}
-
-async fn ensure_segment_bytes<S>(
-    store: &mut S,
-    segment_bytes: &mut HashMap<String, Vec<u8>>,
-    segment_id: &str,
-) -> Result<bool, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    if segment_bytes.contains_key(segment_id) {
-        return Ok(true);
-    }
-    let Some(bytes) = store
-        .changelog_get_many(SEGMENT_SPACE, vec![segment_key(segment_id)])
-        .await?
-        .into_iter()
-        .next()
-        .flatten()
-    else {
-        return Ok(false);
-    };
-    segment_bytes.insert(segment_id.to_string(), bytes);
-    Ok(true)
-}
-
-async fn scan_segments_for_commit<S>(
-    store: &mut S,
-    all_segment_ids: &[String],
-    segment_bytes: &mut HashMap<String, Vec<u8>>,
-    commit_id: &str,
-) -> Result<Option<(SegmentObjectLocation, SegmentCommit)>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let mut found = None;
-    for segment_id in all_segment_ids {
-        if !ensure_segment_bytes(store, segment_bytes, segment_id).await? {
-            continue;
-        }
-        let bytes = &segment_bytes[segment_id];
-        let view = view_segment_directory(bytes)?;
-        let Some(entry) = view
-            .directory_commits
-            .iter()
-            .find(|entry| entry.id == commit_id)
-        else {
-            continue;
-        };
-        let location = location_from_ref(entry.location);
-        let commit =
-            decode_commit_from_segment_bytes(bytes, &location, commit_id)?.ok_or_else(|| {
-                LixError::unknown(format!(
-                    "changelog GC commit '{commit_id}' disappeared from segment directory"
-                ))
-            })?;
-        if found.replace((location, commit)).is_some() {
-            return Err(LixError::unknown(format!(
-                "changelog GC found duplicate commit id '{commit_id}'"
-            )));
-        }
-    }
-    Ok(found)
-}
-
-async fn scan_segments_for_change<S>(
-    store: &mut S,
-    all_segment_ids: &[String],
-    segment_bytes: &mut HashMap<String, Vec<u8>>,
-    change_id: &str,
-) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let mut found = None;
-    for segment_id in all_segment_ids {
-        if !ensure_segment_bytes(store, segment_bytes, segment_id).await? {
-            continue;
-        }
-        let bytes = &segment_bytes[segment_id];
-        let view = view_segment_directory(bytes)?;
-        let Some(entry) = view
-            .directory_changes
-            .iter()
-            .find(|entry| entry.id == change_id)
-        else {
-            continue;
-        };
-        let location = location_from_ref(entry.location);
-        let change =
-            decode_change_from_segment_bytes(bytes, &location, change_id)?.ok_or_else(|| {
-                LixError::unknown(format!(
-                    "changelog GC change '{change_id}' disappeared from segment directory"
-                ))
-            })?;
-        if found.replace((location, change)).is_some() {
-            return Err(LixError::unknown(format!(
-                "changelog GC found duplicate change id '{change_id}'"
-            )));
-        }
-    }
-    Ok(found)
-}
-
-fn decode_commit_from_segment_bytes(
-    bytes: &[u8],
-    location: &SegmentObjectLocation,
-    commit_id: &str,
-) -> Result<Option<SegmentCommit>, LixError> {
-    let view = view_segment_directory(bytes)?;
-    let Some(entry) = view
-        .directory_commits
-        .iter()
-        .find(|entry| entry.id == commit_id)
-    else {
-        return Ok(None);
-    };
-    if location_from_ref(entry.location) != *location {
-        return Ok(None);
-    }
-    let object = segment_object_bytes(bytes, view.segment_id, location, "commit", commit_id)?;
-    let commit = decode_segment_commit(object)?;
-    if commit.header.id != commit_id {
-        return Err(LixError::unknown(format!(
-            "changelog GC commit locator for '{commit_id}' decoded commit '{}'",
-            commit.header.id
-        )));
-    }
-    validate_commit_checksum(&location.checksum, commit_id, &commit)?;
-    Ok(Some(commit))
-}
-
-fn decode_change_from_segment_bytes(
-    bytes: &[u8],
-    location: &SegmentObjectLocation,
-    change_id: &str,
-) -> Result<Option<SegmentChange>, LixError> {
-    let view = view_segment_directory(bytes)?;
-    let Some(entry) = view
-        .directory_changes
-        .iter()
-        .find(|entry| entry.id == change_id)
-    else {
-        return Ok(None);
-    };
-    if location_from_ref(entry.location) != *location {
-        return Ok(None);
-    }
-    let object = segment_object_bytes(bytes, view.segment_id, location, "change", change_id)?;
-    let change = decode_segment_change(object)?;
-    if change.id != change_id {
-        return Err(LixError::unknown(format!(
-            "changelog GC change locator for '{change_id}' decoded change '{}'",
-            change.id
-        )));
-    }
-    validate_change_checksum(&location.checksum, change_id, &change)?;
-    Ok(Some(change))
-}
-
-fn segment_object_bytes<'a>(
-    bytes: &'a [u8],
-    segment_id: &str,
-    location: &SegmentObjectLocation,
-    kind: &str,
-    id: &str,
-) -> Result<&'a [u8], LixError> {
-    if location.segment_id != segment_id {
-        return Err(LixError::unknown(format!(
-            "changelog GC {kind} '{id}' locator points to segment '{}' but loaded '{}'",
-            location.segment_id, segment_id
-        )));
-    }
-    let start = usize::try_from(location.offset).map_err(|_| {
-        LixError::unknown(format!(
-            "changelog GC {kind} '{id}' offset does not fit in usize"
-        ))
-    })?;
-    let len = usize::try_from(location.len).map_err(|_| {
-        LixError::unknown(format!(
-            "changelog GC {kind} '{id}' length does not fit in usize"
-        ))
-    })?;
-    let end = start.checked_add(len).ok_or_else(|| {
-        LixError::unknown(format!("changelog GC {kind} '{id}' offset/len overflows"))
-    })?;
-    bytes.get(start..end).ok_or_else(|| {
-        LixError::unknown(format!(
-            "changelog GC {kind} '{id}' locator is out of bounds"
-        ))
-    })
-}
-
-fn location_from_ref(location: SegmentObjectLocationRef<'_>) -> SegmentObjectLocation {
-    SegmentObjectLocation {
-        segment_id: location.segment_id.to_string(),
-        offset: location.offset,
-        len: location.len,
-        checksum: location.checksum.to_string(),
-    }
-}
-
 fn validate_gc_adopted_memberships(
     commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
     change_index: &HashMap<String, (SegmentObjectLocation, SegmentChange)>,
@@ -850,12 +587,14 @@ where
     Ok(out)
 }
 
-async fn scan_by_change_membership_keys<S>(store: &mut S) -> Result<Vec<(String, String)>, LixError>
+async fn scan_by_change_membership_entries<S>(
+    store: &mut S,
+) -> Result<HashMap<(String, String), Vec<u8>>, LixError>
 where
     S: ChangelogStorageRead + ?Sized,
 {
     let mut after = None;
-    let mut out = Vec::new();
+    let mut out = HashMap::new();
     loop {
         let page = store
             .changelog_scan(
@@ -863,14 +602,19 @@ where
                 Vec::new(),
                 after,
                 256,
-                StorageCoreProjection::KeyOnly,
+                StorageCoreProjection::FullValue,
             )
             .await?;
-        for index in 0..page.keys.len() {
-            let Some(key) = page.keys.get(index) else {
+        for index in 0..page.len() {
+            let Some(key) = page.key(index) else {
                 continue;
             };
-            out.push(by_change_membership_ids_from_key(key)?);
+            let Some(value) = page.value(index) else {
+                return Err(LixError::unknown(
+                    "changelog GC by_change_membership scan returned key without value".to_string(),
+                ));
+            };
+            out.insert(by_change_membership_ids_from_key(key)?, value.to_vec());
         }
         let Some(next_after) = page.resume_after else {
             break;
@@ -1058,9 +802,8 @@ where
         let Some(bytes) = value else {
             continue;
         };
-        if let Ok(proof) = decode_commit_visibility(&bytes) {
-            out.insert(change_id.clone(), proof);
-        }
+        let proof = decode_commit_visibility(&bytes)?;
+        out.insert(change_id.clone(), proof);
     }
     Ok(out)
 }
@@ -1086,11 +829,14 @@ where
         let Some(bytes) = value else {
             continue;
         };
-        if let Ok(visibility) = decode_commit_visibility(&bytes) {
-            if visibility.commit_id == *commit_id {
-                out.insert(commit_id.clone(), visibility);
-            }
+        let visibility = decode_commit_visibility(&bytes)?;
+        if visibility.commit_id != *commit_id {
+            return Err(LixError::unknown(format!(
+                "commit visibility key for '{commit_id}' contains commit_id '{}'",
+                visibility.commit_id
+            )));
         }
+        out.insert(commit_id.clone(), visibility);
     }
     Ok(out)
 }
@@ -1483,6 +1229,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_rejects_corrupt_live_membership_row() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+            by_change_membership_key("change-live", "commit-live"),
+            b"not empty".to_vec(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .expect_err("corrupt live membership index must fail closed");
+
+        assert!(
+            error.message.contains("live by_change_membership entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_sweeps_stale_commit_visibility_and_retains_live_visibility() {
         let storage = test_storage();
         let context = ChangelogContext::new();
@@ -1602,6 +1378,65 @@ mod tests {
             error.message.contains("does not match segment truth"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn collect_garbage_rejects_stale_live_locator_indexes_without_sweeping() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
+        let dead_segment = canonicalize_segment(single_commit_segment(
+            "segment-dead",
+            "commit-dead",
+            "change-dead",
+        ))
+        .unwrap();
+        let stale_location = SegmentObjectLocation {
+            segment_id: "missing-segment".to_string(),
+            offset: 0,
+            len: 0,
+            checksum: "stale-checksum".to_string(),
+        };
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+        write_raw_segment(&storage, &dead_segment).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            COMMIT_VISIBILITY_SPACE,
+            commit_visibility_key("commit-live"),
+            commit_visibility_value(&CommitVisibility {
+                commit_id: "commit-live".to_string(),
+                location: stale_location.clone(),
+                checksum: stale_location.checksum.clone(),
+            })
+            .unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[GcRoot::VersionHead("commit-live".to_string())])
+                .await
+                .expect_err("live locator drift must abort GC before sweeping")
+        };
+        assert!(
+            error.message.contains("does not match segment truth"),
+            "unexpected error: {error}"
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let result = crate::changelog::test_support::read_test_value_groups(
+            &storage,
+            vec![(SEGMENT_SPACE, vec![segment_key("segment-dead")])],
+        );
+        assert!(result[0][0].is_some());
     }
 
     #[tokio::test]
@@ -1806,6 +1641,38 @@ mod tests {
 
         assert!(
             error.message.contains("does not match segment truth"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_rejects_corrupt_live_visible_change_proof() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-live"),
+            b"not a commit visibility".to_vec(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .expect_err("corrupt live visible change proof must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to decode changelog commit visibility"),
             "unexpected error: {error}"
         );
     }

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -112,6 +112,44 @@ where
 
     let live_commits: HashSet<_> = live.commits.iter().cloned().collect();
     let live_changes: HashSet<_> = live.changes.iter().cloned().collect();
+    let retained_segments: HashSet<_> = live.segments.iter().cloned().collect();
+    let retained_commit_ids = truth
+        .commits
+        .iter()
+        .filter_map(|(commit_id, (location, _))| {
+            retained_segments
+                .contains(&location.segment_id)
+                .then(|| commit_id.clone())
+        })
+        .collect::<HashSet<_>>();
+    let retained_change_ids = truth
+        .changes
+        .iter()
+        .filter_map(|(change_id, (location, _))| {
+            retained_segments
+                .contains(&location.segment_id)
+                .then(|| change_id.clone())
+        })
+        .collect::<HashSet<_>>();
+    let mut retained_memberships = HashSet::new();
+    for (commit_id, (_, commit)) in &truth.commits {
+        if !retained_commit_ids.contains(commit_id) {
+            continue;
+        }
+        for membership in &commit.body.membership {
+            retained_memberships.insert((membership.member_change_id.clone(), commit_id.clone()));
+        }
+    }
+    let mut retained_payloads = Vec::new();
+    for (change_id, (_, change)) in &truth.changes {
+        if retained_change_ids.contains(change_id) {
+            mark_change_payloads(&mut retained_payloads, change);
+        }
+    }
+    let retained_payload_hashes = retained_payloads
+        .iter()
+        .map(|json_ref| *json_ref.as_hash_array())
+        .collect::<HashSet<_>>();
     let expected_by_commit = expected_live_by_commit_entries(&commit_index, &live.commits)?;
     let expected_by_change = expected_live_by_change_entries(&change_index, &live.changes);
     let expected_commit_visibility = expected_commit_visibilities(&commit_index, &live_commits);
@@ -208,15 +246,15 @@ where
             .collect(),
         by_commit: all_by_commit
             .into_iter()
-            .filter(|commit_id| !live_commits.contains(commit_id))
+            .filter(|commit_id| !retained_commit_ids.contains(commit_id))
             .collect(),
         by_change: all_by_change
             .into_iter()
-            .filter(|change_id| !live_changes.contains(change_id))
+            .filter(|change_id| !retained_change_ids.contains(change_id))
             .collect(),
         by_change_membership: all_by_change_membership
             .keys()
-            .filter(|membership| !live_memberships.contains(*membership))
+            .filter(|membership| !retained_memberships.contains(*membership))
             .cloned()
             .collect(),
         visible_change_proof: all_visible_change_proof
@@ -241,7 +279,7 @@ where
             .collect(),
         json_payloads: all_json_payloads
             .into_iter()
-            .filter(|json_ref| !live.payloads.contains(json_ref))
+            .filter(|json_ref| !retained_payload_hashes.contains(json_ref.as_hash_array()))
             .collect(),
     };
 
@@ -2213,7 +2251,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_retains_mixed_live_dead_segment_whole_but_sweeps_dead_indexes() {
+    async fn gc_retains_mixed_live_dead_segment_whole_and_its_indexes() {
         let storage = test_storage();
         let context = ChangelogContext::new();
         let segment = mixed_segment();
@@ -2228,8 +2266,60 @@ mod tests {
 
         assert_eq!(plan.live.segments, vec!["segment-mixed"]);
         assert!(plan.sweep.segments.is_empty());
-        assert_eq!(plan.sweep.by_commit, vec!["commit-dead"]);
-        assert_eq!(plan.sweep.by_change, vec!["change-dead"]);
+        assert!(plan.sweep.by_commit.is_empty());
+        assert!(plan.sweep.by_change.is_empty());
+        assert!(plan.sweep.by_change_membership.is_empty());
+    }
+
+    #[tokio::test]
+    async fn gc_retains_payloads_for_dead_changes_in_retained_segments() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let dead_ref = JsonRef::from_hash_bytes([9; 32]);
+        let mut segment = single_commit_segment("segment-mixed", "commit-live", "change-live");
+        let dead = single_commit_segment_with_payloads(
+            "segment-mixed",
+            "commit-dead",
+            "change-dead",
+            Some(dead_ref),
+            None,
+        );
+        segment.commits.push(dead.commits[0].clone());
+        segment.changes.push(dead.changes[0].clone());
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(segment).await.unwrap();
+            writer.stage_publish_commit("commit-live").await.unwrap();
+        }
+        json_store::stage_direct_json_payload_put(&mut writes, &dead_ref, b"dead".to_vec());
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let plan = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[GcRoot::VersionHead("commit-live".to_string())])
+                .await
+                .unwrap()
+        };
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        assert!(plan.sweep.segments.is_empty());
+        assert!(plan.sweep.json_payloads.is_empty());
+        let result = crate::changelog::test_support::read_test_value_groups(
+            &storage,
+            vec![(
+                json_store::store::JSON_SPACE,
+                vec![dead_ref.as_hash_bytes().to_vec()],
+            )],
+        );
+        assert_eq!(result[0][0].as_deref(), Some(&b"dead"[..]));
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -13,14 +13,12 @@ use super::store::{
     commit_visibility_value, segment_key, visible_change_proof_key,
 };
 use super::types::{
-    ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRoot, GcSweepSet,
-    MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation, StateRowIdentity,
+    ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRepairSet, GcRoot,
+    GcSweepSet, MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation,
+    StateRowIdentity,
 };
 use crate::LixError;
-use crate::changelog::{
-    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility,
-    decode_empty_index_value, decode_segment,
-};
+use crate::changelog::{decode_commit_visibility, decode_segment};
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::json_store::{self, JsonRef};
 use crate::storage::{StorageCoreProjection, StorageSpace, StorageWriteSet};
@@ -46,7 +44,6 @@ where
     let mut commit_index: HashMap<String, (SegmentObjectLocation, SegmentCommit)> = HashMap::new();
     let mut change_index: HashMap<String, (SegmentObjectLocation, SegmentChange)> = HashMap::new();
     let mut source_parent_facts = HashMap::<String, GcSourceParentFacts>::new();
-    let mut live_memberships: HashSet<(String, String)> = HashSet::new();
 
     while let Some(commit_id) = pending_commits.pop() {
         if live.commits.contains(&commit_id) {
@@ -94,7 +91,6 @@ where
             }
             push_unique(&mut live.changes, change_id.clone());
             push_unique(&mut live.segments, change_location.segment_id.clone());
-            live_memberships.insert((change_id.clone(), commit.header.id.clone()));
             mark_change_payloads(&mut live.payloads, &change);
         }
     }
@@ -111,29 +107,11 @@ where
     validate_gc_adopted_memberships(&commit_index, &change_index, &mut source_parent_facts)?;
 
     let live_commits: HashSet<_> = live.commits.iter().cloned().collect();
-    let live_changes: HashSet<_> = live.changes.iter().cloned().collect();
-    let retained_segments: HashSet<_> = live.segments.iter().cloned().collect();
-    let retained_commit_ids = truth
-        .commits
-        .iter()
-        .filter_map(|(commit_id, (location, _))| {
-            retained_segments
-                .contains(&location.segment_id)
-                .then(|| commit_id.clone())
-        })
-        .collect::<HashSet<_>>();
-    let retained_change_ids = truth
-        .changes
-        .iter()
-        .filter_map(|(change_id, (location, _))| {
-            retained_segments
-                .contains(&location.segment_id)
-                .then(|| change_id.clone())
-        })
-        .collect::<HashSet<_>>();
+    let retained =
+        compute_retained_primary_closure(&truth, live.segments.iter().cloned().collect())?;
     let mut retained_memberships = HashSet::new();
     for (commit_id, (_, commit)) in &truth.commits {
-        if !retained_commit_ids.contains(commit_id) {
+        if !retained.commits.contains(commit_id) {
             continue;
         }
         for membership in &commit.body.membership {
@@ -142,7 +120,7 @@ where
     }
     let mut retained_payloads = Vec::new();
     for (change_id, (_, change)) in &truth.changes {
-        if retained_change_ids.contains(change_id) {
+        if retained.changes.contains(change_id) {
             mark_change_payloads(&mut retained_payloads, change);
         }
     }
@@ -150,27 +128,49 @@ where
         .iter()
         .map(|json_ref| *json_ref.as_hash_array())
         .collect::<HashSet<_>>();
-    let expected_by_commit = expected_live_by_commit_entries(&commit_index, &live.commits)?;
-    let expected_by_change = expected_live_by_change_entries(&change_index, &live.changes);
     let expected_commit_visibility = expected_commit_visibilities(&commit_index, &live_commits);
-    let live_by_commit_entries = load_by_commit_entries(
-        store,
-        &all_by_commit
-            .iter()
-            .filter(|commit_id| live_commits.contains(*commit_id))
-            .cloned()
-            .collect::<Vec<_>>(),
-    )
-    .await?;
-    let live_by_change_entries = load_by_change_entries(
-        store,
-        &all_by_change
-            .iter()
-            .filter(|change_id| live_changes.contains(*change_id))
-            .cloned()
-            .collect::<Vec<_>>(),
-    )
-    .await?;
+    let retained_commit_order = truth
+        .segment_ids
+        .iter()
+        .flat_map(|segment_id| {
+            truth
+                .commits
+                .iter()
+                .filter(move |(_, (location, _))| &location.segment_id == segment_id)
+                .map(|(commit_id, _)| commit_id.clone())
+        })
+        .filter(|commit_id| retained.commits.contains(commit_id))
+        .collect::<Vec<_>>();
+    let retained_change_order = truth
+        .segment_ids
+        .iter()
+        .flat_map(|segment_id| {
+            truth
+                .changes
+                .iter()
+                .filter(move |(_, (location, _))| &location.segment_id == segment_id)
+                .map(|(change_id, _)| change_id.clone())
+        })
+        .filter(|change_id| retained.changes.contains(change_id))
+        .collect::<Vec<_>>();
+    let retained_commit_index = truth
+        .commits
+        .iter()
+        .filter(|(commit_id, _)| retained.commits.contains(*commit_id))
+        .map(|(commit_id, value)| (commit_id.clone(), value.clone()))
+        .collect::<HashMap<_, _>>();
+    let retained_change_index = truth
+        .changes
+        .iter()
+        .filter(|(change_id, _)| retained.changes.contains(*change_id))
+        .map(|(change_id, value)| (change_id.clone(), value.clone()))
+        .collect::<HashMap<_, _>>();
+    let expected_retained_by_commit =
+        expected_live_by_commit_entries(&retained_commit_index, &retained_commit_order)?;
+    let expected_retained_by_change =
+        expected_live_by_change_entries(&retained_change_index, &retained_change_order);
+    let expected_visible_change_proof =
+        expected_visible_change_proofs(&commit_index, &live.commits, &live_commits);
     let live_commit_visibility_entries = load_commit_visibilities(
         store,
         &all_commit_visibility
@@ -180,34 +180,6 @@ where
             .collect::<Vec<_>>(),
     )
     .await?;
-    let live_visible_change_proofs = load_visible_change_proofs(
-        store,
-        &all_visible_change_proof
-            .iter()
-            .filter(|change_id| live_changes.contains(*change_id))
-            .cloned()
-            .collect::<Vec<_>>(),
-    )
-    .await?;
-
-    for (commit_id, expected) in &expected_by_commit {
-        if let Some(actual) = live_by_commit_entries.get(commit_id) {
-            if actual != expected {
-                return Err(LixError::unknown(format!(
-                    "changelog GC live by_commit entry for '{commit_id}' does not match segment truth"
-                )));
-            }
-        }
-    }
-    for (change_id, expected) in &expected_by_change {
-        if let Some(actual) = live_by_change_entries.get(change_id) {
-            if actual != expected {
-                return Err(LixError::unknown(format!(
-                    "changelog GC live by_change entry for '{change_id}' does not match segment truth"
-                )));
-            }
-        }
-    }
     for (commit_id, expected) in &expected_commit_visibility {
         if let Some(actual) = live_commit_visibility_entries.get(commit_id) {
             if actual != expected {
@@ -218,23 +190,11 @@ where
         }
     }
 
-    for membership in &live_memberships {
-        let Some(value) = all_by_change_membership.get(membership) else {
-            continue;
-        };
-        decode_empty_index_value(value).map_err(|error| {
-            LixError::unknown(format!(
-                "changelog GC live by_change_membership entry for change '{}' commit '{}' is corrupt: {error}",
-                membership.0, membership.1
-            ))
-        })?;
-    }
-
     let sweep = GcSweepSet {
         segments: truth
             .segment_ids
             .into_iter()
-            .filter(|segment_id| !live.segments.contains(segment_id))
+            .filter(|segment_id| !retained.segments.contains(segment_id))
             .collect(),
         commit_visibility: all_commit_visibility
             .into_iter()
@@ -246,11 +206,11 @@ where
             .collect(),
         by_commit: all_by_commit
             .into_iter()
-            .filter(|commit_id| !retained_commit_ids.contains(commit_id))
+            .filter(|commit_id| !retained.commits.contains(commit_id))
             .collect(),
         by_change: all_by_change
             .into_iter()
-            .filter(|change_id| !retained_change_ids.contains(change_id))
+            .filter(|change_id| !retained.changes.contains(change_id))
             .collect(),
         by_change_membership: all_by_change_membership
             .keys()
@@ -259,34 +219,31 @@ where
             .collect(),
         visible_change_proof: all_visible_change_proof
             .into_iter()
-            .filter(|change_id| {
-                if !live_changes.contains(change_id) {
-                    return true;
-                };
-                let Some(proof) = live_visible_change_proofs.get(change_id) else {
-                    return true;
-                };
-                if !live_memberships.contains(&(change_id.clone(), proof.commit_id.clone())) {
-                    return true;
-                }
-                if live_commit_visibility_entries.get(&proof.commit_id)
-                    != expected_commit_visibility.get(&proof.commit_id)
-                {
-                    return true;
-                }
-                expected_commit_visibility.get(&proof.commit_id) != Some(proof)
-            })
+            .filter(|change_id| !expected_visible_change_proof.contains_key(change_id))
             .collect(),
         json_payloads: all_json_payloads
             .into_iter()
             .filter(|json_ref| !retained_payload_hashes.contains(json_ref.as_hash_array()))
             .collect(),
     };
+    let repair = GcRepairSet {
+        by_commit: retained_commit_order
+            .iter()
+            .filter_map(|commit_id| expected_retained_by_commit.get(commit_id).cloned())
+            .collect(),
+        by_change: retained_change_order
+            .iter()
+            .filter_map(|change_id| expected_retained_by_change.get(change_id).cloned())
+            .collect(),
+        by_change_membership: retained_memberships.into_iter().collect(),
+        visible_change_proof: expected_visible_change_proof.into_iter().collect(),
+    };
 
     Ok(GcPlan {
         roots: roots.to_vec(),
         live,
         sweep,
+        repair,
     })
 }
 
@@ -294,6 +251,62 @@ struct SegmentTruthIndex {
     segment_ids: Vec<String>,
     commits: HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
     changes: HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+}
+
+struct RetainedPrimaryClosure {
+    segments: HashSet<String>,
+    commits: HashSet<String>,
+    changes: HashSet<String>,
+}
+
+fn compute_retained_primary_closure(
+    truth: &SegmentTruthIndex,
+    mut segments: HashSet<String>,
+) -> Result<RetainedPrimaryClosure, LixError> {
+    let mut commits = HashSet::new();
+    let mut changes = HashSet::new();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (commit_id, (location, commit)) in &truth.commits {
+            if !segments.contains(&location.segment_id) {
+                continue;
+            }
+            commits.insert(commit_id.clone());
+            for parent_id in &commit.header.parent_commit_ids {
+                let Some((parent_location, _)) = truth.commits.get(parent_id) else {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC retained commit '{commit_id}' references missing parent commit '{parent_id}'"
+                    )));
+                };
+                if segments.insert(parent_location.segment_id.clone()) {
+                    changed = true;
+                }
+            }
+            for membership in &commit.body.membership {
+                let Some((change_location, _)) = truth.changes.get(&membership.member_change_id)
+                else {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC retained commit '{commit_id}' references missing change '{}'",
+                        membership.member_change_id
+                    )));
+                };
+                if segments.insert(change_location.segment_id.clone()) {
+                    changed = true;
+                }
+            }
+        }
+        for (change_id, (location, _)) in &truth.changes {
+            if segments.contains(&location.segment_id) {
+                changes.insert(change_id.clone());
+            }
+        }
+    }
+    Ok(RetainedPrimaryClosure {
+        segments,
+        commits,
+        changes,
+    })
 }
 
 async fn load_segment_truth_index<S>(store: &mut S) -> Result<SegmentTruthIndex, LixError>
@@ -512,6 +525,34 @@ pub(super) fn stage_gc_sweep(writes: &mut StorageWriteSet, plan: &GcPlan) -> Res
     for json_ref in &plan.sweep.json_payloads {
         json_store::stage_direct_json_payload_delete(writes, json_ref);
     }
+    for entry in &plan.repair.by_commit {
+        writes.put(
+            BY_COMMIT_INDEX_SPACE,
+            by_commit_key(&entry.commit_id),
+            by_commit_index_value(entry)?,
+        );
+    }
+    for entry in &plan.repair.by_change {
+        writes.put(
+            BY_CHANGE_INDEX_SPACE,
+            by_change_key(&entry.change_id),
+            by_change_index_value(entry)?,
+        );
+    }
+    for (change_id, commit_id) in &plan.repair.by_change_membership {
+        writes.put(
+            BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+            by_change_membership_key(change_id, commit_id),
+            by_change_membership_index_value(),
+        );
+    }
+    for (change_id, visibility) in &plan.repair.visible_change_proof {
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key(change_id),
+            commit_visibility_value(visibility)?,
+        );
+    }
     Ok(())
 }
 
@@ -682,6 +723,27 @@ fn expected_commit_visibilities(
     out
 }
 
+fn expected_visible_change_proofs(
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    live_commit_order: &[String],
+    live_commits: &HashSet<String>,
+) -> HashMap<String, CommitVisibility> {
+    let visibilities = expected_commit_visibilities(commit_index, live_commits);
+    let mut out = HashMap::new();
+    for commit_id in live_commit_order {
+        let Some((_, commit)) = commit_index.get(commit_id) else {
+            continue;
+        };
+        let Some(visibility) = visibilities.get(commit_id) else {
+            continue;
+        };
+        for membership in &commit.body.membership {
+            out.insert(membership.member_change_id.clone(), visibility.clone());
+        }
+    }
+    out
+}
+
 fn expected_live_by_commit_entries(
     commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
     live_commit_order: &[String],
@@ -751,99 +813,6 @@ fn expected_live_by_change_entries(
         );
     }
     out
-}
-
-async fn load_by_commit_entries<S>(
-    store: &mut S,
-    commit_ids: &[String],
-) -> Result<HashMap<String, ByCommitEntry>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let values = store
-        .changelog_get_many(
-            BY_COMMIT_INDEX_SPACE,
-            commit_ids
-                .iter()
-                .map(|commit_id| by_commit_key(commit_id))
-                .collect(),
-        )
-        .await?;
-    let mut out = HashMap::new();
-    for (commit_id, value) in commit_ids.iter().zip(values.into_iter()) {
-        let Some(bytes) = value else {
-            continue;
-        };
-        let entry = decode_by_commit_entry(&bytes)?;
-        if entry.commit_id != *commit_id {
-            return Err(LixError::unknown(format!(
-                "by_commit key for '{commit_id}' contains commit_id '{}'",
-                entry.commit_id
-            )));
-        }
-        out.insert(commit_id.clone(), entry);
-    }
-    Ok(out)
-}
-
-async fn load_by_change_entries<S>(
-    store: &mut S,
-    change_ids: &[String],
-) -> Result<HashMap<String, ByChangeEntry>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let values = store
-        .changelog_get_many(
-            BY_CHANGE_INDEX_SPACE,
-            change_ids
-                .iter()
-                .map(|change_id| by_change_key(change_id))
-                .collect(),
-        )
-        .await?;
-    let mut out = HashMap::new();
-    for (change_id, value) in change_ids.iter().zip(values.into_iter()) {
-        let Some(bytes) = value else {
-            continue;
-        };
-        let entry = decode_by_change_entry(&bytes)?;
-        if entry.change_id != *change_id {
-            return Err(LixError::unknown(format!(
-                "by_change key for '{change_id}' contains change_id '{}'",
-                entry.change_id
-            )));
-        }
-        out.insert(change_id.clone(), entry);
-    }
-    Ok(out)
-}
-
-async fn load_visible_change_proofs<S>(
-    store: &mut S,
-    change_ids: &[String],
-) -> Result<HashMap<String, CommitVisibility>, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let values = store
-        .changelog_get_many(
-            VISIBLE_CHANGE_PROOF_SPACE,
-            change_ids
-                .iter()
-                .map(|change_id| visible_change_proof_key(change_id))
-                .collect(),
-        )
-        .await?;
-    let mut out = HashMap::new();
-    for (change_id, value) in change_ids.iter().zip(values.into_iter()) {
-        let Some(bytes) = value else {
-            continue;
-        };
-        let proof = decode_commit_visibility(&bytes)?;
-        out.insert(change_id.clone(), proof);
-    }
-    Ok(out)
 }
 
 async fn load_commit_visibilities<S>(
@@ -1267,7 +1236,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_rejects_corrupt_live_membership_row() {
+    async fn gc_repairs_corrupt_live_membership_row() {
         let storage = test_storage();
         let context = ChangelogContext::new();
         let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
@@ -1284,16 +1253,30 @@ mod tests {
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
 
-        let mut reader = context.reader(storage);
-        let error = reader
-            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
-            .await
-            .expect_err("corrupt live membership index must fail closed");
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let plan = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[GcRoot::VersionHead("commit-live".to_string())])
+                .await
+                .unwrap()
+        };
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
 
-        assert!(
-            error.message.contains("live by_change_membership entry"),
-            "unexpected error: {error}"
+        assert_eq!(
+            plan.repair.by_change_membership,
+            vec![("change-live".to_string(), "commit-live".to_string())]
         );
+        let result = crate::changelog::test_support::read_test_value_groups(
+            &storage,
+            vec![(
+                BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+                vec![by_change_membership_key("change-live", "commit-live")],
+            )],
+        );
+        assert_eq!(result[0][0].as_deref(), Some(&[][..]));
     }
 
     #[tokio::test]
@@ -1596,15 +1579,21 @@ mod tests {
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
 
-        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
-        assert_missing(
+        assert!(plan.sweep.visible_change_proof.is_empty());
+        assert!(
+            plan.repair
+                .visible_change_proof
+                .iter()
+                .any(|(change_id, _)| change_id == "change-live")
+        );
+        let result = crate::changelog::test_support::read_test_value_groups(
             &storage,
             vec![(
                 VISIBLE_CHANGE_PROOF_SPACE,
-                visible_change_proof_key("change-live"),
+                vec![visible_change_proof_key("change-live")],
             )],
-        )
-        .await;
+        );
+        assert!(result[0][0].is_some());
     }
 
     #[tokio::test]
@@ -1638,7 +1627,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
+        assert!(plan.sweep.visible_change_proof.is_empty());
+        assert_eq!(plan.repair.visible_change_proof[0].0, "change-live");
     }
 
     #[tokio::test]
@@ -1684,7 +1674,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_rejects_corrupt_live_visible_change_proof() {
+    async fn gc_repairs_corrupt_live_visible_change_proof() {
         let storage = test_storage();
         let context = ChangelogContext::new();
         let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
@@ -1701,18 +1691,28 @@ mod tests {
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
 
-        let mut reader = context.reader(storage);
-        let error = reader
-            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
-            .await
-            .expect_err("corrupt live visible change proof must fail closed");
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let plan = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[GcRoot::VersionHead("commit-live".to_string())])
+                .await
+                .unwrap()
+        };
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
 
-        assert!(
-            error
-                .to_string()
-                .contains("failed to decode changelog commit visibility"),
-            "unexpected error: {error}"
+        assert!(plan.sweep.visible_change_proof.is_empty());
+        assert_eq!(plan.repair.visible_change_proof[0].0, "change-live");
+        let result = crate::changelog::test_support::read_test_value_groups(
+            &storage,
+            vec![(
+                VISIBLE_CHANGE_PROOF_SPACE,
+                vec![visible_change_proof_key("change-live")],
+            )],
         );
+        assert!(result[0][0].is_some());
     }
 
     #[tokio::test]
@@ -1867,6 +1867,56 @@ mod tests {
         assert!(plan.live.segments.contains(&"segment-adopter".to_string()));
         assert_eq!(plan.sweep.commit_visibility, Vec::<String>::new());
         assert!(plan.sweep.segments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn gc_retained_segment_closure_keeps_external_adopted_change_segment() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let author_segment = canonicalize_segment(single_commit_segment(
+            "segment-author",
+            "commit-author",
+            "change-adopted",
+        ))
+        .unwrap();
+        let mut retained_segment =
+            single_commit_segment("segment-retained", "commit-live", "change-live");
+        let mut adopted =
+            adopting_commit_segment("segment-retained", "commit-adopter", "change-adopted")
+                .commits
+                .remove(0);
+        adopted
+            .header
+            .parent_commit_ids
+            .push("commit-author".to_string());
+        retained_segment.commits.push(adopted);
+        let retained_segment = canonicalize_segment(retained_segment).unwrap();
+
+        write_raw_segment(&storage, &author_segment).await;
+        write_raw_segment(&storage, &retained_segment).await;
+
+        let mut reader = context.reader(storage.clone());
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.live.commits, vec!["commit-live"]);
+        assert_eq!(plan.live.changes, vec!["change-live"]);
+        assert!(plan.live.segments.contains(&"segment-retained".to_string()));
+        assert!(!plan.live.segments.contains(&"segment-author".to_string()));
+        assert!(plan.sweep.segments.is_empty());
+        assert!(
+            plan.repair
+                .by_change
+                .iter()
+                .any(|entry| entry.change_id == "change-adopted")
+        );
+        assert!(
+            plan.repair
+                .by_change_membership
+                .contains(&("change-adopted".to_string(), "commit-adopter".to_string()))
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -1,10 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
 use super::context::ChangelogStorageRead;
-use super::segment::{
-    directory_change_location, directory_commit_location, validate_change_checksum,
-    validate_commit_checksum, validate_segment_shape,
-};
 use super::store::{
     BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE,
     COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE, by_change_index_value,
@@ -12,13 +8,14 @@ use super::store::{
     by_change_membership_key, by_commit_index_value, by_commit_key, commit_visibility_key,
     commit_visibility_value, segment_key, visible_change_proof_key,
 };
+use super::truth::{compute_retained_primary_closure, load_segment_truth_index};
 use super::types::{
     ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRepairSet, GcRoot,
     GcSweepSet, MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation,
     StateRowIdentity,
 };
 use crate::LixError;
-use crate::changelog::{decode_commit_visibility, decode_segment};
+use crate::changelog::decode_commit_visibility;
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::json_store::{self, JsonRef};
 use crate::storage::{StorageCoreProjection, StorageSpace, StorageWriteSet};
@@ -244,150 +241,6 @@ where
         live,
         sweep,
         repair,
-    })
-}
-
-struct SegmentTruthIndex {
-    segment_ids: Vec<String>,
-    commits: HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
-    changes: HashMap<String, (SegmentObjectLocation, SegmentChange)>,
-}
-
-struct RetainedPrimaryClosure {
-    segments: HashSet<String>,
-    commits: HashSet<String>,
-    changes: HashSet<String>,
-}
-
-fn compute_retained_primary_closure(
-    truth: &SegmentTruthIndex,
-    mut segments: HashSet<String>,
-) -> Result<RetainedPrimaryClosure, LixError> {
-    let mut commits = HashSet::new();
-    let mut changes = HashSet::new();
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for (commit_id, (location, commit)) in &truth.commits {
-            if !segments.contains(&location.segment_id) {
-                continue;
-            }
-            commits.insert(commit_id.clone());
-            for parent_id in &commit.header.parent_commit_ids {
-                let Some((parent_location, _)) = truth.commits.get(parent_id) else {
-                    return Err(LixError::unknown(format!(
-                        "changelog GC retained commit '{commit_id}' references missing parent commit '{parent_id}'"
-                    )));
-                };
-                if segments.insert(parent_location.segment_id.clone()) {
-                    changed = true;
-                }
-            }
-            for membership in &commit.body.membership {
-                let Some((change_location, _)) = truth.changes.get(&membership.member_change_id)
-                else {
-                    return Err(LixError::unknown(format!(
-                        "changelog GC retained commit '{commit_id}' references missing change '{}'",
-                        membership.member_change_id
-                    )));
-                };
-                if segments.insert(change_location.segment_id.clone()) {
-                    changed = true;
-                }
-            }
-        }
-        for (change_id, (location, _)) in &truth.changes {
-            if segments.contains(&location.segment_id) {
-                changes.insert(change_id.clone());
-            }
-        }
-    }
-    Ok(RetainedPrimaryClosure {
-        segments,
-        commits,
-        changes,
-    })
-}
-
-async fn load_segment_truth_index<S>(store: &mut S) -> Result<SegmentTruthIndex, LixError>
-where
-    S: ChangelogStorageRead + ?Sized,
-{
-    let mut after = None;
-    let mut segment_ids = Vec::new();
-    let mut commits = HashMap::new();
-    let mut changes = HashMap::new();
-    loop {
-        let page = store
-            .changelog_scan(
-                SEGMENT_SPACE,
-                Vec::new(),
-                after,
-                64,
-                StorageCoreProjection::FullValue,
-            )
-            .await?;
-        for index in 0..page.len() {
-            let Some(key) = page.key(index) else {
-                continue;
-            };
-            let segment_id = std::str::from_utf8(key)
-                .map_err(|error| {
-                    LixError::unknown(format!(
-                        "changelog GC found invalid UTF-8 segment key: {error}"
-                    ))
-                })?
-                .to_string();
-            let Some(bytes) = page.value(index) else {
-                return Err(LixError::unknown(format!(
-                    "changelog GC segment '{segment_id}' scan returned key without value"
-                )));
-            };
-            let segment = decode_segment(bytes)?;
-            validate_segment_shape(&segment)?;
-            if segment.header.segment_id != segment_id {
-                return Err(LixError::unknown(format!(
-                    "changelog GC segment key '{segment_id}' contains segment '{}'",
-                    segment.header.segment_id
-                )));
-            }
-            push_unique(&mut segment_ids, segment_id);
-            for commit in &segment.commits {
-                let location = directory_commit_location(&segment, &commit.header.id)?;
-                validate_commit_checksum(&location.checksum, &commit.header.id, commit)?;
-                if commits
-                    .insert(commit.header.id.clone(), (location, commit.clone()))
-                    .is_some()
-                {
-                    return Err(LixError::unknown(format!(
-                        "changelog GC found duplicate commit id '{}'",
-                        commit.header.id
-                    )));
-                }
-            }
-            for change in &segment.changes {
-                let location = directory_change_location(&segment, &change.id)?;
-                validate_change_checksum(&location.checksum, &change.id, change)?;
-                if changes
-                    .insert(change.id.clone(), (location, change.clone()))
-                    .is_some()
-                {
-                    return Err(LixError::unknown(format!(
-                        "changelog GC found duplicate change id '{}'",
-                        change.id
-                    )));
-                }
-            }
-        }
-        let Some(next_after) = page.resume_after else {
-            break;
-        };
-        after = Some(next_after);
-    }
-    Ok(SegmentTruthIndex {
-        segment_ids,
-        commits,
-        changes,
     })
 }
 

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -3,17 +3,18 @@ use std::collections::{HashMap, HashSet};
 use super::context::ChangelogStorageRead;
 use super::segment::{validate_change_checksum, validate_commit_checksum, validate_segment_shape};
 use super::store::{
-    by_change_index_value, by_change_key, by_change_membership_ids_from_key,
-    by_change_membership_index_value, by_change_membership_key, by_commit_index_value,
-    by_commit_key, commit_visibility_key, commit_visibility_value, segment_key,
-    visible_change_proof_key, BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
-    BY_COMMIT_INDEX_SPACE, COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
+    BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE,
+    COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE, by_change_index_value,
+    by_change_key, by_change_membership_ids_from_key, by_change_membership_index_value,
+    by_change_membership_key, by_commit_index_value, by_commit_key, commit_visibility_key,
+    commit_visibility_value, segment_key, visible_change_proof_key,
 };
 use super::types::{
     ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRoot, GcSweepSet,
     MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation,
     SegmentObjectLocationRef, StateRowIdentity,
 };
+use crate::LixError;
 use crate::changelog::{
     decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
     decode_segment_change, decode_segment_commit, view_segment_directory,
@@ -21,7 +22,6 @@ use crate::changelog::{
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::json_store::{self, JsonRef};
 use crate::storage::{StorageCoreProjection, StorageSpace, StorageWriteSet};
-use crate::LixError;
 
 pub(super) async fn plan_gc<S>(store: &mut S, roots: &[GcRoot]) -> Result<GcPlan, LixError>
 where
@@ -159,6 +159,34 @@ where
     )
     .await?;
 
+    for (commit_id, expected) in &expected_by_commit {
+        if let Some(actual) = live_by_commit_entries.get(commit_id) {
+            if actual != expected {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live by_commit entry for '{commit_id}' does not match segment truth"
+                )));
+            }
+        }
+    }
+    for (change_id, expected) in &expected_by_change {
+        if let Some(actual) = live_by_change_entries.get(change_id) {
+            if actual != expected {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live by_change entry for '{change_id}' does not match segment truth"
+                )));
+            }
+        }
+    }
+    for (commit_id, expected) in &expected_commit_visibility {
+        if let Some(actual) = live_commit_visibility_entries.get(commit_id) {
+            if actual != expected {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live commit_visibility entry for '{commit_id}' does not match segment truth"
+                )));
+            }
+        }
+    }
+
     let sweep = GcSweepSet {
         segments: all_segment_ids
             .into_iter()
@@ -174,17 +202,11 @@ where
             .collect(),
         by_commit: all_by_commit
             .into_iter()
-            .filter(|commit_id| {
-                !live_commits.contains(commit_id)
-                    || live_by_commit_entries.get(commit_id) != expected_by_commit.get(commit_id)
-            })
+            .filter(|commit_id| !live_commits.contains(commit_id))
             .collect(),
         by_change: all_by_change
             .into_iter()
-            .filter(|change_id| {
-                !live_changes.contains(change_id)
-                    || live_by_change_entries.get(change_id) != expected_by_change.get(change_id)
-            })
+            .filter(|change_id| !live_changes.contains(change_id))
             .collect(),
         by_change_membership: all_by_change_membership
             .into_iter()
@@ -451,18 +473,6 @@ async fn load_gc_commit<S>(
 where
     S: ChangelogStorageRead + ?Sized,
 {
-    if let Some(entry) = load_by_commit_entry(store, commit_id).await? {
-        if ensure_segment_bytes(store, segment_bytes, &entry.location.segment_id).await? {
-            match decode_commit_from_segment_bytes(
-                &segment_bytes[&entry.location.segment_id],
-                &entry.location,
-                commit_id,
-            )? {
-                Some(commit) => return Ok(Some((entry.location, commit))),
-                None => {}
-            }
-        }
-    }
     scan_segments_for_commit(store, all_segment_ids, segment_bytes, commit_id).await
 }
 
@@ -475,18 +485,6 @@ async fn load_gc_change<S>(
 where
     S: ChangelogStorageRead + ?Sized,
 {
-    if let Some(entry) = load_by_change_entry(store, change_id).await? {
-        if ensure_segment_bytes(store, segment_bytes, &entry.location.segment_id).await? {
-            match decode_change_from_segment_bytes(
-                &segment_bytes[&entry.location.segment_id],
-                &entry.location,
-                change_id,
-            )? {
-                Some(change) => return Ok(Some((entry.location, change))),
-                None => {}
-            }
-        }
-    }
     scan_segments_for_change(store, all_segment_ids, segment_bytes, change_id).await
 }
 
@@ -581,9 +579,7 @@ where
             continue;
         }
         let bytes = &segment_bytes[segment_id];
-        let Ok(view) = view_segment_directory(bytes) else {
-            continue;
-        };
+        let view = view_segment_directory(bytes)?;
         let Some(entry) = view
             .directory_commits
             .iter()
@@ -622,9 +618,7 @@ where
             continue;
         }
         let bytes = &segment_bytes[segment_id];
-        let Ok(view) = view_segment_directory(bytes) else {
-            continue;
-        };
+        let view = view_segment_directory(bytes)?;
         let Some(entry) = view
             .directory_changes
             .iter()
@@ -998,11 +992,14 @@ where
         let Some(bytes) = value else {
             continue;
         };
-        if let Ok(entry) = decode_by_commit_entry(&bytes) {
-            if entry.commit_id == *commit_id {
-                out.insert(commit_id.clone(), entry);
-            }
+        let entry = decode_by_commit_entry(&bytes)?;
+        if entry.commit_id != *commit_id {
+            return Err(LixError::unknown(format!(
+                "by_commit key for '{commit_id}' contains commit_id '{}'",
+                entry.commit_id
+            )));
         }
+        out.insert(commit_id.clone(), entry);
     }
     Ok(out)
 }
@@ -1028,11 +1025,14 @@ where
         let Some(bytes) = value else {
             continue;
         };
-        if let Ok(entry) = decode_by_change_entry(&bytes) {
-            if entry.change_id == *change_id {
-                out.insert(change_id.clone(), entry);
-            }
+        let entry = decode_by_change_entry(&bytes)?;
+        if entry.change_id != *change_id {
+            return Err(LixError::unknown(format!(
+                "by_change key for '{change_id}' contains change_id '{}'",
+                entry.change_id
+            )));
         }
+        out.insert(change_id.clone(), entry);
     }
     Ok(out)
 }
@@ -1166,10 +1166,10 @@ mod tests {
     use crate::changelog::segment::canonicalize_segment;
     use crate::changelog::test_support::commit_visibility_from_segment;
     use crate::changelog::{
-        decode_segment, encode_segment, ChangelogContext, CommitBody, CommitHeader,
-        MembershipRecord, MembershipRole, RebuildIndexStats, Segment, SegmentChange,
-        SegmentChangeDirectory, SegmentCommit, SegmentCommitDirectory, SegmentDirectory,
-        SegmentHeader, SegmentInlinePayload, SegmentPayloadLocation,
+        ChangelogContext, CommitBody, CommitHeader, MembershipRecord, MembershipRole,
+        RebuildIndexStats, Segment, SegmentChange, SegmentChangeDirectory, SegmentCommit,
+        SegmentCommitDirectory, SegmentDirectory, SegmentHeader, SegmentInlinePayload,
+        SegmentPayloadLocation, decode_segment, encode_segment,
     };
     use crate::common::{CanonicalSchemaKey, EntityId, FileId};
     use crate::entity_identity::EntityIdentity;
@@ -1208,14 +1208,16 @@ mod tests {
 
         assert_eq!(plan.live.commits, vec!["commit-1"]);
         assert_eq!(plan.live.changes, vec!["change-1"]);
-        assert!(plan
-            .live
-            .payloads
-            .contains(&JsonRef::from_hash_bytes([7; 32])));
-        assert!(plan
-            .live
-            .payloads
-            .contains(&JsonRef::from_hash_bytes([8; 32])));
+        assert!(
+            plan.live
+                .payloads
+                .contains(&JsonRef::from_hash_bytes([7; 32]))
+        );
+        assert!(
+            plan.live
+                .payloads
+                .contains(&JsonRef::from_hash_bytes([8; 32]))
+        );
         assert_eq!(plan.live.segments, vec!["segment-1"]);
         assert_eq!(plan.sweep.segments, vec!["segment-dead"]);
         assert_eq!(plan.sweep.by_commit, vec!["commit-dead"]);
@@ -1542,7 +1544,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_sweeps_stale_live_locator_indexes() {
+    async fn gc_rejects_stale_live_locator_indexes() {
         let storage = test_storage();
         let context = ChangelogContext::new();
         let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
@@ -1591,14 +1593,15 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut reader = context.reader(storage);
-        let plan = reader
+        let error = reader
             .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
             .await
-            .unwrap();
+            .expect_err("live locator index drift must fail closed");
 
-        assert_eq!(plan.sweep.commit_visibility, vec!["commit-live"]);
-        assert_eq!(plan.sweep.by_commit, vec!["commit-live"]);
-        assert_eq!(plan.sweep.by_change, vec!["change-live"]);
+        assert!(
+            error.message.contains("does not match segment truth"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1623,6 +1626,54 @@ mod tests {
             .unwrap();
 
         assert_eq!(plan.sweep.segments, vec!["segment-dead"]);
+    }
+
+    #[tokio::test]
+    async fn gc_rejects_duplicate_live_commit_even_when_by_commit_exists() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let segment_1 = single_commit_segment("segment-1", "commit-1", "change-1");
+        write_segments(&storage, &context, vec![segment_1], &["commit-1"]).await;
+
+        let segment_2 =
+            canonicalize_segment(single_commit_segment("segment-2", "commit-1", "change-2"))
+                .unwrap();
+        write_raw_segment(&storage, &segment_2).await;
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-1".to_string())])
+            .await
+            .expect_err("GC must reject duplicate commit ids even when by_commit exists");
+
+        assert!(
+            error.message.contains("duplicate commit id 'commit-1'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_rejects_duplicate_live_change_even_when_by_change_exists() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let segment_1 = single_commit_segment("segment-1", "commit-1", "change-1");
+        write_segments(&storage, &context, vec![segment_1], &["commit-1"]).await;
+
+        let segment_2 =
+            canonicalize_segment(single_commit_segment("segment-2", "commit-2", "change-1"))
+                .unwrap();
+        write_raw_segment(&storage, &segment_2).await;
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-1".to_string())])
+            .await
+            .expect_err("GC must reject duplicate change ids even when by_change exists");
+
+        assert!(
+            error.message.contains("duplicate change id 'change-1'"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1718,7 +1769,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_sweeps_visible_change_proof_that_matches_stale_visibility() {
+    async fn gc_rejects_visible_change_proof_that_matches_stale_visibility() {
         let storage = test_storage();
         let context = ChangelogContext::new();
         let live_segment = canonicalize_segment(single_commit_segment(
@@ -1748,13 +1799,15 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut reader = context.reader(storage.clone());
-        let plan = reader
+        let error = reader
             .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
             .await
-            .unwrap();
+            .expect_err("live visibility drift must fail closed");
 
-        assert_eq!(plan.sweep.commit_visibility, vec!["commit-live"]);
-        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
+        assert!(
+            error.message.contains("does not match segment truth"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -2077,17 +2130,12 @@ mod tests {
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
 
-        let mut reader = context.reader(storage.clone());
-        let dead_commit = reader
-            .load_commits(crate::changelog::CommitLoadRequest {
-                commit_ids: &["commit-dead".to_string()],
-                projection: crate::changelog::CommitProjection::Full,
-                visibility: crate::changelog::CommitVisibilityMode::PhysicalOnly,
-            })
-            .await
-            .unwrap();
+        let result = crate::changelog::test_support::read_test_value_groups(
+            &storage,
+            vec![(SEGMENT_SPACE, vec![segment_key("segment-dead")])],
+        );
         assert!(
-            dead_commit.entries[0].is_some(),
+            result[0][0].is_some(),
             "collect_garbage must stage no sweep deletes after graph corruption"
         );
     }
@@ -2132,17 +2180,12 @@ mod tests {
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
 
-        let mut reader = context.reader(storage.clone());
-        let dead_commit = reader
-            .load_commits(crate::changelog::CommitLoadRequest {
-                commit_ids: &["commit-dead".to_string()],
-                projection: crate::changelog::CommitProjection::Full,
-                visibility: crate::changelog::CommitVisibilityMode::PhysicalOnly,
-            })
-            .await
-            .unwrap();
+        let result = crate::changelog::test_support::read_test_value_groups(
+            &storage,
+            vec![(SEGMENT_SPACE, vec![segment_key("segment-dead")])],
+        );
         assert!(
-            dead_commit.entries[0].is_some(),
+            result[0][0].is_some(),
             "collect_garbage must stage no sweep deletes after graph corruption"
         );
     }
@@ -2238,9 +2281,11 @@ mod tests {
             .plan_gc(&[])
             .await
             .expect_err("membership_count drift must be invalid segment input");
-        assert!(error
-            .message
-            .contains("membership_count 0 does not match 1"));
+        assert!(
+            error
+                .message
+                .contains("membership_count 0 does not match 1")
+        );
     }
 
     #[tokio::test]
@@ -2261,9 +2306,11 @@ mod tests {
             .plan_gc(&[])
             .await
             .expect_err("membership directory drift must be invalid segment input");
-        assert!(error
-            .message
-            .contains("is missing membership ordinal for change 'change-1'"));
+        assert!(
+            error
+                .message
+                .contains("is missing membership ordinal for change 'change-1'")
+        );
     }
 
     #[tokio::test]
@@ -2291,9 +2338,11 @@ mod tests {
             .plan_gc(&[])
             .await
             .expect_err("payload directory drift must be invalid segment input");
-        assert!(error
-            .message
-            .contains("payload directory entry does not match inline payload"));
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload")
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::context::ChangelogStorageRead;
-use super::segment::validate_segment_shape;
+use super::segment::{validate_change_checksum, validate_commit_checksum, validate_segment_shape};
 use super::store::{
     by_change_index_value, by_change_key, by_change_membership_ids_from_key,
     by_change_membership_index_value, by_change_membership_key, by_commit_index_value,
@@ -10,10 +10,15 @@ use super::store::{
     BY_COMMIT_INDEX_SPACE, COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
 };
 use super::types::{
-    ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRoot, GcSweepSet, Segment,
-    SegmentChange, SegmentCommit, SegmentObjectLocation,
+    ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRoot, GcSweepSet,
+    MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation,
+    SegmentObjectLocationRef, StateRowIdentity,
 };
-use crate::changelog::decode_segment;
+use crate::changelog::{
+    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
+    decode_segment_change, decode_segment_commit, view_segment_directory,
+};
+use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::json_store::{self, JsonRef};
 use crate::storage::{StorageCoreProjection, StorageSpace, StorageWriteSet};
 use crate::LixError;
@@ -22,48 +27,15 @@ pub(super) async fn plan_gc<S>(store: &mut S, roots: &[GcRoot]) -> Result<GcPlan
 where
     S: ChangelogStorageRead + ?Sized,
 {
-    let segments = scan_all_segments(store).await?;
+    let all_segment_ids = scan_segment_ids(store).await?;
     let all_commit_visibility = scan_utf8_keys(store, COMMIT_VISIBILITY_SPACE).await?;
     let all_by_commit = scan_utf8_keys(store, BY_COMMIT_INDEX_SPACE).await?;
     let all_by_change = scan_utf8_keys(store, BY_CHANGE_INDEX_SPACE).await?;
     let all_by_change_membership = scan_by_change_membership_keys(store).await?;
     let all_visible_change_proof = scan_utf8_keys(store, VISIBLE_CHANGE_PROOF_SPACE).await?;
     let all_json_payloads = scan_json_payload_keys(store).await?;
-
-    let mut commit_index: HashMap<String, (String, SegmentCommit)> = HashMap::new();
-    let mut change_index: HashMap<String, (String, SegmentChange)> = HashMap::new();
-    let mut all_segment_ids = Vec::new();
-
-    for segment in &segments {
-        push_unique(&mut all_segment_ids, segment.header.segment_id.clone());
-        for commit in &segment.commits {
-            if commit_index
-                .insert(
-                    commit.header.id.clone(),
-                    (segment.header.segment_id.clone(), commit.clone()),
-                )
-                .is_some()
-            {
-                return Err(LixError::unknown(format!(
-                    "changelog GC found duplicate commit id '{}'",
-                    commit.header.id
-                )));
-            }
-        }
-        for change in &segment.changes {
-            if change_index
-                .insert(
-                    change.id.clone(),
-                    (segment.header.segment_id.clone(), change.clone()),
-                )
-                .is_some()
-            {
-                return Err(LixError::unknown(format!(
-                    "changelog GC found duplicate change id '{}'",
-                    change.id
-                )));
-            }
-        }
+    if roots.is_empty() {
+        validate_all_segments(store).await?;
     }
 
     let mut live = GcLiveSet::default();
@@ -71,29 +43,35 @@ where
     for root in roots {
         pending_commits.push(gc_root_commit_id(root).to_string());
     }
-    let mut visiting_commits = HashSet::new();
-    let mut checked_commits = HashSet::new();
-    for commit_id in &pending_commits {
-        validate_reachable_commit_graph_acyclic(
-            commit_id,
-            &commit_index,
-            &mut visiting_commits,
-            &mut checked_commits,
-        )?;
-    }
+
+    let mut segment_bytes = HashMap::<String, Vec<u8>>::new();
+    let mut commit_index: HashMap<String, (SegmentObjectLocation, SegmentCommit)> = HashMap::new();
+    let mut change_index: HashMap<String, (SegmentObjectLocation, SegmentChange)> = HashMap::new();
+    let mut source_parent_facts = HashMap::<String, GcSourceParentFacts>::new();
+    let mut live_memberships: HashSet<(String, String)> = HashSet::new();
 
     while let Some(commit_id) = pending_commits.pop() {
         if live.commits.contains(&commit_id) {
             continue;
         }
-        let Some((segment_id, commit)) = commit_index.get(&commit_id).cloned() else {
+        let Some((commit_location, commit)) =
+            load_gc_commit(store, &all_segment_ids, &mut segment_bytes, &commit_id).await?
+        else {
             return Err(LixError::unknown(format!(
                 "changelog GC root/ancestor commit '{commit_id}' was not found in changelog segments"
             )));
         };
+        if commit_index
+            .insert(commit_id.clone(), (commit_location.clone(), commit.clone()))
+            .is_some()
+        {
+            return Err(LixError::unknown(format!(
+                "changelog GC found duplicate live commit id '{commit_id}'"
+            )));
+        }
 
         push_unique(&mut live.commits, commit_id.clone());
-        push_unique(&mut live.segments, segment_id);
+        push_unique(&mut live.segments, commit_location.segment_id.clone());
 
         for parent_id in &commit.header.parent_commit_ids {
             if !live.commits.contains(parent_id) {
@@ -103,20 +81,83 @@ where
 
         for membership in &commit.body.membership {
             let change_id = &membership.member_change_id;
-            let Some((change_segment_id, change)) = change_index.get(change_id).cloned() else {
+            let Some((change_location, change)) =
+                load_gc_change(store, &all_segment_ids, &mut segment_bytes, change_id).await?
+            else {
                 return Err(LixError::unknown(format!(
                     "changelog GC live commit '{}' references missing change '{}'",
                     commit.header.id, change_id
                 )));
             };
+            if let Some((existing_location, existing_change)) =
+                change_index.insert(change_id.clone(), (change_location.clone(), change.clone()))
+            {
+                if existing_location != change_location || existing_change != change {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC found duplicate live change id '{change_id}'"
+                    )));
+                }
+            }
             push_unique(&mut live.changes, change_id.clone());
-            push_unique(&mut live.segments, change_segment_id);
+            push_unique(&mut live.segments, change_location.segment_id.clone());
+            live_memberships.insert((change_id.clone(), commit.header.id.clone()));
             mark_change_payloads(&mut live.payloads, &change);
         }
     }
+    let mut visiting_commits = HashSet::new();
+    let mut checked_commits = HashSet::new();
+    for root in roots {
+        validate_reachable_commit_graph_acyclic(
+            gc_root_commit_id(root),
+            &commit_index,
+            &mut visiting_commits,
+            &mut checked_commits,
+        )?;
+    }
+    validate_live_segments(&segment_bytes, &live.segments)?;
+    validate_gc_adopted_memberships(&commit_index, &change_index, &mut source_parent_facts)?;
 
     let live_commits: HashSet<_> = live.commits.iter().cloned().collect();
     let live_changes: HashSet<_> = live.changes.iter().cloned().collect();
+    let expected_by_commit = expected_live_by_commit_entries(&commit_index, &live.commits)?;
+    let expected_by_change = expected_live_by_change_entries(&change_index, &live.changes);
+    let expected_commit_visibility = expected_commit_visibilities(&commit_index, &live_commits);
+    let live_by_commit_entries = load_by_commit_entries(
+        store,
+        &all_by_commit
+            .iter()
+            .filter(|commit_id| live_commits.contains(*commit_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    let live_by_change_entries = load_by_change_entries(
+        store,
+        &all_by_change
+            .iter()
+            .filter(|change_id| live_changes.contains(*change_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    let live_commit_visibility_entries = load_commit_visibilities(
+        store,
+        &all_commit_visibility
+            .iter()
+            .filter(|commit_id| live_commits.contains(*commit_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    let live_visible_change_proofs = load_visible_change_proofs(
+        store,
+        &all_visible_change_proof
+            .iter()
+            .filter(|change_id| live_changes.contains(*change_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
 
     let sweep = GcSweepSet {
         segments: all_segment_ids
@@ -125,25 +166,49 @@ where
             .collect(),
         commit_visibility: all_commit_visibility
             .into_iter()
-            .filter(|commit_id| !live_commits.contains(commit_id))
+            .filter(|commit_id| {
+                !live_commits.contains(commit_id)
+                    || live_commit_visibility_entries.get(commit_id)
+                        != expected_commit_visibility.get(commit_id)
+            })
             .collect(),
         by_commit: all_by_commit
             .into_iter()
-            .filter(|commit_id| !live_commits.contains(commit_id))
+            .filter(|commit_id| {
+                !live_commits.contains(commit_id)
+                    || live_by_commit_entries.get(commit_id) != expected_by_commit.get(commit_id)
+            })
             .collect(),
         by_change: all_by_change
             .into_iter()
-            .filter(|change_id| !live_changes.contains(change_id))
+            .filter(|change_id| {
+                !live_changes.contains(change_id)
+                    || live_by_change_entries.get(change_id) != expected_by_change.get(change_id)
+            })
             .collect(),
         by_change_membership: all_by_change_membership
             .into_iter()
-            .filter(|(change_id, commit_id)| {
-                !live_changes.contains(change_id) || !live_commits.contains(commit_id)
-            })
+            .filter(|membership| !live_memberships.contains(membership))
             .collect(),
         visible_change_proof: all_visible_change_proof
             .into_iter()
-            .filter(|change_id| !live_changes.contains(change_id))
+            .filter(|change_id| {
+                if !live_changes.contains(change_id) {
+                    return true;
+                };
+                let Some(proof) = live_visible_change_proofs.get(change_id) else {
+                    return true;
+                };
+                if !live_memberships.contains(&(change_id.clone(), proof.commit_id.clone())) {
+                    return true;
+                }
+                if live_commit_visibility_entries.get(&proof.commit_id)
+                    != expected_commit_visibility.get(&proof.commit_id)
+                {
+                    return true;
+                }
+                expected_commit_visibility.get(&proof.commit_id) != Some(proof)
+            })
             .collect(),
         json_payloads: all_json_payloads
             .into_iter()
@@ -158,9 +223,75 @@ where
     })
 }
 
+#[derive(Default)]
+struct GcSourceParentFacts {
+    reachable_memberships: HashSet<String>,
+    first_parent_winners: HashMap<StateRowIdentity, String>,
+}
+
+fn gc_source_parent_facts(
+    root_commit_id: &str,
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+) -> Result<GcSourceParentFacts, LixError> {
+    let mut facts = GcSourceParentFacts::default();
+    let mut stack = vec![root_commit_id.to_string()];
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = stack.pop() {
+        if !visited.insert(commit_id.clone()) {
+            continue;
+        }
+        let Some((_, commit)) = commit_index.get(&commit_id) else {
+            continue;
+        };
+        facts.reachable_memberships.extend(
+            commit
+                .body
+                .membership
+                .iter()
+                .map(|membership| membership.member_change_id.clone()),
+        );
+        stack.extend(commit.header.parent_commit_ids.iter().cloned());
+    }
+
+    let mut next_commit_id = Some(root_commit_id.to_string());
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = next_commit_id.take() {
+        if !visited.insert(commit_id.clone()) {
+            return Err(LixError::unknown(format!(
+                "changelog GC cannot resolve source parent facts because first-parent history contains cycle at commit '{}'",
+                commit_id
+            )));
+        }
+        let Some((_, commit)) = commit_index.get(&commit_id) else {
+            break;
+        };
+        for (identity, change_id) in &commit.directory.state_row_identities {
+            facts
+                .first_parent_winners
+                .entry(identity.clone())
+                .or_insert_with(|| change_id.clone());
+        }
+        next_commit_id = commit.header.parent_commit_ids.first().cloned();
+    }
+    Ok(facts)
+}
+
+fn state_row_identity_for_change(change: &SegmentChange) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(change.schema_key.clone())?,
+        file_id: FileId::new(
+            change
+                .file_id
+                .clone()
+                .unwrap_or_else(|| "__global__".to_string()),
+        )?,
+        entity_id: EntityId::new(change.entity_id.as_json_array_text()?)?,
+    })
+}
+
 fn validate_reachable_commit_graph_acyclic(
     commit_id: &str,
-    commit_index: &HashMap<String, (String, SegmentCommit)>,
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
     visiting: &mut HashSet<String>,
     checked: &mut HashSet<String>,
 ) -> Result<(), LixError> {
@@ -229,12 +360,47 @@ pub(super) fn stage_gc_sweep(writes: &mut StorageWriteSet, plan: &GcPlan) -> Res
     Ok(())
 }
 
-async fn scan_all_segments<S>(store: &mut S) -> Result<Vec<Segment>, LixError>
+async fn scan_segment_ids<S>(store: &mut S) -> Result<Vec<String>, LixError>
 where
     S: ChangelogStorageRead + ?Sized,
 {
     let mut after = None;
-    let mut segments = Vec::new();
+    let mut segment_ids = Vec::new();
+    loop {
+        let page = store
+            .changelog_scan(
+                SEGMENT_SPACE,
+                Vec::new(),
+                after,
+                64,
+                StorageCoreProjection::KeyOnly,
+            )
+            .await?;
+        for key in &page.keys {
+            let segment_id = std::str::from_utf8(key)
+                .map_err(|error| {
+                    LixError::unknown(format!(
+                        "changelog GC found invalid UTF-8 segment key: {error}"
+                    ))
+                })?
+                .to_string();
+            if !segment_ids.iter().any(|existing| existing == &segment_id) {
+                segment_ids.push(segment_id);
+            }
+        }
+        let Some(next_after) = page.resume_after else {
+            break;
+        };
+        after = Some(next_after);
+    }
+    Ok(segment_ids)
+}
+
+async fn validate_all_segments<S>(store: &mut S) -> Result<(), LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut after = None;
     loop {
         let page = store
             .changelog_scan(
@@ -251,14 +417,404 @@ where
             };
             let segment = decode_segment(bytes)?;
             validate_segment_shape(&segment)?;
-            segments.push(segment);
         }
         let Some(next_after) = page.resume_after else {
             break;
         };
         after = Some(next_after);
     }
-    Ok(segments)
+    Ok(())
+}
+
+fn validate_live_segments(
+    segment_bytes: &HashMap<String, Vec<u8>>,
+    live_segment_ids: &[String],
+) -> Result<(), LixError> {
+    for segment_id in live_segment_ids {
+        let Some(bytes) = segment_bytes.get(segment_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog GC live segment '{segment_id}' was not loaded"
+            )));
+        };
+        let segment = decode_segment(bytes)?;
+        validate_segment_shape(&segment)?;
+    }
+    Ok(())
+}
+
+async fn load_gc_commit<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    commit_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentCommit)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    if let Some(entry) = load_by_commit_entry(store, commit_id).await? {
+        if ensure_segment_bytes(store, segment_bytes, &entry.location.segment_id).await? {
+            match decode_commit_from_segment_bytes(
+                &segment_bytes[&entry.location.segment_id],
+                &entry.location,
+                commit_id,
+            )? {
+                Some(commit) => return Ok(Some((entry.location, commit))),
+                None => {}
+            }
+        }
+    }
+    scan_segments_for_commit(store, all_segment_ids, segment_bytes, commit_id).await
+}
+
+async fn load_gc_change<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    change_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    if let Some(entry) = load_by_change_entry(store, change_id).await? {
+        if ensure_segment_bytes(store, segment_bytes, &entry.location.segment_id).await? {
+            match decode_change_from_segment_bytes(
+                &segment_bytes[&entry.location.segment_id],
+                &entry.location,
+                change_id,
+            )? {
+                Some(change) => return Ok(Some((entry.location, change))),
+                None => {}
+            }
+        }
+    }
+    scan_segments_for_change(store, all_segment_ids, segment_bytes, change_id).await
+}
+
+async fn load_by_commit_entry<S>(
+    store: &mut S,
+    commit_id: &str,
+) -> Result<Option<ByCommitEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let Some(bytes) = store
+        .changelog_get_many(BY_COMMIT_INDEX_SPACE, vec![by_commit_key(commit_id)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+    else {
+        return Ok(None);
+    };
+    let entry = decode_by_commit_entry(&bytes)?;
+    if entry.commit_id != commit_id {
+        return Err(LixError::unknown(format!(
+            "by_commit key for '{commit_id}' contains commit_id '{}'",
+            entry.commit_id
+        )));
+    }
+    Ok(Some(entry))
+}
+
+async fn load_by_change_entry<S>(
+    store: &mut S,
+    change_id: &str,
+) -> Result<Option<ByChangeEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let Some(bytes) = store
+        .changelog_get_many(BY_CHANGE_INDEX_SPACE, vec![by_change_key(change_id)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+    else {
+        return Ok(None);
+    };
+    let entry = decode_by_change_entry(&bytes)?;
+    if entry.change_id != change_id {
+        return Err(LixError::unknown(format!(
+            "by_change key for '{change_id}' contains change_id '{}'",
+            entry.change_id
+        )));
+    }
+    Ok(Some(entry))
+}
+
+async fn ensure_segment_bytes<S>(
+    store: &mut S,
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    segment_id: &str,
+) -> Result<bool, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    if segment_bytes.contains_key(segment_id) {
+        return Ok(true);
+    }
+    let Some(bytes) = store
+        .changelog_get_many(SEGMENT_SPACE, vec![segment_key(segment_id)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+    else {
+        return Ok(false);
+    };
+    segment_bytes.insert(segment_id.to_string(), bytes);
+    Ok(true)
+}
+
+async fn scan_segments_for_commit<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    commit_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentCommit)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut found = None;
+    for segment_id in all_segment_ids {
+        if !ensure_segment_bytes(store, segment_bytes, segment_id).await? {
+            continue;
+        }
+        let bytes = &segment_bytes[segment_id];
+        let Ok(view) = view_segment_directory(bytes) else {
+            continue;
+        };
+        let Some(entry) = view
+            .directory_commits
+            .iter()
+            .find(|entry| entry.id == commit_id)
+        else {
+            continue;
+        };
+        let location = location_from_ref(entry.location);
+        let commit =
+            decode_commit_from_segment_bytes(bytes, &location, commit_id)?.ok_or_else(|| {
+                LixError::unknown(format!(
+                    "changelog GC commit '{commit_id}' disappeared from segment directory"
+                ))
+            })?;
+        if found.replace((location, commit)).is_some() {
+            return Err(LixError::unknown(format!(
+                "changelog GC found duplicate commit id '{commit_id}'"
+            )));
+        }
+    }
+    Ok(found)
+}
+
+async fn scan_segments_for_change<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    change_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut found = None;
+    for segment_id in all_segment_ids {
+        if !ensure_segment_bytes(store, segment_bytes, segment_id).await? {
+            continue;
+        }
+        let bytes = &segment_bytes[segment_id];
+        let Ok(view) = view_segment_directory(bytes) else {
+            continue;
+        };
+        let Some(entry) = view
+            .directory_changes
+            .iter()
+            .find(|entry| entry.id == change_id)
+        else {
+            continue;
+        };
+        let location = location_from_ref(entry.location);
+        let change =
+            decode_change_from_segment_bytes(bytes, &location, change_id)?.ok_or_else(|| {
+                LixError::unknown(format!(
+                    "changelog GC change '{change_id}' disappeared from segment directory"
+                ))
+            })?;
+        if found.replace((location, change)).is_some() {
+            return Err(LixError::unknown(format!(
+                "changelog GC found duplicate change id '{change_id}'"
+            )));
+        }
+    }
+    Ok(found)
+}
+
+fn decode_commit_from_segment_bytes(
+    bytes: &[u8],
+    location: &SegmentObjectLocation,
+    commit_id: &str,
+) -> Result<Option<SegmentCommit>, LixError> {
+    let view = view_segment_directory(bytes)?;
+    let Some(entry) = view
+        .directory_commits
+        .iter()
+        .find(|entry| entry.id == commit_id)
+    else {
+        return Ok(None);
+    };
+    if location_from_ref(entry.location) != *location {
+        return Ok(None);
+    }
+    let object = segment_object_bytes(bytes, view.segment_id, location, "commit", commit_id)?;
+    let commit = decode_segment_commit(object)?;
+    if commit.header.id != commit_id {
+        return Err(LixError::unknown(format!(
+            "changelog GC commit locator for '{commit_id}' decoded commit '{}'",
+            commit.header.id
+        )));
+    }
+    validate_commit_checksum(&location.checksum, commit_id, &commit)?;
+    Ok(Some(commit))
+}
+
+fn decode_change_from_segment_bytes(
+    bytes: &[u8],
+    location: &SegmentObjectLocation,
+    change_id: &str,
+) -> Result<Option<SegmentChange>, LixError> {
+    let view = view_segment_directory(bytes)?;
+    let Some(entry) = view
+        .directory_changes
+        .iter()
+        .find(|entry| entry.id == change_id)
+    else {
+        return Ok(None);
+    };
+    if location_from_ref(entry.location) != *location {
+        return Ok(None);
+    }
+    let object = segment_object_bytes(bytes, view.segment_id, location, "change", change_id)?;
+    let change = decode_segment_change(object)?;
+    if change.id != change_id {
+        return Err(LixError::unknown(format!(
+            "changelog GC change locator for '{change_id}' decoded change '{}'",
+            change.id
+        )));
+    }
+    validate_change_checksum(&location.checksum, change_id, &change)?;
+    Ok(Some(change))
+}
+
+fn segment_object_bytes<'a>(
+    bytes: &'a [u8],
+    segment_id: &str,
+    location: &SegmentObjectLocation,
+    kind: &str,
+    id: &str,
+) -> Result<&'a [u8], LixError> {
+    if location.segment_id != segment_id {
+        return Err(LixError::unknown(format!(
+            "changelog GC {kind} '{id}' locator points to segment '{}' but loaded '{}'",
+            location.segment_id, segment_id
+        )));
+    }
+    let start = usize::try_from(location.offset).map_err(|_| {
+        LixError::unknown(format!(
+            "changelog GC {kind} '{id}' offset does not fit in usize"
+        ))
+    })?;
+    let len = usize::try_from(location.len).map_err(|_| {
+        LixError::unknown(format!(
+            "changelog GC {kind} '{id}' length does not fit in usize"
+        ))
+    })?;
+    let end = start.checked_add(len).ok_or_else(|| {
+        LixError::unknown(format!("changelog GC {kind} '{id}' offset/len overflows"))
+    })?;
+    bytes.get(start..end).ok_or_else(|| {
+        LixError::unknown(format!(
+            "changelog GC {kind} '{id}' locator is out of bounds"
+        ))
+    })
+}
+
+fn location_from_ref(location: SegmentObjectLocationRef<'_>) -> SegmentObjectLocation {
+    SegmentObjectLocation {
+        segment_id: location.segment_id.to_string(),
+        offset: location.offset,
+        len: location.len,
+        checksum: location.checksum.to_string(),
+    }
+}
+
+fn validate_gc_adopted_memberships(
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    change_index: &HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+    source_parent_facts: &mut HashMap<String, GcSourceParentFacts>,
+) -> Result<(), LixError> {
+    for commit in commit_index.values().map(|(_, commit)| commit) {
+        for membership in &commit.body.membership {
+            if membership.role != MembershipRole::Adopted {
+                let change_id = &membership.member_change_id;
+                let Some((_, change)) = change_index.get(change_id) else {
+                    continue;
+                };
+                if change.authored_commit_id.as_deref() != Some(commit.header.id.as_str()) {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC live commit '{}' authored membership change '{}' has mismatched authored_commit_id",
+                        commit.header.id, change_id
+                    )));
+                }
+                continue;
+            };
+            let change_id = &membership.member_change_id;
+            let Some((_, change)) = change_index.get(change_id) else {
+                continue;
+            };
+            if change.authored_commit_id.as_deref() == Some(commit.header.id.as_str()) {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is authored by the same commit",
+                    commit.header.id, change_id
+                )));
+            }
+            let source_parent_ordinal = membership.source_parent_ordinal.ok_or_else(|| {
+                LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is missing source_parent_ordinal",
+                    commit.header.id, change_id
+                ))
+            })?;
+            let parent_id = commit
+                .header
+                .parent_commit_ids
+                .get(source_parent_ordinal as usize)
+                .ok_or_else(|| {
+                    LixError::unknown(format!(
+                        "changelog GC live commit '{}' adopted membership change '{}' source_parent_ordinal {} is out of bounds",
+                        commit.header.id, change_id, source_parent_ordinal
+                    ))
+                })?;
+            if !source_parent_facts.contains_key(parent_id) {
+                let facts = gc_source_parent_facts(parent_id, commit_index)?;
+                source_parent_facts.insert(parent_id.clone(), facts);
+            }
+            let facts = source_parent_facts
+                .get(parent_id)
+                .expect("source parent facts should be cached");
+            if !facts.reachable_memberships.contains(change_id) {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is not reachable from source parent '{}'",
+                    commit.header.id, change_id, parent_id
+                )));
+            }
+            let identity = state_row_identity_for_change(change)?;
+            if facts.first_parent_winners.get(&identity) != Some(change_id) {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is not the source parent '{}' winner for {:?}",
+                    commit.header.id, change_id, parent_id, identity
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn scan_utf8_keys<S>(store: &mut S, space: StorageSpace) -> Result<Vec<String>, LixError>
@@ -326,6 +882,215 @@ where
             break;
         };
         after = Some(next_after);
+    }
+    Ok(out)
+}
+
+fn expected_commit_visibilities(
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    live_commits: &HashSet<String>,
+) -> HashMap<String, CommitVisibility> {
+    let mut out = HashMap::new();
+    for (commit_id, (location, commit)) in commit_index {
+        if live_commits.contains(commit_id) {
+            out.insert(
+                commit_id.clone(),
+                CommitVisibility {
+                    commit_id: commit.header.id.clone(),
+                    checksum: location.checksum.clone(),
+                    location: location.clone(),
+                },
+            );
+        }
+    }
+    out
+}
+
+fn expected_live_by_commit_entries(
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    live_commit_order: &[String],
+) -> Result<HashMap<String, ByCommitEntry>, LixError> {
+    let mut generations = HashMap::<String, u64>::new();
+    for commit_id in live_commit_order {
+        expected_live_commit_generation(commit_id, commit_index, &mut generations)?;
+    }
+    let mut out = HashMap::new();
+    for commit_id in live_commit_order {
+        let Some((location, commit)) = commit_index.get(commit_id) else {
+            continue;
+        };
+        let generation = generations.get(commit_id).copied().unwrap_or_default();
+        out.insert(
+            commit_id.clone(),
+            ByCommitEntry {
+                commit_id: commit.header.id.clone(),
+                location: location.clone(),
+                parent_commit_ids: commit.header.parent_commit_ids.clone(),
+                generation,
+            },
+        );
+    }
+    Ok(out)
+}
+
+fn expected_live_commit_generation(
+    commit_id: &str,
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    generations: &mut HashMap<String, u64>,
+) -> Result<u64, LixError> {
+    if let Some(generation) = generations.get(commit_id) {
+        return Ok(*generation);
+    }
+    let Some((_, commit)) = commit_index.get(commit_id) else {
+        return Ok(0);
+    };
+    let mut generation = 0;
+    for parent_id in &commit.header.parent_commit_ids {
+        let parent_generation = if commit_index.contains_key(parent_id) {
+            expected_live_commit_generation(parent_id, commit_index, generations)?
+        } else {
+            0
+        };
+        generation = generation.max(parent_generation.saturating_add(1));
+    }
+    generations.insert(commit_id.to_string(), generation);
+    Ok(generation)
+}
+
+fn expected_live_by_change_entries(
+    change_index: &HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+    live_change_order: &[String],
+) -> HashMap<String, ByChangeEntry> {
+    let mut out = HashMap::new();
+    for change_id in live_change_order {
+        let Some((location, change)) = change_index.get(change_id) else {
+            continue;
+        };
+        out.insert(
+            change_id.clone(),
+            ByChangeEntry {
+                change_id: change.id.clone(),
+                location: location.clone(),
+            },
+        );
+    }
+    out
+}
+
+async fn load_by_commit_entries<S>(
+    store: &mut S,
+    commit_ids: &[String],
+) -> Result<HashMap<String, ByCommitEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            BY_COMMIT_INDEX_SPACE,
+            commit_ids
+                .iter()
+                .map(|commit_id| by_commit_key(commit_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (commit_id, value) in commit_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(entry) = decode_by_commit_entry(&bytes) {
+            if entry.commit_id == *commit_id {
+                out.insert(commit_id.clone(), entry);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn load_by_change_entries<S>(
+    store: &mut S,
+    change_ids: &[String],
+) -> Result<HashMap<String, ByChangeEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            BY_CHANGE_INDEX_SPACE,
+            change_ids
+                .iter()
+                .map(|change_id| by_change_key(change_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (change_id, value) in change_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(entry) = decode_by_change_entry(&bytes) {
+            if entry.change_id == *change_id {
+                out.insert(change_id.clone(), entry);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn load_visible_change_proofs<S>(
+    store: &mut S,
+    change_ids: &[String],
+) -> Result<HashMap<String, CommitVisibility>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            change_ids
+                .iter()
+                .map(|change_id| visible_change_proof_key(change_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (change_id, value) in change_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(proof) = decode_commit_visibility(&bytes) {
+            out.insert(change_id.clone(), proof);
+        }
+    }
+    Ok(out)
+}
+
+async fn load_commit_visibilities<S>(
+    store: &mut S,
+    commit_ids: &[String],
+) -> Result<HashMap<String, CommitVisibility>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            COMMIT_VISIBILITY_SPACE,
+            commit_ids
+                .iter()
+                .map(|commit_id| commit_visibility_key(commit_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (commit_id, value) in commit_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(visibility) = decode_commit_visibility(&bytes) {
+            if visibility.commit_id == *commit_id {
+                out.insert(commit_id.clone(), visibility);
+            }
+        }
     }
     Ok(out)
 }
@@ -399,11 +1164,12 @@ fn mark_change_payloads(payloads: &mut Vec<JsonRef>, change: &SegmentChange) {
 mod tests {
     use super::*;
     use crate::changelog::segment::canonicalize_segment;
+    use crate::changelog::test_support::commit_visibility_from_segment;
     use crate::changelog::{
-        encode_segment, ChangelogContext, CommitBody, CommitHeader, MembershipRecord,
-        MembershipRole, RebuildIndexStats, Segment, SegmentChange, SegmentChangeDirectory,
-        SegmentCommit, SegmentCommitDirectory, SegmentDirectory, SegmentHeader,
-        SegmentInlinePayload, SegmentPayloadLocation,
+        decode_segment, encode_segment, ChangelogContext, CommitBody, CommitHeader,
+        MembershipRecord, MembershipRole, RebuildIndexStats, Segment, SegmentChange,
+        SegmentChangeDirectory, SegmentCommit, SegmentCommitDirectory, SegmentDirectory,
+        SegmentHeader, SegmentInlinePayload, SegmentPayloadLocation,
     };
     use crate::common::{CanonicalSchemaKey, EntityId, FileId};
     use crate::entity_identity::EntityIdentity;
@@ -660,6 +1426,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_sweeps_stale_membership_row_even_when_change_and_commit_are_live() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let change_segment =
+            single_commit_segment("segment-change", "commit-change", "change-live");
+        let commit_segment = single_commit_segment("segment-commit", "commit-live", "change-other");
+
+        write_segments(
+            &storage,
+            &context,
+            vec![change_segment, commit_segment],
+            &["commit-change", "commit-live"],
+        )
+        .await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+            by_change_membership_key("change-live", "commit-live"),
+            by_change_membership_index_value(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let plan = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[
+                    GcRoot::VersionHead("commit-change".to_string()),
+                    GcRoot::PinnedCommit("commit-live".to_string()),
+                ])
+                .await
+                .unwrap()
+        };
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(
+            plan.sweep.by_change_membership,
+            vec![("change-live".to_string(), "commit-live".to_string())]
+        );
+        assert_missing(
+            &storage,
+            vec![(
+                BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+                by_change_membership_key("change-live", "commit-live"),
+            )],
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn gc_sweeps_stale_commit_visibility_and_retains_live_visibility() {
         let storage = test_storage();
         let context = ChangelogContext::new();
@@ -718,6 +1539,222 @@ mod tests {
         );
         assert!(result[0][0].is_some());
         assert_eq!(result[0][1], None);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_stale_live_locator_indexes() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
+        let stale_location = SegmentObjectLocation {
+            segment_id: "missing-segment".to_string(),
+            offset: 0,
+            len: 0,
+            checksum: "stale-checksum".to_string(),
+        };
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            COMMIT_VISIBILITY_SPACE,
+            commit_visibility_key("commit-live"),
+            commit_visibility_value(&CommitVisibility {
+                commit_id: "commit-live".to_string(),
+                location: stale_location.clone(),
+                checksum: stale_location.checksum.clone(),
+            })
+            .unwrap(),
+        );
+        writes.put(
+            BY_COMMIT_INDEX_SPACE,
+            by_commit_key("commit-live"),
+            by_commit_index_value(&ByCommitEntry {
+                commit_id: "commit-live".to_string(),
+                location: stale_location.clone(),
+                parent_commit_ids: Vec::new(),
+                generation: 0,
+            })
+            .unwrap(),
+        );
+        writes.put(
+            BY_CHANGE_INDEX_SPACE,
+            by_change_key("change-live"),
+            by_change_index_value(&ByChangeEntry {
+                change_id: "change-live".to_string(),
+                location: stale_location,
+            })
+            .unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage);
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.commit_visibility, vec!["commit-live"]);
+        assert_eq!(plan.sweep.by_commit, vec!["commit-live"]);
+        assert_eq!(plan.sweep.by_change, vec!["change-live"]);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_dead_segment_with_missing_parent() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
+        let mut dead_segment = single_commit_segment("segment-dead", "commit-dead", "change-dead");
+        dead_segment.commits[0]
+            .header
+            .parent_commit_ids
+            .push("missing-parent".to_string());
+        dead_segment = canonicalize_segment(dead_segment).unwrap();
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+        write_raw_segment(&storage, &dead_segment).await;
+
+        let mut reader = context.reader(storage);
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.segments, vec!["segment-dead"]);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_stale_visible_change_proof_even_when_change_and_commit_are_live() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let change_segment =
+            single_commit_segment("segment-change", "commit-change", "change-live");
+        let commit_segment = canonicalize_segment(single_commit_segment(
+            "segment-commit",
+            "commit-live",
+            "change-other",
+        ))
+        .unwrap();
+        let stale_visibility = commit_visibility_from_segment(&commit_segment, "commit-live");
+
+        write_segments(
+            &storage,
+            &context,
+            vec![change_segment, commit_segment],
+            &["commit-change", "commit-live"],
+        )
+        .await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let plan = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[
+                    GcRoot::VersionHead("commit-change".to_string()),
+                    GcRoot::PinnedCommit("commit-live".to_string()),
+                ])
+                .await
+                .unwrap()
+        };
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
+        assert_missing(
+            &storage,
+            vec![(
+                VISIBLE_CHANGE_PROOF_SPACE,
+                visible_change_proof_key("change-live"),
+            )],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_visible_change_proof_that_does_not_match_current_visibility() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = canonicalize_segment(single_commit_segment(
+            "segment-live",
+            "commit-live",
+            "change-live",
+        ))
+        .unwrap();
+        let mut stale_visibility = commit_visibility_from_segment(&live_segment, "commit-live");
+        stale_visibility.checksum = "stale-checksum".to_string();
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage.clone());
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_visible_change_proof_that_matches_stale_visibility() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = canonicalize_segment(single_commit_segment(
+            "segment-live",
+            "commit-live",
+            "change-live",
+        ))
+        .unwrap();
+        let mut stale_visibility = commit_visibility_from_segment(&live_segment, "commit-live");
+        stale_visibility.checksum = "stale-checksum".to_string();
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            COMMIT_VISIBILITY_SPACE,
+            commit_visibility_key("commit-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage.clone());
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.commit_visibility, vec!["commit-live"]);
+        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
     }
 
     #[tokio::test]
@@ -875,6 +1912,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_rejects_cross_segment_adopted_membership_authored_by_same_commit() {
+        let storage = test_storage();
+        let mut change_segment =
+            single_commit_segment("change-segment", "commit-author", "change-1");
+        change_segment.commits.clear();
+        change_segment.directory.commits.clear();
+        change_segment.changes[0].authored_commit_id = Some("commit-adopter".to_string());
+        let change_segment = canonicalize_segment(change_segment).unwrap();
+        write_raw_segment(&storage, &change_segment).await;
+
+        let mut adopt_segment =
+            adopting_commit_segment("adopt-segment", "commit-adopter", "change-1");
+        adopt_segment.commits[0]
+            .header
+            .parent_commit_ids
+            .push("missing-parent".to_string());
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+        write_raw_segment(&storage, &adopt_segment).await;
+        let parent_segment = canonicalize_segment(single_commit_segment(
+            "parent-segment",
+            "missing-parent",
+            "parent-change",
+        ))
+        .unwrap();
+        write_raw_segment(&storage, &parent_segment).await;
+
+        let context = ChangelogContext::new();
+        let mut reader = context.reader(storage);
+        let error = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-adopter".to_string())])
+            .await
+            .expect_err("GC must reject self-authored adopted membership");
+
+        assert!(
+            error.message.contains("is authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_sweeps_dead_direct_json_payloads_and_retains_live_payloads() {
         let storage = test_storage();
         let context = ChangelogContext::new();
@@ -946,9 +2023,15 @@ mod tests {
             .plan_gc(&[GcRoot::VersionHead("commit-1".to_string())])
             .await
             .expect_err("missing membership change must be corruption");
-        assert!(error
-            .message
-            .contains("references missing change 'change-1'"));
+        assert!(
+            error
+                .message
+                .contains("references missing change 'change-1'")
+                || error
+                    .message
+                    .contains("references missing authored change 'change-1'"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1037,9 +2120,15 @@ mod tests {
                 .await
                 .expect_err("missing membership change must abort collect_garbage")
         };
-        assert!(error
-            .message
-            .contains("references missing change 'change-1'"));
+        assert!(
+            error
+                .message
+                .contains("references missing change 'change-1'")
+                || error
+                    .message
+                    .contains("references missing authored change 'change-1'"),
+            "unexpected error: {error}"
+        );
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
 
@@ -1075,6 +2164,7 @@ mod tests {
         duplicate.header.membership_count = 0;
         segment.commits.push(duplicate);
         segment.header.commit_count = segment.commits.len() as u32;
+        let segment = canonicalize_segment(segment).unwrap();
         write_raw_segment(&storage, &segment).await;
 
         let mut reader = context.reader(storage.clone());
@@ -1082,9 +2172,18 @@ mod tests {
             .plan_gc(&[])
             .await
             .expect_err("duplicate commit ids must be invalid segment input");
-        assert!(error
-            .message
-            .contains("contains duplicate commit 'commit-1'"));
+        assert!(
+            error
+                .message
+                .contains("contains duplicate commit 'commit-1'")
+                || error
+                    .message
+                    .contains("contains duplicate commit directory entry 'commit-1'")
+                || error.message.contains(
+                    "commit 'commit-1' locator offset/len does not match encoded byte range"
+                ),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1099,6 +2198,7 @@ mod tests {
         .await;
         segment.changes.push(segment.changes[0].clone());
         segment.header.change_count = segment.changes.len() as u32;
+        let segment = canonicalize_segment(segment).unwrap();
         write_raw_segment(&storage, &segment).await;
 
         let mut reader = context.reader(storage.clone());
@@ -1106,9 +2206,18 @@ mod tests {
             .plan_gc(&[])
             .await
             .expect_err("duplicate change ids must be invalid segment input");
-        assert!(error
-            .message
-            .contains("contains duplicate change 'change-1'"));
+        assert!(
+            error
+                .message
+                .contains("contains duplicate change 'change-1'")
+                || error
+                    .message
+                    .contains("contains duplicate change directory entry 'change-1'")
+                || error.message.contains(
+                    "change 'change-1' locator offset/len does not match encoded byte range"
+                ),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1161,7 +2270,7 @@ mod tests {
     async fn gc_errors_when_segment_change_payload_directory_drifts() {
         let storage = test_storage();
         let context = ChangelogContext::new();
-        let payload_ref = JsonRef::from_hash_bytes([11; 32]);
+        let payload_ref = JsonRef::for_content(b"payload");
         let mut segment = single_commit_segment("segment-1", "commit-1", "change-1");
         segment.changes[0]
             .inline_payloads

--- a/packages/engine/src/changelog/graph.rs
+++ b/packages/engine/src/changelog/graph.rs
@@ -1,0 +1,130 @@
+use std::collections::{HashMap, HashSet};
+
+use async_trait::async_trait;
+
+use super::types::{SegmentCommit, StateRowIdentity};
+use crate::LixError;
+
+#[derive(Default)]
+pub(super) struct SourceParentFacts {
+    pub(super) reachable_memberships: HashSet<String>,
+    pub(super) first_parent_winners: HashMap<StateRowIdentity, String>,
+}
+
+#[async_trait(?Send)]
+pub(super) trait CommitGraphLoader {
+    async fn load_commit(&mut self, commit_id: &str) -> Result<Option<SegmentCommit>, LixError>;
+}
+
+pub(super) async fn source_parent_facts<L>(
+    loader: &mut L,
+    root_commit_id: &str,
+) -> Result<SourceParentFacts, LixError>
+where
+    L: CommitGraphLoader + ?Sized,
+{
+    let mut facts = SourceParentFacts::default();
+    let mut stack = vec![root_commit_id.to_string()];
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = stack.pop() {
+        if !visited.insert(commit_id.clone()) {
+            continue;
+        }
+        let Some(commit) = loader.load_commit(&commit_id).await? else {
+            continue;
+        };
+        facts.reachable_memberships.extend(
+            commit
+                .body
+                .membership
+                .iter()
+                .map(|membership| membership.member_change_id.clone()),
+        );
+        stack.extend(commit.header.parent_commit_ids);
+    }
+
+    let mut next_commit_id = Some(root_commit_id.to_string());
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = next_commit_id.take() {
+        if !visited.insert(commit_id.clone()) {
+            return Err(LixError::unknown(format!(
+                "cannot resolve source parent facts because first-parent history contains parent cycle at commit '{commit_id}'"
+            )));
+        }
+        let Some(commit) = loader.load_commit(&commit_id).await? else {
+            break;
+        };
+        for (identity, change_id) in &commit.directory.state_row_identities {
+            facts
+                .first_parent_winners
+                .entry(identity.clone())
+                .or_insert_with(|| change_id.clone());
+        }
+        next_commit_id = commit.header.parent_commit_ids.first().cloned();
+    }
+    Ok(facts)
+}
+
+pub(super) async fn commit_history_contains_membership<L>(
+    loader: &mut L,
+    root_commit_id: &str,
+    change_id: &str,
+) -> Result<bool, LixError>
+where
+    L: CommitGraphLoader + ?Sized,
+{
+    let mut stack = vec![root_commit_id.to_string()];
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = stack.pop() {
+        if !visited.insert(commit_id.clone()) {
+            continue;
+        }
+        let Some(commit) = loader.load_commit(&commit_id).await? else {
+            continue;
+        };
+        if commit
+            .body
+            .membership
+            .iter()
+            .any(|membership| membership.member_change_id == change_id)
+        {
+            return Ok(true);
+        }
+        stack.extend(commit.header.parent_commit_ids);
+    }
+    Ok(false)
+}
+
+pub(super) async fn commit_history_projects_state_row<L>(
+    loader: &mut L,
+    root_commit_id: &str,
+    identity: &StateRowIdentity,
+    change_id: &str,
+) -> Result<bool, LixError>
+where
+    L: CommitGraphLoader + ?Sized,
+{
+    let mut next_commit_id = Some(root_commit_id.to_string());
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = next_commit_id.take() {
+        if !visited.insert(commit_id.clone()) {
+            return Err(LixError::unknown(format!(
+                "cannot resolve StateRowIdentity winner for {:?} because first-parent history contains cycle at commit '{}'",
+                identity, commit_id
+            )));
+        }
+        let Some(commit) = loader.load_commit(&commit_id).await? else {
+            return Ok(false);
+        };
+        if let Some((_, winner_change_id)) = commit
+            .directory
+            .state_row_identities
+            .iter()
+            .find(|(candidate, _)| candidate == identity)
+        {
+            return Ok(winner_change_id == change_id);
+        }
+        next_commit_id = commit.header.parent_commit_ids.first().cloned();
+    }
+    Ok(false)
+}

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use codec::{
     decode_empty_index_value, decode_segment, decode_segment_change, decode_segment_commit,
     encode_by_change_entry, encode_by_commit_entry, encode_commit_visibility,
     encode_empty_index_value, encode_segment, segment_commit_membership_contains_any, view_segment,
+    view_segment_directory, view_segment_object_ranges, view_segment_object_slices,
 };
 #[allow(unused_imports)]
 pub(crate) use context::{ChangelogContext, ChangelogStoreReader, ChangelogStoreWriter};

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -31,8 +31,8 @@ pub(crate) use codec::{
 pub(crate) use context::{ChangelogContext, ChangelogStoreReader, ChangelogStoreWriter};
 #[allow(unused_imports)]
 pub(crate) use store::{
-    ChangelogReader, ChangelogWriter, BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
-    BY_COMMIT_INDEX_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
+    BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE,
+    ChangelogReader, ChangelogWriter, VISIBLE_CHANGE_PROOF_SPACE,
 };
 pub use store::{COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE};
 #[allow(unused_imports)]
@@ -41,9 +41,9 @@ pub(crate) use types::{
     ChangeLoadRequest, ChangeLocator, ChangeLocatorRef, ChangeProjection, ChangeRef,
     ChangeVisibilityMode, Commit, CommitBody, CommitHeader, CommitId, CommitLoadBatch,
     CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitVisibility, CommitVisibilityMode,
-    GcLiveSet, GcPlan, GcRoot, GcSweepSet, MembershipRecord, MembershipRole, RebuildIndexStats,
-    Segment, SegmentChange, SegmentChangeDirectory, SegmentCommit, SegmentCommitDirectory,
-    SegmentDirectory, SegmentDirectoryEntryRef, SegmentHeader, SegmentId, SegmentInlinePayload,
-    SegmentObjectLocation, SegmentObjectLocationRef, SegmentObjectSlice, SegmentOffset,
-    SegmentPayloadLocation, SegmentStageReport, SegmentView, StateRowIdentity,
+    GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, MembershipRecord, MembershipRole,
+    RebuildIndexStats, Segment, SegmentChange, SegmentChangeDirectory, SegmentCommit,
+    SegmentCommitDirectory, SegmentDirectory, SegmentDirectoryEntryRef, SegmentHeader, SegmentId,
+    SegmentInlinePayload, SegmentObjectLocation, SegmentObjectLocationRef, SegmentObjectSlice,
+    SegmentOffset, SegmentPayloadLocation, SegmentStageReport, SegmentView, StateRowIdentity,
 };

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -16,6 +16,7 @@ mod segment;
 mod store;
 #[cfg(test)]
 mod test_support;
+mod truth;
 mod types;
 mod visibility;
 

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -12,6 +12,7 @@ mod codec;
 mod commit;
 mod context;
 mod gc;
+mod graph;
 mod segment;
 mod store;
 #[cfg(test)]

--- a/packages/engine/src/changelog/segment.rs
+++ b/packages/engine/src/changelog/segment.rs
@@ -4,16 +4,16 @@ use std::collections::{HashMap, HashSet};
 
 use super::codec::{
     decode_segment, decode_segment_change, decode_segment_commit,
-    encode_segment_with_object_locations, view_segment_directory, view_segment_object_ranges,
-    view_segment_object_slices,
+    encode_segment_with_object_locations, view_segment, view_segment_directory,
+    view_segment_object_ranges, view_segment_object_slices,
 };
 use super::store::segment_value;
 use super::types::{
     MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentDirectory, SegmentObjectLocation,
     SegmentPayloadLocation, StateRowIdentity,
 };
-use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::LixError;
+use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 
 pub(super) fn directory_commit_location(
     segment: &Segment,
@@ -94,7 +94,7 @@ struct SegmentObjectRangeMeta {
 
 impl DecodedSegmentIndex {
     pub(super) fn decode(bytes: &[u8]) -> Result<Self, LixError> {
-        let view = view_segment_directory(bytes)?;
+        let view = view_segment(bytes)?;
         let segment_id = view.segment_id.to_string();
         let mut commit_ordinals = HashMap::new();
         let mut commit_locations = HashMap::new();

--- a/packages/engine/src/changelog/segment.rs
+++ b/packages/engine/src/changelog/segment.rs
@@ -4,13 +4,15 @@ use std::collections::{HashMap, HashSet};
 
 use super::codec::{
     decode_segment, decode_segment_change, decode_segment_commit,
-    encode_segment_with_object_locations, view_segment, view_segment_object_slices,
+    encode_segment_with_object_locations, view_segment_directory, view_segment_object_ranges,
+    view_segment_object_slices,
 };
 use super::store::segment_value;
 use super::types::{
     MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentDirectory, SegmentObjectLocation,
-    SegmentPayloadLocation,
+    SegmentPayloadLocation, StateRowIdentity,
 };
+use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::LixError;
 
 pub(super) fn directory_commit_location(
@@ -80,11 +82,19 @@ pub(super) struct DecodedSegmentIndex {
     change_ordinals: HashMap<String, usize>,
     commit_locations: HashMap<String, SegmentObjectLocation>,
     change_locations: HashMap<String, SegmentObjectLocation>,
+    commit_ranges: HashMap<String, SegmentObjectRangeMeta>,
+    change_ranges: HashMap<String, SegmentObjectRangeMeta>,
+}
+
+struct SegmentObjectRangeMeta {
+    offset: u64,
+    len: u64,
+    encoded_checksum: Option<String>,
 }
 
 impl DecodedSegmentIndex {
     pub(super) fn decode(bytes: &[u8]) -> Result<Self, LixError> {
-        let view = view_segment(bytes)?;
+        let view = view_segment_directory(bytes)?;
         let segment_id = view.segment_id.to_string();
         let mut commit_ordinals = HashMap::new();
         let mut commit_locations = HashMap::new();
@@ -114,6 +124,33 @@ impl DecodedSegmentIndex {
                 },
             );
         }
+        let (commit_ranges, change_ranges) = view_segment_object_ranges(bytes)?;
+        let commit_ranges = commit_ranges
+            .into_iter()
+            .map(|slice| {
+                (
+                    slice.id.to_string(),
+                    SegmentObjectRangeMeta {
+                        offset: slice.offset,
+                        len: slice.len,
+                        encoded_checksum: slice.encoded_checksum.map(str::to_string),
+                    },
+                )
+            })
+            .collect();
+        let change_ranges = change_ranges
+            .into_iter()
+            .map(|slice| {
+                (
+                    slice.id.to_string(),
+                    SegmentObjectRangeMeta {
+                        offset: slice.offset,
+                        len: slice.len,
+                        encoded_checksum: slice.encoded_checksum.map(str::to_string),
+                    },
+                )
+            })
+            .collect();
         Ok(Self {
             bytes: bytes.to_vec(),
             segment_id,
@@ -121,6 +158,8 @@ impl DecodedSegmentIndex {
             change_ordinals,
             commit_locations,
             change_locations,
+            commit_ranges,
+            change_ranges,
         })
     }
 
@@ -182,6 +221,7 @@ impl DecodedSegmentIndex {
                 "changelog commit '{commit_id}' locator does not match segment directory"
             )));
         }
+        self.validate_commit_range(location, commit_id)?;
         Ok(())
     }
 
@@ -201,6 +241,7 @@ impl DecodedSegmentIndex {
                 "changelog change '{change_id}' locator does not match segment directory"
             )));
         }
+        self.validate_change_range(location, change_id)?;
         let Some(change) = self.change(change_id)? else {
             return Err(LixError::unknown(format!(
                 "changelog segment '{}' is missing change '{}'",
@@ -208,6 +249,49 @@ impl DecodedSegmentIndex {
             )));
         };
         validate_change_checksum(&location.checksum, change_id, &change)?;
+        Ok(())
+    }
+
+    fn validate_commit_range(
+        &self,
+        location: &SegmentObjectLocation,
+        commit_id: &str,
+    ) -> Result<(), LixError> {
+        let Some(range) = self.commit_ranges.get(commit_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded commit object '{}'",
+                self.segment_id, commit_id
+            )));
+        };
+        if location.offset != range.offset || location.len != range.len {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' locator does not match encoded object slice"
+            )));
+        }
+        if range.encoded_checksum.as_deref() != Some(location.checksum.as_str()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' locator checksum does not match encoded object checksum"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_change_range(
+        &self,
+        location: &SegmentObjectLocation,
+        change_id: &str,
+    ) -> Result<(), LixError> {
+        let Some(range) = self.change_ranges.get(change_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded change object '{}'",
+                self.segment_id, change_id
+            )));
+        };
+        if location.offset != range.offset || location.len != range.len {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' locator does not match encoded object slice"
+            )));
+        }
         Ok(())
     }
 
@@ -296,6 +380,7 @@ pub(super) fn canonicalize_segment(mut segment: Segment) -> Result<Segment, LixE
     }
 
     let mut change_locations = Vec::with_capacity(segment.changes.len());
+    let mut change_checksums = Vec::with_capacity(segment.changes.len());
     for change in &mut segment.changes {
         change.directory.payloads = change
             .inline_payloads
@@ -307,13 +392,15 @@ pub(super) fn canonicalize_segment(mut segment: Segment) -> Result<Segment, LixE
                 len: payload.bytes.len() as u64,
             })
             .collect();
+        let change_checksum = checksum_change(change)?;
+        change_checksums.push((change.id.clone(), change_checksum.clone()));
         change_locations.push((
             change.id.clone(),
             SegmentObjectLocation {
                 segment_id: segment_id.clone(),
                 offset: 0,
                 len: 0,
-                checksum: checksum_change(change)?,
+                checksum: change_checksum,
             },
         ));
     }
@@ -326,7 +413,7 @@ pub(super) fn canonicalize_segment(mut segment: Segment) -> Result<Segment, LixE
     segment.header.checksum = empty_checksum();
     let encoded = encode_segment_with_object_locations(&segment)?;
     segment.header.byte_count = encoded.bytes.len() as u64;
-    segment.header.checksum = checksum_segment(&segment)?;
+    segment.header.checksum = checksum_segment_with_change_checksums(&segment, &change_checksums)?;
     apply_encoded_object_locations_from_encoded(&mut segment, &encoded)?;
     Ok(segment)
 }
@@ -339,12 +426,13 @@ fn apply_encoded_object_locations_from_encoded(
     segment: &mut Segment,
     encoded: &super::codec::EncodedSegment,
 ) -> Result<(), LixError> {
+    let encoded_commits = encoded
+        .commits
+        .iter()
+        .map(|object| (object.id.as_str(), object))
+        .collect::<HashMap<_, _>>();
     for (commit_id, location) in &mut segment.directory.commits {
-        let Some(object) = encoded
-            .commits
-            .iter()
-            .find(|object| object.id == *commit_id)
-        else {
+        let Some(object) = encoded_commits.get(commit_id.as_str()) else {
             return Err(LixError::unknown(format!(
                 "changelog segment '{}' could not locate encoded commit '{}'",
                 segment.header.segment_id, commit_id
@@ -354,12 +442,13 @@ fn apply_encoded_object_locations_from_encoded(
         location.len = object.len;
     }
 
+    let encoded_changes = encoded
+        .changes
+        .iter()
+        .map(|object| (object.id.as_str(), object))
+        .collect::<HashMap<_, _>>();
     for (change_id, location) in &mut segment.directory.changes {
-        let Some(object) = encoded
-            .changes
-            .iter()
-            .find(|object| object.id == *change_id)
-        else {
+        let Some(object) = encoded_changes.get(change_id.as_str()) else {
             return Err(LixError::unknown(format!(
                 "changelog segment '{}' could not locate encoded change '{}'",
                 segment.header.segment_id, change_id
@@ -377,50 +466,89 @@ pub(super) fn validate_segment_shape(segment: &Segment) -> Result<(), LixError> 
 
     let encoded = segment_value(segment)?;
     let (encoded_commits, encoded_changes) = view_segment_object_slices(&encoded)?;
+    let commits_by_id = segment
+        .commits
+        .iter()
+        .map(|commit| (commit.header.id.as_str(), commit))
+        .collect::<HashMap<_, _>>();
+    let changes_by_id = segment
+        .changes
+        .iter()
+        .map(|change| (change.id.as_str(), change))
+        .collect::<HashMap<_, _>>();
+    let encoded_commits_by_id = encoded_commits
+        .iter()
+        .map(|slice| (slice.id, slice))
+        .collect::<HashMap<_, _>>();
+    let encoded_changes_by_id = encoded_changes
+        .iter()
+        .map(|slice| (slice.id, slice))
+        .collect::<HashMap<_, _>>();
+    let mut change_checksums = Vec::with_capacity(segment.changes.len());
+    for change in &segment.changes {
+        change_checksums.push((change.id.clone(), checksum_change(change)?));
+    }
+    let change_checksums_by_id = change_checksums
+        .iter()
+        .map(|(change_id, checksum)| (change_id.as_str(), checksum.as_str()))
+        .collect::<HashMap<_, _>>();
 
     for (commit_id, location) in &segment.directory.commits {
-        let commit = segment_commit(segment, commit_id).ok_or_else(|| {
+        let commit = commits_by_id.get(commit_id.as_str()).ok_or_else(|| {
             LixError::unknown(format!(
                 "changelog segment '{}' directory points to missing commit '{}'",
                 segment.header.segment_id, commit_id
             ))
         })?;
-        validate_commit_location(location, segment, commit_id)?;
-        validate_encoded_object_location(
+        let Some(slice) = encoded_commits_by_id.get(commit_id.as_str()) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded commit '{}'",
+                segment.header.segment_id, commit_id
+            )));
+        };
+        validate_encoded_object_location_from_parts(
             &segment.header.segment_id,
             "commit",
             commit_id,
             location,
-            encoded_commits.iter().map(|slice| {
-                (
-                    slice.id,
-                    slice.offset,
-                    slice.len,
-                    slice.encoded_checksum.unwrap_or_default(),
-                )
-            }),
+            slice.offset,
+            slice.len,
+            slice.encoded_checksum.unwrap_or_default(),
         )?;
         validate_commit_checksum(&location.checksum, commit_id, commit)?;
     }
 
     for (change_id, location) in &segment.directory.changes {
-        validate_change_location(location, segment, change_id)?;
-        let change = segment_change(segment, change_id).ok_or_else(|| {
+        let _change = changes_by_id.get(change_id.as_str()).ok_or_else(|| {
             LixError::unknown(format!(
                 "changelog segment '{}' directory points to missing change '{}'",
                 segment.header.segment_id, change_id
             ))
         })?;
-        validate_encoded_object_location(
+        let Some(slice) = encoded_changes_by_id.get(change_id.as_str()) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded change '{}'",
+                segment.header.segment_id, change_id
+            )));
+        };
+        validate_encoded_object_location_from_parts(
             &segment.header.segment_id,
             "change",
             change_id,
             location,
-            encoded_changes
-                .iter()
-                .map(|slice| (slice.id, slice.offset, slice.len, "")),
+            slice.offset,
+            slice.len,
+            "",
         )?;
-        validate_change_checksum(&location.checksum, change_id, change)?;
+        let canonical = change_checksums_by_id
+            .get(change_id.as_str())
+            .expect("validated change must have canonical checksum");
+        if location.checksum != *canonical {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' checksum '{}' does not match canonical checksum '{}'",
+                location.checksum, canonical
+            )));
+        }
     }
 
     let encoded_len = encoded.len() as u64;
@@ -431,7 +559,7 @@ pub(super) fn validate_segment_shape(segment: &Segment) -> Result<(), LixError> 
         )));
     }
 
-    let checksum = checksum_segment(segment)?;
+    let checksum = checksum_segment_with_change_checksums(segment, &change_checksums)?;
     if segment.header.checksum != checksum {
         return Err(LixError::unknown(format!(
             "changelog segment '{}' checksum '{}' does not match canonical checksum '{}'",
@@ -497,6 +625,12 @@ pub(super) fn validate_stage_segment_shape(segment: &Segment) -> Result<(), LixE
         )));
     }
     let mut commit_ids = HashSet::new();
+    let directory_commit_ids = segment
+        .directory
+        .commits
+        .iter()
+        .map(|(id, _)| id.as_str())
+        .collect::<HashSet<_>>();
     for commit in &segment.commits {
         if !commit_ids.insert(commit.header.id.as_str()) {
             return Err(LixError::unknown(format!(
@@ -504,7 +638,7 @@ pub(super) fn validate_stage_segment_shape(segment: &Segment) -> Result<(), LixE
                 segment.header.segment_id, commit.header.id
             )));
         }
-        validate_commit_shape(segment, commit)?;
+        validate_commit_shape(segment, commit, &directory_commit_ids)?;
     }
 
     let mut change_ids = HashSet::new();
@@ -541,6 +675,7 @@ pub(super) fn validate_stage_segment_shape(segment: &Segment) -> Result<(), LixE
             .iter()
             .map(|(id, location)| (id.as_str(), location)),
     )?;
+    validate_segment_cross_object_semantics(segment)?;
 
     Ok(())
 }
@@ -560,6 +695,26 @@ fn validate_encoded_object_location<'a>(
             "changelog segment '{segment_id}' is missing encoded {kind} '{object_id}'"
         )));
     };
+    validate_encoded_object_location_from_parts(
+        segment_id,
+        kind,
+        object_id,
+        location,
+        offset,
+        len,
+        encoded_checksum,
+    )
+}
+
+fn validate_encoded_object_location_from_parts(
+    _segment_id: &str,
+    kind: &str,
+    object_id: &str,
+    location: &SegmentObjectLocation,
+    offset: u64,
+    len: u64,
+    encoded_checksum: &str,
+) -> Result<(), LixError> {
     if location.offset != offset || location.len != len {
         return Err(LixError::unknown(format!(
             "changelog {kind} '{object_id}' locator offset/len does not match encoded byte range"
@@ -574,21 +729,67 @@ fn validate_encoded_object_location<'a>(
 }
 
 fn checksum_segment(segment: &Segment) -> Result<String, LixError> {
+    let change_checksums = segment
+        .changes
+        .iter()
+        .map(|change| Ok((change.id.clone(), checksum_change(change)?)))
+        .collect::<Result<Vec<_>, LixError>>()?;
+    checksum_segment_with_change_checksums(segment, &change_checksums)
+}
+
+fn checksum_segment_with_change_checksums(
+    segment: &Segment,
+    change_checksums: &[(String, String)],
+) -> Result<String, LixError> {
+    let change_checksums = change_checksums
+        .iter()
+        .map(|(change_id, checksum)| (change_id.as_str(), checksum.as_str()))
+        .collect::<HashMap<_, _>>();
     let mut hasher = blake3::Hasher::new();
     hash_part(&mut hasher, "segment");
-    hash_part(&mut hasher, &segment.header.segment_id);
-    hash_part(&mut hasher, &segment.header.format_version.to_string());
-    hash_part(&mut hasher, &segment.header.commit_count.to_string());
-    hash_part(&mut hasher, &segment.header.change_count.to_string());
-    hash_part(&mut hasher, &segment.header.byte_count.to_string());
-    hash_part(&mut hasher, &segment.header.payload_count.to_string());
+    hash_field(&mut hasher, "segment_id", &segment.header.segment_id);
+    hash_field(
+        &mut hasher,
+        "format_version",
+        &segment.header.format_version.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "commit_count",
+        &segment.header.commit_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "change_count",
+        &segment.header.change_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "byte_count",
+        &segment.header.byte_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "payload_count",
+        &segment.header.payload_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "commits", segment.commits.len());
     for commit in &segment.commits {
-        hash_part(&mut hasher, &commit.header.id);
-        hash_part(&mut hasher, &commit.checksum);
+        hash_part(&mut hasher, "commit");
+        hash_field(&mut hasher, "id", &commit.header.id);
+        hash_field(&mut hasher, "checksum", &commit.checksum);
     }
+    hash_list_len(&mut hasher, "changes", segment.changes.len());
     for change in &segment.changes {
-        hash_part(&mut hasher, &change.id);
-        hash_part(&mut hasher, &checksum_change(change)?);
+        hash_part(&mut hasher, "change");
+        hash_field(&mut hasher, "id", &change.id);
+        let Some(checksum) = change_checksums.get(change.id.as_str()) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing canonical checksum for change '{}'",
+                segment.header.segment_id, change.id
+            )));
+        };
+        hash_field(&mut hasher, "checksum", checksum);
     }
     Ok(hasher.finalize().to_hex().to_string())
 }
@@ -596,42 +797,80 @@ fn checksum_segment(segment: &Segment) -> Result<String, LixError> {
 fn checksum_commit(commit: &SegmentCommit) -> Result<String, LixError> {
     let mut hasher = blake3::Hasher::new();
     hash_part(&mut hasher, "commit");
-    hash_part(&mut hasher, &commit.header.id);
+    hash_field(&mut hasher, "id", &commit.header.id);
+    hash_list_len(
+        &mut hasher,
+        "parent_commit_ids",
+        commit.header.parent_commit_ids.len(),
+    );
     for parent in &commit.header.parent_commit_ids {
-        hash_part(&mut hasher, parent);
+        hash_field(&mut hasher, "parent_commit_id", parent);
     }
-    hash_part(&mut hasher, &commit.header.derivable_change_id);
+    hash_field(
+        &mut hasher,
+        "derivable_change_id",
+        &commit.header.derivable_change_id,
+    );
+    hash_list_len(
+        &mut hasher,
+        "author_account_ids",
+        commit.header.author_account_ids.len(),
+    );
     for account_id in &commit.header.author_account_ids {
-        hash_part(&mut hasher, account_id);
+        hash_field(&mut hasher, "author_account_id", account_id);
     }
-    hash_part(&mut hasher, &commit.header.created_at);
-    hash_part(&mut hasher, &commit.header.membership_count.to_string());
+    hash_field(&mut hasher, "created_at", &commit.header.created_at);
+    hash_field(
+        &mut hasher,
+        "membership_count",
+        &commit.header.membership_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "memberships", commit.body.membership.len());
     for membership in &commit.body.membership {
-        hash_part(&mut hasher, &membership.member_change_id);
-        hash_part(
+        hash_part(&mut hasher, "membership");
+        hash_field(
             &mut hasher,
+            "member_change_id",
+            &membership.member_change_id,
+        );
+        hash_field(
+            &mut hasher,
+            "role",
             match membership.role {
                 MembershipRole::Authored => "authored",
                 MembershipRole::Adopted => "adopted",
             },
         );
-        hash_part(
+        hash_field(
             &mut hasher,
+            "source_parent_ordinal",
             &membership
                 .source_parent_ordinal
                 .map(|ordinal| ordinal.to_string())
                 .unwrap_or_default(),
         );
     }
+    hash_list_len(
+        &mut hasher,
+        "state_row_identities",
+        commit.directory.state_row_identities.len(),
+    );
     for (identity, change_id) in &commit.directory.state_row_identities {
-        hash_part(&mut hasher, identity.schema_key.as_str());
-        hash_part(&mut hasher, identity.file_id.as_str());
-        hash_part(&mut hasher, identity.entity_id.as_str());
-        hash_part(&mut hasher, change_id);
+        hash_part(&mut hasher, "state_row_identity");
+        hash_field(&mut hasher, "schema_key", identity.schema_key.as_str());
+        hash_field(&mut hasher, "file_id", identity.file_id.as_str());
+        hash_field(&mut hasher, "entity_id", identity.entity_id.as_str());
+        hash_field(&mut hasher, "change_id", change_id);
     }
+    hash_list_len(
+        &mut hasher,
+        "membership_ordinals",
+        commit.directory.membership_ordinals.len(),
+    );
     for (change_id, ordinal) in &commit.directory.membership_ordinals {
-        hash_part(&mut hasher, change_id);
-        hash_part(&mut hasher, &ordinal.to_string());
+        hash_part(&mut hasher, "membership_ordinal");
+        hash_field(&mut hasher, "change_id", change_id);
+        hash_field(&mut hasher, "ordinal", &ordinal.to_string());
     }
     Ok(hasher.finalize().to_hex().to_string())
 }
@@ -639,28 +878,37 @@ fn checksum_commit(commit: &SegmentCommit) -> Result<String, LixError> {
 fn checksum_change(change: &SegmentChange) -> Result<String, LixError> {
     let mut hasher = blake3::Hasher::new();
     hash_part(&mut hasher, "change");
-    hash_part(&mut hasher, &change.id);
-    hash_part(
+    hash_field(&mut hasher, "id", &change.id);
+    hash_optional_str(
         &mut hasher,
-        change.authored_commit_id.as_deref().unwrap_or_default(),
+        "authored_commit_id",
+        change.authored_commit_id.as_deref(),
     );
-    hash_parts(
-        &mut hasher,
-        change.entity_id.parts.iter().map(String::as_str),
-    );
-    hash_part(&mut hasher, &change.schema_key);
-    hash_part(&mut hasher, change.file_id.as_deref().unwrap_or_default());
-    hash_optional_json_ref(&mut hasher, change.snapshot_ref.as_ref());
-    hash_optional_json_ref(&mut hasher, change.metadata_ref.as_ref());
-    hash_part(&mut hasher, &change.created_at);
-    for payload in &change.inline_payloads {
-        hash_json_ref(&mut hasher, &payload.json_ref);
-        hash_bytes_part(&mut hasher, &payload.bytes);
+    hash_list_len(&mut hasher, "entity_id", change.entity_id.parts.len());
+    for part in &change.entity_id.parts {
+        hash_field(&mut hasher, "entity_id_part", part);
     }
+    hash_field(&mut hasher, "schema_key", &change.schema_key);
+    hash_optional_str(&mut hasher, "file_id", change.file_id.as_deref());
+    hash_optional_json_ref(&mut hasher, "snapshot_ref", change.snapshot_ref.as_ref());
+    hash_optional_json_ref(&mut hasher, "metadata_ref", change.metadata_ref.as_ref());
+    hash_field(&mut hasher, "created_at", &change.created_at);
+    hash_list_len(&mut hasher, "inline_payloads", change.inline_payloads.len());
+    for payload in &change.inline_payloads {
+        hash_part(&mut hasher, "inline_payload");
+        hash_json_ref(&mut hasher, "json_ref", &payload.json_ref);
+        hash_bytes_field(&mut hasher, "bytes", &payload.bytes);
+    }
+    hash_list_len(
+        &mut hasher,
+        "directory_payloads",
+        change.directory.payloads.len(),
+    );
     for payload_location in &change.directory.payloads {
-        hash_json_ref(&mut hasher, &payload_location.json_ref);
-        hash_part(&mut hasher, &payload_location.offset.to_string());
-        hash_part(&mut hasher, &payload_location.len.to_string());
+        hash_part(&mut hasher, "payload_location");
+        hash_json_ref(&mut hasher, "json_ref", &payload_location.json_ref);
+        hash_field(&mut hasher, "offset", &payload_location.offset.to_string());
+        hash_field(&mut hasher, "len", &payload_location.len.to_string());
     }
     Ok(hasher.finalize().to_hex().to_string())
 }
@@ -670,10 +918,14 @@ fn hash_part(hasher: &mut blake3::Hasher, value: &str) {
     hasher.update(value.as_bytes());
 }
 
-fn hash_parts<'a>(hasher: &mut blake3::Hasher, values: impl Iterator<Item = &'a str>) {
-    for value in values {
-        hash_part(hasher, value);
-    }
+fn hash_field(hasher: &mut blake3::Hasher, field: &str, value: &str) {
+    hash_part(hasher, field);
+    hash_part(hasher, value);
+}
+
+fn hash_list_len(hasher: &mut blake3::Hasher, field: &str, len: usize) {
+    hash_part(hasher, field);
+    hasher.update(&(len as u64).to_le_bytes());
 }
 
 fn hash_bytes_part(hasher: &mut blake3::Hasher, value: &[u8]) {
@@ -681,21 +933,46 @@ fn hash_bytes_part(hasher: &mut blake3::Hasher, value: &[u8]) {
     hasher.update(value);
 }
 
-fn hash_optional_json_ref(hasher: &mut blake3::Hasher, value: Option<&crate::json_store::JsonRef>) {
+fn hash_bytes_field(hasher: &mut blake3::Hasher, field: &str, value: &[u8]) {
+    hash_part(hasher, field);
+    hash_bytes_part(hasher, value);
+}
+
+fn hash_optional_str(hasher: &mut blake3::Hasher, field: &str, value: Option<&str>) {
+    hash_part(hasher, field);
     match value {
         Some(value) => {
             hash_part(hasher, "some");
-            hash_json_ref(hasher, value);
+            hash_part(hasher, value);
         }
         None => hash_part(hasher, "none"),
     }
 }
 
-fn hash_json_ref(hasher: &mut blake3::Hasher, value: &crate::json_store::JsonRef) {
-    hash_bytes_part(hasher, value.as_hash_bytes());
+fn hash_optional_json_ref(
+    hasher: &mut blake3::Hasher,
+    field: &str,
+    value: Option<&crate::json_store::JsonRef>,
+) {
+    hash_part(hasher, field);
+    match value {
+        Some(value) => {
+            hash_part(hasher, "some");
+            hash_json_ref(hasher, "json_ref", value);
+        }
+        None => hash_part(hasher, "none"),
+    }
 }
 
-fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<(), LixError> {
+fn hash_json_ref(hasher: &mut blake3::Hasher, field: &str, value: &crate::json_store::JsonRef) {
+    hash_bytes_field(hasher, field, value.as_hash_bytes());
+}
+
+fn validate_commit_shape(
+    segment: &Segment,
+    commit: &SegmentCommit,
+    directory_commit_ids: &HashSet<&str>,
+) -> Result<(), LixError> {
     let membership_count = u32::try_from(commit.body.membership.len()).map_err(|_| {
         LixError::unknown(format!(
             "changelog commit '{}' has too many membership records",
@@ -710,6 +987,12 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
             commit.body.membership.len()
         )));
     }
+    let membership_ordinals_by_id = commit
+        .directory
+        .membership_ordinals
+        .iter()
+        .map(|(change_id, ordinal)| (change_id.as_str(), *ordinal))
+        .collect::<HashMap<_, _>>();
 
     let mut member_ids = HashSet::new();
     for (ordinal, membership) in commit.body.membership.iter().enumerate() {
@@ -746,11 +1029,8 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
                 commit.header.id, membership.member_change_id
             )));
         }
-        let Some((_, directory_ordinal)) = commit
-            .directory
-            .membership_ordinals
-            .iter()
-            .find(|(change_id, _)| change_id == &membership.member_change_id)
+        let Some(directory_ordinal) =
+            membership_ordinals_by_id.get(membership.member_change_id.as_str())
         else {
             return Err(LixError::unknown(format!(
                 "changelog commit '{}' is missing membership ordinal for change '{}'",
@@ -819,12 +1099,7 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
         )));
     }
 
-    if !segment
-        .directory
-        .commits
-        .iter()
-        .any(|(id, _)| id == &commit.header.id)
-    {
+    if !directory_commit_ids.contains(commit.header.id.as_str()) {
         return Err(LixError::unknown(format!(
             "changelog segment '{}' is missing directory location for commit '{}'",
             segment.header.segment_id, commit.header.id
@@ -835,23 +1110,30 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
 }
 
 fn validate_change_shape(change: &SegmentChange) -> Result<(), LixError> {
-    let mut inline_payload_refs = Vec::new();
+    let directory_payloads_by_ref = change
+        .directory
+        .payloads
+        .iter()
+        .map(|location| (location.json_ref.as_hash_bytes(), location))
+        .collect::<HashMap<_, _>>();
+    let mut inline_payload_refs = HashSet::with_capacity(change.inline_payloads.len());
     for (ordinal, payload) in change.inline_payloads.iter().enumerate() {
-        if inline_payload_refs
-            .iter()
-            .any(|json_ref| json_ref == &payload.json_ref)
-        {
+        if !inline_payload_refs.insert(payload.json_ref.as_hash_bytes()) {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' contains duplicate inline payload ref",
                 change.id
             )));
         }
-        inline_payload_refs.push(payload.json_ref.clone());
-        let Some(location) = change
-            .directory
-            .payloads
-            .iter()
-            .find(|location| location.json_ref == payload.json_ref)
+        let actual = crate::json_store::JsonRef::for_content(&payload.bytes);
+        if payload.json_ref != actual {
+            return Err(LixError::unknown(format!(
+                "changelog change '{}' inline payload ref '{}' does not match payload bytes '{}'",
+                change.id,
+                payload.json_ref.to_hex(),
+                actual.to_hex()
+            )));
+        }
+        let Some(location) = directory_payloads_by_ref.get(&payload.json_ref.as_hash_bytes())
         else {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' is missing payload directory entry",
@@ -866,22 +1148,15 @@ fn validate_change_shape(change: &SegmentChange) -> Result<(), LixError> {
         }
     }
 
-    let mut directory_payload_refs = Vec::new();
+    let mut directory_payload_refs = HashSet::with_capacity(change.directory.payloads.len());
     for location in &change.directory.payloads {
-        if directory_payload_refs
-            .iter()
-            .any(|json_ref| json_ref == &location.json_ref)
-        {
+        if !directory_payload_refs.insert(location.json_ref.as_hash_bytes()) {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' contains duplicate payload directory entry",
                 change.id
             )));
         }
-        directory_payload_refs.push(location.json_ref.clone());
-        if !inline_payload_refs
-            .iter()
-            .any(|json_ref| json_ref == &location.json_ref)
-        {
+        if !inline_payload_refs.contains(&location.json_ref.as_hash_bytes()) {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' payload directory references unknown inline payload",
                 change.id
@@ -924,6 +1199,86 @@ fn validate_directory_exact_cover<'a>(
         )));
     }
     Ok(())
+}
+
+fn validate_segment_cross_object_semantics(segment: &Segment) -> Result<(), LixError> {
+    let mut changes_by_id = HashMap::with_capacity(segment.changes.len());
+    for change in &segment.changes {
+        changes_by_id.insert(change.id.as_str(), change);
+    }
+
+    for commit in &segment.commits {
+        let memberships_by_id = commit
+            .body
+            .membership
+            .iter()
+            .map(|membership| (membership.member_change_id.as_str(), membership.role))
+            .collect::<HashMap<_, _>>();
+
+        for membership in &commit.body.membership {
+            match membership.role {
+                MembershipRole::Authored => {
+                    let Some(change) = changes_by_id.get(membership.member_change_id.as_str())
+                    else {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{}' authored membership references missing change '{}'",
+                            commit.header.id, membership.member_change_id
+                        )));
+                    };
+                    if change.authored_commit_id.as_deref() != Some(commit.header.id.as_str()) {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{}' authored membership change '{}' has mismatched authored_commit_id",
+                            commit.header.id, membership.member_change_id
+                        )));
+                    }
+                }
+                MembershipRole::Adopted => {
+                    if let Some(change) = changes_by_id.get(membership.member_change_id.as_str()) {
+                        if change.authored_commit_id.as_deref() == Some(commit.header.id.as_str()) {
+                            return Err(LixError::unknown(format!(
+                                "changelog commit '{}' adopted membership change '{}' must not be authored by the same commit",
+                                commit.header.id, membership.member_change_id
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
+        for (identity, change_id) in &commit.directory.state_row_identities {
+            let Some(change) = changes_by_id.get(change_id.as_str()) else {
+                if memberships_by_id.get(change_id.as_str()) == Some(&MembershipRole::Adopted) {
+                    continue;
+                }
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{}' StateRowIdentity winner references missing authored change '{}'",
+                    commit.header.id, change_id
+                )));
+            };
+            let actual = state_row_identity_for_change(change)?;
+            if &actual != identity {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{}' StateRowIdentity winner for change '{}' does not match changelog.change",
+                    commit.header.id, change_id
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn state_row_identity_for_change(change: &SegmentChange) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(change.schema_key.clone())?,
+        file_id: FileId::new(
+            change
+                .file_id
+                .clone()
+                .unwrap_or_else(|| "__global__".to_string()),
+        )?,
+        entity_id: EntityId::new(change.entity_id.as_json_array_text()?)?,
+    })
 }
 
 pub(super) fn validate_commit_location(
@@ -1150,7 +1505,7 @@ mod tests {
 
     #[test]
     fn validation_rejects_payload_directory_drift() {
-        let payload_ref = JsonRef::from_hash_bytes([11; 32]);
+        let payload_ref = JsonRef::for_content(b"payload");
         let mut segment = test_segment_with_inline_payload(payload_ref);
         segment.changes[0].directory.payloads[0].len = 999;
 
@@ -1161,6 +1516,76 @@ mod tests {
             error
                 .message
                 .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_inline_payload_ref_mismatch() {
+        let payload_ref = JsonRef::for_content(b"payload");
+        let mut segment = test_segment_with_inline_payload(payload_ref);
+        let bogus_ref = JsonRef::from_hash_bytes([9; 32]);
+        segment.changes[0].inline_payloads[0].json_ref = bogus_ref;
+        segment.changes[0].directory.payloads[0].json_ref = bogus_ref;
+
+        let error =
+            validate_segment_shape(&segment).expect_err("inline payload hash drift must fail");
+
+        assert!(
+            error.message.contains("does not match payload bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_authored_membership_commit_mismatch() {
+        let mut segment = test_segment();
+        segment.changes[0].authored_commit_id = Some("other-commit".to_string());
+
+        let error = validate_segment_shape(&segment)
+            .expect_err("authored membership ownership drift must fail");
+
+        assert!(
+            error.message.contains("mismatched authored_commit_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_adopted_membership_authored_by_same_commit() {
+        let mut segment = test_segment();
+        segment.commits[0]
+            .header
+            .parent_commit_ids
+            .push("parent-1".to_string());
+        segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+
+        let error = validate_segment_shape(&segment)
+            .expect_err("self-authored adopted membership must fail");
+
+        assert!(
+            error
+                .message
+                .contains("must not be authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_state_row_identity_change_mismatch() {
+        let mut segment = test_segment();
+        segment.commits[0].directory.state_row_identities[0]
+            .0
+            .schema_key = CanonicalSchemaKey::new("other").unwrap();
+
+        let error =
+            validate_segment_shape(&segment).expect_err("state-row identity drift must fail");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner for change 'change-1' does not match"),
             "unexpected error: {error}"
         );
     }
@@ -1260,7 +1685,12 @@ mod tests {
         super::super::types::StateRowIdentity {
             schema_key: CanonicalSchemaKey::new("message").unwrap(),
             file_id: FileId::new("file-1").unwrap(),
-            entity_id: EntityId::new("entity-1").unwrap(),
+            entity_id: EntityId::new(
+                EntityIdentity::single("entity-1")
+                    .as_json_array_text()
+                    .unwrap(),
+            )
+            .unwrap(),
         }
     }
 }

--- a/packages/engine/src/changelog/store.rs
+++ b/packages/engine/src/changelog/store.rs
@@ -187,8 +187,6 @@ pub(crate) trait ChangelogWriter {
 
     async fn collect_garbage(&mut self, roots: &[GcRoot]) -> Result<GcPlan, LixError>;
 
-    async fn stage_gc_sweep(&mut self, plan: &GcPlan) -> Result<(), LixError>;
-
     async fn rebuild_mandatory_indexes(&mut self) -> Result<RebuildIndexStats, LixError>;
 
     async fn rebuild_by_commit_index(&mut self) -> Result<RebuildIndexStats, LixError>;

--- a/packages/engine/src/changelog/test_support.rs
+++ b/packages/engine/src/changelog/test_support.rs
@@ -1,19 +1,20 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::context::ChangelogStorageRead;
 use super::segment::{canonicalize_segment, directory_change_location, directory_commit_location};
 use super::store::{
+    BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE, SEGMENT_SPACE,
     by_change_index_value, by_change_key, by_change_membership_index_value,
     by_change_membership_key, by_commit_index_value, by_commit_key, segment_key, segment_value,
-    BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE, SEGMENT_SPACE,
 };
 use super::{
-    decode_by_change_entry, decode_by_commit_entry, ByChangeEntry, ByCommitEntry, CommitBody,
-    CommitHeader, CommitVisibility, MembershipRecord, MembershipRole, Segment, SegmentChange,
-    SegmentChangeDirectory, SegmentCommit, SegmentCommitDirectory, SegmentDirectory, SegmentHeader,
-    SegmentObjectLocation, StateRowIdentity,
+    ByChangeEntry, ByCommitEntry, CommitBody, CommitHeader, CommitVisibility, MembershipRecord,
+    MembershipRole, Segment, SegmentChange, SegmentChangeDirectory, SegmentCommit,
+    SegmentCommitDirectory, SegmentDirectory, SegmentHeader, SegmentObjectLocation,
+    StateRowIdentity, decode_by_change_entry, decode_by_commit_entry,
 };
+use crate::LixError;
 use crate::changelog::ChangelogContext;
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::entity_identity::EntityIdentity;
@@ -21,7 +22,6 @@ use crate::storage::{
     InMemoryStorageBackend, PointReadPlan, StorageContext, StorageGetOptions, StorageKey,
     StorageProjectedValue, StorageReadOptions, StorageSpace, StorageWriteSet,
 };
-use crate::LixError;
 
 pub(crate) fn changelog_test_context() -> (ChangelogContext, StorageContext) {
     (

--- a/packages/engine/src/changelog/truth.rs
+++ b/packages/engine/src/changelog/truth.rs
@@ -1,0 +1,160 @@
+use std::collections::{HashMap, HashSet};
+
+use super::context::ChangelogStorageRead;
+use super::segment::{
+    directory_change_location, directory_commit_location, validate_change_checksum,
+    validate_commit_checksum, validate_segment_shape,
+};
+use super::store::SEGMENT_SPACE;
+use super::types::{SegmentChange, SegmentCommit, SegmentObjectLocation};
+use crate::LixError;
+use crate::changelog::decode_segment;
+use crate::storage::StorageCoreProjection;
+
+pub(super) struct SegmentTruthIndex {
+    pub(super) segment_ids: Vec<String>,
+    pub(super) commits: HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    pub(super) changes: HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+}
+
+pub(super) struct RetainedPrimaryClosure {
+    pub(super) segments: HashSet<String>,
+    pub(super) commits: HashSet<String>,
+    pub(super) changes: HashSet<String>,
+}
+
+pub(super) fn compute_retained_primary_closure(
+    truth: &SegmentTruthIndex,
+    mut segments: HashSet<String>,
+) -> Result<RetainedPrimaryClosure, LixError> {
+    let mut commits = HashSet::new();
+    let mut changes = HashSet::new();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (commit_id, (location, commit)) in &truth.commits {
+            if !segments.contains(&location.segment_id) {
+                continue;
+            }
+            commits.insert(commit_id.clone());
+            for parent_id in &commit.header.parent_commit_ids {
+                let Some((parent_location, _)) = truth.commits.get(parent_id) else {
+                    return Err(LixError::unknown(format!(
+                        "changelog retained commit '{commit_id}' references missing parent commit '{parent_id}'"
+                    )));
+                };
+                if segments.insert(parent_location.segment_id.clone()) {
+                    changed = true;
+                }
+            }
+            for membership in &commit.body.membership {
+                let Some((change_location, _)) = truth.changes.get(&membership.member_change_id)
+                else {
+                    return Err(LixError::unknown(format!(
+                        "changelog retained commit '{commit_id}' references missing change '{}'",
+                        membership.member_change_id
+                    )));
+                };
+                if segments.insert(change_location.segment_id.clone()) {
+                    changed = true;
+                }
+            }
+        }
+        for (change_id, (location, _)) in &truth.changes {
+            if segments.contains(&location.segment_id) {
+                changes.insert(change_id.clone());
+            }
+        }
+    }
+    Ok(RetainedPrimaryClosure {
+        segments,
+        commits,
+        changes,
+    })
+}
+
+pub(super) async fn load_segment_truth_index<S>(
+    store: &mut S,
+) -> Result<SegmentTruthIndex, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut after = None;
+    let mut segment_ids = Vec::new();
+    let mut commits = HashMap::new();
+    let mut changes = HashMap::new();
+    loop {
+        let page = store
+            .changelog_scan(
+                SEGMENT_SPACE,
+                Vec::new(),
+                after,
+                64,
+                StorageCoreProjection::FullValue,
+            )
+            .await?;
+        for index in 0..page.len() {
+            let Some(key) = page.key(index) else {
+                continue;
+            };
+            let segment_id = std::str::from_utf8(key)
+                .map_err(|error| {
+                    LixError::unknown(format!(
+                        "changelog found invalid UTF-8 segment key: {error}"
+                    ))
+                })?
+                .to_string();
+            let Some(bytes) = page.value(index) else {
+                return Err(LixError::unknown(format!(
+                    "changelog segment '{segment_id}' scan returned key without value"
+                )));
+            };
+            let segment = decode_segment(bytes)?;
+            validate_segment_shape(&segment)?;
+            if segment.header.segment_id != segment_id {
+                return Err(LixError::unknown(format!(
+                    "changelog segment key '{segment_id}' contains segment '{}'",
+                    segment.header.segment_id
+                )));
+            }
+            if !segment_ids.iter().any(|existing| existing == &segment_id) {
+                segment_ids.push(segment_id);
+            }
+            for commit in &segment.commits {
+                let location = directory_commit_location(&segment, &commit.header.id)?;
+                validate_commit_checksum(&location.checksum, &commit.header.id, commit)?;
+                if commits
+                    .insert(commit.header.id.clone(), (location, commit.clone()))
+                    .is_some()
+                {
+                    return Err(LixError::unknown(format!(
+                        "changelog found duplicate commit id '{}'",
+                        commit.header.id
+                    )));
+                }
+            }
+            for change in &segment.changes {
+                let location = directory_change_location(&segment, &change.id)?;
+                validate_change_checksum(&location.checksum, &change.id, change)?;
+                if changes
+                    .insert(change.id.clone(), (location, change.clone()))
+                    .is_some()
+                {
+                    return Err(LixError::unknown(format!(
+                        "changelog found duplicate change id '{}'",
+                        change.id
+                    )));
+                }
+            }
+        }
+        let Some(next_after) = page.resume_after else {
+            break;
+        };
+        after = Some(next_after);
+    }
+    Ok(SegmentTruthIndex {
+        segment_ids,
+        commits,
+        changes,
+    })
+}

--- a/packages/engine/src/changelog/truth.rs
+++ b/packages/engine/src/changelog/truth.rs
@@ -1,20 +1,125 @@
 use std::collections::{HashMap, HashSet};
 
-use super::context::ChangelogStorageRead;
+use super::context::{ChangelogScanPage, ChangelogStorageRead};
 use super::segment::{
     directory_change_location, directory_commit_location, validate_change_checksum,
     validate_commit_checksum, validate_segment_shape,
 };
-use super::store::SEGMENT_SPACE;
-use super::types::{SegmentChange, SegmentCommit, SegmentObjectLocation};
+use super::store::{
+    BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE,
+    COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
+};
+use super::types::{Segment, SegmentChange, SegmentCommit, SegmentObjectLocation};
 use crate::LixError;
 use crate::changelog::decode_segment;
-use crate::storage::StorageCoreProjection;
+use crate::storage::{StorageCoreProjection, StorageSpace};
 
 pub(super) struct SegmentTruthIndex {
     pub(super) segment_ids: Vec<String>,
+    pub(super) segments: Vec<SegmentTruthRecord>,
     pub(super) commits: HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
     pub(super) changes: HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+}
+
+pub(super) type SegmentTruthSnapshot = SegmentTruthIndex;
+
+pub(super) struct SegmentTruthRecord {
+    pub(super) segment_id: String,
+    pub(super) commit_ids: Vec<String>,
+    pub(super) change_ids: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SegmentTruthSource {
+    Stored,
+    Staged,
+}
+
+#[derive(Clone)]
+pub(super) struct SegmentCommitTruthEntry {
+    pub(super) source: SegmentTruthSource,
+    pub(super) location: SegmentObjectLocation,
+    pub(super) commit: SegmentCommit,
+}
+
+#[derive(Clone)]
+pub(super) struct SegmentChangeTruthEntry {
+    pub(super) source: SegmentTruthSource,
+    pub(super) location: SegmentObjectLocation,
+    pub(super) change: SegmentChange,
+}
+
+pub(super) struct SegmentTruthOverlay {
+    pub(super) segment_ids: HashSet<String>,
+    pub(super) commits: HashMap<String, SegmentCommitTruthEntry>,
+    pub(super) changes: HashMap<String, SegmentChangeTruthEntry>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ChangelogSpaceAuthority {
+    Primary,
+    Publication,
+    DerivedRepairable,
+}
+
+pub(super) fn changelog_space_authority(space: StorageSpace) -> Option<ChangelogSpaceAuthority> {
+    if space == SEGMENT_SPACE {
+        Some(ChangelogSpaceAuthority::Primary)
+    } else if space == COMMIT_VISIBILITY_SPACE {
+        Some(ChangelogSpaceAuthority::Publication)
+    } else if space == BY_COMMIT_INDEX_SPACE
+        || space == BY_CHANGE_INDEX_SPACE
+        || space == BY_CHANGE_MEMBERSHIP_INDEX_SPACE
+        || space == VISIBLE_CHANGE_PROOF_SPACE
+    {
+        Some(ChangelogSpaceAuthority::DerivedRepairable)
+    } else {
+        None
+    }
+}
+
+impl SegmentTruthSnapshot {
+    pub(super) fn commits_in_segment_order(
+        &self,
+    ) -> impl Iterator<Item = (&str, &SegmentObjectLocation, &SegmentCommit)> {
+        self.segments.iter().flat_map(|segment| {
+            segment.commit_ids.iter().map(|commit_id| {
+                let (location, commit) = self
+                    .commits
+                    .get(commit_id)
+                    .expect("segment truth record must reference known commit");
+                (commit_id.as_str(), location, commit)
+            })
+        })
+    }
+
+    pub(super) fn changes_in_segment_order(
+        &self,
+    ) -> impl Iterator<Item = (&str, &SegmentObjectLocation, &SegmentChange)> {
+        self.segments.iter().flat_map(|segment| {
+            segment.change_ids.iter().map(|change_id| {
+                let (location, change) = self
+                    .changes
+                    .get(change_id)
+                    .expect("segment truth record must reference known change");
+                (change_id.as_str(), location, change)
+            })
+        })
+    }
+}
+
+impl SegmentTruthOverlay {
+    pub(super) fn contains_segment(&self, segment_id: &str) -> bool {
+        self.segment_ids.contains(segment_id)
+    }
+
+    pub(super) fn commit(&self, commit_id: &str) -> Option<&SegmentCommitTruthEntry> {
+        self.commits.get(commit_id)
+    }
+
+    pub(super) fn change(&self, change_id: &str) -> Option<&SegmentChangeTruthEntry> {
+        self.changes.get(change_id)
+    }
 }
 
 pub(super) struct RetainedPrimaryClosure {
@@ -75,77 +180,55 @@ pub(super) fn compute_retained_primary_closure(
 
 pub(super) async fn load_segment_truth_index<S>(
     store: &mut S,
-) -> Result<SegmentTruthIndex, LixError>
+) -> Result<SegmentTruthSnapshot, LixError>
 where
     S: ChangelogStorageRead + ?Sized,
 {
     let mut after = None;
     let mut segment_ids = Vec::new();
+    let mut seen_segment_ids = HashSet::new();
+    let mut segments = Vec::new();
     let mut commits = HashMap::new();
     let mut changes = HashMap::new();
     loop {
-        let page = store
-            .changelog_scan(
-                SEGMENT_SPACE,
-                Vec::new(),
-                after,
-                64,
-                StorageCoreProjection::FullValue,
-            )
-            .await?;
+        let page = scan_segment_truth_page(store, after).await?;
         for index in 0..page.len() {
-            let Some(key) = page.key(index) else {
-                continue;
+            let (segment_id, segment) =
+                decode_validated_scanned_segment(page.key(index), page.value(index))?;
+            let mut record = SegmentTruthRecord {
+                segment_id: segment_id.clone(),
+                commit_ids: Vec::with_capacity(segment.commits.len()),
+                change_ids: Vec::with_capacity(segment.changes.len()),
             };
-            let segment_id = std::str::from_utf8(key)
-                .map_err(|error| {
-                    LixError::unknown(format!(
-                        "changelog found invalid UTF-8 segment key: {error}"
-                    ))
-                })?
-                .to_string();
-            let Some(bytes) = page.value(index) else {
+            if !seen_segment_ids.insert(segment_id.clone()) {
                 return Err(LixError::unknown(format!(
-                    "changelog segment '{segment_id}' scan returned key without value"
-                )));
-            };
-            let segment = decode_segment(bytes)?;
-            validate_segment_shape(&segment)?;
-            if segment.header.segment_id != segment_id {
-                return Err(LixError::unknown(format!(
-                    "changelog segment key '{segment_id}' contains segment '{}'",
-                    segment.header.segment_id
+                    "changelog found duplicate segment id '{segment_id}'"
                 )));
             }
-            if !segment_ids.iter().any(|existing| existing == &segment_id) {
-                segment_ids.push(segment_id);
-            }
-            for commit in &segment.commits {
-                let location = directory_commit_location(&segment, &commit.header.id)?;
-                validate_commit_checksum(&location.checksum, &commit.header.id, commit)?;
+            segment_ids.push(segment_id.clone());
+            for (commit_id, location, commit) in validated_segment_commit_entries(&segment)? {
+                record.commit_ids.push(commit_id.to_string());
                 if commits
-                    .insert(commit.header.id.clone(), (location, commit.clone()))
+                    .insert(commit_id.to_string(), (location, commit.clone()))
                     .is_some()
                 {
                     return Err(LixError::unknown(format!(
-                        "changelog found duplicate commit id '{}'",
-                        commit.header.id
+                        "changelog found duplicate commit id '{commit_id}'"
                     )));
                 }
             }
-            for change in &segment.changes {
-                let location = directory_change_location(&segment, &change.id)?;
-                validate_change_checksum(&location.checksum, &change.id, change)?;
+            for (change_id, location, change) in validated_segment_change_entries(&segment)? {
+                record.change_ids.push(change_id.to_string());
                 if changes
-                    .insert(change.id.clone(), (location, change.clone()))
+                    .insert(change_id.to_string(), (location, change.clone()))
                     .is_some()
                 {
                     return Err(LixError::unknown(format!(
-                        "changelog found duplicate change id '{}'",
-                        change.id
+                        "changelog found duplicate change id '{change_id}'"
                     )));
                 }
             }
+            segments.push(record);
         }
         let Some(next_after) = page.resume_after else {
             break;
@@ -154,7 +237,302 @@ where
     }
     Ok(SegmentTruthIndex {
         segment_ids,
+        segments,
         commits,
         changes,
     })
+}
+
+pub(super) async fn find_commit_by_exhaustive_segment_scan<S>(
+    store: &mut S,
+    commit_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentCommit)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut results =
+        find_commits_by_exhaustive_segment_scan(store, std::slice::from_ref(&commit_id)).await?;
+    Ok(results.remove(commit_id))
+}
+
+pub(super) async fn find_change_by_exhaustive_segment_scan<S>(
+    store: &mut S,
+    change_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut results =
+        find_changes_by_exhaustive_segment_scan(store, std::slice::from_ref(&change_id)).await?;
+    Ok(results.remove(change_id))
+}
+
+pub(super) async fn find_segment_by_exhaustive_segment_scan<S>(
+    store: &mut S,
+    segment_id: &str,
+) -> Result<Option<Segment>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut found = None::<Segment>;
+    scan_segment_truth(store, |loaded_segment_id, segment| {
+        if loaded_segment_id != segment_id {
+            return Ok(());
+        }
+        if found.is_some() {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' appears multiple times"
+            )));
+        }
+        found = Some(segment.clone());
+        Ok(())
+    })
+    .await?;
+    Ok(found)
+}
+
+pub(super) async fn find_commits_by_exhaustive_segment_scan<S>(
+    store: &mut S,
+    commit_ids: &[&str],
+) -> Result<HashMap<String, (SegmentObjectLocation, SegmentCommit)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let requested = commit_ids.iter().copied().collect::<HashSet<_>>();
+    let mut found = HashMap::<String, (SegmentObjectLocation, SegmentCommit)>::new();
+    scan_segment_truth(store, |_, segment| {
+        for (commit_id, location, commit) in validated_segment_commit_entries(segment)? {
+            if !requested.contains(commit_id) {
+                continue;
+            }
+            if let Some((existing, _)) =
+                found.insert(commit_id.to_string(), (location.clone(), commit.clone()))
+            {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' appears in multiple segments: '{}' and '{}'",
+                    existing.segment_id, location.segment_id
+                )));
+            }
+        }
+        Ok(())
+    })
+    .await?;
+    Ok(found)
+}
+
+pub(super) async fn find_changes_by_exhaustive_segment_scan<S>(
+    store: &mut S,
+    change_ids: &[&str],
+) -> Result<HashMap<String, (SegmentObjectLocation, SegmentChange)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let requested = change_ids.iter().copied().collect::<HashSet<_>>();
+    let mut found = HashMap::<String, (SegmentObjectLocation, SegmentChange)>::new();
+    scan_segment_truth(store, |_, segment| {
+        for (change_id, location, change) in validated_segment_change_entries(segment)? {
+            if !requested.contains(change_id) {
+                continue;
+            }
+            if let Some((existing, _)) =
+                found.insert(change_id.to_string(), (location.clone(), change.clone()))
+            {
+                return Err(LixError::unknown(format!(
+                    "changelog change '{change_id}' appears in multiple segments: '{}' and '{}'",
+                    existing.segment_id, location.segment_id
+                )));
+            }
+        }
+        return Ok(());
+    })
+    .await?;
+    Ok(found)
+}
+
+pub(super) fn build_segment_truth_overlay<'a>(
+    stored: &SegmentTruthSnapshot,
+    staged: impl IntoIterator<Item = &'a Segment>,
+) -> Result<SegmentTruthOverlay, LixError> {
+    let mut segment_ids = stored.segment_ids.iter().cloned().collect::<HashSet<_>>();
+    let mut commits = stored
+        .commits
+        .iter()
+        .map(|(id, (location, commit))| {
+            (
+                id.clone(),
+                SegmentCommitTruthEntry {
+                    source: SegmentTruthSource::Stored,
+                    location: location.clone(),
+                    commit: commit.clone(),
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let mut changes = stored
+        .changes
+        .iter()
+        .map(|(id, (location, change))| {
+            (
+                id.clone(),
+                SegmentChangeTruthEntry {
+                    source: SegmentTruthSource::Stored,
+                    location: location.clone(),
+                    change: change.clone(),
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    for segment in staged {
+        validate_segment_shape(segment)?;
+        if !segment_ids.insert(segment.header.segment_id.clone()) {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' already exists",
+                segment.header.segment_id
+            )));
+        }
+        for (commit_id, location, commit) in validated_segment_commit_entries(segment)? {
+            if commits
+                .insert(
+                    commit_id.to_string(),
+                    SegmentCommitTruthEntry {
+                        source: SegmentTruthSource::Staged,
+                        location,
+                        commit: commit.clone(),
+                    },
+                )
+                .is_some()
+            {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' already exists in another segment"
+                )));
+            }
+        }
+        for (change_id, location, change) in validated_segment_change_entries(segment)? {
+            if changes
+                .insert(
+                    change_id.to_string(),
+                    SegmentChangeTruthEntry {
+                        source: SegmentTruthSource::Staged,
+                        location,
+                        change: change.clone(),
+                    },
+                )
+                .is_some()
+            {
+                return Err(LixError::unknown(format!(
+                    "changelog change '{change_id}' already exists in another segment"
+                )));
+            }
+        }
+    }
+
+    Ok(SegmentTruthOverlay {
+        segment_ids,
+        commits,
+        changes,
+    })
+}
+
+async fn scan_segment_truth<S>(
+    store: &mut S,
+    mut visit: impl FnMut(&str, &Segment) -> Result<(), LixError>,
+) -> Result<(), LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut after = None;
+    loop {
+        let page = scan_segment_truth_page(store, after).await?;
+        for index in 0..page.len() {
+            let (_, segment) =
+                decode_validated_scanned_segment(page.key(index), page.value(index))?;
+            visit(&segment.header.segment_id, &segment)?;
+        }
+        let Some(next_after) = page.resume_after else {
+            break;
+        };
+        after = Some(next_after);
+    }
+    Ok(())
+}
+
+async fn scan_segment_truth_page<S>(
+    store: &mut S,
+    after: Option<Vec<u8>>,
+) -> Result<ChangelogScanPage, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    store
+        .changelog_scan(
+            SEGMENT_SPACE,
+            Vec::new(),
+            after,
+            64,
+            StorageCoreProjection::FullValue,
+        )
+        .await
+}
+
+fn decode_validated_scanned_segment(
+    key: Option<&[u8]>,
+    value: Option<&[u8]>,
+) -> Result<(String, Segment), LixError> {
+    let Some(key) = key else {
+        return Err(LixError::unknown(
+            "changelog segment scan returned row without key",
+        ));
+    };
+    let segment_id = std::str::from_utf8(key)
+        .map_err(|error| {
+            LixError::unknown(format!(
+                "changelog found invalid UTF-8 segment key: {error}"
+            ))
+        })?
+        .to_string();
+    let Some(bytes) = value else {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{segment_id}' scan returned key without value"
+        )));
+    };
+    let segment = decode_segment(bytes)?;
+    validate_segment_shape(&segment)?;
+    if segment.header.segment_id != segment_id {
+        return Err(LixError::unknown(format!(
+            "changelog segment key '{segment_id}' contains segment '{}'",
+            segment.header.segment_id
+        )));
+    }
+    Ok((segment_id, segment))
+}
+
+fn validated_segment_commit_entries(
+    segment: &Segment,
+) -> Result<Vec<(&str, SegmentObjectLocation, &SegmentCommit)>, LixError> {
+    segment
+        .commits
+        .iter()
+        .map(|commit| {
+            let commit_id = commit.header.id.as_str();
+            let location = directory_commit_location(segment, commit_id)?;
+            validate_commit_checksum(&location.checksum, commit_id, commit)?;
+            Ok((commit_id, location, commit))
+        })
+        .collect()
+}
+
+fn validated_segment_change_entries(
+    segment: &Segment,
+) -> Result<Vec<(&str, SegmentObjectLocation, &SegmentChange)>, LixError> {
+    segment
+        .changes
+        .iter()
+        .map(|change| {
+            let change_id = change.id.as_str();
+            let location = directory_change_location(segment, change_id)?;
+            validate_change_checksum(&location.checksum, change_id, change)?;
+            Ok((change_id, location, change))
+        })
+        .collect()
 }

--- a/packages/engine/src/changelog/truth.rs
+++ b/packages/engine/src/changelog/truth.rs
@@ -353,7 +353,7 @@ pub(super) fn build_segment_truth_overlay<'a>(
     stored: &SegmentTruthSnapshot,
     staged: impl IntoIterator<Item = &'a Segment>,
 ) -> Result<SegmentTruthOverlay, LixError> {
-    let mut segment_ids = stored.segment_ids.iter().cloned().collect::<HashSet<_>>();
+    let mut id_set = SegmentTruthIdSet::from_stored(stored);
     let mut commits = stored
         .commits
         .iter()
@@ -384,54 +384,96 @@ pub(super) fn build_segment_truth_overlay<'a>(
         .collect::<HashMap<_, _>>();
 
     for segment in staged {
-        validate_segment_shape(segment)?;
-        if !segment_ids.insert(segment.header.segment_id.clone()) {
-            return Err(LixError::unknown(format!(
-                "changelog segment '{}' already exists",
-                segment.header.segment_id
-            )));
-        }
-        for (commit_id, location, commit) in validated_segment_commit_entries(segment)? {
-            if commits
-                .insert(
+        validate_staged_truth_segment(
+            &mut id_set,
+            segment,
+            |commit_id, location, commit| {
+                commits.insert(
                     commit_id.to_string(),
                     SegmentCommitTruthEntry {
                         source: SegmentTruthSource::Staged,
                         location,
                         commit: commit.clone(),
                     },
-                )
-                .is_some()
-            {
-                return Err(LixError::unknown(format!(
-                    "changelog commit '{commit_id}' already exists in another segment"
-                )));
-            }
-        }
-        for (change_id, location, change) in validated_segment_change_entries(segment)? {
-            if changes
-                .insert(
+                );
+            },
+            |change_id, location, change| {
+                changes.insert(
                     change_id.to_string(),
                     SegmentChangeTruthEntry {
                         source: SegmentTruthSource::Staged,
                         location,
                         change: change.clone(),
                     },
-                )
-                .is_some()
-            {
-                return Err(LixError::unknown(format!(
-                    "changelog change '{change_id}' already exists in another segment"
-                )));
-            }
-        }
+                );
+            },
+        )?;
     }
 
     Ok(SegmentTruthOverlay {
-        segment_ids,
+        segment_ids: id_set.segment_ids,
         commits,
         changes,
     })
+}
+
+pub(super) fn validate_segment_truth_overlay<'a>(
+    stored: &SegmentTruthSnapshot,
+    staged: impl IntoIterator<Item = &'a Segment>,
+) -> Result<(), LixError> {
+    let mut id_set = SegmentTruthIdSet::from_stored(stored);
+    for segment in staged {
+        validate_staged_truth_segment(&mut id_set, segment, |_, _, _| {}, |_, _, _| {})?;
+    }
+    Ok(())
+}
+
+struct SegmentTruthIdSet {
+    segment_ids: HashSet<String>,
+    commit_ids: HashSet<String>,
+    change_ids: HashSet<String>,
+}
+
+impl SegmentTruthIdSet {
+    fn from_stored(stored: &SegmentTruthSnapshot) -> Self {
+        Self {
+            segment_ids: stored.segment_ids.iter().cloned().collect(),
+            commit_ids: stored.commits.keys().cloned().collect(),
+            change_ids: stored.changes.keys().cloned().collect(),
+        }
+    }
+}
+
+fn validate_staged_truth_segment(
+    id_set: &mut SegmentTruthIdSet,
+    segment: &Segment,
+    mut on_commit: impl FnMut(&str, SegmentObjectLocation, &SegmentCommit),
+    mut on_change: impl FnMut(&str, SegmentObjectLocation, &SegmentChange),
+) -> Result<(), LixError> {
+    validate_segment_shape(segment)?;
+    if !id_set.segment_ids.insert(segment.header.segment_id.clone()) {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{}' already exists",
+            segment.header.segment_id
+        )));
+    }
+    for (commit_id, location, commit) in validated_segment_commit_entries(segment)? {
+        if !id_set.commit_ids.insert(commit_id.to_string()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' already exists in another segment"
+            )));
+        }
+        on_commit(commit_id, location, commit);
+    }
+    for (change_id, location, change) in validated_segment_change_entries(segment)? {
+        if !id_set.change_ids.insert(change_id.to_string()) {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' already exists in another segment"
+            )));
+        }
+        on_change(change_id, location, change);
+    }
+    Ok(())
 }
 
 async fn scan_segment_truth<S>(

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -396,8 +396,17 @@ pub(crate) struct GcSweepSet {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct GcRepairSet {
+    pub(crate) by_commit: Vec<ByCommitEntry>,
+    pub(crate) by_change: Vec<ByChangeEntry>,
+    pub(crate) by_change_membership: Vec<(ChangeId, CommitId)>,
+    pub(crate) visible_change_proof: Vec<(ChangeId, CommitVisibility)>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct GcPlan {
     pub(crate) roots: Vec<GcRoot>,
     pub(crate) live: GcLiveSet,
     pub(crate) sweep: GcSweepSet,
+    pub(crate) repair: GcRepairSet,
 }


### PR DESCRIPTION
## Summary
- harden changelog segment decoding with count/min-record guards, canonical byte_count/checksum validation, directory/object locator order checks, and payload budget validation
- validate payload directories and inline JSON content hashes, plus membership role/source-parent semantics and semantic identity parity
- add targeted directory/selected-object validation paths for byte indexing while keeping commit/change checksum verification before returning locators or proofs
- tighten stage/publish/GC adopted provenance with per-parent facts, authored membership checks, and exact GC cleanup for rebuildable indexes/proofs
- make GC use key-only segment enumeration plus verified selected-object loads on the healthy path, while fully validating retained live segments

## Verification
- cargo fmt -p lix_engine
- git diff --check
- cargo check -p lix_engine --quiet
- cargo test -p lix_engine changelog:: --quiet
- final focused reviewer pass: clean after fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core changelog encoding/decoding and index rebuild logic; while changes are mostly additive validation, they can cause previously-accepted data to be rejected and affect GC/index rebuild behavior.
> 
> **Overview**
> **Changelog codec hardening:** segment decode/view paths now validate *format version*, header counts vs encoded vectors, directory/object order and byte ranges, payload budgets, and commit/change canonical checksums (including inline payload `JsonRef` matching content). This also adds a directory-only view (`view_segment_directory`) and an object-range reader (`view_segment_object_ranges`) that still enforce locator/checksum correctness.
> 
> **Index rebuild updates:** `by_commit_entries_for_segments` now rejects duplicate commit IDs, and new `*_for_truth` helpers in `by_change_index`, `by_change_membership_index`, and `by_commit_index` can rebuild entries directly from `SegmentTruthSnapshot` (including generation computation for truth-backed commits).
> 
> **Bench/test updates:** bench payloads now derive `JsonRef` from content, and the codec gains extensive new tests covering corruption/mismatch cases (counts, bounds, UTF-8, payload refs, membership semantics, and checksum mismatches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22a0db28f6ac5e875b24fed798ee62e9a258253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->