### PR TITLE
agent-1: validate changelog get-many cardinality

### DIFF
--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -152,7 +152,8 @@ async fn get_one(
         .into_iter()
         .next()
         .flatten()
-        .and_then(full_value))
+        .map(|value| full_value(space, value))
+        .transpose()?)
 }
 
 async fn scan_all_values(
@@ -177,12 +178,13 @@ async fn scan_all_values(
             },
         )?;
         resume_after = page.value.entries.last().map(|entry| entry.key.clone());
-        values.extend(
-            page.value
-                .entries
-                .into_iter()
-                .filter_map(|entry| full_value(entry.value)),
-        );
+        let page_values = page
+            .value
+            .entries
+            .into_iter()
+            .map(|entry| full_value(space, entry.value))
+            .collect::<Result<Vec<_>, LixError>>()?;
+        values.extend(page_values);
         if !page.value.has_more || resume_after.is_none() {
             break;
         }
@@ -339,8 +341,12 @@ fn point_values(
     Ok(result
         .value
         .into_iter()
-        .map(|value| value.and_then(full_value))
-        .collect())
+        .map(|value| {
+            value
+                .map(|value| full_value(space, value))
+                .transpose()
+        })
+        .collect::<Result<Vec<_>, LixError>>()?)
 }
 
 fn key(bytes: Vec<u8>) -> StorageKey {
@@ -353,10 +359,13 @@ fn value(bytes: Vec<u8>) -> StorageValue {
     }
 }
 
-fn full_value(value: StorageProjectedValue) -> Option<Vec<u8>> {
+fn full_value(space: StorageSpace, value: StorageProjectedValue) -> Result<Vec<u8>, LixError> {
     match value {
-        StorageProjectedValue::FullValue(bytes) => Some(bytes.to_vec()),
-        StorageProjectedValue::KeyOnly => None,
+        StorageProjectedValue::FullValue(bytes) => Ok(bytes.to_vec()),
+        StorageProjectedValue::KeyOnly => Err(LixError::unknown(format!(
+            "binary CAS read over namespace '{}' requested full value but storage returned key-only entry",
+            space.name
+        ))),
     }
 }
 
@@ -686,9 +695,118 @@ fn persisted_size_to_usize(size: u64, label: &str) -> Result<usize, LixError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{
+        BackendError, BackendRead, BufferedRangeScan, GetOptions, Key, KeyRange, PointVisitor,
+        ProjectedValue, ProjectedValueRef, ReadEntry, ScanOptions,
+    };
     use crate::binary_cas::BinaryCasContext;
     use crate::storage::StorageContext;
-    use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
+    use crate::storage::{
+        InMemoryStorageBackend, StorageReadOptions, StorageReadScope, StorageWriteOptions,
+    };
+
+    struct KeyOnlyPointRead;
+
+    impl BackendRead for KeyOnlyPointRead {
+        type RangeScan<'cursor> = BufferedRangeScan;
+
+        fn visit_keys<V>(
+            &self,
+            keys: &[Key],
+            _opts: GetOptions<'_>,
+            visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            for (index, key) in keys.iter().enumerate() {
+                visitor.visit(index, key, Some(ProjectedValueRef::KeyOnly))?;
+            }
+            Ok(())
+        }
+
+        fn with_range_scan<T, F>(
+            &self,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            _f: F,
+        ) -> Result<T, BackendError>
+        where
+            F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+        {
+            unreachable!("binary CAS point-read test does not scan")
+        }
+    }
+
+    struct KeyOnlyScanRead;
+
+    impl BackendRead for KeyOnlyScanRead {
+        type RangeScan<'cursor> = BufferedRangeScan;
+
+        fn visit_keys<V>(
+            &self,
+            _keys: &[Key],
+            _opts: GetOptions<'_>,
+            _visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            unreachable!("binary CAS scan test does not point read")
+        }
+
+        fn with_range_scan<T, F>(
+            &self,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            f: F,
+        ) -> Result<T, BackendError>
+        where
+            F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+        {
+            let key = BINARY_CAS_MANIFEST_CHUNK_SPACE
+                .encode_key(&Key(Bytes::from_static(b"manifest-chunk")));
+            let mut cursor = BufferedRangeScan::new(vec![ReadEntry {
+                key,
+                value: ProjectedValue::KeyOnly,
+            }]);
+            f(&mut cursor)
+        }
+    }
+
+    #[tokio::test]
+    async fn load_manifest_rejects_key_only_point_read() {
+        let read = StorageReadScope::new(KeyOnlyPointRead);
+        let blob_hash = BlobHash::from_content(b"blob");
+
+        let error = load_manifest(&read, blob_hash)
+            .await
+            .expect_err("key-only manifest point read must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_manifest_chunks_rejects_key_only_value() {
+        let read = StorageReadScope::new(KeyOnlyScanRead);
+        let blob_hash = BlobHash::from_content(b"blob");
+
+        let error = scan_manifest_chunks(&read, blob_hash)
+            .await
+            .expect_err("key-only manifest chunk scan must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
 
     #[tokio::test]
     async fn stores_manifest_chunks_in_scan_order() {

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -1718,14 +1718,20 @@ impl BenchPayloadShape {
     fn inline_payloads(self, index: usize) -> Vec<SegmentInlinePayload> {
         match self {
             Self::None | Self::ExternalRefsOnly => Vec::new(),
-            Self::SmallInline => vec![SegmentInlinePayload {
-                json_ref: json_ref(index, 1),
-                bytes: payload_bytes(index, 64),
-            }],
-            Self::LargeInline => vec![SegmentInlinePayload {
-                json_ref: json_ref(index, 1),
-                bytes: payload_bytes(index, 8 * 1024),
-            }],
+            Self::SmallInline => {
+                let bytes = payload_bytes(index, 64);
+                vec![SegmentInlinePayload {
+                    json_ref: JsonRef::for_content(&bytes),
+                    bytes,
+                }]
+            }
+            Self::LargeInline => {
+                let bytes = payload_bytes(index, 8 * 1024);
+                vec![SegmentInlinePayload {
+                    json_ref: JsonRef::for_content(&bytes),
+                    bytes,
+                }]
+            }
         }
     }
 }

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -8,11 +8,27 @@ use super::types::{
 use crate::common::{CanonicalSchemaKey, EntityId, FileId, LixError};
 use crate::entity_identity::EntityIdentity;
 use crate::json_store::JsonRef;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 
 const SEGMENT_MAGIC: &[u8; 5] = b"LXSG1";
 const COMMIT_VISIBILITY_MAGIC: &[u8; 5] = b"LXCV1";
 const BY_COMMIT_MAGIC: &[u8; 5] = b"LXBC1";
 const BY_CHANGE_MAGIC: &[u8; 5] = b"LXBG1";
+const SEGMENT_FORMAT_VERSION: u32 = 1;
+const MIN_STRING_BYTES: usize = 4;
+const MIN_LOCATION_BYTES: usize = MIN_STRING_BYTES + 8 + 8 + MIN_STRING_BYTES;
+const MIN_DIRECTORY_ENTRY_BYTES: usize = MIN_STRING_BYTES + MIN_LOCATION_BYTES;
+const MIN_MEMBERSHIP_RECORD_BYTES: usize = MIN_STRING_BYTES + 1 + 1;
+const MIN_STATE_ROW_IDENTITY_ENTRY_BYTES: usize =
+    MIN_STRING_BYTES + MIN_STRING_BYTES + MIN_STRING_BYTES + MIN_STRING_BYTES;
+const MIN_MEMBERSHIP_ORDINAL_BYTES: usize = MIN_STRING_BYTES + 4;
+const MIN_INLINE_PAYLOAD_BYTES: usize = 32 + 4;
+const MIN_PAYLOAD_LOCATION_BYTES: usize = 32 + 8 + 8;
+const MIN_COMMIT_OBJECT_BYTES: usize =
+    MIN_STRING_BYTES + 4 + MIN_STRING_BYTES + 4 + MIN_STRING_BYTES + 4 + MIN_STRING_BYTES;
+const MIN_CHANGE_OBJECT_BYTES: usize =
+    MIN_STRING_BYTES + 1 + 4 + MIN_STRING_BYTES + 1 + 1 + 1 + MIN_STRING_BYTES + 4 + 4;
 
 pub(crate) fn encode_segment(segment: &Segment) -> Result<Vec<u8>, LixError> {
     Ok(encode_segment_with_object_locations(segment)?.bytes)
@@ -73,26 +89,455 @@ pub(crate) fn decode_segment(bytes: &[u8]) -> Result<Segment, LixError> {
     let mut cursor = ByteCursor::new(bytes);
     cursor.expect_magic(SEGMENT_MAGIC, "segment")?;
     let header = cursor.read_segment_header("header")?;
-    let directory = cursor.read_segment_directory("directory")?;
+    let directory = cursor.read_segment_directory(
+        "directory",
+        header.commit_count as usize,
+        header.change_count as usize,
+    )?;
     let commit_len = cursor.read_len("commits")?;
     cursor.ensure_len_fits_remaining(commit_len, "commits")?;
+    cursor.ensure_counted_records_fit_remaining(commit_len, MIN_COMMIT_OBJECT_BYTES, "commits")?;
+    validate_count_matches_usize("commit_count", header.commit_count, commit_len, "commits")?;
     let mut commits = Vec::with_capacity(commit_len);
     for index in 0..commit_len {
         commits.push(cursor.read_segment_commit(&format!("commits[{index}]"))?);
     }
     let change_len = cursor.read_len("changes")?;
     cursor.ensure_len_fits_remaining(change_len, "changes")?;
+    cursor.ensure_counted_records_fit_remaining(change_len, MIN_CHANGE_OBJECT_BYTES, "changes")?;
+    validate_count_matches_usize("change_count", header.change_count, change_len, "changes")?;
     let mut changes = Vec::with_capacity(change_len);
+    let mut remaining_payload_count = header.payload_count as usize;
     for index in 0..change_len {
-        changes.push(cursor.read_segment_change(&format!("changes[{index}]"))?);
+        changes.push(cursor.read_segment_change(
+            &format!("changes[{index}]"),
+            Some(&mut remaining_payload_count),
+        )?);
     }
     cursor.expect_end("segment")?;
-    Ok(Segment {
+    validate_count_matches_usize(
+        "payload_count",
+        header.payload_count,
+        header.payload_count as usize - remaining_payload_count,
+        "inline payloads",
+    )?;
+    validate_segment_header_object_counts(
+        header.commit_count,
+        header.change_count,
+        header.payload_count,
+        commits.len(),
+        changes.as_slice(),
+    )?;
+    let commit_memberships = commits
+        .iter()
+        .map(|commit| {
+            commit
+                .body
+                .membership
+                .iter()
+                .map(|membership| CommitMembershipDescriptor {
+                    member_change_id: Cow::Owned(membership.member_change_id.clone()),
+                    role: membership.role,
+                    source_parent_ordinal: membership.source_parent_ordinal,
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    validate_segment_commit_state_row_identities(
+        commits
+            .iter()
+            .zip(commit_memberships.iter())
+            .map(|(commit, memberships)| {
+                (
+                    commit.header.id.as_str(),
+                    memberships.as_slice(),
+                    commit.directory.state_row_identities.as_slice(),
+                )
+            }),
+        changes.iter().map(|change| {
+            Ok((
+                change.id.as_str(),
+                ChangeValidationDescriptor {
+                    state_row_identity: state_row_identity_for_change(change)?,
+                    authored_commit_id: change.authored_commit_id.as_deref(),
+                },
+            ))
+        }),
+    )?;
+    let (commit_slices, change_slices) = read_segment_object_slices_view(bytes)?;
+    validate_segment_directory_object_slices_owned(
+        &header.segment_id,
+        &directory,
+        &commit_slices,
+        &change_slices,
+    )?;
+    let segment = Segment {
         header,
         directory,
         commits,
         changes,
-    })
+    };
+    Ok(segment)
+}
+
+fn validate_commit_checksum(commit: &SegmentCommit) -> Result<(), LixError> {
+    let canonical = checksum_commit(commit)?;
+    if commit.checksum != canonical {
+        return Err(LixError::unknown(format!(
+            "changelog commit '{}' checksum '{}' does not match canonical checksum '{}'",
+            commit.header.id, commit.checksum, canonical
+        )));
+    }
+    Ok(())
+}
+
+fn validate_segment_view_checksum(
+    bytes: &[u8],
+    header: &SegmentHeaderView<'_>,
+    directory_changes: &[SegmentDirectoryEntryRef<'_>],
+    commits: &[SegmentCommitSliceRead<'_>],
+    changes: &[SegmentChangeSliceRead<'_>],
+) -> Result<(), LixError> {
+    if header.byte_count != bytes.len() as u64 {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{}' byte_count {} does not match encoded length {}",
+            header.segment_id,
+            header.byte_count,
+            bytes.len()
+        )));
+    }
+    let change_checksums = changes
+        .iter()
+        .map(|change| (change.slice.id, change.checksum.as_str()))
+        .collect::<HashMap<_, _>>();
+    for entry in directory_changes {
+        let Some(canonical) = change_checksums.get(entry.id) else {
+            continue;
+        };
+        if entry.location.checksum != *canonical {
+            return Err(LixError::unknown(format!(
+                "changelog change '{}' locator checksum '{}' does not match canonical checksum '{}'",
+                entry.id, entry.location.checksum, canonical
+            )));
+        }
+    }
+    let canonical = checksum_segment_from_view(header, commits, changes)?;
+    if header.checksum != canonical {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{}' checksum '{}' does not match canonical checksum '{}'",
+            header.segment_id, header.checksum, canonical
+        )));
+    }
+    Ok(())
+}
+
+fn checksum_segment_from_view(
+    header: &SegmentHeaderView<'_>,
+    commits: &[SegmentCommitSliceRead<'_>],
+    changes: &[SegmentChangeSliceRead<'_>],
+) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "segment");
+    hash_field(&mut hasher, "segment_id", header.segment_id);
+    hash_field(
+        &mut hasher,
+        "format_version",
+        &header.format_version.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "commit_count",
+        &header.commit_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "change_count",
+        &header.change_count.to_string(),
+    );
+    hash_field(&mut hasher, "byte_count", &header.byte_count.to_string());
+    hash_field(
+        &mut hasher,
+        "payload_count",
+        &header.payload_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "commits", commits.len());
+    for commit in commits {
+        hash_part(&mut hasher, "commit");
+        hash_field(&mut hasher, "id", commit.slice.id);
+        hash_field(&mut hasher, "checksum", &commit.checksum);
+    }
+    hash_list_len(&mut hasher, "changes", changes.len());
+    for change in changes {
+        hash_part(&mut hasher, "change");
+        hash_field(&mut hasher, "id", change.slice.id);
+        hash_field(&mut hasher, "checksum", &change.checksum);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn checksum_segment(segment: &Segment) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "segment");
+    hash_field(&mut hasher, "segment_id", &segment.header.segment_id);
+    hash_field(
+        &mut hasher,
+        "format_version",
+        &segment.header.format_version.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "commit_count",
+        &segment.header.commit_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "change_count",
+        &segment.header.change_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "byte_count",
+        &segment.header.byte_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "payload_count",
+        &segment.header.payload_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "commits", segment.commits.len());
+    for commit in &segment.commits {
+        hash_part(&mut hasher, "commit");
+        hash_field(&mut hasher, "id", &commit.header.id);
+        hash_field(&mut hasher, "checksum", &commit.checksum);
+    }
+    hash_list_len(&mut hasher, "changes", segment.changes.len());
+    for change in &segment.changes {
+        hash_part(&mut hasher, "change");
+        hash_field(&mut hasher, "id", &change.id);
+        hash_field(&mut hasher, "checksum", &checksum_change(change)?);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn checksum_commit(commit: &SegmentCommit) -> Result<String, LixError> {
+    let memberships = commit
+        .body
+        .membership
+        .iter()
+        .map(|membership| CommitMembershipDescriptor {
+            member_change_id: Cow::Owned(membership.member_change_id.clone()),
+            role: membership.role,
+            source_parent_ordinal: membership.source_parent_ordinal,
+        })
+        .collect::<Vec<_>>();
+    checksum_commit_parts(
+        &commit.header.id,
+        commit.header.parent_commit_ids.iter().map(String::as_str),
+        &commit.header.derivable_change_id,
+        commit.header.author_account_ids.iter().map(String::as_str),
+        &commit.header.created_at,
+        commit.header.membership_count,
+        &memberships,
+        &commit.directory,
+    )
+}
+
+fn checksum_commit_parts<'a>(
+    id: &str,
+    parent_commit_ids: impl Iterator<Item = &'a str>,
+    derivable_change_id: &str,
+    author_account_ids: impl Iterator<Item = &'a str>,
+    created_at: &str,
+    membership_count: u32,
+    memberships: &[CommitMembershipDescriptor<'_>],
+    directory: &SegmentCommitDirectory,
+) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "commit");
+    hash_field(&mut hasher, "id", id);
+    let parent_commit_ids = parent_commit_ids.collect::<Vec<_>>();
+    hash_list_len(&mut hasher, "parent_commit_ids", parent_commit_ids.len());
+    for parent in parent_commit_ids {
+        hash_field(&mut hasher, "parent_commit_id", parent);
+    }
+    hash_field(&mut hasher, "derivable_change_id", derivable_change_id);
+    let author_account_ids = author_account_ids.collect::<Vec<_>>();
+    hash_list_len(&mut hasher, "author_account_ids", author_account_ids.len());
+    for account_id in author_account_ids {
+        hash_field(&mut hasher, "author_account_id", account_id);
+    }
+    hash_field(&mut hasher, "created_at", created_at);
+    hash_field(
+        &mut hasher,
+        "membership_count",
+        &membership_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "memberships", memberships.len());
+    for membership in memberships {
+        hash_part(&mut hasher, "membership");
+        hash_field(
+            &mut hasher,
+            "member_change_id",
+            &membership.member_change_id,
+        );
+        hash_field(
+            &mut hasher,
+            "role",
+            match membership.role {
+                MembershipRole::Authored => "authored",
+                MembershipRole::Adopted => "adopted",
+            },
+        );
+        hash_field(
+            &mut hasher,
+            "source_parent_ordinal",
+            &membership
+                .source_parent_ordinal
+                .map(|ordinal| ordinal.to_string())
+                .unwrap_or_default(),
+        );
+    }
+    hash_list_len(
+        &mut hasher,
+        "state_row_identities",
+        directory.state_row_identities.len(),
+    );
+    for (identity, change_id) in &directory.state_row_identities {
+        hash_part(&mut hasher, "state_row_identity");
+        hash_field(&mut hasher, "schema_key", identity.schema_key.as_str());
+        hash_field(&mut hasher, "file_id", identity.file_id.as_str());
+        hash_field(&mut hasher, "entity_id", identity.entity_id.as_str());
+        hash_field(&mut hasher, "change_id", change_id);
+    }
+    hash_list_len(
+        &mut hasher,
+        "membership_ordinals",
+        directory.membership_ordinals.len(),
+    );
+    for (change_id, ordinal) in &directory.membership_ordinals {
+        hash_part(&mut hasher, "membership_ordinal");
+        hash_field(&mut hasher, "change_id", change_id);
+        hash_field(&mut hasher, "ordinal", &ordinal.to_string());
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn checksum_change(change: &SegmentChange) -> Result<String, LixError> {
+    checksum_change_parts(
+        &change.id,
+        change.authored_commit_id.as_deref(),
+        &change.entity_id,
+        &change.schema_key,
+        change.file_id.as_deref(),
+        change.snapshot_ref.as_ref(),
+        change.metadata_ref.as_ref(),
+        &change.created_at,
+        &change
+            .inline_payloads
+            .iter()
+            .map(|payload| SegmentInlinePayloadRef {
+                json_ref: payload.json_ref.clone(),
+                bytes: payload.bytes.as_slice(),
+            })
+            .collect::<Vec<_>>(),
+        &change.directory,
+    )
+}
+
+fn checksum_change_parts(
+    id: &str,
+    authored_commit_id: Option<&str>,
+    entity_id: &EntityIdentity,
+    schema_key: &str,
+    file_id: Option<&str>,
+    snapshot_ref: Option<&JsonRef>,
+    metadata_ref: Option<&JsonRef>,
+    created_at: &str,
+    inline_payloads: &[SegmentInlinePayloadRef<'_>],
+    directory: &SegmentChangeDirectory,
+) -> Result<String, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, "change");
+    hash_field(&mut hasher, "id", id);
+    hash_optional_str(&mut hasher, "authored_commit_id", authored_commit_id);
+    hash_list_len(&mut hasher, "entity_id", entity_id.parts.len());
+    for part in &entity_id.parts {
+        hash_field(&mut hasher, "entity_id_part", part);
+    }
+    hash_field(&mut hasher, "schema_key", schema_key);
+    hash_optional_str(&mut hasher, "file_id", file_id);
+    hash_optional_json_ref(&mut hasher, "snapshot_ref", snapshot_ref);
+    hash_optional_json_ref(&mut hasher, "metadata_ref", metadata_ref);
+    hash_field(&mut hasher, "created_at", created_at);
+    hash_list_len(&mut hasher, "inline_payloads", inline_payloads.len());
+    for payload in inline_payloads {
+        hash_part(&mut hasher, "inline_payload");
+        hash_json_ref(&mut hasher, "json_ref", &payload.json_ref);
+        hash_bytes_field(&mut hasher, "bytes", payload.bytes);
+    }
+    hash_list_len(&mut hasher, "directory_payloads", directory.payloads.len());
+    for payload_location in &directory.payloads {
+        hash_part(&mut hasher, "payload_location");
+        hash_json_ref(&mut hasher, "json_ref", &payload_location.json_ref);
+        hash_field(&mut hasher, "offset", &payload_location.offset.to_string());
+        hash_field(&mut hasher, "len", &payload_location.len.to_string());
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn hash_part(hasher: &mut blake3::Hasher, value: &str) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn hash_field(hasher: &mut blake3::Hasher, field: &str, value: &str) {
+    hash_part(hasher, field);
+    hash_part(hasher, value);
+}
+
+fn hash_list_len(hasher: &mut blake3::Hasher, field: &str, len: usize) {
+    hash_part(hasher, field);
+    hasher.update(&(len as u64).to_le_bytes());
+}
+
+fn hash_bytes_part(hasher: &mut blake3::Hasher, value: &[u8]) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn hash_bytes_field(hasher: &mut blake3::Hasher, field: &str, value: &[u8]) {
+    hash_part(hasher, field);
+    hash_bytes_part(hasher, value);
+}
+
+fn hash_optional_str(hasher: &mut blake3::Hasher, field: &str, value: Option<&str>) {
+    hash_part(hasher, field);
+    match value {
+        Some(value) => {
+            hash_part(hasher, "some");
+            hash_part(hasher, value);
+        }
+        None => hash_part(hasher, "none"),
+    }
+}
+
+fn hash_optional_json_ref(hasher: &mut blake3::Hasher, field: &str, value: Option<&JsonRef>) {
+    hash_part(hasher, field);
+    match value {
+        Some(value) => {
+            hash_part(hasher, "some");
+            hash_json_ref(hasher, "json_ref", value);
+        }
+        None => hash_part(hasher, "none"),
+    }
+}
+
+fn hash_json_ref(hasher: &mut blake3::Hasher, field: &str, value: &JsonRef) {
+    hash_bytes_field(hasher, field, value.as_hash_bytes());
+}
+
+fn empty_checksum() -> String {
+    "0".repeat(64)
 }
 
 pub(crate) fn decode_segment_commit(bytes: &[u8]) -> Result<SegmentCommit, LixError> {
@@ -104,29 +549,159 @@ pub(crate) fn decode_segment_commit(bytes: &[u8]) -> Result<SegmentCommit, LixEr
 
 pub(crate) fn segment_commit_membership_contains_any(
     bytes: &[u8],
+    expected_commit_id: &str,
+    expected_checksum: &str,
     requested_change_ids: &std::collections::HashSet<String>,
 ) -> Result<Vec<String>, LixError> {
     let mut cursor = ByteCursor::new(bytes);
-    cursor.skip_commit_header_fast()?;
-    cursor.read_matching_membership_change_ids(requested_change_ids)
+    let id = cursor.read_string_ref_fast()?;
+    if id != expected_commit_id {
+        return Err(LixError::unknown(format!(
+            "changelog commit locator for '{expected_commit_id}' decoded commit '{id}'"
+        )));
+    }
+    let parent_commit_ids = cursor.read_strings_fast_refs()?;
+    let parent_count = parent_commit_ids.len();
+    let derivable_change_id = cursor.read_string_ref_fast()?;
+    let author_account_ids = cursor.read_strings_fast_refs()?;
+    let created_at = cursor.read_string_ref_fast()?;
+    let membership_count = cursor.read_u32_fast()? as usize;
+    let (matches, memberships) =
+        cursor.read_matching_membership_change_ids(membership_count, requested_change_ids)?;
+    let directory =
+        cursor.read_segment_commit_directory_fast_validated(id, parent_count, &memberships)?;
+    let checksum = cursor.read_string_ref_fast()?;
+    if checksum != expected_checksum {
+        return Err(LixError::unknown(format!(
+            "changelog commit '{id}' locator checksum '{expected_checksum}' does not match encoded checksum '{checksum}'"
+        )));
+    }
+    cursor.expect_end("commit")?;
+    let canonical = checksum_commit_parts(
+        id,
+        parent_commit_ids.iter().copied(),
+        derivable_change_id,
+        author_account_ids.iter().copied(),
+        created_at,
+        membership_count as u32,
+        &memberships,
+        &directory,
+    )?;
+    if checksum != canonical {
+        return Err(LixError::unknown(format!(
+            "changelog commit '{id}' checksum '{checksum}' does not match canonical checksum '{canonical}'"
+        )));
+    }
+    Ok(matches)
 }
 
 pub(crate) fn decode_segment_change(bytes: &[u8]) -> Result<SegmentChange, LixError> {
     let mut cursor = ByteCursor::new(bytes);
-    let change = cursor.read_segment_change("change")?;
+    let change = cursor.read_segment_change("change", None)?;
     cursor.expect_end("change")?;
+    state_row_identity_for_change(&change)?;
     Ok(change)
 }
 
 pub(crate) fn view_segment(bytes: &[u8]) -> Result<SegmentView<'_>, LixError> {
+    let cursor = read_segment_header_and_directory_view(bytes, false)?;
+    let header = cursor.header;
+    let directory_commits = cursor.directory_commits;
+    let directory_changes = cursor.directory_changes;
+    let mut object_cursor = cursor.cursor.clone();
+    let objects = read_segment_object_slices_for_header_fast(&mut object_cursor, &header)?;
+    let commit_slices = objects.commit_slices();
+    let change_slices = objects.change_slices();
+    validate_segment_directory_object_slices_ref(
+        header.segment_id,
+        &directory_commits,
+        &directory_changes,
+        &commit_slices,
+        &change_slices,
+    )?;
+    validate_segment_view_checksum(
+        bytes,
+        &header,
+        &directory_changes,
+        &objects.commits,
+        &objects.changes,
+    )?;
+    let object_bytes = cursor.cursor.remaining_bytes();
+
+    Ok(segment_view_from_parts(
+        bytes,
+        header,
+        directory_commits,
+        directory_changes,
+        object_bytes,
+    ))
+}
+
+pub(crate) fn view_segment_directory(bytes: &[u8]) -> Result<SegmentView<'_>, LixError> {
+    let cursor = read_segment_header_and_directory_view(bytes, true)?;
+    let object_bytes = cursor.cursor.remaining_bytes();
+
+    Ok(segment_view_from_parts(
+        bytes,
+        cursor.header,
+        cursor.directory_commits,
+        cursor.directory_changes,
+        object_bytes,
+    ))
+}
+
+struct SegmentDirectoryViewRead<'a> {
+    cursor: ByteCursor<'a>,
+    header: SegmentHeaderView<'a>,
+    directory_commits: Vec<SegmentDirectoryEntryRef<'a>>,
+    directory_changes: Vec<SegmentDirectoryEntryRef<'a>>,
+}
+
+fn read_segment_header_and_directory_view(
+    bytes: &[u8],
+    validate_encoded_bounds: bool,
+) -> Result<SegmentDirectoryViewRead<'_>, LixError> {
     let mut cursor = ByteCursor::new(bytes);
     cursor.expect_magic(SEGMENT_MAGIC, "segment")?;
     let header = cursor.read_segment_header_view_fast()?;
-    let directory_commits = cursor.read_segment_directory_commit_views_fast()?;
-    let directory_changes = cursor.read_segment_directory_change_views_fast()?;
-    let object_bytes = cursor.remaining_bytes();
+    let directory_commits =
+        cursor.read_segment_directory_commit_views_fast(header.commit_count as usize)?;
+    let directory_changes =
+        cursor.read_segment_directory_change_views_fast(header.change_count as usize)?;
+    if validate_encoded_bounds && header.byte_count != bytes.len() as u64 {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{}' byte_count {} does not match encoded length {}",
+            header.segment_id,
+            header.byte_count,
+            bytes.len()
+        )));
+    }
+    if validate_encoded_bounds {
+        validate_directory_locations_are_in_bounds(
+            header.segment_id,
+            bytes.len() as u64,
+            directory_commits
+                .iter()
+                .chain(directory_changes.iter())
+                .copied(),
+        )?;
+    }
+    Ok(SegmentDirectoryViewRead {
+        cursor,
+        header,
+        directory_commits,
+        directory_changes,
+    })
+}
 
-    Ok(SegmentView {
+fn segment_view_from_parts<'a>(
+    bytes: &'a [u8],
+    header: SegmentHeaderView<'a>,
+    directory_commits: Vec<SegmentDirectoryEntryRef<'a>>,
+    directory_changes: Vec<SegmentDirectoryEntryRef<'a>>,
+    object_bytes: &'a [u8],
+) -> SegmentView<'a> {
+    SegmentView {
         bytes,
         segment_id: header.segment_id,
         format_version: header.format_version,
@@ -138,20 +713,534 @@ pub(crate) fn view_segment(bytes: &[u8]) -> Result<SegmentView<'_>, LixError> {
         directory_commits,
         directory_changes,
         object_bytes,
-    })
+    }
+}
+
+fn validate_directory_locations_are_in_bounds<'a>(
+    segment_id: &str,
+    byte_count: u64,
+    entries: impl Iterator<Item = SegmentDirectoryEntryRef<'a>>,
+) -> Result<(), LixError> {
+    let mut seen = HashSet::new();
+    for entry in entries {
+        let location = entry.location;
+        if location.segment_id != segment_id {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' directory locator for '{}' points to segment '{}'",
+                entry.id, location.segment_id
+            )));
+        }
+        if !seen.insert(entry.id) {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' contains duplicate directory locator for '{}'",
+                entry.id
+            )));
+        }
+        let end = location.offset.checked_add(location.len).ok_or_else(|| {
+            LixError::unknown(format!(
+                "changelog segment '{segment_id}' directory locator for '{}' overflows",
+                entry.id
+            ))
+        })?;
+        if end > byte_count {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' directory locator for '{}' is outside segment byte range",
+                entry.id
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn view_segment_object_slices(
     bytes: &[u8],
 ) -> Result<(Vec<SegmentObjectSlice<'_>>, Vec<SegmentObjectSlice<'_>>), LixError> {
+    read_segment_object_slices_view(bytes)
+}
+
+pub(crate) fn view_segment_object_ranges(
+    bytes: &[u8],
+) -> Result<(Vec<SegmentObjectSlice<'_>>, Vec<SegmentObjectSlice<'_>>), LixError> {
+    let cursor = read_segment_header_and_directory_view(bytes, true)?;
+    let header = cursor.header;
+    let directory_commits = cursor.directory_commits;
+    let directory_changes = cursor.directory_changes;
+    let mut object_cursor = cursor.cursor.clone();
+
+    let commit_len = object_cursor.read_len("commits")?;
+    object_cursor.ensure_len_fits_remaining(commit_len, "commits")?;
+    object_cursor.ensure_counted_records_fit_remaining(
+        commit_len,
+        MIN_COMMIT_OBJECT_BYTES,
+        "commits",
+    )?;
+    validate_count_matches_usize("commit_count", header.commit_count, commit_len, "commits")?;
+    let mut commits = Vec::with_capacity(commit_len);
+    for index in 0..commit_len {
+        commits.push(object_cursor.read_segment_commit_slice(&format!("commits[{index}]"))?);
+    }
+
+    let change_len = object_cursor.read_len("changes")?;
+    object_cursor.ensure_len_fits_remaining(change_len, "changes")?;
+    object_cursor.ensure_counted_records_fit_remaining(
+        change_len,
+        MIN_CHANGE_OBJECT_BYTES,
+        "changes",
+    )?;
+    validate_count_matches_usize("change_count", header.change_count, change_len, "changes")?;
+    let mut changes = Vec::with_capacity(change_len);
+    for index in 0..change_len {
+        changes.push(object_cursor.read_segment_change_slice(&format!("changes[{index}]"))?);
+    }
+
+    object_cursor.expect_end("segment")?;
+    validate_segment_directory_object_slices_ref(
+        header.segment_id,
+        &directory_commits,
+        &directory_changes,
+        &commits,
+        &changes,
+    )?;
+    Ok((commits, changes))
+}
+
+fn read_segment_object_slices_view(
+    bytes: &[u8],
+) -> Result<(Vec<SegmentObjectSlice<'_>>, Vec<SegmentObjectSlice<'_>>), LixError> {
     let mut cursor = ByteCursor::new(bytes);
     cursor.expect_magic(SEGMENT_MAGIC, "segment")?;
-    let _ = cursor.read_segment_header_view_fast()?;
-    let _ = cursor.read_segment_directory_commit_views_fast()?;
-    let _ = cursor.read_segment_directory_change_views_fast()?;
+    let header = cursor.read_segment_header_view_fast()?;
+    let _directory_commits =
+        cursor.read_segment_directory_commit_views_fast(header.commit_count as usize)?;
+    let _directory_changes =
+        cursor.read_segment_directory_change_views_fast(header.change_count as usize)?;
 
+    let objects = read_segment_object_slices_for_header_fast(&mut cursor, &header)?;
+    let commits = objects.commit_slices();
+    let changes = objects.change_slices();
+    validate_segment_directory_object_slices_ref(
+        header.segment_id,
+        &_directory_commits,
+        &_directory_changes,
+        &commits,
+        &changes,
+    )?;
+    validate_segment_view_checksum(
+        bytes,
+        &header,
+        &_directory_changes,
+        &objects.commits,
+        &objects.changes,
+    )?;
+    Ok((commits, changes))
+}
+
+#[derive(Clone)]
+struct PayloadDescriptor {
+    json_ref: JsonRef,
+    len: u64,
+}
+
+struct SegmentInlinePayloadRef<'a> {
+    json_ref: JsonRef,
+    bytes: &'a [u8],
+}
+
+#[derive(Clone)]
+struct CommitMembershipDescriptor<'a> {
+    member_change_id: Cow<'a, str>,
+    role: MembershipRole,
+    source_parent_ordinal: Option<u32>,
+}
+
+struct SegmentCommitSliceRead<'a> {
+    slice: SegmentObjectSlice<'a>,
+    memberships: Vec<CommitMembershipDescriptor<'a>>,
+    state_row_identities: Vec<(StateRowIdentity, String)>,
+    checksum: String,
+}
+
+struct SegmentChangeSliceRead<'a> {
+    slice: SegmentObjectSlice<'a>,
+    state_row_identity: StateRowIdentity,
+    authored_commit_id: Option<&'a str>,
+    checksum: String,
+}
+
+struct SegmentObjectSliceRead<'a> {
+    commits: Vec<SegmentCommitSliceRead<'a>>,
+    changes: Vec<SegmentChangeSliceRead<'a>>,
+}
+
+impl<'a> SegmentObjectSliceRead<'a> {
+    fn commit_slices(&self) -> Vec<SegmentObjectSlice<'a>> {
+        self.commits.iter().map(|commit| commit.slice).collect()
+    }
+
+    fn change_slices(&self) -> Vec<SegmentObjectSlice<'a>> {
+        self.changes.iter().map(|change| change.slice).collect()
+    }
+}
+
+fn validate_segment_header_object_counts(
+    header_commit_count: u32,
+    header_change_count: u32,
+    header_payload_count: u32,
+    commit_count: usize,
+    changes: &[SegmentChange],
+) -> Result<(), LixError> {
+    validate_count_matches_usize("commit_count", header_commit_count, commit_count, "commits")?;
+    validate_count_matches_usize(
+        "change_count",
+        header_change_count,
+        changes.len(),
+        "changes",
+    )?;
+    let payload_count = changes.iter().try_fold(0_usize, |count, change| {
+        count
+            .checked_add(change.inline_payloads.len())
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "failed to decode changelog segment: inline payload count overflows",
+                )
+            })
+    })?;
+    validate_count_matches_usize(
+        "payload_count",
+        header_payload_count,
+        payload_count,
+        "inline payloads",
+    )
+}
+
+fn validate_change_payload_directory(
+    change_id: &str,
+    inline_payloads: &[SegmentInlinePayload],
+    directory: &SegmentChangeDirectory,
+) -> Result<(), LixError> {
+    validate_count_matches_usize(
+        "payload_count",
+        inline_payloads.len() as u32,
+        directory.payloads.len(),
+        "change directory payloads",
+    )?;
+    let inline_payloads = inline_payloads
+        .iter()
+        .map(|payload| PayloadDescriptor {
+            json_ref: payload.json_ref.clone(),
+            len: payload.bytes.len() as u64,
+        })
+        .collect::<Vec<_>>();
+    validate_payload_descriptors_against_directory(change_id, &inline_payloads, directory)
+}
+
+fn validate_payload_descriptors_against_directory(
+    change_id: &str,
+    inline_payloads: &[PayloadDescriptor],
+    directory: &SegmentChangeDirectory,
+) -> Result<(), LixError> {
+    let mut inline_by_ref = HashMap::with_capacity(inline_payloads.len());
+    for (ordinal, payload) in inline_payloads.iter().enumerate() {
+        if inline_by_ref
+            .insert(
+                payload.json_ref.as_hash_bytes(),
+                (ordinal as u64, payload.len),
+            )
+            .is_some()
+        {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' contains duplicate inline payload ref"
+            )));
+        }
+    }
+
+    let mut directory_payload_refs = HashSet::with_capacity(directory.payloads.len());
+    for location in &directory.payloads {
+        let json_ref = location.json_ref.as_hash_bytes();
+        if !directory_payload_refs.insert(json_ref) {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' contains duplicate payload directory entry"
+            )));
+        }
+        let Some((ordinal, len)) = inline_by_ref.get(&json_ref) else {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' payload directory references unknown inline payload"
+            )));
+        };
+        if location.offset != *ordinal || location.len != *len {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' payload directory entry does not match inline payload"
+            )));
+        }
+    }
+
+    if directory_payload_refs.len() != inline_by_ref.len() {
+        return Err(LixError::unknown(format!(
+            "changelog change '{change_id}' is missing payload directory entry"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_inline_payload_ref(
+    change_id: &str,
+    json_ref: &JsonRef,
+    bytes: &[u8],
+) -> Result<(), LixError> {
+    let actual = JsonRef::for_content(bytes);
+    if json_ref != &actual {
+        return Err(LixError::unknown(format!(
+            "changelog change '{change_id}' inline payload ref '{}' does not match payload bytes '{}'",
+            json_ref.to_hex(),
+            actual.to_hex()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_commit_object_consistency(
+    header: &CommitHeader,
+    body: &CommitBody,
+    directory: &SegmentCommitDirectory,
+) -> Result<(), LixError> {
+    let memberships = body
+        .membership
+        .iter()
+        .map(|membership| CommitMembershipDescriptor {
+            member_change_id: Cow::Owned(membership.member_change_id.clone()),
+            role: membership.role,
+            source_parent_ordinal: membership.source_parent_ordinal,
+        })
+        .collect::<Vec<_>>();
+    validate_commit_membership_descriptors(
+        &header.id,
+        header.parent_commit_ids.len(),
+        &memberships,
+    )?;
+    validate_commit_directory_descriptors(
+        &header.id,
+        &memberships,
+        directory
+            .state_row_identities
+            .iter()
+            .map(|(identity, change_id)| (identity, change_id.as_str())),
+        directory
+            .membership_ordinals
+            .iter()
+            .map(|(change_id, ordinal)| (change_id.as_str(), *ordinal)),
+    )
+}
+
+fn validate_commit_membership_descriptors(
+    commit_id: &str,
+    parent_count: usize,
+    memberships: &[CommitMembershipDescriptor<'_>],
+) -> Result<(), LixError> {
+    let mut member_ids = HashSet::with_capacity(memberships.len());
+    for membership in memberships {
+        match membership.role {
+            MembershipRole::Authored => {
+                if membership.source_parent_ordinal.is_some() {
+                    return Err(LixError::unknown(format!(
+                        "changelog commit '{commit_id}' authored membership change '{}' must not record a source_parent_ordinal",
+                        membership.member_change_id
+                    )));
+                }
+            }
+            MembershipRole::Adopted => {
+                let Some(source_parent_ordinal) = membership.source_parent_ordinal else {
+                    return Err(LixError::unknown(format!(
+                        "changelog commit '{commit_id}' adopted membership change '{}' is missing source_parent_ordinal",
+                        membership.member_change_id
+                    )));
+                };
+                if source_parent_ordinal as usize >= parent_count {
+                    return Err(LixError::unknown(format!(
+                        "changelog commit '{commit_id}' adopted membership change '{}' source_parent_ordinal {} is out of bounds for {} parents",
+                        membership.member_change_id, source_parent_ordinal, parent_count
+                    )));
+                }
+            }
+        }
+        if !member_ids.insert(membership.member_change_id.as_ref()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate membership change '{}'",
+                membership.member_change_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_commit_directory_descriptors<'a>(
+    commit_id: &str,
+    memberships: &[CommitMembershipDescriptor<'_>],
+    state_row_identities: impl Iterator<Item = (&'a StateRowIdentity, &'a str)>,
+    membership_ordinals: impl Iterator<Item = (&'a str, u32)>,
+) -> Result<(), LixError> {
+    let member_ids = memberships
+        .iter()
+        .map(|membership| membership.member_change_id.as_ref())
+        .collect::<HashSet<_>>();
+
+    let mut ordinal_ids = HashSet::with_capacity(memberships.len());
+    let membership_ordinals_by_id = memberships
+        .iter()
+        .enumerate()
+        .map(|(ordinal, membership)| (membership.member_change_id.as_ref(), ordinal))
+        .collect::<HashMap<_, _>>();
+    for (change_id, ordinal) in membership_ordinals {
+        if !ordinal_ids.insert(change_id) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate membership ordinal for change '{change_id}'"
+            )));
+        }
+        let Some(expected_ordinal) = membership_ordinals_by_id.get(change_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' membership ordinal references non-member change '{change_id}'"
+            )));
+        };
+        if ordinal as usize != *expected_ordinal {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' membership ordinal for change '{change_id}' is {ordinal}, expected {expected_ordinal}"
+            )));
+        }
+    }
+    for membership in memberships {
+        if !ordinal_ids.contains(membership.member_change_id.as_ref()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' is missing membership ordinal for change '{}'",
+                membership.member_change_id
+            )));
+        }
+    }
+
+    let mut identities = HashSet::new();
+    let mut directory_change_ids = HashSet::with_capacity(memberships.len());
+    for (identity, change_id) in state_row_identities {
+        if !identities.insert(identity) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate StateRowIdentity winner"
+            )));
+        }
+        if !directory_change_ids.insert(change_id) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' contains duplicate StateRowIdentity winner for change '{change_id}'"
+            )));
+        }
+        if !member_ids.contains(change_id) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' StateRowIdentity winner references non-member change '{change_id}'"
+            )));
+        }
+    }
+    for membership in memberships {
+        if !directory_change_ids.contains(membership.member_change_id.as_ref()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' membership change '{}' is missing from SegmentCommitDirectory",
+                membership.member_change_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_segment_commit_state_row_identities<'a>(
+    commits: impl Iterator<
+        Item = (
+            &'a str,
+            &'a [CommitMembershipDescriptor<'a>],
+            &'a [(StateRowIdentity, String)],
+        ),
+    >,
+    changes: impl Iterator<Item = Result<(&'a str, ChangeValidationDescriptor<'a>), LixError>>,
+) -> Result<(), LixError> {
+    let mut changes_by_id = HashMap::new();
+    for change in changes {
+        let (change_id, descriptor) = change?;
+        changes_by_id.insert(change_id, descriptor);
+    }
+    for (commit_id, memberships, state_row_identities) in commits {
+        let memberships_by_id = memberships
+            .iter()
+            .map(|membership| (membership.member_change_id.as_ref(), membership.role))
+            .collect::<HashMap<_, _>>();
+        for membership in memberships {
+            let Some(change) = changes_by_id.get(membership.member_change_id.as_ref()) else {
+                continue;
+            };
+            match membership.role {
+                MembershipRole::Authored => {
+                    if change.authored_commit_id != Some(commit_id) {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{commit_id}' authored membership change '{}' has mismatched authored_commit_id",
+                            membership.member_change_id
+                        )));
+                    }
+                }
+                MembershipRole::Adopted => {
+                    if change.authored_commit_id == Some(commit_id) {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{commit_id}' adopted membership change '{}' must not be authored by the same commit",
+                            membership.member_change_id
+                        )));
+                    }
+                }
+            }
+        }
+        for (identity, change_id) in state_row_identities {
+            let Some(change) = changes_by_id.get(change_id.as_str()) else {
+                if memberships_by_id.get(change_id.as_str()) == Some(&MembershipRole::Adopted) {
+                    continue;
+                }
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' StateRowIdentity winner references missing authored change '{change_id}'"
+                )));
+            };
+            if change.state_row_identity != *identity {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' StateRowIdentity winner for change '{change_id}' does not match changelog.change"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+struct ChangeValidationDescriptor<'a> {
+    state_row_identity: StateRowIdentity,
+    authored_commit_id: Option<&'a str>,
+}
+
+fn state_row_identity_for_change(change: &SegmentChange) -> Result<StateRowIdentity, LixError> {
+    state_row_identity_for_change_fields(
+        &change.schema_key,
+        change.file_id.as_deref(),
+        &change.entity_id,
+    )
+}
+
+fn state_row_identity_for_change_fields(
+    schema_key: &str,
+    file_id: Option<&str>,
+    entity_id: &EntityIdentity,
+) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(schema_key.to_string())?,
+        file_id: FileId::new(file_id.unwrap_or("__global__").to_string())?,
+        entity_id: EntityId::new(entity_id.as_json_array_text()?)?,
+    })
+}
+
+fn read_segment_object_slices_for_header_fast<'a>(
+    cursor: &mut ByteCursor<'a>,
+    header: &SegmentHeaderView<'_>,
+) -> Result<SegmentObjectSliceRead<'a>, LixError> {
     let commit_len = cursor.read_len_fast()?;
     cursor.ensure_len_fits_remaining_fast(commit_len)?;
+    cursor.ensure_counted_records_fit_remaining_fast(commit_len, MIN_COMMIT_OBJECT_BYTES)?;
+    validate_count_matches_usize("commit_count", header.commit_count, commit_len, "commits")?;
     let mut commits = Vec::with_capacity(commit_len);
     for _ in 0..commit_len {
         commits.push(cursor.read_segment_commit_slice_fast()?);
@@ -159,13 +1248,215 @@ pub(crate) fn view_segment_object_slices(
 
     let change_len = cursor.read_len_fast()?;
     cursor.ensure_len_fits_remaining_fast(change_len)?;
+    cursor.ensure_counted_records_fit_remaining_fast(change_len, MIN_CHANGE_OBJECT_BYTES)?;
+    validate_count_matches_usize("change_count", header.change_count, change_len, "changes")?;
     let mut changes = Vec::with_capacity(change_len);
+    let mut payload_count = 0_usize;
+    let mut remaining_payload_count = header.payload_count as usize;
     for _ in 0..change_len {
-        changes.push(cursor.read_segment_change_slice_fast()?);
+        let (change, change_payload_count) =
+            cursor.read_segment_change_slice_with_count_fast(Some(remaining_payload_count))?;
+        remaining_payload_count = remaining_payload_count
+            .checked_sub(change_payload_count)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "failed to decode changelog segment: inline payload count exceeds header payload_count",
+                )
+            })?;
+        payload_count = payload_count
+            .checked_add(change_payload_count)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "failed to decode changelog segment: inline payload count overflows",
+                )
+            })?;
+        changes.push(change);
     }
 
     cursor.expect_end("segment")?;
-    Ok((commits, changes))
+    validate_count_matches_usize(
+        "payload_count",
+        header.payload_count,
+        payload_count,
+        "inline payloads",
+    )?;
+    validate_segment_commit_state_row_identities(
+        commits.iter().map(|commit| {
+            (
+                commit.slice.id,
+                commit.memberships.as_slice(),
+                commit.state_row_identities.as_slice(),
+            )
+        }),
+        changes.iter().map(|change| {
+            Ok((
+                change.slice.id,
+                ChangeValidationDescriptor {
+                    state_row_identity: change.state_row_identity.clone(),
+                    authored_commit_id: change.authored_commit_id,
+                },
+            ))
+        }),
+    )?;
+    Ok(SegmentObjectSliceRead { commits, changes })
+}
+
+fn validate_segment_directory_object_slices_owned(
+    segment_id: &str,
+    directory: &SegmentDirectory,
+    commit_slices: &[SegmentObjectSlice<'_>],
+    change_slices: &[SegmentObjectSlice<'_>],
+) -> Result<(), LixError> {
+    let commits = directory
+        .commits
+        .iter()
+        .map(|(id, location)| (id.as_str(), location.as_ref()));
+    let changes = directory
+        .changes
+        .iter()
+        .map(|(id, location)| (id.as_str(), location.as_ref()));
+    validate_segment_directory_object_slices(
+        segment_id,
+        commits,
+        changes,
+        commit_slices,
+        change_slices,
+    )
+}
+
+fn validate_segment_directory_object_slices_ref(
+    segment_id: &str,
+    directory_commits: &[SegmentDirectoryEntryRef<'_>],
+    directory_changes: &[SegmentDirectoryEntryRef<'_>],
+    commit_slices: &[SegmentObjectSlice<'_>],
+    change_slices: &[SegmentObjectSlice<'_>],
+) -> Result<(), LixError> {
+    validate_segment_directory_object_slices(
+        segment_id,
+        directory_commits
+            .iter()
+            .map(|entry| (entry.id, entry.location)),
+        directory_changes
+            .iter()
+            .map(|entry| (entry.id, entry.location)),
+        commit_slices,
+        change_slices,
+    )
+}
+
+fn validate_segment_directory_object_slices<'a>(
+    segment_id: &str,
+    directory_commits: impl Iterator<Item = (&'a str, SegmentObjectLocationRef<'a>)>,
+    directory_changes: impl Iterator<Item = (&'a str, SegmentObjectLocationRef<'a>)>,
+    commit_slices: &[SegmentObjectSlice<'_>],
+    change_slices: &[SegmentObjectSlice<'_>],
+) -> Result<(), LixError> {
+    validate_directory_entries_against_slices(
+        segment_id,
+        "commit",
+        directory_commits,
+        commit_slices,
+        true,
+    )?;
+    validate_directory_entries_against_slices(
+        segment_id,
+        "change",
+        directory_changes,
+        change_slices,
+        false,
+    )
+}
+
+fn validate_directory_entries_against_slices<'a>(
+    segment_id: &str,
+    kind: &str,
+    entries: impl Iterator<Item = (&'a str, SegmentObjectLocationRef<'a>)>,
+    slices: &[SegmentObjectSlice<'_>],
+    validate_encoded_checksum: bool,
+) -> Result<(), LixError> {
+    let mut seen = HashSet::with_capacity(slices.len());
+    let mut entry_count = 0_usize;
+    for (index, (id, location)) in entries.enumerate() {
+        entry_count += 1;
+        if location.segment_id != segment_id {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' {kind} '{id}' locator points to segment '{}'",
+                location.segment_id
+            )));
+        }
+        let Some(slice) = slices.get(index) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' contains extra {kind} directory entry '{id}'"
+            )));
+        };
+        if id != slice.id {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' {kind} directory order does not match encoded object order"
+            )));
+        }
+        if !seen.insert(id) {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{segment_id}' contains duplicate {kind} directory entry '{id}'"
+            )));
+        }
+        if location.offset != slice.offset || location.len != slice.len {
+            return Err(LixError::unknown(format!(
+                "changelog {kind} '{id}' locator offset/len does not match encoded byte range"
+            )));
+        }
+        if validate_encoded_checksum {
+            if let Some(encoded_checksum) = slice.encoded_checksum {
+                if location.checksum != encoded_checksum {
+                    return Err(LixError::unknown(format!(
+                        "changelog {kind} '{id}' locator checksum does not match encoded object checksum"
+                    )));
+                }
+            }
+        }
+    }
+    if entry_count != slices.len() {
+        return Err(LixError::unknown(format!(
+            "changelog segment '{segment_id}' {kind} directory count does not match encoded object count"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_segment_format_version(format_version: u32, field: &str) -> Result<(), LixError> {
+    if format_version != SEGMENT_FORMAT_VERSION {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "failed to decode changelog segment: {field} format_version {format_version} is not supported"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_count_matches_usize(
+    header_field: &str,
+    header_count: u32,
+    actual_count: usize,
+    actual_field: &str,
+) -> Result<(), LixError> {
+    let actual_count = u32::try_from(actual_count).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to decode changelog segment: {actual_field} count exceeds u32"),
+        )
+    })?;
+    if header_count != actual_count {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "failed to decode changelog segment: header {header_field} {header_count} does not match {actual_count} {actual_field}"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn encode_commit_visibility(visibility: &CommitVisibility) -> Result<Vec<u8>, LixError> {
@@ -516,6 +1807,7 @@ fn write_strings<'a>(
     Ok(())
 }
 
+#[derive(Clone)]
 struct ByteCursor<'a> {
     bytes: &'a [u8],
     offset: usize,
@@ -580,7 +1872,7 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn read_segment_header(&mut self, field: &str) -> Result<SegmentHeader, LixError> {
-        Ok(SegmentHeader {
+        let header = SegmentHeader {
             segment_id: self.read_string(&format!("{field}.segment_id"))?,
             format_version: self.read_u32(&format!("{field}.format_version"))?,
             commit_count: self.read_u32(&format!("{field}.commit_count"))?,
@@ -588,11 +1880,13 @@ impl<'a> ByteCursor<'a> {
             byte_count: self.read_u64(&format!("{field}.byte_count"))?,
             payload_count: self.read_u32(&format!("{field}.payload_count"))?,
             checksum: self.read_string(&format!("{field}.checksum"))?,
-        })
+        };
+        validate_segment_format_version(header.format_version, field)?;
+        Ok(header)
     }
 
     fn read_segment_header_view(&mut self, field: &str) -> Result<SegmentHeaderView<'a>, LixError> {
-        Ok(SegmentHeaderView {
+        let header = SegmentHeaderView {
             segment_id: self.read_string_ref(&format!("{field}.segment_id"))?,
             format_version: self.read_u32(&format!("{field}.format_version"))?,
             commit_count: self.read_u32(&format!("{field}.commit_count"))?,
@@ -600,11 +1894,13 @@ impl<'a> ByteCursor<'a> {
             byte_count: self.read_u64(&format!("{field}.byte_count"))?,
             payload_count: self.read_u32(&format!("{field}.payload_count"))?,
             checksum: self.read_string_ref(&format!("{field}.checksum"))?,
-        })
+        };
+        validate_segment_format_version(header.format_version, field)?;
+        Ok(header)
     }
 
     fn read_segment_header_view_fast(&mut self) -> Result<SegmentHeaderView<'a>, LixError> {
-        Ok(SegmentHeaderView {
+        let header = SegmentHeaderView {
             segment_id: self.read_string_ref_fast()?,
             format_version: self.read_u32_fast()?,
             commit_count: self.read_u32_fast()?,
@@ -612,12 +1908,30 @@ impl<'a> ByteCursor<'a> {
             byte_count: self.read_u64_fast()?,
             payload_count: self.read_u32_fast()?,
             checksum: self.read_string_ref_fast()?,
-        })
+        };
+        validate_segment_format_version(header.format_version, "header")?;
+        Ok(header)
     }
 
-    fn read_segment_directory(&mut self, field: &str) -> Result<SegmentDirectory, LixError> {
+    fn read_segment_directory(
+        &mut self,
+        field: &str,
+        expected_commit_count: usize,
+        expected_change_count: usize,
+    ) -> Result<SegmentDirectory, LixError> {
         let commit_len = self.read_len(&format!("{field}.commits"))?;
         self.ensure_len_fits_remaining(commit_len, &format!("{field}.commits"))?;
+        self.ensure_counted_records_fit_remaining(
+            commit_len,
+            MIN_DIRECTORY_ENTRY_BYTES,
+            &format!("{field}.commits"),
+        )?;
+        validate_count_matches_usize(
+            "commit_count",
+            expected_commit_count as u32,
+            commit_len,
+            "directory commits",
+        )?;
         let mut commits = Vec::with_capacity(commit_len);
         for index in 0..commit_len {
             let commit_id = self.read_string(&format!("{field}.commits[{index}].commit_id"))?;
@@ -627,6 +1941,17 @@ impl<'a> ByteCursor<'a> {
 
         let change_len = self.read_len(&format!("{field}.changes"))?;
         self.ensure_len_fits_remaining(change_len, &format!("{field}.changes"))?;
+        self.ensure_counted_records_fit_remaining(
+            change_len,
+            MIN_DIRECTORY_ENTRY_BYTES,
+            &format!("{field}.changes"),
+        )?;
+        validate_count_matches_usize(
+            "change_count",
+            expected_change_count as u32,
+            change_len,
+            "directory changes",
+        )?;
         let mut changes = Vec::with_capacity(change_len);
         for index in 0..change_len {
             let change_id = self.read_string(&format!("{field}.changes[{index}].change_id"))?;
@@ -643,6 +1968,7 @@ impl<'a> ByteCursor<'a> {
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_DIRECTORY_ENTRY_BYTES, field)?;
         let mut commits = Vec::with_capacity(len);
         for index in 0..len {
             let id = self.read_string_ref(&format!("{field}[{index}].commit_id"))?;
@@ -654,9 +1980,17 @@ impl<'a> ByteCursor<'a> {
 
     fn read_segment_directory_commit_views_fast(
         &mut self,
+        expected_len: usize,
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_DIRECTORY_ENTRY_BYTES)?;
+        validate_count_matches_usize(
+            "commit_count",
+            expected_len as u32,
+            len,
+            "directory commits",
+        )?;
         let mut commits = Vec::with_capacity(len);
         for _ in 0..len {
             let id = self.read_string_ref_fast()?;
@@ -672,6 +2006,7 @@ impl<'a> ByteCursor<'a> {
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_DIRECTORY_ENTRY_BYTES, field)?;
         let mut changes = Vec::with_capacity(len);
         for index in 0..len {
             let id = self.read_string_ref(&format!("{field}[{index}].change_id"))?;
@@ -683,9 +2018,17 @@ impl<'a> ByteCursor<'a> {
 
     fn read_segment_directory_change_views_fast(
         &mut self,
+        expected_len: usize,
     ) -> Result<Vec<SegmentDirectoryEntryRef<'a>>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_DIRECTORY_ENTRY_BYTES)?;
+        validate_count_matches_usize(
+            "change_count",
+            expected_len as u32,
+            len,
+            "directory changes",
+        )?;
         let mut changes = Vec::with_capacity(len);
         for _ in 0..len {
             let id = self.read_string_ref_fast()?;
@@ -696,12 +2039,19 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn read_segment_commit(&mut self, field: &str) -> Result<SegmentCommit, LixError> {
-        Ok(SegmentCommit {
-            header: self.read_commit_header(&format!("{field}.header"))?,
-            body: self.read_commit_body(&format!("{field}.body"))?,
-            directory: self.read_segment_commit_directory(&format!("{field}.directory"))?,
+        let header = self.read_commit_header(&format!("{field}.header"))?;
+        let body =
+            self.read_commit_body(&format!("{field}.body"), header.membership_count as usize)?;
+        let directory = self.read_segment_commit_directory(&format!("{field}.directory"))?;
+        validate_commit_object_consistency(&header, &body, &directory)?;
+        let commit = SegmentCommit {
+            header,
+            body,
+            directory,
             checksum: self.read_string(&format!("{field}.checksum"))?,
-        })
+        };
+        validate_commit_checksum(&commit)?;
+        Ok(commit)
     }
 
     fn read_segment_commit_slice(
@@ -714,8 +2064,8 @@ impl<'a> ByteCursor<'a> {
         self.skip_string(&format!("{field}.header.derivable_change_id"))?;
         self.skip_strings(&format!("{field}.header.author_account_ids"))?;
         self.skip_string(&format!("{field}.header.created_at"))?;
-        self.skip_u32(&format!("{field}.header.membership_count"))?;
-        self.skip_commit_body(&format!("{field}.body"))?;
+        let membership_count = self.read_u32(&format!("{field}.header.membership_count"))?;
+        self.skip_commit_body(&format!("{field}.body"), membership_count as usize)?;
         self.skip_segment_commit_directory(&format!("{field}.directory"))?;
         let checksum = self.read_string_ref(&format!("{field}.checksum"))?;
         let end = self.offset;
@@ -728,24 +2078,46 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
-    fn read_segment_commit_slice_fast(&mut self) -> Result<SegmentObjectSlice<'a>, LixError> {
+    fn read_segment_commit_slice_fast(&mut self) -> Result<SegmentCommitSliceRead<'a>, LixError> {
         let start = self.offset;
         let id = self.read_string_ref_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_u32_fast()?;
-        self.skip_commit_body_fast()?;
-        self.skip_segment_commit_directory_fast()?;
+        let parent_commit_ids = self.read_strings_fast_owned()?;
+        let parent_count = parent_commit_ids.len();
+        let derivable_change_id = self.read_string_ref_fast()?;
+        let author_account_ids = self.read_strings_fast_owned()?;
+        let created_at = self.read_string_ref_fast()?;
+        let membership_count = self.read_u32_fast()? as usize;
+        let memberships = self.read_commit_body_descriptors_fast(membership_count)?;
+        let directory =
+            self.read_segment_commit_directory_fast_validated(id, parent_count, &memberships)?;
         let checksum = self.read_string_ref_fast()?;
-        let end = self.offset;
-        Ok(SegmentObjectSlice {
+        let canonical = checksum_commit_parts(
             id,
-            offset: start as u64,
-            len: (end - start) as u64,
-            encoded_checksum: Some(checksum),
-            bytes: &self.bytes[start..end],
+            parent_commit_ids.iter().map(String::as_str),
+            derivable_change_id,
+            author_account_ids.iter().map(String::as_str),
+            created_at,
+            membership_count as u32,
+            &memberships,
+            &directory,
+        )?;
+        if checksum != canonical {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{id}' checksum '{checksum}' does not match canonical checksum '{canonical}'"
+            )));
+        }
+        let end = self.offset;
+        Ok(SegmentCommitSliceRead {
+            slice: SegmentObjectSlice {
+                id,
+                offset: start as u64,
+                len: (end - start) as u64,
+                encoded_checksum: Some(checksum),
+                bytes: &self.bytes[start..end],
+            },
+            memberships,
+            state_row_identities: directory.state_row_identities,
+            checksum: canonical,
         })
     }
 
@@ -760,23 +2132,67 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
-    fn skip_commit_header_fast(&mut self) -> Result<(), LixError> {
+    fn read_commit_header_fast(&mut self) -> Result<CommitHeaderView<'a>, LixError> {
+        let id = self.read_string_ref_fast()?;
+        let parent_count = self.read_strings_fast_owned()?.len();
         self.skip_string_fast()?;
-        self.skip_strings_fast()?;
+        self.read_strings_fast_owned()?;
         self.skip_string_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_u32_fast()
+        let membership_count = self.read_u32_fast()?;
+        Ok(CommitHeaderView {
+            id,
+            parent_count,
+            membership_count,
+        })
     }
 
-    fn read_commit_body(&mut self, field: &str) -> Result<CommitBody, LixError> {
+    fn read_commit_body(
+        &mut self,
+        field: &str,
+        expected_membership_count: usize,
+    ) -> Result<CommitBody, LixError> {
         let len = self.read_len(&format!("{field}.membership"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.membership"))?;
+        self.ensure_counted_records_fit_remaining(
+            len,
+            MIN_MEMBERSHIP_RECORD_BYTES,
+            &format!("{field}.membership"),
+        )?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
         let mut membership = Vec::with_capacity(len);
         for index in 0..len {
             membership.push(self.read_membership_record(&format!("{field}.membership[{index}]"))?);
         }
         Ok(CommitBody { membership })
+    }
+
+    fn read_commit_body_descriptors_fast(
+        &mut self,
+        expected_membership_count: usize,
+    ) -> Result<Vec<CommitMembershipDescriptor<'a>>, LixError> {
+        let len = self.read_len_fast()?;
+        self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_MEMBERSHIP_RECORD_BYTES)?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
+        let mut memberships = Vec::with_capacity(len);
+        for _ in 0..len {
+            memberships.push(CommitMembershipDescriptor {
+                member_change_id: Cow::Borrowed(self.read_string_ref_fast()?),
+                role: self.read_membership_role_fast()?,
+                source_parent_ordinal: self.read_optional_u32_fast()?,
+            });
+        }
+        Ok(memberships)
     }
 
     fn read_membership_record(&mut self, field: &str) -> Result<MembershipRecord, LixError> {
@@ -790,20 +2206,34 @@ impl<'a> ByteCursor<'a> {
 
     fn read_matching_membership_change_ids(
         &mut self,
+        expected_membership_count: usize,
         requested_change_ids: &std::collections::HashSet<String>,
-    ) -> Result<Vec<String>, LixError> {
+    ) -> Result<(Vec<String>, Vec<CommitMembershipDescriptor<'a>>), LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_MEMBERSHIP_RECORD_BYTES)?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
         let mut matches = Vec::new();
+        let mut memberships = Vec::with_capacity(len);
         for _ in 0..len {
             let member_change_id = self.read_string_ref_fast()?;
             if requested_change_ids.contains(member_change_id) {
                 matches.push(member_change_id.to_string());
             }
-            self.skip_u8_fast()?;
-            self.skip_optional_u32_fast()?;
+            let role = self.read_membership_role_fast()?;
+            let source_parent_ordinal = self.read_optional_u32_fast()?;
+            memberships.push(CommitMembershipDescriptor {
+                member_change_id: Cow::Borrowed(member_change_id),
+                role,
+                source_parent_ordinal,
+            });
         }
-        Ok(matches)
+        Ok((matches, memberships))
     }
 
     fn read_segment_commit_directory(
@@ -812,6 +2242,11 @@ impl<'a> ByteCursor<'a> {
     ) -> Result<SegmentCommitDirectory, LixError> {
         let identity_len = self.read_len(&format!("{field}.state_row_identities"))?;
         self.ensure_len_fits_remaining(identity_len, &format!("{field}.state_row_identities"))?;
+        self.ensure_counted_records_fit_remaining(
+            identity_len,
+            MIN_STATE_ROW_IDENTITY_ENTRY_BYTES,
+            &format!("{field}.state_row_identities"),
+        )?;
         let mut state_row_identities = Vec::with_capacity(identity_len);
         for index in 0..identity_len {
             let identity = self.read_state_row_identity(&format!(
@@ -824,6 +2259,11 @@ impl<'a> ByteCursor<'a> {
 
         let ordinal_len = self.read_len(&format!("{field}.membership_ordinals"))?;
         self.ensure_len_fits_remaining(ordinal_len, &format!("{field}.membership_ordinals"))?;
+        self.ensure_counted_records_fit_remaining(
+            ordinal_len,
+            MIN_MEMBERSHIP_ORDINAL_BYTES,
+            &format!("{field}.membership_ordinals"),
+        )?;
         let mut membership_ordinals = Vec::with_capacity(ordinal_len);
         for index in 0..ordinal_len {
             let change_id =
@@ -839,7 +2279,11 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
-    fn read_segment_change(&mut self, field: &str) -> Result<SegmentChange, LixError> {
+    fn read_segment_change(
+        &mut self,
+        field: &str,
+        payload_budget: Option<&mut usize>,
+    ) -> Result<SegmentChange, LixError> {
         let id = self.read_string(&format!("{field}.id"))?;
         let authored_commit_id =
             self.read_optional_string(&format!("{field}.authored_commit_id"))?;
@@ -852,14 +2296,44 @@ impl<'a> ByteCursor<'a> {
 
         let payload_len = self.read_len(&format!("{field}.inline_payloads"))?;
         self.ensure_len_fits_remaining(payload_len, &format!("{field}.inline_payloads"))?;
+        self.ensure_counted_records_fit_remaining(
+            payload_len,
+            MIN_INLINE_PAYLOAD_BYTES,
+            &format!("{field}.inline_payloads"),
+        )?;
+        if let Some(payload_budget) = payload_budget {
+            *payload_budget = payload_budget.checked_sub(payload_len).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "failed to decode changelog {field}.inline_payloads: declared inline payload count exceeds header payload_count"
+                    ),
+                )
+            })?;
+        }
         let mut inline_payloads = Vec::with_capacity(payload_len);
+        let mut payload_descriptors = Vec::with_capacity(payload_len);
         for index in 0..payload_len {
-            inline_payloads.push(
-                self.read_segment_inline_payload(&format!("{field}.inline_payloads[{index}]"))?,
-            );
+            let payload =
+                self.read_segment_inline_payload_ref(&format!("{field}.inline_payloads[{index}]"))?;
+            validate_inline_payload_ref(&id, &payload.json_ref, payload.bytes)?;
+            payload_descriptors.push(PayloadDescriptor {
+                json_ref: payload.json_ref.clone(),
+                len: payload.bytes.len() as u64,
+            });
+            inline_payloads.push(payload);
         }
 
-        let directory = self.read_segment_change_directory(&format!("{field}.directory"))?;
+        let directory =
+            self.read_segment_change_directory(&format!("{field}.directory"), payload_len)?;
+        validate_payload_descriptors_against_directory(&id, &payload_descriptors, &directory)?;
+        let inline_payloads = inline_payloads
+            .into_iter()
+            .map(|payload| SegmentInlinePayload {
+                json_ref: payload.json_ref,
+                bytes: payload.bytes.to_vec(),
+            })
+            .collect();
 
         Ok(SegmentChange {
             id,
@@ -882,14 +2356,14 @@ impl<'a> ByteCursor<'a> {
         let start = self.offset;
         let id = self.read_string_ref(&format!("{field}.id"))?;
         self.skip_optional_string(&format!("{field}.authored_commit_id"))?;
-        self.skip_string(&format!("{field}.entity_id"))?;
+        self.read_entity_identity(&format!("{field}.entity_id"))?;
         self.skip_string(&format!("{field}.schema_key"))?;
         self.skip_optional_string(&format!("{field}.file_id"))?;
         self.skip_optional_json_ref(&format!("{field}.snapshot_ref"))?;
         self.skip_optional_json_ref(&format!("{field}.metadata_ref"))?;
         self.skip_string(&format!("{field}.created_at"))?;
-        self.skip_segment_inline_payloads(&format!("{field}.inline_payloads"))?;
-        self.skip_segment_change_directory(&format!("{field}.directory"))?;
+        let payloads = self.skip_segment_inline_payloads(&format!("{field}.inline_payloads"))?;
+        self.skip_segment_change_directory(&format!("{field}.directory"), id, &payloads)?;
         let end = self.offset;
         Ok(SegmentObjectSlice {
             id,
@@ -901,47 +2375,99 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn read_segment_change_slice_fast(&mut self) -> Result<SegmentObjectSlice<'a>, LixError> {
+        self.read_segment_change_slice_with_count_fast(None)
+            .map(|(change, _)| change.slice)
+    }
+
+    fn read_segment_change_slice_with_count_fast(
+        &mut self,
+        payload_budget: Option<usize>,
+    ) -> Result<(SegmentChangeSliceRead<'a>, usize), LixError> {
         let start = self.offset;
         let id = self.read_string_ref_fast()?;
-        self.skip_optional_string_fast()?;
-        self.skip_strings_fast()?;
-        self.skip_string_fast()?;
-        self.skip_optional_string_fast()?;
-        self.skip_optional_json_ref_fast()?;
-        self.skip_optional_json_ref_fast()?;
-        self.skip_string_fast()?;
-        self.skip_segment_inline_payloads_fast()?;
-        self.skip_segment_change_directory_fast()?;
-        let end = self.offset;
-        Ok(SegmentObjectSlice {
+        let authored_commit_id = self.read_optional_string_ref_fast()?;
+        let entity_id = self.read_entity_identity_fast()?;
+        let schema_key = self.read_string_ref_fast()?;
+        let file_id = self.read_optional_string_ref_fast()?;
+        let snapshot_ref = self.read_optional_json_ref_fast()?;
+        let metadata_ref = self.read_optional_json_ref_fast()?;
+        let created_at = self.read_string_ref_fast()?;
+        let payloads = self.read_segment_inline_payloads_fast(payload_budget)?;
+        for payload in &payloads {
+            validate_inline_payload_ref(id, &payload.json_ref, payload.bytes)?;
+        }
+        let payload_descriptors = payloads
+            .iter()
+            .map(|payload| PayloadDescriptor {
+                json_ref: payload.json_ref.clone(),
+                len: payload.bytes.len() as u64,
+            })
+            .collect::<Vec<_>>();
+        let directory = self.read_segment_change_directory_fast(id, &payload_descriptors)?;
+        let checksum = checksum_change_parts(
             id,
-            offset: start as u64,
-            len: (end - start) as u64,
-            encoded_checksum: None,
-            bytes: &self.bytes[start..end],
-        })
+            authored_commit_id,
+            &entity_id,
+            schema_key,
+            file_id,
+            snapshot_ref.as_ref(),
+            metadata_ref.as_ref(),
+            created_at,
+            &payloads,
+            &directory,
+        )?;
+        let end = self.offset;
+        Ok((
+            SegmentChangeSliceRead {
+                slice: SegmentObjectSlice {
+                    id,
+                    offset: start as u64,
+                    len: (end - start) as u64,
+                    encoded_checksum: None,
+                    bytes: &self.bytes[start..end],
+                },
+                state_row_identity: state_row_identity_for_change_fields(
+                    schema_key, file_id, &entity_id,
+                )?,
+                authored_commit_id,
+                checksum,
+            },
+            payloads.len(),
+        ))
     }
 
     fn remaining_bytes(&self) -> &'a [u8] {
         &self.bytes[self.offset..]
     }
 
-    fn read_segment_inline_payload(
+    fn read_segment_inline_payload_ref(
         &mut self,
         field: &str,
-    ) -> Result<SegmentInlinePayload, LixError> {
-        Ok(SegmentInlinePayload {
+    ) -> Result<SegmentInlinePayloadRef<'a>, LixError> {
+        Ok(SegmentInlinePayloadRef {
             json_ref: self.read_json_ref(&format!("{field}.json_ref"))?,
-            bytes: self.read_byte_vec(&format!("{field}.bytes"))?,
+            bytes: self.read_byte_vec_ref(&format!("{field}.bytes"))?,
         })
     }
 
     fn read_segment_change_directory(
         &mut self,
         field: &str,
+        expected_payload_count: usize,
     ) -> Result<SegmentChangeDirectory, LixError> {
         let len = self.read_len(&format!("{field}.payloads"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.payloads"))?;
+        self.ensure_counted_records_fit_remaining(
+            len,
+            MIN_PAYLOAD_LOCATION_BYTES,
+            &format!("{field}.payloads"),
+        )?;
+        validate_count_matches_usize(
+            "payload_count",
+            expected_payload_count as u32,
+            len,
+            "change directory payloads",
+        )?;
         let mut payloads = Vec::with_capacity(len);
         for index in 0..len {
             payloads.push(self.read_payload_location(&format!("{field}.payloads[{index}]"))?);
@@ -965,6 +2491,35 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
+    fn read_state_row_identity_fast(&mut self) -> Result<StateRowIdentity, LixError> {
+        let schema_key = self.read_string_ref_fast()?;
+        let schema_key = CanonicalSchemaKey::new(schema_key.to_string()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog state row identity schema_key: {error}"),
+            )
+        })?;
+        let file_id = self.read_string_ref_fast()?;
+        let file_id = FileId::new(file_id.to_string()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog state row identity file_id: {error}"),
+            )
+        })?;
+        let entity_id = self.read_string_ref_fast()?;
+        let entity_id = EntityId::new(entity_id.to_string()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog state row identity entity_id: {error}"),
+            )
+        })?;
+        Ok(StateRowIdentity {
+            schema_key,
+            file_id,
+            entity_id,
+        })
+    }
+
     fn read_entity_identity(&mut self, field: &str) -> Result<EntityIdentity, LixError> {
         let parts = self.read_strings_fast_owned().map_err(|error| {
             LixError::new(
@@ -982,6 +2537,18 @@ impl<'a> ByteCursor<'a> {
         })
     }
 
+    fn read_entity_identity_fast(&mut self) -> Result<EntityIdentity, LixError> {
+        let parts = self.read_strings_fast_owned()?;
+        EntityIdentity::from_parts(parts).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "failed to decode changelog entity_id: invalid entity identity parts: {error}"
+                ),
+            )
+        })
+    }
+
     fn read_membership_role(&mut self, field: &str) -> Result<MembershipRole, LixError> {
         match self.read_u8(field)? {
             0 => Ok(MembershipRole::Authored),
@@ -993,9 +2560,18 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
+    fn read_membership_role_fast(&mut self) -> Result<MembershipRole, LixError> {
+        match self.read_u8_fast()? {
+            0 => Ok(MembershipRole::Authored),
+            1 => Ok(MembershipRole::Adopted),
+            _ => Err(self.fast_error("invalid membership role")),
+        }
+    }
+
     fn read_strings(&mut self, field: &str) -> Result<Vec<String>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_STRING_BYTES, field)?;
         let mut out = Vec::with_capacity(len);
         for index in 0..len {
             out.push(self.read_string(&format!("{field}[{index}]"))?);
@@ -1006,6 +2582,7 @@ impl<'a> ByteCursor<'a> {
     fn read_strings_fast_owned(&mut self) -> Result<Vec<String>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_STRING_BYTES)?;
         let mut out = Vec::with_capacity(len);
         for _ in 0..len {
             out.push(self.read_string_fast_owned()?);
@@ -1013,9 +2590,21 @@ impl<'a> ByteCursor<'a> {
         Ok(out)
     }
 
+    fn read_strings_fast_refs(&mut self) -> Result<Vec<&'a str>, LixError> {
+        let len = self.read_len_fast()?;
+        self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_STRING_BYTES)?;
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            out.push(self.read_string_ref_fast()?);
+        }
+        Ok(out)
+    }
+
     fn skip_strings(&mut self, field: &str) -> Result<(), LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_STRING_BYTES, field)?;
         for index in 0..len {
             self.skip_string(&format!("{field}[{index}]"))?;
         }
@@ -1025,6 +2614,7 @@ impl<'a> ByteCursor<'a> {
     fn skip_strings_fast(&mut self) -> Result<(), LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_STRING_BYTES)?;
         for _ in 0..len {
             self.skip_string_fast()?;
         }
@@ -1082,19 +2672,13 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn skip_string(&mut self, field: &str) -> Result<(), LixError> {
-        let len = self.read_u32(&format!("{field}.len"))?;
-        let len = usize::try_from(len).map_err(|_| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("failed to decode changelog {field}: length exceeds usize"),
-            )
-        })?;
-        self.skip_bytes(len, field)
+        let _ = self.read_string_ref(field)?;
+        Ok(())
     }
 
     fn skip_string_fast(&mut self) -> Result<(), LixError> {
-        let len = self.read_len_fast()?;
-        self.skip_bytes_fast(len)
+        let _ = self.read_string_ref_fast()?;
+        Ok(())
     }
 
     fn read_optional_string(&mut self, field: &str) -> Result<Option<String>, LixError> {
@@ -1121,6 +2705,14 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
+    fn read_optional_string_ref_fast(&mut self) -> Result<Option<&'a str>, LixError> {
+        if self.read_bool_fast()? {
+            Ok(Some(self.read_string_ref_fast()?))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn read_optional_u32(&mut self, field: &str) -> Result<Option<u32>, LixError> {
         if self.read_bool(&format!("{field}.present"))? {
             Ok(Some(self.read_u32(field)?))
@@ -1134,6 +2726,14 @@ impl<'a> ByteCursor<'a> {
             self.skip_u32(field)
         } else {
             Ok(())
+        }
+    }
+
+    fn read_optional_u32_fast(&mut self) -> Result<Option<u32>, LixError> {
+        if self.read_bool_fast()? {
+            Ok(Some(self.read_u32_fast()?))
+        } else {
+            Ok(None)
         }
     }
 
@@ -1169,6 +2769,14 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
+    fn read_optional_json_ref_fast(&mut self) -> Result<Option<JsonRef>, LixError> {
+        if self.read_bool_fast()? {
+            Ok(Some(JsonRef::from_hash_bytes(self.read_fixed_hash_fast()?)))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn read_json_ref(&mut self, field: &str) -> Result<JsonRef, LixError> {
         let bytes = self.read_bytes(32, field)?;
         let mut hash = [0_u8; 32];
@@ -1176,27 +2784,56 @@ impl<'a> ByteCursor<'a> {
         Ok(JsonRef::from_hash_bytes(hash))
     }
 
+    fn read_fixed_hash_fast(&mut self) -> Result<[u8; 32], LixError> {
+        let bytes = self.read_bytes_fast(32)?;
+        let mut hash = [0_u8; 32];
+        hash.copy_from_slice(bytes);
+        Ok(hash)
+    }
+
     fn read_byte_vec(&mut self, field: &str) -> Result<Vec<u8>, LixError> {
         let len = self.read_len(field)?;
         Ok(self.read_bytes(len, field)?.to_vec())
     }
 
-    fn skip_byte_vec(&mut self, field: &str) -> Result<(), LixError> {
+    fn read_byte_vec_ref(&mut self, field: &str) -> Result<&'a [u8], LixError> {
         let len = self.read_len(field)?;
-        self.skip_bytes(len, field)
+        self.read_bytes(len, field)
     }
 
-    fn skip_byte_vec_fast(&mut self) -> Result<(), LixError> {
+    fn read_byte_vec_ref_fast(&mut self) -> Result<&'a [u8], LixError> {
         let len = self.read_len_fast()?;
-        self.skip_bytes_fast(len)
+        self.read_bytes_fast(len)
     }
 
-    fn skip_commit_body(&mut self, field: &str) -> Result<(), LixError> {
+    fn skip_byte_vec(&mut self, field: &str) -> Result<usize, LixError> {
+        let len = self.read_len(field)?;
+        self.skip_bytes(len, field)?;
+        Ok(len)
+    }
+
+    fn skip_byte_vec_fast(&mut self) -> Result<usize, LixError> {
+        let len = self.read_len_fast()?;
+        self.skip_bytes_fast(len)?;
+        Ok(len)
+    }
+
+    fn skip_commit_body(
+        &mut self,
+        field: &str,
+        expected_membership_count: usize,
+    ) -> Result<(), LixError> {
         let len = self.read_len(&format!("{field}.membership"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.membership"))?;
+        validate_count_matches_usize(
+            "membership_count",
+            expected_membership_count as u32,
+            len,
+            "membership records",
+        )?;
         for index in 0..len {
             self.skip_string(&format!("{field}.membership[{index}].member_change_id"))?;
-            self.skip_u8(&format!("{field}.membership[{index}].role"))?;
+            self.read_membership_role(&format!("{field}.membership[{index}].role"))?;
             self.skip_optional_u32(&format!(
                 "{field}.membership[{index}].source_parent_ordinal"
             ))?;
@@ -1204,20 +2841,19 @@ impl<'a> ByteCursor<'a> {
         Ok(())
     }
 
-    fn skip_commit_body_fast(&mut self) -> Result<(), LixError> {
-        let len = self.read_len_fast()?;
-        self.ensure_len_fits_remaining_fast(len)?;
-        for _ in 0..len {
-            self.skip_string_fast()?;
-            self.skip_u8_fast()?;
-            self.skip_optional_u32_fast()?;
-        }
+    fn skip_commit_body_fast(&mut self, expected_membership_count: usize) -> Result<(), LixError> {
+        let _ = self.read_commit_body_descriptors_fast(expected_membership_count)?;
         Ok(())
     }
 
     fn skip_segment_commit_directory(&mut self, field: &str) -> Result<(), LixError> {
         let identity_len = self.read_len(&format!("{field}.state_row_identities"))?;
         self.ensure_len_fits_remaining(identity_len, &format!("{field}.state_row_identities"))?;
+        self.ensure_counted_records_fit_remaining(
+            identity_len,
+            MIN_STATE_ROW_IDENTITY_ENTRY_BYTES,
+            &format!("{field}.state_row_identities"),
+        )?;
         for index in 0..identity_len {
             self.skip_string(&format!(
                 "{field}.state_row_identities[{index}].state_row_identity.schema_key"
@@ -1233,6 +2869,11 @@ impl<'a> ByteCursor<'a> {
 
         let ordinal_len = self.read_len(&format!("{field}.membership_ordinals"))?;
         self.ensure_len_fits_remaining(ordinal_len, &format!("{field}.membership_ordinals"))?;
+        self.ensure_counted_records_fit_remaining(
+            ordinal_len,
+            MIN_MEMBERSHIP_ORDINAL_BYTES,
+            &format!("{field}.membership_ordinals"),
+        )?;
         for index in 0..ordinal_len {
             self.skip_string(&format!("{field}.membership_ordinals[{index}].change_id"))?;
             self.skip_u32(&format!("{field}.membership_ordinals[{index}].ordinal"))?;
@@ -1241,64 +2882,157 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn skip_segment_commit_directory_fast(&mut self) -> Result<(), LixError> {
+        let _ = self.read_segment_commit_directory_fast()?;
+        Ok(())
+    }
+
+    fn read_segment_commit_directory_fast(&mut self) -> Result<SegmentCommitDirectory, LixError> {
         let identity_len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(identity_len)?;
+        self.ensure_counted_records_fit_remaining_fast(
+            identity_len,
+            MIN_STATE_ROW_IDENTITY_ENTRY_BYTES,
+        )?;
+        let mut state_row_identities = Vec::with_capacity(identity_len);
         for _ in 0..identity_len {
-            self.skip_string_fast()?;
-            self.skip_string_fast()?;
-            self.skip_string_fast()?;
-            self.skip_string_fast()?;
+            let identity = self.read_state_row_identity_fast()?;
+            let change_id = self.read_string_ref_fast()?.to_string();
+            state_row_identities.push((identity, change_id));
         }
 
         let ordinal_len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(ordinal_len)?;
+        self.ensure_counted_records_fit_remaining_fast(ordinal_len, MIN_MEMBERSHIP_ORDINAL_BYTES)?;
+        let mut membership_ordinals = Vec::with_capacity(ordinal_len);
         for _ in 0..ordinal_len {
-            self.skip_string_fast()?;
-            self.skip_u32_fast()?;
+            let change_id = self.read_string_ref_fast()?.to_string();
+            let ordinal = self.read_u32_fast()?;
+            membership_ordinals.push((change_id, ordinal));
         }
-        Ok(())
+        Ok(SegmentCommitDirectory {
+            state_row_identities,
+            membership_ordinals,
+        })
     }
 
-    fn skip_segment_inline_payloads(&mut self, field: &str) -> Result<(), LixError> {
+    fn read_segment_commit_directory_fast_validated(
+        &mut self,
+        commit_id: &str,
+        parent_count: usize,
+        memberships: &[CommitMembershipDescriptor<'_>],
+    ) -> Result<SegmentCommitDirectory, LixError> {
+        validate_commit_membership_descriptors(commit_id, parent_count, memberships)?;
+        let directory = self.read_segment_commit_directory_fast()?;
+        validate_commit_directory_descriptors(
+            commit_id,
+            memberships,
+            directory
+                .state_row_identities
+                .iter()
+                .map(|(identity, change_id)| (identity, change_id.as_str())),
+            directory
+                .membership_ordinals
+                .iter()
+                .map(|(change_id, ordinal)| (change_id.as_str(), *ordinal)),
+        )?;
+        Ok(directory)
+    }
+
+    fn skip_segment_inline_payloads(
+        &mut self,
+        field: &str,
+    ) -> Result<Vec<PayloadDescriptor>, LixError> {
         let len = self.read_len(field)?;
         self.ensure_len_fits_remaining(len, field)?;
+        self.ensure_counted_records_fit_remaining(len, MIN_INLINE_PAYLOAD_BYTES, field)?;
+        let mut payloads = Vec::with_capacity(len);
         for index in 0..len {
-            self.skip_bytes(32, &format!("{field}[{index}].json_ref"))?;
-            self.skip_byte_vec(&format!("{field}[{index}].bytes"))?;
+            let json_ref = self.read_json_ref(&format!("{field}[{index}].json_ref"))?;
+            let bytes_len = self.skip_byte_vec(&format!("{field}[{index}].bytes"))?;
+            payloads.push(PayloadDescriptor {
+                json_ref,
+                len: bytes_len as u64,
+            });
         }
-        Ok(())
+        Ok(payloads)
     }
 
-    fn skip_segment_inline_payloads_fast(&mut self) -> Result<(), LixError> {
+    fn read_segment_inline_payloads_fast(
+        &mut self,
+        payload_budget: Option<usize>,
+    ) -> Result<Vec<SegmentInlinePayloadRef<'a>>, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
-        for _ in 0..len {
-            self.skip_bytes_fast(32)?;
-            self.skip_byte_vec_fast()?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_INLINE_PAYLOAD_BYTES)?;
+        if payload_budget.is_some_and(|budget| len > budget) {
+            return Err(
+                self.fast_error("declared inline payload count exceeds header payload_count")
+            );
         }
-        Ok(())
+        let mut payloads = Vec::with_capacity(len);
+        for _ in 0..len {
+            let json_ref = JsonRef::from_hash_bytes(self.read_fixed_hash_fast()?);
+            let bytes = self.read_byte_vec_ref_fast()?;
+            payloads.push(SegmentInlinePayloadRef { json_ref, bytes });
+        }
+        Ok(payloads)
     }
 
-    fn skip_segment_change_directory(&mut self, field: &str) -> Result<(), LixError> {
+    fn skip_segment_change_directory(
+        &mut self,
+        field: &str,
+        change_id: &str,
+        inline_payloads: &[PayloadDescriptor],
+    ) -> Result<(), LixError> {
         let len = self.read_len(&format!("{field}.payloads"))?;
         self.ensure_len_fits_remaining(len, &format!("{field}.payloads"))?;
+        self.ensure_counted_records_fit_remaining(
+            len,
+            MIN_PAYLOAD_LOCATION_BYTES,
+            &format!("{field}.payloads"),
+        )?;
+        validate_count_matches_usize(
+            "payload_count",
+            inline_payloads.len() as u32,
+            len,
+            "change directory payloads",
+        )?;
+        let mut payloads = Vec::with_capacity(len);
         for index in 0..len {
-            self.skip_bytes(32, &format!("{field}.payloads[{index}].json_ref"))?;
-            self.skip_u64(&format!("{field}.payloads[{index}].offset"))?;
-            self.skip_u64(&format!("{field}.payloads[{index}].len"))?;
+            payloads.push(self.read_payload_location(&format!("{field}.payloads[{index}]"))?);
         }
-        Ok(())
+        validate_payload_descriptors_against_directory(
+            change_id,
+            inline_payloads,
+            &SegmentChangeDirectory { payloads },
+        )
     }
 
-    fn skip_segment_change_directory_fast(&mut self) -> Result<(), LixError> {
+    fn read_segment_change_directory_fast(
+        &mut self,
+        change_id: &str,
+        inline_payloads: &[PayloadDescriptor],
+    ) -> Result<SegmentChangeDirectory, LixError> {
         let len = self.read_len_fast()?;
         self.ensure_len_fits_remaining_fast(len)?;
+        self.ensure_counted_records_fit_remaining_fast(len, MIN_PAYLOAD_LOCATION_BYTES)?;
+        validate_count_matches_usize(
+            "payload_count",
+            inline_payloads.len() as u32,
+            len,
+            "change directory payloads",
+        )?;
+        let mut payloads = Vec::with_capacity(len);
         for _ in 0..len {
-            self.skip_bytes_fast(32)?;
-            self.skip_u64_fast()?;
-            self.skip_u64_fast()?;
+            payloads.push(SegmentPayloadLocation {
+                json_ref: JsonRef::from_hash_bytes(self.read_fixed_hash_fast()?),
+                offset: self.read_u64_fast()?,
+                len: self.read_u64_fast()?,
+            });
         }
-        Ok(())
+        let directory = SegmentChangeDirectory { payloads };
+        validate_payload_descriptors_against_directory(change_id, inline_payloads, &directory)?;
+        Ok(directory)
     }
 
     fn read_len(&mut self, field: &str) -> Result<usize, LixError> {
@@ -1330,6 +3064,43 @@ impl<'a> ByteCursor<'a> {
             return Ok(());
         }
         Err(self.fast_error("declared length exceeds remaining bytes"))
+    }
+
+    fn ensure_counted_records_fit_remaining(
+        &self,
+        len: usize,
+        min_record_bytes: usize,
+        field: &str,
+    ) -> Result<(), LixError> {
+        let min_bytes = len.checked_mul(min_record_bytes).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode changelog {field}: declared count byte size overflows"),
+            )
+        })?;
+        if min_bytes <= self.bytes.len().saturating_sub(self.offset) {
+            return Ok(());
+        }
+        Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "failed to decode changelog {field}: declared count exceeds remaining bytes for minimum record size"
+            ),
+        ))
+    }
+
+    fn ensure_counted_records_fit_remaining_fast(
+        &self,
+        len: usize,
+        min_record_bytes: usize,
+    ) -> Result<(), LixError> {
+        let min_bytes = len
+            .checked_mul(min_record_bytes)
+            .ok_or_else(|| self.fast_error("declared count byte size overflows"))?;
+        if min_bytes <= self.bytes.len().saturating_sub(self.offset) {
+            return Ok(());
+        }
+        Err(self.fast_error("declared count exceeds remaining bytes for minimum record size"))
     }
 
     fn read_bool(&mut self, field: &str) -> Result<bool, LixError> {
@@ -1483,6 +3254,12 @@ struct SegmentHeaderView<'a> {
     checksum: &'a str,
 }
 
+struct CommitHeaderView<'a> {
+    id: &'a str,
+    parent_count: usize,
+    membership_count: u32,
+}
+
 fn changelog_codec_not_implemented(message: impl Into<String>) -> LixError {
     LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
 }
@@ -1493,76 +3270,7 @@ mod tests {
 
     #[test]
     fn segment_roundtrips() {
-        let state_row_identity = StateRowIdentity {
-            schema_key: CanonicalSchemaKey::new("message").unwrap(),
-            file_id: FileId::new("file-1").unwrap(),
-            entity_id: EntityId::new("entity-1").unwrap(),
-        };
-        let snapshot_ref = JsonRef::from_hash_bytes([1; 32]);
-        let metadata_ref = JsonRef::from_hash_bytes([2; 32]);
-        let payload_ref = JsonRef::from_hash_bytes([3; 32]);
-
-        let segment = Segment {
-            header: SegmentHeader {
-                segment_id: "segment-1".to_string(),
-                format_version: 1,
-                commit_count: 1,
-                change_count: 1,
-                byte_count: 123,
-                payload_count: 1,
-                checksum: "segment-checksum".to_string(),
-            },
-            directory: SegmentDirectory {
-                commits: vec![("commit-1".to_string(), location("segment-1", 10, 20, "c"))],
-                changes: vec![("change-1".to_string(), location("segment-1", 30, 40, "ch"))],
-            },
-            commits: vec![SegmentCommit {
-                header: CommitHeader {
-                    id: "commit-1".to_string(),
-                    parent_commit_ids: vec!["parent-1".to_string()],
-                    derivable_change_id: "commit-change-1".to_string(),
-                    author_account_ids: vec!["account-1".to_string()],
-                    created_at: "2026-05-12T00:00:00Z".to_string(),
-                    membership_count: 1,
-                },
-                body: CommitBody {
-                    membership: vec![MembershipRecord {
-                        member_change_id: "change-1".to_string(),
-                        role: MembershipRole::Authored,
-                        source_parent_ordinal: Some(0),
-                    }],
-                },
-                directory: SegmentCommitDirectory {
-                    state_row_identities: vec![(
-                        state_row_identity.clone(),
-                        "change-1".to_string(),
-                    )],
-                    membership_ordinals: vec![("change-1".to_string(), 0)],
-                },
-                checksum: "commit-checksum".to_string(),
-            }],
-            changes: vec![SegmentChange {
-                id: "change-1".to_string(),
-                authored_commit_id: Some("commit-1".to_string()),
-                entity_id: EntityIdentity::single("entity-1"),
-                schema_key: "message".to_string(),
-                file_id: Some("file-1".to_string()),
-                snapshot_ref: Some(snapshot_ref),
-                metadata_ref: Some(metadata_ref),
-                created_at: "2026-05-12T00:00:00Z".to_string(),
-                inline_payloads: vec![SegmentInlinePayload {
-                    json_ref: payload_ref,
-                    bytes: br#"{"hello":"world"}"#.to_vec(),
-                }],
-                directory: SegmentChangeDirectory {
-                    payloads: vec![SegmentPayloadLocation {
-                        json_ref: payload_ref,
-                        offset: 0,
-                        len: 17,
-                    }],
-                },
-            }],
-        };
+        let segment = sample_segment();
 
         assert_eq!(
             decode_segment(&encode_segment(&segment).unwrap()).unwrap(),
@@ -1642,7 +3350,7 @@ mod tests {
             &SegmentHeader {
                 segment_id: "segment-1".to_string(),
                 format_version: 1,
-                commit_count: u32::MAX,
+                commit_count: 0,
                 change_count: 0,
                 byte_count: 0,
                 payload_count: 0,
@@ -1661,6 +3369,1504 @@ mod tests {
                 .contains("declared length exceeds remaining bytes"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn segment_decode_rejects_header_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.commit_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("header count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 2 does not match 1 directory commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_object_count_mismatch_before_allocating_objects() {
+        let bytes = segment_bytes_with_empty_object_lists(sample_segment());
+
+        let error = decode_segment(&bytes).expect_err("object count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 1 does not match 0 commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_directory_count_before_allocating() {
+        let bytes = segment_bytes_with_directory_lengths(sample_segment(), 1, 1_000);
+
+        let error = decode_segment(&bytes).expect_err("impossible directory count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_header_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.change_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("header count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header change_count 2 does not match 1 directory changes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_unsupported_format_version() {
+        let mut segment = sample_segment();
+        segment.header.format_version = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("unsupported format version should reject");
+
+        assert!(
+            error.message.contains("format_version 2 is not supported"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_unsupported_format_version() {
+        let mut segment = sample_segment();
+        segment.header.format_version = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("unsupported format version should reject");
+
+        assert!(
+            error.message.contains("format_version 2 is not supported"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_header_byte_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.byte_count += 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("byte count mismatch should reject");
+
+        assert!(
+            error.message.contains("byte_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_header_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("header checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_header_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("header checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_header_directory_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.change_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("directory count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header change_count 2 does not match 1 directory changes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_directory_locator_offset_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.commits[0].1.offset += 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("directory locator mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("locator offset/len does not match encoded byte range"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_directory_locator_offset_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.commits[0].1.offset += 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("directory locator mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("locator offset/len does not match encoded byte range"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_directory_order_mismatch() {
+        let mut segment = sample_segment_with_two_changes();
+        apply_sample_encoded_locations(&mut segment);
+        segment.directory.changes.swap(0, 1);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("directory order mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("directory order does not match encoded object order"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_directory_view_rejects_duplicate_change_ids_with_different_locations() {
+        let mut segment = sample_segment_with_two_changes();
+        segment.directory.changes[1].0 = segment.directory.changes[0].0.clone();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_directory(&bytes).expect_err("duplicate directory id should reject");
+
+        assert!(
+            error.message.contains("duplicate directory locator"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_directory_order_mismatch() {
+        let mut segment = sample_segment_with_two_changes();
+        apply_sample_encoded_locations(&mut segment);
+        segment.directory.changes.swap(0, 1);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("directory order mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("directory order does not match encoded object order"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_locator_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.changes[0].1.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("change locator checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("locator checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_inline_payload_ref_mismatch() {
+        let mut segment = sample_segment();
+        let bogus_ref = JsonRef::from_hash_bytes([9; 32]);
+        segment.changes[0].inline_payloads[0].json_ref = bogus_ref;
+        segment.changes[0].directory.payloads[0].json_ref = bogus_ref;
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("inline payload hash mismatch should reject");
+
+        assert!(
+            error.message.contains("does not match payload bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_inline_payload_ref_mismatch() {
+        let mut segment = sample_segment();
+        let bogus_ref = JsonRef::from_hash_bytes([9; 32]);
+        segment.changes[0].inline_payloads[0].json_ref = bogus_ref;
+        segment.changes[0].directory.payloads[0].json_ref = bogus_ref;
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("inline payload hash mismatch should reject");
+
+        assert!(
+            error.message.contains("does not match payload bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_change_locator_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.directory.changes[0].1.checksum = empty_checksum();
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("change locator checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("locator checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_object_count_mismatch() {
+        let bytes = segment_bytes_with_empty_object_lists(sample_segment());
+
+        let error = view_segment(&bytes).expect_err("object count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 1 does not match 0 commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_object_count_mismatch() {
+        let bytes = segment_bytes_with_empty_object_lists(sample_segment());
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("object count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header commit_count 1 does not match 0 commits"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("payload count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 2 does not match 1 inline payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("payload count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 2 does not match 1 inline payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("payload count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 2 does not match 1 inline payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_inline_payloads_exceeding_header_payload_count_before_allocating() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 0;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("payload budget overrun should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared inline payload count exceeds header payload_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_inline_payloads_exceeding_header_payload_count_before_scanning() {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 0;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("payload budget overrun should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared inline payload count exceeds header payload_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_inline_payloads_exceeding_header_payload_count_before_scanning(
+    ) {
+        let mut segment = sample_segment();
+        segment.header.payload_count = 0;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("payload budget overrun should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared inline payload count exceeds header payload_count"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_inline_payload_count_before_allocating() {
+        let bytes = segment_change_bytes_with_inline_payload_len(sample_segment(), 1_000);
+
+        let error =
+            decode_segment(&bytes).expect_err("impossible inline payload count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_impossible_inline_payload_count_before_allocating() {
+        let bytes = segment_change_bytes_with_inline_payload_len(sample_segment(), 1_000);
+
+        let error =
+            view_segment(&bytes).expect_err("impossible inline payload count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_string_list_count_before_allocating() {
+        let bytes = commit_bytes_with_parent_count(sample_segment(), 1_000);
+
+        let error = decode_segment(&bytes).expect_err("impossible string list count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_impossible_string_list_count_before_allocating() {
+        let bytes = commit_bytes_with_parent_count(sample_segment(), 1_000);
+
+        let error = view_segment(&bytes).expect_err("impossible string list count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_impossible_top_level_commit_count_before_allocating() {
+        let bytes = segment_bytes_with_object_lengths(sample_segment(), 1_000, 0);
+
+        let error = decode_segment(&bytes).expect_err("impossible commit count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_impossible_top_level_commit_count_before_allocating() {
+        let bytes = segment_bytes_with_object_lengths(sample_segment(), 1_000, 0);
+
+        let error = view_segment(&bytes).expect_err("impossible commit count should reject");
+
+        assert!(
+            error
+                .message
+                .contains("declared count exceeds remaining bytes for minimum record size"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_directory_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0]
+            .directory
+            .payloads
+            .push(SegmentPayloadLocation {
+                json_ref: JsonRef::from_hash_bytes([9; 32]),
+                offset: 1,
+                len: 0,
+            });
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("change directory count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 1 does not match 2 change directory payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_change_decode_rejects_change_directory_payload_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0]
+            .directory
+            .payloads
+            .push(SegmentPayloadLocation {
+                json_ref: JsonRef::from_hash_bytes([9; 32]),
+                offset: 1,
+                len: 0,
+            });
+        let mut bytes = Vec::new();
+        write_segment_change(&mut bytes, &segment.changes[0]).unwrap();
+
+        let error = decode_segment_change(&bytes)
+            .expect_err("change directory count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header payload_count 1 does not match 2 change directory payloads"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes)
+            .expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment_object_slices(&bytes)
+            .expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_change_decode_rejects_change_directory_payload_len_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].len = 999;
+        let mut bytes = Vec::new();
+        write_segment_change(&mut bytes, &segment.changes[0]).unwrap();
+
+        let error = decode_segment_change(&bytes)
+            .expect_err("change directory payload len mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_change_directory_payload_offset_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].directory.payloads[0].offset = 1;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes)
+            .expect_err("change directory payload offset mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_commit_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_commit_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_commit_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment_object_slices(&bytes)
+            .expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_membership_count_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.membership_count = 2;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("membership count mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("header membership_count 2 does not match 1 membership records"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_invalid_membership_role() {
+        let bytes = segment_bytes_with_membership_role(sample_segment(), 9);
+
+        let error = view_segment(&bytes).expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_invalid_utf8_in_skipped_commit_string() {
+        let mut segment = sample_segment();
+        segment.commits[0].header.created_at = "commit-created".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = segment_bytes_with_invalid_string_content(segment, "commit-created");
+
+        let error = view_segment(&bytes).expect_err("invalid UTF-8 should reject");
+
+        assert!(
+            error.message.contains("invalid UTF-8"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_invalid_utf8_in_skipped_change_string() {
+        let mut segment = sample_segment();
+        segment.changes[0].created_at = "change-created".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = segment_bytes_with_invalid_string_content(segment, "change-created");
+
+        let error = view_segment(&bytes).expect_err("invalid UTF-8 should reject");
+
+        assert!(
+            error.message.contains("invalid UTF-8"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_empty_change_entity_identity_part() {
+        let mut segment = sample_segment();
+        segment.changes[0].entity_id = EntityIdentity {
+            parts: vec![String::new()],
+        };
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("empty entity identity should reject");
+
+        assert!(
+            error.message.contains("invalid entity identity parts"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_object_slices_rejects_empty_state_row_identity() {
+        let bytes = segment_bytes_with_empty_state_row_entity_id(sample_segment());
+
+        let error =
+            view_segment_object_slices(&bytes).expect_err("empty state-row identity should reject");
+
+        assert!(
+            error.message.contains("entity_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_state_row_identity_change_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.state_row_identities[0]
+            .0
+            .schema_key = CanonicalSchemaKey::new("other").unwrap();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = decode_segment(&bytes).expect_err("state-row identity mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner for change 'change-1' does not match"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_state_row_identity_change_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.state_row_identities[0]
+            .0
+            .schema_key = CanonicalSchemaKey::new("other").unwrap();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("state-row identity mismatch should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner for change 'change-1' does not match"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_authored_state_row_identity_missing_change() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].member_change_id = "missing-change".to_string();
+        segment.commits[0].directory.state_row_identities[0].1 = "missing-change".to_string();
+        segment.commits[0].directory.membership_ordinals[0].0 = "missing-change".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("missing authored change object should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner references missing authored change"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_authored_state_row_identity_missing_change() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].member_change_id = "missing-change".to_string();
+        segment.commits[0].directory.state_row_identities[0].1 = "missing-change".to_string();
+        segment.commits[0].directory.membership_ordinals[0].0 = "missing-change".to_string();
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error = view_segment(&bytes).expect_err("missing authored change object should reject");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner references missing authored change"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_authored_membership_commit_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].authored_commit_id = Some("other-commit".to_string());
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("authored commit ownership mismatch should reject");
+
+        assert!(
+            error.message.contains("mismatched authored_commit_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_authored_membership_commit_mismatch() {
+        let mut segment = sample_segment();
+        segment.changes[0].authored_commit_id = Some("other-commit".to_string());
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("authored commit ownership mismatch should reject");
+
+        assert!(
+            error.message.contains("mismatched authored_commit_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_adopted_membership_authored_by_same_commit() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            decode_segment(&bytes).expect_err("self-authored adopted membership should reject");
+
+        assert!(
+            error
+                .message
+                .contains("must not be authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_view_rejects_adopted_membership_authored_by_same_commit() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        apply_sample_encoded_locations(&mut segment);
+        let bytes = encode_segment(&segment).unwrap();
+
+        let error =
+            view_segment(&bytes).expect_err("self-authored adopted membership should reject");
+
+        assert!(
+            error
+                .message
+                .contains("must not be authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_checksum_distinguishes_list_boundaries() {
+        let segment = sample_segment();
+        let mut left = segment.commits[0].clone();
+        left.header.parent_commit_ids = vec!["a".to_string(), "b".to_string()];
+        left.header.derivable_change_id = "c".to_string();
+        left.header.author_account_ids = vec!["d".to_string()];
+
+        let mut right = segment.commits[0].clone();
+        right.header.parent_commit_ids = vec!["a".to_string()];
+        right.header.derivable_change_id = "b".to_string();
+        right.header.author_account_ids = vec!["c".to_string(), "d".to_string()];
+
+        assert_ne!(
+            checksum_commit(&left).unwrap(),
+            checksum_commit(&right).unwrap()
+        );
+    }
+
+    #[test]
+    fn change_checksum_distinguishes_entity_schema_boundaries() {
+        let segment = sample_segment();
+        let mut left = segment.changes[0].clone();
+        left.entity_id = EntityIdentity {
+            parts: vec!["a".to_string(), "b".to_string()],
+        };
+        left.schema_key = "c".to_string();
+        left.file_id = Some("d".to_string());
+
+        let mut right = segment.changes[0].clone();
+        right.entity_id = EntityIdentity {
+            parts: vec!["a".to_string()],
+        };
+        right.schema_key = "b".to_string();
+        right.file_id = Some("c".to_string());
+
+        assert_ne!(
+            checksum_change(&left).unwrap(),
+            checksum_change(&right).unwrap()
+        );
+    }
+
+    #[test]
+    fn segment_decode_rejects_invalid_membership_role() {
+        let bytes = segment_bytes_with_membership_role(sample_segment(), 9);
+
+        let error = decode_segment(&bytes).expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_commit_decode_rejects_invalid_membership_role() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+        let role_offset = find_membership_role_offset(&bytes, "change-1");
+        bytes[role_offset] = 9;
+
+        let error = decode_segment_commit(&bytes).expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_invalid_membership_role() {
+        let mut segment = sample_segment();
+        segment.commits[0].body.membership[0].role = MembershipRole::Authored;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+        let role_offset = find_membership_role_offset(&bytes, "change-1");
+        bytes[role_offset] = 9;
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("invalid role should reject");
+
+        assert!(
+            error.message.contains("invalid membership role"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_wrong_expected_commit_id() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "other-commit",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("wrong expected commit id should reject");
+
+        assert!(
+            error.message.contains("decoded commit 'commit-1'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_membership_ordinal_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.membership_ordinals[0].1 = 7;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("membership ordinal mismatch should reject");
+
+        assert!(
+            error.message.contains("membership ordinal"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_commit_decode_rejects_membership_ordinal_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].directory.membership_ordinals[0].1 = 7;
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error =
+            decode_segment_commit(&bytes).expect_err("membership ordinal mismatch should reject");
+
+        assert!(
+            error.message.contains("membership ordinal"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn segment_commit_decode_rejects_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].checksum = empty_checksum();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error =
+            decode_segment_commit(&bytes).expect_err("commit checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_locator_checksum_mismatch() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            "wrong-checksum",
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("locator checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("locator checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_checksum_mismatch() {
+        let mut segment = sample_segment();
+        segment.commits[0].checksum = empty_checksum();
+        let mut bytes = Vec::new();
+        write_segment_commit(&mut bytes, &segment.commits[0]).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("commit checksum mismatch should reject");
+
+        assert!(
+            error.message.contains("checksum"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn commit_membership_scan_rejects_truncated_commit_after_body() {
+        let segment = sample_segment();
+        let mut bytes = Vec::new();
+        write_commit_header(&mut bytes, &segment.commits[0].header).unwrap();
+        write_commit_body(&mut bytes, &segment.commits[0].body).unwrap();
+
+        let error = segment_commit_membership_contains_any(
+            &bytes,
+            "commit-1",
+            &segment.commits[0].checksum,
+            &std::collections::HashSet::new(),
+        )
+        .expect_err("truncated commit should reject");
+
+        assert!(
+            error.message.contains("truncated bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn segment_bytes_with_empty_object_lists(segment: Segment) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, 0, "commits").unwrap();
+        write_len(&mut bytes, 0, "changes").unwrap();
+        bytes
+    }
+
+    fn segment_bytes_with_directory_lengths(
+        segment: Segment,
+        commit_len: usize,
+        change_len: usize,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_len(&mut bytes, commit_len, "directory commits").unwrap();
+        write_len(&mut bytes, change_len, "directory changes").unwrap();
+        write_len(&mut bytes, 0, "commits").unwrap();
+        write_len(&mut bytes, 0, "changes").unwrap();
+        bytes
+    }
+
+    fn segment_bytes_with_object_lengths(
+        segment: Segment,
+        commit_len: usize,
+        change_len: usize,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, commit_len, "commits").unwrap();
+        write_len(&mut bytes, change_len, "changes").unwrap();
+        bytes.resize(bytes.len() + commit_len + change_len, 0);
+        bytes
+    }
+
+    fn segment_change_bytes_with_inline_payload_len(
+        segment: Segment,
+        payload_len: usize,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, segment.commits.len(), "commits").unwrap();
+        for commit in &segment.commits {
+            write_segment_commit(&mut bytes, commit).unwrap();
+        }
+        write_len(&mut bytes, segment.changes.len(), "changes").unwrap();
+        let change = &segment.changes[0];
+        write_str(&mut bytes, &change.id).unwrap();
+        write_optional_str(&mut bytes, change.authored_commit_id.as_deref()).unwrap();
+        write_entity_identity(&mut bytes, &change.entity_id).unwrap();
+        write_str(&mut bytes, &change.schema_key).unwrap();
+        write_optional_str(&mut bytes, change.file_id.as_deref()).unwrap();
+        write_optional_json_ref(&mut bytes, change.snapshot_ref.as_ref());
+        write_optional_json_ref(&mut bytes, change.metadata_ref.as_ref());
+        write_str(&mut bytes, &change.created_at).unwrap();
+        write_len(&mut bytes, payload_len, "inline payloads").unwrap();
+        bytes.resize(bytes.len() + payload_len, 0);
+        bytes
+    }
+
+    fn commit_bytes_with_parent_count(segment: Segment, parent_count: usize) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(SEGMENT_MAGIC);
+        write_segment_header(&mut bytes, &segment.header).unwrap();
+        write_segment_directory(&mut bytes, &segment.directory).unwrap();
+        write_len(&mut bytes, segment.commits.len(), "commits").unwrap();
+        let commit = &segment.commits[0];
+        write_str(&mut bytes, &commit.header.id).unwrap();
+        write_len(&mut bytes, parent_count, "parent commits").unwrap();
+        bytes.resize(bytes.len() + parent_count, 0);
+        bytes
+    }
+
+    fn segment_bytes_with_membership_role(segment: Segment, role: u8) -> Vec<u8> {
+        let mut bytes = encode_segment(&segment).unwrap();
+        let role_offset = find_membership_role_offset(&bytes, "change-1");
+        bytes[role_offset] = role;
+        bytes
+    }
+
+    fn segment_bytes_with_invalid_string_content(segment: Segment, value: &str) -> Vec<u8> {
+        let mut bytes = encode_segment(&segment).unwrap();
+        let mut pattern = Vec::new();
+        append_test_string(&mut pattern, value);
+        let offset = bytes
+            .windows(pattern.len())
+            .position(|window| window == pattern.as_slice())
+            .expect("test string should exist");
+        bytes[offset + 4] = 0xff;
+        bytes
+    }
+
+    fn segment_bytes_with_empty_state_row_entity_id(segment: Segment) -> Vec<u8> {
+        let mut bytes = encode_segment(&segment).unwrap();
+        let entity_len_offset = find_state_row_entity_id_len_offset(&bytes);
+        let entity = EntityIdentity::single("entity-1")
+            .as_json_array_text()
+            .unwrap();
+        let entity_len = entity.len();
+        bytes[entity_len_offset..entity_len_offset + 4].copy_from_slice(&0_u32.to_le_bytes());
+        bytes.drain(entity_len_offset + 4..entity_len_offset + 4 + entity_len);
+        bytes
+    }
+
+    fn find_state_row_entity_id_len_offset(bytes: &[u8]) -> usize {
+        let mut pattern = Vec::new();
+        append_test_string(&mut pattern, "message");
+        append_test_string(&mut pattern, "file-1");
+        let entity_len_offset = pattern.len();
+        append_test_string(
+            &mut pattern,
+            &EntityIdentity::single("entity-1")
+                .as_json_array_text()
+                .unwrap(),
+        );
+        append_test_string(&mut pattern, "change-1");
+        bytes
+            .windows(pattern.len())
+            .position(|window| window == pattern.as_slice())
+            .map(|offset| offset + entity_len_offset)
+            .expect("state-row identity should exist")
+    }
+
+    fn append_test_string(bytes: &mut Vec<u8>, value: &str) {
+        bytes.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(value.as_bytes());
+    }
+
+    fn find_membership_role_offset(bytes: &[u8], member_change_id: &str) -> usize {
+        let needle_len = (member_change_id.len() as u32).to_le_bytes();
+        let needle = member_change_id.as_bytes();
+        bytes
+            .windows(4 + needle.len())
+            .enumerate()
+            .find_map(|(offset, window)| {
+                if &window[..4] != needle_len.as_slice() || &window[4..] != needle {
+                    return None;
+                }
+                let role_offset = offset + 4 + needle.len();
+                let expected_after_role = [0, 0];
+                (bytes.get(role_offset..role_offset + expected_after_role.len())
+                    == Some(expected_after_role.as_slice()))
+                .then_some(role_offset)
+            })
+            .expect("membership record should exist")
+    }
+
+    fn sample_segment() -> Segment {
+        let entity_identity = EntityIdentity::single("entity-1");
+        let state_row_identity = StateRowIdentity {
+            schema_key: CanonicalSchemaKey::new("message").unwrap(),
+            file_id: FileId::new("file-1").unwrap(),
+            entity_id: EntityId::new(entity_identity.as_json_array_text().unwrap()).unwrap(),
+        };
+        let snapshot_ref = JsonRef::from_hash_bytes([1; 32]);
+        let metadata_ref = JsonRef::from_hash_bytes([2; 32]);
+        let payload_bytes = br#"{"hello":"world"}"#.to_vec();
+        let payload_ref = JsonRef::for_content(&payload_bytes);
+
+        let mut segment = Segment {
+            header: SegmentHeader {
+                segment_id: "segment-1".to_string(),
+                format_version: 1,
+                commit_count: 1,
+                change_count: 1,
+                byte_count: 123,
+                payload_count: 1,
+                checksum: "segment-checksum".to_string(),
+            },
+            directory: SegmentDirectory {
+                commits: vec![(
+                    "commit-1".to_string(),
+                    location("segment-1", 10, 20, "commit-checksum"),
+                )],
+                changes: vec![(
+                    "change-1".to_string(),
+                    location("segment-1", 30, 40, "change-checksum"),
+                )],
+            },
+            commits: vec![SegmentCommit {
+                header: CommitHeader {
+                    id: "commit-1".to_string(),
+                    parent_commit_ids: vec!["parent-1".to_string()],
+                    derivable_change_id: "commit-change-1".to_string(),
+                    author_account_ids: vec!["account-1".to_string()],
+                    created_at: "2026-05-12T00:00:00Z".to_string(),
+                    membership_count: 1,
+                },
+                body: CommitBody {
+                    membership: vec![MembershipRecord {
+                        member_change_id: "change-1".to_string(),
+                        role: MembershipRole::Authored,
+                        source_parent_ordinal: None,
+                    }],
+                },
+                directory: SegmentCommitDirectory {
+                    state_row_identities: vec![(state_row_identity, "change-1".to_string())],
+                    membership_ordinals: vec![("change-1".to_string(), 0)],
+                },
+                checksum: "commit-checksum".to_string(),
+            }],
+            changes: vec![SegmentChange {
+                id: "change-1".to_string(),
+                authored_commit_id: Some("commit-1".to_string()),
+                entity_id: entity_identity,
+                schema_key: "message".to_string(),
+                file_id: Some("file-1".to_string()),
+                snapshot_ref: Some(snapshot_ref),
+                metadata_ref: Some(metadata_ref),
+                created_at: "2026-05-12T00:00:00Z".to_string(),
+                inline_payloads: vec![SegmentInlinePayload {
+                    json_ref: payload_ref,
+                    bytes: payload_bytes,
+                }],
+                directory: SegmentChangeDirectory {
+                    payloads: vec![SegmentPayloadLocation {
+                        json_ref: payload_ref,
+                        offset: 0,
+                        len: 17,
+                    }],
+                },
+            }],
+        };
+        apply_sample_encoded_locations(&mut segment);
+        segment
+    }
+
+    fn sample_segment_with_two_changes() -> Segment {
+        let mut segment = sample_segment();
+        let entity_identity = EntityIdentity::single("entity-2");
+        let state_row_identity = StateRowIdentity {
+            schema_key: CanonicalSchemaKey::new("message").unwrap(),
+            file_id: FileId::new("file-1").unwrap(),
+            entity_id: EntityId::new(entity_identity.as_json_array_text().unwrap()).unwrap(),
+        };
+        let payload_bytes = br#"{"goodbye":"world"}"#.to_vec();
+        let payload_ref = JsonRef::for_content(&payload_bytes);
+        segment.commits[0].header.membership_count = 2;
+        segment.commits[0].body.membership.push(MembershipRecord {
+            member_change_id: "change-2".to_string(),
+            role: MembershipRole::Authored,
+            source_parent_ordinal: None,
+        });
+        segment.commits[0]
+            .directory
+            .state_row_identities
+            .push((state_row_identity, "change-2".to_string()));
+        segment.commits[0]
+            .directory
+            .membership_ordinals
+            .push(("change-2".to_string(), 1));
+        segment.changes.push(SegmentChange {
+            id: "change-2".to_string(),
+            authored_commit_id: Some("commit-1".to_string()),
+            entity_id: entity_identity,
+            schema_key: "message".to_string(),
+            file_id: Some("file-1".to_string()),
+            snapshot_ref: None,
+            metadata_ref: None,
+            created_at: "2026-05-12T00:00:01Z".to_string(),
+            inline_payloads: vec![SegmentInlinePayload {
+                json_ref: payload_ref,
+                bytes: payload_bytes,
+            }],
+            directory: SegmentChangeDirectory {
+                payloads: vec![SegmentPayloadLocation {
+                    json_ref: payload_ref,
+                    offset: 0,
+                    len: 19,
+                }],
+            },
+        });
+        segment.header.change_count = 2;
+        segment.header.payload_count = 2;
+        segment.directory.changes.push((
+            "change-2".to_string(),
+            location("segment-1", 0, 0, "change-checksum-2"),
+        ));
+        apply_sample_encoded_locations(&mut segment);
+        segment
+    }
+
+    fn apply_sample_encoded_locations(segment: &mut Segment) {
+        for commit in &mut segment.commits {
+            commit.checksum = checksum_commit(commit).unwrap();
+        }
+        let change_checksums = segment
+            .changes
+            .iter()
+            .map(|change| (change.id.clone(), checksum_change(change).unwrap()))
+            .collect::<HashMap<_, _>>();
+        for (change_id, location) in &mut segment.directory.changes {
+            location.checksum = change_checksums
+                .get(change_id)
+                .expect("change checksum should exist")
+                .clone();
+        }
+        for (commit_id, location) in &mut segment.directory.commits {
+            location.checksum = segment
+                .commits
+                .iter()
+                .find(|commit| commit.header.id == *commit_id)
+                .expect("commit checksum should exist")
+                .checksum
+                .clone();
+        }
+        segment.header.byte_count = 0;
+        segment.header.checksum = empty_checksum();
+        let encoded = encode_segment_with_object_locations(segment).unwrap();
+        for (id, location) in &mut segment.directory.commits {
+            let object = encoded
+                .commits
+                .iter()
+                .find(|object| object.id == *id)
+                .expect("commit location should exist");
+            location.offset = object.offset;
+            location.len = object.len;
+        }
+        for (id, location) in &mut segment.directory.changes {
+            let object = encoded
+                .changes
+                .iter()
+                .find(|object| object.id == *id)
+                .expect("change location should exist");
+            location.offset = object.offset;
+            location.len = object.len;
+        }
+        segment.header.byte_count = encode_segment(segment).unwrap().len() as u64;
+        segment.header.checksum = checksum_segment(segment).unwrap();
     }
 
     fn location(segment_id: &str, offset: u64, len: u64, checksum: &str) -> SegmentObjectLocation {

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -2958,7 +2958,17 @@ async fn get_many(
     if keys.is_empty() {
         return Ok(Vec::new());
     }
-    store.changelog_get_many(space, keys).await
+    let expected_len = keys.len();
+    let values = store.changelog_get_many(space, keys).await?;
+    if values.len() != expected_len {
+        return Err(LixError::unknown(format!(
+            "changelog point read over namespace '{}' returned {} values for {} requested keys",
+            space.name,
+            values.len(),
+            expected_len
+        )));
+    }
+    Ok(values)
 }
 
 fn native_get_many<R>(
@@ -3094,6 +3104,34 @@ mod tests {
         }
     }
 
+    struct ShortGetManyStore;
+
+    #[async_trait]
+    impl ChangelogStorageRead for ShortGetManyStore {
+        async fn changelog_get_many(
+            &mut self,
+            _space: StorageSpace,
+            _keys: Vec<Vec<u8>>,
+        ) -> Result<Vec<Option<Vec<u8>>>, LixError> {
+            Ok(Vec::new())
+        }
+
+        async fn changelog_scan(
+            &mut self,
+            _space: StorageSpace,
+            _prefix: Vec<u8>,
+            _after: Option<Vec<u8>>,
+            _limit: usize,
+            _projection: StorageCoreProjection,
+        ) -> Result<ChangelogScanPage, LixError> {
+            Ok(ChangelogScanPage {
+                keys: Vec::new(),
+                values: Vec::new(),
+                resume_after: None,
+            })
+        }
+    }
+
     struct KeyOnlyPointRead;
 
     impl BackendRead for KeyOnlyPointRead {
@@ -3138,6 +3176,23 @@ mod tests {
             error
                 .message
                 .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_segment_rejects_short_get_many_result() {
+        let mut reader = ChangelogContext::new().reader(ShortGetManyStore);
+
+        let error = reader
+            .load_segment("segment-1")
+            .await
+            .expect_err("short get-many result must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("returned 0 values for 1 requested keys"),
             "unexpected error: {error}"
         );
     }

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -22,9 +22,9 @@ use super::store::{
     COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
 };
 use crate::changelog::{
-    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
-    decode_segment_change, decode_segment_commit, segment_commit_membership_contains_any,
-    view_segment_directory,
+    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility,
+    decode_empty_index_value, decode_segment, decode_segment_change, decode_segment_commit,
+    segment_commit_membership_contains_any, view_segment_directory,
 };
 use crate::changelog::{
     ByChangeEntry, ByCommitEntry, Change, ChangeLoadBatch, ChangeLoadEntry, ChangeLoadRequest,
@@ -1070,13 +1070,19 @@ where
                     prefix.clone(),
                     after,
                     256,
-                    StorageCoreProjection::KeyOnly,
+                    StorageCoreProjection::FullValue,
                 )
                 .await?;
             for index in 0..page.keys.len() {
                 let Some(key) = page.keys.get(index) else {
                     continue;
                 };
+                let Some(value) = page.value(index) else {
+                    return Err(LixError::unknown(format!(
+                        "changelog by_change_membership index returned key without value for visible change '{change_id}'"
+                    )));
+                };
+                decode_empty_index_value(value)?;
                 if let Some(commit_id) = by_change_membership_commit_id_from_key(change_id, key)? {
                     out.push(commit_id);
                 }
@@ -3808,6 +3814,53 @@ mod tests {
             error
                 .to_string()
                 .contains("failed to decode changelog by_change entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_changes_visible_errors_when_by_change_membership_value_is_corrupt() {
+        let (context, storage) = changelog_test_context();
+        let segment = test_segment();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(segment).await.unwrap();
+            writer.stage_publish_commit("commit-1").await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.delete(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-1"),
+        );
+        writes.put(
+            BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+            by_change_membership_key("change-1", "commit-1"),
+            b"not empty".to_vec(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage);
+        let error = reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &["change-1".to_string()],
+                projection: ChangeProjection::Segment,
+                visibility: ChangeVisibilityMode::RequireReachableFromVisibleCommit,
+            })
+            .await
+            .expect_err("visible read should error on corrupt membership value");
+
+        assert!(
+            error
+                .to_string()
+                .contains("changelog empty index value must be zero bytes"),
             "unexpected error: {error}"
         );
     }

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -363,6 +363,15 @@ struct SourceParentFacts {
     first_parent_winners: HashMap<StateRowIdentity, String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct FirstParentWinnerFact {
+    pub(crate) change_id: String,
+    pub(crate) commit_id: String,
+    pub(crate) created_at: String,
+    pub(crate) updated_at: String,
+    pub(crate) deleted: bool,
+}
+
 impl<S> ChangelogStoreReader<S>
 where
     S: ChangelogStorageRead,
@@ -480,6 +489,221 @@ where
             }
         };
         Ok(ChangeLoadBatch { entries })
+    }
+
+    pub(crate) async fn load_physical_segment_changes(
+        &mut self,
+        change_ids: &[String],
+    ) -> Result<Vec<Option<(SegmentObjectLocation, SegmentChange)>>, LixError> {
+        let by_change_entries = self.load_by_change_many(change_ids).await?;
+        let mut segment_ids = Vec::new();
+        let mut seen_segment_ids = HashSet::new();
+        for entry in by_change_entries.iter().flatten() {
+            if seen_segment_ids.insert(entry.location.segment_id.clone()) {
+                segment_ids.push(entry.location.segment_id.clone());
+            }
+        }
+        let segments = self.load_segment_byte_indexes_by_id(&segment_ids).await?;
+        let mut entries = Vec::with_capacity(change_ids.len());
+        for (change_id, by_change) in change_ids.iter().zip(by_change_entries.iter()) {
+            let Some(by_change) = by_change else {
+                entries.push(None);
+                continue;
+            };
+            if by_change.change_id != *change_id {
+                return Err(LixError::unknown(format!(
+                    "by_change key for '{change_id}' contains change_id '{}'",
+                    by_change.change_id
+                )));
+            }
+            let Some(segment) = segments.get(&by_change.location.segment_id) else {
+                return Err(LixError::unknown(format!(
+                    "changelog by_change entry for '{change_id}' points to missing segment '{}'",
+                    by_change.location.segment_id
+                )));
+            };
+            let change = segment.load_change(&by_change.location, change_id)?;
+            validate_change_checksum(&by_change.location.checksum, change_id, &change)?;
+            entries.push(Some((by_change.location.clone(), change)));
+        }
+        Ok(entries)
+    }
+
+    pub(crate) async fn load_first_parent_winner_facts_for_visible_commit(
+        &mut self,
+        root_commit_id: &str,
+        identities: &[StateRowIdentity],
+    ) -> Result<HashMap<StateRowIdentity, FirstParentWinnerFact>, LixError> {
+        let requested = identities.iter().cloned().collect::<HashSet<_>>();
+        if requested.is_empty() {
+            return Ok(HashMap::new());
+        }
+        self.load_first_parent_winner_facts_for_visible_commit_inner(root_commit_id, |identity| {
+            Ok(requested.contains(identity))
+        })
+        .await
+    }
+
+    pub(crate) async fn load_first_parent_winner_facts_matching_visible_commit(
+        &mut self,
+        root_commit_id: &str,
+        include_identity: impl FnMut(&StateRowIdentity) -> Result<bool, LixError>,
+    ) -> Result<HashMap<StateRowIdentity, FirstParentWinnerFact>, LixError> {
+        self.load_first_parent_winner_facts_for_visible_commit_inner(
+            root_commit_id,
+            include_identity,
+        )
+        .await
+    }
+
+    pub(crate) async fn load_visible_commit_winners(
+        &mut self,
+        commit_id: &str,
+        identities: &[StateRowIdentity],
+    ) -> Result<HashMap<StateRowIdentity, String>, LixError> {
+        let requested = identities.iter().cloned().collect::<HashSet<_>>();
+        if requested.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let Some(visibility) = self.load_commit_visibility(commit_id).await? else {
+            return Err(LixError::unknown(format!(
+                "visible changelog commit '{commit_id}' is missing while validating tracked-state diff row"
+            )));
+        };
+        let Some(segment) = self
+            .load_segment_byte_index(&visibility.location.segment_id)
+            .await?
+        else {
+            return Err(LixError::unknown(format!(
+                "visible changelog commit '{commit_id}' points to missing segment '{}'",
+                visibility.location.segment_id
+            )));
+        };
+        if visibility.checksum != visibility.location.checksum {
+            return Err(LixError::unknown(format!(
+                "visible changelog commit '{commit_id}' checksum does not match physical locator checksum"
+            )));
+        }
+        let commit = segment.load_commit(&visibility.location, commit_id)?;
+        validate_commit_checksum(&visibility.checksum, commit_id, &commit)?;
+        let mut winners = HashMap::new();
+        for (identity, change_id) in &commit.directory.state_row_identities {
+            if requested.contains(identity) {
+                winners.insert(identity.clone(), change_id.clone());
+            }
+        }
+        Ok(winners)
+    }
+
+    pub(crate) async fn load_all_first_parent_winner_facts_for_visible_commit(
+        &mut self,
+        root_commit_id: &str,
+    ) -> Result<HashMap<StateRowIdentity, FirstParentWinnerFact>, LixError> {
+        self.load_first_parent_winner_facts_for_visible_commit_inner(root_commit_id, |_| Ok(true))
+            .await
+    }
+
+    async fn load_first_parent_winner_facts_for_visible_commit_inner(
+        &mut self,
+        root_commit_id: &str,
+        mut include_identity: impl FnMut(&StateRowIdentity) -> Result<bool, LixError>,
+    ) -> Result<HashMap<StateRowIdentity, FirstParentWinnerFact>, LixError> {
+        let mut newest_winners = HashMap::<StateRowIdentity, (String, String)>::new();
+        let mut matched_changes = Vec::<(StateRowIdentity, String)>::new();
+        let mut seen_commits = HashSet::new();
+        let mut current = Some(root_commit_id.to_string());
+        while let Some(commit_id) = current.take() {
+            if !seen_commits.insert(commit_id.clone()) {
+                return Err(LixError::unknown(format!(
+                    "visible changelog first-parent history contains cycle at commit '{commit_id}' while validating tracked-state diff row"
+                )));
+            }
+            let Some(visibility) = self.load_commit_visibility(&commit_id).await? else {
+                return Err(LixError::unknown(format!(
+                    "visible changelog commit '{commit_id}' is missing while validating tracked-state diff row"
+                )));
+            };
+            let Some(segment) = self
+                .load_segment_byte_index(&visibility.location.segment_id)
+                .await?
+            else {
+                return Err(LixError::unknown(format!(
+                    "visible changelog commit '{commit_id}' points to missing segment '{}'",
+                    visibility.location.segment_id
+                )));
+            };
+            if visibility.checksum != visibility.location.checksum {
+                return Err(LixError::unknown(format!(
+                    "visible changelog commit '{commit_id}' checksum does not match physical locator checksum"
+                )));
+            }
+            let commit = segment.load_commit(&visibility.location, &commit_id)?;
+            validate_commit_checksum(&visibility.checksum, &commit_id, &commit)?;
+            let mut commit_winners = HashMap::<StateRowIdentity, String>::new();
+            for (identity, change_id) in &commit.directory.state_row_identities {
+                if include_identity(identity)? {
+                    commit_winners.insert(identity.clone(), change_id.clone());
+                }
+            }
+            for (identity, change_id) in commit_winners {
+                newest_winners
+                    .entry(identity.clone())
+                    .or_insert_with(|| (change_id.clone(), commit_id.clone()));
+                matched_changes.push((identity, change_id));
+            }
+            current = commit.header.parent_commit_ids.first().cloned();
+        }
+
+        let mut change_ids = matched_changes
+            .iter()
+            .map(|(_, change_id)| change_id.clone())
+            .collect::<Vec<_>>();
+        change_ids.sort();
+        change_ids.dedup();
+        let loaded_changes = self.load_physical_segment_changes(&change_ids).await?;
+        let mut changes_by_id = HashMap::new();
+        for (change_id, loaded) in change_ids.into_iter().zip(loaded_changes) {
+            let Some((_, change)) = loaded else {
+                return Err(LixError::unknown(format!(
+                    "first-parent winner references missing changelog change '{change_id}'"
+                )));
+            };
+            changes_by_id.insert(change_id, change);
+        }
+
+        let mut created_at_by_identity = HashMap::new();
+        for (identity, change_id) in matched_changes {
+            let Some(change) = changes_by_id.get(&change_id) else {
+                continue;
+            };
+            created_at_by_identity.insert(identity, change.created_at.clone());
+        }
+
+        let mut facts = HashMap::new();
+        for (identity, (change_id, commit_id)) in newest_winners {
+            let Some(change) = changes_by_id.get(&change_id) else {
+                return Err(LixError::unknown(format!(
+                    "first-parent winner references missing changelog change '{change_id}'"
+                )));
+            };
+            let created_at = created_at_by_identity.get(&identity).cloned().ok_or_else(|| {
+                LixError::unknown(format!(
+                    "first-parent winner for commit '{root_commit_id}' and identity {:?} is missing created_at",
+                    identity
+                ))
+            })?;
+            facts.insert(
+                identity,
+                FirstParentWinnerFact {
+                    change_id,
+                    commit_id,
+                    created_at,
+                    updated_at: change.created_at.clone(),
+                    deleted: change.snapshot_ref.is_none(),
+                },
+            );
+        }
+        Ok(facts)
     }
 
     async fn load_physical_change_entries(

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -2979,11 +2979,14 @@ where
         .value
         .into_iter()
         .map(|value| match value {
-            Some(StorageProjectedValue::FullValue(bytes)) => Some(bytes.to_vec()),
-            Some(StorageProjectedValue::KeyOnly) => Some(Vec::new()),
-            None => None,
+            Some(StorageProjectedValue::FullValue(bytes)) => Ok(Some(bytes.to_vec())),
+            Some(StorageProjectedValue::KeyOnly) => Err(LixError::unknown(format!(
+                "changelog point read over namespace '{}' requested full value but storage returned key-only entry",
+                space.name
+            ))),
+            None => Ok(None),
         })
-        .collect())
+        .collect::<Result<Vec<_>, LixError>>()?)
 }
 
 fn native_scan<R>(
@@ -3037,6 +3040,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::backend::{
+        BackendError, BackendRead, BufferedRangeScan, GetOptions, Key, KeyRange, PointVisitor,
+        ProjectedValueRef, ScanOptions,
+    };
     use crate::changelog::test_support::*;
     use crate::changelog::{
         decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
@@ -3044,7 +3051,7 @@ mod tests {
         SegmentCommitDirectory,
     };
     use crate::entity_identity::EntityIdentity;
-    use crate::storage::StorageWriteSet;
+    use crate::storage::{StorageReadScope, StorageWriteSet};
 
     use super::*;
 
@@ -3085,6 +3092,54 @@ mod tests {
                 resume_after: None,
             })
         }
+    }
+
+    struct KeyOnlyPointRead;
+
+    impl BackendRead for KeyOnlyPointRead {
+        type RangeScan<'cursor> = BufferedRangeScan;
+
+        fn visit_keys<V>(
+            &self,
+            keys: &[Key],
+            _opts: GetOptions<'_>,
+            visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            for (index, key) in keys.iter().enumerate() {
+                visitor.visit(index, key, Some(ProjectedValueRef::KeyOnly))?;
+            }
+            Ok(())
+        }
+
+        fn with_range_scan<T, F>(
+            &self,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            _f: F,
+        ) -> Result<T, BackendError>
+        where
+            F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+        {
+            unreachable!("changelog point-read test does not scan")
+        }
+    }
+
+    #[test]
+    fn native_get_many_rejects_key_only_point_read() {
+        let mut read = StorageReadScope::new(KeyOnlyPointRead);
+
+        let error = native_get_many(&mut read, SEGMENT_SPACE, vec![b"segment-1".to_vec()])
+            .expect_err("key-only point read must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -1238,9 +1238,7 @@ where
                 )
                 .await?;
             for index in 0..page.len() {
-                let Some(bytes) = page.value(index) else {
-                    continue;
-                };
+                let bytes = required_scan_value(&page, index, SEGMENT_SPACE, "scan_all_segments")?;
                 let segment = decode_segment(bytes)?;
                 validate_segment_shape(&segment)?;
                 segments.push(segment);
@@ -1387,9 +1385,8 @@ where
                 )
                 .await?;
             for index in 0..page.len() {
-                let Some(bytes) = page.value(index) else {
-                    continue;
-                };
+                let bytes =
+                    required_scan_value(&page, index, SEGMENT_SPACE, "scan_segments_for_change")?;
                 let segment = decode_segment(bytes)?;
                 validate_segment_shape(&segment)?;
                 if let Some(change) = segment_change(&segment, change_id) {
@@ -1762,9 +1759,12 @@ where
                 )
                 .await?;
             for index in 0..page.len() {
-                let Some(bytes) = page.value(index) else {
-                    continue;
-                };
+                let bytes = required_scan_value(
+                    &page,
+                    index,
+                    SEGMENT_SPACE,
+                    "load_stored_commit_location_from_segment_truth",
+                )?;
                 let segment = DecodedSegmentIndex::decode(bytes)?;
                 let Some(location) = segment.commit_location(commit_id) else {
                     continue;
@@ -2645,9 +2645,7 @@ where
                 )
                 .await?;
             for index in 0..page.len() {
-                let Some(bytes) = page.value(index) else {
-                    continue;
-                };
+                let bytes = required_scan_value(&page, index, SEGMENT_SPACE, "scan_all_segments")?;
                 let segment = decode_segment(bytes)?;
                 validate_segment_shape(&segment)?;
                 segments.push(segment);
@@ -2820,6 +2818,20 @@ fn push_unique(values: &mut Vec<String>, value: String) {
     if !values.iter().any(|existing| existing == &value) {
         values.push(value);
     }
+}
+
+fn required_scan_value<'a>(
+    page: &'a ChangelogScanPage,
+    index: usize,
+    space: StorageSpace,
+    operation: &str,
+) -> Result<&'a [u8], LixError> {
+    page.value(index).ok_or_else(|| {
+        LixError::unknown(format!(
+            "changelog {operation} scan over namespace '{}' returned a key without a value",
+            space.name
+        ))
+    })
 }
 
 fn project_segment_commit(commit: &SegmentCommit, projection: CommitProjection) -> CommitLoadEntry {
@@ -3004,8 +3016,15 @@ where
     let mut values = Vec::with_capacity(chunk.entries.len());
     for entry in chunk.entries {
         keys.push(entry.key.0.to_vec());
-        if let StorageProjectedValue::FullValue(bytes) = entry.value {
-            values.push(bytes.to_vec());
+        match entry.value {
+            StorageProjectedValue::FullValue(bytes) => values.push(bytes.to_vec()),
+            StorageProjectedValue::KeyOnly if projection == StorageCoreProjection::FullValue => {
+                return Err(LixError::unknown(format!(
+                    "changelog scan over namespace '{}' requested full values but storage returned key-only entry",
+                    space.name
+                )));
+            }
+            StorageProjectedValue::KeyOnly => {}
         }
     }
     let resume_after = has_more.then(|| keys.last().cloned()).flatten();
@@ -3028,6 +3047,45 @@ mod tests {
     use crate::storage::StorageWriteSet;
 
     use super::*;
+
+    struct MissingSegmentScanValueStore;
+
+    #[async_trait]
+    impl ChangelogStorageRead for MissingSegmentScanValueStore {
+        async fn changelog_get_many(
+            &mut self,
+            _space: StorageSpace,
+            keys: Vec<Vec<u8>>,
+        ) -> Result<Vec<Option<Vec<u8>>>, LixError> {
+            Ok(keys.into_iter().map(|_| None).collect())
+        }
+
+        async fn changelog_scan(
+            &mut self,
+            space: StorageSpace,
+            _prefix: Vec<u8>,
+            _after: Option<Vec<u8>>,
+            _limit: usize,
+            projection: StorageCoreProjection,
+        ) -> Result<ChangelogScanPage, LixError> {
+            if space != SEGMENT_SPACE {
+                return Ok(ChangelogScanPage {
+                    keys: Vec::new(),
+                    values: Vec::new(),
+                    resume_after: None,
+                });
+            }
+            let values = match projection {
+                StorageCoreProjection::KeyOnly => Vec::new(),
+                StorageCoreProjection::FullValue => Vec::new(),
+            };
+            Ok(ChangelogScanPage {
+                keys: vec![b"segment-with-missing-value".to_vec()],
+                values,
+                resume_after: None,
+            })
+        }
+    }
 
     #[tokio::test]
     async fn stage_segment_stages_segment_and_rebuildable_indexes() {
@@ -4214,6 +4272,41 @@ mod tests {
         transaction.commit().await.unwrap();
 
         assert_mandatory_index_rows_match_segment(&storage, &segment).await;
+    }
+
+    #[tokio::test]
+    async fn rebuild_mandatory_indexes_rejects_segment_scan_key_without_value() {
+        let context = ChangelogContext::new();
+        let mut store = MissingSegmentScanValueStore;
+        let mut writes = StorageWriteSet::new();
+        let mut writer = context.writer(&mut store, &mut writes);
+
+        let error = writer
+            .rebuild_mandatory_indexes()
+            .await
+            .expect_err("missing segment scan value must be corruption");
+
+        assert!(
+            error.message.contains("returned a key without a value"),
+            "unexpected error: {error}"
+        );
+        assert!(writes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn plan_gc_rejects_segment_scan_key_without_value() {
+        let context = ChangelogContext::new();
+        let mut reader = context.reader(MissingSegmentScanValueStore);
+
+        let error = reader
+            .plan_gc(&[])
+            .await
+            .expect_err("missing segment scan value must be corruption");
+
+        assert!(
+            error.message.contains("returned a key without a value"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -24,7 +24,7 @@ use super::store::{
 use crate::changelog::{
     decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
     decode_segment_change, decode_segment_commit, segment_commit_membership_contains_any,
-    view_segment,
+    view_segment_directory,
 };
 use crate::changelog::{
     ByChangeEntry, ByCommitEntry, Change, ChangeLoadBatch, ChangeLoadEntry, ChangeLoadRequest,
@@ -192,7 +192,7 @@ struct SegmentByteIndex {
 
 impl SegmentByteIndex {
     fn decode(bytes: Vec<u8>) -> Result<Self, LixError> {
-        let view = view_segment(&bytes)?;
+        let view = view_segment_directory(&bytes)?;
         let segment_id = view.segment_id.to_string();
         let commit_locations = view
             .directory_commits
@@ -256,6 +256,7 @@ impl SegmentByteIndex {
                 commit.header.id
             )));
         }
+        validate_commit_checksum(&location.checksum, commit_id, &commit)?;
         Ok(commit)
     }
 
@@ -277,7 +278,12 @@ impl SegmentByteIndex {
             )));
         }
         let bytes = self.object_bytes(location, "commit", commit_id)?;
-        segment_commit_membership_contains_any(bytes, requested_change_ids)
+        segment_commit_membership_contains_any(
+            bytes,
+            commit_id,
+            &location.checksum,
+            requested_change_ids,
+        )
     }
 
     fn load_change(
@@ -349,6 +355,12 @@ impl SegmentByteIndex {
             ))
         })
     }
+}
+
+#[derive(Default)]
+struct SourceParentFacts {
+    reachable_memberships: HashSet<String>,
+    first_parent_winners: HashMap<StateRowIdentity, String>,
 }
 
 impl<S> ChangelogStoreReader<S>
@@ -500,7 +512,8 @@ where
                 )));
             };
             if projection == ChangeProjection::PhysicalLocation {
-                segment.validate_change_location(&by_change.location, change_id)?;
+                let change = segment.load_change(&by_change.location, change_id)?;
+                validate_change_checksum(&by_change.location.checksum, change_id, &change)?;
                 entries.push(Some(ChangeLoadEntry::PhysicalLocation(
                     by_change.location.clone(),
                 )));
@@ -544,7 +557,8 @@ where
                 }
                 if let Some(segment) = segments.get(&by_change.location.segment_id) {
                     if projection == ChangeProjection::PhysicalLocation {
-                        segment.validate_change_location(&by_change.location, change_id)?;
+                        let change = segment.load_change(&by_change.location, change_id)?;
+                        validate_change_checksum(&by_change.location.checksum, change_id, &change)?;
                         entries.push(Some(ChangeLoadEntry::PhysicalLocation(
                             by_change.location.clone(),
                         )));
@@ -1340,6 +1354,8 @@ where
     ) -> Result<SegmentStageReport, LixError> {
         let segment = canonicalize_segment(segment)?;
         validate_stage_segment_shape(&segment)?;
+        self.validate_stage_adopted_membership_provenance(&segment)
+            .await?;
         self.reject_duplicate_logical_ids(&segment).await?;
         let segment_id = segment.header.segment_id.clone();
         let report = SegmentStageReport {
@@ -1644,6 +1660,7 @@ where
             .map(|membership| membership.member_change_id.clone())
             .collect::<HashSet<_>>();
         let changes = self.resolve_publish_changes(&member_change_ids).await?;
+        let mut source_parent_facts = HashMap::<String, SourceParentFacts>::new();
 
         for membership in &commit.body.membership {
             let Some(change) = changes.get(&membership.member_change_id) else {
@@ -1683,9 +1700,16 @@ where
                             commit.header.id, membership.member_change_id, source_parent_ordinal
                         )));
                     };
-                    if !self
-                        .commit_history_contains_membership(parent_id, &membership.member_change_id)
-                        .await?
+                    if !source_parent_facts.contains_key(parent_id) {
+                        let facts = self.source_parent_facts(parent_id).await?;
+                        source_parent_facts.insert(parent_id.clone(), facts);
+                    }
+                    let facts = source_parent_facts
+                        .get(parent_id)
+                        .expect("source parent facts should be cached");
+                    if !facts
+                        .reachable_memberships
+                        .contains(&membership.member_change_id)
                     {
                         return Err(LixError::unknown(format!(
                             "cannot publish changelog commit '{}' because adopted membership change '{}' is not reachable from source parent '{}'",
@@ -1693,13 +1717,8 @@ where
                         )));
                     }
                     let identity = state_row_identity_for_change(change)?;
-                    if !self
-                        .commit_history_projects_state_row(
-                            parent_id,
-                            &identity,
-                            &membership.member_change_id,
-                        )
-                        .await?
+                    if facts.first_parent_winners.get(&identity)
+                        != Some(&membership.member_change_id)
                     {
                         return Err(LixError::unknown(format!(
                             "cannot publish changelog commit '{}' because adopted membership change '{}' is not the source parent '{}' winner for {:?}",
@@ -1728,11 +1747,111 @@ where
         Ok(())
     }
 
-    async fn commit_history_contains_membership(
+    async fn validate_stage_adopted_membership_provenance(
+        &mut self,
+        segment: &Segment,
+    ) -> Result<(), LixError> {
+        let adopted_change_ids = segment
+            .commits
+            .iter()
+            .flat_map(|commit| {
+                commit
+                    .body
+                    .membership
+                    .iter()
+                    .filter(|membership| membership.role == MembershipRole::Adopted)
+                    .map(|membership| membership.member_change_id.clone())
+            })
+            .collect::<HashSet<_>>();
+        if adopted_change_ids.is_empty() {
+            return Ok(());
+        }
+
+        let mut changes = segment
+            .changes
+            .iter()
+            .filter(|change| adopted_change_ids.contains(&change.id))
+            .map(|change| (change.id.clone(), change.clone()))
+            .collect::<HashMap<_, _>>();
+        let missing = adopted_change_ids
+            .difference(&changes.keys().cloned().collect::<HashSet<_>>())
+            .cloned()
+            .collect::<HashSet<_>>();
+        if !missing.is_empty() {
+            changes.extend(self.resolve_publish_changes(&missing).await?);
+        }
+
+        let mut source_parent_facts = HashMap::<String, SourceParentFacts>::new();
+
+        for commit in &segment.commits {
+            for membership in &commit.body.membership {
+                if membership.role != MembershipRole::Adopted {
+                    continue;
+                }
+                let source_parent_ordinal =
+                    membership.source_parent_ordinal.ok_or_else(|| {
+                        LixError::unknown(format!(
+                            "cannot stage changelog commit '{}' because adopted membership change '{}' is missing source_parent_ordinal",
+                            commit.header.id, membership.member_change_id
+                        ))
+                    })?;
+                let parent_id = commit
+                    .header
+                    .parent_commit_ids
+                    .get(source_parent_ordinal as usize)
+                    .ok_or_else(|| {
+                        LixError::unknown(format!(
+                            "cannot stage changelog commit '{}' because adopted membership change '{}' source_parent_ordinal {} is out of bounds",
+                            commit.header.id, membership.member_change_id, source_parent_ordinal
+                        ))
+                    })?;
+                let Some(change) = changes.get(&membership.member_change_id) else {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' has no changelog.change",
+                        commit.header.id, membership.member_change_id
+                    )));
+                };
+                if change.authored_commit_id.as_deref() == Some(commit.header.id.as_str()) {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' is authored by the same commit",
+                        commit.header.id, membership.member_change_id
+                    )));
+                }
+                if !source_parent_facts.contains_key(parent_id) {
+                    let facts = self
+                        .source_parent_facts_in_segment(parent_id, segment)
+                        .await?;
+                    source_parent_facts.insert(parent_id.clone(), facts);
+                }
+                let facts = source_parent_facts
+                    .get(parent_id)
+                    .expect("source parent facts should be cached");
+                if !facts
+                    .reachable_memberships
+                    .contains(&membership.member_change_id)
+                {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' is not reachable from source parent '{}'",
+                        commit.header.id, membership.member_change_id, parent_id
+                    )));
+                }
+                let identity = state_row_identity_for_change(change)?;
+                if facts.first_parent_winners.get(&identity) != Some(&membership.member_change_id) {
+                    return Err(LixError::unknown(format!(
+                        "cannot stage changelog commit '{}' because adopted membership change '{}' is not the source parent '{}' winner for {:?}",
+                        commit.header.id, membership.member_change_id, parent_id, identity
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn source_parent_facts(
         &mut self,
         root_commit_id: &str,
-        change_id: &str,
-    ) -> Result<bool, LixError> {
+    ) -> Result<SourceParentFacts, LixError> {
+        let mut facts = SourceParentFacts::default();
         let mut stack = vec![root_commit_id.to_string()];
         let mut visited = HashSet::new();
         while let Some(commit_id) = stack.pop() {
@@ -1740,6 +1859,132 @@ where
                 continue;
             }
             let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
+                continue;
+            };
+            facts.reachable_memberships.extend(
+                commit
+                    .body
+                    .membership
+                    .iter()
+                    .map(|membership| membership.member_change_id.clone()),
+            );
+            stack.extend(commit.header.parent_commit_ids);
+        }
+
+        let mut next_commit_id = Some(root_commit_id.to_string());
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = next_commit_id.take() {
+            if !visited.insert(commit_id.clone()) {
+                return Err(LixError::unknown(format!(
+                    "cannot resolve source parent facts because first-parent history contains parent cycle at commit '{commit_id}'"
+                )));
+            }
+            let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
+                break;
+            };
+            for (identity, change_id) in &commit.directory.state_row_identities {
+                facts
+                    .first_parent_winners
+                    .entry(identity.clone())
+                    .or_insert_with(|| change_id.clone());
+            }
+            next_commit_id = commit.header.parent_commit_ids.first().cloned();
+        }
+        Ok(facts)
+    }
+
+    async fn source_parent_facts_in_segment(
+        &mut self,
+        root_commit_id: &str,
+        segment: &Segment,
+    ) -> Result<SourceParentFacts, LixError> {
+        let mut facts = SourceParentFacts::default();
+        let mut stack = vec![root_commit_id.to_string()];
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = stack.pop() {
+            if !visited.insert(commit_id.clone()) {
+                continue;
+            }
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, Some(segment))
+                .await?
+            else {
+                continue;
+            };
+            facts.reachable_memberships.extend(
+                commit
+                    .body
+                    .membership
+                    .iter()
+                    .map(|membership| membership.member_change_id.clone()),
+            );
+            stack.extend(commit.header.parent_commit_ids);
+        }
+
+        let mut next_commit_id = Some(root_commit_id.to_string());
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = next_commit_id.take() {
+            if !visited.insert(commit_id.clone()) {
+                return Err(LixError::unknown(format!(
+                    "cannot resolve source parent facts because first-parent history contains parent cycle at commit '{commit_id}'"
+                )));
+            }
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, Some(segment))
+                .await?
+            else {
+                break;
+            };
+            for (identity, change_id) in &commit.directory.state_row_identities {
+                facts
+                    .first_parent_winners
+                    .entry(identity.clone())
+                    .or_insert_with(|| change_id.clone());
+            }
+            next_commit_id = commit.header.parent_commit_ids.first().cloned();
+        }
+        Ok(facts)
+    }
+
+    async fn commit_history_contains_membership(
+        &mut self,
+        root_commit_id: &str,
+        change_id: &str,
+    ) -> Result<bool, LixError> {
+        self.commit_history_contains_membership_with_loader(root_commit_id, change_id, None)
+            .await
+    }
+
+    async fn commit_history_contains_membership_in_segment(
+        &mut self,
+        root_commit_id: &str,
+        change_id: &str,
+        segment: &Segment,
+    ) -> Result<bool, LixError> {
+        self.commit_history_contains_membership_with_loader(
+            root_commit_id,
+            change_id,
+            Some(segment),
+        )
+        .await
+    }
+
+    async fn commit_history_contains_membership_with_loader(
+        &mut self,
+        root_commit_id: &str,
+        change_id: &str,
+        segment: Option<&Segment>,
+    ) -> Result<bool, LixError> {
+        let mut stack = vec![root_commit_id.to_string()];
+        let mut visited = HashSet::new();
+        while let Some(commit_id) = stack.pop() {
+            if !visited.insert(commit_id.clone()) {
+                continue;
+            }
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, segment)
+                .await?
+            else {
                 continue;
             };
             if commit
@@ -1761,6 +2006,38 @@ where
         identity: &StateRowIdentity,
         change_id: &str,
     ) -> Result<bool, LixError> {
+        self.commit_history_projects_state_row_with_loader(
+            root_commit_id,
+            identity,
+            change_id,
+            None,
+        )
+        .await
+    }
+
+    async fn commit_history_projects_state_row_in_segment(
+        &mut self,
+        root_commit_id: &str,
+        identity: &StateRowIdentity,
+        change_id: &str,
+        segment: &Segment,
+    ) -> Result<bool, LixError> {
+        self.commit_history_projects_state_row_with_loader(
+            root_commit_id,
+            identity,
+            change_id,
+            Some(segment),
+        )
+        .await
+    }
+
+    async fn commit_history_projects_state_row_with_loader(
+        &mut self,
+        root_commit_id: &str,
+        identity: &StateRowIdentity,
+        change_id: &str,
+        segment: Option<&Segment>,
+    ) -> Result<bool, LixError> {
         let mut next_commit_id = Some(root_commit_id.to_string());
         let mut visited = HashSet::new();
         while let Some(commit_id) = next_commit_id.take() {
@@ -1770,7 +2047,10 @@ where
                     identity, commit_id
                 )));
             }
-            let Some(commit) = self.load_published_or_staged_commit(&commit_id).await? else {
+            let Some(commit) = self
+                .load_published_staged_or_segment_commit(&commit_id, segment)
+                .await?
+            else {
                 return Ok(false);
             };
             if let Some((_, winner_change_id)) = commit
@@ -1784,6 +2064,25 @@ where
             next_commit_id = commit.header.parent_commit_ids.first().cloned();
         }
         Ok(false)
+    }
+
+    async fn load_published_staged_or_segment_commit(
+        &mut self,
+        commit_id: &str,
+        segment: Option<&Segment>,
+    ) -> Result<Option<SegmentCommit>, LixError> {
+        if let Some(commit) = segment.and_then(|segment| {
+            segment
+                .commits
+                .iter()
+                .find(|commit| commit.header.id == commit_id)
+        }) {
+            return Ok(Some(commit.clone()));
+        }
+        if let Some(commit) = self.load_published_or_staged_commit(commit_id).await? {
+            return Ok(Some(commit));
+        }
+        self.find_segment_commit(commit_id).await
     }
 
     async fn load_published_or_staged_commit(
@@ -1810,6 +2109,71 @@ where
         self.load_publish_commit(commit_id, &visibility.location)
             .await
             .map(Some)
+    }
+
+    async fn find_segment_commit(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<Option<SegmentCommit>, LixError> {
+        let Some(entry) = get_one(
+            &mut *self.store,
+            BY_COMMIT_INDEX_SPACE,
+            by_commit_key(commit_id),
+        )
+        .await?
+        .map(|bytes| decode_by_commit_entry(&bytes))
+        .transpose()?
+        else {
+            return self.scan_segments_for_commit(commit_id).await;
+        };
+        if entry.commit_id != commit_id {
+            return Err(LixError::unknown(format!(
+                "by_commit key for '{commit_id}' contains commit_id '{}'",
+                entry.commit_id
+            )));
+        }
+        let Some(segment) = self
+            .load_segment_byte_index_for_writer(&entry.location.segment_id)
+            .await?
+        else {
+            return self.scan_segments_for_commit(commit_id).await;
+        };
+        match segment.load_commit(&entry.location, commit_id) {
+            Ok(commit) => {
+                if validate_commit_checksum(&entry.location.checksum, commit_id, &commit).is_ok() {
+                    Ok(Some(commit))
+                } else {
+                    self.scan_segments_for_commit(commit_id).await
+                }
+            }
+            Err(_) => self.scan_segments_for_commit(commit_id).await,
+        }
+    }
+
+    async fn load_segment_byte_index_for_writer(
+        &mut self,
+        segment_id: &str,
+    ) -> Result<Option<SegmentByteIndex>, LixError> {
+        let Some(bytes) = get_one(&mut *self.store, SEGMENT_SPACE, segment_key(segment_id)).await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(SegmentByteIndex::decode(bytes)?))
+    }
+
+    async fn scan_segments_for_commit(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<Option<SegmentCommit>, LixError> {
+        for segment in self.scan_all_segments().await? {
+            let Some(commit) = segment_commit(&segment, commit_id) else {
+                continue;
+            };
+            let location = directory_commit_location(&segment, commit_id)?;
+            validate_commit_checksum(&location.checksum, commit_id, commit)?;
+            return Ok(Some(commit.clone()));
+        }
+        Ok(None)
     }
 
     async fn resolve_publish_changes(
@@ -3654,6 +4018,7 @@ mod tests {
         duplicate.header.segment_id = "segment-2".to_string();
         duplicate.commits[0].header.id = "commit-2".to_string();
         duplicate.commits[0].header.derivable_change_id = "derived-change-2".to_string();
+        duplicate.changes[0].authored_commit_id = Some("commit-2".to_string());
         let duplicate = canonicalize_segment(duplicate).unwrap();
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();
@@ -3996,15 +4361,16 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
             writer
-                .stage_publish_commit("commit-1")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove membership changes exist")
+                .expect_err("staging must prove membership changes exist")
         };
 
         assert!(
-            error.message.contains("no changelog.change exists"),
+            error
+                .message
+                .contains("authored membership references missing change 'change-1'"),
             "unexpected error: {error}"
         );
     }
@@ -4020,11 +4386,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
             writer
-                .stage_publish_commit("commit-1")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove StateRowIdentity matches the change")
+                .expect_err("staging must prove StateRowIdentity matches the change")
         };
 
         assert!(
@@ -4045,20 +4410,141 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
             writer
-                .stage_publish_commit("commit-2")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove authored membership owns its change")
+                .expect_err("staging must prove authored membership owns its change")
         };
 
         assert!(
-            error
-                .message
-                .contains("authored membership change 'change-1' belongs to"),
+            error.message.contains(
+                "authored membership change 'change-1' has mismatched authored_commit_id"
+            ),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn stage_segment_rejects_cross_segment_adopted_membership_authored_by_same_commit() {
+        let (context, storage) = changelog_test_context();
+        let mut change_segment = test_segment();
+        change_segment.header.segment_id = "change-segment".to_string();
+        change_segment.commits.clear();
+        change_segment.directory.commits.clear();
+        change_segment.changes[0].authored_commit_id = Some("commit-2".to_string());
+        let change_segment = canonicalize_segment(change_segment).unwrap();
+
+        let mut adopt_segment = test_segment();
+        adopt_segment.header.segment_id = "adopt-segment".to_string();
+        adopt_segment.changes.clear();
+        adopt_segment.directory.changes.clear();
+        adopt_segment.commits[0].header.id = "commit-2".to_string();
+        adopt_segment.commits[0].header.parent_commit_ids = vec!["missing-parent".to_string()];
+        adopt_segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        adopt_segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(change_segment).await.unwrap();
+            writer
+                .stage_segment(adopt_segment)
+                .await
+                .expect_err("staging must reject self-authored adopted membership")
+        };
+
+        assert!(
+            error.message.contains("is authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage_segment_accepts_adopted_membership_from_unpublished_stored_parent() {
+        let (context, storage) = changelog_test_context();
+        let parent_segment = test_segment();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(parent_segment).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut adopt_segment = test_segment();
+        adopt_segment.header.segment_id = "adopt-segment".to_string();
+        adopt_segment.changes.clear();
+        adopt_segment.directory.changes.clear();
+        adopt_segment.commits[0].header.id = "commit-2".to_string();
+        adopt_segment.commits[0].header.parent_commit_ids = vec!["commit-1".to_string()];
+        adopt_segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        adopt_segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(adopt_segment).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn stage_segment_accepts_adopted_membership_from_physical_parent_when_by_commit_is_stale()
+    {
+        let (context, storage) = changelog_test_context();
+        let parent_segment = test_segment();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(parent_segment).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            BY_COMMIT_INDEX_SPACE,
+            by_commit_key("commit-1"),
+            by_commit_index_value(&ByCommitEntry {
+                commit_id: "commit-1".to_string(),
+                location: SegmentObjectLocation {
+                    segment_id: "missing-segment".to_string(),
+                    offset: 0,
+                    len: 0,
+                    checksum: "stale-checksum".to_string(),
+                },
+                parent_commit_ids: Vec::new(),
+                generation: 0,
+            })
+            .unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut adopt_segment = test_segment();
+        adopt_segment.header.segment_id = "adopt-segment".to_string();
+        adopt_segment.changes.clear();
+        adopt_segment.directory.changes.clear();
+        adopt_segment.commits[0].header.id = "commit-2".to_string();
+        adopt_segment.commits[0].header.parent_commit_ids = vec!["commit-1".to_string()];
+        adopt_segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        adopt_segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_segment(adopt_segment).await.unwrap();
+        }
     }
 
     #[tokio::test]
@@ -4189,16 +4675,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
             writer
-                .stage_publish_commit("commit-other-parent")
+                .stage_segment(segment)
                 .await
-                .unwrap();
-            writer
-                .stage_publish_commit("commit-3")
-                .await
-                .expect_err("publication must prove adopted change reaches through source parent")
+                .expect_err("staging must prove adopted change reaches through source parent")
         };
 
         assert!(
@@ -4278,13 +4758,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
-            writer.stage_publish_commit("commit-2").await.unwrap();
             writer
-                .stage_publish_commit("commit-3")
+                .stage_segment(segment)
                 .await
-                .expect_err("publication must prove adopted change is the source winner")
+                .expect_err("staging must prove adopted change is the source winner")
         };
 
         assert!(
@@ -4423,15 +4900,10 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let error = {
             let mut writer = context.writer(&mut *transaction, &mut writes);
-            writer.stage_segment(segment).await.unwrap();
-            writer.stage_publish_commit("commit-1").await.unwrap();
-            writer.stage_publish_commit("target-commit").await.unwrap();
-            writer.stage_publish_commit("source-commit").await.unwrap();
-            writer.stage_publish_commit("merge-parent").await.unwrap();
             writer
-                .stage_publish_commit("adopting-commit")
+                .stage_segment(segment)
                 .await
-                .expect_err("source parent winner must use first-parent projection")
+                .expect_err("staging source parent winner must use first-parent projection")
         };
 
         assert!(
@@ -4584,7 +5056,10 @@ mod tests {
             error.message.contains("without that change")
                 || error
                     .message
-                    .contains("locator does not match segment directory"),
+                    .contains("locator does not match segment directory")
+                || error
+                    .message
+                    .contains("references missing authored change 'change-1'"),
             "unexpected error: {error}"
         );
     }
@@ -4605,7 +5080,7 @@ mod tests {
         transaction.commit().await.unwrap();
 
         let mut corrupted = segment;
-        corrupted.changes[0].schema_key = "messagb".to_string();
+        corrupted.changes[0].created_at = "2026-05-12T00:00:01Z".to_string();
         write_raw_segment(&storage, &corrupted).await;
 
         let mut reader = context.reader(storage);

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -15,8 +15,9 @@ use super::types::{
     SegmentObjectLocationRef, StateRowIdentity,
 };
 use crate::changelog::{
-    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
-    decode_segment_change, decode_segment_commit, view_segment_directory,
+    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility,
+    decode_empty_index_value, decode_segment, decode_segment_change, decode_segment_commit,
+    view_segment_directory,
 };
 use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::json_store::{self, JsonRef};
@@ -869,13 +870,19 @@ where
                 Vec::new(),
                 after,
                 256,
-                StorageCoreProjection::KeyOnly,
+                StorageCoreProjection::FullValue,
             )
             .await?;
         for index in 0..page.keys.len() {
             let Some(key) = page.keys.get(index) else {
                 continue;
             };
+            let Some(value) = page.value(index) else {
+                return Err(LixError::unknown(
+                    "changelog GC by_change_membership scan returned a key without a value",
+                ));
+            };
+            decode_empty_index_value(value)?;
             out.push(by_change_membership_ids_from_key(key)?);
         }
         let Some(next_after) = page.resume_after else {
@@ -1423,6 +1430,43 @@ mod tests {
             ],
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn gc_errors_when_by_change_membership_value_is_corrupt() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+            by_change_membership_key("change-1", "commit-1"),
+            b"not empty".to_vec(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[])
+                .await
+                .expect_err("GC must reject corrupt membership index values")
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("changelog empty index value must be zero bytes"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            writes.is_empty(),
+            "collect_garbage must stage no writes after index corruption"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::context::ChangelogStorageRead;
-use super::segment::validate_segment_shape;
+use super::segment::{validate_change_checksum, validate_commit_checksum, validate_segment_shape};
 use super::store::{
     by_change_index_value, by_change_key, by_change_membership_ids_from_key,
     by_change_membership_index_value, by_change_membership_key, by_commit_index_value,
@@ -10,10 +10,15 @@ use super::store::{
     BY_COMMIT_INDEX_SPACE, COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
 };
 use super::types::{
-    ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRoot, GcSweepSet, Segment,
-    SegmentChange, SegmentCommit, SegmentObjectLocation,
+    ByChangeEntry, ByCommitEntry, CommitVisibility, GcLiveSet, GcPlan, GcRoot, GcSweepSet,
+    MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentObjectLocation,
+    SegmentObjectLocationRef, StateRowIdentity,
 };
-use crate::changelog::decode_segment;
+use crate::changelog::{
+    decode_by_change_entry, decode_by_commit_entry, decode_commit_visibility, decode_segment,
+    decode_segment_change, decode_segment_commit, view_segment_directory,
+};
+use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::json_store::{self, JsonRef};
 use crate::storage::{StorageCoreProjection, StorageSpace, StorageWriteSet};
 use crate::LixError;
@@ -22,48 +27,15 @@ pub(super) async fn plan_gc<S>(store: &mut S, roots: &[GcRoot]) -> Result<GcPlan
 where
     S: ChangelogStorageRead + ?Sized,
 {
-    let segments = scan_all_segments(store).await?;
+    let all_segment_ids = scan_segment_ids(store).await?;
     let all_commit_visibility = scan_utf8_keys(store, COMMIT_VISIBILITY_SPACE).await?;
     let all_by_commit = scan_utf8_keys(store, BY_COMMIT_INDEX_SPACE).await?;
     let all_by_change = scan_utf8_keys(store, BY_CHANGE_INDEX_SPACE).await?;
     let all_by_change_membership = scan_by_change_membership_keys(store).await?;
     let all_visible_change_proof = scan_utf8_keys(store, VISIBLE_CHANGE_PROOF_SPACE).await?;
     let all_json_payloads = scan_json_payload_keys(store).await?;
-
-    let mut commit_index: HashMap<String, (String, SegmentCommit)> = HashMap::new();
-    let mut change_index: HashMap<String, (String, SegmentChange)> = HashMap::new();
-    let mut all_segment_ids = Vec::new();
-
-    for segment in &segments {
-        push_unique(&mut all_segment_ids, segment.header.segment_id.clone());
-        for commit in &segment.commits {
-            if commit_index
-                .insert(
-                    commit.header.id.clone(),
-                    (segment.header.segment_id.clone(), commit.clone()),
-                )
-                .is_some()
-            {
-                return Err(LixError::unknown(format!(
-                    "changelog GC found duplicate commit id '{}'",
-                    commit.header.id
-                )));
-            }
-        }
-        for change in &segment.changes {
-            if change_index
-                .insert(
-                    change.id.clone(),
-                    (segment.header.segment_id.clone(), change.clone()),
-                )
-                .is_some()
-            {
-                return Err(LixError::unknown(format!(
-                    "changelog GC found duplicate change id '{}'",
-                    change.id
-                )));
-            }
-        }
+    if roots.is_empty() {
+        validate_all_segments(store).await?;
     }
 
     let mut live = GcLiveSet::default();
@@ -71,29 +43,35 @@ where
     for root in roots {
         pending_commits.push(gc_root_commit_id(root).to_string());
     }
-    let mut visiting_commits = HashSet::new();
-    let mut checked_commits = HashSet::new();
-    for commit_id in &pending_commits {
-        validate_reachable_commit_graph_acyclic(
-            commit_id,
-            &commit_index,
-            &mut visiting_commits,
-            &mut checked_commits,
-        )?;
-    }
+
+    let mut segment_bytes = HashMap::<String, Vec<u8>>::new();
+    let mut commit_index: HashMap<String, (SegmentObjectLocation, SegmentCommit)> = HashMap::new();
+    let mut change_index: HashMap<String, (SegmentObjectLocation, SegmentChange)> = HashMap::new();
+    let mut source_parent_facts = HashMap::<String, GcSourceParentFacts>::new();
+    let mut live_memberships: HashSet<(String, String)> = HashSet::new();
 
     while let Some(commit_id) = pending_commits.pop() {
         if live.commits.contains(&commit_id) {
             continue;
         }
-        let Some((segment_id, commit)) = commit_index.get(&commit_id).cloned() else {
+        let Some((commit_location, commit)) =
+            load_gc_commit(store, &all_segment_ids, &mut segment_bytes, &commit_id).await?
+        else {
             return Err(LixError::unknown(format!(
                 "changelog GC root/ancestor commit '{commit_id}' was not found in changelog segments"
             )));
         };
+        if commit_index
+            .insert(commit_id.clone(), (commit_location.clone(), commit.clone()))
+            .is_some()
+        {
+            return Err(LixError::unknown(format!(
+                "changelog GC found duplicate live commit id '{commit_id}'"
+            )));
+        }
 
         push_unique(&mut live.commits, commit_id.clone());
-        push_unique(&mut live.segments, segment_id);
+        push_unique(&mut live.segments, commit_location.segment_id.clone());
 
         for parent_id in &commit.header.parent_commit_ids {
             if !live.commits.contains(parent_id) {
@@ -103,20 +81,83 @@ where
 
         for membership in &commit.body.membership {
             let change_id = &membership.member_change_id;
-            let Some((change_segment_id, change)) = change_index.get(change_id).cloned() else {
+            let Some((change_location, change)) =
+                load_gc_change(store, &all_segment_ids, &mut segment_bytes, change_id).await?
+            else {
                 return Err(LixError::unknown(format!(
                     "changelog GC live commit '{}' references missing change '{}'",
                     commit.header.id, change_id
                 )));
             };
+            if let Some((existing_location, existing_change)) =
+                change_index.insert(change_id.clone(), (change_location.clone(), change.clone()))
+            {
+                if existing_location != change_location || existing_change != change {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC found duplicate live change id '{change_id}'"
+                    )));
+                }
+            }
             push_unique(&mut live.changes, change_id.clone());
-            push_unique(&mut live.segments, change_segment_id);
+            push_unique(&mut live.segments, change_location.segment_id.clone());
+            live_memberships.insert((change_id.clone(), commit.header.id.clone()));
             mark_change_payloads(&mut live.payloads, &change);
         }
     }
+    let mut visiting_commits = HashSet::new();
+    let mut checked_commits = HashSet::new();
+    for root in roots {
+        validate_reachable_commit_graph_acyclic(
+            gc_root_commit_id(root),
+            &commit_index,
+            &mut visiting_commits,
+            &mut checked_commits,
+        )?;
+    }
+    validate_live_segments(&segment_bytes, &live.segments)?;
+    validate_gc_adopted_memberships(&commit_index, &change_index, &mut source_parent_facts)?;
 
     let live_commits: HashSet<_> = live.commits.iter().cloned().collect();
     let live_changes: HashSet<_> = live.changes.iter().cloned().collect();
+    let expected_by_commit = expected_live_by_commit_entries(&commit_index, &live.commits)?;
+    let expected_by_change = expected_live_by_change_entries(&change_index, &live.changes);
+    let expected_commit_visibility = expected_commit_visibilities(&commit_index, &live_commits);
+    let live_by_commit_entries = load_by_commit_entries(
+        store,
+        &all_by_commit
+            .iter()
+            .filter(|commit_id| live_commits.contains(*commit_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    let live_by_change_entries = load_by_change_entries(
+        store,
+        &all_by_change
+            .iter()
+            .filter(|change_id| live_changes.contains(*change_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    let live_commit_visibility_entries = load_commit_visibilities(
+        store,
+        &all_commit_visibility
+            .iter()
+            .filter(|commit_id| live_commits.contains(*commit_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+    let live_visible_change_proofs = load_visible_change_proofs(
+        store,
+        &all_visible_change_proof
+            .iter()
+            .filter(|change_id| live_changes.contains(*change_id))
+            .cloned()
+            .collect::<Vec<_>>(),
+    )
+    .await?;
 
     let sweep = GcSweepSet {
         segments: all_segment_ids
@@ -125,25 +166,49 @@ where
             .collect(),
         commit_visibility: all_commit_visibility
             .into_iter()
-            .filter(|commit_id| !live_commits.contains(commit_id))
+            .filter(|commit_id| {
+                !live_commits.contains(commit_id)
+                    || live_commit_visibility_entries.get(commit_id)
+                        != expected_commit_visibility.get(commit_id)
+            })
             .collect(),
         by_commit: all_by_commit
             .into_iter()
-            .filter(|commit_id| !live_commits.contains(commit_id))
+            .filter(|commit_id| {
+                !live_commits.contains(commit_id)
+                    || live_by_commit_entries.get(commit_id) != expected_by_commit.get(commit_id)
+            })
             .collect(),
         by_change: all_by_change
             .into_iter()
-            .filter(|change_id| !live_changes.contains(change_id))
+            .filter(|change_id| {
+                !live_changes.contains(change_id)
+                    || live_by_change_entries.get(change_id) != expected_by_change.get(change_id)
+            })
             .collect(),
         by_change_membership: all_by_change_membership
             .into_iter()
-            .filter(|(change_id, commit_id)| {
-                !live_changes.contains(change_id) || !live_commits.contains(commit_id)
-            })
+            .filter(|membership| !live_memberships.contains(membership))
             .collect(),
         visible_change_proof: all_visible_change_proof
             .into_iter()
-            .filter(|change_id| !live_changes.contains(change_id))
+            .filter(|change_id| {
+                if !live_changes.contains(change_id) {
+                    return true;
+                };
+                let Some(proof) = live_visible_change_proofs.get(change_id) else {
+                    return true;
+                };
+                if !live_memberships.contains(&(change_id.clone(), proof.commit_id.clone())) {
+                    return true;
+                }
+                if live_commit_visibility_entries.get(&proof.commit_id)
+                    != expected_commit_visibility.get(&proof.commit_id)
+                {
+                    return true;
+                }
+                expected_commit_visibility.get(&proof.commit_id) != Some(proof)
+            })
             .collect(),
         json_payloads: all_json_payloads
             .into_iter()
@@ -158,9 +223,75 @@ where
     })
 }
 
+#[derive(Default)]
+struct GcSourceParentFacts {
+    reachable_memberships: HashSet<String>,
+    first_parent_winners: HashMap<StateRowIdentity, String>,
+}
+
+fn gc_source_parent_facts(
+    root_commit_id: &str,
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+) -> Result<GcSourceParentFacts, LixError> {
+    let mut facts = GcSourceParentFacts::default();
+    let mut stack = vec![root_commit_id.to_string()];
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = stack.pop() {
+        if !visited.insert(commit_id.clone()) {
+            continue;
+        }
+        let Some((_, commit)) = commit_index.get(&commit_id) else {
+            continue;
+        };
+        facts.reachable_memberships.extend(
+            commit
+                .body
+                .membership
+                .iter()
+                .map(|membership| membership.member_change_id.clone()),
+        );
+        stack.extend(commit.header.parent_commit_ids.iter().cloned());
+    }
+
+    let mut next_commit_id = Some(root_commit_id.to_string());
+    let mut visited = HashSet::new();
+    while let Some(commit_id) = next_commit_id.take() {
+        if !visited.insert(commit_id.clone()) {
+            return Err(LixError::unknown(format!(
+                "changelog GC cannot resolve source parent facts because first-parent history contains cycle at commit '{}'",
+                commit_id
+            )));
+        }
+        let Some((_, commit)) = commit_index.get(&commit_id) else {
+            break;
+        };
+        for (identity, change_id) in &commit.directory.state_row_identities {
+            facts
+                .first_parent_winners
+                .entry(identity.clone())
+                .or_insert_with(|| change_id.clone());
+        }
+        next_commit_id = commit.header.parent_commit_ids.first().cloned();
+    }
+    Ok(facts)
+}
+
+fn state_row_identity_for_change(change: &SegmentChange) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(change.schema_key.clone())?,
+        file_id: FileId::new(
+            change
+                .file_id
+                .clone()
+                .unwrap_or_else(|| "__global__".to_string()),
+        )?,
+        entity_id: EntityId::new(change.entity_id.as_json_array_text()?)?,
+    })
+}
+
 fn validate_reachable_commit_graph_acyclic(
     commit_id: &str,
-    commit_index: &HashMap<String, (String, SegmentCommit)>,
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
     visiting: &mut HashSet<String>,
     checked: &mut HashSet<String>,
 ) -> Result<(), LixError> {
@@ -229,12 +360,47 @@ pub(super) fn stage_gc_sweep(writes: &mut StorageWriteSet, plan: &GcPlan) -> Res
     Ok(())
 }
 
-async fn scan_all_segments<S>(store: &mut S) -> Result<Vec<Segment>, LixError>
+async fn scan_segment_ids<S>(store: &mut S) -> Result<Vec<String>, LixError>
 where
     S: ChangelogStorageRead + ?Sized,
 {
     let mut after = None;
-    let mut segments = Vec::new();
+    let mut segment_ids = Vec::new();
+    loop {
+        let page = store
+            .changelog_scan(
+                SEGMENT_SPACE,
+                Vec::new(),
+                after,
+                64,
+                StorageCoreProjection::KeyOnly,
+            )
+            .await?;
+        for key in &page.keys {
+            let segment_id = std::str::from_utf8(key)
+                .map_err(|error| {
+                    LixError::unknown(format!(
+                        "changelog GC found invalid UTF-8 segment key: {error}"
+                    ))
+                })?
+                .to_string();
+            if !segment_ids.iter().any(|existing| existing == &segment_id) {
+                segment_ids.push(segment_id);
+            }
+        }
+        let Some(next_after) = page.resume_after else {
+            break;
+        };
+        after = Some(next_after);
+    }
+    Ok(segment_ids)
+}
+
+async fn validate_all_segments<S>(store: &mut S) -> Result<(), LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut after = None;
     loop {
         let page = store
             .changelog_scan(
@@ -251,14 +417,404 @@ where
             };
             let segment = decode_segment(bytes)?;
             validate_segment_shape(&segment)?;
-            segments.push(segment);
         }
         let Some(next_after) = page.resume_after else {
             break;
         };
         after = Some(next_after);
     }
-    Ok(segments)
+    Ok(())
+}
+
+fn validate_live_segments(
+    segment_bytes: &HashMap<String, Vec<u8>>,
+    live_segment_ids: &[String],
+) -> Result<(), LixError> {
+    for segment_id in live_segment_ids {
+        let Some(bytes) = segment_bytes.get(segment_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog GC live segment '{segment_id}' was not loaded"
+            )));
+        };
+        let segment = decode_segment(bytes)?;
+        validate_segment_shape(&segment)?;
+    }
+    Ok(())
+}
+
+async fn load_gc_commit<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    commit_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentCommit)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    if let Some(entry) = load_by_commit_entry(store, commit_id).await? {
+        if ensure_segment_bytes(store, segment_bytes, &entry.location.segment_id).await? {
+            match decode_commit_from_segment_bytes(
+                &segment_bytes[&entry.location.segment_id],
+                &entry.location,
+                commit_id,
+            )? {
+                Some(commit) => return Ok(Some((entry.location, commit))),
+                None => {}
+            }
+        }
+    }
+    scan_segments_for_commit(store, all_segment_ids, segment_bytes, commit_id).await
+}
+
+async fn load_gc_change<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    change_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    if let Some(entry) = load_by_change_entry(store, change_id).await? {
+        if ensure_segment_bytes(store, segment_bytes, &entry.location.segment_id).await? {
+            match decode_change_from_segment_bytes(
+                &segment_bytes[&entry.location.segment_id],
+                &entry.location,
+                change_id,
+            )? {
+                Some(change) => return Ok(Some((entry.location, change))),
+                None => {}
+            }
+        }
+    }
+    scan_segments_for_change(store, all_segment_ids, segment_bytes, change_id).await
+}
+
+async fn load_by_commit_entry<S>(
+    store: &mut S,
+    commit_id: &str,
+) -> Result<Option<ByCommitEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let Some(bytes) = store
+        .changelog_get_many(BY_COMMIT_INDEX_SPACE, vec![by_commit_key(commit_id)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+    else {
+        return Ok(None);
+    };
+    let entry = decode_by_commit_entry(&bytes)?;
+    if entry.commit_id != commit_id {
+        return Err(LixError::unknown(format!(
+            "by_commit key for '{commit_id}' contains commit_id '{}'",
+            entry.commit_id
+        )));
+    }
+    Ok(Some(entry))
+}
+
+async fn load_by_change_entry<S>(
+    store: &mut S,
+    change_id: &str,
+) -> Result<Option<ByChangeEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let Some(bytes) = store
+        .changelog_get_many(BY_CHANGE_INDEX_SPACE, vec![by_change_key(change_id)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+    else {
+        return Ok(None);
+    };
+    let entry = decode_by_change_entry(&bytes)?;
+    if entry.change_id != change_id {
+        return Err(LixError::unknown(format!(
+            "by_change key for '{change_id}' contains change_id '{}'",
+            entry.change_id
+        )));
+    }
+    Ok(Some(entry))
+}
+
+async fn ensure_segment_bytes<S>(
+    store: &mut S,
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    segment_id: &str,
+) -> Result<bool, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    if segment_bytes.contains_key(segment_id) {
+        return Ok(true);
+    }
+    let Some(bytes) = store
+        .changelog_get_many(SEGMENT_SPACE, vec![segment_key(segment_id)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+    else {
+        return Ok(false);
+    };
+    segment_bytes.insert(segment_id.to_string(), bytes);
+    Ok(true)
+}
+
+async fn scan_segments_for_commit<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    commit_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentCommit)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut found = None;
+    for segment_id in all_segment_ids {
+        if !ensure_segment_bytes(store, segment_bytes, segment_id).await? {
+            continue;
+        }
+        let bytes = &segment_bytes[segment_id];
+        let Ok(view) = view_segment_directory(bytes) else {
+            continue;
+        };
+        let Some(entry) = view
+            .directory_commits
+            .iter()
+            .find(|entry| entry.id == commit_id)
+        else {
+            continue;
+        };
+        let location = location_from_ref(entry.location);
+        let commit =
+            decode_commit_from_segment_bytes(bytes, &location, commit_id)?.ok_or_else(|| {
+                LixError::unknown(format!(
+                    "changelog GC commit '{commit_id}' disappeared from segment directory"
+                ))
+            })?;
+        if found.replace((location, commit)).is_some() {
+            return Err(LixError::unknown(format!(
+                "changelog GC found duplicate commit id '{commit_id}'"
+            )));
+        }
+    }
+    Ok(found)
+}
+
+async fn scan_segments_for_change<S>(
+    store: &mut S,
+    all_segment_ids: &[String],
+    segment_bytes: &mut HashMap<String, Vec<u8>>,
+    change_id: &str,
+) -> Result<Option<(SegmentObjectLocation, SegmentChange)>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let mut found = None;
+    for segment_id in all_segment_ids {
+        if !ensure_segment_bytes(store, segment_bytes, segment_id).await? {
+            continue;
+        }
+        let bytes = &segment_bytes[segment_id];
+        let Ok(view) = view_segment_directory(bytes) else {
+            continue;
+        };
+        let Some(entry) = view
+            .directory_changes
+            .iter()
+            .find(|entry| entry.id == change_id)
+        else {
+            continue;
+        };
+        let location = location_from_ref(entry.location);
+        let change =
+            decode_change_from_segment_bytes(bytes, &location, change_id)?.ok_or_else(|| {
+                LixError::unknown(format!(
+                    "changelog GC change '{change_id}' disappeared from segment directory"
+                ))
+            })?;
+        if found.replace((location, change)).is_some() {
+            return Err(LixError::unknown(format!(
+                "changelog GC found duplicate change id '{change_id}'"
+            )));
+        }
+    }
+    Ok(found)
+}
+
+fn decode_commit_from_segment_bytes(
+    bytes: &[u8],
+    location: &SegmentObjectLocation,
+    commit_id: &str,
+) -> Result<Option<SegmentCommit>, LixError> {
+    let view = view_segment_directory(bytes)?;
+    let Some(entry) = view
+        .directory_commits
+        .iter()
+        .find(|entry| entry.id == commit_id)
+    else {
+        return Ok(None);
+    };
+    if location_from_ref(entry.location) != *location {
+        return Ok(None);
+    }
+    let object = segment_object_bytes(bytes, view.segment_id, location, "commit", commit_id)?;
+    let commit = decode_segment_commit(object)?;
+    if commit.header.id != commit_id {
+        return Err(LixError::unknown(format!(
+            "changelog GC commit locator for '{commit_id}' decoded commit '{}'",
+            commit.header.id
+        )));
+    }
+    validate_commit_checksum(&location.checksum, commit_id, &commit)?;
+    Ok(Some(commit))
+}
+
+fn decode_change_from_segment_bytes(
+    bytes: &[u8],
+    location: &SegmentObjectLocation,
+    change_id: &str,
+) -> Result<Option<SegmentChange>, LixError> {
+    let view = view_segment_directory(bytes)?;
+    let Some(entry) = view
+        .directory_changes
+        .iter()
+        .find(|entry| entry.id == change_id)
+    else {
+        return Ok(None);
+    };
+    if location_from_ref(entry.location) != *location {
+        return Ok(None);
+    }
+    let object = segment_object_bytes(bytes, view.segment_id, location, "change", change_id)?;
+    let change = decode_segment_change(object)?;
+    if change.id != change_id {
+        return Err(LixError::unknown(format!(
+            "changelog GC change locator for '{change_id}' decoded change '{}'",
+            change.id
+        )));
+    }
+    validate_change_checksum(&location.checksum, change_id, &change)?;
+    Ok(Some(change))
+}
+
+fn segment_object_bytes<'a>(
+    bytes: &'a [u8],
+    segment_id: &str,
+    location: &SegmentObjectLocation,
+    kind: &str,
+    id: &str,
+) -> Result<&'a [u8], LixError> {
+    if location.segment_id != segment_id {
+        return Err(LixError::unknown(format!(
+            "changelog GC {kind} '{id}' locator points to segment '{}' but loaded '{}'",
+            location.segment_id, segment_id
+        )));
+    }
+    let start = usize::try_from(location.offset).map_err(|_| {
+        LixError::unknown(format!(
+            "changelog GC {kind} '{id}' offset does not fit in usize"
+        ))
+    })?;
+    let len = usize::try_from(location.len).map_err(|_| {
+        LixError::unknown(format!(
+            "changelog GC {kind} '{id}' length does not fit in usize"
+        ))
+    })?;
+    let end = start.checked_add(len).ok_or_else(|| {
+        LixError::unknown(format!("changelog GC {kind} '{id}' offset/len overflows"))
+    })?;
+    bytes.get(start..end).ok_or_else(|| {
+        LixError::unknown(format!(
+            "changelog GC {kind} '{id}' locator is out of bounds"
+        ))
+    })
+}
+
+fn location_from_ref(location: SegmentObjectLocationRef<'_>) -> SegmentObjectLocation {
+    SegmentObjectLocation {
+        segment_id: location.segment_id.to_string(),
+        offset: location.offset,
+        len: location.len,
+        checksum: location.checksum.to_string(),
+    }
+}
+
+fn validate_gc_adopted_memberships(
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    change_index: &HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+    source_parent_facts: &mut HashMap<String, GcSourceParentFacts>,
+) -> Result<(), LixError> {
+    for commit in commit_index.values().map(|(_, commit)| commit) {
+        for membership in &commit.body.membership {
+            if membership.role != MembershipRole::Adopted {
+                let change_id = &membership.member_change_id;
+                let Some((_, change)) = change_index.get(change_id) else {
+                    continue;
+                };
+                if change.authored_commit_id.as_deref() != Some(commit.header.id.as_str()) {
+                    return Err(LixError::unknown(format!(
+                        "changelog GC live commit '{}' authored membership change '{}' has mismatched authored_commit_id",
+                        commit.header.id, change_id
+                    )));
+                }
+                continue;
+            };
+            let change_id = &membership.member_change_id;
+            let Some((_, change)) = change_index.get(change_id) else {
+                continue;
+            };
+            if change.authored_commit_id.as_deref() == Some(commit.header.id.as_str()) {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is authored by the same commit",
+                    commit.header.id, change_id
+                )));
+            }
+            let source_parent_ordinal = membership.source_parent_ordinal.ok_or_else(|| {
+                LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is missing source_parent_ordinal",
+                    commit.header.id, change_id
+                ))
+            })?;
+            let parent_id = commit
+                .header
+                .parent_commit_ids
+                .get(source_parent_ordinal as usize)
+                .ok_or_else(|| {
+                    LixError::unknown(format!(
+                        "changelog GC live commit '{}' adopted membership change '{}' source_parent_ordinal {} is out of bounds",
+                        commit.header.id, change_id, source_parent_ordinal
+                    ))
+                })?;
+            if !source_parent_facts.contains_key(parent_id) {
+                let facts = gc_source_parent_facts(parent_id, commit_index)?;
+                source_parent_facts.insert(parent_id.clone(), facts);
+            }
+            let facts = source_parent_facts
+                .get(parent_id)
+                .expect("source parent facts should be cached");
+            if !facts.reachable_memberships.contains(change_id) {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is not reachable from source parent '{}'",
+                    commit.header.id, change_id, parent_id
+                )));
+            }
+            let identity = state_row_identity_for_change(change)?;
+            if facts.first_parent_winners.get(&identity) != Some(change_id) {
+                return Err(LixError::unknown(format!(
+                    "changelog GC live commit '{}' adopted membership change '{}' is not the source parent '{}' winner for {:?}",
+                    commit.header.id, change_id, parent_id, identity
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn scan_utf8_keys<S>(store: &mut S, space: StorageSpace) -> Result<Vec<String>, LixError>
@@ -326,6 +882,215 @@ where
             break;
         };
         after = Some(next_after);
+    }
+    Ok(out)
+}
+
+fn expected_commit_visibilities(
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    live_commits: &HashSet<String>,
+) -> HashMap<String, CommitVisibility> {
+    let mut out = HashMap::new();
+    for (commit_id, (location, commit)) in commit_index {
+        if live_commits.contains(commit_id) {
+            out.insert(
+                commit_id.clone(),
+                CommitVisibility {
+                    commit_id: commit.header.id.clone(),
+                    checksum: location.checksum.clone(),
+                    location: location.clone(),
+                },
+            );
+        }
+    }
+    out
+}
+
+fn expected_live_by_commit_entries(
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    live_commit_order: &[String],
+) -> Result<HashMap<String, ByCommitEntry>, LixError> {
+    let mut generations = HashMap::<String, u64>::new();
+    for commit_id in live_commit_order {
+        expected_live_commit_generation(commit_id, commit_index, &mut generations)?;
+    }
+    let mut out = HashMap::new();
+    for commit_id in live_commit_order {
+        let Some((location, commit)) = commit_index.get(commit_id) else {
+            continue;
+        };
+        let generation = generations.get(commit_id).copied().unwrap_or_default();
+        out.insert(
+            commit_id.clone(),
+            ByCommitEntry {
+                commit_id: commit.header.id.clone(),
+                location: location.clone(),
+                parent_commit_ids: commit.header.parent_commit_ids.clone(),
+                generation,
+            },
+        );
+    }
+    Ok(out)
+}
+
+fn expected_live_commit_generation(
+    commit_id: &str,
+    commit_index: &HashMap<String, (SegmentObjectLocation, SegmentCommit)>,
+    generations: &mut HashMap<String, u64>,
+) -> Result<u64, LixError> {
+    if let Some(generation) = generations.get(commit_id) {
+        return Ok(*generation);
+    }
+    let Some((_, commit)) = commit_index.get(commit_id) else {
+        return Ok(0);
+    };
+    let mut generation = 0;
+    for parent_id in &commit.header.parent_commit_ids {
+        let parent_generation = if commit_index.contains_key(parent_id) {
+            expected_live_commit_generation(parent_id, commit_index, generations)?
+        } else {
+            0
+        };
+        generation = generation.max(parent_generation.saturating_add(1));
+    }
+    generations.insert(commit_id.to_string(), generation);
+    Ok(generation)
+}
+
+fn expected_live_by_change_entries(
+    change_index: &HashMap<String, (SegmentObjectLocation, SegmentChange)>,
+    live_change_order: &[String],
+) -> HashMap<String, ByChangeEntry> {
+    let mut out = HashMap::new();
+    for change_id in live_change_order {
+        let Some((location, change)) = change_index.get(change_id) else {
+            continue;
+        };
+        out.insert(
+            change_id.clone(),
+            ByChangeEntry {
+                change_id: change.id.clone(),
+                location: location.clone(),
+            },
+        );
+    }
+    out
+}
+
+async fn load_by_commit_entries<S>(
+    store: &mut S,
+    commit_ids: &[String],
+) -> Result<HashMap<String, ByCommitEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            BY_COMMIT_INDEX_SPACE,
+            commit_ids
+                .iter()
+                .map(|commit_id| by_commit_key(commit_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (commit_id, value) in commit_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(entry) = decode_by_commit_entry(&bytes) {
+            if entry.commit_id == *commit_id {
+                out.insert(commit_id.clone(), entry);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn load_by_change_entries<S>(
+    store: &mut S,
+    change_ids: &[String],
+) -> Result<HashMap<String, ByChangeEntry>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            BY_CHANGE_INDEX_SPACE,
+            change_ids
+                .iter()
+                .map(|change_id| by_change_key(change_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (change_id, value) in change_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(entry) = decode_by_change_entry(&bytes) {
+            if entry.change_id == *change_id {
+                out.insert(change_id.clone(), entry);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn load_visible_change_proofs<S>(
+    store: &mut S,
+    change_ids: &[String],
+) -> Result<HashMap<String, CommitVisibility>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            change_ids
+                .iter()
+                .map(|change_id| visible_change_proof_key(change_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (change_id, value) in change_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(proof) = decode_commit_visibility(&bytes) {
+            out.insert(change_id.clone(), proof);
+        }
+    }
+    Ok(out)
+}
+
+async fn load_commit_visibilities<S>(
+    store: &mut S,
+    commit_ids: &[String],
+) -> Result<HashMap<String, CommitVisibility>, LixError>
+where
+    S: ChangelogStorageRead + ?Sized,
+{
+    let values = store
+        .changelog_get_many(
+            COMMIT_VISIBILITY_SPACE,
+            commit_ids
+                .iter()
+                .map(|commit_id| commit_visibility_key(commit_id))
+                .collect(),
+        )
+        .await?;
+    let mut out = HashMap::new();
+    for (commit_id, value) in commit_ids.iter().zip(values.into_iter()) {
+        let Some(bytes) = value else {
+            continue;
+        };
+        if let Ok(visibility) = decode_commit_visibility(&bytes) {
+            if visibility.commit_id == *commit_id {
+                out.insert(commit_id.clone(), visibility);
+            }
+        }
     }
     Ok(out)
 }
@@ -399,11 +1164,12 @@ fn mark_change_payloads(payloads: &mut Vec<JsonRef>, change: &SegmentChange) {
 mod tests {
     use super::*;
     use crate::changelog::segment::canonicalize_segment;
+    use crate::changelog::test_support::commit_visibility_from_segment;
     use crate::changelog::{
-        encode_segment, ChangelogContext, CommitBody, CommitHeader, MembershipRecord,
-        MembershipRole, RebuildIndexStats, Segment, SegmentChange, SegmentChangeDirectory,
-        SegmentCommit, SegmentCommitDirectory, SegmentDirectory, SegmentHeader,
-        SegmentInlinePayload, SegmentPayloadLocation,
+        decode_segment, encode_segment, ChangelogContext, CommitBody, CommitHeader,
+        MembershipRecord, MembershipRole, RebuildIndexStats, Segment, SegmentChange,
+        SegmentChangeDirectory, SegmentCommit, SegmentCommitDirectory, SegmentDirectory,
+        SegmentHeader, SegmentInlinePayload, SegmentPayloadLocation,
     };
     use crate::common::{CanonicalSchemaKey, EntityId, FileId};
     use crate::entity_identity::EntityIdentity;
@@ -660,6 +1426,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_sweeps_stale_membership_row_even_when_change_and_commit_are_live() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let change_segment =
+            single_commit_segment("segment-change", "commit-change", "change-live");
+        let commit_segment = single_commit_segment("segment-commit", "commit-live", "change-other");
+
+        write_segments(
+            &storage,
+            &context,
+            vec![change_segment, commit_segment],
+            &["commit-change", "commit-live"],
+        )
+        .await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+            by_change_membership_key("change-live", "commit-live"),
+            by_change_membership_index_value(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let plan = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[
+                    GcRoot::VersionHead("commit-change".to_string()),
+                    GcRoot::PinnedCommit("commit-live".to_string()),
+                ])
+                .await
+                .unwrap()
+        };
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(
+            plan.sweep.by_change_membership,
+            vec![("change-live".to_string(), "commit-live".to_string())]
+        );
+        assert_missing(
+            &storage,
+            vec![(
+                BY_CHANGE_MEMBERSHIP_INDEX_SPACE,
+                by_change_membership_key("change-live", "commit-live"),
+            )],
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn gc_sweeps_stale_commit_visibility_and_retains_live_visibility() {
         let storage = test_storage();
         let context = ChangelogContext::new();
@@ -718,6 +1539,222 @@ mod tests {
         );
         assert!(result[0][0].is_some());
         assert_eq!(result[0][1], None);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_stale_live_locator_indexes() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
+        let stale_location = SegmentObjectLocation {
+            segment_id: "missing-segment".to_string(),
+            offset: 0,
+            len: 0,
+            checksum: "stale-checksum".to_string(),
+        };
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            COMMIT_VISIBILITY_SPACE,
+            commit_visibility_key("commit-live"),
+            commit_visibility_value(&CommitVisibility {
+                commit_id: "commit-live".to_string(),
+                location: stale_location.clone(),
+                checksum: stale_location.checksum.clone(),
+            })
+            .unwrap(),
+        );
+        writes.put(
+            BY_COMMIT_INDEX_SPACE,
+            by_commit_key("commit-live"),
+            by_commit_index_value(&ByCommitEntry {
+                commit_id: "commit-live".to_string(),
+                location: stale_location.clone(),
+                parent_commit_ids: Vec::new(),
+                generation: 0,
+            })
+            .unwrap(),
+        );
+        writes.put(
+            BY_CHANGE_INDEX_SPACE,
+            by_change_key("change-live"),
+            by_change_index_value(&ByChangeEntry {
+                change_id: "change-live".to_string(),
+                location: stale_location,
+            })
+            .unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage);
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.commit_visibility, vec!["commit-live"]);
+        assert_eq!(plan.sweep.by_commit, vec!["commit-live"]);
+        assert_eq!(plan.sweep.by_change, vec!["change-live"]);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_dead_segment_with_missing_parent() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = single_commit_segment("segment-live", "commit-live", "change-live");
+        let mut dead_segment = single_commit_segment("segment-dead", "commit-dead", "change-dead");
+        dead_segment.commits[0]
+            .header
+            .parent_commit_ids
+            .push("missing-parent".to_string());
+        dead_segment = canonicalize_segment(dead_segment).unwrap();
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+        write_raw_segment(&storage, &dead_segment).await;
+
+        let mut reader = context.reader(storage);
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.segments, vec!["segment-dead"]);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_stale_visible_change_proof_even_when_change_and_commit_are_live() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let change_segment =
+            single_commit_segment("segment-change", "commit-change", "change-live");
+        let commit_segment = canonicalize_segment(single_commit_segment(
+            "segment-commit",
+            "commit-live",
+            "change-other",
+        ))
+        .unwrap();
+        let stale_visibility = commit_visibility_from_segment(&commit_segment, "commit-live");
+
+        write_segments(
+            &storage,
+            &context,
+            vec![change_segment, commit_segment],
+            &["commit-change", "commit-live"],
+        )
+        .await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let plan = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[
+                    GcRoot::VersionHead("commit-change".to_string()),
+                    GcRoot::PinnedCommit("commit-live".to_string()),
+                ])
+                .await
+                .unwrap()
+        };
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
+        assert_missing(
+            &storage,
+            vec![(
+                VISIBLE_CHANGE_PROOF_SPACE,
+                visible_change_proof_key("change-live"),
+            )],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_visible_change_proof_that_does_not_match_current_visibility() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = canonicalize_segment(single_commit_segment(
+            "segment-live",
+            "commit-live",
+            "change-live",
+        ))
+        .unwrap();
+        let mut stale_visibility = commit_visibility_from_segment(&live_segment, "commit-live");
+        stale_visibility.checksum = "stale-checksum".to_string();
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage.clone());
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
+    }
+
+    #[tokio::test]
+    async fn gc_sweeps_visible_change_proof_that_matches_stale_visibility() {
+        let storage = test_storage();
+        let context = ChangelogContext::new();
+        let live_segment = canonicalize_segment(single_commit_segment(
+            "segment-live",
+            "commit-live",
+            "change-live",
+        ))
+        .unwrap();
+        let mut stale_visibility = commit_visibility_from_segment(&live_segment, "commit-live");
+        stale_visibility.checksum = "stale-checksum".to_string();
+
+        write_segments(&storage, &context, vec![live_segment], &["commit-live"]).await;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            COMMIT_VISIBILITY_SPACE,
+            commit_visibility_key("commit-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.put(
+            VISIBLE_CHANGE_PROOF_SPACE,
+            visible_change_proof_key("change-live"),
+            commit_visibility_value(&stale_visibility).unwrap(),
+        );
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut reader = context.reader(storage.clone());
+        let plan = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-live".to_string())])
+            .await
+            .unwrap();
+
+        assert_eq!(plan.sweep.commit_visibility, vec!["commit-live"]);
+        assert_eq!(plan.sweep.visible_change_proof, vec!["change-live"]);
     }
 
     #[tokio::test]
@@ -875,6 +1912,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gc_rejects_cross_segment_adopted_membership_authored_by_same_commit() {
+        let storage = test_storage();
+        let mut change_segment =
+            single_commit_segment("change-segment", "commit-author", "change-1");
+        change_segment.commits.clear();
+        change_segment.directory.commits.clear();
+        change_segment.changes[0].authored_commit_id = Some("commit-adopter".to_string());
+        let change_segment = canonicalize_segment(change_segment).unwrap();
+        write_raw_segment(&storage, &change_segment).await;
+
+        let mut adopt_segment =
+            adopting_commit_segment("adopt-segment", "commit-adopter", "change-1");
+        adopt_segment.commits[0]
+            .header
+            .parent_commit_ids
+            .push("missing-parent".to_string());
+        let adopt_segment = canonicalize_segment(adopt_segment).unwrap();
+        write_raw_segment(&storage, &adopt_segment).await;
+        let parent_segment = canonicalize_segment(single_commit_segment(
+            "parent-segment",
+            "missing-parent",
+            "parent-change",
+        ))
+        .unwrap();
+        write_raw_segment(&storage, &parent_segment).await;
+
+        let context = ChangelogContext::new();
+        let mut reader = context.reader(storage);
+        let error = reader
+            .plan_gc(&[GcRoot::VersionHead("commit-adopter".to_string())])
+            .await
+            .expect_err("GC must reject self-authored adopted membership");
+
+        assert!(
+            error.message.contains("is authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn gc_sweeps_dead_direct_json_payloads_and_retains_live_payloads() {
         let storage = test_storage();
         let context = ChangelogContext::new();
@@ -946,9 +2023,15 @@ mod tests {
             .plan_gc(&[GcRoot::VersionHead("commit-1".to_string())])
             .await
             .expect_err("missing membership change must be corruption");
-        assert!(error
-            .message
-            .contains("references missing change 'change-1'"));
+        assert!(
+            error
+                .message
+                .contains("references missing change 'change-1'")
+                || error
+                    .message
+                    .contains("references missing authored change 'change-1'"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1037,9 +2120,15 @@ mod tests {
                 .await
                 .expect_err("missing membership change must abort collect_garbage")
         };
-        assert!(error
-            .message
-            .contains("references missing change 'change-1'"));
+        assert!(
+            error
+                .message
+                .contains("references missing change 'change-1'")
+                || error
+                    .message
+                    .contains("references missing authored change 'change-1'"),
+            "unexpected error: {error}"
+        );
         writes.apply(&mut *transaction).await.unwrap();
         transaction.commit().await.unwrap();
 
@@ -1075,6 +2164,7 @@ mod tests {
         duplicate.header.membership_count = 0;
         segment.commits.push(duplicate);
         segment.header.commit_count = segment.commits.len() as u32;
+        let segment = canonicalize_segment(segment).unwrap();
         write_raw_segment(&storage, &segment).await;
 
         let mut reader = context.reader(storage.clone());
@@ -1082,9 +2172,18 @@ mod tests {
             .plan_gc(&[])
             .await
             .expect_err("duplicate commit ids must be invalid segment input");
-        assert!(error
-            .message
-            .contains("contains duplicate commit 'commit-1'"));
+        assert!(
+            error
+                .message
+                .contains("contains duplicate commit 'commit-1'")
+                || error
+                    .message
+                    .contains("contains duplicate commit directory entry 'commit-1'")
+                || error.message.contains(
+                    "commit 'commit-1' locator offset/len does not match encoded byte range"
+                ),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1099,6 +2198,7 @@ mod tests {
         .await;
         segment.changes.push(segment.changes[0].clone());
         segment.header.change_count = segment.changes.len() as u32;
+        let segment = canonicalize_segment(segment).unwrap();
         write_raw_segment(&storage, &segment).await;
 
         let mut reader = context.reader(storage.clone());
@@ -1106,9 +2206,18 @@ mod tests {
             .plan_gc(&[])
             .await
             .expect_err("duplicate change ids must be invalid segment input");
-        assert!(error
-            .message
-            .contains("contains duplicate change 'change-1'"));
+        assert!(
+            error
+                .message
+                .contains("contains duplicate change 'change-1'")
+                || error
+                    .message
+                    .contains("contains duplicate change directory entry 'change-1'")
+                || error.message.contains(
+                    "change 'change-1' locator offset/len does not match encoded byte range"
+                ),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1161,7 +2270,7 @@ mod tests {
     async fn gc_errors_when_segment_change_payload_directory_drifts() {
         let storage = test_storage();
         let context = ChangelogContext::new();
-        let payload_ref = JsonRef::from_hash_bytes([11; 32]);
+        let payload_ref = JsonRef::for_content(b"payload");
         let mut segment = single_commit_segment("segment-1", "commit-1", "change-1");
         segment.changes[0]
             .inline_payloads

--- a/packages/engine/src/changelog/gc.rs
+++ b/packages/engine/src/changelog/gc.rs
@@ -413,9 +413,8 @@ where
             )
             .await?;
         for index in 0..page.len() {
-            let Some(bytes) = page.value(index) else {
-                continue;
-            };
+            let bytes =
+                gc_required_scan_value(&page, index, SEGMENT_SPACE, "validate_all_segments")?;
             let segment = decode_segment(bytes)?;
             validate_segment_shape(&segment)?;
         }
@@ -1136,6 +1135,20 @@ fn push_unique(values: &mut Vec<String>, value: String) {
     if !values.iter().any(|existing| existing == &value) {
         values.push(value);
     }
+}
+
+fn gc_required_scan_value<'a>(
+    page: &'a super::context::ChangelogScanPage,
+    index: usize,
+    space: StorageSpace,
+    operation: &str,
+) -> Result<&'a [u8], LixError> {
+    page.value(index).ok_or_else(|| {
+        LixError::unknown(format!(
+            "changelog GC {operation} scan over namespace '{}' returned a key without a value",
+            space.name
+        ))
+    })
 }
 
 fn push_unique_json_ref(values: &mut Vec<JsonRef>, value: JsonRef) {

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use codec::{
     decode_empty_index_value, decode_segment, decode_segment_change, decode_segment_commit,
     encode_by_change_entry, encode_by_commit_entry, encode_commit_visibility,
     encode_empty_index_value, encode_segment, segment_commit_membership_contains_any, view_segment,
+    view_segment_directory, view_segment_object_ranges, view_segment_object_slices,
 };
 #[allow(unused_imports)]
 pub(crate) use context::{ChangelogContext, ChangelogStoreReader, ChangelogStoreWriter};

--- a/packages/engine/src/changelog/segment.rs
+++ b/packages/engine/src/changelog/segment.rs
@@ -4,13 +4,15 @@ use std::collections::{HashMap, HashSet};
 
 use super::codec::{
     decode_segment, decode_segment_change, decode_segment_commit,
-    encode_segment_with_object_locations, view_segment, view_segment_object_slices,
+    encode_segment_with_object_locations, view_segment_directory, view_segment_object_ranges,
+    view_segment_object_slices,
 };
 use super::store::segment_value;
 use super::types::{
     MembershipRole, Segment, SegmentChange, SegmentCommit, SegmentDirectory, SegmentObjectLocation,
-    SegmentPayloadLocation,
+    SegmentPayloadLocation, StateRowIdentity,
 };
+use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::LixError;
 
 pub(super) fn directory_commit_location(
@@ -80,11 +82,19 @@ pub(super) struct DecodedSegmentIndex {
     change_ordinals: HashMap<String, usize>,
     commit_locations: HashMap<String, SegmentObjectLocation>,
     change_locations: HashMap<String, SegmentObjectLocation>,
+    commit_ranges: HashMap<String, SegmentObjectRangeMeta>,
+    change_ranges: HashMap<String, SegmentObjectRangeMeta>,
+}
+
+struct SegmentObjectRangeMeta {
+    offset: u64,
+    len: u64,
+    encoded_checksum: Option<String>,
 }
 
 impl DecodedSegmentIndex {
     pub(super) fn decode(bytes: &[u8]) -> Result<Self, LixError> {
-        let view = view_segment(bytes)?;
+        let view = view_segment_directory(bytes)?;
         let segment_id = view.segment_id.to_string();
         let mut commit_ordinals = HashMap::new();
         let mut commit_locations = HashMap::new();
@@ -114,6 +124,33 @@ impl DecodedSegmentIndex {
                 },
             );
         }
+        let (commit_ranges, change_ranges) = view_segment_object_ranges(bytes)?;
+        let commit_ranges = commit_ranges
+            .into_iter()
+            .map(|slice| {
+                (
+                    slice.id.to_string(),
+                    SegmentObjectRangeMeta {
+                        offset: slice.offset,
+                        len: slice.len,
+                        encoded_checksum: slice.encoded_checksum.map(str::to_string),
+                    },
+                )
+            })
+            .collect();
+        let change_ranges = change_ranges
+            .into_iter()
+            .map(|slice| {
+                (
+                    slice.id.to_string(),
+                    SegmentObjectRangeMeta {
+                        offset: slice.offset,
+                        len: slice.len,
+                        encoded_checksum: slice.encoded_checksum.map(str::to_string),
+                    },
+                )
+            })
+            .collect();
         Ok(Self {
             bytes: bytes.to_vec(),
             segment_id,
@@ -121,6 +158,8 @@ impl DecodedSegmentIndex {
             change_ordinals,
             commit_locations,
             change_locations,
+            commit_ranges,
+            change_ranges,
         })
     }
 
@@ -182,6 +221,7 @@ impl DecodedSegmentIndex {
                 "changelog commit '{commit_id}' locator does not match segment directory"
             )));
         }
+        self.validate_commit_range(location, commit_id)?;
         Ok(())
     }
 
@@ -201,6 +241,7 @@ impl DecodedSegmentIndex {
                 "changelog change '{change_id}' locator does not match segment directory"
             )));
         }
+        self.validate_change_range(location, change_id)?;
         let Some(change) = self.change(change_id)? else {
             return Err(LixError::unknown(format!(
                 "changelog segment '{}' is missing change '{}'",
@@ -208,6 +249,49 @@ impl DecodedSegmentIndex {
             )));
         };
         validate_change_checksum(&location.checksum, change_id, &change)?;
+        Ok(())
+    }
+
+    fn validate_commit_range(
+        &self,
+        location: &SegmentObjectLocation,
+        commit_id: &str,
+    ) -> Result<(), LixError> {
+        let Some(range) = self.commit_ranges.get(commit_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded commit object '{}'",
+                self.segment_id, commit_id
+            )));
+        };
+        if location.offset != range.offset || location.len != range.len {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' locator does not match encoded object slice"
+            )));
+        }
+        if range.encoded_checksum.as_deref() != Some(location.checksum.as_str()) {
+            return Err(LixError::unknown(format!(
+                "changelog commit '{commit_id}' locator checksum does not match encoded object checksum"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_change_range(
+        &self,
+        location: &SegmentObjectLocation,
+        change_id: &str,
+    ) -> Result<(), LixError> {
+        let Some(range) = self.change_ranges.get(change_id) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded change object '{}'",
+                self.segment_id, change_id
+            )));
+        };
+        if location.offset != range.offset || location.len != range.len {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' locator does not match encoded object slice"
+            )));
+        }
         Ok(())
     }
 
@@ -296,6 +380,7 @@ pub(super) fn canonicalize_segment(mut segment: Segment) -> Result<Segment, LixE
     }
 
     let mut change_locations = Vec::with_capacity(segment.changes.len());
+    let mut change_checksums = Vec::with_capacity(segment.changes.len());
     for change in &mut segment.changes {
         change.directory.payloads = change
             .inline_payloads
@@ -307,13 +392,15 @@ pub(super) fn canonicalize_segment(mut segment: Segment) -> Result<Segment, LixE
                 len: payload.bytes.len() as u64,
             })
             .collect();
+        let change_checksum = checksum_change(change)?;
+        change_checksums.push((change.id.clone(), change_checksum.clone()));
         change_locations.push((
             change.id.clone(),
             SegmentObjectLocation {
                 segment_id: segment_id.clone(),
                 offset: 0,
                 len: 0,
-                checksum: checksum_change(change)?,
+                checksum: change_checksum,
             },
         ));
     }
@@ -326,7 +413,7 @@ pub(super) fn canonicalize_segment(mut segment: Segment) -> Result<Segment, LixE
     segment.header.checksum = empty_checksum();
     let encoded = encode_segment_with_object_locations(&segment)?;
     segment.header.byte_count = encoded.bytes.len() as u64;
-    segment.header.checksum = checksum_segment(&segment)?;
+    segment.header.checksum = checksum_segment_with_change_checksums(&segment, &change_checksums)?;
     apply_encoded_object_locations_from_encoded(&mut segment, &encoded)?;
     Ok(segment)
 }
@@ -339,12 +426,13 @@ fn apply_encoded_object_locations_from_encoded(
     segment: &mut Segment,
     encoded: &super::codec::EncodedSegment,
 ) -> Result<(), LixError> {
+    let encoded_commits = encoded
+        .commits
+        .iter()
+        .map(|object| (object.id.as_str(), object))
+        .collect::<HashMap<_, _>>();
     for (commit_id, location) in &mut segment.directory.commits {
-        let Some(object) = encoded
-            .commits
-            .iter()
-            .find(|object| object.id == *commit_id)
-        else {
+        let Some(object) = encoded_commits.get(commit_id.as_str()) else {
             return Err(LixError::unknown(format!(
                 "changelog segment '{}' could not locate encoded commit '{}'",
                 segment.header.segment_id, commit_id
@@ -354,12 +442,13 @@ fn apply_encoded_object_locations_from_encoded(
         location.len = object.len;
     }
 
+    let encoded_changes = encoded
+        .changes
+        .iter()
+        .map(|object| (object.id.as_str(), object))
+        .collect::<HashMap<_, _>>();
     for (change_id, location) in &mut segment.directory.changes {
-        let Some(object) = encoded
-            .changes
-            .iter()
-            .find(|object| object.id == *change_id)
-        else {
+        let Some(object) = encoded_changes.get(change_id.as_str()) else {
             return Err(LixError::unknown(format!(
                 "changelog segment '{}' could not locate encoded change '{}'",
                 segment.header.segment_id, change_id
@@ -377,50 +466,89 @@ pub(super) fn validate_segment_shape(segment: &Segment) -> Result<(), LixError> 
 
     let encoded = segment_value(segment)?;
     let (encoded_commits, encoded_changes) = view_segment_object_slices(&encoded)?;
+    let commits_by_id = segment
+        .commits
+        .iter()
+        .map(|commit| (commit.header.id.as_str(), commit))
+        .collect::<HashMap<_, _>>();
+    let changes_by_id = segment
+        .changes
+        .iter()
+        .map(|change| (change.id.as_str(), change))
+        .collect::<HashMap<_, _>>();
+    let encoded_commits_by_id = encoded_commits
+        .iter()
+        .map(|slice| (slice.id, slice))
+        .collect::<HashMap<_, _>>();
+    let encoded_changes_by_id = encoded_changes
+        .iter()
+        .map(|slice| (slice.id, slice))
+        .collect::<HashMap<_, _>>();
+    let mut change_checksums = Vec::with_capacity(segment.changes.len());
+    for change in &segment.changes {
+        change_checksums.push((change.id.clone(), checksum_change(change)?));
+    }
+    let change_checksums_by_id = change_checksums
+        .iter()
+        .map(|(change_id, checksum)| (change_id.as_str(), checksum.as_str()))
+        .collect::<HashMap<_, _>>();
 
     for (commit_id, location) in &segment.directory.commits {
-        let commit = segment_commit(segment, commit_id).ok_or_else(|| {
+        let commit = commits_by_id.get(commit_id.as_str()).ok_or_else(|| {
             LixError::unknown(format!(
                 "changelog segment '{}' directory points to missing commit '{}'",
                 segment.header.segment_id, commit_id
             ))
         })?;
-        validate_commit_location(location, segment, commit_id)?;
-        validate_encoded_object_location(
+        let Some(slice) = encoded_commits_by_id.get(commit_id.as_str()) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded commit '{}'",
+                segment.header.segment_id, commit_id
+            )));
+        };
+        validate_encoded_object_location_from_parts(
             &segment.header.segment_id,
             "commit",
             commit_id,
             location,
-            encoded_commits.iter().map(|slice| {
-                (
-                    slice.id,
-                    slice.offset,
-                    slice.len,
-                    slice.encoded_checksum.unwrap_or_default(),
-                )
-            }),
+            slice.offset,
+            slice.len,
+            slice.encoded_checksum.unwrap_or_default(),
         )?;
         validate_commit_checksum(&location.checksum, commit_id, commit)?;
     }
 
     for (change_id, location) in &segment.directory.changes {
-        validate_change_location(location, segment, change_id)?;
-        let change = segment_change(segment, change_id).ok_or_else(|| {
+        let _change = changes_by_id.get(change_id.as_str()).ok_or_else(|| {
             LixError::unknown(format!(
                 "changelog segment '{}' directory points to missing change '{}'",
                 segment.header.segment_id, change_id
             ))
         })?;
-        validate_encoded_object_location(
+        let Some(slice) = encoded_changes_by_id.get(change_id.as_str()) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing encoded change '{}'",
+                segment.header.segment_id, change_id
+            )));
+        };
+        validate_encoded_object_location_from_parts(
             &segment.header.segment_id,
             "change",
             change_id,
             location,
-            encoded_changes
-                .iter()
-                .map(|slice| (slice.id, slice.offset, slice.len, "")),
+            slice.offset,
+            slice.len,
+            "",
         )?;
-        validate_change_checksum(&location.checksum, change_id, change)?;
+        let canonical = change_checksums_by_id
+            .get(change_id.as_str())
+            .expect("validated change must have canonical checksum");
+        if location.checksum != *canonical {
+            return Err(LixError::unknown(format!(
+                "changelog change '{change_id}' checksum '{}' does not match canonical checksum '{}'",
+                location.checksum, canonical
+            )));
+        }
     }
 
     let encoded_len = encoded.len() as u64;
@@ -431,7 +559,7 @@ pub(super) fn validate_segment_shape(segment: &Segment) -> Result<(), LixError> 
         )));
     }
 
-    let checksum = checksum_segment(segment)?;
+    let checksum = checksum_segment_with_change_checksums(segment, &change_checksums)?;
     if segment.header.checksum != checksum {
         return Err(LixError::unknown(format!(
             "changelog segment '{}' checksum '{}' does not match canonical checksum '{}'",
@@ -497,6 +625,12 @@ pub(super) fn validate_stage_segment_shape(segment: &Segment) -> Result<(), LixE
         )));
     }
     let mut commit_ids = HashSet::new();
+    let directory_commit_ids = segment
+        .directory
+        .commits
+        .iter()
+        .map(|(id, _)| id.as_str())
+        .collect::<HashSet<_>>();
     for commit in &segment.commits {
         if !commit_ids.insert(commit.header.id.as_str()) {
             return Err(LixError::unknown(format!(
@@ -504,7 +638,7 @@ pub(super) fn validate_stage_segment_shape(segment: &Segment) -> Result<(), LixE
                 segment.header.segment_id, commit.header.id
             )));
         }
-        validate_commit_shape(segment, commit)?;
+        validate_commit_shape(segment, commit, &directory_commit_ids)?;
     }
 
     let mut change_ids = HashSet::new();
@@ -541,6 +675,7 @@ pub(super) fn validate_stage_segment_shape(segment: &Segment) -> Result<(), LixE
             .iter()
             .map(|(id, location)| (id.as_str(), location)),
     )?;
+    validate_segment_cross_object_semantics(segment)?;
 
     Ok(())
 }
@@ -560,6 +695,26 @@ fn validate_encoded_object_location<'a>(
             "changelog segment '{segment_id}' is missing encoded {kind} '{object_id}'"
         )));
     };
+    validate_encoded_object_location_from_parts(
+        segment_id,
+        kind,
+        object_id,
+        location,
+        offset,
+        len,
+        encoded_checksum,
+    )
+}
+
+fn validate_encoded_object_location_from_parts(
+    _segment_id: &str,
+    kind: &str,
+    object_id: &str,
+    location: &SegmentObjectLocation,
+    offset: u64,
+    len: u64,
+    encoded_checksum: &str,
+) -> Result<(), LixError> {
     if location.offset != offset || location.len != len {
         return Err(LixError::unknown(format!(
             "changelog {kind} '{object_id}' locator offset/len does not match encoded byte range"
@@ -574,21 +729,67 @@ fn validate_encoded_object_location<'a>(
 }
 
 fn checksum_segment(segment: &Segment) -> Result<String, LixError> {
+    let change_checksums = segment
+        .changes
+        .iter()
+        .map(|change| Ok((change.id.clone(), checksum_change(change)?)))
+        .collect::<Result<Vec<_>, LixError>>()?;
+    checksum_segment_with_change_checksums(segment, &change_checksums)
+}
+
+fn checksum_segment_with_change_checksums(
+    segment: &Segment,
+    change_checksums: &[(String, String)],
+) -> Result<String, LixError> {
+    let change_checksums = change_checksums
+        .iter()
+        .map(|(change_id, checksum)| (change_id.as_str(), checksum.as_str()))
+        .collect::<HashMap<_, _>>();
     let mut hasher = blake3::Hasher::new();
     hash_part(&mut hasher, "segment");
-    hash_part(&mut hasher, &segment.header.segment_id);
-    hash_part(&mut hasher, &segment.header.format_version.to_string());
-    hash_part(&mut hasher, &segment.header.commit_count.to_string());
-    hash_part(&mut hasher, &segment.header.change_count.to_string());
-    hash_part(&mut hasher, &segment.header.byte_count.to_string());
-    hash_part(&mut hasher, &segment.header.payload_count.to_string());
+    hash_field(&mut hasher, "segment_id", &segment.header.segment_id);
+    hash_field(
+        &mut hasher,
+        "format_version",
+        &segment.header.format_version.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "commit_count",
+        &segment.header.commit_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "change_count",
+        &segment.header.change_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "byte_count",
+        &segment.header.byte_count.to_string(),
+    );
+    hash_field(
+        &mut hasher,
+        "payload_count",
+        &segment.header.payload_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "commits", segment.commits.len());
     for commit in &segment.commits {
-        hash_part(&mut hasher, &commit.header.id);
-        hash_part(&mut hasher, &commit.checksum);
+        hash_part(&mut hasher, "commit");
+        hash_field(&mut hasher, "id", &commit.header.id);
+        hash_field(&mut hasher, "checksum", &commit.checksum);
     }
+    hash_list_len(&mut hasher, "changes", segment.changes.len());
     for change in &segment.changes {
-        hash_part(&mut hasher, &change.id);
-        hash_part(&mut hasher, &checksum_change(change)?);
+        hash_part(&mut hasher, "change");
+        hash_field(&mut hasher, "id", &change.id);
+        let Some(checksum) = change_checksums.get(change.id.as_str()) else {
+            return Err(LixError::unknown(format!(
+                "changelog segment '{}' is missing canonical checksum for change '{}'",
+                segment.header.segment_id, change.id
+            )));
+        };
+        hash_field(&mut hasher, "checksum", checksum);
     }
     Ok(hasher.finalize().to_hex().to_string())
 }
@@ -596,42 +797,80 @@ fn checksum_segment(segment: &Segment) -> Result<String, LixError> {
 fn checksum_commit(commit: &SegmentCommit) -> Result<String, LixError> {
     let mut hasher = blake3::Hasher::new();
     hash_part(&mut hasher, "commit");
-    hash_part(&mut hasher, &commit.header.id);
+    hash_field(&mut hasher, "id", &commit.header.id);
+    hash_list_len(
+        &mut hasher,
+        "parent_commit_ids",
+        commit.header.parent_commit_ids.len(),
+    );
     for parent in &commit.header.parent_commit_ids {
-        hash_part(&mut hasher, parent);
+        hash_field(&mut hasher, "parent_commit_id", parent);
     }
-    hash_part(&mut hasher, &commit.header.derivable_change_id);
+    hash_field(
+        &mut hasher,
+        "derivable_change_id",
+        &commit.header.derivable_change_id,
+    );
+    hash_list_len(
+        &mut hasher,
+        "author_account_ids",
+        commit.header.author_account_ids.len(),
+    );
     for account_id in &commit.header.author_account_ids {
-        hash_part(&mut hasher, account_id);
+        hash_field(&mut hasher, "author_account_id", account_id);
     }
-    hash_part(&mut hasher, &commit.header.created_at);
-    hash_part(&mut hasher, &commit.header.membership_count.to_string());
+    hash_field(&mut hasher, "created_at", &commit.header.created_at);
+    hash_field(
+        &mut hasher,
+        "membership_count",
+        &commit.header.membership_count.to_string(),
+    );
+    hash_list_len(&mut hasher, "memberships", commit.body.membership.len());
     for membership in &commit.body.membership {
-        hash_part(&mut hasher, &membership.member_change_id);
-        hash_part(
+        hash_part(&mut hasher, "membership");
+        hash_field(
             &mut hasher,
+            "member_change_id",
+            &membership.member_change_id,
+        );
+        hash_field(
+            &mut hasher,
+            "role",
             match membership.role {
                 MembershipRole::Authored => "authored",
                 MembershipRole::Adopted => "adopted",
             },
         );
-        hash_part(
+        hash_field(
             &mut hasher,
+            "source_parent_ordinal",
             &membership
                 .source_parent_ordinal
                 .map(|ordinal| ordinal.to_string())
                 .unwrap_or_default(),
         );
     }
+    hash_list_len(
+        &mut hasher,
+        "state_row_identities",
+        commit.directory.state_row_identities.len(),
+    );
     for (identity, change_id) in &commit.directory.state_row_identities {
-        hash_part(&mut hasher, identity.schema_key.as_str());
-        hash_part(&mut hasher, identity.file_id.as_str());
-        hash_part(&mut hasher, identity.entity_id.as_str());
-        hash_part(&mut hasher, change_id);
+        hash_part(&mut hasher, "state_row_identity");
+        hash_field(&mut hasher, "schema_key", identity.schema_key.as_str());
+        hash_field(&mut hasher, "file_id", identity.file_id.as_str());
+        hash_field(&mut hasher, "entity_id", identity.entity_id.as_str());
+        hash_field(&mut hasher, "change_id", change_id);
     }
+    hash_list_len(
+        &mut hasher,
+        "membership_ordinals",
+        commit.directory.membership_ordinals.len(),
+    );
     for (change_id, ordinal) in &commit.directory.membership_ordinals {
-        hash_part(&mut hasher, change_id);
-        hash_part(&mut hasher, &ordinal.to_string());
+        hash_part(&mut hasher, "membership_ordinal");
+        hash_field(&mut hasher, "change_id", change_id);
+        hash_field(&mut hasher, "ordinal", &ordinal.to_string());
     }
     Ok(hasher.finalize().to_hex().to_string())
 }
@@ -639,28 +878,37 @@ fn checksum_commit(commit: &SegmentCommit) -> Result<String, LixError> {
 fn checksum_change(change: &SegmentChange) -> Result<String, LixError> {
     let mut hasher = blake3::Hasher::new();
     hash_part(&mut hasher, "change");
-    hash_part(&mut hasher, &change.id);
-    hash_part(
+    hash_field(&mut hasher, "id", &change.id);
+    hash_optional_str(
         &mut hasher,
-        change.authored_commit_id.as_deref().unwrap_or_default(),
+        "authored_commit_id",
+        change.authored_commit_id.as_deref(),
     );
-    hash_parts(
-        &mut hasher,
-        change.entity_id.parts.iter().map(String::as_str),
-    );
-    hash_part(&mut hasher, &change.schema_key);
-    hash_part(&mut hasher, change.file_id.as_deref().unwrap_or_default());
-    hash_optional_json_ref(&mut hasher, change.snapshot_ref.as_ref());
-    hash_optional_json_ref(&mut hasher, change.metadata_ref.as_ref());
-    hash_part(&mut hasher, &change.created_at);
-    for payload in &change.inline_payloads {
-        hash_json_ref(&mut hasher, &payload.json_ref);
-        hash_bytes_part(&mut hasher, &payload.bytes);
+    hash_list_len(&mut hasher, "entity_id", change.entity_id.parts.len());
+    for part in &change.entity_id.parts {
+        hash_field(&mut hasher, "entity_id_part", part);
     }
+    hash_field(&mut hasher, "schema_key", &change.schema_key);
+    hash_optional_str(&mut hasher, "file_id", change.file_id.as_deref());
+    hash_optional_json_ref(&mut hasher, "snapshot_ref", change.snapshot_ref.as_ref());
+    hash_optional_json_ref(&mut hasher, "metadata_ref", change.metadata_ref.as_ref());
+    hash_field(&mut hasher, "created_at", &change.created_at);
+    hash_list_len(&mut hasher, "inline_payloads", change.inline_payloads.len());
+    for payload in &change.inline_payloads {
+        hash_part(&mut hasher, "inline_payload");
+        hash_json_ref(&mut hasher, "json_ref", &payload.json_ref);
+        hash_bytes_field(&mut hasher, "bytes", &payload.bytes);
+    }
+    hash_list_len(
+        &mut hasher,
+        "directory_payloads",
+        change.directory.payloads.len(),
+    );
     for payload_location in &change.directory.payloads {
-        hash_json_ref(&mut hasher, &payload_location.json_ref);
-        hash_part(&mut hasher, &payload_location.offset.to_string());
-        hash_part(&mut hasher, &payload_location.len.to_string());
+        hash_part(&mut hasher, "payload_location");
+        hash_json_ref(&mut hasher, "json_ref", &payload_location.json_ref);
+        hash_field(&mut hasher, "offset", &payload_location.offset.to_string());
+        hash_field(&mut hasher, "len", &payload_location.len.to_string());
     }
     Ok(hasher.finalize().to_hex().to_string())
 }
@@ -670,10 +918,14 @@ fn hash_part(hasher: &mut blake3::Hasher, value: &str) {
     hasher.update(value.as_bytes());
 }
 
-fn hash_parts<'a>(hasher: &mut blake3::Hasher, values: impl Iterator<Item = &'a str>) {
-    for value in values {
-        hash_part(hasher, value);
-    }
+fn hash_field(hasher: &mut blake3::Hasher, field: &str, value: &str) {
+    hash_part(hasher, field);
+    hash_part(hasher, value);
+}
+
+fn hash_list_len(hasher: &mut blake3::Hasher, field: &str, len: usize) {
+    hash_part(hasher, field);
+    hasher.update(&(len as u64).to_le_bytes());
 }
 
 fn hash_bytes_part(hasher: &mut blake3::Hasher, value: &[u8]) {
@@ -681,21 +933,46 @@ fn hash_bytes_part(hasher: &mut blake3::Hasher, value: &[u8]) {
     hasher.update(value);
 }
 
-fn hash_optional_json_ref(hasher: &mut blake3::Hasher, value: Option<&crate::json_store::JsonRef>) {
+fn hash_bytes_field(hasher: &mut blake3::Hasher, field: &str, value: &[u8]) {
+    hash_part(hasher, field);
+    hash_bytes_part(hasher, value);
+}
+
+fn hash_optional_str(hasher: &mut blake3::Hasher, field: &str, value: Option<&str>) {
+    hash_part(hasher, field);
     match value {
         Some(value) => {
             hash_part(hasher, "some");
-            hash_json_ref(hasher, value);
+            hash_part(hasher, value);
         }
         None => hash_part(hasher, "none"),
     }
 }
 
-fn hash_json_ref(hasher: &mut blake3::Hasher, value: &crate::json_store::JsonRef) {
-    hash_bytes_part(hasher, value.as_hash_bytes());
+fn hash_optional_json_ref(
+    hasher: &mut blake3::Hasher,
+    field: &str,
+    value: Option<&crate::json_store::JsonRef>,
+) {
+    hash_part(hasher, field);
+    match value {
+        Some(value) => {
+            hash_part(hasher, "some");
+            hash_json_ref(hasher, "json_ref", value);
+        }
+        None => hash_part(hasher, "none"),
+    }
 }
 
-fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<(), LixError> {
+fn hash_json_ref(hasher: &mut blake3::Hasher, field: &str, value: &crate::json_store::JsonRef) {
+    hash_bytes_field(hasher, field, value.as_hash_bytes());
+}
+
+fn validate_commit_shape(
+    segment: &Segment,
+    commit: &SegmentCommit,
+    directory_commit_ids: &HashSet<&str>,
+) -> Result<(), LixError> {
     let membership_count = u32::try_from(commit.body.membership.len()).map_err(|_| {
         LixError::unknown(format!(
             "changelog commit '{}' has too many membership records",
@@ -710,6 +987,12 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
             commit.body.membership.len()
         )));
     }
+    let membership_ordinals_by_id = commit
+        .directory
+        .membership_ordinals
+        .iter()
+        .map(|(change_id, ordinal)| (change_id.as_str(), *ordinal))
+        .collect::<HashMap<_, _>>();
 
     let mut member_ids = HashSet::new();
     for (ordinal, membership) in commit.body.membership.iter().enumerate() {
@@ -746,11 +1029,8 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
                 commit.header.id, membership.member_change_id
             )));
         }
-        let Some((_, directory_ordinal)) = commit
-            .directory
-            .membership_ordinals
-            .iter()
-            .find(|(change_id, _)| change_id == &membership.member_change_id)
+        let Some(directory_ordinal) =
+            membership_ordinals_by_id.get(membership.member_change_id.as_str())
         else {
             return Err(LixError::unknown(format!(
                 "changelog commit '{}' is missing membership ordinal for change '{}'",
@@ -819,12 +1099,7 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
         )));
     }
 
-    if !segment
-        .directory
-        .commits
-        .iter()
-        .any(|(id, _)| id == &commit.header.id)
-    {
+    if !directory_commit_ids.contains(commit.header.id.as_str()) {
         return Err(LixError::unknown(format!(
             "changelog segment '{}' is missing directory location for commit '{}'",
             segment.header.segment_id, commit.header.id
@@ -835,23 +1110,30 @@ fn validate_commit_shape(segment: &Segment, commit: &SegmentCommit) -> Result<()
 }
 
 fn validate_change_shape(change: &SegmentChange) -> Result<(), LixError> {
-    let mut inline_payload_refs = Vec::new();
+    let directory_payloads_by_ref = change
+        .directory
+        .payloads
+        .iter()
+        .map(|location| (location.json_ref.as_hash_bytes(), location))
+        .collect::<HashMap<_, _>>();
+    let mut inline_payload_refs = HashSet::with_capacity(change.inline_payloads.len());
     for (ordinal, payload) in change.inline_payloads.iter().enumerate() {
-        if inline_payload_refs
-            .iter()
-            .any(|json_ref| json_ref == &payload.json_ref)
-        {
+        if !inline_payload_refs.insert(payload.json_ref.as_hash_bytes()) {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' contains duplicate inline payload ref",
                 change.id
             )));
         }
-        inline_payload_refs.push(payload.json_ref.clone());
-        let Some(location) = change
-            .directory
-            .payloads
-            .iter()
-            .find(|location| location.json_ref == payload.json_ref)
+        let actual = crate::json_store::JsonRef::for_content(&payload.bytes);
+        if payload.json_ref != actual {
+            return Err(LixError::unknown(format!(
+                "changelog change '{}' inline payload ref '{}' does not match payload bytes '{}'",
+                change.id,
+                payload.json_ref.to_hex(),
+                actual.to_hex()
+            )));
+        }
+        let Some(location) = directory_payloads_by_ref.get(&payload.json_ref.as_hash_bytes())
         else {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' is missing payload directory entry",
@@ -866,22 +1148,15 @@ fn validate_change_shape(change: &SegmentChange) -> Result<(), LixError> {
         }
     }
 
-    let mut directory_payload_refs = Vec::new();
+    let mut directory_payload_refs = HashSet::with_capacity(change.directory.payloads.len());
     for location in &change.directory.payloads {
-        if directory_payload_refs
-            .iter()
-            .any(|json_ref| json_ref == &location.json_ref)
-        {
+        if !directory_payload_refs.insert(location.json_ref.as_hash_bytes()) {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' contains duplicate payload directory entry",
                 change.id
             )));
         }
-        directory_payload_refs.push(location.json_ref.clone());
-        if !inline_payload_refs
-            .iter()
-            .any(|json_ref| json_ref == &location.json_ref)
-        {
+        if !inline_payload_refs.contains(&location.json_ref.as_hash_bytes()) {
             return Err(LixError::unknown(format!(
                 "changelog change '{}' payload directory references unknown inline payload",
                 change.id
@@ -924,6 +1199,86 @@ fn validate_directory_exact_cover<'a>(
         )));
     }
     Ok(())
+}
+
+fn validate_segment_cross_object_semantics(segment: &Segment) -> Result<(), LixError> {
+    let mut changes_by_id = HashMap::with_capacity(segment.changes.len());
+    for change in &segment.changes {
+        changes_by_id.insert(change.id.as_str(), change);
+    }
+
+    for commit in &segment.commits {
+        let memberships_by_id = commit
+            .body
+            .membership
+            .iter()
+            .map(|membership| (membership.member_change_id.as_str(), membership.role))
+            .collect::<HashMap<_, _>>();
+
+        for membership in &commit.body.membership {
+            match membership.role {
+                MembershipRole::Authored => {
+                    let Some(change) = changes_by_id.get(membership.member_change_id.as_str())
+                    else {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{}' authored membership references missing change '{}'",
+                            commit.header.id, membership.member_change_id
+                        )));
+                    };
+                    if change.authored_commit_id.as_deref() != Some(commit.header.id.as_str()) {
+                        return Err(LixError::unknown(format!(
+                            "changelog commit '{}' authored membership change '{}' has mismatched authored_commit_id",
+                            commit.header.id, membership.member_change_id
+                        )));
+                    }
+                }
+                MembershipRole::Adopted => {
+                    if let Some(change) = changes_by_id.get(membership.member_change_id.as_str()) {
+                        if change.authored_commit_id.as_deref() == Some(commit.header.id.as_str()) {
+                            return Err(LixError::unknown(format!(
+                                "changelog commit '{}' adopted membership change '{}' must not be authored by the same commit",
+                                commit.header.id, membership.member_change_id
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
+        for (identity, change_id) in &commit.directory.state_row_identities {
+            let Some(change) = changes_by_id.get(change_id.as_str()) else {
+                if memberships_by_id.get(change_id.as_str()) == Some(&MembershipRole::Adopted) {
+                    continue;
+                }
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{}' StateRowIdentity winner references missing authored change '{}'",
+                    commit.header.id, change_id
+                )));
+            };
+            let actual = state_row_identity_for_change(change)?;
+            if &actual != identity {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{}' StateRowIdentity winner for change '{}' does not match changelog.change",
+                    commit.header.id, change_id
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn state_row_identity_for_change(change: &SegmentChange) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(change.schema_key.clone())?,
+        file_id: FileId::new(
+            change
+                .file_id
+                .clone()
+                .unwrap_or_else(|| "__global__".to_string()),
+        )?,
+        entity_id: EntityId::new(change.entity_id.as_json_array_text()?)?,
+    })
 }
 
 pub(super) fn validate_commit_location(
@@ -1150,7 +1505,7 @@ mod tests {
 
     #[test]
     fn validation_rejects_payload_directory_drift() {
-        let payload_ref = JsonRef::from_hash_bytes([11; 32]);
+        let payload_ref = JsonRef::for_content(b"payload");
         let mut segment = test_segment_with_inline_payload(payload_ref);
         segment.changes[0].directory.payloads[0].len = 999;
 
@@ -1161,6 +1516,76 @@ mod tests {
             error
                 .message
                 .contains("payload directory entry does not match inline payload"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_inline_payload_ref_mismatch() {
+        let payload_ref = JsonRef::for_content(b"payload");
+        let mut segment = test_segment_with_inline_payload(payload_ref);
+        let bogus_ref = JsonRef::from_hash_bytes([9; 32]);
+        segment.changes[0].inline_payloads[0].json_ref = bogus_ref;
+        segment.changes[0].directory.payloads[0].json_ref = bogus_ref;
+
+        let error =
+            validate_segment_shape(&segment).expect_err("inline payload hash drift must fail");
+
+        assert!(
+            error.message.contains("does not match payload bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_authored_membership_commit_mismatch() {
+        let mut segment = test_segment();
+        segment.changes[0].authored_commit_id = Some("other-commit".to_string());
+
+        let error = validate_segment_shape(&segment)
+            .expect_err("authored membership ownership drift must fail");
+
+        assert!(
+            error.message.contains("mismatched authored_commit_id"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_adopted_membership_authored_by_same_commit() {
+        let mut segment = test_segment();
+        segment.commits[0]
+            .header
+            .parent_commit_ids
+            .push("parent-1".to_string());
+        segment.commits[0].body.membership[0].role = MembershipRole::Adopted;
+        segment.commits[0].body.membership[0].source_parent_ordinal = Some(0);
+
+        let error = validate_segment_shape(&segment)
+            .expect_err("self-authored adopted membership must fail");
+
+        assert!(
+            error
+                .message
+                .contains("must not be authored by the same commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_state_row_identity_change_mismatch() {
+        let mut segment = test_segment();
+        segment.commits[0].directory.state_row_identities[0]
+            .0
+            .schema_key = CanonicalSchemaKey::new("other").unwrap();
+
+        let error =
+            validate_segment_shape(&segment).expect_err("state-row identity drift must fail");
+
+        assert!(
+            error
+                .message
+                .contains("StateRowIdentity winner for change 'change-1' does not match"),
             "unexpected error: {error}"
         );
     }
@@ -1260,7 +1685,12 @@ mod tests {
         super::super::types::StateRowIdentity {
             schema_key: CanonicalSchemaKey::new("message").unwrap(),
             file_id: FileId::new("file-1").unwrap(),
-            entity_id: EntityId::new("entity-1").unwrap(),
+            entity_id: EntityId::new(
+                EntityIdentity::single("entity-1")
+                    .as_json_array_text()
+                    .unwrap(),
+            )
+            .unwrap(),
         }
     }
 }

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -134,7 +134,11 @@ where
         .await
     }
 
-    /// Rebuilds the tracked serving projection root for one version from changelog.
+    /// Rebuilds the tracked serving projection root for one version.
+    ///
+    /// The rebuild replays changelog entries from the nearest available
+    /// first-parent projection root, preserving the existing incremental
+    /// projection metadata shape used by historical SQL reads.
     ///
     /// This is intentionally an engine-level operation: callers should not need
     /// to know which KV namespaces back changelog, commit graph, or tracked

--- a/packages/engine/src/json_store/store.rs
+++ b/packages/engine/src/json_store/store.rs
@@ -274,10 +274,14 @@ fn load_values(
         .value
         .into_iter()
         .map(|value| match value {
-            Some(StorageProjectedValue::FullValue(bytes)) => Some(bytes.to_vec()),
-            Some(StorageProjectedValue::KeyOnly) | None => None,
+            Some(StorageProjectedValue::FullValue(bytes)) => Ok(Some(bytes.to_vec())),
+            Some(StorageProjectedValue::KeyOnly) => Err(LixError::unknown(format!(
+                "json_store read over namespace '{}' requested full value but storage returned key-only entry",
+                space.name
+            ))),
+            None => Ok(None),
         })
-        .collect())
+        .collect::<Result<Vec<_>, LixError>>()?)
 }
 
 fn encode_stored_json_payload(encoded_json: &EncodedJson<'_>) -> Vec<u8> {
@@ -374,10 +378,83 @@ fn decode_json_payload(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{
+        BackendError, BackendRead, BufferedRangeScan, GetOptions, Key, KeyRange, PointVisitor,
+        ProjectedValueRef, ScanOptions,
+    };
     use crate::storage::StorageContext;
     use crate::storage::{
-        InMemoryStorageBackend, StorageKey, StorageReadOptions, StorageValue, StorageWriteOptions,
+        InMemoryStorageBackend, StorageKey, StorageReadOptions, StorageReadScope, StorageValue,
+        StorageWriteOptions,
     };
+
+    struct KeyOnlyPointRead;
+
+    impl BackendRead for KeyOnlyPointRead {
+        type RangeScan<'cursor> = BufferedRangeScan;
+
+        fn visit_keys<V>(
+            &self,
+            keys: &[Key],
+            _opts: GetOptions<'_>,
+            visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            for (index, key) in keys.iter().enumerate() {
+                visitor.visit(index, key, Some(ProjectedValueRef::KeyOnly))?;
+            }
+            Ok(())
+        }
+
+        fn with_range_scan<T, F>(
+            &self,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            _f: F,
+        ) -> Result<T, BackendError>
+        where
+            F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+        {
+            unreachable!("json_store point-read test does not scan")
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_load_rejects_key_only_point_read() {
+        let read = StorageReadScope::new(KeyOnlyPointRead);
+        let json_ref = JsonRef::for_content(br#"{"value":"json"}"#);
+
+        let error = load_json_bytes_direct(&read, &json_ref)
+            .await
+            .expect_err("key-only JSON point read must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_load_rejects_key_only_point_read() {
+        let read = StorageReadScope::new(KeyOnlyPointRead);
+        let json_ref = JsonRef::for_content(br#"{"value":"json"}"#);
+
+        let error =
+            load_json_bytes_many_in_scope(&read, &[json_ref], JsonReadScopeRef::OutOfBand)
+                .await
+                .expect_err("key-only JSON batch read must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
 
     #[tokio::test]
     async fn json_roundtrips_raw_payload() {

--- a/packages/engine/src/session/merge/analysis.rs
+++ b/packages/engine/src/session/merge/analysis.rs
@@ -56,7 +56,13 @@ where
         TrackedStateDiff::default()
     } else {
         reader
-            .diff_commits(&commits.base_commit_id, &commits.target_commit_id, &request)
+            .diff_commits_with_validation(
+                &commits.base_commit_id,
+                &commits.target_commit_id,
+                &request,
+                false,
+                true,
+            )
             .await?
     };
 

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -132,6 +132,60 @@ pub(crate) async fn stage_tracked_root_from_materialized(
     Ok(())
 }
 
+pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
+    read: &mut (impl StorageRead + Send + Sync + ?Sized),
+    writes: &mut StorageWriteSet,
+    tracked_state: &TrackedStateContext,
+    commit_id: &str,
+    parent_ids: &[String],
+    projection_parent_commit_id: Option<&str>,
+    rows: &[MaterializedTrackedStateRow],
+) -> Result<(), crate::LixError> {
+    let changes = rows
+        .iter()
+        .map(tracked_change_from_materialized)
+        .collect::<Result<Vec<_>, _>>()?;
+    let commit_change_id = format!("{commit_id}:commit");
+    let staged = stage_test_changelog_commit(
+        read,
+        writes,
+        commit_id,
+        &commit_change_id,
+        parent_ids,
+        rows,
+        &changes,
+    )
+    .await?;
+    let deltas = staged
+        .locators
+        .iter()
+        .map(|(row_index, locator)| {
+            let change = &changes[*row_index];
+            let row = &rows[*row_index];
+            TrackedStateDeltaRef {
+                change: ChangelogChangeRef {
+                    id: &change.id,
+                    authored_commit_id: Some(&locator.commit_id),
+                    entity_id: &change.entity_id,
+                    schema_key: &change.schema_key,
+                    file_id: change.file_id.as_deref(),
+                    snapshot_ref: change.snapshot_ref.as_ref(),
+                    metadata_ref: change.metadata_ref.as_ref(),
+                    created_at: &change.created_at,
+                },
+                locator: locator.as_ref(),
+                created_at: &row.created_at,
+                updated_at: &row.updated_at,
+            }
+        })
+        .collect::<Vec<_>>();
+    tracked_state
+        .writer(read, writes)
+        .stage_projection_root(commit_id, projection_parent_commit_id, deltas)
+        .await?;
+    Ok(())
+}
+
 pub(crate) async fn stage_empty_changelog_commit(
     read: &mut (impl StorageRead + Send + Sync + ?Sized),
     writes: &mut StorageWriteSet,
@@ -148,6 +202,26 @@ pub(crate) async fn stage_empty_changelog_commit(
         commit_id,
         &commit_change_id,
         &parent_ids,
+        &[],
+        &[],
+    )
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn stage_empty_changelog_commit_with_parents(
+    read: &mut (impl StorageRead + Send + Sync + ?Sized),
+    writes: &mut StorageWriteSet,
+    commit_id: &str,
+    parent_ids: &[String],
+) -> Result<(), crate::LixError> {
+    let commit_change_id = format!("{commit_id}:commit");
+    stage_test_changelog_commit(
+        read,
+        writes,
+        commit_id,
+        &commit_change_id,
+        parent_ids,
         &[],
         &[],
     )
@@ -431,7 +505,7 @@ pub(crate) fn tracked_change_from_materialized(
             let serialized = crate::serialize_row_metadata(value);
             prepare_json_ref(&serialized)
         }),
-        created_at: row.created_at.clone(),
+        created_at: row.updated_at.clone(),
     })
 }
 

--- a/packages/engine/src/tracked_state/codec.rs
+++ b/packages/engine/src/tracked_state/codec.rs
@@ -1,13 +1,13 @@
 use xxhash_rust::xxh3::xxh3_64_with_seed;
 
+use crate::LixError;
 use crate::changelog::{ChangeLocator, SegmentObjectLocation};
 use crate::entity_identity::EntityIdentity;
 use crate::json_store::JsonRef;
 use crate::tracked_state::types::{
-    TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
-    TRACKED_STATE_HASH_BYTES,
+    TRACKED_STATE_HASH_BYTES, TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey,
+    TrackedStateKeyRef,
 };
-use crate::LixError;
 
 const NODE_VERSION: u8 = 2;
 const VALUE_VERSION: u8 = 8;
@@ -211,7 +211,7 @@ pub(crate) fn decode_key(bytes: &[u8]) -> Result<TrackedStateKey, LixError> {
             return Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",
                 format!("tracked-state tree key has invalid file_id presence byte {other}"),
-            ))
+            ));
         }
     };
     let entity_id = read_entity_identity(bytes, &mut cursor)?;
@@ -503,13 +503,14 @@ pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef<'_>, LixErr
                     subtree_count,
                 });
             }
+            validate_internal_children(&children)?;
             DecodedNodeRef::Internal(DecodedInternalNode { children })
         }
         other => {
             return Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",
                 format!("unknown tracked-state tree node kind {other}"),
-            ))
+            ));
         }
     };
     if cursor != bytes.len() {
@@ -565,11 +566,90 @@ fn decode_leaf_node_ref_after_count<'a>(
     }
     let payload_start = *cursor;
     *cursor = bytes.len();
+    validate_leaf_entry_order(bytes, payload_start, &offsets)?;
     Ok(DecodedLeafNodeRef {
         bytes,
         payload_start,
         offsets,
     })
+}
+
+fn validate_leaf_entry_order(
+    bytes: &[u8],
+    payload_start: usize,
+    offsets: &[usize],
+) -> Result<(), LixError> {
+    let mut previous_key: Option<&[u8]> = None;
+    for index in 0..offsets.len().saturating_sub(1) {
+        let start = payload_start + offsets[index];
+        let end = payload_start + offsets[index + 1];
+        let record = bytes.get(start..end).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state leaf offset points outside node payload",
+            )
+        })?;
+        let mut cursor = 0usize;
+        let key = read_sized_slice(record, &mut cursor, "leaf key")?;
+        let _value = read_sized_slice(record, &mut cursor, "leaf value")?;
+        if cursor != record.len() {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state leaf entry decode found trailing bytes",
+            ));
+        }
+        if let Some(previous_key) = previous_key {
+            if previous_key >= key {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state leaf keys must be strictly increasing",
+                ));
+            }
+        }
+        previous_key = Some(key);
+    }
+    Ok(())
+}
+
+fn validate_internal_children(children: &[ChildSummary]) -> Result<(), LixError> {
+    if children.is_empty() {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state internal node must contain at least one child",
+        ));
+    }
+
+    let mut previous_last_key: Option<&[u8]> = None;
+    for child in children {
+        if child.first_key.is_empty() || child.last_key.is_empty() {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal child range keys must be non-empty",
+            ));
+        }
+        if child.first_key > child.last_key {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal child first_key must be <= last_key",
+            ));
+        }
+        if child.subtree_count == 0 {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal child subtree_count must be non-zero",
+            ));
+        }
+        if let Some(previous_last_key) = previous_last_key {
+            if previous_last_key >= child.first_key.as_slice() {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state internal child ranges must be strictly increasing",
+                ));
+            }
+        }
+        previous_last_key = Some(child.last_key.as_slice());
+    }
+    Ok(())
 }
 
 fn ensure_counted_records_fit_remaining(
@@ -692,7 +772,7 @@ fn read_entity_identity(bytes: &[u8], cursor: &mut usize) -> Result<EntityIdenti
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!("tracked-state tree key has invalid entity identity part tag {other}"),
-                ))
+                ));
             }
         }
     }
@@ -755,7 +835,7 @@ fn read_timestamp_pair(bytes: &[u8], cursor: &mut usize) -> Result<(String, Stri
             return Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",
                 format!("tracked-state timestamp pair has invalid updated_at tag {other}"),
-            ))
+            ));
         }
     };
     Ok((created_at, updated_at))
@@ -993,9 +1073,11 @@ mod tests {
         encoded[entity_tag_offset] = 2;
 
         let error = decode_key(&encoded).expect_err("non-string identity tag should reject");
-        assert!(error
-            .to_string()
-            .contains("invalid entity identity part tag 2"));
+        assert!(
+            error
+                .to_string()
+                .contains("invalid entity identity part tag 2")
+        );
     }
 
     #[test]
@@ -1173,25 +1255,68 @@ mod tests {
 
         let mut non_zero_first = encoded.clone();
         non_zero_first[6..10].copy_from_slice(&1u32.to_be_bytes());
-        assert!(decode_node_ref(&non_zero_first)
-            .expect_err("non-zero first offset should reject")
-            .to_string()
-            .contains("offset table must start at zero"));
+        assert!(
+            decode_node_ref(&non_zero_first)
+                .expect_err("non-zero first offset should reject")
+                .to_string()
+                .contains("offset table must start at zero")
+        );
 
         let mut non_monotonic = encoded.clone();
         non_monotonic[10..14].copy_from_slice(&100u32.to_be_bytes());
-        assert!(decode_node_ref(&non_monotonic)
-            .expect_err("non-monotonic offsets should reject")
-            .to_string()
-            .contains("offsets must be monotonic"));
+        assert!(
+            decode_node_ref(&non_monotonic)
+                .expect_err("non-monotonic offsets should reject")
+                .to_string()
+                .contains("offsets must be monotonic")
+        );
 
         let mut short_coverage = encoded;
         let payload_len = short_coverage.len() - 18;
         short_coverage[14..18].copy_from_slice(&((payload_len - 1) as u32).to_be_bytes());
-        assert!(decode_node_ref(&short_coverage)
-            .expect_err("short offset coverage should reject")
-            .to_string()
-            .contains("offset table does not cover full payload"));
+        assert!(
+            decode_node_ref(&short_coverage)
+                .expect_err("short offset coverage should reject")
+                .to_string()
+                .contains("offset table does not cover full payload")
+        );
+    }
+
+    #[test]
+    fn leaf_node_codec_rejects_unsorted_or_duplicate_keys() {
+        let unsorted = encode_leaf_node(&[
+            EncodedLeafEntry {
+                key: b"bravo".to_vec(),
+                value: b"two".to_vec(),
+            },
+            EncodedLeafEntry {
+                key: b"alpha".to_vec(),
+                value: b"one".to_vec(),
+            },
+        ]);
+        assert!(
+            decode_node_ref(&unsorted)
+                .expect_err("unsorted leaf keys should reject")
+                .to_string()
+                .contains("leaf keys must be strictly increasing")
+        );
+
+        let duplicate = encode_leaf_node(&[
+            EncodedLeafEntry {
+                key: b"alpha".to_vec(),
+                value: b"one".to_vec(),
+            },
+            EncodedLeafEntry {
+                key: b"alpha".to_vec(),
+                value: b"two".to_vec(),
+            },
+        ]);
+        assert!(
+            decode_node_ref(&duplicate)
+                .expect_err("duplicate leaf keys should reject")
+                .to_string()
+                .contains("leaf keys must be strictly increasing")
+        );
     }
 
     #[test]
@@ -1201,9 +1326,11 @@ mod tests {
 
         let error = decode_node_ref(&encoded).expect_err("impossible leaf count should reject");
 
-        assert!(error
-            .to_string()
-            .contains("field 'leaf offsets' exceeds remaining node bytes"));
+        assert!(
+            error
+                .to_string()
+                .contains("field 'leaf offsets' exceeds remaining node bytes")
+        );
     }
 
     #[test]
@@ -1213,9 +1340,79 @@ mod tests {
 
         let error = decode_node_ref(&encoded).expect_err("impossible internal count should reject");
 
-        assert!(error
-            .to_string()
-            .contains("field 'internal children' exceeds remaining node bytes"));
+        assert!(
+            error
+                .to_string()
+                .contains("field 'internal children' exceeds remaining node bytes")
+        );
+    }
+
+    #[test]
+    fn internal_node_codec_rejects_invalid_child_ranges() {
+        let child = |first_key: &[u8], last_key: &[u8], subtree_count: u64| ChildSummary {
+            first_key: first_key.to_vec(),
+            last_key: last_key.to_vec(),
+            child_hash: [7; TRACKED_STATE_HASH_BYTES],
+            subtree_count,
+        };
+
+        let empty = encode_internal_node(&[]);
+        assert!(
+            decode_node_ref(&empty)
+                .expect_err("empty internal node should reject")
+                .to_string()
+                .contains("internal node must contain at least one child")
+        );
+
+        let reversed_range = encode_internal_node(&[child(b"bravo", b"alpha", 1)]);
+        assert!(
+            decode_node_ref(&reversed_range)
+                .expect_err("reversed child range should reject")
+                .to_string()
+                .contains("first_key must be <= last_key")
+        );
+
+        let zero_count = encode_internal_node(&[child(b"alpha", b"bravo", 0)]);
+        assert!(
+            decode_node_ref(&zero_count)
+                .expect_err("zero subtree_count should reject")
+                .to_string()
+                .contains("subtree_count must be non-zero")
+        );
+
+        let empty_first = encode_internal_node(&[child(b"", b"bravo", 1)]);
+        assert!(
+            decode_node_ref(&empty_first)
+                .expect_err("empty first_key should reject")
+                .to_string()
+                .contains("range keys must be non-empty")
+        );
+
+        let empty_last = encode_internal_node(&[child(b"alpha", b"", 1)]);
+        assert!(
+            decode_node_ref(&empty_last)
+                .expect_err("empty last_key should reject")
+                .to_string()
+                .contains("range keys must be non-empty")
+        );
+
+        let overlapping =
+            encode_internal_node(&[child(b"alpha", b"charlie", 2), child(b"bravo", b"delta", 2)]);
+        assert!(
+            decode_node_ref(&overlapping)
+                .expect_err("overlapping child ranges should reject")
+                .to_string()
+                .contains("child ranges must be strictly increasing")
+        );
+
+        let duplicate_boundary =
+            encode_internal_node(&[child(b"alpha", b"bravo", 2), child(b"bravo", b"delta", 2)]);
+        assert!(
+            decode_node_ref(&duplicate_boundary)
+                .expect_err("duplicate child boundary should reject")
+                .to_string()
+                .contains("child ranges must be strictly increasing")
+        );
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -793,6 +793,12 @@ where
                         ))
                     })?;
             }
+            if fact.updated_at != row.updated_at {
+                return Err(LixError::unknown(format!(
+                    "tracked-state projection root for commit '{}' has updated_at '{}' for change '{}' but changelog first-parent updated_at is '{}'",
+                    commit_id, row.updated_at, row.change_id, fact.updated_at
+                )));
+            }
             actual_identities.insert(identity);
         }
         if actual_identities != expected_identities {
@@ -2818,6 +2824,106 @@ mod tests {
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].snapshot_content, None);
+    }
+
+    #[tokio::test]
+    async fn validate_tree_rows_rejects_corrupt_updated_at() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row("entity-a", "change-parent", "parent")],
+        )
+        .await
+        .expect("parent root should write");
+        let mut child_row = row_with_value("entity-a", "change-child", "child", "child");
+        child_row.updated_at = "2026-02-01T00:00:00Z".to_string();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            std::slice::from_ref(&child_row),
+        )
+        .await
+        .expect("child root should write");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let child_root = storage::load_root(&read, "child")
+            .await
+            .expect("child root should load")
+            .expect("child root should exist");
+        let child_metadata = storage::load_projection_metadata(&read, "child")
+            .await
+            .expect("child metadata should load")
+            .expect("child metadata should exist");
+        let key = TrackedStateKey {
+            schema_key: child_row.schema_key.clone(),
+            file_id: child_row.file_id.clone(),
+            entity_id: child_row.entity_id.clone(),
+        };
+        let mut corrupt_value = TrackedStateTree::new()
+            .get(&read, &child_root, &key)
+            .await
+            .expect("child value should load")
+            .expect("child value should exist");
+        corrupt_value.updated_at = "1999-01-01T00:00:00Z".to_string();
+        drop(read);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let result = TrackedStateTree::new()
+            .apply_mutations(
+                &read,
+                &mut writes,
+                None,
+                vec![TrackedStateMutation::put_encoded(
+                    crate::tracked_state::codec::encode_key(&key),
+                    crate::tracked_state::codec::encode_value(&corrupt_value),
+                )],
+                Some("child"),
+            )
+            .await
+            .expect("corrupt child root should write");
+        storage::stage_projection_metadata(
+            &mut writes,
+            &TrackedStateProjectionMetadata {
+                commit_id: "child".to_string(),
+                root_id: result.root_id,
+                parent_roots: child_metadata.parent_roots,
+                changed_key_count: child_metadata.changed_key_count,
+                row_count_estimate: result.row_count as u64,
+                tree_height: result.tree_height as u32,
+                primary_chunk_count: result.chunk_count as u64,
+                primary_chunk_bytes: result.chunk_bytes as u64,
+            },
+        )
+        .expect("corrupt child metadata should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("corrupt child root should commit");
+
+        let mut reader = tracked_state.reader(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open"),
+        );
+        let error = reader
+            .validate_tree_rows_at_commit_against_changelog(
+                "child",
+                &TrackedStateTreeScanRequest::default(),
+            )
+            .await
+            .expect_err("corrupt updated_at must be rejected");
+
+        assert!(error.message.contains("has updated_at"));
     }
 
     async fn seed_merge_roots(

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1,9 +1,18 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
+use crate::changelog::{
+    ChangelogContext, CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitVisibilityMode,
+    StateRowIdentity,
+};
+use crate::common::{CanonicalSchemaKey, EntityId, FileId};
+use crate::entity_identity::EntityIdentity;
 use crate::storage::{StorageRead, StorageWriteSet};
 use crate::tracked_state::by_file_index::ByFileIndex;
 use crate::tracked_state::codec::{encode_key_ref, encode_value_ref};
-use crate::tracked_state::diff::{diff_commits, TrackedStateDiff, TrackedStateDiffRequest};
+use crate::tracked_state::diff::{
+    diff_commits, diff_commits_with_validation, TrackedStateDiff, TrackedStateDiffRequest,
+    TrackedStateDiffRow,
+};
 use crate::tracked_state::materialize_rows_from_index_entries;
 use crate::tracked_state::merge::{self, TrackedStateMergePlan};
 use crate::tracked_state::storage;
@@ -90,6 +99,29 @@ impl TrackedStateContext {
 pub(crate) struct TrackedStateStoreReader<S> {
     store: S,
     tree: TrackedStateTree,
+}
+
+#[allow(dead_code)]
+struct DiffProjectionValidationCache {
+    requested_identities: HashSet<StateRowIdentity>,
+    visible_commit_winners: HashMap<String, HashMap<StateRowIdentity, String>>,
+    projection_metadata: HashMap<String, TrackedStateProjectionMetadata>,
+    projection_roots: HashMap<String, TrackedStateRootId>,
+    tree_values: HashMap<(TrackedStateRootId, TrackedStateKey), Option<TrackedStateIndexValue>>,
+    changelog_first_parents: HashMap<String, Option<String>>,
+}
+
+impl DiffProjectionValidationCache {
+    fn new(requested_identities: HashSet<StateRowIdentity>) -> Self {
+        Self {
+            requested_identities,
+            visible_commit_winners: HashMap::new(),
+            projection_metadata: HashMap::new(),
+            projection_roots: HashMap::new(),
+            tree_values: HashMap::new(),
+            changelog_first_parents: HashMap::new(),
+        }
+    }
 }
 
 impl<S> TrackedStateStoreReader<S>
@@ -221,6 +253,514 @@ where
         request: &TrackedStateDiffRequest,
     ) -> Result<TrackedStateDiff, LixError> {
         diff_commits(self, left_commit_id, right_commit_id, request).await
+    }
+
+    pub(crate) async fn diff_commits_with_validation(
+        &mut self,
+        left_commit_id: &str,
+        right_commit_id: &str,
+        request: &TrackedStateDiffRequest,
+        validate_left_root: bool,
+        validate_right_root: bool,
+    ) -> Result<TrackedStateDiff, LixError> {
+        diff_commits_with_validation(
+            self,
+            left_commit_id,
+            right_commit_id,
+            request,
+            validate_left_root,
+            validate_right_root,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn validate_diff_rows_for_commits_against_changelog(
+        &mut self,
+        rows: &[(&TrackedStateDiffRow, &str)],
+    ) -> Result<(), LixError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let mut change_ids = rows
+            .iter()
+            .map(|(row, _)| row.change_id.clone())
+            .collect::<Vec<_>>();
+        change_ids.sort();
+        change_ids.dedup();
+
+        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
+        let loaded_changes = changelog_reader
+            .load_physical_segment_changes(&change_ids)
+            .await?;
+        let mut changes = HashMap::new();
+        for (change_id, loaded) in change_ids.into_iter().zip(loaded_changes) {
+            let Some((location, change)) = loaded else {
+                return Err(LixError::unknown(format!(
+                    "tracked-state diff row references missing changelog change '{change_id}'"
+                )));
+            };
+            changes.insert(change_id, (location, change));
+        }
+
+        let requested_identities = rows
+            .iter()
+            .map(|(row, _)| state_row_identity_from_diff_row(row))
+            .collect::<Result<HashSet<_>, _>>()?;
+        let mut validation_cache = DiffProjectionValidationCache::new(requested_identities);
+        for (row, expected_commit_id) in rows {
+            validate_diff_row_against_changelog(row, &changes)?;
+            let change_created_at = changes
+                .get(&row.change_id)
+                .map(|(_, change)| change.created_at.as_str())
+                .ok_or_else(|| {
+                    LixError::unknown(format!(
+                        "tracked-state diff row references missing changelog change '{}'",
+                        row.change_id
+                    ))
+                })?;
+            self.validate_diff_row_projection_membership(
+                row,
+                expected_commit_id,
+                change_created_at,
+                &mut validation_cache,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn validate_diff_rows_physical_against_changelog(
+        &mut self,
+        rows: &[&TrackedStateDiffRow],
+    ) -> Result<(), LixError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let mut change_ids = rows
+            .iter()
+            .map(|row| row.change_id.clone())
+            .collect::<Vec<_>>();
+        change_ids.sort();
+        change_ids.dedup();
+
+        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
+        let loaded_changes = changelog_reader
+            .load_physical_segment_changes(&change_ids)
+            .await?;
+        let mut changes = HashMap::new();
+        for (change_id, loaded) in change_ids.into_iter().zip(loaded_changes) {
+            let Some((location, change)) = loaded else {
+                return Err(LixError::unknown(format!(
+                    "tracked-state diff row references missing changelog change '{change_id}'"
+                )));
+            };
+            changes.insert(change_id, (location, change));
+        }
+
+        for row in rows {
+            validate_diff_row_against_changelog(row, &changes)?;
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    async fn validate_diff_row_projection_membership(
+        &mut self,
+        row: &TrackedStateDiffRow,
+        root_commit_id: &str,
+        change_created_at: &str,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<(), LixError> {
+        let identity = state_row_identity_from_diff_row(row)?;
+        let key = TrackedStateKey {
+            schema_key: row.schema_key.clone(),
+            file_id: row.file_id.clone(),
+            entity_id: row.entity_id.clone(),
+        };
+        let root_metadata = self
+            .load_cached_projection_metadata(root_commit_id, cache)
+            .await?;
+        self.validate_projection_parent_matches_changelog(root_commit_id, &root_metadata, cache)
+            .await?;
+        let (_, row_value) = row.clone().into_index_entry();
+        let mut current_commit_id = root_commit_id.to_string();
+        let mut seen = HashSet::new();
+        loop {
+            if !seen.insert(current_commit_id.clone()) {
+                return Err(LixError::unknown(format!(
+                    "tracked-state projection parent chain contains cycle at commit '{current_commit_id}'"
+                )));
+            }
+
+            let winners = self
+                .load_cached_visible_commit_winners(&current_commit_id, cache)
+                .await?;
+            if let Some(winner_change_id) = winners.get(&identity) {
+                if winner_change_id != &row.change_id {
+                    return Err(LixError::unknown(format!(
+                        "tracked-state diff row references changelog change '{}' that is not the first-parent winner for commit '{}' and identity {:?}",
+                        row.change_id, root_commit_id, identity
+                    )));
+                }
+                self.validate_diff_row_created_at(row, &key, &current_commit_id, change_created_at)
+                    .await?;
+                return Ok(());
+            }
+
+            let metadata = self
+                .load_cached_projection_metadata(&current_commit_id, cache)
+                .await?;
+            self.validate_projection_parent_matches_changelog(&current_commit_id, &metadata, cache)
+                .await?;
+            let Some(parent) = metadata.parent_roots.first() else {
+                return Err(LixError::unknown(format!(
+                    "tracked-state diff row references changelog change '{}' that is not the first-parent winner for commit '{}' and identity {:?}",
+                    row.change_id, root_commit_id, identity
+                )));
+            };
+            let parent_value = self
+                .load_cached_tree_value(&parent.root_id, &key, cache)
+                .await?;
+            if parent_value.as_ref() != Some(&row_value) {
+                return Err(LixError::unknown(format!(
+                    "tracked-state projection row for commit '{}' does not match parent root '{}' for inherited identity {:?}",
+                    root_commit_id, parent.commit_id, identity
+                )));
+            }
+            current_commit_id = parent.commit_id.clone();
+        }
+    }
+
+    async fn validate_projection_parent_matches_changelog(
+        &mut self,
+        commit_id: &str,
+        metadata: &TrackedStateProjectionMetadata,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<(), LixError> {
+        let changelog_first_parent = self
+            .load_cached_visible_changelog_first_parent(commit_id, cache)
+            .await?;
+        let expected_parent = match changelog_first_parent.as_deref() {
+            Some(first_parent_id) => {
+                self.nearest_available_projection_parent(first_parent_id, cache)
+                    .await?
+            }
+            None => None,
+        };
+        match (expected_parent, metadata.parent_roots.first()) {
+            (None, None) => Ok(()),
+            (Some((expected_parent_id, expected_root)), Some(parent))
+                if parent.commit_id == expected_parent_id && parent.root_id == expected_root =>
+            {
+                Ok(())
+            }
+            (Some((expected_parent_id, expected_root)), Some(parent))
+                if parent.commit_id == expected_parent_id =>
+            {
+                let _ = expected_root;
+                Err(LixError::unknown(format!(
+                    "tracked-state projection metadata for commit '{}' references stale root for projection parent '{}'",
+                    commit_id, expected_parent_id
+                )))
+            }
+            (Some((expected_parent_id, _)), Some(parent)) => Err(LixError::unknown(format!(
+                "tracked-state projection metadata for commit '{}' references parent '{}' but nearest available first-parent root is '{}'",
+                commit_id, parent.commit_id, expected_parent_id
+            ))),
+            (Some((expected_parent_id, _)), None) => Err(LixError::unknown(format!(
+                "tracked-state projection metadata for commit '{}' is missing projection parent '{}'",
+                commit_id, expected_parent_id
+            ))),
+            (None, Some(parent)) => Err(LixError::unknown(format!(
+                "tracked-state projection metadata for root commit '{}' references unexpected parent '{}'",
+                commit_id, parent.commit_id
+            ))),
+        }
+    }
+
+    async fn nearest_available_projection_parent(
+        &mut self,
+        start_commit_id: &str,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<Option<(String, TrackedStateRootId)>, LixError> {
+        let mut current = Some(start_commit_id.to_string());
+        let mut seen = HashSet::new();
+        while let Some(commit_id) = current {
+            if !seen.insert(commit_id.clone()) {
+                return Err(LixError::unknown(format!(
+                    "tracked-state projection parent chain contains cycle at commit '{commit_id}'"
+                )));
+            }
+            if let Some(root_id) = self
+                .load_cached_projection_root_optional(&commit_id, cache)
+                .await?
+            {
+                return Ok(Some((commit_id, root_id)));
+            }
+            current = self
+                .load_cached_visible_changelog_first_parent(&commit_id, cache)
+                .await?;
+        }
+        Ok(None)
+    }
+
+    #[allow(dead_code)]
+    async fn load_cached_visible_commit_winners(
+        &mut self,
+        commit_id: &str,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<HashMap<StateRowIdentity, String>, LixError> {
+        if let Some(winners) = cache.visible_commit_winners.get(commit_id) {
+            return Ok(winners.clone());
+        }
+        let identities = cache
+            .requested_identities
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
+        let winners = changelog_reader
+            .load_visible_commit_winners(commit_id, &identities)
+            .await?;
+        cache
+            .visible_commit_winners
+            .insert(commit_id.to_string(), winners.clone());
+        Ok(winners)
+    }
+
+    async fn load_cached_projection_metadata(
+        &mut self,
+        commit_id: &str,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<TrackedStateProjectionMetadata, LixError> {
+        if let Some(metadata) = cache.projection_metadata.get(commit_id) {
+            return Ok(metadata.clone());
+        }
+        let metadata = storage::load_projection_metadata(&mut self.store, commit_id)
+            .await?
+            .ok_or_else(|| missing_projection_root_error(commit_id))?;
+        cache
+            .projection_metadata
+            .insert(commit_id.to_string(), metadata.clone());
+        Ok(metadata)
+    }
+
+    async fn load_cached_projection_root_optional(
+        &mut self,
+        commit_id: &str,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<Option<TrackedStateRootId>, LixError> {
+        if let Some(root_id) = cache.projection_roots.get(commit_id) {
+            return Ok(Some(root_id.clone()));
+        }
+        let root_id = storage::load_root(&self.store, commit_id).await?;
+        if let Some(root_id) = &root_id {
+            cache
+                .projection_roots
+                .insert(commit_id.to_string(), root_id.clone());
+        }
+        Ok(root_id)
+    }
+
+    #[allow(dead_code)]
+    async fn load_cached_tree_value(
+        &mut self,
+        root_id: &TrackedStateRootId,
+        key: &TrackedStateKey,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<Option<TrackedStateIndexValue>, LixError> {
+        let cache_key = (root_id.clone(), key.clone());
+        if let Some(value) = cache.tree_values.get(&cache_key) {
+            return Ok(value.clone());
+        }
+        let value = self
+            .tree
+            .get_many(&mut self.store, root_id, std::slice::from_ref(key))
+            .await?
+            .into_iter()
+            .next()
+            .flatten();
+        cache.tree_values.insert(cache_key, value.clone());
+        Ok(value)
+    }
+
+    async fn load_cached_visible_changelog_first_parent(
+        &mut self,
+        commit_id: &str,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<Option<String>, LixError> {
+        if let Some(parent_id) = cache.changelog_first_parents.get(commit_id) {
+            return Ok(parent_id.clone());
+        }
+        let commit_ids = [commit_id.to_string()];
+        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
+        let batch = changelog_reader
+            .load_commits(CommitLoadRequest {
+                commit_ids: &commit_ids,
+                projection: CommitProjection::Header,
+                visibility: CommitVisibilityMode::RequireVisible,
+            })
+            .await?;
+        let Some(entry) = batch.entries.into_iter().next().flatten() else {
+            return Err(LixError::unknown(format!(
+                "visible changelog commit '{commit_id}' is missing while validating tracked-state projection metadata"
+            )));
+        };
+        let CommitLoadEntry::Header(header) = entry else {
+            return Err(LixError::unknown(format!(
+                "visible changelog commit '{commit_id}' did not return a header projection"
+            )));
+        };
+        let parent_id = header.parent_commit_ids.first().cloned();
+        cache
+            .changelog_first_parents
+            .insert(commit_id.to_string(), parent_id.clone());
+        Ok(parent_id)
+    }
+
+    async fn validate_diff_row_created_at(
+        &mut self,
+        row: &TrackedStateDiffRow,
+        key: &TrackedStateKey,
+        commit_id: &str,
+        change_created_at: &str,
+    ) -> Result<(), LixError> {
+        if row.created_at == change_created_at {
+            return Ok(());
+        }
+        let Some(metadata) = storage::load_projection_metadata(&mut self.store, commit_id).await?
+        else {
+            return Err(missing_projection_root_error(commit_id));
+        };
+        let Some(parent) = metadata.parent_roots.first() else {
+            return Err(LixError::unknown(format!(
+                "tracked-state diff row for change '{}' created_at '{}' does not match changelog change '{}'",
+                row.change_id, row.created_at, change_created_at
+            )));
+        };
+        let parent_value = self
+            .tree
+            .get_many(&mut self.store, &parent.root_id, std::slice::from_ref(key))
+            .await?
+            .into_iter()
+            .next()
+            .flatten();
+        if parent_value
+            .as_ref()
+            .is_some_and(|value| value.created_at == row.created_at)
+        {
+            return Ok(());
+        }
+        if row.commit_id != commit_id {
+            if let Some(source_created_at) =
+                self.load_parent_created_at_for_row_commit(row, key).await?
+            {
+                if source_created_at == row.created_at {
+                    return Ok(());
+                }
+            }
+        }
+        Err(LixError::unknown(format!(
+            "tracked-state diff row for change '{}' created_at '{}' does not match changelog change '{}' or parent projection",
+            row.change_id, row.created_at, change_created_at
+        )))
+    }
+
+    async fn load_parent_created_at_for_row_commit(
+        &mut self,
+        row: &TrackedStateDiffRow,
+        key: &TrackedStateKey,
+    ) -> Result<Option<String>, LixError> {
+        let Some(metadata) =
+            storage::load_projection_metadata(&mut self.store, &row.commit_id).await?
+        else {
+            return Ok(None);
+        };
+        let Some(parent) = metadata.parent_roots.first() else {
+            return Ok(None);
+        };
+        let parent_value = self
+            .tree
+            .get_many(&mut self.store, &parent.root_id, std::slice::from_ref(key))
+            .await?
+            .into_iter()
+            .next()
+            .flatten();
+        Ok(parent_value.map(|value| value.created_at))
+    }
+
+    pub(crate) async fn validate_tree_rows_at_commit_against_changelog(
+        &mut self,
+        commit_id: &str,
+        request: &TrackedStateTreeScanRequest,
+    ) -> Result<(), LixError> {
+        let root = self.load_ensured_root(commit_id).await?;
+        let rows = self.tree.scan(&mut self.store, &root, request).await?;
+        let rows = rows
+            .into_iter()
+            .map(|(key, value)| TrackedStateDiffRow::from_tree_entry(key, value))
+            .collect::<Vec<_>>();
+        let mut validation_cache = DiffProjectionValidationCache::new(HashSet::new());
+        let metadata = self
+            .load_cached_projection_metadata(commit_id, &mut validation_cache)
+            .await?;
+        self.validate_projection_parent_matches_changelog(
+            commit_id,
+            &metadata,
+            &mut validation_cache,
+        )
+        .await?;
+        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
+        let winner_facts = changelog_reader
+            .load_first_parent_winner_facts_matching_visible_commit(commit_id, |identity| {
+                state_row_identity_matches_tree_request(identity, request)
+            })
+            .await?;
+        let mut expected_identities = HashSet::new();
+        for (identity, fact) in &winner_facts {
+            if !fact.deleted || request.include_tombstones {
+                expected_identities.insert(identity.clone());
+            }
+        }
+        let mut actual_identities = HashSet::new();
+        for row in &rows {
+            let identity = state_row_identity_from_diff_row(row)?;
+            let fact = winner_facts.get(&identity).ok_or_else(|| {
+                LixError::unknown(format!(
+                    "tracked-state projection root for commit '{commit_id}' contains non-winner identity {:?}",
+                    identity
+                ))
+            })?;
+            if fact.change_id != row.change_id {
+                return Err(LixError::unknown(format!(
+                    "tracked-state projection root for commit '{}' has change '{}' but changelog first-parent winner is '{}'",
+                    commit_id, row.change_id, fact.change_id
+                )));
+            }
+            if fact.created_at != row.created_at && fact.updated_at != row.created_at {
+                let (key, _) = row.clone().into_index_entry();
+                self.validate_diff_row_created_at(row, &key, &fact.commit_id, &fact.created_at)
+                    .await
+                    .map_err(|_| {
+                        LixError::unknown(format!(
+                            "tracked-state projection root for commit '{}' has created_at '{}' for change '{}' but changelog first-parent created_at is '{}'",
+                            commit_id, row.created_at, row.change_id, fact.created_at
+                        ))
+                    })?;
+            }
+            actual_identities.insert(identity);
+        }
+        if actual_identities != expected_identities {
+            return Err(LixError::unknown(format!(
+                "tracked-state projection root for commit '{commit_id}' does not match changelog first-parent winners"
+            )));
+        }
+        let row_refs = rows.iter().collect::<Vec<_>>();
+        self.validate_diff_rows_physical_against_changelog(&row_refs)
+            .await
     }
 
     pub(crate) async fn diff_tree_entries_at_commits(
@@ -613,6 +1153,117 @@ fn scan_needs_json_payloads(request: &TrackedStateScanRequest) -> bool {
         .any(|column| column == "snapshot_content" || column == "metadata")
 }
 
+fn validate_diff_row_against_changelog(
+    row: &TrackedStateDiffRow,
+    changes: &HashMap<
+        String,
+        (
+            crate::changelog::SegmentObjectLocation,
+            crate::changelog::SegmentChange,
+        ),
+    >,
+) -> Result<(), LixError> {
+    let Some((location, change)) = changes.get(&row.change_id) else {
+        return Err(LixError::unknown(format!(
+            "tracked-state diff row references missing changelog change '{}'",
+            row.change_id
+        )));
+    };
+    if row.change_location != *location {
+        return Err(LixError::unknown(format!(
+            "tracked-state diff row for change '{}' has stale changelog locator",
+            row.change_id
+        )));
+    }
+    if change.authored_commit_id.as_deref() != Some(row.commit_id.as_str()) {
+        return Err(LixError::unknown(format!(
+            "tracked-state diff row for change '{}' has commit_id '{}' but changelog authored_commit_id is {:?}",
+            row.change_id, row.commit_id, change.authored_commit_id
+        )));
+    }
+    if change.schema_key != row.schema_key
+        || change.file_id != row.file_id
+        || change.entity_id != row.entity_id
+    {
+        return Err(LixError::unknown(format!(
+            "tracked-state diff row for change '{}' does not match changelog change identity",
+            row.change_id
+        )));
+    }
+    if row.deleted != change.snapshot_ref.is_none() {
+        return Err(LixError::unknown(format!(
+            "tracked-state diff row for change '{}' deleted flag does not match changelog snapshot",
+            row.change_id
+        )));
+    }
+    if row.snapshot_ref != change.snapshot_ref || row.metadata_ref != change.metadata_ref {
+        return Err(LixError::unknown(format!(
+            "tracked-state diff row for change '{}' payload refs do not match changelog change",
+            row.change_id
+        )));
+    }
+    if row.updated_at != change.created_at {
+        return Err(LixError::unknown(format!(
+            "tracked-state diff row for change '{}' updated_at does not match changelog change timestamp",
+            row.change_id
+        )));
+    }
+    Ok(())
+}
+
+fn state_row_identity_from_diff_row(
+    row: &TrackedStateDiffRow,
+) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(row.schema_key.clone())?,
+        file_id: FileId::new(
+            row.file_id
+                .clone()
+                .unwrap_or_else(|| "__global__".to_string()),
+        )?,
+        entity_id: EntityId::new(row.entity_id.as_json_array_text()?)?,
+    })
+}
+
+fn state_row_identity_matches_tree_request(
+    identity: &StateRowIdentity,
+    request: &TrackedStateTreeScanRequest,
+) -> Result<bool, LixError> {
+    if !request.schema_keys.is_empty()
+        && !request
+            .schema_keys
+            .iter()
+            .any(|schema_key| schema_key == identity.schema_key.as_str())
+    {
+        return Ok(false);
+    }
+    if !request.file_ids.is_empty()
+        && !request.file_ids.iter().any(|filter| match filter {
+            crate::NullableKeyFilter::Null => identity.file_id.as_str() == "__global__",
+            crate::NullableKeyFilter::Value(value) => identity.file_id.as_str() == value,
+            crate::NullableKeyFilter::Any => true,
+        })
+    {
+        return Ok(false);
+    }
+    if !request.entity_ids.is_empty() {
+        let entity_id =
+            EntityIdentity::from_json_array_text(identity.entity_id.as_str()).map_err(|error| {
+                LixError::unknown(format!(
+                    "tracked-state changelog winner identity contains invalid entity_id: {error}"
+                ))
+            })?;
+        if !request
+            .entity_ids
+            .iter()
+            .any(|requested| requested == &entity_id)
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 #[cfg(any(test, feature = "storage-benches"))]
 fn tracked_key_from_request(request: &TrackedStateRowRequest) -> Result<TrackedStateKey, LixError> {
     let file_id = match &request.file_id {
@@ -929,6 +1580,91 @@ mod tests {
             diff.entries[0].kind,
             crate::tracked_state::TrackedStateDiffKind::Modified
         );
+        assert_eq!(
+            diff.entries[0]
+                .after
+                .as_ref()
+                .map(|row| row.change_id.as_str()),
+            Some("change-child")
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_allows_repaired_root_parented_to_nearest_available_ancestor_root() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "base",
+            None,
+            &[row_with_value("entity-a", "change-base", "base", "base")],
+        )
+        .await
+        .expect("base root should write");
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "middle",
+            Some("base"),
+            &[row_with_value(
+                "entity-a",
+                "change-middle",
+                "middle",
+                "middle",
+            )],
+        )
+        .await
+        .expect("middle root should write");
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("middle"),
+            &[row_with_value("entity-a", "change-child", "child", "child")],
+        )
+        .await
+        .expect("child root should write");
+        {
+            let mut writes = storage.new_write_set();
+            for commit_id in ["middle", "child"] {
+                writes.delete(
+                    storage::TRACKED_STATE_PROJECTION_SPACE,
+                    crate::storage::StorageKey(bytes::Bytes::copy_from_slice(commit_id.as_bytes())),
+                );
+            }
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("projection deletes should commit");
+        }
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let report = tracked_state
+            .root_rebuilder(&mut read, &mut writes)
+            .ensure_projection_root("child")
+            .await
+            .expect("child root should repair");
+        assert!(report.repaired);
+        assert_eq!(report.parent_commit_id.as_deref(), Some("base"));
+        assert_eq!(report.replayed_commits, 2);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("repaired root should commit");
+
+        let diff = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+            )
+            .diff_commits("base", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect("diff should accept repaired nearest-ancestor parent metadata");
+
+        assert_eq!(diff.entries.len(), 1);
         assert_eq!(
             diff.entries[0]
                 .after

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -425,8 +425,14 @@ where
                         row.change_id, root_commit_id, identity
                     )));
                 }
-                self.validate_diff_row_created_at(row, &key, &current_commit_id, change_created_at)
-                    .await?;
+                self.validate_diff_row_created_at(
+                    row,
+                    &key,
+                    &current_commit_id,
+                    change_created_at,
+                    cache,
+                )
+                .await?;
                 return Ok(());
             }
 
@@ -556,16 +562,27 @@ where
         commit_id: &str,
         cache: &mut DiffProjectionValidationCache,
     ) -> Result<TrackedStateProjectionMetadata, LixError> {
-        if let Some(metadata) = cache.projection_metadata.get(commit_id) {
-            return Ok(metadata.clone());
-        }
-        let metadata = storage::load_projection_metadata(&mut self.store, commit_id)
+        self.load_cached_projection_metadata_optional(commit_id, cache)
             .await?
-            .ok_or_else(|| missing_projection_root_error(commit_id))?;
+            .ok_or_else(|| missing_projection_root_error(commit_id))
+    }
+
+    async fn load_cached_projection_metadata_optional(
+        &mut self,
+        commit_id: &str,
+        cache: &mut DiffProjectionValidationCache,
+    ) -> Result<Option<TrackedStateProjectionMetadata>, LixError> {
+        if let Some(metadata) = cache.projection_metadata.get(commit_id) {
+            return Ok(Some(metadata.clone()));
+        }
+        let Some(metadata) = storage::load_projection_metadata(&mut self.store, commit_id).await?
+        else {
+            return Ok(None);
+        };
         cache
             .projection_metadata
             .insert(commit_id.to_string(), metadata.clone());
-        Ok(metadata)
+        Ok(Some(metadata))
     }
 
     async fn load_cached_projection_root_optional(
@@ -647,14 +664,16 @@ where
         key: &TrackedStateKey,
         commit_id: &str,
         change_created_at: &str,
+        cache: &mut DiffProjectionValidationCache,
     ) -> Result<(), LixError> {
         if row.created_at == change_created_at {
             return Ok(());
         }
-        let Some(metadata) = storage::load_projection_metadata(&mut self.store, commit_id).await?
-        else {
-            return Err(missing_projection_root_error(commit_id));
-        };
+        let metadata = self
+            .load_cached_projection_metadata(commit_id, cache)
+            .await?;
+        self.validate_projection_parent_matches_changelog(commit_id, &metadata, cache)
+            .await?;
         let Some(parent) = metadata.parent_roots.first() else {
             return Err(LixError::unknown(format!(
                 "tracked-state diff row for change '{}' created_at '{}' does not match changelog change '{}'",
@@ -662,12 +681,8 @@ where
             )));
         };
         let parent_value = self
-            .tree
-            .get_many(&mut self.store, &parent.root_id, std::slice::from_ref(key))
-            .await?
-            .into_iter()
-            .next()
-            .flatten();
+            .load_cached_tree_value(&parent.root_id, key, cache)
+            .await?;
         if parent_value
             .as_ref()
             .is_some_and(|value| value.created_at == row.created_at)
@@ -676,7 +691,8 @@ where
         }
         if row.commit_id != commit_id {
             if let Some(source_created_at) =
-                self.load_parent_created_at_for_row_commit(row, key).await?
+                self.load_parent_created_at_for_row_commit(row, key, cache)
+                    .await?
             {
                 if source_created_at == row.created_at {
                     return Ok(());
@@ -693,22 +709,22 @@ where
         &mut self,
         row: &TrackedStateDiffRow,
         key: &TrackedStateKey,
+        cache: &mut DiffProjectionValidationCache,
     ) -> Result<Option<String>, LixError> {
-        let Some(metadata) =
-            storage::load_projection_metadata(&mut self.store, &row.commit_id).await?
+        let Some(metadata) = self
+            .load_cached_projection_metadata_optional(&row.commit_id, cache)
+            .await?
         else {
             return Ok(None);
         };
+        self.validate_projection_parent_matches_changelog(&row.commit_id, &metadata, cache)
+            .await?;
         let Some(parent) = metadata.parent_roots.first() else {
             return Ok(None);
         };
         let parent_value = self
-            .tree
-            .get_many(&mut self.store, &parent.root_id, std::slice::from_ref(key))
-            .await?
-            .into_iter()
-            .next()
-            .flatten();
+            .load_cached_tree_value(&parent.root_id, key, cache)
+            .await?;
         Ok(parent_value.map(|value| value.created_at))
     }
 
@@ -762,8 +778,14 @@ where
             }
             if fact.created_at != row.created_at && fact.updated_at != row.created_at {
                 let (key, _) = row.clone().into_index_entry();
-                self.validate_diff_row_created_at(row, &key, &fact.commit_id, &fact.created_at)
-                    .await
+                self.validate_diff_row_created_at(
+                    row,
+                    &key,
+                    &fact.commit_id,
+                    &fact.created_at,
+                    &mut validation_cache,
+                )
+                .await
                     .map_err(|_| {
                         LixError::unknown(format!(
                             "tracked-state projection root for commit '{}' has created_at '{}' for change '{}' but changelog first-parent created_at is '{}'",

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -133,7 +133,7 @@ where
         request: &TrackedStateScanRequest,
     ) -> Result<Vec<MaterializedTrackedStateRow>, LixError> {
         let rows = if let Some(root_id) = self.tree.load_root(&mut self.store, commit_id).await? {
-            if ByFileIndex::should_use(request) {
+            if ByFileIndex::should_use(request) && !request.filter.schema_keys.is_empty() {
                 if let Some(by_file_root_id) =
                     storage::load_by_file_root(&mut self.store, commit_id).await?
                 {
@@ -807,6 +807,18 @@ where
         by_file_root_id: &crate::tracked_state::types::TrackedStateRootId,
         request: &TrackedStateScanRequest,
     ) -> Result<Vec<(TrackedStateKey, TrackedStateIndexValue)>, LixError> {
+        if request.filter.schema_keys.is_empty() {
+            let rows = self
+                .tree
+                .scan(
+                    &mut self.store,
+                    primary_root_id,
+                    &tree_scan_request_from_tracked(request),
+                )
+                .await?;
+            return Ok(rows);
+        }
+
         let by_file_request = ByFileIndex::scan_request_from_tracked(request);
         let index_match_count = self
             .tree
@@ -827,44 +839,51 @@ where
                 .await?;
             return Ok(rows);
         }
+        let primary_rows = self
+            .tree
+            .scan(
+                &mut self.store,
+                primary_root_id,
+                &tree_scan_request_from_tracked(request),
+            )
+            .await?;
         let index_rows = self
             .tree
             .scan(&mut self.store, by_file_root_id, &by_file_request)
             .await?;
-        let mut rows = Vec::new();
-        let tree_request = tree_scan_request_from_tracked(request);
-        let needs_payloads = scan_needs_json_payloads(request);
-        if needs_payloads {
-            let mut primary_keys = Vec::with_capacity(index_rows.len());
-            for (index_key, _) in index_rows {
-                if let Some(primary_key) = ByFileIndex::primary_key_from_index_key(index_key) {
-                    primary_keys.push(primary_key);
-                }
-            }
-            let primary_values = self
-                .tree
-                .get_many(&mut self.store, primary_root_id, &primary_keys)
-                .await?;
-            for (primary_key, value) in primary_keys.into_iter().zip(primary_values) {
-                let Some(value) = value else {
-                    continue;
-                };
-                if !tree_request.matches(&primary_key, &value) {
-                    continue;
-                }
-                rows.push((primary_key, value));
-            }
-            return Ok(rows);
+        if primary_rows.len() != index_rows.len() {
+            return Err(LixError::unknown(format!(
+                "tracked-state by-file index row count {} does not match primary projection row count {}",
+                index_rows.len(),
+                primary_rows.len()
+            )));
         }
 
+        let mut primary_by_key =
+            HashMap::<TrackedStateKey, TrackedStateIndexValue>::with_capacity(primary_rows.len());
+        for (key, value) in primary_rows {
+            primary_by_key.insert(key, value);
+        }
+        let mut rows = Vec::new();
         for (index_key, index_value) in index_rows {
             let Some(primary_key) = ByFileIndex::primary_key_from_index_key(index_key) else {
-                continue;
+                return Err(LixError::unknown(format!(
+                    "tracked-state by-file index contains malformed primary key mapping"
+                )));
             };
-            let value = index_value;
-            if tree_request.matches(&primary_key, &value) {
-                rows.push((primary_key, value));
-            }
+            let Some(value) = primary_by_key.remove(&primary_key) else {
+                return Err(LixError::unknown(format!(
+                    "tracked-state by-file index references row {:?} outside primary projection",
+                    primary_key
+                )));
+            };
+            validate_by_file_index_value_matches_primary(&primary_key, &index_value, &value)?;
+            rows.push((primary_key, value));
+        }
+        if !primary_by_key.is_empty() {
+            return Err(LixError::unknown(
+                "tracked-state by-file index is missing primary projection rows",
+            ));
         }
         Ok(rows)
     }
@@ -1198,15 +1217,28 @@ fn tree_scan_request_from_tracked(
     }
 }
 
-fn scan_needs_json_payloads(request: &TrackedStateScanRequest) -> bool {
-    if request.projection.columns.is_empty() {
-        return true;
+fn validate_by_file_index_value_matches_primary(
+    key: &TrackedStateKey,
+    index_value: &TrackedStateIndexValue,
+    primary_value: &TrackedStateIndexValue,
+) -> Result<(), LixError> {
+    if index_value.snapshot_ref.is_some() || index_value.metadata_ref.is_some() {
+        return Err(LixError::unknown(format!(
+            "tracked-state by-file index value contains payload refs for {:?}",
+            key
+        )));
     }
-    request
-        .projection
-        .columns
-        .iter()
-        .any(|column| column == "snapshot_content" || column == "metadata")
+    if index_value.change_locator != primary_value.change_locator
+        || index_value.deleted != primary_value.deleted
+        || index_value.created_at != primary_value.created_at
+        || index_value.updated_at != primary_value.updated_at
+    {
+        return Err(LixError::unknown(format!(
+            "tracked-state by-file index value does not match primary projection for {:?}",
+            key
+        )));
+    }
+    Ok(())
 }
 
 fn validate_diff_row_against_changelog(
@@ -1737,15 +1769,19 @@ mod tests {
         file_a.file_id = Some("file-a.json".to_string());
         let mut file_b = row("entity-b", "change-b", "commit-1");
         file_b.file_id = Some("file-b.json".to_string());
-        write_root_for_test(
-            &storage,
-            &tracked_state,
-            "commit-1",
-            None,
-            &[file_a, file_b],
-        )
-        .await
-        .expect("root should write");
+        let mut rows = vec![file_a, file_b];
+        for index in 0..25 {
+            let mut row = row(
+                &format!("entity-padding-{index}"),
+                &format!("change-padding-{index}"),
+                "commit-1",
+            );
+            row.file_id = Some("file-b.json".to_string());
+            rows.push(row);
+        }
+        write_root_for_test(&storage, &tracked_state, "commit-1", None, &rows)
+            .await
+            .expect("root should write");
 
         let rows = tracked_state
             .reader(
@@ -1757,6 +1793,7 @@ mod tests {
                 "commit-1",
                 &TrackedStateScanRequest {
                     filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
                         file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
                         ..Default::default()
                     },
@@ -1778,21 +1815,108 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn by_file_header_index_fetches_primary_payload_only_when_requested() {
+    async fn file_only_by_file_scan_falls_back_to_primary_even_with_existing_by_file_root() {
         let storage = StorageContext::new(InMemoryStorageBackend::new());
         let tracked_state = TrackedStateContext::new();
-        let mut row = row("entity-a", "change-a", "commit-1");
-        row.file_id = Some("file-a.json".to_string());
-        let expected_snapshot = row.snapshot_content.clone();
+        let mut primary_row = row("entity-a", "change-a", "commit-1");
+        primary_row.file_id = Some("file-a.json".to_string());
+        let mut other_row = row("entity-b", "change-b", "commit-1");
+        other_row.file_id = Some("file-b.json".to_string());
         write_root_for_test(
             &storage,
             &tracked_state,
             "commit-1",
             None,
-            std::slice::from_ref(&row),
+            &[primary_row.clone(), other_row],
         )
         .await
         .expect("root should write");
+
+        let key = TrackedStateKey {
+            schema_key: primary_row.schema_key.clone(),
+            file_id: primary_row.file_id.clone(),
+            entity_id: primary_row.entity_id.clone(),
+        };
+        let primary_root = storage::load_root(
+            &storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open"),
+            "commit-1",
+        )
+        .await
+        .expect("primary root should load")
+        .expect("primary root should exist");
+        let index_value = TrackedStateTree::new()
+            .get(
+                &storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+                &primary_root,
+                &key,
+            )
+            .await
+            .expect("primary value should load")
+            .expect("primary value should exist");
+        assert!(
+            index_value.snapshot_ref.is_some(),
+            "test setup needs a payload ref to prove the by-file root is bypassed"
+        );
+        write_by_file_entries_for_test(&storage, "commit-1", &[(key, index_value)])
+            .await
+            .expect("payload-bearing by-file root should write");
+
+        let rows = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+            )
+            .scan_rows_at_commit(
+                "commit-1",
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
+                        ..Default::default()
+                    },
+                    projection: crate::tracked_state::TrackedStateProjection {
+                        columns: vec!["entity_id".to_string()],
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("file-only scan should use the primary fallback");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0]
+                .entity_id
+                .as_single_string_owned()
+                .expect("entity id"),
+            "entity-a"
+        );
+    }
+
+    #[tokio::test]
+    async fn by_file_header_index_fetches_primary_payload_only_when_requested() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        let mut primary_row = row("entity-a", "change-a", "commit-1");
+        primary_row.file_id = Some("file-a.json".to_string());
+        let expected_snapshot = primary_row.snapshot_content.clone();
+        let mut rows = vec![primary_row];
+        for index in 0..25 {
+            let mut row = row(
+                &format!("entity-padding-{index}"),
+                &format!("change-padding-{index}"),
+                "commit-1",
+            );
+            row.file_id = Some("file-b.json".to_string());
+            rows.push(row);
+        }
+        write_root_for_test(&storage, &tracked_state, "commit-1", None, &rows)
+            .await
+            .expect("root should write");
 
         let mut reader = tracked_state.reader(
             storage
@@ -1804,6 +1928,7 @@ mod tests {
                 "commit-1",
                 &TrackedStateScanRequest {
                     filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
                         file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
                         ..Default::default()
                     },
@@ -1820,6 +1945,7 @@ mod tests {
                 "commit-1",
                 &TrackedStateScanRequest {
                     filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
                         file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
                         ..Default::default()
                     },
@@ -1831,6 +1957,223 @@ mod tests {
 
         assert_eq!(header_rows[0].snapshot_content, None);
         assert_eq!(full_rows[0].snapshot_content, expected_snapshot);
+    }
+
+    #[tokio::test]
+    async fn by_file_header_index_rejects_value_corruption_against_primary_root() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        let mut primary_row = row("entity-a", "change-a", "commit-1");
+        primary_row.file_id = Some("file-a.json".to_string());
+        let mut corrupt_index_row = row("entity-a", "change-bad", "commit-bad");
+        corrupt_index_row.file_id = Some("file-a.json".to_string());
+        let mut primary_rows = vec![primary_row.clone()];
+        for index in 0..25 {
+            let mut row = row(
+                &format!("entity-padding-{index}"),
+                &format!("change-padding-{index}"),
+                "commit-1",
+            );
+            row.file_id = Some("file-b.json".to_string());
+            primary_rows.push(row);
+        }
+        write_root_for_test(&storage, &tracked_state, "commit-1", None, &primary_rows)
+            .await
+            .expect("primary root should write");
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "commit-bad",
+            None,
+            std::slice::from_ref(&corrupt_index_row),
+        )
+        .await
+        .expect("corrupt by-file donor root should write");
+
+        let corrupt_by_file_root = storage::load_by_file_root(
+            &storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open"),
+            "commit-bad",
+        )
+        .await
+        .expect("corrupt by-file root should load")
+        .expect("corrupt by-file root should exist");
+        let mut writes = storage.new_write_set();
+        storage::stage_by_file_root(&mut writes, "commit-1", &corrupt_by_file_root);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("corrupt by-file root should commit");
+
+        let error = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+            )
+            .scan_rows_at_commit(
+                "commit-1",
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
+                        ..Default::default()
+                    },
+                    projection: crate::tracked_state::TrackedStateProjection {
+                        columns: vec!["entity_id".to_string()],
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("by-file value corruption should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("by-file index value does not match primary projection"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn by_file_header_index_rejects_missing_primary_projection_rows() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        let mut indexed_row = row("entity-indexed", "change-indexed", "commit-1");
+        indexed_row.file_id = Some("file-a.json".to_string());
+        let mut omitted_row = row("entity-omitted", "change-omitted", "commit-1");
+        omitted_row.file_id = Some("file-a.json".to_string());
+        let mut primary_rows = vec![indexed_row.clone(), omitted_row];
+        for index in 0..25 {
+            let mut row = row(
+                &format!("entity-padding-{index}"),
+                &format!("change-padding-{index}"),
+                "commit-1",
+            );
+            row.file_id = Some("file-b.json".to_string());
+            primary_rows.push(row);
+        }
+        write_root_for_test(&storage, &tracked_state, "commit-1", None, &primary_rows)
+            .await
+            .expect("primary root should write");
+        write_by_file_root_for_test(&storage, "commit-1", &[indexed_row])
+            .await
+            .expect("partial by-file root should write");
+
+        let error = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+            )
+            .scan_rows_at_commit(
+                "commit-1",
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
+                        ..Default::default()
+                    },
+                    projection: crate::tracked_state::TrackedStateProjection {
+                        columns: vec!["entity_id".to_string()],
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("by-file omission should be rejected");
+
+        assert!(
+            error.to_string().contains(
+                "by-file index row count 1 does not match primary projection row count 2"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn by_file_header_index_rejects_payload_refs_in_index_values() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        let mut primary_row = row("entity-a", "change-a", "commit-1");
+        primary_row.file_id = Some("file-a.json".to_string());
+        let mut primary_rows = vec![primary_row.clone()];
+        for index in 0..25 {
+            let mut row = row(
+                &format!("entity-padding-{index}"),
+                &format!("change-padding-{index}"),
+                "commit-1",
+            );
+            row.file_id = Some("file-b.json".to_string());
+            primary_rows.push(row);
+        }
+        write_root_for_test(&storage, &tracked_state, "commit-1", None, &primary_rows)
+            .await
+            .expect("primary root should write");
+
+        let key = TrackedStateKey {
+            schema_key: primary_row.schema_key.clone(),
+            file_id: primary_row.file_id.clone(),
+            entity_id: primary_row.entity_id.clone(),
+        };
+        let primary_root = storage::load_root(
+            &storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open"),
+            "commit-1",
+        )
+        .await
+        .expect("primary root should load")
+        .expect("primary root should exist");
+        let index_value = TrackedStateTree::new()
+            .get(
+                &storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+                &primary_root,
+                &key,
+            )
+            .await
+            .expect("primary value should load")
+            .expect("primary value should exist");
+        assert!(
+            index_value.snapshot_ref.is_some(),
+            "test setup needs a payload ref to forge into the by-file index"
+        );
+        write_by_file_entries_for_test(&storage, "commit-1", &[(key, index_value)])
+            .await
+            .expect("payload-bearing by-file root should write");
+
+        let error = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+            )
+            .scan_rows_at_commit(
+                "commit-1",
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
+                        ..Default::default()
+                    },
+                    projection: crate::tracked_state::TrackedStateProjection {
+                        columns: vec!["entity_id".to_string()],
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("payload-bearing by-file value should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("by-file index value contains payload refs"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1951,7 +2294,17 @@ mod tests {
         live.file_id = Some("file-a.json".to_string());
         let mut deleted = tombstone("entity-deleted", "change-delete", "commit-1");
         deleted.file_id = Some("file-a.json".to_string());
-        write_root_for_test(&storage, &tracked_state, "commit-1", None, &[live, deleted])
+        let mut rows = vec![live, deleted];
+        for index in 0..25 {
+            let mut row = row(
+                &format!("entity-padding-{index}"),
+                &format!("change-padding-{index}"),
+                "commit-1",
+            );
+            row.file_id = Some("file-b.json".to_string());
+            rows.push(row);
+        }
+        write_root_for_test(&storage, &tracked_state, "commit-1", None, &rows)
             .await
             .expect("root should write");
 
@@ -1965,6 +2318,7 @@ mod tests {
                 "commit-1",
                 &TrackedStateScanRequest {
                     filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
                         file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
                         ..Default::default()
                     },
@@ -2208,7 +2562,17 @@ mod tests {
         deleted.file_id = Some("file-a.json".to_string());
         let mut live = row("entity-b", "change-live", "commit-1");
         live.file_id = Some("file-a.json".to_string());
-        write_root_for_test(&storage, &tracked_state, "commit-1", None, &[deleted, live])
+        let mut rows = vec![deleted, live];
+        for index in 0..25 {
+            let mut row = row(
+                &format!("entity-padding-{index}"),
+                &format!("change-padding-{index}"),
+                "commit-1",
+            );
+            row.file_id = Some("file-b.json".to_string());
+            rows.push(row);
+        }
+        write_root_for_test(&storage, &tracked_state, "commit-1", None, &rows)
             .await
             .expect("root should write");
 
@@ -2222,6 +2586,7 @@ mod tests {
                 "commit-1",
                 &TrackedStateScanRequest {
                     filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
                         file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
                         ..Default::default()
                     },
@@ -2444,6 +2809,69 @@ mod tests {
             rows,
         )
         .await?;
+        storage.commit_write_set(writes, StorageWriteOptions::default())?;
+        Ok(())
+    }
+
+    async fn write_by_file_root_for_test(
+        storage: &StorageContext,
+        commit_id: &str,
+        rows: &[MaterializedTrackedStateRow],
+    ) -> Result<(), LixError> {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let primary_root = storage::load_root(&read, commit_id)
+            .await?
+            .ok_or_else(|| missing_projection_root_error(commit_id))?;
+        let tree = TrackedStateTree::new();
+        let mut entries = Vec::with_capacity(rows.len());
+        for row in rows {
+            let key = TrackedStateKey {
+                schema_key: row.schema_key.clone(),
+                file_id: row.file_id.clone(),
+                entity_id: row.entity_id.clone(),
+            };
+            let mut value = tree
+                .get(&read, &primary_root, &key)
+                .await?
+                .ok_or_else(|| LixError::unknown("test row is missing from primary root"))?;
+            value.snapshot_ref = None;
+            value.metadata_ref = None;
+            entries.push((key, value));
+        }
+        write_by_file_entries_for_test(storage, commit_id, &entries).await
+    }
+
+    async fn write_by_file_entries_for_test(
+        storage: &StorageContext,
+        commit_id: &str,
+        entries: &[(TrackedStateKey, TrackedStateIndexValue)],
+    ) -> Result<(), LixError> {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut mutations = Vec::with_capacity(entries.len());
+        for (key, value) in entries {
+            if key.file_id.is_none() {
+                return Err(LixError::unknown(
+                    "test by-file index entry requires a concrete file_id",
+                ));
+            }
+            mutations.push(TrackedStateMutation::put_encoded(
+                ByFileIndex::encode_key_ref(TrackedStateKeyRef {
+                    schema_key: &key.schema_key,
+                    file_id: key.file_id.as_deref(),
+                    entity_id: &key.entity_id,
+                }),
+                crate::tracked_state::codec::encode_value(value),
+            ));
+        }
+        let mut writes = storage.new_write_set();
+        let result = TrackedStateTree::new()
+            .apply_mutations(&read, &mut writes, None, mutations, None)
+            .await?;
+        storage::stage_by_file_root(&mut writes, commit_id, &result.root_id);
         storage.commit_write_set(writes, StorageWriteOptions::default())?;
         Ok(())
     }

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -850,7 +850,7 @@ where
             .tree
             .row_count(&mut self.store, primary_root_id)
             .await?;
-        if index_match_count * 20 > primary_row_count {
+        if index_match_count > primary_row_count / 20 {
             let rows = self
                 .tree
                 .scan(
@@ -1397,6 +1397,10 @@ mod tests {
     use super::*;
     use crate::storage::StorageContext;
     use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
+    use crate::tracked_state::codec::{
+        ChildSummary, PendingChunkWrite, encode_internal_node, hash_bytes,
+    };
+    use crate::tracked_state::types::TRACKED_STATE_HASH_BYTES;
     use crate::NullableKeyFilter;
 
     #[tokio::test]
@@ -2111,6 +2115,68 @@ mod tests {
                 "by-file index row count 1 does not match primary projection row count 2"
             ),
             "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn by_file_scan_fallback_heuristic_handles_corrupt_large_index_count() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        let mut primary_row = row("entity-a", "change-a", "commit-1");
+        primary_row.file_id = Some("file-a.json".to_string());
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "commit-1",
+            None,
+            std::slice::from_ref(&primary_row),
+        )
+        .await
+        .expect("primary root should write");
+
+        let encoded_index_key = ByFileIndex::encode_key_ref(TrackedStateKeyRef {
+            schema_key: &primary_row.schema_key,
+            file_id: primary_row.file_id.as_deref(),
+            entity_id: &primary_row.entity_id,
+        });
+        stage_corrupt_by_file_internal_root(
+            &storage,
+            "commit-1",
+            ChildSummary {
+                first_key: encoded_index_key.clone(),
+                last_key: encoded_index_key,
+                child_hash: [7; TRACKED_STATE_HASH_BYTES],
+                subtree_count: u64::MAX,
+            },
+        );
+
+        let rows = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .expect("read should open"),
+            )
+            .scan_rows_at_commit(
+                "commit-1",
+                &TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec!["test_schema".to_string()],
+                        file_ids: vec![NullableKeyFilter::Value("file-a.json".to_string())],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("large by-file count should choose primary fallback without overflow");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0]
+                .entity_id
+                .as_single_string_owned()
+                .expect("entity id"),
+            "entity-a"
         );
     }
 
@@ -2896,6 +2962,21 @@ mod tests {
         storage::stage_by_file_root(&mut writes, commit_id, &result.root_id);
         storage.commit_write_set(writes, StorageWriteOptions::default())?;
         Ok(())
+    }
+
+    fn stage_corrupt_by_file_internal_root(
+        storage: &StorageContext<InMemoryStorageBackend>,
+        commit_id: &str,
+        child: ChildSummary,
+    ) {
+        let node = encode_internal_node(&[child]);
+        let hash = hash_bytes(&node);
+        let mut writes = storage.new_write_set();
+        storage::stage_chunks(&mut writes, &[PendingChunkWrite { hash, data: node }]);
+        storage::stage_by_file_root(&mut writes, commit_id, &TrackedStateRootId::new(hash));
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("corrupt by-file root should commit");
     }
 
     fn tombstone(entity_id: &str, change_id: &str, commit_id: &str) -> MaterializedTrackedStateRow {

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -22,7 +22,6 @@ use crate::tracked_state::types::{
     TrackedStateProjectionMetadata, TrackedStateProjectionParent, TrackedStateRootId,
     TrackedStateTreeScanRequest,
 };
-#[cfg(any(test, feature = "storage-benches"))]
 use crate::tracked_state::TrackedStateRowRequest;
 use crate::tracked_state::{
     MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateScanRequest,
@@ -223,7 +222,7 @@ where
             .map(tracked_key_from_request)
             .collect::<Result<Vec<_>, _>>()?;
         let values = self
-            .projection_values_at_commit_for_keys(commit_id, &keys)
+            .projection_values_at_commit_for_keys_allow_rebuild(commit_id, &keys)
             .await?;
         let mut entry_indices = Vec::new();
         let mut entries = Vec::new();
@@ -244,6 +243,27 @@ where
             rows[index] = Some(row);
         }
         Ok(rows)
+    }
+
+    pub(crate) async fn load_index_entries_at_commit(
+        &mut self,
+        commit_id: &str,
+        requests: &[TrackedStateRowRequest],
+    ) -> Result<Vec<Option<TrackedStateDiffRow>>, LixError> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+        let keys = requests
+            .iter()
+            .map(tracked_key_from_request)
+            .collect::<Result<Vec<_>, _>>()?;
+        let root_id = self.load_ensured_root(commit_id).await?;
+        let values = self.tree.get_many(&mut self.store, &root_id, &keys).await?;
+        Ok(keys
+            .into_iter()
+            .zip(values)
+            .map(|(key, value)| value.map(|value| TrackedStateDiffRow::from_tree_entry(key, value)))
+            .collect())
     }
 
     pub(crate) async fn diff_commits(
@@ -860,13 +880,49 @@ where
     }
 
     #[cfg(any(test, feature = "storage-benches"))]
-    async fn projection_values_at_commit_for_keys(
+    async fn projection_values_at_commit_for_keys_allow_rebuild(
         &mut self,
         commit_id: &str,
         keys: &[TrackedStateKey],
     ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-        let root_id = self.load_ensured_root(commit_id).await?;
-        self.tree.get_many(&mut self.store, &root_id, keys).await
+        if let Some(root_id) = self.tree.load_root(&mut self.store, commit_id).await? {
+            return self.tree.get_many(&mut self.store, &root_id, keys).await;
+        }
+        let input =
+            crate::tracked_state::projection_root_rebuild::build_incremental_projection_root_rebuild_input(
+                &self.store,
+                commit_id,
+            )
+            .await?;
+        let mut values = keys
+            .iter()
+            .cloned()
+            .map(|key| (key, None))
+            .collect::<BTreeMap<_, Option<TrackedStateIndexValue>>>();
+        for delta in input.deltas {
+            let key = TrackedStateKey {
+                schema_key: delta.change.schema_key,
+                file_id: delta.change.file_id,
+                entity_id: delta.change.entity_id,
+            };
+            if values.contains_key(&key) {
+                values.insert(
+                    key,
+                    Some(TrackedStateIndexValue {
+                        change_locator: delta.locator,
+                        deleted: delta.change.snapshot_ref.is_none(),
+                        snapshot_ref: delta.change.snapshot_ref,
+                        metadata_ref: delta.change.metadata_ref,
+                        created_at: delta.created_at,
+                        updated_at: delta.updated_at,
+                    }),
+                );
+            }
+        }
+        Ok(keys
+            .iter()
+            .map(|key| values.get(key).cloned().unwrap_or(None))
+            .collect())
     }
 
     /// Plans a three-way merge by diffing both heads against the same base.
@@ -1264,7 +1320,6 @@ fn state_row_identity_matches_tree_request(
     Ok(true)
 }
 
-#[cfg(any(test, feature = "storage-benches"))]
 fn tracked_key_from_request(request: &TrackedStateRowRequest) -> Result<TrackedStateKey, LixError> {
     let file_id = match &request.file_id {
         crate::NullableKeyFilter::Null => None,

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -84,18 +84,47 @@ pub(crate) async fn diff_commits<S>(
 where
     S: crate::storage::StorageRead + Send + Sync,
 {
+    diff_commits_with_validation(reader, left_commit_id, right_commit_id, request, true, true).await
+}
+
+pub(crate) async fn diff_commits_with_validation<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    left_commit_id: &str,
+    right_commit_id: &str,
+    request: &TrackedStateDiffRequest,
+    validate_left_root: bool,
+    validate_right_root: bool,
+) -> Result<TrackedStateDiff, LixError>
+where
+    S: crate::storage::StorageRead + Send + Sync,
+{
     let scan_request = scan_request_for_diff(request);
     let tree_entries = reader
         .diff_tree_entries_at_commits(left_commit_id, right_commit_id, &scan_request)
         .await?;
-    let mut entries = Vec::with_capacity(tree_entries.len());
-    for tree_entry in tree_entries {
+    if validate_left_root {
+        reader
+            .validate_tree_rows_at_commit_against_changelog(left_commit_id, &scan_request)
+            .await?;
+    }
+    if validate_right_root && left_commit_id != right_commit_id {
+        reader
+            .validate_tree_rows_at_commit_against_changelog(right_commit_id, &scan_request)
+            .await?;
+    }
+    let mut raw_rows = Vec::with_capacity(tree_entries.len());
+    for tree_entry in tree_entries.into_iter() {
         let before = tree_entry
             .before
             .map(|(key, value)| TrackedStateDiffRow::from_tree_entry(key, value));
         let after = tree_entry
             .after
             .map(|(key, value)| TrackedStateDiffRow::from_tree_entry(key, value));
+        raw_rows.push((before, after));
+    }
+
+    let mut entries = Vec::with_capacity(raw_rows.len());
+    for (before, after) in raw_rows {
         let identity = match before.as_ref().or(after.as_ref()) {
             Some(row) => TrackedStateDiffIdentity::from(row),
             None => continue,
@@ -106,7 +135,8 @@ where
         entries.push(entry);
     }
 
-    Ok(TrackedStateDiff { entries })
+    let diff = TrackedStateDiff { entries };
+    Ok(diff)
 }
 
 fn scan_request_for_diff(request: &TrackedStateDiffRequest) -> TrackedStateTreeScanRequest {
@@ -169,7 +199,7 @@ impl TrackedStateDiffIdentity {
 }
 
 impl TrackedStateDiffRow {
-    fn from_tree_entry(key: TrackedStateKey, value: TrackedStateIndexValue) -> Self {
+    pub(crate) fn from_tree_entry(key: TrackedStateKey, value: TrackedStateIndexValue) -> Self {
         Self {
             entity_id: key.entity_id,
             schema_key: key.schema_key,
@@ -235,6 +265,10 @@ mod tests {
     use super::*;
     use crate::storage::StorageContext;
     use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
+    use crate::tracked_state::types::{
+        TrackedStateMutation, TrackedStateProjectionMetadata, TrackedStateProjectionParent,
+        TrackedStateRootId,
+    };
     use crate::tracked_state::{MaterializedTrackedStateRow, TrackedStateContext};
     use crate::NullableKeyFilter;
 
@@ -424,6 +458,1278 @@ mod tests {
         assert_eq!(
             kinds(&diff),
             vec![("entity-b".to_string(), TrackedStateDiffKind::Added)]
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_validation_rejects_row_identity_that_does_not_match_changelog_change() {
+        let (storage, tracked_state) = seed_roots(&[], &[row("entity-a", None, "after")]).await;
+        let mut diff = diff(&storage, &tracked_state).await;
+        diff.entries[0].after.as_mut().expect("after row").entity_id =
+            EntityIdentity::single("entity-corrupt");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .validate_diff_rows_for_commits_against_changelog(&[(
+                diff.entries[0].after.as_ref().expect("after row"),
+                "right",
+            )])
+            .await
+            .expect_err("identity drift must be rejected");
+
+        assert!(
+            error
+                .message
+                .contains("does not match changelog change identity")
+                || error.message.contains("visible changelog commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_validation_rejects_stale_changelog_locator() {
+        let (storage, tracked_state) = seed_roots(&[], &[row("entity-a", None, "after")]).await;
+        let mut diff = diff(&storage, &tracked_state).await;
+        diff.entries[0]
+            .after
+            .as_mut()
+            .expect("after row")
+            .change_location
+            .offset = diff.entries[0]
+            .after
+            .as_ref()
+            .expect("after row")
+            .change_location
+            .offset
+            .saturating_add(1);
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .validate_diff_rows_for_commits_against_changelog(&[(
+                diff.entries[0].after.as_ref().expect("after row"),
+                "right",
+            )])
+            .await
+            .expect_err("stale locator must be rejected");
+
+        assert!(
+            error.message.contains("stale changelog locator"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_validation_rejects_forged_updated_at() {
+        let (storage, tracked_state) = seed_roots(&[], &[row("entity-a", None, "after")]).await;
+        let mut diff = diff(&storage, &tracked_state).await;
+        diff.entries[0]
+            .after
+            .as_mut()
+            .expect("after row")
+            .updated_at = "2026-01-02T00:00:00Z".to_string();
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .validate_diff_rows_for_commits_against_changelog(&[(
+                diff.entries[0].after.as_ref().expect("after row"),
+                "right",
+            )])
+            .await
+            .expect_err("forged updated_at must be rejected");
+
+        assert!(
+            error.message.contains("updated_at does not match"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_validation_rejects_forged_created_at() {
+        let (storage, tracked_state) = seed_roots(&[], &[row("entity-a", None, "after")]).await;
+        let mut diff = diff(&storage, &tracked_state).await;
+        diff.entries[0]
+            .after
+            .as_mut()
+            .expect("after row")
+            .created_at = "2025-12-31T00:00:00Z".to_string();
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .validate_diff_rows_for_commits_against_changelog(&[(
+                diff.entries[0].after.as_ref().expect("after row"),
+                "right",
+            )])
+            .await
+            .expect_err("forged created_at must be rejected");
+
+        assert!(
+            error.message.contains("created_at"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_update_with_arbitrary_forged_created_at() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row_with_times(
+                "entity-a",
+                None,
+                "parent-change",
+                "old",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+            )],
+        )
+        .await
+        .expect("parent root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[row_with_times(
+                "entity-a",
+                None,
+                "child-change",
+                "new",
+                "2026-01-02T00:00:00Z",
+                "2026-01-02T00:00:00Z",
+            )],
+        )
+        .await
+        .expect("child root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let valid_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect("valid update should load");
+        let row = valid_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("child row should appear");
+        let (key, mut value) = row.into_index_entry();
+        value.created_at = "2026-01-03T00:00:00Z".to_string();
+        stage_corrupt_projection_root(
+            &storage,
+            "child",
+            vec![(key, value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "parent".to_string(),
+                root_id: tracked_state_root_id(&storage, "parent").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("arbitrary forged created_at must be rejected");
+
+        assert!(
+            error.message.contains("created_at"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_validates_same_payload_rows_before_classification_drops_them() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "left",
+            None,
+            &[row_with_value("entity-a", None, "left-a", "same")],
+        )
+        .await
+        .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "right-valid",
+            None,
+            &[row_with_value("entity-b", None, "right-b", "same")],
+        )
+        .await
+        .expect("right changelog should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let valid_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "right-valid", &TrackedStateDiffRequest::default())
+            .await
+            .expect("valid diff should load");
+        let source_row = valid_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("right row should appear in valid diff");
+        let (_source_key, source_value) = source_row.into_index_entry();
+        let corrupt_key = TrackedStateKey {
+            schema_key: "test_schema".to_string(),
+            file_id: None,
+            entity_id: EntityIdentity::single("entity-a"),
+        };
+        let result = {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            let result = crate::tracked_state::tree::TrackedStateTree::new()
+                .apply_mutations(
+                    &mut read,
+                    &mut writes,
+                    None,
+                    vec![TrackedStateMutation::put_encoded(
+                        crate::tracked_state::codec::encode_key(&corrupt_key),
+                        crate::tracked_state::codec::encode_value(&source_value),
+                    )],
+                    Some("right-corrupt"),
+                )
+                .await
+                .expect("corrupt root should write");
+            crate::tracked_state::storage::stage_projection_metadata(
+                &mut writes,
+                &TrackedStateProjectionMetadata {
+                    commit_id: "right-corrupt".to_string(),
+                    root_id: result.root_id.clone(),
+                    parent_roots: Vec::new(),
+                    changed_key_count: 1,
+                    row_count_estimate: result.row_count as u64,
+                    tree_height: result.tree_height as u32,
+                    primary_chunk_count: result.chunk_count as u64,
+                    primary_chunk_bytes: result.chunk_bytes as u64,
+                },
+            )
+            .expect("metadata should encode");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("corrupt root should commit");
+            result
+        };
+        assert_eq!(result.row_count, 1);
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "right-corrupt", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("raw same-payload corruption must be rejected before classification");
+
+        assert!(
+            error
+                .message
+                .contains("does not match changelog change identity")
+                || error.message.contains("visible changelog commit"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_stale_ancestor_row_that_is_not_root_winner() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row_with_value("entity-a", None, "parent-change", "old")],
+        )
+        .await
+        .expect("parent root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[row_with_value("entity-a", None, "child-change", "new")],
+        )
+        .await
+        .expect("child root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let parent_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "parent", &TrackedStateDiffRequest::default())
+            .await
+            .expect("parent diff should load");
+        let stale_row = parent_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("parent row should appear");
+        let (stale_key, stale_value) = stale_row.into_index_entry();
+        stage_corrupt_projection_root(
+            &storage,
+            "child",
+            vec![(stale_key, stale_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "parent".to_string(),
+                root_id: tracked_state_root_id(&storage, "parent").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("stale ancestor winner must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_valid_change_from_unreachable_commit_root() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "unrelated",
+            None,
+            &[row_with_value(
+                "entity-a",
+                None,
+                "unrelated-change",
+                "value",
+            )],
+        )
+        .await
+        .expect("unrelated changelog should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let unrelated_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "unrelated", &TrackedStateDiffRequest::default())
+            .await
+            .expect("valid unrelated diff should load");
+        let source_row = unrelated_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("unrelated row should appear in valid diff");
+        let (source_key, source_value) = source_row.into_index_entry();
+
+        let result = {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            crate::test_support::stage_empty_changelog_commit(
+                &mut read,
+                &mut writes,
+                "right-corrupt",
+                None,
+            )
+            .await
+            .expect("empty right changelog should write");
+            let result = crate::tracked_state::tree::TrackedStateTree::new()
+                .apply_mutations(
+                    &mut read,
+                    &mut writes,
+                    None,
+                    vec![TrackedStateMutation::put_encoded(
+                        crate::tracked_state::codec::encode_key(&source_key),
+                        crate::tracked_state::codec::encode_value(&source_value),
+                    )],
+                    Some("right-corrupt"),
+                )
+                .await
+                .expect("corrupt root should write");
+            crate::tracked_state::storage::stage_projection_metadata(
+                &mut writes,
+                &TrackedStateProjectionMetadata {
+                    commit_id: "right-corrupt".to_string(),
+                    root_id: result.root_id.clone(),
+                    parent_roots: Vec::new(),
+                    changed_key_count: 1,
+                    row_count_estimate: result.row_count as u64,
+                    tree_height: result.tree_height as u32,
+                    primary_chunk_count: result.chunk_count as u64,
+                    primary_chunk_bytes: result.chunk_bytes as u64,
+                },
+            )
+            .expect("metadata should encode");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("corrupt root should commit");
+            result
+        };
+        assert_eq!(result.row_count, 1);
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "right-corrupt", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("unreachable valid change must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_non_adopted_second_parent_row() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "target", None, &[])
+            .await
+            .expect("target root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source",
+            None,
+            &[row_with_value("entity-a", None, "source-change", "value")],
+        )
+        .await
+        .expect("source root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let source_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "source", &TrackedStateDiffRequest::default())
+            .await
+            .expect("source diff should load");
+        let source_row = source_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("source row should appear");
+        let (source_key, source_value) = source_row.into_index_entry();
+
+        {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            crate::test_support::stage_empty_changelog_commit_with_parents(
+                &mut read,
+                &mut writes,
+                "merge",
+                &["target".to_string(), "source".to_string()],
+            )
+            .await
+            .expect("merge changelog should write");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("merge changelog should commit");
+        }
+        stage_corrupt_projection_root(
+            &storage,
+            "merge",
+            vec![(source_key, source_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "target".to_string(),
+                root_id: tracked_state_root_id(&storage, "target").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "merge", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("non-adopted second-parent row must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_second_parent_row_with_forged_projection_parent() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "target", None, &[])
+            .await
+            .expect("target root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source",
+            None,
+            &[row_with_value("entity-a", None, "source-change", "value")],
+        )
+        .await
+        .expect("source root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let source_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "source", &TrackedStateDiffRequest::default())
+            .await
+            .expect("source diff should load");
+        let source_row = source_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("source row should appear");
+        let (source_key, source_value) = source_row.into_index_entry();
+
+        {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            crate::test_support::stage_empty_changelog_commit_with_parents(
+                &mut read,
+                &mut writes,
+                "merge",
+                &["target".to_string(), "source".to_string()],
+            )
+            .await
+            .expect("merge changelog should write");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("merge changelog should commit");
+        }
+        stage_corrupt_projection_root(
+            &storage,
+            "merge",
+            vec![(source_key, source_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "source".to_string(),
+                root_id: tracked_state_root_id(&storage, "source").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "merge", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("forged source parent must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_unrelated_row_with_forged_projection_parent() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source",
+            None,
+            &[row_with_value("entity-a", None, "source-change", "value")],
+        )
+        .await
+        .expect("source root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let source_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "source", &TrackedStateDiffRequest::default())
+            .await
+            .expect("source diff should load");
+        let source_row = source_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("source row should appear");
+        let (source_key, source_value) = source_row.into_index_entry();
+
+        {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            crate::test_support::stage_empty_changelog_commit(
+                &mut read,
+                &mut writes,
+                "right-corrupt",
+                None,
+            )
+            .await
+            .expect("empty right changelog should write");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("right changelog should commit");
+        }
+        stage_corrupt_projection_root(
+            &storage,
+            "right-corrupt",
+            vec![(source_key, source_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "source".to_string(),
+                root_id: tracked_state_root_id(&storage, "source").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "right-corrupt", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("forged unrelated parent must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_forged_parent_metadata_even_for_current_winner_rows() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "target", None, &[])
+            .await
+            .expect("target root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source",
+            None,
+            &[row_with_value("entity-b", None, "source-b", "source")],
+        )
+        .await
+        .expect("source root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("target"),
+            &[row_with_value("entity-a", None, "child-a", "current")],
+        )
+        .await
+        .expect("child root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let child_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect("child diff should load");
+        let child_row = child_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("child row should appear");
+        let (child_key, child_value) = child_row.into_index_entry();
+
+        stage_corrupt_projection_root(
+            &storage,
+            "child",
+            vec![(child_key, child_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "source".to_string(),
+                root_id: tracked_state_root_id(&storage, "source").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("current winner root metadata must still be validated");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_stale_grandparent_row_with_forged_projection_parent() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "grandparent",
+            None,
+            &[row_with_value("entity-a", None, "grandparent-a", "old")],
+        )
+        .await
+        .expect("grandparent root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            Some("grandparent"),
+            &[row_with_value("entity-a", None, "parent-a", "new")],
+        )
+        .await
+        .expect("parent root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "child", Some("parent"), &[])
+            .await
+            .expect("child root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let stale_diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "grandparent", &TrackedStateDiffRequest::default())
+            .await
+            .expect("grandparent diff should load");
+        let stale_row = stale_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("grandparent row should appear");
+        let (stale_key, stale_value) = stale_row.into_index_entry();
+
+        stage_corrupt_projection_root(
+            &storage,
+            "child",
+            vec![(stale_key, stale_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "grandparent".to_string(),
+                root_id: tracked_state_root_id(&storage, "grandparent").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("forged grandparent parent must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_allows_rows_reachable_through_parent_commit() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
+            .await
+            .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row_with_value("entity-a", None, "parent-change", "value")],
+        )
+        .await
+        .expect("parent root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "child", Some("parent"), &[])
+            .await
+            .expect("child root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let diff = tracked_state
+            .reader(read)
+            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect("ancestor-reachable row should validate");
+
+        assert_eq!(
+            kinds(&diff),
+            vec![("entity-a".to_string(), TrackedStateDiffKind::Added)]
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_allows_adopted_source_update_with_source_created_at() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "target", None, &[])
+            .await
+            .expect("target root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source-add",
+            None,
+            &[row_with_times(
+                "entity-a",
+                None,
+                "source-add-a",
+                "old",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+            )],
+        )
+        .await
+        .expect("source add root should write");
+        let source_update = row_with_times(
+            "entity-a",
+            None,
+            "source-update-a",
+            "new",
+            "2026-01-01T00:00:00Z",
+            "2026-01-02T00:00:00Z",
+        );
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source-update",
+            Some("source-add"),
+            std::slice::from_ref(&source_update),
+        )
+        .await
+        .expect("source update root should write");
+        {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            crate::test_support::stage_tracked_root_from_materialized_with_parents(
+                &mut read,
+                &mut writes,
+                &tracked_state,
+                "merge",
+                &["target".to_string(), "source-update".to_string()],
+                Some("target"),
+                std::slice::from_ref(&source_update),
+            )
+            .await
+            .expect("merge root should stage");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("merge root should commit");
+        }
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let diff = tracked_state
+            .reader(read)
+            .diff_commits("target", "merge", &TrackedStateDiffRequest::default())
+            .await
+            .expect("adopted source update should validate");
+
+        assert_eq!(
+            kinds(&diff),
+            vec![("entity-a".to_string(), TrackedStateDiffKind::Added)]
+        );
+        let row = diff.entries[0].after.as_ref().expect("after row");
+        assert_eq!(row.created_at, "2026-01-01T00:00:00Z");
+        assert_eq!(row.updated_at, "2026-01-02T00:00:00Z");
+        assert_eq!(row.change_id, "source-update-a");
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_omitted_inherited_row_even_when_diff_is_non_empty() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row_with_value("entity-a", None, "parent-a", "inherited")],
+        )
+        .await
+        .expect("parent root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[row_with_value("entity-b", None, "child-b", "unrelated")],
+        )
+        .await
+        .expect("child root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let valid_diff = tracked_state
+            .reader(read)
+            .diff_commits("parent", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect("valid child diff should load");
+        let unrelated_row = valid_diff
+            .entries
+            .iter()
+            .find_map(|entry| {
+                entry
+                    .after
+                    .as_ref()
+                    .filter(|row| row.change_id == "child-b")
+                    .cloned()
+            })
+            .expect("unrelated child row should appear");
+        let (unrelated_key, unrelated_value) = unrelated_row.into_index_entry();
+        stage_corrupt_projection_root(
+            &storage,
+            "child",
+            vec![(unrelated_key, unrelated_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "parent".to_string(),
+                root_id: tracked_state_root_id(&storage, "parent").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("parent", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("omitted inherited row must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_omitted_updated_row_even_when_diff_is_non_empty() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row_with_value("entity-a", None, "parent-a", "old")],
+        )
+        .await
+        .expect("parent root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[
+                row_with_value("entity-a", None, "child-a", "new"),
+                row_with_value("entity-b", None, "child-b", "unrelated"),
+            ],
+        )
+        .await
+        .expect("child root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let valid_diff = tracked_state
+            .reader(read)
+            .diff_commits("parent", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect("valid child diff should load");
+        let unrelated_row = valid_diff
+            .entries
+            .iter()
+            .find_map(|entry| {
+                entry
+                    .after
+                    .as_ref()
+                    .filter(|row| row.change_id == "child-b")
+                    .cloned()
+            })
+            .expect("unrelated child row should appear");
+        let (unrelated_key, unrelated_value) = unrelated_row.into_index_entry();
+        stage_corrupt_projection_root(
+            &storage,
+            "child",
+            vec![(unrelated_key, unrelated_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "parent".to_string(),
+                root_id: tracked_state_root_id(&storage, "parent").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("parent", "child", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("omitted updated row must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_rejects_shared_omitted_row_even_when_diff_is_non_empty() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row_with_value("entity-a", None, "parent-a", "shared")],
+        )
+        .await
+        .expect("parent root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "left",
+            Some("parent"),
+            &[row_with_value("entity-b", None, "left-b", "left")],
+        )
+        .await
+        .expect("left root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "right",
+            Some("parent"),
+            &[row_with_value("entity-c", None, "right-c", "right")],
+        )
+        .await
+        .expect("right root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let left_diff = tracked_state
+            .reader(read)
+            .diff_commits("parent", "left", &TrackedStateDiffRequest::default())
+            .await
+            .expect("left diff should load");
+        let left_row = left_diff
+            .entries
+            .iter()
+            .find_map(|entry| {
+                entry
+                    .after
+                    .as_ref()
+                    .filter(|row| row.change_id == "left-b")
+                    .cloned()
+            })
+            .expect("left row should appear");
+        let (left_key, left_value) = left_row.into_index_entry();
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let right_diff = tracked_state
+            .reader(read)
+            .diff_commits("parent", "right", &TrackedStateDiffRequest::default())
+            .await
+            .expect("right diff should load");
+        let right_row = right_diff
+            .entries
+            .iter()
+            .find_map(|entry| {
+                entry
+                    .after
+                    .as_ref()
+                    .filter(|row| row.change_id == "right-c")
+                    .cloned()
+            })
+            .expect("right row should appear");
+        let (right_key, right_value) = right_row.into_index_entry();
+        stage_corrupt_projection_root(
+            &storage,
+            "left",
+            vec![(left_key, left_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "parent".to_string(),
+                root_id: tracked_state_root_id(&storage, "parent").await,
+            }],
+        )
+        .await;
+        stage_corrupt_projection_root(
+            &storage,
+            "right",
+            vec![(right_key, right_value)],
+            vec![TrackedStateProjectionParent {
+                commit_id: "parent".to_string(),
+                root_id: tracked_state_root_id(&storage, "parent").await,
+            }],
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits("left", "right", &TrackedStateDiffRequest::default())
+            .await
+            .expect_err("shared hidden omission must be rejected");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn diff_commits_validates_roots_even_when_tree_diff_is_empty() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source",
+            None,
+            &[row_with_value("entity-a", None, "source-change", "value")],
+        )
+        .await
+        .expect("source root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "left-corrupt", None, &[])
+            .await
+            .expect("left changelog should write");
+        write_root_committed_for_test(&storage, &tracked_state, "right-corrupt", None, &[])
+            .await
+            .expect("right changelog should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let source_diff = tracked_state
+            .reader(read)
+            .diff_commits(
+                "left-corrupt",
+                "source",
+                &TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("source diff should load");
+        let source_row = source_diff
+            .entries
+            .iter()
+            .find_map(|entry| entry.after.clone())
+            .expect("source row should appear");
+        let (source_key, source_value) = source_row.into_index_entry();
+
+        stage_corrupt_projection_root(
+            &storage,
+            "left-corrupt",
+            vec![(source_key.clone(), source_value.clone())],
+            Vec::new(),
+        )
+        .await;
+        stage_corrupt_projection_root(
+            &storage,
+            "right-corrupt",
+            vec![(source_key, source_value)],
+            Vec::new(),
+        )
+        .await;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tracked_state
+            .reader(read)
+            .diff_commits(
+                "left-corrupt",
+                "right-corrupt",
+                &TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect_err("identical corrupt roots must still be validated");
+
+        assert!(
+            is_projection_validation_error(&error),
+            "unexpected error: {error}"
         );
     }
 
@@ -658,6 +1964,62 @@ mod tests {
         .await
     }
 
+    async fn tracked_state_root_id(
+        storage: &StorageContext,
+        commit_id: &str,
+    ) -> TrackedStateRootId {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        crate::tracked_state::storage::load_root(&read, commit_id)
+            .await
+            .expect("root should load")
+            .expect("root should exist")
+    }
+
+    async fn stage_corrupt_projection_root(
+        storage: &StorageContext,
+        commit_id: &str,
+        entries: Vec<(TrackedStateKey, TrackedStateIndexValue)>,
+        parent_roots: Vec<TrackedStateProjectionParent>,
+    ) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mutations = entries
+            .into_iter()
+            .map(|(key, value)| {
+                TrackedStateMutation::put_encoded(
+                    crate::tracked_state::codec::encode_key(&key),
+                    crate::tracked_state::codec::encode_value(&value),
+                )
+            })
+            .collect::<Vec<_>>();
+        let changed_key_count = mutations.len() as u64;
+        let result = crate::tracked_state::tree::TrackedStateTree::new()
+            .apply_mutations(&read, &mut writes, None, mutations, Some(commit_id))
+            .await
+            .expect("corrupt root should write");
+        crate::tracked_state::storage::stage_projection_metadata(
+            &mut writes,
+            &TrackedStateProjectionMetadata {
+                commit_id: commit_id.to_string(),
+                root_id: result.root_id,
+                parent_roots,
+                changed_key_count,
+                row_count_estimate: result.row_count as u64,
+                tree_height: result.tree_height as u32,
+                primary_chunk_count: result.chunk_count as u64,
+                primary_chunk_bytes: result.chunk_bytes as u64,
+            },
+        )
+        .expect("metadata should encode");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("corrupt root should commit");
+    }
+
     fn kinds(diff: &TrackedStateDiff) -> Vec<(String, TrackedStateDiffKind)> {
         diff.entries
             .iter()
@@ -672,6 +2034,22 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    fn is_projection_validation_error(error: &LixError) -> bool {
+        error.message.contains("not the first-parent winner")
+            || error.message.contains("does not match parent root")
+            || error
+                .message
+                .contains("does not match changelog first-parent winners")
+            || error.message.contains("contains non-winner identity")
+            || error.message.contains("but changelog first parent is")
+            || error
+                .message
+                .contains("nearest available first-parent root")
+            || error.message.contains("references unexpected parent")
+            || error.message.contains("missing changelog winner")
+            || error.message.contains("has change")
     }
 
     fn tombstone(
@@ -705,6 +2083,20 @@ mod tests {
         value: &str,
     ) -> MaterializedTrackedStateRow {
         row_with_schema_and_value(entity_id, file_id, "test_schema", change_id, value)
+    }
+
+    fn row_with_times(
+        entity_id: &str,
+        file_id: Option<&str>,
+        change_id: &str,
+        value: &str,
+        created_at: &str,
+        updated_at: &str,
+    ) -> MaterializedTrackedStateRow {
+        let mut row = row_with_value(entity_id, file_id, change_id, value);
+        row.created_at = created_at.to_string();
+        row.updated_at = updated_at.to_string();
+        row
     }
 
     fn row_with_schema_and_value(

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -1412,6 +1412,167 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn diff_commits_rejects_adopted_created_at_from_corrupt_source_parent_metadata() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "target", None, &[])
+            .await
+            .expect("target root should write");
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source-add",
+            None,
+            &[row_with_times(
+                "entity-a",
+                None,
+                "source-add-a",
+                "old",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+            )],
+        )
+        .await
+        .expect("source add root should write");
+        let source_update = row_with_times(
+            "entity-a",
+            None,
+            "source-update-a",
+            "new",
+            "2026-01-01T00:00:00Z",
+            "2026-01-02T00:00:00Z",
+        );
+        write_root_committed_for_test(
+            &storage,
+            &tracked_state,
+            "source-update",
+            Some("source-add"),
+            std::slice::from_ref(&source_update),
+        )
+        .await
+        .expect("source update root should write");
+
+        let original_source_update_root = tracked_state_root_id(&storage, "source-update").await;
+        let mut forged_parent_row = row_with_times(
+            "entity-a",
+            None,
+            "source-add-a",
+            "old",
+            "1999-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        forged_parent_row.commit_id = "source-add".to_string();
+        let (forged_key, forged_value) = TrackedStateDiffRow {
+            entity_id: forged_parent_row.entity_id,
+            schema_key: forged_parent_row.schema_key,
+            file_id: forged_parent_row.file_id,
+            deleted: forged_parent_row.snapshot_content.is_none(),
+            snapshot_ref: forged_parent_row
+                .snapshot_content
+                .as_deref()
+                .map(|value| JsonRef::for_content(value.as_bytes())),
+            metadata_ref: forged_parent_row
+                .metadata
+                .as_deref()
+                .map(|value| JsonRef::for_content(value.as_bytes())),
+            created_at: forged_parent_row.created_at,
+            updated_at: forged_parent_row.updated_at,
+            change_id: forged_parent_row.change_id,
+            commit_id: forged_parent_row.commit_id,
+            change_location: SegmentObjectLocation {
+                segment_id: "forged".to_string(),
+                offset: 0,
+                len: 0,
+                checksum: String::new(),
+            },
+        }
+        .into_index_entry();
+        stage_corrupt_projection_root(
+            &storage,
+            "forged-source-parent",
+            vec![(forged_key, forged_value)],
+            Vec::new(),
+        )
+        .await;
+        let forged_source_parent_root =
+            tracked_state_root_id(&storage, "forged-source-parent").await;
+        {
+            let mut writes = storage.new_write_set();
+            crate::tracked_state::storage::stage_projection_metadata(
+                &mut writes,
+                &TrackedStateProjectionMetadata {
+                    commit_id: "source-update".to_string(),
+                    root_id: original_source_update_root,
+                    parent_roots: vec![TrackedStateProjectionParent {
+                        commit_id: "source-add".to_string(),
+                        root_id: forged_source_parent_root,
+                    }],
+                    changed_key_count: 1,
+                    row_count_estimate: 1,
+                    tree_height: 1,
+                    primary_chunk_count: 1,
+                    primary_chunk_bytes: 1,
+                },
+            )
+            .expect("corrupt metadata should encode");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("corrupt source metadata should commit");
+        }
+
+        let mut forged_adopted_row = source_update.clone();
+        forged_adopted_row.created_at = "1999-01-01T00:00:00Z".to_string();
+        {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            crate::test_support::stage_tracked_root_from_materialized_with_parents(
+                &mut read,
+                &mut writes,
+                &tracked_state,
+                "merge",
+                &["target".to_string(), "source-update".to_string()],
+                Some("target"),
+                std::slice::from_ref(&forged_adopted_row),
+            )
+            .await
+            .expect("merge root should stage");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("merge root should commit");
+        }
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let diff = tracked_state
+            .reader(&mut read)
+            .diff_commits_with_validation(
+                "target",
+                "merge",
+                &TrackedStateDiffRequest::default(),
+                false,
+                false,
+            )
+            .await
+            .expect("raw diff should expose forged adopted row");
+        let forged_row = diff.entries[0].after.as_ref().expect("after row");
+        let error = tracked_state
+            .reader(read)
+            .validate_diff_rows_for_commits_against_changelog(&[(forged_row, "merge")])
+            .await
+            .expect_err("forged source parent metadata must not validate created_at");
+
+        assert!(
+            error
+                .message
+                .contains("references stale root for projection parent 'source-add'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn diff_commits_rejects_omitted_inherited_row_even_when_diff_is_non_empty() {
         let storage = StorageContext::new(InMemoryStorageBackend::new());
         let tracked_state = TrackedStateContext::new();

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -26,6 +26,6 @@ pub(crate) use row_materialization::{materialize_rows_from_index_entries, Tracke
 #[allow(unused_imports)]
 pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateFilter,
-    TrackedStateIndexValueRef, TrackedStateKeyRef, TrackedStateProjection, TrackedStateRowRequest,
-    TrackedStateScanRequest,
+    TrackedStateIndexValueRef, TrackedStateKeyRef, TrackedStateProjection,
+    TrackedStateRowRequest, TrackedStateScanRequest,
 };

--- a/packages/engine/src/tracked_state/projection_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/projection_root_rebuild.rs
@@ -2,8 +2,9 @@ use crate::changelog::{
     Change, ChangeLoadEntry, ChangeLoadRequest, ChangeLocator as ChangelogChangeLocator,
     ChangeProjection, ChangeRef as ChangelogChangeRef, ChangeVisibilityMode, ChangelogContext,
     CommitBody, CommitHeader, CommitLoadEntry, CommitLoadRequest, CommitProjection,
-    CommitVisibilityMode,
+    CommitVisibilityMode, StateRowIdentity,
 };
+use crate::common::{CanonicalSchemaKey, EntityId, FileId};
 use crate::storage::StorageRead;
 use crate::tracked_state::context::{TrackedStateRootRebuilder, TrackedStateWriteReport};
 use crate::tracked_state::storage;
@@ -83,7 +84,16 @@ pub(crate) async fn rebuild_projection_root_at<S>(
 where
     S: StorageRead + Send + Sync + ?Sized,
 {
-    let input = build_incremental_projection_root_rebuild_input(rebuilder.store, commit_id).await?;
+    // Explicit rebuilds keep the legacy incremental behavior: they may reuse
+    // the nearest first-parent projection root without validating its rows.
+    // Missing-root repair goes through ensure_projection_root, which enables
+    // parent validation before inheriting created_at values.
+    let input = build_incremental_projection_root_rebuild_input_with_parent_validation(
+        rebuilder.store,
+        commit_id,
+        false,
+    )
+    .await?;
     let delta_refs = input
         .deltas
         .iter()
@@ -163,6 +173,18 @@ pub(super) async fn build_incremental_projection_root_rebuild_input<S>(
 where
     S: StorageRead + Send + Sync + ?Sized,
 {
+    build_incremental_projection_root_rebuild_input_with_parent_validation(store, commit_id, true)
+        .await
+}
+
+async fn build_incremental_projection_root_rebuild_input_with_parent_validation<S>(
+    store: &S,
+    commit_id: &str,
+    validate_parent_values: bool,
+) -> Result<ProjectionRootRebuildInput, LixError>
+where
+    S: StorageRead + Send + Sync + ?Sized,
+{
     let mut reverse_replay = Vec::new();
     let mut seen = BTreeSet::new();
     let mut current = Some(commit_id.to_string());
@@ -198,9 +220,11 @@ where
         Some((commit_id, root_id)) => (Some(commit_id), Some(root_id)),
         None => (None, None),
     };
+    let parent = parent_commit_id.as_deref().zip(parent_root_id.as_ref());
     let deltas = project_projection_root_rebuild_deltas_with_parent(
         store,
-        parent_root_id.as_ref(),
+        parent,
+        validate_parent_values,
         located_changes,
     )
     .await?;
@@ -383,14 +407,15 @@ fn project_projection_root_rebuild_deltas(
 
 async fn project_projection_root_rebuild_deltas_with_parent<S>(
     store: &S,
-    parent_root_id: Option<&TrackedStateRootId>,
+    parent: Option<(&str, &TrackedStateRootId)>,
+    validate_parent_values: bool,
     changes: impl IntoIterator<Item = LocatedChange>,
 ) -> Result<Vec<ProjectionRootRebuildDelta>, LixError>
 where
     S: StorageRead + Send + Sync + ?Sized,
 {
     let mut deltas = project_projection_root_rebuild_deltas(changes);
-    let Some(parent_root_id) = parent_root_id else {
+    let Some((parent_commit_id, parent_root_id)) = parent else {
         return Ok(deltas);
     };
     let keys = deltas
@@ -404,12 +429,76 @@ where
     let parent_values = TrackedStateTree::new()
         .get_many(store, parent_root_id, &keys)
         .await?;
+    if validate_parent_values {
+        validate_parent_values_against_changelog(store, parent_commit_id, &keys, &parent_values)
+            .await?;
+    }
     for (delta, parent_value) in deltas.iter_mut().zip(parent_values) {
         if let Some(TrackedStateIndexValue { created_at, .. }) = parent_value {
             delta.created_at = created_at;
         }
     }
     Ok(deltas)
+}
+
+async fn validate_parent_values_against_changelog<S>(
+    store: &S,
+    parent_commit_id: &str,
+    keys: &[TrackedStateKey],
+    values: &[Option<TrackedStateIndexValue>],
+) -> Result<(), LixError>
+where
+    S: StorageRead + Send + Sync + ?Sized,
+{
+    let identities = keys
+        .iter()
+        .map(state_row_identity_from_key)
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut reader = ChangelogContext::new().reader(store);
+    let facts = reader
+        .load_first_parent_winner_facts_for_visible_commit(parent_commit_id, &identities)
+        .await?;
+    for (identity, value) in identities.into_iter().zip(values) {
+        let fact = facts.get(&identity);
+        let Some(value) = value else {
+            if fact.is_some() {
+                return Err(LixError::unknown(format!(
+                    "tracked_state materialization parent root for commit '{}' is missing changelog first-parent winner for identity {:?}",
+                    parent_commit_id, identity
+                )));
+            }
+            continue;
+        };
+        let Some(fact) = fact else {
+            return Err(LixError::unknown(format!(
+                "tracked_state materialization parent root for commit '{}' contains non-winner identity {:?}",
+                parent_commit_id, identity
+            )));
+        };
+        if fact.change_id != value.change_locator.change_id
+            || fact.created_at != value.created_at
+            || fact.updated_at != value.updated_at
+            || fact.deleted != value.deleted
+        {
+            return Err(LixError::unknown(format!(
+                "tracked_state materialization parent root for commit '{}' does not match changelog first-parent winner for identity {:?}",
+                parent_commit_id, identity
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn state_row_identity_from_key(key: &TrackedStateKey) -> Result<StateRowIdentity, LixError> {
+    Ok(StateRowIdentity {
+        schema_key: CanonicalSchemaKey::new(key.schema_key.clone())?,
+        file_id: FileId::new(
+            key.file_id
+                .clone()
+                .unwrap_or_else(|| "__global__".to_string()),
+        )?,
+        entity_id: EntityId::new(key.entity_id.as_json_array_text()?)?,
+    })
 }
 
 fn missing_change_error(commit_id: &str, change_id: &str) -> LixError {
@@ -431,6 +520,8 @@ mod tests {
     use super::*;
     use crate::changelog::SegmentObjectLocation;
     use crate::entity_identity::EntityIdentity;
+    use crate::tracked_state::tree::TrackedStateTree;
+    use crate::tracked_state::types::TrackedStateIndexValue;
 
     #[test]
     fn projection_root_rebuild_delta_ref_borrows_owned_facts() {
@@ -561,35 +652,90 @@ mod tests {
         let storage =
             crate::storage::StorageContext::new(crate::storage::InMemoryStorageBackend::new());
         let tracked_state = crate::tracked_state::TrackedStateContext::new();
-        let parent_row = crate::tracked_state::MaterializedTrackedStateRow {
-            entity_id: EntityIdentity::single("entity-1"),
-            schema_key: "schema".to_string(),
-            file_id: Some("file".to_string()),
-            snapshot_content: Some("{\"value\":\"parent\"}".to_string()),
-            metadata: None,
-            deleted: false,
-            created_at: "2026-01-01T00:00:00Z".to_string(),
-            updated_at: "2026-01-01T00:00:00Z".to_string(),
-            change_id: "change-parent".to_string(),
-            commit_id: "parent".to_string(),
-        };
-        let mut read = storage
-            .begin_read(crate::storage::StorageReadOptions::default())
-            .expect("read should open");
-        let mut writes = storage.new_write_set();
-        crate::test_support::stage_tracked_root_from_materialized(
-            &mut read,
-            &mut writes,
-            &tracked_state,
+        let parent_row = materialized_row(
+            "entity-1",
+            "change-parent",
             "parent",
-            None,
-            std::slice::from_ref(&parent_row),
+            "parent",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        stage_materialized_root(&storage, &tracked_state, "parent", None, &[parent_row])
+            .await
+            .expect("parent root should stage");
+        let child_row = materialized_row(
+            "entity-1",
+            "change-child",
+            "child",
+            "child",
+            "2026-01-01T00:00:00Z",
+            "2026-02-01T00:00:00Z",
+        );
+        stage_materialized_root(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[child_row],
         )
         .await
-        .expect("parent root should stage");
-        storage
-            .commit_write_set(writes, crate::storage::StorageWriteOptions::default())
-            .expect("parent root should commit");
+        .expect("child root should stage");
+
+        let input = build_incremental_projection_root_rebuild_input(
+            &storage
+                .begin_read(crate::storage::StorageReadOptions::default())
+                .expect("read should open"),
+            "child",
+        )
+        .await
+        .expect("rebuild input should load");
+
+        assert_eq!(input.parent_commit_id.as_deref(), Some("parent"));
+        assert_eq!(input.replayed_commits, 1);
+        assert_eq!(input.deltas.len(), 1);
+        assert_eq!(input.deltas[0].created_at, "2026-01-01T00:00:00Z");
+        assert_eq!(input.deltas[0].updated_at, "2026-02-01T00:00:00Z");
+    }
+
+    #[tokio::test]
+    async fn incremental_projection_rebuild_rejects_corrupt_parent_root_created_at() {
+        let storage =
+            crate::storage::StorageContext::new(crate::storage::InMemoryStorageBackend::new());
+        let tracked_state = crate::tracked_state::TrackedStateContext::new();
+        let parent_row = materialized_row(
+            "entity-1",
+            "change-parent",
+            "parent",
+            "parent",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        stage_materialized_root(&storage, &tracked_state, "parent", None, &[parent_row])
+            .await
+            .expect("parent root should stage");
+        let child_row = materialized_row(
+            "entity-1",
+            "change-child",
+            "child",
+            "child",
+            "2026-01-01T00:00:00Z",
+            "2026-02-01T00:00:00Z",
+        );
+        stage_materialized_root(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[child_row],
+        )
+        .await
+        .expect("child root should stage");
+
+        let parent_key = TrackedStateKey {
+            schema_key: "schema".to_string(),
+            file_id: Some("file".to_string()),
+            entity_id: EntityIdentity::single("entity-1"),
+        };
         let parent_root = storage::load_root(
             &storage
                 .begin_read(crate::storage::StorageReadOptions::default())
@@ -599,26 +745,494 @@ mod tests {
         .await
         .expect("parent root should load")
         .expect("parent root should exist");
+        let mut corrupt_parent_value = TrackedStateTree::new()
+            .get(
+                &storage
+                    .begin_read(crate::storage::StorageReadOptions::default())
+                    .expect("read should open"),
+                &parent_root,
+                &parent_key,
+            )
+            .await
+            .expect("parent value should load")
+            .expect("parent value should exist");
+        corrupt_parent_value.created_at = "1999-01-01T00:00:00Z".to_string();
+        let forged_root = {
+            let read = storage
+                .begin_read(crate::storage::StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            let result = TrackedStateTree::new()
+                .apply_mutations(
+                    &read,
+                    &mut writes,
+                    None,
+                    vec![
+                        crate::tracked_state::types::TrackedStateMutation::put_encoded(
+                            crate::tracked_state::codec::encode_key(&parent_key),
+                            crate::tracked_state::codec::encode_value(&corrupt_parent_value),
+                        ),
+                    ],
+                    Some("forged-parent"),
+                )
+                .await
+                .expect("forged root should write");
+            storage::stage_projection_metadata(
+                &mut writes,
+                &crate::tracked_state::types::TrackedStateProjectionMetadata {
+                    commit_id: "parent".to_string(),
+                    root_id: result.root_id.clone(),
+                    parent_roots: Vec::new(),
+                    changed_key_count: 1,
+                    row_count_estimate: result.row_count as u64,
+                    tree_height: result.tree_height as u32,
+                    primary_chunk_count: result.chunk_count as u64,
+                    primary_chunk_bytes: result.chunk_bytes as u64,
+                },
+            )
+            .expect("corrupt parent metadata should encode");
+            writes.delete(
+                storage::TRACKED_STATE_PROJECTION_SPACE,
+                crate::storage::StorageKey(bytes::Bytes::copy_from_slice(b"child")),
+            );
+            storage
+                .commit_write_set(writes, crate::storage::StorageWriteOptions::default())
+                .expect("corruption should commit");
+            result.root_id
+        };
 
-        let deltas = project_projection_root_rebuild_deltas_with_parent(
+        assert_eq!(
+            storage::load_root(
+                &storage
+                    .begin_read(crate::storage::StorageReadOptions::default())
+                    .expect("read should open"),
+                "parent",
+            )
+            .await
+            .expect("corrupt parent root should load"),
+            Some(forged_root)
+        );
+
+        assert_child_repair_rejects(
+            &storage,
+            &tracked_state,
+            "does not match changelog first-parent winner",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn explicit_projection_rebuild_allows_corrupt_parent_created_at_for_legacy_rebuild_mode() {
+        let storage =
+            crate::storage::StorageContext::new(crate::storage::InMemoryStorageBackend::new());
+        let tracked_state = crate::tracked_state::TrackedStateContext::new();
+        let parent_row = materialized_row(
+            "entity-1",
+            "change-parent",
+            "parent",
+            "parent",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        stage_materialized_root(&storage, &tracked_state, "parent", None, &[parent_row])
+            .await
+            .expect("parent root should stage");
+        let child_row = materialized_row(
+            "entity-1",
+            "change-child",
+            "child",
+            "child",
+            "2026-01-01T00:00:00Z",
+            "2026-02-01T00:00:00Z",
+        );
+        stage_materialized_root(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[child_row],
+        )
+        .await
+        .expect("child root should stage");
+        let parent_key = TrackedStateKey {
+            schema_key: "schema".to_string(),
+            file_id: Some("file".to_string()),
+            entity_id: EntityIdentity::single("entity-1"),
+        };
+        let parent_root = storage::load_root(
             &storage
                 .begin_read(crate::storage::StorageReadOptions::default())
                 .expect("read should open"),
-            Some(&parent_root),
-            vec![located_change(
-                "child",
-                0,
-                "change-child",
-                "entity-1",
-                "2026-02-01T00:00:00Z",
-            )],
+            "parent",
         )
         .await
-        .expect("incremental projection should project");
+        .expect("parent root should load")
+        .expect("parent root should exist");
+        let mut corrupt_parent_value = TrackedStateTree::new()
+            .get(
+                &storage
+                    .begin_read(crate::storage::StorageReadOptions::default())
+                    .expect("read should open"),
+                &parent_root,
+                &parent_key,
+            )
+            .await
+            .expect("parent value should load")
+            .expect("parent value should exist");
+        corrupt_parent_value.created_at = "1999-01-01T00:00:00Z".to_string();
+        stage_parent_projection_root_and_delete_child(
+            &storage,
+            "parent",
+            "child",
+            vec![(parent_key, corrupt_parent_value)],
+        )
+        .await
+        .expect("corruption should stage");
 
-        assert_eq!(deltas.len(), 1);
-        assert_eq!(deltas[0].created_at, "2026-01-01T00:00:00Z");
-        assert_eq!(deltas[0].updated_at, "2026-02-01T00:00:00Z");
+        let mut read = storage
+            .begin_read(crate::storage::StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let report = tracked_state
+            .root_rebuilder(&mut read, &mut writes)
+            .rebuild_projection_root_at("child")
+            .await
+            .expect("explicit rebuild should preserve legacy unvalidated parent behavior");
+        assert_eq!(report.commit_id, "child");
+        storage
+            .commit_write_set(writes, crate::storage::StorageWriteOptions::default())
+            .expect("explicit rebuild should commit");
+        let input = build_incremental_projection_root_rebuild_input_with_parent_validation(
+            &storage
+                .begin_read(crate::storage::StorageReadOptions::default())
+                .expect("read should open"),
+            "child",
+            false,
+        )
+        .await
+        .expect("legacy rebuild input should load");
+        assert_eq!(input.parent_commit_id.as_deref(), Some("parent"));
+        assert_eq!(input.deltas[0].created_at, "1999-01-01T00:00:00Z");
+    }
+
+    #[tokio::test]
+    async fn incremental_projection_rebuild_rejects_parent_root_missing_winner_row() {
+        let storage =
+            crate::storage::StorageContext::new(crate::storage::InMemoryStorageBackend::new());
+        let tracked_state = crate::tracked_state::TrackedStateContext::new();
+        let parent_row = materialized_row(
+            "entity-1",
+            "change-parent",
+            "parent",
+            "parent",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        stage_materialized_root(&storage, &tracked_state, "parent", None, &[parent_row])
+            .await
+            .expect("parent root should stage");
+        let child_row = materialized_row(
+            "entity-1",
+            "change-child",
+            "child",
+            "child",
+            "2026-01-01T00:00:00Z",
+            "2026-02-01T00:00:00Z",
+        );
+        stage_materialized_root(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[child_row],
+        )
+        .await
+        .expect("child root should stage");
+
+        {
+            let read = storage
+                .begin_read(crate::storage::StorageReadOptions::default())
+                .expect("read should open");
+            let mut writes = storage.new_write_set();
+            let result = TrackedStateTree::new()
+                .apply_mutations(&read, &mut writes, None, Vec::new(), Some("empty-parent"))
+                .await
+                .expect("empty root should write");
+            storage::stage_projection_metadata(
+                &mut writes,
+                &crate::tracked_state::types::TrackedStateProjectionMetadata {
+                    commit_id: "parent".to_string(),
+                    root_id: result.root_id.clone(),
+                    parent_roots: Vec::new(),
+                    changed_key_count: 0,
+                    row_count_estimate: result.row_count as u64,
+                    tree_height: result.tree_height as u32,
+                    primary_chunk_count: result.chunk_count as u64,
+                    primary_chunk_bytes: result.chunk_bytes as u64,
+                },
+            )
+            .expect("corrupt parent metadata should encode");
+            writes.delete(
+                storage::TRACKED_STATE_PROJECTION_SPACE,
+                crate::storage::StorageKey(bytes::Bytes::copy_from_slice(b"child")),
+            );
+            storage
+                .commit_write_set(writes, crate::storage::StorageWriteOptions::default())
+                .expect("corruption should commit");
+        }
+
+        assert_child_repair_rejects(
+            &storage,
+            &tracked_state,
+            "is missing changelog first-parent winner",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn incremental_projection_rebuild_rejects_parent_root_non_winner_row() {
+        let storage =
+            crate::storage::StorageContext::new(crate::storage::InMemoryStorageBackend::new());
+        let tracked_state = crate::tracked_state::TrackedStateContext::new();
+        stage_materialized_root(&storage, &tracked_state, "parent", None, &[])
+            .await
+            .expect("parent root should stage");
+        let child_row = materialized_row(
+            "entity-1",
+            "change-child",
+            "child",
+            "child",
+            "2026-02-01T00:00:00Z",
+            "2026-02-01T00:00:00Z",
+        );
+        stage_materialized_root(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[child_row],
+        )
+        .await
+        .expect("child root should stage");
+
+        let forged_key = TrackedStateKey {
+            schema_key: "schema".to_string(),
+            file_id: Some("file".to_string()),
+            entity_id: EntityIdentity::single("entity-1"),
+        };
+        let forged_value = tracked_value(
+            "change-forged",
+            "parent",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        stage_parent_projection_root_and_delete_child(
+            &storage,
+            "parent",
+            "child",
+            vec![(forged_key, forged_value)],
+        )
+        .await
+        .expect("corruption should stage");
+
+        assert_child_repair_rejects(&storage, &tracked_state, "contains non-winner identity").await;
+    }
+
+    #[tokio::test]
+    async fn incremental_projection_rebuild_rejects_parent_root_wrong_winner_change_id() {
+        let storage =
+            crate::storage::StorageContext::new(crate::storage::InMemoryStorageBackend::new());
+        let tracked_state = crate::tracked_state::TrackedStateContext::new();
+        let parent_row = materialized_row(
+            "entity-1",
+            "change-parent",
+            "parent",
+            "parent",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        stage_materialized_root(&storage, &tracked_state, "parent", None, &[parent_row])
+            .await
+            .expect("parent root should stage");
+        let child_row = materialized_row(
+            "entity-1",
+            "change-child",
+            "child",
+            "child",
+            "2026-01-01T00:00:00Z",
+            "2026-02-01T00:00:00Z",
+        );
+        stage_materialized_root(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[child_row],
+        )
+        .await
+        .expect("child root should stage");
+
+        let forged_key = TrackedStateKey {
+            schema_key: "schema".to_string(),
+            file_id: Some("file".to_string()),
+            entity_id: EntityIdentity::single("entity-1"),
+        };
+        let forged_value = tracked_value(
+            "change-forged",
+            "parent",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00Z",
+        );
+        stage_parent_projection_root_and_delete_child(
+            &storage,
+            "parent",
+            "child",
+            vec![(forged_key, forged_value)],
+        )
+        .await
+        .expect("corruption should stage");
+
+        assert_child_repair_rejects(
+            &storage,
+            &tracked_state,
+            "does not match changelog first-parent winner",
+        )
+        .await;
+    }
+
+    async fn assert_child_repair_rejects(
+        storage: &crate::storage::StorageContext,
+        tracked_state: &crate::tracked_state::TrackedStateContext,
+        expected_error: &str,
+    ) {
+        let mut read = storage
+            .begin_read(crate::storage::StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let error = tracked_state
+            .root_rebuilder(&mut read, &mut writes)
+            .ensure_projection_root("child")
+            .await
+            .expect_err("repair must reject corrupt parent projection root");
+        assert!(
+            error.message.contains(expected_error),
+            "unexpected error: {error}"
+        );
+    }
+
+    async fn stage_parent_projection_root_and_delete_child(
+        storage: &crate::storage::StorageContext,
+        parent_commit_id: &str,
+        child_commit_id: &str,
+        entries: Vec<(TrackedStateKey, TrackedStateIndexValue)>,
+    ) -> Result<(), LixError> {
+        let read = storage
+            .begin_read(crate::storage::StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mutations = entries
+            .into_iter()
+            .map(|(key, value)| {
+                crate::tracked_state::types::TrackedStateMutation::put_encoded(
+                    crate::tracked_state::codec::encode_key(&key),
+                    crate::tracked_state::codec::encode_value(&value),
+                )
+            })
+            .collect::<Vec<_>>();
+        let changed_key_count = mutations.len();
+        let result = TrackedStateTree::new()
+            .apply_mutations(&read, &mut writes, None, mutations, Some("forged-parent"))
+            .await?;
+        storage::stage_projection_metadata(
+            &mut writes,
+            &crate::tracked_state::types::TrackedStateProjectionMetadata {
+                commit_id: parent_commit_id.to_string(),
+                root_id: result.root_id,
+                parent_roots: Vec::new(),
+                changed_key_count: changed_key_count as u64,
+                row_count_estimate: result.row_count as u64,
+                tree_height: result.tree_height as u32,
+                primary_chunk_count: result.chunk_count as u64,
+                primary_chunk_bytes: result.chunk_bytes as u64,
+            },
+        )?;
+        writes.delete(
+            storage::TRACKED_STATE_PROJECTION_SPACE,
+            crate::storage::StorageKey(bytes::Bytes::copy_from_slice(child_commit_id.as_bytes())),
+        );
+        storage.commit_write_set(writes, crate::storage::StorageWriteOptions::default())?;
+        Ok(())
+    }
+
+    async fn stage_materialized_root(
+        storage: &crate::storage::StorageContext,
+        tracked_state: &crate::tracked_state::TrackedStateContext,
+        commit_id: &str,
+        parent_commit_id: Option<&str>,
+        rows: &[crate::tracked_state::MaterializedTrackedStateRow],
+    ) -> Result<(), LixError> {
+        let mut read = storage
+            .begin_read(crate::storage::StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        crate::test_support::stage_tracked_root_from_materialized(
+            &mut read,
+            &mut writes,
+            tracked_state,
+            commit_id,
+            parent_commit_id,
+            rows,
+        )
+        .await?;
+        storage.commit_write_set(writes, crate::storage::StorageWriteOptions::default())?;
+        Ok(())
+    }
+
+    fn materialized_row(
+        entity_id: &str,
+        change_id: &str,
+        commit_id: &str,
+        value: &str,
+        created_at: &str,
+        updated_at: &str,
+    ) -> crate::tracked_state::MaterializedTrackedStateRow {
+        crate::tracked_state::MaterializedTrackedStateRow {
+            entity_id: EntityIdentity::single(entity_id),
+            schema_key: "schema".to_string(),
+            file_id: Some("file".to_string()),
+            snapshot_content: Some(format!("{{\"value\":\"{value}\"}}")),
+            metadata: None,
+            deleted: false,
+            created_at: created_at.to_string(),
+            updated_at: updated_at.to_string(),
+            change_id: change_id.to_string(),
+            commit_id: commit_id.to_string(),
+        }
+    }
+
+    fn tracked_value(
+        change_id: &str,
+        commit_id: &str,
+        created_at: &str,
+        updated_at: &str,
+    ) -> TrackedStateIndexValue {
+        TrackedStateIndexValue {
+            change_locator: ChangelogChangeLocator {
+                change_id: change_id.to_string(),
+                commit_id: commit_id.to_string(),
+                location: SegmentObjectLocation {
+                    segment_id: format!("segment-{commit_id}"),
+                    offset: 0,
+                    len: 1,
+                    checksum: change_id.to_string(),
+                },
+            },
+            deleted: false,
+            snapshot_ref: None,
+            metadata_ref: None,
+            created_at: created_at.to_string(),
+            updated_at: updated_at.to_string(),
+        }
     }
 
     fn located_change(

--- a/packages/engine/src/tracked_state/projection_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/projection_root_rebuild.rs
@@ -156,7 +156,7 @@ where
     })
 }
 
-async fn build_incremental_projection_root_rebuild_input<S>(
+pub(super) async fn build_incremental_projection_root_rebuild_input<S>(
     store: &S,
     commit_id: &str,
 ) -> Result<ProjectionRootRebuildInput, LixError>

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -47,7 +47,8 @@ async fn get_one(
         .into_iter()
         .next()
         .flatten()
-        .and_then(full_value))
+        .map(|value| full_value(space, value))
+        .transpose()?)
 }
 
 pub(crate) async fn load_root(
@@ -200,10 +201,13 @@ fn value(bytes: Vec<u8>) -> StorageValue {
     }
 }
 
-fn full_value(value: StorageProjectedValue) -> Option<Vec<u8>> {
+fn full_value(space: StorageSpace, value: StorageProjectedValue) -> Result<Vec<u8>, LixError> {
     match value {
-        StorageProjectedValue::FullValue(bytes) => Some(bytes.to_vec()),
-        StorageProjectedValue::KeyOnly => None,
+        StorageProjectedValue::FullValue(bytes) => Ok(bytes.to_vec()),
+        StorageProjectedValue::KeyOnly => Err(LixError::unknown(format!(
+            "tracked-state point read over namespace '{}' requested full value but storage returned key-only entry",
+            space.name
+        ))),
     }
 }
 
@@ -408,15 +412,21 @@ mod tests {
         BY_CHANGE_INDEX_SPACE, BY_CHANGE_MEMBERSHIP_INDEX_SPACE, BY_COMMIT_INDEX_SPACE,
         COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
     };
+    use crate::backend::{
+        BackendError, BackendRead, BufferedRangeScan, GetOptions, Key, KeyRange, PointVisitor,
+        ProjectedValueRef, ScanOptions,
+    };
     use crate::json_store::store::JSON_SPACE;
-    use crate::storage::{InMemoryStorageBackend, StorageContext, StorageWriteOptions};
+    use crate::storage::{
+        InMemoryStorageBackend, StorageContext, StorageReadScope, StorageWriteOptions,
+    };
     use crate::tracked_state::types::TrackedStateRootId;
     use crate::untracked_state::storage::UNTRACKED_STATE_ROW_SPACE;
 
     use super::{
         PROJECTION_METADATA_MAGIC, TRACKED_STATE_BY_FILE_ROOT_SPACE, TRACKED_STATE_CHUNK_SPACE,
         TRACKED_STATE_HASH_BYTES, TRACKED_STATE_PROJECTION_SPACE, decode_projection_metadata, key,
-        load_projection_metadata, value, write_string,
+        load_by_file_root, load_projection_metadata, value, write_string,
     };
 
     #[test]
@@ -561,6 +571,22 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn load_by_file_root_rejects_key_only_point_read() {
+        let read = StorageReadScope::new(KeyOnlyPointRead);
+
+        let error = load_by_file_root(&read, "commit-1")
+            .await
+            .expect_err("key-only point read must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
+
     #[test]
     fn production_tracked_state_sources_do_not_call_storage_batch_writer() {
         let tracked_state_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/tracked_state");
@@ -653,5 +679,38 @@ mod tests {
         bytes.extend_from_slice(&0u32.to_le_bytes());
         bytes.extend_from_slice(&0u64.to_le_bytes());
         bytes.extend_from_slice(&0u64.to_le_bytes());
+    }
+
+    struct KeyOnlyPointRead;
+
+    impl BackendRead for KeyOnlyPointRead {
+        type RangeScan<'cursor> = BufferedRangeScan;
+
+        fn visit_keys<V>(
+            &self,
+            keys: &[Key],
+            _opts: GetOptions<'_>,
+            visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            for (index, key) in keys.iter().enumerate() {
+                visitor.visit(index, key, Some(ProjectedValueRef::KeyOnly))?;
+            }
+            Ok(())
+        }
+
+        fn with_range_scan<T, F>(
+            &self,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            _f: F,
+        ) -> Result<T, BackendError>
+        where
+            F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+        {
+            unreachable!("tracked-state point-read test does not scan")
+        }
     }
 }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1,15 +1,15 @@
 use std::collections::HashMap;
 
+use crate::LixError;
 use crate::storage::{PointReadPlan, StorageRead, StorageSpace, StorageWriteSet};
 use crate::storage::{
     StorageGetOptions, StorageKey, StorageProjectedValue, StorageSpaceId, StorageValue,
 };
 use crate::tracked_state::codec::PendingChunkWrite;
 use crate::tracked_state::types::{
-    TrackedStateProjectionMetadata, TrackedStateProjectionParent, TrackedStateRootId,
-    TRACKED_STATE_HASH_BYTES,
+    TRACKED_STATE_HASH_BYTES, TrackedStateProjectionMetadata, TrackedStateProjectionParent,
+    TrackedStateRootId,
 };
-use crate::LixError;
 use bytes::Bytes;
 
 pub(crate) const TRACKED_STATE_CHUNK_NAMESPACE: &'static str = "tracked_state.tree.chunk";
@@ -28,6 +28,12 @@ pub(crate) const TRACKED_STATE_PROJECTION_SPACE: StorageSpace = StorageSpace::ne
 );
 
 const PROJECTION_METADATA_MAGIC: &[u8; 5] = b"LXTP1";
+const MIN_PROJECTION_PARENT_BYTES: usize = std::mem::size_of::<u32>() + TRACKED_STATE_HASH_BYTES;
+const PROJECTION_METADATA_FOOTER_BYTES: usize = std::mem::size_of::<u64>()
+    + std::mem::size_of::<u64>()
+    + std::mem::size_of::<u32>()
+    + std::mem::size_of::<u64>()
+    + std::mem::size_of::<u64>();
 
 async fn get_one(
     store: &(impl StorageRead + ?Sized),
@@ -231,6 +237,12 @@ fn decode_projection_metadata(bytes: &[u8]) -> Result<TrackedStateProjectionMeta
     let commit_id = cursor.read_string("commit_id")?;
     let root_id = cursor.read_root_id("root_id")?;
     let parent_count = cursor.read_u32("parent projection count")? as usize;
+    cursor.ensure_counted_records_fit_before_footer(
+        parent_count,
+        MIN_PROJECTION_PARENT_BYTES,
+        PROJECTION_METADATA_FOOTER_BYTES,
+        "parent projections",
+    )?;
     let mut parent_roots = Vec::with_capacity(parent_count);
     for _ in 0..parent_count {
         parent_roots.push(TrackedStateProjectionParent {
@@ -326,6 +338,44 @@ impl ProjectionMetadataCursor<'_> {
         Ok(u64::from_le_bytes(bytes.try_into().expect("fixed u64")))
     }
 
+    fn ensure_counted_records_fit_before_footer(
+        &self,
+        count: usize,
+        record_min_len: usize,
+        footer_len: usize,
+        field: &str,
+    ) -> Result<(), LixError> {
+        let required = count.checked_mul(record_min_len).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode tracked_state projection metadata {field}: byte count overflow"),
+            )
+        })?;
+        let remaining = self.bytes.len().checked_sub(self.offset).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "failed to decode tracked_state projection metadata {field}: cursor overflow"
+                ),
+            )
+        })?;
+        let available = remaining.checked_sub(footer_len).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to decode tracked_state projection metadata {field}: truncated"),
+            )
+        })?;
+        if required > available {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "failed to decode tracked_state projection metadata {field}: count exceeds remaining bytes"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
     fn read_exact(&mut self, len: usize, field: &str) -> Result<&[u8], LixError> {
         let end = self.offset.checked_add(len).ok_or_else(|| {
             LixError::new(
@@ -359,10 +409,14 @@ mod tests {
         COMMIT_VISIBILITY_SPACE, SEGMENT_SPACE, VISIBLE_CHANGE_PROOF_SPACE,
     };
     use crate::json_store::store::JSON_SPACE;
+    use crate::storage::{InMemoryStorageBackend, StorageContext, StorageWriteOptions};
+    use crate::tracked_state::types::TrackedStateRootId;
     use crate::untracked_state::storage::UNTRACKED_STATE_ROW_SPACE;
 
     use super::{
-        TRACKED_STATE_BY_FILE_ROOT_SPACE, TRACKED_STATE_CHUNK_SPACE, TRACKED_STATE_PROJECTION_SPACE,
+        PROJECTION_METADATA_MAGIC, TRACKED_STATE_BY_FILE_ROOT_SPACE, TRACKED_STATE_CHUNK_SPACE,
+        TRACKED_STATE_HASH_BYTES, TRACKED_STATE_PROJECTION_SPACE, decode_projection_metadata, key,
+        load_projection_metadata, value, write_string,
     };
 
     #[test]
@@ -394,6 +448,117 @@ mod tests {
                 space.name
             );
         }
+    }
+
+    #[test]
+    fn projection_metadata_decode_rejects_parent_count_that_exceeds_remaining_before_allocating() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(PROJECTION_METADATA_MAGIC);
+        write_string(&mut bytes, "commit").expect("commit_id should encode");
+        bytes.extend_from_slice(&[1; TRACKED_STATE_HASH_BYTES]);
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+
+        let error = decode_projection_metadata(&bytes)
+            .expect_err("impossible parent_count should reject before allocation");
+
+        assert!(
+            error
+                .message
+                .contains("parent projections: count exceeds remaining bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn projection_metadata_decode_rejects_small_parent_count_without_parent_bytes() {
+        let mut bytes = projection_metadata_header_with_parent_count(1);
+        append_projection_metadata_footer(&mut bytes);
+
+        let error = decode_projection_metadata(&bytes)
+            .expect_err("parent_count without parent bytes should reject before allocation");
+
+        assert!(
+            error
+                .message
+                .contains("parent projections: count exceeds remaining bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn projection_metadata_decode_rejects_parent_count_without_footer_room() {
+        let bytes = projection_metadata_header_with_parent_count(0);
+
+        let error = decode_projection_metadata(&bytes)
+            .expect_err("metadata without footer bytes should reject before allocation");
+
+        assert!(
+            error.message.contains("parent projections: truncated"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn projection_metadata_decode_accepts_minimal_parent_record_before_footer() {
+        let mut bytes = projection_metadata_header_with_parent_count(1);
+        write_string(&mut bytes, "").expect("empty parent commit_id should encode");
+        bytes.extend_from_slice(&[2; TRACKED_STATE_HASH_BYTES]);
+        append_projection_metadata_footer(&mut bytes);
+
+        let metadata =
+            decode_projection_metadata(&bytes).expect("minimal parent metadata should decode");
+
+        assert_eq!(metadata.commit_id, "commit");
+        assert_eq!(
+            metadata.root_id,
+            TrackedStateRootId::new([1; TRACKED_STATE_HASH_BYTES])
+        );
+        assert_eq!(metadata.parent_roots.len(), 1);
+        assert_eq!(metadata.parent_roots[0].commit_id, "");
+        assert_eq!(
+            metadata.parent_roots[0].root_id,
+            TrackedStateRootId::new([2; TRACKED_STATE_HASH_BYTES])
+        );
+        assert_eq!(metadata.changed_key_count, 0);
+        assert_eq!(metadata.row_count_estimate, 0);
+        assert_eq!(metadata.tree_height, 0);
+        assert_eq!(metadata.primary_chunk_count, 0);
+        assert_eq!(metadata.primary_chunk_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn load_projection_metadata_surfaces_parent_count_decode_error() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut bytes = projection_metadata_header_with_parent_count(1);
+        append_projection_metadata_footer(&mut bytes);
+        let mut writes = storage.new_write_set();
+        writes.put(
+            TRACKED_STATE_PROJECTION_SPACE,
+            key(b"commit".to_vec()),
+            value(bytes),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("corrupt projection metadata should commit");
+
+        let read = storage
+            .begin_read(crate::storage::StorageReadOptions::default())
+            .expect("read should open");
+        let error = load_projection_metadata(&read, "commit")
+            .await
+            .expect_err("stored corrupt projection metadata should surface decode error");
+
+        assert!(
+            error
+                .message
+                .contains("parent projections: count exceeds remaining bytes"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -471,5 +636,22 @@ mod tests {
         }
 
         lines
+    }
+
+    fn projection_metadata_header_with_parent_count(parent_count: u32) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(PROJECTION_METADATA_MAGIC);
+        write_string(&mut bytes, "commit").expect("commit_id should encode");
+        bytes.extend_from_slice(&[1; TRACKED_STATE_HASH_BYTES]);
+        bytes.extend_from_slice(&parent_count.to_le_bytes());
+        bytes
+    }
+
+    fn append_projection_metadata_footer(bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
     }
 }

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -140,11 +140,13 @@ impl TrackedStateTree {
     ) -> Result<usize, LixError> {
         match self.load_node(store, root_id.as_bytes()).await? {
             DecodedNode::Leaf(leaf) => Ok(leaf.entries().len()),
-            DecodedNode::Internal(internal) => Ok(internal
-                .children()
-                .iter()
-                .map(|child| child.subtree_count as usize)
-                .sum()),
+            DecodedNode::Internal(internal) => {
+                let mut total = 0usize;
+                for child in internal.children() {
+                    total = checked_add_subtree_count(total, child.subtree_count)?;
+                }
+                Ok(total)
+            }
         }
     }
 
@@ -708,10 +710,8 @@ impl TrackedStateTree {
             ));
         };
 
-        let base_row_count = leaves
-            .iter()
-            .map(|leaf| leaf.subtree_count as usize)
-            .sum::<usize>();
+        let base_row_count =
+            checked_sum_subtree_counts(leaves.iter().map(|leaf| leaf.subtree_count))?;
         let first_mutation_key = mutation_map
             .keys()
             .next()
@@ -985,14 +985,15 @@ impl TrackedStateTree {
                 child_index..child_index + old_child_count,
                 replacement_children,
             );
-            replacement_children = self.build_internal_level(children, parent_level, &mut chunks);
+            replacement_children =
+                self.build_internal_level(children, parent_level, &mut chunks)?;
             old_child_count = 1;
 
             let Some(frame) = path.pop() else {
                 let mut summaries = replacement_children;
                 let mut tree_height = parent_level + 1;
                 while summaries.len() > 1 {
-                    summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
+                    summaries = self.build_internal_level(summaries, tree_height, &mut chunks)?;
                     tree_height += 1;
                 }
                 let root = summaries.pop().ok_or_else(|| {
@@ -1006,7 +1007,7 @@ impl TrackedStateTree {
                 let built = BuiltTree {
                     root_id: TrackedStateRootId::new(root.child_hash),
                     chunks,
-                    row_count: root.subtree_count as usize,
+                    row_count: subtree_count_to_usize(root.subtree_count)?,
                     tree_height,
                     chunk_bytes,
                 };
@@ -1048,7 +1049,7 @@ impl TrackedStateTree {
         let mut summaries = self.build_leaf_level(entries, &mut chunks);
         let mut tree_height = 1usize;
         while summaries.len() > 1 {
-            summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
+            summaries = self.build_internal_level(summaries, tree_height, &mut chunks)?;
             tree_height += 1;
         }
         let root = summaries.pop().ok_or_else(|| {
@@ -1073,14 +1074,12 @@ impl TrackedStateTree {
         leaf_summaries: Vec<ChildSummary>,
         mut chunks: BTreeMap<[u8; TRACKED_STATE_HASH_BYTES], PendingChunkWrite>,
     ) -> Result<BuiltTree, LixError> {
-        let row_count = leaf_summaries
-            .iter()
-            .map(|summary| summary.subtree_count as usize)
-            .sum();
+        let row_count =
+            checked_sum_subtree_counts(leaf_summaries.iter().map(|summary| summary.subtree_count))?;
         let mut summaries = leaf_summaries;
         let mut tree_height = 1usize;
         while summaries.len() > 1 {
-            summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
+            summaries = self.build_internal_level(summaries, tree_height, &mut chunks)?;
             tree_height += 1;
         }
         let root = summaries.pop().ok_or_else(|| {
@@ -1138,7 +1137,7 @@ impl TrackedStateTree {
         let mut summaries = replacement_children;
         let mut tree_height = levels.len();
         while summaries.len() > 1 {
-            summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
+            summaries = self.build_internal_level(summaries, tree_height, &mut chunks)?;
             tree_height += 1;
         }
         let root = summaries.pop().ok_or_else(|| {
@@ -1152,7 +1151,7 @@ impl TrackedStateTree {
         Ok(BuiltTree {
             root_id: TrackedStateRootId::new(root.child_hash),
             chunks,
-            row_count: root.subtree_count as usize,
+            row_count: subtree_count_to_usize(root.subtree_count)?,
             tree_height,
             chunk_bytes,
         })
@@ -1177,7 +1176,7 @@ impl TrackedStateTree {
                     replacement_children,
                     parent_level,
                     chunks,
-                ),
+                )?,
             });
         }
 
@@ -1211,7 +1210,7 @@ impl TrackedStateTree {
                 window_children.iter().copied(),
                 parent_level,
                 &mut candidate_chunks,
-            );
+            )?;
 
             if let Some((generated_resync_index, existing_resync_index)) = first_resync_index(
                 &candidate_parents,
@@ -1311,12 +1310,14 @@ impl TrackedStateTree {
         children: Vec<ChildSummary>,
         level: usize,
         chunks: &mut BTreeMap<[u8; TRACKED_STATE_HASH_BYTES], PendingChunkWrite>,
-    ) -> Vec<ChildSummary> {
+    ) -> Result<Vec<ChildSummary>, LixError> {
         let groups = chunk_internal_entries(children, &self.options, level);
         groups
             .into_iter()
             .map(|group| {
-                let subtree_count = group.children.iter().map(|child| child.subtree_count).sum();
+                let subtree_count = checked_sum_subtree_counts_u64(
+                    group.children.iter().map(|child| child.subtree_count),
+                )?;
                 let first_key = group
                     .children
                     .first()
@@ -1331,7 +1332,7 @@ impl TrackedStateTree {
                 let (chunk, summary) =
                     child_summary_from_node(node, first_key, last_key, subtree_count);
                 chunks.entry(chunk.hash).or_insert(chunk);
-                summary
+                Ok(summary)
             })
             .collect()
     }
@@ -1341,12 +1342,14 @@ impl TrackedStateTree {
         children: impl IntoIterator<Item = ChildSummaryRef<'a>>,
         level: usize,
         chunks: &mut BTreeMap<[u8; TRACKED_STATE_HASH_BYTES], PendingChunkWrite>,
-    ) -> Vec<ChildSummary> {
+    ) -> Result<Vec<ChildSummary>, LixError> {
         let groups = chunk_internal_entry_refs(children, &self.options, level);
         groups
             .into_iter()
             .map(|group| {
-                let subtree_count = group.children.iter().map(|child| child.subtree_count).sum();
+                let subtree_count = checked_sum_subtree_counts_u64(
+                    group.children.iter().map(|child| child.subtree_count),
+                )?;
                 let first_key = group
                     .children
                     .first()
@@ -1361,7 +1364,7 @@ impl TrackedStateTree {
                 let (chunk, summary) =
                     child_summary_from_node(node, first_key, last_key, subtree_count);
                 chunks.entry(chunk.hash).or_insert(chunk);
-                summary
+                Ok(summary)
             })
             .collect()
     }
@@ -1577,11 +1580,24 @@ impl TrackedStateTree {
                         if child_summary_contained_by_scan_ranges(child, ranges)
                             && request.entity_ids.is_empty()
                         {
-                            count += child.subtree_count as usize;
+                            count = checked_add_subtree_count(count, child.subtree_count)?;
                         } else if child_summary_overlaps_scan_ranges(child, ranges) {
-                            count += self
-                                .count_matching_keys_node(store, child.child_hash, request, ranges)
-                                .await?;
+                            count = count
+                                .checked_add(
+                                    self.count_matching_keys_node(
+                                        store,
+                                        child.child_hash,
+                                        request,
+                                        ranges,
+                                    )
+                                    .await?,
+                                )
+                                .ok_or_else(|| {
+                                    LixError::new(
+                                        "LIX_ERROR_UNKNOWN",
+                                        "tracked-state matching row count overflows usize",
+                                    )
+                                })?;
                         }
                     }
                 }
@@ -2206,6 +2222,48 @@ fn parent_index_for_child_index(
         .unwrap_or_else(|| old_parents.len().saturating_sub(1))
 }
 
+fn checked_add_subtree_count(total: usize, subtree_count: u64) -> Result<usize, LixError> {
+    let subtree_count = subtree_count_to_usize(subtree_count)?;
+    total.checked_add(subtree_count).ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state internal child subtree_count sum overflows usize",
+        )
+    })
+}
+
+fn subtree_count_to_usize(subtree_count: u64) -> Result<usize, LixError> {
+    usize::try_from(subtree_count).map_err(|_| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state internal child subtree_count does not fit usize",
+        )
+    })
+}
+
+fn checked_sum_subtree_counts(counts: impl IntoIterator<Item = u64>) -> Result<usize, LixError> {
+    let mut total = 0usize;
+    for count in counts {
+        total = checked_add_subtree_count(total, count)?;
+    }
+    Ok(total)
+}
+
+fn checked_sum_subtree_counts_u64(counts: impl IntoIterator<Item = u64>) -> Result<u64, LixError> {
+    counts.into_iter().try_fold(0u64, |total, count| {
+        total.checked_add(count).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal child subtree_count sum overflows u64",
+            )
+        })
+    })
+}
+
+fn checked_sum_subtree_summaries(children: &[ChildSummary]) -> Result<u64, LixError> {
+    checked_sum_subtree_counts_u64(children.iter().map(|child| child.subtree_count))
+}
+
 fn child_range_for_parent(
     old_children: &[ChildSummary],
     parent: &ChildSummary,
@@ -2276,7 +2334,7 @@ fn internal_summary(
         first_key,
         last_key,
         child_hash: hash,
-        subtree_count: children.iter().map(|child| child.subtree_count).sum(),
+        subtree_count: checked_sum_subtree_summaries(children)?,
     })
 }
 
@@ -2695,6 +2753,79 @@ mod tests {
             error
                 .message
                 .contains("internal child ranges must be strictly increasing"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn row_count_rejects_persisted_internal_subtree_count_overflow() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tree = TrackedStateTree::new();
+        let root_id = stage_raw_root_chunk(&storage, oversized_subtree_count_internal_node());
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tree
+            .row_count(&store, &root_id)
+            .await
+            .expect_err("corrupt persisted subtree counts must reject");
+
+        assert!(
+            error.message.contains("internal child subtree_count")
+                || error.message.contains("row count overflows"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn count_matching_keys_rejects_persisted_internal_subtree_count_overflow() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tree = TrackedStateTree::new();
+        let root_id = stage_raw_root_chunk(&storage, oversized_subtree_count_internal_node());
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tree
+            .count_matching_keys(&store, &root_id, &TrackedStateTreeScanRequest::default())
+            .await
+            .expect_err("corrupt persisted subtree counts must reject");
+
+        assert!(
+            error.message.contains("internal child subtree_count")
+                || error.message.contains("matching row count overflows"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_mutations_rejects_persisted_internal_subtree_count_overflow() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tree = TrackedStateTree::new();
+        let root_id = stage_oversized_subtree_count_tree(&storage);
+
+        let error = apply_mutations_for_test(
+            &tree,
+            &storage,
+            Some(&root_id),
+            vec![
+                mutation_owned(
+                    key("schema", None, "echo"),
+                    value("change-echo", Some("{}")),
+                ),
+                mutation_owned(
+                    key("schema", None, "foxtrot"),
+                    value("change-foxtrot", Some("{}")),
+                ),
+            ],
+            None,
+        )
+        .await
+        .expect_err("mutating corrupt persisted subtree counts must reject");
+
+        assert!(
+            error.message.contains("internal child subtree_count"),
             "unexpected error: {error}"
         );
     }
@@ -3175,6 +3306,13 @@ mod tests {
         storage: &StorageContext<InMemoryStorageBackend>,
         node: Vec<u8>,
     ) -> TrackedStateRootId {
+        TrackedStateRootId::new(stage_raw_chunk(storage, node))
+    }
+
+    fn stage_raw_chunk(
+        storage: &StorageContext<InMemoryStorageBackend>,
+        node: Vec<u8>,
+    ) -> [u8; TRACKED_STATE_HASH_BYTES] {
         let hash = hash_bytes(&node);
         let chunk = PendingChunkWrite { hash, data: node };
         let mut writes = storage.new_write_set();
@@ -3182,7 +3320,68 @@ mod tests {
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .expect("raw chunk should commit");
-        TrackedStateRootId::new(hash)
+        hash
+    }
+
+    fn stage_oversized_subtree_count_tree(
+        storage: &StorageContext<InMemoryStorageBackend>,
+    ) -> TrackedStateRootId {
+        let keys = oversized_subtree_count_keys();
+        let left_hash = stage_raw_chunk(
+            storage,
+            encode_leaf_node(&[EncodedLeafEntry {
+                key: keys[0].clone(),
+                value: encode_value(&value("change-alpha", Some("{}"))),
+            }]),
+        );
+        let right_hash = stage_raw_chunk(
+            storage,
+            encode_leaf_node(&[EncodedLeafEntry {
+                key: keys[2].clone(),
+                value: encode_value(&value("change-charlie", Some("{}"))),
+            }]),
+        );
+        stage_raw_root_chunk(
+            storage,
+            oversized_subtree_count_internal_node_with_hashes(left_hash, right_hash),
+        )
+    }
+
+    fn oversized_subtree_count_internal_node() -> Vec<u8> {
+        oversized_subtree_count_internal_node_with_hashes(
+            [1; TRACKED_STATE_HASH_BYTES],
+            [2; TRACKED_STATE_HASH_BYTES],
+        )
+    }
+
+    fn oversized_subtree_count_internal_node_with_hashes(
+        left_hash: [u8; TRACKED_STATE_HASH_BYTES],
+        right_hash: [u8; TRACKED_STATE_HASH_BYTES],
+    ) -> Vec<u8> {
+        let keys = oversized_subtree_count_keys();
+        encode_internal_node(&[
+            ChildSummary {
+                first_key: keys[0].clone(),
+                last_key: keys[1].clone(),
+                child_hash: left_hash,
+                subtree_count: u64::MAX,
+            },
+            ChildSummary {
+                first_key: keys[2].clone(),
+                last_key: keys[3].clone(),
+                child_hash: right_hash,
+                subtree_count: 1,
+            },
+        ])
+    }
+
+    fn oversized_subtree_count_keys() -> Vec<Vec<u8>> {
+        let mut keys = ["alpha", "bravo", "charlie", "delta"]
+            .into_iter()
+            .map(|entity_id| encode_key(&key("schema", None, entity_id)))
+            .collect::<Vec<_>>();
+        keys.sort();
+        keys
     }
 
     fn encoded_entries_with_change_id(change_id: &str) -> Vec<EncodedLeafEntry> {

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -7,18 +7,18 @@ use std::{
 
 use crate::storage::{StorageRead, StorageWriteSet};
 use crate::tracked_state::codec::{
-    boundary_trigger, child_summary_from_node, decode_key, decode_key_with_trusted_prefix,
-    decode_node, decode_node_ref, decode_value, decode_visible_value, encode_internal_node,
+    ChildSummary, ChildSummaryRef, DecodedLeafNodeRef, DecodedNode, DecodedNodeRef,
+    EncodedLeafEntry, EncodedLeafEntryRef, PendingChunkWrite, boundary_trigger,
+    child_summary_from_node, decode_key, decode_key_with_trusted_prefix, decode_node,
+    decode_node_ref, decode_value, decode_visible_value, encode_internal_node,
     encode_internal_node_refs, encode_key, encode_leaf_node, encode_leaf_node_refs,
-    encode_schema_file_prefix, encode_schema_key_prefix, ChildSummary, ChildSummaryRef,
-    DecodedLeafNodeRef, DecodedNode, DecodedNodeRef, EncodedLeafEntry, EncodedLeafEntryRef,
-    PendingChunkWrite,
+    encode_schema_file_prefix, encode_schema_key_prefix,
 };
 use crate::tracked_state::storage;
 use crate::tracked_state::types::{
-    TrackedStateApplyResult, TrackedStateIndexValue, TrackedStateKey, TrackedStateMutation,
-    TrackedStateRootId, TrackedStateTreeDiffEntry, TrackedStateTreeScanRequest,
-    TRACKED_STATE_HASH_BYTES,
+    TRACKED_STATE_HASH_BYTES, TrackedStateApplyResult, TrackedStateIndexValue, TrackedStateKey,
+    TrackedStateMutation, TrackedStateRootId, TrackedStateTreeDiffEntry,
+    TrackedStateTreeScanRequest,
 };
 use crate::{LixError, NullableKeyFilter};
 
@@ -2453,7 +2453,7 @@ mod tests {
     use crate::entity_identity::EntityIdentity;
     use crate::storage::StorageContext;
     use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
-    use crate::tracked_state::codec::encode_value;
+    use crate::tracked_state::codec::{encode_value, hash_bytes};
 
     #[tokio::test]
     async fn exact_read_roundtrips_from_applied_root() {
@@ -2626,6 +2626,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn scan_rejects_unsorted_persisted_leaf_chunk() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tree = TrackedStateTree::new();
+        let alpha = key("schema", None, "alpha");
+        let bravo = key("schema", None, "bravo");
+        let node = encode_leaf_node(&[
+            EncodedLeafEntry {
+                key: encode_key(&bravo),
+                value: encode_value(&value("change-bravo", Some("{}"))),
+            },
+            EncodedLeafEntry {
+                key: encode_key(&alpha),
+                value: encode_value(&value("change-alpha", Some("{}"))),
+            },
+        ]);
+        let root_id = stage_raw_root_chunk(&storage, node);
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tree
+            .scan(&store, &root_id, &TrackedStateTreeScanRequest::default())
+            .await
+            .expect_err("corrupt persisted leaf order must reject");
+
+        assert!(
+            error
+                .message
+                .contains("leaf keys must be strictly increasing"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_many_rejects_invalid_persisted_internal_child_ranges() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let tree = TrackedStateTree::new();
+        let alpha = encode_key(&key("schema", None, "alpha"));
+        let bravo = encode_key(&key("schema", None, "bravo"));
+        let charlie = encode_key(&key("schema", None, "charlie"));
+        let delta = encode_key(&key("schema", None, "delta"));
+        let node = encode_internal_node(&[
+            ChildSummary {
+                first_key: alpha.clone(),
+                last_key: charlie,
+                child_hash: [1; TRACKED_STATE_HASH_BYTES],
+                subtree_count: 2,
+            },
+            ChildSummary {
+                first_key: bravo,
+                last_key: delta,
+                child_hash: [2; TRACKED_STATE_HASH_BYTES],
+                subtree_count: 2,
+            },
+        ]);
+        let root_id = stage_raw_root_chunk(&storage, node);
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let error = tree
+            .get_many(&store, &root_id, &[key("schema", None, "alpha")])
+            .await
+            .expect_err("corrupt persisted internal ranges must reject");
+
+        assert!(
+            error
+                .message
+                .contains("internal child ranges must be strictly increasing"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn scan_schema_file_prefix_honors_tombstones_and_limit() {
         let storage = StorageContext::new(InMemoryStorageBackend::new());
         let tree = TrackedStateTree::new();
@@ -2794,16 +2868,18 @@ mod tests {
                 .expect("branch b shared row should load"),
             Some(value("shared-change", Some("{\"shared\":true}")))
         );
-        assert!(tree
-            .get(&store, &branch_a.root_id, &branch_b_key)
-            .await
-            .expect("branch a should read")
-            .is_none());
-        assert!(tree
-            .get(&store, &branch_b.root_id, &branch_a_key)
-            .await
-            .expect("branch b should read")
-            .is_none());
+        assert!(
+            tree.get(&store, &branch_a.root_id, &branch_b_key)
+                .await
+                .expect("branch a should read")
+                .is_none()
+        );
+        assert!(
+            tree.get(&store, &branch_b.root_id, &branch_a_key)
+                .await
+                .expect("branch b should read")
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -2843,9 +2919,11 @@ mod tests {
             .collect_leaf_entries(&read, &base.root_id)
             .await
             .expect("base entries should collect");
-        assert!(canonical_entries
-            .windows(2)
-            .all(|window| window[0].key < window[1].key));
+        assert!(
+            canonical_entries
+                .windows(2)
+                .all(|window| window[0].key < window[1].key)
+        );
         let encoded_changed_key = encode_key(&changed_key);
         let encoded_changed_value = encode_value(&changed_value);
         let index = canonical_entries
@@ -3091,6 +3169,20 @@ mod tests {
 
     fn mutation_owned(key: TrackedStateKey, value: TrackedStateIndexValue) -> TrackedStateMutation {
         mutation(&key, &value)
+    }
+
+    fn stage_raw_root_chunk(
+        storage: &StorageContext<InMemoryStorageBackend>,
+        node: Vec<u8>,
+    ) -> TrackedStateRootId {
+        let hash = hash_bytes(&node);
+        let chunk = PendingChunkWrite { hash, data: node };
+        let mut writes = storage.new_write_set();
+        storage::stage_chunks(&mut writes, &[chunk]);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("raw chunk should commit");
+        TrackedStateRootId::new(hash)
     }
 
     fn encoded_entries_with_change_id(change_id: &str) -> Vec<EncodedLeafEntry> {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -11,7 +11,9 @@ use crate::entity_identity::EntityIdentity;
 use crate::functions::FunctionContext;
 use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::storage::{StorageRead, StorageWriteSet};
-use crate::tracked_state::{TrackedStateContext, TrackedStateDeltaRef};
+use crate::tracked_state::{
+    TrackedStateContext, TrackedStateDeltaRef, TrackedStateDiffRow, TrackedStateRowRequest,
+};
 use crate::transaction::prepare_version_ref_row;
 use crate::transaction::staging::PreparedWriteSet;
 use crate::transaction::types::{PreparedAdoptedStateRow, PreparedStateRow, StagedCommitMembers};
@@ -182,6 +184,227 @@ fn json_payloads_from_state_row(
         .map(|json| NormalizedJsonRef::trusted_prehashed(json.normalized.as_ref(), json.json_ref))
 }
 
+async fn validate_adopted_rows_match_source_parent(
+    read: &mut (impl StorageRead + Send + Sync),
+    state_rows: &[PreparedStateRow],
+    tracked_row_indices_by_commit: &BTreeMap<String, Vec<RowIndex>>,
+    rows: &[PreparedAdoptedStateRow],
+) -> Result<(), LixError> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let staged_source_rows =
+        staged_source_rows_by_commit_and_key(state_rows, tracked_row_indices_by_commit)?;
+    let mut reader = TrackedStateContext::new().reader(read);
+    let mut requests_by_source_parent =
+        BTreeMap::<String, Vec<(usize, TrackedStateRowRequest)>>::new();
+    for (index, row) in rows.iter().enumerate() {
+        validate_adopted_row_payload_refs(row)?;
+        let key = adopted_row_tracked_key(row);
+        if let Some(source_row) =
+            staged_source_rows.get(&(row.source_parent_commit_id.clone(), key.clone()))
+        {
+            validate_adopted_row_matches_staged_source(row, source_row)?;
+            continue;
+        }
+        requests_by_source_parent
+            .entry(row.source_parent_commit_id.clone())
+            .or_default()
+            .push((
+                index,
+                TrackedStateRowRequest {
+                    schema_key: row.schema_key.clone(),
+                    entity_id: row.entity_id.clone(),
+                    file_id: match &row.file_id {
+                        Some(file_id) => crate::NullableKeyFilter::Value(file_id.clone()),
+                        None => crate::NullableKeyFilter::Null,
+                    },
+                },
+            ));
+    }
+
+    for (source_parent_commit_id, indexed_requests) in requests_by_source_parent {
+        let requests = indexed_requests
+            .iter()
+            .map(|(_, request)| request.clone())
+            .collect::<Vec<_>>();
+        let source_entries = reader
+            .load_index_entries_at_commit(&source_parent_commit_id, &requests)
+            .await?;
+        for ((row_index, _), source_entry) in indexed_requests.iter().zip(&source_entries) {
+            if source_entry.is_none() {
+                let row = &rows[*row_index];
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "adopted change '{}' is missing from source parent '{}' tracked projection",
+                        row.change_id, row.source_parent_commit_id
+                    ),
+                ));
+            }
+        }
+        let mut validation_rows = Vec::new();
+        for (source_entry, (row_index, _)) in source_entries.iter().zip(&indexed_requests) {
+            if let Some(source_row) = source_entry {
+                validation_rows.push((
+                    source_row,
+                    rows[*row_index].source_parent_commit_id.as_str(),
+                ));
+            }
+        }
+        let validation_refs = validation_rows
+            .iter()
+            .map(|(row, commit_id)| (*row, *commit_id))
+            .collect::<Vec<_>>();
+        reader
+            .validate_diff_rows_for_commits_against_changelog(&validation_refs)
+            .await?;
+        for ((row_index, _), source_entry) in indexed_requests.into_iter().zip(source_entries) {
+            let row = &rows[row_index];
+            let Some(source_row) = source_entry else { unreachable!() };
+            validate_adopted_row_matches_source_parent(row, &source_row)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_adopted_rows_are_parented_by_commits(
+    adopted_rows: &[PreparedAdoptedStateRow],
+    adopted_row_indices_by_commit: &BTreeMap<String, Vec<AdoptedRowIndex>>,
+    commit_rows: &[FinalizedCommitRow],
+) -> Result<(), LixError> {
+    let mut indexed_rows = vec![false; adopted_rows.len()];
+    let commit_rows_by_id = commit_rows
+        .iter()
+        .map(|row| (row.commit_id.as_str(), row))
+        .collect::<BTreeMap<_, _>>();
+    for (commit_id, row_indices) in adopted_row_indices_by_commit {
+        let Some(commit_row) = commit_rows_by_id.get(commit_id.as_str()) else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("adopted rows for commit '{commit_id}' have no finalized commit row"),
+            ));
+        };
+        for &row_index in row_indices {
+            let Some(row_seen) = indexed_rows.get_mut(row_index) else {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("adopted row index {row_index} for commit '{commit_id}' is out of bounds"),
+                ));
+            };
+            *row_seen = true;
+            adopted_source_parent_ordinal(commit_row, &adopted_rows[row_index])?;
+        }
+    }
+    if let Some(row_index) = indexed_rows.iter().position(|seen| !seen) {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("adopted row index {row_index} is not assigned to a finalized commit"),
+        ));
+    }
+    Ok(())
+}
+
+fn staged_source_rows_by_commit_and_key<'a>(
+    state_rows: &'a [PreparedStateRow],
+    tracked_row_indices_by_commit: &BTreeMap<String, Vec<RowIndex>>,
+) -> Result<BTreeMap<(String, AdoptedProjectionKey), &'a PreparedStateRow>, LixError> {
+    let mut out = BTreeMap::new();
+    for (commit_id, indices) in tracked_row_indices_by_commit {
+        for &index in indices {
+            let row = &state_rows[index];
+            out.insert((commit_id.clone(), state_row_tracked_key(row)), row);
+        }
+    }
+    Ok(out)
+}
+
+fn adopted_row_tracked_key(row: &PreparedAdoptedStateRow) -> AdoptedProjectionKey {
+    AdoptedProjectionKey {
+        schema_key: row.schema_key.clone(),
+        file_id: row.file_id.clone(),
+        entity_id: row.entity_id.clone(),
+    }
+}
+
+fn state_row_tracked_key(row: &PreparedStateRow) -> AdoptedProjectionKey {
+    AdoptedProjectionKey {
+        schema_key: row.schema_key.clone(),
+        file_id: row.file_id.clone(),
+        entity_id: row.entity_id.clone(),
+    }
+}
+
+fn validate_adopted_row_matches_staged_source(
+    row: &PreparedAdoptedStateRow,
+    source_row: &PreparedStateRow,
+) -> Result<(), LixError> {
+    if source_row.change_id.as_deref() != Some(row.change_id.as_str())
+        || source_row.commit_id.as_deref() != Some(row.source_commit_id.as_str())
+        || source_row.snapshot.as_ref().map(|json| json.json_ref) != row.snapshot_ref
+        || source_row.metadata.as_ref().map(|json| json.json_ref) != row.metadata_ref
+        || source_row.created_at != row.created_at
+        || source_row.updated_at != row.updated_at
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "adopted change '{}' projection does not match source parent '{}' tracked row",
+                row.change_id, row.source_parent_commit_id
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_adopted_row_matches_source_parent(
+    row: &PreparedAdoptedStateRow,
+    source_row: &TrackedStateDiffRow,
+) -> Result<(), LixError> {
+    if source_row.change_id != row.change_id
+        || source_row.commit_id != row.source_commit_id
+        || source_row.deleted != row.snapshot_ref.is_none()
+        || source_row.snapshot_ref != row.snapshot_ref
+        || source_row.metadata_ref != row.metadata_ref
+        || source_row.created_at != row.created_at
+        || source_row.updated_at != row.updated_at
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "adopted change '{}' projection does not match source parent '{}' tracked row",
+                row.change_id, row.source_parent_commit_id
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_adopted_row_payload_refs(row: &PreparedAdoptedStateRow) -> Result<(), LixError> {
+    let snapshot_ref = row.snapshot.as_ref().map(|json| json.json_ref);
+    if snapshot_ref != row.snapshot_ref {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "adopted change '{}' snapshot_ref does not match materialized snapshot",
+                row.change_id
+            ),
+        ));
+    }
+    let metadata_ref = row.metadata.as_ref().map(|json| json.json_ref);
+    if metadata_ref != row.metadata_ref {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "adopted change '{}' metadata_ref does not match materialized metadata",
+                row.change_id
+            ),
+        ));
+    }
+    Ok(())
+}
+
 async fn existing_untracked_overlay_delete_identities<'a>(
     read: &(impl StorageRead + Send + Sync + ?Sized),
     identities: impl IntoIterator<Item = UntrackedStateIdentityRef<'a>>,
@@ -251,6 +474,13 @@ struct StagedChangelogCommit {
     adopted_locators: Vec<ChangelogChangeLocator>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct AdoptedProjectionKey {
+    schema_key: String,
+    file_id: Option<String>,
+    entity_id: EntityIdentity,
+}
+
 async fn stage_changelog_commits(
     read: &mut (impl StorageRead + Send + Sync),
     writes: &mut StorageWriteSet,
@@ -266,9 +496,21 @@ async fn stage_changelog_commits(
     ),
     LixError,
 > {
+    validate_adopted_rows_are_parented_by_commits(
+        adopted_rows,
+        adopted_row_indices_by_commit,
+        commit_rows,
+    )?;
     if commit_rows.is_empty() {
         return Ok((BTreeMap::new(), BTreeMap::new()));
     }
+    validate_adopted_rows_match_source_parent(
+        read,
+        state_rows,
+        tracked_row_indices_by_commit,
+        adopted_rows,
+    )
+    .await?;
 
     let mut commits = Vec::with_capacity(commit_rows.len());
     let mut changes = Vec::new();
@@ -1210,6 +1452,31 @@ mod tests {
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .expect("source commit should persist");
+        let mut root_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("root rebuild read should open");
+        let mut root_writes = StorageWriteSet::new();
+        crate::tracked_state::TrackedStateContext::new()
+            .root_rebuilder(&mut root_read, &mut root_writes)
+            .ensure_projection_root("source-commit")
+            .await
+            .expect("source-commit root should rebuild");
+        storage
+            .commit_write_set(root_writes, StorageWriteOptions::default())
+            .expect("source-commit root should persist");
+
+        let mut root_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("root rebuild read should open");
+        let mut root_writes = StorageWriteSet::new();
+        crate::tracked_state::TrackedStateContext::new()
+            .root_rebuilder(&mut root_read, &mut root_writes)
+            .ensure_projection_root("source-head")
+            .await
+            .expect("source-head root should rebuild");
+        storage
+            .commit_write_set(root_writes, StorageWriteOptions::default())
+            .expect("source-head root should persist");
 
         let mut adopted_writes = StorageWriteSet::new();
         let mut adopted_read = storage
@@ -1264,6 +1531,737 @@ mod tests {
         assert_eq!(body.membership[0].member_change_id, "source-change");
         assert_eq!(body.membership[0].role, MembershipRole::Adopted);
         assert_eq!(body.membership[0].source_parent_ordinal, Some(1));
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_projection_that_differs_from_source_parent() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let binary_cas = BinaryCasContext::new();
+        let version_ctx = VersionContext::new(Arc::new(UntrackedStateContext::new()));
+
+        let mut source_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("source read should open");
+        let mut source_row = tracked_global_row("source-change");
+        source_row.commit_id = Some("source-commit".to_string());
+        let source_writes = commit_prepared_writes(
+            &binary_cas,
+            &version_ctx,
+            None,
+            &mut source_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![source_row],
+                adopted_rows: Vec::new(),
+                commit_members_by_version: BTreeMap::from([(
+                    GLOBAL_VERSION_ID.to_string(),
+                    members_with_commit(
+                        "source-commit",
+                        "source-commit-change",
+                        ["source-change"],
+                    ),
+                )]),
+                extra_commit_parents_by_version: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("source commit should prepare");
+        storage
+            .commit_write_set(source_writes, StorageWriteOptions::default())
+            .expect("source commit should persist");
+
+        let forged_snapshot = crate::transaction::types::stage_json_from_value(
+            crate::transaction::types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "value": 999 }),
+            ),
+            "forged adopted row snapshot",
+        )
+        .expect("forged snapshot should stage");
+        let mut adopted_row =
+            adopted_global_row("source-change", "source-commit", "source-commit", "adopt-commit");
+        adopted_row.snapshot_ref = Some(forged_snapshot.json_ref);
+        adopted_row.snapshot = Some(forged_snapshot);
+
+        let mut adopt_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("adopt read should open");
+        let err = commit_prepared_writes(
+            &binary_cas,
+            &version_ctx,
+            None,
+            &mut adopt_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: Vec::new(),
+                adopted_rows: vec![adopted_row],
+                commit_members_by_version: BTreeMap::from([(
+                    GLOBAL_VERSION_ID.to_string(),
+                    members_with_commit("adopt-commit", "adopt-commit-change", ["source-change"]),
+                )]),
+                extra_commit_parents_by_version: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("forged adopted projection should be rejected");
+        assert!(
+            err.message
+                .contains("projection does not match source parent"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_projection_matching_corrupt_source_root() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let binary_cas = BinaryCasContext::new();
+        let version_ctx = VersionContext::new(Arc::new(UntrackedStateContext::new()));
+
+        let mut source_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("source read should open");
+        let mut source_row = tracked_global_row("source-change");
+        source_row.commit_id = Some("source-commit".to_string());
+        let source_writes = commit_prepared_writes(
+            &binary_cas,
+            &version_ctx,
+            None,
+            &mut source_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![source_row],
+                adopted_rows: Vec::new(),
+                commit_members_by_version: BTreeMap::from([(
+                    GLOBAL_VERSION_ID.to_string(),
+                    members_with_commit(
+                        "source-commit",
+                        "source-commit-change",
+                        ["source-change"],
+                    ),
+                )]),
+                extra_commit_parents_by_version: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("source commit should prepare");
+        storage
+            .commit_write_set(source_writes, StorageWriteOptions::default())
+            .expect("source commit should persist");
+
+        let request = TrackedStateRowRequest {
+            schema_key: "test_schema".to_string(),
+            entity_id: crate::entity_identity::EntityIdentity::single("entity-1"),
+            file_id: crate::NullableKeyFilter::Null,
+        };
+        let corrupt_row = {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("read should open");
+            let entries = crate::tracked_state::TrackedStateContext::new()
+                .reader(read)
+                .load_index_entries_at_commit("source-commit", &[request])
+                .await
+                .expect("source row should load");
+            entries
+                .into_iter()
+                .next()
+                .flatten()
+                .expect("source row should exist")
+        };
+        let forged_snapshot = crate::transaction::types::stage_json_from_value(
+            crate::transaction::types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "value": 999 }),
+            ),
+            "forged adopted row snapshot",
+        )
+        .expect("forged snapshot should stage");
+        {
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("corrupt read should open");
+            let mut writes = storage.new_write_set();
+            let entity_id = crate::entity_identity::EntityIdentity::single("entity-1");
+            let source_commit_id = "source-commit".to_string();
+            let change = crate::changelog::ChangeRef {
+                id: "source-change",
+                authored_commit_id: Some(&source_commit_id),
+                entity_id: &entity_id,
+                schema_key: "test_schema",
+                file_id: None,
+                snapshot_ref: Some(&forged_snapshot.json_ref),
+                metadata_ref: None,
+                created_at: "2026-01-01T00:00:00Z",
+            };
+            let locator = crate::changelog::ChangeLocatorRef {
+                change_id: &corrupt_row.change_id,
+                commit_id: &corrupt_row.commit_id,
+                location: corrupt_row.change_location.as_ref(),
+            };
+            crate::tracked_state::TrackedStateContext::new()
+                .writer(&mut read, &mut writes)
+                .stage_projection_root(
+                    "source-commit",
+                    None,
+                    [TrackedStateDeltaRef {
+                        change,
+                        locator,
+                        created_at: "2026-01-01T00:00:00Z",
+                        updated_at: "2026-01-01T00:00:00Z",
+                    }],
+                )
+                .await
+                .expect("corrupt source root should stage");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("corrupt source root should commit");
+        }
+        {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .expect("corrupt verification read should open");
+            let request = TrackedStateRowRequest {
+                schema_key: "test_schema".to_string(),
+                entity_id: crate::entity_identity::EntityIdentity::single("entity-1"),
+                file_id: crate::NullableKeyFilter::Null,
+            };
+            let entries = crate::tracked_state::TrackedStateContext::new()
+                .reader(read)
+                .load_index_entries_at_commit("source-commit", &[request])
+                .await
+                .expect("corrupt source row should load");
+            let stored_row = entries
+                .into_iter()
+                .next()
+                .flatten()
+                .expect("corrupt source row should exist");
+            assert_eq!(stored_row.snapshot_ref, Some(forged_snapshot.json_ref));
+        }
+
+        let mut adopted_row =
+            adopted_global_row("source-change", "source-commit", "source-commit", "adopt-commit");
+        adopted_row.snapshot_ref = Some(forged_snapshot.json_ref);
+        adopted_row.snapshot = Some(forged_snapshot);
+        let mut adopt_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("adopt read should open");
+        let err = commit_prepared_writes(
+            &binary_cas,
+            &version_ctx,
+            None,
+            &mut adopt_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: Vec::new(),
+                adopted_rows: vec![adopted_row],
+                commit_members_by_version: BTreeMap::from([(
+                    GLOBAL_VERSION_ID.to_string(),
+                    members_with_commit("adopt-commit", "adopt-commit-change", ["source-change"]),
+                )]),
+                extra_commit_parents_by_version: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("corrupt source projection should be rejected");
+        assert!(
+            err.message
+                .contains("payload refs do not match changelog change"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_change_that_is_not_source_parent_winner() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut writes = StorageWriteSet::new();
+        let mut source_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("source read should open");
+        let mut source_row = tracked_global_row("source-change");
+        source_row.commit_id = Some("source-commit".to_string());
+        let source_commits = vec![
+            FinalizedCommitRow {
+                commit_id: "target-commit".to_string(),
+                parent_commit_ids: Vec::new(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                change_id: "target-commit-change".to_string(),
+            },
+            FinalizedCommitRow {
+                commit_id: "source-commit".to_string(),
+                parent_commit_ids: Vec::new(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                change_id: "source-commit-change".to_string(),
+            },
+            FinalizedCommitRow {
+                commit_id: "source-head".to_string(),
+                parent_commit_ids: vec!["source-commit".to_string()],
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                change_id: "source-head-change".to_string(),
+            },
+        ];
+        stage_changelog_commits(
+            &mut source_read,
+            &mut writes,
+            &[source_row],
+            &BTreeMap::from([("source-commit".to_string(), vec![0])]),
+            &[],
+            &BTreeMap::new(),
+            &source_commits,
+        )
+        .await
+        .expect("source history should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("source history should persist");
+        let mut root_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("root rebuild read should open");
+        let mut root_writes = StorageWriteSet::new();
+        crate::tracked_state::TrackedStateContext::new()
+            .root_rebuilder(&mut root_read, &mut root_writes)
+            .ensure_projection_root("source-head")
+            .await
+            .expect("source-head root should rebuild");
+        storage
+            .commit_write_set(root_writes, StorageWriteOptions::default())
+            .expect("source-head root should persist");
+
+        let mut adopted_writes = StorageWriteSet::new();
+        let mut adopted_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("adopted read should open");
+        let adopted_row =
+            adopted_global_row("source-change", "wrong-source", "source-head", "merge-commit");
+        let merge_commits = vec![FinalizedCommitRow {
+            commit_id: "merge-commit".to_string(),
+            parent_commit_ids: vec!["target-commit".to_string(), "source-head".to_string()],
+            created_at: "2026-01-01T00:00:02Z".to_string(),
+            change_id: "merge-commit-change".to_string(),
+        }];
+        let err = stage_changelog_commits(
+            &mut adopted_read,
+            &mut adopted_writes,
+            &[],
+            &BTreeMap::new(),
+            &[adopted_row],
+            &BTreeMap::from([("merge-commit".to_string(), vec![0])]),
+            &merge_commits,
+        )
+        .await
+        .expect_err("non-winning source change should be rejected");
+        assert!(
+            err.message.contains("not the first-parent winner"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_projection_missing_from_source_parent() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut writes = StorageWriteSet::new();
+        let mut source_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("source read should open");
+        let source_commits = vec![
+            FinalizedCommitRow {
+                commit_id: "target-commit".to_string(),
+                parent_commit_ids: Vec::new(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                change_id: "target-commit-change".to_string(),
+            },
+            FinalizedCommitRow {
+                commit_id: "empty-source-parent".to_string(),
+                parent_commit_ids: Vec::new(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                change_id: "empty-source-change".to_string(),
+            },
+        ];
+        stage_changelog_commits(
+            &mut source_read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[],
+            &BTreeMap::new(),
+            &source_commits,
+        )
+        .await
+        .expect("empty source parent should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("empty source parent should persist");
+        let mut root_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("empty root rebuild read should open");
+        let mut root_writes = StorageWriteSet::new();
+        crate::tracked_state::TrackedStateContext::new()
+            .root_rebuilder(&mut root_read, &mut root_writes)
+            .ensure_projection_root("empty-source-parent")
+            .await
+            .expect("empty source parent root should rebuild");
+        storage
+            .commit_write_set(root_writes, StorageWriteOptions::default())
+            .expect("empty source parent root should persist");
+
+        let mut adopted_writes = StorageWriteSet::new();
+        let mut adopted_read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("adopted read should open");
+        let adopted_row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "empty-source-parent",
+            "merge-commit",
+        );
+        let merge_commits = vec![FinalizedCommitRow {
+            commit_id: "merge-commit".to_string(),
+            parent_commit_ids: vec![
+                "target-commit".to_string(),
+                "empty-source-parent".to_string(),
+            ],
+            created_at: "2026-01-01T00:00:02Z".to_string(),
+            change_id: "merge-commit-change".to_string(),
+        }];
+        let err = stage_changelog_commits(
+            &mut adopted_read,
+            &mut adopted_writes,
+            &[],
+            &BTreeMap::new(),
+            &[adopted_row],
+            &BTreeMap::from([("merge-commit".to_string(), vec![0])]),
+            &merge_commits,
+        )
+        .await
+        .expect_err("missing source parent identity should be rejected");
+        assert!(
+            err.message.contains("is missing from source parent"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_row_for_non_finalized_commit() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let adopted_row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "missing-commit",
+        );
+        let err = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[adopted_row],
+            &BTreeMap::from([("missing-commit".to_string(), vec![0])]),
+            &[FinalizedCommitRow {
+                commit_id: "other-commit".to_string(),
+                parent_commit_ids: vec!["source-parent".to_string()],
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                change_id: "other-commit-change".to_string(),
+            }],
+        )
+        .await
+        .expect_err("adopted rows without finalized commit should be rejected");
+        assert!(
+            err.message.contains("have no finalized commit row"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_row_without_any_finalized_commit() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let adopted_row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "missing-commit",
+        );
+        let err = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[adopted_row],
+            &BTreeMap::from([("missing-commit".to_string(), vec![0])]),
+            &[],
+        )
+        .await
+        .expect_err("adopted rows without any finalized commit should be rejected");
+        assert!(
+            err.message.contains("have no finalized commit row"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_row_whose_source_parent_is_not_parented() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let adopted_row =
+            adopted_global_row("source-change", "source-commit", "source-parent", "merge-commit");
+        let err = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[adopted_row],
+            &BTreeMap::from([("merge-commit".to_string(), vec![0])]),
+            &[FinalizedCommitRow {
+                commit_id: "merge-commit".to_string(),
+                parent_commit_ids: vec!["target-parent".to_string()],
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                change_id: "merge-commit-change".to_string(),
+            }],
+        )
+        .await
+        .expect_err("unparented adopted source parent should be rejected");
+        assert!(
+            err.message.contains("is not parented by adopting commit"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_unindexed_adopted_row_before_source_validation() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let adopted_row =
+            adopted_global_row("source-change", "source-commit", "source-parent", "merge-commit");
+        let err = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[adopted_row],
+            &BTreeMap::new(),
+            &[FinalizedCommitRow {
+                commit_id: "merge-commit".to_string(),
+                parent_commit_ids: vec!["source-parent".to_string()],
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                change_id: "merge-commit-change".to_string(),
+            }],
+        )
+        .await
+        .expect_err("unindexed adopted row should be rejected");
+        assert!(
+            err.message
+                .contains("is not assigned to a finalized commit"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn adopted_projection_rejects_metadata_ref_mismatch() {
+        let metadata = crate::transaction::types::stage_json_from_value(
+            crate::transaction::types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "meta": true }),
+            ),
+            "test adopted row metadata",
+        )
+        .expect("metadata should stage");
+        let mut row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "adopt-commit",
+        );
+        row.metadata = Some(metadata);
+        row.metadata_ref = Some(crate::json_store::JsonRef::for_content(
+            br#"{"meta":"forged-ref"}"#,
+        ));
+
+        let err = validate_adopted_row_payload_refs(&row)
+            .expect_err("metadata ref corruption should be rejected");
+        assert!(
+            err.message
+                .contains("metadata_ref does not match materialized metadata"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_metadata_ref_mismatch() {
+        let mut row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "merge-commit",
+        );
+        let metadata = crate::transaction::types::stage_json_from_value(
+            crate::transaction::types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "meta": true }),
+            ),
+            "test adopted row metadata",
+        )
+        .expect("metadata should stage");
+        row.metadata = Some(metadata);
+        row.metadata_ref = Some(crate::json_store::JsonRef::for_content(
+            br#"{"meta":"forged-ref"}"#,
+        ));
+
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let err = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[row],
+            &BTreeMap::from([("merge-commit".to_string(), vec![0])]),
+            &[FinalizedCommitRow {
+                commit_id: "merge-commit".to_string(),
+                parent_commit_ids: vec!["source-parent".to_string()],
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                change_id: "merge-commit-change".to_string(),
+            }],
+        )
+        .await
+        .expect_err("metadata ref corruption should be rejected in commit path");
+        assert!(
+            err.message
+                .contains("metadata_ref does not match materialized metadata"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn adopted_projection_rejects_tombstone_snapshot_inconsistency() {
+        let mut row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "adopt-commit",
+        );
+        row.snapshot_ref = None;
+
+        let err = validate_adopted_row_payload_refs(&row)
+            .expect_err("snapshot tombstone inconsistency should be rejected");
+        assert!(
+            err.message
+                .contains("snapshot_ref does not match materialized snapshot"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_tombstone_snapshot_inconsistency() {
+        let mut row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "merge-commit",
+        );
+        row.snapshot_ref = None;
+
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let err = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[row],
+            &BTreeMap::from([("merge-commit".to_string(), vec![0])]),
+            &[FinalizedCommitRow {
+                commit_id: "merge-commit".to_string(),
+                parent_commit_ids: vec!["source-parent".to_string()],
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                change_id: "merge-commit-change".to_string(),
+            }],
+        )
+        .await
+        .expect_err("tombstone inconsistency should be rejected in commit path");
+        assert!(
+            err.message
+                .contains("snapshot_ref does not match materialized snapshot"),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_adopted_snapshot_ref_mismatch() {
+        let mut row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "merge-commit",
+        );
+        row.snapshot_ref = Some(crate::json_store::JsonRef::for_content(
+            br#"{"value":"forged-ref"}"#,
+        ));
+
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let err = stage_changelog_commits(
+            &mut read,
+            &mut writes,
+            &[],
+            &BTreeMap::new(),
+            &[row],
+            &BTreeMap::from([("merge-commit".to_string(), vec![0])]),
+            &[FinalizedCommitRow {
+                commit_id: "merge-commit".to_string(),
+                parent_commit_ids: vec!["source-parent".to_string()],
+                created_at: "2026-01-01T00:00:01Z".to_string(),
+                change_id: "merge-commit-change".to_string(),
+            }],
+        )
+        .await
+        .expect_err("snapshot ref corruption should be rejected in commit path");
+        assert!(
+            err.message
+                .contains("snapshot_ref does not match materialized snapshot"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn adopted_projection_rejects_payload_ref_mismatch() {
+        let mut row = adopted_global_row(
+            "source-change",
+            "source-commit",
+            "source-parent",
+            "adopt-commit",
+        );
+        row.snapshot_ref = Some(crate::json_store::JsonRef::for_content(
+            br#"{"value":"forged-ref"}"#,
+        ));
+
+        let err = validate_adopted_row_payload_refs(&row)
+            .expect_err("ref-only corruption should be rejected");
+        assert!(
+            err.message
+                .contains("snapshot_ref does not match materialized snapshot"),
+            "{err:?}"
+        );
     }
 
     #[tokio::test]
@@ -1862,9 +2860,17 @@ mod tests {
     }
 
     fn members<const N: usize>(change_ids: [&str; N]) -> StagedCommitMembers {
+        members_with_commit("test-uuid-1", "test-uuid-2", change_ids)
+    }
+
+    fn members_with_commit<const N: usize>(
+        commit_id: &str,
+        commit_change_id: &str,
+        change_ids: [&str; N],
+    ) -> StagedCommitMembers {
         let mut members = StagedCommitMembers::new(
-            "test-uuid-1".to_string(),
-            "test-uuid-2".to_string(),
+            commit_id.to_string(),
+            commit_change_id.to_string(),
             "test-timestamp-1".to_string(),
         );
         for change_id in change_ids {

--- a/packages/engine/src/untracked_state/storage.rs
+++ b/packages/engine/src/untracked_state/storage.rs
@@ -65,7 +65,8 @@ pub(crate) async fn load_row(
         .into_iter()
         .next()
         .flatten()
-        .and_then(full_value);
+        .map(|value| full_value(value))
+        .transpose()?;
     let Some(bytes) = bytes else {
         return Ok(None);
     };
@@ -197,9 +198,7 @@ fn scan_matching_rows(
         resume_after = page.value.entries.last().map(|entry| entry.key.clone());
 
         for entry in page.value.entries {
-            let Some(bytes) = full_value(entry.value) else {
-                continue;
-            };
+            let bytes = full_value(entry.value)?;
             let identity = decode_untracked_state_row_key_ref(entry.key.0.as_ref())?;
             let row = crate::untracked_state::codec::decode_payload_with_identity(
                 identity,
@@ -308,10 +307,13 @@ fn append_file_prefixes(
     Ok(())
 }
 
-fn full_value(value: StorageProjectedValue) -> Option<Bytes> {
+fn full_value(value: StorageProjectedValue) -> Result<Bytes, LixError> {
     match value {
-        StorageProjectedValue::FullValue(bytes) => Some(bytes),
-        StorageProjectedValue::KeyOnly => None,
+        StorageProjectedValue::FullValue(bytes) => Ok(bytes),
+        StorageProjectedValue::KeyOnly => Err(LixError::unknown(format!(
+            "untracked_state read over namespace '{}' requested full value but storage returned key-only entry",
+            UNTRACKED_STATE_ROW_SPACE.name
+        ))),
     }
 }
 
@@ -560,9 +562,137 @@ fn push_bytes_component(out: &mut Vec<u8>, bytes: &[u8]) -> Result<(), LixError>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{
+        BackendError, BackendRead, BufferedRangeScan, GetOptions, Key, KeyRange, PointVisitor,
+        ProjectedValue, ProjectedValueRef, ReadEntry, ScanOptions,
+    };
     use crate::storage::StorageContext;
-    use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
+    use crate::storage::{
+        InMemoryStorageBackend, StorageReadOptions, StorageReadScope, StorageWriteOptions,
+    };
     use crate::untracked_state::UntrackedStateContext;
+
+    struct KeyOnlyPointRead;
+
+    impl BackendRead for KeyOnlyPointRead {
+        type RangeScan<'cursor> = BufferedRangeScan;
+
+        fn visit_keys<V>(
+            &self,
+            keys: &[Key],
+            _opts: GetOptions<'_>,
+            visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            for (index, key) in keys.iter().enumerate() {
+                visitor.visit(index, key, Some(ProjectedValueRef::KeyOnly))?;
+            }
+            Ok(())
+        }
+
+        fn with_range_scan<T, F>(
+            &self,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            _f: F,
+        ) -> Result<T, BackendError>
+        where
+            F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+        {
+            unreachable!("untracked_state point-read test does not scan")
+        }
+    }
+
+    struct KeyOnlyScanRead;
+
+    impl BackendRead for KeyOnlyScanRead {
+        type RangeScan<'cursor> = BufferedRangeScan;
+
+        fn visit_keys<V>(
+            &self,
+            _keys: &[Key],
+            _opts: GetOptions<'_>,
+            _visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            unreachable!("untracked_state scan test does not point read")
+        }
+
+        fn with_range_scan<T, F>(
+            &self,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            f: F,
+        ) -> Result<T, BackendError>
+        where
+            F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+        {
+            let identity = test_identity();
+            let logical_key =
+                encode_untracked_state_row_key(&identity).expect("test key should encode");
+            let key = UNTRACKED_STATE_ROW_SPACE.encode_key(&Key(Bytes::from(logical_key)));
+            let mut cursor = BufferedRangeScan::new(vec![ReadEntry {
+                key,
+                value: ProjectedValue::KeyOnly,
+            }]);
+            f(&mut cursor)
+        }
+    }
+
+    #[tokio::test]
+    async fn load_row_rejects_key_only_point_read() {
+        let read = StorageReadScope::new(KeyOnlyPointRead);
+
+        let error = load_row(&read, &test_request())
+            .await
+            .expect_err("key-only untracked point read must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_rows_rejects_key_only_value() {
+        let read = StorageReadScope::new(KeyOnlyScanRead);
+
+        let error = scan_rows(&read, &UntrackedStateScanRequest::default())
+            .await
+            .expect_err("key-only untracked scan must be corruption");
+
+        assert!(
+            error
+                .message
+                .contains("requested full value but storage returned key-only entry"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn test_identity() -> UntrackedStateIdentity {
+        UntrackedStateIdentity {
+            version_id: "version-1".to_string(),
+            schema_key: "schema-1".to_string(),
+            entity_id: crate::entity_identity::EntityIdentity::single("entity-1"),
+            file_id: None,
+        }
+    }
+
+    fn test_request() -> UntrackedStateRowRequest {
+        let identity = test_identity();
+        UntrackedStateRowRequest {
+            schema_key: identity.schema_key,
+            version_id: identity.version_id,
+            entity_id: identity.entity_id,
+            file_id: NullableKeyFilter::Null,
+        }
+    }
 
     #[test]
     fn key_v1_roundtrips_null_file_id() {


### PR DESCRIPTION
Summary
- fail closed when a ChangelogStorageRead get-many adapter returns a value count different from the requested key count
- prevent short adapter results from masquerading as missing changelog rows
- add a fake store regression through load_segment over a short get-many response

Tests
- cargo test -p lix_engine load_segment_rejects_short_get_many_result --quiet
- cargo test -p lix_engine changelog::context::tests --quiet
- cargo check -p lix_engine --quiet
- git diff --check
- cargo test -p lix_engine --quiet

Review loop
- Attempted 3 sub-agent reviews after tests passed.
- All 3 review attempts were blocked by the Codex usage limit via remote compact errors: try again at 7:12 AM.
- No reviewer feedback could be collected or applied for this PR before opening.