### PR TITLE
Add SQLite backend conformance coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,10 @@ name = "lix_rs_sdk"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "lix_engine",
+ "rusqlite",
+ "tempfile",
  "tokio",
 ]
 

--- a/packages/js-sdk/SKILL.md
+++ b/packages/js-sdk/SKILL.md
@@ -46,7 +46,7 @@ Do not use this skill for raw SQLite access, private engine/wasm internals, SDK 
 ## Agent Quick Start
 
 1. Install `@lix-js/sdk` and `better-sqlite3`.
-2. Open with `createBetterSqlite3Backend({ path })`; do not open `.lix` with raw SQLite.
+2. Open with `new SqliteBackend({ path })`.
 3. Register a schema with `x-lix-key`, `x-lix-primary-key`, and `additionalProperties: false`.
 4. Write rows through the generated table named by `x-lix-key`.
 5. Use `beginTransaction()` for imports, migrations, and multi-row writes that should be one commit.
@@ -57,7 +57,7 @@ Do not use this skill for raw SQLite access, private engine/wasm internals, SDK 
 ## Core Rules
 
 - Use the public `@lix-js/sdk` API only.
-- Use `createBetterSqlite3Backend()` for persistent apps, demos, and tests.
+- Use `new SqliteBackend({ path })` for persistent apps, demos, and tests.
 - Use numbered SQL placeholders: `$1`, `$2`, `$3`; bare `?` is rejected.
 - Use `lix_json($1)` when inserting JSON text into JSON-typed columns.
 - Use scalar SQL functions `SELECT lix_uuid_v7()` and `SELECT lix_timestamp()` when consumer code needs Lix-generated UUID v7 ids or ISO timestamps. Do not call them as table functions with `SELECT * FROM ...`.
@@ -78,14 +78,14 @@ npm i @lix-js/sdk better-sqlite3
 
 ```ts
 import { openLix } from "@lix-js/sdk";
-import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
+import { SqliteBackend } from "@lix-js/sdk/sqlite";
 
 const lix = await openLix({
-  backend: createBetterSqlite3Backend({ path: "/path/to/app.lix" }),
+  backend: new SqliteBackend({ path: "/path/to/app.lix" }),
 });
 ```
 
-`better-sqlite3` is an optional peer dependency. Install it in projects that import `@lix-js/sdk/sqlite`.
+`better-sqlite3` is an optional peer dependency. Install it in projects that use `SqliteBackend`.
 
 `openLix()` without a backend is in-memory and dies with the process. For anything that should persist, pass a real `.lix` path. Reopening the same path picks up existing state.
 
@@ -96,11 +96,11 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { openLix } from "@lix-js/sdk";
-import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
+import { SqliteBackend } from "@lix-js/sdk/sqlite";
 
 const dir = mkdtempSync(path.join(tmpdir(), "lix-"));
 const lix = await openLix({
-  backend: createBetterSqlite3Backend({ path: path.join(dir, "demo.lix") }),
+  backend: new SqliteBackend({ path: path.join(dir, "demo.lix") }),
 });
 ```
 
@@ -127,11 +127,11 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { openLix } from "@lix-js/sdk";
-import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
+import { SqliteBackend } from "@lix-js/sdk/sqlite";
 
 const dir = mkdtempSync(path.join(tmpdir(), "lix-"));
 const lix = await openLix({
-  backend: createBetterSqlite3Backend({ path: path.join(dir, "demo.lix") }),
+  backend: new SqliteBackend({ path: path.join(dir, "demo.lix") }),
 });
 
 await lix.execute(
@@ -487,7 +487,7 @@ Other UDFs, such as `lix_json_get`, `lix_uuid_v7`, `lix_text_encode`, and `lix_e
 
 | Do | Avoid |
 | --- | --- |
-| Use `createBetterSqlite3Backend({ path })` for persistent state. | Opening `.lix` files with raw SQLite libraries. |
+| Use `new SqliteBackend({ path })` for persistent state. | Opening `.lix` files with raw SQLite libraries. |
 | Use public imports from `@lix-js/sdk` and `@lix-js/sdk/sqlite`. | Importing `engine-wasm` or private internals. |
 | Use `$1`, `$2`, `$3` placeholders. | Bare `?` placeholders. |
 | Use `lix_json($1)` for JSON parameters. | Inlining stringified JSON directly into SQL. |

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -6,13 +6,10 @@ import {
 	openLix,
 	Value,
 	type BackendKvEntryPage,
-	type BackendKvExistsBatch,
 	type BackendKvGetRequest,
-	type BackendKvKeyPage,
 	type BackendKvScanRange,
 	type BackendKvScanRequest,
 	type BackendKvValueBatch,
-	type BackendKvValuePage,
 	type BackendKvWriteBatch,
 	type BackendKvWriteStats,
 	type ExecuteResult,
@@ -202,30 +199,28 @@ test("custom backend applies ordered deleteRange write ops", () => {
 	const tx = backend.beginWriteTransaction();
 
 	tx.writeKvBatch({
-		groups: [
+		ops: [
 			{
-				namespace: "n",
-				ops: [
-					{
-						kind: "put",
-						key: new Uint8Array([1]),
-						value: new Uint8Array([10]),
-					},
-					{
-						kind: "put",
-						key: new Uint8Array([2]),
-						value: new Uint8Array([20]),
-					},
-					{
-						kind: "deleteRange",
-						range: { kind: "prefix", prefix: new Uint8Array([1]) },
-					},
-					{
-						kind: "put",
-						key: new Uint8Array([1]),
-						value: new Uint8Array([11]),
-					},
-				],
+				kind: "put",
+				key: new Uint8Array([1]),
+				value: new Uint8Array([10]),
+			},
+			{
+				kind: "put",
+				key: new Uint8Array([2]),
+				value: new Uint8Array([20]),
+			},
+			{
+				kind: "deleteRange",
+				range: {
+					lower: { kind: "included", key: new Uint8Array([1]) },
+					upper: { kind: "excluded", key: new Uint8Array([2]) },
+				},
+			},
+			{
+				kind: "put",
+				key: new Uint8Array([1]),
+				value: new Uint8Array([11]),
 			},
 		],
 	});
@@ -233,18 +228,10 @@ test("custom backend applies ordered deleteRange write ops", () => {
 
 	const read = backend.beginReadTransaction();
 	const values = read.getValues({
-		groups: [
-			{
-				namespace: "n",
-				keys: [new Uint8Array([1]), new Uint8Array([2])],
-			},
-		],
+		keys: [new Uint8Array([1]), new Uint8Array([2])],
 	});
 
-	expect(values.groups[0]?.values).toEqual([
-		new Uint8Array([11]),
-		new Uint8Array([20]),
-	]);
+	expect(values.values).toEqual([new Uint8Array([11]), new Uint8Array([20])]);
 	expect(read.rollback()).toBeUndefined();
 });
 
@@ -762,7 +749,6 @@ function expectRows(result: ExecuteResult) {
 }
 
 type StoredKvPair = {
-	namespace: string;
 	key: Uint8Array;
 	value: Uint8Array;
 };
@@ -788,54 +774,12 @@ function createMemoryBackend(options: MemoryBackendOptions = {}): LixBackend {
 			getValues(request): BackendKvValueBatch {
 				ensureOpen();
 				return {
-					groups: request.groups.map((group) => ({
-						namespace: group.namespace,
-						values: group.keys.map((key) => {
-							const row = transactionRows.find(
-								(row) =>
-									row.namespace === group.namespace &&
-									compareBytes(row.key, key) === 0,
-							);
-							return row ? new Uint8Array(row.value) : null;
-						}),
-					})),
-				};
-			},
-			existsMany(request): BackendKvExistsBatch {
-				ensureOpen();
-				return {
-					groups: request.groups.map((group) => ({
-						namespace: group.namespace,
-						exists: group.keys.map((key) =>
-							transactionRows.some(
-								(row) =>
-									row.namespace === group.namespace &&
-									compareBytes(row.key, key) === 0,
-							),
-						),
-					})),
-				};
-			},
-			scanKeys(request): BackendKvKeyPage {
-				ensureOpen();
-				const { pairs, resumeAfter } = scanPage(
-					transactionRows,
-					limitScanRequest(request, options.scanPageSize),
-				);
-				return {
-					keys: pairs.map((row) => new Uint8Array(row.key)),
-					resumeAfter,
-				};
-			},
-			scanValues(request): BackendKvValuePage {
-				ensureOpen();
-				const { pairs, resumeAfter } = scanPage(
-					transactionRows,
-					limitScanRequest(request, options.scanPageSize),
-				);
-				return {
-					values: pairs.map((row) => new Uint8Array(row.value)),
-					resumeAfter,
+					values: request.keys.map((key) => {
+						const row = transactionRows.find(
+							(row) => compareBytes(row.key, key) === 0,
+						);
+						return row ? new Uint8Array(row.value) : null;
+					}),
 				};
 			},
 			scanEntries(request): BackendKvEntryPage {
@@ -858,38 +802,29 @@ function createMemoryBackend(options: MemoryBackendOptions = {}): LixBackend {
 					deleteRanges: 0,
 					bytesWritten: 0,
 				};
-				for (const group of batch.groups) {
-					for (const op of group.ops) {
-						if (op.kind === "put") {
-							stats.puts += 1;
-							stats.bytesWritten += op.key.length + op.value.length;
-							transactionRows = transactionRows.filter(
-								(row) =>
-									row.namespace !== group.namespace ||
-									compareBytes(row.key, op.key) !== 0,
-							);
-							transactionRows.push({
-								namespace: group.namespace,
-								key: new Uint8Array(op.key),
-								value: new Uint8Array(op.value),
-							});
-						} else if (op.kind === "delete") {
-							stats.deletes += 1;
-							stats.bytesWritten += op.key.length;
-							transactionRows = transactionRows.filter(
-								(row) =>
-									row.namespace !== group.namespace ||
-									compareBytes(row.key, op.key) !== 0,
-							);
-						} else {
-							stats.deleteRanges += 1;
-							stats.bytesWritten += deleteRangeBytes(op.range);
-							transactionRows = transactionRows.filter(
-								(row) =>
-									row.namespace !== group.namespace ||
-									!keyMatchesRange(row.key, op.range),
-							);
-						}
+				for (const op of batch.ops) {
+					if (op.kind === "put") {
+						stats.puts += 1;
+						stats.bytesWritten += op.key.length + op.value.length;
+						transactionRows = transactionRows.filter(
+							(row) => compareBytes(row.key, op.key) !== 0,
+						);
+						transactionRows.push({
+							key: new Uint8Array(op.key),
+							value: new Uint8Array(op.value),
+						});
+					} else if (op.kind === "delete") {
+						stats.deletes += 1;
+						stats.bytesWritten += op.key.length;
+						transactionRows = transactionRows.filter(
+							(row) => compareBytes(row.key, op.key) !== 0,
+						);
+					} else {
+						stats.deleteRanges += 1;
+						stats.bytesWritten += deleteRangeBytes(op.range);
+						transactionRows = transactionRows.filter(
+							(row) => !keyMatchesRange(row.key, op.range),
+						);
 					}
 				}
 				return stats;
@@ -929,7 +864,6 @@ function limitScanRequest(
 
 function cloneStoredPair(row: StoredKvPair): StoredKvPair {
 	return {
-		namespace: row.namespace,
 		key: new Uint8Array(row.key),
 		value: new Uint8Array(row.value),
 	};
@@ -942,7 +876,6 @@ function scanPage(
 	const matches = rows
 		.filter(
 			(row) =>
-				row.namespace === request.namespace &&
 				keyMatchesRange(row.key, request.range) &&
 				(!request.after || compareBytes(row.key, request.after) > 0),
 		)
@@ -956,20 +889,27 @@ function scanPage(
 }
 
 function keyMatchesRange(key: Uint8Array, range: BackendKvScanRange): boolean {
-	if (range.kind === "prefix") {
-		if (key.length < range.prefix.length) return false;
-		return range.prefix.every((byte, index) => key[index] === byte);
-	}
-	return (
-		compareBytes(key, range.start) >= 0 && compareBytes(key, range.end) < 0
-	);
+	return lowerBoundMatches(key, range.lower) && upperBoundMatches(key, range.upper);
+}
+
+function lowerBoundMatches(key: Uint8Array, bound: BackendKvScanRange["lower"]) {
+	if (bound.kind === "unbounded") return true;
+	const comparison = compareBytes(key, bound.key);
+	return bound.kind === "included" ? comparison >= 0 : comparison > 0;
+}
+
+function upperBoundMatches(key: Uint8Array, bound: BackendKvScanRange["upper"]) {
+	if (bound.kind === "unbounded") return true;
+	const comparison = compareBytes(key, bound.key);
+	return bound.kind === "included" ? comparison <= 0 : comparison < 0;
 }
 
 function deleteRangeBytes(range: BackendKvScanRange): number {
-	if (range.kind === "prefix") {
-		return range.prefix.length;
-	}
-	return range.start.length + range.end.length;
+	return boundBytes(range.lower) + boundBytes(range.upper);
+}
+
+function boundBytes(bound: BackendKvScanRange["lower"]): number {
+	return bound.kind === "unbounded" ? 0 : bound.key.length;
 }
 
 function compareBytes(left: Uint8Array, right: Uint8Array): number {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -124,52 +124,28 @@ function valueToNative(value: Value): LixNativeValue {
 	}
 }
 
-export type BackendKvScanRange =
-	| { kind: "prefix"; prefix: Uint8Array }
-	| { kind: "range"; start: Uint8Array; end: Uint8Array };
+export type BackendKvBound =
+	| { kind: "included"; key: Uint8Array }
+	| { kind: "excluded"; key: Uint8Array }
+	| { kind: "unbounded" };
 
-export type BackendKvGetRequest = {
-	groups: BackendKvGetGroup[];
+export type BackendKvScanRange = {
+	lower: BackendKvBound;
+	upper: BackendKvBound;
 };
 
-export type BackendKvGetGroup = {
-	namespace: string;
+export type BackendKvGetRequest = {
 	keys: Uint8Array[];
 };
 
 export type BackendKvValueBatch = {
-	groups: BackendKvValueGroup[];
-};
-
-export type BackendKvValueGroup = {
-	namespace: string;
 	values: Array<Uint8Array | null>;
 };
 
-export type BackendKvExistsBatch = {
-	groups: BackendKvExistsGroup[];
-};
-
-export type BackendKvExistsGroup = {
-	namespace: string;
-	exists: boolean[];
-};
-
 export type BackendKvScanRequest = {
-	namespace: string;
 	range: BackendKvScanRange;
 	after?: Uint8Array | null;
 	limit: number;
-};
-
-export type BackendKvKeyPage = {
-	keys: Uint8Array[];
-	resumeAfter?: Uint8Array | null;
-};
-
-export type BackendKvValuePage = {
-	values: Uint8Array[];
-	resumeAfter?: Uint8Array | null;
 };
 
 export type BackendKvEntryPage = {
@@ -194,11 +170,6 @@ export type BackendKvWriteOp =
 	  };
 
 export type BackendKvWriteBatch = {
-	groups: BackendKvWriteGroup[];
-};
-
-export type BackendKvWriteGroup = {
-	namespace: string;
 	ops: BackendKvWriteOp[];
 };
 
@@ -211,9 +182,6 @@ export type BackendKvWriteStats = {
 
 export type LixBackendReadTransaction = {
 	getValues(request: BackendKvGetRequest): BackendKvValueBatch;
-	existsMany(request: BackendKvGetRequest): BackendKvExistsBatch;
-	scanKeys(request: BackendKvScanRequest): BackendKvKeyPage;
-	scanValues(request: BackendKvScanRequest): BackendKvValuePage;
 	scanEntries(request: BackendKvScanRequest): BackendKvEntryPage;
 	rollback(): void;
 };

--- a/packages/js-sdk/src/sqlite/index.test.ts
+++ b/packages/js-sdk/src/sqlite/index.test.ts
@@ -1,16 +1,149 @@
 import { expect, test } from "vitest";
-import { openLix, Value, type ExecuteResult, type Lix } from "../index.js";
+import { execFileSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import init, {
+	resolveEngineWasmModuleOrPath,
+	runBackendConformance,
+	type BackendConformanceReport,
+} from "../engine-wasm/index.js";
+import {
+	openLix,
+	Value,
+	type ExecuteResult,
+	type Lix,
+} from "../index.js";
+import { SqliteBackend } from "./index.js";
 
 const hasBetterSqlite3 = await import("better-sqlite3").then(
 	() => true,
 	() => false,
 );
 
+let wasmReady: Promise<void> | undefined;
+
 test.runIf(hasBetterSqlite3)(
-	"createBetterSqlite3Backend can back a Lix session",
+	"SqliteBackend passes backend conformance",
 	async () => {
-		const { createBetterSqlite3Backend } = await import("./index.js");
-		const backend = createBetterSqlite3Backend({ path: ":memory:" });
+		await ensureWasmReady();
+		const report = runBackendConformance({
+			createFixture() {
+				const path = tempLixPath();
+				return {
+					open() {
+						return new SqliteBackend({ path });
+					},
+				};
+			},
+			config: {
+				ephemeral: false,
+			},
+		}) as BackendConformanceReport;
+
+		const failures = report.tests.filter((test) => test.status !== "passed");
+		expect(failures).toEqual([]);
+	},
+);
+
+test.runIf(hasBetterSqlite3)(
+	"SqliteBackend can open an rs-sdk-created SQLite backend file",
+	async () => {
+		const Database = (await import("better-sqlite3")).default;
+		const file = tempLixPath();
+
+		runCargoInteropFixture("create_sqlite_fixture", [file]);
+
+		const db = new Database(file);
+		try {
+			expect(db.pragma("user_version", { simple: true })).toBe(1);
+			const table = db
+				.prepare(
+					"SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'lix_entries'",
+				)
+				.get();
+			expect(table).toMatchObject({ name: "lix_entries" });
+
+			const key = Buffer.from([0, 1, 2, 255]);
+			const value = Buffer.from("js-compat-value");
+			db.prepare(
+				"INSERT INTO lix_entries (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+			).run(key, value);
+
+			const row = db
+				.prepare("SELECT value FROM lix_entries WHERE key = ?")
+				.get(key);
+			expect(Buffer.isBuffer(row.value)).toBe(true);
+			expect(row.value.equals(value)).toBe(true);
+		} finally {
+			db.close();
+		}
+
+		const lix = await openLix({
+			backend: new SqliteBackend({ path: file }),
+		});
+		await lix.execute(
+			"INSERT INTO lix_key_value (key, value) VALUES ('js-sdk-key', 'js-sdk-value')",
+			[],
+		);
+		await lix.close();
+	},
+	120_000,
+);
+
+test.runIf(hasBetterSqlite3)(
+	"SQLite backend matrix: Rust writes and JS reads",
+	async () => {
+		const file = tempLixPath();
+
+		runCargoInteropFixture("write_sqlite_key_value", [
+			file,
+			"rust-wrote-key",
+			"rust-wrote-value",
+		]);
+
+		const lix = await openLix({
+			backend: new SqliteBackend({ path: file }),
+		});
+		const result = await lix.execute(
+			"SELECT value FROM lix_key_value WHERE key = 'rust-wrote-key'",
+			[],
+		);
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0]?.get("value")).toBe("rust-wrote-value");
+		await lix.close();
+	},
+	20_000,
+);
+
+test.runIf(hasBetterSqlite3)(
+	"SQLite backend matrix: JS writes and Rust reads",
+	async () => {
+		const file = tempLixPath();
+		const lix = await openLix({
+			backend: new SqliteBackend({ path: file }),
+		});
+
+		await lix.execute(
+			"INSERT INTO lix_key_value (key, value) VALUES ('js-wrote-key', 'js-wrote-value')",
+			[],
+		);
+		await lix.close();
+
+		runCargoInteropFixture("verify_sqlite_key_value", [
+			file,
+			"js-wrote-key",
+			"js-wrote-value",
+		]);
+	},
+	20_000,
+);
+
+test.runIf(hasBetterSqlite3)(
+	"SqliteBackend can back a Lix session",
+	async () => {
+		const backend = new SqliteBackend({ path: ":memory:" });
 		const lix = await openLix({ backend });
 
 		await registerCrmTaskSchema(lix);
@@ -29,10 +162,9 @@ test.runIf(hasBetterSqlite3)(
 test.runIf(hasBetterSqlite3)(
 	"committed writes survive close and reopen",
 	async () => {
-		const { createBetterSqlite3Backend } = await import("./index.js");
 		const file = tempLixPath();
 		const first = await openLix({
-			backend: createBetterSqlite3Backend({ path: file }),
+			backend: new SqliteBackend({ path: file }),
 		});
 
 		await registerCrmTaskSchema(first);
@@ -43,7 +175,7 @@ test.runIf(hasBetterSqlite3)(
 		await first.close();
 
 		const second = await openLix({
-			backend: createBetterSqlite3Backend({ path: file }),
+			backend: new SqliteBackend({ path: file }),
 		});
 
 		expect(await taskTitle(second, "persistent-task")).toBe(
@@ -54,22 +186,63 @@ test.runIf(hasBetterSqlite3)(
 );
 
 test.runIf(hasBetterSqlite3)(
-	"createBetterSqlite3Backend rejects a second handle for the same file",
+	"SqliteBackend rejects a second handle for the same file",
 	async () => {
-		const { createBetterSqlite3Backend } = await import("./index.js");
 		const file = tempLixPath();
-		const firstBackend = createBetterSqlite3Backend({ path: file });
+		const firstBackend = new SqliteBackend({ path: file });
 		const first = await openLix({ backend: firstBackend });
 
-		expect(() => createBetterSqlite3Backend({ path: file })).toThrow(
+		expect(() => new SqliteBackend({ path: file })).toThrow(
 			/already has an open handle/,
 		);
 
 		await first.close();
 		const second = await openLix({
-			backend: createBetterSqlite3Backend({ path: file }),
+			backend: new SqliteBackend({ path: file }),
 		});
 		await second.close();
+	},
+);
+
+test.runIf(hasBetterSqlite3)(
+	"scanEntries applies resume cursor before limiting",
+	() => {
+		const backend = new SqliteBackend({ path: ":memory:" });
+		try {
+			const write = backend.beginWriteTransaction();
+			write.writeKvBatch({
+				ops: [0, 1, 2, 3, 4].map((byte) => ({
+					kind: "put",
+					key: new Uint8Array([byte]),
+					value: new Uint8Array([byte + 10]),
+				})),
+			});
+			write.commit();
+
+			const read = backend.beginReadTransaction();
+			try {
+				const keys: number[] = [];
+				let after: Uint8Array | null | undefined = null;
+				do {
+					const page = read.scanEntries({
+						range: {
+							lower: { kind: "unbounded" },
+							upper: { kind: "unbounded" },
+						},
+						after,
+						limit: 1,
+					});
+					keys.push(...page.keys.map((key) => key[0]!));
+					after = page.resumeAfter;
+				} while (after);
+
+				expect(keys).toEqual([0, 1, 2, 3, 4]);
+			} finally {
+				read.rollback();
+			}
+		} finally {
+			backend.close();
+		}
 	},
 );
 
@@ -106,9 +279,42 @@ async function taskTitle(lix: Lix, taskId: string): Promise<string> {
 }
 
 function tempLixPath(): string {
-	return `/tmp/lix-sqlite-test-${Date.now()}-${Math.random()
-		.toString(16)
-		.slice(2)}.lix`;
+	const dir = join(tmpdir(), "lix-js-sdk-sqlite-tests");
+	mkdirSync(dir, { recursive: true });
+	return join(
+		dir,
+		`lix-sqlite-test-${Date.now()}-${Math.random().toString(16).slice(2)}.lix`,
+	);
+}
+
+function workspaceRoot(): string {
+	return resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+}
+
+function runCargoInteropFixture(name: string, args: string[]): void {
+	execFileSync(
+		"cargo",
+		[
+			"run",
+			"--quiet",
+			"-p",
+			"lix_rs_sdk",
+			"--features",
+			"sqlite",
+			"--example",
+			name,
+			"--",
+			...args,
+		],
+		{ cwd: workspaceRoot(), stdio: "pipe" },
+	);
+}
+
+async function ensureWasmReady(): Promise<void> {
+	wasmReady ??= resolveEngineWasmModuleOrPath()
+		.then((module_or_path) => init({ module_or_path }))
+		.then(() => undefined);
+	await wasmReady;
 }
 
 function expectRows(result: ExecuteResult) {

--- a/packages/js-sdk/src/sqlite/index.ts
+++ b/packages/js-sdk/src/sqlite/index.ts
@@ -1,13 +1,12 @@
-import DatabaseConstructor, { type Database } from "better-sqlite3";
+import { createRequire } from "node:module";
+import type { Database } from "better-sqlite3";
 import type {
 	BackendKvEntryPage,
-	BackendKvExistsBatch,
+	BackendKvBound,
 	BackendKvGetRequest,
-	BackendKvKeyPage,
 	BackendKvScanRange,
 	BackendKvScanRequest,
 	BackendKvValueBatch,
-	BackendKvValuePage,
 	BackendKvWriteBatch,
 	BackendKvWriteStats,
 	LixBackend,
@@ -15,7 +14,10 @@ import type {
 	LixBackendWriteTransaction,
 } from "../open-lix.js";
 
-export type BetterSqlite3BackendOptions = {
+const SQLITE_FORMAT_VERSION = 1;
+const require = createRequire(import.meta.url);
+
+export type SqliteBackendOptions = {
 	path: string;
 	databaseOptions?: BetterSqlite3DatabaseOptions;
 };
@@ -27,67 +29,111 @@ export type BetterSqlite3DatabaseOptions = {
 	verbose?: (message?: unknown, ...additional: unknown[]) => void;
 };
 
+type BetterSqlite3Constructor = {
+	new (filename: string, options?: BetterSqlite3DatabaseOptions): Database;
+	(filename: string, options?: BetterSqlite3DatabaseOptions): Database;
+};
+
 const openFileHandles = new Set<string>();
 
-export function createBetterSqlite3Backend(
-	options: BetterSqlite3BackendOptions,
-): LixBackend {
-	if (!options.path) {
-		throw new Error("createBetterSqlite3Backend() requires a non-empty path");
-	}
-	const registryKey = registryKeyForPath(options.path);
-	if (registryKey && openFileHandles.has(registryKey)) {
-		throw doubleOpenError(options.path);
-	}
-	let activeRegistryKey: string | null = registryKey;
-	let db: Database | undefined;
-	if (activeRegistryKey) {
-		openFileHandles.add(activeRegistryKey);
-	}
-	try {
-		db = new DatabaseConstructor(options.path, options.databaseOptions);
-		initializeDatabase(db);
-		return new BetterSqlite3Backend(db, activeRegistryKey);
-	} catch (error) {
-		if (activeRegistryKey) {
-			openFileHandles.delete(activeRegistryKey);
-		}
-		if (db) {
-			try {
-				db.close();
-			} catch {
-				// Ignore close errors while preserving the original open failure.
-			}
-		}
-		throw error;
-	}
+function openDatabase(
+	path: string,
+	options: BetterSqlite3DatabaseOptions | undefined,
+): Database {
+	const DatabaseConstructor = require(
+		"better-sqlite3",
+	) as BetterSqlite3Constructor;
+	return new DatabaseConstructor(path, options);
+}
+
+function configureConnection(db: Database): void {
+	db.pragma("busy_timeout = 5000");
 }
 
 function initializeDatabase(db: Database): void {
+	db.pragma("journal_mode = WAL");
+	configureConnection(db);
+	const userVersion = db.pragma("user_version", { simple: true }) as number;
+	if (userVersion > SQLITE_FORMAT_VERSION) {
+		throw new Error(
+			`SQLite file format version ${userVersion} is newer than supported version ${SQLITE_FORMAT_VERSION}`,
+		);
+	}
 	db.exec(`
-		CREATE TABLE IF NOT EXISTS lix_kv (
-			namespace TEXT NOT NULL,
+		CREATE TABLE IF NOT EXISTS lix_entries (
 			key BLOB NOT NULL,
 			value BLOB NOT NULL,
-			PRIMARY KEY (namespace, key)
+			PRIMARY KEY (key)
 		) WITHOUT ROWID
 	`);
+	db.pragma(`user_version = ${SQLITE_FORMAT_VERSION}`);
 }
 
-class BetterSqlite3Backend implements LixBackend {
+export class SqliteBackend implements LixBackend {
 	readonly #db: Database;
+	readonly #path: string;
+	readonly #databaseOptions: BetterSqlite3DatabaseOptions | undefined;
 	readonly #registryKey: string | null;
-	#transactionMode: "read" | "write" | null = null;
 	#closed = false;
 
-	constructor(db: Database, registryKey: string | null) {
-		this.#db = db;
-		this.#registryKey = registryKey;
+	constructor(options: SqliteBackendOptions) {
+		const path = options.path;
+		if (!path) {
+			throw new Error("SqliteBackend requires a non-empty path");
+		}
+		const registryKey = registryKeyForPath(path);
+		if (registryKey && openFileHandles.has(registryKey)) {
+			throw doubleOpenError(path);
+		}
+		let db: Database | undefined;
+		if (registryKey) {
+			openFileHandles.add(registryKey);
+		}
+		try {
+			db = openDatabase(path, options.databaseOptions);
+			initializeDatabase(db);
+			this.#db = db;
+			this.#path = path;
+			this.#databaseOptions = options.databaseOptions;
+			this.#registryKey = registryKey;
+		} catch (error) {
+			if (registryKey) {
+				openFileHandles.delete(registryKey);
+			}
+			if (db) {
+				try {
+					db.close();
+				} catch {
+					// Ignore close errors while preserving the original open failure.
+				}
+			}
+			throw error;
+		}
 	}
 
 	beginReadTransaction(): LixBackendReadTransaction {
 		this.#ensureOpen();
-		return new BetterSqlite3Transaction(this.#db, {
+		if (this.#registryKey) {
+			const db = openDatabase(this.#path, {
+				...this.#databaseOptions,
+				readonly: true,
+				fileMustExist: true,
+			});
+			try {
+				configureConnection(db);
+				db.exec("BEGIN");
+				db.prepare("SELECT 1 FROM lix_entries LIMIT 1").all();
+				return new SqliteTransaction(db, {
+					ownsTransaction: true,
+					writable: false,
+					onClose: () => db.close(),
+				});
+			} catch (error) {
+				db.close();
+				throw error;
+			}
+		}
+		return new SqliteTransaction(this.#db, {
 			ownsTransaction: false,
 			writable: false,
 		});
@@ -96,16 +142,12 @@ class BetterSqlite3Backend implements LixBackend {
 	beginWriteTransaction(): LixBackendWriteTransaction {
 		this.#ensureOpen();
 		if (this.#db.inTransaction) {
-			throw new Error("better-sqlite3 Lix backend write transaction already active");
+			throw new Error("SQLite Lix backend write transaction already active");
 		}
 		this.#db.exec("BEGIN IMMEDIATE");
-		this.#transactionMode = "write";
-		return new BetterSqlite3Transaction(this.#db, {
+		return new SqliteTransaction(this.#db, {
 			ownsTransaction: true,
 			writable: true,
-			onClose: () => {
-				this.#transactionMode = null;
-			},
 		});
 	}
 
@@ -123,12 +165,12 @@ class BetterSqlite3Backend implements LixBackend {
 
 	#ensureOpen(): void {
 		if (this.#closed) {
-			throw new Error("better-sqlite3 Lix backend is closed");
+			throw new Error("SQLite Lix backend is closed");
 		}
 	}
 }
 
-class BetterSqlite3Transaction implements LixBackendWriteTransaction {
+class SqliteTransaction implements LixBackendWriteTransaction {
 	readonly #db: Database;
 	readonly #ownsTransaction: boolean;
 	readonly #writable: boolean;
@@ -154,29 +196,6 @@ class BetterSqlite3Transaction implements LixBackendWriteTransaction {
 		return getValues(this.#db, request);
 	}
 
-	existsMany(request: BackendKvGetRequest): BackendKvExistsBatch {
-		this.#ensureOpen();
-		return existsMany(this.#db, request);
-	}
-
-	scanKeys(request: BackendKvScanRequest): BackendKvKeyPage {
-		this.#ensureOpen();
-		const { pairs, resumeAfter } = scanPage(this.#db, request);
-		return {
-			keys: pairs.map(({ key }) => key),
-			resumeAfter,
-		};
-	}
-
-	scanValues(request: BackendKvScanRequest): BackendKvValuePage {
-		this.#ensureOpen();
-		const { pairs, resumeAfter } = scanPage(this.#db, request);
-		return {
-			values: pairs.map(({ value }) => value),
-			resumeAfter,
-		};
-	}
-
 	scanEntries(request: BackendKvScanRequest): BackendKvEntryPage {
 		this.#ensureOpen();
 		const { pairs, resumeAfter } = scanPage(this.#db, request);
@@ -198,21 +217,19 @@ class BetterSqlite3Transaction implements LixBackendWriteTransaction {
 			deleteRanges: 0,
 			bytesWritten: 0,
 		};
-		for (const group of batch.groups) {
-			for (const op of group.ops) {
-				if (op.kind === "put") {
-					stats.puts += 1;
-					stats.bytesWritten += op.key.length + op.value.length;
-					kvPut(this.#db, group.namespace, op.key, op.value);
-				} else if (op.kind === "delete") {
-					stats.deletes += 1;
-					stats.bytesWritten += op.key.length;
-					kvDelete(this.#db, group.namespace, op.key);
-				} else {
-					stats.deleteRanges += 1;
-					stats.bytesWritten += deleteRangeBytes(op.range);
-					kvDeleteRange(this.#db, group.namespace, op.range);
-				}
+		for (const op of batch.ops) {
+			if (op.kind === "put") {
+				stats.puts += 1;
+				stats.bytesWritten += op.key.length + op.value.length;
+				kvPut(this.#db, op.key, op.value);
+			} else if (op.kind === "delete") {
+				stats.deletes += 1;
+				stats.bytesWritten += op.key.length;
+				kvDelete(this.#db, op.key);
+			} else {
+				stats.deleteRanges += 1;
+				stats.bytesWritten += deleteRangeBytes(op.range);
+				kvDeleteRange(this.#db, op.range);
 			}
 		}
 		return stats;
@@ -259,22 +276,7 @@ function getValues(
 	request: BackendKvGetRequest,
 ): BackendKvValueBatch {
 	return {
-		groups: request.groups.map((group) => ({
-			namespace: group.namespace,
-			values: group.keys.map((key) => kvGet(db, group.namespace, key)),
-		})),
-	};
-}
-
-function existsMany(
-	db: Database,
-	request: BackendKvGetRequest,
-): BackendKvExistsBatch {
-	return {
-		groups: request.groups.map((group) => ({
-			namespace: group.namespace,
-			exists: group.keys.map((key) => kvGet(db, group.namespace, key) !== null),
-		})),
+		values: request.keys.map((key) => kvGet(db, key)),
 	};
 }
 
@@ -282,10 +284,10 @@ function scanPage(
 	db: Database,
 	request: BackendKvScanRequest,
 ): { pairs: KvPair[]; resumeAfter: Uint8Array | null } {
-	const scanLimit = request.limit + 1 + (request.after ? 1 : 0);
-	const pairs = kvScan(db, request.namespace, request.range, scanLimit).filter(
-		(pair) => !request.after || compareBytes(pair.key, request.after) > 0,
-	);
+	const range = request.after
+		? rangeAfter(request.range, request.after)
+		: request.range;
+	const pairs = kvScan(db, range, request.limit + 1);
 	const hasMore = pairs.length > request.limit;
 	const pagePairs = pairs.slice(0, request.limit);
 	return {
@@ -294,79 +296,90 @@ function scanPage(
 	};
 }
 
-function kvGet(
-	db: Database,
-	namespace: string,
-	key: Uint8Array,
-): Uint8Array | null {
+function rangeAfter(
+	range: BackendKvScanRange,
+	after: Uint8Array,
+): BackendKvScanRange {
+	return {
+		...range,
+		lower: laterLowerBound(range.lower, after),
+	};
+}
+
+function laterLowerBound(
+	lower: BackendKvBound,
+	after: Uint8Array,
+): BackendKvBound {
+	if (lower.kind === "unbounded") {
+		return { kind: "excluded", key: after };
+	}
+	const comparison = compareBytes(lower.key, after);
+	if (comparison > 0) {
+		return lower;
+	}
+	return { kind: "excluded", key: after };
+}
+
+function kvGet(db: Database, key: Uint8Array): Uint8Array | null {
 	const row = db
-		.prepare("SELECT value FROM lix_kv WHERE namespace = ? AND key = ?")
-		.get(namespace, sqliteBytes(key));
+		.prepare("SELECT value FROM lix_entries WHERE key = ?")
+		.get(sqliteBytes(key));
 	if (!isObject(row) || !("value" in row)) {
 		return null;
 	}
-	return bytesFromUnknown(row.value, "lix_kv.value");
+	return bytesFromUnknown(row.value, "lix_entries.value");
 }
 
 function kvPut(
 	db: Database,
-	namespace: string,
 	key: Uint8Array,
 	value: Uint8Array,
 ): void {
 	db.prepare(
-		`INSERT INTO lix_kv (namespace, key, value)
-		 VALUES (?, ?, ?)
-		 ON CONFLICT(namespace, key) DO UPDATE SET value = excluded.value`,
-	).run(namespace, sqliteBytes(key), sqliteBytes(value));
+		`INSERT INTO lix_entries (key, value)
+		 VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+	).run(sqliteBytes(key), sqliteBytes(value));
 }
 
-function kvDelete(db: Database, namespace: string, key: Uint8Array): void {
-	db.prepare("DELETE FROM lix_kv WHERE namespace = ? AND key = ?").run(
-		namespace,
-		sqliteBytes(key),
-	);
+function kvDelete(db: Database, key: Uint8Array): void {
+	db.prepare("DELETE FROM lix_entries WHERE key = ?").run(sqliteBytes(key));
 }
 
-function kvDeleteRange(
-	db: Database,
-	namespace: string,
-	range: BackendKvScanRange,
-): void {
-	const { clauses, params } = rangeClauses(namespace, range);
-	db.prepare(`DELETE FROM lix_kv WHERE ${clauses.join(" AND ")}`).run(
+function kvDeleteRange(db: Database, range: BackendKvScanRange): void {
+	const { clauses, params } = rangeClauses(range);
+	db.prepare(`DELETE FROM lix_entries WHERE ${clauses.join(" AND ")}`).run(
 		...params,
 	);
 }
 
 function kvScan(
 	db: Database,
-	namespace: string,
 	range: BackendKvScanRange,
 	limit?: number | null,
 ): KvPair[] {
-	const { sql, params } = scanQuery(namespace, range, limit);
+	const { sql, params } = scanQuery(range, limit);
 	return db
 		.prepare(sql)
 		.all(...params)
 		.map((row) => {
 			if (!isObject(row) || !("key" in row) || !("value" in row)) {
-				throw new Error("invalid lix_kv scan row");
+				throw new Error("invalid lix_entries scan row");
 			}
+			const key = bytesFromUnknown(row.key, "lix_entries.key");
 			return {
-				key: bytesFromUnknown(row.key, "lix_kv.key"),
-				value: bytesFromUnknown(row.value, "lix_kv.value"),
+				key,
+				value: bytesFromUnknown(row.value, "lix_entries.value"),
 			};
 		});
 }
 
 function scanQuery(
-	namespace: string,
 	range: BackendKvScanRange,
 	limit?: number | null,
 ): { sql: string; params: unknown[] } {
-	const { clauses, params } = rangeClauses(namespace, range);
-	let sql = `SELECT key, value FROM lix_kv WHERE ${clauses.join(
+	const { clauses, params } = rangeClauses(range);
+	let sql = `SELECT key, value FROM lix_entries WHERE ${clauses.join(
 		" AND ",
 	)} ORDER BY key`;
 	if (limit != null) {
@@ -377,33 +390,39 @@ function scanQuery(
 }
 
 function rangeClauses(
-	namespace: string,
 	range: BackendKvScanRange,
 ): { clauses: string[]; params: unknown[] } {
-	const params: unknown[] = [namespace];
-	const clauses = ["namespace = ?"];
-
-	if (range.kind === "prefix") {
-		clauses.push("key >= ?");
-		params.push(sqliteBytes(range.prefix));
-		const end = prefixUpperBound(range.prefix);
-		if (end) {
-			clauses.push("key < ?");
-			params.push(sqliteBytes(end));
-		}
-	} else {
-		clauses.push("key >= ?", "key < ?");
-		params.push(sqliteBytes(range.start), sqliteBytes(range.end));
+	const params: unknown[] = [];
+	const clauses: string[] = [];
+	appendBoundClause(clauses, params, range.lower, "key", ">=", ">");
+	appendBoundClause(clauses, params, range.upper, "key", "<=", "<");
+	if (clauses.length === 0) {
+		clauses.push("1 = 1");
 	}
-
 	return { clauses, params };
 }
 
-function deleteRangeBytes(range: BackendKvScanRange): number {
-	if (range.kind === "prefix") {
-		return range.prefix.length;
+function appendBoundClause(
+	clauses: string[],
+	params: unknown[],
+	bound: BackendKvBound,
+	column: string,
+	includedOp: string,
+	excludedOp: string,
+): void {
+	if (bound.kind === "unbounded") {
+		return;
 	}
-	return range.start.length + range.end.length;
+	clauses.push(`${column} ${bound.kind === "included" ? includedOp : excludedOp} ?`);
+	params.push(sqliteBytes(bound.key));
+}
+
+function deleteRangeBytes(range: BackendKvScanRange): number {
+	return boundBytes(range.lower) + boundBytes(range.upper);
+}
+
+function boundBytes(bound: BackendKvBound): number {
+	return bound.kind === "unbounded" ? 0 : bound.key.length;
 }
 
 function compareBytes(left: Uint8Array, right: Uint8Array): number {
@@ -413,17 +432,6 @@ function compareBytes(left: Uint8Array, right: Uint8Array): number {
 		if (delta !== 0) return delta;
 	}
 	return left.length - right.length;
-}
-
-function prefixUpperBound(prefix: Uint8Array): Uint8Array | null {
-	const end = new Uint8Array(prefix);
-	for (let index = end.length - 1; index >= 0; index--) {
-		if (end[index] !== 0xff) {
-			end[index]! += 1;
-			return end.slice(0, index + 1);
-		}
-	}
-	return null;
 }
 
 function bytesFromUnknown(value: unknown, context: string): Uint8Array {
@@ -475,7 +483,7 @@ function normalizeAbsolutePath(filename: string): string {
 
 function doubleOpenError(filename: string): Error {
 	return new Error(
-		`createBetterSqlite3Backend() already has an open handle for ${filename}; close the existing Lix handle before opening this file again`,
+		`SqliteBackend already has an open handle for ${filename}; close the existing Lix handle before opening this file again`,
 	);
 }
 

--- a/packages/js-sdk/src/sqlite/node-module.d.ts
+++ b/packages/js-sdk/src/sqlite/node-module.d.ts
@@ -1,0 +1,3 @@
+declare module "node:module" {
+	export function createRequire(filename: string): (id: string) => unknown;
+}

--- a/packages/js-sdk/wasm-bindgen.rs
+++ b/packages/js-sdk/wasm-bindgen.rs
@@ -6,12 +6,13 @@ mod wasm {
     use bytes::Bytes;
     use js_sys::{Array, Object, Reflect};
     use lix_rs_sdk::{
-        open_lix_with_backend, Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite,
-        CommitResult, CoreProjection, CreateBranchOptions, ExecuteResult, GetOptions,
-        InMemoryBackend, Key, KeyRange, Lix as RsLix, LixError, LixTransaction as RsLixTransaction,
-        MergeBranchOptions, MergeBranchPreviewOptions, PointVisitor, ProjectedValueRef, PutBatch,
-        ReadOptions, ScanOptions, ScanResult, ScanVisitor, StoredValue, SwitchBranchOptions, Value,
-        WriteOptions, WriteStats,
+        open_lix_with_backend, run_backend_conformance, Backend, BackendConformanceStatus,
+        BackendError, BackendFactory, BackendFixture, BackendRangeScan, BackendRead,
+        BackendTestConfig, BackendWrite, CommitResult, CoreProjection, CreateBranchOptions,
+        ExecuteResult, GetOptions, InMemoryBackend, Key, KeyRange, Lix as RsLix, LixError,
+        LixTransaction as RsLixTransaction, MergeBranchOptions, MergeBranchPreviewOptions,
+        PointVisitor, ProjectedValueRef, PutBatch, ReadOptions, ScanOptions, ScanResult,
+        ScanVisitor, StoredValue, SwitchBranchOptions, Value, WriteOptions, WriteStats,
     };
     use serde::Serialize;
     use serde_json::json;
@@ -50,52 +51,28 @@ export type LixNotice = {
   hint?: string;
 };
 
-export type BackendKvScanRange =
-  | { kind: "prefix"; prefix: Uint8Array }
-  | { kind: "range"; start: Uint8Array; end: Uint8Array };
+export type BackendKvBound =
+  | { kind: "included"; key: Uint8Array }
+  | { kind: "excluded"; key: Uint8Array }
+  | { kind: "unbounded" };
 
-export type BackendKvGetRequest = {
-  groups: BackendKvGetGroup[];
+export type BackendKvScanRange = {
+  lower: BackendKvBound;
+  upper: BackendKvBound;
 };
 
-export type BackendKvGetGroup = {
-  namespace: string;
+export type BackendKvGetRequest = {
   keys: Uint8Array[];
 };
 
 export type BackendKvValueBatch = {
-  groups: BackendKvValueGroup[];
-};
-
-export type BackendKvValueGroup = {
-  namespace: string;
   values: Array<Uint8Array | null>;
 };
 
-export type BackendKvExistsBatch = {
-  groups: BackendKvExistsGroup[];
-};
-
-export type BackendKvExistsGroup = {
-  namespace: string;
-  exists: boolean[];
-};
-
 export type BackendKvScanRequest = {
-  namespace: string;
   range: BackendKvScanRange;
   after?: Uint8Array | null;
   limit: number;
-};
-
-export type BackendKvKeyPage = {
-  keys: Uint8Array[];
-  resumeAfter?: Uint8Array | null;
-};
-
-export type BackendKvValuePage = {
-  values: Uint8Array[];
-  resumeAfter?: Uint8Array | null;
 };
 
 export type BackendKvEntryPage = {
@@ -110,11 +87,6 @@ export type BackendKvWriteOp =
   | { kind: "deleteRange"; range: BackendKvScanRange };
 
 export type BackendKvWriteBatch = {
-  groups: BackendKvWriteGroup[];
-};
-
-export type BackendKvWriteGroup = {
-  namespace: string;
   ops: BackendKvWriteOp[];
 };
 
@@ -127,9 +99,6 @@ export type BackendKvWriteStats = {
 
 export type BackendReadTransaction = {
   getValues(request: BackendKvGetRequest): BackendKvValueBatch;
-  existsMany(request: BackendKvGetRequest): BackendKvExistsBatch;
-  scanKeys(request: BackendKvScanRequest): BackendKvKeyPage;
-  scanValues(request: BackendKvScanRequest): BackendKvValuePage;
   scanEntries(request: BackendKvScanRequest): BackendKvEntryPage;
   rollback(): void;
 };
@@ -150,6 +119,32 @@ export type Backend = {
    */
   beginWriteTransaction(): BackendWriteTransaction;
   close?(): void;
+};
+
+export type BackendConformanceFactory = {
+  createFixture(): BackendConformanceFixture;
+  config?: Partial<BackendConformanceConfig>;
+};
+
+export type BackendConformanceFixture = {
+  open(): Backend;
+};
+
+export type BackendConformanceConfig = {
+  maxKeyLen: number;
+  maxValueLen: number;
+  ephemeral: boolean;
+  supportsConcurrentWriters: boolean;
+};
+
+export type BackendConformanceReport = {
+  tests: BackendConformanceTest[];
+};
+
+export type BackendConformanceTest = {
+  name: string;
+  status: "passed" | "failed" | "pending";
+  error?: string;
 };
 
 export type OpenLixOptions = {
@@ -554,6 +549,13 @@ export type MergeConflictSide = {
         })
     }
 
+    #[wasm_bindgen(js_name = runBackendConformance)]
+    pub fn run_backend_conformance_js(factory: JsValue) -> Result<JsValue, JsValue> {
+        let factory = JsBackendConformanceFactory::new(factory).map_err(js_error)?;
+        let report = run_backend_conformance(&factory);
+        backend_conformance_report_to_js(report).map_err(js_error)
+    }
+
     struct WasmOpenLixOptions {
         backend: Option<JsBackend>,
         backend_handle: Option<JsValue>,
@@ -614,6 +616,20 @@ export type MergeConflictSide = {
         inner: JsValue,
     }
 
+    struct JsBackendConformanceFactory {
+        inner: JsValue,
+        config: BackendTestConfig,
+    }
+
+    struct JsBackendConformanceFixture {
+        inner: JsValue,
+    }
+
+    struct JsConformanceBackend {
+        inner: JsBackend,
+        handle: JsValue,
+    }
+
     impl JsBackend {
         fn new(inner: JsValue) -> Self {
             Self { inner }
@@ -627,6 +643,81 @@ export type MergeConflictSide = {
                 )));
             }
             Ok(transaction)
+        }
+    }
+
+    impl JsBackendConformanceFactory {
+        fn new(inner: JsValue) -> Result<Self, LixError> {
+            if inner.is_null() || inner.is_undefined() || !inner.is_object() {
+                return Err(js_sdk_error(
+                    "runBackendConformance() factory must be an object",
+                ));
+            }
+            let object = Object::from(inner.clone());
+            Ok(Self {
+                inner,
+                config: backend_conformance_config_from_js(&object)?,
+            })
+        }
+    }
+
+    impl BackendFactory for JsBackendConformanceFactory {
+        type Backend = JsConformanceBackend;
+        type Fixture = JsBackendConformanceFixture;
+
+        fn create_fixture(&self) -> Self::Fixture {
+            let fixture = call_method0(&self.inner, "createFixture")
+                .expect("runBackendConformance() factory.createFixture() failed");
+            if fixture.is_null() || fixture.is_undefined() || !fixture.is_object() {
+                panic!("runBackendConformance() factory.createFixture() must return an object");
+            }
+            JsBackendConformanceFixture { inner: fixture }
+        }
+
+        fn config(&self) -> BackendTestConfig {
+            self.config.clone()
+        }
+    }
+
+    impl BackendFixture for JsBackendConformanceFixture {
+        type Backend = JsConformanceBackend;
+
+        fn open(&self) -> Self::Backend {
+            let backend = call_method0(&self.inner, "open")
+                .expect("runBackendConformance() fixture.open() failed");
+            if backend.is_null() || backend.is_undefined() || !backend.is_object() {
+                panic!("runBackendConformance() fixture.open() must return a backend object");
+            }
+            JsConformanceBackend {
+                inner: JsBackend::new(backend.clone()),
+                handle: backend,
+            }
+        }
+    }
+
+    impl Backend for JsConformanceBackend {
+        type Read<'a>
+            = JsBackendRead
+        where
+            Self: 'a;
+
+        type Write<'a>
+            = JsBackendWrite
+        where
+            Self: 'a;
+
+        fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
+            self.inner.begin_read(opts)
+        }
+
+        fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+            self.inner.begin_write(opts)
+        }
+    }
+
+    impl Drop for JsConformanceBackend {
+        fn drop(&mut self) {
+            let _ = close_js_backend(&self.handle);
         }
     }
 
@@ -869,8 +960,6 @@ export type MergeConflictSide = {
         JsValue::from_f64(value as f64)
     }
 
-    const JS_BACKEND_NAMESPACE: &str = "default";
-
     enum JsWriteOp {
         Put { key: Key, value: StoredValue },
         Delete(Key),
@@ -917,6 +1006,75 @@ export type MergeConflictSide = {
         Ok(())
     }
 
+    fn backend_conformance_config_from_js(
+        factory: &Object,
+    ) -> Result<BackendTestConfig, LixError> {
+        let mut config = BackendTestConfig::default();
+        let value = Reflect::get(factory, &JsValue::from_str("config"))
+            .map_err(|_| js_sdk_error("runBackendConformance() could not read config"))?;
+        if value.is_undefined() || value.is_null() {
+            return Ok(config);
+        }
+        if !value.is_object() {
+            return Err(js_sdk_error(
+                "runBackendConformance() config must be an object when provided",
+            ));
+        }
+        let object = Object::from(value);
+        if let Some(max_key_len) = optional_usize(&object, "maxKeyLen", "config")? {
+            config.max_key_len = max_key_len;
+        }
+        if let Some(max_value_len) = optional_usize(&object, "maxValueLen", "config")? {
+            config.max_value_len = max_value_len;
+        }
+        if let Some(ephemeral) = optional_bool(&object, "ephemeral", "config")? {
+            config.ephemeral = ephemeral;
+        }
+        if let Some(supports_concurrent_writers) =
+            optional_bool(&object, "supportsConcurrentWriters", "config")?
+        {
+            config.supports_concurrent_writers = supports_concurrent_writers;
+        }
+        Ok(config)
+    }
+
+    fn backend_conformance_report_to_js(
+        report: lix_rs_sdk::BackendConformanceReport,
+    ) -> Result<JsValue, LixError> {
+        let object = Object::new();
+        let tests = Array::new();
+        for test in report.tests {
+            let test_object = Object::new();
+            Reflect::set(
+                &test_object,
+                &JsValue::from_str("name"),
+                &JsValue::from_str(test.name),
+            )
+            .map_err(|_| js_sdk_error("could not set conformance test name"))?;
+            match test.status {
+                BackendConformanceStatus::Passed => {
+                    set_string(&test_object, "status", "passed")?;
+                }
+                BackendConformanceStatus::Pending => {
+                    set_string(&test_object, "status", "pending")?;
+                }
+                BackendConformanceStatus::Failed(error) => {
+                    set_string(&test_object, "status", "failed")?;
+                    Reflect::set(
+                        &test_object,
+                        &JsValue::from_str("error"),
+                        &JsValue::from_str(&error),
+                    )
+                    .map_err(|_| js_sdk_error("could not set conformance test error"))?;
+                }
+            }
+            tests.push(&test_object);
+        }
+        Reflect::set(&object, &JsValue::from_str("tests"), &tests)
+            .map_err(|_| js_sdk_error("could not set conformance tests"))?;
+        Ok(object.into())
+    }
+
     fn to_backend_error(error: LixError) -> BackendError {
         BackendError::Io(error.to_string())
     }
@@ -926,34 +1084,15 @@ export type MergeConflictSide = {
         keys: &[Key],
     ) -> Result<Vec<Option<Vec<u8>>>, BackendError> {
         let object = Object::new();
-        let groups = Array::new();
-        let group_object = Object::new();
-        set_string(&group_object, "namespace", JS_BACKEND_NAMESPACE).map_err(to_backend_error)?;
         let js_keys = Array::new();
         for key in keys {
             js_keys.push(&bytes_to_js(key.0.as_ref()));
         }
-        Reflect::set(&group_object, &JsValue::from_str("keys"), &js_keys)
+        Reflect::set(&object, &JsValue::from_str("keys"), &js_keys)
             .map_err(|_| to_backend_error(js_sdk_error("could not set get request keys")))?;
-        groups.push(&group_object);
-        Reflect::set(&object, &JsValue::from_str("groups"), &groups)
-            .map_err(|_| to_backend_error(js_sdk_error("could not set get request groups")))?;
         let response =
             call_method1(transaction, "getValues", &object.into()).map_err(to_backend_error)?;
         js_value_to_values(response, "transaction.getValues").map_err(to_backend_error)
-    }
-
-    fn next_lexicographic_key(key: &Key) -> Option<Key> {
-        let mut bytes = key.0.to_vec();
-        while let Some(last) = bytes.last_mut() {
-            if *last == u8::MAX {
-                bytes.pop();
-            } else {
-                *last += 1;
-                return Some(Key(Bytes::from(bytes)));
-            }
-        }
-        None
     }
 
     fn choose_scan_after(explicit_after: Option<&Key>, lower_after: Option<&Key>) -> Option<Key> {
@@ -967,76 +1106,63 @@ export type MergeConflictSide = {
         }
     }
 
-    fn kv_range_to_js(start: &Key, end: &Key) -> Result<JsValue, BackendError> {
+    fn kv_bound_to_js(bound: &Bound<Key>) -> Result<JsValue, BackendError> {
         let object = Object::new();
-        set_string(&object, "kind", "range").map_err(to_backend_error)?;
-        Reflect::set(
-            &object,
-            &JsValue::from_str("start"),
-            &bytes_to_js(start.0.as_ref()),
-        )
-        .map_err(|_| to_backend_error(js_sdk_error("could not set range.start")))?;
-        Reflect::set(
-            &object,
-            &JsValue::from_str("end"),
-            &bytes_to_js(end.0.as_ref()),
-        )
-        .map_err(|_| to_backend_error(js_sdk_error("could not set range.end")))?;
-        Ok(object.into())
-    }
-
-    fn kv_prefix_to_js(prefix: &Key) -> Result<JsValue, BackendError> {
-        let object = Object::new();
-        set_string(&object, "kind", "prefix").map_err(to_backend_error)?;
-        Reflect::set(
-            &object,
-            &JsValue::from_str("prefix"),
-            &bytes_to_js(prefix.0.as_ref()),
-        )
-        .map_err(|_| to_backend_error(js_sdk_error("could not set range.prefix")))?;
+        match bound {
+            Bound::Included(key) => {
+                set_string(&object, "kind", "included").map_err(to_backend_error)?;
+                Reflect::set(
+                    &object,
+                    &JsValue::from_str("key"),
+                    &bytes_to_js(key.0.as_ref()),
+                )
+                .map_err(|_| to_backend_error(js_sdk_error("could not set bound.key")))?;
+            }
+            Bound::Excluded(key) => {
+                set_string(&object, "kind", "excluded").map_err(to_backend_error)?;
+                Reflect::set(
+                    &object,
+                    &JsValue::from_str("key"),
+                    &bytes_to_js(key.0.as_ref()),
+                )
+                .map_err(|_| to_backend_error(js_sdk_error("could not set bound.key")))?;
+            }
+            Bound::Unbounded => {
+                set_string(&object, "kind", "unbounded").map_err(to_backend_error)?;
+            }
+        }
         Ok(object.into())
     }
 
     fn kv_scan_range_to_js(range: &KeyRange) -> Result<JsValue, BackendError> {
-        match (&range.lower, &range.upper) {
-            (Bound::Included(start), Bound::Excluded(end)) => kv_range_to_js(start, end),
-            (Bound::Included(start), Bound::Included(end)) => {
-                let end = next_lexicographic_key(end).ok_or(BackendError::InvalidKey)?;
-                kv_range_to_js(start, &end)
-            }
-            (Bound::Included(prefix), Bound::Unbounded) => kv_prefix_to_js(prefix),
-            _ => Err(BackendError::InvalidKey),
-        }
+        let object = Object::new();
+        Reflect::set(
+            &object,
+            &JsValue::from_str("lower"),
+            &kv_bound_to_js(&range.lower)?,
+        )
+        .map_err(|_| to_backend_error(js_sdk_error("could not set range.lower")))?;
+        Reflect::set(
+            &object,
+            &JsValue::from_str("upper"),
+            &kv_bound_to_js(&range.upper)?,
+        )
+        .map_err(|_| to_backend_error(js_sdk_error("could not set range.upper")))?;
+        Ok(object.into())
     }
 
     fn kv_scan_range_and_after_to_js(
         range: &KeyRange,
         after: Option<&Key>,
     ) -> Result<(JsValue, Option<Key>), BackendError> {
-        match (&range.lower, &range.upper) {
-            (Bound::Included(start), Bound::Excluded(end)) => {
-                Ok((kv_range_to_js(start, end)?, choose_scan_after(after, None)))
-            }
-            (Bound::Excluded(start), Bound::Excluded(end)) => Ok((
-                kv_range_to_js(start, end)?,
-                choose_scan_after(after, Some(start)),
-            )),
-            (Bound::Included(start), Bound::Included(end)) => {
-                let end = next_lexicographic_key(end).ok_or(BackendError::InvalidKey)?;
-                Ok((kv_range_to_js(start, &end)?, choose_scan_after(after, None)))
-            }
-            (Bound::Excluded(start), Bound::Included(end)) => {
-                let end = next_lexicographic_key(end).ok_or(BackendError::InvalidKey)?;
-                Ok((
-                    kv_range_to_js(start, &end)?,
-                    choose_scan_after(after, Some(start)),
-                ))
-            }
-            (Bound::Included(prefix), Bound::Unbounded) => {
-                Ok((kv_prefix_to_js(prefix)?, choose_scan_after(after, None)))
-            }
-            _ => Err(BackendError::InvalidKey),
-        }
+        let lower_after = match &range.lower {
+            Bound::Excluded(start) => Some(start),
+            _ => None,
+        };
+        Ok((
+            kv_scan_range_to_js(range)?,
+            choose_scan_after(after, lower_after),
+        ))
     }
 
     fn kv_scan_request_to_js(
@@ -1046,7 +1172,6 @@ export type MergeConflictSide = {
     ) -> Result<JsValue, BackendError> {
         let object = Object::new();
         let (range, after) = kv_scan_range_and_after_to_js(range, after)?;
-        set_string(&object, "namespace", JS_BACKEND_NAMESPACE).map_err(to_backend_error)?;
         Reflect::set(&object, &JsValue::from_str("range"), &range)
             .map_err(|_| to_backend_error(js_sdk_error("could not set scan request range")))?;
         let after = after
@@ -1062,9 +1187,6 @@ export type MergeConflictSide = {
 
     fn kv_write_batch_to_js(ops: Vec<JsWriteOp>) -> Result<JsValue, BackendError> {
         let object = Object::new();
-        let groups = Array::new();
-        let group_object = Object::new();
-        set_string(&group_object, "namespace", JS_BACKEND_NAMESPACE).map_err(to_backend_error)?;
         let js_ops = Array::new();
         for op in ops {
             let op_object = Object::new();
@@ -1109,34 +1231,20 @@ export type MergeConflictSide = {
             }
             js_ops.push(&op_object);
         }
-        Reflect::set(&group_object, &JsValue::from_str("ops"), &js_ops)
+        Reflect::set(&object, &JsValue::from_str("ops"), &js_ops)
             .map_err(|_| to_backend_error(js_sdk_error("could not set write ops")))?;
-        groups.push(&group_object);
-        Reflect::set(&object, &JsValue::from_str("groups"), &groups)
-            .map_err(|_| to_backend_error(js_sdk_error("could not set write groups")))?;
         Ok(object.into())
     }
 
     fn js_value_to_values(value: JsValue, context: &str) -> Result<Vec<Option<Vec<u8>>>, LixError> {
         let object = expect_backend_object(value, context)?;
-        let groups = required_array(&object, "groups", context)?;
-        if groups.length() != 1 {
-            return Err(js_sdk_error(format!(
-                "{context}.groups must contain one group"
-            )));
-        }
-        let group_context = format!("{context}.groups[0]");
-        let group = expect_backend_object(groups.get(0), &group_context)?;
-        let values = required_array(&group, "values", &group_context)?;
+        let values = required_array(&object, "values", context)?;
         let mut out = Vec::with_capacity(values.length() as usize);
         for value in values.iter() {
             if value.is_null() || value.is_undefined() {
                 out.push(None);
             } else {
-                out.push(Some(js_value_to_bytes(
-                    value,
-                    &format!("{group_context}.values"),
-                )?));
+                out.push(Some(js_value_to_bytes(value, &format!("{context}.values"))?));
             }
         }
         Ok(out)
@@ -1209,228 +1317,6 @@ export type MergeConflictSide = {
             .map_err(to_backend_error)
     }
 
-    #[cfg(any())]
-    fn kv_get_request_to_js(request: &BackendKvGetRequest) -> Result<JsValue, LixError> {
-        let object = Object::new();
-        let groups = Array::new();
-        for group in &request.groups {
-            let group_object = Object::new();
-            set_string(&group_object, "namespace", &group.namespace)?;
-            let keys = Array::new();
-            for key in &group.keys {
-                keys.push(&bytes_to_js(key));
-            }
-            Reflect::set(&group_object, &JsValue::from_str("keys"), &keys)
-                .map_err(|_| js_sdk_error("could not set get request keys"))?;
-            groups.push(&group_object);
-        }
-        Reflect::set(&object, &JsValue::from_str("groups"), &groups)
-            .map_err(|_| js_sdk_error("could not set get request groups"))?;
-        Ok(object.into())
-    }
-
-    #[cfg(any())]
-    fn kv_scan_range_to_js(range: &BackendKvScanRange) -> Result<JsValue, LixError> {
-        let object = Object::new();
-        match range {
-            BackendKvScanRange::Prefix(prefix) => {
-                set_string(&object, "kind", "prefix")?;
-                Reflect::set(&object, &JsValue::from_str("prefix"), &bytes_to_js(prefix))
-                    .map_err(|_| js_sdk_error("could not set range.prefix"))?;
-            }
-            BackendKvScanRange::Range { start, end } => {
-                set_string(&object, "kind", "range")?;
-                Reflect::set(&object, &JsValue::from_str("start"), &bytes_to_js(start))
-                    .map_err(|_| js_sdk_error("could not set range.start"))?;
-                Reflect::set(&object, &JsValue::from_str("end"), &bytes_to_js(end))
-                    .map_err(|_| js_sdk_error("could not set range.end"))?;
-            }
-        }
-        Ok(object.into())
-    }
-
-    #[cfg(any())]
-    fn kv_scan_request_to_js(request: &BackendKvScanRequest) -> Result<JsValue, LixError> {
-        let object = Object::new();
-        set_string(&object, "namespace", &request.namespace)?;
-        Reflect::set(
-            &object,
-            &JsValue::from_str("range"),
-            &kv_scan_range_to_js(&request.range)?,
-        )
-        .map_err(|_| js_sdk_error("could not set scan request range"))?;
-        let after = request
-            .after
-            .as_deref()
-            .map(bytes_to_js)
-            .unwrap_or(JsValue::NULL);
-        Reflect::set(&object, &JsValue::from_str("after"), &after)
-            .map_err(|_| js_sdk_error("could not set scan request after"))?;
-        Reflect::set(
-            &object,
-            &JsValue::from_str("limit"),
-            &usize_to_js(request.limit),
-        )
-        .map_err(|_| js_sdk_error("could not set scan request limit"))?;
-        Ok(object.into())
-    }
-
-    #[cfg(any())]
-    fn kv_write_batch_to_js(batch: &BackendKvWriteBatch) -> Result<JsValue, LixError> {
-        let object = Object::new();
-        let groups = Array::new();
-        for group in &batch.groups {
-            let group_object = Object::new();
-            set_string(&group_object, "namespace", group.namespace())?;
-
-            let ops = Array::new();
-            for op in group.ops() {
-                let op_object = Object::new();
-                match op {
-                    BackendKvWriteOp::Put { key, value } => {
-                        set_string(&op_object, "kind", "put")?;
-                        Reflect::set(&op_object, &JsValue::from_str("key"), &bytes_to_js(key))
-                            .map_err(|_| js_sdk_error("could not set write put key"))?;
-                        Reflect::set(&op_object, &JsValue::from_str("value"), &bytes_to_js(value))
-                            .map_err(|_| js_sdk_error("could not set write put value"))?;
-                    }
-                    BackendKvWriteOp::Delete { key } => {
-                        set_string(&op_object, "kind", "delete")?;
-                        Reflect::set(&op_object, &JsValue::from_str("key"), &bytes_to_js(key))
-                            .map_err(|_| js_sdk_error("could not set write delete key"))?;
-                    }
-                    BackendKvWriteOp::DeleteRange { range } => {
-                        set_string(&op_object, "kind", "deleteRange")?;
-                        Reflect::set(
-                            &op_object,
-                            &JsValue::from_str("range"),
-                            &kv_scan_range_to_js(range)?,
-                        )
-                        .map_err(|_| js_sdk_error("could not set write delete range"))?;
-                    }
-                }
-                ops.push(&op_object);
-            }
-            Reflect::set(&group_object, &JsValue::from_str("ops"), &ops)
-                .map_err(|_| js_sdk_error("could not set write ops"))?;
-            groups.push(&group_object);
-        }
-        Reflect::set(&object, &JsValue::from_str("groups"), &groups)
-            .map_err(|_| js_sdk_error("could not set write groups"))?;
-        Ok(object.into())
-    }
-
-    #[cfg(any())]
-    fn js_value_to_value_batch(
-        value: JsValue,
-        context: &str,
-    ) -> Result<BackendKvValueBatch, LixError> {
-        let object = expect_backend_object(value, context)?;
-        let groups = required_array(&object, "groups", context)?;
-        let groups = groups
-            .iter()
-            .enumerate()
-            .map(|(index, group)| {
-                let group_context = format!("{context}.groups[{index}]");
-                let group = expect_backend_object(group, &group_context)?;
-                let namespace = required_string(&group, "namespace", &group_context)?;
-                let values = required_array(&group, "values", &group_context)?;
-                let mut bytes = BytePageBuilder::with_capacity(values.length() as usize, 0);
-                let mut present = Vec::with_capacity(values.length() as usize);
-                for value in values.iter() {
-                    if value.is_null() || value.is_undefined() {
-                        bytes.push([]);
-                        present.push(false);
-                    } else {
-                        bytes.push(js_value_to_bytes(
-                            value,
-                            &format!("{group_context}.values"),
-                        )?);
-                        present.push(true);
-                    }
-                }
-                Ok(BackendKvValueGroup::new(namespace, bytes.finish(), present))
-            })
-            .collect::<Result<Vec<_>, LixError>>()?;
-        Ok(BackendKvValueBatch { groups })
-    }
-
-    #[cfg(any())]
-    fn js_value_to_exists_batch(
-        value: JsValue,
-        context: &str,
-    ) -> Result<BackendKvExistsBatch, LixError> {
-        let object = expect_backend_object(value, context)?;
-        let groups = required_array(&object, "groups", context)?;
-        let groups = groups
-            .iter()
-            .enumerate()
-            .map(|(index, group)| {
-                let group_context = format!("{context}.groups[{index}]");
-                let group = expect_backend_object(group, &group_context)?;
-                let namespace = required_string(&group, "namespace", &group_context)?;
-                let exists = required_array(&group, "exists", &group_context)?
-                    .iter()
-                    .map(|value| {
-                        value.as_bool().ok_or_else(|| {
-                            js_sdk_error(format!("{group_context}.exists must contain booleans"))
-                        })
-                    })
-                    .collect::<Result<Vec<_>, LixError>>()?;
-                Ok(BackendKvExistsGroup { namespace, exists })
-            })
-            .collect::<Result<Vec<_>, LixError>>()?;
-        Ok(BackendKvExistsBatch { groups })
-    }
-
-    #[cfg(any())]
-    fn js_value_to_key_page(value: JsValue, context: &str) -> Result<BackendKvKeyPage, LixError> {
-        let object = expect_backend_object(value, context)?;
-        Ok(BackendKvKeyPage {
-            keys: byte_array_property(&object, "keys", context)?.finish(),
-            resume_after: optional_bytes_property(&object, "resumeAfter", context)?,
-        })
-    }
-
-    #[cfg(any())]
-    fn js_value_to_value_page(
-        value: JsValue,
-        context: &str,
-    ) -> Result<BackendKvValuePage, LixError> {
-        let object = expect_backend_object(value, context)?;
-        Ok(BackendKvValuePage {
-            values: byte_array_property(&object, "values", context)?.finish(),
-            resume_after: optional_bytes_property(&object, "resumeAfter", context)?,
-        })
-    }
-
-    #[cfg(any())]
-    fn js_value_to_entry_page(
-        value: JsValue,
-        context: &str,
-    ) -> Result<BackendKvEntryPage, LixError> {
-        let object = expect_backend_object(value, context)?;
-        Ok(BackendKvEntryPage {
-            keys: byte_array_property(&object, "keys", context)?.finish(),
-            values: byte_array_property(&object, "values", context)?.finish(),
-            resume_after: optional_bytes_property(&object, "resumeAfter", context)?,
-        })
-    }
-
-    #[cfg(any())]
-    fn js_value_to_write_stats(
-        value: JsValue,
-        context: &str,
-    ) -> Result<BackendKvWriteStats, LixError> {
-        let object = expect_backend_object(value, context)?;
-        Ok(BackendKvWriteStats {
-            puts: required_usize(&object, "puts", context)?,
-            deletes: required_usize(&object, "deletes", context)?,
-            delete_ranges: required_usize(&object, "deleteRanges", context)?,
-            bytes_written: required_usize(&object, "bytesWritten", context)?,
-        })
-    }
-
     fn expect_backend_object(value: JsValue, context: &str) -> Result<Object, LixError> {
         if value.is_null() || value.is_undefined() || !value.is_object() {
             return Err(js_sdk_error(format!("{context} must return an object")));
@@ -1445,34 +1331,6 @@ export type MergeConflictSide = {
             return Err(js_sdk_error(format!("{context}.{key} must be an array")));
         }
         Ok(Array::from(&value))
-    }
-
-    #[cfg(any())]
-    fn byte_array_property(
-        object: &Object,
-        key: &str,
-        context: &str,
-    ) -> Result<BytePageBuilder, LixError> {
-        let array = required_array(object, key, context)?;
-        let mut page = BytePageBuilder::with_capacity(array.length() as usize, 0);
-        for value in array.iter() {
-            page.push(js_value_to_bytes(value, &format!("{context}.{key}"))?);
-        }
-        Ok(page)
-    }
-
-    #[cfg(any())]
-    fn optional_bytes_property(
-        object: &Object,
-        key: &str,
-        context: &str,
-    ) -> Result<Option<Vec<u8>>, LixError> {
-        let value = Reflect::get(object, &JsValue::from_str(key))
-            .map_err(|_| js_sdk_error(format!("{context}.{key} could not be read")))?;
-        if value.is_undefined() || value.is_null() {
-            return Ok(None);
-        }
-        Ok(Some(js_value_to_bytes(value, &format!("{context}.{key}"))?))
     }
 
     fn required_usize(object: &Object, key: &str, context: &str) -> Result<usize, LixError> {
@@ -1658,6 +1516,43 @@ export type MergeConflictSide = {
             "LIX_ERROR_JS_SDK",
             format!("{method}() requires {key} to be a non-empty string when provided"),
         ))
+    }
+
+    fn optional_bool(
+        object: &Object,
+        key: &str,
+        context: &str,
+    ) -> Result<Option<bool>, LixError> {
+        let value = Reflect::get(object, &JsValue::from_str(key))
+            .map_err(|_| js_sdk_error(format!("{context}.{key} could not be read")))?;
+        if value.is_undefined() || value.is_null() {
+            return Ok(None);
+        }
+        value
+            .as_bool()
+            .map(Some)
+            .ok_or_else(|| js_sdk_error(format!("{context}.{key} must be a boolean")))
+    }
+
+    fn optional_usize(
+        object: &Object,
+        key: &str,
+        context: &str,
+    ) -> Result<Option<usize>, LixError> {
+        let value = Reflect::get(object, &JsValue::from_str(key))
+            .map_err(|_| js_sdk_error(format!("{context}.{key} could not be read")))?;
+        if value.is_undefined() || value.is_null() {
+            return Ok(None);
+        }
+        let number = value
+            .as_f64()
+            .ok_or_else(|| js_sdk_error(format!("{context}.{key} must be a number")))?;
+        if !number.is_finite() || number < 0.0 || number.fract() != 0.0 {
+            return Err(js_sdk_error(format!(
+                "{context}.{key} must be a non-negative integer"
+            )));
+        }
+        Ok(Some(number as usize))
     }
 
     fn value_from_js(value: JsValue) -> Result<Value, LixError> {

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -7,6 +7,28 @@ edition = "2021"
 lix_engine = { path = "../engine", version = "0.1.0" }
 
 async-trait = "0.1"
+bytes = "1"
+rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+tempfile = { version = "3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
+
+[features]
+default = []
+sqlite = ["dep:rusqlite", "dep:tempfile"]
+
+[[example]]
+name = "create_sqlite_fixture"
+path = "tests/fixtures/create_sqlite_fixture.rs"
+required-features = ["sqlite"]
+
+[[example]]
+name = "write_sqlite_key_value"
+path = "tests/fixtures/write_sqlite_key_value.rs"
+required-features = ["sqlite"]
+
+[[example]]
+name = "verify_sqlite_key_value"
+path = "tests/fixtures/verify_sqlite_key_value.rs"
+required-features = ["sqlite"]

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -5,16 +5,24 @@
 //! surface.
 
 mod lix;
+#[cfg(feature = "sqlite")]
+mod sqlite_backend;
 
 pub use lix::{open_lix, open_lix_with_backend, Lix, LixTransaction, OpenLixOptions};
 pub use lix_engine::{
-    Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite, CommitResult,
+    run_backend_conformance, Backend, BackendConformanceReport, BackendConformanceResult,
+    BackendConformanceStatus, BackendConformanceTest, BackendError, BackendFactory,
+    BackendFixture, BackendRangeScan, BackendRead, BackendTestConfig, BackendWrite, CommitResult,
     CoreProjection, CreateBranchOptions, CreateBranchReceipt as CreateBranchResult, ExecuteResult,
     GetOptions, InMemoryBackend, InMemoryRangeScan, InMemoryRead, InMemoryWrite, Key, KeyRange,
     LixError, LixNotice, MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview,
     MergeBranchPreviewOptions, MergeBranchReceipt as MergeBranchResult, MergeChangeStats,
-    MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, PointVisitor,
-    ProjectedValueRef, PutBatch, ReadOptions, Row, ScanOptions, ScanResult, ScanVisitor,
-    SqlQueryResult, StoredValue, SwitchBranchOptions, SwitchBranchReceipt as SwitchBranchResult,
-    TryFromValue, Value, WriteOptions, WriteStats,
+    MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide,
+    PointVisitor, ProjectedValueRef, PutBatch, ReadOptions, Row, ScanOptions, ScanResult,
+    ScanVisitor, SqlQueryResult, StoredValue, SwitchBranchOptions,
+    SwitchBranchReceipt as SwitchBranchResult, TryFromValue, Value, WriteOptions, WriteStats,
+};
+#[cfg(feature = "sqlite")]
+pub use sqlite_backend::{
+    SqliteBackend, SqliteBackendFactory, SqliteBackendFixture, SQLITE_FORMAT_VERSION,
 };

--- a/packages/rs-sdk/src/sqlite_backend.rs
+++ b/packages/rs-sdk/src/sqlite_backend.rs
@@ -1,0 +1,645 @@
+use std::collections::VecDeque;
+use std::ops::Bound;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use lix_engine::backend::{
+    Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite, CommitResult,
+    CoreProjection, GetOptions, Key, KeyRange, KeyRef, PointVisitor, ProjectedValueRef, PutBatch,
+    ReadOptions, ScanOptions, ScanResult, ScanVisitor, StoredValue, WriteOptions, WriteStats,
+};
+use lix_engine::{BackendFactory, BackendFixture, BackendTestConfig};
+use rusqlite::types::{Value as SqlValue, ValueRef as SqlValueRef};
+use rusqlite::{params, Connection};
+use tempfile::TempDir;
+
+pub const SQLITE_FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug)]
+pub struct SqliteBackendFactory {
+    temp_dir: TempDir,
+    next_database_id: AtomicU64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SqliteBackendFixture {
+    path: PathBuf,
+}
+
+#[derive(Clone)]
+pub struct SqliteBackend {
+    path: PathBuf,
+    write_pool: Arc<Mutex<Vec<Connection>>>,
+}
+
+#[derive(Clone)]
+pub struct SqliteRead {
+    state: Arc<Mutex<SqliteReadState>>,
+}
+
+struct SqliteReadState {
+    conn: Option<Connection>,
+}
+
+pub struct SqliteRangeScan {
+    rows: VecDeque<SqlitePendingRow>,
+    projection: CoreProjection,
+    pending: Option<SqlitePendingRow>,
+    done: bool,
+}
+
+struct SqlitePendingRow {
+    key: Vec<u8>,
+    value: Option<Vec<u8>>,
+}
+
+pub struct SqliteWrite {
+    conn: Option<Connection>,
+    write_pool: Arc<Mutex<Vec<Connection>>>,
+    stats: WriteStats,
+}
+
+impl SqliteBackendFactory {
+    pub fn new() -> Self {
+        Self {
+            temp_dir: tempfile::tempdir().expect("create sqlite backend temp dir"),
+            next_database_id: AtomicU64::new(0),
+        }
+    }
+}
+
+impl BackendFactory for SqliteBackendFactory {
+    type Backend = SqliteBackend;
+    type Fixture = SqliteBackendFixture;
+
+    fn create_fixture(&self) -> Self::Fixture {
+        let database_id = self.next_database_id.fetch_add(1, Ordering::Relaxed);
+        let path = self
+            .temp_dir
+            .path()
+            .join(format!("backend-{database_id}.sqlite"));
+        SqliteBackendFixture { path }
+    }
+
+    fn config(&self) -> BackendTestConfig {
+        BackendTestConfig {
+            ephemeral: false,
+            supports_concurrent_writers: false,
+            ..BackendTestConfig::default()
+        }
+    }
+}
+
+impl BackendFixture for SqliteBackendFixture {
+    type Backend = SqliteBackend;
+
+    fn open(&self) -> Self::Backend {
+        SqliteBackend::open(&self.path).expect("open sqlite backend")
+    }
+}
+
+impl SqliteBackend {
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, BackendError> {
+        let path = path.into();
+        initialize_database(&path)?;
+        Ok(Self {
+            path,
+            write_pool: Arc::new(Mutex::new(Vec::new())),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[allow(dead_code)]
+    pub fn checkpoint(&self) -> Result<(), BackendError> {
+        let conn = self.connect()?;
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .map_err(sqlite_error)
+    }
+
+    pub fn format_version(&self) -> Result<u32, BackendError> {
+        let conn = self.connect()?;
+        sqlite_user_version(&conn)
+    }
+
+    pub fn busy_timeout_ms(&self) -> Result<i64, BackendError> {
+        let conn = self.connect()?;
+        conn.pragma_query_value(None, "busy_timeout", |row| row.get::<_, i64>(0))
+            .map_err(sqlite_error)
+    }
+
+    fn connect(&self) -> Result<Connection, BackendError> {
+        open_connection(&self.path)
+    }
+}
+
+impl Backend for SqliteBackend {
+    type Read<'a>
+        = SqliteRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = SqliteWrite
+    where
+        Self: 'a;
+    fn begin_read(&self, _opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
+        let conn = self.connect()?;
+        execute_cached(&conn, "BEGIN DEFERRED TRANSACTION")?;
+        pin_read_snapshot(&conn)?;
+        Ok(SqliteRead {
+            state: Arc::new(Mutex::new(SqliteReadState { conn: Some(conn) })),
+        })
+    }
+
+    fn begin_write(&self, _opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+        let conn = self
+            .write_pool
+            .lock()
+            .map_err(|error| BackendError::Io(format!("sqlite write pool poisoned: {error}")))?
+            .pop()
+            .map(Ok)
+            .unwrap_or_else(|| self.connect())?;
+        conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")
+            .map_err(sqlite_error)?;
+        Ok(SqliteWrite {
+            conn: Some(conn),
+            write_pool: Arc::clone(&self.write_pool),
+            stats: WriteStats::default(),
+        })
+    }
+}
+
+impl BackendRead for SqliteRead {
+    type RangeScan<'a> = SqliteRangeScan;
+
+    fn visit_keys<V>(
+        &self,
+        keys: &[Key],
+        opts: GetOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<(), BackendError>
+    where
+        V: PointVisitor + ?Sized,
+    {
+        let state = self
+            .state
+            .lock()
+            .map_err(|error| BackendError::Io(format!("sqlite read state poisoned: {error}")))?;
+        let conn = state
+            .conn
+            .as_ref()
+            .ok_or_else(|| BackendError::Io("sqlite read is closed".to_string()))?;
+        visit_keys(conn, keys, opts, visitor)
+    }
+
+    fn with_range_scan<T, F>(
+        &self,
+        range: KeyRange,
+        opts: ScanOptions<'_>,
+        f: F,
+    ) -> Result<T, BackendError>
+    where
+        F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+    {
+        let rows = {
+            let state = self.state.lock().map_err(|error| {
+                BackendError::Io(format!("sqlite read state poisoned: {error}"))
+            })?;
+            let conn = state
+                .conn
+                .as_ref()
+                .ok_or_else(|| BackendError::Io("sqlite read is closed".to_string()))?;
+            collect_range_rows(conn, range, opts)?
+        };
+        let mut cursor = SqliteRangeScan {
+            rows,
+            projection: opts.projection,
+            pending: None,
+            done: opts.limit_rows == 0,
+        };
+        f(&mut cursor)
+    }
+
+    fn close(self) -> Result<(), BackendError> {
+        self.finish()
+    }
+}
+
+impl BackendRangeScan for SqliteRangeScan {
+    fn visit_next<V>(
+        &mut self,
+        limit_rows: usize,
+        visitor: &mut V,
+    ) -> Result<ScanResult, BackendError>
+    where
+        V: ScanVisitor + ?Sized,
+    {
+        if limit_rows == 0 || self.done {
+            return Ok(ScanResult {
+                emitted: 0,
+                has_more: !self.done,
+            });
+        }
+
+        let mut emitted = 0;
+        while emitted < limit_rows {
+            if let Some(pending) = self.pending.take() {
+                visit_sqlite_pending_row(pending, self.projection, visitor)?;
+                emitted += 1;
+                continue;
+            }
+
+            let Some(row) = self.rows.pop_front() else {
+                self.done = true;
+                return Ok(ScanResult {
+                    emitted,
+                    has_more: false,
+                });
+            };
+            visit_sqlite_pending_row(row, self.projection, visitor)?;
+            emitted += 1;
+        }
+
+        let has_more = self.ensure_pending()?;
+        Ok(ScanResult { emitted, has_more })
+    }
+}
+
+impl SqliteRangeScan {
+    fn ensure_pending(&mut self) -> Result<bool, BackendError> {
+        if self.pending.is_some() {
+            return Ok(true);
+        }
+        let Some(row) = self.rows.pop_front() else {
+            self.done = true;
+            return Ok(false);
+        };
+        self.pending = Some(row);
+        Ok(true)
+    }
+}
+
+fn visit_sqlite_pending_row<V>(
+    row: SqlitePendingRow,
+    projection: CoreProjection,
+    visitor: &mut V,
+) -> Result<(), BackendError>
+where
+    V: ScanVisitor + ?Sized,
+{
+    match projection {
+        CoreProjection::KeyOnly => {
+            visitor.visit(KeyRef(row.key.as_slice()), ProjectedValueRef::KeyOnly)
+        }
+        CoreProjection::FullValue => {
+            let value = row
+                .value
+                .as_deref()
+                .ok_or_else(|| BackendError::Io("sqlite pending row missing value".to_string()))?;
+            visitor.visit(
+                KeyRef(row.key.as_slice()),
+                ProjectedValueRef::FullValue(value),
+            )
+        }
+    }
+}
+
+impl SqliteRead {
+    fn finish(&self) -> Result<(), BackendError> {
+        if Arc::strong_count(&self.state) > 1 {
+            return Ok(());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|error| BackendError::Io(format!("sqlite read state poisoned: {error}")))?;
+        let Some(conn) = state.conn.take() else {
+            return Ok(());
+        };
+        execute_cached(&conn, "ROLLBACK").or_else(ignore_no_transaction)
+    }
+}
+
+impl Drop for SqliteRead {
+    fn drop(&mut self) {
+        let _ = self.finish();
+    }
+}
+
+impl BackendWrite for SqliteWrite {
+    fn put_many(&mut self, entries: PutBatch) -> Result<(), BackendError> {
+        let mut put_entries = 0;
+        let mut written_bytes = 0;
+        {
+            let conn = self.conn();
+            let mut stmt = conn
+                .prepare(
+                    "INSERT INTO lix_entries(key, value)
+                     VALUES (?1, ?2)
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                )
+                .map_err(sqlite_error)?;
+
+            for entry in entries.entries {
+                let value = stored_value_bytes(entry.value);
+                put_entries += 1;
+                written_bytes += value.len() as u64;
+                stmt.execute(params![entry.key.0.as_ref(), value.as_ref()])
+                    .map_err(sqlite_error)?;
+            }
+        }
+        self.stats.put_entries += put_entries;
+        self.stats.written_bytes += written_bytes;
+        self.stats.backend_calls += 1;
+        Ok(())
+    }
+
+    fn delete_many(&mut self, keys: &[Key]) -> Result<(), BackendError> {
+        {
+            let conn = self.conn();
+            let mut stmt = conn
+                .prepare("DELETE FROM lix_entries WHERE key = ?1")
+                .map_err(sqlite_error)?;
+
+            for key in keys {
+                stmt.execute(params![key.0.as_ref()])
+                    .map_err(sqlite_error)?;
+            }
+        }
+        self.stats.deleted_entries += keys.len() as u64;
+        self.stats.backend_calls += 1;
+        Ok(())
+    }
+
+    fn delete_range(&mut self, range: KeyRange) -> Result<(), BackendError> {
+        let mut sql = String::from("DELETE FROM lix_entries WHERE 1 = 1");
+        let mut values = Vec::new();
+        append_bound_sql(&mut sql, &mut values, "key", ">=", ">", &range.lower);
+        append_bound_sql(&mut sql, &mut values, "key", "<=", "<", &range.upper);
+        let deleted = self
+            .conn()
+            .execute(&sql, rusqlite::params_from_iter(values))
+            .map_err(sqlite_error)?;
+        self.stats.deleted_entries += deleted as u64;
+        self.stats.deleted_ranges += 1;
+        self.stats.backend_calls += 1;
+        Ok(())
+    }
+
+    fn commit(mut self) -> Result<CommitResult, BackendError> {
+        self.finish("COMMIT")?;
+        Ok(CommitResult {
+            commit_id: None,
+            stats: std::mem::take(&mut self.stats),
+        })
+    }
+
+    fn rollback(mut self) -> Result<(), BackendError> {
+        self.finish("ROLLBACK")
+    }
+}
+
+impl SqliteWrite {
+    fn conn(&self) -> &Connection {
+        self.conn
+            .as_ref()
+            .expect("sqlite write connection should be available")
+    }
+
+    fn finish(&mut self, sql: &str) -> Result<(), BackendError> {
+        let Some(conn) = self.conn.take() else {
+            return Ok(());
+        };
+        let result = execute_cached(&conn, sql);
+        if result.is_ok() {
+            if let Ok(mut pool) = self.write_pool.lock() {
+                pool.push(conn);
+            }
+        }
+        result
+    }
+}
+
+impl Drop for SqliteWrite {
+    fn drop(&mut self) {
+        let _ = self.finish("ROLLBACK");
+    }
+}
+
+fn initialize_database(path: &Path) -> Result<(), BackendError> {
+    let conn = open_connection(path)?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(sqlite_error)?;
+    let user_version = sqlite_user_version(&conn)?;
+    if user_version > SQLITE_FORMAT_VERSION {
+        return Err(BackendError::Io(format!(
+            "sqlite file format version {user_version} is newer than supported version {SQLITE_FORMAT_VERSION}"
+        )));
+    }
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS lix_entries (
+            key BLOB NOT NULL,
+            value BLOB NOT NULL,
+            PRIMARY KEY (key)
+        ) WITHOUT ROWID;",
+    )
+    .map_err(sqlite_error)?;
+    conn.pragma_update(None, "user_version", SQLITE_FORMAT_VERSION)
+        .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn open_connection(path: &Path) -> Result<Connection, BackendError> {
+    let conn = Connection::open(path).map_err(sqlite_error)?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(sqlite_error)?;
+    Ok(conn)
+}
+
+fn sqlite_user_version(conn: &Connection) -> Result<u32, BackendError> {
+    conn.pragma_query_value(None, "user_version", |row| row.get::<_, u32>(0))
+        .map_err(sqlite_error)
+}
+
+fn pin_read_snapshot(conn: &Connection) -> Result<(), BackendError> {
+    let mut stmt = conn
+        .prepare_cached("SELECT COUNT(*) FROM lix_entries")
+        .map_err(sqlite_error)?;
+    let _: i64 = stmt.query_row([], |row| row.get(0)).map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn execute_cached(conn: &Connection, sql: &str) -> Result<(), BackendError> {
+    let mut stmt = conn.prepare_cached(sql).map_err(sqlite_error)?;
+    stmt.execute([]).map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn visit_keys<V>(
+    conn: &Connection,
+    keys: &[Key],
+    opts: GetOptions<'_>,
+    visitor: &mut V,
+) -> Result<(), BackendError>
+where
+    V: PointVisitor + ?Sized,
+{
+    if keys.is_empty() {
+        return Ok(());
+    }
+
+    let mut placeholders = String::with_capacity(keys.len() * 8);
+    let mut values = Vec::with_capacity(keys.len() * 2);
+    for (index, key) in keys.iter().enumerate() {
+        if index > 0 {
+            placeholders.push_str(", ");
+        }
+        placeholders.push_str("(?, ?)");
+        values.push(SqlValue::Integer(index as i64));
+        values.push(SqlValue::Blob(key.0.to_vec()));
+    }
+    let sql = format!(
+        "WITH requested(ord, key) AS (VALUES {placeholders})
+         SELECT r.ord, e.value
+         FROM requested r
+         LEFT JOIN lix_entries e ON e.key = r.key
+         ORDER BY r.ord ASC"
+    );
+
+    let mut stmt = conn.prepare_cached(&sql).map_err(sqlite_error)?;
+    let mut rows = stmt
+        .query(rusqlite::params_from_iter(values))
+        .map_err(sqlite_error)?;
+    while let Some(row) = rows.next().map_err(sqlite_error)? {
+        let index: i64 = row.get(0).map_err(sqlite_error)?;
+        let index = usize::try_from(index).map_err(|_| {
+            BackendError::Corruption(format!("sqlite requested ordinal was negative: {index}"))
+        })?;
+        let Some(key) = keys.get(index) else {
+            return Err(BackendError::Corruption(format!(
+                "sqlite requested ordinal out of bounds: {index}"
+            )));
+        };
+        let value_ref = row.get_ref(1).map_err(sqlite_error)?;
+        let value = match value_ref {
+            SqlValueRef::Null => None,
+            SqlValueRef::Blob(value) => Some(project_value_ref(value, opts.projection)),
+            other => {
+                return Err(BackendError::Corruption(format!(
+                    "sqlite value column was not a blob: {other:?}"
+                )));
+            }
+        };
+        visitor.visit(index, key, value)?;
+    }
+    Ok(())
+}
+
+fn collect_range_rows(
+    conn: &Connection,
+    range: KeyRange,
+    opts: ScanOptions<'_>,
+) -> Result<VecDeque<SqlitePendingRow>, BackendError> {
+    let (sql, values) = scan_sql(range, opts)?;
+    let mut stmt = conn.prepare_cached(&sql).map_err(sqlite_error)?;
+    let mut rows = stmt
+        .query(rusqlite::params_from_iter(values))
+        .map_err(sqlite_error)?;
+    let mut collected = VecDeque::new();
+    while let Some(row) = rows.next().map_err(sqlite_error)? {
+        let key = blob_ref(row.get_ref(0).map_err(sqlite_error)?, "key")?.to_vec();
+        let value = if matches!(opts.projection, CoreProjection::FullValue) {
+            Some(blob_ref(row.get_ref(1).map_err(sqlite_error)?, "value")?.to_vec())
+        } else {
+            None
+        };
+        collected.push_back(SqlitePendingRow { key, value });
+    }
+    Ok(collected)
+}
+
+fn scan_sql(
+    range: KeyRange,
+    opts: ScanOptions<'_>,
+) -> Result<(String, Vec<SqlValue>), BackendError> {
+    let mut sql = match opts.projection {
+        CoreProjection::KeyOnly => String::from("SELECT key FROM lix_entries WHERE 1 = 1"),
+        CoreProjection::FullValue => String::from("SELECT key, value FROM lix_entries WHERE 1 = 1"),
+    };
+    let mut values = Vec::new();
+
+    append_bound_sql(&mut sql, &mut values, "key", ">=", ">", &range.lower);
+    append_bound_sql(&mut sql, &mut values, "key", "<=", "<", &range.upper);
+    if let Some(resume_after) = opts.resume_after {
+        sql.push_str(" AND key > ?");
+        values.push(SqlValue::Blob(resume_after.0.to_vec()));
+    }
+    sql.push_str(" ORDER BY key ASC");
+    Ok((sql, values))
+}
+
+fn append_bound_sql(
+    sql: &mut String,
+    values: &mut Vec<SqlValue>,
+    column: &str,
+    included_op: &str,
+    excluded_op: &str,
+    bound: &Bound<Key>,
+) {
+    match bound {
+        Bound::Included(key) => {
+            sql.push_str(" AND ");
+            sql.push_str(column);
+            sql.push(' ');
+            sql.push_str(included_op);
+            sql.push_str(" ?");
+            values.push(SqlValue::Blob(key.0.to_vec()));
+        }
+        Bound::Excluded(key) => {
+            sql.push_str(" AND ");
+            sql.push_str(column);
+            sql.push(' ');
+            sql.push_str(excluded_op);
+            sql.push_str(" ?");
+            values.push(SqlValue::Blob(key.0.to_vec()));
+        }
+        Bound::Unbounded => {}
+    }
+}
+
+fn blob_ref<'a>(value: SqlValueRef<'a>, column: &str) -> Result<&'a [u8], BackendError> {
+    match value {
+        SqlValueRef::Blob(bytes) => Ok(bytes),
+        other => Err(BackendError::Corruption(format!(
+            "sqlite {column} column was not a blob: {other:?}"
+        ))),
+    }
+}
+
+fn project_value_ref(value: &[u8], projection: CoreProjection) -> ProjectedValueRef<'_> {
+    match projection {
+        CoreProjection::KeyOnly => ProjectedValueRef::KeyOnly,
+        CoreProjection::FullValue => ProjectedValueRef::FullValue(value),
+    }
+}
+
+fn stored_value_bytes(value: StoredValue) -> Bytes {
+    value.bytes
+}
+
+fn sqlite_error(error: rusqlite::Error) -> BackendError {
+    BackendError::Io(error.to_string())
+}
+
+fn ignore_no_transaction(error: BackendError) -> Result<(), BackendError> {
+    match error {
+        BackendError::Io(message) if message.contains("no transaction") => Ok(()),
+        other => Err(other),
+    }
+}

--- a/packages/rs-sdk/tests/fixtures/create_sqlite_fixture.rs
+++ b/packages/rs-sdk/tests/fixtures/create_sqlite_fixture.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use lix_rs_sdk::SqliteBackend;
+
+fn main() {
+    let path = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .expect("usage: create_sqlite_fixture <path>");
+
+    let backend = SqliteBackend::open(&path).expect("sqlite backend should create fixture");
+    backend
+        .checkpoint()
+        .expect("sqlite backend fixture should checkpoint");
+}

--- a/packages/rs-sdk/tests/fixtures/verify_sqlite_key_value.rs
+++ b/packages/rs-sdk/tests/fixtures/verify_sqlite_key_value.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+
+use lix_rs_sdk::{open_lix_with_backend, SqliteBackend, Value};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut args = std::env::args_os();
+    let _program = args.next();
+    let path = args
+        .next()
+        .map(PathBuf::from)
+        .expect("usage: verify_sqlite_key_value <path> <key> <value>");
+    let key = args
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .expect("usage: verify_sqlite_key_value <path> <key> <value>");
+    let value = args
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .expect("usage: verify_sqlite_key_value <path> <key> <value>");
+
+    let lix = open_lix_with_backend(SqliteBackend::open(&path).expect("sqlite backend should open"))
+        .await
+        .expect("lix should open on sqlite backend");
+    let result = lix
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = $1",
+            &[Value::Text(key)],
+        )
+        .await
+        .expect("key/value read should succeed");
+    let actual = result
+        .rows()
+        .first()
+        .and_then(|row| row.values().first())
+        .expect("expected one key/value row");
+    match actual {
+        Value::Json(json) if json.as_str() == Some(&value) => {}
+        Value::Text(text) if text == &value => {}
+        other => panic!("expected value {value:?}, got {other:?}"),
+    }
+    lix.close().await.expect("lix should close");
+}

--- a/packages/rs-sdk/tests/fixtures/write_sqlite_key_value.rs
+++ b/packages/rs-sdk/tests/fixtures/write_sqlite_key_value.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+use lix_rs_sdk::{open_lix_with_backend, SqliteBackend, Value};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut args = std::env::args_os();
+    let _program = args.next();
+    let path = args
+        .next()
+        .map(PathBuf::from)
+        .expect("usage: write_sqlite_key_value <path> <key> <value>");
+    let key = args
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .expect("usage: write_sqlite_key_value <path> <key> <value>");
+    let value = args
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .expect("usage: write_sqlite_key_value <path> <key> <value>");
+
+    let backend = SqliteBackend::open(&path).expect("sqlite backend should open");
+    let lix = open_lix_with_backend(backend.clone())
+        .await
+        .expect("lix should open on sqlite backend");
+    lix.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+        &[Value::Text(key), Value::Text(value)],
+    )
+    .await
+    .expect("key/value write should succeed");
+    lix.close().await.expect("lix should close");
+    backend
+        .checkpoint()
+        .expect("sqlite backend should checkpoint fixture");
+}

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "sqlite")]
+
+use lix_engine::run_backend_conformance;
+use lix_rs_sdk::{
+	open_lix_with_backend, SqliteBackend, SqliteBackendFactory, Value, SQLITE_FORMAT_VERSION,
+};
+use rusqlite::Connection;
+
+#[test]
+fn sqlite_backend_passes_backend_conformance() {
+    let factory = SqliteBackendFactory::new();
+
+    run_backend_conformance(&factory).assert_no_failures();
+}
+
+#[test]
+fn sqlite_backend_initializes_file_format_and_open_pragmas() {
+    let tempdir = tempfile::tempdir().expect("tempdir should create");
+    let path = tempdir.path().join("workspace.lix");
+
+    let backend = SqliteBackend::open(&path).expect("sqlite backend opens");
+
+    assert_eq!(
+        backend
+            .format_version()
+            .expect("format version should read"),
+        SQLITE_FORMAT_VERSION,
+        "empty database should initialize to the current format version"
+    );
+    assert_eq!(
+        sqlite_journal_mode(&path),
+        "wal",
+        "sqlite backend should use WAL journal mode"
+    );
+    assert_eq!(
+        backend.busy_timeout_ms().expect("busy timeout should read"),
+        5000,
+        "sqlite backend should set a 5s busy timeout on opened connections"
+    );
+
+    drop(backend);
+}
+
+#[test]
+fn sqlite_backend_refuses_future_file_format_version() {
+    let tempdir = tempfile::tempdir().expect("tempdir should create");
+    let path = tempdir.path().join("workspace.lix");
+    let conn = Connection::open(&path).expect("sqlite file should create");
+    conn.pragma_update(None, "user_version", 999)
+        .expect("future user_version should write");
+    drop(conn);
+
+    let error = match SqliteBackend::open(&path) {
+        Ok(_) => panic!("future file format version should be refused"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.to_string().contains("newer than supported version"),
+        "error should explain future format version: {error}"
+    );
+}
+
+#[tokio::test]
+async fn sqlite_backend_persists_lix_data_across_reopen() {
+    let tempdir = tempfile::tempdir().expect("tempdir should create");
+    let path = tempdir.path().join("workspace.lix");
+
+    {
+        let lix = open_lix_with_backend(SqliteBackend::open(&path).expect("sqlite backend opens"))
+            .await
+            .expect("lix opens on sqlite backend");
+        lix.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('sqlite-key', 'sqlite-value')",
+            &[],
+        )
+        .await
+        .expect("write succeeds");
+        lix.close().await.expect("lix closes");
+    }
+
+    let lix = open_lix_with_backend(SqliteBackend::open(&path).expect("sqlite backend reopens"))
+        .await
+        .expect("lix reopens on sqlite backend");
+    let result = lix
+        .execute(
+            "SELECT key FROM lix_key_value WHERE key = 'sqlite-key' AND value = lix_json('\"sqlite-value\"')",
+            &[],
+        )
+        .await
+        .expect("read succeeds");
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result.rows()[0].values(),
+        &[Value::Text("sqlite-key".to_string())]
+    );
+    lix.close().await.expect("lix closes");
+}
+
+fn sqlite_journal_mode(path: &std::path::Path) -> String {
+    let conn = Connection::open(path).expect("sqlite file should open");
+    conn.pragma_query_value(None, "journal_mode", |row| row.get(0))
+        .expect("journal_mode should read")
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Breaking changes to the custom backend contract and SQLite file layout (`lix_kv` → `lix_entries`), plus new persistence semantics; consumers with old backends or existing `.lix` KV files need migration.
> 
> **Overview**
> This PR **aligns JS and Rust SQLite persistence** with a shared on-disk layout and a **simplified Lix backend KV contract**, then proves both stacks with **backend conformance** and cross-language interop tests.
> 
> **Backend API (breaking for custom backends):** KV access drops **namespaces** and grouped batches—`getValues` / `writeKvBatch` use flat `keys` and `ops`. Scans use **`lower` / `upper` bounds** (`included` / `excluded` / `unbounded`) instead of prefix/range variants. Read transactions expose **`getValues` + `scanEntries` only** (no `existsMany`, `scanKeys`, or `scanValues`). WASM bindings and the in-memory test backend follow the same shape.
> 
> **JS `@lix-js/sdk/sqlite`:** `createBetterSqlite3Backend()` is replaced by **`new SqliteBackend({ path })`**. Storage moves from `lix_kv` to **`lix_entries`** (blob key PK), with **WAL**, **`user_version`**, and refusal of newer file formats. File-backed backends use a **separate readonly connection** for read transactions; **`scanEntries`** applies the resume cursor before the page limit. **`runBackendConformance`** is exposed from wasm and used in tests. **SKILL.md** documents the new constructor.
> 
> **Rust `lix_rs_sdk`:** Optional **`sqlite`** feature adds **`SqliteBackend`** (rusqlite), **`SqliteBackendFactory`** for conformance, format-version checks, and **cargo examples** for JS↔Rust fixture read/write. Integration tests run **`run_backend_conformance`** and persistence scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2514417a3782192b4e6d24aecfda1d64eabc3bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->