### PR TITLE
Add publish flow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,9 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - blacksmith-32vcpu-ubuntu-2404
+    - blacksmith-32vcpu-ubuntu-2404-arm
+    - blacksmith-12vcpu-macos-15
+    - blacksmith-16vcpu-windows-2025
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,20 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - blacksmith-32vcpu-ubuntu-2404
+
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null
+
+# Configuration for file paths. The keys are glob patterns to match to file
+# paths relative to the repository root. The values are the configurations for
+# the file paths. Note that the path separator is always '/'.
+# The following configurations are available.
+#
+# "ignore" is an array of regular expression patterns. Matched error messages
+# are ignored. This is similar to the "-ignore" command line option.
+paths:
+#  .github/workflows/**/*.yml:
+#    ignore: []

--- a/.github/workflows/changelog-suggest.yml
+++ b/.github/workflows/changelog-suggest.yml
@@ -14,6 +14,7 @@ jobs:
     if: >
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'github-actions[bot]' &&
+      (!endsWith(github.actor, '[bot]') || github.actor == 'cursor[bot]') &&
       !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
 
@@ -34,6 +35,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.5
           effort: medium
+          allow-bots: true
           sandbox: workspace-write
           prompt: |
             You are maintaining Lix release notes.

--- a/.github/workflows/changelog-suggest.yml
+++ b/.github/workflows/changelog-suggest.yml
@@ -1,0 +1,106 @@
+name: Changelog Suggest
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  suggest:
+    name: Suggest changelog fragment
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'github-actions[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
+
+      - name: Run Codex changelog suggester
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5.5
+          effort: medium
+          sandbox: workspace-write
+          prompt: |
+            You are maintaining Lix release notes.
+
+            Inspect only this PR's changes:
+            git diff --stat origin/${{ github.event.pull_request.base.ref }}...HEAD
+            git diff origin/${{ github.event.pull_request.base.ref }}...HEAD
+
+            If the PR has a user-facing change that warrants a release note,
+            create or update exactly one file:
+
+            .changes/pr-${{ github.event.pull_request.number }}.md
+
+            Use this exact format:
+
+            ---
+            type: patch
+            scope: js-sdk
+            ---
+
+            One concise user-facing sentence with a PR link, for example:
+            Fixed native binding loading on Linux. [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})
+
+            Rules:
+            - type must be exactly one of: major, minor, patch.
+            - scope must be exactly one of: engine, lix-sdk, js-sdk, cli.
+            - Only create a fragment for user-facing changes in those core packages.
+            - Use major only for breaking user-facing API or behavior changes.
+            - Use minor for backward-compatible user-facing capability additions.
+            - Use patch for user-facing fixes and compatibility fixes.
+            - If there is no user-facing release note, do not create or edit any file.
+            - End the sentence with [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}).
+            - Do not edit files outside .changes/pr-${{ github.event.pull_request.number }}.md.
+            - Do not run tests or install dependencies.
+            - For repo-only, documentation-only, CI-only, test-only, and chore-only changes, do not create or edit any file.
+
+            Pull request title:
+            ${{ github.event.pull_request.title }}
+
+            Pull request body:
+            ${{ github.event.pull_request.body }}
+
+      - name: Ensure Codex only edited changelog fragment
+        run: |
+          unexpected="$(git diff --name-only | grep -v '^.changes/pr-${{ github.event.pull_request.number }}.md$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "Codex edited files outside the allowed changelog fragment:"
+            echo "$unexpected"
+            exit 1
+          fi
+
+      - name: Validate suggested changelog
+        if: hashFiles(format('.changes/pr-{0}.md', github.event.pull_request.number)) != ''
+        run: |
+          node scripts/validate-changes.mjs
+
+      - name: Commit suggested changelog
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if git diff --quiet -- ".changes/pr-${PR_NUMBER}.md"; then
+            echo "No changelog suggestion to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ".changes/pr-${PR_NUMBER}.md"
+          git commit -m "chore: add changelog suggestion for PR #${PR_NUMBER}"
+          git push origin HEAD:"${PR_HEAD_REF}"

--- a/.github/workflows/changelog-suggest.yml
+++ b/.github/workflows/changelog-suggest.yml
@@ -14,7 +14,7 @@ jobs:
     if: >
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'github-actions[bot]' &&
-      (!endsWith(github.actor, '[bot]') || github.actor == 'cursor[bot]') &&
+      !endsWith(github.actor, '[bot]') &&
       !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install JS SDK dependencies
         working-directory: packages/js-sdk
-        run: npm ci
+        run: npm install
 
       - name: Run JS SDK binding tests
         working-directory: packages/js-sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ permissions:
   contents: read
 
 jobs:
+  changelog:
+    name: Changelog
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate change fragments
+        run: node scripts/validate-changes.mjs
+
   cargo-test:
     name: Cargo Test
     runs-on: blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,44 @@
+name: Publish Packages
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-js-sdk:
+    name: Publish @lix-js/sdk
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: publish-js-sdk
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: packages/js-sdk/package-lock.json
+          registry-url: https://registry.npmjs.org
+
+      - name: Install JS SDK dependencies
+        working-directory: packages/js-sdk
+        run: npm ci
+
+      - name: Test JS SDK package
+        working-directory: packages/js-sdk
+        run: npm test
+
+      - name: Publish JS SDK package
+        working-directory: packages/js-sdk
+        run: npm publish --provenance --access public

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -10,9 +10,89 @@ permissions:
   id-token: write
 
 jobs:
+  build-js-sdk-native-packages:
+    name: Build @lix-js/sdk native package (${{ matrix.suffix }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suffix: linux-x64
+            runner: blacksmith-32vcpu-ubuntu-2404
+          - suffix: linux-arm64
+            runner: blacksmith-32vcpu-ubuntu-2404-arm
+          - suffix: darwin-arm64
+            runner: blacksmith-12vcpu-macos-15
+          - suffix: win32-x64
+            runner: blacksmith-16vcpu-windows-2025
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: publish-js-sdk-${{ matrix.suffix }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: packages/js-sdk/package-lock.json
+
+      - name: Install JS SDK dependencies
+        working-directory: packages/js-sdk
+        run: npm ci
+
+      - name: Build JS SDK native package
+        working-directory: packages/js-sdk
+        run: |
+          npm run build:native
+          npm run prepare:native-package -- --suffix=${{ matrix.suffix }}
+
+      - name: Upload JS SDK native package
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-sdk-native-${{ matrix.suffix }}
+          path: packages/js-sdk/native-packages/${{ matrix.suffix }}
+          if-no-files-found: error
+
+  publish-js-sdk-native-packages:
+    name: Publish @lix-js/sdk native package (${{ matrix.suffix }})
+    runs-on: ubuntu-latest
+    needs: build-js-sdk-native-packages
+    strategy:
+      fail-fast: false
+      matrix:
+        suffix:
+          - linux-x64
+          - linux-arm64
+          - darwin-arm64
+          - win32-x64
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Download JS SDK native package
+        uses: actions/download-artifact@v4
+        with:
+          name: js-sdk-native-${{ matrix.suffix }}
+          path: native-package
+
+      - name: Publish JS SDK native package
+        working-directory: native-package
+        run: npm publish --provenance --access public
+
   publish-js-sdk:
     name: Publish @lix-js/sdk
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
+    needs: publish-js-sdk-native-packages
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install JS SDK dependencies
         working-directory: packages/js-sdk
-        run: npm ci
+        run: npm install
 
       - name: Build JS SDK native package
         working-directory: packages/js-sdk
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install JS SDK dependencies
         working-directory: packages/js-sdk
-        run: npm ci
+        run: npm install
 
       - name: Test JS SDK package
         working-directory: packages/js-sdk

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,50 @@
+name: Release PR
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-pr:
+    name: Open release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare release changes
+        id: prepare
+        run: |
+          output="$(node scripts/prepare-release.mjs)"
+          echo "$output"
+          version="$(printf '%s\n' "$output" | sed -n 's/^version=//p')"
+          if [ -z "$version" ]; then
+            echo "has_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update release PR
+        if: steps.prepare.outputs.has_release == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release/v${{ steps.prepare.outputs.version }}
+          delete-branch: true
+          commit-message: Release v${{ steps.prepare.outputs.version }}
+          title: Release v${{ steps.prepare.outputs.version }}
+          body: |
+            This PR was generated from `.changes/*` fragments.
+
+            Merging this PR updates `CHANGELOG.md`, bumps lockstep package versions,
+            and enables the release tag workflow to create `v${{ steps.prepare.outputs.version }}`.

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,44 @@
+name: Release Tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect release tag
+        id: detect
+        run: |
+          tag="$(node scripts/release-tag.mjs | tail -n 1)"
+          if [ -z "$tag" ] || [ "$tag" = "No release tag needed for this commit." ]; then
+            echo "has_tag=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_tag=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.detect.outputs.has_tag == 'true'
+        run: |
+          tag="${{ steps.detect.outputs.tag }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "$tag already exists."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$tag"
+          git push origin "$tag"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,14 +2440,14 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lix_cli"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "clap",
  "comfy-table",
- "lix_rs_sdk",
+ "lix_sdk",
  "pollster",
  "serde",
  "serde_json",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "lix_engine"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2494,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "lix_js_sdk"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
- "lix_rs_sdk",
+ "lix_sdk",
  "napi",
  "napi-derive",
  "serde",
@@ -2505,8 +2505,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "lix_rs_sdk"
-version = "0.1.0"
+name = "lix_sdk"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,15 @@ resolver = "3"
 members = [
   "packages/*",
 ]
-exclude = [
-  "packages/js-kysely",
-  "packages/react-utils",
-  "packages/website",
-]
 
 [workspace.package]
-version = "0.0.0"
-authors = ["Opral Team"]
+version = "0.6.0"
+authors = ["Opral"]
 edition = "2024"
 license = "LicenseRef-opral"
 publish = false
 rust-version = "1.93"
+
+[workspace.dependencies]
+lix_engine = { path = "packages/engine", version = "0.6.0" }
+lix_sdk = { path = "packages/rs-sdk", version = "0.6.0" }

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ order_id 1002 status:
 
 Agents burn fewer tokens and keep cleaner context when version-control questions are answered with SQL instead of whole-file rereads.
 
-<img src="./assets/claude-sql-question.svg" alt="Claude Code asks: Which orders changed status in this branch? Executing SQL" width="460" />
+<img src="./website/public/assets/claude-sql-question.svg" alt="Claude Code asks: Which orders changed status in this branch? Executing SQL" width="460" />
 
 ```ts
 const rows = await lix.execute(`

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lix_cli"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]
@@ -8,7 +8,7 @@ name = "lix"
 path = "src/main.rs"
 
 [dependencies]
-lix_rs_sdk = { path = "../rs-sdk", version = "0.1.0" }
+lix_sdk = { workspace = true }
 
 async-trait = "0.1"
 clap = { version = "4.5.31", features = ["derive"] }

--- a/packages/cli/src/app/run.rs
+++ b/packages/cli/src/app/run.rs
@@ -63,7 +63,7 @@ pub(crate) fn render_error_output<W: Write>(err: &CliError, no_hints: bool, out:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lix_rs_sdk::LixError;
+    use lix_sdk::LixError;
 
     fn rendered(err: &CliError, no_hints: bool) -> String {
         let mut buf: Vec<u8> = Vec::new();

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -2,7 +2,7 @@ use crate::cli::exp::ExpGitReplayArgs;
 use crate::db;
 use crate::db::FileLix;
 use crate::error::CliError;
-use lix_rs_sdk::Value;
+use lix_sdk::Value;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -182,7 +182,7 @@ pub fn run(args: ExpGitReplayArgs) -> Result<(), CliError> {
     }
     if trace_sql_json_path.is_some() {
         return Err(CliError::msg(
-            "--trace-sql-json is not available with the current rs-sdk backend API",
+            "--trace-sql-json is not available with the current lix-sdk backend API",
         ));
     }
     if args.trace_commit.is_some() && trace_sql_json_path.is_none() {

--- a/packages/cli/src/commands/redo.rs
+++ b/packages/cli/src/commands/redo.rs
@@ -5,6 +5,6 @@ use crate::hints::CommandOutput;
 
 pub fn run(_context: &AppContext, _command: RedoCommand) -> Result<CommandOutput, CliError> {
     Err(CliError::msg(
-        "redo is not available in the current rs-sdk surface",
+        "redo is not available in the current lix-sdk surface",
     ))
 }

--- a/packages/cli/src/commands/sql/execute.rs
+++ b/packages/cli/src/commands/sql/execute.rs
@@ -5,7 +5,7 @@ use crate::error::CliError;
 use crate::hints::{self, CommandOutput};
 use crate::output;
 use base64::Engine as _;
-use lix_rs_sdk::Value;
+use lix_sdk::Value;
 use serde_json::Value as JsonValue;
 use std::io::Read;
 

--- a/packages/cli/src/commands/undo.rs
+++ b/packages/cli/src/commands/undo.rs
@@ -5,6 +5,6 @@ use crate::hints::CommandOutput;
 
 pub fn run(_context: &AppContext, _command: UndoCommand) -> Result<CommandOutput, CliError> {
     Err(CliError::msg(
-        "undo is not available in the current rs-sdk surface",
+        "undo is not available in the current lix-sdk surface",
     ))
 }

--- a/packages/cli/src/commands/version/create.rs
+++ b/packages/cli/src/commands/version/create.rs
@@ -6,7 +6,7 @@ use crate::commands::version::{
 use crate::db::{open_lix_at, resolve_db_path};
 use crate::error::CliError;
 use crate::hints::CommandOutput;
-use lix_rs_sdk::{CreateBranchOptions, CreateBranchResult, SwitchBranchOptions};
+use lix_sdk::{CreateBranchOptions, CreateBranchResult, SwitchBranchOptions};
 
 pub fn run(context: &AppContext, command: CreateVersionCommand) -> Result<CommandOutput, CliError> {
     let path = resolve_db_path(context)?;
@@ -74,7 +74,7 @@ fn create_confirmation_lines(
 mod tests {
     use super::create_confirmation_lines;
     use crate::commands::version::ResolvedVersionRef;
-    use lix_rs_sdk::CreateBranchResult;
+    use lix_sdk::CreateBranchResult;
 
     #[test]
     fn create_confirmation_uses_active_version_not_parent_version() {

--- a/packages/cli/src/commands/version/merge.rs
+++ b/packages/cli/src/commands/version/merge.rs
@@ -4,7 +4,7 @@ use crate::commands::version::{resolve_version_ref, VersionLookup};
 use crate::db::{open_lix_at, resolve_db_path};
 use crate::error::CliError;
 use crate::hints::CommandOutput;
-use lix_rs_sdk::{MergeBranchOptions, MergeBranchOutcome, SwitchBranchOptions};
+use lix_sdk::{MergeBranchOptions, MergeBranchOutcome, SwitchBranchOptions};
 
 pub fn run(context: &AppContext, command: MergeVersionCommand) -> Result<CommandOutput, CliError> {
     let path = resolve_db_path(context)?;

--- a/packages/cli/src/commands/version/mod.rs
+++ b/packages/cli/src/commands/version/mod.rs
@@ -7,7 +7,7 @@ use crate::cli::version::{VersionCommand, VersionSubcommand};
 use crate::db::FileLix;
 use crate::error::CliError;
 use crate::hints::CommandOutput;
-use lix_rs_sdk::{ExecuteResult, Row as LixRow, Value};
+use lix_sdk::{ExecuteResult, Row as LixRow, Value};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum VersionLookup<'a> {
@@ -112,7 +112,7 @@ mod tests {
     use crate::app::AppContext;
     use crate::cli::version::{CreateVersionCommand, MergeVersionCommand, SwitchVersionCommand};
     use crate::db::{init_lix_at, open_lix_at};
-    use lix_rs_sdk::{CreateBranchOptions, ExecuteResult, Value};
+    use lix_sdk::{CreateBranchOptions, ExecuteResult, Value};
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/packages/cli/src/commands/version/switch.rs
+++ b/packages/cli/src/commands/version/switch.rs
@@ -4,7 +4,7 @@ use crate::commands::version::{resolve_version_ref, VersionLookup};
 use crate::db::{open_lix_at, resolve_db_path};
 use crate::error::CliError;
 use crate::hints::CommandOutput;
-use lix_rs_sdk::SwitchBranchOptions;
+use lix_sdk::SwitchBranchOptions;
 
 pub fn run(context: &AppContext, command: SwitchVersionCommand) -> Result<CommandOutput, CliError> {
     let path = resolve_db_path(context)?;

--- a/packages/cli/src/db/mod.rs
+++ b/packages/cli/src/db/mod.rs
@@ -2,7 +2,7 @@ use crate::app::AppContext;
 use crate::error::CliError;
 use base64::Engine as _;
 use bytes::Bytes;
-use lix_rs_sdk::{
+use lix_sdk::{
     open_lix_with_backend, Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite,
     CommitResult, CoreProjection, GetOptions, Key, KeyRange, Lix, LixError, PointVisitor,
     ProjectedValueRef, PutBatch, ReadOptions, ScanOptions, ScanResult, ScanVisitor, StoredValue,

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -1,4 +1,4 @@
-use lix_rs_sdk::LixError;
+use lix_sdk::LixError;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]

--- a/packages/cli/src/hints.rs
+++ b/packages/cli/src/hints.rs
@@ -1,5 +1,5 @@
 use crate::error::CliError;
-use lix_rs_sdk::{ExecuteResult, Value};
+use lix_sdk::{ExecuteResult, Value};
 
 #[derive(Debug)]
 pub struct CommandOutput {
@@ -77,7 +77,7 @@ pub fn render_hints(hints: &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lix_rs_sdk::LixError;
+    use lix_sdk::LixError;
 
     #[test]
     fn hint_from_error_returns_empty_for_non_lix_variants() {

--- a/packages/cli/src/output/mod.rs
+++ b/packages/cli/src/output/mod.rs
@@ -1,6 +1,6 @@
 use base64::Engine as _;
 use comfy_table::{presets::UTF8_BORDERS_ONLY, Cell, ContentArrangement, Row, Table};
-use lix_rs_sdk::{ExecuteResult, Value};
+use lix_sdk::{ExecuteResult, Value};
 use serde_json::Value as JsonValue;
 
 pub fn print_execute_result_table(result: &ExecuteResult) {
@@ -53,7 +53,7 @@ fn execute_result_to_json(result: &ExecuteResult) -> JsonValue {
     })
 }
 
-fn row_to_json(columns: &[String], row: &lix_rs_sdk::Row) -> JsonValue {
+fn row_to_json(columns: &[String], row: &lix_sdk::Row) -> JsonValue {
     let mut object = serde_json::Map::new();
     for (index, column) in columns.iter().enumerate() {
         let value = row

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lix_engine"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 autobenches = false
 

--- a/packages/engine/src/backend/conformance/mod.rs
+++ b/packages/engine/src/backend/conformance/mod.rs
@@ -1,7 +1,7 @@
 //! Conformance harness for backend implementations.
 //!
 //! The harness is colocated with the experimental API for now. Once backend
-//! is stable, rs-sdk can re-export this as the public backend author test kit.
+//! is stable, lix-sdk can re-export this as the public backend author test kit.
 
 mod baseline;
 mod factory;

--- a/packages/js-sdk/.gitignore
+++ b/packages/js-sdk/.gitignore
@@ -1,2 +1,3 @@
 *.node
 dist/
+native-packages/

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lix_js_sdk"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [lib]
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-lix_rs_sdk = { path = "../rs-sdk", features = ["sqlite"] }
+lix_sdk = { workspace = true, features = ["sqlite"] }
 
 napi = { version = "3.9.0", default-features = false, features = ["napi6", "serde-json"] }
 napi-derive = "3.5.6"

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -1,4 +1,4 @@
-use lix_rs_sdk::{
+use lix_sdk::{
     open_lix, open_lix_with_backend, CreateBranchOptions as RsCreateBranchOptions,
     CreateBranchReceipt, ExecuteResult as RsExecuteResult, InMemoryBackend, Lix as RsLix, LixError,
     LixTransaction as RsLixTransaction, MergeBranchOptions as RsMergeBranchOptions,

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -11,6 +11,12 @@
 				"@types/node": "^24.10.2",
 				"typescript": "^5.5.4",
 				"vitest": "^4.0.18"
+			},
+			"optionalDependencies": {
+				"@lix-js/sdk-darwin-arm64": "0.6.0",
+				"@lix-js/sdk-linux-arm64": "0.6.0",
+				"@lix-js/sdk-linux-x64": "0.6.0",
+				"@lix-js/sdk-win32-x64": "0.6.0"
 			}
 		},
 		"node_modules/@emnapi/core": {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -11,15 +11,21 @@
 		}
 	},
 	"files": [
-		"dist",
-		"*.node"
+		"dist"
 	],
 	"scripts": {
 		"build": "npm run build:native && npm run build:ts",
 		"build:native": "node ./scripts/build-native.js",
+		"prepare:native-package": "node ./scripts/prepare-native-package.js",
 		"build:ts": "tsc -p tsconfig.json",
 		"test": "npm run build && vitest run",
 		"typecheck": "tsc -p tsconfig.test.json --noEmit"
+	},
+	"optionalDependencies": {
+		"@lix-js/sdk-darwin-arm64": "0.6.0",
+		"@lix-js/sdk-linux-arm64": "0.6.0",
+		"@lix-js/sdk-linux-x64": "0.6.0",
+		"@lix-js/sdk-win32-x64": "0.6.0"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.2",

--- a/packages/js-sdk/scripts/native-platforms.js
+++ b/packages/js-sdk/scripts/native-platforms.js
@@ -1,0 +1,20 @@
+export const nativePlatforms = [
+	{ suffix: "linux-x64", os: "linux", cpu: "x64" },
+	{ suffix: "linux-arm64", os: "linux", cpu: "arm64" },
+	{ suffix: "darwin-arm64", os: "darwin", cpu: "arm64" },
+	{ suffix: "win32-x64", os: "win32", cpu: "x64" },
+];
+
+export function nativePackageName(suffix) {
+	return `@lix-js/sdk-${suffix}`;
+}
+
+export function nativePlatformForCurrentProcess() {
+	return nativePlatforms.find(
+		(platform) => platform.os === process.platform && platform.cpu === process.arch,
+	);
+}
+
+export function nativePlatformForSuffix(suffix) {
+	return nativePlatforms.find((platform) => platform.suffix === suffix);
+}

--- a/packages/js-sdk/scripts/prepare-native-package.js
+++ b/packages/js-sdk/scripts/prepare-native-package.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+	nativePackageName,
+	nativePlatformForCurrentProcess,
+	nativePlatformForSuffix,
+} from "./native-platforms.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = join(__dirname, "..");
+const binaryPath = join(packageDir, "lix_js_sdk.node");
+const args = process.argv.slice(2);
+const suffixArg = args.find((arg) => arg.startsWith("--suffix="))?.slice("--suffix=".length);
+const outArg = args.find((arg) => arg.startsWith("--out="))?.slice("--out=".length);
+const platform = suffixArg ? nativePlatformForSuffix(suffixArg) : nativePlatformForCurrentProcess();
+const currentPlatform = nativePlatformForCurrentProcess();
+
+if (!platform) {
+	throw new Error(`Unsupported native package platform: ${suffixArg ?? `${process.platform}-${process.arch}`}`);
+}
+if (suffixArg && platform !== currentPlatform && process.env.LIX_NATIVE_PACKAGE_ALLOW_CROSS !== "1") {
+	throw new Error(
+		`Refusing to package ${process.platform}-${process.arch} binary as ${suffixArg}. ` +
+			"Set LIX_NATIVE_PACKAGE_ALLOW_CROSS=1 only for intentional cross-compilation.",
+	);
+}
+
+const sdkPackage = JSON.parse(await readFile(join(packageDir, "package.json"), "utf8"));
+const outDir = outArg ? resolve(process.cwd(), outArg) : join(packageDir, "native-packages", platform.suffix);
+
+await mkdir(outDir, { recursive: true });
+await cp(binaryPath, join(outDir, "lix_js_sdk.node"));
+await writeFile(
+	join(outDir, "package.json"),
+	`${JSON.stringify(
+		{
+			name: nativePackageName(platform.suffix),
+			version: sdkPackage.version,
+			description: `Native binary for @lix-js/sdk on ${platform.os}-${platform.cpu}.`,
+			main: "./lix_js_sdk.node",
+			os: [platform.os],
+			cpu: [platform.cpu],
+			files: ["lix_js_sdk.node"],
+			publishConfig: {
+				access: "public",
+			},
+		},
+		null,
+		"\t",
+	)}\n`,
+);
+
+console.log(outDir);

--- a/packages/js-sdk/src/native.ts
+++ b/packages/js-sdk/src/native.ts
@@ -1,17 +1,49 @@
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
-const nativePath = fileURLToPath(new URL("../lix_js_sdk.node", import.meta.url));
+const require = createRequire(import.meta.url);
+const localNativePath = fileURLToPath(new URL("../lix_js_sdk.node", import.meta.url));
+
+const nativePackages = {
+	"linux-x64": "@lix-js/sdk-linux-x64",
+	"linux-arm64": "@lix-js/sdk-linux-arm64",
+	"darwin-arm64": "@lix-js/sdk-darwin-arm64",
+	"win32-x64": "@lix-js/sdk-win32-x64",
+} as const;
+
+function nativePackageName() {
+	const key = `${process.platform}-${process.arch}` as keyof typeof nativePackages;
+	return nativePackages[key];
+}
+
+function resolveNativePath() {
+	if (existsSync(localNativePath)) {
+		return localNativePath;
+	}
+	const packageName = nativePackageName();
+	let packageResolutionError: unknown;
+	if (packageName) {
+		try {
+			return require.resolve(packageName);
+		} catch (error) {
+			packageResolutionError = error;
+		}
+	}
+	if (!packageName) {
+		throw new Error(`Unsupported platform ${process.platform}-${process.arch}`);
+	}
+	throw packageResolutionError;
+}
+
 const native = { exports: {} as Record<string, any> };
 try {
-	if (!existsSync(nativePath)) {
-		throw new Error(`Native addon not found at ${nativePath}`);
-	}
+	const nativePath = resolveNativePath();
 	process.dlopen(native, nativePath);
 } catch (cause) {
 	const error = new Error(
 		`Failed to load @lix-js/sdk native addon for ${process.platform}-${process.arch}. ` +
-			"This package currently requires a matching Node native binary. " +
+			"This package requires the matching optional native binary package. " +
 			"Run `npm run build` from packages/js-sdk for local development, or install a release that includes your platform binary.",
 	) as Error & { cause?: unknown };
 	error.cause = cause;

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -10,7 +10,7 @@ import {
 	type Lix,
 } from "./index.js";
 
-test("openLix exposes the rs-sdk e2e flow", async () => {
+test("openLix exposes the lix-sdk e2e flow", async () => {
 	const lix = await openLix();
 	const mainBranchId = await lix.activeBranchId();
 

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "lix_rs_sdk"
-version = "0.1.0"
+name = "lix_sdk"
+version.workspace = true
 edition = "2021"
 
 [dependencies]
-lix_engine = { path = "../engine", version = "0.1.0" }
+lix_engine = { workspace = true }
 
 async-trait = "0.1"
 bytes = "1"

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,4 +1,4 @@
-use lix_rs_sdk::{
+use lix_sdk::{
     open_lix, CreateBranchOptions, InMemoryBackend, LixError, MergeBranchOptions,
     MergeBranchOutcome, OpenLixOptions, SwitchBranchOptions, Value,
 };
@@ -347,7 +347,7 @@ async fn transaction_blocks_session_execute_on_same_handle() {
     lix.close().await.unwrap();
 }
 
-async fn register_crm_task_schema(lix: &lix_rs_sdk::Lix) {
+async fn register_crm_task_schema(lix: &lix_sdk::Lix) {
     let schema = r#"{
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "x-lix-key": "crm_task",
@@ -371,7 +371,7 @@ async fn register_crm_task_schema(lix: &lix_rs_sdk::Lix) {
     .unwrap();
 }
 
-fn assert_crm_task_projection(result: &lix_rs_sdk::ExecuteResult) {
+fn assert_crm_task_projection(result: &lix_sdk::ExecuteResult) {
     assert_eq!(result.len(), 1);
     let row = &result.rows()[0];
     assert_eq!(
@@ -417,7 +417,7 @@ fn assert_crm_task_projection(result: &lix_rs_sdk::ExecuteResult) {
     assert_eq!(missing.code, "LIX_COLUMN_NOT_FOUND");
 }
 
-async fn register_poison_task_schema(lix: &lix_rs_sdk::Lix) {
+async fn register_poison_task_schema(lix: &lix_sdk::Lix) {
     let schema = r#"{
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "x-lix-key": "poison_task",
@@ -440,7 +440,7 @@ async fn register_poison_task_schema(lix: &lix_rs_sdk::Lix) {
     .unwrap();
 }
 
-async fn task_done(lix: &lix_rs_sdk::Lix, task_id: &str) -> bool {
+async fn task_done(lix: &lix_sdk::Lix, task_id: &str) -> bool {
     let result = lix
         .execute(
             "SELECT done FROM crm_task WHERE id = $1",

--- a/packages/rs-sdk/tests/fixtures/create_sqlite_fixture.rs
+++ b/packages/rs-sdk/tests/fixtures/create_sqlite_fixture.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use lix_rs_sdk::SqliteBackend;
+use lix_sdk::SqliteBackend;
 
 fn main() {
     let path = std::env::args_os()

--- a/packages/rs-sdk/tests/fixtures/verify_sqlite_key_value.rs
+++ b/packages/rs-sdk/tests/fixtures/verify_sqlite_key_value.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use lix_rs_sdk::{open_lix_with_backend, SqliteBackend, Value};
+use lix_sdk::{open_lix_with_backend, SqliteBackend, Value};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {

--- a/packages/rs-sdk/tests/fixtures/write_sqlite_key_value.rs
+++ b/packages/rs-sdk/tests/fixtures/write_sqlite_key_value.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use lix_rs_sdk::{open_lix_with_backend, SqliteBackend, Value};
+use lix_sdk::{open_lix_with_backend, SqliteBackend, Value};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "sqlite")]
 
 use lix_engine::run_backend_conformance;
-use lix_rs_sdk::{
+use lix_sdk::{
     open_lix_with_backend, SqliteBackend, SqliteBackendFactory, Value, SQLITE_FORMAT_VERSION,
 };
 use rusqlite::Connection;

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { prepareRelease } from "./release.mjs";
+
+try {
+	const result = prepareRelease(process.cwd());
+	if (!result) {
+		console.log("No change fragments found; no release PR needed.");
+		process.exit(0);
+	}
+	console.log(`version=${result.version}`);
+	console.log(`type=${result.type}`);
+} catch (error) {
+	console.error(error.message);
+	process.exit(1);
+}

--- a/scripts/release-tag.mjs
+++ b/scripts/release-tag.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { releaseTagForHead } from "./release.mjs";
+
+try {
+	const tag = releaseTagForHead(process.cwd());
+	if (!tag) {
+		console.log("No release tag needed for this commit.");
+		process.exit(0);
+	}
+	console.log(tag);
+} catch (error) {
+	console.error(error.message);
+	process.exit(1);
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -4,6 +4,12 @@ import { execFileSync } from "node:child_process";
 
 export const CHANGE_TYPES = ["major", "minor", "patch"];
 export const CHANGE_SCOPES = ["engine", "lix-sdk", "js-sdk", "cli"];
+export const JS_SDK_NATIVE_PACKAGES = [
+	"@lix-js/sdk-darwin-arm64",
+	"@lix-js/sdk-linux-arm64",
+	"@lix-js/sdk-linux-x64",
+	"@lix-js/sdk-win32-x64",
+];
 
 export function readText(root, path) {
 	return readFileSync(join(root, path), "utf8");
@@ -133,12 +139,18 @@ export function updatePackageVersion(root, version) {
 	const lockPath = "packages/js-sdk/package-lock.json";
 	const packageJson = readJson(root, packageJsonPath);
 	packageJson.version = version;
+	packageJson.optionalDependencies = Object.fromEntries(
+		JS_SDK_NATIVE_PACKAGES.map((packageName) => [packageName, version]),
+	);
 	writeJson(root, packageJsonPath, packageJson);
 
 	const lock = readJson(root, lockPath);
 	lock.version = version;
 	if (lock.packages?.[""]) {
 		lock.packages[""].version = version;
+		lock.packages[""].optionalDependencies = Object.fromEntries(
+			JS_SDK_NATIVE_PACKAGES.map((packageName) => [packageName, version]),
+		);
 	}
 	writeJson(root, lockPath, lock);
 }
@@ -147,7 +159,10 @@ export function updateChangelog(root, version, date, changes) {
 	const path = "CHANGELOG.md";
 	const existing = existsSync(join(root, path)) ? readText(root, path).trimEnd() : "# Changelog\n";
 	const entry = changelogEntry(version, date, changes).trimEnd();
-	const next = existing.trim() === "# Changelog" ? `# Changelog\n\n${entry}\n` : `${existing}\n\n${entry}\n`;
+	const next =
+		existing.trim() === "# Changelog"
+			? `# Changelog\n\n${entry}\n`
+			: `${existing.replace(/^# Changelog\n*/, `# Changelog\n\n${entry}\n\n`)}\n`;
 	writeText(root, path, next);
 }
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,186 @@
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+export const CHANGE_TYPES = ["major", "minor", "patch"];
+export const CHANGE_SCOPES = ["engine", "lix-sdk", "js-sdk", "cli"];
+
+export function readText(root, path) {
+	return readFileSync(join(root, path), "utf8");
+}
+
+export function writeText(root, path, text) {
+	writeFileSync(join(root, path), text);
+}
+
+export function readJson(root, path) {
+	return JSON.parse(readText(root, path));
+}
+
+export function writeJson(root, path, value) {
+	writeText(root, path, `${JSON.stringify(value, null, "\t")}\n`);
+}
+
+export function currentVersion(root) {
+	const match = readText(root, "Cargo.toml").match(
+		/\[workspace\.package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/,
+	);
+	if (!match) {
+		throw new Error("Could not find [workspace.package].version in Cargo.toml");
+	}
+	return match[1];
+}
+
+export function bumpVersion(version, type) {
+	const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-.+)?$/);
+	if (!match) {
+		throw new Error(`Unsupported version format: ${version}`);
+	}
+	const major = Number(match[1]);
+	const minor = Number(match[2]);
+	const patch = Number(match[3]);
+	if (type === "major") return `${major + 1}.0.0`;
+	if (type === "minor") return `${major}.${minor + 1}.0`;
+	if (type === "patch") return `${major}.${minor}.${patch + 1}`;
+	throw new Error(`Unsupported change type: ${type}`);
+}
+
+export function changeFiles(root) {
+	const dir = join(root, ".changes");
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir)
+		.filter((file) => file.endsWith(".md"))
+		.map((file) => `.changes/${file}`)
+		.sort();
+}
+
+export function parseChange(root, path) {
+	const text = readText(root, path).trim();
+	const match = text.match(/^---\n([\s\S]*?)\n---\n([\s\S]+)$/);
+	if (!match) {
+		throw new Error(`${path}: expected frontmatter followed by a changelog body`);
+	}
+	const metadata = Object.fromEntries(
+		match[1]
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.map((line) => {
+				const separator = line.indexOf(":");
+				if (separator === -1) throw new Error(`${path}: invalid frontmatter line "${line}"`);
+				return [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
+			}),
+	);
+	const type = metadata.type;
+	const scope = metadata.scope;
+	const body = match[2].trim().replace(/\s+/g, " ");
+	if (!CHANGE_TYPES.includes(type)) {
+		throw new Error(`${path}: type must be one of ${CHANGE_TYPES.join(", ")}`);
+	}
+	if (!CHANGE_SCOPES.includes(scope)) {
+		throw new Error(`${path}: scope must be one of ${CHANGE_SCOPES.join(", ")}`);
+	}
+	if (!body) {
+		throw new Error(`${path}: changelog body must not be empty`);
+	}
+	return { path, type, scope, body };
+}
+
+export function loadChanges(root) {
+	return changeFiles(root).map((path) => parseChange(root, path));
+}
+
+export function highestChangeType(changes) {
+	if (changes.some((change) => change.type === "major")) return "major";
+	if (changes.some((change) => change.type === "minor")) return "minor";
+	if (changes.some((change) => change.type === "patch")) return "patch";
+	return null;
+}
+
+export function changelogEntry(version, date, changes) {
+	const labels = { major: "Major", minor: "Minor", patch: "Patch" };
+	let entry = `## ${version} - ${date}\n`;
+	for (const type of CHANGE_TYPES) {
+		const typed = changes.filter((change) => change.type === type);
+		if (typed.length === 0) continue;
+		entry += `\n### ${labels[type]}\n\n`;
+		for (const change of typed) {
+			entry += `- ${change.scope}: ${change.body}\n`;
+		}
+	}
+	return `${entry}\n`;
+}
+
+export function updateCargoToml(root, version) {
+	let text = readText(root, "Cargo.toml");
+	text = text.replace(
+		/(\[workspace\.package\][\s\S]*?\nversion\s*=\s*")[^"]+(")/,
+		`$1${version}$2`,
+	);
+	text = text.replace(
+		/(lix_engine\s*=\s*\{\s*path\s*=\s*"packages\/engine",\s*version\s*=\s*")[^"]+(")/,
+		`$1${version}$2`,
+	);
+	text = text.replace(
+		/(lix_sdk\s*=\s*\{\s*path\s*=\s*"packages\/rs-sdk",\s*version\s*=\s*")[^"]+(")/,
+		`$1${version}$2`,
+	);
+	writeText(root, "Cargo.toml", text);
+}
+
+export function updatePackageVersion(root, version) {
+	const packageJsonPath = "packages/js-sdk/package.json";
+	const lockPath = "packages/js-sdk/package-lock.json";
+	const packageJson = readJson(root, packageJsonPath);
+	packageJson.version = version;
+	writeJson(root, packageJsonPath, packageJson);
+
+	const lock = readJson(root, lockPath);
+	lock.version = version;
+	if (lock.packages?.[""]) {
+		lock.packages[""].version = version;
+	}
+	writeJson(root, lockPath, lock);
+}
+
+export function updateChangelog(root, version, date, changes) {
+	const path = "CHANGELOG.md";
+	const existing = existsSync(join(root, path)) ? readText(root, path).trimEnd() : "# Changelog\n";
+	const entry = changelogEntry(version, date, changes).trimEnd();
+	const next = existing.trim() === "# Changelog" ? `# Changelog\n\n${entry}\n` : `${existing}\n\n${entry}\n`;
+	writeText(root, path, next);
+}
+
+export function prepareRelease(root, { date = new Date().toISOString().slice(0, 10) } = {}) {
+	const changes = loadChanges(root);
+	if (changes.length === 0) {
+		return null;
+	}
+	const type = highestChangeType(changes);
+	const version = bumpVersion(currentVersion(root), type);
+	updateCargoToml(root, version);
+	updatePackageVersion(root, version);
+	updateChangelog(root, version, date, changes);
+	for (const change of changes) {
+		rmSync(join(root, change.path));
+	}
+	execFileSync("cargo", ["update", "-p", "lix_cli", "-p", "lix_engine", "-p", "lix_js_sdk", "-p", "lix_sdk"], {
+		cwd: root,
+		stdio: "inherit",
+	});
+	return { version, type, changes };
+}
+
+export function releaseTagForHead(root) {
+	const message = execFileSync("git", ["log", "-1", "--pretty=%B"], {
+		cwd: root,
+		encoding: "utf8",
+	}).trim();
+	const match = message.match(/Release v(\d+\.\d+\.\d+)/);
+	if (!match) return null;
+	const version = currentVersion(root);
+	if (version !== match[1]) {
+		throw new Error(`Release commit says ${match[1]}, but Cargo.toml says ${version}`);
+	}
+	return `v${version}`;
+}

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,10 +1,10 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { bumpVersion, changelogEntry, loadChanges } from "./release.mjs";
+import { bumpVersion, changelogEntry, loadChanges, updateChangelog, updatePackageVersion } from "./release.mjs";
 
 test("bumpVersion applies semver changes", () => {
 	assert.equal(bumpVersion("0.6.0", "patch"), "0.6.1");
@@ -41,4 +41,51 @@ test("changelogEntry groups entries by type", () => {
 		]),
 		`## 0.7.0 - 2026-05-29\n\n### Minor\n\n- lix-sdk: Added branch merge preview support.\n\n### Patch\n\n- js-sdk: Fixed native binding loading on Linux. [#1](https://github.com/opral/lix/pull/1)\n\n`,
 	);
+});
+
+test("updateChangelog inserts new entries after heading", () => {
+	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
+	writeFileSync(
+		join(root, "CHANGELOG.md"),
+		`# Changelog\n\n## 0.6.0 - 2026-05-28\n\n### Patch\n\n- js-sdk: Previous release.\n`,
+	);
+
+	updateChangelog(root, "0.6.1", "2026-05-29", [
+		{ type: "patch", scope: "js-sdk", body: "Fixed native binding loading on Linux." },
+	]);
+
+	assert.equal(
+		readFileSync(join(root, "CHANGELOG.md"), "utf8"),
+		`# Changelog\n\n## 0.6.1 - 2026-05-29\n\n### Patch\n\n- js-sdk: Fixed native binding loading on Linux.\n\n## 0.6.0 - 2026-05-28\n\n### Patch\n\n- js-sdk: Previous release.\n`,
+	);
+});
+
+test("updatePackageVersion pins native optional dependencies", () => {
+	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
+	mkdirSync(join(root, "packages", "js-sdk"), { recursive: true });
+	writeFileSync(
+		join(root, "packages", "js-sdk", "package.json"),
+		`${JSON.stringify({ name: "@lix-js/sdk", version: "0.6.0" }, null, "\t")}\n`,
+	);
+	writeFileSync(
+		join(root, "packages", "js-sdk", "package-lock.json"),
+		`${JSON.stringify(
+			{
+				name: "@lix-js/sdk",
+				version: "0.6.0",
+				lockfileVersion: 3,
+				requires: true,
+				packages: { "": { name: "@lix-js/sdk", version: "0.6.0" } },
+			},
+			null,
+			"\t",
+		)}\n`,
+	);
+
+	updatePackageVersion(root, "0.7.0");
+
+	const packageJson = JSON.parse(readFileSync(join(root, "packages", "js-sdk", "package.json"), "utf8"));
+	const lock = JSON.parse(readFileSync(join(root, "packages", "js-sdk", "package-lock.json"), "utf8"));
+	assert.equal(packageJson.optionalDependencies["@lix-js/sdk-linux-x64"], "0.7.0");
+	assert.equal(lock.packages[""].optionalDependencies["@lix-js/sdk-darwin-arm64"], "0.7.0");
 });

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,44 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { bumpVersion, changelogEntry, loadChanges } from "./release.mjs";
+
+test("bumpVersion applies semver changes", () => {
+	assert.equal(bumpVersion("0.6.0", "patch"), "0.6.1");
+	assert.equal(bumpVersion("0.6.0", "minor"), "0.7.0");
+	assert.equal(bumpVersion("0.6.0", "major"), "1.0.0");
+});
+
+test("loadChanges validates and parses fragments", () => {
+	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
+	mkdirSync(join(root, ".changes"));
+	writeFileSync(
+		join(root, ".changes", "pr-1.md"),
+		`---\ntype: patch\nscope: js-sdk\n---\n\nFixed native binding loading on Linux. [#1](https://github.com/opral/lix/pull/1)\n`,
+	);
+	assert.deepEqual(loadChanges(root), [
+		{
+			path: ".changes/pr-1.md",
+			type: "patch",
+			scope: "js-sdk",
+			body: "Fixed native binding loading on Linux. [#1](https://github.com/opral/lix/pull/1)",
+		},
+	]);
+});
+
+test("changelogEntry groups entries by type", () => {
+	assert.equal(
+		changelogEntry("0.7.0", "2026-05-29", [
+			{ type: "minor", scope: "lix-sdk", body: "Added branch merge preview support." },
+			{
+				type: "patch",
+				scope: "js-sdk",
+				body: "Fixed native binding loading on Linux. [#1](https://github.com/opral/lix/pull/1)",
+			},
+		]),
+		`## 0.7.0 - 2026-05-29\n\n### Minor\n\n- lix-sdk: Added branch merge preview support.\n\n### Patch\n\n- js-sdk: Fixed native binding loading on Linux. [#1](https://github.com/opral/lix/pull/1)\n\n`,
+	);
+});

--- a/scripts/validate-changes.mjs
+++ b/scripts/validate-changes.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { loadChanges } from "./release.mjs";
+
+try {
+	const root = process.cwd();
+	const changes = loadChanges(root);
+	console.log(`Validated ${changes.length} change fragment(s).`);
+} catch (error) {
+	console.error(error.message);
+	process.exit(1);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches release tagging, npm publish with provenance, automated PR commits (Codex changelog), and a breaking Rust crate rename (lix_rs_sdk → lix_sdk) with lockstep version bumps—errors could ship wrong versions or broken native installs.
> 
> **Overview**
> Adds an end-to-end **release and npm publish pipeline** driven by `.changes/*` fragments, plus **per-platform `@lix-js/sdk` native packages** for published installs.
> 
> **Release automation:** New `scripts/release.mjs` (with tests) validates fragments, bumps lockstep versions in `Cargo.toml` / `@lix-js/sdk`, updates `CHANGELOG.md`, and removes consumed fragments. CI gains a **Changelog** job (`validate-changes.mjs`). **Release PR** opens from `main` when fragments exist; **Release tag** pushes `v*` after a release merge; **Publish Packages** on tags builds four native artifacts (Linux x64/arm64, macOS arm64, Windows x64) and publishes optional platform packages then `@lix-js/sdk`. A **Changelog Suggest** workflow uses Codex to propose a single `.changes/pr-*.md` on PRs. **actionlint** config documents Blacksmith runner labels.
> 
> **Rust workspace:** Workspace version **0.6.0**, `[workspace.dependencies]` for `lix_engine` / `lix_sdk`, crate rename **`lix_rs_sdk` → `lix_sdk`**, and CLI/JS/native imports updated accordingly. Workspace `exclude` for non-Rust packages is removed.
> 
> **JS SDK publishing:** `prepare-native-package.js` / `native-platforms.js` stage platform tarballs; `native.ts` loads a local `.node` in dev or **`require.resolve`** the matching `@lix-js/sdk-*` optional dependency at runtime. Published `package.json` ships `dist` only (not bundled `.node`). CI uses `npm install` instead of `npm ci` for js-sdk jobs.
> 
> **Misc:** README asset path fix; `native-packages/` gitignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14ad6d9c9633f30c4e69283ea30c7c2cef14124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->