### PR TITLE
Add e2e benchmarks

### DIFF
--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -29,7 +29,7 @@ wasmtime = { version = "30.0.2", default-features = false, features = ["componen
 wasmtime-wasi = { version = "30.0.2", default-features = false, optional = true }
 
 [dev-dependencies]
-plugin_csv_wasm = { package = "plugin_csv", path = "../../plugins/csv", artifact = "cdylib", target = "wasm32-wasip2", lib = false }
+plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 rand = { version = "0.9", features = ["small_rng"] }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -68,3 +68,4 @@ required-features = ["sqlite"]
 name = "e2e"
 path = "benches/e2e.rs"
 harness = false
+required-features = ["sqlite"]

--- a/packages/rs-sdk/benches/e2e.rs
+++ b/packages/rs-sdk/benches/e2e.rs
@@ -1,5 +1,7 @@
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use lix_sdk::{FsWriteOptions, InMemoryBackend, LixError, OpenLixOptions, Value, open_lix};
+use lix_sdk::{
+    FsWriteOptions, InMemoryBackend, LixError, OpenLixOptions, SqliteBackend, Value, open_lix,
+};
 use plugin_csv::exports::lix::plugin::api::EntityState as CsvEntityState;
 use plugin_csv::exports::lix::plugin::api::Guest as _;
 use plugin_csv::{CsvPlugin, File as CsvFile};
@@ -12,6 +14,7 @@ use std::hint::black_box;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
 use tokio::runtime::Builder;
 use wasmtime::component::types::ComponentItem;
 use wasmtime::component::{Component, ComponentExportIndex, Instance, Linker, Val};
@@ -123,6 +126,14 @@ fn bench_e2e(c: &mut Criterion) {
             });
         });
     });
+    group.bench_function("setup_inmemory", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let lix = open_lix_with_warmed_csv_plugin_inmemory(&plugin).await;
+                black_box(lix).close().await.unwrap();
+            });
+        });
+    });
     group.bench_function("setup_wasm", |b| {
         b.iter(|| {
             runtime.block_on(async {
@@ -135,6 +146,13 @@ fn bench_e2e(c: &mut Criterion) {
     group.bench_function("insert_10k", |b| {
         b.iter_batched(
             || runtime.block_on(open_lix_with_warmed_csv_plugin(&plugin)),
+            |lix| runtime.block_on(insert_large_csv(lix, &initial_csv)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("insert_10k_inmemory", |b| {
+        b.iter_batched(
+            || runtime.block_on(open_lix_with_warmed_csv_plugin_inmemory(&plugin)),
             |lix| runtime.block_on(insert_large_csv(lix, &initial_csv)),
             BatchSize::SmallInput,
         );
@@ -155,7 +173,7 @@ fn bench_e2e(c: &mut Criterion) {
     group.bench_function("insert_10k_plugin_diff", |b| {
         b.iter_batched(
             || NativeCsvDiffFixture::new(Vec::new(), initial_csv.clone()),
-            |fixture| bench_native_csv_diff(fixture),
+            bench_native_csv_diff,
             BatchSize::SmallInput,
         );
     });
@@ -164,6 +182,24 @@ fn bench_e2e(c: &mut Criterion) {
             || {
                 runtime.block_on(async {
                     let lix = open_lix_with_plugin(&plugin).await;
+                    csv_schema_changes_insert_fixture(
+                        lix,
+                        &[],
+                        &initial_wasm_changes,
+                        INITIAL_ROW_COUNT,
+                    )
+                    .await
+                })
+            },
+            |fixture| runtime.block_on(manual_bulk_insert_schema_changes(fixture)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("insert_10k_insert_inmemory", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin_inmemory(&plugin).await;
                     csv_schema_changes_insert_fixture(
                         lix,
                         &[],
@@ -190,11 +226,36 @@ fn bench_e2e(c: &mut Criterion) {
             BatchSize::SmallInput,
         );
     });
+    group.bench_function("insert_10k_insert_state_inmemory", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin_inmemory(&plugin).await;
+                    csv_changes_insert_fixture(lix, &[], &initial_wasm_changes, INITIAL_ROW_COUNT)
+                        .await
+                })
+            },
+            |fixture| runtime.block_on(manual_bulk_insert_file_changes(fixture)),
+            BatchSize::SmallInput,
+        );
+    });
     group.bench_function("merge_10k", |b| {
         b.iter_batched(
             || {
                 runtime.block_on(async {
                     let lix = open_lix_with_plugin(&plugin).await;
+                    large_csv_fixture(lix, &initial_csv).await
+                })
+            },
+            |fixture| runtime.block_on(overwrite_large_csv(fixture, &updated_csv)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("merge_10k_inmemory", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin_inmemory(&plugin).await;
                     large_csv_fixture(lix, &initial_csv).await
                 })
             },
@@ -218,7 +279,7 @@ fn bench_e2e(c: &mut Criterion) {
     group.bench_function("merge_10k_plugin_diff", |b| {
         b.iter_batched(
             || NativeCsvDiffFixture::new(initial_native_state.clone(), updated_csv.clone()),
-            |fixture| bench_native_csv_diff(fixture),
+            bench_native_csv_diff,
             BatchSize::SmallInput,
         );
     });
@@ -227,6 +288,24 @@ fn bench_e2e(c: &mut Criterion) {
             || {
                 runtime.block_on(async {
                     let lix = open_lix_with_plugin(&plugin).await;
+                    csv_schema_changes_insert_fixture(
+                        lix,
+                        &initial_wasm_changes,
+                        &merge_wasm_changes,
+                        INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+                    )
+                    .await
+                })
+            },
+            |fixture| runtime.block_on(manual_bulk_insert_schema_changes(fixture)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("merge_10k_insert_inmemory", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin_inmemory(&plugin).await;
                     csv_schema_changes_insert_fixture(
                         lix,
                         &initial_wasm_changes,
@@ -258,16 +337,83 @@ fn bench_e2e(c: &mut Criterion) {
             BatchSize::SmallInput,
         );
     });
+    group.bench_function("merge_10k_insert_state_inmemory", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin_inmemory(&plugin).await;
+                    csv_changes_insert_fixture(
+                        lix,
+                        &initial_wasm_changes,
+                        &merge_wasm_changes,
+                        INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+                    )
+                    .await
+                })
+            },
+            |fixture| runtime.block_on(manual_bulk_insert_file_changes(fixture)),
+            BatchSize::SmallInput,
+        );
+    });
     group.finish();
 }
 
+enum BenchLix {
+    Sqlite {
+        lix: lix_sdk::Lix<SqliteBackend>,
+        _temp_dir: TempDir,
+    },
+    InMemory {
+        lix: lix_sdk::Lix<InMemoryBackend>,
+    },
+}
+
+impl BenchLix {
+    async fn execute(
+        &self,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<lix_sdk::ExecuteResult, LixError> {
+        match self {
+            Self::Sqlite { lix, .. } => lix.execute(sql, params).await,
+            Self::InMemory { lix } => lix.execute(sql, params).await,
+        }
+    }
+
+    async fn write_file(
+        &self,
+        path: &str,
+        data: Vec<u8>,
+        options: FsWriteOptions,
+    ) -> Result<(), LixError> {
+        match self {
+            Self::Sqlite { lix, .. } => lix.write_file(path, data, options).await,
+            Self::InMemory { lix } => lix.write_file(path, data, options).await,
+        }
+    }
+
+    async fn read_file(&self, path: &str) -> Result<Option<Vec<u8>>, LixError> {
+        match self {
+            Self::Sqlite { lix, .. } => lix.read_file(path).await,
+            Self::InMemory { lix } => lix.read_file(path).await,
+        }
+    }
+
+    async fn close(&self) -> Result<(), LixError> {
+        match self {
+            Self::Sqlite { lix, .. } => lix.close().await,
+            Self::InMemory { lix } => lix.close().await,
+        }
+    }
+}
+
 struct LargeCsvFixture {
-    lix: lix_sdk::Lix,
+    lix: BenchLix,
     file_id: String,
 }
 
 struct ExtractedCsvChangesFixture {
-    lix: lix_sdk::Lix,
+    lix: BenchLix,
     file_id: String,
     change_count: usize,
     state_insert_sql: String,
@@ -276,7 +422,7 @@ struct ExtractedCsvChangesFixture {
 }
 
 struct ExtractedCsvSchemaChangesFixture {
-    lix: lix_sdk::Lix,
+    lix: BenchLix,
     table_insert_sql: Option<String>,
     table_params: Vec<Value>,
     table_count: usize,
@@ -338,7 +484,27 @@ impl NativeCsvDiffFixture {
     }
 }
 
-async fn open_lix_with_plugin(plugin: &[u8]) -> lix_sdk::Lix {
+async fn open_lix_with_plugin(plugin: &[u8]) -> BenchLix {
+    let temp_dir = tempfile::tempdir().expect("failed to create sqlite bench tempdir");
+    let path = temp_dir.path().join("bench.lix");
+    let lix = open_lix(OpenLixOptions {
+        backend: SqliteBackend::open(path).expect("failed to open sqlite bench backend"),
+        wasm_runtime: Some(Arc::new(
+            WasmtimePluginRuntime::new().expect("failed to create Wasmtime plugin runtime"),
+        )),
+    })
+    .await
+    .unwrap();
+
+    lix.install_plugin_archive(plugin).await.unwrap();
+
+    BenchLix::Sqlite {
+        lix,
+        _temp_dir: temp_dir,
+    }
+}
+
+async fn open_lix_with_plugin_inmemory(plugin: &[u8]) -> BenchLix {
     let lix = open_lix(OpenLixOptions {
         backend: InMemoryBackend::new(),
         wasm_runtime: Some(Arc::new(
@@ -350,16 +516,22 @@ async fn open_lix_with_plugin(plugin: &[u8]) -> lix_sdk::Lix {
 
     lix.install_plugin_archive(plugin).await.unwrap();
 
-    lix
+    BenchLix::InMemory { lix }
 }
 
-async fn open_lix_with_warmed_csv_plugin(plugin: &[u8]) -> lix_sdk::Lix {
+async fn open_lix_with_warmed_csv_plugin(plugin: &[u8]) -> BenchLix {
     let lix = open_lix_with_plugin(plugin).await;
     warm_lix_csv_plugin(&lix).await;
     lix
 }
 
-async fn warm_lix_csv_plugin(lix: &lix_sdk::Lix) {
+async fn open_lix_with_warmed_csv_plugin_inmemory(plugin: &[u8]) -> BenchLix {
+    let lix = open_lix_with_plugin_inmemory(plugin).await;
+    warm_lix_csv_plugin(&lix).await;
+    lix
+}
+
+async fn warm_lix_csv_plugin(lix: &BenchLix) {
     lix.write_file(
         CSV_PLUGIN_WARMUP_PATH,
         Vec::new(),
@@ -384,7 +556,7 @@ async fn warm_wasm_csv_plugin_component(component: &Arc<dyn lix_sdk::WasmCompone
     assert!(changes.is_empty());
 }
 
-async fn large_csv_fixture(lix: lix_sdk::Lix, initial_csv: &[u8]) -> LargeCsvFixture {
+async fn large_csv_fixture(lix: BenchLix, initial_csv: &[u8]) -> LargeCsvFixture {
     lix.write_file(CSV_PATH, initial_csv.to_vec(), FsWriteOptions::default())
         .await
         .unwrap();
@@ -403,7 +575,7 @@ async fn large_csv_fixture(lix: lix_sdk::Lix, initial_csv: &[u8]) -> LargeCsvFix
 }
 
 async fn csv_changes_insert_fixture(
-    lix: lix_sdk::Lix,
+    lix: BenchLix,
     existing_changes: &[FileChange],
     insert_changes: &[FileChange],
     expected_active_row_count: usize,
@@ -452,7 +624,7 @@ async fn csv_changes_insert_fixture(
 }
 
 async fn csv_schema_changes_insert_fixture(
-    lix: lix_sdk::Lix,
+    lix: BenchLix,
     existing_changes: &[FileChange],
     insert_changes: &[FileChange],
     expected_active_row_count: usize,
@@ -490,7 +662,7 @@ async fn csv_schema_changes_insert_fixture(
     }
 }
 
-async fn insert_large_csv(lix: lix_sdk::Lix, initial_csv: &[u8]) {
+async fn insert_large_csv(lix: BenchLix, initial_csv: &[u8]) {
     lix.write_file(CSV_PATH, initial_csv.to_vec(), FsWriteOptions::default())
         .await
         .unwrap();
@@ -588,7 +760,7 @@ async fn assert_large_csv_overwrite_result(fixture: &LargeCsvFixture, updated_cs
     );
 }
 
-async fn active_csv_row_count(lix: &lix_sdk::Lix, file_id: &str) -> usize {
+async fn active_csv_row_count(lix: &BenchLix, file_id: &str) -> usize {
     let active_rows = lix
         .execute(
             "SELECT COUNT(*) AS row_count \
@@ -601,7 +773,7 @@ async fn active_csv_row_count(lix: &lix_sdk::Lix, file_id: &str) -> usize {
     usize::try_from(active_rows.rows()[0].get::<i64>("row_count").unwrap()).unwrap()
 }
 
-async fn active_csv_schema_row_count(lix: &lix_sdk::Lix) -> usize {
+async fn active_csv_schema_row_count(lix: &BenchLix) -> usize {
     let active_rows = lix
         .execute("SELECT COUNT(*) AS row_count FROM csv_row", &[])
         .await
@@ -727,7 +899,7 @@ fn bulk_insert_file_changes_params(file_id: &str, changes: &[FileChange]) -> Vec
     params
 }
 
-async fn bulk_insert_schema_changes(lix: &lix_sdk::Lix, changes: &[FileChange]) {
+async fn bulk_insert_schema_changes(lix: &BenchLix, changes: &[FileChange]) {
     let table_changes = changes
         .iter()
         .filter(|change| change.schema_key == "csv_table")
@@ -1066,7 +1238,7 @@ struct FileChange {
     snapshot_content: Option<serde_json::Value>,
 }
 
-async fn file_changes(lix: &lix_sdk::Lix, file_id: &str) -> Vec<FileChange> {
+async fn file_changes(lix: &BenchLix, file_id: &str) -> Vec<FileChange> {
     let changes = lix
         .execute(
             "SELECT schema_key, entity_pk, snapshot_content \

--- a/packages/rs-sdk/benches/e2e.rs
+++ b/packages/rs-sdk/benches/e2e.rs
@@ -1,11 +1,14 @@
 use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use lix_sdk::{FsWriteOptions, InMemoryBackend, LixError, OpenLixOptions, Value, open_lix};
+use plugin_csv::exports::lix::plugin::api::EntityState as CsvEntityState;
+use plugin_csv::exports::lix::plugin::api::Guest as _;
+use plugin_csv::{CsvPlugin, File as CsvFile};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Write as _;
-use std::io::{Cursor, Write};
+use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tokio::runtime::Builder;
@@ -32,6 +35,25 @@ fn bench_e2e(c: &mut Criterion) {
         &new_rows,
         0x6449_2c6f_179d_31b5,
     ));
+    let initial_wasm_changes = runtime.block_on(wasm_plugin_file_changes(
+        WasmPluginDiffFixture::new(&archive, Vec::new(), &initial_csv),
+    ));
+    assert_detected_csv_changes(&initial_wasm_changes, INITIAL_ROW_COUNT, 1);
+    let initial_wasm_state = plugin_entity_state_from_file_changes(&initial_wasm_changes);
+    let merge_wasm_changes = runtime.block_on(wasm_plugin_file_changes(
+        WasmPluginDiffFixture::new(&archive, initial_wasm_state.clone(), &updated_csv),
+    ));
+    assert_detected_csv_changes(&merge_wasm_changes, NEW_ROW_COUNT, 0);
+
+    let initial_native_changes =
+        native_csv_file_changes(NativeCsvDiffFixture::new(Vec::new(), initial_csv.clone()));
+    assert_file_changes_equivalent(&initial_wasm_changes, &initial_native_changes);
+    let initial_native_state = csv_entity_state_from_file_changes(&initial_native_changes);
+    let merge_native_changes = native_csv_file_changes(NativeCsvDiffFixture::new(
+        initial_native_state.clone(),
+        updated_csv.clone(),
+    ));
+    assert_file_changes_equivalent(&merge_wasm_changes, &merge_native_changes);
 
     let mut group = c.benchmark_group("e2e/csv_plugin");
     group.sample_size(10);
@@ -43,31 +65,94 @@ fn bench_e2e(c: &mut Criterion) {
             BatchSize::SmallInput,
         );
     });
-    group.bench_function("overwrite_random_merge_10k_to_20k", |b| {
+    group.bench_function("insert_10k_plugin", |b| {
+        b.iter_batched(
+            || WasmPluginDiffFixture::new(&archive, Vec::new(), &initial_csv),
+            |fixture| runtime.block_on(bench_wasm_plugin_diff(fixture, INITIAL_ROW_COUNT, 1)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("insert_10k_plugin_diff", |b| {
+        b.iter_batched(
+            || NativeCsvDiffFixture::new(Vec::new(), initial_csv.clone()),
+            |fixture| bench_native_csv_diff(fixture, INITIAL_ROW_COUNT, 1),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("insert_10k_insert", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(csv_schema_changes_insert_fixture(
+                    &archive,
+                    &[],
+                    &initial_wasm_changes,
+                    INITIAL_ROW_COUNT,
+                ))
+            },
+            |fixture| runtime.block_on(manual_bulk_insert_schema_changes(fixture)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("insert_10k_insert_state", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(csv_changes_insert_fixture(
+                    &archive,
+                    &[],
+                    &initial_wasm_changes,
+                    INITIAL_ROW_COUNT,
+                ))
+            },
+            |fixture| runtime.block_on(manual_bulk_insert_file_changes(fixture)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("merge_10k", |b| {
         b.iter_batched(
             || runtime.block_on(large_csv_fixture(&archive, &initial_csv)),
             |fixture| runtime.block_on(overwrite_large_csv(fixture, &updated_csv)),
             BatchSize::SmallInput,
         );
     });
-    group.bench_function("manual_bulk_insert_extracted_10k", |b| {
+    group.bench_function("merge_10k_plugin", |b| {
         b.iter_batched(
-            || runtime.block_on(extracted_csv_changes_fixture(&archive, &initial_csv)),
+            || WasmPluginDiffFixture::new(&archive, initial_wasm_state.clone(), &updated_csv),
+            |fixture| runtime.block_on(bench_wasm_plugin_diff(fixture, NEW_ROW_COUNT, 0)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("merge_10k_plugin_diff", |b| {
+        b.iter_batched(
+            || NativeCsvDiffFixture::new(initial_native_state.clone(), updated_csv.clone()),
+            |fixture| bench_native_csv_diff(fixture, NEW_ROW_COUNT, 0),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("merge_10k_insert", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(csv_schema_changes_insert_fixture(
+                    &archive,
+                    &initial_wasm_changes,
+                    &merge_wasm_changes,
+                    INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+                ))
+            },
+            |fixture| runtime.block_on(manual_bulk_insert_schema_changes(fixture)),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("merge_10k_insert_state", |b| {
+        b.iter_batched(
+            || {
+                runtime.block_on(csv_changes_insert_fixture(
+                    &archive,
+                    &initial_wasm_changes,
+                    &merge_wasm_changes,
+                    INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+                ))
+            },
             |fixture| runtime.block_on(manual_bulk_insert_file_changes(fixture)),
-            BatchSize::SmallInput,
-        );
-    });
-    group.bench_function("manual_bulk_insert_entities_extracted_10k", |b| {
-        b.iter_batched(
-            || runtime.block_on(extracted_csv_changes_fixture(&archive, &initial_csv)),
-            |fixture| runtime.block_on(manual_bulk_insert_entities(fixture)),
-            BatchSize::SmallInput,
-        );
-    });
-    group.bench_function("manual_bulk_insert_entities_direct_plugin_10k", |b| {
-        b.iter_batched(
-            || runtime.block_on(direct_plugin_csv_entities_fixture(&archive, &initial_csv)),
-            |fixture| runtime.block_on(manual_bulk_insert_entities(fixture)),
             BatchSize::SmallInput,
         );
     });
@@ -89,12 +174,48 @@ struct ExtractedCsvChangesFixture {
     change_count: usize,
     state_insert_sql: String,
     state_params: Vec<Value>,
-    table_insert_sql: String,
+    expected_active_row_count: usize,
+}
+
+struct ExtractedCsvSchemaChangesFixture {
+    lix: lix_sdk::Lix,
+    table_insert_sql: Option<String>,
     table_params: Vec<Value>,
+    table_count: usize,
     row_insert_sql: String,
     row_params: Vec<Value>,
     row_count: usize,
-    changes: Vec<FileChange>,
+    expected_active_row_count: usize,
+}
+
+struct WasmPluginDiffFixture {
+    runtime: WasmtimePluginRuntime,
+    archive: Vec<u8>,
+    state: Vec<PluginEntityStatePayload>,
+    file_data: Vec<u8>,
+}
+
+impl WasmPluginDiffFixture {
+    fn new(archive: &[u8], state: Vec<PluginEntityStatePayload>, file_data: &[u8]) -> Self {
+        Self {
+            runtime: WasmtimePluginRuntime::new()
+                .expect("failed to create Wasmtime plugin runtime"),
+            archive: archive.to_vec(),
+            state,
+            file_data: file_data.to_vec(),
+        }
+    }
+}
+
+struct NativeCsvDiffFixture {
+    state: Vec<CsvEntityState>,
+    file_data: Vec<u8>,
+}
+
+impl NativeCsvDiffFixture {
+    fn new(state: Vec<CsvEntityState>, file_data: Vec<u8>) -> Self {
+        Self { state, file_data }
+    }
 }
 
 async fn csv_plugin_fixture(archive: &[u8]) -> CsvPluginFixture {
@@ -137,46 +258,20 @@ async fn large_csv_fixture(archive: &[u8], initial_csv: &[u8]) -> LargeCsvFixtur
     }
 }
 
-async fn extracted_csv_changes_fixture(
+async fn csv_changes_insert_fixture(
     archive: &[u8],
-    initial_csv: &[u8],
+    existing_changes: &[FileChange],
+    insert_changes: &[FileChange],
+    expected_active_row_count: usize,
 ) -> ExtractedCsvChangesFixture {
-    let fixture = large_csv_fixture(archive, initial_csv).await;
-    let changes = file_changes(&fixture.lix, &fixture.file_id)
-        .await
-        .into_iter()
-        .filter(|change| change.schema_key == "csv_row" || change.schema_key == "csv_table")
-        .collect::<Vec<_>>();
-    assert_eq!(
-        changes
-            .iter()
-            .filter(|change| change.schema_key == "csv_row" && change.snapshot_content.is_some())
-            .count(),
-        INITIAL_ROW_COUNT
-    );
-    assert_eq!(
-        changes
-            .iter()
-            .filter(|change| change.schema_key == "csv_table" && change.snapshot_content.is_some())
-            .count(),
-        1
-    );
-
-    fixture
-        .lix
-        .execute(
-            "DELETE FROM lix_file WHERE path = $1",
-            &[Value::Text(CSV_PATH.to_string())],
-        )
-        .await
-        .unwrap();
-    assert_eq!(fixture.lix.read_file(CSV_PATH).await.unwrap(), None);
+    let fixture = csv_plugin_fixture(archive).await;
+    let file_id = "bench-csv-file".to_string();
     fixture
         .lix
         .execute(
             "INSERT INTO lix_file (id, path) VALUES ($1, $2)",
             &[
-                Value::Text(fixture.file_id.clone()),
+                Value::Text(file_id.clone()),
                 Value::Text(CSV_PATH.to_string()),
             ],
         )
@@ -186,87 +281,79 @@ async fn extracted_csv_changes_fixture(
         fixture.lix.read_file(CSV_PATH).await.unwrap(),
         Some(Vec::new())
     );
-    let active_rows = fixture
-        .lix
-        .execute(
-            "SELECT COUNT(*) AS row_count \
-             FROM lix_state \
-             WHERE file_id = $1 AND schema_key IN ('csv_row', 'csv_table')",
-            &[Value::Text(fixture.file_id.clone())],
-        )
-        .await
-        .unwrap();
-    assert_eq!(active_rows.rows()[0].get::<i64>("row_count").unwrap(), 0);
 
-    let state_insert_sql = bulk_insert_file_changes_sql(changes.len());
-    let state_params = bulk_insert_file_changes_params(&fixture.file_id, &changes);
-    let table_changes = changes
-        .iter()
-        .filter(|change| change.schema_key == "csv_table")
-        .collect::<Vec<_>>();
-    let row_changes = changes
-        .iter()
-        .filter(|change| change.schema_key == "csv_row")
-        .collect::<Vec<_>>();
-    let table_insert_sql = bulk_insert_csv_table_sql(table_changes.len());
-    let table_params = bulk_insert_csv_table_params(&table_changes);
-    let row_insert_sql = bulk_insert_csv_row_sql(row_changes.len());
-    let row_params = bulk_insert_csv_row_params(&row_changes);
-    let change_count = changes.len();
-    let row_count = row_changes.len();
+    if !existing_changes.is_empty() {
+        let existing_insert_sql = bulk_insert_file_changes_sql(existing_changes.len());
+        let existing_params = bulk_insert_file_changes_params(&file_id, existing_changes);
+        let result = fixture
+            .lix
+            .execute(&existing_insert_sql, &existing_params)
+            .await
+            .unwrap();
+        assert_eq!(result.rows_affected(), existing_changes.len() as u64);
+    }
 
+    let existing_row_count = existing_changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_row" && change.snapshot_content.is_some())
+        .count();
+    assert_eq!(
+        active_csv_row_count(&fixture.lix, &file_id).await,
+        existing_row_count
+    );
+
+    let state_insert_sql = bulk_insert_file_changes_sql(insert_changes.len());
+    let state_params = bulk_insert_file_changes_params(&file_id, insert_changes);
     ExtractedCsvChangesFixture {
         lix: fixture.lix,
-        file_id: fixture.file_id,
-        change_count,
+        file_id,
+        change_count: insert_changes.len(),
         state_insert_sql,
         state_params,
-        table_insert_sql,
-        table_params,
-        row_insert_sql,
-        row_params,
-        row_count,
-        changes,
+        expected_active_row_count,
     }
 }
 
-async fn direct_plugin_csv_entities_fixture(
+async fn csv_schema_changes_insert_fixture(
     archive: &[u8],
-    initial_csv: &[u8],
-) -> ExtractedCsvChangesFixture {
-    let extracted_fixture = extracted_csv_changes_fixture(archive, initial_csv).await;
-    let direct_changes = direct_plugin_csv_changes(initial_csv).await;
-    assert_file_changes_equivalent(&direct_changes, &extracted_fixture.changes);
+    existing_changes: &[FileChange],
+    insert_changes: &[FileChange],
+    expected_active_row_count: usize,
+) -> ExtractedCsvSchemaChangesFixture {
+    let fixture = csv_plugin_fixture(archive).await;
+    if !existing_changes.is_empty() {
+        bulk_insert_schema_changes(&fixture.lix, existing_changes).await;
+    }
 
-    let table_changes = direct_changes
+    let existing_row_count = existing_changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_row" && change.snapshot_content.is_some())
+        .count();
+    assert_eq!(
+        active_csv_schema_row_count(&fixture.lix).await,
+        existing_row_count
+    );
+
+    let table_changes = insert_changes
         .iter()
         .filter(|change| change.schema_key == "csv_table")
         .collect::<Vec<_>>();
-    let row_changes = direct_changes
+    let row_changes = insert_changes
         .iter()
         .filter(|change| change.schema_key == "csv_row")
         .collect::<Vec<_>>();
-    let table_insert_sql = bulk_insert_csv_table_sql(table_changes.len());
-    let table_params = bulk_insert_csv_table_params(&table_changes);
-    let row_insert_sql = bulk_insert_csv_row_sql(row_changes.len());
-    let row_params = bulk_insert_csv_row_params(&row_changes);
-    let state_insert_sql = bulk_insert_file_changes_sql(direct_changes.len());
-    let state_params = bulk_insert_file_changes_params(&extracted_fixture.file_id, &direct_changes);
-    let change_count = direct_changes.len();
-    let row_count = row_changes.len();
+    assert!(!row_changes.is_empty());
 
-    ExtractedCsvChangesFixture {
-        lix: extracted_fixture.lix,
-        file_id: extracted_fixture.file_id,
-        change_count,
-        state_insert_sql,
-        state_params,
-        table_insert_sql,
-        table_params,
-        row_insert_sql,
-        row_params,
-        row_count,
-        changes: direct_changes,
+    ExtractedCsvSchemaChangesFixture {
+        lix: fixture.lix,
+        table_insert_sql: (!table_changes.is_empty())
+            .then(|| bulk_insert_csv_table_sql(table_changes.len())),
+        table_params: bulk_insert_csv_table_params(&table_changes),
+        table_count: table_changes.len(),
+        row_insert_sql: bulk_insert_csv_row_sql(row_changes.len()),
+        row_params: bulk_insert_csv_row_params(&row_changes),
+        row_count: row_changes.len(),
+        expected_active_row_count,
     }
 }
 
@@ -358,6 +445,27 @@ async fn overwrite_large_csv(fixture: LargeCsvFixture, updated_csv: &[u8]) {
     fixture.lix.close().await.unwrap();
 }
 
+async fn active_csv_row_count(lix: &lix_sdk::Lix, file_id: &str) -> usize {
+    let active_rows = lix
+        .execute(
+            "SELECT COUNT(*) AS row_count \
+             FROM lix_state \
+             WHERE file_id = $1 AND schema_key = 'csv_row'",
+            &[Value::Text(file_id.to_string())],
+        )
+        .await
+        .unwrap();
+    usize::try_from(active_rows.rows()[0].get::<i64>("row_count").unwrap()).unwrap()
+}
+
+async fn active_csv_schema_row_count(lix: &lix_sdk::Lix) -> usize {
+    let active_rows = lix
+        .execute("SELECT COUNT(*) AS row_count FROM csv_row", &[])
+        .await
+        .unwrap();
+    usize::try_from(active_rows.rows()[0].get::<i64>("row_count").unwrap()).unwrap()
+}
+
 async fn manual_bulk_insert_file_changes(fixture: ExtractedCsvChangesFixture) {
     let result = fixture
         .lix
@@ -366,19 +474,9 @@ async fn manual_bulk_insert_file_changes(fixture: ExtractedCsvChangesFixture) {
         .unwrap();
     assert_eq!(result.rows_affected(), fixture.change_count as u64);
 
-    let active_rows = fixture
-        .lix
-        .execute(
-            "SELECT COUNT(*) AS row_count \
-             FROM lix_state \
-             WHERE file_id = $1 AND schema_key = 'csv_row'",
-            &[Value::Text(fixture.file_id.clone())],
-        )
-        .await
-        .unwrap();
     assert_eq!(
-        active_rows.rows()[0].get::<i64>("row_count").unwrap(),
-        i64::try_from(INITIAL_ROW_COUNT).unwrap()
+        active_csv_row_count(&fixture.lix, &fixture.file_id).await,
+        fixture.expected_active_row_count
     );
 
     black_box(fixture.state_insert_sql);
@@ -386,13 +484,15 @@ async fn manual_bulk_insert_file_changes(fixture: ExtractedCsvChangesFixture) {
     fixture.lix.close().await.unwrap();
 }
 
-async fn manual_bulk_insert_entities(fixture: ExtractedCsvChangesFixture) {
-    let table_result = fixture
-        .lix
-        .execute(&fixture.table_insert_sql, &fixture.table_params)
-        .await
-        .unwrap();
-    assert_eq!(table_result.rows_affected(), 1);
+async fn manual_bulk_insert_schema_changes(fixture: ExtractedCsvSchemaChangesFixture) {
+    if let Some(table_insert_sql) = fixture.table_insert_sql.as_ref() {
+        let table_result = fixture
+            .lix
+            .execute(table_insert_sql, &fixture.table_params)
+            .await
+            .unwrap();
+        assert_eq!(table_result.rows_affected(), fixture.table_count as u64);
+    }
 
     let row_result = fixture
         .lix
@@ -400,19 +500,9 @@ async fn manual_bulk_insert_entities(fixture: ExtractedCsvChangesFixture) {
         .await
         .unwrap();
     assert_eq!(row_result.rows_affected(), fixture.row_count as u64);
-
-    let active_rows = fixture
-        .lix
-        .execute(
-            "SELECT COUNT(*) AS row_count \
-             FROM csv_row",
-            &[],
-        )
-        .await
-        .unwrap();
     assert_eq!(
-        active_rows.rows()[0].get::<i64>("row_count").unwrap(),
-        i64::try_from(INITIAL_ROW_COUNT).unwrap()
+        active_csv_schema_row_count(&fixture.lix).await,
+        fixture.expected_active_row_count
     );
 
     black_box(fixture.table_insert_sql);
@@ -456,6 +546,30 @@ fn bulk_insert_file_changes_params(file_id: &str, changes: &[FileChange]) -> Vec
         );
     }
     params
+}
+
+async fn bulk_insert_schema_changes(lix: &lix_sdk::Lix, changes: &[FileChange]) {
+    let table_changes = changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_table")
+        .collect::<Vec<_>>();
+    if !table_changes.is_empty() {
+        let table_insert_sql = bulk_insert_csv_table_sql(table_changes.len());
+        let table_params = bulk_insert_csv_table_params(&table_changes);
+        let result = lix.execute(&table_insert_sql, &table_params).await.unwrap();
+        assert_eq!(result.rows_affected(), table_changes.len() as u64);
+    }
+
+    let row_changes = changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_row")
+        .collect::<Vec<_>>();
+    if !row_changes.is_empty() {
+        let row_insert_sql = bulk_insert_csv_row_sql(row_changes.len());
+        let row_params = bulk_insert_csv_row_params(&row_changes);
+        let result = lix.execute(&row_insert_sql, &row_params).await.unwrap();
+        assert_eq!(result.rows_affected(), row_changes.len() as u64);
+    }
 }
 
 fn bulk_insert_csv_table_sql(change_count: usize) -> String {
@@ -544,25 +658,57 @@ fn bulk_insert_csv_row_params(changes: &[&FileChange]) -> Vec<Value> {
     params
 }
 
-async fn direct_plugin_csv_changes(initial_csv: &[u8]) -> Vec<FileChange> {
-    let runtime = WasmtimePluginRuntime::new().expect("failed to create Wasmtime plugin runtime");
+async fn bench_wasm_plugin_diff(
+    fixture: WasmPluginDiffFixture,
+    expected_row_upserts: usize,
+    expected_table_upserts: usize,
+) {
+    let changes = wasm_plugin_file_changes(fixture).await;
+    assert_detected_csv_changes(&changes, expected_row_upserts, expected_table_upserts);
+    black_box(changes);
+}
+
+async fn wasm_plugin_file_changes(fixture: WasmPluginDiffFixture) -> Vec<FileChange> {
     let component = <WasmtimePluginRuntime as lix_sdk::WasmRuntime>::init_component(
-        &runtime,
-        csv_plugin_wasm(),
+        &fixture.runtime,
+        csv_plugin_wasm_from_archive(&fixture.archive),
         lix_sdk::WasmLimits::default(),
     )
     .await
     .unwrap();
-    let payload = serde_json::json!({
-        "state": [],
-        "file": { "data": initial_csv },
-    });
+    let payload = PluginDetectChangesPayload {
+        state: fixture.state,
+        file: PluginFilePayload {
+            data: fixture.file_data,
+        },
+    };
     let output = component
         .call("detect-changes", &serde_json::to_vec(&payload).unwrap())
         .await
         .unwrap();
     let changes = serde_json::from_slice::<Vec<PluginDetectedChangePayload>>(&output).unwrap();
     plugin_detected_changes_to_file_changes(changes)
+}
+
+fn bench_native_csv_diff(
+    fixture: NativeCsvDiffFixture,
+    expected_row_upserts: usize,
+    expected_table_upserts: usize,
+) {
+    let changes = native_csv_file_changes(fixture);
+    assert_detected_csv_changes(&changes, expected_row_upserts, expected_table_upserts);
+    black_box(changes);
+}
+
+fn native_csv_file_changes(fixture: NativeCsvDiffFixture) -> Vec<FileChange> {
+    let changes = CsvPlugin::detect_changes(
+        fixture.state,
+        CsvFile {
+            data: fixture.file_data,
+        },
+    )
+    .unwrap();
+    csv_detected_changes_to_file_changes(changes)
 }
 
 fn plugin_detected_changes_to_file_changes(
@@ -589,6 +735,110 @@ fn plugin_detected_changes_to_file_changes(
         .collect()
 }
 
+fn csv_detected_changes_to_file_changes(
+    changes: Vec<plugin_csv::DetectedChange>,
+) -> Vec<FileChange> {
+    changes
+        .into_iter()
+        .map(|change| {
+            assert!(change.metadata.is_none());
+            FileChange {
+                schema_key: change.schema_key,
+                entity_pk: serde_json::Value::Array(
+                    change
+                        .entity_pk
+                        .into_iter()
+                        .map(serde_json::Value::String)
+                        .collect(),
+                ),
+                snapshot_content: change
+                    .snapshot_content
+                    .map(|snapshot| serde_json::from_str(&snapshot).unwrap()),
+            }
+        })
+        .collect()
+}
+
+fn plugin_entity_state_from_file_changes(changes: &[FileChange]) -> Vec<PluginEntityStatePayload> {
+    changes
+        .iter()
+        .filter_map(|change| {
+            change
+                .snapshot_content
+                .as_ref()
+                .map(|snapshot_content| PluginEntityStatePayload {
+                    entity_pk: entity_pk_parts(change),
+                    schema_key: change.schema_key.clone(),
+                    snapshot_content: snapshot_content.to_string(),
+                    metadata: None,
+                })
+        })
+        .collect()
+}
+
+fn csv_entity_state_from_file_changes(changes: &[FileChange]) -> Vec<CsvEntityState> {
+    changes
+        .iter()
+        .filter_map(|change| {
+            change
+                .snapshot_content
+                .as_ref()
+                .map(|snapshot_content| CsvEntityState {
+                    entity_pk: entity_pk_parts(change),
+                    schema_key: change.schema_key.clone(),
+                    snapshot_content: snapshot_content.to_string(),
+                    metadata: None,
+                })
+        })
+        .collect()
+}
+
+fn entity_pk_parts(change: &FileChange) -> Vec<String> {
+    change
+        .entity_pk
+        .as_array()
+        .expect("entity_pk should be a JSON array")
+        .iter()
+        .map(|part| {
+            part.as_str()
+                .expect("entity_pk parts should be strings")
+                .to_string()
+        })
+        .collect()
+}
+
+fn assert_detected_csv_changes(
+    changes: &[FileChange],
+    expected_row_upserts: usize,
+    expected_table_upserts: usize,
+) {
+    let row_upserts = changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_row" && change.snapshot_content.is_some())
+        .count();
+    let row_deletes = changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_row" && change.snapshot_content.is_none())
+        .count();
+    let table_upserts = changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_table" && change.snapshot_content.is_some())
+        .count();
+    let table_deletes = changes
+        .iter()
+        .filter(|change| change.schema_key == "csv_table" && change.snapshot_content.is_none())
+        .count();
+
+    assert_eq!(row_upserts, expected_row_upserts);
+    assert_eq!(row_deletes, 0);
+    assert_eq!(table_upserts, expected_table_upserts);
+    assert_eq!(table_deletes, 0);
+    assert_eq!(
+        row_upserts + row_deletes + table_upserts + table_deletes,
+        changes.len()
+    );
+}
+
 fn assert_file_changes_equivalent(direct: &[FileChange], extracted: &[FileChange]) {
     assert_eq!(
         csv_table_dialect(direct),
@@ -602,19 +852,21 @@ fn assert_file_changes_equivalent(direct: &[FileChange], extracted: &[FileChange
     );
 }
 
-fn csv_table_dialect(changes: &[FileChange]) -> serde_json::Value {
+fn csv_table_dialect(changes: &[FileChange]) -> Option<serde_json::Value> {
     let tables = changes
         .iter()
         .filter(|change| change.schema_key == "csv_table")
         .collect::<Vec<_>>();
-    assert_eq!(tables.len(), 1);
-    tables[0]
-        .snapshot_content
-        .as_ref()
-        .expect("csv_table should have snapshot_content")
-        .get("dialect")
-        .expect("csv_table snapshot should have dialect")
-        .clone()
+    assert!(tables.len() <= 1);
+    tables.first().map(|table| {
+        table
+            .snapshot_content
+            .as_ref()
+            .expect("csv_table should have snapshot_content")
+            .get("dialect")
+            .expect("csv_table snapshot should have dialect")
+            .clone()
+    })
 }
 
 fn normalized_csv_rows(changes: &[FileChange]) -> Vec<(String, String)> {
@@ -905,26 +1157,26 @@ impl WasmtimePluginComponent {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct PluginDetectChangesPayload {
     state: Vec<PluginEntityStatePayload>,
     file: PluginFilePayload,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct PluginRenderPayload {
     state: Vec<PluginEntityStatePayload>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct PluginFilePayload {
     data: Vec<u8>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct PluginEntityStatePayload {
     entity_pk: Vec<String>,
@@ -1257,13 +1509,21 @@ fn build_csv_plugin_archive() -> Vec<u8> {
 }
 
 fn csv_plugin_wasm() -> Vec<u8> {
-    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_WASM_plugin_csv"));
+    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv"));
     std::fs::read(wasm_path).unwrap_or_else(|error| {
         panic!(
             "failed to read bindep-built CSV plugin wasm at {}: {error}",
             wasm_path.display()
         )
     })
+}
+
+fn csv_plugin_wasm_from_archive(archive_bytes: &[u8]) -> Vec<u8> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(archive_bytes)).unwrap();
+    let mut entry = archive.by_name("plugin.wasm").unwrap();
+    let mut wasm = Vec::with_capacity(usize::try_from(entry.size()).unwrap_or(0));
+    entry.read_to_end(&mut wasm).unwrap();
+    wasm
 }
 
 criterion_group!(benches, bench_e2e);

--- a/packages/rs-sdk/benches/e2e.rs
+++ b/packages/rs-sdk/benches/e2e.rs
@@ -1,4 +1,4 @@
-use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use lix_sdk::{FsWriteOptions, InMemoryBackend, LixError, OpenLixOptions, Value, open_lix};
 use plugin_csv::exports::lix::plugin::api::EntityState as CsvEntityState;
 use plugin_csv::exports::lix::plugin::api::Guest as _;
@@ -8,6 +8,7 @@ use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Write as _;
+use std::hint::black_box;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -20,13 +21,15 @@ use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
 const INITIAL_ROW_COUNT: usize = 10_000;
 const NEW_ROW_COUNT: usize = 10_000;
 const CSV_PATH: &str = "/large-merge.csv";
+const CSV_PLUGIN_WARMUP_PATH: &str = "/.csv-plugin-warmup.csv";
 
 fn bench_e2e(c: &mut Criterion) {
     let runtime = Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("failed to create Tokio runtime for e2e bench");
-    let archive = build_csv_plugin_archive();
+    let plugin = build_csv_plugin();
+    let plugin_wasm = csv_plugin_wasm_from_archive(&plugin);
     let initial_rows = random_csv_rows("initial", INITIAL_ROW_COUNT, 0x8ae7_b4b1_9f4c_d215);
     let new_rows = random_csv_rows("new", NEW_ROW_COUNT, 0xf3bb_91d4_6a8c_2e73);
     let initial_csv = csv_bytes_from_rows(&initial_rows);
@@ -35,14 +38,20 @@ fn bench_e2e(c: &mut Criterion) {
         &new_rows,
         0x6449_2c6f_179d_31b5,
     ));
-    let initial_wasm_changes = runtime.block_on(wasm_plugin_file_changes(
-        WasmPluginDiffFixture::new(&archive, Vec::new(), &initial_csv),
-    ));
+    let initial_wasm_changes = runtime.block_on(async {
+        wasm_plugin_file_changes(
+            wasm_plugin_diff_fixture(&plugin_wasm, Vec::new(), &initial_csv).await,
+        )
+        .await
+    });
     assert_detected_csv_changes(&initial_wasm_changes, INITIAL_ROW_COUNT, 1);
     let initial_wasm_state = plugin_entity_state_from_file_changes(&initial_wasm_changes);
-    let merge_wasm_changes = runtime.block_on(wasm_plugin_file_changes(
-        WasmPluginDiffFixture::new(&archive, initial_wasm_state.clone(), &updated_csv),
-    ));
+    let merge_wasm_changes = runtime.block_on(async {
+        wasm_plugin_file_changes(
+            wasm_plugin_diff_fixture(&plugin_wasm, initial_wasm_state.clone(), &updated_csv).await,
+        )
+        .await
+    });
     assert_detected_csv_changes(&merge_wasm_changes, NEW_ROW_COUNT, 0);
 
     let initial_native_changes =
@@ -55,39 +64,114 @@ fn bench_e2e(c: &mut Criterion) {
     ));
     assert_file_changes_equivalent(&merge_wasm_changes, &merge_native_changes);
 
+    runtime.block_on(async {
+        validate_overwrite_large_csv(
+            large_csv_fixture(open_lix_with_plugin(&plugin).await, &initial_csv).await,
+            &updated_csv,
+        )
+        .await;
+        validate_manual_bulk_insert_schema_changes(
+            csv_schema_changes_insert_fixture(
+                open_lix_with_plugin(&plugin).await,
+                &[],
+                &initial_wasm_changes,
+                INITIAL_ROW_COUNT,
+            )
+            .await,
+        )
+        .await;
+        validate_manual_bulk_insert_file_changes(
+            csv_changes_insert_fixture(
+                open_lix_with_plugin(&plugin).await,
+                &[],
+                &initial_wasm_changes,
+                INITIAL_ROW_COUNT,
+            )
+            .await,
+        )
+        .await;
+        validate_manual_bulk_insert_schema_changes(
+            csv_schema_changes_insert_fixture(
+                open_lix_with_plugin(&plugin).await,
+                &initial_wasm_changes,
+                &merge_wasm_changes,
+                INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+            )
+            .await,
+        )
+        .await;
+        validate_manual_bulk_insert_file_changes(
+            csv_changes_insert_fixture(
+                open_lix_with_plugin(&plugin).await,
+                &initial_wasm_changes,
+                &merge_wasm_changes,
+                INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+            )
+            .await,
+        )
+        .await;
+    });
+
     let mut group = c.benchmark_group("e2e/csv_plugin");
     group.sample_size(10);
     group.throughput(Throughput::Elements(NEW_ROW_COUNT as u64));
+    group.bench_function("setup", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let lix = open_lix_with_warmed_csv_plugin(&plugin).await;
+                black_box(lix).close().await.unwrap();
+            });
+        });
+    });
+    group.bench_function("setup_wasm", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let fixture =
+                    wasm_plugin_diff_fixture(&plugin_wasm, Vec::new(), &initial_csv).await;
+                black_box(fixture);
+            });
+        });
+    });
     group.bench_function("insert_10k", |b| {
         b.iter_batched(
-            || runtime.block_on(csv_plugin_fixture(&archive)),
-            |fixture| runtime.block_on(insert_large_csv(fixture, &initial_csv)),
+            || runtime.block_on(open_lix_with_warmed_csv_plugin(&plugin)),
+            |lix| runtime.block_on(insert_large_csv(lix, &initial_csv)),
             BatchSize::SmallInput,
         );
     });
     group.bench_function("insert_10k_plugin", |b| {
         b.iter_batched(
-            || WasmPluginDiffFixture::new(&archive, Vec::new(), &initial_csv),
-            |fixture| runtime.block_on(bench_wasm_plugin_diff(fixture, INITIAL_ROW_COUNT, 1)),
+            || {
+                runtime.block_on(wasm_plugin_diff_fixture(
+                    &plugin_wasm,
+                    Vec::new(),
+                    &initial_csv,
+                ))
+            },
+            |fixture| runtime.block_on(bench_wasm_plugin_diff(fixture)),
             BatchSize::SmallInput,
         );
     });
     group.bench_function("insert_10k_plugin_diff", |b| {
         b.iter_batched(
             || NativeCsvDiffFixture::new(Vec::new(), initial_csv.clone()),
-            |fixture| bench_native_csv_diff(fixture, INITIAL_ROW_COUNT, 1),
+            |fixture| bench_native_csv_diff(fixture),
             BatchSize::SmallInput,
         );
     });
     group.bench_function("insert_10k_insert", |b| {
         b.iter_batched(
             || {
-                runtime.block_on(csv_schema_changes_insert_fixture(
-                    &archive,
-                    &[],
-                    &initial_wasm_changes,
-                    INITIAL_ROW_COUNT,
-                ))
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin(&plugin).await;
+                    csv_schema_changes_insert_fixture(
+                        lix,
+                        &[],
+                        &initial_wasm_changes,
+                        INITIAL_ROW_COUNT,
+                    )
+                    .await
+                })
             },
             |fixture| runtime.block_on(manual_bulk_insert_schema_changes(fixture)),
             BatchSize::SmallInput,
@@ -96,12 +180,11 @@ fn bench_e2e(c: &mut Criterion) {
     group.bench_function("insert_10k_insert_state", |b| {
         b.iter_batched(
             || {
-                runtime.block_on(csv_changes_insert_fixture(
-                    &archive,
-                    &[],
-                    &initial_wasm_changes,
-                    INITIAL_ROW_COUNT,
-                ))
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin(&plugin).await;
+                    csv_changes_insert_fixture(lix, &[], &initial_wasm_changes, INITIAL_ROW_COUNT)
+                        .await
+                })
             },
             |fixture| runtime.block_on(manual_bulk_insert_file_changes(fixture)),
             BatchSize::SmallInput,
@@ -109,34 +192,49 @@ fn bench_e2e(c: &mut Criterion) {
     });
     group.bench_function("merge_10k", |b| {
         b.iter_batched(
-            || runtime.block_on(large_csv_fixture(&archive, &initial_csv)),
+            || {
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin(&plugin).await;
+                    large_csv_fixture(lix, &initial_csv).await
+                })
+            },
             |fixture| runtime.block_on(overwrite_large_csv(fixture, &updated_csv)),
             BatchSize::SmallInput,
         );
     });
     group.bench_function("merge_10k_plugin", |b| {
         b.iter_batched(
-            || WasmPluginDiffFixture::new(&archive, initial_wasm_state.clone(), &updated_csv),
-            |fixture| runtime.block_on(bench_wasm_plugin_diff(fixture, NEW_ROW_COUNT, 0)),
+            || {
+                runtime.block_on(wasm_plugin_diff_fixture(
+                    &plugin_wasm,
+                    initial_wasm_state.clone(),
+                    &updated_csv,
+                ))
+            },
+            |fixture| runtime.block_on(bench_wasm_plugin_diff(fixture)),
             BatchSize::SmallInput,
         );
     });
     group.bench_function("merge_10k_plugin_diff", |b| {
         b.iter_batched(
             || NativeCsvDiffFixture::new(initial_native_state.clone(), updated_csv.clone()),
-            |fixture| bench_native_csv_diff(fixture, NEW_ROW_COUNT, 0),
+            |fixture| bench_native_csv_diff(fixture),
             BatchSize::SmallInput,
         );
     });
     group.bench_function("merge_10k_insert", |b| {
         b.iter_batched(
             || {
-                runtime.block_on(csv_schema_changes_insert_fixture(
-                    &archive,
-                    &initial_wasm_changes,
-                    &merge_wasm_changes,
-                    INITIAL_ROW_COUNT + NEW_ROW_COUNT,
-                ))
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin(&plugin).await;
+                    csv_schema_changes_insert_fixture(
+                        lix,
+                        &initial_wasm_changes,
+                        &merge_wasm_changes,
+                        INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+                    )
+                    .await
+                })
             },
             |fixture| runtime.block_on(manual_bulk_insert_schema_changes(fixture)),
             BatchSize::SmallInput,
@@ -145,12 +243,16 @@ fn bench_e2e(c: &mut Criterion) {
     group.bench_function("merge_10k_insert_state", |b| {
         b.iter_batched(
             || {
-                runtime.block_on(csv_changes_insert_fixture(
-                    &archive,
-                    &initial_wasm_changes,
-                    &merge_wasm_changes,
-                    INITIAL_ROW_COUNT + NEW_ROW_COUNT,
-                ))
+                runtime.block_on(async {
+                    let lix = open_lix_with_plugin(&plugin).await;
+                    csv_changes_insert_fixture(
+                        lix,
+                        &initial_wasm_changes,
+                        &merge_wasm_changes,
+                        INITIAL_ROW_COUNT + NEW_ROW_COUNT,
+                    )
+                    .await
+                })
             },
             |fixture| runtime.block_on(manual_bulk_insert_file_changes(fixture)),
             BatchSize::SmallInput,
@@ -162,10 +264,6 @@ fn bench_e2e(c: &mut Criterion) {
 struct LargeCsvFixture {
     lix: lix_sdk::Lix,
     file_id: String,
-}
-
-struct CsvPluginFixture {
-    lix: lix_sdk::Lix,
 }
 
 struct ExtractedCsvChangesFixture {
@@ -189,22 +287,44 @@ struct ExtractedCsvSchemaChangesFixture {
 }
 
 struct WasmPluginDiffFixture {
-    runtime: WasmtimePluginRuntime,
-    archive: Vec<u8>,
-    state: Vec<PluginEntityStatePayload>,
-    file_data: Vec<u8>,
+    component: Arc<dyn lix_sdk::WasmComponentInstance>,
+    detect_changes_input: Vec<u8>,
 }
 
 impl WasmPluginDiffFixture {
-    fn new(archive: &[u8], state: Vec<PluginEntityStatePayload>, file_data: &[u8]) -> Self {
-        Self {
-            runtime: WasmtimePluginRuntime::new()
-                .expect("failed to create Wasmtime plugin runtime"),
-            archive: archive.to_vec(),
+    fn new(
+        component: Arc<dyn lix_sdk::WasmComponentInstance>,
+        state: Vec<PluginEntityStatePayload>,
+        file_data: &[u8],
+    ) -> Self {
+        let payload = PluginDetectChangesPayload {
             state,
-            file_data: file_data.to_vec(),
+            file: PluginFilePayload {
+                data: file_data.to_vec(),
+            },
+        };
+        Self {
+            component,
+            detect_changes_input: serde_json::to_vec(&payload).unwrap(),
         }
     }
+}
+
+async fn wasm_plugin_diff_fixture(
+    wasm: &[u8],
+    state: Vec<PluginEntityStatePayload>,
+    file_data: &[u8],
+) -> WasmPluginDiffFixture {
+    let runtime = WasmtimePluginRuntime::new().expect("failed to create Wasmtime plugin runtime");
+    let component = <WasmtimePluginRuntime as lix_sdk::WasmRuntime>::init_component(
+        &runtime,
+        wasm.to_vec(),
+        lix_sdk::WasmLimits::default(),
+    )
+    .await
+    .unwrap();
+    warm_wasm_csv_plugin_component(&component).await;
+    WasmPluginDiffFixture::new(component, state, file_data)
 }
 
 struct NativeCsvDiffFixture {
@@ -218,7 +338,7 @@ impl NativeCsvDiffFixture {
     }
 }
 
-async fn csv_plugin_fixture(archive: &[u8]) -> CsvPluginFixture {
+async fn open_lix_with_plugin(plugin: &[u8]) -> lix_sdk::Lix {
     let lix = open_lix(OpenLixOptions {
         backend: InMemoryBackend::new(),
         wasm_runtime: Some(Arc::new(
@@ -228,21 +348,48 @@ async fn csv_plugin_fixture(archive: &[u8]) -> CsvPluginFixture {
     .await
     .unwrap();
 
-    lix.install_plugin_archive(archive).await.unwrap();
+    lix.install_plugin_archive(plugin).await.unwrap();
 
-    CsvPluginFixture { lix }
+    lix
 }
 
-async fn large_csv_fixture(archive: &[u8], initial_csv: &[u8]) -> LargeCsvFixture {
-    let fixture = csv_plugin_fixture(archive).await;
-    fixture
-        .lix
-        .write_file(CSV_PATH, initial_csv.to_vec(), FsWriteOptions::default())
+async fn open_lix_with_warmed_csv_plugin(plugin: &[u8]) -> lix_sdk::Lix {
+    let lix = open_lix_with_plugin(plugin).await;
+    warm_lix_csv_plugin(&lix).await;
+    lix
+}
+
+async fn warm_lix_csv_plugin(lix: &lix_sdk::Lix) {
+    lix.write_file(
+        CSV_PLUGIN_WARMUP_PATH,
+        Vec::new(),
+        FsWriteOptions::default(),
+    )
+    .await
+    .unwrap();
+    let removed = lix
+        .execute(
+            "DELETE FROM lix_file WHERE path = $1",
+            &[Value::Text(CSV_PLUGIN_WARMUP_PATH.to_string())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(removed.rows_affected(), 1);
+}
+
+async fn warm_wasm_csv_plugin_component(component: &Arc<dyn lix_sdk::WasmComponentInstance>) {
+    let fixture = WasmPluginDiffFixture::new(component.clone(), Vec::new(), &[]);
+    let output = wasm_plugin_detect_changes_output(fixture).await;
+    let changes = serde_json::from_slice::<Vec<PluginDetectedChangePayload>>(&output).unwrap();
+    assert!(changes.is_empty());
+}
+
+async fn large_csv_fixture(lix: lix_sdk::Lix, initial_csv: &[u8]) -> LargeCsvFixture {
+    lix.write_file(CSV_PATH, initial_csv.to_vec(), FsWriteOptions::default())
         .await
         .unwrap();
 
-    let file_id = fixture
-        .lix
+    let file_id = lix
         .execute(
             "SELECT id FROM lix_file WHERE path = $1",
             &[Value::Text(CSV_PATH.to_string())],
@@ -252,41 +399,31 @@ async fn large_csv_fixture(archive: &[u8], initial_csv: &[u8]) -> LargeCsvFixtur
     assert_eq!(file_id.len(), 1);
     let file_id = file_id.rows()[0].get::<String>("id").unwrap();
 
-    LargeCsvFixture {
-        lix: fixture.lix,
-        file_id,
-    }
+    LargeCsvFixture { lix, file_id }
 }
 
 async fn csv_changes_insert_fixture(
-    archive: &[u8],
+    lix: lix_sdk::Lix,
     existing_changes: &[FileChange],
     insert_changes: &[FileChange],
     expected_active_row_count: usize,
 ) -> ExtractedCsvChangesFixture {
-    let fixture = csv_plugin_fixture(archive).await;
     let file_id = "bench-csv-file".to_string();
-    fixture
-        .lix
-        .execute(
-            "INSERT INTO lix_file (id, path) VALUES ($1, $2)",
-            &[
-                Value::Text(file_id.clone()),
-                Value::Text(CSV_PATH.to_string()),
-            ],
-        )
-        .await
-        .unwrap();
-    assert_eq!(
-        fixture.lix.read_file(CSV_PATH).await.unwrap(),
-        Some(Vec::new())
-    );
+    lix.execute(
+        "INSERT INTO lix_file (id, path) VALUES ($1, $2)",
+        &[
+            Value::Text(file_id.clone()),
+            Value::Text(CSV_PATH.to_string()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert_eq!(lix.read_file(CSV_PATH).await.unwrap(), Some(Vec::new()));
 
     if !existing_changes.is_empty() {
         let existing_insert_sql = bulk_insert_file_changes_sql(existing_changes.len());
         let existing_params = bulk_insert_file_changes_params(&file_id, existing_changes);
-        let result = fixture
-            .lix
+        let result = lix
             .execute(&existing_insert_sql, &existing_params)
             .await
             .unwrap();
@@ -298,14 +435,14 @@ async fn csv_changes_insert_fixture(
         .filter(|change| change.schema_key == "csv_row" && change.snapshot_content.is_some())
         .count();
     assert_eq!(
-        active_csv_row_count(&fixture.lix, &file_id).await,
+        active_csv_row_count(&lix, &file_id).await,
         existing_row_count
     );
 
     let state_insert_sql = bulk_insert_file_changes_sql(insert_changes.len());
     let state_params = bulk_insert_file_changes_params(&file_id, insert_changes);
     ExtractedCsvChangesFixture {
-        lix: fixture.lix,
+        lix,
         file_id,
         change_count: insert_changes.len(),
         state_insert_sql,
@@ -315,24 +452,20 @@ async fn csv_changes_insert_fixture(
 }
 
 async fn csv_schema_changes_insert_fixture(
-    archive: &[u8],
+    lix: lix_sdk::Lix,
     existing_changes: &[FileChange],
     insert_changes: &[FileChange],
     expected_active_row_count: usize,
 ) -> ExtractedCsvSchemaChangesFixture {
-    let fixture = csv_plugin_fixture(archive).await;
     if !existing_changes.is_empty() {
-        bulk_insert_schema_changes(&fixture.lix, existing_changes).await;
+        bulk_insert_schema_changes(&lix, existing_changes).await;
     }
 
     let existing_row_count = existing_changes
         .iter()
         .filter(|change| change.schema_key == "csv_row" && change.snapshot_content.is_some())
         .count();
-    assert_eq!(
-        active_csv_schema_row_count(&fixture.lix).await,
-        existing_row_count
-    );
+    assert_eq!(active_csv_schema_row_count(&lix).await, existing_row_count);
 
     let table_changes = insert_changes
         .iter()
@@ -345,7 +478,7 @@ async fn csv_schema_changes_insert_fixture(
     assert!(!row_changes.is_empty());
 
     ExtractedCsvSchemaChangesFixture {
-        lix: fixture.lix,
+        lix,
         table_insert_sql: (!table_changes.is_empty())
             .then(|| bulk_insert_csv_table_sql(table_changes.len())),
         table_params: bulk_insert_csv_table_params(&table_changes),
@@ -357,22 +490,35 @@ async fn csv_schema_changes_insert_fixture(
     }
 }
 
-async fn insert_large_csv(fixture: CsvPluginFixture, initial_csv: &[u8]) {
-    fixture
-        .lix
-        .write_file(CSV_PATH, initial_csv.to_vec(), FsWriteOptions::default())
+async fn insert_large_csv(lix: lix_sdk::Lix, initial_csv: &[u8]) {
+    lix.write_file(CSV_PATH, initial_csv.to_vec(), FsWriteOptions::default())
         .await
         .unwrap();
     black_box(initial_csv);
-    fixture.lix.close().await.unwrap();
+    lix.close().await.unwrap();
 }
 
 async fn overwrite_large_csv(fixture: LargeCsvFixture, updated_csv: &[u8]) {
+    write_updated_csv(&fixture, updated_csv).await;
+    black_box(updated_csv);
+    fixture.lix.close().await.unwrap();
+}
+
+async fn validate_overwrite_large_csv(fixture: LargeCsvFixture, updated_csv: &[u8]) {
+    write_updated_csv(&fixture, updated_csv).await;
+    assert_large_csv_overwrite_result(&fixture, updated_csv).await;
+    fixture.lix.close().await.unwrap();
+}
+
+async fn write_updated_csv(fixture: &LargeCsvFixture, updated_csv: &[u8]) {
     fixture
         .lix
         .write_file(CSV_PATH, updated_csv.to_vec(), FsWriteOptions::default())
         .await
         .unwrap();
+}
+
+async fn assert_large_csv_overwrite_result(fixture: &LargeCsvFixture, updated_csv: &[u8]) {
     assert_eq!(
         fixture.lix.read_file(CSV_PATH).await.unwrap().as_deref(),
         Some(updated_csv)
@@ -432,7 +578,7 @@ async fn overwrite_large_csv(fixture: LargeCsvFixture, updated_csv: &[u8]) {
             "SELECT COUNT(*) AS row_count \
              FROM lix_state \
              WHERE file_id = $1 AND schema_key = 'csv_row'",
-            &[Value::Text(fixture.file_id)],
+            &[Value::Text(fixture.file_id.clone())],
         )
         .await
         .unwrap();
@@ -440,9 +586,6 @@ async fn overwrite_large_csv(fixture: LargeCsvFixture, updated_csv: &[u8]) {
         active_rows.rows()[0].get::<i64>("row_count").unwrap(),
         20_000
     );
-
-    black_box(changes);
-    fixture.lix.close().await.unwrap();
 }
 
 async fn active_csv_row_count(lix: &lix_sdk::Lix, file_id: &str) -> usize {
@@ -467,49 +610,85 @@ async fn active_csv_schema_row_count(lix: &lix_sdk::Lix) -> usize {
 }
 
 async fn manual_bulk_insert_file_changes(fixture: ExtractedCsvChangesFixture) {
-    let result = fixture
-        .lix
-        .execute(&fixture.state_insert_sql, &fixture.state_params)
-        .await
-        .unwrap();
-    assert_eq!(result.rows_affected(), fixture.change_count as u64);
+    let rows_affected = execute_bulk_insert_file_changes(&fixture).await;
+    black_box(rows_affected);
+    black_box(fixture.state_insert_sql);
+    black_box(fixture.state_params);
+    fixture.lix.close().await.unwrap();
+}
+
+async fn validate_manual_bulk_insert_file_changes(fixture: ExtractedCsvChangesFixture) {
+    let rows_affected = execute_bulk_insert_file_changes(&fixture).await;
+    assert_eq!(rows_affected, fixture.change_count as u64);
 
     assert_eq!(
         active_csv_row_count(&fixture.lix, &fixture.file_id).await,
         fixture.expected_active_row_count
     );
 
-    black_box(fixture.state_insert_sql);
-    black_box(fixture.state_params);
     fixture.lix.close().await.unwrap();
 }
 
+async fn execute_bulk_insert_file_changes(fixture: &ExtractedCsvChangesFixture) -> u64 {
+    let result = fixture
+        .lix
+        .execute(&fixture.state_insert_sql, &fixture.state_params)
+        .await
+        .unwrap();
+    result.rows_affected()
+}
+
 async fn manual_bulk_insert_schema_changes(fixture: ExtractedCsvSchemaChangesFixture) {
-    if let Some(table_insert_sql) = fixture.table_insert_sql.as_ref() {
+    let (table_rows_affected, row_rows_affected) =
+        execute_bulk_insert_schema_changes(&fixture).await;
+    black_box(table_rows_affected);
+    black_box(row_rows_affected);
+    black_box(fixture.table_insert_sql);
+    black_box(fixture.table_params);
+    black_box(fixture.row_insert_sql);
+    black_box(fixture.row_params);
+    fixture.lix.close().await.unwrap();
+}
+
+async fn validate_manual_bulk_insert_schema_changes(fixture: ExtractedCsvSchemaChangesFixture) {
+    let (table_rows_affected, row_rows_affected) =
+        execute_bulk_insert_schema_changes(&fixture).await;
+    assert_eq!(
+        table_rows_affected,
+        fixture
+            .table_insert_sql
+            .as_ref()
+            .map(|_| fixture.table_count as u64)
+    );
+    assert_eq!(row_rows_affected, fixture.row_count as u64);
+    assert_eq!(
+        active_csv_schema_row_count(&fixture.lix).await,
+        fixture.expected_active_row_count
+    );
+
+    fixture.lix.close().await.unwrap();
+}
+
+async fn execute_bulk_insert_schema_changes(
+    fixture: &ExtractedCsvSchemaChangesFixture,
+) -> (Option<u64>, u64) {
+    let table_rows_affected = if let Some(table_insert_sql) = fixture.table_insert_sql.as_ref() {
         let table_result = fixture
             .lix
             .execute(table_insert_sql, &fixture.table_params)
             .await
             .unwrap();
-        assert_eq!(table_result.rows_affected(), fixture.table_count as u64);
-    }
+        Some(table_result.rows_affected())
+    } else {
+        None
+    };
 
     let row_result = fixture
         .lix
         .execute(&fixture.row_insert_sql, &fixture.row_params)
         .await
         .unwrap();
-    assert_eq!(row_result.rows_affected(), fixture.row_count as u64);
-    assert_eq!(
-        active_csv_schema_row_count(&fixture.lix).await,
-        fixture.expected_active_row_count
-    );
-
-    black_box(fixture.table_insert_sql);
-    black_box(fixture.table_params);
-    black_box(fixture.row_insert_sql);
-    black_box(fixture.row_params);
-    fixture.lix.close().await.unwrap();
+    (table_rows_affected, row_result.rows_affected())
 }
 
 fn bulk_insert_file_changes_sql(change_count: usize) -> String {
@@ -658,57 +837,42 @@ fn bulk_insert_csv_row_params(changes: &[&FileChange]) -> Vec<Value> {
     params
 }
 
-async fn bench_wasm_plugin_diff(
-    fixture: WasmPluginDiffFixture,
-    expected_row_upserts: usize,
-    expected_table_upserts: usize,
-) {
-    let changes = wasm_plugin_file_changes(fixture).await;
-    assert_detected_csv_changes(&changes, expected_row_upserts, expected_table_upserts);
-    black_box(changes);
+async fn bench_wasm_plugin_diff(fixture: WasmPluginDiffFixture) {
+    let output = wasm_plugin_detect_changes_output(fixture).await;
+    black_box(output);
 }
 
 async fn wasm_plugin_file_changes(fixture: WasmPluginDiffFixture) -> Vec<FileChange> {
-    let component = <WasmtimePluginRuntime as lix_sdk::WasmRuntime>::init_component(
-        &fixture.runtime,
-        csv_plugin_wasm_from_archive(&fixture.archive),
-        lix_sdk::WasmLimits::default(),
-    )
-    .await
-    .unwrap();
-    let payload = PluginDetectChangesPayload {
-        state: fixture.state,
-        file: PluginFilePayload {
-            data: fixture.file_data,
-        },
-    };
-    let output = component
-        .call("detect-changes", &serde_json::to_vec(&payload).unwrap())
-        .await
-        .unwrap();
+    let output = wasm_plugin_detect_changes_output(fixture).await;
     let changes = serde_json::from_slice::<Vec<PluginDetectedChangePayload>>(&output).unwrap();
     plugin_detected_changes_to_file_changes(changes)
 }
 
-fn bench_native_csv_diff(
-    fixture: NativeCsvDiffFixture,
-    expected_row_upserts: usize,
-    expected_table_upserts: usize,
-) {
-    let changes = native_csv_file_changes(fixture);
-    assert_detected_csv_changes(&changes, expected_row_upserts, expected_table_upserts);
+async fn wasm_plugin_detect_changes_output(fixture: WasmPluginDiffFixture) -> Vec<u8> {
+    fixture
+        .component
+        .call("detect-changes", &fixture.detect_changes_input)
+        .await
+        .unwrap()
+}
+
+fn bench_native_csv_diff(fixture: NativeCsvDiffFixture) {
+    let changes = native_csv_detected_changes(fixture);
     black_box(changes);
 }
 
 fn native_csv_file_changes(fixture: NativeCsvDiffFixture) -> Vec<FileChange> {
-    let changes = CsvPlugin::detect_changes(
+    csv_detected_changes_to_file_changes(native_csv_detected_changes(fixture))
+}
+
+fn native_csv_detected_changes(fixture: NativeCsvDiffFixture) -> Vec<plugin_csv::DetectedChange> {
+    CsvPlugin::detect_changes(
         fixture.state,
         CsvFile {
             data: fixture.file_data,
         },
     )
-    .unwrap();
-    csv_detected_changes_to_file_changes(changes)
+    .unwrap()
 }
 
 fn plugin_detected_changes_to_file_changes(
@@ -1482,7 +1646,7 @@ fn wasm_runtime_error(context: impl Into<String>, error: impl fmt::Display) -> L
     )
 }
 
-fn build_csv_plugin_archive() -> Vec<u8> {
+fn build_csv_plugin() -> Vec<u8> {
     let wasm = csv_plugin_wasm();
     let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
     let options =
@@ -1519,8 +1683,8 @@ fn csv_plugin_wasm() -> Vec<u8> {
 }
 
 fn csv_plugin_wasm_from_archive(archive_bytes: &[u8]) -> Vec<u8> {
-    let mut archive = zip::ZipArchive::new(Cursor::new(archive_bytes)).unwrap();
-    let mut entry = archive.by_name("plugin.wasm").unwrap();
+    let mut plugin = zip::ZipArchive::new(Cursor::new(archive_bytes)).unwrap();
+    let mut entry = plugin.by_name("plugin.wasm").unwrap();
     let mut wasm = Vec::with_capacity(usize::try_from(entry.size()).unwrap_or(0));
     entry.read_to_end(&mut wasm).unwrap();
     wasm

--- a/packages/rs-sdk/benches/sqlite_backend.rs
+++ b/packages/rs-sdk/benches/sqlite_backend.rs
@@ -1,12 +1,11 @@
+use std::hint::black_box;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bytes::Bytes;
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
-};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use lix_engine::backend::{KeyRef, PutEntry};
 use lix_sdk::{
     Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite, CommitResult,

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -944,7 +944,7 @@ async fn transaction_blocks_session_execute_on_same_handle() {
 
 #[cfg(feature = "default_wasm_runtime")]
 fn build_csv_plugin_archive() -> Vec<u8> {
-    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_WASM_plugin_csv"));
+    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv"));
     let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
         panic!(
             "failed to read bindep-built CSV plugin wasm at {}: {error}",


### PR DESCRIPTION
```text
e2e/csv_plugin/setup
       time:   [755.22 ms 770.69 ms 788.45 ms]
e2e/csv_plugin/setup_inmemory
       time:   [706.34 ms 714.07 ms 722.26 ms]
e2e/csv_plugin/setup_wasm
       time:   [636.46 ms 640.62 ms 645.95 ms]
e2e/csv_plugin/insert_10k
       time:   [382.16 ms 390.84 ms 399.95 ms]
e2e/csv_plugin/insert_10k_inmemory
       time:   [161.83 ms 161.99 ms 162.17 ms]
e2e/csv_plugin/insert_10k_plugin
       time:   [42.679 ms 43.113 ms 43.912 ms]
e2e/csv_plugin/insert_10k_plugin_diff
       time:   [12.638 ms 12.745 ms 12.950 ms]
e2e/csv_plugin/insert_10k_insert
       time:   [333.99 ms 339.77 ms 345.44 ms]
e2e/csv_plugin/insert_10k_insert_inmemory
       time:   [130.87 ms 131.26 ms 131.51 ms]
e2e/csv_plugin/insert_10k_insert_state
       time:   [1.2437 s 1.3097 s 1.3770 s]
e2e/csv_plugin/insert_10k_insert_state_inmemory
       time:   [816.89 ms 849.15 ms 885.61 ms]
e2e/csv_plugin/merge_10k
       time:   [1.1927 s 1.2966 s 1.4250 s]
e2e/csv_plugin/merge_10k_inmemory
       time:   [541.09 ms 556.25 ms 575.26 ms]
e2e/csv_plugin/merge_10k_plugin
       time:   [82.567 ms 83.566 ms 84.485 ms]
e2e/csv_plugin/merge_10k_plugin_diff
       time:   [27.379 ms 27.502 ms 27.616 ms]
e2e/csv_plugin/merge_10k_insert
       time:   [476.33 ms 499.63 ms 526.25 ms]
e2e/csv_plugin/merge_10k_insert_inmemory
       time:   [360.52 ms 361.62 ms 363.26 ms]
e2e/csv_plugin/merge_10k_insert_state
       time:   [1.7571 s 1.8470 s 1.9433 s]
e2e/csv_plugin/merge_10k_insert_state_inmemory
       time:   [1.1629 s 1.1714 s 1.1832 s]
```