### PR TITLE
Perf fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,6 +3523,7 @@ dependencies = [
  "itertools 0.14.0",
  "rand 0.9.2",
  "serde_json",
+ "uuid",
  "wit-bindgen 0.57.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,11 +4719,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -348,7 +348,7 @@ fn assemble_blob_bytes(
     let expected_blob_size = persisted_size_to_usize(metadata.size_bytes, "binary CAS blob")?;
     let bytes = match &metadata.layout {
         BlobLayout::Empty => {
-            if metadata.hash != BlobHash::from_content(&[]) {
+            if cfg!(debug_assertions) && metadata.hash != BlobHash::from_content(&[]) {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
@@ -366,7 +366,10 @@ fn assemble_blob_bytes(
                 *chunk_hash,
                 expected_blob_size,
             )?;
-            if *chunk_hash != metadata.hash && BlobHash::from_content(&chunk) != metadata.hash {
+            if cfg!(debug_assertions)
+                && *chunk_hash != metadata.hash
+                && BlobHash::from_content(&chunk) != metadata.hash
+            {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
@@ -422,7 +425,7 @@ fn assemble_blob_bytes(
                     ),
                 ));
             }
-            if BlobHash::from_content(&out) != metadata.hash {
+            if cfg!(debug_assertions) && BlobHash::from_content(&out) != metadata.hash {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
@@ -488,7 +491,7 @@ fn decode_and_verify_chunk(
             ),
         ));
     }
-    if BlobHash::from_content(chunk_payload) != chunk_hash {
+    if cfg!(debug_assertions) && BlobHash::from_content(chunk_payload) != chunk_hash {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!(

--- a/packages/engine/src/json_store/store.rs
+++ b/packages/engine/src/json_store/store.rs
@@ -347,7 +347,7 @@ fn decode_json_payload(
             ),
         ));
     }
-    if hash_check == JsonHashCheck::Verify {
+    if hash_check == JsonHashCheck::Verify && cfg!(debug_assertions) {
         let actual_hash = blake3::hash(&data);
         if actual_hash.as_bytes() != json_ref.as_hash_bytes() {
             return Err(LixError::new(

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -10,12 +10,12 @@ pub(crate) use context::{LiveStateContext, LiveStateStoreReader};
 pub(crate) use reader::LiveStateReader;
 #[allow(unused_imports)]
 pub(crate) use types::{
-    Bound, LiveStateFilter, LiveStateProjection, LiveStateRowFilter, LiveStateRowIdentity,
-    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow, ScanConstraint, ScanField,
-    ScanOperator,
+    Bound, LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection, LiveStateRowFilter,
+    LiveStateRowIdentity, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
+    ScanConstraint, ScanField, ScanOperator,
 };
 #[allow(unused_imports)]
 pub(crate) use visibility::{
     StagedLiveStateRows, VisibilityBranchScope, VisibilityRequest, expanded_branch_ids,
-    overlay_scan_rows, resolve_visible_rows,
+    overlay_scan_file_rows, overlay_scan_rows, resolve_visible_rows,
 };

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::LixError;
 use crate::live_state::MaterializedLiveStateRow;
-use crate::live_state::{LiveStateRowRequest, LiveStateScanRequest};
+use crate::live_state::{LiveStateFileScanRequest, LiveStateRowRequest, LiveStateScanRequest};
 
 /// Minimal engine read model for transaction planning and SQL providers.
 ///
@@ -15,6 +15,13 @@ pub(crate) trait LiveStateReader: Send + Sync {
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
+
+    async fn scan_file_rows(
+        &self,
+        request: &LiveStateFileScanRequest,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        self.scan_rows(&request.to_scan_request()).await
+    }
 
     async fn load_row(
         &self,

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -191,6 +191,46 @@ pub(crate) struct LiveStateScanRequest {
     pub(crate) limit: Option<usize>,
 }
 
+/// File-scoped scan request for visible live-state rows.
+///
+/// This is the named form of the common query shape "rows for this branch,
+/// concrete file id, and schema set". It deliberately lowers to
+/// `LiveStateScanRequest` so optimized implementations can preserve the exact
+/// generic scan semantics while specializing the storage path.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+pub(crate) struct LiveStateFileScanRequest {
+    #[serde(default)]
+    pub(crate) branch_ids: Vec<String>,
+    pub(crate) file_id: String,
+    #[serde(default)]
+    pub(crate) schema_keys: Vec<String>,
+    #[serde(default)]
+    pub(crate) untracked: Option<bool>,
+    #[serde(default)]
+    pub(crate) include_tombstones: bool,
+    #[serde(default)]
+    pub(crate) projection: LiveStateProjection,
+    #[serde(default)]
+    pub(crate) limit: Option<usize>,
+}
+
+impl LiveStateFileScanRequest {
+    pub(crate) fn to_scan_request(&self) -> LiveStateScanRequest {
+        LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: self.schema_keys.clone(),
+                branch_ids: self.branch_ids.clone(),
+                file_ids: vec![NullableKeyFilter::Value(self.file_id.clone())],
+                untracked: self.untracked,
+                include_tombstones: self.include_tombstones,
+                ..LiveStateFilter::default()
+            },
+            projection: self.projection.clone(),
+            limit: self.limit,
+        }
+    }
+}
+
 /// Point lookup request for one visible live-state row.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct LiveStateRowRequest {

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::live_state::{
-    LiveStateReader, LiveStateRowIdentity, LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateFileScanRequest, LiveStateReader, LiveStateRowIdentity, LiveStateScanRequest,
+    MaterializedLiveStateRow,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,6 +24,13 @@ pub(crate) trait StagedLiveStateRows {
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
+
+    fn staged_file_rows(
+        &self,
+        request: &LiveStateFileScanRequest,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        self.staged_rows(&request.to_scan_request())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -90,6 +98,33 @@ where
                 branch_ids: request.filter.branch_ids.clone(),
             },
             include_tombstones: request.filter.include_tombstones,
+            limit: request.limit,
+        },
+    ))
+}
+
+pub(crate) async fn overlay_scan_file_rows<S>(
+    base: &dyn LiveStateReader,
+    staged: &S,
+    request: &LiveStateFileScanRequest,
+) -> Result<Vec<MaterializedLiveStateRow>, LixError>
+where
+    S: StagedLiveStateRows + ?Sized,
+{
+    let mut candidate_request = request.clone();
+    candidate_request.limit = None;
+    candidate_request.include_tombstones = true;
+    candidate_request.branch_ids = expanded_branch_ids(&request.branch_ids);
+    let staged_rows = staged.staged_file_rows(&candidate_request)?;
+    let rows = base.scan_file_rows(&candidate_request).await?;
+    Ok(resolve_visible_rows(
+        rows,
+        staged_rows,
+        &VisibilityRequest {
+            branch_scope: VisibilityBranchScope::BranchIds {
+                branch_ids: request.branch_ids.clone(),
+            },
+            include_tombstones: request.include_tombstones,
             limit: request.limit,
         },
     ))
@@ -234,9 +269,10 @@ fn insert_row_preferring_untracked(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::NullableKeyFilter;
     use crate::changelog::{ChangeId, CommitId};
     use crate::entity_pk::EntityPk;
-    use crate::live_state::LiveStateRowRequest;
+    use crate::live_state::{LiveStateFileScanRequest, LiveStateProjection, LiveStateRowRequest};
     use async_trait::async_trait;
 
     #[test]
@@ -551,6 +587,40 @@ mod tests {
         assert_eq!(rows.len(), 1);
     }
 
+    #[test]
+    fn file_scan_request_lowers_to_equivalent_generic_scan_request() {
+        let request = LiveStateFileScanRequest {
+            branch_ids: vec!["branch-a".to_string()],
+            file_id: "file-a".to_string(),
+            schema_keys: vec!["schema-a".to_string(), "schema-b".to_string()],
+            untracked: Some(false),
+            include_tombstones: true,
+            projection: LiveStateProjection {
+                columns: vec!["snapshot_content".to_string(), "metadata".to_string()],
+            },
+            limit: Some(3),
+        };
+
+        let scan = request.to_scan_request();
+
+        assert_eq!(scan.filter.branch_ids, vec!["branch-a"]);
+        assert_eq!(
+            scan.filter.file_ids,
+            vec![NullableKeyFilter::Value("file-a".to_string())]
+        );
+        assert_eq!(
+            scan.filter.schema_keys,
+            vec!["schema-a".to_string(), "schema-b".to_string()]
+        );
+        assert_eq!(scan.filter.untracked, Some(false));
+        assert!(scan.filter.include_tombstones);
+        assert_eq!(
+            scan.projection.columns,
+            vec!["snapshot_content".to_string(), "metadata".to_string()]
+        );
+        assert_eq!(scan.limit, Some(3));
+    }
+
     #[tokio::test]
     async fn overlay_scan_fetches_base_global_candidates_for_staged_only_branch_scope() {
         let base = ExistingGlobalOnlyReader {
@@ -587,6 +657,68 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn overlay_scan_file_rows_matches_equivalent_generic_overlay_scan() {
+        let base = FilteringReader {
+            rows: vec![
+                file_row_at("global", "shared", "global", true, "schema-a", "file-a"),
+                file_row_at(
+                    "branch-a",
+                    "shared",
+                    "branch-base",
+                    false,
+                    "schema-a",
+                    "file-a",
+                ),
+                file_row_at(
+                    "branch-a",
+                    "other-file",
+                    "ignored",
+                    false,
+                    "schema-a",
+                    "file-b",
+                ),
+                file_row_at(
+                    "branch-a",
+                    "other-schema",
+                    "ignored",
+                    false,
+                    "schema-b",
+                    "file-a",
+                ),
+            ],
+        };
+        let staged = FilteringStagedRows {
+            rows: vec![file_row_at(
+                "branch-a", "shared", "staged", false, "schema-a", "file-a",
+            )],
+        };
+        let file_request = LiveStateFileScanRequest {
+            branch_ids: vec!["branch-a".to_string()],
+            file_id: "file-a".to_string(),
+            schema_keys: vec!["schema-a".to_string()],
+            projection: LiveStateProjection {
+                columns: vec!["snapshot_content".to_string()],
+            },
+            ..Default::default()
+        };
+        let generic_request = file_request.to_scan_request();
+
+        let file_rows = overlay_scan_file_rows(&base, &staged, &file_request)
+            .await
+            .expect("file overlay scan should succeed");
+        let generic_rows = overlay_scan_rows(&base, &staged, &generic_request)
+            .await
+            .expect("generic overlay scan should succeed");
+
+        assert_eq!(file_rows, generic_rows);
+        assert_eq!(file_rows.len(), 1);
+        assert_eq!(
+            file_rows[0].snapshot_content.as_deref(),
+            Some("{\"value\":\"staged\"}")
+        );
+    }
+
     fn row_at(
         branch_id: &str,
         entity_pk: &str,
@@ -611,6 +743,21 @@ mod tests {
         }
     }
 
+    fn file_row_at(
+        branch_id: &str,
+        entity_pk: &str,
+        value: &str,
+        global: bool,
+        schema_key: &str,
+        file_id: &str,
+    ) -> MaterializedLiveStateRow {
+        MaterializedLiveStateRow {
+            schema_key: schema_key.to_string(),
+            file_id: Some(file_id.to_string()),
+            ..row_at(branch_id, entity_pk, value, global, Some("change"))
+        }
+    }
+
     fn tombstone_at(
         branch_id: &str,
         entity_pk: &str,
@@ -624,6 +771,25 @@ mod tests {
         }
     }
 
+    fn matches_scan_request(
+        row: &MaterializedLiveStateRow,
+        request: &LiveStateScanRequest,
+    ) -> bool {
+        let filter = &request.filter;
+        let branch_matches =
+            filter.branch_ids.is_empty() || filter.branch_ids.contains(&row.branch_id);
+        let schema_matches =
+            filter.schema_keys.is_empty() || filter.schema_keys.contains(&row.schema_key);
+        let file_matches = filter.file_ids.is_empty()
+            || filter.file_ids.iter().any(|file_id| match file_id {
+                NullableKeyFilter::Any => true,
+                NullableKeyFilter::Value(file_id) => row.file_id.as_ref() == Some(file_id),
+                NullableKeyFilter::Null => row.file_id.is_none(),
+            });
+        let tombstone_matches = filter.include_tombstones || !row.deleted;
+        branch_matches && schema_matches && file_matches && tombstone_matches
+    }
+
     struct EmptyStagedRows;
 
     impl StagedLiveStateRows for EmptyStagedRows {
@@ -632,6 +798,24 @@ mod tests {
             _request: &LiveStateScanRequest,
         ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
             Ok(Vec::new())
+        }
+    }
+
+    struct FilteringStagedRows {
+        rows: Vec<MaterializedLiveStateRow>,
+    }
+
+    impl StagedLiveStateRows for FilteringStagedRows {
+        fn staged_rows(
+            &self,
+            request: &LiveStateScanRequest,
+        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            Ok(self
+                .rows
+                .iter()
+                .filter(|row| matches_scan_request(row, request))
+                .cloned()
+                .collect())
         }
     }
 
@@ -655,6 +839,32 @@ mod tests {
             } else {
                 Ok(Vec::new())
             }
+        }
+
+        async fn load_row(
+            &self,
+            _request: &LiveStateRowRequest,
+        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
+            Ok(None)
+        }
+    }
+
+    struct FilteringReader {
+        rows: Vec<MaterializedLiveStateRow>,
+    }
+
+    #[async_trait]
+    impl LiveStateReader for FilteringReader {
+        async fn scan_rows(
+            &self,
+            request: &LiveStateScanRequest,
+        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            Ok(self
+                .rows
+                .iter()
+                .filter(|row| matches_scan_request(row, request))
+                .cloned()
+                .collect())
         }
 
         async fn load_row(

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use crate::common::LixError;
-use crate::wasm::{WasmComponentInstance, WasmLimits, WasmRuntime};
+use crate::wasm::{
+    WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime,
+};
 
 use super::InstalledPlugin;
 
@@ -11,9 +14,6 @@ pub(crate) struct CachedPluginComponent {
     pub(crate) wasm: Vec<u8>,
     pub(crate) instance: Arc<dyn WasmComponentInstance>,
 }
-
-const RENDER_EXPORTS: &[&str] = &["render", "api#render"];
-const DETECT_CHANGES_EXPORTS: &[&str] = &["detect-changes", "api#detect-changes"];
 
 #[derive(Clone)]
 pub(crate) struct PluginRuntimeHost {
@@ -92,43 +92,20 @@ pub(crate) async fn load_or_init_plugin_component(
 pub(crate) async fn render_with_plugin(
     host: &impl PluginComponentHost,
     plugin: &InstalledPlugin,
-    payload: &[u8],
+    state: Vec<WasmPluginEntityState>,
 ) -> Result<Vec<u8>, LixError> {
     let instance = load_or_init_plugin_component(host, plugin).await?;
-    invoke_plugin_export(instance.as_ref(), RENDER_EXPORTS, payload).await
+    instance.render(state).await
 }
 
 pub(crate) async fn detect_changes_with_plugin(
     host: &impl PluginComponentHost,
     plugin: &InstalledPlugin,
-    payload: &[u8],
-) -> Result<Vec<u8>, LixError> {
+    state: Vec<WasmPluginEntityState>,
+    file: WasmPluginFile,
+) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
     let instance = load_or_init_plugin_component(host, plugin).await?;
-    invoke_plugin_export(instance.as_ref(), DETECT_CHANGES_EXPORTS, payload).await
-}
-
-async fn invoke_plugin_export(
-    instance: &dyn WasmComponentInstance,
-    exports: &[&str],
-    payload: &[u8],
-) -> Result<Vec<u8>, LixError> {
-    let mut errors = Vec::new();
-    for export in exports {
-        match instance.call(export, payload).await {
-            Ok(output) => return Ok(output),
-            Err(error) => errors.push(format!("{export}: {}", error.message)),
-        }
-    }
-
-    Err(LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!(
-            "plugin materialization: failed to call component export ({})",
-            errors.join("; ")
-        ),
-        hint: None,
-        details: None,
-    })
+    instance.detect_changes(state, file).await
 }
 
 #[cfg(test)]
@@ -177,7 +154,15 @@ mod tests {
 
     #[async_trait]
     impl WasmComponentInstance for NoopComponent {
-        async fn call(&self, _export: &str, _input: &[u8]) -> Result<Vec<u8>, LixError> {
+        async fn detect_changes(
+            &self,
+            _state: Vec<WasmPluginEntityState>,
+            _file: WasmPluginFile,
+        ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+            Ok(Vec::new())
+        }
+
+        async fn render(&self, _state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
             Ok(Vec::new())
         }
     }

--- a/packages/engine/src/plugin/materializer.rs
+++ b/packages/engine/src/plugin/materializer.rs
@@ -1,12 +1,11 @@
 use std::collections::BTreeSet;
 
-use serde::{Deserialize, Serialize};
-
 use crate::LixError;
 use crate::binary_cas::{BlobDataReader, BlobHash};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::FilesystemIndex;
 use crate::live_state::{LiveStateProjection, MaterializedLiveStateRow};
+use crate::wasm::{WasmPluginEntityState, WasmPluginFile};
 
 use super::component::{
     PluginComponentHost, detect_changes_with_plugin as detect_changes_with_component,
@@ -23,43 +22,6 @@ pub(crate) struct PluginDetectedChange {
     pub(crate) schema_key: String,
     pub(crate) snapshot_content: Option<String>,
     pub(crate) metadata: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginDetectChangesRequest<'a> {
-    state: Vec<PluginEntityState<'a>>,
-    file: PluginFile,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginRenderRequest<'a> {
-    state: Vec<PluginEntityState<'a>>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginFile {
-    data: Vec<u8>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginEntityState<'a> {
-    entity_pk: &'a [String],
-    schema_key: &'a str,
-    snapshot_content: &'a str,
-    metadata: Option<&'a str>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginDetectedChangeWire {
-    entity_pk: Vec<String>,
-    schema_key: String,
-    snapshot_content: Option<String>,
-    metadata: Option<String>,
 }
 
 pub(crate) async fn load_installed_plugins_from_filesystem(
@@ -115,19 +77,13 @@ pub(crate) async fn detect_changes_with_plugin(
     active_state: &[MaterializedLiveStateRow],
     file_data: Vec<u8>,
 ) -> Result<Vec<PluginDetectedChange>, LixError> {
-    let request = PluginDetectChangesRequest {
-        state: plugin_entity_state_from_live_rows(active_state)?,
-        file: PluginFile { data: file_data },
-    };
-    let payload = serialize_plugin_payload(&request, "detect-changes")?;
-    let output = detect_changes_with_component(host, plugin, &payload).await?;
-    let changes: Vec<PluginDetectedChangeWire> =
-        serde_json::from_slice(&output).map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("plugin detect-changes returned invalid JSON: {error}"),
-            )
-        })?;
+    let changes = detect_changes_with_component(
+        host,
+        plugin,
+        plugin_entity_state_from_live_rows(active_state)?,
+        WasmPluginFile { data: file_data },
+    )
+    .await?;
     changes
         .into_iter()
         .map(|change| {
@@ -148,11 +104,12 @@ pub(crate) async fn render_plugin_state(
     plugin: &InstalledPlugin,
     active_state: &[MaterializedLiveStateRow],
 ) -> Result<Vec<u8>, LixError> {
-    let request = PluginRenderRequest {
-        state: plugin_entity_state_from_live_rows(active_state)?,
-    };
-    let payload = serialize_plugin_payload(&request, "render")?;
-    render_with_component(host, plugin, &payload).await
+    render_with_component(
+        host,
+        plugin,
+        plugin_entity_state_from_live_rows(active_state)?,
+    )
+    .await
 }
 
 pub(crate) async fn render_materialized_plugin_file(
@@ -195,9 +152,9 @@ pub(crate) fn plugin_state_live_state_projection() -> LiveStateProjection {
     }
 }
 
-fn plugin_entity_state_from_live_rows<'a>(
-    rows: &'a [MaterializedLiveStateRow],
-) -> Result<Vec<PluginEntityState<'a>>, LixError> {
+fn plugin_entity_state_from_live_rows(
+    rows: &[MaterializedLiveStateRow],
+) -> Result<Vec<WasmPluginEntityState>, LixError> {
     rows.iter()
         .map(|row| {
             let snapshot_content = row.snapshot_content.as_deref().ok_or_else(|| {
@@ -210,24 +167,12 @@ fn plugin_entity_state_from_live_rows<'a>(
                     ),
                 )
             })?;
-            Ok(PluginEntityState {
-                entity_pk: &row.entity_pk.parts,
-                schema_key: &row.schema_key,
-                snapshot_content,
-                metadata: row.metadata.as_deref(),
+            Ok(WasmPluginEntityState {
+                entity_pk: row.entity_pk.parts.clone(),
+                schema_key: row.schema_key.clone(),
+                snapshot_content: snapshot_content.to_string(),
+                metadata: row.metadata.clone(),
             })
         })
         .collect()
-}
-
-fn serialize_plugin_payload<T: Serialize>(
-    value: &T,
-    export_name: &str,
-) -> Result<Vec<u8>, LixError> {
-    serde_json::to_vec(value).map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("failed to encode plugin {export_name} payload: {error}"),
-        )
-    })
 }

--- a/packages/engine/src/plugin/materializer.rs
+++ b/packages/engine/src/plugin/materializer.rs
@@ -6,7 +6,7 @@ use crate::LixError;
 use crate::binary_cas::{BlobDataReader, BlobHash};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::FilesystemIndex;
-use crate::live_state::MaterializedLiveStateRow;
+use crate::live_state::{LiveStateProjection, MaterializedLiveStateRow};
 
 use super::component::{
     PluginComponentHost, detect_changes_with_plugin as detect_changes_with_component,
@@ -27,15 +27,15 @@ pub(crate) struct PluginDetectedChange {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "kebab-case")]
-struct PluginDetectChangesRequest {
-    state: Vec<PluginEntityState>,
+struct PluginDetectChangesRequest<'a> {
+    state: Vec<PluginEntityState<'a>>,
     file: PluginFile,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "kebab-case")]
-struct PluginRenderRequest {
-    state: Vec<PluginEntityState>,
+struct PluginRenderRequest<'a> {
+    state: Vec<PluginEntityState<'a>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -46,11 +46,11 @@ struct PluginFile {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "kebab-case")]
-struct PluginEntityState {
-    entity_pk: Vec<String>,
-    schema_key: String,
-    snapshot_content: String,
-    metadata: Option<String>,
+struct PluginEntityState<'a> {
+    entity_pk: &'a [String],
+    schema_key: &'a str,
+    snapshot_content: &'a str,
+    metadata: Option<&'a str>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,12 +180,27 @@ pub(crate) fn plugin_state_rows<'a>(
         .collect()
 }
 
-fn plugin_entity_state_from_live_rows(
-    rows: &[MaterializedLiveStateRow],
-) -> Result<Vec<PluginEntityState>, LixError> {
+pub(crate) fn retain_plugin_state_rows(
+    plugin: &InstalledPlugin,
+    mut rows: Vec<MaterializedLiveStateRow>,
+) -> Vec<MaterializedLiveStateRow> {
+    let schema_keys = plugin.schema_keys.iter().collect::<BTreeSet<_>>();
+    rows.retain(|row| schema_keys.contains(&row.schema_key) && row.snapshot_content.is_some());
+    rows
+}
+
+pub(crate) fn plugin_state_live_state_projection() -> LiveStateProjection {
+    LiveStateProjection {
+        columns: vec!["snapshot_content".to_string(), "metadata".to_string()],
+    }
+}
+
+fn plugin_entity_state_from_live_rows<'a>(
+    rows: &'a [MaterializedLiveStateRow],
+) -> Result<Vec<PluginEntityState<'a>>, LixError> {
     rows.iter()
         .map(|row| {
-            let snapshot_content = row.snapshot_content.clone().ok_or_else(|| {
+            let snapshot_content = row.snapshot_content.as_deref().ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
@@ -196,10 +211,10 @@ fn plugin_entity_state_from_live_rows(
                 )
             })?;
             Ok(PluginEntityState {
-                entity_pk: row.entity_pk.parts.clone(),
-                schema_key: row.schema_key.clone(),
+                entity_pk: &row.entity_pk.parts,
+                schema_key: &row.schema_key,
                 snapshot_content,
-                metadata: row.metadata.clone(),
+                metadata: row.metadata.as_deref(),
             })
         })
         .collect()

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -24,8 +24,8 @@ pub(crate) use manifest::{
 #[allow(unused_imports)]
 pub(crate) use materializer::{
     PluginDetectedChange, detect_changes_with_plugin, load_installed_plugins_from_filesystem,
-    plugin_state_rows, render_materialized_plugin_file, render_plugin_state,
-    select_plugin_for_path,
+    plugin_state_live_state_projection, plugin_state_rows, render_materialized_plugin_file,
+    render_plugin_state, retain_plugin_state_rows, select_plugin_for_path,
 };
 #[allow(unused_imports)]
 pub(crate) use storage::{

--- a/packages/engine/src/session/fs.rs
+++ b/packages/engine/src/session/fs.rs
@@ -1,7 +1,6 @@
 use serde_json::Value as JsonValue;
 
 use crate::LixError;
-use crate::NullableKeyFilter;
 use crate::binary_cas::BlobDataReader;
 use crate::common::{ParsedFilePath, directory_ancestor_paths, normalize_directory_path};
 use crate::filesystem::{
@@ -14,12 +13,13 @@ use crate::filesystem::{
     wrong_kind_error,
 };
 use crate::live_state::{
-    LiveStateFilter, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateFileScanRequest, LiveStateFilter, LiveStateReader, LiveStateScanRequest,
+    MaterializedLiveStateRow,
 };
 use crate::plugin::{
     InstalledPlugin, is_plugin_storage_path, load_installed_plugins_from_filesystem,
-    plugin_state_rows, reject_normal_plugin_storage_mutation, render_materialized_plugin_file,
-    select_plugin_for_path,
+    plugin_state_live_state_projection, reject_normal_plugin_storage_mutation,
+    render_materialized_plugin_file, retain_plugin_state_rows, select_plugin_for_path,
 };
 use crate::sql2::SqlWriteExecutionContext;
 use crate::storage::{SharedStorageRead, StorageBackend, StorageReadOptions};
@@ -456,25 +456,15 @@ async fn scan_plugin_state_rows_from_reader(
     plugin: &InstalledPlugin,
 ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
     let rows = live_state
-        .scan_rows(&LiveStateScanRequest {
-            filter: plugin_state_filter(branch_id, file_id, plugin),
+        .scan_file_rows(&LiveStateFileScanRequest {
+            branch_ids: vec![branch_id.to_string()],
+            file_id: file_id.to_string(),
+            schema_keys: plugin.schema_keys.clone(),
+            projection: plugin_state_live_state_projection(),
             ..Default::default()
         })
         .await?;
-    Ok(plugin_state_rows(plugin, rows.iter()))
-}
-
-fn plugin_state_filter(
-    branch_id: &str,
-    file_id: &str,
-    plugin: &InstalledPlugin,
-) -> LiveStateFilter {
-    LiveStateFilter {
-        schema_keys: plugin.schema_keys.clone(),
-        branch_ids: vec![branch_id.to_string()],
-        file_ids: vec![NullableKeyFilter::Value(file_id.to_string())],
-        ..Default::default()
-    }
+    Ok(retain_plugin_state_rows(plugin, rows))
 }
 
 async fn read_plugin_file_bytes(

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -44,13 +44,14 @@ use crate::common::ParsedFilePath;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::FilesystemIndex;
 use crate::functions::FunctionProviderHandle;
-use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{
-    LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateScanRequest,
+    LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection, LiveStateReader,
+    LiveStateScanRequest, MaterializedLiveStateRow,
 };
 use crate::plugin::{
-    InstalledPlugin, PluginRuntimeHost, load_installed_plugins_from_filesystem, plugin_state_rows,
-    reject_normal_plugin_storage_mutation, render_materialized_plugin_file, select_plugin_for_path,
+    InstalledPlugin, PluginRuntimeHost, load_installed_plugins_from_filesystem,
+    plugin_state_live_state_projection, reject_normal_plugin_storage_mutation,
+    render_materialized_plugin_file, retain_plugin_state_rows, select_plugin_for_path,
 };
 use crate::sql2::branch_scope::{
     BranchBinding, explicit_branch_ids_from_dml_filters, resolve_provider_branch_ids,
@@ -2197,17 +2198,15 @@ async fn render_plugin_file_for_sql(
     };
     let rows = plugin_render
         .live_state
-        .scan_rows(&LiveStateScanRequest {
-            filter: LiveStateFilter {
-                schema_keys: plugin.schema_keys.clone(),
-                branch_ids: vec![file.live.branch_id.clone()],
-                file_ids: vec![crate::NullableKeyFilter::Value(file.id.clone())],
-                ..Default::default()
-            },
+        .scan_file_rows(&LiveStateFileScanRequest {
+            branch_ids: vec![file.live.branch_id.clone()],
+            file_id: file.id.clone(),
+            schema_keys: plugin.schema_keys.clone(),
+            projection: plugin_state_live_state_projection(),
             ..Default::default()
         })
         .await?;
-    let active_state = plugin_state_rows(plugin, rows.iter());
+    let active_state = retain_plugin_state_rows(plugin, rows);
     render_materialized_plugin_file(&plugin_render.host, plugin, &active_state).await
 }
 

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -137,12 +137,14 @@ pub(crate) fn verify_chunk_hash(
     expected: &[u8; TRACKED_STATE_HASH_BYTES],
     bytes: &[u8],
 ) -> Result<(), LixError> {
-    let actual = crate::tracked_state::codec::hash_bytes(bytes);
-    if &actual != expected {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            "tracked-state chunk hash mismatch",
-        ));
+    if cfg!(debug_assertions) {
+        let actual = crate::tracked_state::codec::hash_bytes(bytes);
+        if &actual != expected {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state chunk hash mismatch",
+            ));
+        }
     }
     Ok(())
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -26,15 +26,15 @@ use crate::filesystem::{
     FilesystemIndex, FilesystemRowContext, blob_ref_tombstone_row, filesystem_schema_keys,
 };
 use crate::functions::{FunctionContext, FunctionProviderHandle};
-use crate::live_state::overlay_scan_rows;
 use crate::live_state::{
-    LiveStateContext, LiveStateFilter, LiveStateRowRequest, LiveStateScanRequest,
-    MaterializedLiveStateRow,
+    LiveStateContext, LiveStateFileScanRequest, LiveStateFilter, LiveStateRowRequest,
+    LiveStateScanRequest, MaterializedLiveStateRow,
 };
+use crate::live_state::{overlay_scan_file_rows, overlay_scan_rows};
 use crate::plugin::{
     InstalledPlugin, PLUGIN_STORAGE_ROOT_DIRECTORY_PATH, PluginDetectedChange, PluginRuntimeHost,
-    detect_changes_with_plugin, load_installed_plugins_from_filesystem, plugin_state_rows,
-    select_plugin_for_path,
+    detect_changes_with_plugin, load_installed_plugins_from_filesystem,
+    plugin_state_live_state_projection, retain_plugin_state_rows, select_plugin_for_path,
 };
 use crate::session::{SessionMode, WORKSPACE_BRANCH_KEY};
 use crate::sql2::SqlWriteExecutionContext;
@@ -418,6 +418,16 @@ where
         overlay_scan_rows(&base, &staged, request).await
     }
 
+    async fn scan_visible_live_state_file(
+        &mut self,
+        request: &LiveStateFileScanRequest,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        let staged = self.staged_writes.staging_overlay()?;
+        let read = SharedStorageRead::new(self.storage.begin_read(StorageReadOptions::default())?);
+        let base = self.live_state.reader(read);
+        overlay_scan_file_rows(&base, &staged, request).await
+    }
+
     async fn reconcile_plugin_write(
         &mut self,
         write: TransactionWrite,
@@ -622,17 +632,15 @@ where
         plugin: &InstalledPlugin,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
         let rows = self
-            .scan_visible_live_state(&LiveStateScanRequest {
-                filter: LiveStateFilter {
-                    schema_keys: plugin.schema_keys.clone(),
-                    branch_ids: vec![branch_id.to_string()],
-                    file_ids: vec![NullableKeyFilter::Value(file_id.to_string())],
-                    ..Default::default()
-                },
+            .scan_visible_live_state_file(&LiveStateFileScanRequest {
+                branch_ids: vec![branch_id.to_string()],
+                file_id: file_id.to_string(),
+                schema_keys: plugin.schema_keys.clone(),
+                projection: plugin_state_live_state_projection(),
                 ..Default::default()
             })
             .await?;
-        Ok(plugin_state_rows(plugin, rows.iter()))
+        Ok(retain_plugin_state_rows(plugin, rows))
     }
 
     async fn prepare_transaction_write(
@@ -1047,6 +1055,13 @@ where
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
         overlay_scan_rows(&self.base, &self.staged, request).await
+    }
+
+    async fn scan_file_rows(
+        &self,
+        request: &LiveStateFileScanRequest,
+    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+        overlay_scan_file_rows(&self.base, &self.staged, request).await
     }
 
     async fn load_row(

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -161,6 +161,9 @@ pub(crate) async fn validate_prepared_writes(
     let pending_schema_domains = PendingSchemaDomains::from_staged_rows(&staged_rows)?;
     validate_registered_schema_identity_is_canonical(&input, &staged_rows).await?;
     let mut pending_constraints = PendingConstraintIndexes::default();
+    let mut validated_constraint_rows =
+        BTreeMap::<DomainRowIdentity, ValidatedRowContent<'_>>::new();
+    let mut file_owner_validator = FileOwnerReferenceValidator::default();
     let mut staged_snapshots = Vec::new();
     for row in &constraint_rows {
         let row = *row;
@@ -168,20 +171,27 @@ pub(crate) async fn validate_prepared_writes(
             pending_constraints.remember_tombstone(row);
             continue;
         };
-        let schema_plan = schema_plan_for_row(input.schema_catalog, &pending_schema_domains, row)?;
-        validate_schema_matches_row(row, schema_plan)?;
-        validate_snapshot_content(row, schema_plan)?;
-        pending_constraints.remember_row(row, schema_plan, snapshot)?;
+        let validated = validate_row_content(input.schema_catalog, &pending_schema_domains, row)?;
+        pending_constraints.remember_row(row, validated.schema_plan, snapshot)?;
+        validated_constraint_rows.insert(row.domain_row_identity(), validated);
     }
     for row in &staged_rows {
         let row = *row;
         validate_staged_row_shape(row)?;
         validate_staged_row_metadata(row)?;
-        let schema_plan = schema_plan_for_row(input.schema_catalog, &pending_schema_domains, row)?;
-        validate_schema_matches_row(row, schema_plan)?;
-        let snapshot = validate_snapshot_content(row, schema_plan)?;
+        let validated = validated_constraint_rows
+            .get(&row.domain_row_identity())
+            .copied()
+            .map(Ok)
+            .unwrap_or_else(|| {
+                validate_row_content(input.schema_catalog, &pending_schema_domains, row)
+            })?;
+        let schema_plan = validated.schema_plan;
+        let snapshot = validated.snapshot;
         if let Some(snapshot) = snapshot {
-            validate_file_owner_reference(&input, &pending_file_descriptors, row).await?;
+            file_owner_validator
+                .validate(&input, &pending_file_descriptors, row)
+                .await?;
             validate_primary_key_identity(row, schema_plan, snapshot)?;
             pending_constraints.remember_foreign_key_references(row, schema_plan, snapshot)?;
             staged_snapshots.push((row, schema_plan, snapshot));
@@ -979,50 +989,88 @@ impl PendingFileDescriptorIndex {
     }
 }
 
-async fn validate_file_owner_reference(
-    input: &TransactionValidationInput<'_>,
-    pending_file_descriptors: &PendingFileDescriptorIndex,
-    row: PreparedValidationRow<'_>,
-) -> Result<(), LixError> {
-    let Some(file_id) = row.file_id().as_deref() else {
-        return Ok(());
-    };
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct FileOwnerDescriptorKey {
+    domain: Domain,
+    file_id: String,
+}
 
-    let row_domain = row.domain();
-    let target_domains = row_domain
-        .with_untracked(row.untracked())
-        .file_owner_domains();
+#[derive(Default)]
+struct FileOwnerReferenceValidator {
+    committed_descriptor_exists: BTreeMap<FileOwnerDescriptorKey, bool>,
+}
 
-    for domain in &target_domains {
-        if pending_file_descriptors.state_in_domain(domain, file_id)
-            == Some(PendingFileDescriptorState::Present)
-        {
+impl FileOwnerReferenceValidator {
+    async fn validate(
+        &mut self,
+        input: &TransactionValidationInput<'_>,
+        pending_file_descriptors: &PendingFileDescriptorIndex,
+        row: PreparedValidationRow<'_>,
+    ) -> Result<(), LixError> {
+        let Some(file_id) = row.file_id().as_deref() else {
             return Ok(());
+        };
+
+        let row_domain = row.domain();
+        let target_domains = row_domain
+            .with_untracked(row.untracked())
+            .file_owner_domains();
+
+        for domain in &target_domains {
+            if pending_file_descriptors.state_in_domain(domain, file_id)
+                == Some(PendingFileDescriptorState::Present)
+            {
+                return Ok(());
+            }
         }
+
+        for domain in &target_domains {
+            if pending_file_descriptors.state_in_domain(domain, file_id)
+                == Some(PendingFileDescriptorState::Tombstone)
+            {
+                continue;
+            }
+            if self
+                .committed_file_descriptor_exists_in_domain(input.live_state, domain, file_id)
+                .await?
+            {
+                return Ok(());
+            }
+        }
+
+        Err(missing_file_owner_reference_error(row, file_id)?)
     }
 
-    for domain in &target_domains {
-        if pending_file_descriptors.state_in_domain(domain, file_id)
-            == Some(PendingFileDescriptorState::Tombstone)
-        {
-            continue;
+    async fn committed_file_descriptor_exists_in_domain(
+        &mut self,
+        live_state: &dyn LiveStateReader,
+        domain: &Domain,
+        file_id: &str,
+    ) -> Result<bool, LixError> {
+        let descriptor_domain = domain.with_exact_file_scope(None);
+        let key = FileOwnerDescriptorKey {
+            domain: descriptor_domain.clone(),
+            file_id: file_id.to_string(),
+        };
+        if let Some(exists) = self.committed_descriptor_exists.get(&key) {
+            return Ok(*exists);
         }
-        if committed_file_descriptor_exists_in_domain(input.live_state, domain, file_id).await? {
-            return Ok(());
-        }
+        let exists =
+            committed_file_descriptor_exists_in_domain(live_state, &descriptor_domain, file_id)
+                .await?;
+        self.committed_descriptor_exists.insert(key, exists);
+        Ok(exists)
     }
-
-    Err(missing_file_owner_reference_error(row, file_id)?)
 }
 
 async fn committed_file_descriptor_exists_in_domain(
     live_state: &dyn LiveStateReader,
-    domain: &Domain,
+    descriptor_domain: &Domain,
     file_id: &str,
 ) -> Result<bool, LixError> {
     let Some(row) = load_committed_constraint_row(
         live_state,
-        &domain.with_exact_file_scope(None),
+        descriptor_domain,
         FILE_DESCRIPTOR_SCHEMA_KEY,
         EntityPk::single(file_id),
         false,
@@ -1125,6 +1173,26 @@ impl PendingSchemaDomains {
             ),
         ))
     }
+}
+
+#[derive(Clone, Copy)]
+struct ValidatedRowContent<'a> {
+    schema_plan: &'a SchemaPlan,
+    snapshot: Option<&'a JsonValue>,
+}
+
+fn validate_row_content<'a>(
+    schema_catalog: &'a CatalogSnapshot,
+    pending_schema_domains: &PendingSchemaDomains,
+    row: PreparedValidationRow<'a>,
+) -> Result<ValidatedRowContent<'a>, LixError> {
+    let schema_plan = schema_plan_for_row(schema_catalog, pending_schema_domains, row)?;
+    validate_schema_matches_row(row, schema_plan)?;
+    let snapshot = validate_snapshot_content(row, schema_plan)?;
+    Ok(ValidatedRowContent {
+        schema_plan,
+        snapshot,
+    })
 }
 
 fn schema_plan_for_row<'a>(
@@ -3499,6 +3567,32 @@ mod tests {
         ))
         .await
         .expect("committed file descriptor should satisfy file ownership");
+    }
+
+    #[tokio::test]
+    async fn validation_caches_committed_file_owner_reference_by_domain() {
+        let visible_schemas = vec![unique_schema()];
+        let staged_writes = PreparedWriteSet {
+            state_rows: vec![
+                unique_row("post-1", "hello-world", "first"),
+                unique_row("post-2", "second-slug", "second"),
+            ],
+            ..empty_staged_write_set()
+        };
+        let live_state = CountingStaticLiveStateReader {
+            rows: Vec::new(),
+            scan_count: AtomicUsize::new(0),
+        };
+
+        validate_prepared_writes(TransactionValidationInput::from_visible_schemas_for_tests(
+            &staged_writes,
+            &visible_schemas,
+            &live_state,
+        ))
+        .await
+        .expect("shared committed file descriptor should satisfy file ownership");
+
+        assert_eq!(live_state.scan_count.load(Ordering::Relaxed), 2);
     }
 
     #[tokio::test]

--- a/packages/engine/src/wasm/mod.rs
+++ b/packages/engine/src/wasm/mod.rs
@@ -4,6 +4,27 @@ use async_trait::async_trait;
 
 use crate::LixError;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmPluginFile {
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmPluginEntityState {
+    pub entity_pk: Vec<String>,
+    pub schema_key: String,
+    pub snapshot_content: String,
+    pub metadata: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmPluginDetectedChange {
+    pub entity_pk: Vec<String>,
+    pub schema_key: String,
+    pub snapshot_content: Option<String>,
+    pub metadata: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WasmLimits {
     pub max_memory_bytes: u64,
@@ -32,7 +53,13 @@ pub trait WasmRuntime: Send + Sync {
 
 #[async_trait]
 pub trait WasmComponentInstance: Send + Sync {
-    async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError>;
+    async fn detect_changes(
+        &self,
+        state: Vec<WasmPluginEntityState>,
+        file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, LixError>;
+
+    async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError>;
 
     async fn close(&self) -> Result<(), LixError> {
         Ok(())

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -7,7 +7,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
-use lix_engine::wasm::{WasmComponentInstance, WasmLimits, WasmRuntime};
+use lix_engine::wasm::{
+    WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime,
+};
 use lix_engine::{
     Engine, FsDirEntryKind, FsMkdirOptions, FsRmOptions, FsWriteOptions, InMemoryBackend, LixError,
 };
@@ -1010,41 +1013,31 @@ impl WasmRuntime for SentinelPluginRuntime {
 
 #[async_trait]
 impl WasmComponentInstance for SentinelPluginComponent {
-    async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
-        match export {
-            "render" | "api#render" => {
-                self.render_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(b"plugin-rendered".to_vec())
-            }
-            "detect-changes" | "api#detect-changes" => {
-                let payload: serde_json::Value =
-                    serde_json::from_slice(input).map_err(|error| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("test plugin received invalid detect payload: {error}"),
-                        )
-                    })?;
-                let data = payload
-                    .get("file")
-                    .and_then(|file| file.get("data"))
-                    .and_then(|data| data.as_array())
-                    .ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            "test plugin detect payload is missing file data",
-                        )
-                    })?;
-                if data.is_empty() {
-                    Ok(br#"[{"entity-pk":["note"],"schema-key":"plugin_note","snapshot-content":null,"metadata":null}]"#.to_vec())
-                } else {
-                    Ok(br#"[{"entity-pk":["note"],"schema-key":"plugin_note","snapshot-content":"{\"id\":\"note\",\"value\":\"detected\"}","metadata":null}]"#.to_vec())
-                }
-            }
-            other => Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("unexpected plugin export {other}"),
-            )),
+    async fn detect_changes(
+        &self,
+        _state: Vec<WasmPluginEntityState>,
+        file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+        if file.data.is_empty() {
+            Ok(vec![WasmPluginDetectedChange {
+                entity_pk: vec!["note".to_string()],
+                schema_key: "plugin_note".to_string(),
+                snapshot_content: None,
+                metadata: None,
+            }])
+        } else {
+            Ok(vec![WasmPluginDetectedChange {
+                entity_pk: vec!["note".to_string()],
+                schema_key: "plugin_note".to_string(),
+                snapshot_content: Some("{\"id\":\"note\",\"value\":\"detected\"}".to_string()),
+                metadata: None,
+            }])
         }
+    }
+
+    async fn render(&self, _state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
+        self.render_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(b"plugin-rendered".to_vec())
     }
 }
 

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -22,8 +22,6 @@ lix_engine = { workspace = true }
 async-trait = "0.1"
 bytes = "1"
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
 tempfile = { version = "3", optional = true }
 wasmtime = { version = "30.0.2", default-features = false, features = ["component-model", "cranelift", "runtime", "std"], optional = true }
 wasmtime-wasi = { version = "30.0.2", default-features = false, optional = true }
@@ -40,7 +38,7 @@ zip = { version = "8", default-features = false }
 
 [features]
 default = ["default_wasm_runtime"]
-default_wasm_runtime = ["dep:serde", "dep:serde_json", "dep:wasmtime", "dep:wasmtime-wasi"]
+default_wasm_runtime = ["dep:wasmtime", "dep:wasmtime-wasi"]
 sqlite = ["dep:rusqlite", "dep:tempfile"]
 
 [[example]]

--- a/packages/rs-sdk/benches/e2e.rs
+++ b/packages/rs-sdk/benches/e2e.rs
@@ -491,12 +491,9 @@ impl NativeCsvDiffFixture {
 async fn open_lix_with_plugin(plugin: &[u8]) -> BenchLix {
     let temp_dir = tempfile::tempdir().expect("failed to create sqlite bench tempdir");
     let path = temp_dir.path().join("bench.lix");
-    let lix = open_lix(OpenLixOptions {
-        backend: SqliteBackend::open(path).expect("failed to open sqlite bench backend"),
-        wasm_runtime: Some(Arc::new(
-            WasmtimePluginRuntime::new().expect("failed to create Wasmtime plugin runtime"),
-        )),
-    })
+    let lix = open_lix(OpenLixOptions::new(
+        SqliteBackend::open(path).expect("failed to open sqlite bench backend"),
+    ))
     .await
     .unwrap();
 
@@ -509,14 +506,7 @@ async fn open_lix_with_plugin(plugin: &[u8]) -> BenchLix {
 }
 
 async fn open_lix_with_plugin_inmemory(plugin: &[u8]) -> BenchLix {
-    let lix = open_lix(OpenLixOptions {
-        backend: InMemoryBackend::new(),
-        wasm_runtime: Some(Arc::new(
-            WasmtimePluginRuntime::new().expect("failed to create Wasmtime plugin runtime"),
-        )),
-    })
-    .await
-    .unwrap();
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
 
     lix.install_plugin_archive(plugin).await.unwrap();
 

--- a/packages/rs-sdk/benches/e2e.rs
+++ b/packages/rs-sdk/benches/e2e.rs
@@ -1,13 +1,13 @@
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use lix_sdk::{
-    FsWriteOptions, InMemoryBackend, LixError, OpenLixOptions, SqliteBackend, Value, open_lix,
+    FsWriteOptions, InMemoryBackend, LixError, OpenLixOptions, SqliteBackend, Value,
+    WasmPluginDetectedChange, WasmPluginEntityState, WasmPluginFile, open_lix,
 };
 use plugin_csv::exports::lix::plugin::api::EntityState as CsvEntityState;
 use plugin_csv::exports::lix::plugin::api::Guest as _;
 use plugin_csv::{CsvPlugin, File as CsvFile};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Write as _;
 use std::hint::black_box;
@@ -16,10 +16,16 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use tokio::runtime::Builder;
-use wasmtime::component::types::ComponentItem;
-use wasmtime::component::{Component, ComponentExportIndex, Instance, Linker, Val};
+use wasmtime::component::{Component, Linker};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+
+mod plugin_bindings {
+    wasmtime::component::bindgen!({
+        path: "../engine/wit",
+        world: "plugin",
+    });
+}
 
 const INITIAL_ROW_COUNT: usize = 10_000;
 const NEW_ROW_COUNT: usize = 10_000;
@@ -434,31 +440,29 @@ struct ExtractedCsvSchemaChangesFixture {
 
 struct WasmPluginDiffFixture {
     component: Arc<dyn lix_sdk::WasmComponentInstance>,
-    detect_changes_input: Vec<u8>,
+    state: Vec<WasmPluginEntityState>,
+    file: WasmPluginFile,
 }
 
 impl WasmPluginDiffFixture {
     fn new(
         component: Arc<dyn lix_sdk::WasmComponentInstance>,
-        state: Vec<PluginEntityStatePayload>,
+        state: Vec<WasmPluginEntityState>,
         file_data: &[u8],
     ) -> Self {
-        let payload = PluginDetectChangesPayload {
-            state,
-            file: PluginFilePayload {
-                data: file_data.to_vec(),
-            },
-        };
         Self {
             component,
-            detect_changes_input: serde_json::to_vec(&payload).unwrap(),
+            state,
+            file: WasmPluginFile {
+                data: file_data.to_vec(),
+            },
         }
     }
 }
 
 async fn wasm_plugin_diff_fixture(
     wasm: &[u8],
-    state: Vec<PluginEntityStatePayload>,
+    state: Vec<WasmPluginEntityState>,
     file_data: &[u8],
 ) -> WasmPluginDiffFixture {
     let runtime = WasmtimePluginRuntime::new().expect("failed to create Wasmtime plugin runtime");
@@ -551,8 +555,7 @@ async fn warm_lix_csv_plugin(lix: &BenchLix) {
 
 async fn warm_wasm_csv_plugin_component(component: &Arc<dyn lix_sdk::WasmComponentInstance>) {
     let fixture = WasmPluginDiffFixture::new(component.clone(), Vec::new(), &[]);
-    let output = wasm_plugin_detect_changes_output(fixture).await;
-    let changes = serde_json::from_slice::<Vec<PluginDetectedChangePayload>>(&output).unwrap();
+    let changes = wasm_plugin_detect_changes_output(fixture).await;
     assert!(changes.is_empty());
 }
 
@@ -1015,15 +1018,16 @@ async fn bench_wasm_plugin_diff(fixture: WasmPluginDiffFixture) {
 }
 
 async fn wasm_plugin_file_changes(fixture: WasmPluginDiffFixture) -> Vec<FileChange> {
-    let output = wasm_plugin_detect_changes_output(fixture).await;
-    let changes = serde_json::from_slice::<Vec<PluginDetectedChangePayload>>(&output).unwrap();
+    let changes = wasm_plugin_detect_changes_output(fixture).await;
     plugin_detected_changes_to_file_changes(changes)
 }
 
-async fn wasm_plugin_detect_changes_output(fixture: WasmPluginDiffFixture) -> Vec<u8> {
+async fn wasm_plugin_detect_changes_output(
+    fixture: WasmPluginDiffFixture,
+) -> Vec<WasmPluginDetectedChange> {
     fixture
         .component
-        .call("detect-changes", &fixture.detect_changes_input)
+        .detect_changes(fixture.state, fixture.file)
         .await
         .unwrap()
 }
@@ -1048,7 +1052,7 @@ fn native_csv_detected_changes(fixture: NativeCsvDiffFixture) -> Vec<plugin_csv:
 }
 
 fn plugin_detected_changes_to_file_changes(
-    changes: Vec<PluginDetectedChangePayload>,
+    changes: Vec<WasmPluginDetectedChange>,
 ) -> Vec<FileChange> {
     changes
         .into_iter()
@@ -1095,14 +1099,14 @@ fn csv_detected_changes_to_file_changes(
         .collect()
 }
 
-fn plugin_entity_state_from_file_changes(changes: &[FileChange]) -> Vec<PluginEntityStatePayload> {
+fn plugin_entity_state_from_file_changes(changes: &[FileChange]) -> Vec<WasmPluginEntityState> {
     changes
         .iter()
         .filter_map(|change| {
             change
                 .snapshot_content
                 .as_ref()
-                .map(|snapshot_content| PluginEntityStatePayload {
+                .map(|snapshot_content| WasmPluginEntityState {
                     entity_pk: entity_pk_parts(change),
                     schema_key: change.schema_key.clone(),
                     snapshot_content: snapshot_content.to_string(),
@@ -1345,14 +1349,7 @@ impl WasmtimePluginRuntime {
 
 struct WasmtimePluginComponent {
     store: Mutex<Store<WasiHostState>>,
-    instance: Instance,
-    exports: WasmtimePluginExports,
-}
-
-#[derive(Clone, Copy)]
-struct WasmtimePluginExports {
-    detect_changes: ComponentExportIndex,
-    render: ComponentExportIndex,
+    bindings: plugin_bindings::Plugin,
 }
 
 struct WasiHostState {
@@ -1390,425 +1387,113 @@ impl lix_sdk::WasmRuntime for WasmtimePluginRuntime {
     ) -> Result<Arc<dyn lix_sdk::WasmComponentInstance>, LixError> {
         let component = Component::new(&self.engine, bytes)
             .map_err(|error| wasm_runtime_error("failed to compile plugin component", error))?;
-        let exports = WasmtimePluginExports::from_component(&self.engine, &component)?;
         let mut linker = Linker::<WasiHostState>::new(&self.engine);
         wasmtime_wasi::add_to_linker_sync(&mut linker)
             .map_err(|error| wasm_runtime_error("failed to configure WASI linker", error))?;
         let mut store = Store::new(&self.engine, WasiHostState::new());
-        let instance = linker
-            .instantiate(&mut store, &component)
+        let bindings = plugin_bindings::Plugin::instantiate(&mut store, &component, &linker)
             .map_err(|error| wasm_runtime_error("failed to instantiate plugin component", error))?;
         Ok(Arc::new(WasmtimePluginComponent {
             store: Mutex::new(store),
-            instance,
-            exports,
+            bindings,
         }))
     }
 }
 
 #[async_trait::async_trait]
 impl lix_sdk::WasmComponentInstance for WasmtimePluginComponent {
-    async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
-        match export {
-            "detect-changes" | "api#detect-changes" => self.detect_changes(input),
-            "render" | "api#render" => self.render(input),
-            other => Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("Wasmtime test runtime does not implement export '{other}'"),
-            )),
+    async fn detect_changes(
+        &self,
+        state: Vec<WasmPluginEntityState>,
+        file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+        let mut store = self.store("detect-changes")?;
+        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        let file = file.into();
+        match self
+            .bindings
+            .lix_plugin_api()
+            .call_detect_changes(&mut *store, &state, &file)
+            .map_err(|error| wasm_runtime_error("failed to call detect-changes", error))?
+        {
+            Ok(changes) => Ok(changes.into_iter().map(Into::into).collect()),
+            Err(error) => Err(plugin_error_from_binding("detect-changes", error)),
         }
     }
-}
 
-impl WasmtimePluginExports {
-    fn from_component(engine: &Engine, component: &Component) -> Result<Self, LixError> {
-        Ok(Self {
-            detect_changes: find_plugin_func_export(engine, component, "detect-changes")?,
-            render: find_plugin_func_export(engine, component, "render")?,
-        })
+    async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
+        let mut store = self.store("render")?;
+        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        match self
+            .bindings
+            .lix_plugin_api()
+            .call_render(&mut *store, &state)
+            .map_err(|error| wasm_runtime_error("failed to call render", error))?
+        {
+            Ok(bytes) => Ok(bytes),
+            Err(error) => Err(plugin_error_from_binding("render", error)),
+        }
     }
 }
 
 impl WasmtimePluginComponent {
-    fn detect_changes(&self, input: &[u8]) -> Result<Vec<u8>, LixError> {
-        let payload: PluginDetectChangesPayload =
-            serde_json::from_slice(input).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("plugin detect-changes payload is invalid JSON: {error}"),
-                )
-            })?;
-        let params = [
-            entity_state_list_to_val(payload.state),
-            Val::Record(vec![("data".to_string(), bytes_to_val(payload.file.data))]),
-        ];
-        let result =
-            self.call_component_func(self.exports.detect_changes, &params, "detect-changes")?;
-        let changes = expect_detected_changes_result(result, "detect-changes")?;
-        serde_json::to_vec(&changes).map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("failed to encode plugin detect-changes output: {error}"),
-            )
-        })
-    }
-
-    fn render(&self, input: &[u8]) -> Result<Vec<u8>, LixError> {
-        let payload: PluginRenderPayload = serde_json::from_slice(input).map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("plugin render payload is invalid JSON: {error}"),
-            )
-        })?;
-        let params = [entity_state_list_to_val(payload.state)];
-        let result = self.call_component_func(self.exports.render, &params, "render")?;
-        expect_render_result(result, "render")
-    }
-
-    fn call_component_func(
+    fn store(
         &self,
-        export: ComponentExportIndex,
-        params: &[Val],
         export_name: &str,
-    ) -> Result<Val, LixError> {
-        let mut store = self.store.lock().map_err(|_| {
+    ) -> Result<std::sync::MutexGuard<'_, Store<WasiHostState>>, LixError> {
+        self.store.lock().map_err(|_| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "Wasmtime store lock poisoned",
+                format!("Wasmtime store lock poisoned before calling {export_name}"),
             )
-        })?;
-        let func = self.instance.get_func(&mut *store, export).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("plugin component export '{export_name}' is not a function"),
-            )
-        })?;
-        let mut results = [Val::Result(Ok(None))];
-        func.call(&mut *store, params, &mut results)
-            .map_err(|error| wasm_runtime_error(format!("failed to call {export_name}"), error))?;
-        func.post_return(&mut *store).map_err(|error| {
-            wasm_runtime_error(format!("failed to finish {export_name} call"), error)
-        })?;
-        Ok(results.into_iter().next().unwrap())
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginDetectChangesPayload {
-    state: Vec<PluginEntityStatePayload>,
-    file: PluginFilePayload,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginRenderPayload {
-    state: Vec<PluginEntityStatePayload>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginFilePayload {
-    data: Vec<u8>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginEntityStatePayload {
-    entity_pk: Vec<String>,
-    schema_key: String,
-    snapshot_content: String,
-    metadata: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginDetectedChangePayload {
-    entity_pk: Vec<String>,
-    schema_key: String,
-    snapshot_content: Option<String>,
-    metadata: Option<String>,
-}
-
-fn find_plugin_func_export(
-    engine: &Engine,
-    component: &Component,
-    func_name: &str,
-) -> Result<ComponentExportIndex, LixError> {
-    if let Some((ComponentItem::ComponentFunc(_), export)) = component.export_index(None, func_name)
-    {
-        return Ok(export);
-    }
-
-    let component_type = component.component_type();
-    for (instance_name, item) in component_type.exports(engine) {
-        if !matches!(item, ComponentItem::ComponentInstance(_)) {
-            continue;
-        }
-        let Some((ComponentItem::ComponentInstance(_), instance_export)) =
-            component.export_index(None, instance_name)
-        else {
-            continue;
-        };
-        if let Some((ComponentItem::ComponentFunc(_), export)) =
-            component.export_index(Some(&instance_export), func_name)
-        {
-            return Ok(export);
-        }
-    }
-
-    Err(LixError::new(
-        LixError::CODE_INTERNAL_ERROR,
-        format!(
-            "plugin component is missing export '{func_name}'. Available exports: {}",
-            component_exports_summary(engine, component)
-        ),
-    ))
-}
-
-fn component_exports_summary(engine: &Engine, component: &Component) -> String {
-    let component_type = component.component_type();
-    let mut exports = Vec::new();
-    for (name, item) in component_type.exports(engine) {
-        match item {
-            ComponentItem::ComponentInstance(instance) => {
-                let nested = instance
-                    .exports(engine)
-                    .map(|(nested_name, _)| nested_name.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                exports.push(format!("{name}({nested})"));
-            }
-            _ => exports.push(name.to_string()),
-        }
-    }
-    exports.join(", ")
-}
-
-fn entity_state_list_to_val(state: Vec<PluginEntityStatePayload>) -> Val {
-    Val::List(state.into_iter().map(entity_state_to_val).collect())
-}
-
-fn entity_state_to_val(state: PluginEntityStatePayload) -> Val {
-    Val::Record(vec![
-        ("entity-pk".to_string(), string_list_to_val(state.entity_pk)),
-        ("schema-key".to_string(), Val::String(state.schema_key)),
-        (
-            "snapshot-content".to_string(),
-            Val::String(state.snapshot_content),
-        ),
-        (
-            "metadata".to_string(),
-            optional_string_to_val(state.metadata),
-        ),
-    ])
-}
-
-fn string_list_to_val(values: Vec<String>) -> Val {
-    Val::List(values.into_iter().map(Val::String).collect())
-}
-
-fn bytes_to_val(bytes: Vec<u8>) -> Val {
-    Val::List(bytes.into_iter().map(Val::U8).collect())
-}
-
-fn optional_string_to_val(value: Option<String>) -> Val {
-    Val::Option(value.map(|value| Box::new(Val::String(value))))
-}
-
-fn expect_detected_changes_result(
-    result: Val,
-    export_name: &str,
-) -> Result<Vec<PluginDetectedChangePayload>, LixError> {
-    let output = expect_plugin_ok_result(result, export_name)?;
-    let Val::List(values) = output else {
-        return Err(plugin_abi_error(format!(
-            "{export_name} returned {}, expected list",
-            val_type_name(&output)
-        )));
-    };
-    values.into_iter().map(detected_change_from_val).collect()
-}
-
-fn expect_render_result(result: Val, export_name: &str) -> Result<Vec<u8>, LixError> {
-    let output = expect_plugin_ok_result(result, export_name)?;
-    expect_u8_list(output, export_name)
-}
-
-fn expect_plugin_ok_result(result: Val, export_name: &str) -> Result<Val, LixError> {
-    match result {
-        Val::Result(Ok(Some(output))) => Ok(*output),
-        Val::Result(Ok(None)) => Err(plugin_abi_error(format!(
-            "{export_name} returned ok without a payload"
-        ))),
-        Val::Result(Err(error)) => Err(plugin_error_from_val(export_name, error.map(|v| *v))),
-        other => Err(plugin_abi_error(format!(
-            "{export_name} returned {}, expected result",
-            val_type_name(&other)
-        ))),
-    }
-}
-
-fn detected_change_from_val(value: Val) -> Result<PluginDetectedChangePayload, LixError> {
-    let Val::Record(fields) = value else {
-        return Err(plugin_abi_error(format!(
-            "detect-changes item was {}, expected record",
-            val_type_name(&value)
-        )));
-    };
-    let mut fields = fields.into_iter();
-    let entity_pk = expect_string_list(
-        expect_next_field(&mut fields, "entity-pk", "detected-change")?,
-        "detected-change.entity-pk",
-    )?;
-    let schema_key = expect_string(
-        expect_next_field(&mut fields, "schema-key", "detected-change")?,
-        "detected-change.schema-key",
-    )?;
-    let snapshot_content = expect_optional_string(
-        expect_next_field(&mut fields, "snapshot-content", "detected-change")?,
-        "detected-change.snapshot-content",
-    )?;
-    let metadata = expect_optional_string(
-        expect_next_field(&mut fields, "metadata", "detected-change")?,
-        "detected-change.metadata",
-    )?;
-    if let Some((field, _)) = fields.next() {
-        return Err(plugin_abi_error(format!(
-            "detected-change returned unexpected field '{field}'"
-        )));
-    }
-    Ok(PluginDetectedChangePayload {
-        entity_pk,
-        schema_key,
-        snapshot_content,
-        metadata,
-    })
-}
-
-fn expect_next_field(
-    fields: &mut impl Iterator<Item = (String, Val)>,
-    expected: &str,
-    label: &str,
-) -> Result<Val, LixError> {
-    let Some((field, value)) = fields.next() else {
-        return Err(plugin_abi_error(format!(
-            "{label} is missing field '{expected}'"
-        )));
-    };
-    if field != expected {
-        return Err(plugin_abi_error(format!(
-            "{label} returned field '{field}', expected '{expected}'"
-        )));
-    }
-    Ok(value)
-}
-
-fn expect_string_list(value: Val, label: &str) -> Result<Vec<String>, LixError> {
-    let Val::List(values) = value else {
-        return Err(plugin_abi_error(format!(
-            "{label} was {}, expected list<string>",
-            val_type_name(&value)
-        )));
-    };
-    values
-        .into_iter()
-        .map(|value| expect_string(value, label))
-        .collect()
-}
-
-fn expect_u8_list(value: Val, label: &str) -> Result<Vec<u8>, LixError> {
-    let Val::List(values) = value else {
-        return Err(plugin_abi_error(format!(
-            "{label} was {}, expected list<u8>",
-            val_type_name(&value)
-        )));
-    };
-    values
-        .into_iter()
-        .map(|value| match value {
-            Val::U8(value) => Ok(value),
-            other => Err(plugin_abi_error(format!(
-                "{label} list item was {}, expected u8",
-                val_type_name(&other)
-            ))),
         })
-        .collect()
-}
-
-fn expect_string(value: Val, label: &str) -> Result<String, LixError> {
-    match value {
-        Val::String(value) => Ok(value),
-        other => Err(plugin_abi_error(format!(
-            "{label} was {}, expected string",
-            val_type_name(&other)
-        ))),
     }
 }
 
-fn expect_optional_string(value: Val, label: &str) -> Result<Option<String>, LixError> {
-    match value {
-        Val::Option(None) => Ok(None),
-        Val::Option(Some(value)) => expect_string(*value, label).map(Some),
-        other => Err(plugin_abi_error(format!(
-            "{label} was {}, expected option<string>",
-            val_type_name(&other)
-        ))),
+impl From<WasmPluginFile> for plugin_bindings::exports::lix::plugin::api::File {
+    fn from(file: WasmPluginFile) -> Self {
+        Self { data: file.data }
     }
 }
 
-fn plugin_error_from_val(export_name: &str, value: Option<Val>) -> LixError {
-    let message = match value {
-        Some(Val::Variant(kind, Some(payload))) => match *payload {
-            Val::String(message) => {
-                format!("{export_name} returned plugin error {kind}: {message}")
-            }
-            other => format!(
-                "{export_name} returned plugin error {kind} with {} payload",
-                val_type_name(&other)
-            ),
-        },
-        Some(Val::Variant(kind, None)) => {
-            format!("{export_name} returned plugin error {kind} without payload")
+impl From<WasmPluginEntityState> for plugin_bindings::exports::lix::plugin::api::EntityState {
+    fn from(state: WasmPluginEntityState) -> Self {
+        Self {
+            entity_pk: state.entity_pk,
+            schema_key: state.schema_key,
+            snapshot_content: state.snapshot_content,
+            metadata: state.metadata,
         }
-        Some(other) => format!(
-            "{export_name} returned malformed plugin error {}",
-            val_type_name(&other)
-        ),
-        None => format!("{export_name} returned plugin error without payload"),
-    };
-    LixError::new(LixError::CODE_INTERNAL_ERROR, message)
-}
-
-fn val_type_name(value: &Val) -> &'static str {
-    match value {
-        Val::Bool(_) => "bool",
-        Val::S8(_) => "s8",
-        Val::U8(_) => "u8",
-        Val::S16(_) => "s16",
-        Val::U16(_) => "u16",
-        Val::S32(_) => "s32",
-        Val::U32(_) => "u32",
-        Val::S64(_) => "s64",
-        Val::U64(_) => "u64",
-        Val::Float32(_) => "float32",
-        Val::Float64(_) => "float64",
-        Val::Char(_) => "char",
-        Val::String(_) => "string",
-        Val::List(_) => "list",
-        Val::Record(_) => "record",
-        Val::Tuple(_) => "tuple",
-        Val::Variant(_, _) => "variant",
-        Val::Enum(_) => "enum",
-        Val::Option(_) => "option",
-        Val::Result(_) => "result",
-        Val::Flags(_) => "flags",
-        Val::Resource(_) => "resource",
     }
 }
 
-fn plugin_abi_error(message: impl Into<String>) -> LixError {
-    LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
+impl From<plugin_bindings::exports::lix::plugin::api::DetectedChange> for WasmPluginDetectedChange {
+    fn from(change: plugin_bindings::exports::lix::plugin::api::DetectedChange) -> Self {
+        Self {
+            entity_pk: change.entity_pk,
+            schema_key: change.schema_key,
+            snapshot_content: change.snapshot_content,
+            metadata: change.metadata,
+        }
+    }
+}
+
+fn plugin_error_from_binding(
+    export_name: &str,
+    error: plugin_bindings::exports::lix::plugin::api::PluginError,
+) -> LixError {
+    let (kind, message) = match error {
+        plugin_bindings::exports::lix::plugin::api::PluginError::InvalidInput(message) => {
+            ("invalid-input", message)
+        }
+        plugin_bindings::exports::lix::plugin::api::PluginError::Internal(message) => {
+            ("internal", message)
+        }
+    };
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("{export_name} returned plugin error {kind}: {message}"),
+    )
 }
 
 fn wasm_runtime_error(context: impl Into<String>, error: impl fmt::Display) -> LixError {

--- a/packages/rs-sdk/src/default_wasm_runtime.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime.rs
@@ -6,12 +6,20 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use lix_engine::LixError;
-use lix_engine::wasm::{WasmComponentInstance, WasmLimits, WasmRuntime};
-use serde::{Deserialize, Serialize};
-use wasmtime::component::types::ComponentItem;
-use wasmtime::component::{Component, ComponentExportIndex, Instance, Linker, Val};
+use lix_engine::wasm::{
+    WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime,
+};
+use wasmtime::component::{Component, Linker};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+
+mod plugin_bindings {
+    wasmtime::component::bindgen!({
+        path: "../engine/wit",
+        world: "plugin",
+    });
+}
 
 pub(crate) fn runtime() -> Result<Arc<dyn WasmRuntime>, LixError> {
     Ok(Arc::new(WasmtimePluginRuntime::new()?))
@@ -55,16 +63,9 @@ impl WasmtimePluginRuntime {
 
 struct WasmtimePluginComponent {
     store: Mutex<Store<WasiHostState>>,
-    instance: Instance,
-    exports: WasmtimePluginExports,
+    bindings: plugin_bindings::Plugin,
     limits: WasmLimits,
     _timeout_ticker: Option<TimeoutTicker>,
-}
-
-#[derive(Clone, Copy)]
-struct WasmtimePluginExports {
-    detect_changes: ComponentExportIndex,
-    render: ComponentExportIndex,
 }
 
 struct WasiHostState {
@@ -108,7 +109,6 @@ impl WasmRuntime for WasmtimePluginRuntime {
         };
         let component = Component::new(engine, bytes)
             .map_err(|error| wasm_runtime_error("failed to compile plugin component", error))?;
-        let exports = WasmtimePluginExports::from_component(engine, &component)?;
         let mut linker = Linker::<WasiHostState>::new(engine);
         wasmtime_wasi::add_to_linker_sync(&mut linker)
             .map_err(|error| wasm_runtime_error("failed to configure WASI linker", error))?;
@@ -125,13 +125,11 @@ impl WasmRuntime for WasmtimePluginRuntime {
         let timeout_ticker = limits
             .timeout_ms
             .map(|_| TimeoutTicker::start(engine.clone()));
-        let instance = linker
-            .instantiate(&mut store, &component)
+        let bindings = plugin_bindings::Plugin::instantiate(&mut store, &component, &linker)
             .map_err(|error| wasm_runtime_error("failed to instantiate plugin component", error))?;
         Ok(Arc::new(WasmtimePluginComponent {
             store: Mutex::new(store),
-            instance,
-            exports,
+            bindings,
             limits,
             _timeout_ticker: timeout_ticker,
         }))
@@ -140,81 +138,56 @@ impl WasmRuntime for WasmtimePluginRuntime {
 
 #[async_trait]
 impl WasmComponentInstance for WasmtimePluginComponent {
-    async fn call(&self, export: &str, input: &[u8]) -> Result<Vec<u8>, LixError> {
-        match export {
-            "detect-changes" | "api#detect-changes" => self.detect_changes(input),
-            "render" | "api#render" => self.render(input),
-            other => Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("Wasmtime runtime does not implement export '{other}'"),
-            )),
+    async fn detect_changes(
+        &self,
+        state: Vec<WasmPluginEntityState>,
+        file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+        let mut store = self.store("detect-changes")?;
+        self.reset_limits(&mut store)?;
+        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        let file = file.into();
+        match self
+            .bindings
+            .lix_plugin_api()
+            .call_detect_changes(&mut *store, &state, &file)
+            .map_err(|error| wasm_runtime_error("failed to call detect-changes", error))?
+        {
+            Ok(changes) => Ok(changes.into_iter().map(Into::into).collect()),
+            Err(error) => Err(plugin_error_from_binding("detect-changes", error)),
+        }
+    }
+
+    async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
+        let mut store = self.store("render")?;
+        self.reset_limits(&mut store)?;
+        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        match self
+            .bindings
+            .lix_plugin_api()
+            .call_render(&mut *store, &state)
+            .map_err(|error| wasm_runtime_error("failed to call render", error))?
+        {
+            Ok(bytes) => Ok(bytes),
+            Err(error) => Err(plugin_error_from_binding("render", error)),
         }
     }
 }
 
-impl WasmtimePluginExports {
-    fn from_component(engine: &Engine, component: &Component) -> Result<Self, LixError> {
-        Ok(Self {
-            detect_changes: find_plugin_func_export(engine, component, "detect-changes")?,
-            render: find_plugin_func_export(engine, component, "render")?,
-        })
-    }
-}
-
 impl WasmtimePluginComponent {
-    fn detect_changes(&self, input: &[u8]) -> Result<Vec<u8>, LixError> {
-        let payload: PluginDetectChangesPayload =
-            serde_json::from_slice(input).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("plugin detect-changes payload is invalid JSON: {error}"),
-                )
-            })?;
-        let params = [
-            entity_state_list_to_val(payload.state),
-            Val::Record(vec![("data".to_string(), bytes_to_val(payload.file.data))]),
-        ];
-        let result =
-            self.call_component_func(self.exports.detect_changes, &params, "detect-changes")?;
-        let changes = expect_detected_changes_result(result, "detect-changes")?;
-        serde_json::to_vec(&changes).map_err(|error| {
+    fn store(
+        &self,
+        export_name: &str,
+    ) -> Result<std::sync::MutexGuard<'_, Store<WasiHostState>>, LixError> {
+        self.store.lock().map_err(|_| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                format!("failed to encode plugin detect-changes output: {error}"),
+                format!("Wasmtime store lock poisoned before calling {export_name}"),
             )
         })
     }
 
-    fn render(&self, input: &[u8]) -> Result<Vec<u8>, LixError> {
-        let payload: PluginRenderPayload = serde_json::from_slice(input).map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("plugin render payload is invalid JSON: {error}"),
-            )
-        })?;
-        let params = [entity_state_list_to_val(payload.state)];
-        let result = self.call_component_func(self.exports.render, &params, "render")?;
-        expect_render_result(result, "render")
-    }
-
-    fn call_component_func(
-        &self,
-        export: ComponentExportIndex,
-        params: &[Val],
-        export_name: &str,
-    ) -> Result<Val, LixError> {
-        let mut store = self.store.lock().map_err(|_| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "Wasmtime store lock poisoned",
-            )
-        })?;
-        let func = self.instance.get_func(&mut *store, export).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("plugin component export '{export_name}' is not a function"),
-            )
-        })?;
+    fn reset_limits(&self, store: &mut Store<WasiHostState>) -> Result<(), LixError> {
         if let Some(max_fuel) = self.limits.max_fuel {
             store
                 .set_fuel(max_fuel)
@@ -223,13 +196,7 @@ impl WasmtimePluginComponent {
         if let Some(timeout_ms) = self.limits.timeout_ms {
             store.set_epoch_deadline(timeout_ms.max(1));
         }
-        let mut results = [Val::Result(Ok(None))];
-        func.call(&mut *store, params, &mut results)
-            .map_err(|error| wasm_runtime_error(format!("failed to call {export_name}"), error))?;
-        func.post_return(&mut *store).map_err(|error| {
-            wasm_runtime_error(format!("failed to finish {export_name} call"), error)
-        })?;
-        Ok(results.into_iter().next().unwrap())
+        Ok(())
     }
 }
 
@@ -264,322 +231,50 @@ impl Drop for TimeoutTicker {
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginDetectChangesPayload {
-    state: Vec<PluginEntityStatePayload>,
-    file: PluginFilePayload,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginRenderPayload {
-    state: Vec<PluginEntityStatePayload>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginFilePayload {
-    data: Vec<u8>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginEntityStatePayload {
-    entity_pk: Vec<String>,
-    schema_key: String,
-    snapshot_content: String,
-    metadata: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct PluginDetectedChangePayload {
-    entity_pk: Vec<String>,
-    schema_key: String,
-    snapshot_content: Option<String>,
-    metadata: Option<String>,
-}
-
-fn find_plugin_func_export(
-    engine: &Engine,
-    component: &Component,
-    func_name: &str,
-) -> Result<ComponentExportIndex, LixError> {
-    if let Some((ComponentItem::ComponentFunc(_), export)) = component.export_index(None, func_name)
-    {
-        return Ok(export);
+impl From<WasmPluginFile> for plugin_bindings::exports::lix::plugin::api::File {
+    fn from(file: WasmPluginFile) -> Self {
+        Self { data: file.data }
     }
+}
 
-    let component_type = component.component_type();
-    for (instance_name, item) in component_type.exports(engine) {
-        if !matches!(item, ComponentItem::ComponentInstance(_)) {
-            continue;
-        }
-        let Some((ComponentItem::ComponentInstance(_), instance_export)) =
-            component.export_index(None, instance_name)
-        else {
-            continue;
-        };
-        if let Some((ComponentItem::ComponentFunc(_), export)) =
-            component.export_index(Some(&instance_export), func_name)
-        {
-            return Ok(export);
+impl From<WasmPluginEntityState> for plugin_bindings::exports::lix::plugin::api::EntityState {
+    fn from(state: WasmPluginEntityState) -> Self {
+        Self {
+            entity_pk: state.entity_pk,
+            schema_key: state.schema_key,
+            snapshot_content: state.snapshot_content,
+            metadata: state.metadata,
         }
     }
-
-    Err(LixError::new(
-        LixError::CODE_INTERNAL_ERROR,
-        format!(
-            "plugin component is missing export '{func_name}'. Available exports: {}",
-            component_exports_summary(engine, component)
-        ),
-    ))
 }
 
-fn component_exports_summary(engine: &Engine, component: &Component) -> String {
-    let component_type = component.component_type();
-    let mut exports = Vec::new();
-    for (name, item) in component_type.exports(engine) {
-        match item {
-            ComponentItem::ComponentInstance(instance) => {
-                let nested = instance
-                    .exports(engine)
-                    .map(|(nested_name, _)| nested_name.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                exports.push(format!("{name}({nested})"));
-            }
-            _ => exports.push(name.to_string()),
+impl From<plugin_bindings::exports::lix::plugin::api::DetectedChange> for WasmPluginDetectedChange {
+    fn from(change: plugin_bindings::exports::lix::plugin::api::DetectedChange) -> Self {
+        Self {
+            entity_pk: change.entity_pk,
+            schema_key: change.schema_key,
+            snapshot_content: change.snapshot_content,
+            metadata: change.metadata,
         }
     }
-    exports.join(", ")
 }
 
-fn entity_state_list_to_val(state: Vec<PluginEntityStatePayload>) -> Val {
-    Val::List(state.into_iter().map(entity_state_to_val).collect())
-}
-
-fn entity_state_to_val(state: PluginEntityStatePayload) -> Val {
-    Val::Record(vec![
-        ("entity-pk".to_string(), string_list_to_val(state.entity_pk)),
-        ("schema-key".to_string(), Val::String(state.schema_key)),
-        (
-            "snapshot-content".to_string(),
-            Val::String(state.snapshot_content),
-        ),
-        (
-            "metadata".to_string(),
-            optional_string_to_val(state.metadata),
-        ),
-    ])
-}
-
-fn string_list_to_val(values: Vec<String>) -> Val {
-    Val::List(values.into_iter().map(Val::String).collect())
-}
-
-fn bytes_to_val(bytes: Vec<u8>) -> Val {
-    Val::List(bytes.into_iter().map(Val::U8).collect())
-}
-
-fn optional_string_to_val(value: Option<String>) -> Val {
-    Val::Option(value.map(|value| Box::new(Val::String(value))))
-}
-
-fn expect_detected_changes_result(
-    result: Val,
+fn plugin_error_from_binding(
     export_name: &str,
-) -> Result<Vec<PluginDetectedChangePayload>, LixError> {
-    let output = expect_plugin_ok_result(result, export_name)?;
-    let Val::List(values) = output else {
-        return Err(plugin_abi_error(format!(
-            "{export_name} returned {}, expected list",
-            val_type_name(&output)
-        )));
-    };
-    values.into_iter().map(detected_change_from_val).collect()
-}
-
-fn expect_render_result(result: Val, export_name: &str) -> Result<Vec<u8>, LixError> {
-    let output = expect_plugin_ok_result(result, export_name)?;
-    expect_u8_list(output, export_name)
-}
-
-fn expect_plugin_ok_result(result: Val, export_name: &str) -> Result<Val, LixError> {
-    match result {
-        Val::Result(Ok(Some(output))) => Ok(*output),
-        Val::Result(Ok(None)) => Err(plugin_abi_error(format!(
-            "{export_name} returned ok without a payload"
-        ))),
-        Val::Result(Err(error)) => Err(plugin_error_from_val(export_name, error.map(|v| *v))),
-        other => Err(plugin_abi_error(format!(
-            "{export_name} returned {}, expected result",
-            val_type_name(&other)
-        ))),
-    }
-}
-
-fn detected_change_from_val(value: Val) -> Result<PluginDetectedChangePayload, LixError> {
-    let Val::Record(fields) = value else {
-        return Err(plugin_abi_error(format!(
-            "detect-changes item was {}, expected record",
-            val_type_name(&value)
-        )));
-    };
-    let mut fields = fields.into_iter();
-    let entity_pk = expect_string_list(
-        expect_next_field(&mut fields, "entity-pk", "detected-change")?,
-        "detected-change.entity-pk",
-    )?;
-    let schema_key = expect_string(
-        expect_next_field(&mut fields, "schema-key", "detected-change")?,
-        "detected-change.schema-key",
-    )?;
-    let snapshot_content = expect_optional_string(
-        expect_next_field(&mut fields, "snapshot-content", "detected-change")?,
-        "detected-change.snapshot-content",
-    )?;
-    let metadata = expect_optional_string(
-        expect_next_field(&mut fields, "metadata", "detected-change")?,
-        "detected-change.metadata",
-    )?;
-    if let Some((field, _)) = fields.next() {
-        return Err(plugin_abi_error(format!(
-            "detected-change returned unexpected field '{field}'"
-        )));
-    }
-    Ok(PluginDetectedChangePayload {
-        entity_pk,
-        schema_key,
-        snapshot_content,
-        metadata,
-    })
-}
-
-fn expect_next_field(
-    fields: &mut impl Iterator<Item = (String, Val)>,
-    expected: &str,
-    label: &str,
-) -> Result<Val, LixError> {
-    let Some((field, value)) = fields.next() else {
-        return Err(plugin_abi_error(format!(
-            "{label} is missing field '{expected}'"
-        )));
-    };
-    if field != expected {
-        return Err(plugin_abi_error(format!(
-            "{label} returned field '{field}', expected '{expected}'"
-        )));
-    }
-    Ok(value)
-}
-
-fn expect_string_list(value: Val, label: &str) -> Result<Vec<String>, LixError> {
-    let Val::List(values) = value else {
-        return Err(plugin_abi_error(format!(
-            "{label} was {}, expected list<string>",
-            val_type_name(&value)
-        )));
-    };
-    values
-        .into_iter()
-        .map(|value| expect_string(value, label))
-        .collect()
-}
-
-fn expect_u8_list(value: Val, label: &str) -> Result<Vec<u8>, LixError> {
-    let Val::List(values) = value else {
-        return Err(plugin_abi_error(format!(
-            "{label} was {}, expected list<u8>",
-            val_type_name(&value)
-        )));
-    };
-    values
-        .into_iter()
-        .map(|value| match value {
-            Val::U8(value) => Ok(value),
-            other => Err(plugin_abi_error(format!(
-                "{label} list item was {}, expected u8",
-                val_type_name(&other)
-            ))),
-        })
-        .collect()
-}
-
-fn expect_string(value: Val, label: &str) -> Result<String, LixError> {
-    match value {
-        Val::String(value) => Ok(value),
-        other => Err(plugin_abi_error(format!(
-            "{label} was {}, expected string",
-            val_type_name(&other)
-        ))),
-    }
-}
-
-fn expect_optional_string(value: Val, label: &str) -> Result<Option<String>, LixError> {
-    match value {
-        Val::Option(None) => Ok(None),
-        Val::Option(Some(value)) => expect_string(*value, label).map(Some),
-        other => Err(plugin_abi_error(format!(
-            "{label} was {}, expected option<string>",
-            val_type_name(&other)
-        ))),
-    }
-}
-
-fn plugin_error_from_val(export_name: &str, value: Option<Val>) -> LixError {
-    let message = match value {
-        Some(Val::Variant(kind, Some(payload))) => match *payload {
-            Val::String(message) => {
-                format!("{export_name} returned plugin error {kind}: {message}")
-            }
-            other => format!(
-                "{export_name} returned plugin error {kind} with {} payload",
-                val_type_name(&other)
-            ),
-        },
-        Some(Val::Variant(kind, None)) => {
-            format!("{export_name} returned plugin error {kind} without payload")
+    error: plugin_bindings::exports::lix::plugin::api::PluginError,
+) -> LixError {
+    let (kind, message) = match error {
+        plugin_bindings::exports::lix::plugin::api::PluginError::InvalidInput(message) => {
+            ("invalid-input", message)
         }
-        Some(other) => format!(
-            "{export_name} returned malformed plugin error {}",
-            val_type_name(&other)
-        ),
-        None => format!("{export_name} returned plugin error without payload"),
+        plugin_bindings::exports::lix::plugin::api::PluginError::Internal(message) => {
+            ("internal", message)
+        }
     };
-    LixError::new(LixError::CODE_INTERNAL_ERROR, message)
-}
-
-fn val_type_name(value: &Val) -> &'static str {
-    match value {
-        Val::Bool(_) => "bool",
-        Val::S8(_) => "s8",
-        Val::U8(_) => "u8",
-        Val::S16(_) => "s16",
-        Val::U16(_) => "u16",
-        Val::S32(_) => "s32",
-        Val::U32(_) => "u32",
-        Val::S64(_) => "s64",
-        Val::U64(_) => "u64",
-        Val::Float32(_) => "float32",
-        Val::Float64(_) => "float64",
-        Val::Char(_) => "char",
-        Val::String(_) => "string",
-        Val::List(_) => "list",
-        Val::Record(_) => "record",
-        Val::Tuple(_) => "tuple",
-        Val::Variant(_, _) => "variant",
-        Val::Enum(_) => "enum",
-        Val::Option(_) => "option",
-        Val::Result(_) => "result",
-        Val::Flags(_) => "flags",
-        Val::Resource(_) => "resource",
-    }
-}
-
-fn plugin_abi_error(message: impl Into<String>) -> LixError {
-    LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("{export_name} returned plugin error {kind}: {message}"),
+    )
 }
 
 fn wasm_runtime_error(context: impl Into<String>, error: impl fmt::Display) -> LixError {

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -11,7 +11,10 @@ mod lix;
 mod sqlite_backend;
 
 pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_backend};
-pub use lix_engine::wasm::{WasmComponentInstance, WasmLimits, WasmRuntime};
+pub use lix_engine::wasm::{
+    WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime,
+};
 pub use lix_engine::{
     Backend, BackendConformanceReport, BackendConformanceResult, BackendConformanceStatus,
     BackendConformanceTest, BackendError, BackendFactory, BackendFixture, BackendRangeScan,

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -2,7 +2,8 @@
 use lix_engine::run_backend_conformance;
 use lix_sdk::{
     FsWriteOptions, OpenLixOptions, SQLITE_FORMAT_VERSION, SqliteBackend, SqliteBackendFactory,
-    Value, WasmComponentInstance, WasmLimits, WasmRuntime, open_lix, open_lix_with_backend,
+    Value, WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime, open_lix, open_lix_with_backend,
 };
 use rusqlite::Connection;
 use std::io::{Cursor, Write};
@@ -177,21 +178,26 @@ impl WasmRuntime for RecordingWasmRuntime {
 
 #[async_trait::async_trait]
 impl WasmComponentInstance for RecordingWasmComponent {
-    async fn call(&self, export: &str, _input: &[u8]) -> Result<Vec<u8>, lix_sdk::LixError> {
-        match export {
-            "detect-changes" | "api#detect-changes" => {
-                self.detect_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(br#"[{"entity-pk":["doc"],"schema-key":"test_plugin_doc","snapshot-content":"{\"id\":\"doc\",\"content\":\"from runtime\"}","metadata":null}]"#.to_vec())
-            }
-            "render" | "api#render" => {
-                self.render_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(b"rendered by custom runtime".to_vec())
-            }
-            other => Err(lix_sdk::LixError::new(
-                lix_sdk::LixError::CODE_INTERNAL_ERROR,
-                format!("unexpected plugin export {other}"),
-            )),
-        }
+    async fn detect_changes(
+        &self,
+        _state: Vec<WasmPluginEntityState>,
+        _file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, lix_sdk::LixError> {
+        self.detect_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![WasmPluginDetectedChange {
+            entity_pk: vec!["doc".to_string()],
+            schema_key: "test_plugin_doc".to_string(),
+            snapshot_content: Some("{\"id\":\"doc\",\"content\":\"from runtime\"}".to_string()),
+            metadata: None,
+        }])
+    }
+
+    async fn render(
+        &self,
+        _state: Vec<WasmPluginEntityState>,
+    ) -> Result<Vec<u8>, lix_sdk::LixError> {
+        self.render_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(b"rendered by custom runtime".to_vec())
     }
 }
 

--- a/plugins/csv/Cargo.toml
+++ b/plugins/csv/Cargo.toml
@@ -27,6 +27,9 @@ csv-nose = { version = "1.0.1", default-features = false }
 encoding_rs = "0.8"
 imara-diff = "0.2"
 itertools = "0.14"
-rand = { version = "0.9", features = ["small_rng"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v7", "std", "js", "fast-rng"] }
 wit-bindgen = "0.57"
+
+[dev-dependencies]
+rand = { version = "0.9", features = ["small_rng"] }

--- a/plugins/csv/schema/csv_row.json
+++ b/plugins/csv/schema/csv_row.json
@@ -9,7 +9,7 @@
     "id": {
       "type": "string",
       "minLength": 1,
-      "description": "Stable row entity pk. Must match the row entity_pk."
+      "description": "Stable row entity pk. New rows are generated as UUIDv7 strings. Must match the row entity_pk."
     },
     "order_key": {
       "type": "string",

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -19,11 +19,11 @@ pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use crate::order_key::OrderKey;
 use itertools::Itertools;
-use rand::Rng;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::str;
+use uuid::Uuid;
 
 pub const ROOT_ENTITY_PK: &str = "root";
 pub const TABLE_SCHEMA_KEY: &str = schemas::TABLE_SCHEMA_KEY;
@@ -80,7 +80,6 @@ fn detect_changes_for_rows(
     let base = before.to_rows();
     let op_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
     let mut changes = Vec::new();
-    let mut rng = rand::rng();
     let mut base_index = 0;
     let mut file_index = 0;
     let mut previous_order_key = None;
@@ -123,7 +122,7 @@ fn detect_changes_for_rows(
                 let order_keys =
                     OrderKey::evenly_between(previous_order_key, next_order_key, run.len);
                 for order_key in order_keys {
-                    let id = RowId::random(&mut rng).to_entity_pk();
+                    let id = Uuid::now_v7().to_string();
                     changes.push(row_upsert_change(&id, order_key, &file_rows[file_index])?);
                     previous_order_key = Some(order_key);
                     file_index += 1;
@@ -317,38 +316,6 @@ fn parse_order_key_snapshot(
             "invalid csv row order_key for entity_pk '{entity_pk}': {message}"
         ))
     })
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-struct RowId([u8; 8]);
-
-impl RowId {
-    fn random(rng: &mut impl Rng) -> Self {
-        let mut bytes = [0_u8; 8];
-        rng.fill(&mut bytes);
-        Self(bytes)
-    }
-
-    fn to_entity_pk(self) -> String {
-        format!("row:{}", bytes_to_hex(&self.0))
-    }
-}
-
-fn bytes_to_hex(bytes: &[u8]) -> String {
-    let mut output = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        output.push(hex_char(byte >> 4));
-        output.push(hex_char(byte & 0x0f));
-    }
-    output
-}
-
-fn hex_char(value: u8) -> char {
-    match value {
-        0..=9 => (b'0' + value) as char,
-        10..=15 => (b'a' + (value - 10)) as char,
-        _ => unreachable!(),
-    }
 }
 
 #[cfg(test)]

--- a/plugins/csv/tests/roundtrip.rs
+++ b/plugins/csv/tests/roundtrip.rs
@@ -5,6 +5,7 @@ use plugin_csv::{
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
+use uuid::Uuid;
 
 fn file_from_bytes(data: &[u8]) -> File {
     File {
@@ -95,6 +96,19 @@ fn snapshot_order_key(change: &DetectedChange) -> u128 {
     snapshot_order_key_from_value(&snapshot_value(change))
 }
 
+fn assert_generated_row_id_is_uuid_v7(change: &DetectedChange) {
+    let [entity_pk] = change.entity_pk.as_slice() else {
+        panic!("row entity_pk should have one component");
+    };
+    let value = snapshot_value(change);
+    assert_eq!(
+        value.get("id").and_then(Value::as_str),
+        Some(entity_pk.as_str())
+    );
+    let uuid = Uuid::parse_str(entity_pk).expect("row entity_pk should parse as UUID");
+    assert_eq!(uuid.get_version_num(), 7);
+}
+
 fn row_order_keys_by_first_cell(active_state: &[EntityState]) -> BTreeMap<String, u128> {
     active_state
         .iter()
@@ -152,6 +166,7 @@ fn detects_initial_projection_and_renders_csv() {
         .iter()
         .filter(|change| change.schema_key == ROW_SCHEMA_KEY)
     {
+        assert_generated_row_id_is_uuid_v7(row);
         assert_eq!(
             snapshot_value(row)
                 .get("order_key")


### PR DESCRIPTION
* Cache validation
* Switch csv plugin to UUID v7
* Add file-scoped live-state scans 
* Use typed WIT bindings for plugin runtime calls
* Gate integrity rehashes behind debug assertions

```text
e2e/csv_plugin/setup
       time:   [716.44 ms 720.96 ms 726.35 ms]
e2e/csv_plugin/setup_inmemory
       time:   [671.73 ms 689.15 ms 715.98 ms]
e2e/csv_plugin/setup_wasm
       time:   [622.88 ms 627.96 ms 635.08 ms]
e2e/csv_plugin/insert_10k
       time:   [383.17 ms 411.90 ms 434.25 ms]
e2e/csv_plugin/insert_10k_inmemory
       time:   [139.87 ms 141.31 ms 142.83 ms]
e2e/csv_plugin/insert_10k_plugin
       time:   [32.582 ms 32.808 ms 33.134 ms]
e2e/csv_plugin/insert_10k_plugin_diff
       time:   [12.792 ms 12.865 ms 12.935 ms]
e2e/csv_plugin/insert_10k_insert
       time:   [380.52 ms 423.45 ms 463.61 ms]
e2e/csv_plugin/insert_10k_insert_inmemory
       time:   [132.26 ms 134.46 ms 137.31 ms]
e2e/csv_plugin/insert_10k_insert_state
       time:   [832.01 ms 870.56 ms 917.12 ms]
e2e/csv_plugin/insert_10k_insert_state_inmemory
       time:   [637.51 ms 643.49 ms 650.96 ms]
e2e/csv_plugin/merge_10k
       time:   [428.51 ms 458.03 ms 493.41 ms]
e2e/csv_plugin/merge_10k_inmemory
       time:   [233.02 ms 234.36 ms 235.85 ms]
e2e/csv_plugin/merge_10k_plugin
       time:   [59.786 ms 60.473 ms 61.183 ms]
e2e/csv_plugin/merge_10k_plugin_diff
       time:   [26.459 ms 26.563 ms 26.664 ms]
e2e/csv_plugin/merge_10k_insert
       time:   [268.21 ms 301.50 ms 339.03 ms]
e2e/csv_plugin/merge_10k_insert_inmemory
       time:   [138.77 ms 139.78 ms 140.74 ms]
e2e/csv_plugin/merge_10k_insert_state
       time:   [755.43 ms 782.61 ms 811.57 ms]
e2e/csv_plugin/merge_10k_insert_state_inmemory
       time:   [648.74 ms 669.19 ms 691.80 ms]
```
