### PR TITLE
pass snapshot-content as map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -148,15 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
-dependencies = [
- "object 0.37.3",
 ]
 
 [[package]]
@@ -547,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
@@ -568,9 +559,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2-sys"
@@ -602,7 +593,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 1.1.3",
+ "rustix",
  "smallvec",
 ]
 
@@ -618,20 +609,10 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.3",
+ "rustix",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -643,7 +624,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -656,7 +637,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "winx",
 ]
 
@@ -988,6 +969,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,43 +997,48 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b83fcf2fc1c8954561490d02079b496fd0c757da88129981e15bfe3a548229"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7496a6e92b5cee48c5d772b0443df58816dee30fed6ba19b2a28e78037ecedf"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
+dependencies = [
+ "cranelift-srcgen",
+]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a9dc0a8d3d49ee772101924968830f1c1937d650c571d3c2dd69dc36a68f41"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573c641174c40ef31021ae4a5a3ad78974e280633502d0dfc6e362385e0c100f"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
 dependencies = [
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7c94d572615156f2db682181cadbd96342892c31e08cc26a757344319a9220"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1055,7 +1050,8 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
+ "libm",
  "log",
  "pulley-interpreter",
  "regalloc2",
@@ -1063,50 +1059,54 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beecd9fcf2c3e06da436d565de61a42676097ea6eb6b4499346ac6264b6bb9ce"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
 dependencies = [
- "cranelift-assembler-x64",
+ "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4ff8d2e1235f2d6e7fc3c6738be6954ba972cd295f09079ebffeca2f864e22"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
 
 [[package]]
 name = "cranelift-control"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001312e9fbc7d9ca9517474d6fe71e29d07e52997fd7efe18f19e8836446ceb2"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0fd6d4aae680275fcbceb08683416b744e65c8b607352043d3f0951d72b3b2"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
 dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd44e7e5dcea20ca104d45894748205c51365ce4cdb18f4418e3ba955971d1b"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1116,20 +1116,26 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f900e0a3847d51eed0321f0777947fb852ccfce0da7fb070100357f69a2f37fc"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
 
 [[package]]
 name = "cranelift-native"
-version = "0.117.2"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7617f13f392ebb63c5126258aca8b8eca739636ca7e4eeee301d3eff68489a6a"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
 dependencies = [
  "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
 name = "crc32fast"
@@ -1211,7 +1217,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix",
  "winapi",
 ]
 
@@ -2026,17 +2032,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.1.3",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2062,12 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -2106,7 +2107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2265,11 +2266,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -2321,7 +2323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -2342,6 +2343,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2722,12 +2725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "leb128"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2860,15 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3063,7 +3054,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -3084,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3195,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3327,22 +3318,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "indexmap",
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
  "memchr",
 ]
 
@@ -3685,24 +3667,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
-dependencies = [
- "ar_archive_writer",
- "cc",
-]
-
-[[package]]
 name = "pulley-interpreter"
-version = "30.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0ecb9823083f71df8735f21f6c44f2f2b55986d674802831df20f27e26c907"
+checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
 dependencies = [
  "cranelift-bitset",
  "log",
- "wasmtime-math",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3728,22 +3712,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -3760,31 +3733,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3842,13 +3796,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.11.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash 2.1.1",
  "smallvec",
@@ -3914,6 +3868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3936,27 +3896,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3967,7 +3914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -4143,12 +4090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "sqlparser"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,22 +4209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,7 +4223,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4449,9 +4374,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4464,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4557,17 +4482,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "trait-variant"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4793,16 +4707,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.224.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab7a13a23790fe91ea4eb7526a1f3131001d874e3e00c2976c48861f2e82920"
-dependencies = [
- "leb128",
- "wasmparser 0.224.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
@@ -4819,6 +4723,16 @@ checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -4847,19 +4761,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.224.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -4883,102 +4784,140 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.224.1"
+name = "wasmparser"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0095b53a3b09cbc2f90f789ea44aa1b17ecc2dad8b267e657c7391f3ded6293d"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.224.1",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "30.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809cc8780708f1deed0a7c3fcab46954f0e8c08a6fe0252772481fbc88fcf946"
+checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
 dependencies = [
  "addr2line",
- "anyhow",
  "async-trait",
  "bitflags",
  "bumpalo",
  "cc",
  "cfg-if",
  "encoding_rs",
- "hashbrown 0.15.5",
- "indexmap",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object",
  "once_cell",
- "paste",
  "postcard",
- "psm",
  "pulley-interpreter",
- "rustix 0.38.44",
+ "rustix",
  "semver",
  "serde",
  "serde_derive",
  "smallvec",
- "sptr",
  "target-lexicon",
- "trait-variant",
- "wasmparser 0.224.1",
- "wasmtime-asm-macros",
- "wasmtime-component-macro",
- "wasmtime-component-util",
- "wasmtime-cranelift",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-icache-coherence",
- "wasmtime-math",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros",
- "wasmtime-winch",
- "windows-sys 0.59.0",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "30.0.2"
+name = "wasmtime-environ"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236964b6b35af0f08879c9c56dbfbc5adc12e8d624672341a0121df31adaa3fa"
+checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
 dependencies = [
- "cfg-if",
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
-name = "wasmtime-component-macro"
-version = "30.0.2"
+name = "wasmtime-internal-component-macro"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581ef04bf33904db9a902ffb558e7b2de534d6a4881ee985ea833f187a78fdf"
+checksum = "86991f201391afc1504e4fc363dc29b66f92af0287b4ac2efc3c0b0c19435eeb"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser 0.224.1",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
-name = "wasmtime-component-util"
-version = "30.0.2"
+name = "wasmtime-internal-component-util"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7108498a8a0afc81c7d2d81b96cdc509cd631d7bbaa271b7db5137026f10e3"
+checksum = "47fda091250d7ab839ea51e4d98190b6eee37e9de4ab2462e8fe8465369c1986"
 
 [[package]]
-name = "wasmtime-cranelift"
-version = "30.0.2"
+name = "wasmtime-internal-core"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcc9179097235c91f299a8ff56b358ee921266b61adff7d14d6e48428954dd2"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
 dependencies = [
- "anyhow",
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
+dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
@@ -4986,90 +4925,75 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser 0.224.1",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-environ"
-version = "30.0.2"
+name = "wasmtime-internal-fiber"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e90f6cba665939381839bbf2ddf12d732fca03278867910348ef1281b700954"
+checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
 dependencies = [
- "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap",
- "log",
- "object 0.36.7",
- "postcard",
- "semver",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.224.1",
- "wasmparser 0.224.1",
- "wasmprinter",
- "wasmtime-component-util",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "30.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5c2ac21f0b39d72d2dac198218a12b3ddeb4ab388a8fa0d2e429855876783c"
-dependencies = [
- "anyhow",
  "cc",
  "cfg-if",
- "rustix 0.38.44",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
- "windows-sys 0.59.0",
+ "libc",
+ "rustix",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "30.0.2"
+name = "wasmtime-internal-jit-debug"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f180cc0d2745e3a5df5d02231cd3046f49c75512eaa987b8202363b112e125d"
+checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
 dependencies = [
- "anyhow",
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
+dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-math"
-version = "30.0.2"
+name = "wasmtime-internal-unwinder"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f04c5dcf5b2f88f81cfb8d390294b2f67109dc4d0197ea7303c60a092df27c"
+checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
 dependencies = [
- "libm",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
 ]
 
 [[package]]
-name = "wasmtime-slab"
-version = "30.0.2"
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9681707f1ae9a4708ca22058722fca5c135775c495ba9b9624fe3732b94c97"
-
-[[package]]
-name = "wasmtime-versioned-export-macros"
-version = "30.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2fe69d04986a12fc759d2e79494100d600adcb3bb79e63dedfc8e6bb2ab03e"
+checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5077,75 +5001,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-wasi"
-version = "30.0.2"
+name = "wasmtime-internal-winch"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce639c7d398586bc539ae9bba752084c1db7a49ab0f391a3230dcbcc6a64cfd"
+checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
+dependencies = [
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce382df367ad2a2d48e139b191dbca3329f7232a43057dc9efc889dac54f1b0b"
 dependencies = [
  "anyhow",
+ "bitflags",
+ "heck",
+ "indexmap",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e92a304eaafd672718011c69084041db74fa0fcc3532c5920f492c557b721"
+dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
- "cap-rand",
  "cap-std",
  "cap-time-ext",
+ "cfg-if",
  "fs-set-times",
  "futures",
  "io-extras",
  "io-lifetimes",
- "rustix 0.38.44",
- "system-interface",
- "thiserror 1.0.69",
+ "rand 0.10.1",
+ "rustix",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
  "wasmtime",
  "wasmtime-wasi-io",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "30.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcad7178fddaa07786abe8ff5e043acb4bc8c8f737eb117f11e028b48d92792"
+checksum = "8e0013e1f37d2e0e1b030fa186972f6f5819f69814bb07d3b6d3cab0c40b50e2"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "futures",
+ "tracing",
  "wasmtime",
-]
-
-[[package]]
-name = "wasmtime-winch"
-version = "30.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9c8eae8395d530bb00a388030de9f543528674c382326f601de47524376975"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object 0.36.7",
- "target-lexicon",
- "wasmparser 0.224.1",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "30.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5531455e2c55994a1540355140369bb7ec0e46d2699731c5ee9f4cf9c3f7d4"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "wit-parser 0.224.1",
 ]
 
 [[package]]
@@ -5201,20 +5125,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "30.0.2"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbd4e07bd92c7ddace2f3267bdd31d4197b5ec58c315751325d45c19bfb56df"
+checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
 dependencies = [
- "anyhow",
+ "cranelift-assembler-x64",
  "cranelift-codegen",
  "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser 0.224.1",
- "wasmtime-cranelift",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
 ]
 
 [[package]]
@@ -5512,24 +5437,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.224.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.224.1",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
@@ -5563,6 +5470,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]

--- a/packages/engine/wit/lix-plugin.wit
+++ b/packages/engine/wit/lix-plugin.wit
@@ -4,6 +4,14 @@ interface api {
   type json-text = string;
   type bytes = list<u8>;
 
+  variant scalar {
+    nil,
+    boolean(bool),
+    number(f64),
+    text(string),
+    json(json-text),
+  }
+
   /// Current materialized file payload supplied to `detect-changes`.
   record file {
     data: bytes,
@@ -17,7 +25,7 @@ interface api {
     entity-pk: list<string>,
     schema-key: string,
     /// Deterministically encoded JSON text.
-    snapshot-content: option<json-text>,
+    snapshot-content: option<map<string, scalar>>,
     /// Deterministically encoded JSON text.
     metadata: option<json-text>,
   }
@@ -33,7 +41,7 @@ interface api {
     entity-pk: list<string>,
     schema-key: string,
     /// Deterministically encoded JSON text.
-    snapshot-content: json-text,
+    snapshot-content: map<string, scalar>,
     /// Deterministically encoded JSON text.
     metadata: option<json-text>,
   }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -22,9 +22,10 @@ lix_engine = { workspace = true }
 async-trait = "0.1"
 bytes = "1"
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+serde_json = "1"
 tempfile = { version = "3", optional = true }
-wasmtime = { version = "30.0.2", default-features = false, features = ["component-model", "cranelift", "runtime", "std"], optional = true }
-wasmtime-wasi = { version = "30.0.2", default-features = false, optional = true }
+wasmtime = { version = "45.0.0", default-features = false, features = ["component-model", "cranelift", "runtime", "std"], optional = true }
+wasmtime-wasi = { version = "45.0.0", default-features = false, optional = true }
 
 [dev-dependencies]
 plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
@@ -32,7 +33,6 @@ plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", targ
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 rand = { version = "0.9", features = ["small_rng"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 tokio = { version = "1", features = ["rt", "macros"] }
 zip = { version = "8", default-features = false }
 

--- a/packages/rs-sdk/benches/e2e.rs
+++ b/packages/rs-sdk/benches/e2e.rs
@@ -8,6 +8,7 @@ use plugin_csv::exports::lix::plugin::api::Guest as _;
 use plugin_csv::{CsvPlugin, File as CsvFile};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::fmt::Write as _;
 use std::hint::black_box;
@@ -18,7 +19,7 @@ use tempfile::TempDir;
 use tokio::runtime::Builder;
 use wasmtime::component::{Component, Linker};
 use wasmtime::{Config, Engine, Store};
-use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 mod plugin_bindings {
     wasmtime::component::bindgen!({
@@ -26,6 +27,8 @@ mod plugin_bindings {
         world: "plugin",
     });
 }
+
+type BindingSnapshotContent = HashMap<String, plugin_bindings::exports::lix::plugin::api::Scalar>;
 
 const INITIAL_ROW_COUNT: usize = 10_000;
 const NEW_ROW_COUNT: usize = 10_000;
@@ -1083,7 +1086,7 @@ fn csv_detected_changes_to_file_changes(
                 ),
                 snapshot_content: change
                     .snapshot_content
-                    .map(|snapshot| serde_json::from_str(&snapshot).unwrap()),
+                    .map(|snapshot| csv_snapshot_content_value(&snapshot)),
             }
         })
         .collect()
@@ -1116,11 +1119,61 @@ fn csv_entity_state_from_file_changes(changes: &[FileChange]) -> Vec<CsvEntitySt
                 .map(|snapshot_content| CsvEntityState {
                     entity_pk: entity_pk_parts(change),
                     schema_key: change.schema_key.clone(),
-                    snapshot_content: snapshot_content.to_string(),
+                    snapshot_content: csv_snapshot_content_from_value(snapshot_content),
                     metadata: None,
                 })
         })
         .collect()
+}
+
+fn csv_snapshot_content_value(
+    snapshot_content: &BTreeMap<String, plugin_csv::Scalar>,
+) -> serde_json::Value {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| (key.clone(), value_from_csv_scalar(value)))
+        .collect::<serde_json::Map<_, _>>();
+    serde_json::Value::Object(object)
+}
+
+fn csv_snapshot_content_from_value(
+    value: &serde_json::Value,
+) -> BTreeMap<String, plugin_csv::Scalar> {
+    let serde_json::Value::Object(object) = value else {
+        panic!("CSV snapshot_content should be a JSON object");
+    };
+
+    object
+        .iter()
+        .map(|(key, value)| (key.clone(), csv_scalar_from_value(value.clone())))
+        .collect()
+}
+
+fn csv_scalar_from_value(value: serde_json::Value) -> plugin_csv::Scalar {
+    match value {
+        serde_json::Value::Null => plugin_csv::Scalar::Nil,
+        serde_json::Value::Bool(value) => plugin_csv::Scalar::Boolean(value),
+        serde_json::Value::String(value) => plugin_csv::Scalar::Text(value),
+        serde_json::Value::Number(_)
+        | serde_json::Value::Array(_)
+        | serde_json::Value::Object(_) => plugin_csv::Scalar::Json(
+            serde_json::to_string(&value).expect("CSV snapshot scalar should encode"),
+        ),
+    }
+}
+
+fn value_from_csv_scalar(value: &plugin_csv::Scalar) -> serde_json::Value {
+    match value {
+        plugin_csv::Scalar::Nil => serde_json::Value::Null,
+        plugin_csv::Scalar::Boolean(value) => serde_json::Value::Bool(*value),
+        plugin_csv::Scalar::Number(value) => serde_json::Value::Number(
+            serde_json::Number::from_f64(*value).expect("finite CSV snapshot number"),
+        ),
+        plugin_csv::Scalar::Text(value) => serde_json::Value::String(value.clone()),
+        plugin_csv::Scalar::Json(value) => {
+            serde_json::from_str(value).expect("CSV snapshot JSON scalar should parse")
+        }
+    }
 }
 
 fn entity_pk_parts(change: &FileChange) -> Vec<String> {
@@ -1331,6 +1384,7 @@ impl WasmtimePluginRuntime {
     fn new() -> Result<Self, LixError> {
         let mut config = Config::new();
         config.wasm_component_model(true);
+        config.wasm_component_model_map(true);
         let engine = Engine::new(&config)
             .map_err(|error| wasm_runtime_error("failed to create Wasmtime engine", error))?;
         Ok(Self { engine })
@@ -1356,15 +1410,12 @@ impl WasiHostState {
     }
 }
 
-impl IoView for WasiHostState {
-    fn table(&mut self) -> &mut ResourceTable {
-        &mut self.table
-    }
-}
-
 impl WasiView for WasiHostState {
-    fn ctx(&mut self) -> &mut WasiCtx {
-        &mut self.ctx
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.ctx,
+            table: &mut self.table,
+        }
     }
 }
 
@@ -1378,7 +1429,7 @@ impl lix_sdk::WasmRuntime for WasmtimePluginRuntime {
         let component = Component::new(&self.engine, bytes)
             .map_err(|error| wasm_runtime_error("failed to compile plugin component", error))?;
         let mut linker = Linker::<WasiHostState>::new(&self.engine);
-        wasmtime_wasi::add_to_linker_sync(&mut linker)
+        wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
             .map_err(|error| wasm_runtime_error("failed to configure WASI linker", error))?;
         let mut store = Store::new(&self.engine, WasiHostState::new());
         let bindings = plugin_bindings::Plugin::instantiate(&mut store, &component, &linker)
@@ -1398,7 +1449,10 @@ impl lix_sdk::WasmComponentInstance for WasmtimePluginComponent {
         file: WasmPluginFile,
     ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
         let mut store = self.store("detect-changes")?;
-        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        let state = state
+            .into_iter()
+            .map(binding_entity_state_from_wasm)
+            .collect::<Result<Vec<_>, _>>()?;
         let file = file.into();
         match self
             .bindings
@@ -1406,14 +1460,20 @@ impl lix_sdk::WasmComponentInstance for WasmtimePluginComponent {
             .call_detect_changes(&mut *store, &state, &file)
             .map_err(|error| wasm_runtime_error("failed to call detect-changes", error))?
         {
-            Ok(changes) => Ok(changes.into_iter().map(Into::into).collect()),
+            Ok(changes) => changes
+                .into_iter()
+                .map(wasm_detected_change_from_binding)
+                .collect(),
             Err(error) => Err(plugin_error_from_binding("detect-changes", error)),
         }
     }
 
     async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
         let mut store = self.store("render")?;
-        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        let state = state
+            .into_iter()
+            .map(binding_entity_state_from_wasm)
+            .collect::<Result<Vec<_>, _>>()?;
         match self
             .bindings
             .lix_plugin_api()
@@ -1446,24 +1506,126 @@ impl From<WasmPluginFile> for plugin_bindings::exports::lix::plugin::api::File {
     }
 }
 
-impl From<WasmPluginEntityState> for plugin_bindings::exports::lix::plugin::api::EntityState {
-    fn from(state: WasmPluginEntityState) -> Self {
-        Self {
-            entity_pk: state.entity_pk,
-            schema_key: state.schema_key,
-            snapshot_content: state.snapshot_content,
-            metadata: state.metadata,
-        }
+fn binding_entity_state_from_wasm(
+    state: WasmPluginEntityState,
+) -> Result<plugin_bindings::exports::lix::plugin::api::EntityState, LixError> {
+    Ok(plugin_bindings::exports::lix::plugin::api::EntityState {
+        entity_pk: state.entity_pk,
+        schema_key: state.schema_key,
+        snapshot_content: snapshot_content_from_json(
+            &state.snapshot_content,
+            "plugin state snapshot_content",
+        )?,
+        metadata: state.metadata,
+    })
+}
+
+fn wasm_detected_change_from_binding(
+    change: plugin_bindings::exports::lix::plugin::api::DetectedChange,
+) -> Result<WasmPluginDetectedChange, LixError> {
+    Ok(WasmPluginDetectedChange {
+        entity_pk: change.entity_pk,
+        schema_key: change.schema_key,
+        snapshot_content: change
+            .snapshot_content
+            .as_ref()
+            .map(|snapshot_content| {
+                snapshot_content_to_json(snapshot_content, "plugin emitted snapshot_content")
+            })
+            .transpose()?,
+        metadata: change.metadata,
+    })
+}
+
+fn snapshot_content_from_json(raw: &str, label: &str) -> Result<BindingSnapshotContent, LixError> {
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("{label} is invalid JSON: {error}"),
+        )
+    })?;
+    let serde_json::Value::Object(object) = value else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("{label} must be a JSON object"),
+        ));
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| Ok((key, scalar_from_json_value(value)?)))
+        .collect()
+}
+
+fn snapshot_content_to_json(
+    snapshot_content: &BindingSnapshotContent,
+    label: &str,
+) -> Result<String, LixError> {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| Ok((key.clone(), json_value_from_scalar(value, label)?)))
+        .collect::<Result<serde_json::Map<_, _>, LixError>>()?;
+    serde_json::to_string(&serde_json::Value::Object(object)).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to encode {label} JSON: {error}"),
+        )
+    })
+}
+
+fn scalar_from_json_value(
+    value: serde_json::Value,
+) -> Result<plugin_bindings::exports::lix::plugin::api::Scalar, LixError> {
+    match value {
+        serde_json::Value::Null => Ok(plugin_bindings::exports::lix::plugin::api::Scalar::Nil),
+        serde_json::Value::Bool(value) => Ok(
+            plugin_bindings::exports::lix::plugin::api::Scalar::Boolean(value),
+        ),
+        serde_json::Value::String(value) => Ok(
+            plugin_bindings::exports::lix::plugin::api::Scalar::Text(value),
+        ),
+        serde_json::Value::Number(_)
+        | serde_json::Value::Array(_)
+        | serde_json::Value::Object(_) => serde_json::to_string(&value)
+            .map(plugin_bindings::exports::lix::plugin::api::Scalar::Json)
+            .map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("failed to encode snapshot scalar JSON: {error}"),
+                )
+            }),
     }
 }
 
-impl From<plugin_bindings::exports::lix::plugin::api::DetectedChange> for WasmPluginDetectedChange {
-    fn from(change: plugin_bindings::exports::lix::plugin::api::DetectedChange) -> Self {
-        Self {
-            entity_pk: change.entity_pk,
-            schema_key: change.schema_key,
-            snapshot_content: change.snapshot_content,
-            metadata: change.metadata,
+fn json_value_from_scalar(
+    value: &plugin_bindings::exports::lix::plugin::api::Scalar,
+    label: &str,
+) -> Result<serde_json::Value, LixError> {
+    match value {
+        plugin_bindings::exports::lix::plugin::api::Scalar::Nil => Ok(serde_json::Value::Null),
+        plugin_bindings::exports::lix::plugin::api::Scalar::Boolean(value) => {
+            Ok(serde_json::Value::Bool(*value))
+        }
+        plugin_bindings::exports::lix::plugin::api::Scalar::Number(value) => {
+            serde_json::Number::from_f64(*value)
+                .map(serde_json::Value::Number)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("{label} contains NaN or infinite number"),
+                    )
+                })
+        }
+        plugin_bindings::exports::lix::plugin::api::Scalar::Text(value) => {
+            Ok(serde_json::Value::String(value.clone()))
+        }
+        plugin_bindings::exports::lix::plugin::api::Scalar::Json(value) => {
+            serde_json::from_str(value).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("{label} contains invalid JSON scalar: {error}"),
+                )
+            })
         }
     }
 }

--- a/packages/rs-sdk/src/default_wasm_runtime.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -12,7 +13,7 @@ use lix_engine::wasm::{
 };
 use wasmtime::component::{Component, Linker};
 use wasmtime::{Config, Engine, Store};
-use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 mod plugin_bindings {
     wasmtime::component::bindgen!({
@@ -21,6 +22,8 @@ mod plugin_bindings {
     });
 }
 
+type BindingSnapshotContent = HashMap<String, plugin_bindings::exports::lix::plugin::api::Scalar>;
+
 pub(crate) fn runtime() -> Result<Arc<dyn WasmRuntime>, LixError> {
     Ok(Arc::new(WasmtimePluginRuntime::new()?))
 }
@@ -28,6 +31,7 @@ pub(crate) fn runtime() -> Result<Arc<dyn WasmRuntime>, LixError> {
 fn create_engine(consume_fuel: bool, epoch_interruption: bool) -> wasmtime::Result<Engine> {
     let mut config = Config::new();
     config.wasm_component_model(true);
+    config.wasm_component_model_map(true);
     config.consume_fuel(consume_fuel);
     config.epoch_interruption(epoch_interruption);
     Engine::new(&config)
@@ -82,15 +86,12 @@ impl WasiHostState {
     }
 }
 
-impl IoView for WasiHostState {
-    fn table(&mut self) -> &mut ResourceTable {
-        &mut self.table
-    }
-}
-
 impl WasiView for WasiHostState {
-    fn ctx(&mut self) -> &mut WasiCtx {
-        &mut self.ctx
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.ctx,
+            table: &mut self.table,
+        }
     }
 }
 
@@ -110,7 +111,7 @@ impl WasmRuntime for WasmtimePluginRuntime {
         let component = Component::new(engine, bytes)
             .map_err(|error| wasm_runtime_error("failed to compile plugin component", error))?;
         let mut linker = Linker::<WasiHostState>::new(engine);
-        wasmtime_wasi::add_to_linker_sync(&mut linker)
+        wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
             .map_err(|error| wasm_runtime_error("failed to configure WASI linker", error))?;
         let mut store = Store::new(engine, WasiHostState::new());
         if let Some(max_fuel) = limits.max_fuel {
@@ -145,7 +146,10 @@ impl WasmComponentInstance for WasmtimePluginComponent {
     ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
         let mut store = self.store("detect-changes")?;
         self.reset_limits(&mut store)?;
-        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        let state = state
+            .into_iter()
+            .map(binding_entity_state_from_wasm)
+            .collect::<Result<Vec<_>, _>>()?;
         let file = file.into();
         match self
             .bindings
@@ -153,7 +157,10 @@ impl WasmComponentInstance for WasmtimePluginComponent {
             .call_detect_changes(&mut *store, &state, &file)
             .map_err(|error| wasm_runtime_error("failed to call detect-changes", error))?
         {
-            Ok(changes) => Ok(changes.into_iter().map(Into::into).collect()),
+            Ok(changes) => changes
+                .into_iter()
+                .map(wasm_detected_change_from_binding)
+                .collect(),
             Err(error) => Err(plugin_error_from_binding("detect-changes", error)),
         }
     }
@@ -161,7 +168,10 @@ impl WasmComponentInstance for WasmtimePluginComponent {
     async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
         let mut store = self.store("render")?;
         self.reset_limits(&mut store)?;
-        let state = state.into_iter().map(Into::into).collect::<Vec<_>>();
+        let state = state
+            .into_iter()
+            .map(binding_entity_state_from_wasm)
+            .collect::<Result<Vec<_>, _>>()?;
         match self
             .bindings
             .lix_plugin_api()
@@ -237,24 +247,126 @@ impl From<WasmPluginFile> for plugin_bindings::exports::lix::plugin::api::File {
     }
 }
 
-impl From<WasmPluginEntityState> for plugin_bindings::exports::lix::plugin::api::EntityState {
-    fn from(state: WasmPluginEntityState) -> Self {
-        Self {
-            entity_pk: state.entity_pk,
-            schema_key: state.schema_key,
-            snapshot_content: state.snapshot_content,
-            metadata: state.metadata,
-        }
+fn binding_entity_state_from_wasm(
+    state: WasmPluginEntityState,
+) -> Result<plugin_bindings::exports::lix::plugin::api::EntityState, LixError> {
+    Ok(plugin_bindings::exports::lix::plugin::api::EntityState {
+        entity_pk: state.entity_pk,
+        schema_key: state.schema_key,
+        snapshot_content: snapshot_content_from_json(
+            &state.snapshot_content,
+            "plugin state snapshot_content",
+        )?,
+        metadata: state.metadata,
+    })
+}
+
+fn wasm_detected_change_from_binding(
+    change: plugin_bindings::exports::lix::plugin::api::DetectedChange,
+) -> Result<WasmPluginDetectedChange, LixError> {
+    Ok(WasmPluginDetectedChange {
+        entity_pk: change.entity_pk,
+        schema_key: change.schema_key,
+        snapshot_content: change
+            .snapshot_content
+            .as_ref()
+            .map(|snapshot_content| {
+                snapshot_content_to_json(snapshot_content, "plugin emitted snapshot_content")
+            })
+            .transpose()?,
+        metadata: change.metadata,
+    })
+}
+
+fn snapshot_content_from_json(raw: &str, label: &str) -> Result<BindingSnapshotContent, LixError> {
+    let value: serde_json::Value = serde_json::from_str(raw).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("{label} is invalid JSON: {error}"),
+        )
+    })?;
+    let serde_json::Value::Object(object) = value else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("{label} must be a JSON object"),
+        ));
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| Ok((key, scalar_from_json_value(value)?)))
+        .collect()
+}
+
+fn snapshot_content_to_json(
+    snapshot_content: &BindingSnapshotContent,
+    label: &str,
+) -> Result<String, LixError> {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| Ok((key.clone(), json_value_from_scalar(value, label)?)))
+        .collect::<Result<serde_json::Map<_, _>, LixError>>()?;
+    serde_json::to_string(&serde_json::Value::Object(object)).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to encode {label} JSON: {error}"),
+        )
+    })
+}
+
+fn scalar_from_json_value(
+    value: serde_json::Value,
+) -> Result<plugin_bindings::exports::lix::plugin::api::Scalar, LixError> {
+    match value {
+        serde_json::Value::Null => Ok(plugin_bindings::exports::lix::plugin::api::Scalar::Nil),
+        serde_json::Value::Bool(value) => Ok(
+            plugin_bindings::exports::lix::plugin::api::Scalar::Boolean(value),
+        ),
+        serde_json::Value::String(value) => Ok(
+            plugin_bindings::exports::lix::plugin::api::Scalar::Text(value),
+        ),
+        serde_json::Value::Number(_)
+        | serde_json::Value::Array(_)
+        | serde_json::Value::Object(_) => serde_json::to_string(&value)
+            .map(plugin_bindings::exports::lix::plugin::api::Scalar::Json)
+            .map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("failed to encode snapshot scalar JSON: {error}"),
+                )
+            }),
     }
 }
 
-impl From<plugin_bindings::exports::lix::plugin::api::DetectedChange> for WasmPluginDetectedChange {
-    fn from(change: plugin_bindings::exports::lix::plugin::api::DetectedChange) -> Self {
-        Self {
-            entity_pk: change.entity_pk,
-            schema_key: change.schema_key,
-            snapshot_content: change.snapshot_content,
-            metadata: change.metadata,
+fn json_value_from_scalar(
+    value: &plugin_bindings::exports::lix::plugin::api::Scalar,
+    label: &str,
+) -> Result<serde_json::Value, LixError> {
+    match value {
+        plugin_bindings::exports::lix::plugin::api::Scalar::Nil => Ok(serde_json::Value::Null),
+        plugin_bindings::exports::lix::plugin::api::Scalar::Boolean(value) => {
+            Ok(serde_json::Value::Bool(*value))
+        }
+        plugin_bindings::exports::lix::plugin::api::Scalar::Number(value) => {
+            serde_json::Number::from_f64(*value)
+                .map(serde_json::Value::Number)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("{label} contains NaN or infinite number"),
+                    )
+                })
+        }
+        plugin_bindings::exports::lix::plugin::api::Scalar::Text(value) => {
+            Ok(serde_json::Value::String(value.clone()))
+        }
+        plugin_bindings::exports::lix::plugin::api::Scalar::Json(value) => {
+            serde_json::from_str(value).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("{label} contains invalid JSON scalar: {error}"),
+                )
+            })
         }
     }
 }

--- a/plugins/csv/src/csv.rs
+++ b/plugins/csv/src/csv.rs
@@ -1,6 +1,9 @@
 use crate::exports::lix::plugin::api::PluginError;
 use crate::{DetectedChange, File};
-use crate::{Projection, ROOT_ENTITY_PK, TABLE_SCHEMA_KEY, reject_unknown_fields};
+use crate::{
+    Projection, ROOT_ENTITY_PK, SnapshotContent, TABLE_SCHEMA_KEY, reject_unknown_fields,
+    snapshot_content_from_value, snapshot_content_to_value,
+};
 use chardetng::{EncodingDetector, Iso2022JpDetection, Utf8Detection};
 use csv::{ByteRecord, QuoteStyle, ReaderBuilder, Terminator, WriterBuilder};
 use csv_nose::{Quote, Sniffer};
@@ -98,11 +101,13 @@ pub(crate) struct TableSnapshot {
 }
 
 pub(crate) fn table_upsert_change(dialect: CsvDialect) -> Result<DetectedChange, PluginError> {
-    let snapshot_content = serde_json::to_string(&serde_json::json!({
-        "id": ROOT_ENTITY_PK,
-        "dialect": dialect_snapshot_content(dialect),
-    }))
-    .map_err(|error| PluginError::Internal(format!("failed to serialize CSV table: {error}")))?;
+    let snapshot_content = snapshot_content_from_value(
+        serde_json::json!({
+            "id": ROOT_ENTITY_PK,
+            "dialect": dialect_snapshot_content(dialect),
+        }),
+        "CSV table",
+    )?;
 
     Ok(DetectedChange {
         entity_pk: vec![ROOT_ENTITY_PK.to_string()],
@@ -123,10 +128,10 @@ fn dialect_snapshot_content(dialect: CsvDialect) -> Value {
     })
 }
 
-pub(crate) fn parse_table_snapshot(raw: &str) -> Result<TableSnapshot, PluginError> {
-    let value: Value = serde_json::from_str(raw).map_err(|error| {
-        PluginError::InvalidInput(format!("invalid csv table snapshot_content: {error}"))
-    })?;
+pub(crate) fn parse_table_snapshot(
+    snapshot_content: &SnapshotContent,
+) -> Result<TableSnapshot, PluginError> {
+    let value = snapshot_content_to_value(snapshot_content, "CSV table")?;
     let object = value.as_object().ok_or_else(|| {
         PluginError::InvalidInput("csv table snapshot_content must be an object".to_string())
     })?;

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -15,11 +15,11 @@ use crate::csv::{
     CsvDialect, parse_file, parse_table_snapshot, render_projection, table_upsert_change,
 };
 use crate::diff::{Op, imara_diff_runs};
-pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
+pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError, Scalar};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use crate::order_key::OrderKey;
 use itertools::Itertools;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::str;
@@ -30,6 +30,7 @@ pub const TABLE_SCHEMA_KEY: &str = schemas::TABLE_SCHEMA_KEY;
 pub const ROW_SCHEMA_KEY: &str = schemas::ROW_SCHEMA_KEY;
 
 pub const MANIFEST_JSON: &str = include_str!("../manifest.json");
+pub(crate) type SnapshotContent = BTreeMap<String, Scalar>;
 
 #[derive(Clone, Copy, Debug)]
 pub struct CsvPlugin;
@@ -218,12 +219,14 @@ fn row_upsert_change(
     order_key: OrderKey,
     cells: &[String],
 ) -> Result<DetectedChange, PluginError> {
-    let snapshot_content = serde_json::to_string(&serde_json::json!({
-        "id": id,
-        "order_key": order_key.to_snapshot_string(),
-        "cells": cells,
-    }))
-    .map_err(|error| PluginError::Internal(format!("failed to serialize CSV row: {error}")))?;
+    let snapshot_content = snapshot_content_from_value(
+        serde_json::json!({
+            "id": id,
+            "order_key": order_key.to_snapshot_string(),
+            "cells": cells,
+        }),
+        "CSV row",
+    )?;
 
     Ok(DetectedChange {
         entity_pk: vec![id.to_string()],
@@ -233,12 +236,11 @@ fn row_upsert_change(
     })
 }
 
-fn parse_row_snapshot(raw: &str, entity_pk: &str) -> Result<RowSnapshot, PluginError> {
-    let value: Value = serde_json::from_str(raw).map_err(|error| {
-        PluginError::InvalidInput(format!(
-            "invalid csv row snapshot_content for entity_pk '{entity_pk}': {error}"
-        ))
-    })?;
+fn parse_row_snapshot(
+    snapshot_content: &SnapshotContent,
+    entity_pk: &str,
+) -> Result<RowSnapshot, PluginError> {
+    let value = snapshot_content_to_value(snapshot_content, "CSV row")?;
     let object = value.as_object().ok_or_else(|| {
         PluginError::InvalidInput(format!(
             "csv row snapshot_content for entity_pk '{entity_pk}' must be an object"
@@ -284,6 +286,66 @@ fn parse_row_snapshot(raw: &str, entity_pk: &str) -> Result<RowSnapshot, PluginE
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(RowSnapshot { order_key, cells })
+}
+
+pub(crate) fn snapshot_content_from_value(
+    value: Value,
+    label: &str,
+) -> Result<SnapshotContent, PluginError> {
+    let Value::Object(object) = value else {
+        return Err(PluginError::Internal(format!(
+            "{label} snapshot must serialize to a JSON object"
+        )));
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| Ok((key, scalar_from_json_value(value)?)))
+        .collect()
+}
+
+pub(crate) fn snapshot_content_to_value(
+    snapshot_content: &SnapshotContent,
+    label: &str,
+) -> Result<Value, PluginError> {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| Ok((key.clone(), json_value_from_scalar(value, label)?)))
+        .collect::<Result<Map<_, _>, _>>()?;
+    Ok(Value::Object(object))
+}
+
+fn scalar_from_json_value(value: Value) -> Result<Scalar, PluginError> {
+    match value {
+        Value::Null => Ok(Scalar::Nil),
+        Value::Bool(value) => Ok(Scalar::Boolean(value)),
+        Value::String(value) => Ok(Scalar::Text(value)),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => serde_json::to_string(&value)
+            .map(Scalar::Json)
+            .map_err(|error| {
+                PluginError::Internal(format!("failed to encode snapshot scalar JSON: {error}"))
+            }),
+    }
+}
+
+fn json_value_from_scalar(value: &Scalar, label: &str) -> Result<Value, PluginError> {
+    match value {
+        Scalar::Nil => Ok(Value::Null),
+        Scalar::Boolean(value) => Ok(Value::Bool(*value)),
+        Scalar::Number(value) => serde_json::Number::from_f64(*value)
+            .map(Value::Number)
+            .ok_or_else(|| {
+                PluginError::InvalidInput(format!(
+                    "{label} snapshot contains NaN or infinite number"
+                ))
+            }),
+        Scalar::Text(value) => Ok(Value::String(value.clone())),
+        Scalar::Json(value) => serde_json::from_str(value).map_err(|error| {
+            PluginError::InvalidInput(format!(
+                "{label} snapshot contains invalid JSON scalar: {error}"
+            ))
+        }),
+    }
 }
 
 fn reject_unknown_fields<'a>(

--- a/plugins/csv/tests/roundtrip.rs
+++ b/plugins/csv/tests/roundtrip.rs
@@ -1,8 +1,9 @@
 use plugin_csv::exports::lix::plugin::api::{EntityState, Guest};
 use plugin_csv::{
-    CsvPlugin, DetectedChange, File, PluginError, ROOT_ENTITY_PK, ROW_SCHEMA_KEY, TABLE_SCHEMA_KEY,
+    CsvPlugin, DetectedChange, File, PluginError, ROOT_ENTITY_PK, ROW_SCHEMA_KEY, Scalar,
+    TABLE_SCHEMA_KEY,
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use uuid::Uuid;
@@ -72,15 +73,57 @@ fn render_changes(changes: Vec<DetectedChange>) -> Result<Vec<u8>, PluginError> 
 }
 
 fn snapshot_value(change: &DetectedChange) -> Value {
-    let raw = change
+    let snapshot_content = change
         .snapshot_content
         .as_ref()
         .expect("snapshot_content should exist");
-    serde_json::from_str(raw).expect("snapshot_content should parse")
+    snapshot_content_value(snapshot_content)
 }
 
 fn active_state_snapshot_value(row: &EntityState) -> Value {
-    serde_json::from_str(&row.snapshot_content).expect("snapshot_content should parse")
+    snapshot_content_value(&row.snapshot_content)
+}
+
+fn snapshot_content(value: Value) -> BTreeMap<String, Scalar> {
+    let Value::Object(object) = value else {
+        panic!("snapshot_content must be a JSON object");
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| (key, scalar_from_value(value)))
+        .collect()
+}
+
+fn snapshot_content_value(snapshot_content: &BTreeMap<String, Scalar>) -> Value {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| (key.clone(), value_from_scalar(value)))
+        .collect::<Map<_, _>>();
+    Value::Object(object)
+}
+
+fn scalar_from_value(value: Value) -> Scalar {
+    match value {
+        Value::Null => Scalar::Nil,
+        Value::Bool(value) => Scalar::Boolean(value),
+        Value::String(value) => Scalar::Text(value),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+            Scalar::Json(serde_json::to_string(&value).expect("snapshot scalar should encode"))
+        }
+    }
+}
+
+fn value_from_scalar(value: &Scalar) -> Value {
+    match value {
+        Scalar::Nil => Value::Null,
+        Scalar::Boolean(value) => Value::Bool(*value),
+        Scalar::Number(value) => {
+            Value::Number(serde_json::Number::from_f64(*value).expect("finite JSON number"))
+        }
+        Scalar::Text(value) => Value::String(value.clone()),
+        Scalar::Json(value) => serde_json::from_str(value).expect("JSON scalar should parse"),
+    }
 }
 
 fn snapshot_order_key_from_value(value: &Value) -> u128 {
@@ -311,19 +354,20 @@ fn render_uses_quote_byte_from_table_dialect() {
         DetectedChange {
             entity_pk: vec!["row:0".to_string()],
             schema_key: ROW_SCHEMA_KEY.to_string(),
-            snapshot_content: Some(
-                r#"{"id":"row:0","order_key":"80000000000000000000000000000000","cells":["a;b","plain"]}"#
-                    .to_string(),
-            ),
+            snapshot_content: Some(snapshot_content(serde_json::json!({
+                "id": "row:0",
+                "order_key": "80000000000000000000000000000000",
+                "cells": ["a;b", "plain"],
+            }))),
             metadata: None,
         },
         DetectedChange {
             entity_pk: vec![ROOT_ENTITY_PK.to_string()],
             schema_key: TABLE_SCHEMA_KEY.to_string(),
-            snapshot_content: Some(
-                r#"{"id":"root","dialect":{"delimiter":";","quote":"'","terminator":"\n"}}"#
-                    .to_string(),
-            ),
+            snapshot_content: Some(snapshot_content(serde_json::json!({
+                "id": "root",
+                "dialect": {"delimiter": ";", "quote": "'", "terminator": "\n"},
+            }))),
             metadata: None,
         },
     ];
@@ -363,7 +407,11 @@ fn rejects_row_snapshot_with_invalid_order_key() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["row:0".to_string()],
         schema_key: ROW_SCHEMA_KEY.to_string(),
-        snapshot_content: Some(r#"{"id":"row:0","order_key":"bad","cells":["a"]}"#.to_string()),
+        snapshot_content: Some(snapshot_content(serde_json::json!({
+            "id": "row:0",
+            "order_key": "bad",
+            "cells": ["a"],
+        }))),
         metadata: None,
     }];
 

--- a/plugins/json/src/lib.rs
+++ b/plugins/json/src/lib.rs
@@ -6,7 +6,7 @@ wit_bindgen::generate!({
     world: "plugin",
 });
 
-pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
+pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError, Scalar};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -49,8 +49,10 @@ struct ProjectionUpsert {
 #[derive(Debug)]
 struct ProjectionRow {
     entity_pk: Vec<String>,
-    snapshot_content: String,
+    snapshot_content: SnapshotContent,
 }
+
+type SnapshotContent = BTreeMap<String, Scalar>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProjectionNodeKind {
@@ -243,8 +245,12 @@ fn parse_json_bytes(data: &[u8]) -> Result<Value, PluginError> {
     })
 }
 
-fn parse_snapshot_value(raw: &str, pointer: &str) -> Result<Value, PluginError> {
-    if let Ok(parsed) = serde_json::from_str::<SnapshotContentWithPath>(raw) {
+fn parse_snapshot_value(
+    snapshot_content: &SnapshotContent,
+    pointer: &str,
+) -> Result<Value, PluginError> {
+    let raw = snapshot_content_to_json(snapshot_content, "JSON pointer snapshot")?;
+    if let Ok(parsed) = serde_json::from_str::<SnapshotContentWithPath>(&raw) {
         if parsed.path != pointer {
             return Err(PluginError::InvalidInput(format!(
                 "snapshot path '{}' does not match entity_pk '{}'",
@@ -254,7 +260,7 @@ fn parse_snapshot_value(raw: &str, pointer: &str) -> Result<Value, PluginError> 
         return Ok(parsed.value);
     }
 
-    parse_snapshot_value_slow(raw, pointer)
+    parse_snapshot_value_slow(&raw, pointer)
 }
 
 fn parse_snapshot_value_slow(raw: &str, pointer: &str) -> Result<Value, PluginError> {
@@ -490,7 +496,7 @@ fn push_upsert(
     pointer: String,
     value: Value,
 ) -> Result<(), PluginError> {
-    let snapshot_content = serde_json::to_string(&SnapshotContentRef {
+    let snapshot_value = serde_json::to_value(&SnapshotContentRef {
         path: &pointer,
         value: &value,
     })
@@ -499,6 +505,7 @@ fn push_upsert(
             "failed to serialize snapshot content for '{pointer}': {error}"
         ))
     })?;
+    let snapshot_content = snapshot_content_from_value(snapshot_value, "JSON pointer snapshot")?;
 
     changes.push(DetectedChange {
         entity_pk: vec![pointer],
@@ -508,6 +515,60 @@ fn push_upsert(
     });
 
     Ok(())
+}
+
+fn snapshot_content_from_value(value: Value, label: &str) -> Result<SnapshotContent, PluginError> {
+    let Value::Object(object) = value else {
+        return Err(PluginError::Internal(format!(
+            "{label} must serialize to a JSON object"
+        )));
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| Ok((key, scalar_from_json_value(value)?)))
+        .collect()
+}
+
+fn snapshot_content_to_json(
+    snapshot_content: &SnapshotContent,
+    label: &str,
+) -> Result<String, PluginError> {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| Ok((key.clone(), json_value_from_scalar(value, label)?)))
+        .collect::<Result<Map<_, _>, _>>()?;
+    serde_json::to_string(&Value::Object(object))
+        .map_err(|error| PluginError::Internal(format!("failed to encode {label} JSON: {error}")))
+}
+
+fn scalar_from_json_value(value: Value) -> Result<Scalar, PluginError> {
+    match value {
+        Value::Null => Ok(Scalar::Nil),
+        Value::Bool(value) => Ok(Scalar::Boolean(value)),
+        Value::String(value) => Ok(Scalar::Text(value)),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => serde_json::to_string(&value)
+            .map(Scalar::Json)
+            .map_err(|error| {
+                PluginError::Internal(format!("failed to encode snapshot scalar JSON: {error}"))
+            }),
+    }
+}
+
+fn json_value_from_scalar(value: &Scalar, label: &str) -> Result<Value, PluginError> {
+    match value {
+        Scalar::Nil => Ok(Value::Null),
+        Scalar::Boolean(value) => Ok(Value::Bool(*value)),
+        Scalar::Number(value) => serde_json::Number::from_f64(*value)
+            .map(Value::Number)
+            .ok_or_else(|| {
+                PluginError::InvalidInput(format!("{label} contains NaN or infinite number"))
+            }),
+        Scalar::Text(value) => Ok(Value::String(value.clone())),
+        Scalar::Json(value) => serde_json::from_str(value).map_err(|error| {
+            PluginError::InvalidInput(format!("{label} contains invalid JSON scalar: {error}"))
+        }),
+    }
 }
 
 fn is_container(value: &Value) -> bool {

--- a/plugins/json/tests/common/mod.rs
+++ b/plugins/json/tests/common/mod.rs
@@ -1,16 +1,18 @@
 #![allow(dead_code)]
 
 use plugin_json_v2::exports::lix::plugin::api::{EntityState, Guest};
-use plugin_json_v2::{DetectedChange, File, JsonPlugin, PluginError};
+use plugin_json_v2::{DetectedChange, File, JsonPlugin, PluginError, Scalar};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize)]
-struct SnapshotContent {
+struct SnapshotContentJson {
     path: String,
     value: Value,
 }
+
+pub type SnapshotContent = BTreeMap<String, Scalar>;
 
 pub fn file_from_json(json: &str) -> File {
     File {
@@ -19,22 +21,64 @@ pub fn file_from_json(json: &str) -> File {
 }
 
 pub fn parse_snapshot_value_from_change(change: &DetectedChange) -> Value {
-    let Some(snapshot_content) = change.snapshot_content.as_ref() else {
-        panic!("change should have snapshot_content");
-    };
-
-    let parsed: SnapshotContent =
-        serde_json::from_str(snapshot_content).expect("snapshot content should parse");
+    let parsed: SnapshotContentJson = serde_json::from_value(snapshot_content_value(
+        change
+            .snapshot_content
+            .as_ref()
+            .expect("change should have snapshot_content"),
+    ))
+    .expect("snapshot content should parse");
     assert_eq!(change.entity_pk, [parsed.path]);
     parsed.value
 }
 
-pub fn snapshot_content(path: &str, value: Value) -> String {
-    serde_json::json!({
+pub fn snapshot_content(path: &str, value: Value) -> SnapshotContent {
+    snapshot_content_from_value(serde_json::json!({
         "path": path,
         "value": value,
-    })
-    .to_string()
+    }))
+}
+
+pub fn snapshot_content_from_value(value: Value) -> SnapshotContent {
+    let Value::Object(object) = value else {
+        panic!("snapshot_content must be a JSON object");
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| (key, scalar_from_value(value)))
+        .collect()
+}
+
+fn snapshot_content_value(snapshot_content: &SnapshotContent) -> Value {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| (key.clone(), value_from_scalar(value)))
+        .collect::<Map<_, _>>();
+    Value::Object(object)
+}
+
+fn scalar_from_value(value: Value) -> Scalar {
+    match value {
+        Value::Null => Scalar::Nil,
+        Value::Bool(value) => Scalar::Boolean(value),
+        Value::String(value) => Scalar::Text(value),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+            Scalar::Json(serde_json::to_string(&value).expect("snapshot scalar should encode"))
+        }
+    }
+}
+
+fn value_from_scalar(value: &Scalar) -> Value {
+    match value {
+        Scalar::Nil => Value::Null,
+        Scalar::Boolean(value) => Value::Bool(*value),
+        Scalar::Number(value) => {
+            Value::Number(serde_json::Number::from_f64(*value).expect("finite JSON number"))
+        }
+        Scalar::Text(value) => Value::String(value.clone()),
+        Scalar::Json(value) => serde_json::from_str(value).expect("JSON scalar should parse"),
+    }
 }
 
 pub fn active_state_from_changes(changes: Vec<DetectedChange>) -> Vec<EntityState> {

--- a/plugins/json/tests/detect_changes.rs
+++ b/plugins/json/tests/detect_changes.rs
@@ -47,7 +47,7 @@ fn detects_nested_array_updates_and_deletions() {
         Value::String("x".to_string())
     );
     assert_eq!(changes[1].entity_pk, ["/list/2"]);
-    assert_eq!(changes[1].snapshot_content, None);
+    assert!(changes[1].snapshot_content.is_none());
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn detects_container_replacement() {
 
     assert_eq!(changes.len(), 2);
     assert_eq!(changes[0].entity_pk, ["/a/x"]);
-    assert_eq!(changes[0].snapshot_content, None);
+    assert!(changes[0].snapshot_content.is_none());
     assert_eq!(changes[1].entity_pk, ["/a"]);
     assert_eq!(
         parse_snapshot_value_from_change(&changes[1]),
@@ -97,11 +97,11 @@ fn detects_multi_delete_array_in_descending_order() {
 
     assert_eq!(changes.len(), 3);
     assert_eq!(changes[0].entity_pk, ["/list/3"]);
-    assert_eq!(changes[0].snapshot_content, None);
+    assert!(changes[0].snapshot_content.is_none());
     assert_eq!(changes[1].entity_pk, ["/list/2"]);
-    assert_eq!(changes[1].snapshot_content, None);
+    assert!(changes[1].snapshot_content.is_none());
     assert_eq!(changes[2].entity_pk, ["/list/1"]);
-    assert_eq!(changes[2].snapshot_content, None);
+    assert!(changes[2].snapshot_content.is_none());
 }
 
 #[test]
@@ -114,9 +114,9 @@ fn deleting_non_empty_container_emits_subtree_tombstones() {
 
     assert_eq!(changes.len(), 2);
     assert_eq!(changes[0].entity_pk, ["/a"]);
-    assert_eq!(changes[0].snapshot_content, None);
+    assert!(changes[0].snapshot_content.is_none());
     assert_eq!(changes[1].entity_pk, ["/a/b"]);
-    assert_eq!(changes[1].snapshot_content, None);
+    assert!(changes[1].snapshot_content.is_none());
 }
 
 #[test]
@@ -129,9 +129,9 @@ fn replacing_non_empty_container_with_scalar_tombstones_subtree() {
 
     assert_eq!(changes.len(), 3);
     assert_eq!(changes[0].entity_pk, ["/a"]);
-    assert_eq!(changes[0].snapshot_content, None);
+    assert!(changes[0].snapshot_content.is_none());
     assert_eq!(changes[1].entity_pk, ["/a/b"]);
-    assert_eq!(changes[1].snapshot_content, None);
+    assert!(changes[1].snapshot_content.is_none());
     assert_eq!(changes[2].entity_pk, [""]);
     assert_eq!(
         parse_snapshot_value_from_change(&changes[2]),

--- a/plugins/json/tests/render_changes.rs
+++ b/plugins/json/tests/render_changes.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::snapshot_content;
+use common::{snapshot_content, snapshot_content_from_value};
 use plugin_json_v2::{DetectedChange, PluginError, SCHEMA_KEY};
 use serde_json::Value;
 
@@ -93,7 +93,9 @@ fn rejects_snapshot_missing_path() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["/foo".to_string()],
         schema_key: SCHEMA_KEY.to_string(),
-        snapshot_content: Some(r#"{"value":2}"#.to_string()),
+        snapshot_content: Some(snapshot_content_from_value(serde_json::json!({
+            "value": 2,
+        }))),
         metadata: None,
     }];
 
@@ -178,7 +180,10 @@ fn rejects_mismatched_snapshot_path() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["/foo".to_string()],
         schema_key: SCHEMA_KEY.to_string(),
-        snapshot_content: Some(r#"{"path":"/bar","value":2}"#.to_string()),
+        snapshot_content: Some(snapshot_content_from_value(serde_json::json!({
+            "path": "/bar",
+            "value": 2,
+        }))),
         metadata: None,
     }];
 
@@ -281,7 +286,10 @@ fn rejects_snapshot_path_non_string() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["/safe".to_string()],
         schema_key: SCHEMA_KEY.to_string(),
-        snapshot_content: Some(r#"{"path":123,"value":1}"#.to_string()),
+        snapshot_content: Some(snapshot_content_from_value(serde_json::json!({
+            "path": 123,
+            "value": 1,
+        }))),
         metadata: None,
     }];
 
@@ -302,7 +310,11 @@ fn rejects_snapshot_with_additional_properties_or_missing_value() {
     let with_extra = vec![DetectedChange {
         entity_pk: vec!["/safe".to_string()],
         schema_key: SCHEMA_KEY.to_string(),
-        snapshot_content: Some(r#"{"path":"/safe","value":1,"extra":true}"#.to_string()),
+        snapshot_content: Some(snapshot_content_from_value(serde_json::json!({
+            "path": "/safe",
+            "value": 1,
+            "extra": true,
+        }))),
         metadata: None,
     }];
     let error = common::render_projection(with_root_object(with_extra))
@@ -319,7 +331,9 @@ fn rejects_snapshot_with_additional_properties_or_missing_value() {
     let missing_value = vec![DetectedChange {
         entity_pk: vec!["/safe".to_string()],
         schema_key: SCHEMA_KEY.to_string(),
-        snapshot_content: Some(r#"{"path":"/safe"}"#.to_string()),
+        snapshot_content: Some(snapshot_content_from_value(serde_json::json!({
+            "path": "/safe",
+        }))),
         metadata: None,
     }];
     let error = common::render_projection(with_root_object(missing_value))

--- a/plugins/markdown/src/common.rs
+++ b/plugins/markdown/src/common.rs
@@ -1,3 +1,9 @@
+use crate::exports::lix::plugin::api::{PluginError, Scalar};
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+
+pub(crate) type SnapshotContent = BTreeMap<String, Scalar>;
+
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct DocumentSnapshotContent {
@@ -11,6 +17,68 @@ pub(crate) struct BlockSnapshotContent {
     pub(crate) id: String,
     #[serde(rename = "type")]
     pub(crate) node_type: String,
-    pub(crate) node: serde_json::Value,
+    pub(crate) node: Value,
     pub(crate) markdown: String,
+}
+
+pub(crate) fn snapshot_content_from_value(
+    value: Value,
+    label: &str,
+) -> Result<SnapshotContent, PluginError> {
+    let Value::Object(object) = value else {
+        return Err(PluginError::Internal(format!(
+            "{label} snapshot must serialize to a JSON object"
+        )));
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| Ok((key, scalar_from_json_value(value)?)))
+        .collect()
+}
+
+pub(crate) fn snapshot_content_to_json(
+    snapshot_content: &SnapshotContent,
+    label: &str,
+) -> Result<String, PluginError> {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| Ok((key.clone(), json_value_from_scalar(value, label)?)))
+        .collect::<Result<Map<_, _>, _>>()?;
+    serde_json::to_string(&Value::Object(object)).map_err(|error| {
+        PluginError::Internal(format!("failed to encode {label} snapshot JSON: {error}"))
+    })
+}
+
+fn scalar_from_json_value(value: Value) -> Result<Scalar, PluginError> {
+    match value {
+        Value::Null => Ok(Scalar::Nil),
+        Value::Bool(value) => Ok(Scalar::Boolean(value)),
+        Value::String(value) => Ok(Scalar::Text(value)),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => serde_json::to_string(&value)
+            .map(Scalar::Json)
+            .map_err(|error| {
+                PluginError::Internal(format!("failed to encode snapshot scalar JSON: {error}"))
+            }),
+    }
+}
+
+fn json_value_from_scalar(value: &Scalar, label: &str) -> Result<Value, PluginError> {
+    match value {
+        Scalar::Nil => Ok(Value::Null),
+        Scalar::Boolean(value) => Ok(Value::Bool(*value)),
+        Scalar::Number(value) => serde_json::Number::from_f64(*value)
+            .map(Value::Number)
+            .ok_or_else(|| {
+                PluginError::InvalidInput(format!(
+                    "{label} snapshot contains NaN or infinite number"
+                ))
+            }),
+        Scalar::Text(value) => Ok(Value::String(value.clone())),
+        Scalar::Json(value) => serde_json::from_str(value).map_err(|error| {
+            PluginError::InvalidInput(format!(
+                "{label} snapshot contains invalid JSON scalar: {error}"
+            ))
+        }),
+    }
 }

--- a/plugins/markdown/src/detect_changes.rs
+++ b/plugins/markdown/src/detect_changes.rs
@@ -1,5 +1,8 @@
 use crate::ROOT_ENTITY_PK;
-use crate::common::{BlockSnapshotContent, DocumentSnapshotContent};
+use crate::common::{
+    BlockSnapshotContent, DocumentSnapshotContent, snapshot_content_from_value,
+    snapshot_content_to_json,
+};
 use crate::exports::lix::plugin::api::{EntityState, PluginError};
 use crate::schemas::{BLOCK_SCHEMA_KEY, DOCUMENT_SCHEMA_KEY};
 use crate::{DetectedChange, File, single_entity_pk};
@@ -82,7 +85,7 @@ pub(crate) fn detect_changes(
     }
 
     if before_order != after_order {
-        let snapshot_content = serde_json::to_string(&DocumentSnapshotContent {
+        let snapshot_value = serde_json::to_value(&DocumentSnapshotContent {
             id: ROOT_ENTITY_PK.to_string(),
             order: after_order,
         })
@@ -91,6 +94,7 @@ pub(crate) fn detect_changes(
                 "failed to serialize markdown document snapshot: {error}"
             ))
         })?;
+        let snapshot_content = snapshot_content_from_value(snapshot_value, "markdown document")?;
 
         changes.push(DetectedChange {
             entity_pk: vec![ROOT_ENTITY_PK.to_string()],
@@ -117,10 +121,11 @@ fn parse_state_context_projection(
 
     for row in state_context {
         let schema_key = row.schema_key.as_str();
-        let snapshot_content = row.snapshot_content.as_str();
 
         if schema_key == DOCUMENT_SCHEMA_KEY {
-            let snapshot: DocumentSnapshotContent = serde_json::from_str(snapshot_content)
+            let snapshot_content =
+                snapshot_content_to_json(&row.snapshot_content, "markdown document")?;
+            let snapshot: DocumentSnapshotContent = serde_json::from_str(&snapshot_content)
                 .map_err(|error| {
                     PluginError::Internal(format!(
                         "invalid markdown document row in detect state context: {error}"
@@ -134,8 +139,9 @@ fn parse_state_context_projection(
             continue;
         }
 
+        let snapshot_content = snapshot_content_to_json(&row.snapshot_content, "markdown block")?;
         let snapshot: BlockSnapshotContent =
-            serde_json::from_str(snapshot_content).map_err(|error| {
+            serde_json::from_str(&snapshot_content).map_err(|error| {
                 PluginError::Internal(format!(
                     "invalid markdown block row in detect state context: {error}"
                 ))
@@ -441,7 +447,7 @@ fn assign_missing_ids(
 }
 
 fn block_upsert_change(block: &ParsedBlock) -> Result<DetectedChange, PluginError> {
-    let snapshot_content = serde_json::to_string(&BlockSnapshotContent {
+    let snapshot_value = serde_json::to_value(&BlockSnapshotContent {
         id: block.id.clone(),
         node_type: block.node_type.clone(),
         node: block.node_json.clone(),
@@ -452,6 +458,7 @@ fn block_upsert_change(block: &ParsedBlock) -> Result<DetectedChange, PluginErro
             "failed to serialize markdown block snapshot: {error}"
         ))
     })?;
+    let snapshot_content = snapshot_content_from_value(snapshot_value, "markdown block")?;
 
     Ok(DetectedChange {
         entity_pk: vec![block.id.clone()],

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -6,7 +6,7 @@ wit_bindgen::generate!({
     world: "plugin",
 });
 
-pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
+pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError, Scalar};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 
 mod common;

--- a/plugins/markdown/src/render_changes.rs
+++ b/plugins/markdown/src/render_changes.rs
@@ -1,5 +1,7 @@
 use crate::ROOT_ENTITY_PK;
-use crate::common::{BlockSnapshotContent, DocumentSnapshotContent};
+use crate::common::{
+    BlockSnapshotContent, DocumentSnapshotContent, SnapshotContent, snapshot_content_to_json,
+};
 use crate::exports::lix::plugin::api::{EntityState, PluginError};
 use crate::schemas::{BLOCK_SCHEMA_KEY, DOCUMENT_SCHEMA_KEY};
 use crate::{File, single_entity_pk};
@@ -8,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 struct RenderRow {
     entity_pk: Vec<String>,
     schema_key: String,
-    snapshot_content: String,
+    snapshot_content: SnapshotContent,
 }
 
 pub(crate) fn render_state(file: File, state: Vec<EntityState>) -> Result<Vec<u8>, PluginError> {
@@ -48,7 +50,9 @@ fn render_rows(
                 )));
             }
 
-            let snapshot: DocumentSnapshotContent = serde_json::from_str(&row.snapshot_content)
+            let snapshot_content =
+                snapshot_content_to_json(&row.snapshot_content, "markdown document")?;
+            let snapshot: DocumentSnapshotContent = serde_json::from_str(&snapshot_content)
                 .map_err(|error| {
                     PluginError::InvalidInput(format!(
                         "invalid snapshot_content for entity_pk '{ROOT_ENTITY_PK}': {error}"
@@ -73,8 +77,9 @@ fn render_rows(
             )));
         }
 
+        let snapshot_content = snapshot_content_to_json(&row.snapshot_content, "markdown block")?;
         let snapshot: BlockSnapshotContent =
-            serde_json::from_str(&row.snapshot_content).map_err(|error| {
+            serde_json::from_str(&snapshot_content).map_err(|error| {
                 PluginError::InvalidInput(format!(
                     "invalid snapshot_content for entity_pk '{entity_pk}': {error}"
                 ))

--- a/plugins/markdown/tests/common/mod.rs
+++ b/plugins/markdown/tests/common/mod.rs
@@ -3,8 +3,9 @@
 use plugin_md_v2::exports::lix::plugin::api::{EntityState, Guest};
 use plugin_md_v2::{
     BLOCK_SCHEMA_KEY, DOCUMENT_SCHEMA_KEY, DetectedChange, File, MarkdownPlugin, PluginError,
-    ROOT_ENTITY_PK,
+    ROOT_ENTITY_PK, Scalar,
 };
+use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 
 pub type StateKey = (String, Vec<String>);
@@ -34,19 +35,14 @@ pub fn is_block_change(change: &DetectedChange) -> bool {
 
 pub fn parse_document_order(change: &DetectedChange) -> Vec<String> {
     assert!(is_document_change(change));
-    let raw = change
-        .snapshot_content
-        .as_ref()
-        .expect("document snapshot should be present");
-    let parsed: serde_json::Value =
-        serde_json::from_str(raw).expect("document snapshot should be valid JSON");
+    let parsed = snapshot_value(change);
     assert_eq!(
-        parsed.get("id").and_then(serde_json::Value::as_str),
+        parsed.get("id").and_then(Value::as_str),
         Some(ROOT_ENTITY_PK)
     );
     parsed
         .get("order")
-        .and_then(serde_json::Value::as_array)
+        .and_then(Value::as_array)
         .expect("document snapshot should contain order array")
         .iter()
         .map(|entry| {
@@ -60,17 +56,24 @@ pub fn parse_document_order(change: &DetectedChange) -> Vec<String> {
 
 pub fn parse_block_markdown(change: &DetectedChange) -> String {
     assert!(is_block_change(change));
-    let raw = change
-        .snapshot_content
-        .as_ref()
-        .expect("block snapshot should be present");
-    let parsed: serde_json::Value =
-        serde_json::from_str(raw).expect("block snapshot should be valid JSON");
+    let parsed = snapshot_value(change);
     parsed
         .get("markdown")
-        .and_then(serde_json::Value::as_str)
+        .and_then(Value::as_str)
         .expect("block snapshot should contain markdown")
         .to_string()
+}
+
+pub fn snapshot_value(change: &DetectedChange) -> Value {
+    let snapshot_content = change
+        .snapshot_content
+        .as_ref()
+        .expect("snapshot should be present");
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| (key.clone(), value_from_scalar(value)))
+        .collect::<Map<_, _>>();
+    Value::Object(object)
 }
 
 pub fn assert_invalid_input(error: PluginError) {
@@ -168,13 +171,10 @@ pub fn document_change(order: Vec<String>) -> DetectedChange {
     DetectedChange {
         entity_pk: vec![ROOT_ENTITY_PK.to_string()],
         schema_key: DOCUMENT_SCHEMA_KEY.to_string(),
-        snapshot_content: Some(
-            serde_json::json!({
-                "id": ROOT_ENTITY_PK,
-                "order": order,
-            })
-            .to_string(),
-        ),
+        snapshot_content: Some(snapshot_content(serde_json::json!({
+            "id": ROOT_ENTITY_PK,
+            "order": order,
+        }))),
         metadata: None,
     }
 }
@@ -183,15 +183,46 @@ pub fn block_change(id: &str, node_type: &str, markdown: &str) -> DetectedChange
     DetectedChange {
         entity_pk: vec![id.to_string()],
         schema_key: BLOCK_SCHEMA_KEY.to_string(),
-        snapshot_content: Some(
-            serde_json::json!({
-                "id": id,
-                "type": node_type,
-                "node": {},
-                "markdown": markdown,
-            })
-            .to_string(),
-        ),
+        snapshot_content: Some(snapshot_content(serde_json::json!({
+            "id": id,
+            "type": node_type,
+            "node": {},
+            "markdown": markdown,
+        }))),
         metadata: None,
+    }
+}
+
+pub fn snapshot_content(value: Value) -> BTreeMap<String, Scalar> {
+    let Value::Object(object) = value else {
+        panic!("snapshot_content must be a JSON object");
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| (key, scalar_from_value(value)))
+        .collect()
+}
+
+fn scalar_from_value(value: Value) -> Scalar {
+    match value {
+        Value::Null => Scalar::Nil,
+        Value::Bool(value) => Scalar::Boolean(value),
+        Value::String(value) => Scalar::Text(value),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+            Scalar::Json(serde_json::to_string(&value).expect("snapshot scalar should encode"))
+        }
+    }
+}
+
+fn value_from_scalar(value: &Scalar) -> Value {
+    match value {
+        Scalar::Nil => Value::Null,
+        Scalar::Boolean(value) => Value::Bool(*value),
+        Scalar::Number(value) => {
+            Value::Number(serde_json::Number::from_f64(*value).expect("finite JSON number"))
+        }
+        Scalar::Text(value) => Value::String(value.clone()),
+        Scalar::Json(value) => serde_json::from_str(value).expect("JSON scalar should parse"),
     }
 }

--- a/plugins/markdown/tests/detect_changes.rs
+++ b/plugins/markdown/tests/detect_changes.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{
     active_state_from_changes, assert_invalid_input, detect_changes_from_files, file_from_markdown,
-    is_block_change, is_document_change, parse_document_order,
+    is_block_change, is_document_change, parse_document_order, snapshot_value,
 };
 use plugin_md_v2::exports::lix::plugin::api::{EntityState, Guest};
 use plugin_md_v2::{BLOCK_SCHEMA_KEY, DOCUMENT_SCHEMA_KEY, DetectedChange, File, MarkdownPlugin};
@@ -33,10 +33,9 @@ fn upsert_types(changes: &[DetectedChange]) -> Vec<String> {
     changes
         .iter()
         .filter(|change| change.schema_key == BLOCK_SCHEMA_KEY)
-        .filter_map(|change| change.snapshot_content.as_ref())
-        .map(|raw| {
-            let parsed: serde_json::Value =
-                serde_json::from_str(raw).expect("block snapshot should be valid JSON");
+        .filter(|change| change.snapshot_content.is_some())
+        .map(|change| {
+            let parsed = snapshot_value(change);
             parsed
                 .get("type")
                 .and_then(serde_json::Value::as_str)
@@ -50,10 +49,9 @@ fn upsert_markdowns(changes: &[DetectedChange]) -> Vec<String> {
     changes
         .iter()
         .filter(|change| change.schema_key == BLOCK_SCHEMA_KEY)
-        .filter_map(|change| change.snapshot_content.as_ref())
-        .map(|raw| {
-            let parsed: serde_json::Value =
-                serde_json::from_str(raw).expect("block snapshot should be valid JSON");
+        .filter(|change| change.snapshot_content.is_some())
+        .map(|change| {
+            let parsed = snapshot_value(change);
             parsed
                 .get("markdown")
                 .and_then(serde_json::Value::as_str)

--- a/plugins/markdown/tests/render_changes.rs
+++ b/plugins/markdown/tests/render_changes.rs
@@ -1,7 +1,12 @@
 mod common;
 
-use common::{assert_invalid_input, block_change, decode_utf8, document_change};
-use plugin_md_v2::{BLOCK_SCHEMA_KEY, DOCUMENT_SCHEMA_KEY, DetectedChange};
+use common::{assert_invalid_input, block_change, decode_utf8, document_change, snapshot_content};
+use plugin_md_v2::{BLOCK_SCHEMA_KEY, DOCUMENT_SCHEMA_KEY, DetectedChange, Scalar};
+use std::collections::BTreeMap;
+
+fn invalid_json_scalar_snapshot() -> BTreeMap<String, Scalar> {
+    BTreeMap::from([("bad".to_string(), Scalar::Json("{".to_string()))])
+}
 
 #[test]
 fn materializes_markdown_from_document_order_and_blocks() {
@@ -52,13 +57,10 @@ fn rejects_unknown_document_entity_pk() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["other".to_string()],
         schema_key: DOCUMENT_SCHEMA_KEY.to_string(),
-        snapshot_content: Some(
-            serde_json::json!({
-                "id": "other",
-                "order": ["b1"],
-            })
-            .to_string(),
-        ),
+        snapshot_content: Some(snapshot_content(serde_json::json!({
+            "id": "other",
+            "order": ["b1"],
+        }))),
         metadata: None,
     }];
 
@@ -72,7 +74,7 @@ fn rejects_invalid_block_snapshot_json() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["b1".to_string()],
         schema_key: BLOCK_SCHEMA_KEY.to_string(),
-        snapshot_content: Some("{".to_string()),
+        snapshot_content: Some(invalid_json_scalar_snapshot()),
         metadata: None,
     }];
 
@@ -86,7 +88,7 @@ fn rejects_invalid_document_snapshot_json() {
     let changes = vec![DetectedChange {
         entity_pk: vec![plugin_md_v2::ROOT_ENTITY_PK.to_string()],
         schema_key: DOCUMENT_SCHEMA_KEY.to_string(),
-        snapshot_content: Some("{".to_string()),
+        snapshot_content: Some(invalid_json_scalar_snapshot()),
         metadata: None,
     }];
 
@@ -100,15 +102,12 @@ fn rejects_block_snapshot_id_mismatch_with_entity_pk() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["b1".to_string()],
         schema_key: BLOCK_SCHEMA_KEY.to_string(),
-        snapshot_content: Some(
-            serde_json::json!({
-                "id": "b2",
-                "type": "paragraph",
-                "node": {},
-                "markdown": "hello",
-            })
-            .to_string(),
-        ),
+        snapshot_content: Some(snapshot_content(serde_json::json!({
+            "id": "b2",
+            "type": "paragraph",
+            "node": {},
+            "markdown": "hello",
+        }))),
         metadata: None,
     }];
 
@@ -122,13 +121,10 @@ fn rejects_document_snapshot_id_mismatch_with_root() {
     let changes = vec![DetectedChange {
         entity_pk: vec![plugin_md_v2::ROOT_ENTITY_PK.to_string()],
         schema_key: DOCUMENT_SCHEMA_KEY.to_string(),
-        snapshot_content: Some(
-            serde_json::json!({
-                "id": "other",
-                "order": ["b1"],
-            })
-            .to_string(),
-        ),
+        snapshot_content: Some(snapshot_content(serde_json::json!({
+            "id": "other",
+            "order": ["b1"],
+        }))),
         metadata: None,
     }];
 
@@ -142,7 +138,7 @@ fn ignores_unknown_schema_rows() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["unknown1".to_string()],
         schema_key: "other_schema".to_string(),
-        snapshot_content: Some("{\"x\":1}".to_string()),
+        snapshot_content: Some(snapshot_content(serde_json::json!({"x": 1}))),
         metadata: None,
     }];
 

--- a/plugins/markdown/tests/roundtrip.rs
+++ b/plugins/markdown/tests/roundtrip.rs
@@ -3,6 +3,7 @@ mod common;
 use common::{
     StateRows, active_state_from_changes, apply_changes_to_active_state, collect_state_rows,
     decode_utf8, detect_changes_from_files, file_from_markdown, is_document_change, merge_delta,
+    snapshot_value,
 };
 use plugin_md_v2::exports::lix::plugin::api::Guest;
 use plugin_md_v2::{BLOCK_SCHEMA_KEY, DOCUMENT_SCHEMA_KEY, DetectedChange, MarkdownPlugin};
@@ -48,12 +49,7 @@ fn upsert_block_types(changes: &[DetectedChange]) -> Vec<String> {
         .iter()
         .filter(|c| c.schema_key == BLOCK_SCHEMA_KEY && c.snapshot_content.is_some())
         .map(|c| {
-            let raw = c
-                .snapshot_content
-                .as_ref()
-                .expect("upsert should have snapshot");
-            let parsed: serde_json::Value =
-                serde_json::from_str(raw).expect("block snapshot should be valid JSON");
+            let parsed = snapshot_value(c);
             parsed
                 .get("type")
                 .and_then(serde_json::Value::as_str)

--- a/plugins/text/src/lib.rs
+++ b/plugins/text/src/lib.rs
@@ -6,15 +6,15 @@ wit_bindgen::generate!({
     world: "plugin",
 });
 
-pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
+pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError, Scalar};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use imara_diff::{Algorithm, Diff, InternedInput};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use sha1::{Digest, Sha1};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::OnceLock;
 
 pub const LINE_SCHEMA_KEY: &str = "text_line";
@@ -79,8 +79,10 @@ struct DocumentSnapshotOwned {
 struct RenderRow {
     entity_pk: Vec<String>,
     schema_key: String,
-    snapshot_content: Option<String>,
+    snapshot_content: Option<SnapshotContent>,
 }
+
+type SnapshotContent = BTreeMap<String, Scalar>;
 
 impl Plugin for TextLinesPlugin {
     fn detect_changes(
@@ -153,7 +155,10 @@ fn detect_changes_from_files(
         changes.push(DetectedChange {
             entity_pk: vec![line.id.clone()],
             schema_key: LINE_SCHEMA_KEY.to_string(),
-            snapshot_content: Some(serialize_line_snapshot(line)?),
+            snapshot_content: Some(snapshot_content_from_json(
+                &serialize_line_snapshot(line)?,
+                "text line",
+            )?),
             metadata: None,
         });
     }
@@ -168,7 +173,7 @@ fn detect_changes_from_files(
         changes.push(DetectedChange {
             entity_pk: vec![DOCUMENT_ENTITY_PK.to_string()],
             schema_key: DOCUMENT_SCHEMA_KEY.to_string(),
-            snapshot_content: Some(snapshot),
+            snapshot_content: Some(snapshot_content_from_json(&snapshot, "text document")?),
             metadata: None,
         });
     }
@@ -226,7 +231,8 @@ fn render_rows(
             }
 
             match row.snapshot_content {
-                Some(snapshot_raw) => {
+                Some(snapshot_content) => {
+                    let snapshot_raw = snapshot_content_to_json(&snapshot_content, "text line")?;
                     let snapshot = parse_line_snapshot(&snapshot_raw, &entity_pk)?;
                     line_by_id.insert(
                         entity_pk.clone(),
@@ -253,12 +259,14 @@ fn render_rows(
             }
 
             match row.snapshot_content {
-                Some(snapshot_raw) => {
+                Some(snapshot_content) => {
                     if document_snapshot.is_some() || document_tombstoned {
                         return Err(PluginError::InvalidInput(
                             "duplicate text_document snapshot in render_changes input".to_string(),
                         ));
                     }
+                    let snapshot_raw =
+                        snapshot_content_to_json(&snapshot_content, "text document")?;
                     let parsed = parse_document_snapshot(&snapshot_raw)?;
                     document_snapshot = Some(parsed);
                 }
@@ -587,6 +595,72 @@ fn base64_to_bytes(raw: &str) -> Result<Vec<u8>, String> {
     BASE64_STANDARD
         .decode(raw)
         .map_err(|error| format!("invalid base64: {error}"))
+}
+
+fn snapshot_content_from_json(raw: &str, label: &str) -> Result<SnapshotContent, PluginError> {
+    let value: Value = serde_json::from_str(raw).map_err(|error| {
+        PluginError::Internal(format!("failed to parse {label} snapshot JSON: {error}"))
+    })?;
+    snapshot_content_from_value(value, label)
+}
+
+fn snapshot_content_from_value(value: Value, label: &str) -> Result<SnapshotContent, PluginError> {
+    let Value::Object(object) = value else {
+        return Err(PluginError::Internal(format!(
+            "{label} snapshot must serialize to a JSON object"
+        )));
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| Ok((key, scalar_from_json_value(value)?)))
+        .collect()
+}
+
+fn snapshot_content_to_json(
+    snapshot_content: &SnapshotContent,
+    label: &str,
+) -> Result<String, PluginError> {
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| Ok((key.clone(), json_value_from_scalar(value, label)?)))
+        .collect::<Result<Map<_, _>, _>>()?;
+    serde_json::to_string(&Value::Object(object)).map_err(|error| {
+        PluginError::Internal(format!("failed to encode {label} snapshot JSON: {error}"))
+    })
+}
+
+fn scalar_from_json_value(value: Value) -> Result<Scalar, PluginError> {
+    match value {
+        Value::Null => Ok(Scalar::Nil),
+        Value::Bool(value) => Ok(Scalar::Boolean(value)),
+        Value::String(value) => Ok(Scalar::Text(value)),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => serde_json::to_string(&value)
+            .map(Scalar::Json)
+            .map_err(|error| {
+                PluginError::Internal(format!("failed to encode snapshot scalar JSON: {error}"))
+            }),
+    }
+}
+
+fn json_value_from_scalar(value: &Scalar, label: &str) -> Result<Value, PluginError> {
+    match value {
+        Scalar::Nil => Ok(Value::Null),
+        Scalar::Boolean(value) => Ok(Value::Bool(*value)),
+        Scalar::Number(value) => serde_json::Number::from_f64(*value)
+            .map(Value::Number)
+            .ok_or_else(|| {
+                PluginError::InvalidInput(format!(
+                    "{label} snapshot contains NaN or infinite number"
+                ))
+            }),
+        Scalar::Text(value) => Ok(Value::String(value.clone())),
+        Scalar::Json(value) => serde_json::from_str(value).map_err(|error| {
+            PluginError::InvalidInput(format!(
+                "{label} snapshot contains invalid JSON scalar: {error}"
+            ))
+        }),
+    }
 }
 
 fn file_from_state_context(state: Vec<DetectedChange>) -> Result<Option<File>, PluginError> {

--- a/plugins/text/tests/common/mod.rs
+++ b/plugins/text/tests/common/mod.rs
@@ -1,7 +1,11 @@
 #![allow(dead_code)]
 
 use serde::Deserialize;
-use text_plugin::{DetectedChange, File};
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+use text_plugin::{DetectedChange, File, Scalar};
+
+pub type SnapshotContent = BTreeMap<String, Scalar>;
 
 #[derive(Debug, Deserialize)]
 pub struct LineSnapshot {
@@ -21,17 +25,55 @@ pub fn file_from_bytes(data: &[u8]) -> File {
 }
 
 pub fn parse_line_snapshot(change: &DetectedChange) -> LineSnapshot {
-    let raw = change
-        .snapshot_content
-        .as_ref()
-        .expect("line snapshot should exist");
-    serde_json::from_str(raw).expect("line snapshot should parse")
+    serde_json::from_value(snapshot_value(change)).expect("line snapshot should parse")
 }
 
 pub fn parse_document_snapshot(change: &DetectedChange) -> DocumentSnapshot {
-    let raw = change
+    serde_json::from_value(snapshot_value(change)).expect("document snapshot should parse")
+}
+
+pub fn snapshot_content(value: Value) -> SnapshotContent {
+    let Value::Object(object) = value else {
+        panic!("snapshot_content must be a JSON object");
+    };
+
+    object
+        .into_iter()
+        .map(|(key, value)| (key, scalar_from_value(value)))
+        .collect()
+}
+
+fn snapshot_value(change: &DetectedChange) -> Value {
+    let snapshot_content = change
         .snapshot_content
         .as_ref()
-        .expect("document snapshot should exist");
-    serde_json::from_str(raw).expect("document snapshot should parse")
+        .expect("snapshot should exist");
+    let object = snapshot_content
+        .iter()
+        .map(|(key, value)| (key.clone(), value_from_scalar(value)))
+        .collect::<Map<_, _>>();
+    Value::Object(object)
+}
+
+fn scalar_from_value(value: Value) -> Scalar {
+    match value {
+        Value::Null => Scalar::Nil,
+        Value::Bool(value) => Scalar::Boolean(value),
+        Value::String(value) => Scalar::Text(value),
+        Value::Number(_) | Value::Array(_) | Value::Object(_) => {
+            Scalar::Json(serde_json::to_string(&value).expect("snapshot scalar should encode"))
+        }
+    }
+}
+
+fn value_from_scalar(value: &Scalar) -> Value {
+    match value {
+        Scalar::Nil => Value::Null,
+        Scalar::Boolean(value) => Value::Bool(*value),
+        Scalar::Number(value) => {
+            Value::Number(serde_json::Number::from_f64(*value).expect("finite JSON number"))
+        }
+        Scalar::Text(value) => Value::String(value.clone()),
+        Scalar::Json(value) => serde_json::from_str(value).expect("JSON scalar should parse"),
+    }
 }

--- a/plugins/text/tests/render_changes.rs
+++ b/plugins/text/tests/render_changes.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{file_from_bytes, parse_document_snapshot};
+use common::{file_from_bytes, parse_document_snapshot, snapshot_content};
 use text_plugin::{
     DOCUMENT_SCHEMA_KEY, DetectedChange, LINE_SCHEMA_KEY, PluginError, detect_changes,
     render_changes,
@@ -35,7 +35,10 @@ fn rejects_missing_document_snapshot() {
     let changes = vec![DetectedChange {
         entity_pk: vec!["line:abc:0".to_string()],
         schema_key: LINE_SCHEMA_KEY.to_string(),
-        snapshot_content: Some(r#"{"content_base64":"YQ==","ending":"\n"}"#.to_string()),
+        snapshot_content: Some(snapshot_content(serde_json::json!({
+            "content_base64": "YQ==",
+            "ending": "\n",
+        }))),
         metadata: None,
     }];
 
@@ -63,12 +66,9 @@ fn document_order_drives_output_order() {
         .expect("document row should exist");
     let mut doc = parse_document_snapshot(&changes[document_index]);
     doc.line_ids.reverse();
-    changes[document_index].snapshot_content = Some(
-        serde_json::json!({
-            "line_ids": doc.line_ids,
-        })
-        .to_string(),
-    );
+    changes[document_index].snapshot_content = Some(snapshot_content(serde_json::json!({
+        "line_ids": doc.line_ids,
+    })));
 
     let output =
         render_changes(file_from_bytes(b""), changes).expect("render_changes should succeed");


### PR DESCRIPTION
Likely cause: this branch adds a typed WIT map layer, but the engine still stores and passes snapshot content as JSON strings. So it is not replacing JSON work; it is adding JSON <-> map/scalar conversions around it.

Key spots:

- WIT changed `snapshot-content` from `json-text` to `map<string, scalar>` in [lix-plugin.wit](packages/engine/wit/lix-plugin.wit:24).
- Engine-facing types are still `String` / `Option<String>` in [wasm/mod.rs](packages/engine/src/wasm/mod.rs:13).
- The default Wasm runtime now parses state JSON into maps before calling the plugin and serializes returned maps back to JSON after the call in [default_wasm_runtime.rs](packages/rs-sdk/src/default_wasm_runtime.rs:149) and [default_wasm_runtime.rs](packages/rs-sdk/src/default_wasm_runtime.rs:270).
- CSV now builds `BTreeMap<String, Scalar>` snapshots instead of one JSON string in [plugins/csv/src/lib.rs](plugins/csv/src/lib.rs:222), then converts maps back through `serde_json::Value` when reading state in [plugins/csv/src/lib.rs](plugins/csv/src/lib.rs:243).

That maps cleanly to the bench pattern:

- `*_plugin_diff` is native CSV diff, not Wasm. Its regression points at the CSV map/scalar conversion itself: per row, `cells` is an array, so it becomes `Scalar::Json`, meaning extra serialization plus `BTreeMap` allocation.
- `*_plugin` adds Wasm component ABI cost on top of that.
- `merge_*` pays more incoming-state cost because 10k existing rows are converted from engine JSON strings into WIT maps before diffing.
- `setup_wasm` likely regresses from the Wasmtime 30 -> 45 update and enabling component model maps in [Cargo.toml](packages/rs-sdk/Cargo.toml:27), even before row-level conversion matters.

So the short version: this branch introduces a generic typed boundary, but the hot path still wants JSON on both sides. For CSV especially, `map<string, scalar>` is awkward because row snapshots contain nested arrays, so the code now does map allocation plus inner JSON strings instead of one JSON payload.

```text
e2e/csv_plugin/setup
              time:   [759.32 ms 776.39 ms 796.76 ms]
       change:
              time:   [+5.2527% +7.6879% +10.520%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/setup_inmemory
              time:   [699.57 ms 702.30 ms 705.94 ms]
       change:
              time:   [-1.9644% +1.9072% +4.6231%] (p = 0.36 > 0.05)
              No change in performance detected.
e2e/csv_plugin/setup_wasm
              time:   [653.06 ms 658.85 ms 664.65 ms]
       change:
              time:   [+3.4804% +4.9202% +6.1955%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/insert_10k
              time:   [385.09 ms 394.80 ms 404.69 ms]
       change:
              time:   [-9.7179% -4.1536% +3.4480%] (p = 0.28 > 0.05)
              No change in performance detected.
e2e/csv_plugin/insert_10k_inmemory
              time:   [143.58 ms 145.15 ms 146.68 ms]
       change:
              time:   [+1.1836% +2.7203% +4.2612%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/insert_10k_plugin
              time:   [36.157 ms 36.510 ms 36.858 ms]
       change:
              time:   [+9.7171% +11.284% +12.717%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/insert_10k_plugin_diff
              time:   [17.580 ms 20.645 ms 23.891 ms]
       change:
              time:   [+47.205% +65.833% +83.523%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/insert_10k_insert
              time:   [443.54 ms 453.76 ms 464.06 ms]
       change:
              time:   [-2.4433% +7.1571% +19.732%] (p = 0.21 > 0.05)
              No change in performance detected.
e2e/csv_plugin/insert_10k_insert_inmemory
              time:   [133.51 ms 149.20 ms 168.91 ms]
       change:
              time:   [-1.2081% +10.859% +25.999%] (p = 0.13 > 0.05)
              No change in performance detected.
e2e/csv_plugin/insert_10k_insert_state
              time:   [910.10 ms 947.53 ms 989.09 ms]
       change:
              time:   [+1.8875% +8.8406% +16.068%] (p = 0.03 < 0.05)
              Performance has regressed.
e2e/csv_plugin/insert_10k_insert_state_inmemory
              time:   [679.72 ms 687.29 ms 694.72 ms]
       change:
              time:   [+5.1454% +6.8061% +8.3217%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/merge_10k
              time:   [433.81 ms 459.82 ms 490.42 ms]
       change:
              time:   [-8.3984% +0.3912% +10.378%] (p = 0.94 > 0.05)
              No change in performance detected.
e2e/csv_plugin/merge_10k_inmemory
              time:   [243.77 ms 251.63 ms 263.32 ms]
       change:
              time:   [+3.8461% +7.3693% +12.496%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/merge_10k_plugin
              time:   [69.821 ms 71.028 ms 72.514 ms]
       change:
              time:   [+14.878% +17.454% +20.391%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/merge_10k_plugin_diff
              time:   [30.595 ms 30.861 ms 31.153 ms]
       change:
              time:   [+12.986% +15.048% +16.784%] (p = 0.00 < 0.05)
              Performance has regressed.
e2e/csv_plugin/merge_10k_insert
              time:   [267.57 ms 285.31 ms 304.70 ms]
       change:
              time:   [-17.135% -5.3700% +8.3820%] (p = 0.47 > 0.05)
              No change in performance detected.
e2e/csv_plugin/merge_10k_insert_inmemory
              time:   [136.86 ms 139.55 ms 142.73 ms]
       change:
              time:   [-2.0822% -0.1680% +2.4327%] (p = 0.89 > 0.05)
              No change in performance detected.
e2e/csv_plugin/merge_10k_insert_state
              time:   [793.29 ms 818.05 ms 842.77 ms]
       change:
              time:   [-0.2658% +4.5284% +9.5535%] (p = 0.10 > 0.05)
              No change in performance detected.
e2e/csv_plugin/merge_10k_insert_state_inmemory
              time:   [684.22 ms 733.46 ms 809.32 ms]
       change:
              time:   [+0.8499% +9.6028% +22.845%] (p = 0.08 > 0.05)
              No change in performance detected.
```