### PR TITLE
Plugins: detect reorders

### DIFF
--- a/plugins/csv/src/diff.rs
+++ b/plugins/csv/src/diff.rs
@@ -1,82 +1,17 @@
 use imara_diff::{Algorithm, Diff, InternedInput, Interner};
-use itertools::Itertools;
 use std::hash::Hash;
-use std::{cmp, iter};
+use std::iter;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum Op {
-    Equal,
-    Replace,
-    Insert,
-    Delete,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) struct OpRun {
-    pub(crate) op: Op,
-    pub(crate) len: usize,
-}
-
-#[expect(dead_code)]
-fn diff_runs_by<'a, T, U>(
-    a: &'a [T],
-    b: &'a [U],
-    eq: impl FnMut(&T, &U) -> bool + 'a,
-) -> impl Iterator<Item = OpRun> + 'a {
-    diff_by(a, b, eq)
-        .map(|op| OpRun { op, len: 1 })
-        .coalesce(|left, right| {
-            if left.op == right.op {
-                Ok(OpRun {
-                    op: left.op,
-                    len: left.len + right.len,
-                })
-            } else {
-                Err((left, right))
-            }
-        })
-}
-
-#[expect(dead_code)]
-fn diff_by<'a, T, U>(
-    a: &'a [T],
-    b: &'a [U],
-    mut eq: impl FnMut(&T, &U) -> bool + 'a,
-) -> impl Iterator<Item = Op> + 'a {
-    let prefix = a.iter().zip(b.iter()).take_while(|(a, b)| eq(a, b)).count();
-
-    let a_rest = &a[prefix..];
-    let b_rest = &b[prefix..];
-    let suffix = a_rest
-        .iter()
-        .rev()
-        .zip(b_rest.iter().rev())
-        .take_while(|(a, b)| eq(a, b))
-        .count()
-        .min(a_rest.len())
-        .min(b_rest.len());
-
-    let a_mid = a.len() - prefix - suffix;
-    let b_mid = b.len() - prefix - suffix;
-    let replace = cmp::min(a_mid, b_mid);
-
-    iter::empty()
-        .chain((0..prefix).map(|_| Op::Equal))
-        .chain(
-            a[prefix..prefix + replace]
-                .iter()
-                .zip_eq(&b[prefix..prefix + replace])
-                .map(move |(a, b)| if eq(a, b) { Op::Equal } else { Op::Replace }),
-        )
-        .chain((replace..a_mid).map(|_| Op::Delete))
-        .chain((replace..b_mid).map(|_| Op::Insert))
-        .chain((0..suffix).map(|_| Op::Equal))
+pub(crate) enum DiffRun {
+    Equal { len: usize },
+    Replace { old: usize, new: usize },
 }
 
 pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
     a: impl ExactSizeIterator<Item = &'a T>,
     b: impl ExactSizeIterator<Item = &'a T>,
-) -> impl Iterator<Item = OpRun> {
+) -> impl Iterator<Item = DiffRun> {
     let before_capacity = a.len();
     let after_capacity = b.len();
     let mut input = InternedInput {
@@ -98,19 +33,8 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
     let after_len = u32::try_from(input.after.len()).unwrap();
     let mut before_pos = 0u32;
     let mut after_pos = 0u32;
-    let mut pending = [None; 3];
-    let mut pending_index = 0usize;
-    let mut pending_len = 0usize;
 
     iter::from_fn(move || {
-        if pending_index < pending_len {
-            let run = pending[pending_index];
-            pending_index += 1;
-            return run;
-        }
-        pending_index = 0;
-        pending_len = 0;
-
         let equal_start = before_pos;
         while before_pos < before_len
             && after_pos < after_len
@@ -122,8 +46,7 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
         }
         let equal_len = before_pos - equal_start;
         if equal_len != 0 {
-            return Some(OpRun {
-                op: Op::Equal,
+            return Some(DiffRun::Equal {
                 len: usize::try_from(equal_len).unwrap(),
             });
         }
@@ -140,30 +63,11 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
         }
         let after_run_len = after_pos - after_start;
 
-        let replace_len = before_run_len.min(after_run_len);
-        for run in [
-            OpRun {
-                op: Op::Replace,
-                len: usize::try_from(replace_len).unwrap(),
-            },
-            OpRun {
-                op: Op::Delete,
-                len: usize::try_from(before_run_len - replace_len).unwrap(),
-            },
-            OpRun {
-                op: Op::Insert,
-                len: usize::try_from(after_run_len - replace_len).unwrap(),
-            },
-        ] {
-            if run.len != 0 {
-                pending[pending_len] = Some(run);
-                pending_len += 1;
-            }
-        }
-
-        if pending_len != 0 {
-            pending_index = 1;
-            return pending[0].take();
+        if before_run_len != 0 || after_run_len != 0 {
+            return Some(DiffRun::Replace {
+                old: usize::try_from(before_run_len).unwrap(),
+                new: usize::try_from(after_run_len).unwrap(),
+            });
         }
 
         debug_assert_eq!(before_pos, before_len);

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -19,8 +19,9 @@ use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use itertools::Itertools;
 use lix_order_key::OrderKey;
 use serde_json::Value;
-use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, HashMap};
+use std::ops::Range;
 use std::str;
 use uuid::Uuid;
 
@@ -55,6 +56,12 @@ struct RowSnapshot {
     cells: Vec<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReplaceRun {
+    old: Range<usize>,
+    new: Range<usize>,
+}
+
 impl Plugin for CsvPlugin {
     fn detect_changes(
         state: Vec<EntityState>,
@@ -77,62 +84,23 @@ fn detect_changes_for_rows(
     after_dialect: CsvDialect,
 ) -> Result<Vec<DetectedChange>, PluginError> {
     let base = before.to_rows();
-    let diff_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
+    let (old_for_new, new_for_old) = match_diff_rows(
+        &base,
+        file_rows,
+        imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter()),
+    );
+    let inserted_ids = inserted_row_ids(&old_for_new);
     let mut changes = Vec::new();
-    let mut base_index = 0;
-    let mut file_index = 0;
-    let mut previous_order_key = None::<OrderKey>;
 
-    for run in diff_runs {
-        match run {
-            DiffRun::Equal { len } => {
-                for _ in 0..len {
-                    previous_order_key = Some(base[base_index].order_key.clone());
-                    base_index += 1;
-                    file_index += 1;
-                }
-            }
-            DiffRun::Replace { old, new } => {
-                let update_len = old.min(new);
-
-                for _ in 0..update_len {
-                    let row = &base[base_index];
-                    changes.push(row_upsert_change(
-                        &row.id,
-                        &row.order_key,
-                        &file_rows[file_index],
-                    )?);
-                    previous_order_key = Some(row.order_key.clone());
-                    base_index += 1;
-                    file_index += 1;
-                }
-
-                for _ in 0..old - update_len {
-                    changes.push(DetectedChange {
-                        entity_pk: vec![base[base_index].id.clone()],
-                        schema_key: ROW_SCHEMA_KEY.to_string(),
-                        snapshot_content: None,
-                        metadata: None,
-                    });
-                    base_index += 1;
-                }
-
-                let insert_len = new - update_len;
-                if insert_len != 0 {
-                    let next_order_key = base.get(base_index).map(|row| &row.order_key);
-                    let ids = new_ids(insert_len);
-                    let order_keys =
-                        OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, &ids)
-                            .map_err(PluginError::Internal)?;
-                    for (id, order_key) in ids.into_iter().zip(order_keys) {
-                        changes.push(row_upsert_change(&id, &order_key, &file_rows[file_index])?);
-                        previous_order_key = Some(order_key.clone());
-                        file_index += 1;
-                    }
-                }
-            }
-        }
+    for base_index in (0..base.len()).filter(|index| new_for_old[*index].is_none()) {
+        changes.push(DetectedChange {
+            entity_pk: vec![base[base_index].id.clone()],
+            schema_key: ROW_SCHEMA_KEY.to_string(),
+            snapshot_content: None,
+            metadata: None,
+        });
     }
+    detect_row_upsert_changes(&base, file_rows, &old_for_new, &inserted_ids, &mut changes)?;
 
     if before.dialect != after_dialect
         || (!before.table_present
@@ -144,8 +112,259 @@ fn detect_changes_for_rows(
     Ok(changes)
 }
 
-fn new_ids(count: usize) -> Vec<String> {
-    (0..count).map(|_| Uuid::now_v7().to_string()).collect()
+fn match_diff_rows(
+    base: &[Row],
+    file_rows: &[Vec<String>],
+    diff_runs: impl IntoIterator<Item = DiffRun>,
+) -> (Vec<Option<usize>>, Vec<Option<usize>>) {
+    let mut old_for_new = vec![None; file_rows.len()];
+    let mut new_for_old = vec![None; base.len()];
+    let mut replace_runs = Vec::new();
+    let mut base_index = 0usize;
+    let mut file_index = 0usize;
+
+    for run in diff_runs {
+        match run {
+            DiffRun::Equal { len } => {
+                for (old_index, new_index) in
+                    (base_index..base_index + len).zip(file_index..file_index + len)
+                {
+                    old_for_new[new_index] = Some(old_index);
+                    new_for_old[old_index] = Some(new_index);
+                }
+                base_index += len;
+                file_index += len;
+            }
+            DiffRun::Replace { old, new } => {
+                replace_runs.push(ReplaceRun {
+                    old: base_index..base_index + old,
+                    new: file_index..file_index + new,
+                });
+                base_index += old;
+                file_index += new;
+            }
+        }
+    }
+
+    let old_replace_len = replace_runs.iter().map(|run| run.old.len()).sum();
+    let mut old_rows_by_cells = HashMap::<&[String], Vec<usize>>::with_capacity(old_replace_len);
+    for run in replace_runs.iter().rev() {
+        for old_index in run.old.clone().rev() {
+            old_rows_by_cells
+                .entry(base[old_index].cells.as_slice())
+                .or_default()
+                .push(old_index);
+        }
+    }
+
+    for run in &replace_runs {
+        for new_index in run.new.clone() {
+            let Some(old_indices) = old_rows_by_cells.get_mut(file_rows[new_index].as_slice())
+            else {
+                continue;
+            };
+            let Some(old_index) = old_indices.pop() else {
+                continue;
+            };
+            old_for_new[new_index] = Some(old_index);
+            new_for_old[old_index] = Some(new_index);
+        }
+    }
+
+    for run in &replace_runs {
+        let mut old_index = run.old.start;
+        let mut new_index = run.new.start;
+        loop {
+            while old_index < run.old.end && new_for_old[old_index].is_some() {
+                old_index += 1;
+            }
+            while new_index < run.new.end && old_for_new[new_index].is_some() {
+                new_index += 1;
+            }
+            if old_index == run.old.end || new_index == run.new.end {
+                break;
+            }
+            old_for_new[new_index] = Some(old_index);
+            new_for_old[old_index] = Some(new_index);
+            old_index += 1;
+            new_index += 1;
+        }
+    }
+
+    (old_for_new, new_for_old)
+}
+
+fn inserted_row_ids(old_for_new: &[Option<usize>]) -> Vec<Option<String>> {
+    old_for_new
+        .iter()
+        .map(|old_index| match old_index {
+            Some(_) => None,
+            None => Some(Uuid::now_v7().to_string()),
+        })
+        .collect()
+}
+
+fn row_id_for_new<'a>(
+    base: &'a [Row],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &'a [Option<String>],
+    new_index: usize,
+) -> &'a str {
+    match old_for_new[new_index] {
+        Some(old_index) => &base[old_index].id,
+        None => inserted_ids[new_index]
+            .as_deref()
+            .expect("inserted row id should exist"),
+    }
+}
+
+fn detect_row_upsert_changes(
+    base: &[Row],
+    file_rows: &[Vec<String>],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &[Option<String>],
+    changes: &mut Vec<DetectedChange>,
+) -> Result<(), PluginError> {
+    let keep_order_key = kept_order_key_indices(base, old_for_new);
+    let mut previous_order_key = None::<OrderKey>;
+    let mut pending = Vec::new();
+
+    for new_index in 0..file_rows.len() {
+        if keep_order_key[new_index] {
+            let old_index =
+                old_for_new[new_index].expect("kept order key should belong to an existing row");
+            let order_key = &base[old_index].order_key;
+            flush_generated_row_upserts(
+                &mut pending,
+                &mut previous_order_key,
+                Some(order_key),
+                base,
+                file_rows,
+                old_for_new,
+                inserted_ids,
+                changes,
+            )?;
+            if base[old_index].cells.as_slice() != file_rows[new_index].as_slice() {
+                changes.push(row_upsert_change(
+                    row_id_for_new(base, old_for_new, inserted_ids, new_index),
+                    order_key,
+                    &file_rows[new_index],
+                )?);
+            }
+            previous_order_key = Some(order_key.clone());
+        } else {
+            pending.push(new_index);
+        }
+    }
+
+    flush_generated_row_upserts(
+        &mut pending,
+        &mut previous_order_key,
+        None,
+        base,
+        file_rows,
+        old_for_new,
+        inserted_ids,
+        changes,
+    )
+}
+
+fn kept_order_key_indices(base: &[Row], old_for_new: &[Option<usize>]) -> Vec<bool> {
+    let mut keep = vec![false; old_for_new.len()];
+    if order_keys_are_strictly_increasing(base, old_for_new) {
+        for (new_index, old_index) in old_for_new.iter().enumerate() {
+            keep[new_index] = old_index.is_some();
+        }
+        return keep;
+    }
+
+    let mut pile_tops = Vec::<usize>::new();
+    let mut predecessors = vec![None; old_for_new.len()];
+
+    for (new_index, old_index) in old_for_new.iter().copied().enumerate() {
+        let Some(old_index) = old_index else {
+            continue;
+        };
+        let order_key = &base[old_index].order_key;
+        let pile = pile_tops
+            .partition_point(|top_index| old_order_key(base, old_for_new, *top_index) < order_key);
+        if pile != 0 {
+            predecessors[new_index] = Some(pile_tops[pile - 1]);
+        }
+        if pile == pile_tops.len() {
+            pile_tops.push(new_index);
+        } else if old_order_key(base, old_for_new, pile_tops[pile]) > order_key {
+            pile_tops[pile] = new_index;
+        }
+    }
+
+    let Some(mut current) = pile_tops.last().copied() else {
+        return keep;
+    };
+    loop {
+        keep[current] = true;
+        let Some(previous) = predecessors[current] else {
+            break;
+        };
+        current = previous;
+    }
+    keep
+}
+
+fn order_keys_are_strictly_increasing(base: &[Row], old_for_new: &[Option<usize>]) -> bool {
+    let mut previous_order_key = None::<&OrderKey>;
+
+    for old_index in old_for_new.iter().copied().flatten() {
+        let order_key = &base[old_index].order_key;
+        if previous_order_key.is_some_and(|previous| previous >= order_key) {
+            return false;
+        }
+        previous_order_key = Some(order_key);
+    }
+
+    true
+}
+
+fn old_order_key<'a>(
+    base: &'a [Row],
+    old_for_new: &[Option<usize>],
+    new_index: usize,
+) -> &'a OrderKey {
+    let old_index = old_for_new[new_index].expect("old order key should belong to existing row");
+    &base[old_index].order_key
+}
+
+fn flush_generated_row_upserts(
+    pending: &mut Vec<usize>,
+    previous_order_key: &mut Option<OrderKey>,
+    next_order_key: Option<&OrderKey>,
+    base: &[Row],
+    file_rows: &[Vec<String>],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &[Option<String>],
+    changes: &mut Vec<DetectedChange>,
+) -> Result<(), PluginError> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let ids = pending
+        .iter()
+        .map(|new_index| row_id_for_new(base, old_for_new, inserted_ids, *new_index).to_string())
+        .collect_vec();
+    let order_keys = OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, &ids)
+        .map_err(PluginError::Internal)?;
+
+    for (new_index, order_key) in pending.drain(..).zip(order_keys) {
+        changes.push(row_upsert_change(
+            row_id_for_new(base, old_for_new, inserted_ids, new_index),
+            &order_key,
+            &file_rows[new_index],
+        )?);
+        *previous_order_key = Some(order_key);
+    }
+
+    Ok(())
 }
 
 fn single_entity_pk(mut entity_pk: Vec<String>) -> Result<String, PluginError> {

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -348,12 +348,9 @@ fn flush_generated_row_upserts(
         return Ok(());
     }
 
-    let ids = pending
-        .iter()
-        .map(|new_index| row_id_for_new(base, old_for_new, inserted_ids, *new_index).to_string())
-        .collect_vec();
-    let order_keys = OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, &ids)
-        .map_err(PluginError::Internal)?;
+    let order_keys =
+        OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, pending.len())
+            .map_err(PluginError::Internal)?;
 
     for (new_index, order_key) in pending.drain(..).zip(order_keys) {
         changes.push(row_upsert_change(
@@ -605,7 +602,7 @@ mod tests {
         let ids = (0..rows.len())
             .map(|offset| format!("row:{offset}"))
             .collect::<Vec<_>>();
-        let order_keys = OrderKey::evenly_between(None, None, &ids).unwrap();
+        let order_keys = OrderKey::evenly_between(None, None, ids.len()).unwrap();
         let rows_by_id = rows
             .into_iter()
             .zip(ids.into_iter().zip(order_keys))

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -77,15 +77,6 @@ fn detect_changes_for_rows(
     after_dialect: CsvDialect,
 ) -> Result<Vec<DetectedChange>, PluginError> {
     let base = before.to_rows();
-    if has_duplicate_order_keys(&base) {
-        return detect_changes_for_rows_with_reindexed_order(
-            before,
-            file_rows,
-            after_dialect,
-            &base,
-        );
-    }
-
     let diff_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
     let mut changes = Vec::new();
     let mut base_index = 0;
@@ -151,106 +142,6 @@ fn detect_changes_for_rows(
     }
 
     Ok(changes)
-}
-
-#[derive(Debug)]
-struct PlannedRow {
-    id: String,
-    cells: Vec<String>,
-}
-
-fn detect_changes_for_rows_with_reindexed_order(
-    before: &Projection,
-    file_rows: &[Vec<String>],
-    after_dialect: CsvDialect,
-    base: &[Row],
-) -> Result<Vec<DetectedChange>, PluginError> {
-    let planned_rows = plan_rows(base, file_rows);
-    let planned_ids = planned_rows
-        .iter()
-        .map(|row| row.id.clone())
-        .collect::<Vec<_>>();
-    let order_keys =
-        OrderKey::evenly_between(None, None, &planned_ids).map_err(PluginError::Internal)?;
-    let planned_id_set = planned_ids
-        .iter()
-        .collect::<std::collections::BTreeSet<_>>();
-    let mut changes = Vec::new();
-
-    for id in before.rows_by_id.keys() {
-        if !planned_id_set.contains(id) {
-            changes.push(DetectedChange {
-                entity_pk: vec![id.clone()],
-                schema_key: ROW_SCHEMA_KEY.to_string(),
-                snapshot_content: None,
-                metadata: None,
-            });
-        }
-    }
-
-    for (row, order_key) in planned_rows.iter().zip(order_keys.iter()) {
-        changes.push(row_upsert_change(&row.id, order_key, &row.cells)?);
-    }
-
-    if before.dialect != after_dialect
-        || (!before.table_present
-            && (!file_rows.is_empty() || after_dialect != CsvDialect::default()))
-    {
-        changes.push(table_upsert_change(after_dialect)?);
-    }
-
-    Ok(changes)
-}
-
-fn plan_rows(base: &[Row], file_rows: &[Vec<String>]) -> Vec<PlannedRow> {
-    let diff_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
-    let mut planned_rows = Vec::with_capacity(file_rows.len());
-    let mut base_index = 0;
-    let mut file_index = 0;
-
-    for run in diff_runs {
-        match run {
-            DiffRun::Equal { len } => {
-                for _ in 0..len {
-                    planned_rows.push(PlannedRow {
-                        id: base[base_index].id.clone(),
-                        cells: file_rows[file_index].clone(),
-                    });
-                    base_index += 1;
-                    file_index += 1;
-                }
-            }
-            DiffRun::Replace { old, new } => {
-                let update_len = old.min(new);
-
-                for _ in 0..update_len {
-                    planned_rows.push(PlannedRow {
-                        id: base[base_index].id.clone(),
-                        cells: file_rows[file_index].clone(),
-                    });
-                    base_index += 1;
-                    file_index += 1;
-                }
-
-                base_index += old - update_len;
-
-                for id in new_ids(new - update_len) {
-                    planned_rows.push(PlannedRow {
-                        id,
-                        cells: file_rows[file_index].clone(),
-                    });
-                    file_index += 1;
-                }
-            }
-        }
-    }
-
-    planned_rows
-}
-
-fn has_duplicate_order_keys(rows: &[Row]) -> bool {
-    rows.windows(2)
-        .any(|pair| pair[0].order_key == pair[1].order_key)
 }
 
 fn new_ids(count: usize) -> Vec<String> {

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -13,7 +13,7 @@ pub mod schemas;
 use crate::csv::{
     CsvDialect, parse_file, parse_table_snapshot, render_projection, table_upsert_change,
 };
-use crate::diff::{Op, imara_diff_runs};
+use crate::diff::{DiffRun, imara_diff_runs};
 pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use itertools::Itertools;
@@ -86,23 +86,25 @@ fn detect_changes_for_rows(
         );
     }
 
-    let op_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
+    let diff_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
     let mut changes = Vec::new();
     let mut base_index = 0;
     let mut file_index = 0;
     let mut previous_order_key = None::<OrderKey>;
 
-    for run in op_runs {
-        match run.op {
-            Op::Equal => {
-                for _ in 0..run.len {
+    for run in diff_runs {
+        match run {
+            DiffRun::Equal { len } => {
+                for _ in 0..len {
                     previous_order_key = Some(base[base_index].order_key.clone());
                     base_index += 1;
                     file_index += 1;
                 }
             }
-            Op::Replace => {
-                for _ in 0..run.len {
+            DiffRun::Replace { old, new } => {
+                let update_len = old.min(new);
+
+                for _ in 0..update_len {
                     let row = &base[base_index];
                     changes.push(row_upsert_change(
                         &row.id,
@@ -113,9 +115,8 @@ fn detect_changes_for_rows(
                     base_index += 1;
                     file_index += 1;
                 }
-            }
-            Op::Delete => {
-                for _ in 0..run.len {
+
+                for _ in 0..old - update_len {
                     changes.push(DetectedChange {
                         entity_pk: vec![base[base_index].id.clone()],
                         schema_key: ROW_SCHEMA_KEY.to_string(),
@@ -124,17 +125,19 @@ fn detect_changes_for_rows(
                     });
                     base_index += 1;
                 }
-            }
-            Op::Insert => {
-                let next_order_key = base.get(base_index).map(|row| &row.order_key);
-                let ids = new_ids(run.len);
-                let order_keys =
-                    OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, &ids)
-                        .map_err(PluginError::Internal)?;
-                for (id, order_key) in ids.into_iter().zip(order_keys) {
-                    changes.push(row_upsert_change(&id, &order_key, &file_rows[file_index])?);
-                    previous_order_key = Some(order_key.clone());
-                    file_index += 1;
+
+                let insert_len = new - update_len;
+                if insert_len != 0 {
+                    let next_order_key = base.get(base_index).map(|row| &row.order_key);
+                    let ids = new_ids(insert_len);
+                    let order_keys =
+                        OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, &ids)
+                            .map_err(PluginError::Internal)?;
+                    for (id, order_key) in ids.into_iter().zip(order_keys) {
+                        changes.push(row_upsert_change(&id, &order_key, &file_rows[file_index])?);
+                        previous_order_key = Some(order_key.clone());
+                        file_index += 1;
+                    }
                 }
             }
         }
@@ -200,15 +203,15 @@ fn detect_changes_for_rows_with_reindexed_order(
 }
 
 fn plan_rows(base: &[Row], file_rows: &[Vec<String>]) -> Vec<PlannedRow> {
-    let op_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
+    let diff_runs = imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter());
     let mut planned_rows = Vec::with_capacity(file_rows.len());
     let mut base_index = 0;
     let mut file_index = 0;
 
-    for run in op_runs {
-        match run.op {
-            Op::Equal | Op::Replace => {
-                for _ in 0..run.len {
+    for run in diff_runs {
+        match run {
+            DiffRun::Equal { len } => {
+                for _ in 0..len {
                     planned_rows.push(PlannedRow {
                         id: base[base_index].id.clone(),
                         cells: file_rows[file_index].clone(),
@@ -217,11 +220,21 @@ fn plan_rows(base: &[Row], file_rows: &[Vec<String>]) -> Vec<PlannedRow> {
                     file_index += 1;
                 }
             }
-            Op::Delete => {
-                base_index += run.len;
-            }
-            Op::Insert => {
-                for id in new_ids(run.len) {
+            DiffRun::Replace { old, new } => {
+                let update_len = old.min(new);
+
+                for _ in 0..update_len {
+                    planned_rows.push(PlannedRow {
+                        id: base[base_index].id.clone(),
+                        cells: file_rows[file_index].clone(),
+                    });
+                    base_index += 1;
+                    file_index += 1;
+                }
+
+                base_index += old - update_len;
+
+                for id in new_ids(new - update_len) {
                     planned_rows.push(PlannedRow {
                         id,
                         cells: file_rows[file_index].clone(),

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -89,7 +89,13 @@ fn detect_changes_for_rows(
         file_rows,
         imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter()),
     );
-    let inserted_ids = inserted_row_ids(&old_for_new);
+    let inserted_ids = old_for_new
+        .iter()
+        .map(|old_index| match old_index {
+            Some(_) => None,
+            None => Some(Uuid::now_v7().to_string()),
+        })
+        .collect::<Vec<_>>();
     let mut changes = Vec::new();
 
     for base_index in (0..base.len()).filter(|index| new_for_old[*index].is_none()) {
@@ -194,16 +200,6 @@ fn match_diff_rows(
     (old_for_new, new_for_old)
 }
 
-fn inserted_row_ids(old_for_new: &[Option<usize>]) -> Vec<Option<String>> {
-    old_for_new
-        .iter()
-        .map(|old_index| match old_index {
-            Some(_) => None,
-            None => Some(Uuid::now_v7().to_string()),
-        })
-        .collect()
-}
-
 fn row_id_for_new<'a>(
     base: &'a [Row],
     old_for_new: &[Option<usize>],
@@ -271,7 +267,13 @@ fn detect_row_upsert_changes(
 
 fn kept_order_key_indices(base: &[Row], old_for_new: &[Option<usize>]) -> Vec<bool> {
     let mut keep = vec![false; old_for_new.len()];
-    if order_keys_are_strictly_increasing(base, old_for_new) {
+    if old_for_new
+        .iter()
+        .copied()
+        .flatten()
+        .map(|old_index| &base[old_index].order_key)
+        .is_sorted_by(|previous, current| previous < current)
+    {
         for (new_index, old_index) in old_for_new.iter().enumerate() {
             keep[new_index] = old_index.is_some();
         }
@@ -309,20 +311,6 @@ fn kept_order_key_indices(base: &[Row], old_for_new: &[Option<usize>]) -> Vec<bo
         current = previous;
     }
     keep
-}
-
-fn order_keys_are_strictly_increasing(base: &[Row], old_for_new: &[Option<usize>]) -> bool {
-    let mut previous_order_key = None::<&OrderKey>;
-
-    for old_index in old_for_new.iter().copied().flatten() {
-        let order_key = &base[old_index].order_key;
-        if previous_order_key.is_some_and(|previous| previous >= order_key) {
-            return false;
-        }
-        previous_order_key = Some(order_key);
-    }
-
-    true
 }
 
 fn old_order_key<'a>(

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -569,6 +569,60 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fuzz_detect_changes_reorders_rows_without_changing_ids() {
+        let mut rng = SmallRng::seed_from_u64(1);
+
+        for _ in 0..100_000 {
+            let base_rows = random_csv(&mut rng);
+            let before = projection_from_rows(base_rows.clone());
+            let mut reordered_rows = base_rows.clone();
+            shuffle(&mut reordered_rows, &mut rng);
+
+            let changes =
+                detect_changes_for_rows(&before, &reordered_rows, CsvDialect::default()).unwrap();
+
+            for change in &changes {
+                assert_eq!(
+                    change.schema_key, ROW_SCHEMA_KEY,
+                    "reordering rows should not change the table snapshot"
+                );
+
+                let entity_pk = single_entity_pk(change.entity_pk.clone()).unwrap();
+                let before_row = before
+                    .rows_by_id
+                    .get(&entity_pk)
+                    .expect("reordering rows should only update existing row ids");
+                let snapshot_content = change
+                    .snapshot_content
+                    .as_deref()
+                    .expect("reordering rows should not delete existing row entities");
+                let after_row = parse_row_snapshot(snapshot_content, &entity_pk).unwrap();
+
+                assert_eq!(
+                    after_row.cells, before_row.cells,
+                    "reordering rows should only update order keys"
+                );
+                assert_ne!(
+                    after_row.order_key, before_row.order_key,
+                    "reordering rows should not emit unchanged row snapshots"
+                );
+            }
+
+            let mut applied = before;
+            for change in changes {
+                apply_entity_change(&mut applied, change).unwrap();
+            }
+
+            let applied_rows = applied
+                .to_rows()
+                .into_iter()
+                .map(|row| row.cells)
+                .collect::<Vec<_>>();
+            assert_eq!(applied_rows, reordered_rows);
+        }
+    }
+
     fn random_csv(rng: &mut (impl Rng + ?Sized)) -> Vec<Vec<String>> {
         let random_cell_alphabet_len: u8 = rng.random_range(1..=6);
         let width = rng.random_range(1..=10);
@@ -584,6 +638,12 @@ mod tests {
                     .collect()
             })
             .collect()
+    }
+
+    fn shuffle<T>(items: &mut [T], rng: &mut (impl Rng + ?Sized)) {
+        for index in (1..items.len()).rev() {
+            items.swap(index, rng.random_range(0..=index));
+        }
     }
 
     fn projection_from_rows(rows: Vec<Vec<String>>) -> Projection {

--- a/plugins/csv/tests/roundtrip.rs
+++ b/plugins/csv/tests/roundtrip.rs
@@ -128,6 +128,27 @@ fn row_order_keys_by_first_cell(active_state: &[EntityState]) -> BTreeMap<String
         .collect()
 }
 
+fn row_ids_by_first_cell(active_state: &[EntityState]) -> BTreeMap<String, String> {
+    active_state
+        .iter()
+        .filter(|row| row.schema_key == ROW_SCHEMA_KEY)
+        .map(|row| {
+            let value = active_state_snapshot_value(row);
+            let first_cell = value
+                .get("cells")
+                .and_then(Value::as_array)
+                .and_then(|cells| cells.first())
+                .and_then(Value::as_str)
+                .expect("row first cell should exist")
+                .to_string();
+            let [entity_pk] = row.entity_pk.as_slice() else {
+                panic!("row entity_pk should have one component");
+            };
+            (first_cell, entity_pk.clone())
+        })
+        .collect()
+}
+
 fn csv_active_state_with_row_order_keys(rows: &[(&str, &str, &str)]) -> Vec<EntityState> {
     let mut state = vec![EntityState {
         entity_pk: vec![ROOT_ENTITY_PK.to_string()],
@@ -301,6 +322,32 @@ fn applies_delta_to_existing_tsv() {
     let output = render_active_state(apply_changes_to_active_state(before_state, changes))
         .expect("render should succeed");
 
+    assert_eq!(output, after_bytes);
+}
+
+#[test]
+fn detects_sorted_rows_as_order_key_changes() {
+    let before_bytes = b"a\nb\nc\n";
+    let after_bytes = b"c\nb\na\n";
+    let before_state = active_state_from_file(file_from_bytes(before_bytes));
+    let before_ids = row_ids_by_first_cell(&before_state);
+
+    let changes = CsvPlugin::detect_changes(before_state.clone(), file_from_bytes(after_bytes))
+        .expect("detect_changes should succeed");
+
+    assert!(
+        changes
+            .iter()
+            .filter(|change| change.schema_key == ROW_SCHEMA_KEY)
+            .all(|change| change.snapshot_content.is_some()),
+        "sorting rows should not delete existing row entities"
+    );
+
+    let active_state = apply_changes_to_active_state(before_state, changes);
+    let after_ids = row_ids_by_first_cell(&active_state);
+    let output = render_active_state(active_state).expect("render should succeed");
+
+    assert_eq!(after_ids, before_ids);
     assert_eq!(output, after_bytes);
 }
 

--- a/plugins/markdown/src/diff.rs
+++ b/plugins/markdown/src/diff.rs
@@ -3,23 +3,15 @@ use std::hash::Hash;
 use std::iter;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum Op {
-    Equal,
-    Replace,
-    Insert,
-    Delete,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) struct OpRun {
-    pub(crate) op: Op,
-    pub(crate) len: usize,
+pub(crate) enum DiffRun {
+    Equal { len: usize },
+    Replace { old: usize, new: usize },
 }
 
 pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
     a: impl ExactSizeIterator<Item = &'a T>,
     b: impl ExactSizeIterator<Item = &'a T>,
-) -> impl Iterator<Item = OpRun> {
+) -> impl Iterator<Item = DiffRun> {
     let before_capacity = a.len();
     let after_capacity = b.len();
     let mut input = InternedInput {
@@ -41,19 +33,7 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
     let after_len = u32::try_from(input.after.len()).unwrap();
     let mut before_pos = 0u32;
     let mut after_pos = 0u32;
-    let mut pending = [None; 3];
-    let mut pending_index = 0usize;
-    let mut pending_len = 0usize;
-
     iter::from_fn(move || {
-        if pending_index < pending_len {
-            let run = pending[pending_index];
-            pending_index += 1;
-            return run;
-        }
-        pending_index = 0;
-        pending_len = 0;
-
         let equal_start = before_pos;
         while before_pos < before_len
             && after_pos < after_len
@@ -65,8 +45,7 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
         }
         let equal_len = before_pos - equal_start;
         if equal_len != 0 {
-            return Some(OpRun {
-                op: Op::Equal,
+            return Some(DiffRun::Equal {
                 len: usize::try_from(equal_len).unwrap(),
             });
         }
@@ -83,30 +62,11 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
         }
         let after_run_len = after_pos - after_start;
 
-        let replace_len = before_run_len.min(after_run_len);
-        for run in [
-            OpRun {
-                op: Op::Replace,
-                len: usize::try_from(replace_len).unwrap(),
-            },
-            OpRun {
-                op: Op::Delete,
-                len: usize::try_from(before_run_len - replace_len).unwrap(),
-            },
-            OpRun {
-                op: Op::Insert,
-                len: usize::try_from(after_run_len - replace_len).unwrap(),
-            },
-        ] {
-            if run.len != 0 {
-                pending[pending_len] = Some(run);
-                pending_len += 1;
-            }
-        }
-
-        if pending_len != 0 {
-            pending_index = 1;
-            return pending[0].take();
+        if before_run_len != 0 || after_run_len != 0 {
+            return Some(DiffRun::Replace {
+                old: usize::try_from(before_run_len).unwrap(),
+                new: usize::try_from(after_run_len).unwrap(),
+            });
         }
 
         debug_assert_eq!(before_pos, before_len);

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -10,7 +10,7 @@ mod diff;
 mod markdown_file;
 pub mod schemas;
 
-use crate::diff::{Op, imara_diff_runs};
+use crate::diff::{DiffRun, imara_diff_runs};
 pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use crate::markdown_file::{
@@ -19,8 +19,9 @@ use crate::markdown_file::{
 };
 use lix_order_key::OrderKey;
 use serde_json::Value;
-use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, HashMap};
+use std::ops::Range;
 use std::str;
 use uuid::Uuid;
 
@@ -55,6 +56,12 @@ struct BlockSnapshot {
     block: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReplaceRun {
+    old: Range<usize>,
+    new: Range<usize>,
+}
+
 impl Plugin for MarkdownPlugin {
     fn detect_changes(
         state: Vec<EntityState>,
@@ -80,63 +87,29 @@ fn detect_changes_for_markdown(
         return detect_changes_for_markdown_with_reindexed_order(before, after, &base);
     }
 
-    let op_runs = imara_diff_runs(base.iter().map(|block| &block.block), after.blocks.iter());
+    let (old_for_new, new_for_old) = match_diff_blocks(
+        &base,
+        &after.blocks,
+        imara_diff_runs(base.iter().map(|block| &block.block), after.blocks.iter()),
+    );
+    let inserted_ids = inserted_block_ids(&old_for_new);
     let mut changes = Vec::new();
-    let mut base_index = 0;
-    let mut file_index = 0;
-    let mut previous_order_key = None::<OrderKey>;
 
-    for run in op_runs {
-        match run.op {
-            Op::Equal => {
-                for _ in 0..run.len {
-                    previous_order_key = Some(base[base_index].order_key.clone());
-                    base_index += 1;
-                    file_index += 1;
-                }
-            }
-            Op::Replace => {
-                for _ in 0..run.len {
-                    let block = &base[base_index];
-                    changes.push(block_upsert_change(
-                        &block.id,
-                        &block.order_key,
-                        &after.blocks[file_index],
-                    )?);
-                    previous_order_key = Some(block.order_key.clone());
-                    base_index += 1;
-                    file_index += 1;
-                }
-            }
-            Op::Delete => {
-                for _ in 0..run.len {
-                    changes.push(DetectedChange {
-                        entity_pk: vec![base[base_index].id.clone()],
-                        schema_key: BLOCK_SCHEMA_KEY.to_string(),
-                        snapshot_content: None,
-                        metadata: None,
-                    });
-                    base_index += 1;
-                }
-            }
-            Op::Insert => {
-                let next_order_key = base.get(base_index).map(|block| &block.order_key);
-                let ids = new_ids(run.len);
-                let order_keys =
-                    OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, run.len)
-                        .map_err(PluginError::Internal)?;
-                for (id, order_key) in ids.into_iter().zip(order_keys) {
-                    changes.push(block_upsert_change(
-                        &id,
-                        &order_key,
-                        &after.blocks[file_index],
-                    )?);
-                    previous_order_key = Some(order_key.clone());
-                    file_index += 1;
-                }
-            }
-        }
+    for base_index in (0..base.len()).filter(|index| new_for_old[*index].is_none()) {
+        changes.push(DetectedChange {
+            entity_pk: vec![base[base_index].id.clone()],
+            schema_key: BLOCK_SCHEMA_KEY.to_string(),
+            snapshot_content: None,
+            metadata: None,
+        });
     }
+    detect_block_upsert_changes(
+        &base,
+        &after.blocks,
+        &old_for_new,
+        &inserted_ids,
+        &mut changes,
+    )?;
 
     if !before.document_present || before.document != after.document {
         changes.push(document_upsert_change(after.document)?);
@@ -145,21 +118,19 @@ fn detect_changes_for_markdown(
     Ok(changes)
 }
 
-#[derive(Debug)]
-struct PlannedBlock {
-    id: String,
-    block: String,
-}
-
 fn detect_changes_for_markdown_with_reindexed_order(
     before: &Projection,
     after: &ParsedMarkdown,
     base: &[Block],
 ) -> Result<Vec<DetectedChange>, PluginError> {
-    let planned_blocks = plan_markdown_blocks(base, after);
-    let planned_ids = planned_blocks
-        .iter()
-        .map(|block| block.id.clone())
+    let (old_for_new, new_for_old) = match_diff_blocks(
+        base,
+        &after.blocks,
+        imara_diff_runs(base.iter().map(|block| &block.block), after.blocks.iter()),
+    );
+    let inserted_ids = inserted_block_ids(&old_for_new);
+    let planned_ids = (0..after.blocks.len())
+        .map(|new_index| block_id_for_new(base, &old_for_new, &inserted_ids, new_index).to_string())
         .collect::<Vec<_>>();
     let order_keys =
         OrderKey::evenly_between(None, None, planned_ids.len()).map_err(PluginError::Internal)?;
@@ -168,7 +139,8 @@ fn detect_changes_for_markdown_with_reindexed_order(
         .collect::<std::collections::BTreeSet<_>>();
     let mut changes = Vec::new();
 
-    for id in before.blocks_by_id.keys() {
+    for base_index in (0..base.len()).filter(|index| new_for_old[*index].is_none()) {
+        let id = &base[base_index].id;
         if !planned_id_set.contains(id) {
             changes.push(DetectedChange {
                 entity_pk: vec![id.clone()],
@@ -179,8 +151,12 @@ fn detect_changes_for_markdown_with_reindexed_order(
         }
     }
 
-    for (block, order_key) in planned_blocks.iter().zip(order_keys.iter()) {
-        changes.push(block_upsert_change(&block.id, order_key, &block.block)?);
+    for ((id, block), order_key) in planned_ids
+        .iter()
+        .zip(after.blocks.iter())
+        .zip(order_keys.iter())
+    {
+        changes.push(block_upsert_change(id, order_key, block)?);
     }
 
     if !before.document_present || before.document != after.document {
@@ -190,50 +166,254 @@ fn detect_changes_for_markdown_with_reindexed_order(
     Ok(changes)
 }
 
-fn plan_markdown_blocks(base: &[Block], after: &ParsedMarkdown) -> Vec<PlannedBlock> {
-    let op_runs = imara_diff_runs(base.iter().map(|block| &block.block), after.blocks.iter());
-    let mut planned_blocks = Vec::with_capacity(after.blocks.len());
-    let mut base_index = 0;
-    let mut file_index = 0;
+fn match_diff_blocks(
+    base: &[Block],
+    file_blocks: &[String],
+    diff_runs: impl IntoIterator<Item = DiffRun>,
+) -> (Vec<Option<usize>>, Vec<Option<usize>>) {
+    let mut old_for_new = vec![None; file_blocks.len()];
+    let mut new_for_old = vec![None; base.len()];
+    let mut replace_runs = Vec::new();
+    let mut base_index = 0usize;
+    let mut file_index = 0usize;
 
-    for run in op_runs {
-        match run.op {
-            Op::Equal | Op::Replace => {
-                for _ in 0..run.len {
-                    planned_blocks.push(PlannedBlock {
-                        id: base[base_index].id.clone(),
-                        block: after.blocks[file_index].clone(),
-                    });
-                    base_index += 1;
-                    file_index += 1;
+    for run in diff_runs {
+        match run {
+            DiffRun::Equal { len } => {
+                for (old_index, new_index) in
+                    (base_index..base_index + len).zip(file_index..file_index + len)
+                {
+                    old_for_new[new_index] = Some(old_index);
+                    new_for_old[old_index] = Some(new_index);
                 }
+                base_index += len;
+                file_index += len;
             }
-            Op::Delete => {
-                base_index += run.len;
-            }
-            Op::Insert => {
-                for id in new_ids(run.len) {
-                    planned_blocks.push(PlannedBlock {
-                        id,
-                        block: after.blocks[file_index].clone(),
-                    });
-                    file_index += 1;
-                }
+            DiffRun::Replace { old, new } => {
+                replace_runs.push(ReplaceRun {
+                    old: base_index..base_index + old,
+                    new: file_index..file_index + new,
+                });
+                base_index += old;
+                file_index += new;
             }
         }
     }
 
-    planned_blocks
+    let old_replace_len = replace_runs.iter().map(|run| run.old.len()).sum();
+    let mut old_blocks_by_content = HashMap::<&str, Vec<usize>>::with_capacity(old_replace_len);
+    for run in replace_runs.iter().rev() {
+        for old_index in run.old.clone().rev() {
+            old_blocks_by_content
+                .entry(base[old_index].block.as_str())
+                .or_default()
+                .push(old_index);
+        }
+    }
+
+    for run in &replace_runs {
+        for new_index in run.new.clone() {
+            let Some(old_indices) = old_blocks_by_content.get_mut(file_blocks[new_index].as_str())
+            else {
+                continue;
+            };
+            let Some(old_index) = old_indices.pop() else {
+                continue;
+            };
+            old_for_new[new_index] = Some(old_index);
+            new_for_old[old_index] = Some(new_index);
+        }
+    }
+
+    for run in &replace_runs {
+        let mut old_index = run.old.start;
+        let mut new_index = run.new.start;
+        loop {
+            while old_index < run.old.end && new_for_old[old_index].is_some() {
+                old_index += 1;
+            }
+            while new_index < run.new.end && old_for_new[new_index].is_some() {
+                new_index += 1;
+            }
+            if old_index == run.old.end || new_index == run.new.end {
+                break;
+            }
+            old_for_new[new_index] = Some(old_index);
+            new_for_old[old_index] = Some(new_index);
+            old_index += 1;
+            new_index += 1;
+        }
+    }
+
+    (old_for_new, new_for_old)
+}
+
+fn inserted_block_ids(old_for_new: &[Option<usize>]) -> Vec<Option<String>> {
+    old_for_new
+        .iter()
+        .map(|old_index| match old_index {
+            Some(_) => None,
+            None => Some(Uuid::now_v7().to_string()),
+        })
+        .collect()
+}
+
+fn block_id_for_new<'a>(
+    base: &'a [Block],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &'a [Option<String>],
+    new_index: usize,
+) -> &'a str {
+    match old_for_new[new_index] {
+        Some(old_index) => &base[old_index].id,
+        None => inserted_ids[new_index]
+            .as_deref()
+            .expect("inserted block id should exist"),
+    }
+}
+
+fn detect_block_upsert_changes(
+    base: &[Block],
+    file_blocks: &[String],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &[Option<String>],
+    changes: &mut Vec<DetectedChange>,
+) -> Result<(), PluginError> {
+    let keep_order_key = kept_order_key_indices(base, old_for_new);
+    let mut previous_order_key = None::<OrderKey>;
+    let mut pending = Vec::new();
+
+    for new_index in 0..file_blocks.len() {
+        if keep_order_key[new_index] {
+            let old_index =
+                old_for_new[new_index].expect("kept order key should belong to an existing block");
+            let order_key = &base[old_index].order_key;
+            flush_generated_block_upserts(
+                &mut pending,
+                &mut previous_order_key,
+                Some(order_key),
+                base,
+                file_blocks,
+                old_for_new,
+                inserted_ids,
+                changes,
+            )?;
+            if base[old_index].block != file_blocks[new_index] {
+                changes.push(block_upsert_change(
+                    block_id_for_new(base, old_for_new, inserted_ids, new_index),
+                    order_key,
+                    &file_blocks[new_index],
+                )?);
+            }
+            previous_order_key = Some(order_key.clone());
+        } else {
+            pending.push(new_index);
+        }
+    }
+
+    flush_generated_block_upserts(
+        &mut pending,
+        &mut previous_order_key,
+        None,
+        base,
+        file_blocks,
+        old_for_new,
+        inserted_ids,
+        changes,
+    )
+}
+
+fn kept_order_key_indices(base: &[Block], old_for_new: &[Option<usize>]) -> Vec<bool> {
+    let mut keep = vec![false; old_for_new.len()];
+    if old_for_new
+        .iter()
+        .copied()
+        .flatten()
+        .map(|old_index| &base[old_index].order_key)
+        .is_sorted_by(|previous, current| previous < current)
+    {
+        for (new_index, old_index) in old_for_new.iter().enumerate() {
+            keep[new_index] = old_index.is_some();
+        }
+        return keep;
+    }
+
+    let mut pile_tops = Vec::<usize>::new();
+    let mut predecessors = vec![None; old_for_new.len()];
+
+    for (new_index, old_index) in old_for_new.iter().copied().enumerate() {
+        let Some(old_index) = old_index else {
+            continue;
+        };
+        let order_key = &base[old_index].order_key;
+        let pile = pile_tops
+            .partition_point(|top_index| old_order_key(base, old_for_new, *top_index) < order_key);
+        if pile != 0 {
+            predecessors[new_index] = Some(pile_tops[pile - 1]);
+        }
+        if pile == pile_tops.len() {
+            pile_tops.push(new_index);
+        } else if old_order_key(base, old_for_new, pile_tops[pile]) > order_key {
+            pile_tops[pile] = new_index;
+        }
+    }
+
+    let Some(mut current) = pile_tops.last().copied() else {
+        return keep;
+    };
+    loop {
+        keep[current] = true;
+        let Some(previous) = predecessors[current] else {
+            break;
+        };
+        current = previous;
+    }
+    keep
+}
+
+fn old_order_key<'a>(
+    base: &'a [Block],
+    old_for_new: &[Option<usize>],
+    new_index: usize,
+) -> &'a OrderKey {
+    let old_index = old_for_new[new_index].expect("old order key should belong to existing block");
+    &base[old_index].order_key
+}
+
+fn flush_generated_block_upserts(
+    pending: &mut Vec<usize>,
+    previous_order_key: &mut Option<OrderKey>,
+    next_order_key: Option<&OrderKey>,
+    base: &[Block],
+    file_blocks: &[String],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &[Option<String>],
+    changes: &mut Vec<DetectedChange>,
+) -> Result<(), PluginError> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let order_keys =
+        OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, pending.len())
+            .map_err(PluginError::Internal)?;
+
+    for (new_index, order_key) in pending.drain(..).zip(order_keys) {
+        changes.push(block_upsert_change(
+            block_id_for_new(base, old_for_new, inserted_ids, new_index),
+            &order_key,
+            &file_blocks[new_index],
+        )?);
+        *previous_order_key = Some(order_key);
+    }
+
+    Ok(())
 }
 
 fn has_duplicate_order_keys(blocks: &[Block]) -> bool {
     blocks
         .windows(2)
         .any(|pair| pair[0].order_key == pair[1].order_key)
-}
-
-fn new_ids(count: usize) -> Vec<String> {
-    (0..count).map(|_| Uuid::now_v7().to_string()).collect()
 }
 
 fn single_entity_pk(mut entity_pk: Vec<String>) -> Result<String, PluginError> {
@@ -450,6 +630,65 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fuzz_detect_changes_reorders_blocks_without_changing_ids() {
+        let mut rng = SmallRng::seed_from_u64(1);
+
+        for _ in 0..10_000 {
+            let before_markdown = parse_markdown_source(&random_markdown_source(&mut rng))
+                .expect("random before markdown should parse");
+            let before = projection_from_markdown(before_markdown.clone());
+            let mut reordered_blocks = before_markdown.blocks.clone();
+            shuffle(&mut reordered_blocks, &mut rng);
+            let after_markdown = ParsedMarkdown {
+                document: before_markdown.document,
+                blocks: reordered_blocks.clone(),
+            };
+
+            let changes = detect_changes_for_markdown(&before, &after_markdown).unwrap();
+
+            for change in &changes {
+                assert_eq!(
+                    change.schema_key, BLOCK_SCHEMA_KEY,
+                    "reordering blocks should not change the document snapshot"
+                );
+
+                let entity_pk = single_entity_pk(change.entity_pk.clone()).unwrap();
+                let before_block = before
+                    .blocks_by_id
+                    .get(&entity_pk)
+                    .expect("reordering blocks should only update existing block ids");
+                let snapshot_content = change
+                    .snapshot_content
+                    .as_deref()
+                    .expect("reordering blocks should not delete existing block entities");
+                let after_block = parse_block_snapshot(snapshot_content, &entity_pk).unwrap();
+
+                assert_eq!(
+                    after_block.block, before_block.block,
+                    "reordering blocks should only update order keys"
+                );
+                assert_ne!(
+                    after_block.order_key, before_block.order_key,
+                    "reordering blocks should not emit unchanged block snapshots"
+                );
+            }
+
+            let mut applied = before;
+            for change in changes {
+                apply_entity_change(&mut applied, change).unwrap();
+            }
+
+            let applied_blocks = applied
+                .to_blocks()
+                .into_iter()
+                .map(|block| block.block)
+                .collect::<Vec<_>>();
+            assert_eq!(applied_blocks, reordered_blocks);
+            assert_eq!(applied.document, after_markdown.document);
+        }
+    }
+
     fn random_markdown_source(rng: &mut (impl Rng + ?Sized)) -> String {
         let block_count = rng.random_range(0..=8);
         let mut output = String::new();
@@ -530,6 +769,12 @@ mod tests {
     fn random_word(rng: &mut (impl Rng + ?Sized)) -> String {
         let alphabet = ["alpha", "beta", "gamma", "delta", "one", "two", "x"];
         alphabet[rng.random_range(0..alphabet.len())].to_string()
+    }
+
+    fn shuffle<T>(items: &mut [T], rng: &mut (impl Rng + ?Sized)) {
+        for index in (1..items.len()).rev() {
+            items.swap(index, rng.random_range(0..=index));
+        }
     }
 
     fn projection_from_markdown(markdown: ParsedMarkdown) -> Projection {

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -123,7 +123,7 @@ fn detect_changes_for_markdown(
                 let next_order_key = base.get(base_index).map(|block| &block.order_key);
                 let ids = new_ids(run.len);
                 let order_keys =
-                    OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, &ids)
+                    OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, run.len)
                         .map_err(PluginError::Internal)?;
                 for (id, order_key) in ids.into_iter().zip(order_keys) {
                     changes.push(block_upsert_change(
@@ -162,7 +162,7 @@ fn detect_changes_for_markdown_with_reindexed_order(
         .map(|block| block.id.clone())
         .collect::<Vec<_>>();
     let order_keys =
-        OrderKey::evenly_between(None, None, &planned_ids).map_err(PluginError::Internal)?;
+        OrderKey::evenly_between(None, None, planned_ids.len()).map_err(PluginError::Internal)?;
     let planned_id_set = planned_ids
         .iter()
         .collect::<std::collections::BTreeSet<_>>();
@@ -536,7 +536,7 @@ mod tests {
         let ids = (0..markdown.blocks.len())
             .map(|offset| format!("block:{offset}"))
             .collect::<Vec<_>>();
-        let order_keys = OrderKey::evenly_between(None, None, &ids).unwrap();
+        let order_keys = OrderKey::evenly_between(None, None, ids.len()).unwrap();
         let blocks_by_id = markdown
             .blocks
             .into_iter()

--- a/plugins/markdown/tests/roundtrip.rs
+++ b/plugins/markdown/tests/roundtrip.rs
@@ -126,6 +126,25 @@ fn block_order_keys_by_content(active_state: &[EntityState]) -> BTreeMap<String,
         .collect()
 }
 
+fn block_ids_by_content(active_state: &[EntityState]) -> BTreeMap<String, String> {
+    active_state
+        .iter()
+        .filter(|row| row.schema_key == BLOCK_SCHEMA_KEY)
+        .map(|row| {
+            let value = active_state_snapshot_value(row);
+            let block = value
+                .get("block")
+                .and_then(Value::as_str)
+                .expect("block content should exist")
+                .to_string();
+            let [entity_pk] = row.entity_pk.as_slice() else {
+                panic!("block entity_pk should have one component");
+            };
+            (block, entity_pk.clone())
+        })
+        .collect()
+}
+
 fn markdown_active_state_with_block_order_keys(blocks: &[(&str, &str, &str)]) -> Vec<EntityState> {
     let mut state = vec![EntityState {
         entity_pk: vec![ROOT_ENTITY_PK.to_string()],
@@ -280,6 +299,33 @@ fn normalizes_adjacent_blocks_to_blank_line_separators() {
     .expect("render should succeed");
 
     assert_eq!(output, b"# Title\n\nparagraph\n");
+}
+
+#[test]
+fn detects_sorted_blocks_as_order_key_changes() {
+    let before_bytes = b"# A\n\n# B\n\n# C\n";
+    let after_bytes = b"# C\n\n# B\n\n# A\n";
+    let before_state = active_state_from_file(file_from_bytes(before_bytes));
+    let before_ids = block_ids_by_content(&before_state);
+
+    let changes =
+        MarkdownPlugin::detect_changes(before_state.clone(), file_from_bytes(after_bytes))
+            .expect("detect_changes should succeed");
+
+    assert!(
+        changes
+            .iter()
+            .filter(|change| change.schema_key == BLOCK_SCHEMA_KEY)
+            .all(|change| change.snapshot_content.is_some()),
+        "sorting blocks should not delete existing block entities"
+    );
+
+    let active_state = apply_changes_to_active_state(before_state, changes);
+    let after_ids = block_ids_by_content(&active_state);
+    let output = render_active_state(active_state).expect("render should succeed");
+
+    assert_eq!(after_ids, before_ids);
+    assert_eq!(output, after_bytes);
 }
 
 #[test]

--- a/plugins/markdown/tests/schema.rs
+++ b/plugins/markdown/tests/schema.rs
@@ -1,9 +1,9 @@
-use plugin_md_v2::schemas::{
-    block_schema_definition, block_schema_json, document_schema_definition, document_schema_json,
-    schema_definitions, schema_jsons, BLOCK_SCHEMA_KEY, BLOCK_SCHEMA_PATH, DOCUMENT_SCHEMA_KEY,
-    DOCUMENT_SCHEMA_PATH,
-};
 use plugin_md_v2::MANIFEST_JSON;
+use plugin_md_v2::schemas::{
+    BLOCK_SCHEMA_KEY, BLOCK_SCHEMA_PATH, DOCUMENT_SCHEMA_KEY, DOCUMENT_SCHEMA_PATH,
+    block_schema_definition, block_schema_json, document_schema_definition, document_schema_json,
+    schema_definitions, schema_jsons,
+};
 use std::collections::BTreeSet;
 
 #[test]

--- a/plugins/order-key/src/lib.rs
+++ b/plugins/order-key/src/lib.rs
@@ -18,9 +18,9 @@ impl OrderKey {
     pub fn evenly_between(
         previous: Option<&Self>,
         next: Option<&Self>,
-        ids: &[String],
+        count: usize,
     ) -> Result<Vec<Self>, String> {
-        if ids.is_empty() {
+        if count == 0 {
             return Ok(Vec::new());
         }
 
@@ -32,8 +32,8 @@ impl OrderKey {
             }
         }
 
-        let mut keys = Vec::with_capacity(ids.len());
-        fill_evenly(previous, next, ids, &mut keys)?;
+        let mut keys = Vec::with_capacity(count);
+        fill_evenly(previous, next, count, &mut keys)?;
         Ok(keys)
     }
 
@@ -47,10 +47,8 @@ impl OrderKey {
         Ok(Self(bytes))
     }
 
-    fn between(previous: Option<&Self>, next: Option<&Self>, id: &str) -> Result<Self, String> {
-        let mut bytes = midpoint(previous.map(Self::as_bytes), next.map(Self::as_bytes))?;
-        let suffix = suffix_from_id(id);
-        bytes.extend(suffix);
+    fn between(previous: Option<&Self>, next: Option<&Self>) -> Result<Self, String> {
+        let bytes = midpoint(previous.map(Self::as_bytes), next.map(Self::as_bytes))?;
         validate_bytes(&bytes)?;
         Ok(Self(bytes))
     }
@@ -63,18 +61,19 @@ impl OrderKey {
 fn fill_evenly(
     previous: Option<&OrderKey>,
     next: Option<&OrderKey>,
-    ids: &[String],
+    count: usize,
     out: &mut Vec<OrderKey>,
 ) -> Result<(), String> {
-    if ids.is_empty() {
+    if count == 0 {
         return Ok(());
     }
 
-    let mid = ids.len() / 2;
-    let key = OrderKey::between(previous, next, &ids[mid])?;
-    fill_evenly(previous, Some(&key), &ids[..mid], out)?;
+    let left_count = count / 2;
+    let right_count = count - left_count - 1;
+    let key = OrderKey::between(previous, next)?;
+    fill_evenly(previous, Some(&key), left_count, out)?;
     out.push(key.clone());
-    fill_evenly(Some(&key), next, &ids[mid + 1..], out)
+    fill_evenly(Some(&key), next, right_count, out)
 }
 
 fn validate_bytes(bytes: &[u8]) -> Result<(), String> {
@@ -122,12 +121,6 @@ fn midpoint(previous: Option<&[u8]>, next: Option<&[u8]>) -> Result<Vec<u8>, Str
     }
 }
 
-fn suffix_from_id(id: &str) -> Vec<u8> {
-    let mut suffix = id.as_bytes().to_vec();
-    suffix.push(1);
-    suffix
-}
-
 fn encode_hex(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut encoded = String::with_capacity(bytes.len() * 2);
@@ -172,14 +165,12 @@ mod tests {
 
     #[test]
     fn allocates_ordered_keys_between_open_bounds() {
-        let ids = ids(200);
+        let keys = OrderKey::evenly_between(None, None, 200).unwrap();
 
-        let keys = OrderKey::evenly_between(None, None, &ids).unwrap();
-
-        assert_eq!(keys.len(), ids.len());
+        assert_eq!(keys.len(), 200);
         assert_strictly_increasing(&keys);
         assert_serialized_order_matches(&keys);
-        assert!(keys.iter().all(|key| key.to_snapshot_string().len() < 192));
+        assert!(keys.iter().all(|key| key.to_snapshot_string().len() < 16));
     }
 
     #[test]
@@ -189,9 +180,8 @@ mod tests {
         let mut previous = lower;
         let mut keys = Vec::new();
 
-        for offset in 0..256 {
-            let id = vec![format!("id-{offset}")];
-            let key = OrderKey::evenly_between(Some(&previous), Some(&upper), &id)
+        for _ in 0..256 {
+            let key = OrderKey::evenly_between(Some(&previous), Some(&upper), 1)
                 .unwrap()
                 .remove(0);
             assert!(key > previous);
@@ -208,11 +198,10 @@ mod tests {
     fn allocates_multiple_keys_inside_a_narrow_gap() {
         let lower = OrderKey::from_snapshot_string("80").unwrap();
         let upper = OrderKey::from_snapshot_string("8001").unwrap();
-        let ids = ids(64);
 
-        let keys = OrderKey::evenly_between(Some(&lower), Some(&upper), &ids).unwrap();
+        let keys = OrderKey::evenly_between(Some(&lower), Some(&upper), 64).unwrap();
 
-        assert_eq!(keys.len(), ids.len());
+        assert_eq!(keys.len(), 64);
         assert!(keys.first().unwrap() > &lower);
         assert!(keys.last().unwrap() < &upper);
         assert_strictly_increasing(&keys);
@@ -220,19 +209,12 @@ mod tests {
     }
 
     #[test]
-    fn id_suffix_disambiguates_same_bounds() {
-        let left = OrderKey::evenly_between(None, None, &["id-a".to_string()])
-            .unwrap()
-            .remove(0);
-        let right = OrderKey::evenly_between(None, None, &["id-b".to_string()])
-            .unwrap()
-            .remove(0);
+    fn repeated_single_allocation_in_same_bounds_is_deterministic() {
+        let left = OrderKey::evenly_between(None, None, 1).unwrap().remove(0);
+        let right = OrderKey::evenly_between(None, None, 1).unwrap().remove(0);
 
-        assert_ne!(left, right);
-        assert_eq!(
-            left.cmp(&right),
-            left.to_snapshot_string().cmp(&right.to_snapshot_string())
-        );
+        assert_eq!(left, right);
+        assert_eq!(left.to_snapshot_string(), "80");
     }
 
     #[test]
@@ -242,10 +224,6 @@ mod tests {
         assert!(OrderKey::from_snapshot_string("zz").is_err());
         assert!(OrderKey::from_snapshot_string("abc").is_err());
         assert!(OrderKey::from_snapshot_string("ab00").is_err());
-    }
-
-    fn ids(count: usize) -> Vec<String> {
-        (0..count).map(|offset| format!("id-{offset}")).collect()
     }
 
     fn assert_strictly_increasing(keys: &[OrderKey]) {

--- a/plugins/order-key/src/lib.rs
+++ b/plugins/order-key/src/lib.rs
@@ -15,25 +15,34 @@ impl fmt::Debug for OrderKey {
 }
 
 impl OrderKey {
+    fn new(bytes: Vec<u8>) -> Self {
+        assert!(!bytes.is_empty(), "must not be empty");
+        assert!(bytes.last() != Some(&MIN_BYTE), "must not end with 00");
+        Self(bytes)
+    }
     pub fn evenly_between(
         previous: Option<&Self>,
         next: Option<&Self>,
         count: usize,
     ) -> Result<Vec<Self>, String> {
+        if let (Some(previous), Some(next)) = (previous, next) {
+            if previous == next {
+                return Err(format!(
+                    "order key bounds are equal: previous={previous:?}, next={next:?}"
+                ));
+            }
+            assert!(
+                previous < next,
+                "order key bounds are out of order: previous={previous:?}, next={next:?}"
+            );
+        }
+
         if count == 0 {
             return Ok(Vec::new());
         }
 
-        if let (Some(previous), Some(next)) = (previous, next) {
-            if previous >= next {
-                return Err(format!(
-                    "order key bounds are out of order: previous={previous:?}, next={next:?}"
-                ));
-            }
-        }
-
         let mut keys = Vec::with_capacity(count);
-        fill_evenly(previous, next, count, &mut keys)?;
+        fill_evenly(previous, next, count, &mut keys);
         Ok(keys)
     }
 
@@ -43,14 +52,18 @@ impl OrderKey {
 
     pub fn from_snapshot_string(raw: &str) -> Result<Self, String> {
         let bytes = decode_hex(raw)?;
-        validate_bytes(&bytes)?;
-        Ok(Self(bytes))
+        if bytes.is_empty() {
+            return Err("must not be empty".to_owned());
+        }
+        if bytes.last() == Some(&MIN_BYTE) {
+            return Err("must not end with 00".to_owned());
+        }
+        Ok(Self::new(bytes))
     }
 
-    fn between(previous: Option<&Self>, next: Option<&Self>) -> Result<Self, String> {
-        let bytes = midpoint(previous.map(Self::as_bytes), next.map(Self::as_bytes))?;
-        validate_bytes(&bytes)?;
-        Ok(Self(bytes))
+    fn between(previous: Option<&Self>, next: Option<&Self>) -> Self {
+        let bytes = midpoint(previous.map(Self::as_bytes), next.map(Self::as_bytes));
+        Self::new(bytes)
     }
 
     fn as_bytes(&self) -> &[u8] {
@@ -63,36 +76,25 @@ fn fill_evenly(
     next: Option<&OrderKey>,
     count: usize,
     out: &mut Vec<OrderKey>,
-) -> Result<(), String> {
+) {
     if count == 0 {
-        return Ok(());
+        return;
     }
 
     let left_count = count / 2;
     let right_count = count - left_count - 1;
-    let key = OrderKey::between(previous, next)?;
-    fill_evenly(previous, Some(&key), left_count, out)?;
+    let key = OrderKey::between(previous, next);
+    fill_evenly(previous, Some(&key), left_count, out);
     out.push(key.clone());
-    fill_evenly(Some(&key), next, right_count, out)
+    fill_evenly(Some(&key), next, right_count, out);
 }
 
-fn validate_bytes(bytes: &[u8]) -> Result<(), String> {
-    if bytes.is_empty() {
-        return Err("must not be empty".to_string());
-    }
-    if bytes.last() == Some(&MIN_BYTE) {
-        return Err("must not end with 00".to_string());
-    }
-    Ok(())
-}
-
-fn midpoint(previous: Option<&[u8]>, next: Option<&[u8]>) -> Result<Vec<u8>, String> {
+fn midpoint(previous: Option<&[u8]>, next: Option<&[u8]>) -> Vec<u8> {
     if let (Some(previous), Some(next)) = (previous, next) {
-        if previous >= next {
-            return Err(format!(
-                "order key bounds are out of order: previous={previous:?}, next={next:?}"
-            ));
-        }
+        assert!(
+            previous < next,
+            "order key bounds are out of order: previous={previous:?}, next={next:?}"
+        );
     }
 
     let previous = previous.unwrap_or_default();
@@ -113,7 +115,7 @@ fn midpoint(previous: Option<&[u8]>, next: Option<&[u8]>) -> Result<Vec<u8>, Str
         if next_digit > previous_digit + 1 {
             let mid_digit = previous_digit + (next_digit - previous_digit) / 2;
             prefix.push(u8::try_from(mid_digit).expect("midpoint byte is always in range"));
-            return Ok(prefix);
+            return prefix;
         }
 
         prefix.push(u8::try_from(previous_digit).expect("previous byte is always in range"));
@@ -215,6 +217,39 @@ mod tests {
 
         assert_eq!(left, right);
         assert_eq!(left.to_snapshot_string(), "80");
+    }
+
+    #[test]
+    fn equal_bounds_return_an_error() {
+        let key = OrderKey::from_snapshot_string("80").unwrap();
+
+        let error = OrderKey::evenly_between(Some(&key), Some(&key), 1).unwrap_err();
+
+        assert!(error.contains("order key bounds are equal"));
+    }
+
+    #[test]
+    fn equal_bounds_return_an_error_even_when_count_is_zero() {
+        let key = OrderKey::from_snapshot_string("80").unwrap();
+
+        let error = OrderKey::evenly_between(Some(&key), Some(&key), 0).unwrap_err();
+
+        assert!(error.contains("order key bounds are equal"));
+    }
+
+    #[test]
+    #[should_panic(expected = "order key bounds are out of order")]
+    fn reversed_bounds_panic() {
+        let lower = OrderKey::from_snapshot_string("80").unwrap();
+        let upper = OrderKey::from_snapshot_string("c0").unwrap();
+
+        OrderKey::evenly_between(Some(&upper), Some(&lower), 1).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "order key bounds are out of order")]
+    fn midpoint_asserts_bounds_are_ordered() {
+        midpoint(Some(&[0xc0]), Some(&[0x80]));
     }
 
     #[test]

--- a/plugins/text/src/diff.rs
+++ b/plugins/text/src/diff.rs
@@ -3,23 +3,15 @@ use std::hash::Hash;
 use std::iter;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum Op {
-    Equal,
-    Replace,
-    Insert,
-    Delete,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) struct OpRun {
-    pub(crate) op: Op,
-    pub(crate) len: usize,
+pub(crate) enum DiffRun {
+    Equal { len: usize },
+    Replace { old: usize, new: usize },
 }
 
 pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
     a: impl ExactSizeIterator<Item = &'a T>,
     b: impl ExactSizeIterator<Item = &'a T>,
-) -> impl Iterator<Item = OpRun> {
+) -> impl Iterator<Item = DiffRun> {
     let before_capacity = a.len();
     let after_capacity = b.len();
     let mut input = InternedInput {
@@ -41,19 +33,7 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
     let after_len = u32::try_from(input.after.len()).unwrap();
     let mut before_pos = 0u32;
     let mut after_pos = 0u32;
-    let mut pending = [None; 3];
-    let mut pending_index = 0usize;
-    let mut pending_len = 0usize;
-
     iter::from_fn(move || {
-        if pending_index < pending_len {
-            let run = pending[pending_index];
-            pending_index += 1;
-            return run;
-        }
-        pending_index = 0;
-        pending_len = 0;
-
         let equal_start = before_pos;
         while before_pos < before_len
             && after_pos < after_len
@@ -65,8 +45,7 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
         }
         let equal_len = before_pos - equal_start;
         if equal_len != 0 {
-            return Some(OpRun {
-                op: Op::Equal,
+            return Some(DiffRun::Equal {
                 len: usize::try_from(equal_len).unwrap(),
             });
         }
@@ -83,30 +62,11 @@ pub(crate) fn imara_diff_runs<'a, T: Eq + Hash + ?Sized + 'a>(
         }
         let after_run_len = after_pos - after_start;
 
-        let replace_len = before_run_len.min(after_run_len);
-        for run in [
-            OpRun {
-                op: Op::Replace,
-                len: usize::try_from(replace_len).unwrap(),
-            },
-            OpRun {
-                op: Op::Delete,
-                len: usize::try_from(before_run_len - replace_len).unwrap(),
-            },
-            OpRun {
-                op: Op::Insert,
-                len: usize::try_from(after_run_len - replace_len).unwrap(),
-            },
-        ] {
-            if run.len != 0 {
-                pending[pending_len] = Some(run);
-                pending_len += 1;
-            }
-        }
-
-        if pending_len != 0 {
-            pending_index = 1;
-            return pending[0].take();
+        if before_run_len != 0 || after_run_len != 0 {
+            return Some(DiffRun::Replace {
+                old: usize::try_from(before_run_len).unwrap(),
+                new: usize::try_from(after_run_len).unwrap(),
+            });
         }
 
         debug_assert_eq!(before_pos, before_len);

--- a/plugins/text/src/lib.rs
+++ b/plugins/text/src/lib.rs
@@ -123,7 +123,7 @@ fn detect_changes_for_text(
                 let next_order_key = base.get(base_index).map(|line| &line.order_key);
                 let ids = new_ids(run.len);
                 let order_keys =
-                    OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, &ids)
+                    OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, run.len)
                         .map_err(PluginError::Internal)?;
                 for (id, order_key) in ids.into_iter().zip(order_keys) {
                     changes.push(line_upsert_change(
@@ -162,7 +162,7 @@ fn detect_changes_for_text_with_reindexed_order(
         .map(|line| line.id.clone())
         .collect::<Vec<_>>();
     let order_keys =
-        OrderKey::evenly_between(None, None, &planned_ids).map_err(PluginError::Internal)?;
+        OrderKey::evenly_between(None, None, planned_ids.len()).map_err(PluginError::Internal)?;
     let planned_id_set = planned_ids
         .iter()
         .collect::<std::collections::BTreeSet<_>>();
@@ -476,7 +476,7 @@ mod tests {
         let ids = (0..text.lines.len())
             .map(|offset| format!("line:{offset}"))
             .collect::<Vec<_>>();
-        let order_keys = OrderKey::evenly_between(None, None, &ids).unwrap();
+        let order_keys = OrderKey::evenly_between(None, None, ids.len()).unwrap();
         let lines_by_id = text
             .lines
             .into_iter()

--- a/plugins/text/src/lib.rs
+++ b/plugins/text/src/lib.rs
@@ -10,7 +10,7 @@ mod diff;
 pub mod schemas;
 mod text;
 
-use crate::diff::{Op, imara_diff_runs};
+use crate::diff::{DiffRun, imara_diff_runs};
 pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
 use crate::text::{
@@ -19,8 +19,9 @@ use crate::text::{
 };
 use lix_order_key::OrderKey;
 use serde_json::Value;
-use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, HashMap};
+use std::ops::Range;
 use std::str;
 use uuid::Uuid;
 
@@ -55,6 +56,12 @@ struct LineSnapshot {
     line: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReplaceRun {
+    old: Range<usize>,
+    new: Range<usize>,
+}
+
 impl Plugin for TextPlugin {
     fn detect_changes(
         state: Vec<EntityState>,
@@ -80,63 +87,29 @@ fn detect_changes_for_text(
         return detect_changes_for_text_with_reindexed_order(before, after, &base);
     }
 
-    let op_runs = imara_diff_runs(base.iter().map(|line| &line.line), after.lines.iter());
+    let (old_for_new, new_for_old) = match_diff_lines(
+        &base,
+        &after.lines,
+        imara_diff_runs(base.iter().map(|line| &line.line), after.lines.iter()),
+    );
+    let inserted_ids = inserted_line_ids(&old_for_new);
     let mut changes = Vec::new();
-    let mut base_index = 0;
-    let mut file_index = 0;
-    let mut previous_order_key = None::<OrderKey>;
 
-    for run in op_runs {
-        match run.op {
-            Op::Equal => {
-                for _ in 0..run.len {
-                    previous_order_key = Some(base[base_index].order_key.clone());
-                    base_index += 1;
-                    file_index += 1;
-                }
-            }
-            Op::Replace => {
-                for _ in 0..run.len {
-                    let line = &base[base_index];
-                    changes.push(line_upsert_change(
-                        &line.id,
-                        &line.order_key,
-                        &after.lines[file_index],
-                    )?);
-                    previous_order_key = Some(line.order_key.clone());
-                    base_index += 1;
-                    file_index += 1;
-                }
-            }
-            Op::Delete => {
-                for _ in 0..run.len {
-                    changes.push(DetectedChange {
-                        entity_pk: vec![base[base_index].id.clone()],
-                        schema_key: LINE_SCHEMA_KEY.to_string(),
-                        snapshot_content: None,
-                        metadata: None,
-                    });
-                    base_index += 1;
-                }
-            }
-            Op::Insert => {
-                let next_order_key = base.get(base_index).map(|line| &line.order_key);
-                let ids = new_ids(run.len);
-                let order_keys =
-                    OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, run.len)
-                        .map_err(PluginError::Internal)?;
-                for (id, order_key) in ids.into_iter().zip(order_keys) {
-                    changes.push(line_upsert_change(
-                        &id,
-                        &order_key,
-                        &after.lines[file_index],
-                    )?);
-                    previous_order_key = Some(order_key.clone());
-                    file_index += 1;
-                }
-            }
-        }
+    for base_index in (0..base.len()).filter(|index| new_for_old[*index].is_none()) {
+        changes.push(DetectedChange {
+            entity_pk: vec![base[base_index].id.clone()],
+            schema_key: LINE_SCHEMA_KEY.to_string(),
+            snapshot_content: None,
+            metadata: None,
+        });
     }
+    detect_line_upsert_changes(
+        &base,
+        &after.lines,
+        &old_for_new,
+        &inserted_ids,
+        &mut changes,
+    )?;
 
     if !before.document_present || before.document != after.document {
         changes.push(document_upsert_change(after.document)?);
@@ -145,21 +118,19 @@ fn detect_changes_for_text(
     Ok(changes)
 }
 
-#[derive(Debug)]
-struct PlannedLine {
-    id: String,
-    line: String,
-}
-
 fn detect_changes_for_text_with_reindexed_order(
     before: &Projection,
     after: &ParsedText,
     base: &[Line],
 ) -> Result<Vec<DetectedChange>, PluginError> {
-    let planned_lines = plan_text_lines(base, after);
-    let planned_ids = planned_lines
-        .iter()
-        .map(|line| line.id.clone())
+    let (old_for_new, new_for_old) = match_diff_lines(
+        base,
+        &after.lines,
+        imara_diff_runs(base.iter().map(|line| &line.line), after.lines.iter()),
+    );
+    let inserted_ids = inserted_line_ids(&old_for_new);
+    let planned_ids = (0..after.lines.len())
+        .map(|new_index| line_id_for_new(base, &old_for_new, &inserted_ids, new_index).to_string())
         .collect::<Vec<_>>();
     let order_keys =
         OrderKey::evenly_between(None, None, planned_ids.len()).map_err(PluginError::Internal)?;
@@ -168,7 +139,8 @@ fn detect_changes_for_text_with_reindexed_order(
         .collect::<std::collections::BTreeSet<_>>();
     let mut changes = Vec::new();
 
-    for id in before.lines_by_id.keys() {
+    for base_index in (0..base.len()).filter(|index| new_for_old[*index].is_none()) {
+        let id = &base[base_index].id;
         if !planned_id_set.contains(id) {
             changes.push(DetectedChange {
                 entity_pk: vec![id.clone()],
@@ -179,8 +151,12 @@ fn detect_changes_for_text_with_reindexed_order(
         }
     }
 
-    for (line, order_key) in planned_lines.iter().zip(order_keys.iter()) {
-        changes.push(line_upsert_change(&line.id, order_key, &line.line)?);
+    for ((id, line), order_key) in planned_ids
+        .iter()
+        .zip(after.lines.iter())
+        .zip(order_keys.iter())
+    {
+        changes.push(line_upsert_change(id, order_key, line)?);
     }
 
     if !before.document_present || before.document != after.document {
@@ -190,50 +166,254 @@ fn detect_changes_for_text_with_reindexed_order(
     Ok(changes)
 }
 
-fn plan_text_lines(base: &[Line], after: &ParsedText) -> Vec<PlannedLine> {
-    let op_runs = imara_diff_runs(base.iter().map(|line| &line.line), after.lines.iter());
-    let mut planned_lines = Vec::with_capacity(after.lines.len());
-    let mut base_index = 0;
-    let mut file_index = 0;
+fn match_diff_lines(
+    base: &[Line],
+    file_lines: &[String],
+    diff_runs: impl IntoIterator<Item = DiffRun>,
+) -> (Vec<Option<usize>>, Vec<Option<usize>>) {
+    let mut old_for_new = vec![None; file_lines.len()];
+    let mut new_for_old = vec![None; base.len()];
+    let mut replace_runs = Vec::new();
+    let mut base_index = 0usize;
+    let mut file_index = 0usize;
 
-    for run in op_runs {
-        match run.op {
-            Op::Equal | Op::Replace => {
-                for _ in 0..run.len {
-                    planned_lines.push(PlannedLine {
-                        id: base[base_index].id.clone(),
-                        line: after.lines[file_index].clone(),
-                    });
-                    base_index += 1;
-                    file_index += 1;
+    for run in diff_runs {
+        match run {
+            DiffRun::Equal { len } => {
+                for (old_index, new_index) in
+                    (base_index..base_index + len).zip(file_index..file_index + len)
+                {
+                    old_for_new[new_index] = Some(old_index);
+                    new_for_old[old_index] = Some(new_index);
                 }
+                base_index += len;
+                file_index += len;
             }
-            Op::Delete => {
-                base_index += run.len;
-            }
-            Op::Insert => {
-                for id in new_ids(run.len) {
-                    planned_lines.push(PlannedLine {
-                        id,
-                        line: after.lines[file_index].clone(),
-                    });
-                    file_index += 1;
-                }
+            DiffRun::Replace { old, new } => {
+                replace_runs.push(ReplaceRun {
+                    old: base_index..base_index + old,
+                    new: file_index..file_index + new,
+                });
+                base_index += old;
+                file_index += new;
             }
         }
     }
 
-    planned_lines
+    let old_replace_len = replace_runs.iter().map(|run| run.old.len()).sum();
+    let mut old_lines_by_content = HashMap::<&str, Vec<usize>>::with_capacity(old_replace_len);
+    for run in replace_runs.iter().rev() {
+        for old_index in run.old.clone().rev() {
+            old_lines_by_content
+                .entry(base[old_index].line.as_str())
+                .or_default()
+                .push(old_index);
+        }
+    }
+
+    for run in &replace_runs {
+        for new_index in run.new.clone() {
+            let Some(old_indices) = old_lines_by_content.get_mut(file_lines[new_index].as_str())
+            else {
+                continue;
+            };
+            let Some(old_index) = old_indices.pop() else {
+                continue;
+            };
+            old_for_new[new_index] = Some(old_index);
+            new_for_old[old_index] = Some(new_index);
+        }
+    }
+
+    for run in &replace_runs {
+        let mut old_index = run.old.start;
+        let mut new_index = run.new.start;
+        loop {
+            while old_index < run.old.end && new_for_old[old_index].is_some() {
+                old_index += 1;
+            }
+            while new_index < run.new.end && old_for_new[new_index].is_some() {
+                new_index += 1;
+            }
+            if old_index == run.old.end || new_index == run.new.end {
+                break;
+            }
+            old_for_new[new_index] = Some(old_index);
+            new_for_old[old_index] = Some(new_index);
+            old_index += 1;
+            new_index += 1;
+        }
+    }
+
+    (old_for_new, new_for_old)
+}
+
+fn inserted_line_ids(old_for_new: &[Option<usize>]) -> Vec<Option<String>> {
+    old_for_new
+        .iter()
+        .map(|old_index| match old_index {
+            Some(_) => None,
+            None => Some(Uuid::now_v7().to_string()),
+        })
+        .collect()
+}
+
+fn line_id_for_new<'a>(
+    base: &'a [Line],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &'a [Option<String>],
+    new_index: usize,
+) -> &'a str {
+    match old_for_new[new_index] {
+        Some(old_index) => &base[old_index].id,
+        None => inserted_ids[new_index]
+            .as_deref()
+            .expect("inserted line id should exist"),
+    }
+}
+
+fn detect_line_upsert_changes(
+    base: &[Line],
+    file_lines: &[String],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &[Option<String>],
+    changes: &mut Vec<DetectedChange>,
+) -> Result<(), PluginError> {
+    let keep_order_key = kept_order_key_indices(base, old_for_new);
+    let mut previous_order_key = None::<OrderKey>;
+    let mut pending = Vec::new();
+
+    for new_index in 0..file_lines.len() {
+        if keep_order_key[new_index] {
+            let old_index =
+                old_for_new[new_index].expect("kept order key should belong to an existing line");
+            let order_key = &base[old_index].order_key;
+            flush_generated_line_upserts(
+                &mut pending,
+                &mut previous_order_key,
+                Some(order_key),
+                base,
+                file_lines,
+                old_for_new,
+                inserted_ids,
+                changes,
+            )?;
+            if base[old_index].line != file_lines[new_index] {
+                changes.push(line_upsert_change(
+                    line_id_for_new(base, old_for_new, inserted_ids, new_index),
+                    order_key,
+                    &file_lines[new_index],
+                )?);
+            }
+            previous_order_key = Some(order_key.clone());
+        } else {
+            pending.push(new_index);
+        }
+    }
+
+    flush_generated_line_upserts(
+        &mut pending,
+        &mut previous_order_key,
+        None,
+        base,
+        file_lines,
+        old_for_new,
+        inserted_ids,
+        changes,
+    )
+}
+
+fn kept_order_key_indices(base: &[Line], old_for_new: &[Option<usize>]) -> Vec<bool> {
+    let mut keep = vec![false; old_for_new.len()];
+    if old_for_new
+        .iter()
+        .copied()
+        .flatten()
+        .map(|old_index| &base[old_index].order_key)
+        .is_sorted_by(|previous, current| previous < current)
+    {
+        for (new_index, old_index) in old_for_new.iter().enumerate() {
+            keep[new_index] = old_index.is_some();
+        }
+        return keep;
+    }
+
+    let mut pile_tops = Vec::<usize>::new();
+    let mut predecessors = vec![None; old_for_new.len()];
+
+    for (new_index, old_index) in old_for_new.iter().copied().enumerate() {
+        let Some(old_index) = old_index else {
+            continue;
+        };
+        let order_key = &base[old_index].order_key;
+        let pile = pile_tops
+            .partition_point(|top_index| old_order_key(base, old_for_new, *top_index) < order_key);
+        if pile != 0 {
+            predecessors[new_index] = Some(pile_tops[pile - 1]);
+        }
+        if pile == pile_tops.len() {
+            pile_tops.push(new_index);
+        } else if old_order_key(base, old_for_new, pile_tops[pile]) > order_key {
+            pile_tops[pile] = new_index;
+        }
+    }
+
+    let Some(mut current) = pile_tops.last().copied() else {
+        return keep;
+    };
+    loop {
+        keep[current] = true;
+        let Some(previous) = predecessors[current] else {
+            break;
+        };
+        current = previous;
+    }
+    keep
+}
+
+fn old_order_key<'a>(
+    base: &'a [Line],
+    old_for_new: &[Option<usize>],
+    new_index: usize,
+) -> &'a OrderKey {
+    let old_index = old_for_new[new_index].expect("old order key should belong to existing line");
+    &base[old_index].order_key
+}
+
+fn flush_generated_line_upserts(
+    pending: &mut Vec<usize>,
+    previous_order_key: &mut Option<OrderKey>,
+    next_order_key: Option<&OrderKey>,
+    base: &[Line],
+    file_lines: &[String],
+    old_for_new: &[Option<usize>],
+    inserted_ids: &[Option<String>],
+    changes: &mut Vec<DetectedChange>,
+) -> Result<(), PluginError> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let order_keys =
+        OrderKey::evenly_between(previous_order_key.as_ref(), next_order_key, pending.len())
+            .map_err(PluginError::Internal)?;
+
+    for (new_index, order_key) in pending.drain(..).zip(order_keys) {
+        changes.push(line_upsert_change(
+            line_id_for_new(base, old_for_new, inserted_ids, new_index),
+            &order_key,
+            &file_lines[new_index],
+        )?);
+        *previous_order_key = Some(order_key);
+    }
+
+    Ok(())
 }
 
 fn has_duplicate_order_keys(lines: &[Line]) -> bool {
     lines
         .windows(2)
         .any(|pair| pair[0].order_key == pair[1].order_key)
-}
-
-fn new_ids(count: usize) -> Vec<String> {
-    (0..count).map(|_| Uuid::now_v7().to_string()).collect()
 }
 
 fn single_entity_pk(mut entity_pk: Vec<String>) -> Result<String, PluginError> {
@@ -444,6 +624,65 @@ mod tests {
         }
     }
 
+    #[test]
+    fn fuzz_detect_changes_reorders_lines_without_changing_ids() {
+        let mut rng = SmallRng::seed_from_u64(1);
+
+        for _ in 0..100_000 {
+            let before_text = random_text(&mut rng);
+            let mut before = projection_from_text(before_text.clone());
+            before.document_present = true;
+            let mut reordered_lines = before_text.lines.clone();
+            shuffle(&mut reordered_lines, &mut rng);
+            let after_text = ParsedText {
+                document: before_text.document,
+                lines: reordered_lines.clone(),
+            };
+
+            let changes = detect_changes_for_text(&before, &after_text).unwrap();
+
+            for change in &changes {
+                assert_eq!(
+                    change.schema_key, LINE_SCHEMA_KEY,
+                    "reordering lines should not change the document snapshot"
+                );
+
+                let entity_pk = single_entity_pk(change.entity_pk.clone()).unwrap();
+                let before_line = before
+                    .lines_by_id
+                    .get(&entity_pk)
+                    .expect("reordering lines should only update existing line ids");
+                let snapshot_content = change
+                    .snapshot_content
+                    .as_deref()
+                    .expect("reordering lines should not delete existing line entities");
+                let after_line = parse_line_snapshot(snapshot_content, &entity_pk).unwrap();
+
+                assert_eq!(
+                    after_line.line, before_line.line,
+                    "reordering lines should only update order keys"
+                );
+                assert_ne!(
+                    after_line.order_key, before_line.order_key,
+                    "reordering lines should not emit unchanged line snapshots"
+                );
+            }
+
+            let mut applied = before;
+            for change in changes {
+                apply_entity_change(&mut applied, change).unwrap();
+            }
+
+            let applied_lines = applied
+                .to_lines()
+                .into_iter()
+                .map(|line| line.line)
+                .collect::<Vec<_>>();
+            assert_eq!(applied_lines, reordered_lines);
+            assert_eq!(applied.document, after_text.document);
+        }
+    }
+
     fn random_text(rng: &mut (impl Rng + ?Sized)) -> ParsedText {
         let random_line_alphabet_len: u8 = rng.random_range(1..=6);
         let height = rng.random_range(0..=10);
@@ -467,6 +706,12 @@ mod tests {
         ParsedText {
             document: TextDocumentSnapshot { line_endings },
             lines,
+        }
+    }
+
+    fn shuffle<T>(items: &mut [T], rng: &mut (impl Rng + ?Sized)) {
+        for index in (1..items.len()).rev() {
+            items.swap(index, rng.random_range(0..=index));
         }
     }
 

--- a/plugins/text/tests/roundtrip.rs
+++ b/plugins/text/tests/roundtrip.rs
@@ -135,6 +135,25 @@ fn line_order_keys_by_content(active_state: &[EntityState]) -> BTreeMap<String, 
         .collect()
 }
 
+fn line_ids_by_content(active_state: &[EntityState]) -> BTreeMap<String, String> {
+    active_state
+        .iter()
+        .filter(|row| row.schema_key == LINE_SCHEMA_KEY)
+        .map(|row| {
+            let value = active_state_snapshot_value(row);
+            let line = value
+                .get("line")
+                .and_then(Value::as_str)
+                .expect("line content should exist")
+                .to_string();
+            let [entity_pk] = row.entity_pk.as_slice() else {
+                panic!("line entity_pk should have one component");
+            };
+            (line, entity_pk.clone())
+        })
+        .collect()
+}
+
 fn text_active_state_with_line_order_keys(lines: &[(&str, &str, &str)]) -> Vec<EntityState> {
     let mut state = vec![EntityState {
         entity_pk: vec![ROOT_ENTITY_PK.to_string()],
@@ -420,6 +439,32 @@ fn silently_decodes_malformed_text() {
 
     let output = render_changes(changes).expect("render should succeed");
     assert_eq!(output, "aÿ\n".as_bytes());
+}
+
+#[test]
+fn detects_sorted_lines_as_order_key_changes() {
+    let before_bytes = b"a\nb\nc\n";
+    let after_bytes = b"c\nb\na\n";
+    let before_state = active_state_from_file(file_from_bytes(before_bytes));
+    let before_ids = line_ids_by_content(&before_state);
+
+    let changes = TextPlugin::detect_changes(before_state.clone(), file_from_bytes(after_bytes))
+        .expect("detect_changes should succeed");
+
+    assert!(
+        changes
+            .iter()
+            .filter(|change| change.schema_key == LINE_SCHEMA_KEY)
+            .all(|change| change.snapshot_content.is_some()),
+        "sorting lines should not delete existing line entities"
+    );
+
+    let active_state = apply_changes_to_active_state(before_state, changes);
+    let after_ids = line_ids_by_content(&active_state);
+    let output = render_active_state(active_state).expect("render should succeed");
+
+    assert_eq!(after_ids, before_ids);
+    assert_eq!(output, after_bytes);
 }
 
 #[test]


### PR DESCRIPTION
Updates CSV, Markdown, and text diff detection so reordered rows, blocks, and lines are treated as order-key changes instead of delete/reinsert operations. This keeps existing entity IDs stable across sorts and moves, while still generating new IDs only for true inserts.

Also simplifies order-key allocation to use deterministic count-based spacing, updates diff runs to preserve replace ranges, and adds reorder-focused roundtrip/fuzz coverage for CSV, Markdown, and text plugins.

```text
e2e/csv_plugin/setup
       time:   [751.04 ms 754.38 ms 757.45 ms]
e2e/csv_plugin/setup_inmemory
       time:   [710.33 ms 714.14 ms 717.92 ms]
e2e/csv_plugin/setup_wasm
       time:   [641.91 ms 644.28 ms 646.74 ms]
e2e/csv_plugin/insert_10k
       time:   [398.46 ms 425.52 ms 448.37 ms]
e2e/csv_plugin/insert_10k_inmemory
       time:   [126.96 ms 127.81 ms 128.79 ms]
e2e/csv_plugin/insert_10k_plugin
       time:   [24.041 ms 24.064 ms 24.084 ms]
e2e/csv_plugin/insert_10k_plugin_diff
       time:   [12.130 ms 12.217 ms 12.288 ms]
e2e/csv_plugin/insert_10k_insert
       time:   [412.50 ms 433.89 ms 450.04 ms]
e2e/csv_plugin/insert_10k_insert_inmemory
       time:   [128.59 ms 129.06 ms 129.73 ms]
e2e/csv_plugin/insert_10k_insert_state
       time:   [888.62 ms 909.81 ms 922.69 ms]
e2e/csv_plugin/insert_10k_insert_state_inmemory
       time:   [618.52 ms 621.30 ms 624.12 ms]
e2e/csv_plugin/merge_10k
       time:   [339.50 ms 372.88 ms 420.96 ms]
e2e/csv_plugin/merge_10k_inmemory
       time:   [219.93 ms 222.28 ms 224.59 ms]
e2e/csv_plugin/merge_10k_plugin
       time:   [48.359 ms 48.412 ms 48.468 ms]
e2e/csv_plugin/merge_10k_plugin_diff
       time:   [25.928 ms 25.997 ms 26.063 ms]
e2e/csv_plugin/merge_10k_insert
       time:   [301.09 ms 320.18 ms 337.80 ms]
e2e/csv_plugin/merge_10k_insert_inmemory
       time:   [135.29 ms 135.86 ms 136.44 ms]
e2e/csv_plugin/merge_10k_insert_state
       time:   [767.59 ms 816.19 ms 882.51 ms]
e2e/csv_plugin/merge_10k_insert_state_inmemory
       time:   [624.65 ms 627.67 ms 631.08 ms]
```