### PR TITLE
Key catalog cache on raw schema rows to skip per-transaction decode

### DIFF
--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -947,3 +947,108 @@ smoke sample above landed at 9.00 ms, so the bulk-insert win is real but
 within a few percent of run variance. The dominant, robust win is the removal
 of the fixed per-transaction catalog compile, which was about half of every
 single-row transaction operation.
+
+## Optimization Run: raw-row keyed catalog cache
+
+Date: 2026-06-09
+
+Commands:
+
+```sh
+cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- smoke
+LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+cargo test -p lix_engine --lib
+```
+
+Profiling:
+
+- After the compiled-catalog cache, samply showed the schema-facts pipeline as
+  the dominant fixed cost of single-row transaction ops: about 60% of
+  `update_one_by_pk` on RocksDB, paid twice per transaction (once in
+  `open_transaction`'s prefetch, once at row normalization). The pipeline was
+  live-state scan (~15% + ~14%) plus `decode_registered_schema_row` serde
+  parsing of every schema row (~8% + ~9%) plus `fingerprint_schema_facts`
+  canonical-JSON serialization (~11%).
+- The decode and canonicalization existed only to compute the cache key.
+  Decoding is deterministic, so the raw `snapshot_content` bytes already
+  uniquely determine the decoded facts.
+
+Change:
+
+- `CatalogContext::compiled_catalog_for_domain` is the new transaction hot
+  path: it scans the raw registered-schema rows for a domain, fingerprints
+  the raw row contents (blake3, length-prefixed schema-domain component +
+  `snapshot_content`), and returns the cached `Arc<CatalogSnapshot>` on a
+  hit. Rows are only JSON-decoded and canonicalized on a miss, where the
+  result flows through the existing facts-fingerprint cache.
+- A raw-key variation (ordering or textual differences with equal canonical
+  content) can only cause a conservative cache miss, never a wrong hit.
+- `open_transaction` now prefetches the compiled catalog `Arc` instead of a
+  decoded facts `Vec`, and `TransactionSchemaResolver` stores
+  `TransactionCatalog` directly; the intermediate `SchemaFacts` staging
+  variant is gone.
+- Storage accounting is byte-identical to the previous entry.
+- `cargo test -p lix_engine --lib`: 930 passed, 0 failed.
+- Verification profile: `decode_registered_schema_row` and
+  `fingerprint_schema_facts` no longer appear in the `update_one_by_pk`
+  stacks; the remaining facts cost is `scan_catalog_rows` only.
+
+### 1k Smoke Scorecard
+
+Note: this run was taken while the machine was in interactive use, so
+individual cells carry more noise than earlier entries. The kv_layout control
+group stayed within historical variance.
+
+#### Transaction Layer
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |   10.79 ms |  2.88 ms |         202 us |          688 us |   13.26 ms |     885 us |   11.83 ms |     947 us |
+| RocksDB |    8.16 ms |  2.65 ms |        41.7 us |          260 us |    8.46 ms |     420 us |    8.08 ms |     493 us |
+| redb    |   19.41 ms |  2.80 ms |        57.3 us |          275 us |   19.50 ms |    5.19 ms |   16.37 ms |    5.08 ms |
+
+#### SQL Session
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: |
+| SQLite  |   17.50 ms |  6.33 ms |        1.27 ms |         1.47 ms |   15.80 ms |    6.67 ms |
+| RocksDB |   14.30 ms |  5.49 ms |        1.11 ms |         1.15 ms |   12.14 ms |    5.54 ms |
+| redb    |   30.18 ms |  5.77 ms |        1.19 ms |         1.34 ms |   20.02 ms |   10.15 ms |
+
+#### Direct KV Layout
+
+Control group; untouched by this patch.
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |    1.51 ms |   303 us |         158 us |          189 us |    1.57 ms |    74.1 us |     485 us |    43.7 us |
+| RocksDB |     425 us |   156 us |        2.61 us |         7.29 us |     477 us |    8.53 us |    4.64 us |    5.08 us |
+| redb    |    8.12 ms |   241 us |        15.5 us |         31.6 us |    9.86 ms |    4.10 ms |    4.75 ms |    4.03 ms |
+
+### Delta From Previous Entry (compiled schema catalog cache)
+
+| Workload                             | Previous |  Current |  Delta |
+| ------------------------------------ | -------: | -------: | -----: |
+| RocksDB transaction update_one_by_pk |   623 us |   420 us | -32.6% |
+| RocksDB transaction delete_one_by_pk |   613 us |   493 us | -19.6% |
+| SQLite transaction update_one_by_pk  |  1.06 ms |   885 us | -16.2% |
+| SQLite transaction delete_one_by_pk  |  1.25 ms |   947 us | -24.1% |
+| RocksDB transaction insert_all 1k    |  9.00 ms |  8.16 ms |  -9.3% |
+| RocksDB sql_session insert_all 1k    | 15.77 ms | 14.30 ms |  -9.3% |
+| SQLite transaction update_all 1k     | 14.30 ms | 13.26 ms |  -7.3% |
+| redb transaction update_one_by_pk    |  5.14 ms |  5.19 ms |  +1.0% |
+
+redb single-row ops are dominated by redb's fixed per-commit durability cost,
+so the catalog-path savings do not move them; that cost is a backend
+characteristic, not an engine overhead.
+
+Cumulative since the 2026-06-09 baseline (both catalog cache rounds):
+RocksDB transaction update_one_by_pk 1.35 ms -> 420 us (3.2x), delete_one_by_pk
+1.34 ms -> 493 us (2.7x), SQLite update_one_by_pk 1.57 ms -> 885 us (1.8x).
+
+Remaining target from the verification profile: the live-state scan of
+registered-schema rows still runs twice per transaction (~19% of
+update_one_by_pk each). Eliminating it requires caching scan results keyed on
+storage state, which needs an invalidation story; deferred. The validation
+fast-path (unconsumable fk_target bookkeeping, jsonschema is_valid) remains
+the next bulk-op target.

--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::Value as JsonValue;
 
-use crate::catalog::snapshot::{CatalogFingerprint, fingerprint_schema_facts};
+use crate::catalog::snapshot::{
+    CatalogFingerprint, fingerprint_schema_facts, hash_fingerprint_part,
+};
 use crate::catalog::{CatalogSnapshot, SchemaCatalogFact};
 use crate::domain::{Domain, committed_row_is_exact_branch_scoped};
 use crate::live_state::MaterializedLiveStateRow;
@@ -26,13 +28,72 @@ const COMPILED_CATALOG_CACHE_LIMIT: usize = 64;
 /// the engine-wide cache of compiled catalog snapshots, keyed by fact content.
 pub(crate) struct CatalogContext {
     compiled_catalogs: Mutex<HashMap<CatalogFingerprint, Arc<CatalogSnapshot>>>,
+    compiled_catalogs_by_rows: Mutex<HashMap<CatalogRowsFingerprint, Arc<CatalogSnapshot>>>,
 }
+
+/// Fingerprint of the raw catalog rows visible to a domain, hashed before any
+/// JSON decoding. The raw `snapshot_content` bytes uniquely determine the
+/// decoded facts, so this key is at least as discriminating as the facts
+/// fingerprint: textual or ordering variations can only cause a conservative
+/// cache miss, never a wrong hit.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CatalogRowsFingerprint(String);
 
 impl CatalogContext {
     pub(crate) fn new() -> Self {
         Self {
             compiled_catalogs: Mutex::new(HashMap::new()),
+            compiled_catalogs_by_rows: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Returns the compiled snapshot for the catalog rows visible to `domain`.
+    ///
+    /// This is the transaction hot path. On a hit it costs one live-state scan
+    /// plus a hash of the raw row contents; schema rows are only JSON-decoded
+    /// and canonicalized when the raw fingerprint has not been seen before.
+    pub(crate) async fn compiled_catalog_for_domain<R>(
+        &self,
+        live_state: &R,
+        domain: &Domain,
+    ) -> Result<Arc<CatalogSnapshot>, LixError>
+    where
+        R: LiveStateReader + ?Sized,
+    {
+        let catalog_rows = scan_catalog_rows(live_state, domain).await?;
+        let mut hasher = blake3::Hasher::new();
+        for (schema_domain, row) in &catalog_rows {
+            hash_fingerprint_part(&mut hasher, &schema_domain.fingerprint_component());
+            let snapshot_content = row
+                .snapshot_content
+                .as_deref()
+                .expect("catalog rows are filtered to rows with snapshot_content");
+            hash_fingerprint_part(&mut hasher, snapshot_content);
+        }
+        let fingerprint = CatalogRowsFingerprint(hasher.finalize().to_hex().to_string());
+
+        if let Some(snapshot) = self
+            .compiled_catalogs_by_rows
+            .lock()
+            .expect("compiled catalog rows cache lock should not be poisoned")
+            .get(&fingerprint)
+        {
+            return Ok(Arc::clone(snapshot));
+        }
+
+        let facts = facts_from_catalog_rows(&catalog_rows)?;
+        let snapshot = self.compiled_catalog_for_facts(&facts)?;
+        let mut cache = self
+            .compiled_catalogs_by_rows
+            .lock()
+            .expect("compiled catalog rows cache lock should not be poisoned");
+        if cache.len() >= COMPILED_CATALOG_CACHE_LIMIT {
+            if let Some(evicted) = cache.keys().find(|key| **key != fingerprint).cloned() {
+                cache.remove(&evicted);
+            }
+        }
+        cache.insert(fingerprint, Arc::clone(&snapshot));
+        Ok(snapshot)
     }
 
     /// Returns the compiled snapshot for `facts`, building it on first use.
@@ -118,33 +179,55 @@ impl CatalogContext {
     where
         R: LiveStateReader + ?Sized,
     {
-        let mut facts = Vec::new();
-        for schema_domain in domain.schema_catalog_domains() {
-            let rows = live_state
-                .scan_rows(&LiveStateScanRequest {
-                    filter: LiveStateFilter {
-                        schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
-                        branch_ids: vec![schema_domain.branch_id().to_string()],
-                        file_ids: vec![NullableKeyFilter::Null],
-                        untracked: Some(schema_domain.untracked()),
-                        include_tombstones: false,
-                        ..LiveStateFilter::default()
-                    },
-                    ..LiveStateScanRequest::default()
-                })
-                .await?;
-            for row in rows
-                .into_iter()
-                .filter(|row| row_belongs_to_schema_catalog_domain(row, &schema_domain))
-            {
-                let Some((key, schema)) = decode_registered_schema_row(&row)? else {
-                    continue;
-                };
-                facts.push(SchemaCatalogFact::new(schema_domain.clone(), key, schema));
-            }
-        }
-        Ok(facts)
+        let catalog_rows = scan_catalog_rows(live_state, domain).await?;
+        facts_from_catalog_rows(&catalog_rows)
     }
+}
+
+/// Scans the raw registered-schema rows reachable from `domain`, without
+/// decoding their snapshots.
+async fn scan_catalog_rows<R>(
+    live_state: &R,
+    domain: &Domain,
+) -> Result<Vec<(Domain, MaterializedLiveStateRow)>, LixError>
+where
+    R: LiveStateReader + ?Sized,
+{
+    let mut catalog_rows = Vec::new();
+    for schema_domain in domain.schema_catalog_domains() {
+        let rows = live_state
+            .scan_rows(&LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
+                    branch_ids: vec![schema_domain.branch_id().to_string()],
+                    file_ids: vec![NullableKeyFilter::Null],
+                    untracked: Some(schema_domain.untracked()),
+                    include_tombstones: false,
+                    ..LiveStateFilter::default()
+                },
+                ..LiveStateScanRequest::default()
+            })
+            .await?;
+        catalog_rows.extend(
+            rows.into_iter()
+                .filter(|row| row_belongs_to_schema_catalog_domain(row, &schema_domain))
+                .map(|row| (schema_domain.clone(), row)),
+        );
+    }
+    Ok(catalog_rows)
+}
+
+fn facts_from_catalog_rows(
+    catalog_rows: &[(Domain, MaterializedLiveStateRow)],
+) -> Result<Vec<SchemaCatalogFact>, LixError> {
+    let mut facts = Vec::new();
+    for (schema_domain, row) in catalog_rows {
+        let Some((key, schema)) = decode_registered_schema_row(row)? else {
+            continue;
+        };
+        facts.push(SchemaCatalogFact::new(schema_domain.clone(), key, schema));
+    }
+    Ok(facts)
 }
 
 fn row_belongs_to_schema_catalog_domain(row: &MaterializedLiveStateRow, domain: &Domain) -> bool {
@@ -198,6 +281,44 @@ mod tests {
     use crate::GLOBAL_BRANCH_ID;
     use crate::changelog::ChangeId;
     use crate::live_state::LiveStateRowRequest;
+
+    #[tokio::test]
+    async fn compiled_catalog_for_domain_hits_cache_without_decoding() {
+        let context = CatalogContext::new();
+        let domain = Domain::schema_catalog("global", true);
+        let reader = RowsLiveStateReader::new(vec![
+            registered_schema_row("alpha_schema"),
+            registered_schema_row("beta_schema"),
+        ]);
+
+        let first = context
+            .compiled_catalog_for_domain(&reader, &domain)
+            .await
+            .expect("catalog should compile");
+        let second = context
+            .compiled_catalog_for_domain(&reader, &domain)
+            .await
+            .expect("catalog should hit the raw-rows cache");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "identical raw rows must return the cached snapshot"
+        );
+
+        let changed_reader = RowsLiveStateReader::new(vec![
+            registered_schema_row("alpha_schema"),
+            registered_schema_row("gamma_schema"),
+        ]);
+        let changed = context
+            .compiled_catalog_for_domain(&changed_reader, &domain)
+            .await
+            .expect("changed catalog should compile");
+        assert!(
+            !Arc::ptr_eq(&first, &changed),
+            "changed raw rows must compile a different snapshot"
+        );
+        assert!(changed.contains("gamma_schema"));
+        assert!(!first.contains("gamma_schema"));
+    }
 
     #[test]
     fn compiled_catalog_cache_shares_snapshots_for_equal_facts() {

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -270,7 +270,7 @@ impl CatalogSnapshot {
     }
 }
 
-fn hash_fingerprint_part(hasher: &mut blake3::Hasher, value: &str) {
+pub(super) fn hash_fingerprint_part(hasher: &mut blake3::Hasher, value: &str) {
     hasher.update(&(value.len() as u64).to_le_bytes());
     hasher.update(value.as_bytes());
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -271,19 +271,24 @@ where
                 FunctionContext::prepare(&runtime_live_state).await?
             };
             let functions = runtime_functions.provider();
-            let schema_facts = {
+            let schema_catalog = {
                 let visible_live_state = live_state.reader(&read);
                 catalog_context
-                    .schema_facts_for_domain(
+                    .compiled_catalog_for_domain(
                         &visible_live_state,
                         &Domain::schema_catalog(active_branch_id.clone(), true),
                     )
                     .await?
             };
-            Ok::<_, LixError>((active_branch_id, runtime_functions, functions, schema_facts))
+            Ok::<_, LixError>((
+                active_branch_id,
+                runtime_functions,
+                functions,
+                schema_catalog,
+            ))
         }
         .await;
-        let (active_branch_id, runtime_functions, functions, schema_facts) = match setup_result {
+        let (active_branch_id, runtime_functions, functions, schema_catalog) = match setup_result {
             Ok(result) => result,
             Err(error) => {
                 return Err(error);
@@ -291,9 +296,9 @@ where
         };
         drop(read);
         let mut schema_resolver = TransactionSchemaResolver::new(Arc::clone(&catalog_context));
-        schema_resolver.remember_schema_facts(
+        schema_resolver.remember_compiled_catalog(
             &Domain::schema_catalog(active_branch_id.clone(), true),
-            schema_facts,
+            schema_catalog,
         );
         let staged_writes = Arc::new(TransactionWriteBuffer::new(functions.clone()));
         Ok(OpenTransaction {

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::LixError;
-use crate::catalog::{CatalogContext, CatalogSnapshot, SchemaCatalogFact, TransactionCatalog};
+use crate::catalog::{CatalogContext, CatalogSnapshot, TransactionCatalog};
 use crate::domain::Domain;
 use crate::live_state::{
     LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
@@ -14,12 +14,7 @@ use crate::transaction::staging::PreparedStateRowOverlay;
 
 pub(crate) struct TransactionSchemaResolver {
     context: Arc<CatalogContext>,
-    catalogs_by_domain: BTreeMap<Domain, CatalogEntry>,
-}
-
-enum CatalogEntry {
-    SchemaFacts(Vec<SchemaCatalogFact>),
-    Catalog(TransactionCatalog),
+    catalogs_by_domain: BTreeMap<Domain, TransactionCatalog>,
 }
 
 impl TransactionSchemaResolver {
@@ -37,45 +32,26 @@ impl TransactionSchemaResolver {
         domain: &Domain,
     ) -> Result<(), LixError> {
         let domain = domain.schema_catalog_domain();
-        let needs_load = !self.catalogs_by_domain.contains_key(&domain);
-        if needs_load {
-            let facts = if let Some(staged) = staged {
-                let reader = TransactionSchemaLiveStateReader {
-                    base: live_state,
-                    staged,
-                };
-                self.context
-                    .schema_facts_for_domain(&reader, &domain)
-                    .await?
-            } else {
-                self.context
-                    .schema_facts_for_domain(live_state, &domain)
-                    .await?
-            };
-            self.catalogs_by_domain
-                .insert(domain.clone(), CatalogEntry::SchemaFacts(facts));
+        if self.catalogs_by_domain.contains_key(&domain) {
+            return Ok(());
         }
-
-        let should_materialize = self
-            .catalogs_by_domain
-            .get(&domain)
-            .is_some_and(|entry| matches!(entry, CatalogEntry::SchemaFacts(_)));
-        if should_materialize {
-            #[cfg(feature = "storage-benches")]
-            crate::storage_bench::record_transaction_schema_catalog_load();
-            let entry = self
-                .catalogs_by_domain
-                .remove(&domain)
-                .expect("schema catalog entry should exist after load");
-            let CatalogEntry::SchemaFacts(facts) = entry else {
-                unreachable!("catalog entry was checked as schema facts");
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_transaction_schema_catalog_load();
+        let catalog = if let Some(staged) = staged {
+            let reader = TransactionSchemaLiveStateReader {
+                base: live_state,
+                staged,
             };
-            let catalog = self.context.compiled_catalog_for_facts(&facts)?;
-            self.catalogs_by_domain.insert(
-                domain,
-                CatalogEntry::Catalog(TransactionCatalog::Shared(catalog)),
-            );
-        }
+            self.context
+                .compiled_catalog_for_domain(&reader, &domain)
+                .await?
+        } else {
+            self.context
+                .compiled_catalog_for_domain(live_state, &domain)
+                .await?
+        };
+        self.catalogs_by_domain
+            .insert(domain, TransactionCatalog::Shared(catalog));
         Ok(())
     }
 
@@ -88,16 +64,10 @@ impl TransactionSchemaResolver {
         self.load_catalog_for_domain(live_state, Some(staged), domain)
             .await?;
         let domain = domain.schema_catalog_domain();
-        match self
+        Ok(self
             .catalogs_by_domain
             .get_mut(&domain)
-            .expect("catalog cache should contain requested branch")
-        {
-            CatalogEntry::Catalog(catalog) => Ok(catalog),
-            CatalogEntry::SchemaFacts(_) => {
-                unreachable!("schema catalog should be materialized before mutable access")
-            }
-        }
+            .expect("catalog cache should contain requested branch"))
     }
 
     pub(crate) async fn catalog_for_validation(
@@ -108,22 +78,21 @@ impl TransactionSchemaResolver {
         self.load_catalog_for_domain(live_state, None, domain)
             .await?;
         let domain = domain.schema_catalog_domain();
-        match self
+        Ok(self
             .catalogs_by_domain
             .get(&domain)
             .expect("catalog cache should contain requested branch")
-        {
-            CatalogEntry::Catalog(catalog) => Ok(catalog.snapshot()),
-            CatalogEntry::SchemaFacts(_) => {
-                unreachable!("schema catalog should be materialized before validation access")
-            }
-        }
+            .snapshot())
     }
 
-    pub(crate) fn remember_schema_facts(&mut self, domain: &Domain, facts: Vec<SchemaCatalogFact>) {
+    pub(crate) fn remember_compiled_catalog(
+        &mut self,
+        domain: &Domain,
+        catalog: Arc<CatalogSnapshot>,
+    ) {
         self.catalogs_by_domain.insert(
             domain.schema_catalog_domain(),
-            CatalogEntry::SchemaFacts(facts),
+            TransactionCatalog::Shared(catalog),
         );
     }
 }


### PR DESCRIPTION
Stacked on #506 — retarget to `main` after it merges; the diff here is round 2 only.

## Problem

With the compiled-catalog cache (#506) in place, samply showed the schema-facts pipeline as the new dominant fixed cost: **~60% of a single-row transaction op, paid twice per transaction** (once in `open_transaction`'s prefetch, once at row normalization):

- live-state scan of the ~17 registered-schema rows (~15% + ~14%)
- `decode_registered_schema_row` serde-parsing every schema snapshot (~8% + ~9%)
- `fingerprint_schema_facts` canonical-JSON serializing every schema just to compute the cache key (~11%)

The decode and canonicalization exist only to produce the cache key — but decoding is deterministic, so the raw `snapshot_content` bytes already uniquely determine the decoded facts.

## Change

- `CatalogContext::compiled_catalog_for_domain` is the new transaction hot path: scan raw rows → blake3 over (schema-domain component + raw `snapshot_content`) → return cached `Arc<CatalogSnapshot>` on hit. Rows are JSON-decoded and canonicalized **only on a miss**, where the result still flows through the facts-fingerprint cache from #506.
- Raw-key variations (ordering/textual differences with equal canonical content) can only cause a conservative miss, never a wrong hit — still content-addressed, still no invalidation protocol.
- `open_transaction` prefetches the compiled `Arc` instead of a decoded facts `Vec`; the resolver's `SchemaFacts` staging variant is deleted (net simplification).

## Results (1k smoke)

| Workload | Before | After | Delta |
|---|---:|---:|---:|
| RocksDB transaction update_one_by_pk | 623 µs | 420 µs | **−33%** |
| RocksDB transaction delete_one_by_pk | 613 µs | 493 µs | **−20%** |
| SQLite transaction update_one_by_pk | 1.06 ms | 885 µs | **−16%** |
| SQLite transaction delete_one_by_pk | 1.25 ms | 947 µs | **−24%** |
| RocksDB transaction / sql_session insert 1k | ~9.0 / 15.8 ms | 8.2 / 14.3 ms | −9% |

Cumulative across both rounds since today's baseline: RocksDB `update_one` **1.35 ms → 420 µs (3.2×)**.

No regressions: storage accounting byte-identical, kv_layout control group within noise, redb single-row ops unmoved (dominated by redb's fixed per-commit durability cost). Verification profile confirms the decode/canonicalize frames are gone — remaining facts cost is the scan only.

## Validation

- `cargo test -p lix_engine --lib`: 930 passed, 0 failed (includes a new raw-rows cache test)
- Full smoke + accounting scorecards appended to the optimization log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction schema resolution and caching semantics on a hot path; incorrect fingerprinting could serve wrong catalogs, though the design only allows conservative misses.
> 
> **Overview**
> Adds a **second catalog cache layer** keyed on raw registered-schema row bytes so transactions can reuse compiled `CatalogSnapshot`s without decoding or canonicalizing schema JSON on every open/normalization pass.
> 
> `CatalogContext::compiled_catalog_for_domain` scans live state, blake3-fingerprints domain components plus raw `snapshot_content`, and returns a cached `Arc` on hit; decode and the existing facts-fingerprint compile path run only on miss. `open_transaction` and `TransactionSchemaResolver` now prefetch and hold compiled catalogs directly, removing the intermediate `SchemaFacts` staging type.
> 
> Shared helpers (`scan_catalog_rows`, `facts_from_catalog_rows`) dedupe catalog loading for SQL fact paths. A unit test covers cache hits and invalidation when raw rows change; the optimization log documents ~16–33% faster single-row transaction ops on SQLite/RocksDB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d280b229fa21d9d43c401202958b87e64b58b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->