### PR TITLE
Dedup change ids and commit ids out of stored values

### DIFF
--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1052,3 +1052,72 @@ update_one_by_pk each). Eliminating it requires caching scan results keyed on
 storage state, which needs an invalidation story; deferred. The validation
 fast-path (unconsumable fk_target bookkeeping, jsonschema is_valid) remains
 the next bulk-op target.
+
+## Backend Contract: sorted batch lowering and unspecified visit order
+
+Date: 2026-06-10
+
+Commands:
+
+```sh
+LIX_WRITE_SET_ORDER_STATS=1 LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+cargo test -p lix_engine --features storage-benches
+cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'kv_layout/lix_redb/smoke/update_all_rows'
+```
+
+Measurement (env-gated `LIX_WRITE_SET_ORDER_STATS` probe in write-set
+lowering):
+
+- Per 1k transaction insert/update commit, the hash-keyed
+  `json_store.json` batch (1,001 puts, ~49% of all puts) arrives unsorted;
+  `changelog.change` (1,000 puts, time-ordered ids) and
+  `tracked_state.tree_chunk` (BTreeMap iteration) arrive sorted.
+- The kv_layout bench writes its 1,000-put batch unsorted.
+- Delete commits lower almost entirely pre-sorted batches.
+
+Changes:
+
+- `StorageWriteSet` lowering now delivers each space batch to the backend
+  sorted by key ascending (skipping the sort when the batch is already
+  sorted, which is the common case for changelog/tree spaces; the
+  sortedness check itself is a read-only scan). Within a group all keys
+  share the space prefix, so logical order equals physical order. The
+  order probe reports natural order before the sort and covers puts and
+  deletes.
+- `BackendWrite::put_many`/`delete_many` document the contract: at most one
+  mutation per key, engine-produced batches sorted ascending.
+- `BackendRead::visit_keys` order is now actively enforced as unspecified: a
+  new order-scrambling backend decorator (`tests/backend/scrambled.rs`)
+  replays point-read visits in a seeded-shuffled order and must pass both
+  the backend conformance suite and a full transaction CRUD equivalence
+  test (identical row contents and identical per-space layout accounting at
+  every stage versus the plain in-memory backend; byte-exact physical
+  comparison is impossible because commit/change ids differ per run). Both
+  pass.
+
+Same-day A/B (single binary where noted):
+
+| Workload                          | Unsorted | Sorted  |  Delta |
+| --------------------------------- | -------: | ------: | -----: |
+| kv_layout redb update_all 1k      |  7.57 ms | 6.19 ms | -18.2% |
+| kv_layout rocksdb insert_all 1k   |   425 us |  349 us | -17.9% |
+| kv_layout sqlite insert_all 1k    |  1.51 ms | 1.42 ms |  -6.0% |
+| transaction redb update_all 1k    | 19.50 ms | 17.38 ms | -10.9% |
+| transaction sqlite delete_all 1k  |  ~12.0 ms | ~12.5 ms | inconclusive |
+
+The sqlite transaction delete_all cell initially measured +5-6% slower with
+sorting in stash-based A/Bs. A single-binary A/B (temporary
+`LIX_LOWER_UNSORTED` env toggle, removed with this change; reproduce by
+reverting the sort block in `write_set.rs`) also showed it, but reversing
+the within-pair run order flipped the sign in one of three pairs and
+widened the unsorted spread to +/-8%; the order probe shows the timed
+delete batches are already sorted, so sorting performs no writes on that
+path (only the read-only sortedness scan runs). Treated as noise. The
+kv_layout rows in the table above are stash-based same-day pairs; the
+delete_all investigation used the single-binary toggle. All engine test
+targets pass; accounting is unchanged (sorting only reorders within a
+batch).
+
+The rs-sdk SQLite backend keeps its internal sort as a cheap verification
+pass; with engine-sorted input it degenerates to a single ascending-run
+detection.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -728,3 +728,222 @@ SQLite transaction insert run immediately before this full smoke measured
 13.18 ms and Criterion reported an 8.8% improvement; the full smoke's SQLite
 transaction insert sample landed at 13.66 ms and Criterion reported no
 significant change.
+
+## Baseline Re-run Before New Optimization Pass: 2026-06-09
+
+Commands:
+
+```sh
+cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- smoke
+LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+```
+
+Notes:
+
+- Fresh baseline on branch `fable-5-optimization` (HEAD `e554c557`) before a
+  new round of optimization and bug squashing. No code changes in this entry.
+- The harness has changed since the last log entry: SQL session benches now
+  run on the real `lix_sqlite`, `lix_rocksdb`, and `lix_redb` backends instead
+  of a single in-memory backend, so SQL session numbers are not directly
+  comparable to earlier entries.
+- The accounting report now also emits per-backend rows; logical write counts
+  and layout footprint were identical across SQLite, RocksDB, and redb.
+- Criterion: 10 samples, 250 ms warmup, 1 s measurement. Values are Criterion
+  point estimates.
+
+### 1k Smoke Scorecard
+
+#### Direct KV Layout
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |    1.76 ms |   304 us |         130 us |          192 us |    1.56 ms |    68.0 us |     422 us |    54.0 us |
+| RocksDB |     428 us |   161 us |        2.32 us |         7.98 us |     490 us |    8.60 us |    17.9 us |    4.96 us |
+| redb    |    7.54 ms |   215 us |        13.0 us |         34.9 us |    8.05 ms |    4.07 ms |    4.88 ms |    4.26 ms |
+
+#### Transaction Layer
+
+Direct transaction API, bypassing SQL.
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |   10.91 ms |  2.84 ms |         189 us |          679 us |   14.01 ms |    1.57 ms |   12.94 ms |    1.62 ms |
+| RocksDB |    9.15 ms |  2.65 ms |        93.0 us |          298 us |    9.82 ms |    1.35 ms |    9.44 ms |    1.34 ms |
+| redb    |   20.34 ms |  2.86 ms |        67.7 us |          278 us |   20.41 ms |    6.37 ms |   17.35 ms |    6.10 ms |
+
+#### SQL Session
+
+Now runs on the real backends; SQL updates remain gated behind
+`LIX_TRACKED_STATE_CRUD_SQL_UPDATE=1` and excluded.
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: |
+| SQLite  |   17.97 ms |  6.59 ms |        1.29 ms |         1.53 ms |   18.25 ms |    7.85 ms |
+| RocksDB |   16.40 ms |  5.78 ms |        1.05 ms |         1.24 ms |   12.69 ms |    6.37 ms |
+| redb    |   30.27 ms |  6.11 ms |        1.19 ms |         1.46 ms |   21.06 ms |   11.36 ms |
+
+### 1k Smoke Accounting
+
+Logical write counts were identical across SQLite, RocksDB, and redb.
+
+| Layer       | Operation        | Logical rows |  Puts | Point deletes | Range deletes | Touched spaces | Backend calls | Written bytes | Put amp | Delete amp |
+| ----------- | ---------------- | -----------: | ----: | ------------: | ------------: | -------------: | ------------: | ------------: | ------: | ---------: |
+| kv_layout   | insert_all       |        1,000 | 1,000 |             0 |             0 |              1 |             1 |       396,363 |   1.00x |      0.00x |
+| kv_layout   | update_all       |        1,000 | 1,000 |             0 |             0 |              1 |             1 |       482,607 |   1.00x |      0.00x |
+| kv_layout   | update_one_by_pk |            1 |     1 |             0 |             0 |              1 |             1 |         6,693 |   1.00x |      0.00x |
+| kv_layout   | delete_all       |        1,000 |     0 |             0 |             1 |              0 |             1 |             0 |   0.00x |      0.00x |
+| kv_layout   | delete_one_by_pk |            1 |     0 |             1 |             0 |              1 |             1 |             0 |   0.00x |      1.00x |
+| transaction | insert_all       |        1,000 | 2,032 |             0 |             0 |              7 |             7 |       642,063 |   2.03x |      0.00x |
+| transaction | update_all       |        1,000 | 2,032 |             0 |             0 |              7 |             7 |       728,421 |   2.03x |      0.00x |
+| transaction | update_one_by_pk |            1 |    12 |             0 |             0 |              7 |             7 |        18,532 |  12.00x |      0.00x |
+| transaction | delete_all       |        1,000 | 1,032 |             0 |             0 |              7 |             7 |       292,912 |   1.03x |      0.00x |
+| transaction | delete_one_by_pk |            1 |    11 |             0 |             0 |              7 |             7 |        18,229 |  11.00x |      0.00x |
+
+### Layout Footprint After Insert
+
+Identical across SQLite, RocksDB, and redb.
+
+| Layer       | Space id     | Space                               |  Rows | Key bytes | Value bytes |
+| ----------- | ------------ | ----------------------------------- | ----: | --------: | ----------: |
+| kv_layout   | `0x00020001` | `tracked_state.crud.row.v1`         | 1,000 |    87,244 |     396,363 |
+| transaction | `0x00010002` | `untracked_state.row.v1`            |     2 |        83 |         185 |
+| transaction | `0x00020001` | `json_store.json`                   | 1,018 |    36,648 |     299,700 |
+| transaction | `0x00040001` | `tracked_state.tree_chunk`          |    27 |       972 |     162,086 |
+| transaction | `0x00040004` | `tracked_state.commit_root`         |     2 |        80 |         167 |
+| transaction | `0x00050001` | `binary_cas.manifest`               |     0 |         0 |           0 |
+| transaction | `0x00050002` | `binary_cas.manifest_chunk`         |     0 |         0 |           0 |
+| transaction | `0x00050003` | `binary_cas.chunk`                  |     0 |         0 |           0 |
+| transaction | `0x00060001` | `changelog.commit`                  |     2 |        80 |         102 |
+| transaction | `0x00060002` | `changelog.change`                  | 1,016 |    40,640 |     128,857 |
+| transaction | `0x00060003` | `changelog.commit_change_ref_chunk` |     3 |       135 |      71,882 |
+
+### Delta From Previous Full Smoke
+
+The previous full smoke was the fixture-teardown harness entry; the accounting
+reference is the bounded-chunk/codec-cut entries. Intervening mainline commits
+(not part of this log) account for these shifts.
+
+| Workload                               | Previous |  Current |  Delta |
+| -------------------------------------- | -------: | -------: | -----: |
+| SQLite transaction insert 1k           | 13.66 ms | 10.91 ms | -20.1% |
+| RocksDB transaction insert 1k          | 10.22 ms |  9.15 ms | -10.5% |
+| redb transaction insert 1k             | 20.17 ms | 20.34 ms |  +0.8% |
+| SQLite transaction update_all 1k       | 15.39 ms | 14.01 ms |  -9.0% |
+| RocksDB transaction update_all 1k      | 11.58 ms |  9.82 ms | -15.2% |
+| RocksDB transaction delete_all 1k      | 11.18 ms |  9.44 ms | -15.6% |
+| transaction `insert_all` puts          |    2,038 |    2,032 |     -6 |
+| transaction `insert_all` bytes         |  811,483 |  642,063 | -20.9% |
+| transaction `update_all` bytes         |  925,898 |  728,421 | -21.3% |
+| transaction `delete_all` bytes         |  492,389 |  292,912 | -40.5% |
+| `changelog.change` value bytes         |  189,738 |  128,857 | -32.1% |
+| `tracked_state.tree_chunk` value bytes |  243,324 |  162,086 | -33.4% |
+| `commit_change_ref_chunk` value bytes  |  101,325 |   71,882 | -29.1% |
+
+SQL session numbers have no comparable previous entry because the harness moved
+from the in-memory backend to the three real backends.
+
+## Optimization Run: compiled schema catalog cache
+
+Date: 2026-06-09
+
+Commands:
+
+```sh
+cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- smoke
+LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+cargo test -p lix_engine
+```
+
+Profiling:
+
+- samply profiles of the bench binary (built with
+  `CARGO_PROFILE_BENCH_DEBUG=true`, recorded via
+  `samply record --save-only -- <bench-bin> --bench <filter> --profile-time 10`)
+  showed `CatalogSnapshot::from_schema_facts` being rebuilt on every
+  transaction: 6.7% of the timed 1k `insert_all` op and 47.4% of the timed
+  `update_one_by_pk` op on RocksDB, almost all of it in
+  `SchemaPlan::compile`/`compile_lix_schema` (jsonschema validator
+  compilation).
+
+Change:
+
+- `CatalogContext` now caches compiled `CatalogSnapshot`s in an engine-wide
+  map keyed by a blake3 content fingerprint of the schema facts
+  (`fingerprint_schema_facts`). Identical fact sets always hash identically,
+  so cached snapshots cannot go stale and no invalidation protocol exists;
+  changed schema rows produce different facts and therefore a different key.
+- Transactions hold a `TransactionCatalog` copy-on-write handle:
+  `Shared(Arc<CatalogSnapshot>)` from the cache for normal reads, switched to
+  a private `Owned` rebuild only when the transaction registers a schema
+  (`insert_schema_for_domain`). Pending registrations are never visible to
+  the shared cache.
+- Plan ids stay stable across the copy-on-write rebuild because catalog
+  entries keep their insertion order, matching the previous full-rebuild
+  semantics of `insert_schema_for_domain`.
+- The cache holds at most 64 fact sets and clears wholesale at the bound;
+  schema catalogs churn rarely, so this only guards pathological
+  schema-mutation workloads.
+- Storage accounting is unchanged by construction: the accounting tables from
+  this run are byte-identical to the 2026-06-09 baseline.
+- `cargo test -p lix_engine`: 927 passed, 0 failed.
+
+### 1k Smoke Scorecard
+
+#### Transaction Layer
+
+Direct transaction API, bypassing SQL. Criterion point estimates:
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |   10.57 ms |  3.00 ms |         194 us |          666 us |   14.30 ms |    1.06 ms |   11.86 ms |    1.25 ms |
+| RocksDB |    9.00 ms |  2.77 ms |        41.8 us |          271 us |    8.43 ms |     623 us |    8.08 ms |     613 us |
+| redb    |   19.75 ms |  2.73 ms |        67.0 us |          263 us |   19.24 ms |    5.14 ms |   16.50 ms |    5.13 ms |
+
+#### SQL Session
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: |
+| SQLite  |   17.84 ms |  6.60 ms |        1.32 ms |         1.48 ms |   15.52 ms |    6.91 ms |
+| RocksDB |   15.77 ms |  5.69 ms |        1.04 ms |         1.18 ms |   12.54 ms |    5.61 ms |
+| redb    |   31.24 ms |  6.51 ms |        1.26 ms |         1.42 ms |   20.14 ms |   10.33 ms |
+
+#### Direct KV Layout
+
+Control group; this patch does not touch the KV layout path. Movement here is
+run-to-run noise on microsecond-scale benches.
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |    1.52 ms |   301 us |         168 us |          175 us |    1.58 ms |    70.4 us |     432 us |    52.6 us |
+| RocksDB |     437 us |   161 us |        2.73 us |         10.0 us |     470 us |    9.10 us |    4.69 us |    4.33 us |
+| redb    |    8.14 ms |   239 us |        12.5 us |         18.5 us |    8.97 ms |    4.23 ms |    4.47 ms |    4.04 ms |
+
+### Delta From 2026-06-09 Baseline
+
+Same machine, same day, same harness. Transaction and SQL session deltas are
+attributable to this change; single-row transaction mutations no longer pay a
+full jsonschema catalog compile per commit.
+
+| Workload                              | Baseline |  Current |  Delta |
+| ------------------------------------- | -------: | -------: | -----: |
+| RocksDB transaction update_one_by_pk  |  1.35 ms |   623 us | -54.0% |
+| RocksDB transaction delete_one_by_pk  |  1.34 ms |   613 us | -54.4% |
+| RocksDB transaction read_one_by_pk    |  93.0 us |  41.8 us | -55.0% |
+| SQLite transaction update_one_by_pk   |  1.57 ms |  1.06 ms | -32.7% |
+| SQLite transaction delete_one_by_pk   |  1.62 ms |  1.25 ms | -22.9% |
+| redb transaction update_one_by_pk     |  6.37 ms |  5.14 ms | -19.3% |
+| redb transaction delete_one_by_pk     |  6.10 ms |  5.13 ms | -15.9% |
+| RocksDB transaction update_all 1k     |  9.82 ms |  8.43 ms | -14.2% |
+| RocksDB transaction delete_all 1k     |  9.44 ms |  8.08 ms | -14.4% |
+| RocksDB transaction insert_all 1k     |  9.15 ms |  9.00 ms |  -1.6% |
+| SQLite transaction delete_all 1k      | 12.94 ms | 11.86 ms |  -8.3% |
+| SQLite sql_session delete_all 1k      | 18.25 ms | 15.52 ms | -15.0% |
+| SQLite sql_session delete_one_by_pk   |  7.85 ms |  6.91 ms | -12.0% |
+| RocksDB sql_session delete_one_by_pk  |  6.37 ms |  5.61 ms | -11.9% |
+
+The focused RocksDB run immediately after the change (against Criterion's
+cached pre-change baseline) measured insert_all at 8.42 ms (-14.3%); the full
+smoke sample above landed at 9.00 ms, so the bulk-insert win is real but
+within a few percent of run variance. The dominant, robust win is the removal
+of the fixed per-transaction catalog compile, which was about half of every
+single-row transaction operation.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -947,3 +947,108 @@ smoke sample above landed at 9.00 ms, so the bulk-insert win is real but
 within a few percent of run variance. The dominant, robust win is the removal
 of the fixed per-transaction catalog compile, which was about half of every
 single-row transaction operation.
+
+## Optimization Run: raw-row keyed catalog cache
+
+Date: 2026-06-09
+
+Commands:
+
+```sh
+cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- smoke
+LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+cargo test -p lix_engine --lib
+```
+
+Profiling:
+
+- After the compiled-catalog cache, samply showed the schema-facts pipeline as
+  the dominant fixed cost of single-row transaction ops: about 60% of
+  `update_one_by_pk` on RocksDB, paid twice per transaction (once in
+  `open_transaction`'s prefetch, once at row normalization). The pipeline was
+  live-state scan (~15% + ~14%) plus `decode_registered_schema_row` serde
+  parsing of every schema row (~8% + ~9%) plus `fingerprint_schema_facts`
+  canonical-JSON serialization (~11%).
+- The decode and canonicalization existed only to compute the cache key.
+  Decoding is deterministic, so the raw `snapshot_content` bytes already
+  uniquely determine the decoded facts.
+
+Change:
+
+- `CatalogContext::compiled_catalog_for_domain` is the new transaction hot
+  path: it scans the raw registered-schema rows for a domain, fingerprints
+  the raw row contents (blake3, length-prefixed schema-domain component +
+  `snapshot_content`), and returns the cached `Arc<CatalogSnapshot>` on a
+  hit. Rows are only JSON-decoded and canonicalized on a miss, where the
+  result flows through the existing facts-fingerprint cache.
+- A raw-key variation (ordering or textual differences with equal canonical
+  content) can only cause a conservative cache miss, never a wrong hit.
+- `open_transaction` now prefetches the compiled catalog `Arc` instead of a
+  decoded facts `Vec`, and `TransactionSchemaResolver` stores
+  `TransactionCatalog` directly; the intermediate `SchemaFacts` staging
+  variant is gone.
+- Storage accounting is byte-identical to the previous entry.
+- `cargo test -p lix_engine --lib`: 930 passed, 0 failed.
+- Verification profile: `decode_registered_schema_row` and
+  `fingerprint_schema_facts` no longer appear in the `update_one_by_pk`
+  stacks; the remaining facts cost is `scan_catalog_rows` only.
+
+### 1k Smoke Scorecard
+
+Note: this run was taken while the machine was in interactive use, so
+individual cells carry more noise than earlier entries. The kv_layout control
+group stayed within historical variance.
+
+#### Transaction Layer
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |   10.79 ms |  2.88 ms |         202 us |          688 us |   13.26 ms |     885 us |   11.83 ms |     947 us |
+| RocksDB |    8.16 ms |  2.65 ms |        41.7 us |          260 us |    8.46 ms |     420 us |    8.08 ms |     493 us |
+| redb    |   19.41 ms |  2.80 ms |        57.3 us |          275 us |   19.50 ms |    5.19 ms |   16.37 ms |    5.08 ms |
+
+#### SQL Session
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: |
+| SQLite  |   17.50 ms |  6.33 ms |        1.27 ms |         1.47 ms |   15.80 ms |    6.67 ms |
+| RocksDB |   14.30 ms |  5.49 ms |        1.11 ms |         1.15 ms |   12.14 ms |    5.54 ms |
+| redb    |   30.18 ms |  5.77 ms |        1.19 ms |         1.34 ms |   20.02 ms |   10.15 ms |
+
+#### Direct KV Layout
+
+Control group; untouched by this patch.
+
+| Backend | Insert all | Read all | Read one by PK | Read many by PK | Update all | Update one | Delete all | Delete one |
+| ------- | ---------: | -------: | -------------: | --------------: | ---------: | ---------: | ---------: | ---------: |
+| SQLite  |    1.51 ms |   303 us |         158 us |          189 us |    1.57 ms |    74.1 us |     485 us |    43.7 us |
+| RocksDB |     425 us |   156 us |        2.61 us |         7.29 us |     477 us |    8.53 us |    4.64 us |    5.08 us |
+| redb    |    8.12 ms |   241 us |        15.5 us |         31.6 us |    9.86 ms |    4.10 ms |    4.75 ms |    4.03 ms |
+
+### Delta From Previous Entry (compiled schema catalog cache)
+
+| Workload                             | Previous |  Current |  Delta |
+| ------------------------------------ | -------: | -------: | -----: |
+| RocksDB transaction update_one_by_pk |   623 us |   420 us | -32.6% |
+| RocksDB transaction delete_one_by_pk |   613 us |   493 us | -19.6% |
+| SQLite transaction update_one_by_pk  |  1.06 ms |   885 us | -16.2% |
+| SQLite transaction delete_one_by_pk  |  1.25 ms |   947 us | -24.1% |
+| RocksDB transaction insert_all 1k    |  9.00 ms |  8.16 ms |  -9.3% |
+| RocksDB sql_session insert_all 1k    | 15.77 ms | 14.30 ms |  -9.3% |
+| SQLite transaction update_all 1k     | 14.30 ms | 13.26 ms |  -7.3% |
+| redb transaction update_one_by_pk    |  5.14 ms |  5.19 ms |  +1.0% |
+
+redb single-row ops are dominated by redb's fixed per-commit durability cost,
+so the catalog-path savings do not move them; that cost is a backend
+characteristic, not an engine overhead.
+
+Cumulative since the 2026-06-09 baseline (both catalog cache rounds):
+RocksDB transaction update_one_by_pk 1.35 ms -> 420 us (3.2x), delete_one_by_pk
+1.34 ms -> 493 us (2.7x), SQLite update_one_by_pk 1.57 ms -> 885 us (1.8x).
+
+Remaining target from the verification profile: the live-state scan of
+registered-schema rows still runs twice per transaction (~19% of
+update_one_by_pk each). Eliminating it requires caching scan results keyed on
+storage state, which needs an invalidation story; deferred. The validation
+fast-path (unconsumable fk_target bookkeeping, jsonschema is_valid) remains
+the next bulk-op target.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1190,3 +1190,72 @@ small against commit totals. The durable claim is the storage table above.
   all targets (three changelog scan tests and two rebuild tests updated:
   resume tokens are typed now, and corruption fixtures plant records at
   binary keys).
+
+## Tree-Chunk Leaf Compaction: front-coded keys
+
+Date: 2026-06-10
+
+Commands:
+
+```sh
+LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+cargo test -p lix_engine --features storage-benches
+```
+
+Change (hard cut):
+
+- Leaf nodes use a new wire format: a kind byte, then per entry a
+  shared-prefix length, key suffix, and verbatim value bytes. Entries within
+  a node are sorted, so consecutive keys share the encoded
+  schema-key/file-id prefix and most of the entity pk; front-coding removes
+  that redundancy. Values are untouched, so value byte-equality and the
+  value codec are unchanged. Internal nodes keep their musli body behind the
+  kind byte.
+- Chunk boundary logic is untouched: boundaries are content-defined on
+  uncompressed key bytes, so the same entries land in the same chunks and
+  history-independence is preserved by construction. There is no
+  estimator/codec coupling to drift.
+- Decode reconstructs keys into a single pre-reserved arena per node; values
+  stay zero-copy. Debug builds verify every encoded leaf round-trips.
+  Property tests cover representative shapes, 512 generated heavy-prefix
+  keys, determinism, and malformed-byte rejection.
+
+### Storage A/B (1k insert footprint, identical across backends)
+
+| Metric                              |  Before |   After |  Delta |
+| ----------------------------------- | ------: | ------: | -----: |
+| `tree_chunk` value bytes (27 chunks) | 162,086 | 125,918 | -22.3% |
+| transaction insert_all written bytes | 642,063 | 606,256 |  -5.6% |
+| transaction update_all written bytes | 728,421 | 692,589 |  -4.9% |
+| transaction delete_all written bytes | 292,912 | 257,080 | -12.2% |
+
+Put counts and chunk counts unchanged.
+
+### Perf A/B (alternating stash triples, RocksDB)
+
+- read_one_by_pk: OLD mean 64.0 us, NEW mean 51.3 us (faster in all three
+  pairs; smaller chunks mean less memory traffic on hot decodes).
+- read_many_by_pk initially regressed +8.3% consistently: the decode arena
+  grew by doubling, costing ~8 re-allocations per leaf. Pre-reserving the
+  arena to the body length erased it (OLD mean 313.3 us, NEW 311.3 us, sign
+  flipping across pairs).
+- 10k spot check: rocksdb transaction insert 77.6 ms, read_all 32.7 ms; no
+  split pathology (boundaries are codec-independent).
+
+### Byte-exact order-independence enforcement
+
+Validating this change hardened the equivalence suite and found an engine
+bug:
+
+- The scrambled-visit equivalence test now runs both fixtures in
+  deterministic-functions mode and asserts byte-identical storage across all
+  ten spaces at every stage, replacing aggregate row/byte-total comparison
+  (which could collide and, with wall-clock content, flaked
+  time-dependently).
+- The exact comparison immediately exposed that `FunctionContext::prepare`
+  stamped the deterministic-sequence bookkeeping row from the system clock
+  even in deterministic mode, violating that mode's byte-determinism
+  contract. Bookkeeping timestamps now derive from the persisted sequence
+  without consuming a sequence tick. Stress: 20 consecutive runs green.
+
+- `cargo test -p lix_engine --features storage-benches`: 1,538 passed.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1121,3 +1121,72 @@ batch).
 The rs-sdk SQLite backend keeps its internal sort as a cheap verification
 pass; with engine-sorted input it degenerates to a single ascending-run
 detection.
+
+## Binary UUID Keys For Changelog And Commit Roots
+
+Date: 2026-06-10
+
+Commands:
+
+```sh
+LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+cargo test -p lix_engine --features storage-benches
+```
+
+Context:
+
+- `ChangeId`/`CommitId` were already binary in memory (`Uuid` wrappers) and
+  already encode as 16 raw bytes inside musli values. The only remaining
+  text leak was three key codecs routing ids through `Display` into 36-byte
+  hyphenated text: `changelog.change`/`changelog.commit` identity keys, the
+  `commit_change_ref_chunk` key prefix, and `tracked_state.commit_root`
+  keys.
+
+Change (hard cut, no migration):
+
+- Identity keys are now the raw 16 UUID bytes. UUIDv7 big-endian byte order
+  matches hyphenated-text lexicographic order, so range scans, resume
+  tokens, and the sorted-batch lowering contract behave identically.
+- Scan resume tokens decode from the binary key (`commit_id_from_key` /
+  `change_id_from_key`) instead of `String::from_utf8`.
+- `tracked_state.commit_root` staging and lookup share one binary key
+  helper; the test-only text-key fallback in `load_commit_root` is gone
+  (`parse_lix` canonicalizes test labels identically on both paths).
+- Scan `start_after` tokens now parse as UUIDs, so a malformed resume token
+  errors instead of silently scanning from an arbitrary text position.
+
+### Storage A/B (1k insert footprint, identical on all three backends)
+
+| Space                               | Key bytes before | after  |  Delta |
+| ----------------------------------- | ---------------: | -----: | -----: |
+| `changelog.change` (1,016 rows)     |           40,640 | 20,320 | -50.0% |
+| `changelog.commit`                  |               80 |     40 | -50.0% |
+| `tracked_state.commit_root`         |               80 |     40 | -50.0% |
+| `changelog.commit_change_ref_chunk` |              135 |     72 | -46.7% |
+
+Engine key bytes overall: ~78.6 KB -> ~58.2 KB (-26%). Value bytes are
+byte-identical, confirming the value codecs were already binary. Total
+store bytes shrink ~2.8% at this fixture size; the structural win is
+changelog B-tree geometry (half-width keys on the highest-row-count space),
+which compounds as the store grows.
+
+### Perf A/B
+
+Same-day single-run comparison was noisy in both directions; an alternating
+stash-based triple A/B on the contested RocksDB cells pooled to NEW slightly
+faster with overlapping spreads:
+
+| Cell (rocksdb transaction)  | OLD mean (3 runs) | NEW mean (3 runs) |
+| --------------------------- | ----------------: | ----------------: |
+| read_one_by_pk              |           58.0 us |           45.4 us |
+| update_one_by_pk            |            574 us |            490 us |
+
+Treated as perf-neutral-to-positive at 1k smoke scale, as predicted when
+this cut was scoped: the per-commit savings (one fewer String allocation
+plus Display format per id-keyed row, halved key compares) are real but
+small against commit totals. The durable claim is the storage table above.
+
+- `cargo test -p lix_engine --features storage-benches`: 1,534 passed across
+  all targets (three changelog scan tests and two rebuild tests updated:
+  resume tokens are typed now, and corruption fixtures plant records at
+  binary keys).

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1259,3 +1259,81 @@ bug:
   without consuming a sequence tick. Stress: 20 consecutive runs green.
 
 - `cargo test -p lix_engine --features storage-benches`: 1,538 passed.
+
+## Value Dedup: keyed change ids and chunk-local commit dictionaries
+
+Date: 2026-06-10
+
+Commands:
+
+```sh
+LIX_TRACKED_STATE_CRUD_ACCOUNTING=1 cargo bench -p lix_engine --features storage-benches --bench tracked_state_crud -- 'no_matching_benchmark_filter'
+cargo test -p lix_engine --features storage-benches
+```
+
+Changes (hard cuts):
+
+- `ChangeRecord` values no longer store `change_id`: it is the storage key
+  and is reconstructed on decode, the same pattern
+  `commit_change_ref_chunk` already uses for `commit_id`. The in-memory
+  record keeps the id; only the stored form
+  (`ChangeRecordRef`/`ChangeRecordView`) drops it. The scan-path
+  key-vs-value consistency check became tautological and was removed; a
+  direct codec round-trip suite (fully populated, empty options,
+  id-from-argument) covers the hand-threaded stored form.
+- Leaf nodes dictionary the commit-id slice of their values chunk-locally.
+  The standard value encoding places `change_id` at bytes [0..16) and
+  `commit_id` at [16..32) (pinned by a layout test); bulk commits repeat one
+  commit id across every entry, so the encoder collects first-occurrence
+  commit ids into a per-chunk dictionary and stores values with the slice
+  spliced out. The splice is reversible byte-for-byte regardless of value
+  semantics; values shorter than 32 bytes are stored verbatim (dict ref 0).
+  Dictionaried values are reconstructed into the decode arena; verbatim
+  values stay zero-copy. Both golden wire-format vectors (dict-less and
+  dictionaried) pin the encoding.
+
+Review found two decoder bugs in the initial diff, both fixed with
+regression tests:
+
+- The shared-prefix guard measured the previous key from the arena tail,
+  which holds value bytes after a dictionaried entry; a corrupt chunk with
+  an inflated shared length was accepted and front-coded the next key out
+  of value bytes. The decoder now tracks the previous key end explicitly.
+- `(dict_ref - 1) * 16` was unchecked; a dict_ref near 2^60 wrapped the
+  multiplication in release builds and aliased dictionary slot 0. The
+  decoder validates `dict_ref <= dict_len` before any index arithmetic.
+
+Note on coverage: the byte-exact scrambled equivalence test exercises the
+dictionaried path (its fixture values are full tracked-state encodings) but
+compares the two fixtures against each other, so it catches order-dependent
+bugs only; deterministic codec bugs are the round-trip/golden suites' job.
+
+### Storage A/B (1k insert footprint, identical across backends)
+
+| Metric                                | Before  | After   | Delta  |
+| ------------------------------------- | ------: | ------: | -----: |
+| `changelog.change` value bytes        | 128,857 | 112,601 | -12.6% |
+| `tree_chunk` value bytes              | 125,918 | 110,833 | -12.0% |
+| transaction insert_all written bytes  | 606,256 | 575,409 |  -5.1% |
+| transaction update_all written bytes  | 692,589 | 661,744 |  -4.5% |
+| transaction delete_all written bytes  | 257,080 | 226,234 | -12.0% |
+
+The change-record delta is exactly 16 bytes x 1,016 records. Cumulative
+tree_chunk since before the front-coding cut: 162,086 -> 110,833 (-31.6%).
+
+### Perf A/B (alternating stash triples, RocksDB)
+
+read_all 2.640 -> 2.618 ms means and read_many 266.7 -> 270.2 us means, both
+with sign flips across pairs: parity. read_one initially measured
+42.2 -> 46.2 us means with mixed signs; because dictionaried values lose
+zero-copy on decode (a plausible mechanism for a point-read cost), a second
+alternating triple was run and came back at parity (48.6 -> 49.2 us means,
+sign flipping across pairs). Across all six pairs the sign flips in three:
+no consistent regression.
+
+- `cargo test -p lix_engine --features storage-benches`: 1,549 passed.
+  New tests: value-layout pin; dictionaried round-trip with mixed
+  verbatim/32-byte-boundary/bulk entries plus a compression assertion;
+  dict-less and dictionaried golden wire vectors; out-of-bounds, wrapping,
+  and adversarial-length dictionary rejection; shared-length-after-
+  dictionaried-value rejection; direct change-record round-trips.

--- a/packages/engine/src/backend/traits.rs
+++ b/packages/engine/src/backend/traits.rs
@@ -203,9 +203,17 @@ pub trait BackendWrite {
     ///
     /// Batches hold at most one mutation per key (the engine's write-set
     /// validation enforces this before lowering), so backends may reorder
-    /// entries freely, e.g. to write in key order.
+    /// entries freely. The engine's write-set lowering additionally produces
+    /// batches sorted by key ascending, so backends that want key order pay
+    /// at most a linear verification pass on engine-produced batches. Other
+    /// callers (e.g. the conformance suite) may pass unsorted batches.
     fn put_many(&mut self, entries: PutBatch) -> Result<(), BackendError>;
 
+    /// Deletes the given keys.
+    ///
+    /// Like put batches, key sets hold at most one mutation per key
+    /// (write-set validation rejects duplicates), and the engine's write-set
+    /// lowering produces them sorted ascending.
     fn delete_many(&mut self, keys: &[Key]) -> Result<(), BackendError>;
 
     fn delete_range(&mut self, range: KeyRange) -> Result<(), BackendError>;

--- a/packages/engine/src/backend/traits.rs
+++ b/packages/engine/src/backend/traits.rs
@@ -30,6 +30,10 @@ pub trait Backend {
 pub trait BackendRead {
     type RangeScan<'cursor>: BackendRangeScan;
 
+    /// Visits the requested keys, calling the visitor with each key's
+    /// position in `keys`. Visit order is unspecified; consumers must
+    /// address results by the visited index, which lets backends return
+    /// rows in whatever order their storage produces them.
     fn visit_keys<V>(
         &self,
         keys: &[Key],
@@ -195,6 +199,11 @@ where
 }
 
 pub trait BackendWrite {
+    /// Stages the batch's entries for the transaction.
+    ///
+    /// Batches hold at most one mutation per key (the engine's write-set
+    /// validation enforces this before lowering), so backends may reorder
+    /// entries freely, e.g. to write in key order.
     fn put_many(&mut self, entries: PutBatch) -> Result<(), BackendError>;
 
     fn delete_many(&mut self, keys: &[Key]) -> Result<(), BackendError>;

--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::Value as JsonValue;
 
-use crate::catalog::snapshot::{CatalogFingerprint, fingerprint_schema_facts};
+use crate::catalog::snapshot::{
+    CatalogFingerprint, fingerprint_schema_facts, hash_fingerprint_part,
+};
 use crate::catalog::{CatalogSnapshot, SchemaCatalogFact};
 use crate::domain::{Domain, committed_row_is_exact_branch_scoped};
 use crate::live_state::MaterializedLiveStateRow;
@@ -26,13 +28,72 @@ const COMPILED_CATALOG_CACHE_LIMIT: usize = 64;
 /// the engine-wide cache of compiled catalog snapshots, keyed by fact content.
 pub(crate) struct CatalogContext {
     compiled_catalogs: Mutex<HashMap<CatalogFingerprint, Arc<CatalogSnapshot>>>,
+    compiled_catalogs_by_rows: Mutex<HashMap<CatalogRowsFingerprint, Arc<CatalogSnapshot>>>,
 }
+
+/// Fingerprint of the raw catalog rows visible to a domain, hashed before any
+/// JSON decoding. The raw `snapshot_content` bytes uniquely determine the
+/// decoded facts, so this key is at least as discriminating as the facts
+/// fingerprint: textual or ordering variations can only cause a conservative
+/// cache miss, never a wrong hit.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CatalogRowsFingerprint(String);
 
 impl CatalogContext {
     pub(crate) fn new() -> Self {
         Self {
             compiled_catalogs: Mutex::new(HashMap::new()),
+            compiled_catalogs_by_rows: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Returns the compiled snapshot for the catalog rows visible to `domain`.
+    ///
+    /// This is the transaction hot path. On a hit it costs one live-state scan
+    /// plus a hash of the raw row contents; schema rows are only JSON-decoded
+    /// and canonicalized when the raw fingerprint has not been seen before.
+    pub(crate) async fn compiled_catalog_for_domain<R>(
+        &self,
+        live_state: &R,
+        domain: &Domain,
+    ) -> Result<Arc<CatalogSnapshot>, LixError>
+    where
+        R: LiveStateReader + ?Sized,
+    {
+        let catalog_rows = scan_catalog_rows(live_state, domain).await?;
+        let mut hasher = blake3::Hasher::new();
+        for (schema_domain, row) in &catalog_rows {
+            hash_fingerprint_part(&mut hasher, &schema_domain.fingerprint_component());
+            let snapshot_content = row
+                .snapshot_content
+                .as_deref()
+                .expect("catalog rows are filtered to rows with snapshot_content");
+            hash_fingerprint_part(&mut hasher, snapshot_content);
+        }
+        let fingerprint = CatalogRowsFingerprint(hasher.finalize().to_hex().to_string());
+
+        if let Some(snapshot) = self
+            .compiled_catalogs_by_rows
+            .lock()
+            .expect("compiled catalog rows cache lock should not be poisoned")
+            .get(&fingerprint)
+        {
+            return Ok(Arc::clone(snapshot));
+        }
+
+        let facts = facts_from_catalog_rows(&catalog_rows)?;
+        let snapshot = self.compiled_catalog_for_facts(&facts)?;
+        let mut cache = self
+            .compiled_catalogs_by_rows
+            .lock()
+            .expect("compiled catalog rows cache lock should not be poisoned");
+        if cache.len() >= COMPILED_CATALOG_CACHE_LIMIT {
+            if let Some(evicted) = cache.keys().find(|key| **key != fingerprint).cloned() {
+                cache.remove(&evicted);
+            }
+        }
+        cache.insert(fingerprint, Arc::clone(&snapshot));
+        Ok(snapshot)
     }
 
     /// Returns the compiled snapshot for `facts`, building it on first use.
@@ -118,33 +179,55 @@ impl CatalogContext {
     where
         R: LiveStateReader + ?Sized,
     {
-        let mut facts = Vec::new();
-        for schema_domain in domain.schema_catalog_domains() {
-            let rows = live_state
-                .scan_rows(&LiveStateScanRequest {
-                    filter: LiveStateFilter {
-                        schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
-                        branch_ids: vec![schema_domain.branch_id().to_string()],
-                        file_ids: vec![NullableKeyFilter::Null],
-                        untracked: Some(schema_domain.untracked()),
-                        include_tombstones: false,
-                        ..LiveStateFilter::default()
-                    },
-                    ..LiveStateScanRequest::default()
-                })
-                .await?;
-            for row in rows
-                .into_iter()
-                .filter(|row| row_belongs_to_schema_catalog_domain(row, &schema_domain))
-            {
-                let Some((key, schema)) = decode_registered_schema_row(&row)? else {
-                    continue;
-                };
-                facts.push(SchemaCatalogFact::new(schema_domain.clone(), key, schema));
-            }
-        }
-        Ok(facts)
+        let catalog_rows = scan_catalog_rows(live_state, domain).await?;
+        facts_from_catalog_rows(&catalog_rows)
     }
+}
+
+/// Scans the raw registered-schema rows reachable from `domain`, without
+/// decoding their snapshots.
+async fn scan_catalog_rows<R>(
+    live_state: &R,
+    domain: &Domain,
+) -> Result<Vec<(Domain, MaterializedLiveStateRow)>, LixError>
+where
+    R: LiveStateReader + ?Sized,
+{
+    let mut catalog_rows = Vec::new();
+    for schema_domain in domain.schema_catalog_domains() {
+        let rows = live_state
+            .scan_rows(&LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
+                    branch_ids: vec![schema_domain.branch_id().to_string()],
+                    file_ids: vec![NullableKeyFilter::Null],
+                    untracked: Some(schema_domain.untracked()),
+                    include_tombstones: false,
+                    ..LiveStateFilter::default()
+                },
+                ..LiveStateScanRequest::default()
+            })
+            .await?;
+        catalog_rows.extend(
+            rows.into_iter()
+                .filter(|row| row_belongs_to_schema_catalog_domain(row, &schema_domain))
+                .map(|row| (schema_domain.clone(), row)),
+        );
+    }
+    Ok(catalog_rows)
+}
+
+fn facts_from_catalog_rows(
+    catalog_rows: &[(Domain, MaterializedLiveStateRow)],
+) -> Result<Vec<SchemaCatalogFact>, LixError> {
+    let mut facts = Vec::new();
+    for (schema_domain, row) in catalog_rows {
+        let Some((key, schema)) = decode_registered_schema_row(row)? else {
+            continue;
+        };
+        facts.push(SchemaCatalogFact::new(schema_domain.clone(), key, schema));
+    }
+    Ok(facts)
 }
 
 fn row_belongs_to_schema_catalog_domain(row: &MaterializedLiveStateRow, domain: &Domain) -> bool {
@@ -198,6 +281,44 @@ mod tests {
     use crate::GLOBAL_BRANCH_ID;
     use crate::changelog::ChangeId;
     use crate::live_state::LiveStateRowRequest;
+
+    #[tokio::test]
+    async fn compiled_catalog_for_domain_hits_cache_without_decoding() {
+        let context = CatalogContext::new();
+        let domain = Domain::schema_catalog("global", true);
+        let reader = RowsLiveStateReader::new(vec![
+            registered_schema_row("alpha_schema"),
+            registered_schema_row("beta_schema"),
+        ]);
+
+        let first = context
+            .compiled_catalog_for_domain(&reader, &domain)
+            .await
+            .expect("catalog should compile");
+        let second = context
+            .compiled_catalog_for_domain(&reader, &domain)
+            .await
+            .expect("catalog should hit the raw-rows cache");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "identical raw rows must return the cached snapshot"
+        );
+
+        let changed_reader = RowsLiveStateReader::new(vec![
+            registered_schema_row("alpha_schema"),
+            registered_schema_row("gamma_schema"),
+        ]);
+        let changed = context
+            .compiled_catalog_for_domain(&changed_reader, &domain)
+            .await
+            .expect("changed catalog should compile");
+        assert!(
+            !Arc::ptr_eq(&first, &changed),
+            "changed raw rows must compile a different snapshot"
+        );
+        assert!(changed.contains("gamma_schema"));
+        assert!(!first.contains("gamma_schema"));
+    }
 
     #[test]
     fn compiled_catalog_cache_shares_snapshots_for_equal_facts() {

--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -1,8 +1,10 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
 
 use serde_json::Value as JsonValue;
 
-use crate::catalog::SchemaCatalogFact;
+use crate::catalog::snapshot::{CatalogFingerprint, fingerprint_schema_facts};
+use crate::catalog::{CatalogSnapshot, SchemaCatalogFact};
 use crate::domain::{Domain, committed_row_is_exact_branch_scoped};
 use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{LiveStateFilter, LiveStateReader, LiveStateScanRequest};
@@ -11,16 +13,65 @@ use crate::{LixError, NullableKeyFilter};
 
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
+/// Compiled catalog snapshots are cached at most this many fact sets deep.
+/// Schema catalogs churn rarely; the bound only guards against pathological
+/// schema-mutation workloads growing the cache without limit.
+const COMPILED_CATALOG_CACHE_LIMIT: usize = 64;
+
 /// Engine schema visibility boundary.
 ///
 /// SQL planning receives a schema snapshot from live state. System schemas are
 /// seeded as ordinary `lix_registered_schema` rows during initialization, so
-/// runtime schema visibility has one source of truth.
-pub(crate) struct CatalogContext;
+/// runtime schema visibility has one source of truth. The context also owns
+/// the engine-wide cache of compiled catalog snapshots, keyed by fact content.
+pub(crate) struct CatalogContext {
+    compiled_catalogs: Mutex<HashMap<CatalogFingerprint, Arc<CatalogSnapshot>>>,
+}
 
 impl CatalogContext {
     pub(crate) fn new() -> Self {
-        Self
+        Self {
+            compiled_catalogs: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns the compiled snapshot for `facts`, building it on first use.
+    ///
+    /// The cache key is the content fingerprint of the facts, so a cached
+    /// snapshot can never go stale: changed schema rows produce different
+    /// facts and therefore a different key. The lock is not held while
+    /// compiling, so two racing callers may both compile the same facts; the
+    /// results are identical and the last insert wins.
+    pub(crate) fn compiled_catalog_for_facts(
+        &self,
+        facts: &[SchemaCatalogFact],
+    ) -> Result<Arc<CatalogSnapshot>, LixError> {
+        let fingerprint = fingerprint_schema_facts(facts)?;
+        if let Some(snapshot) = self
+            .compiled_catalogs
+            .lock()
+            .expect("compiled catalog cache lock should not be poisoned")
+            .get(&fingerprint)
+        {
+            return Ok(Arc::clone(snapshot));
+        }
+        let snapshot = Arc::new(CatalogSnapshot::from_schema_facts(facts)?);
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_transaction_schema_catalog_compile();
+        let mut cache = self
+            .compiled_catalogs
+            .lock()
+            .expect("compiled catalog cache lock should not be poisoned");
+        if cache.len() >= COMPILED_CATALOG_CACHE_LIMIT {
+            // Evict one other entry instead of clearing: identical schema
+            // content on N branches occupies N keys, so a full clear would
+            // recompile every hot catalog whenever the bound is reached.
+            if let Some(evicted) = cache.keys().find(|key| **key != fingerprint).cloned() {
+                cache.remove(&evicted);
+            }
+        }
+        cache.insert(fingerprint, Arc::clone(&snapshot));
+        Ok(snapshot)
     }
 
     /// Loads schema definitions for SQL surface planning at `branch_id`.
@@ -147,6 +198,49 @@ mod tests {
     use crate::GLOBAL_BRANCH_ID;
     use crate::changelog::ChangeId;
     use crate::live_state::LiveStateRowRequest;
+
+    #[test]
+    fn compiled_catalog_cache_shares_snapshots_for_equal_facts() {
+        let context = CatalogContext::new();
+        let parent = catalog_fact("parent_schema");
+        let child = catalog_fact("child_schema");
+
+        let first = context
+            .compiled_catalog_for_facts(&[parent.clone(), child.clone()])
+            .expect("catalog should compile");
+        let reordered = context
+            .compiled_catalog_for_facts(&[child, parent.clone()])
+            .expect("catalog should compile");
+        let different = context
+            .compiled_catalog_for_facts(&[parent])
+            .expect("catalog should compile");
+
+        assert!(
+            Arc::ptr_eq(&first, &reordered),
+            "equal facts in any order must hit the same cached snapshot"
+        );
+        assert!(
+            !Arc::ptr_eq(&first, &different),
+            "different facts must compile a different snapshot"
+        );
+    }
+
+    fn catalog_fact(schema_key: &str) -> SchemaCatalogFact {
+        SchemaCatalogFact::new(
+            Domain::schema_catalog("main", false),
+            crate::schema::SchemaKey::new(schema_key),
+            json!({
+                "x-lix-key": schema_key,
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+            }),
+        )
+    }
 
     #[tokio::test]
     async fn visible_schemas_are_loaded_from_registered_schema_rows() {

--- a/packages/engine/src/catalog/mod.rs
+++ b/packages/engine/src/catalog/mod.rs
@@ -7,4 +7,4 @@ pub(crate) use schema::{
     ForeignKeyPlan, SchemaCatalogFact, SchemaCatalogKey, SchemaPlan, SchemaPlanId,
     StateForeignKeyPlan,
 };
-pub(crate) use snapshot::{CatalogSnapshot, StateDeleteReferencePlan};
+pub(crate) use snapshot::{CatalogSnapshot, StateDeleteReferencePlan, TransactionCatalog};

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -70,6 +70,16 @@ impl CatalogSnapshot {
         Self::from_entries(entries)
     }
 
+    /// Rebuilds an owned snapshot with the same entries.
+    ///
+    /// Compiled plans are not clonable, so a transaction that needs a private
+    /// mutable catalog recompiles from the recorded entries. Entry order is
+    /// preserved, so `SchemaPlanId`s issued by the source snapshot remain
+    /// valid against the rebuilt one.
+    pub(crate) fn rebuild_owned(&self) -> Result<Self, LixError> {
+        Self::from_entries(self.entries.clone())
+    }
+
     #[cfg(test)]
     pub(crate) fn fingerprint(&self) -> &CatalogFingerprint {
         &self.fingerprint
@@ -208,15 +218,12 @@ impl CatalogSnapshot {
         let mut entries = self.entries.iter().collect::<Vec<_>>();
         entries.sort_by(|left, right| left.identity.cmp(&right.identity));
         for entry in entries {
-            hash_fingerprint_part(&mut hasher, &entry.identity.fingerprint_component());
-            hash_fingerprint_part(&mut hasher, &entry.key.schema_key);
-            let canonical_schema = canonical_json_text(&entry.schema).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_SCHEMA_DEFINITION,
-                    format!("failed to canonicalize schema for catalog fingerprint: {error}"),
-                )
-            })?;
-            hash_fingerprint_part(&mut hasher, &canonical_schema);
+            hash_catalog_fact(
+                &mut hasher,
+                &entry.identity,
+                &entry.key.schema_key,
+                &entry.schema,
+            )?;
         }
         Ok(CatalogFingerprint(hasher.finalize().to_hex().to_string()))
     }
@@ -266,6 +273,88 @@ impl CatalogSnapshot {
 fn hash_fingerprint_part(hasher: &mut blake3::Hasher, value: &str) {
     hasher.update(&(value.len() as u64).to_le_bytes());
     hasher.update(value.as_bytes());
+}
+
+/// Hashes one catalog fact as three length-prefixed parts.
+///
+/// `CatalogSnapshot::compute_fingerprint` and `fingerprint_schema_facts` must
+/// hash the identical part stream: the facts fingerprint keys the compiled
+/// snapshot cache, so any drift between the two would silently split or merge
+/// cache entries. The schema key is hashed as its own part even though the
+/// identity component embeds it; the standalone part keeps the stream
+/// injective regardless of separator characters inside identity fields.
+fn hash_catalog_fact(
+    hasher: &mut blake3::Hasher,
+    identity: &DomainSchemaIdentity,
+    schema_key: &str,
+    schema: &JsonValue,
+) -> Result<(), LixError> {
+    hash_fingerprint_part(hasher, &identity.fingerprint_component());
+    hash_fingerprint_part(hasher, schema_key);
+    let canonical_schema = canonical_json_text(schema).map_err(|error| {
+        LixError::new(
+            LixError::CODE_SCHEMA_DEFINITION,
+            format!("failed to canonicalize schema for catalog fingerprint: {error}"),
+        )
+    })?;
+    hash_fingerprint_part(hasher, &canonical_schema);
+    Ok(())
+}
+
+/// Content fingerprint of raw schema facts, before any snapshot is built.
+///
+/// Identical fact sets always produce the same fingerprint, so it can key a
+/// cache of compiled snapshots without an invalidation protocol.
+pub(crate) fn fingerprint_schema_facts(
+    facts: &[SchemaCatalogFact],
+) -> Result<CatalogFingerprint, LixError> {
+    let mut hasher = blake3::Hasher::new();
+    let mut facts = facts.iter().collect::<Vec<_>>();
+    facts.sort_by(|left, right| left.identity.cmp(&right.identity));
+    for fact in facts {
+        hash_catalog_fact(
+            &mut hasher,
+            &fact.identity,
+            &fact.catalog_key.schema_key,
+            &fact.schema,
+        )?;
+    }
+    Ok(CatalogFingerprint(hasher.finalize().to_hex().to_string()))
+}
+
+/// Copy-on-write catalog handle for one transaction schema scope.
+///
+/// Transactions normally share an immutable compiled snapshot from the
+/// engine-wide cache. Registering a schema inside the transaction switches the
+/// handle to a private rebuilt snapshot, so pending registrations are never
+/// observable outside the transaction that staged them.
+pub(crate) enum TransactionCatalog {
+    Shared(Arc<CatalogSnapshot>),
+    Owned(CatalogSnapshot),
+}
+
+impl TransactionCatalog {
+    pub(crate) fn snapshot(&self) -> &CatalogSnapshot {
+        match self {
+            Self::Shared(snapshot) => snapshot,
+            Self::Owned(snapshot) => snapshot,
+        }
+    }
+
+    pub(crate) fn insert_schema_for_domain(
+        &mut self,
+        domain: Domain,
+        key: SchemaKey,
+        schema: JsonValue,
+    ) -> Result<SchemaPlanId, LixError> {
+        if let Self::Shared(snapshot) = self {
+            *self = Self::Owned(snapshot.rebuild_owned()?);
+        }
+        let Self::Owned(snapshot) = self else {
+            unreachable!("transaction catalog is owned after copy-on-write");
+        };
+        snapshot.insert_schema_for_domain(domain, key, schema)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -965,6 +1054,71 @@ mod tests {
         assert!(
             !catalog.contains("bad_child_schema"),
             "failed catalog insert must not publish a partially bound schema"
+        );
+    }
+
+    #[test]
+    fn facts_fingerprint_matches_built_snapshot_fingerprint() {
+        let facts = vec![
+            SchemaCatalogFact::new(
+                Domain::schema_catalog("main", false),
+                SchemaKey::new("parent_schema"),
+                schema_json("parent_schema"),
+            ),
+            SchemaCatalogFact::new(
+                Domain::schema_catalog("main", false),
+                SchemaKey::new("child_schema"),
+                child_schema_json("child_schema", "parent_schema"),
+            ),
+        ];
+
+        let facts_fingerprint =
+            fingerprint_schema_facts(&facts).expect("facts fingerprint should hash");
+        let snapshot = CatalogSnapshot::from_schema_facts(&facts).expect("catalog should bind");
+
+        assert_eq!(
+            &facts_fingerprint,
+            snapshot.fingerprint(),
+            "cache key and snapshot fingerprint must use the same hashing scheme"
+        );
+    }
+
+    #[test]
+    fn transaction_catalog_copy_on_write_isolates_shared_snapshot() {
+        let shared = Arc::new(
+            CatalogSnapshot::from_schema_facts(&[SchemaCatalogFact::new(
+                Domain::schema_catalog("main", false),
+                SchemaKey::new("base_schema"),
+                schema_json("base_schema"),
+            )])
+            .expect("base catalog should bind"),
+        );
+        let (base_plan_id, _) = shared
+            .plan_for_key("base_schema")
+            .expect("base schema plan should exist");
+        let mut handle = TransactionCatalog::Shared(Arc::clone(&shared));
+
+        handle
+            .insert_schema_for_domain(
+                Domain::schema_catalog("main", false),
+                SchemaKey::new("registered_schema"),
+                schema_json("registered_schema"),
+            )
+            .expect("registration should rebuild an owned catalog");
+
+        assert!(matches!(handle, TransactionCatalog::Owned(_)));
+        assert!(handle.snapshot().contains("registered_schema"));
+        assert!(
+            !shared.contains("registered_schema"),
+            "pending registrations must not mutate the shared snapshot"
+        );
+        let (rebuilt_plan_id, _) = handle
+            .snapshot()
+            .plan_for_key("base_schema")
+            .expect("base schema plan should survive the rebuild");
+        assert_eq!(
+            base_plan_id, rebuilt_plan_id,
+            "plan ids issued by the shared snapshot must stay valid after copy-on-write"
         );
     }
 

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -270,7 +270,7 @@ impl CatalogSnapshot {
     }
 }
 
-fn hash_fingerprint_part(hasher: &mut blake3::Hasher, value: &str) {
+pub(super) fn hash_fingerprint_part(hasher: &mut blake3::Hasher, value: &str) {
     hasher.update(&(value.len() as u64).to_le_bytes());
     hasher.update(value.as_bytes());
 }

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -1,8 +1,8 @@
 use super::types::{
-    ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRef, CommitChangeRefChunk,
-    CommitChangeRefChunkRef, CommitChangeRefChunkView, CommitChangeRefEntryRef,
-    CommitChangeRefEntryView, CommitChangeRefView, CommitId, CommitRecord, EntityPkRef,
-    ExpandedCommitChangeRefChunkView,
+    ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRef,
+    CommitChangeRefChunk, CommitChangeRefChunkRef, CommitChangeRefChunkView,
+    CommitChangeRefEntryRef, CommitChangeRefEntryView, CommitChangeRefView, CommitId, CommitRecord,
+    EntityPkRef, ExpandedCommitChangeRefChunkView,
 };
 use crate::common::LixError;
 use crate::entity_pk::EntityPk;
@@ -17,11 +17,36 @@ pub(crate) fn decode_commit_record(bytes: &[u8]) -> Result<CommitRecord, LixErro
 }
 
 pub(crate) fn encode_change_record(record: &ChangeRecord) -> Result<Vec<u8>, LixError> {
-    storage_codec::encode("change record", record)
+    // change_id is the storage key; the value intentionally omits it.
+    storage_codec::encode(
+        "change record",
+        &ChangeRecordRef {
+            format_version: record.format_version,
+            schema_key: &record.schema_key,
+            entity_pk: &record.entity_pk.parts,
+            file_id: record.file_id.as_deref(),
+            snapshot_ref: record.snapshot_ref.as_ref(),
+            metadata_ref: record.metadata_ref.as_ref(),
+            created_at: record.created_at,
+        },
+    )
 }
 
-pub(crate) fn decode_change_record(bytes: &[u8]) -> Result<ChangeRecord, LixError> {
-    storage_codec::decode("change record", bytes)
+pub(crate) fn decode_change_record(
+    bytes: &[u8],
+    change_id: ChangeId,
+) -> Result<ChangeRecord, LixError> {
+    let view: ChangeRecordView<'_> = storage_codec::decode("change record", bytes)?;
+    Ok(ChangeRecord {
+        format_version: view.format_version,
+        change_id,
+        schema_key: view.schema_key.to_string(),
+        entity_pk: entity_pk_from_ref(view.entity_pk)?,
+        file_id: view.file_id.map(str::to_string),
+        snapshot_ref: view.snapshot_ref,
+        metadata_ref: view.metadata_ref,
+        created_at: view.created_at,
+    })
 }
 
 pub(crate) fn encode_commit_change_ref_chunk(
@@ -192,4 +217,60 @@ fn entity_pk_from_ref(value: EntityPkRef<'_>) -> Result<EntityPk, LixError> {
             )
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::changelog::ChangeId;
+    use crate::common::LixTimestamp;
+    use crate::json_store::JsonRef;
+
+    fn full_record() -> ChangeRecord {
+        ChangeRecord {
+            format_version: 1,
+            change_id: ChangeId::for_test_label("roundtrip-change"),
+            schema_key: "schema-\u{00e9}\u{4e2d}".to_string(),
+            entity_pk: EntityPk::from_parts(vec!["part-a".to_string(), "part-b".to_string()])
+                .expect("entity pk should build"),
+            file_id: Some("file-1".to_string()),
+            snapshot_ref: Some(JsonRef::for_content(b"snapshot")),
+            metadata_ref: Some(JsonRef::for_content(b"metadata")),
+            created_at: LixTimestamp::expect_parse("created_at", "2026-06-10T00:00:00.000Z"),
+        }
+    }
+
+    #[test]
+    fn change_record_round_trips_fully_populated() {
+        let record = full_record();
+        let encoded = encode_change_record(&record).expect("record should encode");
+        let decoded =
+            decode_change_record(&encoded, record.change_id).expect("record should decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn change_record_round_trips_with_empty_options() {
+        let record = ChangeRecord {
+            file_id: None,
+            snapshot_ref: None,
+            metadata_ref: None,
+            ..full_record()
+        };
+        let encoded = encode_change_record(&record).expect("record should encode");
+        let decoded =
+            decode_change_record(&encoded, record.change_id).expect("record should decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn change_record_takes_identity_from_the_decode_argument() {
+        // The stored value omits change_id; whatever id the key supplies is
+        // what the decoded record carries.
+        let record = full_record();
+        let encoded = encode_change_record(&record).expect("record should encode");
+        let other_id = ChangeId::for_test_label("other-change");
+        let decoded = decode_change_record(&encoded, other_id).expect("record should decode");
+        assert_eq!(decoded.change_id, other_id);
+    }
 }

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -19,8 +19,8 @@ use super::codec::{
     encode_commit_change_ref_chunk, encode_commit_record,
 };
 use super::store::{
-    CHANGE_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, change_key,
-    commit_change_ref_chunk_key, commit_change_ref_chunk_prefix, commit_key,
+    CHANGE_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, change_id_from_key, change_key,
+    commit_change_ref_chunk_key, commit_change_ref_chunk_prefix, commit_id_from_key, commit_key,
 };
 use crate::changelog::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeScanBatch, ChangeScanRequest,
@@ -489,7 +489,10 @@ where
         &mut self,
         commit_ids: &HashSet<CommitId>,
     ) -> Result<(), LixError> {
-        let keys = commit_ids.iter().map(commit_key).collect::<Vec<_>>();
+        let keys = commit_ids
+            .iter()
+            .map(|id| commit_key(*id))
+            .collect::<Vec<_>>();
         for (commit_id, found) in commit_ids
             .iter()
             .zip(get_many(self.store, COMMIT_SPACE, keys).await?)
@@ -508,7 +511,10 @@ where
         change_ids: impl IntoIterator<Item = ChangeId>,
     ) -> Result<(), LixError> {
         let change_ids = change_ids.into_iter().collect::<Vec<_>>();
-        let keys = change_ids.iter().map(change_key).collect::<Vec<_>>();
+        let keys = change_ids
+            .iter()
+            .map(|id| change_key(*id))
+            .collect::<Vec<_>>();
         for (change_id, found) in change_ids
             .iter()
             .zip(get_many(self.store, CHANGE_SPACE, keys).await?)
@@ -533,7 +539,10 @@ where
             .flat_map(|commit| commit.parent_commit_ids.iter().copied())
             .filter(|parent_id| !append_commit_ids.contains(parent_id))
             .collect::<HashSet<_>>();
-        let keys = parent_ids.iter().map(commit_key).collect::<Vec<_>>();
+        let keys = parent_ids
+            .iter()
+            .map(|id| commit_key(*id))
+            .collect::<Vec<_>>();
         for (parent_id, found) in parent_ids
             .iter()
             .zip(get_many(self.store, COMMIT_SPACE, keys).await?)
@@ -584,7 +593,10 @@ where
         change_ids: impl IntoIterator<Item = ChangeId>,
     ) -> Result<HashMap<ChangeId, ChangeRecord>, LixError> {
         let change_ids = change_ids.into_iter().collect::<Vec<_>>();
-        let keys = change_ids.iter().map(change_key).collect::<Vec<_>>();
+        let keys = change_ids
+            .iter()
+            .map(|id| change_key(*id))
+            .collect::<Vec<_>>();
         let values = get_many(self.store, CHANGE_SPACE, keys).await?;
         let mut out = HashMap::new();
         for (change_id, value) in change_ids.into_iter().zip(values) {
@@ -599,7 +611,7 @@ where
         if self.staged_changes.contains_key(change_id) {
             return Ok(true);
         }
-        Ok(get_one(self.store, CHANGE_SPACE, change_key(change_id))
+        Ok(get_one(self.store, CHANGE_SPACE, change_key(*change_id))
             .await?
             .is_some())
     }
@@ -612,7 +624,7 @@ async fn load_commits_from_store(
     let keys = request
         .commit_ids
         .iter()
-        .map(|commit_id| commit_key(commit_id))
+        .map(|commit_id| commit_key(*commit_id))
         .collect::<Vec<_>>();
     let commit_values = get_many(store, COMMIT_SPACE, keys).await?;
     let mut entries = Vec::with_capacity(request.commit_ids.len());
@@ -661,7 +673,10 @@ async fn scan_commits_from_store(
         .changelog_scan(
             COMMIT_SPACE,
             Vec::new(),
-            request.start_after.map(commit_key),
+            request
+                .start_after
+                .map(|id| CommitId::parse_lix(id, "commit scan start_after").map(commit_key))
+                .transpose()?,
             limit,
             StorageCoreProjection::FullValue,
         )
@@ -682,15 +697,7 @@ async fn scan_commits_from_store(
     }
     let next_start_after = page
         .resume_after
-        .map(|key| {
-            String::from_utf8(key).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("changelog commit scan resume key is not UTF-8: {error}"),
-                )
-            })
-        })
-        .map(|result| result.and_then(|id| CommitId::parse_lix(&id, "commit scan resume key")))
+        .map(|key| commit_id_from_key(&key))
         .transpose()?;
     Ok(CommitScanBatch {
         entries,
@@ -705,7 +712,7 @@ async fn load_changes_from_store(
     let keys = request
         .change_ids
         .iter()
-        .map(|change_id| change_key(change_id))
+        .map(|change_id| change_key(*change_id))
         .collect::<Vec<_>>();
     let entries = get_many(store, CHANGE_SPACE, keys)
         .await?
@@ -733,7 +740,10 @@ async fn scan_changes_from_store(
         .changelog_scan(
             CHANGE_SPACE,
             Vec::new(),
-            request.start_after.map(change_key),
+            request
+                .start_after
+                .map(|id| ChangeId::parse_lix(id, "change scan start_after").map(change_key))
+                .transpose()?,
             limit,
             StorageCoreProjection::FullValue,
         )
@@ -754,15 +764,7 @@ async fn scan_changes_from_store(
     }
     let next_start_after = page
         .resume_after
-        .map(|key| {
-            String::from_utf8(key).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("changelog change scan resume key is not UTF-8: {error}"),
-                )
-            })
-        })
-        .map(|result| result.and_then(|id| ChangeId::parse_lix(&id, "change scan resume key")))
+        .map(|key| change_id_from_key(&key))
         .transpose()?;
     Ok(ChangeScanBatch {
         entries,
@@ -774,8 +776,7 @@ async fn load_commit_change_ref_chunks(
     store: &mut (impl ChangelogStorageRead + ?Sized),
     commit_id: &CommitId,
 ) -> Result<Vec<CommitChangeRefChunk>, LixError> {
-    let commit_id_text = commit_id.to_string();
-    let prefix = commit_change_ref_chunk_prefix(&commit_id_text);
+    let prefix = commit_change_ref_chunk_prefix(*commit_id);
     let mut after = None;
     let mut chunks = Vec::new();
     loop {

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -601,7 +601,7 @@ where
         let mut out = HashMap::new();
         for (change_id, value) in change_ids.into_iter().zip(values) {
             if let Some(value) = value {
-                out.insert(change_id, decode_change_record(&value)?);
+                out.insert(change_id, decode_change_record(&value, change_id)?);
             }
         }
         Ok(out)
@@ -717,7 +717,13 @@ async fn load_changes_from_store(
     let entries = get_many(store, CHANGE_SPACE, keys)
         .await?
         .into_iter()
-        .map(|value| value.as_deref().map(decode_change_record).transpose())
+        .zip(request.change_ids.iter())
+        .map(|(value, change_id)| {
+            value
+                .as_deref()
+                .map(|value| decode_change_record(value, *change_id))
+                .transpose()
+        })
         .collect::<Result<Vec<_>, LixError>>()?;
     Ok(ChangeLoadBatch { entries })
 }
@@ -750,17 +756,9 @@ async fn scan_changes_from_store(
         .await?;
     let mut entries = Vec::with_capacity(page.values.len());
     for (key, value) in page.keys.iter().zip(page.values.iter()) {
-        let record = decode_change_record(value)?;
-        if key.as_slice() != change_key(record.change_id).as_slice() {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "changelog change scan key does not match decoded change_id '{}'",
-                    record.change_id
-                ),
-            ));
-        }
-        entries.push(record);
+        // change_id lives in the key; the stored value omits it.
+        let change_id = change_id_from_key(key)?;
+        entries.push(decode_change_record(value, change_id)?);
     }
     let next_start_after = page
         .resume_after

--- a/packages/engine/src/changelog/store.rs
+++ b/packages/engine/src/changelog/store.rs
@@ -1,11 +1,11 @@
 use super::types::{
-    ChangeLoadBatch, ChangeLoadRequest, ChangeScanBatch, ChangeScanRequest, ChangelogAppend,
-    CommitLoadBatch, CommitLoadRequest, CommitScanBatch, CommitScanRequest, GcPlan, GcRoot,
+    ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeScanBatch, ChangeScanRequest,
+    ChangelogAppend, CommitId, CommitLoadBatch, CommitLoadRequest, CommitScanBatch,
+    CommitScanRequest, GcPlan, GcRoot,
 };
 use crate::common::LixError;
 use crate::storage::{StorageSpace, StorageSpaceId};
 use async_trait::async_trait;
-use std::fmt;
 
 pub(crate) const COMMIT_NAMESPACE: &str = "changelog.commit";
 pub(crate) const CHANGE_NAMESPACE: &str = "changelog.change";
@@ -20,82 +20,63 @@ pub(crate) const COMMIT_CHANGE_REF_CHUNK_SPACE: StorageSpace = StorageSpace::new
     COMMIT_CHANGE_REF_CHUNK_NAMESPACE,
 );
 
-pub(crate) fn commit_key(commit_id: impl fmt::Display) -> Vec<u8> {
-    identity_key(commit_id)
+const ID_KEY_LEN: usize = 16;
+
+// Identity keys are the raw 16 UUID bytes. UUIDv7's big-endian byte order
+// matches the lexicographic order of its lowercase hyphenated text, so range
+// scans and resume tokens behave identically to the former text keys at
+// 20 fewer bytes per key.
+pub(crate) fn commit_key(commit_id: CommitId) -> Vec<u8> {
+    commit_id.as_uuid().as_bytes().to_vec()
 }
 
-pub(crate) fn change_key(change_id: impl fmt::Display) -> Vec<u8> {
-    identity_key(change_id)
+pub(crate) fn change_key(change_id: ChangeId) -> Vec<u8> {
+    change_id.as_uuid().as_bytes().to_vec()
 }
 
-pub(crate) fn commit_change_ref_chunk_prefix(commit_id: impl fmt::Display) -> Vec<u8> {
-    let mut key = Vec::new();
-    push_ordered_str(&mut key, commit_id);
-    key
+pub(crate) fn commit_change_ref_chunk_prefix(commit_id: CommitId) -> Vec<u8> {
+    commit_id.as_uuid().as_bytes().to_vec()
 }
 
-pub(crate) fn commit_change_ref_chunk_key(commit_id: impl fmt::Display, chunk_no: u32) -> Vec<u8> {
+pub(crate) fn commit_change_ref_chunk_key(commit_id: CommitId, chunk_no: u32) -> Vec<u8> {
     let mut key = commit_change_ref_chunk_prefix(commit_id);
     key.extend_from_slice(&chunk_no.to_be_bytes());
     key
 }
 
-pub(crate) fn commit_change_ref_chunk_ids_from_key(key: &[u8]) -> Result<(String, u32), LixError> {
-    let (commit_id, consumed_commit) = read_ordered_str(key)?;
-    let rest = &key[consumed_commit..];
-    if rest.len() != 4 {
+pub(crate) fn commit_id_from_key(key: &[u8]) -> Result<CommitId, LixError> {
+    uuid_from_key(key, "commit").map(CommitId::new)
+}
+
+pub(crate) fn change_id_from_key(key: &[u8]) -> Result<ChangeId, LixError> {
+    uuid_from_key(key, "change").map(ChangeId::new)
+}
+
+fn uuid_from_key(key: &[u8], kind: &str) -> Result<uuid::Uuid, LixError> {
+    uuid::Uuid::from_slice(key).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("changelog {kind} key is not a 16-byte uuid: {error}"),
+        )
+    })
+}
+
+pub(crate) fn commit_change_ref_chunk_ids_from_key(
+    key: &[u8],
+) -> Result<(CommitId, u32), LixError> {
+    if key.len() != ID_KEY_LEN + 4 {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
-            "changelog commit_change_ref_chunk key has invalid chunk number",
+            "changelog commit_change_ref_chunk key has invalid length",
         ));
     }
-    let chunk_no = u32::from_be_bytes([rest[0], rest[1], rest[2], rest[3]]);
-    Ok((commit_id, chunk_no))
-}
-
-fn identity_key(id: impl fmt::Display) -> Vec<u8> {
-    id.to_string().into_bytes()
-}
-
-fn push_ordered_str(out: &mut Vec<u8>, value: impl fmt::Display) {
-    let value = value.to_string();
-    for byte in value.as_bytes() {
-        out.push(*byte);
-        if *byte == 0 {
-            out.push(0xff);
-        }
-    }
-    out.push(0);
-}
-
-fn read_ordered_str(bytes: &[u8]) -> Result<(String, usize), LixError> {
-    let mut out = Vec::new();
-    let mut index = 0;
-    while index < bytes.len() {
-        match bytes[index] {
-            0 => {
-                if bytes.get(index + 1) == Some(&0xff) {
-                    out.push(0);
-                    index += 2;
-                    continue;
-                }
-                let value = String::from_utf8(out).map_err(|error| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!("changelog ordered key contains invalid UTF-8: {error}"),
-                    )
-                })?;
-                return Ok((value, index + 1));
-            }
-            byte => {
-                out.push(byte);
-                index += 1;
-            }
-        }
-    }
-    Err(LixError::new(
-        LixError::CODE_INTERNAL_ERROR,
-        "changelog ordered key component is missing terminator",
+    let mut commit_id = [0u8; ID_KEY_LEN];
+    commit_id.copy_from_slice(&key[..ID_KEY_LEN]);
+    let mut chunk_no = [0u8; 4];
+    chunk_no.copy_from_slice(&key[ID_KEY_LEN..]);
+    Ok((
+        CommitId::new(uuid::Uuid::from_bytes(commit_id)),
+        u32::from_be_bytes(chunk_no),
     ))
 }
 
@@ -146,20 +127,49 @@ mod tests {
     }
 
     #[test]
-    fn identity_keys_use_utf8_bytes() {
-        assert_eq!(commit_key("commit-1"), b"commit-1".to_vec());
-        assert_eq!(change_key("change-1"), b"change-1".to_vec());
+    fn identity_keys_use_raw_uuid_bytes() {
+        let commit_id = CommitId::for_test_label("commit-1");
+        let change_id = ChangeId::for_test_label("change-1");
+        assert_eq!(
+            commit_key(commit_id),
+            commit_id.as_uuid().as_bytes().to_vec()
+        );
+        assert_eq!(
+            change_key(change_id),
+            change_id.as_uuid().as_bytes().to_vec()
+        );
+        assert_eq!(commit_key(commit_id).len(), ID_KEY_LEN);
+    }
+
+    #[test]
+    fn identity_key_order_matches_text_order() {
+        let mut ids = (0..32)
+            .map(|index| CommitId::for_test_label(&format!("commit-{index}")))
+            .collect::<Vec<_>>();
+        ids.sort_by_key(|id| commit_key(*id));
+        let text_sorted = {
+            let mut text = ids.iter().map(CommitId::to_string).collect::<Vec<_>>();
+            text.sort();
+            text
+        };
+        assert_eq!(
+            ids.iter().map(CommitId::to_string).collect::<Vec<_>>(),
+            text_sorted,
+            "binary key order must match hyphenated text order"
+        );
     }
 
     #[test]
     fn commit_change_ref_chunk_keys_are_prefixed_by_commit_id() {
-        let prefix = commit_change_ref_chunk_prefix("commit-1");
-        let key = commit_change_ref_chunk_key("commit-1", 42);
+        let commit_id = CommitId::for_test_label("commit-1");
+        let other_commit_id = CommitId::for_test_label("commit-10");
+        let prefix = commit_change_ref_chunk_prefix(commit_id);
+        let key = commit_change_ref_chunk_key(commit_id, 42);
         assert!(key.starts_with(&prefix));
-        assert!(!commit_change_ref_chunk_key("commit-10", 0).starts_with(&prefix));
+        assert!(!commit_change_ref_chunk_key(other_commit_id, 0).starts_with(&prefix));
         assert_eq!(
             commit_change_ref_chunk_ids_from_key(&key).unwrap(),
-            ("commit-1".to_string(), 42)
+            (commit_id, 42)
         );
     }
 }

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -439,18 +439,17 @@ pub(crate) enum CommitLoadEntry {
     },
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-#[musli(packed)]
+/// In-memory change record. The stored form (`ChangeRecordRef` /
+/// `ChangeRecordView`) omits `change_id`: it is the storage key and gets
+/// reconstructed on decode.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ChangeRecord {
     pub(crate) format_version: u32,
     pub(crate) change_id: ChangeId,
     pub(crate) schema_key: String,
     pub(crate) entity_pk: EntityPk,
-    #[musli(with = crate::storage_codec::option)]
     pub(crate) file_id: Option<String>,
-    #[musli(with = crate::storage_codec::option)]
     pub(crate) snapshot_ref: Option<JsonRef>,
-    #[musli(with = crate::storage_codec::option)]
     pub(crate) metadata_ref: Option<JsonRef>,
     pub(crate) created_at: LixTimestamp,
 }
@@ -459,7 +458,6 @@ pub(crate) struct ChangeRecord {
 #[musli(packed)]
 pub(crate) struct ChangeRecordRef<'a> {
     pub(crate) format_version: u32,
-    pub(crate) change_id: ChangeId,
     pub(crate) schema_key: &'a str,
     pub(crate) entity_pk: &'a [String],
     #[musli(with = crate::storage_codec::option)]
@@ -475,7 +473,6 @@ pub(crate) struct ChangeRecordRef<'a> {
 #[musli(packed)]
 pub(crate) struct ChangeRecordView<'a> {
     pub(crate) format_version: u32,
-    pub(crate) change_id: ChangeId,
     pub(crate) schema_key: &'a str,
     #[musli(with = entity_pk_ref_storage)]
     pub(crate) entity_pk: EntityPkRef<'a>,

--- a/packages/engine/src/functions/context.rs
+++ b/packages/engine/src/functions/context.rs
@@ -26,16 +26,23 @@ impl FunctionContext {
     #[expect(trivial_casts)]
     pub(crate) async fn prepare(live_state: &dyn LiveStateReader) -> Result<Self, LixError> {
         let mode = state::load_mode(live_state).await?;
-        let mut bookkeeping_functions = SystemFunctionProvider;
-        let bookkeeping_timestamp = bookkeeping_functions.timestamp();
         if !mode.enabled {
+            let mut bookkeeping_functions = SystemFunctionProvider;
             return Ok(Self {
                 functions: FunctionProviderHandle::system(),
-                bookkeeping_timestamp,
+                bookkeeping_timestamp: bookkeeping_functions.timestamp(),
             });
         }
 
         let sequence = state::load_sequence(live_state).await?;
+        // Deterministic mode must produce byte-identical state across runs;
+        // bookkeeping rows (sequence persistence) take a timestamp derived
+        // from the persisted sequence instead of the system clock, without
+        // consuming a sequence tick from user-visible functions. The value
+        // is intentionally un-shuffled: timestamp_shuffle exists to break
+        // ordering assumptions on user-visible timestamps only.
+        let bookkeeping_timestamp =
+            LixTimestamp::from_unix_millis_utc_lossy(sequence.next_sequence());
         Ok(Self {
             functions: FunctionProviderHandle::shared(Box::new(DeterministicFunctionProvider::new(
                 sequence.next_sequence(),
@@ -237,6 +244,27 @@ mod tests {
         );
         let sequence = load_sequence(&reader).await.expect("sequence should load");
         assert_eq!(sequence, DeterministicSequence { highest_seen: 0 });
+
+        // Deterministic mode must stamp the bookkeeping row from the
+        // persisted sequence, never from the system clock; the persisted
+        // sequence was empty, so next_sequence is 0 -> epoch.
+        let row = LiveStateReader::load_row(
+            &reader,
+            &crate::live_state::LiveStateRowRequest {
+                schema_key: "lix_key_value".to_string(),
+                branch_id: GLOBAL_BRANCH_ID.to_string(),
+                entity_pk: crate::entity_pk::EntityPk::single(DETERMINISTIC_SEQUENCE_KEY),
+                file_id: crate::NullableKeyFilter::Null,
+            },
+        )
+        .await
+        .expect("sequence row should load")
+        .expect("sequence row should exist");
+        assert_eq!(
+            row.created_at, "1970-01-01T00:00:00.000Z",
+            "bookkeeping timestamp must derive from the sequence, not the system clock"
+        );
+        assert_eq!(row.created_at, row.updated_at);
     }
 
     #[tokio::test]

--- a/packages/engine/src/functions/mod.rs
+++ b/packages/engine/src/functions/mod.rs
@@ -13,6 +13,8 @@ mod types;
 pub(crate) use context::FunctionContext;
 pub(crate) use deterministic::DeterministicFunctionProvider;
 pub(crate) use provider::{FunctionProvider, FunctionProviderHandle, SystemFunctionProvider};
+#[cfg(feature = "storage-benches")]
+pub(crate) use state::DETERMINISTIC_MODE_KEY;
 pub(crate) use types::{DeterministicMode, DeterministicSequence};
 
 pub(crate) type DeterministicRuntimeGuard = tokio::sync::OwnedMutexGuard<()>;

--- a/packages/engine/src/storage/write_set.rs
+++ b/packages/engine/src/storage/write_set.rs
@@ -260,7 +260,36 @@ impl StorageWriteSet {
             groups, mut stats, ..
         } = self;
 
-        for group in groups {
+        for mut group in groups {
+            // Lower each space batch in ascending key order. Hash-keyed
+            // spaces such as json_store produce effectively random insertion
+            // order; sorted batches let B-tree backends write with cursor
+            // locality instead of a fresh seek per key. Within a group every
+            // key shares the space prefix, so logical order equals physical
+            // order. Most other spaces already produce key order (BTreeMap
+            // iteration, time-ordered ids), so the common case is a
+            // read-only scan.
+            let puts_sorted = group
+                .puts
+                .is_sorted_by(|left, right| left.key.0 <= right.key.0);
+            let deletes_sorted = group.deletes.is_sorted();
+            #[cfg(feature = "storage-benches")]
+            if order_stats_enabled() && !group.puts.is_empty() {
+                eprintln!(
+                    "write-set-order space={} puts={} puts_sorted={puts_sorted} deletes={} deletes_sorted={deletes_sorted}",
+                    group.space.name,
+                    group.puts.len(),
+                    group.deletes.len(),
+                );
+            }
+            if !puts_sorted {
+                group
+                    .puts
+                    .sort_unstable_by(|left, right| left.key.0.cmp(&right.key.0));
+            }
+            if !deletes_sorted {
+                group.deletes.sort_unstable();
+            }
             if !group.puts.is_empty() {
                 stats.put_batches += 1;
                 stats.backend_calls += 1;
@@ -383,6 +412,14 @@ impl From<BackendError> for StorageWriteSetError {
     fn from(error: BackendError) -> Self {
         Self::Backend(error)
     }
+}
+
+#[cfg(feature = "storage-benches")]
+fn order_stats_enabled() -> bool {
+    use std::sync::LazyLock;
+    static ENABLED: LazyLock<bool> =
+        LazyLock::new(|| std::env::var_os("LIX_WRITE_SET_ORDER_STATS").is_some());
+    *ENABLED
 }
 
 #[cfg(test)]

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -70,6 +70,53 @@ where
         .collect()
 }
 
+/// Per-row (key, value bytes) inventory of one space.
+///
+/// Equivalence tests compare these inventories byte-for-byte, so the scan
+/// must be complete; the function asserts it observed every row.
+pub fn space_inventory<R>(read: &R, space_name: &str) -> Vec<(Vec<u8>, Vec<u8>)>
+where
+    R: StorageRead,
+{
+    let space = *native_storage_spaces()
+        .iter()
+        .find(|space| space.name == space_name)
+        .expect("space name should exist");
+    let result = ScanPlan::prefix(
+        space,
+        StoragePrefix {
+            bytes: Bytes::new(),
+        },
+    )
+    .collect(
+        read,
+        StorageScanOptions {
+            projection: StorageCoreProjection::FullValue,
+            limit_rows: 1_000_000,
+            ..StorageScanOptions::default()
+        },
+    )
+    .expect("inventory scan should succeed");
+    assert!(
+        !result.value.has_more,
+        "space inventory scan must observe every row"
+    );
+    result
+        .value
+        .entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.key.0.to_vec(),
+                match &entry.value {
+                    StorageProjectedValue::KeyOnly => Vec::new(),
+                    StorageProjectedValue::FullValue(value) => value.to_vec(),
+                },
+            )
+        })
+        .collect()
+}
+
 fn native_storage_spaces() -> &'static [crate::storage::StorageSpace] {
     &[
         crate::untracked_state::storage::UNTRACKED_STATE_ROW_SPACE,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -13,6 +13,7 @@ static TRANSACTION_ROWS_STAGED: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_UNTRACKED_ROWS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_VALIDATION_BRANCHS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_SCHEMA_CATALOG_LOADS: AtomicU64 = AtomicU64::new(0);
+static TRANSACTION_SCHEMA_CATALOG_COMPILES: AtomicU64 = AtomicU64::new(0);
 static JSON_STORE_STAGE_BYTES: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn record_transaction_rows_staged(count: usize) {
@@ -29,6 +30,10 @@ pub(crate) fn record_transaction_validation_branch() {
 
 pub(crate) fn record_transaction_schema_catalog_load() {
     TRANSACTION_SCHEMA_CATALOG_LOADS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_transaction_schema_catalog_compile() {
+    TRANSACTION_SCHEMA_CATALOG_COMPILES.fetch_add(1, Ordering::Relaxed);
 }
 
 pub(crate) fn record_json_store_stage_bytes(hash: [u8; 32]) {

--- a/packages/engine/src/tracked_state/codec.rs
+++ b/packages/engine/src/tracked_state/codec.rs
@@ -101,24 +101,42 @@ impl DecodedLeafNode {
     }
 }
 
+/// Decoded view of a leaf node.
+///
+/// Keys are stored front-coded on disk and reconstructed into one arena at
+/// decode time; values stay borrowed from the chunk bytes verbatim.
 #[derive(Debug, Clone)]
 pub(crate) struct DecodedLeafNodeRef<'a> {
-    entries: Vec<EncodedLeafEntryRef<'a>>,
+    key_arena: Vec<u8>,
+    entries: Vec<LeafEntrySpan<'a>>,
 }
 
-impl<'a> DecodedLeafNodeRef<'a> {
+#[derive(Debug, Clone, Copy)]
+struct LeafEntrySpan<'a> {
+    key_start: usize,
+    key_end: usize,
+    value: &'a [u8],
+}
+
+impl DecodedLeafNodeRef<'_> {
     pub(crate) fn len(&self) -> usize {
         self.entries.len()
     }
 
     #[expect(clippy::unnecessary_wraps)]
-    pub(crate) fn entry(&self, index: usize) -> Result<Option<EncodedLeafEntryRef<'a>>, LixError> {
-        Ok(self.entries.get(index).copied())
+    pub(crate) fn entry(&self, index: usize) -> Result<Option<EncodedLeafEntryRef<'_>>, LixError> {
+        Ok(self.entries.get(index).map(|span| EncodedLeafEntryRef {
+            key: &self.key_arena[span.key_start..span.key_end],
+            value: span.value,
+        }))
     }
 
     #[expect(clippy::unnecessary_wraps)]
-    pub(crate) fn key(&self, index: usize) -> Result<Option<&'a [u8]>, LixError> {
-        Ok(self.entries.get(index).map(|entry| entry.key))
+    pub(crate) fn key(&self, index: usize) -> Result<Option<&[u8]>, LixError> {
+        Ok(self
+            .entries
+            .get(index)
+            .map(|span| &self.key_arena[span.key_start..span.key_end]))
     }
 }
 
@@ -133,10 +151,12 @@ impl DecodedInternalNode {
     }
 }
 
+const NODE_KIND_LEAF_V2: u8 = 1;
+const NODE_KIND_INTERNAL: u8 = 2;
+
 #[derive(Encode, Decode)]
-enum StorageDecodedNode<'a> {
-    Leaf(Vec<EncodedLeafEntryRef<'a>>),
-    Internal(Vec<ChildSummaryRef<'a>>),
+struct StorageInternalNode<'a> {
+    children: Vec<ChildSummaryRef<'a>>,
 }
 
 pub(crate) fn hash_bytes(bytes: &[u8]) -> [u8; TRACKED_STATE_HASH_BYTES] {
@@ -264,12 +284,173 @@ pub(crate) fn encode_leaf_node(entries: &[EncodedLeafEntry]) -> Vec<u8> {
     encode_leaf_node_refs(&entries)
 }
 
+/// Leaf node wire format (v2):
+///
+/// ```text
+/// [NODE_KIND_LEAF_V2]
+/// varint entry_count
+/// per entry:
+///   varint shared_key_len   bytes shared with the previous entry's key
+///   varint key_suffix_len ++ key suffix bytes
+///   varint value_len ++ value bytes (verbatim standard value encoding)
+/// ```
+///
+/// Entries within a node are sorted by key, so consecutive keys share the
+/// encoded schema-key/file-id prefix and most of the entity-pk; front-coding
+/// removes that redundancy. Values are untouched: byte equality and the
+/// value codec stay exactly as before. Sortedness is a caller invariant
+/// (the tree builder always produces sorted entries); it is asserted in
+/// debug builds but not enforced in release, where unsorted input would
+/// round-trip faithfully and only confuse downstream binary search.
 pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<u8> {
-    storage_codec::encode(
-        "tracked-state leaf node",
-        &StorageDecodedNode::Leaf(entries.to_vec()),
-    )
-    .expect("tracked-state leaf node storage encoding should not fail")
+    debug_assert!(
+        entries.windows(2).all(|pair| pair[0].key < pair[1].key),
+        "leaf entries must be strictly sorted by key"
+    );
+    let mut out = Vec::with_capacity(64 + entries.len() * 24);
+    out.push(NODE_KIND_LEAF_V2);
+    write_varint(&mut out, entries.len() as u64);
+    let mut previous_key: &[u8] = &[];
+    for entry in entries {
+        let shared = shared_prefix_len(previous_key, entry.key);
+        write_varint(&mut out, shared as u64);
+        write_varint(&mut out, (entry.key.len() - shared) as u64);
+        out.extend_from_slice(&entry.key[shared..]);
+        write_varint(&mut out, entry.value.len() as u64);
+        out.extend_from_slice(entry.value);
+        previous_key = entry.key;
+    }
+    #[cfg(debug_assertions)]
+    verify_leaf_round_trip(&out, entries);
+    out
+}
+
+#[cfg(debug_assertions)]
+fn verify_leaf_round_trip(encoded: &[u8], entries: &[EncodedLeafEntryRef<'_>]) {
+    let decoded = match decode_node_ref(encoded) {
+        Ok(DecodedNodeRef::Leaf(leaf)) => leaf,
+        other => panic!("leaf round trip decoded unexpectedly: {other:?}"),
+    };
+    assert_eq!(decoded.len(), entries.len(), "leaf round trip entry count");
+    for (index, entry) in entries.iter().enumerate() {
+        let round_tripped = decoded
+            .entry(index)
+            .expect("leaf round trip entry should read")
+            .expect("leaf round trip entry should exist");
+        assert_eq!(round_tripped.key, entry.key, "leaf round trip key {index}");
+        assert_eq!(
+            round_tripped.value, entry.value,
+            "leaf round trip value {index}"
+        );
+    }
+}
+
+fn decode_leaf_v2(body: &[u8]) -> Result<DecodedLeafNodeRef<'_>, LixError> {
+    fn usize_from(value: u64, what: &str) -> Result<usize, LixError> {
+        usize::try_from(value).map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                format!("tracked-state leaf node {what} does not fit in usize"),
+            )
+        })
+    }
+    fn slice<'b>(body: &'b [u8], offset: &mut usize, len: usize) -> Result<&'b [u8], LixError> {
+        let end = offset.checked_add(len).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state leaf node length overflow",
+            )
+        })?;
+        let bytes = body.get(*offset..end).ok_or_else(|| {
+            LixError::new("LIX_ERROR_UNKNOWN", "tracked-state leaf node is truncated")
+        })?;
+        *offset = end;
+        Ok(bytes)
+    }
+
+    let mut offset = 0usize;
+    let entry_count = usize_from(read_varint(body, &mut offset)?, "entry count")?;
+    // Reconstructed keys total the suffix bytes plus every re-expanded
+    // shared prefix, so heavy sharing can exceed the body length; the body
+    // length is a cheap reservation that avoids re-allocation for typical
+    // value-dominated chunks.
+    let mut key_arena = Vec::with_capacity(body.len());
+    let mut entries = Vec::with_capacity(entry_count.min(body.len()));
+    let mut previous_key_start = 0usize;
+    for _ in 0..entry_count {
+        let shared = usize_from(read_varint(body, &mut offset)?, "shared key length")?;
+        let suffix_len = usize_from(read_varint(body, &mut offset)?, "key suffix length")?;
+        let previous_key_len = key_arena.len() - previous_key_start;
+        if shared > previous_key_len {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state leaf node shares more key bytes than the previous key holds",
+            ));
+        }
+        let key_start = key_arena.len();
+        key_arena.extend_from_within(previous_key_start..previous_key_start + shared);
+        let suffix = slice(body, &mut offset, suffix_len)?;
+        key_arena.extend_from_slice(suffix);
+        let value_len = usize_from(read_varint(body, &mut offset)?, "value length")?;
+        let value = slice(body, &mut offset, value_len)?;
+        entries.push(LeafEntrySpan {
+            key_start,
+            key_end: key_arena.len(),
+            value,
+        });
+        previous_key_start = key_start;
+    }
+    if offset != body.len() {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state leaf node has trailing bytes",
+        ));
+    }
+    Ok(DecodedLeafNodeRef { key_arena, entries })
+}
+
+fn shared_prefix_len(left: &[u8], right: &[u8]) -> usize {
+    left.iter()
+        .zip(right.iter())
+        .take_while(|(a, b)| a == b)
+        .count()
+}
+
+fn write_varint(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+fn read_varint(bytes: &[u8], offset: &mut usize) -> Result<u64, LixError> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *bytes.get(*offset).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state leaf node varint is truncated",
+            )
+        })?;
+        *offset += 1;
+        if shift >= 64 || (shift == 63 && byte > 1) {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state leaf node varint overflows u64",
+            ));
+        }
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+    }
 }
 
 pub(crate) fn encode_internal_node(children: &[ChildSummary]) -> Vec<u8> {
@@ -281,11 +462,17 @@ pub(crate) fn encode_internal_node(children: &[ChildSummary]) -> Vec<u8> {
 }
 
 pub(crate) fn encode_internal_node_refs(children: &[ChildSummaryRef<'_>]) -> Vec<u8> {
-    storage_codec::encode(
-        "tracked-state internal node",
-        &StorageDecodedNode::Internal(children.to_vec()),
-    )
-    .expect("tracked-state internal node storage encoding should not fail")
+    let mut out = vec![NODE_KIND_INTERNAL];
+    out.extend_from_slice(
+        &storage_codec::encode(
+            "tracked-state internal node",
+            &StorageInternalNode {
+                children: children.to_vec(),
+            },
+        )
+        .expect("tracked-state internal node storage encoding should not fail"),
+    );
+    out
 }
 
 pub(crate) fn decode_node(bytes: &[u8]) -> Result<DecodedNode, LixError> {
@@ -311,13 +498,17 @@ pub(crate) fn decode_node(bytes: &[u8]) -> Result<DecodedNode, LixError> {
 }
 
 pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef<'_>, LixError> {
-    match storage_codec::decode("tracked-state tree node", bytes)? {
-        StorageDecodedNode::Leaf(entries) => {
-            Ok(DecodedNodeRef::Leaf(DecodedLeafNodeRef { entries }))
-        }
-        StorageDecodedNode::Internal(children) => {
+    let (&kind, body) = bytes
+        .split_first()
+        .ok_or_else(|| LixError::new("LIX_ERROR_UNKNOWN", "tracked-state tree node is empty"))?;
+    match kind {
+        NODE_KIND_LEAF_V2 => Ok(DecodedNodeRef::Leaf(decode_leaf_v2(body)?)),
+        NODE_KIND_INTERNAL => {
+            let node: StorageInternalNode<'_> =
+                storage_codec::decode("tracked-state internal node", body)?;
             Ok(DecodedNodeRef::Internal(DecodedInternalNode {
-                children: children
+                children: node
+                    .children
                     .into_iter()
                     .map(|child| ChildSummary {
                         first_key: child.first_key.to_vec(),
@@ -328,6 +519,10 @@ pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef<'_>, LixErr
                     .collect(),
             }))
         }
+        other => Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("tracked-state tree node has unknown kind byte {other}"),
+        )),
     }
 }
 
@@ -393,6 +588,154 @@ fn level_salt(level: usize) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        DecodedNodeRef as NodeRefForLeafTests, decode_node_ref as decode_node_ref_for_leaf_tests,
+        encode_leaf_node_refs as encode_leaf_refs_for_tests,
+    };
+
+    fn leaf_entries_round_trip(entries: &[(Vec<u8>, Vec<u8>)]) {
+        let refs = entries
+            .iter()
+            .map(|(key, value)| EncodedLeafEntryRef {
+                key: key.as_slice(),
+                value: value.as_slice(),
+            })
+            .collect::<Vec<_>>();
+        let encoded = encode_leaf_refs_for_tests(&refs);
+        let NodeRefForLeafTests::Leaf(decoded) =
+            decode_node_ref_for_leaf_tests(&encoded).expect("leaf should decode")
+        else {
+            panic!("leaf encoded bytes decoded as non-leaf");
+        };
+        assert_eq!(decoded.len(), entries.len());
+        for (index, (key, value)) in entries.iter().enumerate() {
+            let entry = decoded
+                .entry(index)
+                .expect("entry should read")
+                .expect("entry should exist");
+            assert_eq!(entry.key, key.as_slice(), "key {index}");
+            assert_eq!(entry.value, value.as_slice(), "value {index}");
+        }
+    }
+
+    #[test]
+    fn leaf_v2_round_trips_representative_shapes() {
+        leaf_entries_round_trip(&[]);
+        leaf_entries_round_trip(&[(b"only".to_vec(), b"value".to_vec())]);
+        leaf_entries_round_trip(&[
+            (b"a".to_vec(), Vec::new()),
+            (b"ab".to_vec(), vec![0u8; 300]),
+            (b"abc/0001".to_vec(), b"x".to_vec()),
+            (b"abc/0002".to_vec(), b"y".to_vec()),
+            (b"zzz".to_vec(), vec![0xff; 7]),
+        ]);
+        // No shared prefixes at all (front-coding worst case).
+        leaf_entries_round_trip(&[
+            (vec![0x00], b"a".to_vec()),
+            (vec![0x80, 0x01], b"b".to_vec()),
+            (vec![0xff, 0xff, 0xff], b"c".to_vec()),
+        ]);
+    }
+
+    #[test]
+    fn leaf_v2_round_trips_generated_sorted_keys() {
+        // Deterministic pseudo-random keys with heavy shared prefixes,
+        // mimicking encoded (schema_key, file_id, entity_pk) keys.
+        let mut entries = (0..512usize)
+            .map(|index| {
+                let mut state = (index as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15) | 1;
+                state ^= state >> 31;
+                let key = format!(
+                    "json_pointer\u{0}/packages/{:04}/{}",
+                    index % 7,
+                    state % 1000
+                )
+                .into_bytes();
+                let value = state.to_be_bytes().repeat(1 + (index % 5));
+                (key, value)
+            })
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries.dedup_by(|a, b| a.0 == b.0);
+        leaf_entries_round_trip(&entries);
+    }
+
+    #[test]
+    fn leaf_v2_round_trips_multibyte_varint_fields() {
+        // Keys long enough that shared and suffix lengths need two-byte
+        // varints, with >127 entries so the count does too.
+        let mut entries = Vec::new();
+        let prefix = "p".repeat(160);
+        for index in 0..200usize {
+            let key = format!("{prefix}/{index:05}").into_bytes();
+            let value = vec![index.to_le_bytes()[0]; 130];
+            entries.push((key, value));
+        }
+        entries.sort();
+        leaf_entries_round_trip(&entries);
+    }
+
+    /// Pins the exact wire bytes. Tree chunks are content-addressed, so any
+    /// accidental format drift changes chunk hashes; this golden test makes
+    /// such drift fail a unit test instead of only surfacing in storage.
+    #[test]
+    fn leaf_v2_wire_format_is_pinned() {
+        let entries = [
+            (b"shared/aaaa".to_vec(), b"v1".to_vec()),
+            (b"shared/aabb".to_vec(), b"v2".to_vec()),
+            (b"shared/bbbb".to_vec(), b"v3".to_vec()),
+        ];
+        let refs = entries
+            .iter()
+            .map(|(key, value)| EncodedLeafEntryRef {
+                key: key.as_slice(),
+                value: value.as_slice(),
+            })
+            .collect::<Vec<_>>();
+        let encoded = encode_leaf_refs_for_tests(&refs);
+        let expected: &[u8] = &[
+            1, // NODE_KIND_LEAF_V2
+            3, // entry count
+            0, 11, b's', b'h', b'a', b'r', b'e', b'd', b'/', b'a', b'a', b'a', b'a', 2, b'v',
+            b'1', // entry 0: shared=0, suffix "shared/aaaa", value "v1"
+            9, 2, b'b', b'b', 2, b'v', b'2', // entry 1: shared=9, suffix "bb"
+            7, 4, b'b', b'b', b'b', b'b', 2, b'v', b'3', // entry 2: shared=7, suffix "bbbb"
+        ];
+        assert_eq!(encoded, expected, "leaf v2 wire bytes must stay stable");
+    }
+
+    #[test]
+    fn leaf_v2_rejects_malformed_bytes() {
+        let entries = [(b"key-a".to_vec(), b"value-a".to_vec())];
+        let encoded = encode_leaf_refs_for_tests(
+            &entries
+                .iter()
+                .map(|(key, value)| EncodedLeafEntryRef {
+                    key: key.as_slice(),
+                    value: value.as_slice(),
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let mut unknown_kind = encoded.clone();
+        unknown_kind[0] = 0x7f;
+        assert!(decode_node_ref_for_leaf_tests(&unknown_kind).is_err());
+
+        let truncated = &encoded[..encoded.len() - 1];
+        assert!(decode_node_ref_for_leaf_tests(truncated).is_err());
+
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        assert!(decode_node_ref_for_leaf_tests(&trailing).is_err());
+
+        // shared_len larger than the previous key reconstructs nothing valid.
+        let mut bogus_share = vec![NODE_KIND_LEAF_V2];
+        bogus_share.extend_from_slice(&[1, 9, 1, b'k', 1, b'v']);
+        assert!(decode_node_ref_for_leaf_tests(&bogus_share).is_err());
+
+        assert!(decode_node_ref_for_leaf_tests(&[]).is_err());
+    }
+
     use super::*;
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
@@ -728,9 +1071,8 @@ mod tests {
         let error = decode_node_ref(&encoded).expect_err("truncated leaf should reject");
 
         assert!(
-            error
-                .to_string()
-                .contains("failed to decode tracked-state tree node")
+            error.to_string().contains("tracked-state leaf node"),
+            "unexpected error: {error}"
         );
     }
 

--- a/packages/engine/src/tracked_state/codec.rs
+++ b/packages/engine/src/tracked_state/codec.rs
@@ -104,7 +104,8 @@ impl DecodedLeafNode {
 /// Decoded view of a leaf node.
 ///
 /// Keys are stored front-coded on disk and reconstructed into one arena at
-/// decode time; values stay borrowed from the chunk bytes verbatim.
+/// decode time. Values with a dictionaried commit-id slice are reconstructed
+/// into the same arena; verbatim values stay borrowed from the chunk bytes.
 #[derive(Debug, Clone)]
 pub(crate) struct DecodedLeafNodeRef<'a> {
     key_arena: Vec<u8>,
@@ -115,7 +116,15 @@ pub(crate) struct DecodedLeafNodeRef<'a> {
 struct LeafEntrySpan<'a> {
     key_start: usize,
     key_end: usize,
-    value: &'a [u8],
+    value: LeafValueSpan<'a>,
+}
+
+/// Values whose commit-id slice was dictionaried are reconstructed into the
+/// arena; verbatim values stay borrowed from the chunk bytes.
+#[derive(Debug, Clone, Copy)]
+enum LeafValueSpan<'a> {
+    Borrowed(&'a [u8]),
+    Arena { start: usize, end: usize },
 }
 
 impl DecodedLeafNodeRef<'_> {
@@ -127,7 +136,10 @@ impl DecodedLeafNodeRef<'_> {
     pub(crate) fn entry(&self, index: usize) -> Result<Option<EncodedLeafEntryRef<'_>>, LixError> {
         Ok(self.entries.get(index).map(|span| EncodedLeafEntryRef {
             key: &self.key_arena[span.key_start..span.key_end],
-            value: span.value,
+            value: match span.value {
+                LeafValueSpan::Borrowed(value) => value,
+                LeafValueSpan::Arena { start, end } => &self.key_arena[start..end],
+            },
         }))
     }
 
@@ -284,16 +296,32 @@ pub(crate) fn encode_leaf_node(entries: &[EncodedLeafEntry]) -> Vec<u8> {
     encode_leaf_node_refs(&entries)
 }
 
+/// Offsets of the commit-id slice inside a standard encoded value; pinned by
+/// `encoded_value_layout_places_ids_at_fixed_offsets`.
+const VALUE_COMMIT_ID_START: usize = 16;
+const VALUE_COMMIT_ID_END: usize = 32;
+
 /// Leaf node wire format (v2):
 ///
 /// ```text
 /// [NODE_KIND_LEAF_V2]
 /// varint entry_count
+/// varint commit_dict_len ++ commit_dict_len x 16 commit-id bytes
 /// per entry:
 ///   varint shared_key_len   bytes shared with the previous entry's key
 ///   varint key_suffix_len ++ key suffix bytes
-///   varint value_len ++ value bytes (verbatim standard value encoding)
+///   varint dict_ref         0 = value stored verbatim; n>0 = the value's
+///                           commit-id slice [16..32) is dict entry n-1 and
+///                           is omitted from the stored bytes
+///   varint stored_value_len ++ stored value bytes
 /// ```
+///
+/// Bulk commits repeat one commit id across every entry, so the chunk-local
+/// dictionary collapses the 16-byte slice to a 1-byte ref; the splice is
+/// reversible byte-for-byte regardless of value semantics, and values
+/// shorter than 32 bytes are stored verbatim. The dictionary uses
+/// first-occurrence order, keeping the encoding a deterministic function of
+/// the entries.
 ///
 /// Entries within a node are sorted by key, so consecutive keys share the
 /// encoded schema-key/file-id prefix and most of the entity-pk; front-coding
@@ -307,17 +335,49 @@ pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<
         entries.windows(2).all(|pair| pair[0].key < pair[1].key),
         "leaf entries must be strictly sorted by key"
     );
+    let mut commit_dictionary: Vec<&[u8]> = Vec::new();
+    let mut dict_refs = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if entry.value.len() >= VALUE_COMMIT_ID_END {
+            let commit_id = &entry.value[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END];
+            let index = commit_dictionary
+                .iter()
+                .position(|known| *known == commit_id)
+                .unwrap_or_else(|| {
+                    commit_dictionary.push(commit_id);
+                    commit_dictionary.len() - 1
+                });
+            dict_refs.push(index as u64 + 1);
+        } else {
+            dict_refs.push(0);
+        }
+    }
+
     let mut out = Vec::with_capacity(64 + entries.len() * 24);
     out.push(NODE_KIND_LEAF_V2);
     write_varint(&mut out, entries.len() as u64);
+    write_varint(&mut out, commit_dictionary.len() as u64);
+    for commit_id in &commit_dictionary {
+        out.extend_from_slice(commit_id);
+    }
     let mut previous_key: &[u8] = &[];
-    for entry in entries {
+    for (entry, dict_ref) in entries.iter().zip(&dict_refs) {
         let shared = shared_prefix_len(previous_key, entry.key);
         write_varint(&mut out, shared as u64);
         write_varint(&mut out, (entry.key.len() - shared) as u64);
         out.extend_from_slice(&entry.key[shared..]);
-        write_varint(&mut out, entry.value.len() as u64);
-        out.extend_from_slice(entry.value);
+        write_varint(&mut out, *dict_ref);
+        if *dict_ref == 0 {
+            write_varint(&mut out, entry.value.len() as u64);
+            out.extend_from_slice(entry.value);
+        } else {
+            write_varint(
+                &mut out,
+                (entry.value.len() - (VALUE_COMMIT_ID_END - VALUE_COMMIT_ID_START)) as u64,
+            );
+            out.extend_from_slice(&entry.value[..VALUE_COMMIT_ID_START]);
+            out.extend_from_slice(&entry.value[VALUE_COMMIT_ID_END..]);
+        }
         previous_key = entry.key;
     }
     #[cfg(debug_assertions)]
@@ -370,17 +430,29 @@ fn decode_leaf_v2(body: &[u8]) -> Result<DecodedLeafNodeRef<'_>, LixError> {
 
     let mut offset = 0usize;
     let entry_count = usize_from(read_varint(body, &mut offset)?, "entry count")?;
-    // Reconstructed keys total the suffix bytes plus every re-expanded
-    // shared prefix, so heavy sharing can exceed the body length; the body
-    // length is a cheap reservation that avoids re-allocation for typical
-    // value-dominated chunks.
+    let dict_len = usize_from(read_varint(body, &mut offset)?, "commit dictionary length")?;
+    let dict_bytes = dict_len.checked_mul(16).ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state leaf node commit dictionary length overflow",
+        )
+    })?;
+    let commit_dictionary = slice(body, &mut offset, dict_bytes)?;
+    // Reconstructed keys (and dictionary-spliced values) total the stored
+    // bytes plus re-expanded prefixes and commit ids, so heavy sharing can
+    // exceed the body length; the body length is a cheap reservation that
+    // avoids re-allocation for typical chunks.
     let mut key_arena = Vec::with_capacity(body.len());
     let mut entries = Vec::with_capacity(entry_count.min(body.len()));
     let mut previous_key_start = 0usize;
+    // Tracked separately from the arena length: dictionaried values are
+    // appended to the same arena after their key, so the arena tail is not
+    // necessarily the previous key.
+    let mut previous_key_end = 0usize;
     for _ in 0..entry_count {
         let shared = usize_from(read_varint(body, &mut offset)?, "shared key length")?;
         let suffix_len = usize_from(read_varint(body, &mut offset)?, "key suffix length")?;
-        let previous_key_len = key_arena.len() - previous_key_start;
+        let previous_key_len = previous_key_end - previous_key_start;
         if shared > previous_key_len {
             return Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",
@@ -391,14 +463,44 @@ fn decode_leaf_v2(body: &[u8]) -> Result<DecodedLeafNodeRef<'_>, LixError> {
         key_arena.extend_from_within(previous_key_start..previous_key_start + shared);
         let suffix = slice(body, &mut offset, suffix_len)?;
         key_arena.extend_from_slice(suffix);
+        let key_end = key_arena.len();
+        let dict_ref = usize_from(read_varint(body, &mut offset)?, "commit dictionary ref")?;
         let value_len = usize_from(read_varint(body, &mut offset)?, "value length")?;
-        let value = slice(body, &mut offset, value_len)?;
+        let stored_value = slice(body, &mut offset, value_len)?;
+        let value = if dict_ref == 0 {
+            LeafValueSpan::Borrowed(stored_value)
+        } else {
+            // Validate before index arithmetic: a huge dict_ref would wrap
+            // the multiplication and alias a valid dictionary slot.
+            if dict_ref > dict_len {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state leaf node commit dictionary ref is out of bounds",
+                ));
+            }
+            let commit_id = &commit_dictionary[(dict_ref - 1) * 16..dict_ref * 16];
+            if stored_value.len() < VALUE_COMMIT_ID_START {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state leaf node dictionaried value is too short",
+                ));
+            }
+            let start = key_arena.len();
+            key_arena.extend_from_slice(&stored_value[..VALUE_COMMIT_ID_START]);
+            key_arena.extend_from_slice(commit_id);
+            key_arena.extend_from_slice(&stored_value[VALUE_COMMIT_ID_START..]);
+            LeafValueSpan::Arena {
+                start,
+                end: key_arena.len(),
+            }
+        };
         entries.push(LeafEntrySpan {
             key_start,
-            key_end: key_arena.len(),
+            key_end,
             value,
         });
         previous_key_start = key_start;
+        previous_key_end = key_end;
     }
     if offset != body.len() {
         return Err(LixError::new(
@@ -675,6 +777,173 @@ mod tests {
         leaf_entries_round_trip(&entries);
     }
 
+    /// Pins the assumption the leaf commit-id dictionary relies on: the
+    /// encoded value places change_id at bytes [0..16) and commit_id at
+    /// bytes [16..32) as raw uuid bytes.
+    #[test]
+    fn encoded_value_layout_places_ids_at_fixed_offsets() {
+        let change_id = ChangeId::for_test_label("layout-change");
+        let commit_id = CommitId::for_test_label("layout-commit");
+        let encoded = encode_value(&TrackedStateIndexValue {
+            change_id,
+            commit_id,
+            deleted: false,
+            snapshot_ref: Some(JsonRef::for_content(b"layout-snapshot")),
+            metadata_ref: None,
+            created_at: timestamp("created_at", "2026-01-01T00:00:00Z"),
+            updated_at: timestamp("updated_at", "2026-01-01T00:00:00Z"),
+        });
+        assert_eq!(&encoded[..16], change_id.as_uuid().as_bytes());
+        assert_eq!(&encoded[16..32], commit_id.as_uuid().as_bytes());
+    }
+
+    #[test]
+    fn leaf_v2_round_trips_dictionaried_commit_ids() {
+        // Realistic shape: >=32-byte values where bytes [16..32) repeat
+        // across entries (one commit id per bulk commit, a few stragglers),
+        // including a boundary 32-byte value and a verbatim short value.
+        let mut entries = Vec::new();
+        for index in 0..300usize {
+            let key = format!("rows/{index:05}").into_bytes();
+            let value_len = match index {
+                0 => 32,
+                1 => 8,
+                _ => 90,
+            };
+            let mut value = vec![0u8; value_len];
+            if value_len >= 32 {
+                value[..16].copy_from_slice(&(index as u128).to_be_bytes());
+                let commit = (index % 3).to_le_bytes()[0];
+                value[16..32].copy_from_slice(&[commit; 16]);
+            }
+            entries.push((key, value));
+        }
+        entries.sort();
+        leaf_entries_round_trip(&entries);
+
+        // The dictionary must actually compress: ~300 entries x 16 bytes of
+        // commit id collapse to 3 dictionary rows.
+        let refs = entries
+            .iter()
+            .map(|(key, value)| EncodedLeafEntryRef {
+                key: key.as_slice(),
+                value: value.as_slice(),
+            })
+            .collect::<Vec<_>>();
+        let encoded = encode_leaf_refs_for_tests(&refs);
+        let verbatim_size: usize = entries
+            .iter()
+            .map(|(key, value)| key.len() + value.len())
+            .sum();
+        assert!(
+            encoded.len() + 298 * 14 < verbatim_size,
+            "dictionary must remove ~15 bytes per entry: encoded={} verbatim={}",
+            encoded.len(),
+            verbatim_size
+        );
+    }
+
+    /// Pins the dictionaried wire bytes. The dict-len-0 golden test covers
+    /// verbatim values; this one pins the dictionary section and the
+    /// spliced value layout, so a drift (e.g. sorted instead of
+    /// first-occurrence dictionary order) fails a unit test instead of
+    /// silently changing every chunk hash.
+    #[test]
+    fn leaf_v2_dictionaried_wire_format_is_pinned() {
+        let mut value_a = vec![0xAAu8; 33];
+        value_a[16..32].copy_from_slice(&[0xCC; 16]); // commit id slice
+        let mut value_b = vec![0xBBu8; 32];
+        value_b[16..32].copy_from_slice(&[0xCC; 16]); // same commit id
+        let entries = [(b"k1".to_vec(), value_a), (b"k2".to_vec(), value_b)];
+        let refs = entries
+            .iter()
+            .map(|(key, value)| EncodedLeafEntryRef {
+                key: key.as_slice(),
+                value: value.as_slice(),
+            })
+            .collect::<Vec<_>>();
+        let encoded = encode_leaf_refs_for_tests(&refs);
+        let mut expected = vec![
+            1, // NODE_KIND_LEAF_V2
+            2, // entry count
+            1, // commit dictionary length
+        ];
+        expected.extend_from_slice(&[0xCC; 16]); // dictionary slot 0
+        // entry 0: shared=0, suffix "k1", dict_ref=1, stored 17 bytes
+        expected.extend_from_slice(&[0, 2, b'k', b'1', 1, 17]);
+        expected.extend_from_slice(&[0xAA; 16]); // value prefix
+        expected.push(0xAA); // value rest (byte 32)
+        // entry 1: shared=1, suffix "2", dict_ref=1, stored 16 bytes
+        expected.extend_from_slice(&[1, 1, b'2', 1, 16]);
+        expected.extend_from_slice(&[0xBB; 16]);
+        assert_eq!(
+            encoded, expected,
+            "dictionaried wire bytes must stay stable"
+        );
+    }
+
+    #[test]
+    fn leaf_v2_rejects_adversarial_dictionary_lengths() {
+        // dict_len claims more 16-byte slots than the body holds.
+        assert!(decode_node_ref_for_leaf_tests(&[1u8, 1, 200, 0, 0]).is_err());
+        // dict_len * 16 overflows usize.
+        let mut huge = vec![1u8, 1];
+        huge.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]);
+        assert!(decode_node_ref_for_leaf_tests(&huge).is_err());
+        // dict_ref > 0 with a stored value shorter than the splice prefix.
+        let mut short = vec![1u8, 1, 1];
+        short.extend_from_slice(&[9u8; 16]); // dictionary slot
+        short.extend_from_slice(&[0, 1, b'k', 1, 8]); // stored value only 8 bytes
+        short.extend_from_slice(&[0u8; 8]);
+        assert!(
+            decode_node_ref_for_leaf_tests(&short).is_err(),
+            "dictionaried values shorter than the splice prefix must be rejected"
+        );
+    }
+
+    #[test]
+    fn leaf_v2_rejects_out_of_bounds_dictionary_ref() {
+        // kind, count=1, dict_len=0, shared=0, suffix_len=1, 'k',
+        // dict_ref=1 (out of bounds), stored value 16 bytes.
+        let mut bytes = vec![1u8, 1, 0, 0, 1, b'k', 1, 16];
+        bytes.extend_from_slice(&[0u8; 16]);
+        assert!(decode_node_ref_for_leaf_tests(&bytes).is_err());
+    }
+
+    #[test]
+    fn leaf_v2_rejects_wrapping_dictionary_ref() {
+        // dict_ref = 2^60 + 1 would wrap (dict_ref - 1) * 16 to zero and
+        // alias dictionary slot 0 if validated after the multiplication.
+        let mut bytes = vec![1u8, 1, 1];
+        bytes.extend_from_slice(&[7u8; 16]); // one dictionary slot
+        bytes.extend_from_slice(&[0, 1, b'k']); // shared=0, suffix 'k'
+        bytes.extend_from_slice(&[0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x10]);
+        bytes.push(16); // stored value length
+        bytes.extend_from_slice(&[0u8; 16]);
+        assert!(
+            decode_node_ref_for_leaf_tests(&bytes).is_err(),
+            "wrapping dictionary refs must be rejected"
+        );
+    }
+
+    #[test]
+    fn leaf_v2_rejects_shared_len_exceeding_previous_key_after_dictionaried_value() {
+        // Entry A: 1-byte key, dictionaried value (reconstructed value bytes
+        // land in the arena after the key). Entry B claims shared=3, which
+        // exceeds A's key length; a guard computed from the arena tail
+        // instead of the previous key end would accept it and splice value
+        // bytes into B's key.
+        let mut bytes = vec![1u8, 2, 1];
+        bytes.extend_from_slice(&[7u8; 16]); // dictionary slot 0
+        bytes.extend_from_slice(&[0, 1, b'k', 1, 16]); // A: shared=0, 'k', dict_ref=1
+        bytes.extend_from_slice(&[1u8; 16]);
+        bytes.extend_from_slice(&[3, 0, 0, 0]); // B: shared=3, suffix 0, dict_ref=0, value 0
+        assert!(
+            decode_node_ref_for_leaf_tests(&bytes).is_err(),
+            "shared length beyond the previous key must be rejected"
+        );
+    }
+
     /// Pins the exact wire bytes. Tree chunks are content-addressed, so any
     /// accidental format drift changes chunk hashes; this golden test makes
     /// such drift fail a unit test instead of only surfacing in storage.
@@ -696,10 +965,12 @@ mod tests {
         let expected: &[u8] = &[
             1, // NODE_KIND_LEAF_V2
             3, // entry count
-            0, 11, b's', b'h', b'a', b'r', b'e', b'd', b'/', b'a', b'a', b'a', b'a', 2, b'v',
-            b'1', // entry 0: shared=0, suffix "shared/aaaa", value "v1"
-            9, 2, b'b', b'b', 2, b'v', b'2', // entry 1: shared=9, suffix "bb"
-            7, 4, b'b', b'b', b'b', b'b', 2, b'v', b'3', // entry 2: shared=7, suffix "bbbb"
+            0, // commit dictionary length (values too short to dictionary)
+            0, 11, b's', b'h', b'a', b'r', b'e', b'd', b'/', b'a', b'a', b'a', b'a', 0, 2, b'v',
+            b'1', // entry 0: shared=0, suffix "shared/aaaa", dict_ref=0, value "v1"
+            9, 2, b'b', b'b', 0, 2, b'v', b'2', // entry 1: shared=9, suffix "bb"
+            7, 4, b'b', b'b', b'b', b'b', 0, 2, b'v',
+            b'3', // entry 2: shared=7, suffix "bbbb"
         ];
         assert_eq!(encoded, expected, "leaf v2 wire bytes must stay stable");
     }

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1150,12 +1150,10 @@ mod tests {
     use crate::storage::StorageContext;
     use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
 
-    fn commit_id(label: &str) -> String {
-        CommitId::for_test_label(label).to_string()
-    }
-
     fn commit_root_key(label: &str) -> crate::storage::StorageKey {
-        crate::storage::StorageKey(bytes::Bytes::from(commit_id(label).into_bytes()))
+        crate::storage::StorageKey(bytes::Bytes::copy_from_slice(
+            CommitId::for_test_label(label).as_uuid().as_bytes(),
+        ))
     }
 
     fn change_id(label: &str) -> String {
@@ -1666,10 +1664,11 @@ mod tests {
             let mut writes = storage.new_write_set();
             let commit_a = CommitId::for_test_label("commit-a");
             let commit_b = CommitId::for_test_label("commit-b");
-            let commit_a_text = commit_a.to_string();
             writes.put(
                 crate::changelog::COMMIT_SPACE,
-                crate::storage::StorageKey(bytes::Bytes::copy_from_slice(commit_a_text.as_bytes())),
+                crate::storage::StorageKey(bytes::Bytes::copy_from_slice(
+                    commit_a.as_uuid().as_bytes(),
+                )),
                 crate::changelog::encode_commit_record(&CommitRecord {
                     format_version: 1,
                     commit_id: commit_a,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -6,7 +6,6 @@
 
 use std::collections::HashMap;
 
-#[cfg(test)]
 use crate::changelog::CommitId;
 use crate::storage::{PointReadPlan, StorageRead, StorageSpace, StorageWriteSet};
 use crate::storage::{
@@ -54,55 +53,30 @@ pub(crate) async fn load_root(
         .map(|metadata| metadata.root_id))
 }
 
+/// Commit-root keys are the raw 16 UUID bytes of the commit id; binary
+/// UUIDv7 order matches the former hyphenated-text key order.
+fn commit_root_key(commit_id: CommitId) -> Vec<u8> {
+    commit_id.as_uuid().as_bytes().to_vec()
+}
+
 pub(crate) async fn load_commit_root(
     store: &(impl StorageRead + ?Sized),
     commit_id: &str,
 ) -> Result<Option<TrackedStateCommitRoot>, LixError> {
+    // parse_lix canonicalizes test labels to the same synthetic UUID the
+    // staging path produces, so label-keyed test fixtures keep matching.
+    let typed_commit_id = CommitId::parse_lix(commit_id, "tracked-state commit root lookup")?;
     let Some(bytes) = get_one(
         store,
         TRACKED_STATE_COMMIT_ROOT_SPACE,
-        commit_id.as_bytes().to_vec(),
-    )
-    .await?
-    else {
-        #[cfg(test)]
-        {
-            let test_commit_id = CommitId::for_test_label(commit_id).to_string();
-            if test_commit_id != commit_id {
-                return load_commit_root_by_storage_key(store, &test_commit_id).await;
-            }
-        }
-        return Ok(None);
-    };
-    let metadata = decode_commit_root(&bytes)?;
-    if metadata.commit_id != commit_id {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "tracked_state commit_root key for commit '{commit_id}' contains root metadata for commit '{}'",
-                metadata.commit_id
-            ),
-        ));
-    }
-    Ok(Some(metadata))
-}
-
-#[cfg(test)]
-async fn load_commit_root_by_storage_key(
-    store: &(impl StorageRead + ?Sized),
-    commit_id: &str,
-) -> Result<Option<TrackedStateCommitRoot>, LixError> {
-    let Some(bytes) = get_one(
-        store,
-        TRACKED_STATE_COMMIT_ROOT_SPACE,
-        commit_id.as_bytes().to_vec(),
+        commit_root_key(typed_commit_id),
     )
     .await?
     else {
         return Ok(None);
     };
     let metadata = decode_commit_root(&bytes)?;
-    if metadata.commit_id.to_string() != commit_id {
+    if metadata.commit_id != typed_commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
@@ -120,7 +94,7 @@ pub(crate) fn stage_commit_root(
 ) -> Result<(), LixError> {
     writes.put(
         TRACKED_STATE_COMMIT_ROOT_SPACE,
-        key(metadata.commit_id.to_string().into_bytes()),
+        key(commit_root_key(metadata.commit_id)),
         value(encode_commit_root(metadata)?),
     );
     Ok(())

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -197,6 +197,45 @@ where
         self.read_one(&self.rows[self.rows.len() / 2]).await
     }
 
+    /// Returns every visible row's identity and snapshot content, sorted by
+    /// identity. Unlike the timed read helpers this materializes contents,
+    /// so equivalence tests can compare logical state across backends.
+    pub async fn read_all_contents(&self) -> Vec<(String, String)> {
+        let read = SharedStorageRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .expect("begin transaction bench read"),
+        );
+        let rows = self
+            .live_state
+            .reader(read)
+            .scan_rows(&LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec!["json_pointer".to_string()],
+                    branch_ids: vec![BENCH_BRANCH_ID.to_string()],
+                    file_ids: vec![NullableKeyFilter::Null],
+                    include_tombstones: false,
+                    ..LiveStateFilter::default()
+                },
+                projection: LiveStateProjection::default(),
+                limit: None,
+            })
+            .await
+            .expect("scan transaction bench rows");
+        let mut contents = rows
+            .into_iter()
+            .map(|row| {
+                let entity_pk = row
+                    .entity_pk
+                    .as_json_array_text()
+                    .expect("bench entity pk should render");
+                (entity_pk, row.snapshot_content.unwrap_or_default())
+            })
+            .collect::<Vec<_>>();
+        contents.sort();
+        contents
+    }
+
     async fn read_one(&self, row: &BenchTransactionRow) -> usize {
         let read = SharedStorageRead::new(
             self.storage

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -72,6 +72,17 @@ where
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
+    /// Like [`Self::new`], but enables the engine's deterministic functions
+    /// before any transaction runs, so ids and timestamps are
+    /// sequence-derived and two fixtures produce byte-identical storage.
+    pub async fn new_deterministic(
+        storage: StorageContext<B>,
+        rows: Vec<BenchTransactionRow>,
+    ) -> Self {
+        seed_deterministic_mode(storage.clone());
+        Self::new(storage, rows).await
+    }
+
     pub async fn new(storage: StorageContext<B>, rows: Vec<BenchTransactionRow>) -> Self {
         let tracked_state = Arc::new(TrackedStateContext::new());
         let live_state = Arc::new(LiveStateContext::new(
@@ -286,6 +297,15 @@ where
         write_accounting(logical_rows, outcome.storage_stats)
     }
 
+    /// Per-row inventory of one space, for byte-exact layout comparison.
+    pub fn space_inventory(&self, space_name: &str) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let read = self
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .expect("begin transaction inventory read");
+        crate::storage_bench::space_inventory(&read, space_name)
+    }
+
     pub fn layout_accounting(&self) -> Vec<BenchLayoutAccounting> {
         let read = self
             .storage
@@ -302,6 +322,41 @@ where
             })
             .collect()
     }
+}
+
+fn seed_deterministic_mode<B>(storage: StorageContext<B>)
+where
+    B: StorageBackend + Clone + Send + Sync + 'static,
+{
+    let snapshot_content = serde_json::to_string(&json!({
+        "key": crate::functions::DETERMINISTIC_MODE_KEY,
+        "value": { "enabled": true },
+    }))
+    .expect("deterministic mode snapshot should serialize");
+    let mut writes = storage.new_write_set();
+    let row = crate::untracked_state::UntrackedStateRow {
+        entity_pk: EntityPk::single(crate::functions::DETERMINISTIC_MODE_KEY),
+        schema_key: "lix_key_value".to_string(),
+        file_id: None,
+        snapshot_content: Some(snapshot_content),
+        metadata: None,
+        created_at: crate::common::LixTimestamp::expect_parse(
+            "created_at",
+            "1970-01-01T00:00:00.000Z",
+        ),
+        updated_at: crate::common::LixTimestamp::expect_parse(
+            "updated_at",
+            "1970-01-01T00:00:00.000Z",
+        ),
+        global: true,
+        branch_id: GLOBAL_BRANCH_ID.to_string(),
+    };
+    UntrackedStateContext::new()
+        .writer(&mut writes)
+        .stage_rows(std::iter::once(row.as_ref()))
+        .expect("deterministic mode row should stage");
+    crate::storage_bench::commit_write_set_for_bench(&storage, writes)
+        .expect("deterministic mode row should commit");
 }
 
 fn write_accounting(logical_rows: usize, stats: StorageWriteSetStats) -> BenchWriteAccounting {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -271,19 +271,24 @@ where
                 FunctionContext::prepare(&runtime_live_state).await?
             };
             let functions = runtime_functions.provider();
-            let schema_facts = {
+            let schema_catalog = {
                 let visible_live_state = live_state.reader(&read);
                 catalog_context
-                    .schema_facts_for_domain(
+                    .compiled_catalog_for_domain(
                         &visible_live_state,
                         &Domain::schema_catalog(active_branch_id.clone(), true),
                     )
                     .await?
             };
-            Ok::<_, LixError>((active_branch_id, runtime_functions, functions, schema_facts))
+            Ok::<_, LixError>((
+                active_branch_id,
+                runtime_functions,
+                functions,
+                schema_catalog,
+            ))
         }
         .await;
-        let (active_branch_id, runtime_functions, functions, schema_facts) = match setup_result {
+        let (active_branch_id, runtime_functions, functions, schema_catalog) = match setup_result {
             Ok(result) => result,
             Err(error) => {
                 return Err(error);
@@ -291,9 +296,9 @@ where
         };
         drop(read);
         let mut schema_resolver = TransactionSchemaResolver::new(Arc::clone(&catalog_context));
-        schema_resolver.remember_schema_facts(
+        schema_resolver.remember_compiled_catalog(
             &Domain::schema_catalog(active_branch_id.clone(), true),
-            schema_facts,
+            schema_catalog,
         );
         let staged_writes = Arc::new(TransactionWriteBuffer::new(functions.clone()));
         Ok(OpenTransaction {

--- a/packages/engine/src/transaction/normalization.rs
+++ b/packages/engine/src/transaction/normalization.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::LixError;
-use crate::catalog::{CatalogSnapshot, SchemaPlan, SchemaPlanId};
+use crate::catalog::{SchemaPlan, SchemaPlanId, TransactionCatalog};
 use crate::common::format_json_pointer;
 use crate::common::normalize_path_segment;
 use crate::domain::Domain;
@@ -42,12 +42,14 @@ pub(crate) struct NormalizedTransactionWriteRow {
 /// normalization has produced the final identity.
 pub(crate) fn normalize_transaction_write_row(
     mut row: TransactionWriteRow,
-    schema_catalog: &mut CatalogSnapshot,
+    schema_catalog: &mut TransactionCatalog,
     functions: FunctionProviderHandle,
 ) -> Result<NormalizedTransactionWriteRow, LixError> {
     validate_transaction_write_row_schema_identity(&row)?;
 
-    let Some((schema_plan_id, schema_plan)) = schema_catalog.plan_for_key(&row.schema_key) else {
+    let Some((schema_plan_id, schema_plan)) =
+        schema_catalog.snapshot().plan_for_key(&row.schema_key)
+    else {
         return Err(LixError::new(
             LixError::CODE_SCHEMA_DEFINITION,
             format!(
@@ -278,7 +280,7 @@ fn entity_pk_derivation_error(
 pub(crate) fn remember_pending_registered_schema(
     snapshot: Option<&JsonValue>,
     domain: Domain,
-    schema_catalog: &mut CatalogSnapshot,
+    schema_catalog: &mut TransactionCatalog,
 ) -> Result<(), LixError> {
     let Some(snapshot) = snapshot else {
         return Err(LixError::new(
@@ -291,6 +293,7 @@ pub(crate) fn remember_pending_registered_schema(
     }
     {
         let registered_schema_definition = schema_catalog
+            .snapshot()
             .schema(REGISTERED_SCHEMA_KEY)
             .ok_or_else(|| {
                 LixError::new(
@@ -705,7 +708,7 @@ mod tests {
             .value()
     }
 
-    fn catalog_with(schemas: Vec<JsonValue>) -> CatalogSnapshot {
+    fn catalog_with(schemas: Vec<JsonValue>) -> TransactionCatalog {
         let mut visible_schemas = schemas;
         if visible_schemas.iter().any(|schema| {
             schema.get("x-lix-key").and_then(JsonValue::as_str) == Some(FILE_DESCRIPTOR_SCHEMA_KEY)
@@ -715,7 +718,10 @@ mod tests {
         }) {
             visible_schemas.push(builtin_schema(DIRECTORY_DESCRIPTOR_SCHEMA_KEY));
         }
-        CatalogSnapshot::from_visible_schemas(&visible_schemas).expect("catalog")
+        TransactionCatalog::Owned(
+            crate::catalog::CatalogSnapshot::from_visible_schemas(&visible_schemas)
+                .expect("catalog"),
+        )
     }
 
     fn builtin_schema(schema_key: &str) -> JsonValue {

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::LixError;
-use crate::catalog::{CatalogContext, CatalogSnapshot, SchemaCatalogFact};
+use crate::catalog::{CatalogContext, CatalogSnapshot, SchemaCatalogFact, TransactionCatalog};
 use crate::domain::Domain;
 use crate::live_state::{
     LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
@@ -19,7 +19,7 @@ pub(crate) struct TransactionSchemaResolver {
 
 enum CatalogEntry {
     SchemaFacts(Vec<SchemaCatalogFact>),
-    Catalog(CatalogSnapshot),
+    Catalog(TransactionCatalog),
 }
 
 impl TransactionSchemaResolver {
@@ -70,9 +70,11 @@ impl TransactionSchemaResolver {
             let CatalogEntry::SchemaFacts(facts) = entry else {
                 unreachable!("catalog entry was checked as schema facts");
             };
-            let catalog = CatalogSnapshot::from_schema_facts(&facts)?;
-            self.catalogs_by_domain
-                .insert(domain, CatalogEntry::Catalog(catalog));
+            let catalog = self.context.compiled_catalog_for_facts(&facts)?;
+            self.catalogs_by_domain.insert(
+                domain,
+                CatalogEntry::Catalog(TransactionCatalog::Shared(catalog)),
+            );
         }
         Ok(())
     }
@@ -82,7 +84,7 @@ impl TransactionSchemaResolver {
         live_state: &dyn LiveStateReader,
         staged: &PreparedStateRowOverlay,
         domain: &Domain,
-    ) -> Result<&mut CatalogSnapshot, LixError> {
+    ) -> Result<&mut TransactionCatalog, LixError> {
         self.load_catalog_for_domain(live_state, Some(staged), domain)
             .await?;
         let domain = domain.schema_catalog_domain();
@@ -111,7 +113,7 @@ impl TransactionSchemaResolver {
             .get(&domain)
             .expect("catalog cache should contain requested branch")
         {
-            CatalogEntry::Catalog(catalog) => Ok(catalog),
+            CatalogEntry::Catalog(catalog) => Ok(catalog.snapshot()),
             CatalogEntry::SchemaFacts(_) => {
                 unreachable!("schema catalog should be materialized before validation access")
             }

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::LixError;
-use crate::catalog::{CatalogContext, CatalogSnapshot, SchemaCatalogFact, TransactionCatalog};
+use crate::catalog::{CatalogContext, CatalogSnapshot, TransactionCatalog};
 use crate::domain::Domain;
 use crate::live_state::{
     LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
@@ -14,12 +14,7 @@ use crate::transaction::staging::PreparedStateRowOverlay;
 
 pub(crate) struct TransactionSchemaResolver {
     context: Arc<CatalogContext>,
-    catalogs_by_domain: BTreeMap<Domain, CatalogEntry>,
-}
-
-enum CatalogEntry {
-    SchemaFacts(Vec<SchemaCatalogFact>),
-    Catalog(TransactionCatalog),
+    catalogs_by_domain: BTreeMap<Domain, TransactionCatalog>,
 }
 
 impl TransactionSchemaResolver {
@@ -37,45 +32,26 @@ impl TransactionSchemaResolver {
         domain: &Domain,
     ) -> Result<(), LixError> {
         let domain = domain.schema_catalog_domain();
-        let needs_load = !self.catalogs_by_domain.contains_key(&domain);
-        if needs_load {
-            let facts = if let Some(staged) = staged {
-                let reader = TransactionSchemaLiveStateReader {
-                    base: live_state,
-                    staged,
-                };
-                self.context
-                    .schema_facts_for_domain(&reader, &domain)
-                    .await?
-            } else {
-                self.context
-                    .schema_facts_for_domain(live_state, &domain)
-                    .await?
-            };
-            self.catalogs_by_domain
-                .insert(domain.clone(), CatalogEntry::SchemaFacts(facts));
+        if self.catalogs_by_domain.contains_key(&domain) {
+            return Ok(());
         }
-
-        let should_materialize = self
-            .catalogs_by_domain
-            .get(&domain)
-            .is_some_and(|entry| matches!(entry, CatalogEntry::SchemaFacts(_)));
-        if should_materialize {
-            #[cfg(feature = "storage-benches")]
-            crate::storage_bench::record_transaction_schema_catalog_load();
-            let entry = self
-                .catalogs_by_domain
-                .remove(&domain)
-                .expect("schema catalog entry should exist after load");
-            let CatalogEntry::SchemaFacts(facts) = entry else {
-                unreachable!("catalog entry was checked as schema facts");
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_transaction_schema_catalog_load();
+        let catalog = if let Some(staged) = staged {
+            let reader = TransactionSchemaLiveStateReader {
+                base: live_state,
+                staged,
             };
-            let catalog = self.context.compiled_catalog_for_facts(&facts)?;
-            self.catalogs_by_domain.insert(
-                domain,
-                CatalogEntry::Catalog(TransactionCatalog::Shared(catalog)),
-            );
-        }
+            self.context
+                .compiled_catalog_for_domain(&reader, &domain)
+                .await?
+        } else {
+            self.context
+                .compiled_catalog_for_domain(live_state, &domain)
+                .await?
+        };
+        self.catalogs_by_domain
+            .insert(domain, TransactionCatalog::Shared(catalog));
         Ok(())
     }
 
@@ -88,16 +64,10 @@ impl TransactionSchemaResolver {
         self.load_catalog_for_domain(live_state, Some(staged), domain)
             .await?;
         let domain = domain.schema_catalog_domain();
-        match self
+        Ok(self
             .catalogs_by_domain
             .get_mut(&domain)
-            .expect("catalog cache should contain requested branch")
-        {
-            CatalogEntry::Catalog(catalog) => Ok(catalog),
-            CatalogEntry::SchemaFacts(_) => {
-                unreachable!("schema catalog should be materialized before mutable access")
-            }
-        }
+            .expect("catalog cache should contain requested branch"))
     }
 
     pub(crate) async fn catalog_for_validation(
@@ -108,22 +78,21 @@ impl TransactionSchemaResolver {
         self.load_catalog_for_domain(live_state, None, domain)
             .await?;
         let domain = domain.schema_catalog_domain();
-        match self
+        Ok(self
             .catalogs_by_domain
             .get(&domain)
             .expect("catalog cache should contain requested branch")
-        {
-            CatalogEntry::Catalog(catalog) => Ok(catalog.snapshot()),
-            CatalogEntry::SchemaFacts(_) => {
-                unreachable!("schema catalog should be materialized before validation access")
-            }
-        }
+            .snapshot())
     }
 
-    pub(crate) fn remember_schema_facts(&mut self, domain: &Domain, facts: Vec<SchemaCatalogFact>) {
+    pub(crate) fn remember_compiled_catalog(
+        &mut self,
+        domain: &Domain,
+        catalog: Arc<CatalogSnapshot>,
+    ) {
         self.catalogs_by_domain.insert(
             domain.schema_catalog_domain(),
-            CatalogEntry::SchemaFacts(facts),
+            TransactionCatalog::Shared(catalog),
         );
     }
 }

--- a/packages/engine/tests/backend.rs
+++ b/packages/engine/tests/backend.rs
@@ -6,6 +6,9 @@ mod redb;
 #[path = "backend/rocksdb.rs"]
 mod rocksdb;
 
+#[path = "backend/scrambled.rs"]
+mod scrambled;
+
 #[path = "backend/sqlite.rs"]
 mod sqlite;
 

--- a/packages/engine/tests/backend/scrambled.rs
+++ b/packages/engine/tests/backend/scrambled.rs
@@ -1,0 +1,332 @@
+//! Backend decorator that adversarially scrambles `visit_keys` callback
+//! order.
+//!
+//! `BackendRead::visit_keys` documents that visit order is unspecified and
+//! consumers must address results by index. This suite enforces that
+//! contract actively: the decorator replays point-read visits in reverse,
+//! and both the backend conformance suite and the full transaction engine
+//! paths must behave identically to the plain in-memory backend.
+
+use lix_engine::backend::{
+    Backend, BackendError, BackendRead, GetOptions, InMemoryBackend, InMemoryBackendFactory,
+    InMemoryBackendFixture, Key, KeyRange, PointVisitor, ProjectedValueRef, ReadOptions,
+    ScanOptions, WriteOptions,
+};
+use lix_engine::{BackendFactory, BackendFixture, BackendTestConfig, run_backend_conformance};
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ScrambledVisitBackendFactory {
+    inner: InMemoryBackendFactory,
+}
+
+#[derive(Clone, Debug)]
+struct ScrambledVisitFixture {
+    inner: InMemoryBackendFixture,
+}
+
+#[derive(Clone, Debug)]
+struct ScrambledVisitBackend {
+    inner: InMemoryBackend,
+}
+
+struct ScrambledVisitRead {
+    inner: <InMemoryBackend as Backend>::Read<'static>,
+}
+
+enum OwnedProjected {
+    KeyOnly,
+    FullValue(Vec<u8>),
+}
+
+impl BackendFactory for ScrambledVisitBackendFactory {
+    type Backend = ScrambledVisitBackend;
+    type Fixture = ScrambledVisitFixture;
+
+    fn create_fixture(&self) -> Self::Fixture {
+        ScrambledVisitFixture {
+            inner: self.inner.create_fixture(),
+        }
+    }
+
+    fn config(&self) -> BackendTestConfig {
+        self.inner.config()
+    }
+}
+
+impl BackendFixture for ScrambledVisitFixture {
+    type Backend = ScrambledVisitBackend;
+
+    fn open(&self) -> Self::Backend {
+        ScrambledVisitBackend {
+            inner: self.inner.open(),
+        }
+    }
+}
+
+impl Backend for ScrambledVisitBackend {
+    type Read<'a>
+        = ScrambledVisitRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = <InMemoryBackend as Backend>::Write<'a>
+    where
+        Self: 'a;
+
+    fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
+        Ok(ScrambledVisitRead {
+            inner: self.inner.begin_read(opts)?,
+        })
+    }
+
+    fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+        self.inner.begin_write(opts)
+    }
+}
+
+impl BackendRead for ScrambledVisitRead {
+    type RangeScan<'a> =
+        <<InMemoryBackend as Backend>::Read<'static> as BackendRead>::RangeScan<'a>;
+
+    fn visit_keys<V>(
+        &self,
+        keys: &[Key],
+        opts: GetOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<(), BackendError>
+    where
+        V: PointVisitor + ?Sized,
+    {
+        let mut buffered = Vec::with_capacity(keys.len());
+        self.inner.visit_keys(
+            keys,
+            opts,
+            &mut |index: usize, _key: &Key, value: Option<ProjectedValueRef<'_>>| {
+                let value = value.map(|value| match value {
+                    ProjectedValueRef::KeyOnly => OwnedProjected::KeyOnly,
+                    ProjectedValueRef::FullValue(bytes) => {
+                        OwnedProjected::FullValue(bytes.to_vec())
+                    }
+                });
+                buffered.push((index, value));
+                Ok(())
+            },
+        )?;
+        // Replay in a seeded-shuffled order: a consumer that depends on
+        // visit order instead of the visited index fails loudly here.
+        shuffle(&mut buffered);
+        for (index, value) in buffered {
+            let Some(key) = keys.get(index) else {
+                return Err(BackendError::Corruption(format!(
+                    "scrambled visit index out of bounds: {index}"
+                )));
+            };
+            let value = value.as_ref().map(|value| match value {
+                OwnedProjected::KeyOnly => ProjectedValueRef::KeyOnly,
+                OwnedProjected::FullValue(bytes) => ProjectedValueRef::FullValue(bytes),
+            });
+            visitor.visit(index, key, value)?;
+        }
+        Ok(())
+    }
+
+    fn with_range_scan<T, F>(
+        &self,
+        range: KeyRange,
+        opts: ScanOptions<'_>,
+        f: F,
+    ) -> Result<T, BackendError>
+    where
+        F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
+    {
+        // Range scans stay ordered: ascending key order is contractual.
+        self.inner.with_range_scan(range, opts, f)
+    }
+
+    fn close(self) -> Result<(), BackendError> {
+        self.inner.close()
+    }
+}
+
+/// Deterministic Fisher-Yates with a fixed xorshift seed, so failures
+/// replay exactly. Stronger than plain reversal, which is an involution
+/// that preserves adjacency structure.
+fn shuffle<T>(items: &mut [T]) {
+    const SEED: u64 = 0x5eed_1234_abcd_9876;
+    let mut state = SEED;
+    for index in (1..items.len()).rev() {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        #[expect(clippy::cast_possible_truncation)]
+        let swap_with = (state % (index as u64 + 1)) as usize;
+        items.swap(index, swap_with);
+    }
+}
+
+#[test]
+fn scrambled_visit_backend_passes_backend_conformance() {
+    let factory = ScrambledVisitBackendFactory::default();
+
+    run_backend_conformance(&factory).assert_no_failures();
+}
+
+#[cfg(feature = "storage-benches")]
+mod engine_paths {
+    use lix_engine::storage::StorageContext;
+    use lix_engine::transaction::bench::{BenchTransactionFixture, BenchTransactionRow};
+
+    use super::*;
+
+    const ROWS: usize = 64;
+    const READ_MANY_KEYS: usize = 10;
+
+    fn bench_rows() -> Vec<BenchTransactionRow> {
+        (0..ROWS)
+            .map(|index| BenchTransactionRow {
+                schema_key: "json_pointer".to_string(),
+                file_id: None,
+                entity_pk: format!("/packages/{index:03}/version"),
+                value: serde_json::json!({
+                    "path": format!("/packages/{index:03}/version"),
+                    "value": format!("1.0.{index}"),
+                }),
+                updated_value: serde_json::json!({
+                    "path": format!("/packages/{index:03}/version"),
+                    "value": format!("2.0.{index}"),
+                }),
+            })
+            .collect()
+    }
+
+    /// Runs the full transaction CRUD surface (normalization, validation,
+    /// changelog, tracked-state tree, json store) on the plain in-memory
+    /// backend and on the scrambled decorator, asserting identical logical
+    /// results and byte-identical physical layout.
+    #[tokio::test]
+    async fn engine_transaction_paths_are_visit_order_independent() {
+        let plain =
+            BenchTransactionFixture::new(StorageContext::new(InMemoryBackend::new()), bench_rows())
+                .await;
+        let scrambled = BenchTransactionFixture::new(
+            StorageContext::new(ScrambledVisitBackend {
+                inner: InMemoryBackend::new(),
+            }),
+            bench_rows(),
+        )
+        .await;
+
+        run_crud_surface(plain, scrambled).await;
+    }
+
+    async fn run_crud_surface(
+        mut plain: BenchTransactionFixture<InMemoryBackend>,
+        mut scrambled: BenchTransactionFixture<ScrambledVisitBackend>,
+    ) {
+        assert_eq!(plain.seed().await, scrambled.seed().await, "seed");
+        assert_state_matches(&plain, &scrambled, "after seed").await;
+
+        assert_eq!(
+            plain.read_all().await,
+            scrambled.read_all().await,
+            "read_all"
+        );
+        assert_eq!(
+            plain.read_many_by_pk(READ_MANY_KEYS).await,
+            scrambled.read_many_by_pk(READ_MANY_KEYS).await,
+            "read_many_by_pk"
+        );
+
+        // Bulk rounds keep validation and changelog running 64-key point
+        // reads through the scrambled visitor, not just single-key visits.
+        assert_eq!(
+            plain.update_all().await,
+            scrambled.update_all().await,
+            "update_all"
+        );
+        assert_state_matches(&plain, &scrambled, "after update_all").await;
+
+        assert_eq!(
+            plain.update_one_by_pk().await,
+            scrambled.update_one_by_pk().await,
+            "update_one_by_pk"
+        );
+        assert_state_matches(&plain, &scrambled, "after update_one").await;
+
+        assert_eq!(
+            plain.delete_all().await,
+            scrambled.delete_all().await,
+            "delete_all"
+        );
+        assert_state_matches(&plain, &scrambled, "after delete_all").await;
+
+        assert_eq!(
+            plain.insert_all().await,
+            scrambled.insert_all().await,
+            "insert_all after delete_all"
+        );
+        assert_state_matches(&plain, &scrambled, "after re-insert").await;
+
+        assert_eq!(
+            plain.read_many_by_pk(READ_MANY_KEYS).await,
+            scrambled.read_many_by_pk(READ_MANY_KEYS).await,
+            "read_many_by_pk after mutations"
+        );
+    }
+
+    /// Compares full logical row contents (identity + snapshot) plus
+    /// per-space layout accounting. Contents catch value cross-wiring that
+    /// count or byte-sum aggregates would miss; ids and timestamps differ
+    /// between the fixtures, so byte-exact physical comparison is not
+    /// possible without injecting deterministic functions.
+    async fn assert_state_matches(
+        plain: &BenchTransactionFixture<InMemoryBackend>,
+        scrambled: &BenchTransactionFixture<ScrambledVisitBackend>,
+        stage: &str,
+    ) {
+        assert_eq!(
+            plain.read_all_contents().await,
+            scrambled.read_all_contents().await,
+            "row contents must match regardless of visit order ({stage})"
+        );
+        assert_layouts_match(plain, scrambled, stage);
+    }
+
+    fn assert_layouts_match(
+        plain: &BenchTransactionFixture<InMemoryBackend>,
+        scrambled: &BenchTransactionFixture<ScrambledVisitBackend>,
+        stage: &str,
+    ) {
+        let plain_layout = plain
+            .layout_accounting()
+            .into_iter()
+            .map(|space| {
+                (
+                    space.space_id,
+                    space.space,
+                    space.rows,
+                    space.key_bytes,
+                    space.value_bytes,
+                )
+            })
+            .collect::<Vec<_>>();
+        let scrambled_layout = scrambled
+            .layout_accounting()
+            .into_iter()
+            .map(|space| {
+                (
+                    space.space_id,
+                    space.space,
+                    space.rows,
+                    space.key_bytes,
+                    space.value_bytes,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            plain_layout, scrambled_layout,
+            "layout accounting (per-space row counts and key/value byte totals) must match regardless of visit order ({stage})"
+        );
+    }
+}

--- a/packages/engine/tests/backend/scrambled.rs
+++ b/packages/engine/tests/backend/scrambled.rs
@@ -206,10 +206,15 @@ mod engine_paths {
     /// results and byte-identical physical layout.
     #[tokio::test]
     async fn engine_transaction_paths_are_visit_order_independent() {
-        let plain =
-            BenchTransactionFixture::new(StorageContext::new(InMemoryBackend::new()), bench_rows())
-                .await;
-        let scrambled = BenchTransactionFixture::new(
+        // Deterministic functions make ids and timestamps sequence-derived,
+        // so the two fixtures must produce byte-identical storage and the
+        // comparison below can be exact instead of aggregate.
+        let plain = BenchTransactionFixture::new_deterministic(
+            StorageContext::new(InMemoryBackend::new()),
+            bench_rows(),
+        )
+        .await;
+        let scrambled = BenchTransactionFixture::new_deterministic(
             StorageContext::new(ScrambledVisitBackend {
                 inner: InMemoryBackend::new(),
             }),
@@ -275,11 +280,10 @@ mod engine_paths {
         );
     }
 
-    /// Compares full logical row contents (identity + snapshot) plus
-    /// per-space layout accounting. Contents catch value cross-wiring that
-    /// count or byte-sum aggregates would miss; ids and timestamps differ
-    /// between the fixtures, so byte-exact physical comparison is not
-    /// possible without injecting deterministic functions.
+    /// Compares full logical row contents (identity + snapshot) and the
+    /// byte-exact per-space physical inventories. Both fixtures run with
+    /// deterministic functions, so ids and timestamps are identical and any
+    /// divergence is a real visit-order dependence.
     async fn assert_state_matches(
         plain: &BenchTransactionFixture<InMemoryBackend>,
         scrambled: &BenchTransactionFixture<ScrambledVisitBackend>,
@@ -293,40 +297,48 @@ mod engine_paths {
         assert_layouts_match(plain, scrambled, stage);
     }
 
+    const COMPARED_SPACES: [&str; 10] = [
+        "untracked_state.row.v1",
+        "json_store.json",
+        "tracked_state.tree_chunk",
+        "tracked_state.commit_root",
+        "binary_cas.manifest",
+        "binary_cas.manifest_chunk",
+        "binary_cas.chunk",
+        "changelog.commit",
+        "changelog.change",
+        "changelog.commit_change_ref_chunk",
+    ];
+
+    /// Asserts byte-identical storage across every native space. Possible
+    /// because both fixtures run with deterministic functions; any
+    /// visit-order dependence in engine reads shows up as a content diff.
     fn assert_layouts_match(
         plain: &BenchTransactionFixture<InMemoryBackend>,
         scrambled: &BenchTransactionFixture<ScrambledVisitBackend>,
         stage: &str,
     ) {
-        let plain_layout = plain
+        // Guard against the space list rotting: every native space reported
+        // by layout accounting must be in the compared set.
+        let accounted = plain
             .layout_accounting()
             .into_iter()
-            .map(|space| {
-                (
-                    space.space_id,
-                    space.space,
-                    space.rows,
-                    space.key_bytes,
-                    space.value_bytes,
-                )
-            })
-            .collect::<Vec<_>>();
-        let scrambled_layout = scrambled
-            .layout_accounting()
-            .into_iter()
-            .map(|space| {
-                (
-                    space.space_id,
-                    space.space,
-                    space.rows,
-                    space.key_bytes,
-                    space.value_bytes,
-                )
-            })
+            .map(|space| space.space)
             .collect::<Vec<_>>();
         assert_eq!(
-            plain_layout, scrambled_layout,
-            "layout accounting (per-space row counts and key/value byte totals) must match regardless of visit order ({stage})"
+            accounted,
+            COMPARED_SPACES.to_vec(),
+            "COMPARED_SPACES must list every native storage space"
         );
+        for space in COMPARED_SPACES {
+            let mut plain_rows = plain.space_inventory(space);
+            let mut scrambled_rows = scrambled.space_inventory(space);
+            plain_rows.sort();
+            scrambled_rows.sort();
+            assert_eq!(
+                plain_rows, scrambled_rows,
+                "space {space} must be byte-identical regardless of visit order ({stage})"
+            );
+        }
     }
 }

--- a/packages/rs-sdk/benches/sqlite_backend.rs
+++ b/packages/rs-sdk/benches/sqlite_backend.rs
@@ -1,65 +1,28 @@
 use std::hint::black_box;
 use std::ops::Bound;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bytes::Bytes;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use lix_engine::backend::{KeyRef, PutEntry};
 use lix_sdk::{
-    Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite, CommitResult,
-    CoreProjection, GetOptions, Key, KeyRange, PointVisitor, ProjectedValueRef, PutBatch,
-    ReadOptions, ScanOptions, ScanResult, ScanVisitor, SqliteBackend, StoredValue, WriteOptions,
-    WriteStats,
+    Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite, CoreProjection, GetOptions,
+    Key, KeyRange, PointVisitor, ProjectedValueRef, PutBatch, ReadOptions, ScanOptions, ScanResult,
+    ScanVisitor, SqliteBackend, StoredValue, WriteOptions,
 };
-use rusqlite::types::{Value as SqlValue, ValueRef as SqlValueRef};
-use rusqlite::{Connection, Rows, params};
 use tempfile::TempDir;
 
 const ROWS: usize = 50_000;
 const POINT_KEYS: usize = 1_000;
 const VALUE_SIZE: usize = 256;
 const SCAN_CHUNK_ROWS: usize = 1_024;
-const POINT_READ_CHUNK_KEYS: usize = 400;
+/// Pre-existing rows for the random-key write benches, so inserts land in a
+/// grown B-tree instead of a trivially cached fresh one.
+const RANDOM_WRITE_SEED_ROWS: usize = 25_000;
 
 struct SqliteFixture {
-    _temp_dir: TempDir,
     backend: SqliteBackend,
-}
-
-struct DirectSqliteFixture {
     _temp_dir: TempDir,
-    backend: DirectSqliteBackend,
-}
-
-#[derive(Clone)]
-struct DirectSqliteBackend {
-    path: PathBuf,
-    read_pool: Arc<Mutex<Vec<Connection>>>,
-    write_pool: Arc<Mutex<Vec<Connection>>>,
-}
-
-struct DirectSqliteRead {
-    conn: Option<Connection>,
-    read_pool: Arc<Mutex<Vec<Connection>>>,
-}
-
-struct DirectSqliteRangeScan<'stmt> {
-    rows: Rows<'stmt>,
-    projection: CoreProjection,
-    pending: Option<DirectSqlitePendingRow>,
-    done: bool,
-}
-
-struct DirectSqlitePendingRow {
-    key: Vec<u8>,
-    value: Option<Vec<u8>>,
-}
-
-struct DirectSqliteWrite {
-    conn: Option<Connection>,
-    write_pool: Arc<Mutex<Vec<Connection>>>,
 }
 
 #[derive(Default)]
@@ -107,11 +70,56 @@ impl ScanVisitor for CountingScanVisitor {
 
 fn bench_sqlite_backend(c: &mut Criterion) {
     let fixture = sqlite_fixture(ROWS, VALUE_SIZE);
-    let direct_fixture = direct_sqlite_fixture(ROWS, VALUE_SIZE);
+    bench_open(c);
+    bench_txn_begin(c, &fixture);
     bench_point_reads(c, &fixture);
-    bench_direct_point_reads(c, &direct_fixture);
-    bench_range_scans(c, &fixture, &direct_fixture);
+    bench_range_scans(c, &fixture);
     bench_write_batches(c);
+}
+
+fn bench_open(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sqlite_backend/open");
+    configure_group(&mut group);
+    group.bench_function("existing_database", |b| {
+        b.iter_batched(
+            || {
+                let fixture = sqlite_fixture(1_000, VALUE_SIZE);
+                let path = fixture.backend.path().to_path_buf();
+                (fixture, path)
+            },
+            |(fixture, path)| {
+                let backend = SqliteBackend::open(&path).expect("reopen backend");
+                black_box(&backend);
+                (fixture, backend)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn bench_txn_begin(c: &mut Criterion, fixture: &SqliteFixture) {
+    let mut group = c.benchmark_group("sqlite_backend/txn_begin");
+    configure_group(&mut group);
+    group.bench_function("read", |b| {
+        b.iter(|| {
+            let read = fixture
+                .backend
+                .begin_read(ReadOptions::default())
+                .expect("begin read");
+            read.close().expect("close read");
+        });
+    });
+    group.bench_function("write_rollback", |b| {
+        b.iter(|| {
+            let write = fixture
+                .backend
+                .begin_write(WriteOptions::default())
+                .expect("begin write");
+            write.rollback().expect("rollback write");
+        });
+    });
+    group.finish();
 }
 
 fn bench_point_reads(c: &mut Criterion, fixture: &SqliteFixture) {
@@ -166,59 +174,7 @@ fn bench_point_reads(c: &mut Criterion, fixture: &SqliteFixture) {
     group.finish();
 }
 
-fn bench_direct_point_reads(c: &mut Criterion, fixture: &DirectSqliteFixture) {
-    let mut group = c.benchmark_group("sqlite_backend/direct_point_reads");
-    configure_group(&mut group);
-    group.throughput(Throughput::Elements(POINT_KEYS as u64));
-
-    let existing_keys = point_keys(0, POINT_KEYS);
-    group.bench_function(BenchmarkId::new("existing/full_value", POINT_KEYS), |b| {
-        b.iter(|| {
-            let read = fixture
-                .backend
-                .begin_read(ReadOptions::default())
-                .expect("begin read");
-            let mut visitor = CountingPointVisitor::default();
-            read.visit_keys(
-                black_box(existing_keys.as_slice()),
-                GetOptions {
-                    projection: CoreProjection::FullValue,
-                    _reserved: std::marker::PhantomData,
-                },
-                &mut visitor,
-            )
-            .expect("visit keys");
-            read.close().expect("close read");
-            black_box(visitor);
-        });
-    });
-
-    let missing_keys = point_keys(ROWS * 2, POINT_KEYS);
-    group.bench_function(BenchmarkId::new("missing/key_only", POINT_KEYS), |b| {
-        b.iter(|| {
-            let read = fixture
-                .backend
-                .begin_read(ReadOptions::default())
-                .expect("begin read");
-            let mut visitor = CountingPointVisitor::default();
-            read.visit_keys(
-                black_box(missing_keys.as_slice()),
-                GetOptions {
-                    projection: CoreProjection::KeyOnly,
-                    _reserved: std::marker::PhantomData,
-                },
-                &mut visitor,
-            )
-            .expect("visit keys");
-            read.close().expect("close read");
-            black_box(visitor);
-        });
-    });
-
-    group.finish();
-}
-
-fn bench_range_scans(c: &mut Criterion, fixture: &SqliteFixture, direct: &DirectSqliteFixture) {
+fn bench_range_scans(c: &mut Criterion, fixture: &SqliteFixture) {
     let mut group = c.benchmark_group("sqlite_backend/range_scan");
     configure_group(&mut group);
     group.throughput(Throughput::Elements(ROWS as u64));
@@ -228,34 +184,9 @@ fn bench_range_scans(c: &mut Criterion, fixture: &SqliteFixture, direct: &Direct
             CoreProjection::KeyOnly => "key_only",
             CoreProjection::FullValue => "full_value",
         };
-        group.bench_function(BenchmarkId::new(format!("current/{name}"), ROWS), |b| {
+        group.bench_function(BenchmarkId::new(name, ROWS), |b| {
             b.iter(|| {
                 let read = fixture
-                    .backend
-                    .begin_read(ReadOptions::default())
-                    .expect("begin read");
-                let mut visitor = CountingScanVisitor::default();
-                let result = read
-                    .with_range_scan(
-                        KeyRange {
-                            lower: Bound::Unbounded,
-                            upper: Bound::Unbounded,
-                        },
-                        ScanOptions {
-                            projection,
-                            limit_rows: usize::MAX,
-                            resume_after: None,
-                        },
-                        |cursor| visit_all(cursor, &mut visitor),
-                    )
-                    .expect("range scan");
-                read.close().expect("close read");
-                black_box((result, visitor));
-            });
-        });
-        group.bench_function(BenchmarkId::new(format!("direct/{name}"), ROWS), |b| {
-            b.iter(|| {
-                let read = direct
                     .backend
                     .begin_read(ReadOptions::default())
                     .expect("begin read");
@@ -295,17 +226,52 @@ fn bench_write_batches(c: &mut Criterion) {
                     let temp_dir = tempfile::tempdir().expect("tempdir");
                     let path = temp_dir.path().join("bench.lix");
                     let backend = SqliteBackend::open(path).expect("open backend");
-                    (temp_dir, backend, put_batch(0, rows, VALUE_SIZE))
+                    (backend, temp_dir, put_batch(0, rows, VALUE_SIZE))
                 },
-                |(_temp_dir, backend, batch)| {
+                |(backend, temp_dir, batch)| {
                     let mut write = backend
                         .begin_write(WriteOptions::default())
                         .expect("begin write");
                     write.put_many(black_box(batch)).expect("put many");
                     let result = write.commit().expect("commit");
                     black_box(result);
+                    // Returned so backend teardown (connection close + WAL
+                    // checkpoint) drops outside the timed window. The backend
+                    // precedes the tempdir so connections close before the
+                    // database files are removed.
+                    (backend, temp_dir)
                 },
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
+            );
+        });
+        // Content-hash keyed spaces (json_store, tree chunks) arrive in
+        // effectively random key order and land in an already-grown tree;
+        // this variant models that shape.
+        group.bench_function(BenchmarkId::new("put_many_commit_random", rows), |b| {
+            b.iter_batched(
+                || {
+                    let temp_dir = tempfile::tempdir().expect("tempdir");
+                    let path = temp_dir.path().join("bench.lix");
+                    let backend = SqliteBackend::open(path).expect("open backend");
+                    let mut write = backend
+                        .begin_write(WriteOptions::default())
+                        .expect("begin seed write");
+                    write
+                        .put_many(random_put_batch(rows, RANDOM_WRITE_SEED_ROWS, VALUE_SIZE))
+                        .expect("seed rows");
+                    write.commit().expect("seed commit");
+                    (backend, temp_dir, random_put_batch(0, rows, VALUE_SIZE))
+                },
+                |(backend, temp_dir, batch)| {
+                    let mut write = backend
+                        .begin_write(WriteOptions::default())
+                        .expect("begin write");
+                    write.put_many(black_box(batch)).expect("put many");
+                    let result = write.commit().expect("commit");
+                    black_box(result);
+                    (backend, temp_dir)
+                },
+                BatchSize::PerIteration,
             );
         });
     }
@@ -340,624 +306,8 @@ fn sqlite_fixture(rows: usize, value_size: usize) -> SqliteFixture {
         .expect("seed rows");
     write.commit().expect("seed commit");
     SqliteFixture {
-        _temp_dir: temp_dir,
         backend,
-    }
-}
-
-fn direct_sqlite_fixture(rows: usize, value_size: usize) -> DirectSqliteFixture {
-    let temp_dir = tempfile::tempdir().expect("tempdir");
-    let path = temp_dir.path().join("bench-direct.lix");
-    let backend = DirectSqliteBackend::open(path).expect("open direct backend");
-    let mut write = backend
-        .begin_write(WriteOptions::default())
-        .expect("begin direct write");
-    write
-        .put_many(put_batch(0, rows, value_size))
-        .expect("seed direct rows");
-    write.commit().expect("seed direct commit");
-    DirectSqliteFixture {
         _temp_dir: temp_dir,
-        backend,
-    }
-}
-
-impl DirectSqliteBackend {
-    fn open(path: impl Into<PathBuf>) -> Result<Self, BackendError> {
-        let path = path.into();
-        direct_initialize_database(&path)?;
-        Ok(Self {
-            path,
-            read_pool: Arc::new(Mutex::new(Vec::new())),
-            write_pool: Arc::new(Mutex::new(Vec::new())),
-        })
-    }
-
-    fn connect(&self) -> Result<Connection, BackendError> {
-        direct_open_connection(&self.path)
-    }
-}
-
-impl Backend for DirectSqliteBackend {
-    type Read<'a>
-        = DirectSqliteRead
-    where
-        Self: 'a;
-
-    type Write<'a>
-        = DirectSqliteWrite
-    where
-        Self: 'a;
-
-    fn begin_read(&self, _opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
-        let conn = self
-            .read_pool
-            .lock()
-            .map_err(|error| {
-                BackendError::Io(format!("direct sqlite read pool poisoned: {error}"))
-            })?
-            .pop()
-            .map(Ok)
-            .unwrap_or_else(|| self.connect())?;
-        direct_execute_cached(&conn, "BEGIN DEFERRED TRANSACTION")?;
-        direct_pin_read_snapshot(&conn)?;
-        Ok(DirectSqliteRead {
-            conn: Some(conn),
-            read_pool: Arc::clone(&self.read_pool),
-        })
-    }
-
-    fn begin_write(&self, _opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
-        let conn = self
-            .write_pool
-            .lock()
-            .map_err(|error| {
-                BackendError::Io(format!("direct sqlite write pool poisoned: {error}"))
-            })?
-            .pop()
-            .map(Ok)
-            .unwrap_or_else(|| self.connect())?;
-        conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")
-            .map_err(sqlite_error)?;
-        Ok(DirectSqliteWrite {
-            conn: Some(conn),
-            write_pool: Arc::clone(&self.write_pool),
-        })
-    }
-}
-
-impl BackendRead for DirectSqliteRead {
-    type RangeScan<'a> = DirectSqliteRangeScan<'a>;
-
-    fn visit_keys<V>(
-        &self,
-        keys: &[Key],
-        opts: GetOptions<'_>,
-        visitor: &mut V,
-    ) -> Result<(), BackendError>
-    where
-        V: PointVisitor + ?Sized,
-    {
-        direct_visit_keys(self.conn()?, keys, opts, visitor)
-    }
-
-    fn with_range_scan<T, F>(
-        &self,
-        range: KeyRange,
-        opts: ScanOptions<'_>,
-        f: F,
-    ) -> Result<T, BackendError>
-    where
-        F: FnOnce(&mut Self::RangeScan<'_>) -> Result<T, BackendError>,
-    {
-        let (sql, values) = direct_scan_sql(range, opts);
-        let mut stmt = self.conn()?.prepare_cached(&sql).map_err(sqlite_error)?;
-        let rows = stmt
-            .query(rusqlite::params_from_iter(values))
-            .map_err(sqlite_error)?;
-        let mut cursor = DirectSqliteRangeScan {
-            rows,
-            projection: opts.projection,
-            pending: None,
-            done: opts.limit_rows == 0,
-        };
-        f(&mut cursor)
-    }
-
-    fn close(mut self) -> Result<(), BackendError> {
-        self.finish()
-    }
-}
-
-impl BackendRangeScan for DirectSqliteRangeScan<'_> {
-    fn visit_next<V>(
-        &mut self,
-        limit_rows: usize,
-        visitor: &mut V,
-    ) -> Result<ScanResult, BackendError>
-    where
-        V: ScanVisitor + ?Sized,
-    {
-        if limit_rows == 0 || self.done {
-            return Ok(ScanResult {
-                emitted: 0,
-                has_more: !self.done,
-            });
-        }
-
-        let mut emitted = 0;
-        while emitted < limit_rows {
-            if let Some(pending) = self.pending.take() {
-                direct_visit_pending_row(pending, self.projection, visitor)?;
-                emitted += 1;
-                continue;
-            }
-
-            let Some(row) = self.rows.next().map_err(sqlite_error)? else {
-                self.done = true;
-                return Ok(ScanResult {
-                    emitted,
-                    has_more: false,
-                });
-            };
-            let key = direct_blob_ref(row.get_ref(0).map_err(sqlite_error)?, "key")?;
-            match self.projection {
-                CoreProjection::KeyOnly => {
-                    visitor.visit(KeyRef(key), ProjectedValueRef::KeyOnly)?;
-                }
-                CoreProjection::FullValue => {
-                    let value = direct_blob_ref(row.get_ref(1).map_err(sqlite_error)?, "value")?;
-                    visitor.visit(KeyRef(key), ProjectedValueRef::FullValue(value))?;
-                }
-            }
-            emitted += 1;
-        }
-
-        let has_more = self.ensure_pending()?;
-        Ok(ScanResult { emitted, has_more })
-    }
-}
-
-impl DirectSqliteRangeScan<'_> {
-    fn ensure_pending(&mut self) -> Result<bool, BackendError> {
-        if self.pending.is_some() {
-            return Ok(true);
-        }
-        let Some(row) = self.rows.next().map_err(sqlite_error)? else {
-            self.done = true;
-            return Ok(false);
-        };
-        let key = direct_blob_ref(row.get_ref(0).map_err(sqlite_error)?, "key")?.to_vec();
-        let value = if matches!(self.projection, CoreProjection::FullValue) {
-            Some(direct_blob_ref(row.get_ref(1).map_err(sqlite_error)?, "value")?.to_vec())
-        } else {
-            None
-        };
-        self.pending = Some(DirectSqlitePendingRow { key, value });
-        Ok(true)
-    }
-}
-
-impl DirectSqliteRead {
-    fn conn(&self) -> Result<&Connection, BackendError> {
-        self.conn
-            .as_ref()
-            .ok_or_else(|| BackendError::Io("direct sqlite read is closed".to_string()))
-    }
-
-    fn finish(&mut self) -> Result<(), BackendError> {
-        let Some(conn) = self.conn.take() else {
-            return Ok(());
-        };
-        let result = direct_execute_cached(&conn, "ROLLBACK").or_else(ignore_no_transaction);
-        if result.is_ok() {
-            if let Ok(mut pool) = self.read_pool.lock() {
-                pool.push(conn);
-            }
-        }
-        result
-    }
-}
-
-impl Drop for DirectSqliteRead {
-    fn drop(&mut self) {
-        let _ = self.finish();
-    }
-}
-
-impl BackendWrite for DirectSqliteWrite {
-    fn put_many(&mut self, entries: PutBatch) -> Result<(), BackendError> {
-        let conn = self.conn()?;
-        let mut stmt = conn
-            .prepare_cached(
-                "INSERT INTO lix_internal_entries(key, value)
-                 VALUES (?1, ?2)
-                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            )
-            .map_err(sqlite_error)?;
-
-        for entry in entries.entries {
-            stmt.execute(params![entry.key.0.as_ref(), entry.value.bytes.as_ref()])
-                .map_err(sqlite_error)?;
-        }
-        Ok(())
-    }
-
-    fn delete_many(&mut self, keys: &[Key]) -> Result<(), BackendError> {
-        let conn = self.conn()?;
-        let mut stmt = conn
-            .prepare_cached("DELETE FROM lix_internal_entries WHERE key = ?1")
-            .map_err(sqlite_error)?;
-        for key in keys {
-            stmt.execute(params![key.0.as_ref()])
-                .map_err(sqlite_error)?;
-        }
-        Ok(())
-    }
-
-    fn delete_range(&mut self, range: KeyRange) -> Result<(), BackendError> {
-        let mut sql = String::from("DELETE FROM lix_internal_entries WHERE 1 = 1");
-        let mut values = Vec::new();
-        direct_append_bound_sql(&mut sql, &mut values, "key", ">=", ">", &range.lower);
-        direct_append_bound_sql(&mut sql, &mut values, "key", "<=", "<", &range.upper);
-        self.conn()?
-            .execute(&sql, rusqlite::params_from_iter(values))
-            .map_err(sqlite_error)?;
-        Ok(())
-    }
-
-    fn commit(mut self) -> Result<CommitResult, BackendError> {
-        self.finish("COMMIT")?;
-        Ok(CommitResult {
-            commit_id: None,
-            stats: WriteStats::default(),
-        })
-    }
-
-    fn rollback(mut self) -> Result<(), BackendError> {
-        self.finish("ROLLBACK")
-    }
-}
-
-impl DirectSqliteWrite {
-    fn conn(&self) -> Result<&Connection, BackendError> {
-        self.conn
-            .as_ref()
-            .ok_or_else(|| BackendError::Io("direct sqlite write is closed".to_string()))
-    }
-
-    fn finish(&mut self, sql: &str) -> Result<(), BackendError> {
-        let Some(conn) = self.conn.take() else {
-            return Ok(());
-        };
-        let result = direct_execute_cached(&conn, sql);
-        if result.is_ok() {
-            if let Ok(mut pool) = self.write_pool.lock() {
-                pool.push(conn);
-            }
-        }
-        result
-    }
-}
-
-impl Drop for DirectSqliteWrite {
-    fn drop(&mut self) {
-        let _ = self.finish("ROLLBACK");
-    }
-}
-
-fn direct_initialize_database(path: &Path) -> Result<(), BackendError> {
-    let conn = direct_open_connection(path)?;
-    conn.pragma_update(None, "journal_mode", "WAL")
-        .map_err(sqlite_error)?;
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS lix_internal_entries (
-            key BLOB NOT NULL,
-            value BLOB NOT NULL,
-            PRIMARY KEY (key)
-        ) WITHOUT ROWID;",
-    )
-    .map_err(sqlite_error)
-}
-
-fn direct_open_connection(path: &Path) -> Result<Connection, BackendError> {
-    let conn = Connection::open(path).map_err(sqlite_error)?;
-    conn.busy_timeout(Duration::from_secs(5))
-        .map_err(sqlite_error)?;
-    conn.execute_batch(
-        "PRAGMA synchronous = NORMAL;
-         PRAGMA temp_store = MEMORY;
-         PRAGMA cache_size = -20000;
-         PRAGMA mmap_size = 268435456;
-         PRAGMA wal_autocheckpoint = 10000;",
-    )
-    .map_err(sqlite_error)?;
-    Ok(conn)
-}
-
-fn direct_pin_read_snapshot(conn: &Connection) -> Result<(), BackendError> {
-    let mut stmt = conn
-        .prepare_cached("SELECT key FROM lix_internal_entries LIMIT 1")
-        .map_err(sqlite_error)?;
-    let mut rows = stmt.query([]).map_err(sqlite_error)?;
-    let _ = rows.next().map_err(sqlite_error)?;
-    Ok(())
-}
-
-fn direct_execute_cached(conn: &Connection, sql: &str) -> Result<(), BackendError> {
-    let mut stmt = conn.prepare_cached(sql).map_err(sqlite_error)?;
-    stmt.execute([]).map_err(sqlite_error)?;
-    Ok(())
-}
-
-fn direct_visit_keys<V>(
-    conn: &Connection,
-    keys: &[Key],
-    opts: GetOptions<'_>,
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: PointVisitor + ?Sized,
-{
-    if keys.is_empty() {
-        return Ok(());
-    }
-
-    match opts.projection {
-        CoreProjection::KeyOnly => direct_visit_key_only_points(conn, keys, visitor),
-        CoreProjection::FullValue => direct_visit_full_value_points(conn, keys, visitor),
-    }
-}
-
-fn direct_visit_key_only_points<V>(
-    conn: &Connection,
-    keys: &[Key],
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: PointVisitor + ?Sized,
-{
-    for (chunk_index, chunk) in keys.chunks(POINT_READ_CHUNK_KEYS).enumerate() {
-        direct_visit_key_only_points_chunk(
-            conn,
-            keys,
-            chunk_index * POINT_READ_CHUNK_KEYS,
-            chunk,
-            visitor,
-        )?;
-    }
-    Ok(())
-}
-
-#[expect(clippy::cast_possible_wrap)]
-fn direct_visit_key_only_points_chunk<V>(
-    conn: &Connection,
-    keys: &[Key],
-    offset: usize,
-    chunk: &[Key],
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: PointVisitor + ?Sized,
-{
-    let mut placeholders = String::with_capacity(chunk.len() * 8);
-    let mut values = Vec::with_capacity(chunk.len() * 2);
-    for (index, key) in chunk.iter().enumerate() {
-        if index > 0 {
-            placeholders.push_str(", ");
-        }
-        placeholders.push_str("(?, ?)");
-        values.push(SqlValue::Integer((offset + index) as i64));
-        values.push(SqlValue::Blob(key.0.to_vec()));
-    }
-    let sql = format!(
-        "WITH requested(ord, key) AS (VALUES {placeholders})
-         SELECT r.ord, e.key
-         FROM requested r
-         LEFT JOIN lix_internal_entries e ON e.key = r.key
-         ORDER BY r.ord ASC"
-    );
-
-    let mut stmt = conn.prepare_cached(&sql).map_err(sqlite_error)?;
-    let mut rows = stmt
-        .query(rusqlite::params_from_iter(values))
-        .map_err(sqlite_error)?;
-    while let Some(row) = rows.next().map_err(sqlite_error)? {
-        let index: i64 = row.get(0).map_err(sqlite_error)?;
-        let index = usize::try_from(index).map_err(|_| {
-            BackendError::Corruption(format!(
-                "direct sqlite requested ordinal was negative: {index}"
-            ))
-        })?;
-        let Some(key) = keys.get(index) else {
-            return Err(BackendError::Corruption(format!(
-                "direct sqlite requested ordinal out of bounds: {index}"
-            )));
-        };
-        let key_ref = row.get_ref(1).map_err(sqlite_error)?;
-        let value = match key_ref {
-            SqlValueRef::Null => None,
-            SqlValueRef::Blob(_) => Some(ProjectedValueRef::KeyOnly),
-            other => {
-                return Err(BackendError::Corruption(format!(
-                    "direct sqlite key column was not a blob: {other:?}"
-                )));
-            }
-        };
-        visitor.visit(index, key, value)?;
-    }
-    Ok(())
-}
-
-fn direct_visit_full_value_points<V>(
-    conn: &Connection,
-    keys: &[Key],
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: PointVisitor + ?Sized,
-{
-    for (chunk_index, chunk) in keys.chunks(POINT_READ_CHUNK_KEYS).enumerate() {
-        direct_visit_full_value_points_chunk(
-            conn,
-            keys,
-            chunk_index * POINT_READ_CHUNK_KEYS,
-            chunk,
-            visitor,
-        )?;
-    }
-    Ok(())
-}
-
-#[expect(clippy::cast_possible_wrap)]
-fn direct_visit_full_value_points_chunk<V>(
-    conn: &Connection,
-    keys: &[Key],
-    offset: usize,
-    chunk: &[Key],
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: PointVisitor + ?Sized,
-{
-    let mut placeholders = String::with_capacity(chunk.len() * 8);
-    let mut values = Vec::with_capacity(chunk.len() * 2);
-    for (index, key) in chunk.iter().enumerate() {
-        if index > 0 {
-            placeholders.push_str(", ");
-        }
-        placeholders.push_str("(?, ?)");
-        values.push(SqlValue::Integer((offset + index) as i64));
-        values.push(SqlValue::Blob(key.0.to_vec()));
-    }
-    let sql = format!(
-        "WITH requested(ord, key) AS (VALUES {placeholders})
-         SELECT r.ord, e.value
-         FROM requested r
-         LEFT JOIN lix_internal_entries e ON e.key = r.key
-         ORDER BY r.ord ASC"
-    );
-
-    let mut stmt = conn.prepare_cached(&sql).map_err(sqlite_error)?;
-    let mut rows = stmt
-        .query(rusqlite::params_from_iter(values))
-        .map_err(sqlite_error)?;
-    while let Some(row) = rows.next().map_err(sqlite_error)? {
-        let index: i64 = row.get(0).map_err(sqlite_error)?;
-        let index = usize::try_from(index).map_err(|_| {
-            BackendError::Corruption(format!(
-                "direct sqlite requested ordinal was negative: {index}"
-            ))
-        })?;
-        let Some(key) = keys.get(index) else {
-            return Err(BackendError::Corruption(format!(
-                "direct sqlite requested ordinal out of bounds: {index}"
-            )));
-        };
-        let value_ref = row.get_ref(1).map_err(sqlite_error)?;
-        let value = match value_ref {
-            SqlValueRef::Null => None,
-            SqlValueRef::Blob(value) => Some(ProjectedValueRef::FullValue(value)),
-            other => {
-                return Err(BackendError::Corruption(format!(
-                    "direct sqlite value column was not a blob: {other:?}"
-                )));
-            }
-        };
-        visitor.visit(index, key, value)?;
-    }
-    Ok(())
-}
-
-fn direct_scan_sql(range: KeyRange, opts: ScanOptions<'_>) -> (String, Vec<SqlValue>) {
-    let mut sql = match opts.projection {
-        CoreProjection::KeyOnly => String::from("SELECT key FROM lix_internal_entries WHERE 1 = 1"),
-        CoreProjection::FullValue => {
-            String::from("SELECT key, value FROM lix_internal_entries WHERE 1 = 1")
-        }
-    };
-    let mut values = Vec::new();
-
-    direct_append_bound_sql(&mut sql, &mut values, "key", ">=", ">", &range.lower);
-    direct_append_bound_sql(&mut sql, &mut values, "key", "<=", "<", &range.upper);
-    if let Some(resume_after) = opts.resume_after {
-        sql.push_str(" AND key > ?");
-        values.push(SqlValue::Blob(resume_after.0.to_vec()));
-    }
-    sql.push_str(" ORDER BY key ASC");
-    (sql, values)
-}
-
-fn direct_append_bound_sql(
-    sql: &mut String,
-    values: &mut Vec<SqlValue>,
-    column: &str,
-    included_op: &str,
-    excluded_op: &str,
-    bound: &Bound<Key>,
-) {
-    match bound {
-        Bound::Included(key) => {
-            sql.push_str(" AND ");
-            sql.push_str(column);
-            sql.push(' ');
-            sql.push_str(included_op);
-            sql.push_str(" ?");
-            values.push(SqlValue::Blob(key.0.to_vec()));
-        }
-        Bound::Excluded(key) => {
-            sql.push_str(" AND ");
-            sql.push_str(column);
-            sql.push(' ');
-            sql.push_str(excluded_op);
-            sql.push_str(" ?");
-            values.push(SqlValue::Blob(key.0.to_vec()));
-        }
-        Bound::Unbounded => {}
-    }
-}
-
-fn direct_blob_ref<'a>(value: SqlValueRef<'a>, column: &str) -> Result<&'a [u8], BackendError> {
-    match value {
-        SqlValueRef::Blob(bytes) => Ok(bytes),
-        other => Err(BackendError::Corruption(format!(
-            "direct sqlite {column} column was not a blob: {other:?}"
-        ))),
-    }
-}
-
-fn direct_visit_pending_row<V>(
-    row: DirectSqlitePendingRow,
-    projection: CoreProjection,
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: ScanVisitor + ?Sized,
-{
-    match projection {
-        CoreProjection::KeyOnly => {
-            visitor.visit(KeyRef(row.key.as_slice()), ProjectedValueRef::KeyOnly)
-        }
-        CoreProjection::FullValue => {
-            let value = row.value.as_deref().ok_or_else(|| {
-                BackendError::Io("direct sqlite pending row missing value".to_string())
-            })?;
-            visitor.visit(
-                KeyRef(row.key.as_slice()),
-                ProjectedValueRef::FullValue(value),
-            )
-        }
-    }
-}
-
-fn sqlite_error(error: rusqlite::Error) -> BackendError {
-    BackendError::Io(error.to_string())
-}
-
-fn ignore_no_transaction(error: BackendError) -> Result<(), BackendError> {
-    match error {
-        BackendError::Io(message) if message.contains("no transaction") => Ok(()),
-        other => Err(other),
     }
 }
 
@@ -978,6 +328,27 @@ fn put_batch(start: usize, count: usize, value_size: usize) -> PutBatch {
 
 fn key_for(index: usize) -> Key {
     Key(Bytes::from(format!("bench/{index:016x}")))
+}
+
+fn random_put_batch(start: usize, count: usize, value_size: usize) -> PutBatch {
+    PutBatch {
+        entries: (start..start + count)
+            .map(|index| PutEntry {
+                key: random_key_for(index),
+                value: value_for(index, value_size),
+            })
+            .collect(),
+    }
+}
+
+fn random_key_for(index: usize) -> Key {
+    // splitmix64: deterministic pseudo-random spread, no dependency. The
+    // {index:08x} suffix guarantees uniqueness independent of the hash.
+    let mut x = (index as u64).wrapping_add(0x9e37_79b9_7f4a_7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^= x >> 31;
+    Key(Bytes::from(format!("bench/{x:016x}/{index:08x}")))
 }
 
 fn value_for(index: usize, size: usize) -> StoredValue {

--- a/packages/rs-sdk/src/sqlite_backend.rs
+++ b/packages/rs-sdk/src/sqlite_backend.rs
@@ -381,6 +381,10 @@ impl BackendWrite for SqliteWrite {
         // Sorting keeps the upsert's conflict probe on a near-neighbor B-tree
         // descent instead of a fresh root-to-leaf seek per row. Batches hold
         // at most one mutation per key, so apply order does not matter.
+        // Engine write-set lowering already produces sorted batches, making
+        // this a linear verification pass; it stays because the sorted
+        // guarantee is scoped to the engine and other callers may pass
+        // unsorted batches.
         entries.sort_unstable_by(|left, right| left.key.0.cmp(&right.key.0));
         debug_assert!(
             entries.windows(2).all(|pair| pair[0].key != pair[1].key),

--- a/packages/rs-sdk/src/sqlite_backend.rs
+++ b/packages/rs-sdk/src/sqlite_backend.rs
@@ -3,11 +3,10 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use bytes::Bytes;
 use lix_engine::backend::{
     Backend, BackendError, BackendRangeScan, BackendRead, BackendWrite, CommitResult,
     CoreProjection, GetOptions, Key, KeyRange, KeyRef, PointVisitor, ProjectedValueRef, PutBatch,
-    ReadOptions, ScanOptions, ScanResult, ScanVisitor, StoredValue, WriteOptions, WriteStats,
+    ReadOptions, ScanOptions, ScanResult, ScanVisitor, WriteOptions, WriteStats,
 };
 use lix_engine::{BackendFactory, BackendFixture, BackendTestConfig};
 use rusqlite::types::{Value as SqlValue, ValueRef as SqlValueRef};
@@ -16,7 +15,15 @@ use tempfile::TempDir;
 
 pub const SQLITE_FORMAT_VERSION: u32 = 1;
 const ENTRIES_TABLE: &str = "lix_internal_entries";
+/// Keys per point-read chunk; each key binds 2 parameters (ordinal + key),
+/// so a full chunk uses 800 of SQLite's historical 999-parameter floor.
+/// The specific value is bench-chosen.
 const POINT_READ_CHUNK_KEYS: usize = 400;
+/// Rows per multi-row upsert statement; each row binds 2 parameters
+/// (key + value), so a full chunk uses 256 parameters. Bench-chosen.
+const PUT_CHUNK_ROWS: usize = 128;
+const _: () = assert!(POINT_READ_CHUNK_KEYS * 2 < 999);
+const _: () = assert!(PUT_CHUNK_ROWS * 2 < 999);
 
 #[derive(Debug)]
 pub struct SqliteBackendFactory {
@@ -120,11 +127,16 @@ impl SqliteBackend {
 
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, BackendError> {
         let path = path.into();
-        initialize_database(&path)?;
+        // Warm one connection per pool at open so the first read and write
+        // do not pay connection setup (open + busy_timeout + pragmas) inside
+        // their own latency window. The init connection becomes the warm
+        // write connection.
+        let write_conn = initialize_database(&path)?;
+        let read_conn = open_connection(&path)?;
         Ok(Self {
             path,
-            read_pool: Arc::new(Mutex::new(Vec::new())),
-            write_pool: Arc::new(Mutex::new(Vec::new())),
+            read_pool: Arc::new(Mutex::new(vec![read_conn])),
+            write_pool: Arc::new(Mutex::new(vec![write_conn])),
         })
     }
 
@@ -190,8 +202,7 @@ impl Backend for SqliteBackend {
             .pop()
             .map(Ok)
             .unwrap_or_else(|| self.connect())?;
-        conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")
-            .map_err(sqlite_error)?;
+        execute_cached(&conn, "BEGIN IMMEDIATE TRANSACTION")?;
         Ok(SqliteWrite {
             conn: Some(conn),
             write_pool: Arc::clone(&self.write_pool),
@@ -366,24 +377,52 @@ impl Drop for SqliteRead {
 
 impl BackendWrite for SqliteWrite {
     fn put_many(&mut self, entries: PutBatch) -> Result<(), BackendError> {
-        let mut put_entries = 0;
-        let mut written_bytes = 0;
+        let mut entries = entries.entries;
+        // Sorting keeps the upsert's conflict probe on a near-neighbor B-tree
+        // descent instead of a fresh root-to-leaf seek per row. Batches hold
+        // at most one mutation per key, so apply order does not matter.
+        entries.sort_unstable_by(|left, right| left.key.0.cmp(&right.key.0));
+        debug_assert!(
+            entries.windows(2).all(|pair| pair[0].key != pair[1].key),
+            "put batches must hold at most one mutation per key"
+        );
+        let put_entries = entries.len() as u64;
+        let written_bytes = entries
+            .iter()
+            .map(|entry| entry.value.bytes.len() as u64)
+            .sum::<u64>();
         {
             let conn = self.conn();
-            let mut stmt = conn
-                .prepare_cached(
-                    "INSERT INTO lix_internal_entries(key, value)
-                     VALUES (?1, ?2)
-                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                )
-                .map_err(sqlite_error)?;
-
-            for entry in entries.entries {
-                let value = stored_value_bytes(entry.value);
-                put_entries += 1;
-                written_bytes += value.len() as u64;
-                stmt.execute(params![entry.key.0.as_ref(), value.as_ref()])
+            let mut chunks = entries.chunks_exact(PUT_CHUNK_ROWS);
+            if chunks.len() > 0 {
+                let sql = multi_upsert_sql(PUT_CHUNK_ROWS);
+                let mut stmt = conn.prepare_cached(&sql).map_err(sqlite_error)?;
+                for chunk in chunks.by_ref() {
+                    for (index, entry) in chunk.iter().enumerate() {
+                        stmt.raw_bind_parameter(2 * index + 1, &entry.key.0[..])
+                            .map_err(sqlite_error)?;
+                        stmt.raw_bind_parameter(2 * index + 2, &entry.value.bytes[..])
+                            .map_err(sqlite_error)?;
+                    }
+                    stmt.raw_execute().map_err(sqlite_error)?;
+                }
+            }
+            // The remainder reuses the single-row statement instead of a
+            // sized multi-row one so the prepared-statement cache holds two
+            // upsert shapes total rather than one per remainder length.
+            let remainder = chunks.remainder();
+            if !remainder.is_empty() {
+                let mut stmt = conn
+                    .prepare_cached(
+                        "INSERT INTO lix_internal_entries(key, value)
+                         VALUES (?1, ?2)
+                         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    )
                     .map_err(sqlite_error)?;
+                for entry in remainder {
+                    stmt.execute(params![entry.key.0.as_ref(), entry.value.bytes.as_ref()])
+                        .map_err(sqlite_error)?;
+                }
             }
         }
         self.stats.put_entries += put_entries;
@@ -464,7 +503,7 @@ impl Drop for SqliteWrite {
     }
 }
 
-fn initialize_database(path: &Path) -> Result<(), BackendError> {
+fn initialize_database(path: &Path) -> Result<Connection, BackendError> {
     let conn = open_connection(path)?;
     let user_version = sqlite_user_version(&conn)?;
     if user_version > SQLITE_FORMAT_VERSION {
@@ -489,7 +528,7 @@ fn initialize_database(path: &Path) -> Result<(), BackendError> {
             .map_err(sqlite_error)?;
     }
 
-    Ok(())
+    Ok(conn)
 }
 
 fn open_connection(path: &Path) -> Result<Connection, BackendError> {
@@ -542,26 +581,25 @@ where
         return Ok(());
     }
 
-    match opts.projection {
-        CoreProjection::KeyOnly => visit_key_only_points(conn, keys, visitor),
-        CoreProjection::FullValue => visit_full_value_points(conn, keys, visitor),
-    }
+    visit_points(conn, keys, opts.projection, visitor)
 }
 
-fn visit_key_only_points<V>(
+fn visit_points<V>(
     conn: &Connection,
     keys: &[Key],
+    projection: CoreProjection,
     visitor: &mut V,
 ) -> Result<(), BackendError>
 where
     V: PointVisitor + ?Sized,
 {
     for (chunk_index, chunk) in keys.chunks(POINT_READ_CHUNK_KEYS).enumerate() {
-        visit_key_only_points_chunk(
+        visit_points_chunk(
             conn,
             keys,
             chunk_index * POINT_READ_CHUNK_KEYS,
             chunk,
+            projection,
             visitor,
         )?;
     }
@@ -569,38 +607,39 @@ where
 }
 
 #[expect(clippy::cast_possible_wrap)]
-fn visit_key_only_points_chunk<V>(
+fn visit_points_chunk<V>(
     conn: &Connection,
     keys: &[Key],
     offset: usize,
     chunk: &[Key],
+    projection: CoreProjection,
     visitor: &mut V,
 ) -> Result<(), BackendError>
 where
     V: PointVisitor + ?Sized,
 {
-    let mut placeholders = String::with_capacity(chunk.len() * 8);
-    let mut values = Vec::with_capacity(chunk.len() * 2);
-    for (index, key) in chunk.iter().enumerate() {
-        if index > 0 {
-            placeholders.push_str(", ");
-        }
-        placeholders.push_str("(?, ?)");
-        values.push(SqlValue::Integer((offset + index) as i64));
-        values.push(SqlValue::Blob(key.0.to_vec()));
-    }
+    // No ORDER BY: callers address results by the returned ordinal, never by
+    // visit order, and binding by reference avoids an owned copy of every key.
+    let projected_column = match projection {
+        CoreProjection::KeyOnly => "e.key",
+        CoreProjection::FullValue => "e.value",
+    };
     let sql = format!(
         "WITH requested(ord, key) AS (VALUES {placeholders})
-         SELECT r.ord, e.key
+         SELECT r.ord, {projected_column}
          FROM requested r
-         LEFT JOIN lix_internal_entries e ON e.key = r.key
-         ORDER BY r.ord ASC"
+         LEFT JOIN lix_internal_entries e ON e.key = r.key",
+        placeholders = point_chunk_placeholders(chunk.len()),
     );
 
     let mut stmt = conn.prepare_cached(&sql).map_err(sqlite_error)?;
-    let mut rows = stmt
-        .query(rusqlite::params_from_iter(values))
-        .map_err(sqlite_error)?;
+    for (index, key) in chunk.iter().enumerate() {
+        stmt.raw_bind_parameter(2 * index + 1, (offset + index) as i64)
+            .map_err(sqlite_error)?;
+        stmt.raw_bind_parameter(2 * index + 2, &key.0[..])
+            .map_err(sqlite_error)?;
+    }
+    let mut rows = stmt.raw_query();
     while let Some(row) = rows.next().map_err(sqlite_error)? {
         let index: i64 = row.get(0).map_err(sqlite_error)?;
         let index = usize::try_from(index).map_err(|_| {
@@ -611,13 +650,16 @@ where
                 "sqlite requested ordinal out of bounds: {index}"
             )));
         };
-        let key_ref = row.get_ref(1).map_err(sqlite_error)?;
-        let value = match key_ref {
-            SqlValueRef::Null => None,
-            SqlValueRef::Blob(_) => Some(ProjectedValueRef::KeyOnly),
-            other => {
+        let projected = row.get_ref(1).map_err(sqlite_error)?;
+        let value = match (projection, projected) {
+            (_, SqlValueRef::Null) => None,
+            (CoreProjection::KeyOnly, SqlValueRef::Blob(_)) => Some(ProjectedValueRef::KeyOnly),
+            (CoreProjection::FullValue, SqlValueRef::Blob(value)) => {
+                Some(ProjectedValueRef::FullValue(value))
+            }
+            (_, other) => {
                 return Err(BackendError::Corruption(format!(
-                    "sqlite key column was not a blob: {other:?}"
+                    "sqlite projected column was not a blob: {other:?}"
                 )));
             }
         };
@@ -626,82 +668,28 @@ where
     Ok(())
 }
 
-fn visit_full_value_points<V>(
-    conn: &Connection,
-    keys: &[Key],
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: PointVisitor + ?Sized,
-{
-    for (chunk_index, chunk) in keys.chunks(POINT_READ_CHUNK_KEYS).enumerate() {
-        visit_full_value_points_chunk(
-            conn,
-            keys,
-            chunk_index * POINT_READ_CHUNK_KEYS,
-            chunk,
-            visitor,
-        )?;
+fn multi_upsert_sql(rows: usize) -> String {
+    let mut sql = String::with_capacity(64 + rows * 8);
+    sql.push_str("INSERT INTO lix_internal_entries(key, value) VALUES ");
+    for index in 0..rows {
+        if index > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str("(?, ?)");
     }
-    Ok(())
+    sql.push_str(" ON CONFLICT(key) DO UPDATE SET value = excluded.value");
+    sql
 }
 
-#[expect(clippy::cast_possible_wrap)]
-fn visit_full_value_points_chunk<V>(
-    conn: &Connection,
-    keys: &[Key],
-    offset: usize,
-    chunk: &[Key],
-    visitor: &mut V,
-) -> Result<(), BackendError>
-where
-    V: PointVisitor + ?Sized,
-{
-    let mut placeholders = String::with_capacity(chunk.len() * 8);
-    let mut values = Vec::with_capacity(chunk.len() * 2);
-    for (index, key) in chunk.iter().enumerate() {
+fn point_chunk_placeholders(len: usize) -> String {
+    let mut placeholders = String::with_capacity(len * 8);
+    for index in 0..len {
         if index > 0 {
             placeholders.push_str(", ");
         }
         placeholders.push_str("(?, ?)");
-        values.push(SqlValue::Integer((offset + index) as i64));
-        values.push(SqlValue::Blob(key.0.to_vec()));
     }
-    let sql = format!(
-        "WITH requested(ord, key) AS (VALUES {placeholders})
-         SELECT r.ord, e.value
-         FROM requested r
-         LEFT JOIN lix_internal_entries e ON e.key = r.key
-         ORDER BY r.ord ASC"
-    );
-
-    let mut stmt = conn.prepare_cached(&sql).map_err(sqlite_error)?;
-    let mut rows = stmt
-        .query(rusqlite::params_from_iter(values))
-        .map_err(sqlite_error)?;
-    while let Some(row) = rows.next().map_err(sqlite_error)? {
-        let index: i64 = row.get(0).map_err(sqlite_error)?;
-        let index = usize::try_from(index).map_err(|_| {
-            BackendError::Corruption(format!("sqlite requested ordinal was negative: {index}"))
-        })?;
-        let Some(key) = keys.get(index) else {
-            return Err(BackendError::Corruption(format!(
-                "sqlite requested ordinal out of bounds: {index}"
-            )));
-        };
-        let value_ref = row.get_ref(1).map_err(sqlite_error)?;
-        let value = match value_ref {
-            SqlValueRef::Null => None,
-            SqlValueRef::Blob(value) => Some(ProjectedValueRef::FullValue(value)),
-            other => {
-                return Err(BackendError::Corruption(format!(
-                    "sqlite value column was not a blob: {other:?}"
-                )));
-            }
-        };
-        visitor.visit(index, key, value)?;
-    }
-    Ok(())
+    placeholders
 }
 
 fn scan_sql(range: KeyRange, opts: ScanOptions<'_>) -> (String, Vec<SqlValue>) {
@@ -759,10 +747,6 @@ fn blob_ref<'a>(value: SqlValueRef<'a>, column: &str) -> Result<&'a [u8], Backen
             "sqlite {column} column was not a blob: {other:?}"
         ))),
     }
-}
-
-fn stored_value_bytes(value: StoredValue) -> Bytes {
-    value.bytes
 }
 
 fn sqlite_error(error: rusqlite::Error) -> BackendError {

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -370,3 +370,95 @@ const RUNTIME_TEST_PLUGIN_SCHEMA: &str = r#"{
   },
   "additionalProperties": false
 }"#;
+
+#[test]
+fn sqlite_backend_put_many_handles_multi_chunk_batches() {
+    use bytes::Bytes;
+    use lix_engine::backend::PutEntry;
+    use lix_sdk::{
+        Backend, BackendRead, BackendWrite, CoreProjection, GetOptions, Key, PointVisitor,
+        ProjectedValueRef, PutBatch, ReadOptions, StoredValue, WriteOptions,
+    };
+
+    // 300 entries: two full 128-row upsert chunks plus a 44-row remainder.
+    const ROWS: usize = 300;
+    let tempdir = tempfile::tempdir().expect("tempdir should create");
+    let backend =
+        SqliteBackend::open(tempdir.path().join("chunked.lix")).expect("sqlite backend opens");
+
+    let key = |index: usize| Key(Bytes::from(format!("chunked/{:03}", index)));
+    let batch = |tag: u8| PutBatch {
+        entries: (0..ROWS)
+            // Reverse insertion order so put_many's internal key sort is
+            // exercised against out-of-order input.
+            .rev()
+            .map(|index| PutEntry {
+                key: key(index),
+                value: StoredValue {
+                    bytes: Bytes::from(vec![tag, index as u8]),
+                },
+            })
+            .collect(),
+    };
+
+    let mut write = backend
+        .begin_write(WriteOptions::default())
+        .expect("begin insert write");
+    write.put_many(batch(1)).expect("insert all rows");
+    let insert_stats = write.commit().expect("commit inserts").stats;
+    assert_eq!(insert_stats.put_entries, ROWS as u64);
+    assert_eq!(insert_stats.written_bytes, (ROWS * 2) as u64);
+
+    // Overwrite every row so both the chunked and remainder paths take the
+    // upsert conflict branch.
+    let mut write = backend
+        .begin_write(WriteOptions::default())
+        .expect("begin overwrite write");
+    write.put_many(batch(2)).expect("overwrite all rows");
+    write.commit().expect("commit overwrites");
+
+    struct CollectingVisitor {
+        values: Vec<Option<Vec<u8>>>,
+    }
+    impl PointVisitor for CollectingVisitor {
+        fn visit(
+            &mut self,
+            index: usize,
+            _key: &Key,
+            value: Option<ProjectedValueRef<'_>>,
+        ) -> Result<(), lix_sdk::BackendError> {
+            self.values[index] = match value {
+                Some(ProjectedValueRef::FullValue(bytes)) => Some(bytes.to_vec()),
+                Some(ProjectedValueRef::KeyOnly) => Some(Vec::new()),
+                None => None,
+            };
+            Ok(())
+        }
+    }
+
+    let keys = (0..ROWS).map(key).collect::<Vec<_>>();
+    let read = backend
+        .begin_read(ReadOptions::default())
+        .expect("begin read");
+    let mut visitor = CollectingVisitor {
+        values: vec![None; ROWS],
+    };
+    read.visit_keys(
+        &keys,
+        GetOptions {
+            projection: CoreProjection::FullValue,
+            _reserved: std::marker::PhantomData,
+        },
+        &mut visitor,
+    )
+    .expect("visit keys");
+    read.close().expect("close read");
+
+    for (index, value) in visitor.values.iter().enumerate() {
+        assert_eq!(
+            value.as_deref(),
+            Some([2u8, index as u8].as_slice()),
+            "row {index} should hold the overwritten value"
+        );
+    }
+}

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -382,11 +382,31 @@ fn sqlite_backend_put_many_handles_multi_chunk_batches() {
 
     // 300 entries: two full 128-row upsert chunks plus a 44-row remainder.
     const ROWS: usize = 300;
+
+    struct CollectingVisitor {
+        values: Vec<Option<Vec<u8>>>,
+    }
+    impl PointVisitor for CollectingVisitor {
+        fn visit(
+            &mut self,
+            index: usize,
+            _key: &Key,
+            value: Option<ProjectedValueRef<'_>>,
+        ) -> Result<(), lix_sdk::BackendError> {
+            self.values[index] = match value {
+                Some(ProjectedValueRef::FullValue(bytes)) => Some(bytes.to_vec()),
+                Some(ProjectedValueRef::KeyOnly) => Some(Vec::new()),
+                None => None,
+            };
+            Ok(())
+        }
+    }
+
     let tempdir = tempfile::tempdir().expect("tempdir should create");
     let backend =
         SqliteBackend::open(tempdir.path().join("chunked.lix")).expect("sqlite backend opens");
 
-    let key = |index: usize| Key(Bytes::from(format!("chunked/{:03}", index)));
+    let key = |index: usize| Key(Bytes::from(format!("chunked/{index:03}")));
     let batch = |tag: u8| PutBatch {
         entries: (0..ROWS)
             // Reverse insertion order so put_many's internal key sort is
@@ -395,7 +415,7 @@ fn sqlite_backend_put_many_handles_multi_chunk_batches() {
             .map(|index| PutEntry {
                 key: key(index),
                 value: StoredValue {
-                    bytes: Bytes::from(vec![tag, index as u8]),
+                    bytes: Bytes::from(vec![tag, index.to_le_bytes()[0]]),
                 },
             })
             .collect(),
@@ -416,25 +436,6 @@ fn sqlite_backend_put_many_handles_multi_chunk_batches() {
         .expect("begin overwrite write");
     write.put_many(batch(2)).expect("overwrite all rows");
     write.commit().expect("commit overwrites");
-
-    struct CollectingVisitor {
-        values: Vec<Option<Vec<u8>>>,
-    }
-    impl PointVisitor for CollectingVisitor {
-        fn visit(
-            &mut self,
-            index: usize,
-            _key: &Key,
-            value: Option<ProjectedValueRef<'_>>,
-        ) -> Result<(), lix_sdk::BackendError> {
-            self.values[index] = match value {
-                Some(ProjectedValueRef::FullValue(bytes)) => Some(bytes.to_vec()),
-                Some(ProjectedValueRef::KeyOnly) => Some(Vec::new()),
-                None => None,
-            };
-            Ok(())
-        }
-    }
 
     let keys = (0..ROWS).map(key).collect::<Vec<_>>();
     let read = backend
@@ -457,7 +458,7 @@ fn sqlite_backend_put_many_handles_multi_chunk_batches() {
     for (index, value) in visitor.values.iter().enumerate() {
         assert_eq!(
             value.as_deref(),
-            Some([2u8, index as u8].as_slice()),
+            Some([2u8, index.to_le_bytes()[0]].as_slice()),
             "row {index} should hold the overwritten value"
         );
     }


### PR DESCRIPTION
Note: stacks on #506–#512; the value-dedup work is the last commit (`206a138a`). The diff slims to it as those merge. Hard cut of stored value formats (no compat), continuing the breaking-change window.

## Changes

**1. `ChangeRecord` values drop `change_id`.** It's the storage key (16 raw UUID bytes since #510) and is reconstructed on decode — the same pattern the ref-chunk codec already uses for `commit_id`. The stored form (`ChangeRecordRef`/`ChangeRecordView`) drops the field; the in-memory record keeps it; the now-tautological scan-path consistency check is removed. A direct codec round-trip suite (fully-populated, empty options, id-from-argument) covers the hand-threaded stored form.

**2. Chunk-local commit-ID dictionaries in leaf values.** The standard value encoding places `change_id` at bytes `[0..16)` and `commit_id` at `[16..32)` — pinned by a layout test that fails loudly if the value codec ever moves them. Bulk commits repeat one commit ID across every entry, so the encoder collects first-occurrence commit IDs into a per-chunk dictionary and splices the slice out of stored values (16 B → ~1 B ref). The splice is reversible byte-for-byte regardless of value semantics; sub-32-byte values stay verbatim and zero-copy. Golden wire vectors pin both the dict-less and dictionaried encodings, so format drift fails a unit test instead of silently changing content-addressed chunk hashes.

## Storage A/B (1k insert footprint, identical across SQLite / RocksDB / redb)

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| `changelog.change` value bytes | 128,857 | 112,601 | **−12.6%** (exactly 16 B × 1,016 records) |
| `tree_chunk` value bytes | 125,918 | 110,833 | **−12.0%** |
| insert_all written bytes/commit | 606,256 | 575,409 | −5.1% |
| delete_all written bytes | 257,080 | 226,234 | **−12.0%** |

Cumulative tree-chunk bytes across the leaf-format work (#512 + this): **162,086 → 110,833 (−31.6%)**.

## Perf

Read cells at parity across six alternating stash pairs on RocksDB (read_all / read_many sign-flipping; read_one initially showed a +9.5% mean shift, re-run because dictionaried values lose zero-copy — a plausible point-read mechanism — and came back at parity; full methodology in the optimization log).

## Review (3 independent passes) — found and fixed two real decoder bugs

The adversarial splice review empirically confirmed two bugs in the initial diff, both fixed with regression tests using the exact attack inputs:

1. **Arena-tail shared-prefix guard**: after a dictionaried entry, the arena tail holds value bytes, so a corrupt chunk with an inflated shared length was *accepted* and front-coded the next key out of value bytes (silent garbage instead of a corruption error — and chunk hashes aren't verified in release). The decoder now tracks the previous key end explicitly.
2. **Wrapping dictionary ref**: `(dict_ref − 1) * 16` was unchecked; `dict_ref = 2⁶⁰+1` wrapped the multiplication and aliased dictionary slot 0. Validation now precedes any index arithmetic.

The change-record review verified field-order fidelity, entity-pk encode/decode symmetry, all call-site id-threading, and honestly assessed the removed consistency check (scan-path-only coverage; no cheap replacement exists by construction). The claims review verified every number above arithmetically and demanded the additional coverage now present: dictionaried golden vector, adversarial dictionary-length rejection, 32-byte-boundary and mixed-chunk cases, and the second read_one triple.

## Validation

- `cargo test -p lix_engine --features storage-benches`: **1,549 passed, 0 failed**
- clippy `--all-targets` zero warnings; fmt clean; accounting byte-identical across backends
- The byte-exact scrambled equivalence test exercises the dictionaried path end-to-end (scoped honestly in the log: it catches order-dependent bugs; deterministic codec bugs are the round-trip/golden suites' job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Multiple hard-cut on-disk encodings (changelog values, tree leaf v2) and transaction hot-path catalog caching; incorrect decode or cache keys would corrupt or mis-validate data.
> 
> **Overview**
> This PR tightens **on-disk storage** by dropping redundant IDs from stored values and compressing repeated commit IDs inside tree leaf chunks, on top of related engine work in the same diff (catalog compile caching, binary UUID changelog keys, sorted write batches, front-coded leaf keys).
> 
> **Changelog:** `ChangeRecord` values no longer embed `change_id`; decode takes the id from the 16-byte storage key (same pattern as ref chunks for `commit_id`). Scan no longer cross-checks key vs value for `change_id`.
> 
> **Tracked-state leaves:** Leaf wire format adds a per-chunk **commit-id dictionary** that splices bytes `[16..32)` out of stored values when they match a dict entry (pinned layout test). Shorter values stay verbatim. Decoder fixes guard shared-prefix length against the previous key end (not arena tail) and validate `dict_ref` before index math.
> 
> **Supporting changes in the diff:** Engine-wide compiled schema catalog cache (`TransactionCatalog` COW), `visit_keys` order documented as unspecified with a scrambled backend equivalence suite, deterministic-mode bookkeeping timestamps derived from sequence, and bench/log updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206a138a49feb8d6e9c30a0cf2b8079e043af88e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->