### PR TITLE
Pack canonical UUID id strings as raw bytes in change records

### DIFF
--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1826,27 +1826,44 @@ byte for the tag. `CommitRecord.author_account_ids` rides the same
 codec; commit_change_ref chunks already stored raw change-id bytes and
 dictionary-encoded file ids, so they are untouched.
 
+Review follow-up shaved one more byte per packed id: the 16-byte arm
+now encodes via `encode_array` (no length prefix — the tag already
+implies the length, matching how `ChangeId` encodes in ref chunks), so
+a packed id is 17 B, not 18. The wire layout is pinned by test.
+
 Measured on the e2e 10k CSV merge fixture (post-merge sqlite file,
 20,028 change records, UUID entity and file ids):
 
 | | text ids | packed ids |
 |---|---|---|
-| changelog.change avg value | 222.4 B | 184.4 B (−17%) |
-| changelog.change payload | 4,453,469 B | 3,693,359 B (−17%) |
-| changelog.change page bytes | 5,640,192 B | 4,726,784 B (−16%) |
-| whole file | 34,078,720 B | 33,144,832 B (−2.7%) |
+| changelog.change avg value | 222.4 B | 182.4 B (−18%) |
+| changelog.change payload | 4,453,469 B | 3,653,351 B (−18%) |
+| changelog.change page bytes | 5,640,192 B | 4,636,672 B (−18%) |
 
-The whole-file delta is diluted by the 24.7 MB of raw plugin wasm in
-binary_cas.chunk (a separate, pending optimization); against the
-non-bcas remainder this is −10%.
+Measurement correction recorded for honesty: earlier drafts cited a
+34.1 MB whole file dominated by 24.7 MB of raw plugin wasm in
+binary_cas.chunk. That wasm was bloated by the profiling harness's own
+CARGO_PROFILE_RELEASE_DEBUG=true leaking into the bindep-built plugin
+artifact. A normal release build stores the CSV plugin wasm at
+2,073,015 B, and the honest post-merge file is 10,010,624 B, where
+changelog.change is the largest table at 46% (4.64 MB), tree_chunk 26%,
+bcas.chunk 21%, ref chunks 7%. This reorders the remaining
+opportunities: change-record encoding work ranks above bcas chunk
+compression (zstd -3 on the real wasm: 2,073,015 → 652,633 B, ~1.4 MB
+recoverable, not ~18 MB).
 
 The tracked_state_crud 1k bench moves the other way, deliberately:
 insert written bytes 436,472 → 437,472 (+0.23%). Its entity ids are
-synthetic labels ("row-00001"), so every record pays the text tag and
-nothing packs. The empty-length-marker encoding that would make text
+JSON-pointer paths flattened from the pnpm-lock fixture, so every
+record pays the text tag and nothing packs (file_id is None there:
+zero delta). The empty-length-marker encoding that would make text
 free was rejected because empty id strings are currently legal
 (EntityPk validates the parts list, not part contents), making the
 marker ambiguous. Real workloads key on lix_uuid_v7() defaults.
 
-No version gate: shipped inside the current breaking window alongside
-format v3. Suites: engine 972 lib + integration all green, sdk green.
+No version gate: shipped inside the open SQLITE_FORMAT_VERSION = 3
+window (the backend gate in sqlite_backend.rs) on the premise that no
+v3 file with the old record encoding exists outside this branch. A
+pre-packing record read by the new decoder fails loudly ("unknown id
+string tag 36"). Suites: engine 972 lib + integration all green, sdk
+green.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1810,3 +1810,43 @@ e2e merge_10k (stash-alternating, two pairs): 191.5/197.5 →
 
 Cumulative campaign written-bytes: 534.4 → 436.5 KB per 1k-row insert
 commit (−18.3%). Suites: engine 1,569 all green.
+
+## 2026-06-11 — Opportunistic UUID Packing for Change Record Ids
+
+Change records stored entity_pk parts and file_id as text. Lix-generated
+ids are canonical lowercase hyphenated UUIDs, so each one cost 37 bytes
+(length + 36 chars) where 16 carry the information — and the storage key
+of the same row already stores the change id as raw bytes. Each id string
+is now a 1-byte tag plus either the raw 16 UUID bytes or the original
+text. Only the exact canonical form takes the UUID arm (uppercase, simple,
+braced forms stay text), so decode re-hyphenates byte-identically and
+round-tripping is structural, not probabilistic. Plugin-chosen entity
+keys ("row 5 of sheet 2") and test labels keep their text form at +1
+byte for the tag. `CommitRecord.author_account_ids` rides the same
+codec; commit_change_ref chunks already stored raw change-id bytes and
+dictionary-encoded file ids, so they are untouched.
+
+Measured on the e2e 10k CSV merge fixture (post-merge sqlite file,
+20,028 change records, UUID entity and file ids):
+
+| | text ids | packed ids |
+|---|---|---|
+| changelog.change avg value | 222.4 B | 184.4 B (−17%) |
+| changelog.change payload | 4,453,469 B | 3,693,359 B (−17%) |
+| changelog.change page bytes | 5,640,192 B | 4,726,784 B (−16%) |
+| whole file | 34,078,720 B | 33,144,832 B (−2.7%) |
+
+The whole-file delta is diluted by the 24.7 MB of raw plugin wasm in
+binary_cas.chunk (a separate, pending optimization); against the
+non-bcas remainder this is −10%.
+
+The tracked_state_crud 1k bench moves the other way, deliberately:
+insert written bytes 436,472 → 437,472 (+0.23%). Its entity ids are
+synthetic labels ("row-00001"), so every record pays the text tag and
+nothing packs. The empty-length-marker encoding that would make text
+free was rejected because empty id strings are currently legal
+(EntityPk validates the parts list, not part contents), making the
+marker ambiguous. Real workloads key on lix_uuid_v7() defaults.
+
+No version gate: shipped inside the current breaking window alongside
+format v3. Suites: engine 972 lib + integration all green, sdk green.

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -711,8 +711,8 @@ mod tests {
         };
         let text_encoded = encode_change_record(&text_only).expect("record should encode");
         assert!(
-            encoded.len() + 38 <= text_encoded.len(),
-            "uuid arm should save ~19 bytes per id ({} vs {})",
+            encoded.len() + 40 <= text_encoded.len(),
+            "uuid arm should save 20 bytes per id ({} vs {})",
             encoded.len(),
             text_encoded.len()
         );

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -1,7 +1,7 @@
 use super::types::{
     ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRef,
     CommitChangeRefChunk, CommitChangeRefChunkRef, CommitChangeRefChunkView,
-    CommitChangeRefEntryRef, CommitChangeRefEntryView, CommitId, CommitRecord, EntityPkRef,
+    CommitChangeRefEntryRef, CommitChangeRefEntryView, CommitId, CommitRecord,
 };
 use crate::common::LixError;
 use crate::entity_pk::EntityPk;
@@ -40,8 +40,8 @@ pub(crate) fn decode_change_record(
         format_version: view.format_version,
         change_id,
         schema_key: view.schema_key.to_string(),
-        entity_pk: entity_pk_from_ref(view.entity_pk)?,
-        file_id: view.file_id.map(str::to_string),
+        entity_pk: entity_pk_from_parts(view.entity_pk)?,
+        file_id: view.file_id,
         snapshot: view.snapshot,
         metadata: view.metadata,
         created_at: view.created_at,
@@ -296,15 +296,13 @@ fn u16_index(value: usize, context: &str) -> Result<u16, LixError> {
     })
 }
 
-fn entity_pk_from_ref(value: EntityPkRef<'_>) -> Result<EntityPk, LixError> {
-    EntityPk::from_parts(value.parts.iter().map(|part| (*part).to_string()).collect()).map_err(
-        |error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("changelog entity primary key is invalid: {error}"),
-            )
-        },
-    )
+fn entity_pk_from_parts(parts: Vec<String>) -> Result<EntityPk, LixError> {
+    EntityPk::from_parts(parts).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("changelog entity primary key is invalid: {error}"),
+        )
+    })
 }
 
 #[cfg(test)]
@@ -681,6 +679,59 @@ mod tests {
             file_id: None,
             snapshot: JsonSlot::None,
             metadata: JsonSlot::None,
+            ..full_record()
+        };
+        let encoded = encode_change_record(&record).expect("record should encode");
+        let decoded =
+            decode_change_record(&encoded, record.change_id).expect("record should decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn change_record_packs_canonical_uuid_ids_and_round_trips() {
+        // Canonical lowercase UUID entity pks and file ids take the 16-byte
+        // arm; the record must round-trip to the identical text form and be
+        // smaller than the unpacked text encoding.
+        let record = ChangeRecord {
+            entity_pk: EntityPk::from_parts(vec![
+                "019eb805-60d0-71c0-ade3-b0f0efab9d9a".to_string(),
+            ])
+            .expect("entity pk should build"),
+            file_id: Some("019eb805-5e65-7270-861d-cb341bc904c8".to_string()),
+            ..full_record()
+        };
+        let encoded = encode_change_record(&record).expect("record should encode");
+        let text_only = ChangeRecord {
+            entity_pk: EntityPk::from_parts(vec![
+                "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A".to_string(),
+            ])
+            .expect("entity pk should build"),
+            file_id: Some("019EB805-5E65-7270-861D-CB341BC904C8".to_string()),
+            ..full_record()
+        };
+        let text_encoded = encode_change_record(&text_only).expect("record should encode");
+        assert!(
+            encoded.len() + 38 <= text_encoded.len(),
+            "uuid arm should save ~19 bytes per id ({} vs {})",
+            encoded.len(),
+            text_encoded.len()
+        );
+        let decoded =
+            decode_change_record(&encoded, record.change_id).expect("record should decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn change_record_keeps_non_canonical_ids_as_text() {
+        // Uppercase hex re-hyphenates differently, so it must stay text to
+        // round-trip byte-identically; same for arbitrary plugin keys.
+        let record = ChangeRecord {
+            entity_pk: EntityPk::from_parts(vec![
+                "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A".to_string(),
+                "row 5 of sheet 2".to_string(),
+            ])
+            .expect("entity pk should build"),
+            file_id: Some("not-a-uuid".to_string()),
             ..full_record()
         };
         let encoded = encode_change_record(&record).expect("record should encode");

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -23,6 +23,6 @@ pub(crate) use types::{
     ChangeScanRequest, ChangelogAppend, CommitChangeRef, CommitChangeRefChunk,
     CommitChangeRefChunkView, CommitChangeRefSet, CommitId, CommitLoadBatch, CommitLoadEntry,
     CommitLoadRequest, CommitProjection, CommitRecord, CommitScanBatch, CommitScanRequest,
-    EntityPkRef, GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, RebuildIndexStats,
+    GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, RebuildIndexStats,
     commit_row_snapshot_json,
 };

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -6,19 +6,6 @@ use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
 
-mod entity_pk_ref_storage {
-    use super::EntityPkRef;
-
-    pub(crate) fn decode<'de, D>(decoder: D) -> Result<EntityPkRef<'de>, D::Error>
-    where
-        D: musli::Decoder<'de>,
-        Vec<&'de str>: musli::Decode<'de, D::Mode, D::Allocator>,
-    {
-        let parts = musli::Decode::decode(decoder)?;
-        Ok(EntityPkRef { parts })
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct CommitId {
     uuid: Uuid,
@@ -315,6 +302,7 @@ pub(crate) struct CommitRecord {
     pub(crate) commit_id: CommitId,
     pub(crate) parent_commit_ids: Vec<CommitId>,
     pub(crate) change_id: ChangeId,
+    #[musli(with = crate::storage_codec::id_string_seq)]
     pub(crate) author_account_ids: Vec<String>,
     pub(crate) created_at: LixTimestamp,
 }
@@ -384,11 +372,6 @@ pub(crate) struct CommitChangeRefEntryView<'a> {
     pub(crate) change_id: ChangeId,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct EntityPkRef<'a> {
-    pub(crate) parts: Vec<&'a str>,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CommitProjection {
     Record,
@@ -450,8 +433,9 @@ pub(crate) struct ChangeRecord {
 pub(crate) struct ChangeRecordRef<'a> {
     pub(crate) format_version: u32,
     pub(crate) schema_key: &'a str,
+    #[musli(with = crate::storage_codec::id_string_seq)]
     pub(crate) entity_pk: &'a [String],
-    #[musli(with = crate::storage_codec::option)]
+    #[musli(with = crate::storage_codec::option_id_string)]
     pub(crate) file_id: Option<&'a str>,
     #[musli(with = crate::json_store::json_slot_storage_ref)]
     pub(crate) snapshot: crate::json_store::JsonSlotRef<'a>,
@@ -465,10 +449,10 @@ pub(crate) struct ChangeRecordRef<'a> {
 pub(crate) struct ChangeRecordView<'a> {
     pub(crate) format_version: u32,
     pub(crate) schema_key: &'a str,
-    #[musli(with = entity_pk_ref_storage)]
-    pub(crate) entity_pk: EntityPkRef<'a>,
-    #[musli(with = crate::storage_codec::option)]
-    pub(crate) file_id: Option<&'a str>,
+    #[musli(with = crate::storage_codec::id_string_seq)]
+    pub(crate) entity_pk: Vec<String>,
+    #[musli(with = crate::storage_codec::option_id_string)]
+    pub(crate) file_id: Option<String>,
     #[musli(with = crate::json_store::json_slot_storage)]
     pub(crate) snapshot: JsonSlot,
     #[musli(with = crate::json_store::json_slot_storage)]

--- a/packages/engine/src/storage_codec.rs
+++ b/packages/engine/src/storage_codec.rs
@@ -71,6 +71,155 @@ pub(crate) mod vec_option {
     }
 }
 
+/// Opportunistic UUID packing for stored id strings.
+///
+/// Lix-generated ids are canonical lowercase hyphenated UUIDs; as text they
+/// cost 36 bytes where 16 carry the information. Each id is stored as a
+/// 1-byte tag followed by either the raw 16 UUID bytes or the original text.
+/// Only the exact canonical form takes the UUID arm, so decode re-hyphenates
+/// byte-identically; every other string (plugin-chosen entity keys, test
+/// labels) keeps its text form.
+pub(crate) mod id_string {
+    use musli::Context;
+    use musli::de::SequenceDecoder;
+    use musli::en::SequenceEncoder;
+
+    const TAG_TEXT: u8 = 0;
+    const TAG_UUID: u8 = 1;
+
+    pub(crate) fn uuid_bytes_from_canonical(value: &str) -> Option<[u8; 16]> {
+        let bytes = value.as_bytes();
+        if bytes.len() != 36 {
+            return None;
+        }
+        let mut out = [0u8; 16];
+        let mut nibble_index = 0usize;
+        for (position, &byte) in bytes.iter().enumerate() {
+            if matches!(position, 8 | 13 | 18 | 23) {
+                if byte != b'-' {
+                    return None;
+                }
+                continue;
+            }
+            // Lowercase hex only: uppercase input would re-hyphenate
+            // differently and break round-tripping.
+            let nibble = match byte {
+                b'0'..=b'9' => byte - b'0',
+                b'a'..=b'f' => byte - b'a' + 10,
+                _ => return None,
+            };
+            out[nibble_index / 2] |= nibble << (4 * (1 - nibble_index % 2));
+            nibble_index += 1;
+        }
+        Some(out)
+    }
+
+    pub(crate) fn uuid_string_from_bytes(bytes: [u8; 16]) -> String {
+        uuid::Uuid::from_bytes(bytes).as_hyphenated().to_string()
+    }
+
+    pub(crate) fn encode_one<E>(value: &str, pack: &mut E) -> Result<(), E::Error>
+    where
+        E: SequenceEncoder,
+    {
+        match uuid_bytes_from_canonical(value) {
+            Some(bytes) => {
+                pack.push(TAG_UUID)?;
+                pack.push(bytes)
+            }
+            None => {
+                pack.push(TAG_TEXT)?;
+                pack.push(value.as_bytes())
+            }
+        }
+    }
+
+    pub(crate) fn decode_one<'de, D>(pack: &mut D) -> Result<String, D::Error>
+    where
+        D: SequenceDecoder<'de>,
+    {
+        let cx = pack.cx();
+        let tag: u8 = pack.next()?;
+        match tag {
+            TAG_UUID => Ok(uuid_string_from_bytes(pack.next::<[u8; 16]>()?)),
+            TAG_TEXT => {
+                let bytes: Vec<u8> = pack.next()?;
+                String::from_utf8(bytes).map_err(|_| cx.message("id string is not UTF-8"))
+            }
+            other => Err(cx.message(format_args!("unknown id string tag {other}"))),
+        }
+    }
+
+}
+
+/// [`id_string`] values behind the same bool prefix as [`option`].
+pub(crate) mod option_id_string {
+    use musli::de::SequenceDecoder;
+    use musli::en::SequenceEncoder;
+
+    #[expect(clippy::ref_option_ref)]
+    pub(crate) fn encode<E>(value: &Option<&str>, encoder: E) -> Result<(), E::Error>
+    where
+        E: musli::Encoder,
+    {
+        encoder.encode_pack_fn(|pack| {
+            pack.push(value.is_some())?;
+            if let Some(value) = value {
+                super::id_string::encode_one(value, pack)?;
+            }
+            Ok(())
+        })
+    }
+
+    pub(crate) fn decode<'de, D>(decoder: D) -> Result<Option<String>, D::Error>
+    where
+        D: musli::Decoder<'de>,
+    {
+        decoder.decode_pack(|pack| {
+            if pack.next()? {
+                Ok(Some(super::id_string::decode_one(pack)?))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+}
+
+/// A length-prefixed sequence of [`id_string`] values.
+pub(crate) mod id_string_seq {
+    use musli::de::SequenceDecoder;
+    use musli::en::SequenceEncoder;
+
+    pub(crate) fn encode<S, E>(value: &S, encoder: E) -> Result<(), E::Error>
+    where
+        S: AsRef<[String]> + ?Sized,
+        E: musli::Encoder,
+    {
+        let parts = value.as_ref();
+        encoder.encode_pack_fn(|pack| {
+            pack.push(parts.len())?;
+            for part in parts {
+                super::id_string::encode_one(part, pack)?;
+            }
+            Ok(())
+        })
+    }
+
+    pub(crate) fn decode<'de, D>(decoder: D) -> Result<Vec<String>, D::Error>
+    where
+        D: musli::Decoder<'de>,
+    {
+        decoder.decode_pack(|pack| {
+            let len: usize = pack.next()?;
+            let mut out = Vec::with_capacity(len.min(4096));
+            for _ in 0..len {
+                out.push(super::id_string::decode_one(pack)?);
+            }
+            Ok(out)
+        })
+    }
+}
+
 pub(crate) fn encode<T>(context: &str, value: &T) -> Result<Vec<u8>, LixError>
 where
     T: ?Sized + musli::Encode<musli::mode::Binary>,
@@ -135,6 +284,79 @@ mod tests {
             super::decode("option roundtrip", &bytes).expect("value should decode cleanly");
 
         assert_eq!(decoded, value);
+    }
+
+    #[derive(Debug, Eq, PartialEq, musli::Encode)]
+    #[musli(packed)]
+    struct IdStringEncode<'a> {
+        #[musli(with = crate::storage_codec::id_string_seq)]
+        parts: &'a [String],
+        #[musli(with = crate::storage_codec::option_id_string)]
+        file_id: Option<&'a str>,
+    }
+
+    #[derive(Debug, Eq, PartialEq, musli::Decode)]
+    #[musli(packed)]
+    struct IdStringDecode {
+        #[musli(with = crate::storage_codec::id_string_seq)]
+        parts: Vec<String>,
+        #[musli(with = crate::storage_codec::option_id_string)]
+        file_id: Option<String>,
+    }
+
+    #[test]
+    fn uuid_bytes_from_canonical_accepts_only_the_exact_canonical_form() {
+        use super::id_string::uuid_bytes_from_canonical;
+        let canonical = "019eb805-60d0-71c0-ade3-b0f0efab9d9a";
+        let bytes = uuid_bytes_from_canonical(canonical).expect("canonical uuid should pack");
+        assert_eq!(super::id_string::uuid_string_from_bytes(bytes), canonical);
+
+        for rejected in [
+            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",     // uppercase
+            "019eb80560d071c0ade3b0f0efab9d9a",         // simple form
+            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}",   // braced
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9",      // short
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",    // long
+            "019eb805x60d0-71c0-ade3-b0f0efab9d9aa",    // hyphen replaced
+            "not-a-uuid",
+            "",
+        ] {
+            assert_eq!(uuid_bytes_from_canonical(rejected), None, "{rejected:?}");
+        }
+    }
+
+    #[test]
+    fn id_strings_round_trip_through_both_arms() {
+        let parts = vec![
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9a".to_string(),
+            "row 5 of sheet 2".to_string(),
+        ];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: Some("019eb805-5e65-7270-861d-cb341bc904c8"),
+        };
+        let bytes = super::encode("id string roundtrip", &value).expect("encode");
+        let decoded: IdStringDecode =
+            super::decode("id string roundtrip", &bytes).expect("decode");
+        assert_eq!(decoded.parts, parts);
+        assert_eq!(
+            decoded.file_id.as_deref(),
+            Some("019eb805-5e65-7270-861d-cb341bc904c8")
+        );
+    }
+
+    #[test]
+    fn id_string_none_file_id_round_trips() {
+        let parts = vec!["plain".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: None,
+        };
+        let bytes = super::encode("id string roundtrip", &value).expect("encode");
+        let decoded: IdStringDecode =
+            super::decode("id string roundtrip", &bytes).expect("decode");
+        assert_eq!(decoded.parts, parts);
+        assert_eq!(decoded.file_id, None);
     }
 
     #[test]

--- a/packages/engine/src/storage_codec.rs
+++ b/packages/engine/src/storage_codec.rs
@@ -87,6 +87,42 @@ pub(crate) mod id_string {
     const TAG_TEXT: u8 = 0;
     const TAG_UUID: u8 = 1;
 
+    /// Raw 16-byte arm. The tag already implies the length, so this encodes
+    /// via `encode_array` (no length prefix), like the uuid id types in
+    /// `changelog::types`.
+    struct UuidArm([u8; 16]);
+
+    impl<M> musli::Encode<M> for UuidArm {
+        type Encode = Self;
+
+        fn encode<E>(&self, encoder: E) -> Result<(), E::Error>
+        where
+            E: musli::Encoder<Mode = M>,
+        {
+            encoder.encode_array(&self.0)
+        }
+
+        fn size_hint(&self) -> Option<usize> {
+            Some(16)
+        }
+
+        fn as_encode(&self) -> &Self {
+            self
+        }
+    }
+
+    impl<'de, M, A> musli::Decode<'de, M, A> for UuidArm
+    where
+        A: musli::Allocator,
+    {
+        fn decode<D>(decoder: D) -> Result<Self, D::Error>
+        where
+            D: musli::Decoder<'de, Mode = M, Allocator = A>,
+        {
+            Ok(Self(decoder.decode_array()?))
+        }
+    }
+
     pub(crate) fn uuid_bytes_from_canonical(value: &str) -> Option<[u8; 16]> {
         let bytes = value.as_bytes();
         if bytes.len() != 36 {
@@ -125,7 +161,7 @@ pub(crate) mod id_string {
         match uuid_bytes_from_canonical(value) {
             Some(bytes) => {
                 pack.push(TAG_UUID)?;
-                pack.push(bytes)
+                pack.push(UuidArm(bytes))
             }
             None => {
                 pack.push(TAG_TEXT)?;
@@ -141,7 +177,7 @@ pub(crate) mod id_string {
         let cx = pack.cx();
         let tag: u8 = pack.next()?;
         match tag {
-            TAG_UUID => Ok(uuid_string_from_bytes(pack.next::<[u8; 16]>()?)),
+            TAG_UUID => Ok(uuid_string_from_bytes(pack.next::<UuidArm>()?.0)),
             TAG_TEXT => {
                 let bytes: Vec<u8> = pack.next()?;
                 String::from_utf8(bytes).map_err(|_| cx.message("id string is not UTF-8"))
@@ -312,12 +348,16 @@ mod tests {
         assert_eq!(super::id_string::uuid_string_from_bytes(bytes), canonical);
 
         for rejected in [
-            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",     // uppercase
-            "019eb80560d071c0ade3b0f0efab9d9a",         // simple form
-            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}",   // braced
-            "019eb805-60d0-71c0-ade3-b0f0efab9d9",      // short
-            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",    // long
-            "019eb805x60d0-71c0-ade3-b0f0efab9d9aa",    // hyphen replaced
+            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",   // uppercase
+            "019eb80560d071c0ade3b0f0efab9d9a",       // simple form
+            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}", // braced
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9",    // short
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",  // long
+            "019eb805x60d0-71c0-ade3-b0f0efab9d9a",   // 36 bytes, hyphen replaced
+            "019eb805-60d0x71c0-ade3-b0f0efab9d9a",   // 36 bytes, hex at hyphen slot
+            "019eb805-60d0-71c0-ade3-b0f0efab9d\u{e9}", // 36 bytes via multi-byte char
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9\0",  // embedded NUL
+            "------------------------------------",   // all hyphens
             "not-a-uuid",
             "",
         ] {
@@ -342,6 +382,72 @@ mod tests {
         assert_eq!(
             decoded.file_id.as_deref(),
             Some("019eb805-5e65-7270-861d-cb341bc904c8")
+        );
+    }
+
+    #[test]
+    fn id_string_wire_format_is_pinned() {
+        // Persisted layout: uuid arm = tag 1 + 16 raw bytes (no length
+        // prefix); text arm = tag 0 + varint length + bytes. Sequences are
+        // count-prefixed; options are bool-prefixed.
+        let parts = vec!["019eb805-60d0-71c0-ade3-b0f0efab9d9a".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: Some("ab"),
+        };
+        let bytes = super::encode("id string wire pin", &value).expect("encode");
+        let expected: Vec<u8> = [
+            &[1u8][..],     // parts count
+            &[1u8][..],     // TAG_UUID
+            &[
+                0x01, 0x9e, 0xb8, 0x05, 0x60, 0xd0, 0x71, 0xc0, 0xad, 0xe3, 0xb0, 0xf0, 0xef,
+                0xab, 0x9d, 0x9a,
+            ][..],          // raw uuid bytes
+            &[1u8][..],     // file_id Some
+            &[0u8][..],     // TAG_TEXT
+            &[2u8][..],     // text length
+            b"ab",          // text bytes
+        ]
+        .concat();
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn id_string_decode_rejects_unknown_tag_loudly() {
+        let parts = vec!["a".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: None,
+        };
+        let mut bytes = super::encode("id string tag", &value).expect("encode");
+        // Layout: [count=1][tag][len=1][b'a'][file_id=false]; corrupt the tag.
+        assert_eq!(bytes[1], 0, "expected the text tag at offset 1");
+        bytes[1] = 9;
+        let error = super::decode::<IdStringDecode>("id string tag", &bytes)
+            .expect_err("unknown tag should fail decode");
+        assert!(
+            error.message.contains("unknown id string tag 9"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn id_string_decode_rejects_non_utf8_text_loudly() {
+        let parts = vec!["ab".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: None,
+        };
+        let mut bytes = super::encode("id string utf8", &value).expect("encode");
+        // Layout: [count=1][tag=0][len=2][b'a'][b'b'][file_id=false].
+        bytes[3] = 0xFF;
+        let error = super::decode::<IdStringDecode>("id string utf8", &bytes)
+            .expect_err("invalid UTF-8 should fail decode");
+        assert!(
+            error.message.contains("id string is not UTF-8"),
+            "{}",
+            error.message
         );
     }
 

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -61,6 +61,11 @@ name = "verify_sqlite_key_value"
 path = "tests/fixtures/verify_sqlite_key_value.rs"
 required-features = ["sqlite"]
 
+[[example]]
+name = "profile_merge_10k"
+path = "examples/profile_merge_10k.rs"
+required-features = ["sqlite"]
+
 [[bench]]
 name = "sqlite_backend"
 path = "benches/sqlite_backend.rs"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -61,9 +61,10 @@ name = "verify_sqlite_key_value"
 path = "tests/fixtures/verify_sqlite_key_value.rs"
 required-features = ["sqlite"]
 
-[[example]]
+[[bench]]
 name = "profile_merge_10k"
-path = "examples/profile_merge_10k.rs"
+path = "benches/profile_merge_10k.rs"
+harness = false
 required-features = ["sqlite"]
 
 [[bench]]

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -13,8 +13,6 @@
 //! comparable; absolute times are not.
 
 use lix_sdk::{FsWriteOptions, OpenLixOptions, SqliteBackend, Value, open_lix};
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 use std::io::{Cursor, Write as _};
 use std::path::Path;
 use std::time::Instant;
@@ -112,21 +110,43 @@ async fn profile_merge_phase(lix: &lix_sdk::Lix<SqliteBackend>, updated_csv: Vec
         .unwrap();
 }
 
+/// Deterministic splitmix64 generator. The bench (e2e.rs) seeds rand's
+/// SmallRng, a dev-dependency this harness deliberately avoids; the fixture
+/// bytes therefore differ from the bench's, but the harness only needs
+/// setup and merge to agree with each other.
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform value in `0..bound` (bound > 0); modulo bias is irrelevant
+    /// for fixture shuffling.
+    fn next_below(&mut self, bound: usize) -> usize {
+        usize::try_from(self.next_u64() % bound as u64).expect("bound fits usize")
+    }
+}
+
 fn random_csv_rows(prefix: &str, count: usize, seed: u64) -> Vec<String> {
-    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut rng = SplitMix64(seed);
     (0..count)
         .map(|offset| {
             format!(
                 "{prefix}-{offset:05},{:016x},{:016x}",
-                rng.random::<u64>(),
-                rng.random::<u64>()
+                rng.next_u64(),
+                rng.next_u64()
             )
         })
         .collect()
 }
 
 fn randomly_merge_csv_rows(initial_rows: &[String], new_rows: &[String], seed: u64) -> Vec<String> {
-    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut rng = SplitMix64(seed);
     let mut merged = Vec::with_capacity(initial_rows.len() + new_rows.len());
     let mut initial_index = 0usize;
     let mut new_index = 0usize;
@@ -139,7 +159,7 @@ fn randomly_merge_csv_rows(initial_rows: &[String], new_rows: &[String], seed: u
         } else {
             let remaining_initial = initial_rows.len() - initial_index;
             let remaining_new = new_rows.len() - new_index;
-            rng.random_range(0..(remaining_initial + remaining_new)) < remaining_initial
+            rng.next_below(remaining_initial + remaining_new) < remaining_initial
         };
 
         if take_initial {
@@ -164,8 +184,17 @@ fn csv_bytes_from_rows(rows: &[String]) -> Vec<u8> {
 }
 
 fn build_csv_plugin() -> Vec<u8> {
-    let wasm = std::fs::read(Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv")))
-        .expect("read bindep-built CSV plugin wasm");
+    // option_env: the bindep artifact env var is absent in some CI target
+    // contexts; this harness is only ever run manually, so resolve at
+    // runtime and fail with instructions instead of failing the compile.
+    let Some(wasm_path) = option_env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv") else {
+        eprintln!(
+            "CSV plugin wasm path unavailable; build via `cargo build --bench \
+             profile_merge_10k --features sqlite` so cargo provides the bindep artifact"
+        );
+        std::process::exit(2);
+    };
+    let wasm = std::fs::read(Path::new(wasm_path)).expect("read bindep-built CSV plugin wasm");
     let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
     let options =
         zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -27,10 +27,16 @@ const CSV_PLUGIN_WARMUP_PATH: &str = "/.csv-plugin-warmup.csv";
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let (mode, dir) = match args.as_slice() {
-        [_, mode, dir] => (mode.as_str(), dir.clone()),
+        [_, mode, dir] if matches!(mode.as_str(), "setup" | "merge") => {
+            (mode.as_str(), dir.clone())
+        }
         _ => {
+            // `cargo bench` invokes every bench target with harness flags
+            // (--bench, filters); this profiling harness only runs when
+            // called explicitly, so a plain usage note and success exit
+            // keeps bench sweeps green.
             eprintln!("usage: profile_merge_10k <setup|merge> <dir>");
-            std::process::exit(2);
+            return;
         }
     };
     let lix_path = Path::new(&dir).join("bench.lix");

--- a/packages/rs-sdk/examples/profile_merge_10k.rs
+++ b/packages/rs-sdk/examples/profile_merge_10k.rs
@@ -5,6 +5,12 @@
 //! the prepared file, warms the plugin outside the measured region, then runs the
 //! merge inside `profile_merge_phase` so samply samples can be filtered to that
 //! frame. The post-merge sqlite file is left on disk for inspection.
+//!
+//! Differences from the merge_10k criterion bench (benches/e2e.rs): the bench's
+//! measured region includes `lix.close()`, which this marker frame excludes, and
+//! the merge here runs in a fresh process against a reopened file, so cold-load
+//! frames appear that the bench's in-process setup absorbs. Profile shapes are
+//! comparable; absolute times are not.
 
 use lix_sdk::{FsWriteOptions, OpenLixOptions, SqliteBackend, Value, open_lix};
 use rand::rngs::SmallRng;

--- a/packages/rs-sdk/examples/profile_merge_10k.rs
+++ b/packages/rs-sdk/examples/profile_merge_10k.rs
@@ -1,0 +1,179 @@
+//! Two-phase profiling harness for the raw merge_10k operation.
+//!
+//! `setup <dir>` builds the fixture: opens a lix at <dir>/bench.lix, installs the
+//! CSV plugin, writes the initial 10k-row CSV, and closes. `merge <dir>` reopens
+//! the prepared file, warms the plugin outside the measured region, then runs the
+//! merge inside `profile_merge_phase` so samply samples can be filtered to that
+//! frame. The post-merge sqlite file is left on disk for inspection.
+
+use lix_sdk::{FsWriteOptions, OpenLixOptions, SqliteBackend, Value, open_lix};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use std::io::{Cursor, Write as _};
+use std::path::Path;
+use std::time::Instant;
+
+const INITIAL_ROW_COUNT: usize = 10_000;
+const NEW_ROW_COUNT: usize = 10_000;
+const CSV_PATH: &str = "/large-merge.csv";
+const CSV_PLUGIN_WARMUP_PATH: &str = "/.csv-plugin-warmup.csv";
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let (mode, dir) = match args.as_slice() {
+        [_, mode, dir] => (mode.as_str(), dir.clone()),
+        _ => {
+            eprintln!("usage: profile_merge_10k <setup|merge> <dir>");
+            std::process::exit(2);
+        }
+    };
+    let lix_path = Path::new(&dir).join("bench.lix");
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let initial_rows = random_csv_rows("initial", INITIAL_ROW_COUNT, 0x8ae7_b4b1_9f4c_d215);
+    let new_rows = random_csv_rows("new", NEW_ROW_COUNT, 0xf3bb_91d4_6a8c_2e73);
+
+    match mode {
+        "setup" => runtime.block_on(async {
+            let plugin = build_csv_plugin();
+            let lix = open_lix(OpenLixOptions::new(
+                SqliteBackend::open(&lix_path).expect("open sqlite backend"),
+            ))
+            .await
+            .unwrap();
+            lix.install_plugin_archive(&plugin).await.unwrap();
+            let initial_csv = csv_bytes_from_rows(&initial_rows);
+            let start = Instant::now();
+            lix.write_file(CSV_PATH, initial_csv, FsWriteOptions::default())
+                .await
+                .unwrap();
+            eprintln!("setup insert took {:?}", start.elapsed());
+            lix.close().await.unwrap();
+        }),
+        "merge" => runtime.block_on(async {
+            let updated_csv = csv_bytes_from_rows(&randomly_merge_csv_rows(
+                &initial_rows,
+                &new_rows,
+                0x6449_2c6f_179d_31b5,
+            ));
+            let lix = open_lix(OpenLixOptions::new(
+                SqliteBackend::open(&lix_path).expect("open sqlite backend"),
+            ))
+            .await
+            .unwrap();
+            // Warm: compiles the wasm component and primes caches outside the
+            // measured region, mirroring warm_lix_csv_plugin in the bench.
+            lix.write_file(
+                CSV_PLUGIN_WARMUP_PATH,
+                Vec::new(),
+                FsWriteOptions::default(),
+            )
+            .await
+            .unwrap();
+            lix.execute(
+                "DELETE FROM lix_file WHERE path = $1",
+                &[Value::Text(CSV_PLUGIN_WARMUP_PATH.to_string())],
+            )
+            .await
+            .unwrap();
+
+            let start = Instant::now();
+            profile_merge_phase(&lix, updated_csv).await;
+            eprintln!("merge took {:?}", start.elapsed());
+            lix.close().await.unwrap();
+        }),
+        other => {
+            eprintln!("unknown mode {other}");
+            std::process::exit(2);
+        }
+    }
+}
+
+#[inline(never)]
+async fn profile_merge_phase(lix: &lix_sdk::Lix<SqliteBackend>, updated_csv: Vec<u8>) {
+    lix.write_file(CSV_PATH, updated_csv, FsWriteOptions::default())
+        .await
+        .unwrap();
+}
+
+fn random_csv_rows(prefix: &str, count: usize, seed: u64) -> Vec<String> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    (0..count)
+        .map(|offset| {
+            format!(
+                "{prefix}-{offset:05},{:016x},{:016x}",
+                rng.random::<u64>(),
+                rng.random::<u64>()
+            )
+        })
+        .collect()
+}
+
+fn randomly_merge_csv_rows(initial_rows: &[String], new_rows: &[String], seed: u64) -> Vec<String> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut merged = Vec::with_capacity(initial_rows.len() + new_rows.len());
+    let mut initial_index = 0usize;
+    let mut new_index = 0usize;
+
+    while initial_index < initial_rows.len() || new_index < new_rows.len() {
+        let take_initial = if initial_index == initial_rows.len() {
+            false
+        } else if new_index == new_rows.len() {
+            true
+        } else {
+            let remaining_initial = initial_rows.len() - initial_index;
+            let remaining_new = new_rows.len() - new_index;
+            rng.random_range(0..(remaining_initial + remaining_new)) < remaining_initial
+        };
+
+        if take_initial {
+            merged.push(initial_rows[initial_index].clone());
+            initial_index += 1;
+        } else {
+            merged.push(new_rows[new_index].clone());
+            new_index += 1;
+        }
+    }
+
+    merged
+}
+
+fn csv_bytes_from_rows(rows: &[String]) -> Vec<u8> {
+    let mut csv = String::with_capacity(rows.iter().map(|row| row.len() + 1).sum());
+    for row in rows {
+        csv.push_str(row);
+        csv.push('\n');
+    }
+    csv.into_bytes()
+}
+
+fn build_csv_plugin() -> Vec<u8> {
+    let wasm = std::fs::read(Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv")))
+        .expect("read bindep-built CSV plugin wasm");
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/csv/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/csv_table.json",
+            include_str!("../../../plugins/csv/schema/csv_table.json").as_bytes(),
+        ),
+        (
+            "schema/csv_row.json",
+            include_str!("../../../plugins/csv/schema/csv_row.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}


### PR DESCRIPTION
## What

Change records stored `entity_pk` parts and `file_id` as 36-char UUID text while the row key already held the change id as raw bytes. Each stored id string is now a 1-byte tag plus either:

- the raw 16 UUID bytes (no length prefix — the tag implies it), taken only when the string is the exact canonical lowercase hyphenated form, so decode re-hyphenates byte-identically, or
- the original text, for everything else (plugin-chosen keys, custom file ids, test labels) at +1 tag byte.

`CommitRecord.author_account_ids` rides the same codec. commit_change_ref chunks already stored raw change-id bytes and are untouched. The borrowed `EntityPkRef` decode type is deleted; the only consumer materialized owned strings anyway. The wire layout is pinned by test.

## Measured

e2e 10k CSV merge fixture (20,028 change records, UUID entity/file ids):

| | text ids | packed ids |
|---|---|---|
| changelog.change avg value | 222.4 B | 182.4 B (-18%) |
| changelog.change payload | 4,453,469 B | 3,653,351 B (-18%) |
| changelog.change page bytes | 5,640,192 B | 4,636,672 B (-18%) |

In the honest post-merge file (10.0 MB with a normal-release plugin wasm), changelog.change is the largest table at 46%. An earlier draft cited a 34 MB file dominated by 24.7 MB of wasm; that wasm was bloated by `CARGO_PROFILE_RELEASE_DEBUG` leaking into the bindep artifact during profiling, and the correction is recorded in the optimization log.

tracked_state_crud 1k bench (non-UUID pointer-path ids, nothing packs): insert written bytes 436,472 -> 437,472 (+0.23%), the text-tag cost. The empty-marker encoding that would make text free is ambiguous because empty id strings are currently legal.

## Format

Breaking change to the change record value encoding, shipped inside the current v3 window without a version bump (no v3 files with the old encoding exist outside this branch's history). A pre-packing v3 file fails loudly at decode ("unknown id string tag 36"), not silently.

## Review

Three independent review passes (codec correctness, integration/architecture, perf/storage math): zero blockers, zero majors. All actionable findings applied in the follow-up commit: uuid arm length byte elided (17 B/id), wire-format pin test, loud-error decode tests, a true 36-byte misplaced-hyphen rejection case, log wording fixes, and the wasm measurement correction above.

## Also included

`packages/rs-sdk/examples/profile_merge_10k.rs`: two-phase harness (`setup <dir>` builds the 10k fixture file, `merge <dir>` reopens and merges) so samply profiles isolate the raw merge from setup/wasm-compile.

Suites: engine 1,582 green, sdk green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking on-disk change-record encoding without migration; mis-parsed legacy files error at read time, and UUID packing must preserve byte-identical round-trip for canonical ids only.
> 
> **Overview**
> **Opportunistic UUID packing** shrinks stored change-record identity strings: `entity_pk` parts, optional `file_id`, and `CommitRecord.author_account_ids` now use a tagged wire format in `storage_codec` (canonical lowercase hyphenated UUID → 17 bytes; everything else → text + 1-byte tag). Change-record encode/decode drops borrowed `EntityPkRef` in favor of owned strings from the new codec.
> 
> **Format / compatibility:** Treated as a breaking change to the musli change-record value layout inside the current SQLite v3 window—no separate version bump; old text-encoded records fail decode with an explicit unknown-tag error.
> 
> **Tooling & docs:** Adds `profile_merge_10k` (setup/merge harness for samply) under `lix_sdk` benches, and extends the optimization log with ~18% `changelog.change` savings on the 10k merge fixture plus corrected wasm size accounting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6273e1fe076181091ca686f1eb5308d0eeeb048d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->