### PR TITLE
Store commit change ref chunks as bare change ids

### DIFF
--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1826,27 +1826,44 @@ byte for the tag. `CommitRecord.author_account_ids` rides the same
 codec; commit_change_ref chunks already stored raw change-id bytes and
 dictionary-encoded file ids, so they are untouched.
 
+Review follow-up shaved one more byte per packed id: the 16-byte arm
+now encodes via `encode_array` (no length prefix — the tag already
+implies the length, matching how `ChangeId` encodes in ref chunks), so
+a packed id is 17 B, not 18. The wire layout is pinned by test.
+
 Measured on the e2e 10k CSV merge fixture (post-merge sqlite file,
 20,028 change records, UUID entity and file ids):
 
 | | text ids | packed ids |
 |---|---|---|
-| changelog.change avg value | 222.4 B | 184.4 B (−17%) |
-| changelog.change payload | 4,453,469 B | 3,693,359 B (−17%) |
-| changelog.change page bytes | 5,640,192 B | 4,726,784 B (−16%) |
-| whole file | 34,078,720 B | 33,144,832 B (−2.7%) |
+| changelog.change avg value | 222.4 B | 182.4 B (−18%) |
+| changelog.change payload | 4,453,469 B | 3,653,351 B (−18%) |
+| changelog.change page bytes | 5,640,192 B | 4,636,672 B (−18%) |
 
-The whole-file delta is diluted by the 24.7 MB of raw plugin wasm in
-binary_cas.chunk (a separate, pending optimization); against the
-non-bcas remainder this is −10%.
+Measurement correction recorded for honesty: earlier drafts cited a
+34.1 MB whole file dominated by 24.7 MB of raw plugin wasm in
+binary_cas.chunk. That wasm was bloated by the profiling harness's own
+CARGO_PROFILE_RELEASE_DEBUG=true leaking into the bindep-built plugin
+artifact. A normal release build stores the CSV plugin wasm at
+2,073,015 B, and the honest post-merge file is 10,010,624 B, where
+changelog.change is the largest table at 46% (4.64 MB), tree_chunk 26%,
+bcas.chunk 21%, ref chunks 7%. This reorders the remaining
+opportunities: change-record encoding work ranks above bcas chunk
+compression (zstd -3 on the real wasm: 2,073,015 → 652,633 B, ~1.4 MB
+recoverable, not ~18 MB).
 
 The tracked_state_crud 1k bench moves the other way, deliberately:
 insert written bytes 436,472 → 437,472 (+0.23%). Its entity ids are
-synthetic labels ("row-00001"), so every record pays the text tag and
-nothing packs. The empty-length-marker encoding that would make text
+JSON-pointer paths flattened from the pnpm-lock fixture, so every
+record pays the text tag and nothing packs (file_id is None there:
+zero delta). The empty-length-marker encoding that would make text
 free was rejected because empty id strings are currently legal
 (EntityPk validates the parts list, not part contents), making the
 marker ambiguous. Real workloads key on lix_uuid_v7() defaults.
 
-No version gate: shipped inside the current breaking window alongside
-format v3. Suites: engine 972 lib + integration all green, sdk green.
+No version gate: shipped inside the open SQLITE_FORMAT_VERSION = 3
+window (the backend gate in sqlite_backend.rs) on the premise that no
+v3 file with the old record encoding exists outside this branch. A
+pre-packing record read by the new decoder fails loudly ("unknown id
+string tag 36"). Suites: engine 972 lib + integration all green, sdk
+green.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1810,3 +1810,43 @@ e2e merge_10k (stash-alternating, two pairs): 191.5/197.5 →
 
 Cumulative campaign written-bytes: 534.4 → 436.5 KB per 1k-row insert
 commit (−18.3%). Suites: engine 1,569 all green.
+
+## 2026-06-11 — Opportunistic UUID Packing for Change Record Ids
+
+Change records stored entity_pk parts and file_id as text. Lix-generated
+ids are canonical lowercase hyphenated UUIDs, so each one cost 37 bytes
+(length + 36 chars) where 16 carry the information — and the storage key
+of the same row already stores the change id as raw bytes. Each id string
+is now a 1-byte tag plus either the raw 16 UUID bytes or the original
+text. Only the exact canonical form takes the UUID arm (uppercase, simple,
+braced forms stay text), so decode re-hyphenates byte-identically and
+round-tripping is structural, not probabilistic. Plugin-chosen entity
+keys ("row 5 of sheet 2") and test labels keep their text form at +1
+byte for the tag. `CommitRecord.author_account_ids` rides the same
+codec; commit_change_ref chunks already stored raw change-id bytes and
+dictionary-encoded file ids, so they are untouched.
+
+Measured on the e2e 10k CSV merge fixture (post-merge sqlite file,
+20,028 change records, UUID entity and file ids):
+
+| | text ids | packed ids |
+|---|---|---|
+| changelog.change avg value | 222.4 B | 184.4 B (−17%) |
+| changelog.change payload | 4,453,469 B | 3,693,359 B (−17%) |
+| changelog.change page bytes | 5,640,192 B | 4,726,784 B (−16%) |
+| whole file | 34,078,720 B | 33,144,832 B (−2.7%) |
+
+The whole-file delta is diluted by the 24.7 MB of raw plugin wasm in
+binary_cas.chunk (a separate, pending optimization); against the
+non-bcas remainder this is −10%.
+
+The tracked_state_crud 1k bench moves the other way, deliberately:
+insert written bytes 436,472 → 437,472 (+0.23%). Its entity ids are
+synthetic labels ("row-00001"), so every record pays the text tag and
+nothing packs. The empty-length-marker encoding that would make text
+free was rejected because empty id strings are currently legal
+(EntityPk validates the parts list, not part contents), making the
+marker ambiguous. Real workloads key on lix_uuid_v7() defaults.
+
+No version gate: shipped inside the current breaking window alongside
+format v3. Suites: engine 972 lib + integration all green, sdk green.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1867,3 +1867,55 @@ v3 file with the old record encoding exists outside this branch. A
 pre-packing record read by the new decoder fails loudly ("unknown id
 string tag 36"). Suites: engine 972 lib + integration all green, sdk
 green.
+
+## 2026-06-11 — Commit Change Ref Chunks Carry Ids Only
+
+Ref-chunk entries duplicated each change's schema_key, file_id, and
+entity_pk next to its change id, served by a dictionary-encoding plus
+front-coding plus NUL-escaping codec. Both production readers of those
+fields are covered without them: commit-root rebuild loads the full
+change records anyway and used the chunk copy only as a cross-check,
+and diff validation's commit-ref winners now batch point-reads the
+change records (the standard single-copy pattern). A chunk entry is
+now the raw 16-byte change id, sorted ascending, split at 2048 entries
+per chunk; decode rejects unknown chunk format versions explicitly.
+The front-coding codec, its size-estimating builder, the chunk
+dictionaries, and the now-orphaned vec_option storage codec are
+deleted (-900 lines net in the diff; format_version field kept per
+scope).
+
+Storage, 1k accounting (lix_sqlite, transaction layer):
+
+| | fields in chunks | ids only |
+|---|---|---|
+| insert_all written bytes | 437,472 | 423,200 (−3.3%) |
+| update_all written bytes | 540,284 | 526,013 (−2.6%) |
+| delete_all written bytes | 183,497 | 169,226 (−7.8%) |
+| ref chunk value bytes | 30,823 | 16,261 (−47%) |
+
+e2e 10k merge fixture: ref chunk payload 643,617 → 320,486 B (−50%),
+whole file 10,010,624 → 9,682,944 B. changelog.change unchanged.
+
+Perf A/B (stash-alternating, criterion):
+
+| bench | fields in chunks | ids only |
+|---|---|---|
+| merge_10k | 187.5 ms | 182.5 ms (≈−2.7%, p = 0.11) |
+| insert_all 10k | 87.3 / 80.6 ms | 73.3 / 75.6 / 72.2 ms (−9 to −12%; clean pair −10.4%, p = 0.00) |
+| update_all 10k | 87.3 ms | 84.9 ms (−2.8%, p = 0.00) |
+| delete_all 10k | 79.9 ms | 77.4 ms (−3.2%, p = 0.00) |
+| read_one_by_pk 10k | 141.4 / 177.6 µs | 173.6 / 166.9 µs (inconclusive at this spread, p = 0.28 on rematch; mechanism predicts parity — reads never touch ref chunks) |
+| smoke suite (1k) | — | parity within noise |
+
+The bulk-write speedups come from deleting per-commit work that scaled
+with change count: the identity-tuple sort over (String, Option,
+EntityPk) keys, per-entry front-coding allocations and prefix scans,
+and ref-struct construction (the identity uniqueness check still reads
+the same fields at validation, now via borrowed keys). read_one_by_pk
+initially looked ±20% in both directions across runs; a third run at
+p = 0.28 showed the spread is process-level noise at the ~150 µs
+scale, not an effect.
+
+Read-path cost added: diff/commit-root validation loads change records
+for a commit's ref list instead of reading identities from the chunk —
+batched point reads on a validation path, not on live reads.

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -5,9 +5,8 @@
 use super::context::ChangelogContext;
 use super::store::{ChangelogReader, ChangelogWriter};
 use super::types::{
-    ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogAppend, CommitChangeRef,
-    CommitChangeRefSet, CommitId, CommitLoadRequest, CommitProjection, CommitRecord, GcPlan,
-    GcRoot, RebuildIndexStats,
+    ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogAppend, CommitChangeRefSet, CommitId,
+    CommitLoadRequest, CommitProjection, CommitRecord, GcPlan, GcRoot, RebuildIndexStats,
 };
 use crate::LixError;
 use crate::entity_pk::EntityPk;
@@ -638,12 +637,7 @@ fn direct_append_with_shape(
                     "2026-05-20T00:00:00Z",
                 ),
             });
-            refs.push(CommitChangeRef {
-                schema_key: "message".to_string(),
-                file_id: None,
-                entity_pk,
-                change_id: typed_change_id,
-            });
+            refs.push(typed_change_id);
             next_change += 1;
         }
         append.commits.push(CommitRecord {

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -1,7 +1,6 @@
 use super::types::{
-    ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRef,
-    CommitChangeRefChunk, CommitChangeRefChunkRef, CommitChangeRefChunkView,
-    CommitChangeRefEntryRef, CommitChangeRefEntryView, CommitId, CommitRecord,
+    ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRefChunk,
+    CommitChangeRefChunkWire, CommitChangeRefChunkWireRef, CommitId, CommitRecord,
 };
 use crate::common::LixError;
 use crate::entity_pk::EntityPk;
@@ -51,248 +50,33 @@ pub(crate) fn decode_change_record(
 pub(crate) fn encode_commit_change_ref_chunk(
     chunk: &CommitChangeRefChunk,
 ) -> Result<Vec<u8>, LixError> {
-    let schema_keys = commit_change_ref_schema_dictionary(&chunk.entries);
-    let file_ids = commit_change_ref_file_dictionary(&chunk.entries);
-    // Entity pks are stored front-coded against the previous entry's encoded
-    // pk; the chunker sorts entries, so consecutive pks share long prefixes.
-    // Correctness does not depend on sortedness: unsorted input only loses
-    // compression (shared prefix collapses toward zero).
-    let encoded_pks = chunk
-        .entries
-        .iter()
-        .map(|entry| encode_ref_entity_pk(&entry.entity_pk.parts))
-        .collect::<Vec<_>>();
-    let mut entries = Vec::with_capacity(chunk.entries.len());
-    let mut previous_pk: &[u8] = &[];
-    for (entry, pk_bytes) in chunk.entries.iter().zip(&encoded_pks) {
-        let schema_index = dictionary_index(
-            schema_keys.iter().copied(),
-            entry.schema_key.as_str(),
-            "commit change ref schema dictionary",
-        )?;
-        let file_index = optional_dictionary_index(
-            file_ids.iter().copied(),
-            entry.file_id.as_deref(),
-            "commit change ref file dictionary",
-        )?;
-        let shared = shared_prefix_len(previous_pk, pk_bytes);
-        entries.push(CommitChangeRefEntryRef {
-            schema_index: u16_index(schema_index, "commit change ref schema index")?,
-            file_index: u16_index(file_index, "commit change ref file index")?,
-            pk_shared: u32::try_from(shared).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "commit change ref shared pk length exceeds u32",
-                )
-            })?,
-            pk_suffix: &pk_bytes[shared..],
-            change_id: entry.change_id,
-        });
-        previous_pk = pk_bytes;
-    }
     storage_codec::encode(
         "commit change ref chunk",
-        &CommitChangeRefChunkRef {
+        &CommitChangeRefChunkWireRef {
             format_version: chunk.format_version,
-            schema_keys,
-            file_ids,
-            entries,
+            entries: &chunk.entries,
         },
     )
-}
-
-pub(crate) fn shared_prefix_len(left: &[u8], right: &[u8]) -> usize {
-    left.iter().zip(right).take_while(|(l, r)| l == r).count()
-}
-
-/// Length-free entity-pk byte encoding for front-coding.
-///
-/// Length-prefixed encodings put a varying length byte ahead of the content,
-/// which truncates prefix sharing between same-shaped pks of different
-/// lengths. Instead, each part's bytes are emitted with `0x00` escaped as
-/// `0x00 0xFF` and the part terminated by `0x00 0x01`, so byte-prefix
-/// sharing equals content-prefix sharing.
-pub(crate) fn encode_ref_entity_pk(parts: &[String]) -> Vec<u8> {
-    // An empty parts list encodes to zero bytes, which decode rejects via
-    // EntityPk validation; all constructors validate, this catches bypasses.
-    debug_assert!(!parts.is_empty(), "entity pk parts must not be empty");
-    let mut out = Vec::with_capacity(parts.iter().map(|part| part.len() + 2).sum());
-    for part in parts {
-        for &byte in part.as_bytes() {
-            if byte == 0 {
-                out.extend_from_slice(&[0x00, 0xFF]);
-            } else {
-                out.push(byte);
-            }
-        }
-        out.extend_from_slice(&[0x00, 0x01]);
-    }
-    out
-}
-
-fn decode_ref_entity_pk(context: &str, bytes: &[u8]) -> Result<Vec<String>, LixError> {
-    let mut parts = Vec::new();
-    let mut current = Vec::new();
-    let mut offset = 0usize;
-    while offset < bytes.len() {
-        let byte = bytes[offset];
-        offset += 1;
-        if byte != 0 {
-            current.push(byte);
-            continue;
-        }
-        match bytes.get(offset) {
-            Some(0xFF) => {
-                current.push(0);
-                offset += 1;
-            }
-            Some(0x01) => {
-                offset += 1;
-                let part = String::from_utf8(std::mem::take(&mut current)).map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!("changelog {context} entity pk part is not UTF-8"),
-                    )
-                })?;
-                parts.push(part);
-            }
-            _ => {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("changelog {context} entity pk has an invalid escape"),
-                ));
-            }
-        }
-    }
-    if !current.is_empty() {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("changelog {context} entity pk has an unterminated part"),
-        ));
-    }
-    Ok(parts)
 }
 
 pub(crate) fn decode_commit_change_ref_chunk(
     bytes: &[u8],
     commit_id: CommitId,
 ) -> Result<CommitChangeRefChunk, LixError> {
-    let CommitChangeRefChunkView {
-        format_version,
-        schema_keys,
-        file_ids,
-        entries: storage_entries,
-    } = storage_codec::decode("commit change ref chunk", bytes)?;
-    let mut entries = Vec::with_capacity(storage_entries.len());
-    let mut previous_pk: Vec<u8> = Vec::new();
-    for (index, entry) in storage_entries.into_iter().enumerate() {
-        let context = format!("commit change ref entries[{index}]");
-        let CommitChangeRefEntryView {
-            schema_index,
-            file_index,
-            pk_shared,
-            pk_suffix,
-            change_id,
-        } = entry;
-        let schema_index = schema_index as usize;
-        let file_index = file_index as usize;
-        let schema_key = *schema_keys.get(schema_index).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("changelog {context}.schema_index is out of bounds"),
-            )
-        })?;
-        let file_id = *file_ids.get(file_index).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("changelog {context}.file_index is out of bounds"),
-            )
-        })?;
-        let shared = pk_shared as usize;
-        if shared > previous_pk.len() {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("changelog {context}.pk_shared exceeds the previous entity pk length"),
-            ));
-        }
-        let mut pk_bytes = Vec::with_capacity(shared + pk_suffix.len());
-        pk_bytes.extend_from_slice(&previous_pk[..shared]);
-        pk_bytes.extend_from_slice(pk_suffix);
-        let parts = decode_ref_entity_pk(&context, &pk_bytes)?;
-        let entity_pk = EntityPk::from_parts(parts).map_err(|error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("changelog {context} entity primary key is invalid: {error}"),
-            )
-        })?;
-        entries.push(CommitChangeRef {
-            schema_key: schema_key.to_string(),
-            file_id: file_id.map(str::to_string),
-            entity_pk,
-            change_id,
-        });
-        previous_pk = pk_bytes;
+    let wire: CommitChangeRefChunkWire = storage_codec::decode("commit change ref chunk", bytes)?;
+    if wire.format_version != super::context::COMMIT_CHANGE_REF_CHUNK_FORMAT_VERSION {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "commit change ref chunk has unsupported format version {}",
+                wire.format_version
+            ),
+        ));
     }
     Ok(CommitChangeRefChunk {
-        format_version,
+        format_version: wire.format_version,
         commit_id,
-        entries,
-    })
-}
-
-fn commit_change_ref_schema_dictionary(entries: &[CommitChangeRef]) -> Vec<&str> {
-    let mut values = Vec::new();
-    for entry in entries {
-        if !values.contains(&entry.schema_key.as_str()) {
-            values.push(entry.schema_key.as_str());
-        }
-    }
-    values
-}
-
-fn commit_change_ref_file_dictionary(entries: &[CommitChangeRef]) -> Vec<Option<&str>> {
-    let mut values = Vec::new();
-    for entry in entries {
-        let value = entry.file_id.as_deref();
-        if !values.contains(&value) {
-            values.push(value);
-        }
-    }
-    values
-}
-
-fn dictionary_index<'a>(
-    mut values: impl Iterator<Item = &'a str>,
-    needle: &str,
-    context: &str,
-) -> Result<usize, LixError> {
-    values.position(|value| value == needle).ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("changelog {context} is missing value '{needle}'"),
-        )
-    })
-}
-
-fn optional_dictionary_index<'a>(
-    mut values: impl Iterator<Item = Option<&'a str>>,
-    needle: Option<&str>,
-    context: &str,
-) -> Result<usize, LixError> {
-    values.position(|value| value == needle).ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("changelog {context} is missing optional value"),
-        )
-    })
-}
-
-fn u16_index(value: usize, context: &str) -> Result<u16, LixError> {
-    u16::try_from(value).map_err(|_| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("changelog {context} exceeds u16"),
-        )
+        entries: wire.entries,
     })
 }
 
@@ -312,7 +96,7 @@ mod tests {
     use crate::common::LixTimestamp;
     use crate::json_store::{JsonRef, JsonSlot};
 
-    fn ref_chunk(entries: Vec<CommitChangeRef>) -> CommitChangeRefChunk {
+    fn ref_chunk(entries: Vec<ChangeId>) -> CommitChangeRefChunk {
         CommitChangeRefChunk {
             format_version: 1,
             commit_id: CommitId::for_test_label("ref-chunk-commit"),
@@ -320,96 +104,12 @@ mod tests {
         }
     }
 
-    fn ref_entry(
-        schema: &str,
-        file: Option<&str>,
-        parts: &[&str],
-        change: &str,
-    ) -> CommitChangeRef {
-        CommitChangeRef {
-            schema_key: schema.to_string(),
-            file_id: file.map(str::to_string),
-            entity_pk: EntityPk::from_parts(parts.iter().map(ToString::to_string).collect())
-                .expect("entity pk should build"),
-            change_id: ChangeId::for_test_label(change),
-        }
-    }
-
     #[test]
-    fn ref_chunk_round_trips_front_coded_entity_pks() {
-        // Sorted, prefix-heavy single-part pks plus multi-part and unicode
-        // entries; mixed file ids exercise both dictionaries.
-        let mut entries = vec![
-            ref_entry(
-                "schema_a",
-                Some("file-1"),
-                &["/packages/0001/version"],
-                "c1",
-            ),
-            ref_entry(
-                "schema_a",
-                Some("file-1"),
-                &["/packages/0002/version"],
-                "c2",
-            ),
-            ref_entry(
-                "schema_a",
-                Some("file-2"),
-                &["/packages/0002/version"],
-                "c3",
-            ),
-            ref_entry("schema_b", None, &["ns", "42"], "c4"),
-            ref_entry("schema_b", None, &["ns", "43"], "c5"),
-            ref_entry("schema_b", None, &["sch\u{00e9}ma-\u{4e2d}"], "c6"),
-        ];
-        entries.sort_by(|l, r| {
-            (l.schema_key.as_str(), l.file_id.as_deref(), &l.entity_pk).cmp(&(
-                r.schema_key.as_str(),
-                r.file_id.as_deref(),
-                &r.entity_pk,
-            ))
-        });
-        let chunk = ref_chunk(entries);
-        let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
-        let decoded =
-            decode_commit_change_ref_chunk(&encoded, chunk.commit_id).expect("chunk should decode");
-        assert_eq!(decoded, chunk);
-    }
-
-    #[test]
-    fn ref_chunk_front_coding_compresses_sorted_prefix_heavy_pks() {
-        let entries = (0..500usize)
-            .map(|index| {
-                ref_entry(
-                    "json_pointer",
-                    Some("pnpm-lock"),
-                    &[&format!("/packages/{index:04}/resolution/integrity")],
-                    &format!("change-{index:04}"),
-                )
-            })
-            .collect::<Vec<_>>();
-        let chunk = ref_chunk(entries);
-        let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
-        // Each pk encodes to 37 bytes (35 content + terminator); adjacent
-        // sorted pks share a ~13-byte head (the identical tail is not
-        // prefix-sharable), so the front-coded form must shed at least 7
-        // bytes per entry against the ~55-byte verbatim entry footprint.
-        let decoded =
-            decode_commit_change_ref_chunk(&encoded, chunk.commit_id).expect("chunk should decode");
-        assert_eq!(decoded, chunk);
-        assert!(
-            encoded.len() < 500 * 48,
-            "front coding must compress sorted pks: encoded={}",
-            encoded.len()
-        );
-    }
-
-    #[test]
-    fn ref_chunk_round_trips_unsorted_entries_without_compression() {
-        // Correctness must not depend on sortedness.
+    fn ref_chunk_round_trips_change_ids() {
         let chunk = ref_chunk(vec![
-            ref_entry("schema_b", None, &["zzz"], "c1"),
-            ref_entry("schema_a", Some("file-1"), &["aaa"], "c2"),
+            ChangeId::for_test_label("change-a"),
+            ChangeId::for_test_label("change-b"),
+            ChangeId::for_test_label("change-c"),
         ]);
         let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
         let decoded =
@@ -417,221 +117,60 @@ mod tests {
         assert_eq!(decoded, chunk);
     }
 
-    /// Pins the stored entry layout. Drift in the front-coding (e.g. a
-    /// different pk byte encoding) silently changes every persisted chunk.
+    #[test]
+    fn ref_chunk_round_trips_empty_entries() {
+        let chunk = ref_chunk(Vec::new());
+        let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
+        let decoded =
+            decode_commit_change_ref_chunk(&encoded, chunk.commit_id).expect("chunk should decode");
+        assert_eq!(decoded, chunk);
+    }
+
     #[test]
     fn ref_chunk_wire_format_is_pinned() {
-        let chunk = ref_chunk(vec![
-            ref_entry("s", None, &["abc"], "pin-1"),
-            ref_entry("s", None, &["abd"], "pin-2"),
-        ]);
+        // Persisted layout: varint format_version, varint entry count, then
+        // 16 raw uuid bytes per entry (ChangeId encodes via encode_array).
+        let id = ChangeId::parse("019eb805-60d0-71c0-ade3-b0f0efab9d9a").expect("uuid");
+        let chunk = ref_chunk(vec![id]);
         let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
-        let change_1 = ChangeId::for_test_label("pin-1");
-        let change_2 = ChangeId::for_test_label("pin-2");
-        let mut expected = vec![
-            1, // format_version
-            1, 1, b's', // schema dictionary: ["s"]
-            1, 0, // file dictionary: [None]
-            2, // entry count
-            // entry 0: schema 0, file 0, pk_shared 0,
-            // suffix "abc" + part terminator 0x00 0x01
-            0, 0, 0, 5, b'a', b'b', b'c', 0x00, 0x01,
-        ];
-        expected.extend_from_slice(change_1.as_uuid().as_bytes());
-        // entry 1: schema 0, file 0, pk_shared 2 ("ab"), suffix "d" + terminator
-        expected.extend_from_slice(&[0, 0, 2, 3, b'd', 0x00, 0x01]);
-        expected.extend_from_slice(change_2.as_uuid().as_bytes());
-        assert_eq!(encoded, expected, "ref chunk wire bytes must stay stable");
+        let expected: Vec<u8> = [
+            &[1u8][..], // format_version
+            &[1u8][..], // entry count
+            &[
+                0x01, 0x9e, 0xb8, 0x05, 0x60, 0xd0, 0x71, 0xc0, 0xad, 0xe3, 0xb0, 0xf0, 0xef, 0xab,
+                0x9d, 0x9a,
+            ][..],
+        ]
+        .concat();
+        assert_eq!(encoded, expected);
     }
 
     #[test]
-    fn ref_chunk_round_trips_nul_bytes_in_pk_parts() {
-        // Embedded 0x00 exercises the escape; an empty part exercises the
-        // bare terminator.
-        let chunk = ref_chunk(vec![ref_entry(
-            "s",
-            None,
-            &["a\u{0}b", "", "plain"],
-            "nul-change",
-        )]);
-        let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
-        let decoded =
-            decode_commit_change_ref_chunk(&encoded, chunk.commit_id).expect("chunk should decode");
-        assert_eq!(decoded, chunk);
-    }
-
-    #[test]
-    fn ref_chunk_rejects_truncated_pk_escape() {
-        // A pk ending mid-escape (bare trailing 0x00) must be rejected.
-        let bogus = CommitChangeRefChunkRef {
-            format_version: 1,
-            schema_keys: vec!["s"],
-            file_ids: vec![None],
-            entries: vec![CommitChangeRefEntryRef {
-                schema_index: 0,
-                file_index: 0,
-                pk_shared: 0,
-                pk_suffix: &[b'a', 0x00],
-                change_id: ChangeId::for_test_label("bogus"),
-            }],
+    fn ref_chunk_decode_rejects_unknown_format_version() {
+        let chunk = CommitChangeRefChunk {
+            format_version: 2,
+            commit_id: CommitId::for_test_label("ref-chunk-commit"),
+            entries: vec![ChangeId::for_test_label("change-a")],
         };
-        let bytes = storage_codec::encode("test chunk", &bogus).expect("should encode");
-        let error =
-            decode_commit_change_ref_chunk(&bytes, CommitId::for_test_label("ref-chunk-commit"))
-                .expect_err("truncated escape must reject");
-        assert!(error.message.contains("invalid escape"));
-    }
-
-    /// Pins the escape bytes themselves: 0x00 content escapes to 0x00 0xFF.
-    #[test]
-    fn ref_chunk_escape_wire_format_is_pinned() {
-        let chunk = ref_chunk(vec![ref_entry("s", None, &["a\u{0}b"], "esc-pin")]);
         let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
-        let change = ChangeId::for_test_label("esc-pin");
-        let mut expected = vec![
-            1, // format_version
-            1, 1, b's', // schema dictionary
-            1, 0, // file dictionary
-            1, // entry count
-            // pk_shared 0, suffix: 'a', escaped NUL, 'b', part terminator
-            0, 0, 0, 6, b'a', 0x00, 0xFF, b'b', 0x00, 0x01,
-        ];
-        expected.extend_from_slice(change.as_uuid().as_bytes());
-        assert_eq!(encoded, expected, "escape wire bytes must stay stable");
-    }
-
-    #[test]
-    fn ref_chunk_round_trips_escape_edge_cases() {
-        // Part "\0" alone, trailing NUL, consecutive NULs, and 0x01 as plain
-        // content; the x-entries' shared prefix splits the previous pk's
-        // escape pair between 0x00 and 0xFF.
-        let chunk = ref_chunk(vec![
-            ref_entry("s", None, &["\u{0}"], "e1"),
-            ref_entry("s", None, &["\u{0}\u{0}"], "e2"),
-            ref_entry("s", None, &["a\u{0}"], "e3"),
-            ref_entry("s", None, &["a\u{1}b"], "e4"),
-            ref_entry("s", None, &["x\u{0}"], "e5"),
-            ref_entry("s", None, &["x"], "e6"),
-        ]);
-        let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
-        let decoded =
-            decode_commit_change_ref_chunk(&encoded, chunk.commit_id).expect("chunk should decode");
-        assert_eq!(decoded, chunk);
-    }
-
-    #[test]
-    fn ref_chunk_rejects_non_utf8_pk_part() {
-        // 0xFF as plain content can never come from the encoder (parts are
-        // UTF-8 strings); a crafted suffix must fail the UTF-8 check.
-        let bogus = CommitChangeRefChunkRef {
-            format_version: 1,
-            schema_keys: vec!["s"],
-            file_ids: vec![None],
-            entries: vec![CommitChangeRefEntryRef {
-                schema_index: 0,
-                file_index: 0,
-                pk_shared: 0,
-                pk_suffix: &[0xFF, 0x00, 0x01],
-                change_id: ChangeId::for_test_label("bogus"),
-            }],
-        };
-        let bytes = storage_codec::encode("test chunk", &bogus).expect("should encode");
-        let error =
-            decode_commit_change_ref_chunk(&bytes, CommitId::for_test_label("ref-chunk-commit"))
-                .expect_err("non-UTF-8 part must reject");
-        assert!(error.message.contains("is not UTF-8"));
-    }
-
-    #[test]
-    fn ref_chunk_rejects_out_of_bounds_dictionary_indices() {
-        for (schema_index, file_index) in [(7u16, 0u16), (0, 7)] {
-            let bogus = CommitChangeRefChunkRef {
-                format_version: 1,
-                schema_keys: vec!["s"],
-                file_ids: vec![None],
-                entries: vec![CommitChangeRefEntryRef {
-                    schema_index,
-                    file_index,
-                    pk_shared: 0,
-                    pk_suffix: &[b'k', 0x00, 0x01],
-                    change_id: ChangeId::for_test_label("bogus"),
-                }],
-            };
-            let bytes = storage_codec::encode("test chunk", &bogus).expect("should encode");
-            let error = decode_commit_change_ref_chunk(
-                &bytes,
-                CommitId::for_test_label("ref-chunk-commit"),
-            )
-            .expect_err("out-of-bounds dictionary index must reject");
-            assert!(error.message.contains("is out of bounds"));
-        }
-    }
-
-    #[test]
-    fn ref_chunk_rejects_adversarial_extreme_shared_len() {
-        // The over-share guard must fire before any allocation at u32::MAX.
-        let extreme = CommitChangeRefChunkRef {
-            format_version: 1,
-            schema_keys: vec!["s"],
-            file_ids: vec![None],
-            entries: vec![CommitChangeRefEntryRef {
-                schema_index: 0,
-                file_index: 0,
-                pk_shared: u32::MAX,
-                pk_suffix: b"",
-                change_id: ChangeId::for_test_label("bogus"),
-            }],
-        };
-        let bytes = storage_codec::encode("test chunk", &extreme).expect("should encode");
+        let error = decode_commit_change_ref_chunk(&encoded, chunk.commit_id)
+            .expect_err("unknown format version should fail decode");
         assert!(
-            decode_commit_change_ref_chunk(&bytes, CommitId::for_test_label("ref-chunk-commit"))
-                .is_err()
+            error.message.contains("unsupported format version 2"),
+            "{}",
+            error.message
         );
     }
 
     #[test]
-    fn ref_chunk_rejects_empty_pk() {
-        // A zero-byte pk decodes to an empty parts list, which EntityPk
-        // validation must reject.
-        let bogus = CommitChangeRefChunkRef {
-            format_version: 1,
-            schema_keys: vec!["s"],
-            file_ids: vec![None],
-            entries: vec![CommitChangeRefEntryRef {
-                schema_index: 0,
-                file_index: 0,
-                pk_shared: 0,
-                pk_suffix: b"",
-                change_id: ChangeId::for_test_label("bogus"),
-            }],
-        };
-        let bytes = storage_codec::encode("test chunk", &bogus).expect("should encode");
-        let error =
-            decode_commit_change_ref_chunk(&bytes, CommitId::for_test_label("ref-chunk-commit"))
-                .expect_err("empty pk must reject");
-        assert!(error.message.contains("entity primary key is invalid"));
-    }
-
-    #[test]
-    fn ref_chunk_rejects_over_shared_pk() {
-        // First entry cannot share bytes with a non-existent predecessor.
-        let bogus = CommitChangeRefChunkRef {
-            format_version: 1,
-            schema_keys: vec!["s"],
-            file_ids: vec![None],
-            entries: vec![CommitChangeRefEntryRef {
-                schema_index: 0,
-                file_index: 0,
-                pk_shared: 4,
-                pk_suffix: b"",
-                change_id: ChangeId::for_test_label("bogus"),
-            }],
-        };
-        let bytes = storage_codec::encode("test chunk", &bogus).expect("should encode");
-        let error =
-            decode_commit_change_ref_chunk(&bytes, CommitId::for_test_label("ref-chunk-commit"))
-                .expect_err("over-shared pk must reject");
-        assert!(error.message.contains("pk_shared exceeds"));
+    fn ref_chunk_takes_commit_identity_from_the_decode_argument() {
+        // The stored value omits commit_id; it lives in the storage key.
+        let chunk = ref_chunk(vec![ChangeId::for_test_label("change-a")]);
+        let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
+        let other = CommitId::for_test_label("other-commit");
+        let decoded = decode_commit_change_ref_chunk(&encoded, other).expect("chunk should decode");
+        assert_eq!(decoded.commit_id, other);
+        assert_eq!(decoded.entries, chunk.entries);
     }
 
     fn full_record() -> ChangeRecord {

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -711,8 +711,8 @@ mod tests {
         };
         let text_encoded = encode_change_record(&text_only).expect("record should encode");
         assert!(
-            encoded.len() + 38 <= text_encoded.len(),
-            "uuid arm should save ~19 bytes per id ({} vs {})",
+            encoded.len() + 40 <= text_encoded.len(),
+            "uuid arm should save 20 bytes per id ({} vs {})",
             encoded.len(),
             text_encoded.len()
         );

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -1,7 +1,7 @@
 use super::types::{
     ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRef,
     CommitChangeRefChunk, CommitChangeRefChunkRef, CommitChangeRefChunkView,
-    CommitChangeRefEntryRef, CommitChangeRefEntryView, CommitId, CommitRecord, EntityPkRef,
+    CommitChangeRefEntryRef, CommitChangeRefEntryView, CommitId, CommitRecord,
 };
 use crate::common::LixError;
 use crate::entity_pk::EntityPk;
@@ -40,8 +40,8 @@ pub(crate) fn decode_change_record(
         format_version: view.format_version,
         change_id,
         schema_key: view.schema_key.to_string(),
-        entity_pk: entity_pk_from_ref(view.entity_pk)?,
-        file_id: view.file_id.map(str::to_string),
+        entity_pk: entity_pk_from_parts(view.entity_pk)?,
+        file_id: view.file_id,
         snapshot: view.snapshot,
         metadata: view.metadata,
         created_at: view.created_at,
@@ -296,15 +296,13 @@ fn u16_index(value: usize, context: &str) -> Result<u16, LixError> {
     })
 }
 
-fn entity_pk_from_ref(value: EntityPkRef<'_>) -> Result<EntityPk, LixError> {
-    EntityPk::from_parts(value.parts.iter().map(|part| (*part).to_string()).collect()).map_err(
-        |error| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("changelog entity primary key is invalid: {error}"),
-            )
-        },
-    )
+fn entity_pk_from_parts(parts: Vec<String>) -> Result<EntityPk, LixError> {
+    EntityPk::from_parts(parts).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("changelog entity primary key is invalid: {error}"),
+        )
+    })
 }
 
 #[cfg(test)]
@@ -681,6 +679,59 @@ mod tests {
             file_id: None,
             snapshot: JsonSlot::None,
             metadata: JsonSlot::None,
+            ..full_record()
+        };
+        let encoded = encode_change_record(&record).expect("record should encode");
+        let decoded =
+            decode_change_record(&encoded, record.change_id).expect("record should decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn change_record_packs_canonical_uuid_ids_and_round_trips() {
+        // Canonical lowercase UUID entity pks and file ids take the 16-byte
+        // arm; the record must round-trip to the identical text form and be
+        // smaller than the unpacked text encoding.
+        let record = ChangeRecord {
+            entity_pk: EntityPk::from_parts(vec![
+                "019eb805-60d0-71c0-ade3-b0f0efab9d9a".to_string(),
+            ])
+            .expect("entity pk should build"),
+            file_id: Some("019eb805-5e65-7270-861d-cb341bc904c8".to_string()),
+            ..full_record()
+        };
+        let encoded = encode_change_record(&record).expect("record should encode");
+        let text_only = ChangeRecord {
+            entity_pk: EntityPk::from_parts(vec![
+                "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A".to_string(),
+            ])
+            .expect("entity pk should build"),
+            file_id: Some("019EB805-5E65-7270-861D-CB341BC904C8".to_string()),
+            ..full_record()
+        };
+        let text_encoded = encode_change_record(&text_only).expect("record should encode");
+        assert!(
+            encoded.len() + 38 <= text_encoded.len(),
+            "uuid arm should save ~19 bytes per id ({} vs {})",
+            encoded.len(),
+            text_encoded.len()
+        );
+        let decoded =
+            decode_change_record(&encoded, record.change_id).expect("record should decode");
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn change_record_keeps_non_canonical_ids_as_text() {
+        // Uppercase hex re-hyphenates differently, so it must stay text to
+        // round-trip byte-identically; same for arbitrary plugin keys.
+        let record = ChangeRecord {
+            entity_pk: EntityPk::from_parts(vec![
+                "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A".to_string(),
+                "row 5 of sheet 2".to_string(),
+            ])
+            .expect("entity pk should build"),
+            file_id: Some("not-a-uuid".to_string()),
             ..full_record()
         };
         let encoded = encode_change_record(&record).expect("record should encode");

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -24,9 +24,9 @@ use super::store::{
 };
 use crate::changelog::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeScanBatch, ChangeScanRequest,
-    ChangelogAppend, ChangelogReader, ChangelogWriter, CommitChangeRef, CommitChangeRefChunk,
-    CommitChangeRefSet, CommitId, CommitLoadBatch, CommitLoadEntry, CommitLoadRequest,
-    CommitProjection, CommitRecord, CommitScanBatch, CommitScanRequest, GcPlan, GcRoot,
+    ChangelogAppend, ChangelogReader, ChangelogWriter, CommitChangeRefChunk, CommitChangeRefSet,
+    CommitId, CommitLoadBatch, CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitRecord,
+    CommitScanBatch, CommitScanRequest, GcPlan, GcRoot,
 };
 use crate::json_store::JsonSlot;
 use crate::storage::{
@@ -36,9 +36,7 @@ use crate::storage::{
 };
 use crate::{LixError, storage_codec};
 
-const COMMIT_CHANGE_REF_CHUNK_FORMAT_VERSION: u32 = 1;
-const COMMIT_CHANGE_REF_CHUNK_TARGET_BYTES: usize = 64 * 1024;
-const COMMIT_CHANGE_REF_CHUNK_MAX_BYTES: usize = 128 * 1024;
+pub(super) const COMMIT_CHANGE_REF_CHUNK_FORMAT_VERSION: u32 = 1;
 const COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES: usize = 2048;
 const SCAN_PAGE_LIMIT: usize = 1024;
 
@@ -335,7 +333,7 @@ where
             self.staged_changes.insert(change.change_id, change);
         }
 
-        let chunks = chunk_commit_change_refs(append.commit_change_refs)?;
+        let chunks = chunk_commit_change_refs(append.commit_change_refs);
         for commit in append.commits {
             self.writes.put(
                 COMMIT_SPACE,
@@ -426,7 +424,6 @@ where
                     refs.commit_id
                 )));
             }
-            validate_unique_ref_keys(&refs.entries, &refs.commit_id)?;
             self.validate_change_refs(refs, &append_changes).await?;
         }
 
@@ -557,6 +554,9 @@ where
         Ok(())
     }
 
+    /// Every ref must resolve to a change record (in this append, already
+    /// staged, or stored), and no two refs in one commit may target the same
+    /// (schema_key, file_id, entity_pk) identity.
     async fn validate_change_refs(
         &mut self,
         refs: &CommitChangeRefSet,
@@ -565,26 +565,37 @@ where
         let missing_from_append = refs
             .entries
             .iter()
-            .filter(|entry| !append_changes.contains_key(&entry.change_id))
-            .map(|entry| entry.change_id)
+            .filter(|change_id| !append_changes.contains_key(change_id))
+            .copied()
             .collect::<HashSet<_>>();
         let stored = self
             .load_stored_changes(missing_from_append.iter().copied())
             .await?;
 
-        for entry in &refs.entries {
+        let mut seen_identities = HashSet::new();
+        for change_id in &refs.entries {
             let change = append_changes
-                .get(&entry.change_id)
+                .get(change_id)
                 .copied()
-                .or_else(|| self.staged_changes.get(&entry.change_id))
-                .or_else(|| stored.get(&entry.change_id))
+                .or_else(|| self.staged_changes.get(change_id))
+                .or_else(|| stored.get(change_id))
                 .ok_or_else(|| {
                     LixError::unknown(format!(
                         "changelog commit '{}' references missing change '{}'",
-                        refs.commit_id, entry.change_id
+                        refs.commit_id, change_id
                     ))
                 })?;
-            validate_ref_matches_change(&refs.commit_id, entry, change)?;
+            let identity = (
+                change.schema_key.as_str(),
+                change.file_id.as_deref(),
+                &change.entity_pk,
+            );
+            if !seen_identities.insert(identity) {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{}' has duplicate change ref key",
+                    refs.commit_id
+                )));
+            }
         }
         Ok(())
     }
@@ -824,206 +835,41 @@ fn commit_entry_id(entry: &CommitLoadEntry) -> Option<CommitId> {
 
 fn chunk_commit_change_refs(
     refs: Vec<CommitChangeRefSet>,
-) -> Result<HashMap<CommitId, Vec<CommitChangeRefChunk>>, LixError> {
+) -> HashMap<CommitId, Vec<CommitChangeRefChunk>> {
     refs.into_iter()
         .map(|refs| {
             let commit_id = refs.commit_id;
-            Ok((
+            (
                 commit_id,
-                chunk_one_commit_change_refs(
-                    refs,
-                    COMMIT_CHANGE_REF_CHUNK_TARGET_BYTES,
-                    COMMIT_CHANGE_REF_CHUNK_MAX_BYTES,
-                    COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES,
-                )?,
-            ))
+                chunk_one_commit_change_refs(refs, COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES),
+            )
         })
         .collect()
 }
 
+/// Each entry is a fixed 16 raw bytes on the wire, so chunking is a plain
+/// fixed-capacity split over the change ids, sorted ascending for
+/// deterministic output.
 fn chunk_one_commit_change_refs(
     mut refs: CommitChangeRefSet,
-    target_bytes: usize,
-    max_bytes: usize,
     max_entries: usize,
-) -> Result<Vec<CommitChangeRefChunk>, LixError> {
-    refs.entries.sort_by(|left, right| {
-        (
-            left.schema_key.as_str(),
-            left.file_id.as_deref(),
-            &left.entity_pk,
-            left.change_id,
-        )
-            .cmp(&(
-                right.schema_key.as_str(),
-                right.file_id.as_deref(),
-                &right.entity_pk,
-                right.change_id,
-            ))
-    });
-
-    let mut chunks = Vec::new();
-    let mut builder = CommitChangeRefChunkBuilder::new(refs.commit_id);
-    for entry in refs.entries {
-        // The encoded pk is entry-intrinsic; encode once per entry and share
-        // it between the close decision and the accepted push.
-        let encoded_pk = super::codec::encode_ref_entity_pk(&entry.entity_pk.parts);
-        let candidate_size = builder.estimated_size_after(&entry, &encoded_pk);
-        if !builder.is_empty()
-            && (builder.len() >= max_entries
-                || builder.estimated_size() >= target_bytes
-                || candidate_size > max_bytes)
-        {
-            chunks.push(builder.finish()?);
-            builder = CommitChangeRefChunkBuilder::new(refs.commit_id);
-        }
-
-        builder.push(entry, encoded_pk);
-        validate_commit_change_ref_chunk_size(&builder, max_bytes)?;
+) -> Vec<CommitChangeRefChunk> {
+    refs.entries.sort_unstable();
+    if refs.entries.is_empty() {
+        return vec![commit_change_ref_chunk(refs.commit_id, Vec::new())];
     }
-
-    if !builder.is_empty() {
-        chunks.push(builder.finish()?);
-    }
-    Ok(chunks)
+    refs.entries
+        .chunks(max_entries)
+        .map(|entries| commit_change_ref_chunk(refs.commit_id, entries.to_vec()))
+        .collect()
 }
 
-fn commit_change_ref_chunk(
-    commit_id: CommitId,
-    entries: Vec<CommitChangeRef>,
-) -> CommitChangeRefChunk {
+fn commit_change_ref_chunk(commit_id: CommitId, entries: Vec<ChangeId>) -> CommitChangeRefChunk {
     CommitChangeRefChunk {
         format_version: COMMIT_CHANGE_REF_CHUNK_FORMAT_VERSION,
         commit_id,
         entries,
     }
-}
-
-fn validate_commit_change_ref_chunk_size(
-    builder: &CommitChangeRefChunkBuilder,
-    max_bytes: usize,
-) -> Result<(), LixError> {
-    let size = builder.estimated_size();
-    if size > max_bytes {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "single changelog commit_change_ref_chunk entry for commit '{}' exceeds {max_bytes} bytes",
-                builder.commit_id
-            ),
-        ));
-    }
-    Ok(())
-}
-
-struct CommitChangeRefChunkBuilder {
-    commit_id: CommitId,
-    entries: Vec<CommitChangeRef>,
-    schema_keys: HashSet<String>,
-    file_ids: HashSet<Option<String>>,
-    estimated_size: usize,
-    /// The previous entry's encoded entity pk: the front-coding base the
-    /// codec will use, so entry sizes can be charged exactly.
-    previous_encoded_pk: Vec<u8>,
-}
-
-impl CommitChangeRefChunkBuilder {
-    fn new(commit_id: CommitId) -> Self {
-        Self {
-            commit_id,
-            entries: Vec::new(),
-            schema_keys: HashSet::new(),
-            file_ids: HashSet::new(),
-            estimated_size: commit_change_ref_chunk_fixed_size(),
-            previous_encoded_pk: Vec::new(),
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    fn estimated_size(&self) -> usize {
-        self.estimated_size
-    }
-
-    fn estimated_size_after(&self, entry: &CommitChangeRef, encoded_pk: &[u8]) -> usize {
-        self.estimated_size + self.incremental_size(entry, encoded_pk)
-    }
-
-    fn push(&mut self, entry: CommitChangeRef, encoded_pk: Vec<u8>) {
-        self.estimated_size += self.incremental_size(&entry, &encoded_pk);
-        self.schema_keys.insert(entry.schema_key.clone());
-        self.file_ids.insert(entry.file_id.clone());
-        self.previous_encoded_pk = encoded_pk;
-        self.entries.push(entry);
-    }
-
-    fn incremental_size(&self, entry: &CommitChangeRef, encoded_pk: &[u8]) -> usize {
-        let schema_dictionary_bytes = if self.schema_keys.contains(&entry.schema_key) {
-            0
-        } else {
-            encoded_str_size(&entry.schema_key)
-        };
-        let file_dictionary_bytes = if self.file_ids.contains(&entry.file_id) {
-            0
-        } else {
-            encoded_optional_str_size(entry.file_id.as_deref())
-        };
-        // Charge the pk at its front-coded cost against the same base the
-        // codec will use; escape overhead is exact because the real encoded
-        // bytes are measured.
-        let shared = super::codec::shared_prefix_len(&self.previous_encoded_pk, encoded_pk);
-        let suffix_len = encoded_pk.len() - shared;
-        let pk_bytes = varint_size(shared) + varint_size(suffix_len) + suffix_len;
-        schema_dictionary_bytes
-            + file_dictionary_bytes
-            + encoded_commit_change_ref_entry_fixed_size()
-            + pk_bytes
-    }
-
-    fn finish(self) -> Result<CommitChangeRefChunk, LixError> {
-        Ok(commit_change_ref_chunk(self.commit_id, self.entries))
-    }
-}
-
-/// Deliberately loose upper bound on the chunk header (the real musli
-/// header is ~4-7 varint bytes); the dictionary and header charges in this
-/// file are conservative bounds, while the pk charge is exact.
-fn commit_change_ref_chunk_fixed_size() -> usize {
-    21
-}
-
-// The 2-byte-per-index charge below is an upper bound only while dictionary
-// indices stay under musli's 3-byte varint threshold (16384); the entry cap
-// keeps them there.
-const _: () = assert!(COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES < 16384);
-
-fn encoded_commit_change_ref_entry_fixed_size() -> usize {
-    2 // schema index upper bound (varint, <= 2 bytes under the entry cap)
-        + 2 // file index upper bound
-        + size_of::<uuid::Bytes>() // change id (16 raw bytes)
-}
-
-fn varint_size(mut value: usize) -> usize {
-    let mut bytes = 1;
-    while value >= 0x80 {
-        value >>= 7;
-        bytes += 1;
-    }
-    bytes
-}
-
-fn encoded_optional_str_size(value: Option<&str>) -> usize {
-    1 + value.map(encoded_str_size).unwrap_or(0)
-}
-
-fn encoded_str_size(value: &str) -> usize {
-    4 + value.len()
 }
 
 fn validate_unique<T>(values: impl IntoIterator<Item = T>, label: &str) -> Result<(), LixError>
@@ -1037,43 +883,6 @@ where
                 "changelog append contains duplicate {label} '{value}'"
             )));
         }
-    }
-    Ok(())
-}
-
-fn validate_unique_ref_keys(
-    entries: &[CommitChangeRef],
-    commit_id: &CommitId,
-) -> Result<(), LixError> {
-    let mut seen = HashSet::new();
-    for entry in entries {
-        let key = (
-            entry.schema_key.as_str(),
-            entry.file_id.as_deref(),
-            &entry.entity_pk,
-        );
-        if !seen.insert(key) {
-            return Err(LixError::unknown(format!(
-                "changelog commit '{commit_id}' has duplicate change ref key"
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn validate_ref_matches_change(
-    commit_id: &CommitId,
-    entry: &CommitChangeRef,
-    change: &ChangeRecord,
-) -> Result<(), LixError> {
-    if entry.schema_key != change.schema_key
-        || entry.file_id != change.file_id
-        || entry.entity_pk != change.entity_pk
-    {
-        return Err(LixError::unknown(format!(
-            "changelog commit '{}' change ref '{}' does not match referenced ChangeRecord key",
-            commit_id, entry.change_id
-        )));
     }
     Ok(())
 }
@@ -1177,7 +986,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::changelog::test_support::{changelog_test_context, test_append};
+    use crate::changelog::test_support::{changelog_test_context, test_append, test_change_record};
     use crate::changelog::{
         ChangeId, ChangeLoadRequest, ChangeRecord, ChangeScanRequest, ChangelogAppend,
         ChangelogReader, ChangelogWriter, CommitId, CommitLoadEntry, CommitLoadRequest,
@@ -1215,141 +1024,17 @@ mod tests {
         ids
     }
 
-    fn test_change_ref(entity: &str, change_id: &str) -> CommitChangeRef {
-        CommitChangeRef {
-            schema_key: "message".to_string(),
-            file_id: None,
-            entity_pk: EntityPk::single(entity.to_string()),
-            change_id: ChangeId::for_test_label(change_id),
-        }
-    }
-
     #[test]
-    fn chunk_one_commit_change_refs_splits_by_encoded_size() {
-        let refs = CommitChangeRefSet {
-            commit_id: CommitId::for_test_label("commit-1"),
-            entries: (0..8)
-                .map(|index| {
-                    test_change_ref(
-                        &format!("entity-{index:04}-{}", "x".repeat(24)),
-                        &format!("change-{index:04}-{}", "y".repeat(24)),
-                    )
-                })
-                .collect(),
-        };
-
-        let chunks = chunk_one_commit_change_refs(refs, 180, 260, 2048)
-            .expect("refs should chunk under small test limit");
-
-        assert!(chunks.len() > 1);
-        assert!(
-            chunks
-                .iter()
-                .all(|chunk| encode_commit_change_ref_chunk(chunk).unwrap().len() <= 260)
-        );
-        assert_eq!(
-            chunks
-                .iter()
-                .flat_map(|chunk| chunk.entries.iter())
-                .map(|entry| entry.change_id.to_string())
-                .collect::<Vec<_>>(),
-            change_ids([
-                "change-0000-yyyyyyyyyyyyyyyyyyyyyyyy",
-                "change-0001-yyyyyyyyyyyyyyyyyyyyyyyy",
-                "change-0002-yyyyyyyyyyyyyyyyyyyyyyyy",
-                "change-0003-yyyyyyyyyyyyyyyyyyyyyyyy",
-                "change-0004-yyyyyyyyyyyyyyyyyyyyyyyy",
-                "change-0005-yyyyyyyyyyyyyyyyyyyyyyyy",
-                "change-0006-yyyyyyyyyyyyyyyyyyyyyyyy",
-                "change-0007-yyyyyyyyyyyyyyyyyyyyyyyy",
-            ])
-        );
-    }
-
-    #[test]
-    fn chunk_one_commit_change_refs_rejects_oversized_single_entry() {
-        let refs = CommitChangeRefSet {
-            commit_id: CommitId::for_test_label("commit-1"),
-            entries: vec![test_change_ref(&"p".repeat(512), "change-big")],
-        };
-        let error = chunk_one_commit_change_refs(refs, 64, 128, 2048)
-            .expect_err("oversized single entry must reject");
-        assert!(error.message.contains("exceeds 128 bytes"));
-    }
-
-    /// Pins that the size estimator charges pks at their front-coded cost:
-    /// prefix-heavy sorted pks whose verbatim sizes blow the target must
-    /// still pack into one chunk when their front-coded sizes fit, and the
-    /// estimate must stay an upper bound on the real encoding.
-    #[test]
-    fn chunk_one_commit_change_refs_packs_to_front_coded_size() {
-        let prefix = "shared-prefix-".repeat(8); // 112 chars shared per pk
-        let refs = CommitChangeRefSet {
-            commit_id: CommitId::for_test_label("commit-1"),
-            entries: (0..30)
-                .map(|index| {
-                    test_change_ref(&format!("{prefix}{index:04}"), &format!("chg-{index:04}"))
-                })
-                .collect(),
-        };
-        // Verbatim pks are 30 x ~120 bytes = ~3.6KB; front-coded they are
-        // one full pk plus 29 short suffixes = well under 1KB.
-        let chunks =
-            chunk_one_commit_change_refs(refs, 1024, 2048, 2048).expect("refs should chunk");
-        assert_eq!(
-            chunks.len(),
-            1,
-            "front-coded entries must pack into one chunk"
-        );
-    }
-
-    /// Directly pins the safety property `validate_commit_change_ref_chunk_size`
-    /// relies on: the builder's estimate is an upper bound on the real
-    /// encoding. The fixture includes a pk whose suffix crosses the 128-byte
-    /// varint boundary and NUL-bearing pks (escape overhead).
-    #[test]
-    fn chunk_builder_estimate_is_an_upper_bound_on_the_encoding() {
-        let entries = vec![
-            test_change_ref("plain-entity", "chg-1"),
-            test_change_ref(&format!("plain-{}", "q".repeat(200)), "chg-2"),
-            test_change_ref("with\u{0}nul\u{0}\u{0}parts", "chg-3"),
-            test_change_ref("with\u{0}nul\u{0}\u{0}partz", "chg-4"),
-        ];
-        let mut builder = CommitChangeRefChunkBuilder::new(CommitId::for_test_label("commit-1"));
-        for entry in entries {
-            let encoded_pk = crate::changelog::codec::encode_ref_entity_pk(&entry.entity_pk.parts);
-            builder.push(entry, encoded_pk);
-        }
-        let estimate = builder.estimated_size();
-        let chunk = builder.finish().expect("chunk should build");
-        let encoded = encode_commit_change_ref_chunk(&chunk).expect("chunk should encode");
-        assert!(
-            estimate >= encoded.len(),
-            "estimate {estimate} must be >= encoded {}",
-            encoded.len()
-        );
-    }
-
-    #[test]
-    fn varint_size_matches_encoding_boundaries() {
-        for (value, expected) in [(0usize, 1usize), (127, 1), (128, 2), (16383, 2), (16384, 3)] {
-            assert_eq!(varint_size(value), expected, "varint_size({value})");
-        }
-    }
-
-    #[test]
-    fn chunk_one_commit_change_refs_splits_by_entry_count() {
+    fn chunk_one_commit_change_refs_sorts_and_splits_by_entry_count() {
         let refs = CommitChangeRefSet {
             commit_id: CommitId::for_test_label("commit-1"),
             entries: (0..5)
-                .map(|index| {
-                    test_change_ref(&format!("entity-{index}"), &format!("change-{index}"))
-                })
+                .rev()
+                .map(|index| ChangeId::for_test_label(&format!("change-{index}")))
                 .collect(),
         };
 
-        let chunks = chunk_one_commit_change_refs(refs, usize::MAX, usize::MAX, 2)
-            .expect("refs should chunk by entry cap");
+        let chunks = chunk_one_commit_change_refs(refs, 2);
 
         assert_eq!(
             chunks
@@ -1358,6 +1043,24 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![2, 2, 1]
         );
+        let flattened = chunks
+            .iter()
+            .flat_map(|chunk| chunk.entries.iter().copied())
+            .collect::<Vec<_>>();
+        let mut sorted = flattened.clone();
+        sorted.sort_unstable();
+        assert_eq!(flattened, sorted, "entries must be sorted ascending");
+    }
+
+    #[test]
+    fn chunk_one_commit_change_refs_keeps_empty_commits_addressable() {
+        let refs = CommitChangeRefSet {
+            commit_id: CommitId::for_test_label("commit-1"),
+            entries: Vec::new(),
+        };
+        let chunks = chunk_one_commit_change_refs(refs, 2048);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].entries.is_empty());
     }
 
     #[tokio::test]
@@ -1398,7 +1101,7 @@ mod tests {
             change_ref_chunks[0]
                 .entries
                 .iter()
-                .map(|entry| entry.change_id.to_string())
+                .map(ToString::to_string)
                 .collect::<Vec<_>>(),
             change_ids(["change-1"])
         );
@@ -1417,10 +1120,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stage_append_rejects_ref_key_mismatch() {
+    async fn stage_append_rejects_duplicate_ref_identities() {
+        // Two different change records targeting the same
+        // (schema_key, file_id, entity_pk) must not land in one commit.
         let (context, storage) = changelog_test_context();
         let mut append = test_append();
-        append.commit_change_refs[0].entries[0].schema_key = "wrong".to_string();
+        append.changes.push(ChangeRecord {
+            change_id: ChangeId::for_test_label("change-dup"),
+            ..test_change_record()
+        });
+        append.commit_change_refs[0]
+            .entries
+            .push(ChangeId::for_test_label("change-dup"));
 
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();
@@ -1429,9 +1140,7 @@ mod tests {
             writer.stage_append(append).await.unwrap_err()
         };
         assert!(
-            error
-                .message
-                .contains("does not match referenced ChangeRecord key"),
+            error.message.contains("duplicate change ref key"),
             "{error:?}"
         );
     }
@@ -1459,7 +1168,7 @@ mod tests {
         let (context, storage) = changelog_test_context();
         let mut append = test_append();
         append.changes[0].change_id = append.commits[0].change_id.clone();
-        append.commit_change_refs[0].entries[0].change_id = append.commits[0].change_id.clone();
+        append.commit_change_refs[0].entries[0] = append.commits[0].change_id.clone();
 
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();
@@ -1472,6 +1181,70 @@ mod tests {
                 .message
                 .contains("collides with an existing change id"),
             "{error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage_append_splits_large_ref_sets_at_the_entry_cap() {
+        // Pins COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES end-to-end: one commit
+        // with 2049 refs must persist as chunks of [2048, 1] whose
+        // concatenation is globally sorted and gap-free.
+        let (context, storage) = changelog_test_context();
+        let mut append = test_append();
+        append.changes.clear();
+        append.commit_change_refs[0].entries.clear();
+        for index in 0..=COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES {
+            let change_id = ChangeId::for_test_label(&format!("bulk-change-{index:05}"));
+            append.changes.push(ChangeRecord {
+                change_id,
+                entity_pk: EntityPk::single(format!("bulk-entity-{index:05}")),
+                ..test_change_record()
+            });
+            append.commit_change_refs[0].entries.push(change_id);
+        }
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(append).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut read = storage.begin_read_transaction().await.unwrap();
+        let mut reader = context.reader(&mut *read);
+        let commits = reader
+            .load_commits(CommitLoadRequest {
+                commit_ids: &[CommitId::for_test_label("commit-1")],
+                projection: CommitProjection::Full,
+            })
+            .await
+            .unwrap();
+        let Some(CommitLoadEntry::Full {
+            change_ref_chunks, ..
+        }) = commits.entries.into_iter().next().flatten()
+        else {
+            panic!("expected full commit entry");
+        };
+        assert_eq!(
+            change_ref_chunks
+                .iter()
+                .map(|chunk| chunk.entries.len())
+                .collect::<Vec<_>>(),
+            vec![COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES, 1]
+        );
+        let flattened = change_ref_chunks
+            .iter()
+            .flat_map(|chunk| chunk.entries.iter().copied())
+            .collect::<Vec<_>>();
+        let mut sorted = flattened.clone();
+        sorted.sort_unstable();
+        assert_eq!(flattened, sorted, "entries must be globally sorted");
+        assert_eq!(
+            flattened.len(),
+            COMMIT_CHANGE_REF_CHUNK_MAX_ENTRIES + 1,
+            "no entry may be lost across the chunk boundary"
         );
     }
 
@@ -1489,15 +1262,9 @@ mod tests {
             metadata: JsonSlot::None,
             created_at: ts("2026-05-12T00:00:00Z"),
         });
-        append.commit_change_refs[0].entries.insert(
-            0,
-            CommitChangeRef {
-                schema_key: "alpha".to_string(),
-                file_id: None,
-                entity_pk: EntityPk::single("entity-0"),
-                change_id: ChangeId::for_test_label("change-0"),
-            },
-        );
+        append.commit_change_refs[0]
+            .entries
+            .insert(0, ChangeId::for_test_label("change-0"));
         append.commit_change_refs[0].entries.swap(0, 1);
 
         let mut transaction = storage.begin_write_transaction().await.unwrap();
@@ -1528,7 +1295,7 @@ mod tests {
             change_ref_chunks[0]
                 .entries
                 .iter()
-                .map(|entry| entry.change_id.to_string())
+                .map(ToString::to_string)
                 .collect::<Vec<_>>(),
             change_ids(["change-0", "change-1"])
         );
@@ -1547,7 +1314,7 @@ mod tests {
         second.commits[0].change_id = ChangeId::for_test_label("commit-a-row-change");
         second.changes[0].change_id = ChangeId::for_test_label("change-a");
         second.commit_change_refs[0].commit_id = CommitId::for_test_label("commit-a");
-        second.commit_change_refs[0].entries[0].change_id = ChangeId::for_test_label("change-a");
+        second.commit_change_refs[0].entries[0] = ChangeId::for_test_label("change-a");
 
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();
@@ -1608,14 +1375,14 @@ mod tests {
         first.commits[0].change_id = ChangeId::for_test_label("commit-b-row-change");
         first.changes[0].change_id = ChangeId::for_test_label("change-b");
         first.commit_change_refs[0].commit_id = CommitId::for_test_label("commit-b");
-        first.commit_change_refs[0].entries[0].change_id = ChangeId::for_test_label("change-b");
+        first.commit_change_refs[0].entries[0] = ChangeId::for_test_label("change-b");
 
         let mut second = test_append();
         second.commits[0].commit_id = CommitId::for_test_label("commit-a");
         second.commits[0].change_id = ChangeId::for_test_label("commit-a-row-change");
         second.changes[0].change_id = ChangeId::for_test_label("change-a");
         second.commit_change_refs[0].commit_id = CommitId::for_test_label("commit-a");
-        second.commit_change_refs[0].entries[0].change_id = ChangeId::for_test_label("change-a");
+        second.commit_change_refs[0].entries[0] = ChangeId::for_test_label("change-a");
 
         let mut transaction = storage.begin_write_transaction().await.unwrap();
         let mut writes = StorageWriteSet::new();

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -20,9 +20,8 @@ pub(crate) use store::{CHANGE_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE
 pub(crate) use store::{ChangelogReader, ChangelogWriter};
 pub(crate) use types::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeRecordView, ChangeScanBatch,
-    ChangeScanRequest, ChangelogAppend, CommitChangeRef, CommitChangeRefChunk,
-    CommitChangeRefChunkView, CommitChangeRefSet, CommitId, CommitLoadBatch, CommitLoadEntry,
-    CommitLoadRequest, CommitProjection, CommitRecord, CommitScanBatch, CommitScanRequest,
-    GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, RebuildIndexStats,
-    commit_row_snapshot_json,
+    ChangeScanRequest, ChangelogAppend, CommitChangeRefChunk, CommitChangeRefSet, CommitId,
+    CommitLoadBatch, CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitRecord,
+    CommitScanBatch, CommitScanRequest, GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet,
+    RebuildIndexStats, commit_row_snapshot_json,
 };

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -23,6 +23,6 @@ pub(crate) use types::{
     ChangeScanRequest, ChangelogAppend, CommitChangeRef, CommitChangeRefChunk,
     CommitChangeRefChunkView, CommitChangeRefSet, CommitId, CommitLoadBatch, CommitLoadEntry,
     CommitLoadRequest, CommitProjection, CommitRecord, CommitScanBatch, CommitScanRequest,
-    EntityPkRef, GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, RebuildIndexStats,
+    GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, RebuildIndexStats,
     commit_row_snapshot_json,
 };

--- a/packages/engine/src/changelog/test_support.rs
+++ b/packages/engine/src/changelog/test_support.rs
@@ -1,6 +1,5 @@
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangelogAppend, CommitChangeRef, CommitChangeRefSet, CommitId,
-    CommitRecord,
+    ChangeId, ChangeRecord, ChangelogAppend, CommitChangeRefSet, CommitId, CommitRecord,
 };
 use crate::entity_pk::EntityPk;
 use crate::storage::{InMemoryStorageBackend, StorageContext};
@@ -20,12 +19,7 @@ pub(crate) fn test_append() -> ChangelogAppend {
         changes: vec![test_change_record()],
         commit_change_refs: vec![CommitChangeRefSet {
             commit_id: CommitId::for_test_label("commit-1"),
-            entries: vec![CommitChangeRef {
-                schema_key: "message".to_string(),
-                file_id: Some("file-1".to_string()),
-                entity_pk: EntityPk::single("entity-1"),
-                change_id: ChangeId::for_test_label("change-1"),
-            }],
+            entries: vec![ChangeId::for_test_label("change-1")],
         }],
     }
 }

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -6,19 +6,6 @@ use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
 
-mod entity_pk_ref_storage {
-    use super::EntityPkRef;
-
-    pub(crate) fn decode<'de, D>(decoder: D) -> Result<EntityPkRef<'de>, D::Error>
-    where
-        D: musli::Decoder<'de>,
-        Vec<&'de str>: musli::Decode<'de, D::Mode, D::Allocator>,
-    {
-        let parts = musli::Decode::decode(decoder)?;
-        Ok(EntityPkRef { parts })
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct CommitId {
     uuid: Uuid,
@@ -315,6 +302,7 @@ pub(crate) struct CommitRecord {
     pub(crate) commit_id: CommitId,
     pub(crate) parent_commit_ids: Vec<CommitId>,
     pub(crate) change_id: ChangeId,
+    #[musli(with = crate::storage_codec::id_string_seq)]
     pub(crate) author_account_ids: Vec<String>,
     pub(crate) created_at: LixTimestamp,
 }
@@ -384,11 +372,6 @@ pub(crate) struct CommitChangeRefEntryView<'a> {
     pub(crate) change_id: ChangeId,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct EntityPkRef<'a> {
-    pub(crate) parts: Vec<&'a str>,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CommitProjection {
     Record,
@@ -450,8 +433,9 @@ pub(crate) struct ChangeRecord {
 pub(crate) struct ChangeRecordRef<'a> {
     pub(crate) format_version: u32,
     pub(crate) schema_key: &'a str,
+    #[musli(with = crate::storage_codec::id_string_seq)]
     pub(crate) entity_pk: &'a [String],
-    #[musli(with = crate::storage_codec::option)]
+    #[musli(with = crate::storage_codec::option_id_string)]
     pub(crate) file_id: Option<&'a str>,
     #[musli(with = crate::json_store::json_slot_storage_ref)]
     pub(crate) snapshot: crate::json_store::JsonSlotRef<'a>,
@@ -465,10 +449,10 @@ pub(crate) struct ChangeRecordRef<'a> {
 pub(crate) struct ChangeRecordView<'a> {
     pub(crate) format_version: u32,
     pub(crate) schema_key: &'a str,
-    #[musli(with = entity_pk_ref_storage)]
-    pub(crate) entity_pk: EntityPkRef<'a>,
-    #[musli(with = crate::storage_codec::option)]
-    pub(crate) file_id: Option<&'a str>,
+    #[musli(with = crate::storage_codec::id_string_seq)]
+    pub(crate) entity_pk: Vec<String>,
+    #[musli(with = crate::storage_codec::option_id_string)]
+    pub(crate) file_id: Option<String>,
     #[musli(with = crate::json_store::json_slot_storage)]
     pub(crate) snapshot: JsonSlot,
     #[musli(with = crate::json_store::json_slot_storage)]

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -310,66 +310,33 @@ pub(crate) struct CommitRecord {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CommitChangeRefSet {
     pub(crate) commit_id: CommitId,
-    pub(crate) entries: Vec<CommitChangeRef>,
+    pub(crate) entries: Vec<ChangeId>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CommitChangeRefChunk {
     pub(crate) format_version: u32,
     pub(crate) commit_id: CommitId,
-    pub(crate) entries: Vec<CommitChangeRef>,
+    pub(crate) entries: Vec<ChangeId>,
 }
 
-#[derive(musli::Encode)]
-#[musli(packed)]
-pub(crate) struct CommitChangeRefChunkRef<'a> {
-    pub(crate) format_version: u32,
-    pub(crate) schema_keys: Vec<&'a str>,
-    #[musli(with = crate::storage_codec::vec_option)]
-    pub(crate) file_ids: Vec<Option<&'a str>>,
-    pub(crate) entries: Vec<CommitChangeRefEntryRef<'a>>,
-}
-
+/// Stored ref chunk: the commit id lives in the storage key, the entries are
+/// the referenced change ids sorted ascending. Everything else about a change
+/// (schema key, file id, entity pk, payloads) lives in its change record and
+/// is point-read by change id when needed.
 #[derive(musli::Decode)]
 #[musli(packed)]
-pub(crate) struct CommitChangeRefChunkView<'a> {
+pub(crate) struct CommitChangeRefChunkWire {
     pub(crate) format_version: u32,
-    pub(crate) schema_keys: Vec<&'a str>,
-    #[musli(with = crate::storage_codec::vec_option)]
-    pub(crate) file_ids: Vec<Option<&'a str>>,
-    pub(crate) entries: Vec<CommitChangeRefEntryView<'a>>,
+    pub(crate) entries: Vec<ChangeId>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct CommitChangeRef {
-    pub(crate) schema_key: String,
-    pub(crate) file_id: Option<String>,
-    pub(crate) entity_pk: EntityPk,
-    pub(crate) change_id: ChangeId,
-}
-
-/// Stored ref entry. Entries within a chunk are sorted by
-/// (schema_key, file_id, entity_pk), so consecutive encoded entity pks share
-/// long prefixes; the pk is stored front-coded against the previous entry's
-/// encoded pk bytes.
+/// Encode-only borrowed twin of [`CommitChangeRefChunkWire`].
 #[derive(musli::Encode)]
 #[musli(packed)]
-pub(crate) struct CommitChangeRefEntryRef<'a> {
-    pub(crate) schema_index: u16,
-    pub(crate) file_index: u16,
-    pub(crate) pk_shared: u32,
-    pub(crate) pk_suffix: &'a [u8],
-    pub(crate) change_id: ChangeId,
-}
-
-#[derive(musli::Decode)]
-#[musli(packed)]
-pub(crate) struct CommitChangeRefEntryView<'a> {
-    pub(crate) schema_index: u16,
-    pub(crate) file_index: u16,
-    pub(crate) pk_shared: u32,
-    pub(crate) pk_suffix: &'a [u8],
-    pub(crate) change_id: ChangeId,
+pub(crate) struct CommitChangeRefChunkWireRef<'a> {
+    pub(crate) format_version: u32,
+    pub(crate) entries: &'a [ChangeId],
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -258,7 +258,7 @@ where
             } => {
                 let change_ids = change_ref_chunks
                     .into_iter()
-                    .flat_map(|chunk| chunk.entries.into_iter().map(|entry| entry.change_id))
+                    .flat_map(|chunk| chunk.entries)
                     .collect::<Vec<_>>();
                 Ok(Some(commit_graph_commit_from_commit_record(
                     record, change_ids,
@@ -382,7 +382,7 @@ mod tests {
 
     use crate::changelog::{
         ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter,
-        CommitChangeRef, CommitChangeRefSet, CommitId, CommitRecord,
+        CommitChangeRefSet, CommitId, CommitRecord,
     };
     use crate::commit_graph::{
         CommitGraphChange, CommitGraphChangeHistoryRequest, CommitGraphContext,
@@ -891,13 +891,8 @@ mod tests {
         }
     }
 
-    fn commit_change_ref_from_test_change(change: &TestChange) -> CommitChangeRef {
-        CommitChangeRef {
-            schema_key: change.change.schema_key.clone(),
-            file_id: change.change.file_id.clone(),
-            entity_pk: change.change.entity_pk.clone(),
-            change_id: change.change.id,
-        }
+    fn commit_change_ref_from_test_change(change: &TestChange) -> ChangeId {
+        change.change.id
     }
 
     fn commit_change(

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -4,8 +4,8 @@ use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::branch::{BRANCH_DESCRIPTOR_SCHEMA_KEY, BRANCH_REF_SCHEMA_KEY};
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitChangeRef,
-    CommitChangeRefSet, CommitId, CommitRecord,
+    ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitChangeRefSet,
+    CommitId, CommitRecord,
 };
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -309,11 +309,7 @@ async fn stage_init_changelog_commit(
     };
     let commit_change_refs = CommitChangeRefSet {
         commit_id: plan.commit.id,
-        entries: plan
-            .changes
-            .iter()
-            .map(commit_change_ref_from_seed_change)
-            .collect(),
+        entries: plan.changes.iter().map(|change| change.id).collect(),
     };
     let mut writer = ChangelogContext::new().writer(read, writes);
     writer
@@ -327,15 +323,6 @@ async fn stage_init_changelog_commit(
 
 fn commit_row_snapshot_content(commit_id: &str) -> Result<String, LixError> {
     crate::changelog::commit_row_snapshot_json(commit_id)
-}
-
-fn commit_change_ref_from_seed_change(change: &InitSeedChange) -> CommitChangeRef {
-    CommitChangeRef {
-        schema_key: change.schema_key.clone(),
-        file_id: None,
-        entity_pk: change.entity_pk.clone(),
-        change_id: change.id,
-    }
 }
 
 fn untracked_state_row_from_seed(row: &InitSeedLiveRow) -> Result<UntrackedStateRow, LixError> {
@@ -601,14 +588,14 @@ mod tests {
         assert!(
             !change_refs
                 .iter()
-                .any(|change_ref| change_ref.change_id == record.change_id),
+                .any(|change_id| **change_id == record.change_id),
             "initial commit row is derived from changelog.commit, not stored in commit refs"
         );
 
-        let sampled_change_id = change_refs
+        let sampled_change_id = *change_refs
             .first()
-            .expect("initial commit should reference at least one change")
-            .change_id;
+            .copied()
+            .expect("initial commit should reference at least one change");
         let changes = reader
             .load_changes(crate::changelog::ChangeLoadRequest {
                 change_ids: &[sampled_change_id],

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -681,12 +681,7 @@ mod tests {
                 .unwrap_or_else(|| ts("1970-01-01T00:00:00.000Z"));
             let change_refs = rows
                 .iter()
-                .map(|(change, _, _)| crate::changelog::CommitChangeRef {
-                    schema_key: change.schema_key.clone(),
-                    file_id: change.file_id.clone(),
-                    entity_pk: change.entity_pk.clone(),
-                    change_id: change.change_id.clone(),
-                })
+                .map(|(change, _, _)| change.change_id)
                 .collect::<Vec<_>>();
             let commit_change_id = format!("{commit_id}:commit");
             let mut append = crate::changelog::ChangelogAppend::default();

--- a/packages/engine/src/storage_codec.rs
+++ b/packages/engine/src/storage_codec.rs
@@ -71,6 +71,155 @@ pub(crate) mod vec_option {
     }
 }
 
+/// Opportunistic UUID packing for stored id strings.
+///
+/// Lix-generated ids are canonical lowercase hyphenated UUIDs; as text they
+/// cost 36 bytes where 16 carry the information. Each id is stored as a
+/// 1-byte tag followed by either the raw 16 UUID bytes or the original text.
+/// Only the exact canonical form takes the UUID arm, so decode re-hyphenates
+/// byte-identically; every other string (plugin-chosen entity keys, test
+/// labels) keeps its text form.
+pub(crate) mod id_string {
+    use musli::Context;
+    use musli::de::SequenceDecoder;
+    use musli::en::SequenceEncoder;
+
+    const TAG_TEXT: u8 = 0;
+    const TAG_UUID: u8 = 1;
+
+    pub(crate) fn uuid_bytes_from_canonical(value: &str) -> Option<[u8; 16]> {
+        let bytes = value.as_bytes();
+        if bytes.len() != 36 {
+            return None;
+        }
+        let mut out = [0u8; 16];
+        let mut nibble_index = 0usize;
+        for (position, &byte) in bytes.iter().enumerate() {
+            if matches!(position, 8 | 13 | 18 | 23) {
+                if byte != b'-' {
+                    return None;
+                }
+                continue;
+            }
+            // Lowercase hex only: uppercase input would re-hyphenate
+            // differently and break round-tripping.
+            let nibble = match byte {
+                b'0'..=b'9' => byte - b'0',
+                b'a'..=b'f' => byte - b'a' + 10,
+                _ => return None,
+            };
+            out[nibble_index / 2] |= nibble << (4 * (1 - nibble_index % 2));
+            nibble_index += 1;
+        }
+        Some(out)
+    }
+
+    pub(crate) fn uuid_string_from_bytes(bytes: [u8; 16]) -> String {
+        uuid::Uuid::from_bytes(bytes).as_hyphenated().to_string()
+    }
+
+    pub(crate) fn encode_one<E>(value: &str, pack: &mut E) -> Result<(), E::Error>
+    where
+        E: SequenceEncoder,
+    {
+        match uuid_bytes_from_canonical(value) {
+            Some(bytes) => {
+                pack.push(TAG_UUID)?;
+                pack.push(bytes)
+            }
+            None => {
+                pack.push(TAG_TEXT)?;
+                pack.push(value.as_bytes())
+            }
+        }
+    }
+
+    pub(crate) fn decode_one<'de, D>(pack: &mut D) -> Result<String, D::Error>
+    where
+        D: SequenceDecoder<'de>,
+    {
+        let cx = pack.cx();
+        let tag: u8 = pack.next()?;
+        match tag {
+            TAG_UUID => Ok(uuid_string_from_bytes(pack.next::<[u8; 16]>()?)),
+            TAG_TEXT => {
+                let bytes: Vec<u8> = pack.next()?;
+                String::from_utf8(bytes).map_err(|_| cx.message("id string is not UTF-8"))
+            }
+            other => Err(cx.message(format_args!("unknown id string tag {other}"))),
+        }
+    }
+
+}
+
+/// [`id_string`] values behind the same bool prefix as [`option`].
+pub(crate) mod option_id_string {
+    use musli::de::SequenceDecoder;
+    use musli::en::SequenceEncoder;
+
+    #[expect(clippy::ref_option_ref)]
+    pub(crate) fn encode<E>(value: &Option<&str>, encoder: E) -> Result<(), E::Error>
+    where
+        E: musli::Encoder,
+    {
+        encoder.encode_pack_fn(|pack| {
+            pack.push(value.is_some())?;
+            if let Some(value) = value {
+                super::id_string::encode_one(value, pack)?;
+            }
+            Ok(())
+        })
+    }
+
+    pub(crate) fn decode<'de, D>(decoder: D) -> Result<Option<String>, D::Error>
+    where
+        D: musli::Decoder<'de>,
+    {
+        decoder.decode_pack(|pack| {
+            if pack.next()? {
+                Ok(Some(super::id_string::decode_one(pack)?))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+}
+
+/// A length-prefixed sequence of [`id_string`] values.
+pub(crate) mod id_string_seq {
+    use musli::de::SequenceDecoder;
+    use musli::en::SequenceEncoder;
+
+    pub(crate) fn encode<S, E>(value: &S, encoder: E) -> Result<(), E::Error>
+    where
+        S: AsRef<[String]> + ?Sized,
+        E: musli::Encoder,
+    {
+        let parts = value.as_ref();
+        encoder.encode_pack_fn(|pack| {
+            pack.push(parts.len())?;
+            for part in parts {
+                super::id_string::encode_one(part, pack)?;
+            }
+            Ok(())
+        })
+    }
+
+    pub(crate) fn decode<'de, D>(decoder: D) -> Result<Vec<String>, D::Error>
+    where
+        D: musli::Decoder<'de>,
+    {
+        decoder.decode_pack(|pack| {
+            let len: usize = pack.next()?;
+            let mut out = Vec::with_capacity(len.min(4096));
+            for _ in 0..len {
+                out.push(super::id_string::decode_one(pack)?);
+            }
+            Ok(out)
+        })
+    }
+}
+
 pub(crate) fn encode<T>(context: &str, value: &T) -> Result<Vec<u8>, LixError>
 where
     T: ?Sized + musli::Encode<musli::mode::Binary>,
@@ -135,6 +284,79 @@ mod tests {
             super::decode("option roundtrip", &bytes).expect("value should decode cleanly");
 
         assert_eq!(decoded, value);
+    }
+
+    #[derive(Debug, Eq, PartialEq, musli::Encode)]
+    #[musli(packed)]
+    struct IdStringEncode<'a> {
+        #[musli(with = crate::storage_codec::id_string_seq)]
+        parts: &'a [String],
+        #[musli(with = crate::storage_codec::option_id_string)]
+        file_id: Option<&'a str>,
+    }
+
+    #[derive(Debug, Eq, PartialEq, musli::Decode)]
+    #[musli(packed)]
+    struct IdStringDecode {
+        #[musli(with = crate::storage_codec::id_string_seq)]
+        parts: Vec<String>,
+        #[musli(with = crate::storage_codec::option_id_string)]
+        file_id: Option<String>,
+    }
+
+    #[test]
+    fn uuid_bytes_from_canonical_accepts_only_the_exact_canonical_form() {
+        use super::id_string::uuid_bytes_from_canonical;
+        let canonical = "019eb805-60d0-71c0-ade3-b0f0efab9d9a";
+        let bytes = uuid_bytes_from_canonical(canonical).expect("canonical uuid should pack");
+        assert_eq!(super::id_string::uuid_string_from_bytes(bytes), canonical);
+
+        for rejected in [
+            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",     // uppercase
+            "019eb80560d071c0ade3b0f0efab9d9a",         // simple form
+            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}",   // braced
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9",      // short
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",    // long
+            "019eb805x60d0-71c0-ade3-b0f0efab9d9aa",    // hyphen replaced
+            "not-a-uuid",
+            "",
+        ] {
+            assert_eq!(uuid_bytes_from_canonical(rejected), None, "{rejected:?}");
+        }
+    }
+
+    #[test]
+    fn id_strings_round_trip_through_both_arms() {
+        let parts = vec![
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9a".to_string(),
+            "row 5 of sheet 2".to_string(),
+        ];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: Some("019eb805-5e65-7270-861d-cb341bc904c8"),
+        };
+        let bytes = super::encode("id string roundtrip", &value).expect("encode");
+        let decoded: IdStringDecode =
+            super::decode("id string roundtrip", &bytes).expect("decode");
+        assert_eq!(decoded.parts, parts);
+        assert_eq!(
+            decoded.file_id.as_deref(),
+            Some("019eb805-5e65-7270-861d-cb341bc904c8")
+        );
+    }
+
+    #[test]
+    fn id_string_none_file_id_round_trips() {
+        let parts = vec!["plain".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: None,
+        };
+        let bytes = super::encode("id string roundtrip", &value).expect("encode");
+        let decoded: IdStringDecode =
+            super::decode("id string roundtrip", &bytes).expect("decode");
+        assert_eq!(decoded.parts, parts);
+        assert_eq!(decoded.file_id, None);
     }
 
     #[test]

--- a/packages/engine/src/storage_codec.rs
+++ b/packages/engine/src/storage_codec.rs
@@ -36,41 +36,6 @@ pub(crate) mod option {
     }
 }
 
-pub(crate) mod vec_option {
-    use musli::de::SequenceDecoder;
-    use musli::en::SequenceEncoder;
-
-    pub(crate) fn encode<T, E>(value: &Vec<Option<T>>, encoder: E) -> Result<(), E::Error>
-    where
-        T: musli::Encode<E::Mode>,
-        E: musli::Encoder,
-    {
-        encoder.encode_sequence_fn(value.len(), |sequence| {
-            for item in value {
-                super::option::encode(item, sequence.encode_next()?)?;
-            }
-
-            Ok(())
-        })
-    }
-
-    pub(crate) fn decode<'de, T, D>(decoder: D) -> Result<Vec<Option<T>>, D::Error>
-    where
-        T: musli::Decode<'de, D::Mode, D::Allocator>,
-        D: musli::Decoder<'de>,
-    {
-        decoder.decode_sequence(|sequence| {
-            let mut out = Vec::with_capacity(sequence.size_hint().or_default());
-
-            while let Some(decoder) = sequence.try_decode_next()? {
-                out.push(super::option::decode(decoder)?);
-            }
-
-            Ok(out)
-        })
-    }
-}
-
 /// Opportunistic UUID packing for stored id strings.
 ///
 /// Lix-generated ids are canonical lowercase hyphenated UUIDs; as text they
@@ -185,7 +150,6 @@ pub(crate) mod id_string {
             other => Err(cx.message(format_args!("unknown id string tag {other}"))),
         }
     }
-
 }
 
 /// [`id_string`] values behind the same bool prefix as [`option`].
@@ -301,27 +265,6 @@ mod tests {
         marker: &'a str,
     }
 
-    #[derive(Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-    #[musli(packed)]
-    struct VecOptionRoundtrip<'a> {
-        #[musli(with = crate::storage_codec::vec_option)]
-        values: Vec<Option<&'a str>>,
-    }
-
-    #[test]
-    fn option_none_does_not_consume_following_packed_field() {
-        let value = OptionRoundtrip {
-            value: None,
-            marker: "after",
-        };
-
-        let bytes = super::encode("option roundtrip", &value).expect("value should encode cleanly");
-        let decoded: OptionRoundtrip<'_> =
-            super::decode("option roundtrip", &bytes).expect("value should decode cleanly");
-
-        assert_eq!(decoded, value);
-    }
-
     #[derive(Debug, Eq, PartialEq, musli::Encode)]
     #[musli(packed)]
     struct IdStringEncode<'a> {
@@ -341,6 +284,20 @@ mod tests {
     }
 
     #[test]
+    fn option_none_does_not_consume_following_packed_field() {
+        let value = OptionRoundtrip {
+            value: None,
+            marker: "after",
+        };
+
+        let bytes = super::encode("option roundtrip", &value).expect("value should encode cleanly");
+        let decoded: OptionRoundtrip<'_> =
+            super::decode("option roundtrip", &bytes).expect("value should decode cleanly");
+
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
     fn uuid_bytes_from_canonical_accepts_only_the_exact_canonical_form() {
         use super::id_string::uuid_bytes_from_canonical;
         let canonical = "019eb805-60d0-71c0-ade3-b0f0efab9d9a";
@@ -348,16 +305,16 @@ mod tests {
         assert_eq!(super::id_string::uuid_string_from_bytes(bytes), canonical);
 
         for rejected in [
-            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",   // uppercase
-            "019eb80560d071c0ade3b0f0efab9d9a",       // simple form
-            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}", // braced
-            "019eb805-60d0-71c0-ade3-b0f0efab9d9",    // short
-            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",  // long
-            "019eb805x60d0-71c0-ade3-b0f0efab9d9a",   // 36 bytes, hyphen replaced
-            "019eb805-60d0x71c0-ade3-b0f0efab9d9a",   // 36 bytes, hex at hyphen slot
+            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",     // uppercase
+            "019eb80560d071c0ade3b0f0efab9d9a",         // simple form
+            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}",   // braced
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9",      // short
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",    // long
+            "019eb805x60d0-71c0-ade3-b0f0efab9d9a",     // 36 bytes, hyphen replaced
+            "019eb805-60d0x71c0-ade3-b0f0efab9d9a",     // 36 bytes, hex at hyphen slot
             "019eb805-60d0-71c0-ade3-b0f0efab9d\u{e9}", // 36 bytes via multi-byte char
-            "019eb805-60d0-71c0-ade3-b0f0efab9d9\0",  // embedded NUL
-            "------------------------------------",   // all hyphens
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9\0",    // embedded NUL
+            "------------------------------------",     // all hyphens
             "not-a-uuid",
             "",
         ] {
@@ -376,8 +333,7 @@ mod tests {
             file_id: Some("019eb805-5e65-7270-861d-cb341bc904c8"),
         };
         let bytes = super::encode("id string roundtrip", &value).expect("encode");
-        let decoded: IdStringDecode =
-            super::decode("id string roundtrip", &bytes).expect("decode");
+        let decoded: IdStringDecode = super::decode("id string roundtrip", &bytes).expect("decode");
         assert_eq!(decoded.parts, parts);
         assert_eq!(
             decoded.file_id.as_deref(),
@@ -397,16 +353,16 @@ mod tests {
         };
         let bytes = super::encode("id string wire pin", &value).expect("encode");
         let expected: Vec<u8> = [
-            &[1u8][..],     // parts count
-            &[1u8][..],     // TAG_UUID
+            &[1u8][..], // parts count
+            &[1u8][..], // TAG_UUID
             &[
-                0x01, 0x9e, 0xb8, 0x05, 0x60, 0xd0, 0x71, 0xc0, 0xad, 0xe3, 0xb0, 0xf0, 0xef,
-                0xab, 0x9d, 0x9a,
-            ][..],          // raw uuid bytes
-            &[1u8][..],     // file_id Some
-            &[0u8][..],     // TAG_TEXT
-            &[2u8][..],     // text length
-            b"ab",          // text bytes
+                0x01, 0x9e, 0xb8, 0x05, 0x60, 0xd0, 0x71, 0xc0, 0xad, 0xe3, 0xb0, 0xf0, 0xef, 0xab,
+                0x9d, 0x9a,
+            ][..], // raw uuid bytes
+            &[1u8][..], // file_id Some
+            &[0u8][..], // TAG_TEXT
+            &[2u8][..], // text length
+            b"ab",      // text bytes
         ]
         .concat();
         assert_eq!(bytes, expected);
@@ -459,23 +415,8 @@ mod tests {
             file_id: None,
         };
         let bytes = super::encode("id string roundtrip", &value).expect("encode");
-        let decoded: IdStringDecode =
-            super::decode("id string roundtrip", &bytes).expect("decode");
+        let decoded: IdStringDecode = super::decode("id string roundtrip", &bytes).expect("decode");
         assert_eq!(decoded.parts, parts);
         assert_eq!(decoded.file_id, None);
-    }
-
-    #[test]
-    fn vec_option_roundtrips_borrowed_values() {
-        let value = VecOptionRoundtrip {
-            values: vec![Some("first"), None, Some("third")],
-        };
-
-        let bytes =
-            super::encode("vec option roundtrip", &value).expect("value should encode cleanly");
-        let decoded: VecOptionRoundtrip<'_> =
-            super::decode("vec option roundtrip", &bytes).expect("value should decode cleanly");
-
-        assert_eq!(decoded, value);
     }
 }

--- a/packages/engine/src/storage_codec.rs
+++ b/packages/engine/src/storage_codec.rs
@@ -87,6 +87,42 @@ pub(crate) mod id_string {
     const TAG_TEXT: u8 = 0;
     const TAG_UUID: u8 = 1;
 
+    /// Raw 16-byte arm. The tag already implies the length, so this encodes
+    /// via `encode_array` (no length prefix), like the uuid id types in
+    /// `changelog::types`.
+    struct UuidArm([u8; 16]);
+
+    impl<M> musli::Encode<M> for UuidArm {
+        type Encode = Self;
+
+        fn encode<E>(&self, encoder: E) -> Result<(), E::Error>
+        where
+            E: musli::Encoder<Mode = M>,
+        {
+            encoder.encode_array(&self.0)
+        }
+
+        fn size_hint(&self) -> Option<usize> {
+            Some(16)
+        }
+
+        fn as_encode(&self) -> &Self {
+            self
+        }
+    }
+
+    impl<'de, M, A> musli::Decode<'de, M, A> for UuidArm
+    where
+        A: musli::Allocator,
+    {
+        fn decode<D>(decoder: D) -> Result<Self, D::Error>
+        where
+            D: musli::Decoder<'de, Mode = M, Allocator = A>,
+        {
+            Ok(Self(decoder.decode_array()?))
+        }
+    }
+
     pub(crate) fn uuid_bytes_from_canonical(value: &str) -> Option<[u8; 16]> {
         let bytes = value.as_bytes();
         if bytes.len() != 36 {
@@ -125,7 +161,7 @@ pub(crate) mod id_string {
         match uuid_bytes_from_canonical(value) {
             Some(bytes) => {
                 pack.push(TAG_UUID)?;
-                pack.push(bytes)
+                pack.push(UuidArm(bytes))
             }
             None => {
                 pack.push(TAG_TEXT)?;
@@ -141,7 +177,7 @@ pub(crate) mod id_string {
         let cx = pack.cx();
         let tag: u8 = pack.next()?;
         match tag {
-            TAG_UUID => Ok(uuid_string_from_bytes(pack.next::<[u8; 16]>()?)),
+            TAG_UUID => Ok(uuid_string_from_bytes(pack.next::<UuidArm>()?.0)),
             TAG_TEXT => {
                 let bytes: Vec<u8> = pack.next()?;
                 String::from_utf8(bytes).map_err(|_| cx.message("id string is not UTF-8"))
@@ -312,12 +348,16 @@ mod tests {
         assert_eq!(super::id_string::uuid_string_from_bytes(bytes), canonical);
 
         for rejected in [
-            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",     // uppercase
-            "019eb80560d071c0ade3b0f0efab9d9a",         // simple form
-            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}",   // braced
-            "019eb805-60d0-71c0-ade3-b0f0efab9d9",      // short
-            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",    // long
-            "019eb805x60d0-71c0-ade3-b0f0efab9d9aa",    // hyphen replaced
+            "019EB805-60D0-71C0-ADE3-B0F0EFAB9D9A",   // uppercase
+            "019eb80560d071c0ade3b0f0efab9d9a",       // simple form
+            "{019eb805-60d0-71c0-ade3-b0f0efab9d9a}", // braced
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9",    // short
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9ax",  // long
+            "019eb805x60d0-71c0-ade3-b0f0efab9d9a",   // 36 bytes, hyphen replaced
+            "019eb805-60d0x71c0-ade3-b0f0efab9d9a",   // 36 bytes, hex at hyphen slot
+            "019eb805-60d0-71c0-ade3-b0f0efab9d\u{e9}", // 36 bytes via multi-byte char
+            "019eb805-60d0-71c0-ade3-b0f0efab9d9\0",  // embedded NUL
+            "------------------------------------",   // all hyphens
             "not-a-uuid",
             "",
         ] {
@@ -342,6 +382,72 @@ mod tests {
         assert_eq!(
             decoded.file_id.as_deref(),
             Some("019eb805-5e65-7270-861d-cb341bc904c8")
+        );
+    }
+
+    #[test]
+    fn id_string_wire_format_is_pinned() {
+        // Persisted layout: uuid arm = tag 1 + 16 raw bytes (no length
+        // prefix); text arm = tag 0 + varint length + bytes. Sequences are
+        // count-prefixed; options are bool-prefixed.
+        let parts = vec!["019eb805-60d0-71c0-ade3-b0f0efab9d9a".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: Some("ab"),
+        };
+        let bytes = super::encode("id string wire pin", &value).expect("encode");
+        let expected: Vec<u8> = [
+            &[1u8][..],     // parts count
+            &[1u8][..],     // TAG_UUID
+            &[
+                0x01, 0x9e, 0xb8, 0x05, 0x60, 0xd0, 0x71, 0xc0, 0xad, 0xe3, 0xb0, 0xf0, 0xef,
+                0xab, 0x9d, 0x9a,
+            ][..],          // raw uuid bytes
+            &[1u8][..],     // file_id Some
+            &[0u8][..],     // TAG_TEXT
+            &[2u8][..],     // text length
+            b"ab",          // text bytes
+        ]
+        .concat();
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn id_string_decode_rejects_unknown_tag_loudly() {
+        let parts = vec!["a".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: None,
+        };
+        let mut bytes = super::encode("id string tag", &value).expect("encode");
+        // Layout: [count=1][tag][len=1][b'a'][file_id=false]; corrupt the tag.
+        assert_eq!(bytes[1], 0, "expected the text tag at offset 1");
+        bytes[1] = 9;
+        let error = super::decode::<IdStringDecode>("id string tag", &bytes)
+            .expect_err("unknown tag should fail decode");
+        assert!(
+            error.message.contains("unknown id string tag 9"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn id_string_decode_rejects_non_utf8_text_loudly() {
+        let parts = vec!["ab".to_string()];
+        let value = IdStringEncode {
+            parts: &parts,
+            file_id: None,
+        };
+        let mut bytes = super::encode("id string utf8", &value).expect("encode");
+        // Layout: [count=1][tag=0][len=2][b'a'][b'b'][file_id=false].
+        bytes[3] = 0xFF;
+        let error = super::decode::<IdStringDecode>("id string utf8", &bytes)
+            .expect_err("invalid UTF-8 should fail decode");
+        assert!(
+            error.message.contains("id string is not UTF-8"),
+            "{}",
+            error.message
         );
     }
 

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -6,7 +6,7 @@ use crate::branch::BranchContext;
 use crate::changelog::CommitId;
 use crate::changelog::{
     ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogReader,
-    ChangelogWriter, CommitChangeRef, CommitChangeRefSet, CommitRecord,
+    ChangelogWriter, CommitChangeRefSet, CommitRecord,
 };
 use crate::json_store::{JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::storage::StorageContext;
@@ -440,13 +440,8 @@ fn stage_json_payloads(
     Ok(())
 }
 
-fn commit_change_ref_from_change(change: &ChangeRecord) -> CommitChangeRef {
-    CommitChangeRef {
-        schema_key: change.schema_key.clone(),
-        file_id: change.file_id.clone(),
-        entity_pk: change.entity_pk.clone(),
-        change_id: change.change_id,
-    }
+fn commit_change_ref_from_change(change: &ChangeRecord) -> ChangeId {
+    change.change_id
 }
 
 #[expect(clippy::unnecessary_wraps)]

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -4,8 +4,8 @@ use std::pin::Pin;
 
 use crate::LixError;
 use crate::changelog::{
-    ChangeId, ChangeLoadRequest, ChangelogContext, ChangelogReader, CommitChangeRef, CommitId,
-    CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitRecord,
+    ChangeId, ChangeLoadRequest, ChangelogContext, ChangelogReader, CommitId, CommitLoadEntry,
+    CommitLoadRequest, CommitProjection, CommitRecord,
 };
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -228,29 +228,24 @@ where
             ));
         }
     };
-    let change_ids = change_refs
-        .iter()
-        .map(|entry| entry.change_id)
-        .collect::<Vec<_>>();
     let changes = reader
         .load_changes(ChangeLoadRequest {
-            change_ids: &change_ids,
+            change_ids: &change_refs,
         })
         .await?;
     let mut deltas = change_refs
         .iter()
         .zip(changes.entries)
-        .map(|(change_ref, change)| {
+        .map(|(change_id, change)| {
             let change = change.ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
-                        "commit '{commit_id}' references missing changelog.change '{}'",
-                        change_ref.change_id
+                        "commit '{commit_id}' references missing changelog.change '{change_id}'"
                     ),
                 )
             })?;
-            rebuild_delta_from_change_ref(commit_id, change_ref, change)
+            rebuild_delta_from_change_ref(commit_id, *change_id, change)
         })
         .collect::<Result<Vec<_>, _>>()?;
     deltas.push(rebuild_delta_from_commit_record(&commit)?);
@@ -317,27 +312,15 @@ fn commit_row_snapshot_content(commit_id: &str) -> Result<String, LixError> {
 
 fn rebuild_delta_from_change_ref(
     commit_id: &str,
-    change_ref: &CommitChangeRef,
+    ref_change_id: ChangeId,
     change: crate::changelog::ChangeRecord,
 ) -> Result<CommitRootRebuildDelta, LixError> {
-    if change.change_id != change_ref.change_id {
+    if change.change_id != ref_change_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
-                "commit '{commit_id}' change ref '{}' loaded mismatched changelog.change '{}'",
-                change_ref.change_id, change.change_id
-            ),
-        ));
-    }
-    if change.schema_key != change_ref.schema_key
-        || change.file_id != change_ref.file_id
-        || change.entity_pk != change_ref.entity_pk
-    {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "commit '{commit_id}' change ref '{}' does not match changelog.change identity",
-                change_ref.change_id
+                "commit '{commit_id}' change ref '{ref_change_id}' loaded mismatched changelog.change '{}'",
+                change.change_id
             ),
         ));
     }

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -485,14 +485,30 @@ where
             },
             record.change_id,
         );
-        for change_ref in chunks.into_iter().flat_map(|chunk| chunk.entries) {
+        // Ref chunks carry change ids only; row identities live in the
+        // change records, batch point-read here.
+        let change_ids = chunks
+            .into_iter()
+            .flat_map(|chunk| chunk.entries)
+            .collect::<Vec<_>>();
+        let changes = changelog_reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &change_ids,
+            })
+            .await?;
+        for (change_id, change) in change_ids.iter().zip(changes.entries) {
+            let Some(change) = change else {
+                return Err(LixError::unknown(format!(
+                    "changelog commit '{commit_id}' references change '{change_id}' that is missing from the changelog"
+                )));
+            };
             winners.insert(
                 TrackedStateIdentity {
-                    schema_key: change_ref.schema_key,
-                    file_id: change_ref.file_id,
-                    entity_pk: change_ref.entity_pk,
+                    schema_key: change.schema_key,
+                    file_id: change.file_id,
+                    entity_pk: change.entity_pk,
                 },
-                change_ref.change_id,
+                *change_id,
             );
         }
         cache

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -8,8 +8,8 @@ use crate::LixError;
 use crate::binary_cas::BinaryCasContext;
 use crate::branch::{BranchContext, BranchRefReader};
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitChangeRef,
-    CommitChangeRefSet, CommitId, CommitRecord,
+    ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitChangeRefSet,
+    CommitId, CommitRecord,
 };
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -253,12 +253,12 @@ async fn stage_changelog_commits(
                     "tracked staged row is missing change_id before changelog append",
                 )
             })?;
-            refs.push(commit_change_ref_from_state_row(row, *change_id));
+            refs.push(*change_id);
             change_ids.push(*change_id);
             changes.push(change_record_from_state_row(row)?);
         }
         for change_ref in &commit_row.selected_change_refs {
-            refs.push(commit_change_ref_from_selected_change_ref(change_ref));
+            refs.push(change_ref.change_id);
             change_ids.push(change_ref.change_id);
         }
         commits.push(CommitRecord {
@@ -322,29 +322,6 @@ fn change_record_from_state_row(row: &PreparedStateRow) -> Result<ChangeRecord, 
             }),
         created_at: row.updated_at,
     })
-}
-
-fn commit_change_ref_from_state_row(
-    row: &PreparedStateRow,
-    change_id: ChangeId,
-) -> CommitChangeRef {
-    CommitChangeRef {
-        schema_key: row.schema_key.clone(),
-        file_id: row.file_id.clone(),
-        entity_pk: row.entity_pk.clone(),
-        change_id,
-    }
-}
-
-fn commit_change_ref_from_selected_change_ref(
-    change_ref: &StagedCommitChangeRef,
-) -> CommitChangeRef {
-    CommitChangeRef {
-        schema_key: change_ref.schema_key.clone(),
-        file_id: change_ref.file_id.clone(),
-        entity_pk: change_ref.entity_pk.clone(),
-        change_id: change_ref.change_id,
-    }
 }
 
 fn tracked_delta_from_state_row(
@@ -794,7 +771,7 @@ mod tests {
             change_ref_chunks
                 .iter()
                 .flat_map(|chunk| chunk.entries.iter())
-                .any(|entry| entry.change_id == change_id("change-1"))
+                .any(|entry| *entry == change_id("change-1"))
         );
         let changes = changelog_reader
             .load_changes(crate::changelog::ChangeLoadRequest {

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -61,6 +61,11 @@ name = "verify_sqlite_key_value"
 path = "tests/fixtures/verify_sqlite_key_value.rs"
 required-features = ["sqlite"]
 
+[[example]]
+name = "profile_merge_10k"
+path = "examples/profile_merge_10k.rs"
+required-features = ["sqlite"]
+
 [[bench]]
 name = "sqlite_backend"
 path = "benches/sqlite_backend.rs"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -61,9 +61,10 @@ name = "verify_sqlite_key_value"
 path = "tests/fixtures/verify_sqlite_key_value.rs"
 required-features = ["sqlite"]
 
-[[example]]
+[[bench]]
 name = "profile_merge_10k"
-path = "examples/profile_merge_10k.rs"
+path = "benches/profile_merge_10k.rs"
+harness = false
 required-features = ["sqlite"]
 
 [[bench]]

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -13,8 +13,6 @@
 //! comparable; absolute times are not.
 
 use lix_sdk::{FsWriteOptions, OpenLixOptions, SqliteBackend, Value, open_lix};
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 use std::io::{Cursor, Write as _};
 use std::path::Path;
 use std::time::Instant;
@@ -112,21 +110,43 @@ async fn profile_merge_phase(lix: &lix_sdk::Lix<SqliteBackend>, updated_csv: Vec
         .unwrap();
 }
 
+/// Deterministic splitmix64 generator. The bench (e2e.rs) seeds rand's
+/// SmallRng, a dev-dependency this harness deliberately avoids; the fixture
+/// bytes therefore differ from the bench's, but the harness only needs
+/// setup and merge to agree with each other.
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform value in `0..bound` (bound > 0); modulo bias is irrelevant
+    /// for fixture shuffling.
+    fn next_below(&mut self, bound: usize) -> usize {
+        usize::try_from(self.next_u64() % bound as u64).expect("bound fits usize")
+    }
+}
+
 fn random_csv_rows(prefix: &str, count: usize, seed: u64) -> Vec<String> {
-    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut rng = SplitMix64(seed);
     (0..count)
         .map(|offset| {
             format!(
                 "{prefix}-{offset:05},{:016x},{:016x}",
-                rng.random::<u64>(),
-                rng.random::<u64>()
+                rng.next_u64(),
+                rng.next_u64()
             )
         })
         .collect()
 }
 
 fn randomly_merge_csv_rows(initial_rows: &[String], new_rows: &[String], seed: u64) -> Vec<String> {
-    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut rng = SplitMix64(seed);
     let mut merged = Vec::with_capacity(initial_rows.len() + new_rows.len());
     let mut initial_index = 0usize;
     let mut new_index = 0usize;
@@ -139,7 +159,7 @@ fn randomly_merge_csv_rows(initial_rows: &[String], new_rows: &[String], seed: u
         } else {
             let remaining_initial = initial_rows.len() - initial_index;
             let remaining_new = new_rows.len() - new_index;
-            rng.random_range(0..(remaining_initial + remaining_new)) < remaining_initial
+            rng.next_below(remaining_initial + remaining_new) < remaining_initial
         };
 
         if take_initial {
@@ -164,8 +184,17 @@ fn csv_bytes_from_rows(rows: &[String]) -> Vec<u8> {
 }
 
 fn build_csv_plugin() -> Vec<u8> {
-    let wasm = std::fs::read(Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv")))
-        .expect("read bindep-built CSV plugin wasm");
+    // option_env: the bindep artifact env var is absent in some CI target
+    // contexts; this harness is only ever run manually, so resolve at
+    // runtime and fail with instructions instead of failing the compile.
+    let Some(wasm_path) = option_env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv") else {
+        eprintln!(
+            "CSV plugin wasm path unavailable; build via `cargo build --bench \
+             profile_merge_10k --features sqlite` so cargo provides the bindep artifact"
+        );
+        std::process::exit(2);
+    };
+    let wasm = std::fs::read(Path::new(wasm_path)).expect("read bindep-built CSV plugin wasm");
     let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
     let options =
         zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -27,10 +27,16 @@ const CSV_PLUGIN_WARMUP_PATH: &str = "/.csv-plugin-warmup.csv";
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let (mode, dir) = match args.as_slice() {
-        [_, mode, dir] => (mode.as_str(), dir.clone()),
+        [_, mode, dir] if matches!(mode.as_str(), "setup" | "merge") => {
+            (mode.as_str(), dir.clone())
+        }
         _ => {
+            // `cargo bench` invokes every bench target with harness flags
+            // (--bench, filters); this profiling harness only runs when
+            // called explicitly, so a plain usage note and success exit
+            // keeps bench sweeps green.
             eprintln!("usage: profile_merge_10k <setup|merge> <dir>");
-            std::process::exit(2);
+            return;
         }
     };
     let lix_path = Path::new(&dir).join("bench.lix");

--- a/packages/rs-sdk/examples/profile_merge_10k.rs
+++ b/packages/rs-sdk/examples/profile_merge_10k.rs
@@ -5,6 +5,12 @@
 //! the prepared file, warms the plugin outside the measured region, then runs the
 //! merge inside `profile_merge_phase` so samply samples can be filtered to that
 //! frame. The post-merge sqlite file is left on disk for inspection.
+//!
+//! Differences from the merge_10k criterion bench (benches/e2e.rs): the bench's
+//! measured region includes `lix.close()`, which this marker frame excludes, and
+//! the merge here runs in a fresh process against a reopened file, so cold-load
+//! frames appear that the bench's in-process setup absorbs. Profile shapes are
+//! comparable; absolute times are not.
 
 use lix_sdk::{FsWriteOptions, OpenLixOptions, SqliteBackend, Value, open_lix};
 use rand::rngs::SmallRng;

--- a/packages/rs-sdk/examples/profile_merge_10k.rs
+++ b/packages/rs-sdk/examples/profile_merge_10k.rs
@@ -1,0 +1,179 @@
+//! Two-phase profiling harness for the raw merge_10k operation.
+//!
+//! `setup <dir>` builds the fixture: opens a lix at <dir>/bench.lix, installs the
+//! CSV plugin, writes the initial 10k-row CSV, and closes. `merge <dir>` reopens
+//! the prepared file, warms the plugin outside the measured region, then runs the
+//! merge inside `profile_merge_phase` so samply samples can be filtered to that
+//! frame. The post-merge sqlite file is left on disk for inspection.
+
+use lix_sdk::{FsWriteOptions, OpenLixOptions, SqliteBackend, Value, open_lix};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use std::io::{Cursor, Write as _};
+use std::path::Path;
+use std::time::Instant;
+
+const INITIAL_ROW_COUNT: usize = 10_000;
+const NEW_ROW_COUNT: usize = 10_000;
+const CSV_PATH: &str = "/large-merge.csv";
+const CSV_PLUGIN_WARMUP_PATH: &str = "/.csv-plugin-warmup.csv";
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let (mode, dir) = match args.as_slice() {
+        [_, mode, dir] => (mode.as_str(), dir.clone()),
+        _ => {
+            eprintln!("usage: profile_merge_10k <setup|merge> <dir>");
+            std::process::exit(2);
+        }
+    };
+    let lix_path = Path::new(&dir).join("bench.lix");
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let initial_rows = random_csv_rows("initial", INITIAL_ROW_COUNT, 0x8ae7_b4b1_9f4c_d215);
+    let new_rows = random_csv_rows("new", NEW_ROW_COUNT, 0xf3bb_91d4_6a8c_2e73);
+
+    match mode {
+        "setup" => runtime.block_on(async {
+            let plugin = build_csv_plugin();
+            let lix = open_lix(OpenLixOptions::new(
+                SqliteBackend::open(&lix_path).expect("open sqlite backend"),
+            ))
+            .await
+            .unwrap();
+            lix.install_plugin_archive(&plugin).await.unwrap();
+            let initial_csv = csv_bytes_from_rows(&initial_rows);
+            let start = Instant::now();
+            lix.write_file(CSV_PATH, initial_csv, FsWriteOptions::default())
+                .await
+                .unwrap();
+            eprintln!("setup insert took {:?}", start.elapsed());
+            lix.close().await.unwrap();
+        }),
+        "merge" => runtime.block_on(async {
+            let updated_csv = csv_bytes_from_rows(&randomly_merge_csv_rows(
+                &initial_rows,
+                &new_rows,
+                0x6449_2c6f_179d_31b5,
+            ));
+            let lix = open_lix(OpenLixOptions::new(
+                SqliteBackend::open(&lix_path).expect("open sqlite backend"),
+            ))
+            .await
+            .unwrap();
+            // Warm: compiles the wasm component and primes caches outside the
+            // measured region, mirroring warm_lix_csv_plugin in the bench.
+            lix.write_file(
+                CSV_PLUGIN_WARMUP_PATH,
+                Vec::new(),
+                FsWriteOptions::default(),
+            )
+            .await
+            .unwrap();
+            lix.execute(
+                "DELETE FROM lix_file WHERE path = $1",
+                &[Value::Text(CSV_PLUGIN_WARMUP_PATH.to_string())],
+            )
+            .await
+            .unwrap();
+
+            let start = Instant::now();
+            profile_merge_phase(&lix, updated_csv).await;
+            eprintln!("merge took {:?}", start.elapsed());
+            lix.close().await.unwrap();
+        }),
+        other => {
+            eprintln!("unknown mode {other}");
+            std::process::exit(2);
+        }
+    }
+}
+
+#[inline(never)]
+async fn profile_merge_phase(lix: &lix_sdk::Lix<SqliteBackend>, updated_csv: Vec<u8>) {
+    lix.write_file(CSV_PATH, updated_csv, FsWriteOptions::default())
+        .await
+        .unwrap();
+}
+
+fn random_csv_rows(prefix: &str, count: usize, seed: u64) -> Vec<String> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    (0..count)
+        .map(|offset| {
+            format!(
+                "{prefix}-{offset:05},{:016x},{:016x}",
+                rng.random::<u64>(),
+                rng.random::<u64>()
+            )
+        })
+        .collect()
+}
+
+fn randomly_merge_csv_rows(initial_rows: &[String], new_rows: &[String], seed: u64) -> Vec<String> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut merged = Vec::with_capacity(initial_rows.len() + new_rows.len());
+    let mut initial_index = 0usize;
+    let mut new_index = 0usize;
+
+    while initial_index < initial_rows.len() || new_index < new_rows.len() {
+        let take_initial = if initial_index == initial_rows.len() {
+            false
+        } else if new_index == new_rows.len() {
+            true
+        } else {
+            let remaining_initial = initial_rows.len() - initial_index;
+            let remaining_new = new_rows.len() - new_index;
+            rng.random_range(0..(remaining_initial + remaining_new)) < remaining_initial
+        };
+
+        if take_initial {
+            merged.push(initial_rows[initial_index].clone());
+            initial_index += 1;
+        } else {
+            merged.push(new_rows[new_index].clone());
+            new_index += 1;
+        }
+    }
+
+    merged
+}
+
+fn csv_bytes_from_rows(rows: &[String]) -> Vec<u8> {
+    let mut csv = String::with_capacity(rows.iter().map(|row| row.len() + 1).sum());
+    for row in rows {
+        csv.push_str(row);
+        csv.push('\n');
+    }
+    csv.into_bytes()
+}
+
+fn build_csv_plugin() -> Vec<u8> {
+    let wasm = std::fs::read(Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_CSV_plugin_csv")))
+        .expect("read bindep-built CSV plugin wasm");
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/csv/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/csv_table.json",
+            include_str!("../../../plugins/csv/schema/csv_table.json").as_bytes(),
+        ),
+        (
+            "schema/csv_row.json",
+            include_str!("../../../plugins/csv/schema/csv_row.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}


### PR DESCRIPTION
Stacked on #518 (includes its two commits; review the last commit, or the range after #518 merges).

## What

Commit change-ref chunk entries duplicated each change's `schema_key`, `file_id`, and `entity_pk` next to its change id, served by the most complex codec in the changelog: per-chunk schema/file dictionaries, front-coded entity pks with NUL escaping, and a size-estimating chunk builder. Every production reader either already loads the full change records (commit-root rebuild, which used the chunk copy only as a cross-check) or now batch point-reads them (diff validation's commit-ref winners) — the standard single-copy pattern.

A chunk entry is now the raw 16-byte change id, sorted ascending, split at 2048 entries per chunk (~32 KB worst case). Decode rejects unknown chunk format versions explicitly. Deleted: the front-coding codec, builder, dictionaries, and the orphaned `vec_option` storage codec — **-900 lines net**.

Append validation keeps the same invariants from the single copy: every ref must resolve to a change record, and no two refs in a commit may target the same (schema_key, file_id, entity_pk) identity (checked over resolved records with borrowed keys).

## Measured

Storage (1k accounting, lix_sqlite):

| | fields in chunks | ids only |
|---|---|---|
| insert_all written bytes | 437,472 | 423,200 (-3.3%) |
| delete_all written bytes | 183,497 | 169,226 (-7.8%) |
| ref chunk value bytes | 30,823 | 16,261 (-47%) |

e2e 10k merge fixture: ref chunk payload 643,617 -> 320,486 B (-50%), file 10,010,624 -> 9,682,944 B.

Perf A/B (stash-alternating): insert_all 10k **-9 to -12%** (A: 87.3/80.6 ms, B: 73.3/75.6/72.2 ms, p = 0.00 on the clean pair), update_all -2.8%, delete_all -3.2% (both p = 0.00), merge_10k 187.5 -> 182.5 ms (p = 0.11, directional), reads unaffected (point reads never touch ref chunks; an apparent read_one regression was chased to process-level noise at p = 0.28). The write speedup comes from deleting per-commit work that scaled with change count: the identity-tuple sort, front-coding allocations and prefix scans, and ref-struct construction.

## Review

Three independent review passes (codec/chunker correctness, integration completeness + semantic preservation, math/claims): zero blockers, zero majors. All actionable findings applied: explicit format-version rejection on decode, borrowed encode twin (no entries clone), borrowed validation keys, an end-to-end test pinning the 2048 split across chunk-key boundaries, and optimization-log precision fixes. Known accepted trade: the chunk-vs-record divergence cross-check in rebuild is structurally gone with the duplicate copy — single-copy means there is nothing left to diverge.

Suites: engine 1,570 green, sdk green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> On-disk changelog encoding changes within SQLITE_FORMAT_VERSION 3 without a migration path; old ref-chunk and pre-packing change records fail decode loudly. Validation and rebuild paths now depend on batched change-record reads.
> 
> **Overview**
> **Commit change-ref chunks** no longer duplicate `schema_key`, `file_id`, and `entity_pk` beside each change id. `CommitChangeRefSet` / chunk payloads are sorted **`ChangeId` lists** (2048 ids per chunk); wire encoding drops dictionaries, front-coded entity PKs, and the size-estimating chunk builder (~900 lines removed). Append validation still enforces resolvable changes and unique `(schema_key, file_id, entity_pk)` per commit, but does so by **batch-loading change records** instead of comparing chunk copies.
> 
> **Readers** that needed identities from refs now point-read change records: diff validation’s commit-ref winners, commit-root rebuild (identity cross-check against chunk fields removed). `CommitChangeRef` and `vec_option` codec are deleted.
> 
> **Change record encoding** adds opportunistic **UUID packing** for canonical lowercase hyphenated ids in `entity_pk`, `file_id`, and `author_account_ids` via new `storage_codec::id_string` helpers (non-canonical strings stay as text).
> 
> Docs in `optimization_log.md` capture storage/perf measurements; **`profile_merge_10k`** is added as a two-phase SDK bench for merge profiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091e7a62d43908a425c8f6eb98f0deb6b0318220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->