### PR TITLE
Add observe API with durable invalidation

### DIFF
--- a/.changenotes/observe-api.md
+++ b/.changenotes/observe-api.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added `lix.observe()` for subscribing to SQL query results.
+
+The Rust and JavaScript SDKs can now create observe streams that emit an initial result and re-run after Lix mutations, making it possible to build reactive views without manual polling.

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -100,7 +100,7 @@ paste = "1"
 rustc-hash = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 tempfile = "3"
-tokio = { version = "1", features = ["rt", "macros", "sync"] }
+tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 zstd = "0.13"

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -9,6 +9,8 @@ use crate::entity_pk::EntityPk;
 use crate::init::InitReceipt;
 use crate::live_state::LiveStateContext;
 use crate::live_state::LiveStateRowRequest;
+use crate::observe_coordinator::ObserveCoordinator;
+use crate::observe_invalidation::ObserveInvalidation;
 use crate::plugin::PluginRuntimeHost;
 use crate::session::SessionContext;
 use crate::storage::{SharedStorageRead, StorageBackend, StorageReadOptions, StorageWriteOptions};
@@ -28,6 +30,8 @@ pub struct Engine<B: StorageBackend = crate::storage::InMemoryStorageBackend> {
     binary_cas: Arc<BinaryCasContext>,
     catalog_context: Arc<CatalogContext>,
     deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
+    observe_coordinator: Arc<ObserveCoordinator>,
+    observe_invalidation: Arc<ObserveInvalidation>,
     plugin_host: PluginRuntimeHost,
 }
 
@@ -95,6 +99,8 @@ where
             branch_ctx,
             catalog_context: Arc::new(CatalogContext::new()),
             deterministic_runtime_gate: Arc::new(tokio::sync::Mutex::new(())),
+            observe_coordinator: Arc::new(ObserveCoordinator::new()),
+            observe_invalidation: Arc::new(ObserveInvalidation::new()),
             plugin_host: PluginRuntimeHost::new(wasm_runtime),
         })
     }
@@ -135,6 +141,8 @@ where
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
             Arc::clone(&self.deterministic_runtime_gate),
+            Arc::clone(&self.observe_coordinator),
+            Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),
         )
         .await
@@ -149,6 +157,8 @@ where
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
             Arc::clone(&self.deterministic_runtime_gate),
+            Arc::clone(&self.observe_coordinator),
+            Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),
         )
         .await

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -31,7 +31,9 @@ pub(crate) mod functions;
 pub(crate) mod init;
 pub(crate) mod json_store;
 pub(crate) mod live_state;
-#[allow(unused_imports)]
+pub(crate) mod observe_coordinator;
+pub(crate) mod observe_invalidation;
+#[allow(dead_code, unused_imports)]
 pub(crate) mod plugin;
 mod schema;
 pub mod session;
@@ -88,6 +90,6 @@ pub use session::{
     MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, SessionContext,
     SessionFs, SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt,
 };
-pub use session::{ExecuteResult, Row, RowRef, TryFromValue};
+pub use session::{ExecuteResult, ObserveEvent, ObserveEvents, Row, RowRef, TryFromValue};
 
 pub(crate) const GLOBAL_BRANCH_ID: &str = "global";

--- a/packages/engine/src/observe_coordinator.rs
+++ b/packages/engine/src/observe_coordinator.rs
@@ -1,0 +1,324 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::future::Future;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex, Weak};
+
+use tokio::sync::watch;
+
+use crate::{ExecuteResult, LixError, Value};
+
+const MAX_CACHED_GENERATIONS_PER_QUERY: usize = 4;
+const MAX_WEAK_QUERY_ENTRIES_BEFORE_PRUNE: usize = 1024;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum ObserveSessionScope {
+    Workspace,
+    Pinned(String),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct ObserveQueryKey {
+    scope: ObserveSessionScope,
+    sql: String,
+    params: Vec<ObserveParamKey>,
+}
+
+impl ObserveQueryKey {
+    pub(crate) fn new(
+        scope: ObserveSessionScope,
+        sql: impl Into<String>,
+        params: &[Value],
+    ) -> Result<Self, LixError> {
+        let params = params
+            .iter()
+            .map(ObserveParamKey::from_value)
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            scope,
+            sql: sql.into(),
+            params,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ObserveParamKey {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    Real(u64),
+    Text(String),
+    Json(String),
+    Blob(Vec<u8>),
+}
+
+impl ObserveParamKey {
+    fn from_value(value: &Value) -> Result<Self, LixError> {
+        match value {
+            Value::Null => Ok(Self::Null),
+            Value::Boolean(value) => Ok(Self::Boolean(*value)),
+            Value::Integer(value) => Ok(Self::Integer(*value)),
+            Value::Real(value) => Ok(Self::Real(value.to_bits())),
+            Value::Text(value) => Ok(Self::Text(value.clone())),
+            Value::Json(value) => {
+                let json = serde_json::to_string(value).map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_UNKNOWN,
+                        format!("failed to serialize observe JSON parameter: {error}"),
+                    )
+                })?;
+                Ok(Self::Json(json))
+            }
+            Value::Blob(value) => Ok(Self::Blob(value.clone())),
+        }
+    }
+}
+
+impl Hash for ObserveParamKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Null => {}
+            Self::Boolean(value) => value.hash(state),
+            Self::Integer(value) => value.hash(state),
+            Self::Real(value) => value.hash(state),
+            Self::Text(value) | Self::Json(value) => value.hash(state),
+            Self::Blob(value) => value.hash(state),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ObserveCoordinator {
+    queries: Mutex<HashMap<ObserveQueryKey, Weak<ObserveQueryState>>>,
+}
+
+impl ObserveCoordinator {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn state_for(&self, key: &ObserveQueryKey) -> Arc<ObserveQueryState> {
+        let mut queries = self
+            .queries
+            .lock()
+            .expect("observe coordinator lock should not poison");
+        if let Some(state) = queries.get(key).and_then(Weak::upgrade) {
+            return state;
+        }
+        if queries.len() > MAX_WEAK_QUERY_ENTRIES_BEFORE_PRUNE {
+            queries.retain(|_, state| state.strong_count() > 0);
+        }
+
+        let state = Arc::new(ObserveQueryState::new());
+        queries.insert(key.clone(), Arc::downgrade(&state));
+        state
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ObserveQueryState {
+    inner: Mutex<ObserveQueryStateInner>,
+    changes: watch::Sender<u64>,
+}
+
+impl ObserveQueryState {
+    pub(crate) async fn evaluate<F, Fut>(
+        &self,
+        generation: u64,
+        evaluate: F,
+    ) -> Result<ExecuteResult, LixError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<ExecuteResult, LixError>>,
+    {
+        let mut changes = self.subscribe();
+
+        loop {
+            {
+                let mut inner = self.lock();
+                if let Some(rows) = inner.cached.get(&generation) {
+                    return Ok(rows.clone());
+                }
+
+                if !inner.in_flight.contains(&generation) {
+                    inner.in_flight.insert(generation);
+                    break;
+                }
+
+                let _ = changes.borrow_and_update();
+            }
+
+            if changes.changed().await.is_err() {
+                return evaluate().await;
+            }
+        }
+
+        let guard = InFlightGuard::new(self, generation);
+        match evaluate().await {
+            Ok(rows) => {
+                guard.finish_success(rows.clone());
+                Ok(rows)
+            }
+            Err(error) => {
+                guard.finish_without_cache();
+                Err(error)
+            }
+        }
+    }
+
+    fn new() -> Self {
+        let (changes, _) = watch::channel(0);
+        Self {
+            inner: Mutex::new(ObserveQueryStateInner::default()),
+            changes,
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, ObserveQueryStateInner> {
+        self.inner
+            .lock()
+            .expect("observe query state lock should not poison")
+    }
+
+    fn subscribe(&self) -> watch::Receiver<u64> {
+        self.changes.subscribe()
+    }
+
+    fn send_change(&self, sequence: u64) {
+        self.changes.send_replace(sequence);
+    }
+}
+
+#[derive(Debug, Default)]
+struct ObserveQueryStateInner {
+    cached: BTreeMap<u64, ExecuteResult>,
+    in_flight: BTreeSet<u64>,
+    change_sequence: u64,
+}
+
+struct InFlightGuard<'a> {
+    state: &'a ObserveQueryState,
+    generation: u64,
+    active: bool,
+}
+
+impl<'a> InFlightGuard<'a> {
+    fn new(state: &'a ObserveQueryState, generation: u64) -> Self {
+        Self {
+            state,
+            generation,
+            active: true,
+        }
+    }
+
+    fn finish_success(mut self, rows: ExecuteResult) {
+        self.finish(Some(rows));
+    }
+
+    fn finish_without_cache(mut self) {
+        self.finish(None);
+    }
+
+    fn finish(&mut self, rows: Option<ExecuteResult>) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+        let mut inner = self.state.lock();
+        inner.in_flight.remove(&self.generation);
+        if let Some(rows) = rows {
+            inner.cached.insert(self.generation, rows);
+            while inner.cached.len() > MAX_CACHED_GENERATIONS_PER_QUERY {
+                let Some(oldest_generation) = inner.cached.first_key_value().map(|(key, _)| *key)
+                else {
+                    break;
+                };
+                inner.cached.remove(&oldest_generation);
+            }
+        }
+        inner.change_sequence = inner.change_sequence.saturating_add(1);
+        self.state.send_change(inner.change_sequence);
+    }
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.finish(None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use tokio::sync::oneshot;
+
+    use super::ObserveQueryState;
+    use crate::ExecuteResult;
+
+    #[tokio::test]
+    async fn evaluate_cleans_up_in_flight_generation_when_leader_is_cancelled() {
+        let state = Arc::new(ObserveQueryState::new());
+        let (started_tx, started_rx) = oneshot::channel();
+        let leader_state = Arc::clone(&state);
+        let leader = tokio::spawn(async move {
+            leader_state
+                .evaluate(1, || async move {
+                    let _ = started_tx.send(());
+                    std::future::pending().await
+                })
+                .await
+        });
+        started_rx
+            .await
+            .expect("leader evaluation should have started");
+
+        leader.abort();
+        let _ = leader.await;
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            state.evaluate(1, || async { Ok(ExecuteResult::from_rows_affected(0)) }),
+        )
+        .await
+        .expect("cancelled in-flight generation should not strand followers")
+        .expect("replacement evaluation should succeed");
+
+        assert_eq!(result, ExecuteResult::from_rows_affected(0));
+    }
+
+    #[tokio::test]
+    async fn evaluate_does_not_cache_errors_for_generation() {
+        let state = ObserveQueryState::new();
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let first_attempts = Arc::clone(&attempts);
+        let first = state
+            .evaluate(1, || async move {
+                first_attempts.fetch_add(1, Ordering::SeqCst);
+                Err(crate::LixError::new(crate::LixError::CODE_UNKNOWN, "boom"))
+            })
+            .await;
+        assert!(first.is_err());
+
+        let second_attempts = Arc::clone(&attempts);
+        let second = state
+            .evaluate(1, || async move {
+                second_attempts.fetch_add(1, Ordering::SeqCst);
+                Ok(ExecuteResult::from_rows_affected(0))
+            })
+            .await
+            .expect("second evaluation should not reuse the first error");
+
+        assert_eq!(second, ExecuteResult::from_rows_affected(0));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            2,
+            "failed evaluations must not be cached for followers"
+        );
+    }
+}

--- a/packages/engine/src/observe_coordinator.rs
+++ b/packages/engine/src/observe_coordinator.rs
@@ -141,8 +141,7 @@ impl ObserveQueryState {
                     return Ok(rows.clone());
                 }
 
-                if !inner.in_flight.contains(&generation) {
-                    inner.in_flight.insert(generation);
+                if inner.in_flight.insert(generation) {
                     break;
                 }
 

--- a/packages/engine/src/observe_invalidation.rs
+++ b/packages/engine/src/observe_invalidation.rs
@@ -1,0 +1,37 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::watch;
+
+use crate::storage::StorageWriteSetStats;
+
+#[derive(Debug)]
+pub(crate) struct ObserveInvalidation {
+    generation: AtomicU64,
+    sender: watch::Sender<u64>,
+}
+
+impl ObserveInvalidation {
+    pub(crate) fn new() -> Self {
+        let (sender, _) = watch::channel(0);
+        Self {
+            generation: AtomicU64::new(0),
+            sender,
+        }
+    }
+
+    pub(crate) fn bump(&self) -> u64 {
+        let next = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        self.sender.send_replace(next);
+        next
+    }
+
+    pub(crate) fn bump_if_storage_changed(&self, stats: &StorageWriteSetStats) {
+        if stats.staged_puts > 0 || stats.staged_deletes > 0 {
+            self.bump();
+        }
+    }
+
+    pub(crate) fn subscribe(&self) -> watch::Receiver<u64> {
+        self.sender.subscribe()
+    }
+}

--- a/packages/engine/src/observe_invalidation.rs
+++ b/packages/engine/src/observe_invalidation.rs
@@ -53,7 +53,6 @@ impl ObserveInvalidation {
         for<'backend> B::Write<'backend>: Send,
     {
         let mut last_seen_revision = storage.load_mutation_revision()?;
-        let mut last_seen_generation = self.generation.load(Ordering::SeqCst);
         if self
             .external_watcher_started
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -75,12 +74,7 @@ impl ObserveInvalidation {
                     };
                     if current_revision != last_seen_revision {
                         last_seen_revision = current_revision;
-                        let current_generation = invalidation.generation.load(Ordering::SeqCst);
-                        if current_generation == last_seen_generation {
-                            last_seen_generation = invalidation.bump();
-                        } else {
-                            last_seen_generation = current_generation;
-                        }
+                        invalidation.bump();
                     }
                 }
             });

--- a/packages/engine/src/observe_invalidation.rs
+++ b/packages/engine/src/observe_invalidation.rs
@@ -1,13 +1,20 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
 
 use tokio::sync::watch;
 
-use crate::storage::StorageWriteSetStats;
+use crate::LixError;
+use crate::storage::{StorageBackend, StorageContext, StorageWriteSetStats};
+
+const EXTERNAL_MUTATION_REVISION_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 pub(crate) struct ObserveInvalidation {
     generation: AtomicU64,
     sender: watch::Sender<u64>,
+    external_watcher_started: AtomicBool,
 }
 
 impl ObserveInvalidation {
@@ -16,6 +23,7 @@ impl ObserveInvalidation {
         Self {
             generation: AtomicU64::new(0),
             sender,
+            external_watcher_started: AtomicBool::new(false),
         }
     }
 
@@ -33,5 +41,55 @@ impl ObserveInvalidation {
 
     pub(crate) fn subscribe(&self) -> watch::Receiver<u64> {
         self.sender.subscribe()
+    }
+
+    pub(crate) fn ensure_external_watcher<B>(
+        self: &Arc<Self>,
+        storage: StorageContext<B>,
+    ) -> Result<(), LixError>
+    where
+        B: StorageBackend + Clone + Send + Sync + 'static,
+        for<'backend> B::Read<'backend>: Send,
+        for<'backend> B::Write<'backend>: Send,
+    {
+        let mut last_seen_revision = storage.load_mutation_revision()?;
+        let mut last_seen_generation = self.generation.load(Ordering::SeqCst);
+        if self
+            .external_watcher_started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Ok(());
+        }
+        let invalidation = Arc::downgrade(self);
+        let spawn_result = thread::Builder::new()
+            .name("lix-observe-invalidation".to_string())
+            .spawn(move || {
+                loop {
+                    thread::sleep(EXTERNAL_MUTATION_REVISION_POLL_INTERVAL);
+                    let Some(invalidation) = invalidation.upgrade() else {
+                        break;
+                    };
+                    let Ok(current_revision) = storage.load_mutation_revision() else {
+                        continue;
+                    };
+                    if current_revision != last_seen_revision {
+                        last_seen_revision = current_revision;
+                        let current_generation = invalidation.generation.load(Ordering::SeqCst);
+                        if current_generation == last_seen_generation {
+                            last_seen_generation = invalidation.bump();
+                        } else {
+                            last_seen_generation = current_generation;
+                        }
+                    }
+                }
+            });
+        if let Err(error) = spawn_result {
+            self.external_watcher_started.store(false, Ordering::SeqCst);
+            return Err(LixError::unknown(format!(
+                "failed to spawn observe invalidation watcher: {error}"
+            )));
+        }
+        Ok(())
     }
 }

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -17,6 +17,8 @@ use crate::entity_pk::EntityPk;
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreContext;
 use crate::live_state::{LiveStateContext, LiveStateReader, LiveStateRowRequest};
+use crate::observe_coordinator::ObserveCoordinator;
+use crate::observe_invalidation::ObserveInvalidation;
 use crate::plugin::{PluginComponentHost, PluginRuntimeHost};
 use crate::sql2::{
     ChangelogQuerySource, HistoryQuerySource, SqlChangelogQuerySource, SqlExecutionContext,
@@ -56,6 +58,8 @@ pub struct SessionContext<B: StorageBackend = InMemoryStorageBackend> {
     pub(super) branch_ctx: Arc<BranchContext>,
     pub(super) catalog_context: Arc<CatalogContext>,
     pub(super) deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
+    pub(super) observe_coordinator: Arc<ObserveCoordinator>,
+    pub(super) observe_invalidation: Arc<ObserveInvalidation>,
     pub(super) plugin_host: PluginRuntimeHost,
     transaction_manager: SessionTransactionManager,
 }
@@ -74,6 +78,8 @@ where
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
+        observe_coordinator: Arc<ObserveCoordinator>,
+        observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
     ) -> Result<Self, LixError> {
         let session = Self::new(
@@ -85,6 +91,8 @@ where
             branch_ctx,
             catalog_context,
             deterministic_runtime_gate,
+            observe_coordinator,
+            observe_invalidation,
             plugin_host,
         );
         session.active_branch_id().await?;
@@ -100,6 +108,8 @@ where
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
+        observe_coordinator: Arc<ObserveCoordinator>,
+        observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
     ) -> Result<Self, LixError> {
         Ok(Self::new(
@@ -113,6 +123,8 @@ where
             branch_ctx,
             catalog_context,
             deterministic_runtime_gate,
+            observe_coordinator,
+            observe_invalidation,
             plugin_host,
         ))
     }
@@ -126,6 +138,8 @@ where
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
+        observe_coordinator: Arc<ObserveCoordinator>,
+        observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
     ) -> Self {
         Self::new_with_transaction_manager(
@@ -137,6 +151,8 @@ where
             branch_ctx,
             catalog_context,
             deterministic_runtime_gate,
+            observe_coordinator,
+            observe_invalidation,
             plugin_host,
             SessionTransactionManager::new(),
         )
@@ -151,6 +167,8 @@ where
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
+        observe_coordinator: Arc<ObserveCoordinator>,
+        observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
         transaction_manager: SessionTransactionManager,
     ) -> Self {
@@ -163,6 +181,8 @@ where
             branch_ctx,
             catalog_context,
             deterministic_runtime_gate,
+            observe_coordinator,
+            observe_invalidation,
             plugin_host,
             transaction_manager,
         }
@@ -171,7 +191,9 @@ where
     /// Releases this logical session handle. This is a lifecycle boundary only:
     /// successful writes are committed before their operation returns.
     pub async fn close(&self) -> Result<(), LixError> {
-        self.transaction_manager.close().await
+        self.transaction_manager.close().await?;
+        self.observe_invalidation.bump();
+        Ok(())
     }
 
     pub fn is_closed(&self) -> bool {
@@ -355,7 +377,7 @@ where
 
     pub(super) async fn with_write_transaction_reserved<T, F>(
         &self,
-        _write_access: SessionWriteAccess,
+        write_access: SessionWriteAccess,
         f: F,
     ) -> Result<T, LixError>
     where
@@ -387,7 +409,10 @@ where
         match f(&mut transaction).await {
             Ok(value) => {
                 self.ensure_open()?;
-                transaction.commit(&runtime_functions).await?;
+                let outcome = transaction.commit(&runtime_functions).await?;
+                drop(write_access);
+                self.observe_invalidation
+                    .bump_if_storage_changed(&outcome.storage_stats);
                 Ok(value)
             }
             Err(error) => Err(error),

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -390,11 +390,16 @@ where
                 return Err(normalize_sql_surface_error(error, sql));
             }
         };
-        self.persist_runtime_functions_if_needed(
-            &read_result.runtime_functions,
-            runtime_write_access.as_ref(),
-        )
-        .await?;
+        let runtime_storage_stats = self
+            .persist_runtime_functions_if_needed(
+                &read_result.runtime_functions,
+                runtime_write_access.as_ref(),
+            )
+            .await?;
+        drop(runtime_write_access);
+        if let Some(stats) = runtime_storage_stats {
+            self.observe_invalidation.bump_if_storage_changed(&stats);
+        }
         Ok(ExecuteResult::from_sql_query_result(read_result.query))
     }
 
@@ -444,13 +449,13 @@ where
         &self,
         runtime_functions: &FunctionContext,
         runtime_write_access: Option<&SessionWriteAccess>,
-    ) -> Result<(), LixError> {
+    ) -> Result<Option<crate::storage::StorageWriteSetStats>, LixError> {
         let mut writes = StorageWriteSet::new();
         runtime_functions
             .stage_persist_if_needed(&mut writes)
             .await?;
         if writes.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         if runtime_write_access.is_none() {
             return Err(LixError::new(
@@ -463,11 +468,11 @@ where
         let prepared_commit = self
             .storage
             .prepare_write_set(writes, StorageWriteOptions::default())?;
-        commit_at_boundary(Some(&commit_boundary), || {
-            prepared_commit.commit()?;
-            Ok(())
+        let stats = commit_at_boundary(Some(&commit_boundary), || {
+            let (_commit, stats) = prepared_commit.commit()?;
+            Ok(stats)
         })?;
-        Ok(())
+        Ok(Some(stats))
     }
 }
 

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -15,6 +15,7 @@ mod create_branch;
 mod execute;
 mod fs;
 mod merge;
+pub(crate) mod observe;
 mod plugin;
 mod switch_branch;
 mod transaction;
@@ -29,6 +30,7 @@ pub use merge::{
     MergeBranchReceipt, MergeChangeStats, MergeConflict, MergeConflictChangeKind,
     MergeConflictKind, MergeConflictSide,
 };
+pub use observe::{ObserveEvent, ObserveEvents};
 pub use plugin::InstalledPluginInfo;
 pub use switch_branch::{SwitchBranchOptions, SwitchBranchReceipt};
 pub use transaction::SessionTransaction;

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -37,7 +37,7 @@ pub struct ObserveEvent {
 }
 
 #[expect(missing_debug_implementations)]
-pub struct ObserveEvents<B: StorageBackend = InMemoryStorageBackend>
+pub struct ObserveEvents<B = InMemoryStorageBackend>
 where
     B: StorageBackend + Clone + Send + Sync + 'static,
     for<'backend> B::Read<'backend>: Send,

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -62,6 +62,9 @@ where
             self.closed = true;
             return Ok(None);
         }
+        self.session
+            .observe_invalidation
+            .ensure_external_watcher(self.session.storage.clone())?;
 
         if self.last_rows.is_none() {
             let Some((mutation_sequence, rows)) = self.evaluate_stable_snapshot().await? else {
@@ -81,7 +84,7 @@ where
                 return Ok(None);
             }
 
-            if self.receiver.changed().await.is_err() {
+            if !self.wait_for_invalidation().await? {
                 self.closed = true;
                 return Ok(None);
             }
@@ -112,6 +115,10 @@ where
 
     pub fn close(&mut self) {
         self.closed = true;
+    }
+
+    async fn wait_for_invalidation(&mut self) -> Result<bool, LixError> {
+        Ok(self.receiver.changed().await.is_ok())
     }
 
     async fn evaluate_stable_snapshot(&mut self) -> Result<Option<(u64, ExecuteResult)>, LixError> {

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -1,0 +1,214 @@
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+use crate::observe_coordinator::{ObserveQueryKey, ObserveQueryState, ObserveSessionScope};
+use crate::storage::{InMemoryStorageBackend, StorageBackend};
+use crate::{ExecuteResult, LixError, Value, sql2};
+
+use super::{SessionContext, SessionMode};
+
+#[derive(Debug, Clone)]
+struct ObserveQuery {
+    sql: String,
+    params: Vec<Value>,
+    shared_state: Option<Arc<ObserveQueryState>>,
+}
+
+impl ObserveQuery {
+    fn new(
+        sql: impl Into<String>,
+        params: Vec<Value>,
+        shared_state: Option<Arc<ObserveQueryState>>,
+    ) -> Self {
+        Self {
+            sql: sql.into(),
+            params,
+            shared_state,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObserveEvent {
+    pub sequence: u64,
+    pub mutation_sequence: u64,
+    pub rows: ExecuteResult,
+}
+
+#[expect(missing_debug_implementations)]
+pub struct ObserveEvents<B: StorageBackend = InMemoryStorageBackend>
+where
+    B: StorageBackend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    session: SessionContext<B>,
+    query: ObserveQuery,
+    receiver: watch::Receiver<u64>,
+    sequence: u64,
+    last_rows: Option<ExecuteResult>,
+    closed: bool,
+}
+
+impl<B> ObserveEvents<B>
+where
+    B: StorageBackend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    pub async fn next(&mut self) -> Result<Option<ObserveEvent>, LixError> {
+        if self.closed || self.session.is_closed() {
+            self.closed = true;
+            return Ok(None);
+        }
+
+        if self.last_rows.is_none() {
+            let Some((mutation_sequence, rows)) = self.evaluate_stable_snapshot().await? else {
+                return Ok(None);
+            };
+            self.last_rows = Some(rows.clone());
+            return Ok(Some(ObserveEvent {
+                sequence: self.sequence,
+                mutation_sequence,
+                rows,
+            }));
+        }
+
+        loop {
+            if self.closed || self.session.is_closed() {
+                self.closed = true;
+                return Ok(None);
+            }
+
+            if self.receiver.changed().await.is_err() {
+                self.closed = true;
+                return Ok(None);
+            }
+
+            if self.session.is_closed() {
+                self.closed = true;
+                return Ok(None);
+            }
+
+            let Some((mutation_sequence, rows)) = self.evaluate_stable_snapshot().await? else {
+                return Ok(None);
+            };
+            if self
+                .last_rows
+                .as_ref()
+                .is_none_or(|last_rows| *last_rows != rows)
+            {
+                self.sequence += 1;
+                self.last_rows = Some(rows.clone());
+                return Ok(Some(ObserveEvent {
+                    sequence: self.sequence,
+                    mutation_sequence,
+                    rows,
+                }));
+            }
+        }
+    }
+
+    pub fn close(&mut self) {
+        self.closed = true;
+    }
+
+    async fn evaluate_stable_snapshot(&mut self) -> Result<Option<(u64, ExecuteResult)>, LixError> {
+        loop {
+            let operation_guard = self.session.begin_session_operation()?;
+            let before = *self.receiver.borrow_and_update();
+            let rows = self.execute_or_share(before).await;
+            drop(operation_guard);
+            let rows = match rows {
+                Ok(rows) => rows,
+                Err(error) if error.code == LixError::CODE_CLOSED => {
+                    self.closed = true;
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
+            };
+            let after = *self.receiver.borrow_and_update();
+            if before == after {
+                return Ok(Some((after, rows)));
+            }
+        }
+    }
+
+    async fn execute_or_share(&self, generation: u64) -> Result<ExecuteResult, LixError> {
+        let Some(shared_state) = &self.query.shared_state else {
+            return self
+                .session
+                .execute(&self.query.sql, &self.query.params)
+                .await;
+        };
+
+        shared_state
+            .evaluate(generation, || async {
+                self.session
+                    .execute(&self.query.sql, &self.query.params)
+                    .await
+            })
+            .await
+    }
+}
+
+impl<B> Drop for ObserveEvents<B>
+where
+    B: StorageBackend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl<B> SessionContext<B>
+where
+    B: StorageBackend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    pub fn observe(&self, sql: &str, params: &[Value]) -> Result<ObserveEvents<B>, LixError> {
+        let operation_guard = self.begin_session_operation()?;
+        if sql.trim().is_empty() {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "observe requires a non-empty SQL string",
+            ));
+        }
+        let statement = sql2::parse_statement(sql)?;
+        if sql2::bind_statement_route(&statement)? == sql2::BoundStatementRoute::Write {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "observe only supports read statements",
+            ));
+        }
+        if sql2::statement_has_durable_runtime_function(&statement) {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "observe does not support durable runtime functions",
+            ));
+        }
+        let key = ObserveQueryKey::new(self.observe_scope(), sql, params)?;
+        let shared_state = Some(self.observe_coordinator.state_for(&key));
+        drop(operation_guard);
+
+        Ok(ObserveEvents {
+            session: self.clone(),
+            query: ObserveQuery::new(sql, params.to_vec(), shared_state),
+            receiver: self.observe_invalidation.subscribe(),
+            sequence: 0,
+            last_rows: None,
+            closed: false,
+        })
+    }
+
+    fn observe_scope(&self) -> ObserveSessionScope {
+        match &self.mode {
+            SessionMode::Workspace => ObserveSessionScope::Workspace,
+            SessionMode::Pinned { branch_id } => ObserveSessionScope::Pinned(branch_id.clone()),
+        }
+    }
+}

--- a/packages/engine/src/session/switch_branch.rs
+++ b/packages/engine/src/session/switch_branch.rs
@@ -80,6 +80,8 @@ where
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
             Arc::clone(&self.deterministic_runtime_gate),
+            Arc::clone(&self.observe_coordinator),
+            Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),
             self.transaction_manager(),
         );

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::functions::{DeterministicRuntimeGuard, FunctionContext};
+use crate::observe_invalidation::ObserveInvalidation;
 use crate::storage::{InMemoryStorageBackend, StorageBackend};
 use tokio::sync::Notify;
 
@@ -19,8 +20,9 @@ pub struct SessionTransaction<B: StorageBackend = InMemoryStorageBackend> {
     pub(super) transaction: Option<Transaction<B>>,
     pub(super) runtime_functions: FunctionContext,
     transaction_manager: SessionTransactionManager,
+    observe_invalidation: Arc<ObserveInvalidation>,
     _deterministic_runtime_guard: Option<DeterministicRuntimeGuard>,
-    _write_access: SessionWriteAccess,
+    write_access: Option<SessionWriteAccess>,
 }
 
 impl<B> SessionContext<B>
@@ -64,8 +66,9 @@ where
             transaction: Some(opened.transaction),
             runtime_functions: opened.runtime_functions,
             transaction_manager: self.transaction_manager(),
+            observe_invalidation: Arc::clone(&self.observe_invalidation),
             _deterministic_runtime_guard: deterministic_runtime_guard,
-            _write_access: write_access,
+            write_access: Some(write_access),
         })
     }
 }
@@ -97,12 +100,13 @@ where
             .transaction
             .take()
             .ok_or_else(|| transaction_state_error("Lix transaction is closed"))?;
-        let result = transaction
-            .commit(&self.runtime_functions)
-            .await
-            .map(|_| ());
+        let result = transaction.commit(&self.runtime_functions).await;
         drop(operation_guard);
-        result
+        let outcome = result?;
+        drop(self.write_access.take());
+        self.observe_invalidation
+            .bump_if_storage_changed(&outcome.storage_stats);
+        Ok(())
     }
 
     pub async fn rollback(mut self) -> Result<(), LixError> {

--- a/packages/engine/src/storage/context.rs
+++ b/packages/engine/src/storage/context.rs
@@ -1,13 +1,20 @@
 use std::ops::Bound;
 
+use bytes::Bytes;
+
 use crate::backend::{
-    Backend, BackendError, BackendWrite, CommitResult, InMemoryBackend, KeyRange, Prefix,
-    ReadOptions, WriteOptions,
+    Backend, BackendError, BackendWrite, CommitResult, CoreProjection, GetOptions, InMemoryBackend,
+    Key, KeyRange, Prefix, ProjectedValue, PutBatch, PutEntry, ReadOptions, StoredValue,
+    WriteOptions, get_many,
 };
 use crate::storage::{
     StorageRead, StorageReadScope, StorageSpace, StorageWriteSet, StorageWriteSetError,
     StorageWriteSetStats,
 };
+
+use super::spaces::MUTATION_REVISION_SPACE;
+
+const MUTATION_REVISION_KEY: &[u8] = b"global";
 
 #[derive(Clone, Debug)]
 pub struct StorageContext<B = InMemoryBackend> {
@@ -84,10 +91,38 @@ where
                 return Err(error);
             }
         };
+        if stats.staged_puts > 0 || stats.staged_deletes > 0 {
+            if let Err(error) = stage_mutation_revision(&mut write) {
+                let _ = write.rollback();
+                return Err(StorageWriteSetError::Backend(error));
+            }
+        }
         Ok(PreparedStorageCommit {
             write: Some(write),
             stats: Some(stats),
         })
+    }
+
+    pub(crate) fn load_mutation_revision(&self) -> Result<Option<Bytes>, BackendError> {
+        let read = self.backend.begin_read(ReadOptions::default())?;
+        let values = get_many(
+            &read,
+            MUTATION_REVISION_SPACE.id,
+            &[mutation_revision_key()],
+            GetOptions {
+                projection: CoreProjection::FullValue,
+                ..GetOptions::default()
+            },
+        )?;
+        Ok(values
+            .values
+            .into_iter()
+            .next()
+            .flatten()
+            .and_then(|value| match value {
+                ProjectedValue::FullValue(bytes) => Some(bytes),
+                ProjectedValue::KeyOnly => None,
+            }))
     }
 
     pub fn delete_range(
@@ -127,6 +162,27 @@ where
             opts,
         )
     }
+}
+
+fn mutation_revision_key() -> Key {
+    Key(Bytes::from_static(MUTATION_REVISION_KEY))
+}
+
+fn stage_mutation_revision<W>(write: &mut W) -> Result<(), BackendError>
+where
+    W: BackendWrite,
+{
+    write.put_many(
+        MUTATION_REVISION_SPACE.id,
+        PutBatch {
+            entries: vec![PutEntry {
+                key: mutation_revision_key(),
+                value: StoredValue {
+                    bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
+                },
+            }],
+        },
+    )
 }
 
 impl<'a, B> PreparedStorageCommit<'a, B>
@@ -348,8 +404,10 @@ mod shape_tests {
     };
     use crate::storage::{PointReadPlan, ScanPlan, StorageContext, StorageReadScope, StorageSpace};
 
+    use super::MUTATION_REVISION_SPACE;
+
     #[test]
-    fn write_set_across_g_spaces_lowers_to_g_put_many_calls_and_one_commit() {
+    fn write_set_commit_stamps_mutation_revision_in_same_backend_commit() {
         let backend = CountingBackend::default();
         let storage = StorageContext::new(backend.clone());
         let mut writes = storage.new_write_set();
@@ -363,7 +421,7 @@ mod shape_tests {
 
         assert_eq!(backend.state.begin_write_calls.get(), 1);
         assert_eq!(backend.state.commit_calls.get(), 1);
-        assert_eq!(backend.state.put_batches.borrow().len(), 3);
+        assert_eq!(backend.state.put_batches.borrow().len(), 4);
         assert_eq!(
             backend
                 .state
@@ -376,6 +434,7 @@ mod shape_tests {
                 (SpaceId(1), vec![key("a")]),
                 (SpaceId(2), vec![key("a")]),
                 (SpaceId(3), vec![key("a")]),
+                (MUTATION_REVISION_SPACE.id, vec![key("global")]),
             ]
         );
     }

--- a/packages/engine/src/storage/spaces.rs
+++ b/packages/engine/src/storage/spaces.rs
@@ -4,6 +4,9 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::backend::{BackendError, Key, KeyRange, SpaceId};
 
+pub(crate) const MUTATION_REVISION_SPACE: StorageSpace =
+    StorageSpace::new(SpaceId(0x0007_0001), "observe.mutation_revision");
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StorageSpace {
     pub id: SpaceId,

--- a/packages/engine/tests/observe.rs
+++ b/packages/engine/tests/observe.rs
@@ -1,4 +1,3 @@
-#[path = "support/mod.rs"]
 mod support;
 
 use std::sync::Arc;

--- a/packages/engine/tests/observe.rs
+++ b/packages/engine/tests/observe.rs
@@ -2,12 +2,13 @@
 mod support;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use lix_engine::{
-    Backend, BackendError, Engine, InMemoryBackend, InMemoryRead, InMemoryWrite, ObserveEvent,
-    ReadOptions, SessionContext, Value, WriteOptions,
+    Backend, BackendError, BackendRead, Engine, GetOptions, InMemoryBackend, InMemoryRead,
+    InMemoryWrite, Key, KeyRange, ObserveEvent, PointVisitor, ReadOptions, ScanOptions, ScanResult,
+    ScanVisitor, SessionContext, SpaceId, Value, WriteOptions,
 };
 use serde_json::json;
 use support::simulation_test::engine::{SimSession, Simulation};
@@ -553,6 +554,12 @@ struct CountingReadBackend {
     read_count: Arc<AtomicUsize>,
 }
 
+struct CountingRead {
+    inner: InMemoryRead,
+    read_count: Arc<AtomicUsize>,
+    counted: AtomicBool,
+}
+
 impl CountingReadBackend {
     fn new() -> Self {
         Self {
@@ -572,7 +579,7 @@ impl CountingReadBackend {
 
 impl Backend for CountingReadBackend {
     type Read<'a>
-        = InMemoryRead
+        = CountingRead
     where
         Self: 'a;
 
@@ -582,12 +589,53 @@ impl Backend for CountingReadBackend {
         Self: 'a;
 
     fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
-        self.read_count.fetch_add(1, Ordering::SeqCst);
-        self.inner.begin_read(opts)
+        Ok(CountingRead {
+            inner: self.inner.begin_read(opts)?,
+            read_count: Arc::clone(&self.read_count),
+            counted: AtomicBool::new(false),
+        })
     }
 
     fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
         self.inner.begin_write(opts)
+    }
+}
+
+impl BackendRead for CountingRead {
+    fn visit_keys<V>(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<(), BackendError>
+    where
+        V: PointVisitor + ?Sized,
+    {
+        self.count_user_read(space);
+        self.inner.visit_keys(space, keys, opts, visitor)
+    }
+
+    fn scan<V>(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<ScanResult, BackendError>
+    where
+        V: ScanVisitor + ?Sized,
+    {
+        self.count_user_read(space);
+        self.inner.scan(space, range, opts, visitor)
+    }
+}
+
+impl CountingRead {
+    fn count_user_read(&self, space: SpaceId) {
+        if space != SpaceId(0x0007_0001) && !self.counted.swap(true, Ordering::SeqCst) {
+            self.read_count.fetch_add(1, Ordering::SeqCst);
+        }
     }
 }
 

--- a/packages/engine/tests/observe.rs
+++ b/packages/engine/tests/observe.rs
@@ -1,0 +1,633 @@
+#[path = "support/mod.rs"]
+mod support;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use lix_engine::{
+    Backend, BackendError, Engine, InMemoryBackend, InMemoryRead, InMemoryWrite, ObserveEvent,
+    ReadOptions, SessionContext, Value, WriteOptions,
+};
+use serde_json::json;
+use support::simulation_test::engine::{SimSession, Simulation};
+
+const NEXT_TIMEOUT: Duration = Duration::from_secs(1);
+const NO_EVENT_TIMEOUT: Duration = Duration::from_millis(250);
+const KEY_VALUE_SQL: &str = "SELECT key, value FROM lix_key_value WHERE key = $1 ORDER BY key";
+
+async fn open_workspace_session(sim: &Simulation, engine: &Engine) -> (SessionContext, SimSession) {
+    let raw_session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    let session = sim.wrap_session(raw_session.clone(), engine);
+    (raw_session, session)
+}
+
+fn observe_key(session: &SessionContext, key: &str) -> lix_engine::ObserveEvents {
+    let params = [Value::Text(key.to_string())];
+    session
+        .observe(KEY_VALUE_SQL, &params)
+        .expect("observe should open")
+}
+
+async fn next_event<B>(events: &mut lix_engine::ObserveEvents<B>, label: &str) -> ObserveEvent
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    tokio::time::timeout(NEXT_TIMEOUT, events.next())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for observe event: {label}"))
+        .unwrap_or_else(|error| panic!("observe next failed for {label}: {error:?}"))
+        .unwrap_or_else(|| panic!("observe closed before event: {label}"))
+}
+
+async fn expect_no_event<B>(events: &mut lix_engine::ObserveEvents<B>, label: &str)
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    match tokio::time::timeout(NO_EVENT_TIMEOUT, events.next()).await {
+        Err(_) => {}
+        Ok(Ok(Some(event))) => panic!("unexpected observe event for {label}: {event:?}"),
+        Ok(Ok(None)) => panic!("observe closed unexpectedly while waiting for no event: {label}"),
+        Ok(Err(error)) => panic!("observe errored while waiting for no event {label}: {error:?}"),
+    }
+}
+
+fn assert_key_value_row(event: &ObserveEvent, key: &str, value: &str) {
+    assert_eq!(event.rows.columns(), &["key", "value"]);
+    assert_eq!(event.rows.len(), 1);
+    assert_eq!(
+        event.rows.rows()[0].values(),
+        &[Value::Text(key.to_string()), Value::Json(json!(value)),]
+    );
+}
+
+simulation_test!(observe_next_returns_initial_snapshot, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('observe-initial', 'v0')",
+            &[],
+        )
+        .await
+        .expect("seed insert should succeed");
+
+    let mut events = raw_session
+        .observe(KEY_VALUE_SQL, &[Value::Text("observe-initial".to_string())])
+        .expect("observe should open");
+    let initial = next_event(&mut events, "initial snapshot").await;
+
+    assert_eq!(initial.sequence, 0);
+    assert_key_value_row(&initial, "observe-initial", "v0");
+});
+
+simulation_test!(
+    observe_emits_after_committed_mutation_changes_result,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&raw_session, "observe-update");
+
+        let initial = next_event(&mut events, "initial empty snapshot").await;
+        assert_eq!(initial.sequence, 0);
+        assert!(initial.rows.is_empty());
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-update', 'v0')",
+                &[],
+            )
+            .await
+            .expect("insert should commit");
+
+        let update = next_event(&mut events, "insert update").await;
+        assert_eq!(update.sequence, 1);
+        assert!(
+            update.mutation_sequence > initial.mutation_sequence,
+            "committed mutation should advance observe mutation sequence"
+        );
+        assert_key_value_row(&update, "observe-update", "v0");
+    }
+);
+
+simulation_test!(
+    observe_sees_mutation_from_another_session,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (observer_raw_session, _) = open_workspace_session(&sim, &engine).await;
+        let (_, writer_session) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&observer_raw_session, "observe-cross-session");
+
+        let initial = next_event(&mut events, "initial empty snapshot").await;
+        assert!(initial.rows.is_empty());
+
+        writer_session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-cross-session', 'v0')",
+                &[],
+            )
+            .await
+            .expect("cross-session insert should commit");
+
+        let update = next_event(&mut events, "cross-session update").await;
+        assert_eq!(update.sequence, 1);
+        assert!(
+            update.mutation_sequence > initial.mutation_sequence,
+            "cross-session committed mutation should advance observe mutation sequence"
+        );
+        assert_key_value_row(&update, "observe-cross-session", "v0");
+    }
+);
+
+simulation_test!(
+    observe_does_not_emit_for_read_only_execute,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&raw_session, "observe-read-only");
+        let _initial = next_event(&mut events, "initial snapshot").await;
+
+        session
+            .execute("SELECT key FROM lix_key_value ORDER BY key", &[])
+            .await
+            .expect("read should succeed");
+
+        expect_no_event(&mut events, "read-only execute").await;
+    }
+);
+
+simulation_test!(
+    observe_does_not_emit_when_unrelated_mutation_leaves_rows_unchanged,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&raw_session, "observe-target");
+        let _initial = next_event(&mut events, "initial snapshot").await;
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-other', 'v0')",
+                &[],
+            )
+            .await
+            .expect("unrelated insert should commit");
+
+        expect_no_event(&mut events, "unchanged rows after unrelated mutation").await;
+    }
+);
+
+simulation_test!(observe_does_not_emit_after_failed_write, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+    let mut events = observe_key(&raw_session, "observe-failed-write");
+    let initial = next_event(&mut events, "initial empty snapshot").await;
+    assert!(initial.rows.is_empty());
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('observe-failed-write', 'v0')",
+            &[],
+        )
+        .await
+        .expect("seed insert should commit");
+    let seeded = next_event(&mut events, "seed insert").await;
+    assert_key_value_row(&seeded, "observe-failed-write", "v0");
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('observe-failed-write', 'v1')",
+            &[],
+        )
+        .await
+        .expect_err("duplicate key insert should fail");
+
+    expect_no_event(&mut events, "failed duplicate insert").await;
+});
+
+simulation_test!(
+    observe_emits_only_after_explicit_transaction_commit,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&raw_session, "observe-transaction");
+        let _initial = next_event(&mut events, "initial snapshot").await;
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should open");
+        transaction
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-transaction', 'v0')",
+                &[],
+            )
+            .await
+            .expect("transaction write should stage");
+
+        expect_no_event(&mut events, "staged transaction write before commit").await;
+
+        transaction
+            .commit()
+            .await
+            .expect("transaction should commit");
+        let update = next_event(&mut events, "transaction commit").await;
+        assert_eq!(update.sequence, 1);
+        assert_key_value_row(&update, "observe-transaction", "v0");
+    }
+);
+
+simulation_test!(
+    observe_does_not_emit_after_explicit_transaction_rollback,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&raw_session, "observe-rollback");
+        let _initial = next_event(&mut events, "initial snapshot").await;
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should open");
+        transaction
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-rollback', 'v0')",
+                &[],
+            )
+            .await
+            .expect("transaction write should stage");
+        transaction
+            .rollback()
+            .await
+            .expect("transaction should roll back");
+
+        expect_no_event(&mut events, "transaction rollback").await;
+
+        let result = session
+            .execute(
+                "SELECT key, value FROM lix_key_value WHERE key = 'observe-rollback'",
+                &[],
+            )
+            .await
+            .expect("post-rollback read should succeed");
+        assert!(
+            result.is_empty(),
+            "rolled-back transaction should not leave visible rows"
+        );
+    }
+);
+
+simulation_test!(
+    observe_coalesces_multiple_writes_before_next_into_latest_snapshot,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&raw_session, "observe-coalesce");
+        let initial = next_event(&mut events, "initial snapshot").await;
+        assert!(initial.rows.is_empty());
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-coalesce', 'v0')",
+                &[],
+            )
+            .await
+            .expect("insert should commit");
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'v1' WHERE key = 'observe-coalesce'",
+                &[],
+            )
+            .await
+            .expect("update should commit");
+
+        let update = next_event(&mut events, "coalesced update").await;
+        assert_eq!(update.sequence, 1);
+        assert!(
+            update.mutation_sequence > initial.mutation_sequence,
+            "coalesced mutations should advance observe mutation sequence"
+        );
+        assert_key_value_row(&update, "observe-coalesce", "v1");
+        expect_no_event(&mut events, "coalesced write should not queue stale event").await;
+    }
+);
+
+simulation_test!(
+    observe_multiple_observers_receive_updates_independently,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let mut events_a = observe_key(&raw_session, "observe-multi");
+        let mut events_b = observe_key(&raw_session, "observe-multi");
+        let initial_a = next_event(&mut events_a, "first initial snapshot").await;
+        let initial_b = next_event(&mut events_b, "second initial snapshot").await;
+        assert_eq!(initial_a.sequence, 0);
+        assert_eq!(initial_b.sequence, 0);
+        assert!(initial_a.rows.is_empty());
+        assert!(initial_b.rows.is_empty());
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-multi', 'v0')",
+                &[],
+            )
+            .await
+            .expect("insert should commit");
+
+        let update_a = next_event(&mut events_a, "first observer update").await;
+        let update_b = next_event(&mut events_b, "second observer update").await;
+        assert_eq!(update_a.sequence, 1);
+        assert_eq!(update_b.sequence, 1);
+        assert_key_value_row(&update_a, "observe-multi", "v0");
+        assert_key_value_row(&update_b, "observe-multi", "v0");
+    }
+);
+
+#[tokio::test]
+async fn observe_identical_queries_share_one_evaluation_per_generation() {
+    let backend = CountingReadBackend::new();
+    Engine::initialize(backend.clone())
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(backend.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    let params = [Value::Text("observe-singleflight".to_string())];
+    let mut first = session
+        .observe(KEY_VALUE_SQL, &params)
+        .expect("first observe should open");
+    let mut second = session
+        .observe(KEY_VALUE_SQL, &params)
+        .expect("second observe should open");
+    let _first_initial = next_event(&mut first, "first initial snapshot").await;
+    let _second_initial = next_event(&mut second, "second initial snapshot").await;
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('observe-singleflight', 'v0')",
+            &[],
+        )
+        .await
+        .expect("insert should commit");
+    backend.reset_read_count();
+
+    let (first_update, second_update) = tokio::join!(
+        next_event(&mut first, "first update"),
+        next_event(&mut second, "second update"),
+    );
+
+    assert_key_value_row(&first_update, "observe-singleflight", "v0");
+    assert_key_value_row(&second_update, "observe-singleflight", "v0");
+    assert_eq!(
+        backend.read_count(),
+        1,
+        "identical observers should share the same query evaluation for one invalidation generation"
+    );
+}
+
+simulation_test!(
+    observe_rejects_durable_runtime_functions,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+
+        match raw_session.observe("SELECT lix_uuid_v7()", &[]) {
+            Ok(_) => panic!("observe should reject durable runtime functions"),
+            Err(error) => {
+                assert_eq!(error.code, lix_engine::LixError::CODE_INVALID_PARAM);
+                assert!(
+                    error.message.contains("durable runtime functions"),
+                    "unexpected observe error: {error:?}"
+                );
+            }
+        }
+    }
+);
+
+simulation_test!(
+    observe_next_rejects_active_transaction_even_when_shared_cache_is_warm,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (blocked_raw_session, _) = open_workspace_session(&sim, &engine).await;
+        let (cache_raw_session, _) = open_workspace_session(&sim, &engine).await;
+        let (_, writer_session) = open_workspace_session(&sim, &engine).await;
+        let params = [Value::Text("observe-active-transaction-cache".to_string())];
+        let mut blocked_events = blocked_raw_session
+            .observe(KEY_VALUE_SQL, &params)
+            .expect("blocked observer should open");
+        let mut cache_events = cache_raw_session
+            .observe(KEY_VALUE_SQL, &params)
+            .expect("cache observer should open");
+        let blocked_initial = next_event(&mut blocked_events, "blocked observer initial").await;
+        let cache_initial = next_event(&mut cache_events, "cache observer initial").await;
+        assert!(blocked_initial.rows.is_empty());
+        assert!(cache_initial.rows.is_empty());
+
+        writer_session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) \
+                 VALUES ('observe-active-transaction-cache', 'v0')",
+                &[],
+            )
+            .await
+            .expect("writer insert should commit");
+
+        let cache_update = next_event(&mut cache_events, "cache observer update").await;
+        assert_key_value_row(&cache_update, "observe-active-transaction-cache", "v0");
+
+        let transaction = blocked_raw_session
+            .begin_transaction()
+            .await
+            .expect("transaction should open on blocked observer session");
+
+        match tokio::time::timeout(NEXT_TIMEOUT, blocked_events.next())
+            .await
+            .expect("blocked observer next should resolve")
+        {
+            Ok(result) => {
+                panic!("observe next should reject active transaction, got {result:?}")
+            }
+            Err(error) => assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE"),
+        }
+
+        transaction
+            .rollback()
+            .await
+            .expect("transaction should roll back");
+    }
+);
+
+simulation_test!(observe_close_makes_next_return_none, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+    let mut events = observe_key(&raw_session, "observe-close");
+    let _initial = next_event(&mut events, "initial snapshot").await;
+
+    events.close();
+
+    let closed = tokio::time::timeout(NEXT_TIMEOUT, events.next())
+        .await
+        .expect("closed observe next should resolve")
+        .expect("closed observe next should not error");
+    assert!(closed.is_none());
+});
+
+simulation_test!(observe_rejects_closed_session, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+
+    raw_session
+        .close()
+        .await
+        .expect("session close should succeed");
+
+    let params = [Value::Text("observe-closed-session".to_string())];
+    match raw_session.observe(KEY_VALUE_SQL, &params) {
+        Ok(_) => panic!("observe should reject a closed session"),
+        Err(error) => assert_eq!(error.code, lix_engine::LixError::CODE_CLOSED),
+    }
+});
+
+simulation_test!(observe_rejects_active_transaction, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+    let transaction = raw_session
+        .begin_transaction()
+        .await
+        .expect("transaction should open");
+
+    let params = [Value::Text("observe-active-transaction".to_string())];
+    match raw_session.observe(KEY_VALUE_SQL, &params) {
+        Ok(_) => panic!("observe should reject a session with an active transaction"),
+        Err(error) => assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE"),
+    }
+
+    transaction
+        .rollback()
+        .await
+        .expect("transaction should roll back");
+});
+
+simulation_test!(
+    observe_pending_next_returns_none_when_session_closes,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+        let mut events = observe_key(&raw_session, "observe-session-close");
+        let _initial = next_event(&mut events, "initial snapshot").await;
+
+        let mut pending_next = Box::pin(events.next());
+        tokio::select! {
+            () = tokio::time::sleep(NO_EVENT_TIMEOUT) => {}
+            result = pending_next.as_mut() => {
+                panic!("observe next resolved before session close: {result:?}");
+            }
+        }
+
+        raw_session
+            .close()
+            .await
+            .expect("session close should succeed");
+
+        let closed = tokio::time::timeout(NEXT_TIMEOUT, pending_next)
+            .await
+            .expect("pending observe next should wake after session close")
+            .expect("pending observe next should not error after session close");
+        assert!(closed.is_none());
+    }
+);
+
+#[derive(Clone)]
+struct CountingReadBackend {
+    inner: InMemoryBackend,
+    read_count: Arc<AtomicUsize>,
+}
+
+impl CountingReadBackend {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            read_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn reset_read_count(&self) {
+        self.read_count.store(0, Ordering::SeqCst);
+    }
+
+    fn read_count(&self) -> usize {
+        self.read_count.load(Ordering::SeqCst)
+    }
+}
+
+impl Backend for CountingReadBackend {
+    type Read<'a>
+        = InMemoryRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = InMemoryWrite
+    where
+        Self: 'a;
+
+    fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
+        self.read_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.begin_read(opts)
+    }
+
+    fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+        self.inner.begin_write(opts)
+    }
+}
+
+simulation_test!(
+    observe_emits_after_durable_runtime_function_read_changes_storage,
+    options = support::simulation_test::engine::SimulationOptions {
+        deterministic: false,
+    },
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_global, lixcol_untracked) \
+                 VALUES ('lix_deterministic_mode', \
+                 lix_json('{\"enabled\":true}'), true, true)",
+                &[],
+            )
+            .await
+            .expect("deterministic mode insert should succeed");
+
+        let mut events = observe_key(&raw_session, "lix_deterministic_sequence_number");
+        let initial = next_event(&mut events, "initial deterministic sequence snapshot").await;
+        assert!(initial.rows.is_empty());
+
+        session
+            .execute("SELECT lix_uuid_v7()", &[])
+            .await
+            .expect("deterministic uuid read should succeed");
+
+        let update = next_event(&mut events, "deterministic sequence update").await;
+        assert_eq!(update.sequence, 1);
+        assert_eq!(update.rows.columns(), &["key", "value"]);
+        assert_eq!(update.rows.len(), 1);
+        assert_eq!(
+            update.rows.rows()[0].values(),
+            &[
+                Value::Text("lix_deterministic_sequence_number".to_string()),
+                Value::Json(json!(0)),
+            ]
+        );
+    }
+);

--- a/packages/engine/tests/observe_mutation_revision.rs
+++ b/packages/engine/tests/observe_mutation_revision.rs
@@ -1,0 +1,257 @@
+use std::time::Duration;
+
+use lix_engine::{Backend, Engine, InMemoryBackend, ObserveEvent, ObserveEvents, Value};
+use serde_json::json;
+
+#[allow(dead_code)]
+#[path = "backend/support/sqlite_backend.rs"]
+mod sqlite_backend;
+
+use sqlite_backend::SqliteBackend;
+
+const NEXT_TIMEOUT: Duration = Duration::from_secs(1);
+const NO_EVENT_TIMEOUT: Duration = Duration::from_millis(250);
+const KEY_VALUE_SQL: &str = "SELECT key, value FROM lix_key_value WHERE key = $1 ORDER BY key";
+
+async fn open_two_engines() -> (Engine, Engine) {
+    let backend = InMemoryBackend::new();
+    Engine::initialize(backend.clone())
+        .await
+        .expect("backend should initialize");
+    let observer_engine = Engine::new(backend.clone())
+        .await
+        .expect("observer engine should open");
+    let writer_engine = Engine::new(backend)
+        .await
+        .expect("writer engine should open");
+    (observer_engine, writer_engine)
+}
+
+fn observe_key<B>(session: &lix_engine::SessionContext<B>, key: &str) -> ObserveEvents<B>
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    session
+        .observe(KEY_VALUE_SQL, &[Value::Text(key.to_string())])
+        .expect("observe should open")
+}
+
+async fn next_event<B>(events: &mut ObserveEvents<B>, label: &str) -> ObserveEvent
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    tokio::time::timeout(NEXT_TIMEOUT, events.next())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for observe event: {label}"))
+        .unwrap_or_else(|error| panic!("observe next failed for {label}: {error:?}"))
+        .unwrap_or_else(|| panic!("observe closed before event: {label}"))
+}
+
+async fn expect_no_event<B>(events: &mut ObserveEvents<B>, label: &str)
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    match tokio::time::timeout(NO_EVENT_TIMEOUT, events.next()).await {
+        Err(_) => {}
+        Ok(Ok(Some(event))) => panic!("unexpected observe event for {label}: {event:?}"),
+        Ok(Ok(None)) => panic!("observe closed unexpectedly while waiting for no event: {label}"),
+        Ok(Err(error)) => panic!("observe errored while waiting for no event {label}: {error:?}"),
+    }
+}
+
+fn assert_key_value_row(event: &ObserveEvent, key: &str, value: &str) {
+    assert_eq!(event.rows.columns(), &["key", "value"]);
+    assert_eq!(event.rows.len(), 1);
+    assert_eq!(
+        event.rows.rows()[0].values(),
+        &[Value::Text(key.to_string()), Value::Json(json!(value)),]
+    );
+}
+
+#[tokio::test]
+async fn observe_emits_when_another_engine_commits() {
+    let (observer_engine, writer_engine) = open_two_engines().await;
+    let observer_session = observer_engine
+        .open_workspace_session()
+        .await
+        .expect("observer session should open");
+    let writer_session = writer_engine
+        .open_workspace_session()
+        .await
+        .expect("writer session should open");
+    let mut events = observe_key(&observer_session, "mutation-revision-external");
+
+    let initial = next_event(&mut events, "initial empty snapshot").await;
+    assert_eq!(initial.sequence, 0);
+    assert!(initial.rows.is_empty());
+
+    writer_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('mutation-revision-external', 'v0')",
+            &[],
+        )
+        .await
+        .expect("external engine insert should commit");
+
+    let update = next_event(&mut events, "external engine commit").await;
+    assert_eq!(update.sequence, 1);
+    assert_key_value_row(&update, "mutation-revision-external", "v0");
+}
+
+#[tokio::test]
+async fn observe_external_transaction_emits_only_after_commit() {
+    let (observer_engine, writer_engine) = open_two_engines().await;
+    let observer_session = observer_engine
+        .open_workspace_session()
+        .await
+        .expect("observer session should open");
+    let writer_session = writer_engine
+        .open_workspace_session()
+        .await
+        .expect("writer session should open");
+    let mut events = observe_key(&observer_session, "mutation-revision-transaction");
+
+    let initial = next_event(&mut events, "initial empty snapshot").await;
+    assert!(initial.rows.is_empty());
+
+    let mut transaction = writer_session
+        .begin_transaction()
+        .await
+        .expect("external transaction should open");
+    transaction
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('mutation-revision-transaction', 'v0')",
+            &[],
+        )
+        .await
+        .expect("external transaction write should stage");
+
+    expect_no_event(&mut events, "external staged write before commit").await;
+
+    transaction
+        .commit()
+        .await
+        .expect("external transaction should commit");
+
+    let update = next_event(&mut events, "external transaction commit").await;
+    assert_eq!(update.sequence, 1);
+    assert_key_value_row(&update, "mutation-revision-transaction", "v0");
+}
+
+#[tokio::test]
+async fn observe_external_rollback_does_not_emit() {
+    let (observer_engine, writer_engine) = open_two_engines().await;
+    let observer_session = observer_engine
+        .open_workspace_session()
+        .await
+        .expect("observer session should open");
+    let writer_session = writer_engine
+        .open_workspace_session()
+        .await
+        .expect("writer session should open");
+    let mut events = observe_key(&observer_session, "mutation-revision-rollback");
+
+    let initial = next_event(&mut events, "initial empty snapshot").await;
+    assert!(initial.rows.is_empty());
+
+    let mut transaction = writer_session
+        .begin_transaction()
+        .await
+        .expect("external transaction should open");
+    transaction
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('mutation-revision-rollback', 'v0')",
+            &[],
+        )
+        .await
+        .expect("external transaction write should stage");
+    transaction
+        .rollback()
+        .await
+        .expect("external transaction should roll back");
+
+    expect_no_event(&mut events, "external transaction rollback").await;
+}
+
+#[tokio::test]
+async fn observe_external_writes_can_coalesce_to_latest_snapshot() {
+    let (observer_engine, writer_engine) = open_two_engines().await;
+    let observer_session = observer_engine
+        .open_workspace_session()
+        .await
+        .expect("observer session should open");
+    let writer_session = writer_engine
+        .open_workspace_session()
+        .await
+        .expect("writer session should open");
+    let mut events = observe_key(&observer_session, "mutation-revision-coalesce");
+
+    let initial = next_event(&mut events, "initial empty snapshot").await;
+    assert!(initial.rows.is_empty());
+
+    writer_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('mutation-revision-coalesce', 'v0')",
+            &[],
+        )
+        .await
+        .expect("external insert should commit");
+    writer_session
+        .execute(
+            "UPDATE lix_key_value SET value = 'v1' WHERE key = 'mutation-revision-coalesce'",
+            &[],
+        )
+        .await
+        .expect("external update should commit");
+
+    let update = next_event(&mut events, "coalesced external writes").await;
+    assert_eq!(update.sequence, 1);
+    assert_key_value_row(&update, "mutation-revision-coalesce", "v1");
+}
+
+#[tokio::test]
+async fn observe_emits_when_independently_opened_sqlite_backend_commits() {
+    let tempdir = tempfile::tempdir().expect("tempdir should be created");
+    let path = tempdir.path().join("repo.sqlite");
+    Engine::initialize(SqliteBackend::open(&path).expect("init backend should open"))
+        .await
+        .expect("backend should initialize");
+    let observer_engine =
+        Engine::new(SqliteBackend::open(&path).expect("observer sqlite backend should open"))
+            .await
+            .expect("observer engine should open");
+    let writer_engine =
+        Engine::new(SqliteBackend::open(&path).expect("writer sqlite backend should open"))
+            .await
+            .expect("writer engine should open");
+    let observer_session = observer_engine
+        .open_workspace_session()
+        .await
+        .expect("observer session should open");
+    let writer_session = writer_engine
+        .open_workspace_session()
+        .await
+        .expect("writer session should open");
+    let mut events = observe_key(&observer_session, "mutation-revision-sqlite");
+
+    let initial = next_event(&mut events, "initial empty sqlite snapshot").await;
+    assert!(initial.rows.is_empty());
+
+    writer_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('mutation-revision-sqlite', 'v0')",
+            &[],
+        )
+        .await
+        .expect("external sqlite insert should commit");
+
+    let update = next_event(&mut events, "external sqlite backend commit").await;
+    assert_eq!(update.sequence, 1);
+    assert_key_value_row(&update, "mutation-revision-sqlite", "v0");
+}

--- a/packages/engine/tests/observe_mutation_revision.rs
+++ b/packages/engine/tests/observe_mutation_revision.rs
@@ -1,13 +1,8 @@
 use std::time::Duration;
 
+use lix_backends::SqliteBackend;
 use lix_engine::{Backend, Engine, InMemoryBackend, ObserveEvent, ObserveEvents, Value};
 use serde_json::json;
-
-#[allow(dead_code)]
-#[path = "backend/support/sqlite_backend.rs"]
-mod sqlite_backend;
-
-use sqlite_backend::SqliteBackend;
 
 const NEXT_TIMEOUT: Duration = Duration::from_secs(1);
 const NO_EVENT_TIMEOUT: Duration = Duration::from_millis(250);
@@ -102,6 +97,46 @@ async fn observe_emits_when_another_engine_commits() {
     let update = next_event(&mut events, "external engine commit").await;
     assert_eq!(update.sequence, 1);
     assert_key_value_row(&update, "mutation-revision-external", "v0");
+}
+
+#[tokio::test]
+async fn observe_emits_after_local_generation_bump_without_storage_revision_change() {
+    let (observer_engine, writer_engine) = open_two_engines().await;
+    let observer_session = observer_engine
+        .open_workspace_session()
+        .await
+        .expect("observer session should open");
+    let local_session = observer_engine
+        .open_workspace_session()
+        .await
+        .expect("local session should open");
+    let writer_session = writer_engine
+        .open_workspace_session()
+        .await
+        .expect("writer session should open");
+    let mut events = observe_key(&observer_session, "mutation-revision-after-close");
+
+    let initial = next_event(&mut events, "initial empty snapshot").await;
+    assert_eq!(initial.sequence, 0);
+    assert!(initial.rows.is_empty());
+
+    local_session
+        .close()
+        .await
+        .expect("closing another local session should succeed");
+    expect_no_event(&mut events, "local close does not change observed rows").await;
+
+    writer_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('mutation-revision-after-close', 'v0')",
+            &[],
+        )
+        .await
+        .expect("external engine insert should commit");
+
+    let update = next_event(&mut events, "external commit after local generation bump").await;
+    assert_eq!(update.sequence, 1);
+    assert_key_value_row(&update, "mutation-revision-after-close", "v0");
 }
 
 #[tokio::test]

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -27,4 +27,4 @@ napi = { version = "3.9.0", default-features = false, features = ["napi6", "serd
 napi-derive = "3.5.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["rt", "sync"] }

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -4,13 +4,22 @@ use lix_sdk::{
     LixTransaction as RsLixTransaction, MergeBranchOptions as RsMergeBranchOptions,
     MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
     MergeChangeStats, MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide,
+    ObserveEvent as RsObserveEvent, ObserveEvents as RsObserveEvents,
     OpenLixOptions as RsOpenLixOptions, SqliteBackend, SqliteBackendOptions,
     SwitchBranchOptions as RsSwitchBranchOptions, SwitchBranchReceipt, Value, open_lix,
     open_lix_with_backend,
 };
+use napi::JsDeferred;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use std::sync::mpsc::{self, Sender};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
 use tokio::runtime::{Builder, Runtime};
+use tokio::sync::watch;
 
 #[expect(missing_debug_implementations)]
 #[napi(js_name = "Lix")]
@@ -29,6 +38,12 @@ enum NativeLixTransactionInner {
     Memory(RsLixTransaction<InMemoryBackend>),
     Sqlite(RsLixTransaction<SqliteBackend>),
     Fs(RsLixTransaction<FsBackend>),
+}
+
+enum NativeObserveEventsInner {
+    Memory(RsObserveEvents<InMemoryBackend>),
+    Sqlite(RsObserveEvents<SqliteBackend>),
+    Fs(RsObserveEvents<FsBackend>),
 }
 
 impl NativeLixInner {
@@ -55,6 +70,18 @@ impl NativeLixInner {
             Self::Fs(lix) => Ok(NativeLixTransactionInner::Fs(
                 lix.begin_transaction().await?,
             )),
+        }
+    }
+
+    fn observe(
+        &self,
+        sql: &str,
+        params: &[Value],
+    ) -> std::result::Result<NativeObserveEventsInner, LixError> {
+        match self {
+            Self::Memory(lix) => Ok(NativeObserveEventsInner::Memory(lix.observe(sql, params)?)),
+            Self::Sqlite(lix) => Ok(NativeObserveEventsInner::Sqlite(lix.observe(sql, params)?)),
+            Self::Fs(lix) => Ok(NativeObserveEventsInner::Fs(lix.observe(sql, params)?)),
         }
     }
 
@@ -149,6 +176,24 @@ impl NativeLixTransactionInner {
     }
 }
 
+impl NativeObserveEventsInner {
+    async fn next(&mut self) -> std::result::Result<Option<RsObserveEvent>, LixError> {
+        match self {
+            Self::Memory(events) => events.next().await,
+            Self::Sqlite(events) => events.next().await,
+            Self::Fs(events) => events.next().await,
+        }
+    }
+
+    fn close(&mut self) {
+        match self {
+            Self::Memory(events) => events.close(),
+            Self::Sqlite(events) => events.close(),
+            Self::Fs(events) => events.close(),
+        }
+    }
+}
+
 #[napi]
 impl NativeLix {
     #[napi(factory, js_name = "openMemory")]
@@ -225,6 +270,29 @@ impl NativeLix {
             )
             .map_err(|error| throw_lix_error(&env, error))?;
         ExecuteResult::try_from(result).map_err(|error| throw_lix_error(&env, error))
+    }
+
+    #[napi]
+    pub fn observe(
+        &self,
+        env: Env,
+        sql: String,
+        params: Option<Vec<LixValue>>,
+    ) -> Result<NativeObserveEvents> {
+        let params = match params {
+            Some(params) => params
+                .into_iter()
+                .map(Value::try_from)
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|error| throw_lix_error(&env, error))?,
+            None => Vec::new(),
+        };
+        let events = self
+            .lix()
+            .map_err(|error| throw_lix_error(&env, error))?
+            .observe(&sql, &params)
+            .map_err(|error| throw_lix_error(&env, error))?;
+        NativeObserveEvents::new(events)
     }
 
     #[napi(js_name = "beginTransaction")]
@@ -330,6 +398,248 @@ impl NativeLix {
         self.lix = None;
         Ok(())
     }
+}
+
+#[expect(missing_debug_implementations)]
+#[napi(js_name = "ObserveEvents")]
+pub struct NativeObserveEvents {
+    commands: Sender<ObserveCommand>,
+    closed: Arc<AtomicBool>,
+    close_signal: watch::Sender<bool>,
+    next_in_flight: Arc<AtomicBool>,
+}
+
+#[napi]
+impl NativeObserveEvents {
+    fn new(events: NativeObserveEventsInner) -> Result<Self> {
+        let (commands, receiver) = mpsc::channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let (close_signal, actor_close_signal) = watch::channel(false);
+        let next_in_flight = Arc::new(AtomicBool::new(false));
+
+        let actor_closed = Arc::clone(&closed);
+        let actor_next_in_flight = Arc::clone(&next_in_flight);
+        thread::Builder::new()
+            .name("lix-observe-events".to_string())
+            .spawn(move || {
+                run_observe_actor(
+                    events,
+                    receiver,
+                    actor_closed,
+                    actor_close_signal,
+                    actor_next_in_flight,
+                );
+            })
+            .map_err(to_napi_error)?;
+
+        Ok(Self {
+            commands,
+            closed,
+            close_signal,
+            next_in_flight,
+        })
+    }
+
+    #[napi]
+    pub fn next<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
+        if self.closed.load(Ordering::SeqCst) {
+            let (deferred, promise): (ObserveNextDeferred, Object<'env>) = env.create_deferred()?;
+            resolve_observe_deferred(deferred, Ok(None), Arc::clone(&self.next_in_flight));
+            return Ok(promise);
+        }
+
+        if self
+            .next_in_flight
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(throw_lix_error(
+                env,
+                LixError::new(
+                    "LIX_OBSERVE_NEXT_IN_FLIGHT",
+                    "ObserveEvents.next() is already in flight",
+                )
+                .with_hint("Await the pending next() call before calling next() again."),
+            ));
+        }
+
+        let (deferred, promise): (ObserveNextDeferred, Object<'env>) = match env.create_deferred() {
+            Ok(deferred) => deferred,
+            Err(error) => {
+                self.next_in_flight.store(false, Ordering::SeqCst);
+                return Err(error);
+            }
+        };
+        match self.commands.send(ObserveCommand::Next(deferred)) {
+            Ok(()) => Ok(promise),
+            Err(error) => {
+                self.closed.store(true, Ordering::SeqCst);
+                let ObserveCommand::Next(deferred) = error.0 else {
+                    unreachable!("next() only sends ObserveCommand::Next");
+                };
+                resolve_observe_deferred(deferred, Ok(None), Arc::clone(&self.next_in_flight));
+                Ok(promise)
+            }
+        }
+    }
+
+    #[napi]
+    pub fn close(&self) {
+        close_observe_events(&self.commands, &self.closed, &self.close_signal);
+    }
+}
+
+impl Drop for NativeObserveEvents {
+    fn drop(&mut self) {
+        close_observe_events(&self.commands, &self.closed, &self.close_signal);
+    }
+}
+
+type ObserveNextResult = std::result::Result<Option<RsObserveEvent>, LixError>;
+type ObserveNextResolver = Box<dyn FnOnce(Env) -> Result<Option<ObserveEventDto>> + Send>;
+type ObserveNextDeferred = JsDeferred<Option<ObserveEventDto>, ObserveNextResolver>;
+
+enum ObserveCommand {
+    Next(ObserveNextDeferred),
+    Close,
+}
+
+fn run_observe_actor(
+    mut events: NativeObserveEventsInner,
+    receiver: mpsc::Receiver<ObserveCommand>,
+    closed: Arc<AtomicBool>,
+    mut close_signal: watch::Receiver<bool>,
+    next_in_flight: Arc<AtomicBool>,
+) {
+    let rt = match Builder::new_current_thread().enable_all().build() {
+        Ok(rt) => rt,
+        Err(error) => {
+            closed.store(true, Ordering::SeqCst);
+            while let Ok(command) = receiver.recv() {
+                match command {
+                    ObserveCommand::Next(deferred) => {
+                        next_in_flight.store(false, Ordering::SeqCst);
+                        deferred.reject(to_napi_error(&error));
+                    }
+                    ObserveCommand::Close => break,
+                }
+            }
+            return;
+        }
+    };
+
+    while let Ok(command) = receiver.recv() {
+        match command {
+            ObserveCommand::Next(deferred) => {
+                let result = rt.block_on(observe_next(&mut events, &closed, &mut close_signal));
+                let result = match result {
+                    Ok(Some(_)) | Err(_) if closed.load(Ordering::SeqCst) => Ok(None),
+                    Err(error) if error.code == LixError::CODE_CLOSED => Ok(None),
+                    other => other,
+                };
+                let result = match result {
+                    Ok(Some(_)) | Err(_)
+                        if closed.load(Ordering::SeqCst) || *close_signal.borrow() =>
+                    {
+                        Ok(None)
+                    }
+                    other => other,
+                };
+                let terminal = observe_result_is_terminal(&result);
+                if terminal {
+                    closed.store(true, Ordering::SeqCst);
+                }
+                resolve_observe_deferred(deferred, result, Arc::clone(&next_in_flight));
+                if terminal {
+                    events.close();
+                    break;
+                }
+            }
+            ObserveCommand::Close => {
+                closed.store(true, Ordering::SeqCst);
+                events.close();
+                break;
+            }
+        }
+    }
+    closed.store(true, Ordering::SeqCst);
+}
+
+async fn observe_next(
+    events: &mut NativeObserveEventsInner,
+    closed: &AtomicBool,
+    close_signal: &mut watch::Receiver<bool>,
+) -> ObserveNextResult {
+    if closed.load(Ordering::SeqCst) || *close_signal.borrow() {
+        events.close();
+        return Ok(None);
+    }
+
+    let result = tokio::select! {
+        result = events.next() => result,
+        changed = close_signal.changed() => {
+            events.close();
+            match changed {
+                Ok(()) => Ok(None),
+                Err(_) => Ok(None),
+            }
+        }
+    };
+
+    match result {
+        Ok(Some(_)) | Err(_) if closed.load(Ordering::SeqCst) || *close_signal.borrow() => {
+            events.close();
+            Ok(None)
+        }
+        Ok(Some(event)) => Ok(Some(event)),
+        Ok(None) => {
+            closed.store(true, Ordering::SeqCst);
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn observe_result_is_terminal(result: &ObserveNextResult) -> bool {
+    match result {
+        Ok(None) => true,
+        Err(error) if error.code == LixError::CODE_CLOSED => true,
+        _ => false,
+    }
+}
+
+fn resolve_observe_deferred(
+    deferred: ObserveNextDeferred,
+    result: ObserveNextResult,
+    next_in_flight: Arc<AtomicBool>,
+) {
+    deferred.resolve(Box::new(move |env| {
+        next_in_flight.store(false, Ordering::SeqCst);
+        observe_next_to_js(&env, result)
+    }));
+}
+
+fn observe_next_to_js(env: &Env, result: ObserveNextResult) -> Result<Option<ObserveEventDto>> {
+    match result {
+        Ok(Some(event)) => Ok(Some(
+            ObserveEventDto::try_from(event)
+                .map_err(|error| lix_error_to_napi_error(env, error))?,
+        )),
+        Ok(None) => Ok(None),
+        Err(error) => Err(lix_error_to_napi_error(env, error)),
+    }
+}
+
+fn close_observe_events(
+    commands: &Sender<ObserveCommand>,
+    closed: &AtomicBool,
+    close_signal: &watch::Sender<bool>,
+) {
+    if closed.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let _ = close_signal.send(true);
+    let _ = commands.send(ObserveCommand::Close);
 }
 
 impl NativeLix {
@@ -807,6 +1117,26 @@ impl TryFrom<RsExecuteResult> for ExecuteResult {
     }
 }
 
+#[napi(object)]
+pub struct ObserveEventDto {
+    pub sequence: f64,
+    pub mutation_sequence: f64,
+    pub rows: ExecuteResult,
+}
+
+impl TryFrom<RsObserveEvent> for ObserveEventDto {
+    type Error = LixError;
+
+    #[expect(clippy::cast_precision_loss)]
+    fn try_from(event: RsObserveEvent) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            sequence: event.sequence as f64,
+            mutation_sequence: event.mutation_sequence as f64,
+            rows: ExecuteResult::try_from(event.rows)?,
+        })
+    }
+}
+
 #[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct LixNotice {
@@ -819,17 +1149,28 @@ fn to_napi_error(error: impl std::fmt::Display) -> Error {
     Error::from_reason(error.to_string())
 }
 
+fn create_lix_error<'env>(env: &'env Env, error: &LixError) -> Result<Object<'env>> {
+    let mut js_error = env.create_error(Error::new(Status::GenericFailure, &error.message))?;
+    js_error.set_named_property("name", "LixError")?;
+    js_error.set_named_property("code", error.code.clone())?;
+    if let Some(hint) = &error.hint {
+        js_error.set_named_property("hint", hint.clone())?;
+    }
+    if let Some(details) = &error.details {
+        js_error.set_named_property("details", details.clone())?;
+    }
+    Ok(js_error)
+}
+
+fn lix_error_to_napi_error(env: &Env, error: LixError) -> Error {
+    create_lix_error(env, &error)
+        .map(|js_error| Error::from(js_error.to_unknown()))
+        .unwrap_or_else(|fallback| fallback)
+}
+
 fn throw_lix_error(env: &Env, error: LixError) -> Error {
     let thrown = (|| -> Result<()> {
-        let mut js_error = env.create_error(Error::new(Status::GenericFailure, &error.message))?;
-        js_error.set_named_property("name", "LixError")?;
-        js_error.set_named_property("code", error.code.clone())?;
-        if let Some(hint) = &error.hint {
-            js_error.set_named_property("hint", hint.clone())?;
-        }
-        if let Some(details) = &error.details {
-            js_error.set_named_property("details", details.clone())?;
-        }
+        let js_error = create_lix_error(env, &error)?;
         env.throw(js_error)?;
         Ok(())
     })();

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -580,8 +580,7 @@ async fn observe_next(
         changed = close_signal.changed() => {
             events.close();
             match changed {
-                Ok(()) => Ok(None),
-                Err(_) => Ok(None),
+                Ok(()) | Err(_) => Ok(None),
             }
         }
     };

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -2,6 +2,7 @@ export {
 	FsBackend,
 	Lix,
 	LixTransaction,
+	ObserveEvents,
 	openLix,
 	SqliteBackend,
 } from "./open-lix.js";
@@ -26,6 +27,7 @@ export type {
 	MergeChangeStats,
 	MergeConflict,
 	MergeConflictSide,
+	ObserveEvent,
 	OpenLixOptions,
 	SqlParam,
 	SqliteBackendOptions,

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -135,6 +135,110 @@ test("committed writes survive close and reopen", async () => {
 	await second.close();
 });
 
+test("observe emits initial snapshot and committed updates", async () => {
+	const lix = await openLix();
+	const events = lix.observe(
+		"SELECT key, value FROM lix_key_value WHERE key = $1 ORDER BY key",
+		["js-observe"],
+	);
+
+	const initial = await events.next();
+	expect(initial?.sequence).toBe(0);
+	expect(typeof initial?.mutationSequence).toBe("number");
+	expect(initial?.result.rows).toHaveLength(0);
+
+	await lix.execute(
+		"INSERT INTO lix_key_value (key, value) VALUES ('js-observe', 'v0')",
+	);
+
+	const update = await events.next();
+	expect(update?.sequence).toBe(1);
+	expect(update?.mutationSequence).toBeGreaterThanOrEqual(
+		initial?.mutationSequence ?? 0,
+	);
+	expect(update?.result.rows).toHaveLength(1);
+	expect(update?.result.rows[0]?.value("key").toJS()).toBe("js-observe");
+	expect(update?.result.rows[0]?.value("value").toJS()).toBe("v0");
+
+	events.close();
+	await expect(events.next()).resolves.toBeUndefined();
+	await lix.close();
+});
+
+test("observe rejects concurrent next calls on the same handle", async () => {
+	const lix = await openLix();
+	const events = lix.observe("SELECT key FROM lix_key_value WHERE key = $1", [
+		"js-observe-concurrent",
+	]);
+
+	await events.next();
+	const pending = events.next();
+	await expect(events.next()).rejects.toMatchObject({
+		code: "LIX_OBSERVE_NEXT_IN_FLIGHT",
+	});
+
+	events.close();
+	await expect(withTimeout(pending)).resolves.toBeUndefined();
+	await lix.close();
+});
+
+test("observe close resolves a pending next call", async () => {
+	const lix = await openLix();
+	const events = lix.observe("SELECT key FROM lix_key_value WHERE key = $1", [
+		"js-observe-close",
+	]);
+
+	await events.next();
+	const pending = events.next();
+	events.close();
+
+	await expect(withTimeout(pending)).resolves.toBeUndefined();
+	await expect(events.next()).resolves.toBeUndefined();
+	await lix.close();
+});
+
+test("observe close reliably resolves pending next calls", async () => {
+	const lix = await openLix();
+
+	for (let i = 0; i < 50; i += 1) {
+		const events = lix.observe("SELECT key FROM lix_key_value WHERE key = $1", [
+			`js-observe-close-stress-${i}`,
+		]);
+
+		await events.next();
+		const pending = events.next();
+		events.close();
+		await expect(withTimeout(pending)).resolves.toBeUndefined();
+	}
+
+	await lix.close();
+});
+
+test("observe remains usable after next rejects", async () => {
+	const lix = await openLix();
+	const events = lix.observe(
+		"SELECT key, value FROM lix_key_value WHERE key = $1",
+		["js-observe-error"],
+	);
+
+	const tx = await lix.beginTransaction();
+	await tx.execute(
+		"INSERT INTO lix_key_value (key, value) VALUES ('js-observe-error', 'rolled-back')",
+	);
+	await expect(events.next()).rejects.toMatchObject({ name: "LixError" });
+	await tx.rollback();
+
+	await lix.execute(
+		"INSERT INTO lix_key_value (key, value) VALUES ('js-observe-error', 'after-error')",
+	);
+	const update = await events.next();
+	expect(update?.sequence).toBe(0);
+	expect(update?.result.rows[0]?.value("value").toJS()).toBe("after-error");
+
+	events.close();
+	await lix.close();
+});
+
 test.each([
 	["memory", () => openLix()],
 	[
@@ -1080,6 +1184,25 @@ async function taskTitle(lix: Lix, taskId: string): Promise<string> {
 
 function get(result: ExecuteResult, column: string, rowIndex = 0): unknown {
 	return result.rows[rowIndex]?.get(column);
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms = 1_000): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(`timed out after ${ms}ms`)),
+					ms,
+				);
+			}),
+		]);
+	} finally {
+		if (timeout !== undefined) {
+			clearTimeout(timeout);
+		}
+	}
 }
 
 function tempLixPath(): string {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -11,6 +11,7 @@ import type {
 	MergeBranchOptions,
 	MergeBranchPreview,
 	MergeBranchReceipt,
+	ObserveEvent,
 	OpenLixOptions,
 	SqlParam,
 	SqliteBackendOptions,
@@ -20,10 +21,16 @@ import type {
 } from "./types.js";
 
 type NativeExecuteResult = Parameters<typeof wrapExecuteResult>[0];
+type NativeObserveEvent = {
+	sequence: number;
+	mutationSequence: number;
+	rows: NativeExecuteResult;
+};
 type NativeParam = ReturnType<typeof toNativeValue>;
 
 type NativeLix = {
 	execute(sql: string, params: NativeParam[]): NativeExecuteResult;
+	observe(sql: string, params: NativeParam[]): NativeObserveEvents;
 	beginTransaction(): NativeLixTransaction;
 	activeBranchId(): string;
 	createBranch(options: CreateBranchOptions): CreateBranchReceipt;
@@ -37,6 +44,11 @@ type NativeLixTransaction = {
 	execute(sql: string, params: NativeParam[]): NativeExecuteResult;
 	commit(): void;
 	rollback(): void;
+};
+
+type NativeObserveEvents = {
+	next(): Promise<NativeObserveEvent | null | undefined>;
+	close(): void;
 };
 
 export class SqliteBackend {
@@ -106,6 +118,18 @@ export class Lix {
 		);
 	}
 
+	observe(sql: string, params: SqlParam[] = []): ObserveEvents {
+		assertSqlArgs("observe", "lix", sql, params);
+		return new ObserveEvents(
+			this.native.observe(
+				sql,
+				params.map((param, index) =>
+					toNativeValue(normalizeParam(param, index)),
+				),
+			),
+		);
+	}
+
 	async beginTransaction(): Promise<LixTransaction> {
 		return new LixTransaction(this.native.beginTransaction());
 	}
@@ -148,6 +172,26 @@ export class Lix {
 
 	async close(): Promise<void> {
 		return this.native.close();
+	}
+}
+
+export class ObserveEvents {
+	constructor(private readonly native: NativeObserveEvents) {}
+
+	async next(): Promise<ObserveEvent | undefined> {
+		const event = await this.native.next();
+		if (event == null) {
+			return undefined;
+		}
+		return {
+			sequence: event.sequence,
+			mutationSequence: event.mutationSequence,
+			result: wrapExecuteResult(event.rows),
+		};
+	}
+
+	close(): void {
+		this.native.close();
 	}
 }
 
@@ -253,12 +297,21 @@ function assertBytesArg(
 }
 
 function assertExecuteArgs(receiver: string, sql: string, params: SqlParam[]) {
+	assertSqlArgs("execute", receiver, sql, params);
+}
+
+function assertSqlArgs(
+	operation: string,
+	receiver: string,
+	sql: string,
+	params: SqlParam[],
+) {
 	if (typeof sql !== "string") {
-		throw invalidArgument("execute", "sql", "string", typeof sql, receiver);
+		throw invalidArgument(operation, "sql", "string", typeof sql, receiver);
 	}
 	if (!Array.isArray(params)) {
 		throw invalidArgument(
-			"execute",
+			operation,
 			"params",
 			"array",
 			typeof params,

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -42,6 +42,12 @@ export type ExecuteResult = {
 	}>;
 };
 
+export type ObserveEvent = {
+	sequence: number;
+	mutationSequence: number;
+	result: ExecuteResult;
+};
+
 export type LixFs = {
 	readFile(path: string): Promise<Uint8Array | undefined>;
 	writeFile(path: string, data: Uint8Array): Promise<void>;

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -92,7 +92,13 @@ struct Snapshot {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct MaterializedSnapshot {
     disk: Snapshot,
-    lix: Snapshot,
+    lix_revision: LixRevision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct LixRevision {
+    active_branch_id: String,
+    active_branch_commit_id: String,
 }
 
 enum FilesystemEvent {
@@ -393,7 +399,8 @@ where
         let _guard = self.sync_lock.lock().await;
         let lix = self.collect_lix_snapshot().await?;
         let disk = self.materialize_snapshot(&lix)?;
-        self.remember_materialized(disk, lix);
+        let lix_revision = self.collect_lix_revision().await?;
+        self.remember_materialized(disk, lix_revision);
         Ok(())
     }
 
@@ -401,8 +408,8 @@ where
         let _guard = self.sync_lock.lock().await;
         let local = collect_local_snapshot(&self.root)?;
         if skip_if_last_materialized && self.is_last_materialized_disk(&local) {
-            let lix = self.collect_lix_snapshot().await?;
-            if self.is_last_materialized(&local, &lix) {
+            let lix_revision = self.collect_lix_revision().await?;
+            if self.is_last_materialized(&local, &lix_revision) {
                 return Ok(());
             }
         }
@@ -411,7 +418,8 @@ where
             .await?;
         let lix = self.collect_lix_snapshot().await?;
         let materialized = self.materialize_snapshot_after_disk_sync(&lix, &local)?;
-        self.remember_materialized(materialized, lix);
+        let lix_revision = self.collect_lix_revision().await?;
+        self.remember_materialized(materialized, lix_revision);
         Ok(())
     }
 
@@ -444,6 +452,32 @@ where
             snapshot.files.insert(path, data);
         }
         Ok(snapshot)
+    }
+
+    async fn collect_lix_revision(&self) -> Result<LixRevision, LixError> {
+        let active_branch_id = self.session.active_branch_id().await?;
+        let rows = self
+            .session
+            .execute(
+                "SELECT lix_active_branch_commit_id() AS active_branch_commit_id",
+                &[],
+            )
+            .await?;
+        let active_branch_commit_id = rows
+            .rows()
+            .first()
+            .ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "lix_active_branch_commit_id() returned no rows",
+                )
+            })?
+            .get::<String>("active_branch_commit_id")?;
+
+        Ok(LixRevision {
+            active_branch_id,
+            active_branch_commit_id,
+        })
     }
 
     async fn apply_local_snapshot_to_lix(
@@ -647,12 +681,12 @@ where
         Ok(remembered)
     }
 
-    fn remember_materialized(&self, disk: Snapshot, lix: Snapshot) {
+    fn remember_materialized(&self, disk: Snapshot, lix_revision: LixRevision) {
         *self
             .last_materialized
             .lock()
             .expect("filesystem materialized snapshot lock should not poison") =
-            Some(MaterializedSnapshot { disk, lix });
+            Some(MaterializedSnapshot { disk, lix_revision });
     }
 
     fn last_materialized_disk(&self) -> Option<Snapshot> {
@@ -671,12 +705,14 @@ where
             .is_some_and(|materialized| &materialized.disk == snapshot)
     }
 
-    fn is_last_materialized(&self, disk: &Snapshot, lix: &Snapshot) -> bool {
+    fn is_last_materialized(&self, disk: &Snapshot, lix_revision: &LixRevision) -> bool {
         self.last_materialized
             .lock()
             .expect("filesystem materialized snapshot lock should not poison")
             .as_ref()
-            .is_some_and(|materialized| &materialized.disk == disk && &materialized.lix == lix)
+            .is_some_and(|materialized| {
+                &materialized.disk == disk && &materialized.lix_revision == lix_revision
+            })
     }
 }
 
@@ -690,7 +726,7 @@ where
         return;
     };
     loop {
-        match event_rx.recv_timeout(Duration::from_secs(1)) {
+        match event_rx.recv() {
             Ok(FilesystemEvent::DiskChanged) => {
                 if drain_filesystem_events(&runtime, &state, &event_rx, true) {
                     return;
@@ -702,12 +738,9 @@ where
                     return;
                 }
             }
-            Ok(FilesystemEvent::Shutdown) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Ok(FilesystemEvent::Shutdown) | Err(_) => {
                 let _ = runtime.block_on(state.close());
                 return;
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                let _ = runtime.block_on(state.sync_disk_to_lix(true));
             }
         }
     }
@@ -1368,9 +1401,9 @@ mod tests {
         state.sync_disk_to_lix(false).await.unwrap();
 
         let local = collect_local_snapshot(&state.root).unwrap();
-        let lix = state.collect_lix_snapshot().await.unwrap();
+        let lix_revision = state.collect_lix_revision().await.unwrap();
         assert!(
-            state.is_last_materialized(&local, &lix),
+            state.is_last_materialized(&local, &lix_revision),
             "an unchanged filesystem should be recognized as already materialized"
         );
 
@@ -1432,6 +1465,51 @@ mod tests {
 
     #[cfg(feature = "sqlite")]
     #[tokio::test]
+    async fn disk_sync_does_not_skip_lix_side_file_data_change() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
+        let engine = crate::lix::open_or_initialize_engine(backend, None)
+            .await
+            .unwrap();
+        let root = std::fs::canonicalize(tempdir.path()).unwrap();
+        let state = FilesystemState {
+            session: engine.open_workspace_session().await.unwrap(),
+            root,
+            sync_lock: tokio::sync::Mutex::new(()),
+            last_materialized: Mutex::new(None),
+        };
+
+        state.sync_disk_to_lix(false).await.unwrap();
+        state
+            .session
+            .fs()
+            .write_file("/sql.txt", b"first".to_vec(), FsWriteOptions::default())
+            .await
+            .unwrap();
+        state.sync_from_lix().await.unwrap();
+        assert_eq!(
+            std::fs::read(tempdir.path().join("sql.txt")).unwrap(),
+            b"first"
+        );
+
+        state
+            .session
+            .fs()
+            .write_file("/sql.txt", b"second".to_vec(), FsWriteOptions::default())
+            .await
+            .unwrap();
+        state.sync_disk_to_lix(true).await.unwrap();
+
+        assert_eq!(
+            std::fs::read(tempdir.path().join("sql.txt")).unwrap(),
+            b"second"
+        );
+
+        state.close().await.unwrap();
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
     async fn disk_sync_materialization_preserves_file_changed_after_import() {
         let tempdir = tempfile::tempdir().unwrap();
         let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
@@ -1472,7 +1550,8 @@ mod tests {
         let materialized = state
             .materialize_snapshot_after_disk_sync(&target, &local)
             .unwrap();
-        state.remember_materialized(materialized, target);
+        let target_revision = state.collect_lix_revision().await.unwrap();
+        state.remember_materialized(materialized, target_revision);
         assert_eq!(std::fs::read(&disk_path).unwrap(), b"changed");
 
         state.sync_disk_to_lix(true).await.unwrap();

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -79,7 +79,7 @@ where
     session: SessionContext<B>,
     root: PathBuf,
     sync_lock: tokio::sync::Mutex<()>,
-    last_materialized: Mutex<Option<Snapshot>>,
+    last_materialized: Mutex<Option<MaterializedSnapshot>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -87,6 +87,12 @@ struct Snapshot {
     directories: BTreeSet<String>,
     files: BTreeMap<String, Vec<u8>>,
     unmanaged_paths: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MaterializedSnapshot {
+    disk: Snapshot,
+    lix: Snapshot,
 }
 
 enum FilesystemEvent {
@@ -385,24 +391,27 @@ where
 {
     async fn sync_from_lix(&self) -> Result<(), LixError> {
         let _guard = self.sync_lock.lock().await;
-        let snapshot = self.collect_lix_snapshot().await?;
-        let materialized = self.materialize_snapshot(&snapshot)?;
-        self.remember_materialized(materialized);
+        let lix = self.collect_lix_snapshot().await?;
+        let disk = self.materialize_snapshot(&lix)?;
+        self.remember_materialized(disk, lix);
         Ok(())
     }
 
     async fn sync_disk_to_lix(&self, skip_if_last_materialized: bool) -> Result<(), LixError> {
         let _guard = self.sync_lock.lock().await;
         let local = collect_local_snapshot(&self.root)?;
-        if skip_if_last_materialized && self.is_last_materialized(&local) {
-            return Ok(());
+        if skip_if_last_materialized && self.is_last_materialized_disk(&local) {
+            let lix = self.collect_lix_snapshot().await?;
+            if self.is_last_materialized(&local, &lix) {
+                return Ok(());
+            }
         }
-        let previous = self.last_materialized();
+        let previous = self.last_materialized_disk();
         self.apply_local_snapshot_to_lix(&local, previous.as_ref())
             .await?;
         let lix = self.collect_lix_snapshot().await?;
         let materialized = self.materialize_snapshot_after_disk_sync(&lix, &local)?;
-        self.remember_materialized(materialized);
+        self.remember_materialized(materialized, lix);
         Ok(())
     }
 
@@ -412,6 +421,7 @@ where
 
     async fn collect_lix_snapshot(&self) -> Result<Snapshot, LixError> {
         let mut snapshot = Snapshot::default();
+        snapshot.directories.insert("/".to_string());
         let directories = self
             .session
             .execute("SELECT path FROM lix_directory ORDER BY path", &[])
@@ -558,7 +568,7 @@ where
     ) -> Result<Snapshot, LixError> {
         ensure_filesystem_root_directory(&self.root)?;
         let local = collect_local_snapshot(&self.root)?;
-        let previous = self.last_materialized();
+        let previous = self.last_materialized_disk();
 
         for path in local.files.keys().filter(|path| {
             !target.files.contains_key(*path)
@@ -637,26 +647,36 @@ where
         Ok(remembered)
     }
 
-    fn remember_materialized(&self, snapshot: Snapshot) {
+    fn remember_materialized(&self, disk: Snapshot, lix: Snapshot) {
         *self
             .last_materialized
             .lock()
-            .expect("filesystem materialized snapshot lock should not poison") = Some(snapshot);
+            .expect("filesystem materialized snapshot lock should not poison") =
+            Some(MaterializedSnapshot { disk, lix });
     }
 
-    fn last_materialized(&self) -> Option<Snapshot> {
-        self.last_materialized
-            .lock()
-            .expect("filesystem materialized snapshot lock should not poison")
-            .clone()
-    }
-
-    fn is_last_materialized(&self, snapshot: &Snapshot) -> bool {
+    fn last_materialized_disk(&self) -> Option<Snapshot> {
         self.last_materialized
             .lock()
             .expect("filesystem materialized snapshot lock should not poison")
             .as_ref()
-            == Some(snapshot)
+            .map(|snapshot| snapshot.disk.clone())
+    }
+
+    fn is_last_materialized_disk(&self, snapshot: &Snapshot) -> bool {
+        self.last_materialized
+            .lock()
+            .expect("filesystem materialized snapshot lock should not poison")
+            .as_ref()
+            .is_some_and(|materialized| &materialized.disk == snapshot)
+    }
+
+    fn is_last_materialized(&self, disk: &Snapshot, lix: &Snapshot) -> bool {
+        self.last_materialized
+            .lock()
+            .expect("filesystem materialized snapshot lock should not poison")
+            .as_ref()
+            .is_some_and(|materialized| &materialized.disk == disk && &materialized.lix == lix)
     }
 }
 
@@ -1331,6 +1351,34 @@ mod tests {
 
     #[cfg(feature = "sqlite")]
     #[tokio::test]
+    async fn disk_sync_remembers_canonical_snapshot_for_idle_skip() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
+        let engine = crate::lix::open_or_initialize_engine(backend, None)
+            .await
+            .unwrap();
+        let root = std::fs::canonicalize(tempdir.path()).unwrap();
+        let state = FilesystemState {
+            session: engine.open_workspace_session().await.unwrap(),
+            root,
+            sync_lock: tokio::sync::Mutex::new(()),
+            last_materialized: Mutex::new(None),
+        };
+
+        state.sync_disk_to_lix(false).await.unwrap();
+
+        let local = collect_local_snapshot(&state.root).unwrap();
+        let lix = state.collect_lix_snapshot().await.unwrap();
+        assert!(
+            state.is_last_materialized(&local, &lix),
+            "an unchanged filesystem should be recognized as already materialized"
+        );
+
+        state.close().await.unwrap();
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
     async fn disk_sync_does_not_reimport_unchanged_materialized_file_deleted_in_lix() {
         let tempdir = tempfile::tempdir().unwrap();
         let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
@@ -1402,7 +1450,7 @@ mod tests {
         let disk_path = tempdir.path().join("disk.txt");
         std::fs::write(&disk_path, b"disk").unwrap();
         let local = collect_local_snapshot(&state.root).unwrap();
-        let previous = state.last_materialized();
+        let previous = state.last_materialized_disk();
         state
             .apply_local_snapshot_to_lix(&local, previous.as_ref())
             .await
@@ -1424,7 +1472,7 @@ mod tests {
         let materialized = state
             .materialize_snapshot_after_disk_sync(&target, &local)
             .unwrap();
-        state.remember_materialized(materialized);
+        state.remember_materialized(materialized, target);
         assert_eq!(std::fs::read(&disk_path).unwrap(), b"changed");
 
         state.sync_disk_to_lix(true).await.unwrap();

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -28,9 +28,9 @@ pub use lix_engine::{
     GetOptions, InMemoryBackend, InMemoryRead, InMemoryWrite, Key, KeyRange, LixError, LixNotice,
     MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions,
     MergeBranchReceipt, MergeBranchReceipt as MergeBranchResult, MergeChangeStats, MergeConflict,
-    MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, PointVisitor, ProjectedValueRef,
-    PutBatch, ReadOptions, Row, ScanOptions, ScanResult, ScanVisitor, SpaceId, SqlQueryResult,
-    StoredValue, SwitchBranchOptions, SwitchBranchReceipt,
+    MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, ObserveEvent, ObserveEvents,
+    PointVisitor, ProjectedValueRef, PutBatch, ReadOptions, Row, ScanOptions, ScanResult,
+    ScanVisitor, SpaceId, SqlQueryResult, StoredValue, SwitchBranchOptions, SwitchBranchReceipt,
     SwitchBranchReceipt as SwitchBranchResult, TryFromValue, Value, WriteOptions, WriteStats,
     run_backend_conformance,
 };

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -3,7 +3,7 @@ use lix_engine::{
     Backend, CreateBranchOptions, CreateBranchReceipt, Engine, ExecuteResult, FsDirEntry,
     FsMkdirOptions, FsRmOptions, FsWriteOptions, InMemoryBackend, InstalledPluginInfo, LixError,
     MergeBranchOptions, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
-    SessionContext, SwitchBranchOptions, SwitchBranchReceipt, Value,
+    ObserveEvents, SessionContext, SwitchBranchOptions, SwitchBranchReceipt, Value,
 };
 use std::sync::Arc;
 
@@ -94,6 +94,10 @@ where
     /// handle instead.
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {
         self.session.execute(sql, params).await
+    }
+
+    pub fn observe(&self, sql: &str, params: &[Value]) -> Result<ObserveEvents<B>, LixError> {
+        self.session.observe(sql, params)
     }
 
     pub async fn begin_transaction(&self) -> Result<LixTransaction<B>, LixError> {


### PR DESCRIPTION
## Summary

- Add the Rust/JS observe API surface and exact-query singleflight behavior.
- Add a durable mutation revision marker so observe subscribers in one engine process are invalidated when another engine process commits to the same repository.
- Add engine regression tests for cross-engine observe invalidation, commit/rollback behavior, coalescing, and independently opened SQLite backends.
- Tighten FsBackend materialization so disk sync avoids repeated broad work and still detects Lix-side file data changes.

## Validation

- `cargo test -p lix_engine --test observe`
- `cargo test -p lix_engine --test observe_mutation_revision -- --nocapture`
- `cargo clippy -p lix_engine --all-targets -- -D warnings`
- `cargo test -p lix_engine`

## Notes

- Observe invalidation is intentionally MVP-level: one process-local watcher polls the durable mutation revision and re-runs subscribed queries on external commits.
- The normal session/SQL write path advances the mutation revision. Very low-level storage helpers that bypass session commit paths are not covered by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New reactive query path touches commit boundaries, storage revision stamping, and background polling; behavior is heavily tested but cross-process invalidation is MVP polling with known gaps for low-level storage bypasses.
> 
> **Overview**
> Adds **`lix.observe()`** on the engine, Rust SDK, and JS SDK so clients can subscribe to **read-only** SQL and receive an initial snapshot plus later updates when query results actually change.
> 
> The engine wires **invalidation** into normal session commits (implicit writes, explicit transactions, and reads that persist runtime function state) and stamps a **durable mutation revision** on storage commits. A process-local watcher polls that revision so observers in one process still refresh after commits from **another** engine on the same repository. Identical observers **singleflight** evaluations per invalidation generation via an `ObserveCoordinator`.
> 
> **`ObserveEvents`** only emits when row sets differ, coalesces rapid writes, and rejects writes, durable runtime functions, and active transactions. JS exposes **`ObserveEvents`** with promise-based `next()`, single in-flight `next()`, and a dedicated actor thread.
> 
> FsBackend disk sync now tracks **Lix revision** (branch + commit) with the materialized disk snapshot so idle sync can skip work without missing Lix-side file changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed687354354a7695568221dde5c0c15ee63be28e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->