### PR TITLE
[codex] Fix observe initial read write race

### DIFF
--- a/packages/engine/src/observe_invalidation.rs
+++ b/packages/engine/src/observe_invalidation.rs
@@ -52,7 +52,6 @@ impl ObserveInvalidation {
         for<'backend> B::Read<'backend>: Send,
         for<'backend> B::Write<'backend>: Send,
     {
-        let mut last_seen_revision = storage.load_mutation_revision()?;
         if self
             .external_watcher_started
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -60,6 +59,14 @@ impl ObserveInvalidation {
         {
             return Ok(());
         }
+        let mut last_seen_revision = match storage.load_mutation_revision() {
+            Ok(revision) => revision,
+            Err(error) => {
+                self.external_watcher_started
+                    .store(false, Ordering::SeqCst);
+                return Err(error.into());
+            }
+        };
         let invalidation = Arc::downgrade(self);
         let spawn_result = thread::Builder::new()
             .name("lix-observe-invalidation".to_string())

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -241,8 +241,8 @@ where
         self.transaction_manager.begin_session_operation()
     }
 
-    pub(super) fn begin_session_write_lease(&self) -> Result<SessionWriteLease, LixError> {
-        self.transaction_manager.begin_write_lease()
+    pub(super) async fn begin_session_write_lease(&self) -> Result<SessionWriteLease, LixError> {
+        self.transaction_manager.begin_write_lease().await
     }
 
     pub(super) fn begin_explicit_session_write_lease(&self) -> Result<SessionWriteLease, LixError> {
@@ -250,7 +250,7 @@ where
     }
 
     pub(super) async fn begin_session_write_access(&self) -> Result<SessionWriteAccess, LixError> {
-        let write_lease = self.begin_session_write_lease()?;
+        let write_lease = self.begin_session_write_lease().await?;
         self.begin_session_write_access_with_lease(write_lease)
             .await
     }

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -62,10 +62,6 @@ where
             self.closed = true;
             return Ok(None);
         }
-        self.session
-            .observe_invalidation
-            .ensure_external_watcher(self.session.storage.clone())?;
-
         if self.last_rows.is_none() {
             let Some((mutation_sequence, rows)) = self.evaluate_stable_snapshot().await? else {
                 return Ok(None);
@@ -124,6 +120,9 @@ where
     async fn evaluate_stable_snapshot(&mut self) -> Result<Option<(u64, ExecuteResult)>, LixError> {
         loop {
             let operation_guard = self.session.begin_session_operation()?;
+            self.session
+                .observe_invalidation
+                .ensure_external_watcher(self.session.storage.clone())?;
             let before = *self.receiver.borrow_and_update();
             let rows = self.execute_or_share(before).await;
             drop(operation_guard);

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -289,8 +289,25 @@ impl SessionTransactionManager {
         })
     }
 
-    pub(super) fn begin_write_lease(&self) -> Result<SessionWriteLease, LixError> {
-        self.begin_write_lease_for(TransactionOwner::Automatic)
+    pub(super) async fn begin_write_lease(&self) -> Result<SessionWriteLease, LixError> {
+        loop {
+            let notified = self.inner.state_changed.notified();
+            let wait_for_session_operation = {
+                let mut state = self.lock_state();
+                if state.is_session_operation_in_progress() {
+                    true
+                } else {
+                    state.begin_write_lease(TransactionOwner::Automatic)?;
+                    false
+                }
+            };
+            if wait_for_session_operation {
+                notified.await;
+                continue;
+            }
+            self.inner.state_changed.notify_waiters();
+            return self.open_reserved_write_lease();
+        }
     }
 
     pub(super) fn begin_explicit_write_lease(&self) -> Result<SessionWriteLease, LixError> {
@@ -307,6 +324,10 @@ impl SessionTransactionManager {
         }
         self.inner.state_changed.notify_waiters();
 
+        self.open_reserved_write_lease()
+    }
+
+    fn open_reserved_write_lease(&self) -> Result<SessionWriteLease, LixError> {
         let operation_guard = SessionOperationGuard {
             manager: self.clone(),
         };
@@ -412,6 +433,10 @@ impl SessionTransactionState {
                 ..
             }
         )
+    }
+
+    fn is_session_operation_in_progress(&self) -> bool {
+        matches!(self, Self::OpenOperation { .. })
     }
 
     fn begin_operation(&mut self, scope: SessionOperationScope) -> Result<(), LixError> {

--- a/packages/engine/tests/observe.rs
+++ b/packages/engine/tests/observe.rs
@@ -1,8 +1,9 @@
 mod support;
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use lix_engine::{
     Backend, BackendError, BackendRead, Engine, GetOptions, InMemoryBackend, InMemoryRead,
@@ -87,6 +88,67 @@ simulation_test!(observe_next_returns_initial_snapshot, |sim| async move {
     assert_eq!(initial.sequence, 0);
     assert_key_value_row(&initial, "observe-initial", "v0");
 });
+
+#[tokio::test]
+async fn observe_initial_next_waits_without_rejecting_same_session_write() {
+    let backend = BlockingBeginReadBackend::new();
+    let gate = backend.gate();
+    Engine::initialize(backend.clone())
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(backend).await.expect("engine should open");
+    let session = Arc::new(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open"),
+    );
+    let mut warmup = session
+        .observe("SELECT 1", &[])
+        .expect("warmup observe should open");
+    let _ = next_event(&mut warmup, "warmup snapshot").await;
+    let params = [Value::Text("observe-blocked-initial-write".to_string())];
+    let mut events = session
+        .observe(KEY_VALUE_SQL, &params)
+        .expect("observe should open");
+
+    gate.block_next_read();
+    let observer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move { events.next().await })
+    });
+    gate.wait_until_blocked();
+
+    let writer_session = Arc::clone(&session);
+    let writer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move {
+            writer_session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) \
+                     VALUES ('observe-blocked-initial-write', 'v0')",
+                    &[],
+                )
+                .await
+        })
+    });
+
+    gate.release();
+    let initial = observer
+        .join()
+        .expect("observer thread should not panic")
+        .expect("observe next should not fail")
+        .expect("observe next should emit initial snapshot");
+    assert_eq!(initial.sequence, 0);
+    writer
+        .join()
+        .expect("writer thread should not panic")
+        .expect("write should succeed after observe initial read finishes");
+}
 
 simulation_test!(
     observe_emits_after_committed_mutation_changes_result,
@@ -551,6 +613,137 @@ simulation_test!(
 struct CountingReadBackend {
     inner: InMemoryBackend,
     read_count: Arc<AtomicUsize>,
+}
+
+#[derive(Clone)]
+struct BlockingBeginReadBackend {
+    inner: InMemoryBackend,
+    gate: BlockingReadGate,
+}
+
+impl BlockingBeginReadBackend {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            gate: BlockingReadGate::new(),
+        }
+    }
+
+    fn gate(&self) -> BlockingReadGate {
+        self.gate.clone()
+    }
+}
+
+impl Backend for BlockingBeginReadBackend {
+    type Read<'a>
+        = InMemoryRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = InMemoryWrite
+    where
+        Self: 'a;
+
+    fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
+        self.gate.maybe_block();
+        self.inner.begin_read(opts)
+    }
+
+    fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+        self.inner.begin_write(opts)
+    }
+}
+
+#[derive(Clone)]
+struct BlockingReadGate {
+    state: Arc<(Mutex<BlockingReadState>, Condvar)>,
+}
+
+impl BlockingReadGate {
+    fn new() -> Self {
+        Self {
+            state: Arc::new((Mutex::new(BlockingReadState::default()), Condvar::new())),
+        }
+    }
+
+    fn block_next_read(&self) {
+        let (lock, _) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("blocking read gate lock should not poison");
+        state.block_next = true;
+        state.blocked = false;
+        state.released = false;
+    }
+
+    fn maybe_block(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("blocking read gate lock should not poison");
+        if !state.block_next {
+            return;
+        }
+        state.block_next = false;
+        state.blocked = true;
+        condvar.notify_all();
+        let deadline = Instant::now() + NEXT_TIMEOUT;
+        while !state.released {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for blocking read gate release"
+            );
+            let (next_state, wait_result) = condvar
+                .wait_timeout(state, remaining)
+                .expect("blocking read gate lock should not poison after wait");
+            state = next_state;
+            assert!(
+                !wait_result.timed_out() || state.released,
+                "timed out waiting for blocking read gate release"
+            );
+        }
+    }
+
+    fn wait_until_blocked(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("blocking read gate lock should not poison");
+        let deadline = Instant::now() + NEXT_TIMEOUT;
+        while !state.blocked {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for blocking read gate"
+            );
+            let (next_state, wait_result) = condvar
+                .wait_timeout(state, remaining)
+                .expect("blocking read gate lock should not poison after wait");
+            state = next_state;
+            assert!(
+                !wait_result.timed_out() || state.blocked,
+                "timed out waiting for blocking read gate"
+            );
+        }
+    }
+
+    fn release(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("blocking read gate lock should not poison");
+        state.released = true;
+        condvar.notify_all();
+    }
+}
+
+#[derive(Default)]
+struct BlockingReadState {
+    block_next: bool,
+    blocked: bool,
+    released: bool,
 }
 
 struct CountingRead {


### PR DESCRIPTION
## What changed

- Serialize automatic same-session writes behind active session operations instead of failing with `LIX_INVALID_TRANSACTION_STATE`.
- Move observe external watcher setup into the stable snapshot operation guard.
- Avoid repeated mutation-revision reads when the observe invalidation watcher is already running.
- Add an engine regression test that blocks the observe initial snapshot read and verifies a same-session write succeeds after the read completes.

## Why

`observe().next()` can evaluate the initial snapshot concurrently with a same-handle write. In the JS SDK this happens because observe events run on a separate native thread, while app code can issue a write from another effect. The write previously attempted to reserve an implicit transaction while the observe snapshot was still holding a session operation, causing `LIX_INVALID_TRANSACTION_STATE` even though there was no explicit transaction.

## Validation

- `cargo test -p lix_engine --test observe`
- `cargo test -p lix_engine --test observe observe_initial_next_waits_without_rejecting_same_session_write`
- `cargo test -p lix_engine --test transaction begin_transaction_cannot_race_with_opening_session_write`
- `cargo test -p lix_engine --test transaction active_transaction_blocks_session_read_and_allows_transaction_read`
- `pnpm vitest run` from the Flashtype parent checkout after rebuilding Lix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session transaction serialization for automatic writes; behavior is narrower (wait vs error) but affects all implicit writes during active session operations.
> 
> **Overview**
> Fixes a concurrency bug where **`observe().next()`** could hold a session operation while an implicit write on the **same session** failed with **`LIX_INVALID_TRANSACTION_STATE`** (common when observe runs on another thread in the JS SDK).
> 
> **Automatic write leases** now **async-wait** until an in-flight session operation (e.g. an observe snapshot read) finishes, instead of rejecting immediately. Explicit transaction opens keep the previous fail-fast behavior.
> 
> **Observe** starts the external invalidation watcher inside **`evaluate_stable_snapshot`**, under the same operation guard as the snapshot SQL. **`ensure_external_watcher`** skips extra mutation-revision reads when the watcher is already running and rolls back the started flag if revision load fails.
> 
> Adds a regression test that blocks the initial observe read and verifies a concurrent same-session **`execute`** write succeeds after the read completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd2b4068e2fd306107b44b92cbe1df8b63fe01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->