### PR TITLE
[codex] Implement path-based SQL upsert

### DIFF
--- a/packages/engine/src/session/fs.rs
+++ b/packages/engine/src/session/fs.rs
@@ -69,44 +69,21 @@ where
         options: FsWriteOptions,
     ) -> Result<(), LixError> {
         let path_value = Value::Text(path.to_string());
-        let lane_value = Value::Boolean(options.untracked);
-        let existing = self
-            .session
+        let metadata_value = json_metadata_value(options.metadata);
+        self.session
             .execute(
-                "SELECT id, lixcol_untracked FROM lix_file WHERE path = $1",
-                std::slice::from_ref(&path_value),
+                "INSERT INTO lix_file (path, data, lixcol_metadata, lixcol_untracked) \
+                 VALUES ($1, $2, $3, $4) \
+                 ON CONFLICT (path) DO UPDATE SET \
+                 data = excluded.data, lixcol_metadata = excluded.lixcol_metadata",
+                &[
+                    path_value,
+                    Value::Blob(data),
+                    metadata_value,
+                    Value::Boolean(options.untracked),
+                ],
             )
             .await?;
-        let metadata_value = json_metadata_value(options.metadata);
-        for row in existing.rows() {
-            let existing_untracked: bool = row.get("lixcol_untracked")?;
-            if existing_untracked != options.untracked {
-                return Err(filesystem_conflict_error(format!(
-                    "fs.write_file cannot write {} path {path:?} over existing {} file",
-                    lane_name(options.untracked),
-                    lane_name(existing_untracked)
-                )));
-            }
-        }
-
-        if existing.is_empty() {
-            self.session
-                .execute(
-                    "INSERT INTO lix_file (path, data, lixcol_metadata, lixcol_untracked) \
-                     VALUES ($1, $2, $3, $4)",
-                    &[path_value, Value::Blob(data), metadata_value, lane_value],
-                )
-                .await?;
-        } else {
-            self.session
-                .execute(
-                    "UPDATE lix_file \
-                     SET data = $2, lixcol_metadata = $3 \
-                     WHERE path = $1 AND lixcol_untracked = $4",
-                    &[path_value, Value::Blob(data), metadata_value, lane_value],
-                )
-                .await?;
-        }
         Ok(())
     }
 
@@ -151,31 +128,11 @@ where
             return Ok(());
         }
 
-        let existing = self
-            .session
-            .execute(
-                "SELECT id, lixcol_untracked FROM lix_directory WHERE path = $1",
-                std::slice::from_ref(&path_value),
-            )
-            .await?;
-        for row in existing.rows() {
-            let existing_untracked: bool = row.get("lixcol_untracked")?;
-            if existing_untracked != options.untracked {
-                return Err(filesystem_conflict_error(format!(
-                    "fs.mkdir cannot write {} path {path:?} over existing {} directory",
-                    lane_name(options.untracked),
-                    lane_name(existing_untracked)
-                )));
-            }
-        }
-        if !existing.is_empty() {
-            return Ok(());
-        }
-
         self.session
             .execute(
                 "INSERT INTO lix_directory (path, lixcol_metadata, lixcol_untracked) \
-                 VALUES ($1, $2, $3)",
+                 VALUES ($1, $2, $3) \
+                 ON CONFLICT (path) DO NOTHING",
                 &[
                     path_value,
                     json_metadata_value(options.metadata),
@@ -349,10 +306,6 @@ where
     }
 }
 
-fn lane_name(untracked: bool) -> &'static str {
-    if untracked { "untracked" } else { "tracked" }
-}
-
 fn json_metadata_value(value: Option<JsonValue>) -> Value {
     value.map(Value::Json).unwrap_or(Value::Null)
 }
@@ -386,8 +339,4 @@ fn wrong_kind_error(path: &str, expected: &str, actual: &str) -> LixError {
         LixError::CODE_CONSTRAINT_VIOLATION,
         format!("fs path {path:?} expected {expected}, found {actual}"),
     )
-}
-
-fn filesystem_conflict_error(message: String) -> LixError {
-    LixError::new(LixError::CODE_CONSTRAINT_VIOLATION, message)
 }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -282,10 +282,19 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                 return Ok(0);
             }
             if let Some(conflict) = &plan.bound.conflict {
-                let proposed_batches =
-                    crate::sql2::runtime::collect_input_plan(input, session.task_ctx())
-                        .await
-                        .map_err(datafusion_error_to_lix_error)?;
+                let target_columns: Vec<String> = conflict
+                    .target_columns
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect();
+                crate::sql2::providers::validate_spec_upsert(&table, &input, &target_columns)
+                    .await?;
+                let proposed_batches = crate::sql2::runtime::collect_input_plan(
+                    std::sync::Arc::clone(&input),
+                    session.task_ctx(),
+                )
+                .await
+                .map_err(datafusion_error_to_lix_error)?;
                 let action = match &conflict.action {
                     crate::sql2::bind::write::BoundConflictAction::DoNothing => {
                         crate::sql2::providers::UpsertAction::DoNothing
@@ -301,13 +310,9 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                         }
                     }
                 };
-                let target_columns: Vec<String> = conflict
-                    .target_columns
-                    .iter()
-                    .map(|column| column.name.clone())
-                    .collect();
                 return crate::sql2::providers::execute_spec_upsert(
                     &table,
+                    &input,
                     proposed_batches,
                     &target_columns,
                     &action,
@@ -363,6 +368,13 @@ pub(crate) async fn validate_datafusion_write_logical_plan(
         BoundWriteOp::Insert => {
             let input = insert_input_plan(&session, table_schema.clone(), plan, params).await?;
             if let Some(conflict) = &plan.bound.conflict {
+                let target_columns: Vec<String> = conflict
+                    .target_columns
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect();
+                crate::sql2::providers::validate_spec_upsert(&table, &input, &target_columns)
+                    .await?;
                 // Validate-only: compile DO UPDATE assignments to surface
                 // expression errors; the row-level upsert runs at execute time.
                 if let crate::sql2::bind::write::BoundConflictAction::DoUpdate { assignments } =
@@ -696,7 +708,13 @@ fn datafusion_conflict_assignments(
     schema: &Schema,
     assignments: &[crate::sql2::bind::write::BoundAssignment],
     params: &[Value],
-) -> Result<Vec<(String, std::sync::Arc<dyn datafusion::physical_expr::PhysicalExpr>)>, LixError> {
+) -> Result<
+    Vec<(
+        String,
+        std::sync::Arc<dyn datafusion::physical_expr::PhysicalExpr>,
+    )>,
+    LixError,
+> {
     let mut fields: Vec<Field> = schema
         .fields()
         .iter()
@@ -722,8 +740,9 @@ fn datafusion_conflict_assignments(
             let expr = datafusion_expr_from_bound_expr(session, &assignment.value, params)?
                 .cast_to(field.data_type(), &df_schema)
                 .map_err(datafusion_error_to_lix_error)?;
-            let physical = datafusion::physical_expr::create_physical_expr(&expr, &df_schema, &props)
-                .map_err(datafusion_error_to_lix_error)?;
+            let physical =
+                datafusion::physical_expr::create_physical_expr(&expr, &df_schema, &props)
+                    .map_err(datafusion_error_to_lix_error)?;
             Ok((assignment.column.name.clone(), physical))
         })
         .collect()

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::execution::context::ExecutionProps;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_expr::PhysicalExpr;
 use futures_util::FutureExt;
@@ -106,12 +106,18 @@ impl TableSpec for BranchSpec {
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             load: row_source(
-                (Arc::clone(&self.live_state), Arc::clone(&self.branch_ref), schema),
+                (
+                    Arc::clone(&self.live_state),
+                    Arc::clone(&self.branch_ref),
+                    schema,
+                ),
                 |(live_state, branch_ref, schema)| async move {
                     let rows = load_branch_rows(live_state, branch_ref)
                         .await
                         .map_err(lix_error_to_datafusion_error)?;
-                    LIX_BRANCH_COLS.build(schema, &rows).map_err(branch_batch_error)
+                    LIX_BRANCH_COLS
+                        .build(schema, &rows)
+                        .map_err(branch_batch_error)
                 },
             ),
         })
@@ -295,6 +301,7 @@ impl UpsertSupport for BranchSpec {
         &self,
         _write_ctx: &SqlWriteContext,
         _proposed: &RecordBatch,
+        _target: &super::upsert::UpsertConflictTarget,
     ) -> Result<RecordBatch> {
         let rows = load_branch_rows(Arc::clone(&self.live_state), Arc::clone(&self.branch_ref))
             .await
@@ -699,4 +706,3 @@ pub(super) fn lix_branch_schema() -> SchemaRef {
         Field::new("commit_id", DataType::Utf8, false),
     ]))
 }
-

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -40,7 +40,7 @@ use crate::transaction::types::{
     LogicalPrimaryKey, TransactionJson, TransactionWriteOperation, TransactionWriteOrigin,
     TransactionWriteRow,
 };
-use crate::{LixError, parse_row_metadata_value, serialize_row_metadata};
+use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value, serialize_row_metadata};
 
 use crate::filesystem::{
     DirectoryDescriptorWriteIntent, DirectoryPathRecord, DirectoryPathResolver,
@@ -57,10 +57,12 @@ use crate::sql2::{
 use crate::transaction::types::{TransactionWrite, TransactionWriteMode};
 
 use super::spec::{
-    PlannedDml, PlannedScan, RowSource, TableSpec, finish_scan_batch, projected_schema, row_source,
-    register_spec_table,
+    PlannedDml, PlannedScan, RowSource, TableSpec, finish_scan_batch, projected_schema,
+    register_spec_table, row_source,
 };
-use super::upsert::{StagedUpsert, UpsertSupport};
+use super::upsert::{
+    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport, validate_target_columns,
+};
 use crate::entity_pk::EntityPk;
 
 const DIRECTORY_SCHEMA_KEY: &str = "lix_directory_descriptor";
@@ -69,6 +71,8 @@ const DIRECTORY_SCHEMA_KEY: &str = "lix_directory_descriptor";
 /// A directory's identity is its `id`; the underlying live state keys on the
 /// directory id as a single-element entity primary key.
 const LIX_DIRECTORY_IDENTITY: &[&str] = &["id"];
+const LIX_DIRECTORY_PATH_IDENTITY: &[&str] = &["path"];
+const LIX_DIRECTORY_BY_BRANCH_PATH_IDENTITY: &[&str] = &["path", "lixcol_branch_id"];
 
 pub(super) async fn register_lix_directory_active_provider(
     session: &SessionContext,
@@ -101,7 +105,9 @@ pub(super) async fn register_lix_directory_by_branch_provider(
     register_spec_table(
         session,
         surface_name,
-        Arc::new(LixDirectorySpec::by_branch(live_state, branch_ref, functions)),
+        Arc::new(LixDirectorySpec::by_branch(
+            live_state, branch_ref, functions,
+        )),
         WriteAccess::read_only(),
     )
 }
@@ -117,7 +123,9 @@ pub(super) async fn register_by_branch_write_provider(
     register_spec_table(
         session,
         surface_name,
-        Arc::new(LixDirectorySpec::by_branch(live_state, branch_ref, functions)),
+        Arc::new(LixDirectorySpec::by_branch(
+            live_state, branch_ref, functions,
+        )),
         WriteAccess::write(write_ctx),
     )
 }
@@ -208,7 +216,12 @@ impl LixDirectorySpec {
         captured: Arc<Mutex<Option<RecordBatch>>>,
     ) -> RowSource {
         row_source(
-            (write_ctx.clone(), request, Arc::clone(&self.schema), captured),
+            (
+                write_ctx.clone(),
+                request,
+                Arc::clone(&self.schema),
+                captured,
+            ),
             |(write_ctx, request, table_schema, captured)| async move {
                 let rows = write_ctx
                     .scan_live_state(&request)
@@ -216,8 +229,7 @@ impl LixDirectorySpec {
                     .map_err(lix_error_to_datafusion_error)?;
                 let source_batch = lix_directory_record_batch(&table_schema, rows)
                     .map_err(lix_error_to_datafusion_error)?;
-                *captured.lock().expect("dml source mutex poisoned") =
-                    Some(source_batch.clone());
+                *captured.lock().expect("dml source mutex poisoned") = Some(source_batch.clone());
                 Ok(source_batch)
             },
         )
@@ -484,9 +496,7 @@ impl TableSpec for LixDirectorySpec {
                         &mut || functions.call_uuid_v7().to_string(),
                     )?;
                     let count = u64::try_from(write_rows.len()).map_err(|_| {
-                        DataFusionError::Execution(
-                            "lix_directory UPDATE row count overflow".into(),
-                        )
+                        DataFusionError::Execution("lix_directory UPDATE row count overflow".into())
                     })?;
 
                     if count > 0 {
@@ -511,6 +521,35 @@ impl TableSpec for LixDirectorySpec {
 impl UpsertSupport for LixDirectorySpec {
     fn conflict_identity_columns(&self) -> &[&'static str] {
         LIX_DIRECTORY_IDENTITY
+    }
+
+    fn resolve_conflict_target(
+        &self,
+        table_name: &str,
+        target_columns: &[String],
+    ) -> Result<UpsertConflictTarget> {
+        if validate_target_columns(
+            table_name,
+            target_columns,
+            LIX_DIRECTORY_IDENTITY,
+            "conflict identity columns",
+        )
+        .is_ok()
+        {
+            return Ok(UpsertConflictTarget::id(LIX_DIRECTORY_IDENTITY));
+        }
+
+        let path_identity = match self.branch_binding {
+            BranchBinding::Active { .. } => LIX_DIRECTORY_PATH_IDENTITY,
+            BranchBinding::Explicit => LIX_DIRECTORY_BY_BRANCH_PATH_IDENTITY,
+        };
+        validate_target_columns(
+            table_name,
+            target_columns,
+            path_identity,
+            "path identity columns",
+        )?;
+        Ok(UpsertConflictTarget::path(path_identity))
     }
 
     /// Produce the staged INSERT rows for the non-conflicting proposed rows,
@@ -561,9 +600,18 @@ impl UpsertSupport for LixDirectorySpec {
         &self,
         write_ctx: &SqlWriteContext,
         proposed: &RecordBatch,
+        target: &UpsertConflictTarget,
     ) -> Result<RecordBatch> {
         let mut request =
             lix_directory_scan_request(self.branch_binding.active_branch_id(), None, None);
+        if matches!(self.branch_binding, BranchBinding::Explicit) {
+            request.filter.branch_ids = match target.kind() {
+                UpsertConflictKind::Id => proposed_branch_ids(proposed)?,
+                UpsertConflictKind::Path => {
+                    required_proposed_branch_ids(proposed, "lix_directory")?
+                }
+            };
+        }
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -571,13 +619,48 @@ impl UpsertSupport for LixDirectorySpec {
         )
         .await
         .map_err(lix_error_to_datafusion_error)?;
-        request.filter.entity_pks = proposed_directory_entity_pks(proposed)?;
+        request.filter.entity_pks = match target.kind() {
+            UpsertConflictKind::Id => proposed_directory_entity_pks(proposed)?,
+            UpsertConflictKind::Path => {
+                validate_required_paths(proposed, "lix_directory")?;
+                Vec::new()
+            }
+        };
 
         let rows = write_ctx
             .scan_live_state(&request)
             .await
             .map_err(lix_error_to_datafusion_error)?;
         lix_directory_record_batch(&self.schema, rows).map_err(lix_error_to_datafusion_error)
+    }
+
+    fn validate_conflict_pair(
+        &self,
+        existing: &RecordBatch,
+        existing_row: usize,
+        proposed: &RecordBatch,
+        proposed_row: usize,
+        target: &UpsertConflictTarget,
+    ) -> Result<()> {
+        if target.kind() != UpsertConflictKind::Path {
+            return Ok(());
+        }
+        let existing_untracked =
+            optional_bool_value(existing, existing_row, "lixcol_untracked")?.unwrap_or(false);
+        let proposed_untracked =
+            optional_bool_value(proposed, proposed_row, "lixcol_untracked")?.unwrap_or(false);
+        if existing_untracked == proposed_untracked {
+            return Ok(());
+        }
+        let path = required_string_value(proposed, proposed_row, "path")?;
+        Err(lix_error_to_datafusion_error(LixError::new(
+            LixError::CODE_CONSTRAINT_VIOLATION,
+            format!(
+                "INSERT ON CONFLICT (path) on lix_directory cannot write {} path {path:?} over existing {} directory",
+                lane_name(proposed_untracked),
+                lane_name(existing_untracked)
+            ),
+        )))
     }
 
     /// Apply the `DO UPDATE` assignments to the augmented batch (existing
@@ -622,6 +705,46 @@ fn proposed_directory_entity_pks(proposed: &RecordBatch) -> Result<Vec<EntityPk>
         }
     }
     Ok(entity_pks)
+}
+
+fn proposed_branch_ids(batch: &RecordBatch) -> Result<Vec<String>> {
+    let mut branch_ids = BTreeSet::new();
+    for row_index in 0..batch.num_rows() {
+        if let Some(branch_id) = optional_string_value(batch, row_index, "lixcol_branch_id")? {
+            branch_ids.insert(branch_id);
+        }
+    }
+    Ok(branch_ids.into_iter().collect())
+}
+
+fn required_proposed_branch_ids(batch: &RecordBatch, table_name: &str) -> Result<Vec<String>> {
+    let mut branch_ids = BTreeSet::new();
+    for row_index in 0..batch.num_rows() {
+        let branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?.ok_or_else(
+            || {
+                DataFusionError::Execution(format!(
+                    "INSERT ON CONFLICT (path, lixcol_branch_id) on {table_name} requires non-null lixcol_branch_id"
+                ))
+            },
+        )?;
+        branch_ids.insert(branch_id);
+    }
+    Ok(branch_ids.into_iter().collect())
+}
+
+fn validate_required_paths(batch: &RecordBatch, table_name: &str) -> Result<()> {
+    for row_index in 0..batch.num_rows() {
+        if optional_string_value(batch, row_index, "path")?.is_none() {
+            return Err(DataFusionError::Execution(format!(
+                "INSERT ON CONFLICT (path) on {table_name} requires non-null path"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn lane_name(untracked: bool) -> &'static str {
+    if untracked { "untracked" } else { "tracked" }
 }
 
 fn lix_directory_surface_name(branch_binding: &BranchBinding) -> &'static str {
@@ -1074,9 +1197,15 @@ fn directory_row_context_from_update(
     row_index: usize,
     branch_binding: Option<&str>,
 ) -> Result<FilesystemRowContext> {
+    let explicit_global = optional_bool_value(batch, row_index, "lixcol_global")?;
+    let explicit_branch_id = if explicit_global == Some(true) {
+        Some(GLOBAL_BRANCH_ID.to_string())
+    } else {
+        optional_string_value(batch, row_index, "lixcol_branch_id")?
+    };
     let scope = resolve_write_branch_scope(
-        optional_bool_value(batch, row_index, "lixcol_global")?,
-        optional_string_value(batch, row_index, "lixcol_branch_id")?,
+        explicit_global,
+        explicit_branch_id,
         branch_binding,
         "UPDATE into lix_directory_by_branch",
         "lix_directory",
@@ -1531,10 +1660,12 @@ mod tests {
         branch_binding: BranchBinding,
         batch: RecordBatch,
     ) -> Result<u64, datafusion::common::DataFusionError> {
-        let live_state =
-            Arc::new(crate::sql2::WriteContextLiveStateReader::new(write_ctx.clone()));
-        let branch_ref =
-            Arc::new(crate::sql2::WriteContextBranchRefReader::new(write_ctx.clone()));
+        let live_state = Arc::new(crate::sql2::WriteContextLiveStateReader::new(
+            write_ctx.clone(),
+        ));
+        let branch_ref = Arc::new(crate::sql2::WriteContextBranchRefReader::new(
+            write_ctx.clone(),
+        ));
         let spec = match branch_binding {
             BranchBinding::Active { .. } => LixDirectorySpec::active_branch(
                 write_ctx.active_branch_id(),
@@ -2058,10 +2189,12 @@ mod tests {
     fn directory_provider_is_writable_when_given_write_access() {
         let mut write_context = CapturingWriteContext::default();
         let write_ctx = SqlWriteContext::new(&mut write_context);
-        let live_state =
-            Arc::new(crate::sql2::WriteContextLiveStateReader::new(write_ctx.clone()));
-        let branch_ref =
-            Arc::new(crate::sql2::WriteContextBranchRefReader::new(write_ctx.clone()));
+        let live_state = Arc::new(crate::sql2::WriteContextLiveStateReader::new(
+            write_ctx.clone(),
+        ));
+        let branch_ref = Arc::new(crate::sql2::WriteContextBranchRefReader::new(
+            write_ctx.clone(),
+        ));
         let provider = SpecTableProvider::new(
             Arc::new(LixDirectorySpec::active_branch(
                 write_ctx.active_branch_id(),

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -61,7 +61,7 @@ use crate::sql2::write_normalization::{
     reject_non_binary_casts_for_insert_column, scalar_is_binary_or_null,
 };
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
-use crate::{LixError, parse_row_metadata_value, serialize_row_metadata};
+use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value, serialize_row_metadata};
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
@@ -90,7 +90,9 @@ use super::spec::{
     DmlApply, InsertApply, PlannedDml, PlannedScan, RowSource, TableSpec, finish_scan_batch,
     register_spec_table, row_source,
 };
-use super::upsert::{StagedUpsert, UpsertSupport};
+use super::upsert::{
+    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport, validate_target_columns,
+};
 
 pub(super) async fn register_lix_file_active_provider(
     session: &SessionContext,
@@ -149,7 +151,10 @@ pub(super) async fn register_by_branch_write_provider(
     register_spec_table(
         session,
         surface_name,
-        Arc::new(LixFileSpec::by_branch_with_write(write_ctx.clone(), options)),
+        Arc::new(LixFileSpec::by_branch_with_write(
+            write_ctx.clone(),
+            options,
+        )),
         WriteAccess::write(write_ctx),
     )
 }
@@ -244,10 +249,7 @@ impl LixFileSpec {
         }
     }
 
-    fn by_branch_with_write(
-        write_ctx: SqlWriteContext,
-        options: SqlWriteSessionOptions,
-    ) -> Self {
+    fn by_branch_with_write(write_ctx: SqlWriteContext, options: SqlWriteSessionOptions) -> Self {
         let functions = write_ctx.functions();
         let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
         let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
@@ -285,7 +287,15 @@ impl LixFileSpec {
                 target_file_ids,
                 needs_data,
             ),
-            |(write_ctx, blob_reader, plugin_host, table_schema, request, target_file_ids, needs_data)| async move {
+            |(
+                write_ctx,
+                blob_reader,
+                plugin_host,
+                table_schema,
+                request,
+                target_file_ids,
+                needs_data,
+            )| async move {
                 let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
                 let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
                     .await
@@ -397,14 +407,15 @@ impl TableSpec for LixFileSpec {
                     needs_data,
                     limit,
                 )| async move {
-                    let rows =
-                        scan_lix_file_live_rows(Arc::clone(&live_state), &request, &target_file_ids)
-                            .await
-                            .map_err(|error| {
-                                DataFusionError::Execution(format!(
-                                    "sql2 lix_file scan failed: {error}"
-                                ))
-                            })?;
+                    let rows = scan_lix_file_live_rows(
+                        Arc::clone(&live_state),
+                        &request,
+                        &target_file_ids,
+                    )
+                    .await
+                    .map_err(|error| {
+                        DataFusionError::Execution(format!("sql2 lix_file scan failed: {error}"))
+                    })?;
                     let plugin_render = plugin_render_context_for_lix_file_scan(
                         Arc::clone(&live_state),
                         &blob_reader,
@@ -493,7 +504,12 @@ impl TableSpec for LixFileSpec {
         .await
         .map_err(lix_error_to_datafusion_error)?;
 
-        let source = self.dml_source(&write_ctx, request.clone(), target_file_ids.clone(), needs_data);
+        let source = self.dml_source(
+            &write_ctx,
+            request.clone(),
+            target_file_ids.clone(),
+            needs_data,
+        );
         let branch_binding = self.branch_binding.clone();
         let apply: DmlApply = Arc::new(move |matched_batch| {
             let write_ctx = write_ctx.clone();
@@ -552,7 +568,12 @@ impl TableSpec for LixFileSpec {
         .await
         .map_err(lix_error_to_datafusion_error)?;
 
-        let source = self.dml_source(&write_ctx, request.clone(), target_file_ids.clone(), needs_data);
+        let source = self.dml_source(
+            &write_ctx,
+            request.clone(),
+            target_file_ids.clone(),
+            needs_data,
+        );
         let branch_binding = self.branch_binding.clone();
         let functions = self.functions.clone();
         let blob_reader = Arc::clone(&self.blob_reader);
@@ -650,15 +671,46 @@ impl TableSpec for LixFileSpec {
     }
 }
 
-/// Physical-identity column the upsert driver matches conflicting `lix_file`
-/// rows on. A `lix_file` row is uniquely identified by its file `id`; the
-/// `ON CONFLICT (id)` target is the supported (and only) conflict target.
+/// Physical and path identities the upsert driver can match `lix_file` rows
+/// on. Path targets model the visible filesystem identity for active and
+/// by-branch surfaces.
 const LIX_FILE_IDENTITY: &[&str] = &["id"];
+const LIX_FILE_PATH_IDENTITY: &[&str] = &["path"];
+const LIX_FILE_BY_BRANCH_PATH_IDENTITY: &[&str] = &["path", "lixcol_branch_id"];
 
 #[async_trait]
 impl UpsertSupport for LixFileSpec {
     fn conflict_identity_columns(&self) -> &[&'static str] {
         LIX_FILE_IDENTITY
+    }
+
+    fn resolve_conflict_target(
+        &self,
+        table_name: &str,
+        target_columns: &[String],
+    ) -> Result<UpsertConflictTarget> {
+        if validate_target_columns(
+            table_name,
+            target_columns,
+            LIX_FILE_IDENTITY,
+            "conflict identity columns",
+        )
+        .is_ok()
+        {
+            return Ok(UpsertConflictTarget::id(LIX_FILE_IDENTITY));
+        }
+
+        let path_identity = match self.branch_binding {
+            BranchBinding::Active { .. } => LIX_FILE_PATH_IDENTITY,
+            BranchBinding::Explicit => LIX_FILE_BY_BRANCH_PATH_IDENTITY,
+        };
+        validate_target_columns(
+            table_name,
+            target_columns,
+            path_identity,
+            "path identity columns",
+        )?;
+        Ok(UpsertConflictTarget::path(path_identity))
     }
 
     async fn insert_staged_rows(
@@ -711,14 +763,24 @@ impl UpsertSupport for LixFileSpec {
         &self,
         write_ctx: &SqlWriteContext,
         proposed: &RecordBatch,
+        target: &UpsertConflictTarget,
     ) -> Result<RecordBatch> {
         // Existing rows whose `id` matches a proposed row, rendered as a full
         // `lix_file` batch (with materialized `data`) so the driver can build
         // the augmented `excluded.*` batch the conflict assignments run over.
-        let target_file_ids = proposed_file_id_constraint(proposed)?;
+        let target_file_ids = match target.kind() {
+            UpsertConflictKind::Id => proposed_file_id_constraint(proposed)?,
+            UpsertConflictKind::Path => {
+                validate_required_paths(proposed, "lix_file")?;
+                FileIdConstraint::All
+            }
+        };
         let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
         if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = proposed_branch_ids(proposed)?;
+            request.filter.branch_ids = match target.kind() {
+                UpsertConflictKind::Id => proposed_branch_ids(proposed)?,
+                UpsertConflictKind::Path => required_proposed_branch_ids(proposed, "lix_file")?,
+            };
         }
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
@@ -746,6 +808,35 @@ impl UpsertSupport for LixFileSpec {
         lix_file_record_batch(&self.schema, &self.blob_reader, plugin_render, true, rows)
             .await
             .map_err(lix_error_to_datafusion_error)
+    }
+
+    fn validate_conflict_pair(
+        &self,
+        existing: &RecordBatch,
+        existing_row: usize,
+        proposed: &RecordBatch,
+        proposed_row: usize,
+        target: &UpsertConflictTarget,
+    ) -> Result<()> {
+        if target.kind() != UpsertConflictKind::Path {
+            return Ok(());
+        }
+        let existing_untracked =
+            optional_bool_value(existing, existing_row, "lixcol_untracked")?.unwrap_or(false);
+        let proposed_untracked =
+            optional_bool_value(proposed, proposed_row, "lixcol_untracked")?.unwrap_or(false);
+        if existing_untracked == proposed_untracked {
+            return Ok(());
+        }
+        let path = required_string_value(proposed, proposed_row, "path")?;
+        Err(lix_error_to_datafusion_error(LixError::new(
+            LixError::CODE_CONSTRAINT_VIOLATION,
+            format!(
+                "INSERT ON CONFLICT (path) on lix_file cannot write {} path {path:?} over existing {} file",
+                lane_name(proposed_untracked),
+                lane_name(existing_untracked)
+            ),
+        )))
     }
 
     async fn apply_conflict_update(
@@ -875,9 +966,39 @@ fn proposed_branch_ids(batch: &RecordBatch) -> Result<Vec<String>> {
     Ok(branch_ids.into_iter().collect())
 }
 
+fn required_proposed_branch_ids(batch: &RecordBatch, table_name: &str) -> Result<Vec<String>> {
+    let mut branch_ids = BTreeSet::new();
+    for row_index in 0..batch.num_rows() {
+        let branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?.ok_or_else(
+            || {
+                DataFusionError::Execution(format!(
+                    "INSERT ON CONFLICT (path, lixcol_branch_id) on {table_name} requires non-null lixcol_branch_id"
+                ))
+            },
+        )?;
+        branch_ids.insert(branch_id);
+    }
+    Ok(branch_ids.into_iter().collect())
+}
+
 /// Distinct `lixcol_branch_id` values carried by an augmented conflict batch.
 fn augmented_branch_ids(batch: &RecordBatch) -> Result<Vec<String>> {
     proposed_branch_ids(batch)
+}
+
+fn validate_required_paths(batch: &RecordBatch, table_name: &str) -> Result<()> {
+    for row_index in 0..batch.num_rows() {
+        if optional_string_value(batch, row_index, "path")?.is_none() {
+            return Err(DataFusionError::Execution(format!(
+                "INSERT ON CONFLICT (path) on {table_name} requires non-null path"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn lane_name(untracked: bool) -> &'static str {
+    if untracked { "untracked" } else { "tracked" }
 }
 
 struct LixFileInsertSink {
@@ -1862,9 +1983,14 @@ fn file_row_context_from_update(
     row_index: usize,
     branch_binding: Option<&str>,
 ) -> Result<FilesystemRowContext> {
-    let explicit_branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?;
+    let explicit_global = optional_bool_value(batch, row_index, "lixcol_global")?;
+    let explicit_branch_id = if explicit_global == Some(true) {
+        Some(GLOBAL_BRANCH_ID.to_string())
+    } else {
+        optional_string_value(batch, row_index, "lixcol_branch_id")?
+    };
     let scope = resolve_write_branch_scope(
-        optional_bool_value(batch, row_index, "lixcol_global")?,
+        explicit_global,
         explicit_branch_id,
         branch_binding,
         "UPDATE into lix_file_by_branch",

--- a/packages/engine/src/sql2/providers/lix_state.rs
+++ b/packages/engine/src/sql2/providers/lix_state.rs
@@ -8,10 +8,10 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::execution::context::ExecutionProps;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator, TableProviderFilterPushDown};
 use datafusion::physical_expr::PhysicalExpr;
@@ -44,12 +44,12 @@ use crate::sql2::predicate_typecheck::{
 use crate::sql2::result_metadata::json_field;
 
 use super::columns::{ColumnTableError, LIVE_STATE_COLS};
-use super::upsert::{StagedUpsert, UpsertSupport};
-use super::values::string_expr_literal;
 use super::spec::{
     PlannedDml, PlannedScan, RowSource, TableSpec, projected_schema, register_spec_table,
     row_source,
 };
+use super::upsert::{StagedUpsert, UpsertSupport};
+use super::values::string_expr_literal;
 
 pub(super) async fn register_lix_state_active_provider(
     session: &SessionContext,
@@ -183,8 +183,7 @@ impl LixStateSpec {
 /// The active surface scopes by the active branch implicitly; the by-branch
 /// surface carries `branch_id` as a column.
 const LIX_STATE_ACTIVE_IDENTITY: &[&str] = &["entity_pk", "schema_key", "file_id"];
-const LIX_STATE_BY_BRANCH_IDENTITY: &[&str] =
-    &["entity_pk", "schema_key", "file_id", "branch_id"];
+const LIX_STATE_BY_BRANCH_IDENTITY: &[&str] = &["entity_pk", "schema_key", "file_id", "branch_id"];
 
 #[async_trait]
 impl UpsertSupport for LixStateSpec {
@@ -210,8 +209,10 @@ impl UpsertSupport for LixStateSpec {
         &self,
         write_ctx: &SqlWriteContext,
         proposed: &RecordBatch,
+        _target: &super::upsert::UpsertConflictTarget,
     ) -> Result<RecordBatch> {
-        let request = lix_state_conflict_scan_request(&self.schema, &self.branch_binding, proposed)?;
+        let request =
+            lix_state_conflict_scan_request(&self.schema, &self.branch_binding, proposed)?;
         let rows = write_ctx
             .scan_live_state(&request)
             .await
@@ -591,8 +592,8 @@ fn update_optional_metadata_value(
 ) -> Result<Option<TransactionJson>> {
     update_optional_string_value(batch, assignment_values, row_index, column_name)?
         .map(|value| {
-            let metadata = parse_row_metadata_value(&value, context)
-                .map_err(lix_error_to_datafusion_error)?;
+            let metadata =
+                parse_row_metadata_value(&value, context).map_err(lix_error_to_datafusion_error)?;
             TransactionJson::from_value(metadata, &format!("{context} metadata"))
                 .map_err(lix_error_to_datafusion_error)
         })
@@ -728,8 +729,8 @@ fn optional_metadata_value(
 ) -> Result<Option<TransactionJson>> {
     optional_string_value(batch, row_index, column_name)?
         .map(|value| {
-            let metadata = parse_row_metadata_value(&value, context)
-                .map_err(lix_error_to_datafusion_error)?;
+            let metadata =
+                parse_row_metadata_value(&value, context).map_err(lix_error_to_datafusion_error)?;
             TransactionJson::from_value(metadata, &format!("{context} metadata"))
                 .map_err(lix_error_to_datafusion_error)
         })
@@ -1096,7 +1097,6 @@ fn nullable_key_literal(expr: &Expr) -> Option<NullableKeyFilter<String>> {
     }
     string_expr_literal(expr).map(NullableKeyFilter::Value)
 }
-
 
 fn is_null_literal(expr: &Expr) -> bool {
     matches!(expr, Expr::Literal(ScalarValue::Null, _))

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 
 use crate::LixError;
@@ -34,6 +35,7 @@ pub(crate) use upsert::{UpsertAction, excluded_field_name};
 /// The four builtin writable surfaces are all [`spec::SpecTableProvider`]s.
 pub(crate) async fn execute_spec_upsert(
     table: &Arc<dyn TableProvider>,
+    input: &Arc<dyn ExecutionPlan>,
     proposed_batches: Vec<datafusion::arrow::record_batch::RecordBatch>,
     target_columns: &[String],
     action: &UpsertAction,
@@ -48,9 +50,31 @@ pub(crate) async fn execute_spec_upsert(
             )
         })?;
     provider
-        .execute_upsert(proposed_batches, target_columns, action)
+        .execute_upsert(input, proposed_batches, target_columns, action)
         .await
         .map_err(crate::sql2::error::datafusion_error_to_lix_error)
+}
+
+/// Validate an `INSERT ... ON CONFLICT` against a registered table provider.
+pub(crate) async fn validate_spec_upsert(
+    table: &Arc<dyn TableProvider>,
+    input: &Arc<dyn ExecutionPlan>,
+    target_columns: &[String],
+) -> Result<(), LixError> {
+    let provider = table
+        .as_any()
+        .downcast_ref::<spec::SpecTableProvider>()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "INSERT ON CONFLICT is not supported on this table",
+            )
+        })?;
+    let _ = provider
+        .validate_upsert(input, target_columns)
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+    Ok(())
 }
 
 pub(crate) async fn register_read<C>(session: &SessionContext, ctx: &C) -> Result<(), LixError>

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -43,8 +43,7 @@ use super::upsert;
 /// Exec-time row loader. Captures whatever plan-time state the spec computed
 /// (scan requests, readers, projections) and produces the source batch.
 /// Re-invocable: DataFusion may execute a scan node more than once.
-pub(super) type RowSource =
-    Arc<dyn Fn() -> BoxFuture<'static, Result<RecordBatch>> + Send + Sync>;
+pub(super) type RowSource = Arc<dyn Fn() -> BoxFuture<'static, Result<RecordBatch>> + Send + Sync>;
 
 /// Build a [`RowSource`] from owned plan-time state and an async body taking
 /// that state by value. Owns the once-per-invocation clone that
@@ -234,23 +233,40 @@ impl SpecTableProvider {
     }
 
     /// Execute an `INSERT ... ON CONFLICT` against this table. The conflict
-    /// target columns are validated against the spec's identity, then the
-    /// generic upsert driver composes the spec's insert/scan/update builders.
+    /// target columns are resolved by the spec, then the generic upsert driver
+    /// composes the spec's insert/scan/update builders.
     pub(crate) async fn execute_upsert(
         &self,
+        input: &Arc<dyn ExecutionPlan>,
         proposed_batches: Vec<RecordBatch>,
         target_columns: &[String],
         action: &upsert::UpsertAction,
     ) -> Result<u64> {
+        let (write_ctx, support, target) = self.validate_upsert(input, target_columns).await?;
+        upsert::execute_upsert(support, &write_ctx, proposed_batches, &target, action).await
+    }
+
+    pub(crate) async fn validate_upsert(
+        &self,
+        input: &Arc<dyn ExecutionPlan>,
+        target_columns: &[String],
+    ) -> Result<(
+        SqlWriteContext,
+        &dyn upsert::UpsertSupport,
+        upsert::UpsertConflictTarget,
+    )> {
         let table = self.spec.table_name();
         let write_ctx = self
             .write_access
             .require_write(&format!("INSERT into {table}"))?;
+        self.schema
+            .logically_equivalent_names_and_types(&input.schema())?;
         let support = self.spec.upsert_support().ok_or_else(|| {
             DataFusionError::Execution(format!("INSERT ON CONFLICT is not supported on {table}"))
         })?;
-        upsert::validate_conflict_target(support, table, target_columns)?;
-        upsert::execute_upsert(support, &write_ctx, proposed_batches, action).await
+        let target = support.resolve_conflict_target(table, target_columns)?;
+        self.spec.plan_insert(write_ctx.clone(), input).await?;
+        Ok((write_ctx, support, target))
     }
 }
 
@@ -319,20 +335,17 @@ impl TableProvider for SpecTableProvider {
             .require_write(&format!("INSERT into {table}"))?;
         self.schema
             .logically_equivalent_names_and_types(&input.schema())?;
-        let sink: Arc<dyn InsertSink> = match self
-            .spec
-            .plan_insert(write_ctx.clone(), &input)
-            .await?
-        {
-            Some(apply) => Arc::new(PlannedInsertSink {
-                table: table.into(),
-                apply,
-            }),
-            None => Arc::new(SpecInsertSink {
-                spec: Arc::clone(&self.spec),
-                write_ctx,
-            }),
-        };
+        let sink: Arc<dyn InsertSink> =
+            match self.spec.plan_insert(write_ctx.clone(), &input).await? {
+                Some(apply) => Arc::new(PlannedInsertSink {
+                    table: table.into(),
+                    apply,
+                }),
+                None => Arc::new(SpecInsertSink {
+                    spec: Arc::clone(&self.spec),
+                    write_ctx,
+                }),
+            };
         Ok(Arc::new(InsertExec::new(input, sink)))
     }
 

--- a/packages/engine/src/sql2/providers/upsert.rs
+++ b/packages/engine/src/sql2/providers/upsert.rs
@@ -9,11 +9,11 @@
 //! absent and replaces when present.
 //!
 //! Each spec contributes only the small pieces that genuinely vary — its
-//! identity columns, its insert/candidate-scan/assignment-apply builders —
-//! via [`UpsertSupport`]. The loop, identity matching, and the `excluded`
+//! conflict-target resolution, its insert/candidate-scan/assignment-apply
+//! builders — via [`UpsertSupport`]. The loop, matching, and the `excluded`
 //! batch augmentation live here once.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -38,6 +38,44 @@ pub(crate) enum UpsertAction {
     },
     /// `DO NOTHING` — keep the existing row.
     DoNothing,
+}
+
+/// The semantic identity the table resolved the SQL conflict target to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UpsertConflictKind {
+    Id,
+    Path,
+}
+
+/// A provider-resolved `ON CONFLICT (...)` target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct UpsertConflictTarget {
+    kind: UpsertConflictKind,
+    columns: Vec<&'static str>,
+}
+
+impl UpsertConflictTarget {
+    pub(super) fn id(columns: &[&'static str]) -> Self {
+        Self {
+            kind: UpsertConflictKind::Id,
+            columns: columns.to_vec(),
+        }
+    }
+
+    pub(super) fn path(columns: &[&'static str]) -> Self {
+        Self {
+            kind: UpsertConflictKind::Path,
+            columns: columns.to_vec(),
+        }
+    }
+
+    pub(super) fn kind(&self) -> UpsertConflictKind {
+        self.kind
+    }
+
+    pub(super) fn columns(&self) -> &[&'static str] {
+        &self.columns
+    }
 }
 
 /// The staged writes a spec produces for a slice of upsert rows: the state
@@ -78,9 +116,24 @@ impl StagedUpsert {
 /// reuses logic the spec already has for plain INSERT/UPDATE.
 #[async_trait]
 pub(super) trait UpsertSupport: Send + Sync {
-    /// The columns forming the unique identity; the conflicting-row lookup
-    /// matches on these, and the `ON CONFLICT` target must be a subset.
+    /// The columns forming the default physical identity.
     fn conflict_identity_columns(&self) -> &[&'static str];
+
+    /// Resolve and validate the SQL `ON CONFLICT (...)` target for this table.
+    fn resolve_conflict_target(
+        &self,
+        table_name: &str,
+        target_columns: &[String],
+    ) -> Result<UpsertConflictTarget> {
+        let identity = self.conflict_identity_columns();
+        validate_target_columns(
+            table_name,
+            target_columns,
+            identity,
+            "conflict identity columns",
+        )?;
+        Ok(UpsertConflictTarget::id(identity))
+    }
 
     /// Build staged INSERT rows for a proposed batch (the same builder
     /// `stage_insert` uses).
@@ -96,7 +149,22 @@ pub(super) trait UpsertSupport: Send + Sync {
         &self,
         write_ctx: &SqlWriteContext,
         proposed: &RecordBatch,
+        target: &UpsertConflictTarget,
     ) -> Result<RecordBatch>;
+
+    /// Validate a matched existing/proposed pair before applying the conflict
+    /// action. Most tables need no extra check; filesystem path targets use it
+    /// to reject tracked/untracked namespace collisions.
+    fn validate_conflict_pair(
+        &self,
+        _existing: &RecordBatch,
+        _existing_row: usize,
+        _proposed: &RecordBatch,
+        _proposed_row: usize,
+        _target: &UpsertConflictTarget,
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /// Apply the `DO UPDATE` assignments to an augmented batch — this table's
     /// columns (carrying the existing row) plus `excluded.*` columns (carrying
@@ -115,22 +183,29 @@ pub(super) async fn execute_upsert<S: UpsertSupport + ?Sized>(
     spec: &S,
     write_ctx: &SqlWriteContext,
     proposed_batches: Vec<RecordBatch>,
+    target: &UpsertConflictTarget,
     action: &UpsertAction,
 ) -> Result<u64> {
-    let identity_columns = spec.conflict_identity_columns();
+    let conflict_columns = target.columns();
     let mut staged = StagedUpsert::default();
     let mut affected: u64 = 0;
 
     for batch in &proposed_batches {
-        let existing = spec.scan_conflict_candidates(write_ctx, batch).await?;
-        let existing_by_identity = index_by_identity(&existing, identity_columns)?;
+        let existing = spec
+            .scan_conflict_candidates(write_ctx, batch, target)
+            .await?;
+        let existing_by_identity = index_by_identity(&existing, conflict_columns)?;
 
         let mut matched_proposed = Vec::new();
         let mut matched_existing = Vec::new();
         let mut unmatched_proposed = Vec::new();
         for row in 0..batch.num_rows() {
-            let key = identity_key(batch, row, identity_columns)?;
-            if let Some(&existing_row) = existing_by_identity.get(&key) {
+            let key = identity_key(batch, row, conflict_columns)?;
+            if let Some(existing_rows) = existing_by_identity.get(&key) {
+                for &existing_row in existing_rows {
+                    spec.validate_conflict_pair(&existing, existing_row, batch, row, target)?;
+                }
+                let existing_row = existing_rows[0];
                 matched_proposed.push(row as u64);
                 matched_existing.push(existing_row as u64);
             } else {
@@ -182,27 +257,33 @@ pub(super) async fn execute_upsert<S: UpsertSupport + ?Sized>(
     Ok(affected)
 }
 
-/// Validate the stated `ON CONFLICT (...)` target: it must be non-empty and
-/// every named column must be part of the table's conflict identity (the
-/// driver always matches on the full identity).
-pub(super) fn validate_conflict_target<S: UpsertSupport + ?Sized>(
-    spec: &S,
+pub(super) fn validate_target_columns(
     table_name: &str,
     target_columns: &[String],
+    expected_columns: &[&'static str],
+    expected_label: &str,
 ) -> Result<()> {
-    let identity = spec.conflict_identity_columns();
     if target_columns.is_empty() {
         return Err(DataFusionError::Execution(format!(
             "INSERT ON CONFLICT on {table_name} requires a conflict target"
         )));
     }
-    for column in target_columns {
-        if !identity.contains(&column.as_str()) {
-            return Err(DataFusionError::Execution(format!(
-                "INSERT ON CONFLICT on {table_name} does not support the conflict target column '{column}'; expected a subset of ({})",
-                identity.join(", ")
-            )));
-        }
+    if target_columns.len() != expected_columns.len() {
+        return Err(DataFusionError::Execution(format!(
+            "INSERT ON CONFLICT on {table_name} target must match {expected_label} ({})",
+            expected_columns.join(", ")
+        )));
+    }
+    let actual = target_columns
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let expected = expected_columns.iter().copied().collect::<BTreeSet<_>>();
+    if actual != expected {
+        return Err(DataFusionError::Execution(format!(
+            "INSERT ON CONFLICT on {table_name} target must match {expected_label} ({})",
+            expected_columns.join(", ")
+        )));
     }
     Ok(())
 }
@@ -217,10 +298,13 @@ pub(crate) fn excluded_field_name(column: &str) -> String {
 fn index_by_identity(
     batch: &RecordBatch,
     identity_columns: &[&str],
-) -> Result<HashMap<Vec<ScalarValue>, usize>> {
+) -> Result<HashMap<Vec<ScalarValue>, Vec<usize>>> {
     let mut index = HashMap::with_capacity(batch.num_rows());
     for row in 0..batch.num_rows() {
-        index.insert(identity_key(batch, row, identity_columns)?, row);
+        index
+            .entry(identity_key(batch, row, identity_columns)?)
+            .or_insert_with(Vec::new)
+            .push(row);
     }
     Ok(index)
 }

--- a/packages/engine/tests/sql/lix_directory.rs
+++ b/packages/engine/tests/sql/lix_directory.rs
@@ -1324,3 +1324,300 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    lix_directory_insert_on_conflict_path_do_nothing_is_idempotent,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) \
+                 VALUES ('dir-path-keep', '/path-keep/')",
+                &[],
+            )
+            .await
+            .expect("seed directory insert should succeed");
+
+        let result = session
+            .execute(
+                "INSERT INTO lix_directory (path) \
+                 VALUES ('/path-keep/') \
+                 ON CONFLICT (path) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect("directory path DO NOTHING should succeed");
+        assert_eq!(result.rows_affected(), 0);
+
+        let read = session
+            .execute(
+                "SELECT id, path FROM lix_directory WHERE path = '/path-keep/'",
+                &[],
+            )
+            .await
+            .expect("directory read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![
+                Value::Text("dir-path-keep".to_string()),
+                Value::Text("/path-keep/".to_string()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_directory_insert_on_conflict_path_do_update_metadata,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path, lixcol_metadata) \
+                 VALUES ('dir-path-meta', '/path-meta/', lix_json('{\"version\":1}'))",
+                &[],
+            )
+            .await
+            .expect("seed directory insert should succeed");
+
+        let result = session
+            .execute(
+                "INSERT INTO lix_directory (path, lixcol_metadata) \
+                 VALUES ('/path-meta/', lix_json('{\"version\":2}')) \
+                 ON CONFLICT (path) DO UPDATE SET lixcol_metadata = excluded.lixcol_metadata",
+                &[],
+            )
+            .await
+            .expect("directory path DO UPDATE should succeed");
+        assert_eq!(result.rows_affected(), 1);
+
+        let read = session
+            .execute(
+                "SELECT id, lixcol_metadata FROM lix_directory WHERE path = '/path-meta/'",
+                &[],
+            )
+            .await
+            .expect("directory read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![
+                Value::Text("dir-path-meta".to_string()),
+                Value::Json(json!({"version": 2})),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_directory_by_branch_insert_on_conflict_path_branch_do_nothing,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let branch_id = sim.main_branch_id();
+
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_directory_by_branch \
+                     (id, path, lixcol_branch_id) \
+                     VALUES ('dir-branch-path-upsert', '/branch-dir/', '{branch_id}')"
+                ),
+                &[],
+            )
+            .await
+            .expect("seed by-branch directory insert should succeed");
+
+        let result = session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_directory_by_branch \
+                     (path, lixcol_branch_id) \
+                     VALUES ('/branch-dir/', '{branch_id}') \
+                     ON CONFLICT (path, lixcol_branch_id) DO NOTHING"
+                ),
+                &[],
+            )
+            .await
+            .expect("by-branch directory path upsert should succeed");
+        assert_eq!(result.rows_affected(), 0);
+
+        let read = session
+            .execute(
+                "SELECT id FROM lix_directory WHERE path = '/branch-dir/'",
+                &[],
+            )
+            .await
+            .expect("directory read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![Value::Text("dir-branch-path-upsert".to_string())]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_directory_by_branch_insert_on_conflict_path_without_branch_target_rejects,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let branch_id = sim.main_branch_id();
+
+        let error = session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_directory_by_branch \
+                     (path, lixcol_branch_id) \
+                     VALUES ('/dir-reject/', '{branch_id}') \
+                     ON CONFLICT (path) DO NOTHING"
+                ),
+                &[],
+            )
+            .await
+            .expect_err("by-branch path-only target should be rejected");
+        assert!(
+            error
+                .message
+                .contains("path identity columns (path, lixcol_branch_id)")
+        );
+    }
+);
+
+simulation_test!(
+    lix_directory_insert_on_conflict_path_rejects_missing_path,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let error = session
+            .execute(
+                "INSERT INTO lix_directory (id) \
+                 VALUES ('dir-missing-path-upsert') \
+                 ON CONFLICT (path) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect_err("path upsert without path should be rejected");
+        assert!(error.message.contains("requires non-null path"));
+    }
+);
+
+simulation_test!(
+    lix_directory_insert_on_conflict_path_rejects_untracked_collision,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) \
+                 VALUES ('dir-tracked-collision', '/dir-collision/')",
+                &[],
+            )
+            .await
+            .expect("tracked directory insert should succeed");
+
+        let error = session
+            .execute(
+                "INSERT INTO lix_directory (path, lixcol_untracked) \
+                 VALUES ('/dir-collision/', true) \
+                 ON CONFLICT (path) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect_err("tracked/untracked path collision should be rejected");
+        assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert!(error.message.contains("existing tracked directory"));
+    }
+);
+
+simulation_test!(
+    lix_directory_insert_on_conflict_path_updates_visible_global_directory,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path, lixcol_metadata, lixcol_global) \
+                 VALUES ('dir-global-path-upsert', '/global-dir/', lix_json('{\"version\":1}'), true)",
+                &[],
+            )
+            .await
+            .expect("global seed directory insert should succeed");
+
+        let result = session
+            .execute(
+                "INSERT INTO lix_directory (path, lixcol_metadata) \
+                 VALUES ('/global-dir/', lix_json('{\"version\":2}')) \
+                 ON CONFLICT (path) DO UPDATE SET lixcol_metadata = excluded.lixcol_metadata",
+                &[],
+            )
+            .await
+            .expect("path upsert should update visible global directory");
+        assert_eq!(result.rows_affected(), 1);
+
+        let read = session
+            .execute(
+                "SELECT id, lixcol_metadata, lixcol_global, lixcol_branch_id \
+                 FROM lix_directory_by_branch \
+                 WHERE id = 'dir-global-path-upsert' AND lixcol_branch_id = 'global'",
+                &[],
+            )
+            .await
+            .expect("global directory read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![
+                Value::Text("dir-global-path-upsert".to_string()),
+                Value::Json(json!({"version": 2})),
+                Value::Boolean(true),
+                Value::Text("global".to_string()),
+            ]],
+        );
+    }
+);

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -2261,3 +2261,346 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    lix_file_insert_on_conflict_path_inserts_when_absent,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let result = session
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/docs/path-fresh.md', X'6E6577') \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+                &[],
+            )
+            .await
+            .expect("path upsert on absent file should insert");
+        assert_eq!(result.rows_affected(), 1);
+
+        let read = session
+            .execute(
+                "SELECT path, data FROM lix_file WHERE path = '/docs/path-fresh.md'",
+                &[],
+            )
+            .await
+            .expect("file read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![
+                Value::Text("/docs/path-fresh.md".to_string()),
+                Value::Blob(b"new".to_vec()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_insert_on_conflict_path_updates_existing_data_and_preserves_id,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('file-path-upsert', '/docs/path-upsert.md', X'6F6C64')",
+                &[],
+            )
+            .await
+            .expect("seed insert should succeed");
+
+        let result = session
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/docs/path-upsert.md', X'6E6577') \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+                &[],
+            )
+            .await
+            .expect("path upsert DO UPDATE should succeed");
+        assert_eq!(result.rows_affected(), 1);
+
+        let read = session
+            .execute(
+                "SELECT id, path, data FROM lix_file WHERE path = '/docs/path-upsert.md'",
+                &[],
+            )
+            .await
+            .expect("file read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![
+                Value::Text("file-path-upsert".to_string()),
+                Value::Text("/docs/path-upsert.md".to_string()),
+                Value::Blob(b"new".to_vec()),
+            ]],
+        );
+
+        let files = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/docs/path-upsert.md'",
+                &[],
+            )
+            .await
+            .expect("file count read should succeed");
+        assert_eq!(files.len(), 1);
+
+        let blob_refs = session
+            .execute(
+                "SELECT entity_pk \
+                 FROM lix_state \
+                 WHERE schema_key = 'lix_binary_blob_ref' \
+                   AND entity_pk = lix_json('[\"file-path-upsert\"]')",
+                &[],
+            )
+            .await
+            .expect("blob ref read should succeed");
+        assert_eq!(blob_refs.len(), 1);
+    }
+);
+
+simulation_test!(
+    lix_file_by_branch_insert_on_conflict_path_branch_updates_existing,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let branch_id = sim.main_branch_id();
+
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file_by_branch \
+                     (id, path, data, lixcol_branch_id) \
+                     VALUES ('file-branch-path-upsert', '/docs/branch.md', X'6F6C64', '{branch_id}')"
+                ),
+                &[],
+            )
+            .await
+            .expect("seed by-branch insert should succeed");
+
+        let result = session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file_by_branch \
+                     (path, data, lixcol_branch_id) \
+                     VALUES ('/docs/branch.md', X'6E6577', '{branch_id}') \
+                     ON CONFLICT (path, lixcol_branch_id) DO UPDATE SET data = excluded.data"
+                ),
+                &[],
+            )
+            .await
+            .expect("by-branch path upsert should succeed");
+        assert_eq!(result.rows_affected(), 1);
+
+        let read = session
+            .execute(
+                "SELECT id, data FROM lix_file WHERE path = '/docs/branch.md'",
+                &[],
+            )
+            .await
+            .expect("file read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![
+                Value::Text("file-branch-path-upsert".to_string()),
+                Value::Blob(b"new".to_vec()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_by_branch_insert_on_conflict_path_without_branch_target_rejects,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let branch_id = sim.main_branch_id();
+
+        let error = session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file_by_branch \
+                     (path, data, lixcol_branch_id) \
+                     VALUES ('/docs/reject.md', X'00', '{branch_id}') \
+                     ON CONFLICT (path) DO UPDATE SET data = excluded.data"
+                ),
+                &[],
+            )
+            .await
+            .expect_err("by-branch path-only target should be rejected");
+        assert!(
+            error
+                .message
+                .contains("path identity columns (path, lixcol_branch_id)")
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_insert_on_conflict_path_rejects_missing_path,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let error = session
+            .execute(
+                "INSERT INTO lix_file (id, data) \
+                 VALUES ('file-missing-path-upsert', X'00') \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+                &[],
+            )
+            .await
+            .expect_err("path upsert without path should be rejected");
+        assert!(error.message.contains("requires non-null path"));
+    }
+);
+
+simulation_test!(
+    lix_file_insert_on_conflict_path_rejects_untracked_collision,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('file-tracked-collision', '/docs/collision.md', X'00')",
+                &[],
+            )
+            .await
+            .expect("tracked file insert should succeed");
+
+        let error = session
+            .execute(
+                "INSERT INTO lix_file (path, data, lixcol_untracked) \
+                 VALUES ('/docs/collision.md', X'01', true) \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+                &[],
+            )
+            .await
+            .expect_err("tracked/untracked path collision should be rejected");
+        assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert!(error.message.contains("existing tracked file"));
+    }
+);
+
+simulation_test!(
+    lix_file_insert_on_conflict_path_updates_visible_global_file,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data, lixcol_global) \
+                 VALUES ('file-global-path-upsert', '/docs/global.md', X'6F6C64', true)",
+                &[],
+            )
+            .await
+            .expect("global seed insert should succeed");
+
+        let result = session
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/docs/global.md', X'6E6577') \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+                &[],
+            )
+            .await
+            .expect("path upsert should update visible global file");
+        assert_eq!(result.rows_affected(), 1);
+
+        let read = session
+            .execute(
+                "SELECT id, data, lixcol_global, lixcol_branch_id \
+                 FROM lix_file_by_branch \
+                 WHERE id = 'file-global-path-upsert' AND lixcol_branch_id = 'global'",
+                &[],
+            )
+            .await
+            .expect("global file read should succeed");
+        assert_rows_eq(
+            read,
+            vec![vec![
+                Value::Text("file-global-path-upsert".to_string()),
+                Value::Blob(b"new".to_vec()),
+                Value::Boolean(true),
+                Value::Text("global".to_string()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_insert_on_conflict_rejects_duplicate_target_columns,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let error = session
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/docs/duplicate-target.md', X'00') \
+                 ON CONFLICT (path, path) DO UPDATE SET data = excluded.data",
+                &[],
+            )
+            .await
+            .expect_err("duplicate conflict target columns should be rejected");
+        assert!(
+            error
+                .message
+                .contains("duplicate write target column 'path'"),
+            "unexpected error: {error:?}"
+        );
+    }
+);

--- a/packages/engine/tests/sql/lix_state.rs
+++ b/packages/engine/tests/sql/lix_state.rs
@@ -559,17 +559,19 @@ simulation_test!(
     }
 );
 
-simulation_test!(lix_state_insert_on_conflict_do_update_uses_excluded, |sim| async move {
-    let engine = sim.boot_engine().await;
-    let session = sim.wrap_session(
-        engine
-            .open_workspace_session()
-            .await
-            .expect("main session should open"),
-        &engine,
-    );
+simulation_test!(
+    lix_state_insert_on_conflict_do_update_uses_excluded,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
 
-    session
+        session
         .execute(
             "INSERT INTO lix_state (\
              entity_pk, schema_key, file_id, snapshot_content, global, untracked\
@@ -581,41 +583,44 @@ simulation_test!(lix_state_insert_on_conflict_do_update_uses_excluded, |sim| asy
         .await
         .expect("seed insert should succeed");
 
-    let result = session
+        let result = session
         .execute(
             "INSERT INTO lix_state (\
              entity_pk, schema_key, file_id, snapshot_content, global, untracked\
              ) VALUES (\
              lix_json('[\"state-upsert\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"state-upsert\",\"value\":\"new\"}'), false, false\
-             ) ON CONFLICT (entity_pk, schema_key) DO UPDATE SET snapshot_content = excluded.snapshot_content",
+             ) ON CONFLICT (entity_pk, schema_key, file_id) DO UPDATE SET snapshot_content = excluded.snapshot_content",
             &[],
         )
         .await
         .expect("upsert DO UPDATE should succeed");
-    assert_eq!(result.rows_affected(), 1);
+        assert_eq!(result.rows_affected(), 1);
 
-    let read = session
-        .execute(
-            "SELECT snapshot_content FROM lix_state \
+        let read = session
+            .execute(
+                "SELECT snapshot_content FROM lix_state \
              WHERE entity_pk = lix_json('[\"state-upsert\"]') AND schema_key = 'lix_key_value'",
-            &[],
-        )
-        .await
-        .expect("read should succeed");
-    assert_single_text(read, "{\"key\":\"state-upsert\",\"value\":\"new\"}");
-});
-
-simulation_test!(lix_state_insert_on_conflict_do_nothing_keeps_existing, |sim| async move {
-    let engine = sim.boot_engine().await;
-    let session = sim.wrap_session(
-        engine
-            .open_workspace_session()
+                &[],
+            )
             .await
-            .expect("main session should open"),
-        &engine,
-    );
+            .expect("read should succeed");
+        assert_single_text(read, "{\"key\":\"state-upsert\",\"value\":\"new\"}");
+    }
+);
 
-    session
+simulation_test!(
+    lix_state_insert_on_conflict_do_nothing_keeps_existing,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
         .execute(
             "INSERT INTO lix_state (\
              entity_pk, schema_key, file_id, snapshot_content, global, untracked\
@@ -627,63 +632,100 @@ simulation_test!(lix_state_insert_on_conflict_do_nothing_keeps_existing, |sim| a
         .await
         .expect("seed insert should succeed");
 
-    let result = session
+        let result = session
         .execute(
             "INSERT INTO lix_state (\
              entity_pk, schema_key, file_id, snapshot_content, global, untracked\
              ) VALUES (\
              lix_json('[\"state-nothing\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"state-nothing\",\"value\":\"ignored\"}'), false, false\
-             ) ON CONFLICT (entity_pk, schema_key) DO NOTHING",
+             ) ON CONFLICT (entity_pk, schema_key, file_id) DO NOTHING",
             &[],
         )
         .await
         .expect("upsert DO NOTHING should succeed");
-    assert_eq!(result.rows_affected(), 0);
+        assert_eq!(result.rows_affected(), 0);
 
-    let read = session
-        .execute(
-            "SELECT snapshot_content FROM lix_state \
+        let read = session
+            .execute(
+                "SELECT snapshot_content FROM lix_state \
              WHERE entity_pk = lix_json('[\"state-nothing\"]') AND schema_key = 'lix_key_value'",
-            &[],
-        )
-        .await
-        .expect("read should succeed");
-    assert_single_text(read, "{\"key\":\"state-nothing\",\"value\":\"keep\"}");
-});
-
-simulation_test!(lix_state_insert_on_conflict_inserts_when_absent, |sim| async move {
-    let engine = sim.boot_engine().await;
-    let session = sim.wrap_session(
-        engine
-            .open_workspace_session()
+                &[],
+            )
             .await
-            .expect("main session should open"),
-        &engine,
-    );
+            .expect("read should succeed");
+        assert_single_text(read, "{\"key\":\"state-nothing\",\"value\":\"keep\"}");
+    }
+);
 
-    let result = session
+simulation_test!(
+    lix_state_insert_on_conflict_inserts_when_absent,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let result = session
         .execute(
             "INSERT INTO lix_state (\
              entity_pk, schema_key, file_id, snapshot_content, global, untracked\
              ) VALUES (\
              lix_json('[\"state-fresh\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"state-fresh\",\"value\":\"created\"}'), false, false\
-             ) ON CONFLICT (entity_pk, schema_key) DO UPDATE SET snapshot_content = excluded.snapshot_content",
+             ) ON CONFLICT (entity_pk, schema_key, file_id) DO UPDATE SET snapshot_content = excluded.snapshot_content",
             &[],
         )
         .await
         .expect("upsert on absent row should insert");
-    assert_eq!(result.rows_affected(), 1);
+        assert_eq!(result.rows_affected(), 1);
 
-    let read = session
-        .execute(
-            "SELECT snapshot_content FROM lix_state \
+        let read = session
+            .execute(
+                "SELECT snapshot_content FROM lix_state \
              WHERE entity_pk = lix_json('[\"state-fresh\"]') AND schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("read should succeed");
+        assert_single_text(read, "{\"key\":\"state-fresh\",\"value\":\"created\"}");
+    }
+);
+
+simulation_test!(
+    lix_state_insert_on_conflict_rejects_partial_target,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let error = session
+        .execute(
+            "INSERT INTO lix_state (\
+             entity_pk, schema_key, file_id, snapshot_content, global, untracked\
+             ) VALUES (\
+             lix_json('[\"state-partial-target\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"state-partial-target\",\"value\":\"new\"}'), false, false\
+             ) ON CONFLICT (entity_pk, schema_key) DO NOTHING",
             &[],
         )
         .await
-        .expect("read should succeed");
-    assert_single_text(read, "{\"key\":\"state-fresh\",\"value\":\"created\"}");
-});
+        .expect_err("partial conflict target should be rejected");
+
+        assert!(
+            error
+                .message
+                .contains("target must match conflict identity columns"),
+            "expected conflict identity target error: {error}"
+        );
+    }
+);
 
 fn assert_single_text(result: ExecuteResult, expected: &str) {
     let row_set = result;

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -244,21 +244,10 @@ function createFsApi(
 		async writeFile(path: string, data: Uint8Array): Promise<void> {
 			assertPathArg(receiver, "fs.writeFile", path);
 			assertBytesArg(receiver, "fs.writeFile", "data", data);
-			const existing = await executeSql(
-				"SELECT id FROM lix_file WHERE path = $1",
-				[path],
+			await executeSql(
+				"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+				[path, data],
 			);
-			if (existing.rows.length === 0) {
-				await executeSql("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
-					path,
-					data,
-				]);
-				return;
-			}
-			await executeSql("UPDATE lix_file SET data = $2 WHERE path = $1", [
-				path,
-				data,
-			]);
 		},
 	};
 }


### PR DESCRIPTION
## Summary
- add resolved `ON CONFLICT` targets so SQL upsert can match by id or filesystem path
- support path upsert for `lix_file`, `lix_directory`, and their by-branch surfaces
- simplify Rust and JS filesystem helpers to use single-statement path upserts
- preserve global storage scope on visible global path updates and reject tracked/untracked path collisions

## Validation
- `cargo test --manifest-path packages/engine/Cargo.toml`
- `cargo clippy --manifest-path packages/engine/Cargo.toml --all-targets -- -D warnings`
- focused path-upsert SQL and fs helper regressions
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SQL write and visible filesystem identity semantics (upsert matching, lane collisions, and helper write paths); broad engine test coverage mitigates regressions but behavior shifts are user-visible.
> 
> **Overview**
> **Path-based SQL upsert** is now a first-class conflict mode alongside id-based identity. The generic upsert driver resolves `ON CONFLICT (...)` through per-table `resolve_conflict_target`, matches rows on the resolved columns, and runs `validate_conflict_pair` so **tracked vs untracked** paths cannot collide on path upserts. `lix_file` and `lix_directory` (active and by-branch surfaces) support `(path)` or `(path, lixcol_branch_id)` targets with stricter **exact** target-column validation; `lix_state` tests now require the full identity including `file_id` and reject partial targets.
> 
> **Execution plumbing** adds `validate_spec_upsert` (schema + `plan_insert` + target resolution) before upsert runs at compile and execute time, and passes the insert `ExecutionPlan` into `execute_spec_upsert`.
> 
> **Filesystem helpers** in `session/fs.rs` and the JS SDK replace select-then-insert/update with `INSERT ... ON CONFLICT (path)` for writes; `mkdir` uses `ON CONFLICT DO NOTHING`. Global path updates honor `lixcol_global` when resolving branch scope on conflict updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb34c6ef29c92e46bf1dc86309f557b23f75a5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->