### PR TITLE
Serialize reads behind automatic transactions

### DIFF
--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
 
-use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobDataReader};
 use crate::branch::{
     BranchContext, BranchLifecycle, BranchOperation, BranchRefReader, BranchReferenceRole,
@@ -27,7 +26,8 @@ use crate::sql2::{
 use crate::storage::{InMemoryStorageBackend, StorageBackend, StorageReadOptions};
 use crate::storage::{SharedStorageRead, StorageContext, StorageRead};
 use crate::tracked_state::TrackedStateContext;
-use crate::transaction::{Transaction, open_transaction};
+use crate::transaction::{open_transaction, Transaction};
+use crate::GLOBAL_BRANCH_ID;
 use crate::{LixError, NullableKeyFilter};
 
 use super::transaction::{SessionOperationGuard, SessionTransactionManager, SessionWriteLease};
@@ -237,8 +237,17 @@ where
             .await
     }
 
-    pub(super) fn begin_session_operation(&self) -> Result<SessionOperationGuard, LixError> {
-        self.transaction_manager.begin_session_operation()
+    pub(super) fn ensure_observe_registration_allowed(&self) -> Result<(), LixError> {
+        self.transaction_manager
+            .ensure_observe_registration_allowed()
+    }
+
+    pub(super) async fn begin_waitable_session_operation(
+        &self,
+    ) -> Result<SessionOperationGuard, LixError> {
+        self.transaction_manager
+            .begin_waitable_session_operation()
+            .await
     }
 
     pub(super) async fn begin_session_write_lease(&self) -> Result<SessionWriteLease, LixError> {
@@ -285,7 +294,7 @@ where
     /// `lix_key_value` state so multiple open app sessions can observe the same
     /// active workspace branch.
     pub async fn active_branch_id(&self) -> Result<String, LixError> {
-        let _operation_guard = self.begin_session_operation()?;
+        let _operation_guard = self.begin_waitable_session_operation().await?;
         let read = SharedStorageRead::new(self.storage.begin_read(StorageReadOptions::default())?);
         let result = self.active_branch_id_from_reader(&read).await;
         match result {
@@ -535,11 +544,11 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    use crate::Engine;
     use crate::backend::{
         Backend, BackendError, InMemoryBackend, InMemoryRead, InMemoryWrite, ReadOptions,
         WriteOptions,
     };
+    use crate::Engine;
     use futures_util::task::noop_waker_ref;
 
     const TEST_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -650,7 +659,8 @@ mod tests {
     async fn close_waits_for_session_operation_guard_to_drop() {
         let session = open_session().await;
         let guard = session
-            .begin_session_operation()
+            .begin_waitable_session_operation()
+            .await
             .expect("session operation should begin");
         let mut close = Box::pin(session.close());
         assert_close_pending(close.as_mut());

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -341,7 +341,7 @@ where
         let _operation_guard = if runtime_write_access.is_some() {
             None
         } else {
-            Some(self.begin_session_operation()?)
+            Some(self.begin_waitable_session_operation().await?)
         };
         // Lock by statement shape, not by a pre-lock mode read. The read
         // snapshot below is where FunctionContext observes deterministic mode;

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -4,7 +4,7 @@ use tokio::sync::watch;
 
 use crate::observe_coordinator::{ObserveQueryKey, ObserveQueryState, ObserveSessionScope};
 use crate::storage::{InMemoryStorageBackend, StorageBackend};
-use crate::{ExecuteResult, LixError, Value, sql2};
+use crate::{sql2, ExecuteResult, LixError, Value};
 
 use super::{SessionContext, SessionMode};
 
@@ -119,7 +119,7 @@ where
 
     async fn evaluate_stable_snapshot(&mut self) -> Result<Option<(u64, ExecuteResult)>, LixError> {
         loop {
-            let operation_guard = self.session.begin_session_operation()?;
+            let operation_guard = self.session.begin_waitable_session_operation().await?;
             self.session
                 .observe_invalidation
                 .ensure_external_watcher(self.session.storage.clone())?;
@@ -177,7 +177,7 @@ where
     for<'backend> B::Write<'backend>: Send,
 {
     pub fn observe(&self, sql: &str, params: &[Value]) -> Result<ObserveEvents<B>, LixError> {
-        let operation_guard = self.begin_session_operation()?;
+        self.ensure_observe_registration_allowed()?;
         if sql.trim().is_empty() {
             return Err(LixError::new(
                 LixError::CODE_INVALID_PARAM,
@@ -199,7 +199,6 @@ where
         }
         let key = ObserveQueryKey::new(self.observe_scope(), sql, params)?;
         let shared_state = Some(self.observe_coordinator.state_for(&key));
-        drop(operation_guard);
 
         Ok(ObserveEvents {
             session: self.clone(),

--- a/packages/engine/src/session/plugin.rs
+++ b/packages/engine/src/session/plugin.rs
@@ -1,11 +1,11 @@
-use crate::LixError;
-use crate::filesystem::{FilesystemIndex, filesystem_schema_keys};
+use crate::filesystem::{filesystem_schema_keys, FilesystemIndex};
 use crate::live_state::{LiveStateFilter, LiveStateScanRequest};
 use crate::plugin::{
-    PluginContentType, load_installed_plugins_from_filesystem, parse_plugin_archive_for_install,
-    plugin_storage_archive_path,
+    load_installed_plugins_from_filesystem, parse_plugin_archive_for_install,
+    plugin_storage_archive_path, PluginContentType,
 };
 use crate::storage::{SharedStorageRead, StorageBackend, StorageReadOptions};
+use crate::LixError;
 
 use super::{FsWriteOptions, SessionContext};
 
@@ -39,7 +39,7 @@ where
     }
 
     pub async fn list_installed_plugins(&self) -> Result<Vec<InstalledPluginInfo>, LixError> {
-        let _operation_guard = self.begin_session_operation()?;
+        let _operation_guard = self.begin_waitable_session_operation().await?;
         let read = SharedStorageRead::new(self.storage.begin_read(StorageReadOptions::default())?);
         let active_branch_id = self.active_branch_id_from_reader(&read).await?;
         let live_state = self.live_state.reader(&read);

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -5,15 +5,15 @@ use crate::observe_invalidation::ObserveInvalidation;
 use crate::storage::{InMemoryStorageBackend, StorageBackend};
 use tokio::sync::Notify;
 
-use crate::LixError;
 #[cfg(test)]
 use crate::transaction::CommitBoundaryGuard;
 use crate::transaction::{
-    CommitBoundaryState, Transaction, TransactionCommitBoundary, open_transaction,
+    open_transaction, CommitBoundaryState, Transaction, TransactionCommitBoundary,
 };
+use crate::LixError;
 
+use super::context::{closed_error, SessionWriteAccess};
 use super::SessionContext;
-use super::context::{SessionWriteAccess, closed_error};
 
 #[expect(missing_debug_implementations)]
 pub struct SessionTransaction<B: StorageBackend = InMemoryStorageBackend> {
@@ -255,8 +255,39 @@ impl SessionTransactionManager {
         Ok(())
     }
 
-    pub(super) fn begin_session_operation(&self) -> Result<SessionOperationGuard, LixError> {
-        self.begin_operation(SessionOperationScope::Session)
+    pub(super) fn ensure_observe_registration_allowed(&self) -> Result<(), LixError> {
+        self.lock_state().ensure_observe_registration_allowed()
+    }
+
+    pub(super) async fn begin_waitable_session_operation(
+        &self,
+    ) -> Result<SessionOperationGuard, LixError> {
+        loop {
+            let notified = self.inner.state_changed.notified();
+            let should_wait = {
+                let mut state = self.lock_state();
+                if state.is_automatic_transaction_in_progress() {
+                    true
+                } else {
+                    state.begin_operation(SessionOperationScope::Session)?;
+                    false
+                }
+            };
+            if should_wait {
+                notified.await;
+                continue;
+            }
+            self.inner.state_changed.notify_waiters();
+
+            if let Err(error) = self.ensure_open() {
+                self.finish_operation();
+                return Err(error);
+            }
+
+            return Ok(SessionOperationGuard {
+                manager: self.clone(),
+            });
+        }
     }
 
     pub(super) fn begin_transaction_operation(&self) -> Result<SessionOperationGuard, LixError> {
@@ -437,6 +468,29 @@ impl SessionTransactionState {
 
     fn is_session_operation_in_progress(&self) -> bool {
         matches!(self, Self::OpenOperation { .. })
+    }
+
+    fn is_automatic_transaction_in_progress(&self) -> bool {
+        matches!(
+            self,
+            Self::OpenTransaction {
+                owner: TransactionOwner::Automatic,
+                ..
+            }
+        )
+    }
+
+    fn ensure_observe_registration_allowed(&self) -> Result<(), LixError> {
+        match self {
+            Self::OpenIdle
+            | Self::OpenOperation { .. }
+            | Self::OpenTransaction {
+                owner: TransactionOwner::Automatic,
+                ..
+            } => Ok(()),
+            Self::OpenTransaction { .. } => Err(active_transaction_error()),
+            Self::Closing { .. } | Self::Closed => Err(closed_error()),
+        }
     }
 
     fn begin_operation(&mut self, scope: SessionOperationScope) -> Result<(), LixError> {

--- a/packages/engine/tests/observe.rs
+++ b/packages/engine/tests/observe.rs
@@ -150,6 +150,112 @@ async fn observe_initial_next_waits_without_rejecting_same_session_write() {
         .expect("write should succeed after observe initial read finishes");
 }
 
+#[tokio::test]
+async fn observe_registration_allows_automatic_write_instead_of_rejecting() {
+    let backend = BlockingBeginWriteBackend::new();
+    let gate = backend.gate();
+    Engine::initialize(backend.clone())
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(backend).await.expect("engine should open");
+    let session = Arc::new(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open"),
+    );
+
+    gate.block_next();
+    let writer_session = Arc::clone(&session);
+    let writer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move {
+            writer_session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) \
+                     VALUES ('observe-registration-after-automatic-write', 'v0')",
+                    &[],
+                )
+                .await
+        })
+    });
+    gate.wait_until_blocked();
+
+    let params = [Value::Text(
+        "observe-registration-after-automatic-write".to_string(),
+    )];
+    let mut events = session
+        .observe(KEY_VALUE_SQL, &params)
+        .expect("observe registration should not reject an automatic transaction");
+
+    gate.release();
+    writer
+        .join()
+        .expect("writer thread should not panic")
+        .expect("automatic write should finish after release");
+    let initial = next_event(&mut events, "observe after automatic write").await;
+    assert_key_value_row(&initial, "observe-registration-after-automatic-write", "v0");
+}
+
+#[tokio::test]
+async fn observe_initial_next_waits_for_automatic_write_instead_of_rejecting() {
+    let backend = BlockingBeginWriteBackend::new();
+    let gate = backend.gate();
+    Engine::initialize(backend.clone())
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(backend).await.expect("engine should open");
+    let session = Arc::new(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open"),
+    );
+    let params = [Value::Text("observe-after-automatic-write".to_string())];
+    let mut events = session
+        .observe(KEY_VALUE_SQL, &params)
+        .expect("observe should open");
+
+    gate.block_next();
+    let writer_session = Arc::clone(&session);
+    let writer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move {
+            writer_session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) \
+                     VALUES ('observe-after-automatic-write', 'v0')",
+                    &[],
+                )
+                .await
+        })
+    });
+    gate.wait_until_blocked();
+
+    let observer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move { events.next().await })
+    });
+
+    gate.release();
+    writer
+        .join()
+        .expect("writer thread should not panic")
+        .expect("automatic write should finish after release");
+    let initial = observer
+        .join()
+        .expect("observer thread should not panic")
+        .expect("observe next should not fail")
+        .expect("observe next should emit initial snapshot");
+    assert_key_value_row(&initial, "observe-after-automatic-write", "v0");
+}
+
 simulation_test!(
     observe_emits_after_committed_mutation_changes_result,
     |sim| async move {
@@ -621,7 +727,26 @@ struct BlockingBeginReadBackend {
     gate: BlockingReadGate,
 }
 
+#[derive(Clone)]
+struct BlockingBeginWriteBackend {
+    inner: InMemoryBackend,
+    gate: BlockingReadGate,
+}
+
 impl BlockingBeginReadBackend {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryBackend::new(),
+            gate: BlockingReadGate::new(),
+        }
+    }
+
+    fn gate(&self) -> BlockingReadGate {
+        self.gate.clone()
+    }
+}
+
+impl BlockingBeginWriteBackend {
     fn new() -> Self {
         Self {
             inner: InMemoryBackend::new(),
@@ -655,6 +780,27 @@ impl Backend for BlockingBeginReadBackend {
     }
 }
 
+impl Backend for BlockingBeginWriteBackend {
+    type Read<'a>
+        = InMemoryRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = InMemoryWrite
+    where
+        Self: 'a;
+
+    fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
+        self.inner.begin_read(opts)
+    }
+
+    fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+        self.gate.maybe_block();
+        self.inner.begin_write(opts)
+    }
+}
+
 #[derive(Clone)]
 struct BlockingReadGate {
     state: Arc<(Mutex<BlockingReadState>, Condvar)>,
@@ -668,6 +814,10 @@ impl BlockingReadGate {
     }
 
     fn block_next_read(&self) {
+        self.block_next();
+    }
+
+    fn block_next(&self) {
         let (lock, _) = &*self.state;
         let mut state = lock
             .lock()

--- a/packages/engine/tests/transaction.rs
+++ b/packages/engine/tests/transaction.rs
@@ -3,12 +3,12 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use lix_engine::Engine;
 use lix_engine::backend::{
     Backend, BackendError, BackendRead, BackendWrite, CommitResult, GetOptions, InMemoryBackend,
     InMemoryRead, InMemoryWrite, Key, KeyRange, PointVisitor, PutBatch, ReadOptions, ScanOptions,
     ScanResult, ScanVisitor, SpaceId, WriteOptions,
 };
+use lix_engine::Engine;
 
 const TEST_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -663,6 +663,63 @@ async fn begin_transaction_cannot_race_with_opening_session_write() {
         .await
         .expect("timed out closing after transaction reservation rejection")
         .expect("session close should succeed after reservation rejection");
+}
+
+#[tokio::test]
+async fn session_read_waits_for_automatic_write_instead_of_rejecting() {
+    let backend = BlockingBeginWriteBackend::new();
+    let gate = backend.gate();
+    let _receipt = Engine::initialize(backend.clone())
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(backend)
+        .await
+        .expect("initialized backend should create an engine");
+    let session = Arc::new(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open"),
+    );
+
+    gate.block_next_write();
+    let writer_session = Arc::clone(&session);
+    let writer = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move {
+            writer_session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ('read-after-automatic-write', 'value')",
+                    &[],
+                )
+                .await
+        })
+    });
+    gate.wait_until_blocked();
+
+    let reader_session = Arc::clone(&session);
+    let reader = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move {
+            reader_session
+                .execute(
+                    "SELECT key FROM lix_key_value WHERE key = 'read-after-automatic-write'",
+                    &[],
+                )
+                .await
+        })
+    });
+
+    gate.release();
+    join_thread(writer, "blocked automatic writer")
+        .expect("automatic write should finish after release");
+    let result = join_thread(reader, "reader waiting for automatic write")
+        .expect("session read should wait behind automatic write");
+    assert_eq!(result.len(), 1);
 }
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
## Summary
- make session read operations wait behind automatic internal transactions instead of rejecting with `LIX_INVALID_TRANSACTION_STATE`
- keep explicit/user transactions strict: session reads and observe still reject while an explicit transaction is active
- allow synchronous observe registration during automatic writes, and serialize the actual observe snapshot read in `next()`
- add deterministic engine regressions for session reads, observe registration, and observe initial snapshots racing with automatic writes

## Verification
- `cargo test -p lix_engine --test transaction --test observe`
- `cargo test -p lix_engine close_waits_for_session_operation_guard_to_drop`
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session concurrency and ordering around automatic transactions and observe; incorrect waiting or state checks could cause deadlocks or stale reads, though behavior for explicit transactions is preserved.
> 
> **Overview**
> **Session reads and observe snapshots now wait behind in-flight automatic (single-statement) writes** instead of failing with `LIX_INVALID_TRANSACTION_STATE`. `begin_waitable_session_operation` blocks on session state until an automatic transaction finishes, then acquires the usual session operation guard; callers such as `execute` read paths, `active_branch_id`, plugin listing, and observe snapshot evaluation use this path.
> 
> **Explicit user transactions stay strict.** Session-scoped reads and observe `next()` still error while an explicit transaction is open; only automatic write leases are treated as serializable with waiting readers.
> 
> **Observe registration is relaxed for automatic writes.** `observe()` checks `ensure_observe_registration_allowed()` (allows idle, session operations, and automatic transactions) and no longer holds a session operation guard at registration time—the first serialized read happens in `next()` via the waitable guard.
> 
> Regression tests cover concurrent session read vs blocked automatic write and observe registration/initial `next()` during blocked automatic writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1899c9912ec4fb0274056938f20ae90ef744d8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->