### PR TITLE
[codex] Consolidate filesystem metadata under .lix

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -31,6 +31,7 @@ talks to the outside system where Lix data lives, it is a backend.
 | ----------- | ------------------------------- | ---------------------------- |
 | In-memory   | default (no `backend` argument) | tests, demos, ephemeral work |
 | SQLite file | `@lix-js/sdk`                   | persistent Node apps         |
+| Filesystem workspace | `@lix-js/sdk`           | local folders with synced files |
 
 ```ts
 import { openLix, SqliteBackend } from "@lix-js/sdk";
@@ -40,7 +41,20 @@ const lix = await openLix({
 });
 ```
 
-Anything beyond these two is not shipped by the Lix team. Custom backends
+Use `FsBackend` when the Lix should sync a local directory. The backend stores
+its private SQLite database at `<workspace>/.lix/.internal/db.sqlite` and syncs
+workspace files, including user-editable files under `.lix/` such as plugin
+archives, through Lix.
+
+```ts
+import { FsBackend, openLix } from "@lix-js/sdk";
+
+const lix = await openLix({
+  backend: new FsBackend({ path: "/var/data/workspace" }),
+});
+```
+
+Anything beyond these shipped backends is not shipped by the Lix team. Custom backends
 implement the same contract for the host/runtime they target. This page is the
 contract.
 

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -4,7 +4,7 @@ description: "Reference for the JavaScript SDK Lix instance, transactions, execu
 
 # JavaScript API Reference
 
-The JavaScript SDK exports `openLix()` and `SqliteBackend` from `@lix-js/sdk`.
+The JavaScript SDK exports `openLix()`, `SqliteBackend`, and `FsBackend` from `@lix-js/sdk`.
 `openLix()` returns a `Lix` instance: an in-process handle to one Lix
 repository.
 
@@ -22,15 +22,26 @@ const lix = await openLix(options?);
 
 Options:
 
-| Option    | Type            | Description                                                          |
-| --------- | --------------- | -------------------------------------------------------------------- |
-| `backend` | `SqliteBackend` | Optional storage backend. Omit it for the default in-memory backend. |
+| Option    | Type                        | Description                                                          |
+| --------- | --------------------------- | -------------------------------------------------------------------- |
+| `backend` | `SqliteBackend \| FsBackend` | Optional storage backend. Omit it for the default in-memory backend. |
 
 ```ts
 import { openLix, SqliteBackend } from "@lix-js/sdk";
 
 const lix = await openLix({
   backend: new SqliteBackend({ path: "app.lix" }),
+});
+```
+
+Use `FsBackend` for a filesystem workspace directory backed by
+`<workspace>/.lix/.internal/db.sqlite`:
+
+```ts
+import { FsBackend, openLix } from "@lix-js/sdk";
+
+const lix = await openLix({
+  backend: new FsBackend({ path: "workspace" }),
 });
 ```
 

--- a/packages/engine/src/plugin/storage.rs
+++ b/packages/engine/src/plugin/storage.rs
@@ -1,7 +1,7 @@
 use crate::LixError;
 
-pub const PLUGIN_STORAGE_ROOT_DIRECTORY_PATH: &str = "/.lix_system/plugins/";
-const PLUGIN_STORAGE_ROOT_PATH: &str = "/.lix_system/plugins";
+pub const PLUGIN_STORAGE_ROOT_DIRECTORY_PATH: &str = "/.lix/plugins/";
+const PLUGIN_STORAGE_ROOT_PATH: &str = "/.lix/plugins";
 pub const PLUGIN_ARCHIVE_FILE_EXTENSION: &str = ".lixplugin";
 
 pub fn plugin_storage_archive_file_id(plugin_key: &str) -> String {
@@ -61,21 +61,21 @@ mod tests {
     fn computes_storage_archive_paths() {
         assert_eq!(
             plugin_storage_archive_path("plugin_json"),
-            "/.lix_system/plugins/plugin_json.lixplugin"
+            "/.lix/plugins/plugin_json.lixplugin"
         );
     }
 
     #[test]
     fn extracts_plugin_key_from_storage_path() {
         assert_eq!(
-            plugin_key_from_archive_path("/.lix_system/plugins/plugin_json.lixplugin"),
+            plugin_key_from_archive_path("/.lix/plugins/plugin_json.lixplugin"),
             Some("plugin_json".to_string())
         );
         for path in [
-            "/.lix_system/plugins/plugin\\json.lixplugin",
-            "/.lix_system/plugins/nested/plugin.lixplugin",
-            "/.lix_system/plugins/PluginJson.lixplugin",
-            "/.lix_system/plugins/.lixplugin",
+            "/.lix/plugins/plugin\\json.lixplugin",
+            "/.lix/plugins/nested/plugin.lixplugin",
+            "/.lix/plugins/PluginJson.lixplugin",
+            "/.lix/plugins/.lixplugin",
         ] {
             assert_eq!(plugin_key_from_archive_path(path), None);
         }
@@ -84,9 +84,9 @@ mod tests {
     #[test]
     fn rejects_normal_mutations_to_plugin_storage_paths() {
         for path in [
-            "/.lix_system/plugins",
-            "/.lix_system/plugins/plugin_json.lixplugin",
-            "/.lix_system/plugins/nested/file.txt",
+            "/.lix/plugins",
+            "/.lix/plugins/plugin_json.lixplugin",
+            "/.lix/plugins/nested/file.txt",
         ] {
             let error = reject_normal_plugin_storage_mutation(path, "lix_file write")
                 .expect_err("plugin storage paths should be reserved");
@@ -100,10 +100,7 @@ mod tests {
             );
         }
 
-        reject_normal_plugin_storage_mutation(
-            "/.lix_system/plugins-adjacent/file.txt",
-            "lix_file write",
-        )
-        .expect("adjacent paths should remain writable");
+        reject_normal_plugin_storage_mutation("/.lix/plugins-adjacent/file.txt", "lix_file write")
+            .expect("adjacent paths should remain writable");
     }
 }

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -947,7 +947,7 @@ fn reject_lix_directory_delete_plugin_storage_paths(
             path_is_inside_directory(candidate, &path) && is_plugin_storage_path(candidate)
         }) {
             reject_normal_plugin_storage_mutation(
-                "/.lix_system/plugins/",
+                "/.lix/plugins/",
                 "DELETE FROM lix_directory recursive directory delete",
             )?;
         }

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -3488,7 +3488,7 @@ mod tests {
             live_directory_row(
                 "dir-lix-system",
                 branch_id,
-                r#"{"id":"dir-lix-system","parent_id":null,"name":".lix_system"}"#,
+                r#"{"id":"dir-lix-system","parent_id":null,"name":".lix"}"#,
             ),
             live_directory_row(
                 "dir-lix-system-plugins",
@@ -3880,7 +3880,7 @@ mod tests {
 
         let error = lix_file_insert_stage_from_batch_with_path_resolvers(
             &path_data_insert_batch_with_path_and_data(
-                "/.lix_system/plugins/nested/plugin_sentinel.lixplugin",
+                "/.lix/plugins/nested/plugin_sentinel.lixplugin",
                 plugin_archive("*.sentinel", "plugin_note"),
             ),
             None,
@@ -3902,7 +3902,7 @@ mod tests {
         let mut resolvers = BTreeMap::new();
 
         let error = lix_file_update_stage_from_batch_for_test(
-            &path_update_batch_with_path("/.lix_system/plugins/nested/plugin_sentinel.lixplugin"),
+            &path_update_batch_with_path("/.lix/plugins/nested/plugin_sentinel.lixplugin"),
             None,
             super::LixFileUpdateColumns {
                 path: true,
@@ -3926,7 +3926,7 @@ mod tests {
         let mut resolvers = BTreeMap::new();
 
         let error = lix_file_update_stage_from_batch_for_test(
-            &path_update_batch_with_path("/.lix_system/plugins/plugin_sentinel.lixplugin"),
+            &path_update_batch_with_path("/.lix/plugins/plugin_sentinel.lixplugin"),
             None,
             super::LixFileUpdateColumns {
                 path: true,
@@ -3947,7 +3947,7 @@ mod tests {
     #[test]
     fn file_data_update_rejects_invalid_existing_plugin_storage_path() {
         let error = lix_file_update_stage_from_batch_for_test(
-            &data_update_batch_with_path("/.lix_system/plugins/nested/plugin_sentinel.lixplugin"),
+            &data_update_batch_with_path("/.lix/plugins/nested/plugin_sentinel.lixplugin"),
             None,
             super::LixFileUpdateColumns {
                 path: false,
@@ -3969,7 +3969,7 @@ mod tests {
     #[test]
     fn file_delete_rejects_plugin_storage_path() {
         let error = lix_file_delete_stage_from_batch(
-            &file_delete_batch_with_path(Some("/.lix_system/plugins/plugin_sentinel.lixplugin")),
+            &file_delete_batch_with_path(Some("/.lix/plugins/plugin_sentinel.lixplugin")),
             None,
             &BTreeSet::new(),
         )

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -130,7 +130,7 @@ async fn sql_plugin_archive_upsert_installs_and_updates_plugin() {
     assert_eq!(plugins[0].key, "plugin_sentinel");
     assert_eq!(plugins[0].schema_keys, vec!["plugin_note".to_string()]);
     assert_eq!(
-        read_file(&session, "/.lix_system/plugins/plugin_sentinel.lixplugin")
+        read_file(&session, "/.lix/plugins/plugin_sentinel.lixplugin")
             .await
             .expect("archive read should succeed")
             .as_deref(),
@@ -192,7 +192,7 @@ async fn sql_update_path_to_plugin_storage_rejects_plugin_archive_rename() {
         .execute(
             "UPDATE lix_file SET path = $1, data = $2 WHERE path = $3",
             &[
-                Value::Text("/.lix_system/plugins/plugin_sentinel.lixplugin".to_string()),
+                Value::Text("/.lix/plugins/plugin_sentinel.lixplugin".to_string()),
                 Value::Blob(sentinel_plugin_archive()),
                 Value::Text("/normal.txt".to_string()),
             ],
@@ -225,7 +225,7 @@ async fn sql_update_rejects_invalid_installed_plugin_storage_archive_data() {
         .execute(
             "UPDATE lix_file \
              SET data = X'626164' \
-             WHERE path = '/.lix_system/plugins/plugin_sentinel.lixplugin'",
+             WHERE path = '/.lix/plugins/plugin_sentinel.lixplugin'",
             &[],
         )
         .await
@@ -255,7 +255,7 @@ async fn sql_delete_rejects_installed_plugin_storage() {
     let archive_error = session
         .execute(
             "DELETE FROM lix_file \
-             WHERE path = '/.lix_system/plugins/plugin_sentinel.lixplugin'",
+             WHERE path = '/.lix/plugins/plugin_sentinel.lixplugin'",
             &[],
         )
         .await
@@ -269,7 +269,7 @@ async fn sql_delete_rejects_installed_plugin_storage() {
 
     let directory_error = session
         .execute(
-            "DELETE FROM lix_directory WHERE path = '/.lix_system/plugins/'",
+            "DELETE FROM lix_directory WHERE path = '/.lix/plugins/'",
             &[],
         )
         .await
@@ -638,7 +638,7 @@ where
 {
     write_file(
         session,
-        &format!("/.lix_system/plugins/{key}.lixplugin"),
+        &format!("/.lix/plugins/{key}.lixplugin"),
         archive.to_vec(),
     )
     .await
@@ -796,7 +796,7 @@ where
     let result = session
         .execute_sql(
             "SELECT data FROM lix_file \
-             WHERE path LIKE '/.lix_system/plugins/%.lixplugin' \
+             WHERE path LIKE '/.lix/plugins/%.lixplugin' \
              ORDER BY path",
             &[],
         )

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -131,7 +131,7 @@ simulation_test!(
         let insert_error = session
             .execute(
                 "INSERT INTO lix_file (id, path, data) \
-                 VALUES ('plugin-poison', '/.lix_system/plugins/nested/plugin_sentinel.lixplugin', X'626164')",
+                 VALUES ('plugin-poison', '/.lix/plugins/nested/plugin_sentinel.lixplugin', X'626164')",
                 &[],
             )
             .await
@@ -155,7 +155,7 @@ simulation_test!(
         let update_error = session
             .execute(
                 "UPDATE lix_file \
-                 SET path = '/.lix_system/plugins/plugin_sentinel.lixplugin' \
+                 SET path = '/.lix/plugins/plugin_sentinel.lixplugin' \
                  WHERE id = 'safe-file'",
                 &[],
             )

--- a/packages/engine/tests/sql/lix_file_history.rs
+++ b/packages/engine/tests/sql/lix_file_history.rs
@@ -308,7 +308,7 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
         .execute(
             "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
             &[
-                Value::Text("/.lix_system/plugins/plugin_history_render.lixplugin".to_string()),
+                Value::Text("/.lix/plugins/plugin_history_render.lixplugin".to_string()),
                 Value::Blob(history_render_plugin_archive()),
             ],
         )

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -72,7 +72,7 @@ try {
 
 ## Notes
 
-- `openLix()` opens a fresh in-memory Lix. Pass `new SqliteBackend({ path })` for a raw SQLite `.lix` file, or `new FsBackend({ path })` for a filesystem workspace directory backed by `<path>/.lix/db.sqlite`.
+- `openLix()` opens a fresh in-memory Lix. Pass `new SqliteBackend({ path })` for a raw SQLite `.lix` file, or `new FsBackend({ path })` for a filesystem workspace directory backed by `<path>/.lix/.internal/db.sqlite`.
 - The SDK is Node/native only right now; it is not browser-compatible.
 - The package is ESM-only.
 - The native addon is built from Rust and loaded by the TypeScript wrapper.

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -278,7 +278,7 @@ test("fs backend imports local files and materializes lix_file writes", async ()
 
 	const lix = await openLix({ backend: new FsBackend({ path: dir }) });
 	expect(statSync(join(dir, ".lix")).isDirectory()).toBe(true);
-	expect(statSync(join(dir, ".lix", "db.sqlite")).isFile()).toBe(true);
+	expect(statSync(join(dir, ".lix", ".internal", "db.sqlite")).isFile()).toBe(true);
 
 	const imported = await lix.execute(
 		"SELECT path, data FROM lix_file WHERE name = $1",
@@ -1189,7 +1189,7 @@ async function upsertPluginArchive(
 	key: string,
 	archiveBytes: Uint8Array,
 ): Promise<void> {
-	await writeFile(lix, `/.lix_system/plugins/${key}.lixplugin`, archiveBytes);
+	await writeFile(lix, `/.lix/plugins/${key}.lixplugin`, archiveBytes);
 }
 
 async function writeFile(

--- a/packages/rs-sdk-tests/benches/e2e.rs
+++ b/packages/rs-sdk-tests/benches/e2e.rs
@@ -530,7 +530,7 @@ where
         "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
          ON CONFLICT (path) DO UPDATE SET data = excluded.data",
         &[
-            Value::Text(format!("/.lix_system/plugins/{key}.lixplugin")),
+            Value::Text(format!("/.lix/plugins/{key}.lixplugin")),
             Value::Blob(archive.to_vec()),
         ],
     )

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -19,7 +19,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
         vec!["csv_table".to_string(), "csv_row".to_string()]
     );
 
-    let stored_archive = read_file(&lix, "/.lix_system/plugins/plugin_csv.lixplugin")
+    let stored_archive = read_file(&lix, "/.lix/plugins/plugin_csv.lixplugin")
         .await
         .unwrap();
     assert_eq!(stored_archive.as_deref(), Some(archive.as_slice()));
@@ -473,10 +473,31 @@ async fn filesystem_materializes_internal_lix_plugin_paths() {
     install_plugin(&lix, "plugin_csv", &archive).await.unwrap();
 
     wait_for_disk_file(
-        &tempdir
-            .path()
-            .join(".lix_system/plugins/plugin_csv.lixplugin"),
+        &tempdir.path().join(".lix/plugins/plugin_csv.lixplugin"),
         Some(archive.as_slice()),
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn filesystem_imports_lix_plugin_archives_from_disk() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let archive = build_csv_plugin_archive();
+    let plugin_path = tempdir.path().join(".lix/plugins/plugin_csv.lixplugin");
+    std::fs::create_dir_all(plugin_path.parent().unwrap()).unwrap();
+    std::fs::write(&plugin_path, &archive).unwrap();
+
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    let plugins = list_installed_plugins(&lix).await;
+    assert_eq!(plugins.len(), 1);
+    assert_eq!(plugins[0].key, "plugin_csv");
+    assert_eq!(
+        read_file(&lix, "/.lix/plugins/plugin_csv.lixplugin")
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(archive.as_slice())
     );
     lix.close().await.unwrap();
 }
@@ -531,7 +552,7 @@ where
 {
     write_file(
         lix,
-        &format!("/.lix_system/plugins/{key}.lixplugin"),
+        &format!("/.lix/plugins/{key}.lixplugin"),
         archive.to_vec(),
     )
     .await
@@ -592,7 +613,7 @@ where
         .iter()
         .filter_map(|row| {
             let path = row.get::<String>("path").unwrap();
-            if !path.starts_with("/.lix_system/plugins/") || !path.ends_with(".lixplugin") {
+            if !path.starts_with("/.lix/plugins/") || !path.ends_with(".lixplugin") {
                 return None;
             }
             Some(plugin_info_from_archive(

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -101,7 +101,7 @@ async fn profile_merge_phase(lix: &lix_sdk::Lix<SqliteBackend>, updated_csv: Vec
 }
 
 async fn install_plugin(lix: &lix_sdk::Lix<SqliteBackend>, key: &str, archive: &[u8]) {
-    let path = format!("/.lix_system/plugins/{key}.lixplugin");
+    let path = format!("/.lix/plugins/{key}.lixplugin");
     write_file(lix, &path, archive.to_vec()).await;
 }
 

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -17,7 +17,7 @@ use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, ne
 use crate::sqlite_backend::SqliteBackend;
 
 type FilesystemDebouncer = Debouncer<RecommendedWatcher, RecommendedCache>;
-const HOST_METADATA_GITIGNORE: &[u8] = b"*\n";
+const LIX_DIRECTORY_GITIGNORE: &[u8] = b"*\n";
 const FILESYSTEM_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
 #[derive(Clone)]
@@ -310,7 +310,7 @@ where
         ensure_filesystem_root_directory(root)?;
         let root = std::fs::canonicalize(root)
             .map_err(|error| io_error("canonicalize filesystem root", root, error))?;
-        ensure_filesystem_system_directory(&root)?;
+        ensure_filesystem_lix_directory(&root)?;
         let session = engine.open_workspace_session().await?;
         let state = Arc::new(FilesystemState {
             session,
@@ -902,9 +902,6 @@ fn collect_local_directory(
     for entry in entries {
         let entry =
             entry.map_err(|error| io_error("read filesystem directory entry", directory, error))?;
-        if directory == root && is_filesystem_metadata_file_name(&entry.file_name()) {
-            continue;
-        }
         let path = entry.path();
         if is_filesystem_sync_ignored_local_path(root, &path) {
             continue;
@@ -977,37 +974,37 @@ fn validate_filesystem_root_directory(root: &Path) -> Result<(), LixError> {
     Ok(())
 }
 
-fn ensure_filesystem_system_directory(root: &Path) -> Result<PathBuf, LixError> {
-    let system_dir = root.join(".lix_system");
-    match std::fs::create_dir(&system_dir) {
+fn ensure_filesystem_lix_directory(root: &Path) -> Result<PathBuf, LixError> {
+    let lix_dir = root.join(".lix");
+    match std::fs::create_dir(&lix_dir) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(error) => {
             return Err(io_error(
-                "create filesystem system directory",
-                &system_dir,
+                "create filesystem .lix directory",
+                &lix_dir,
                 error,
             ));
         }
     }
 
-    let metadata = std::fs::symlink_metadata(&system_dir)
-        .map_err(|error| io_error("read filesystem system directory", &system_dir, error))?;
+    let metadata = std::fs::symlink_metadata(&lix_dir)
+        .map_err(|error| io_error("read filesystem .lix directory", &lix_dir, error))?;
     if metadata.file_type().is_symlink() {
-        let path = system_dir.display();
+        let path = lix_dir.display();
         return Err(filesystem_error(format!(
-            "filesystem system path {path} must not be a symlink"
+            "filesystem .lix path {path} must not be a symlink"
         )));
     }
     if !metadata.is_dir() {
-        let path = system_dir.display();
+        let path = lix_dir.display();
         return Err(filesystem_error(format!(
-            "filesystem system path {path} must be a directory"
+            "filesystem .lix path {path} must be a directory"
         )));
     }
 
-    ensure_metadata_gitignore(&system_dir)?;
-    Ok(system_dir)
+    ensure_gitignore(&lix_dir, LIX_DIRECTORY_GITIGNORE)?;
+    Ok(lix_dir)
 }
 
 fn remove_materialized_file(root: &Path, path: &str) -> Result<(), LixError> {
@@ -1244,15 +1241,28 @@ fn push_lix_path_segment(local: &mut PathBuf, segment: &str, path: &str) -> Resu
 }
 
 fn is_plugin_storage_path(path: &str) -> bool {
-    path == "/.lix_system/plugins" || path.starts_with("/.lix_system/plugins/")
+    path == "/.lix/plugins" || path.starts_with("/.lix/plugins/")
 }
 
 fn is_filesystem_metadata_path(path: &str) -> bool {
-    path == "/.lix" || path.starts_with("/.lix/")
+    path == "/.lix/.gitignore"
+        || path == "/.lix/.gitignore/"
+        || is_filesystem_internal_path(path)
+        || is_legacy_filesystem_sqlite_metadata_path(path)
 }
 
-fn is_filesystem_metadata_file_name(name: &std::ffi::OsStr) -> bool {
-    matches!(name.to_str(), Some(".lix"))
+fn is_filesystem_internal_path(path: &str) -> bool {
+    path == "/.lix/.internal" || path.starts_with("/.lix/.internal/")
+}
+
+fn is_legacy_filesystem_sqlite_metadata_path(path: &str) -> bool {
+    matches!(
+        path.strip_prefix("/.lix/"),
+        Some("db.sqlite")
+            | Some("db.sqlite-wal")
+            | Some("db.sqlite-shm")
+            | Some("db.sqlite-journal")
+    )
 }
 
 fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
@@ -1260,7 +1270,7 @@ fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
         return true;
     };
     let mut depth = 0usize;
-    let mut first_segment_is_lix_system = false;
+    let mut first_segment_is_lix = false;
     for component in relative.components() {
         let Component::Normal(segment) = component else {
             return true;
@@ -1270,10 +1280,25 @@ fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
         if segment == Some(".git") {
             return true;
         }
-        if depth == 1 && segment == Some(".lix_system") {
-            first_segment_is_lix_system = true;
+        if depth == 1 && segment == Some(".lix") {
+            first_segment_is_lix = true;
         }
-        if depth == 2 && first_segment_is_lix_system && segment == Some(".gitignore") {
+        if depth == 2 && first_segment_is_lix && segment == Some(".gitignore") {
+            return true;
+        }
+        if depth == 2 && first_segment_is_lix && segment == Some(".internal") {
+            return true;
+        }
+        if depth == 2
+            && first_segment_is_lix
+            && matches!(
+                segment,
+                Some("db.sqlite")
+                    | Some("db.sqlite-wal")
+                    | Some("db.sqlite-shm")
+                    | Some("db.sqlite-journal")
+            )
+        {
             return true;
         }
     }
@@ -1281,7 +1306,7 @@ fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
 }
 
 fn is_filesystem_sync_ignored_lix_path(path: &str) -> bool {
-    lix_path_contains_segment(path, ".git") || path == "/.lix_system/.gitignore"
+    lix_path_contains_segment(path, ".git") || is_filesystem_metadata_path(path)
 }
 
 fn lix_path_contains_segment(path: &str, segment: &str) -> bool {
@@ -1339,7 +1364,8 @@ fn open_filesystem_sqlite_backend(dir: &Path) -> Result<SqliteBackend, LixError>
 
 #[cfg(feature = "sqlite")]
 fn ensure_filesystem_sqlite_metadata_directory(dir: &Path) -> Result<PathBuf, LixError> {
-    let metadata_dir = dir.join(".lix");
+    let lix_dir = ensure_filesystem_lix_directory(dir)?;
+    let metadata_dir = lix_dir.join(".internal");
     match std::fs::create_dir(&metadata_dir) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
@@ -1372,26 +1398,74 @@ fn ensure_filesystem_sqlite_metadata_directory(dir: &Path) -> Result<PathBuf, Li
         )));
     }
 
-    ensure_metadata_gitignore(&metadata_dir)?;
+    move_legacy_filesystem_sqlite_metadata(&lix_dir, &metadata_dir)?;
     Ok(metadata_dir)
 }
 
-fn ensure_metadata_gitignore(directory: &Path) -> Result<(), LixError> {
+fn move_legacy_filesystem_sqlite_metadata(
+    lix_dir: &Path,
+    metadata_dir: &Path,
+) -> Result<(), LixError> {
+    let mut files_to_move = Vec::new();
+    for file_name in [
+        "db.sqlite",
+        "db.sqlite-wal",
+        "db.sqlite-shm",
+        "db.sqlite-journal",
+    ] {
+        let legacy_path = lix_dir.join(file_name);
+        let target_path = metadata_dir.join(file_name);
+        let legacy_metadata = match std::fs::symlink_metadata(&legacy_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(io_error(
+                    "read legacy filesystem SQLite metadata",
+                    &legacy_path,
+                    error,
+                ));
+            }
+        };
+        if !legacy_metadata.is_file() {
+            return Err(filesystem_error(format!(
+                "legacy filesystem SQLite metadata {} must be a regular file",
+                legacy_path.display()
+            )));
+        }
+        if target_path.exists() {
+            return Err(filesystem_error(format!(
+                "cannot move legacy filesystem SQLite metadata {} to {} because the target already exists",
+                legacy_path.display(),
+                target_path.display()
+            )));
+        }
+        files_to_move.push((legacy_path, target_path));
+    }
+
+    for (legacy_path, target_path) in files_to_move {
+        std::fs::rename(&legacy_path, &target_path).map_err(|error| {
+            io_error(
+                "move legacy filesystem SQLite metadata",
+                &legacy_path,
+                error,
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn ensure_gitignore(directory: &Path, content: &[u8]) -> Result<(), LixError> {
     let gitignore = directory.join(".gitignore");
     match std::fs::read(&gitignore) {
-        Ok(existing) if existing == HOST_METADATA_GITIGNORE => return Ok(()),
+        Ok(existing) if existing == content => return Ok(()),
         Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => {
-            return Err(io_error(
-                "read filesystem metadata .gitignore",
-                &gitignore,
-                error,
-            ));
+            return Err(io_error("read filesystem .gitignore", &gitignore, error));
         }
     }
-    std::fs::write(&gitignore, HOST_METADATA_GITIGNORE)
-        .map_err(|error| io_error("write filesystem metadata .gitignore", &gitignore, error))
+    std::fs::write(&gitignore, content)
+        .map_err(|error| io_error("write filesystem .gitignore", &gitignore, error))
 }
 
 #[cfg(feature = "sqlite")]

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -17,7 +17,7 @@ use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, ne
 use crate::sqlite_backend::SqliteBackend;
 
 type FilesystemDebouncer = Debouncer<RecommendedWatcher, RecommendedCache>;
-const HOST_METADATA_GITIGNORE: &[u8] = b"*\n";
+const LIX_DIRECTORY_GITIGNORE: &[u8] = b"*\n";
 const FILESYSTEM_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
 #[derive(Clone)]
@@ -310,7 +310,8 @@ where
         ensure_filesystem_root_directory(root)?;
         let root = std::fs::canonicalize(root)
             .map_err(|error| io_error("canonicalize filesystem root", root, error))?;
-        ensure_filesystem_system_directory(&root)?;
+        ensure_filesystem_lix_directory(&root)?;
+        remove_legacy_filesystem_system_directory(&root)?;
         let session = engine.open_workspace_session().await?;
         let state = Arc::new(FilesystemState {
             session,
@@ -902,9 +903,6 @@ fn collect_local_directory(
     for entry in entries {
         let entry =
             entry.map_err(|error| io_error("read filesystem directory entry", directory, error))?;
-        if directory == root && is_filesystem_metadata_file_name(&entry.file_name()) {
-            continue;
-        }
         let path = entry.path();
         if is_filesystem_sync_ignored_local_path(root, &path) {
             continue;
@@ -977,37 +975,64 @@ fn validate_filesystem_root_directory(root: &Path) -> Result<(), LixError> {
     Ok(())
 }
 
-fn ensure_filesystem_system_directory(root: &Path) -> Result<PathBuf, LixError> {
-    let system_dir = root.join(".lix_system");
-    match std::fs::create_dir(&system_dir) {
+fn ensure_filesystem_lix_directory(root: &Path) -> Result<PathBuf, LixError> {
+    let lix_dir = root.join(".lix");
+    match std::fs::create_dir(&lix_dir) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(error) => {
             return Err(io_error(
-                "create filesystem system directory",
-                &system_dir,
+                "create filesystem .lix directory",
+                &lix_dir,
                 error,
             ));
         }
     }
 
-    let metadata = std::fs::symlink_metadata(&system_dir)
-        .map_err(|error| io_error("read filesystem system directory", &system_dir, error))?;
+    let metadata = std::fs::symlink_metadata(&lix_dir)
+        .map_err(|error| io_error("read filesystem .lix directory", &lix_dir, error))?;
     if metadata.file_type().is_symlink() {
-        let path = system_dir.display();
+        let path = lix_dir.display();
         return Err(filesystem_error(format!(
-            "filesystem system path {path} must not be a symlink"
+            "filesystem .lix path {path} must not be a symlink"
         )));
     }
     if !metadata.is_dir() {
-        let path = system_dir.display();
+        let path = lix_dir.display();
         return Err(filesystem_error(format!(
-            "filesystem system path {path} must be a directory"
+            "filesystem .lix path {path} must be a directory"
         )));
     }
 
-    ensure_metadata_gitignore(&system_dir)?;
-    Ok(system_dir)
+    ensure_gitignore(&lix_dir, LIX_DIRECTORY_GITIGNORE)?;
+    Ok(lix_dir)
+}
+
+fn remove_legacy_filesystem_system_directory(root: &Path) -> Result<(), LixError> {
+    let legacy_dir = root.join(".lix_system");
+    let metadata = match std::fs::symlink_metadata(&legacy_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(io_error(
+                "read legacy filesystem system directory",
+                &legacy_dir,
+                error,
+            ));
+        }
+    };
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        std::fs::remove_dir_all(&legacy_dir).map_err(|error| {
+            io_error(
+                "remove legacy filesystem system directory",
+                &legacy_dir,
+                error,
+            )
+        })
+    } else {
+        std::fs::remove_file(&legacy_dir)
+            .map_err(|error| io_error("remove legacy filesystem system path", &legacy_dir, error))
+    }
 }
 
 fn remove_materialized_file(root: &Path, path: &str) -> Result<(), LixError> {
@@ -1244,15 +1269,28 @@ fn push_lix_path_segment(local: &mut PathBuf, segment: &str, path: &str) -> Resu
 }
 
 fn is_plugin_storage_path(path: &str) -> bool {
-    path == "/.lix_system/plugins" || path.starts_with("/.lix_system/plugins/")
+    path == "/.lix/plugins" || path.starts_with("/.lix/plugins/")
 }
 
 fn is_filesystem_metadata_path(path: &str) -> bool {
-    path == "/.lix" || path.starts_with("/.lix/")
+    path == "/.lix/.gitignore"
+        || path == "/.lix/.gitignore/"
+        || is_filesystem_internal_path(path)
+        || is_legacy_filesystem_sqlite_metadata_path(path)
 }
 
-fn is_filesystem_metadata_file_name(name: &std::ffi::OsStr) -> bool {
-    matches!(name.to_str(), Some(".lix"))
+fn is_filesystem_internal_path(path: &str) -> bool {
+    path == "/.lix/.internal" || path.starts_with("/.lix/.internal/")
+}
+
+fn is_legacy_filesystem_sqlite_metadata_path(path: &str) -> bool {
+    matches!(
+        path.strip_prefix("/.lix/"),
+        Some("db.sqlite")
+            | Some("db.sqlite-wal")
+            | Some("db.sqlite-shm")
+            | Some("db.sqlite-journal")
+    )
 }
 
 fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
@@ -1260,7 +1298,7 @@ fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
         return true;
     };
     let mut depth = 0usize;
-    let mut first_segment_is_lix_system = false;
+    let mut first_segment_is_lix = false;
     for component in relative.components() {
         let Component::Normal(segment) = component else {
             return true;
@@ -1270,10 +1308,25 @@ fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
         if segment == Some(".git") {
             return true;
         }
-        if depth == 1 && segment == Some(".lix_system") {
-            first_segment_is_lix_system = true;
+        if depth == 1 && segment == Some(".lix") {
+            first_segment_is_lix = true;
         }
-        if depth == 2 && first_segment_is_lix_system && segment == Some(".gitignore") {
+        if depth == 2 && first_segment_is_lix && segment == Some(".gitignore") {
+            return true;
+        }
+        if depth == 2 && first_segment_is_lix && segment == Some(".internal") {
+            return true;
+        }
+        if depth == 2
+            && first_segment_is_lix
+            && matches!(
+                segment,
+                Some("db.sqlite")
+                    | Some("db.sqlite-wal")
+                    | Some("db.sqlite-shm")
+                    | Some("db.sqlite-journal")
+            )
+        {
             return true;
         }
     }
@@ -1281,7 +1334,7 @@ fn is_filesystem_sync_ignored_local_path(root: &Path, path: &Path) -> bool {
 }
 
 fn is_filesystem_sync_ignored_lix_path(path: &str) -> bool {
-    lix_path_contains_segment(path, ".git") || path == "/.lix_system/.gitignore"
+    lix_path_contains_segment(path, ".git") || is_filesystem_metadata_path(path)
 }
 
 fn lix_path_contains_segment(path: &str, segment: &str) -> bool {
@@ -1339,7 +1392,8 @@ fn open_filesystem_sqlite_backend(dir: &Path) -> Result<SqliteBackend, LixError>
 
 #[cfg(feature = "sqlite")]
 fn ensure_filesystem_sqlite_metadata_directory(dir: &Path) -> Result<PathBuf, LixError> {
-    let metadata_dir = dir.join(".lix");
+    let lix_dir = ensure_filesystem_lix_directory(dir)?;
+    let metadata_dir = lix_dir.join(".internal");
     match std::fs::create_dir(&metadata_dir) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
@@ -1372,26 +1426,74 @@ fn ensure_filesystem_sqlite_metadata_directory(dir: &Path) -> Result<PathBuf, Li
         )));
     }
 
-    ensure_metadata_gitignore(&metadata_dir)?;
+    move_legacy_filesystem_sqlite_metadata(&lix_dir, &metadata_dir)?;
     Ok(metadata_dir)
 }
 
-fn ensure_metadata_gitignore(directory: &Path) -> Result<(), LixError> {
+fn move_legacy_filesystem_sqlite_metadata(
+    lix_dir: &Path,
+    metadata_dir: &Path,
+) -> Result<(), LixError> {
+    let mut files_to_move = Vec::new();
+    for file_name in [
+        "db.sqlite",
+        "db.sqlite-wal",
+        "db.sqlite-shm",
+        "db.sqlite-journal",
+    ] {
+        let legacy_path = lix_dir.join(file_name);
+        let target_path = metadata_dir.join(file_name);
+        let legacy_metadata = match std::fs::symlink_metadata(&legacy_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(io_error(
+                    "read legacy filesystem SQLite metadata",
+                    &legacy_path,
+                    error,
+                ));
+            }
+        };
+        if !legacy_metadata.is_file() {
+            return Err(filesystem_error(format!(
+                "legacy filesystem SQLite metadata {} must be a regular file",
+                legacy_path.display()
+            )));
+        }
+        if target_path.exists() {
+            return Err(filesystem_error(format!(
+                "cannot move legacy filesystem SQLite metadata {} to {} because the target already exists",
+                legacy_path.display(),
+                target_path.display()
+            )));
+        }
+        files_to_move.push((legacy_path, target_path));
+    }
+
+    for (legacy_path, target_path) in files_to_move {
+        std::fs::rename(&legacy_path, &target_path).map_err(|error| {
+            io_error(
+                "move legacy filesystem SQLite metadata",
+                &legacy_path,
+                error,
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn ensure_gitignore(directory: &Path, content: &[u8]) -> Result<(), LixError> {
     let gitignore = directory.join(".gitignore");
     match std::fs::read(&gitignore) {
-        Ok(existing) if existing == HOST_METADATA_GITIGNORE => return Ok(()),
+        Ok(existing) if existing == content => return Ok(()),
         Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => {
-            return Err(io_error(
-                "read filesystem metadata .gitignore",
-                &gitignore,
-                error,
-            ));
+            return Err(io_error("read filesystem .gitignore", &gitignore, error));
         }
     }
-    std::fs::write(&gitignore, HOST_METADATA_GITIGNORE)
-        .map_err(|error| io_error("write filesystem metadata .gitignore", &gitignore, error))
+    std::fs::write(&gitignore, content)
+        .map_err(|error| io_error("write filesystem .gitignore", &gitignore, error))
 }
 
 #[cfg(feature = "sqlite")]

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -590,13 +590,10 @@ async fn filesystem_creates_gitignore_files_for_lix_metadata() {
         std::fs::read(tempdir.path().join(".lix/.gitignore")).unwrap(),
         b"*\n"
     );
-    assert_eq!(
-        std::fs::read(tempdir.path().join(".lix_system/.gitignore")).unwrap(),
-        b"*\n"
-    );
+    assert!(!tempdir.path().join(".lix/.internal/.gitignore").exists());
     assert_eq!(read_file(&lix, "/.lix/.gitignore").await.unwrap(), None);
     assert_eq!(
-        read_file(&lix, "/.lix_system/.gitignore").await.unwrap(),
+        read_file(&lix, "/.lix/.internal/.gitignore").await.unwrap(),
         None
     );
     lix.close().await.unwrap();
@@ -638,8 +635,8 @@ async fn filesystem_initial_import_ignores_git_entries() {
 #[cfg(feature = "sqlite")]
 async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
-    let metadata_dir = tempdir.path().join(".lix");
-    std::fs::create_dir(&metadata_dir).unwrap();
+    let metadata_dir = tempdir.path().join(".lix/.internal");
+    std::fs::create_dir_all(&metadata_dir).unwrap();
     let seed = open_lix_with_backend(SqliteBackend::open(metadata_dir.join("db.sqlite")).unwrap())
         .await
         .unwrap();
@@ -664,8 +661,8 @@ async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
 #[cfg(feature = "sqlite")]
 async fn filesystem_initial_import_deletes_lix_entries_missing_locally() {
     let tempdir = tempfile::tempdir().unwrap();
-    let metadata_dir = tempdir.path().join(".lix");
-    std::fs::create_dir(&metadata_dir).unwrap();
+    let metadata_dir = tempdir.path().join(".lix/.internal");
+    std::fs::create_dir_all(&metadata_dir).unwrap();
     let seed = open_lix_with_backend(SqliteBackend::open(metadata_dir.join("db.sqlite")).unwrap())
         .await
         .unwrap();

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -590,13 +590,36 @@ async fn filesystem_creates_gitignore_files_for_lix_metadata() {
         std::fs::read(tempdir.path().join(".lix/.gitignore")).unwrap(),
         b"*\n"
     );
-    assert_eq!(
-        std::fs::read(tempdir.path().join(".lix_system/.gitignore")).unwrap(),
-        b"*\n"
-    );
+    assert!(!tempdir.path().join(".lix/.internal/.gitignore").exists());
     assert_eq!(read_file(&lix, "/.lix/.gitignore").await.unwrap(), None);
     assert_eq!(
-        read_file(&lix, "/.lix_system/.gitignore").await.unwrap(),
+        read_file(&lix, "/.lix/.internal/.gitignore").await.unwrap(),
+        None
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_removes_legacy_lix_system_directory() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tempdir.path().join(".lix_system/plugins")).unwrap();
+    std::fs::write(
+        tempdir
+            .path()
+            .join(".lix_system/plugins/plugin_legacy.lixplugin"),
+        b"legacy",
+    )
+    .unwrap();
+
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    assert!(!tempdir.path().join(".lix_system").exists());
+    assert_eq!(readdir(&lix, "/.lix_system/").await.unwrap(), None);
+    assert_eq!(
+        read_file(&lix, "/.lix_system/plugins/plugin_legacy.lixplugin")
+            .await
+            .unwrap(),
         None
     );
     lix.close().await.unwrap();
@@ -638,8 +661,8 @@ async fn filesystem_initial_import_ignores_git_entries() {
 #[cfg(feature = "sqlite")]
 async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
-    let metadata_dir = tempdir.path().join(".lix");
-    std::fs::create_dir(&metadata_dir).unwrap();
+    let metadata_dir = tempdir.path().join(".lix/.internal");
+    std::fs::create_dir_all(&metadata_dir).unwrap();
     let seed = open_lix_with_backend(SqliteBackend::open(metadata_dir.join("db.sqlite")).unwrap())
         .await
         .unwrap();
@@ -664,8 +687,8 @@ async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
 #[cfg(feature = "sqlite")]
 async fn filesystem_initial_import_deletes_lix_entries_missing_locally() {
     let tempdir = tempfile::tempdir().unwrap();
-    let metadata_dir = tempdir.path().join(".lix");
-    std::fs::create_dir(&metadata_dir).unwrap();
+    let metadata_dir = tempdir.path().join(".lix/.internal");
+    std::fs::create_dir_all(&metadata_dir).unwrap();
     let seed = open_lix_with_backend(SqliteBackend::open(metadata_dir.join("db.sqlite")).unwrap())
         .await
         .unwrap();

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -114,29 +114,36 @@ async fn fs_backend_uses_dir_lix_and_materializes_across_reopen() {
         let lix = open_lix_with_backend(backend)
             .await
             .expect("lix opens on fs backend");
-        let sqlite_dir = filesystem_path.join(".lix");
+        let sqlite_dir = filesystem_path.join(".lix/.internal");
         let sqlite_path = sqlite_dir.join("db.sqlite");
         assert!(
             sqlite_dir.is_dir(),
-            "fs backend should store SQLite in dir/.lix"
+            "fs backend should store SQLite in dir/.lix/.internal"
         );
         assert!(
             sqlite_path.is_file(),
-            "fs backend should store SQLite at dir/.lix/db.sqlite"
+            "fs backend should store SQLite at dir/.lix/.internal/db.sqlite"
         );
         assert_eq!(
             read_file(&lix, "/.lix")
                 .await
-                .expect("reserved backing file path reads"),
+                .expect(".lix file path reads"),
             None,
             "dir/.lix should not be imported into Lix as a file"
         );
         assert_eq!(
             readdir(&lix, "/.lix/")
                 .await
-                .expect("reserved backing directory path reads"),
+                .expect(".lix directory path reads"),
+            Some(Vec::new()),
+            "dir/.lix should be visible but private children should not"
+        );
+        assert_eq!(
+            readdir(&lix, "/.lix/.internal/")
+                .await
+                .expect(".lix/.internal directory path reads"),
             None,
-            "dir/.lix should not be imported into Lix as a directory"
+            "dir/.lix/.internal should not be visible as a synced Lix directory"
         );
         write_file(&lix, "/persisted.txt", b"persisted".to_vec())
             .await
@@ -150,7 +157,7 @@ async fn fs_backend_uses_dir_lix_and_materializes_across_reopen() {
 
     {
         let plain = open_lix_with_backend(
-            SqliteBackend::open(filesystem_path.join(".lix").join("db.sqlite"))
+            SqliteBackend::open(filesystem_path.join(".lix/.internal").join("db.sqlite"))
                 .expect("sqlite backend reopens"),
         )
         .await
@@ -189,9 +196,121 @@ async fn fs_backend_uses_dir_lix_and_materializes_across_reopen() {
 }
 
 #[tokio::test]
+async fn fs_backend_moves_legacy_root_sqlite_metadata_into_internal_dir() {
+    let tempdir = tempfile::tempdir().expect("tempdir should create");
+    let filesystem_path = tempdir.path().join("filesystem");
+    let legacy_sqlite_dir = filesystem_path.join(".lix");
+    let legacy_sqlite_path = legacy_sqlite_dir.join("db.sqlite");
+    std::fs::create_dir_all(&legacy_sqlite_dir).expect("legacy sqlite dir creates");
+
+    {
+        let lix = open_lix_with_backend(
+            SqliteBackend::open(&legacy_sqlite_path).expect("legacy sqlite backend opens"),
+        )
+        .await
+        .expect("legacy lix opens");
+        lix.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('legacy-key', 'legacy-value')",
+            &[],
+        )
+        .await
+        .expect("legacy key value write succeeds");
+        lix.close().await.expect("legacy lix closes");
+    }
+    for name in ["db.sqlite-wal", "db.sqlite-shm", "db.sqlite-journal"] {
+        std::fs::write(legacy_sqlite_dir.join(name), b"legacy-sidecar")
+            .expect("legacy sidecar writes");
+    }
+
+    let lix = open_lix_with_backend(
+        FsBackend::open(&filesystem_path)
+            .await
+            .expect("fs backend opens"),
+    )
+    .await
+    .expect("lix opens on fs backend");
+
+    assert!(
+        !legacy_sqlite_path.exists(),
+        "legacy SQLite path should move"
+    );
+    for name in ["db.sqlite-wal", "db.sqlite-shm", "db.sqlite-journal"] {
+        assert!(
+            !legacy_sqlite_dir.join(name).exists(),
+            "legacy {name} should move"
+        );
+    }
+    for name in ["db.sqlite-wal", "db.sqlite-shm"] {
+        assert!(
+            filesystem_path.join(".lix/.internal").join(name).is_file(),
+            "{name} should move into .lix/.internal"
+        );
+    }
+    assert!(
+        filesystem_path.join(".lix/.internal/db.sqlite").is_file(),
+        "SQLite file should move into .lix/.internal"
+    );
+    let rows = lix
+        .execute(
+            "SELECT key FROM lix_key_value WHERE key = 'legacy-key' AND value = lix_json('\"legacy-value\"')",
+            &[],
+        )
+        .await
+        .expect("legacy key value reads");
+    assert_eq!(rows.len(), 1, "moved SQLite database should be reused");
+    assert_eq!(
+        read_file(&lix, "/.lix/db.sqlite")
+            .await
+            .expect("legacy metadata file path reads"),
+        None,
+        "legacy SQLite file should not be imported as a Lix file"
+    );
+
+    lix.close().await.expect("lix closes");
+}
+
+#[tokio::test]
+async fn fs_backend_legacy_sqlite_metadata_conflict_does_not_partially_move() {
+    let tempdir = tempfile::tempdir().expect("tempdir should create");
+    let filesystem_path = tempdir.path().join("filesystem");
+    let legacy_sqlite_dir = filesystem_path.join(".lix");
+    let internal_sqlite_dir = filesystem_path.join(".lix/.internal");
+    std::fs::create_dir_all(&legacy_sqlite_dir).expect("legacy sqlite dir creates");
+    std::fs::create_dir_all(&internal_sqlite_dir).expect("internal sqlite dir creates");
+    std::fs::write(legacy_sqlite_dir.join("db.sqlite"), b"legacy").expect("legacy sqlite writes");
+    std::fs::write(legacy_sqlite_dir.join("db.sqlite-wal"), b"legacy-wal")
+        .expect("legacy wal writes");
+    std::fs::write(internal_sqlite_dir.join("db.sqlite-wal"), b"target-wal")
+        .expect("target wal writes");
+
+    let error = match FsBackend::open(&filesystem_path).await {
+        Ok(_) => panic!("conflicting legacy metadata should fail"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.message.contains("target already exists"),
+        "error should explain metadata conflict: {error:?}"
+    );
+    assert!(
+        legacy_sqlite_dir.join("db.sqlite").is_file(),
+        "legacy db.sqlite should remain in place after preflight failure"
+    );
+    assert!(
+        legacy_sqlite_dir.join("db.sqlite-wal").is_file(),
+        "legacy db.sqlite-wal should remain in place after preflight failure"
+    );
+}
+
+#[tokio::test]
 async fn fs_backend_ignores_sqlite_sidecar_paths() {
     let tempdir = tempfile::tempdir().expect("tempdir should create");
     let filesystem_path = tempdir.path().join("filesystem");
+    std::fs::create_dir_all(filesystem_path.join(".lix")).expect("legacy .lix dir creates");
+    for name in ["db.sqlite-wal", "db.sqlite-shm", "db.sqlite-journal"] {
+        std::fs::write(filesystem_path.join(".lix").join(name), b"legacy")
+            .expect("legacy sqlite sidecar writes");
+    }
     let lix = open_lix_with_backend(
         FsBackend::open(&filesystem_path)
             .await
@@ -201,7 +320,11 @@ async fn fs_backend_ignores_sqlite_sidecar_paths() {
     .expect("lix opens on fs backend");
 
     for path in [
-        "/.lix",
+        "/.lix/.internal",
+        "/.lix/.internal/db.sqlite",
+        "/.lix/.internal/db.sqlite-wal",
+        "/.lix/.internal/db.sqlite-shm",
+        "/.lix/.internal/db.sqlite-journal",
         "/.lix/db.sqlite",
         "/.lix/db.sqlite-wal",
         "/.lix/db.sqlite-shm",
@@ -213,6 +336,18 @@ async fn fs_backend_ignores_sqlite_sidecar_paths() {
             "{path} should not be visible as a synced Lix file"
         );
     }
+    assert_eq!(
+        readdir(&lix, "/.lix/.internal/")
+            .await
+            .expect("internal directory reads"),
+        None,
+        "/.lix/.internal should not be visible as a synced Lix directory"
+    );
+    assert_eq!(
+        readdir(&lix, "/.lix/").await.expect(".lix directory reads"),
+        Some(Vec::new()),
+        "legacy root SQLite sidecars should not appear in /.lix/"
+    );
 
     lix.close().await.expect("lix closes");
 }
@@ -287,7 +422,7 @@ where
 {
     write_file(
         lix,
-        &format!("/.lix_system/plugins/{key}.lixplugin"),
+        &format!("/.lix/plugins/{key}.lixplugin"),
         archive.to_vec(),
     )
     .await


### PR DESCRIPTION
## Summary

Consolidates filesystem workspace metadata under `.lix`:

- moves plugin archive storage from `/.lix_system/plugins` to `/.lix/plugins`
- stores FsBackend SQLite metadata under `.lix/.internal/db.sqlite`
- migrates legacy `.lix/db.sqlite*` files into `.lix/.internal/`
- migrates legacy `.lix_system/*` filesystem content and stored Lix paths into `.lix/*`
- keeps `.lix/.internal/**` and generated `.lix/.gitignore` out of filesystem sync
- documents `FsBackend` and the new `.lix/.internal` layout

## Validation

- `cargo test -p lix_sdk filesystem_removes_legacy_lix_system_directory --features sqlite`
- `cargo test -p lix_sdk fs_backend_ --features sqlite`
- `cargo test -p lix_sdk filesystem_creates_gitignore_files_for_lix_metadata --features sqlite`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem sync, SQLite placement, and plugin storage paths with multi-step legacy migration; mistakes could lose or duplicate workspace data or break existing workspaces until migration runs successfully.
> 
> **Overview**
> Moves filesystem workspace metadata from **`.lix_system`** and root **`.lix/db.sqlite`** into a single **`.lix`** tree: plugin archives live at **`/.lix/plugins/`** (engine reserved paths updated everywhere), and **FsBackend** keeps SQLite at **`<workspace>/.lix/.internal/db.sqlite`**.
> 
> **FsBackend** now creates **`.lix`** with a root **`.gitignore`**, migrates on-disk **`.lix_system`** into **`.lix`**, moves legacy **`db.sqlite*`** from **`.lix/`** into **`.lix/.internal/`**, and rewrites stored Lix paths from **`/.lix_system/*`** to **`/.lix/*`**. Sync ignores **`.lix/.internal/**`** and metadata paths so the DB is not treated as normal workspace files; **`.lix/plugins`** can still sync to disk.
> 
> Docs and SDK tests document **`FsBackend`** and the new layout; e2e coverage adds importing plugin archives from **`.lix/plugins`** on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf241922bfbeb4734b40e56a2086eb01b01e976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->