### PR TITLE
[codex] Add Google Analytics tracking

### DIFF
--- a/website/src/routes/__root.tsx
+++ b/website/src/routes/__root.tsx
@@ -8,11 +8,29 @@ import React from "react";
 import { PostHogProvider } from "posthog-js/react";
 import appCss from "../styles.css?url";
 
-const GA_MEASUREMENT_ID = "G-3GEP4W5688";
+const GA_MEASUREMENT_ID = "G-1M7SY9LBT7";
 const posthogOptions = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
   defaults: "2025-11-30",
 } as const;
+
+const googleAnalyticsScripts = import.meta.env.PROD
+  ? [
+      {
+        async: true,
+        src: `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`,
+      },
+      {
+        children: `
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){window.dataLayer.push(arguments);}
+          window.gtag = gtag;
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', { send_page_view: false });
+        `,
+      },
+    ]
+  : [];
 
 export const Route = createRootRoute({
   head: () => ({
@@ -67,6 +85,7 @@ export const Route = createRootRoute({
           ],
         }),
       },
+      ...googleAnalyticsScripts,
     ],
   }),
 
@@ -74,37 +93,28 @@ export const Route = createRootRoute({
   shellComponent: RootDocument,
 });
 
-function GoogleAnalytics() {
+function GoogleAnalyticsPageViews() {
   const router = useRouter();
 
   React.useEffect(() => {
     if (!import.meta.env.PROD) return;
-    if ((window as any).__gaInitialized) return;
-    (window as any).__gaInitialized = true;
-
-    (window as any).dataLayer = (window as any).dataLayer || [];
-    function gtag(...args: unknown[]) {
-      (window as any).dataLayer.push(args);
-    }
-    (window as any).gtag = gtag;
-
-    const script = document.createElement("script");
-    script.async = true;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
-    document.head.appendChild(script);
-
-    gtag("js", new Date());
-    gtag("config", GA_MEASUREMENT_ID, { send_page_view: false });
+    const gtag = (window as any).gtag;
+    if (typeof gtag !== "function") return;
 
     const sendPageView = (location: {
       href: string;
+      publicHref?: string;
       pathname: string;
       search: string;
       hash: string;
     }) => {
+      const publicPath =
+        location.publicHref ??
+        `${location.pathname}${location.search}${location.hash}`;
+
       gtag("event", "page_view", {
-        page_location: location.href,
-        page_path: `${location.pathname}${location.search}${location.hash}`,
+        page_location: new URL(publicPath, window.location.origin).href,
+        page_path: publicPath,
         page_title: document.title,
       });
     };
@@ -152,7 +162,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <GoogleAnalytics />
+        <GoogleAnalyticsPageViews />
         {appContent}
         <Scripts />
       </body>


### PR DESCRIPTION
## Summary

- Update the Google Analytics measurement ID to `G-1M7SY9LBT7`.
- Move GA loading and initialization into TanStack route-managed head scripts for production SSG output.
- Keep client-side page-view tracking in a small router history subscriber for initial load and SPA navigation.

## Validation

- `npm run test`
- `npm run build`
- Verified prerendered HTML includes `https://www.googletagmanager.com/gtag/js?id=G-1M7SY9LBT7`
- Verified old GA ID `G-3GEP4W5688` is absent from source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to the marketing site root layout; no auth, APIs, or user data handling.
> 
> **Overview**
> Updates Google Analytics to measurement ID **`G-1M7SY9LBT7`** and loads **gtag** through TanStack root route **`head` scripts** in production so prerendered HTML includes the tag manager script and inline init (with **`send_page_view: false`**). Dev builds skip those scripts entirely.
> 
> Client-side tracking is narrowed to **`GoogleAnalyticsPageViews`**, which fires **`page_view`** on first load and router navigations using **`publicHref`** when present (otherwise pathname/search/hash), instead of injecting scripts in **`useEffect`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7bd1c80a9f82f1c444b867c6d6784346013519c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->