### PR TITLE
[codex] Simplify filesystem backend memory mode

### DIFF
--- a/.changenotes/simplify-fs-backend-memory-storage.md
+++ b/.changenotes/simplify-fs-backend-memory-storage.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Simplified filesystem-backed Lix storage around `FsBackend`.
+
+Use `new FsBackend({ path: "./workspace" })` for persistent filesystem-backed storage, or `new FsBackend({ path: "./workspace", storage: "memory" })` when the workspace should be synced into an in-memory Lix without writing `.lix` state back to disk. Filesystem sync can now be limited to exact workspace-relative paths with `filter.includePaths`.

--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ npm install @lix-js/sdk
 ```
 
 ```ts
-import { openLix, SqliteBackend } from "@lix-js/sdk";
+import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  backend: new SqliteBackend({ path: "app.lix" }),
+	backend: new FsBackend({ path: "./workspace" }),
 });
 
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-  ["/notes/status.txt", new TextEncoder().encode("draft")],
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+	["/notes/status.txt", new TextEncoder().encode("draft")],
 );
 
 const main = await lix.activeBranchId();
@@ -60,14 +60,14 @@ const draft = await lix.createBranch({ name: "Explore" });
 await lix.switchBranch({ branchId: draft.id });
 
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-  ["/notes/status.txt", new TextEncoder().encode("ready for review")],
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+	["/notes/status.txt", new TextEncoder().encode("ready for review")],
 );
 
 await lix.switchBranch({ branchId: main });
 
 const changes = await lix.execute(
-  "SELECT schema_key, count(*) AS count FROM lix_change GROUP BY schema_key",
+	"SELECT schema_key, count(*) AS count FROM lix_change GROUP BY schema_key",
 );
 ```
 
@@ -90,10 +90,10 @@ Lix is built for those files. Plugins translate file updates into semantic chang
 Import Lix and open it inside your worker, service, CLI, browser, desktop app, or server-side runtime. No daemon, no protocol.
 
 ```ts
-import { openLix, SqliteBackend } from "@lix-js/sdk";
+import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  backend: new SqliteBackend({ path: "app.lix" }),
+	backend: new FsBackend({ path: "./workspace" }),
 });
 ```
 
@@ -105,18 +105,18 @@ Write files, blobs, and history in one transaction.
 const tx = await lix.beginTransaction();
 
 try {
-  await tx.execute(
-    "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-    ["/spec.docx", body],
-  );
-  await tx.execute(
-    "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-    ["/spec.png", image],
-  );
-  await tx.commit();
+	await tx.execute(
+		"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+		["/spec.docx", body],
+	);
+	await tx.execute(
+		"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+		["/spec.png", image],
+	);
+	await tx.commit();
 } catch (error) {
-  await tx.rollback();
-  throw error;
+	await tx.rollback();
+	throw error;
 }
 ```
 
@@ -133,20 +133,20 @@ const qa = await lix.createBranch({ name: "QA draft" });
 
 await lix.switchBranch({ branchId: copy.id });
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-  ["/landing.md", copyDraft],
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+	["/landing.md", copyDraft],
 );
 
 await lix.switchBranch({ branchId: pricing.id });
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-  ["/plans.json", priceModel],
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+	["/plans.json", priceModel],
 );
 
 await lix.switchBranch({ branchId: qa.id });
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-  ["/checks/report.json", testRun],
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+	["/checks/report.json", testRun],
 );
 
 await lix.switchBranch({ branchId: main });
@@ -222,16 +222,20 @@ Use Lix standalone or plug it into the infrastructure your product already runs.
 <p><img src="https://cdn.simpleicons.org/sqlite/003B57" alt="SQLite" width="18" height="18" /> SQLite · <img src="https://cdn.simpleicons.org/postgresql/4169E1" alt="Postgres" width="18" height="18" /> Postgres · <img src="https://api.iconify.design/logos:aws-s3.svg" alt="S3" width="18" height="18" /> S3 · <img src="https://cdn.simpleicons.org/cloudflareworkers/F38020" alt="Cloudflare Workers" width="18" height="18" /> Cloudflare Workers · <img src="https://cdn.simpleicons.org/supabase/3FCF8E" alt="Supabase" width="18" height="18" /> Supabase</p>
 
 ```ts
+import { FsBackend, openLix } from "@lix-js/sdk";
+
 const lix = await openLix({
-  backend: new SqliteBackend({ path: "app.lix" }),
+	backend: new FsBackend({ path: "./workspace" }),
 });
 ```
+
+Use `SqliteBackend` when a single `.lix` SQLite file is the application document itself, for example when defining a new file format and using Lix as the application's file format.
 
 ## How Lix works
 
 Lix runs in-process inside your runtime.
 
-It owns the version-control model: files, blobs, versions, history, transactions, and semantic changes. Use it standalone or plug it into whatever backend you need: in-memory, SQLite, Postgres, S3, Cloudflare, or your own adapter.
+It owns the version-control model: files, blobs, versions, history, transactions, and semantic changes. Use it standalone with `FsBackend` for filesystem workspaces, use SQLite for single-file application formats, or plug it into whatever backend you need: in-memory, Postgres, S3, Cloudflare, or your own adapter.
 
 SQL is the query interface on top. Products, scripts, and agents can ask what changed without rereading whole files.
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -11,7 +11,7 @@ such as changelog commits, changelog changes, commit change-ref chunks, JSON
 payload rows, and tracked-state tree chunks. The backend is responsible for the
 physical layout underneath those rows: pages, B-trees, LSM/SST files, WALs,
 checksums, caches, locks, compaction, and file/object placement. In other
-words, Lix defines *what facts exist*; the backend decides *how bytes are stored*.
+words, Lix defines _what facts exist_; the backend decides _how bytes are stored_.
 
 ## The system interface
 
@@ -27,21 +27,22 @@ talks to the outside system where Lix data lives, it is a backend.
 
 ## What ships today
 
-| Backend     | Module                          | Use for                      |
-| ----------- | ------------------------------- | ---------------------------- |
-| In-memory   | default (no `backend` argument) | tests, demos, ephemeral work |
-| SQLite file | `@lix-js/sdk`                   | persistent Node apps         |
-| Filesystem workspace | `@lix-js/sdk`           | local folders with synced files |
+| Backend              | Module                          | Use for                         |
+| -------------------- | ------------------------------- | ------------------------------- |
+| In-memory            | default (no `backend` argument) | tests, demos, ephemeral work    |
+| Filesystem workspace | `@lix-js/sdk`                   | local folders with synced files |
+| SQLite file          | `@lix-js/sdk`                   | single-file application formats |
 
 ```ts
-import { openLix, SqliteBackend } from "@lix-js/sdk";
+import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  backend: new SqliteBackend({ path: "/var/data/app.lix" }),
+	backend: new FsBackend({ path: "/var/data/workspace" }),
 });
 ```
 
-Use `FsBackend` when the Lix should sync a local directory. The backend stores
+Use `FsBackend` when the Lix should sync a local directory. This is the
+recommended persistent backend for filesystem workspaces. The backend stores
 its private SQLite database at `<workspace>/.lix/.internal/db.sqlite` and syncs
 workspace files, including user-editable files under `.lix/` such as plugin
 archives, through Lix.
@@ -50,7 +51,23 @@ archives, through Lix.
 import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  backend: new FsBackend({ path: "/var/data/workspace" }),
+	backend: new FsBackend({ path: "/Users/me/Downloads", storage: "memory" }),
+});
+```
+
+Pass `storage: "memory"` when the filesystem should be synced but Lix should not
+write `.lix` repository metadata into that folder.
+
+Use `SqliteBackend` when the `.lix` SQLite file is the application document
+itself. This is useful when defining a new file format and using Lix as the
+application file format: one portable file containing versioned application
+state.
+
+```ts
+import { openLix, SqliteBackend } from "@lix-js/sdk";
+
+const lix = await openLix({
+	backend: new SqliteBackend({ path: "/var/data/app.lix" }),
 });
 ```
 
@@ -72,118 +89,118 @@ storage:
 
 ```ts
 type LixBackend = {
-  beginReadTransaction(): LixBackendReadTransaction;
-  beginWriteTransaction(): LixBackendWriteTransaction;
-  close?(): void;
+	beginReadTransaction(): LixBackendReadTransaction;
+	beginWriteTransaction(): LixBackendWriteTransaction;
+	close?(): void;
 };
 
 type LixBackendReadTransaction = {
-  getValues(request: BackendKvGetRequest): BackendKvValueBatch;
-  existsMany(request: BackendKvGetRequest): BackendKvExistsBatch;
-  scanKeys(request: BackendKvScanRequest): BackendKvKeyPage;
-  scanValues(request: BackendKvScanRequest): BackendKvValuePage;
-  scanEntries(request: BackendKvScanRequest): BackendKvEntryPage;
-  rollback(): void;
+	getValues(request: BackendKvGetRequest): BackendKvValueBatch;
+	existsMany(request: BackendKvGetRequest): BackendKvExistsBatch;
+	scanKeys(request: BackendKvScanRequest): BackendKvKeyPage;
+	scanValues(request: BackendKvScanRequest): BackendKvValuePage;
+	scanEntries(request: BackendKvScanRequest): BackendKvEntryPage;
+	rollback(): void;
 };
 
 type LixBackendWriteTransaction = LixBackendReadTransaction & {
-  writeKvBatch(batch: BackendKvWriteBatch): BackendKvWriteStats;
-  commit(): void;
+	writeKvBatch(batch: BackendKvWriteBatch): BackendKvWriteStats;
+	commit(): void;
 };
 
 // ── Scan ranges ────────────────────────────────────────────────────────────
 
 type BackendKvScanRange =
-  | { kind: "prefix"; prefix: Uint8Array }
-  | { kind: "range"; start: Uint8Array; end: Uint8Array };
+	| { kind: "prefix"; prefix: Uint8Array }
+	| { kind: "range"; start: Uint8Array; end: Uint8Array };
 
 // ── Get / exists ───────────────────────────────────────────────────────────
 
 type BackendKvGetRequest = {
-  groups: BackendKvGetGroup[];
+	groups: BackendKvGetGroup[];
 };
 
 type BackendKvGetGroup = {
-  namespace: string;
-  keys: Uint8Array[];
+	namespace: string;
+	keys: Uint8Array[];
 };
 
 type BackendKvValueBatch = {
-  groups: BackendKvValueGroup[];
+	groups: BackendKvValueGroup[];
 };
 
 type BackendKvValueGroup = {
-  namespace: string;
-  values: Array<Uint8Array | null>; // null = key not present
+	namespace: string;
+	values: Array<Uint8Array | null>; // null = key not present
 };
 
 type BackendKvExistsBatch = {
-  groups: BackendKvExistsGroup[];
+	groups: BackendKvExistsGroup[];
 };
 
 type BackendKvExistsGroup = {
-  namespace: string;
-  exists: boolean[];
+	namespace: string;
+	exists: boolean[];
 };
 
 // ── Scan ───────────────────────────────────────────────────────────────────
 
 type BackendKvScanRequest = {
-  namespace: string;
-  range: BackendKvScanRange;
-  after?: Uint8Array | null; // exclusive cursor; returns keys strictly greater
-  limit: number;
+	namespace: string;
+	range: BackendKvScanRange;
+	after?: Uint8Array | null; // exclusive cursor; returns keys strictly greater
+	limit: number;
 };
 
 type BackendKvKeyPage = {
-  keys: Uint8Array[];
-  resumeAfter?: Uint8Array | null;
+	keys: Uint8Array[];
+	resumeAfter?: Uint8Array | null;
 };
 
 type BackendKvValuePage = {
-  values: Uint8Array[];
-  resumeAfter?: Uint8Array | null;
+	values: Uint8Array[];
+	resumeAfter?: Uint8Array | null;
 };
 
 type BackendKvEntryPage = {
-  keys: Uint8Array[];
-  values: Uint8Array[];
-  resumeAfter?: Uint8Array | null;
+	keys: Uint8Array[];
+	values: Uint8Array[];
+	resumeAfter?: Uint8Array | null;
 };
 
 // ── Write ──────────────────────────────────────────────────────────────────
 
 type BackendKvWriteBatch = {
-  groups: BackendKvWriteGroup[];
+	groups: BackendKvWriteGroup[];
 };
 
 type BackendKvWriteGroup = {
-  namespace: string;
-  ops: BackendKvWriteOp[];
+	namespace: string;
+	ops: BackendKvWriteOp[];
 };
 
 type BackendKvWriteOp =
-  | { kind: "put"; key: Uint8Array; value: Uint8Array }
-  | { kind: "delete"; key: Uint8Array }
-  | { kind: "deleteRange"; range: BackendKvScanRange };
+	| { kind: "put"; key: Uint8Array; value: Uint8Array }
+	| { kind: "delete"; key: Uint8Array }
+	| { kind: "deleteRange"; range: BackendKvScanRange };
 
 type BackendKvWriteStats = {
-  puts: number;
-  deletes: number;
-  deleteRanges: number;
-  bytesWritten: number;
+	puts: number;
+	deletes: number;
+	deleteRanges: number;
+	bytesWritten: number;
 };
 ```
 
 ### Operations
 
-| Method                                    | Purpose                                                                                                                                                                                                                                                              |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `getValues`                               | Batch fetch values by exact key, grouped by namespace. Missing keys come back as `null` in the same position.                                                                                                                                                        |
-| `existsMany`                              | Same request shape as `getValues`, returns booleans. Used when Lix only needs to know whether a key is present.                                                                                                                                                      |
-| `scanKeys` / `scanValues` / `scanEntries` | Range or prefix scan within one namespace, with `limit` and a resumable `after` cursor.                                                                                                                                                                              |
-| `writeKvBatch`                            | Atomic batch of ordered `ops`, grouped by namespace. Apply operations in list order. Either all of it lands or none of it does. `deleteRange` removes every key matching the same half-open range or prefix shape used by scans.                                     |
-| `commit` / `rollback`                     | Transaction control. After either, the transaction object is finished; do not call further methods on it.                                                                                                                                                            |
+| Method                                    | Purpose                                                                                                                                                                                                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getValues`                               | Batch fetch values by exact key, grouped by namespace. Missing keys come back as `null` in the same position.                                                                                                                                                       |
+| `existsMany`                              | Same request shape as `getValues`, returns booleans. Used when Lix only needs to know whether a key is present.                                                                                                                                                     |
+| `scanKeys` / `scanValues` / `scanEntries` | Range or prefix scan within one namespace, with `limit` and a resumable `after` cursor.                                                                                                                                                                             |
+| `writeKvBatch`                            | Atomic batch of ordered `ops`, grouped by namespace. Apply operations in list order. Either all of it lands or none of it does. `deleteRange` removes every key matching the same half-open range or prefix shape used by scans.                                    |
+| `commit` / `rollback`                     | Transaction control. After either, the transaction object is finished; do not call further methods on it.                                                                                                                                                           |
 | `close()` / `destroy()` (on the backend)  | Lifecycle. `close()` releases handles without affecting durability. `destroy()` (optional, not in the type signature above for backends that don't own their target) removes the entire storage target: file plus WAL/SHM, the OPFS target, the schema, the bucket. |
 
 ### Scan semantics

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ This walks through opening Lix, registering a schema, writing a row, isolating a
 npm install @lix-js/sdk
 ```
 
-`openLix()` with no arguments opens an in-memory Lix, enough for tests and demos. For persistent storage see [Persistence](./persistence.md).
+`openLix()` with no arguments opens an in-memory Lix, enough for tests and demos. For persistent local files, use `FsBackend`; see [Persistence](./persistence.md).
 
 ## Open Lix
 
@@ -22,28 +22,36 @@ import { openLix } from "@lix-js/sdk";
 const lix = await openLix();
 ```
 
+```ts
+import { FsBackend, openLix } from "@lix-js/sdk";
+
+const lix = await openLix({
+	backend: new FsBackend({ path: "./workspace" }),
+});
+```
+
 ## Register a schema
 
 Lix stores application state as typed entities. Register a schema once, then read and write through the generated SQL table named after `x-lix-key`.
 
 ```ts
 await lix.execute(
-  "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
-  [
-    JSON.stringify({
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      "x-lix-key": "task",
-      "x-lix-primary-key": ["/id"],
-      type: "object",
-      required: ["id", "title", "done"],
-      properties: {
-        id: { type: "string" },
-        title: { type: "string" },
-        done: { type: "boolean" },
-      },
-      additionalProperties: false,
-    }),
-  ],
+	"INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+	[
+		JSON.stringify({
+			$schema: "https://json-schema.org/draft/2020-12/schema",
+			"x-lix-key": "task",
+			"x-lix-primary-key": ["/id"],
+			type: "object",
+			required: ["id", "title", "done"],
+			properties: {
+				id: { type: "string" },
+				title: { type: "string" },
+				done: { type: "boolean" },
+			},
+			additionalProperties: false,
+		}),
+	],
 );
 ```
 
@@ -53,14 +61,14 @@ await lix.execute(
 
 ```ts
 await lix.execute("INSERT INTO task (id, title, done) VALUES ($1, $2, $3)", [
-  "task-1",
-  "Review agent changes",
-  false,
+	"task-1",
+	"Review agent changes",
+	false,
 ]);
 
 const result = await lix.execute(
-  "SELECT id, title, done FROM task WHERE id = $1",
-  ["task-1"],
+	"SELECT id, title, done FROM task WHERE id = $1",
+	["task-1"],
 );
 
 const row = result.rows[0]!;
@@ -73,20 +81,20 @@ console.log(row.value("title").asText(), row.value("done").asBoolean());
 
 Each row is a `Row`. Use `row.value(name)` for a typed `Value`, or `row.get(name)` / `row.toObject()` for plain JavaScript values.
 
-| Accessor | Use for |
-| --- | --- |
-| `asText()` | text columns |
-| `asBoolean()` | boolean columns |
-| `asInteger()` | integer columns |
-| `asReal()` | decimal columns |
-| `asJson()` | JSON columns such as `snapshot_content` and `entity_pk` |
-| `asBytes()` | binary columns such as `lix_file.data` |
+| Accessor      | Use for                                                 |
+| ------------- | ------------------------------------------------------- |
+| `asText()`    | text columns                                            |
+| `asBoolean()` | boolean columns                                         |
+| `asInteger()` | integer columns                                         |
+| `asReal()`    | decimal columns                                         |
+| `asJson()`    | JSON columns such as `snapshot_content` and `entity_pk` |
+| `asBytes()`   | binary columns such as `lix_file.data`                  |
 
 Use `asBytes()` for byte content:
 
 ```ts
 const file = await lix.execute("SELECT data FROM lix_file WHERE path = $1", [
-  "/orders.xlsx",
+	"/orders.xlsx",
 ]);
 const bytes = file.rows[0]!.value("data").asBytes();
 ```
@@ -116,7 +124,7 @@ console.log(preview.outcome, preview.changeStats);
 // fastForward { total: 1, added: 0, modified: 1, removed: 0 }
 
 if (preview.conflicts.length === 0) {
-  await lix.mergeVersion({ sourceVersionId: draft.id });
+	await lix.mergeVersion({ sourceVersionId: draft.id });
 }
 ```
 

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -22,17 +22,9 @@ const lix = await openLix(options?);
 
 Options:
 
-| Option    | Type                        | Description                                                          |
-| --------- | --------------------------- | -------------------------------------------------------------------- |
-| `backend` | `SqliteBackend \| FsBackend` | Optional storage backend. Omit it for the default in-memory backend. |
-
-```ts
-import { openLix, SqliteBackend } from "@lix-js/sdk";
-
-const lix = await openLix({
-  backend: new SqliteBackend({ path: "app.lix" }),
-});
-```
+| Option    | Type                         | Description                                                          |
+| --------- | ---------------------------- | -------------------------------------------------------------------- |
+| `backend` | `FsBackend \| SqliteBackend` | Optional storage backend. Omit it for the default in-memory backend. |
 
 Use `FsBackend` for a filesystem workspace directory backed by
 `<workspace>/.lix/.internal/db.sqlite`:
@@ -41,7 +33,44 @@ Use `FsBackend` for a filesystem workspace directory backed by
 import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  backend: new FsBackend({ path: "workspace" }),
+	backend: new FsBackend({ path: "./workspace" }),
+});
+```
+
+Pass `storage: "memory"` to sync files from a directory without writing `.lix`
+repository metadata into that directory:
+
+```ts
+const lix = await openLix({
+	backend: new FsBackend({ path: "./workspace", storage: "memory" }),
+});
+```
+
+Add `filter.includePaths` to limit filesystem sync to selected files.
+`includePaths` entries are exact workspace-relative file paths, not directories
+or globs. They may be written with or without a leading slash, for example
+`"notes/today.md"` or `"/notes/today.md"`. The filter scopes disk import, file
+watching, and materialization; it does not filter unrelated Lix SQL state.
+
+```ts
+const lix = await openLix({
+	backend: new FsBackend({
+		path: "./workspace",
+		storage: "memory",
+		filter: { includePaths: ["notes/today.md"] },
+	}),
+});
+```
+
+Use `SqliteBackend` when a single `.lix` SQLite file is the application document
+itself, for example when defining a new file format and using Lix as the
+application file format:
+
+```ts
+import { openLix, SqliteBackend } from "@lix-js/sdk";
+
+const lix = await openLix({
+	backend: new SqliteBackend({ path: "app.lix" }),
 });
 ```
 
@@ -68,10 +97,10 @@ Result:
 
 ```ts
 type ExecuteResult = {
-  columns: string[];
-  rows: Row[];
-  rowsAffected: number;
-  notices: LixNotice[];
+	columns: string[];
+	rows: Row[];
+	rowsAffected: number;
+	notices: LixNotice[];
 };
 ```
 
@@ -86,8 +115,8 @@ Example:
 
 ```ts
 const result = await lix.execute(
-  "SELECT path, data FROM lix_file WHERE path = $1",
-  ["/hello.txt"],
+	"SELECT path, data FROM lix_file WHERE path = $1",
+	["/hello.txt"],
 );
 
 const path = result.rows[0]?.value("path").asText();
@@ -105,14 +134,14 @@ Starts a transaction. While it is open, execute statements on the transaction ha
 ```ts
 const tx = await lix.beginTransaction();
 try {
-  await tx.execute("INSERT INTO lix_file (path, data) VALUES (?, ?)", [
-    "/hello.txt",
-    new TextEncoder().encode("hello"),
-  ]);
-  await tx.commit();
+	await tx.execute("INSERT INTO lix_file (path, data) VALUES (?, ?)", [
+		"/hello.txt",
+		new TextEncoder().encode("hello"),
+	]);
+	await tx.commit();
 } catch (error) {
-  await tx.rollback();
-  throw error;
+	await tx.rollback();
+	throw error;
 }
 ```
 
@@ -128,7 +157,7 @@ Returns the id of the version the Lix handle is currently reading and writing.
 
 ```ts
 const version = await lix.createVersion({
-  name: "Explore",
+	name: "Explore",
 });
 ```
 
@@ -146,10 +175,10 @@ Result:
 
 ```ts
 type CreateVersionResult = {
-  id: string;
-  name: string;
-  hidden: boolean;
-  commitId: string;
+	id: string;
+	name: string;
+	hidden: boolean;
+	commitId: string;
 };
 ```
 
@@ -165,7 +194,7 @@ Switches the Lix handle to another version. Plain SQL tables read and write the 
 
 ```ts
 const preview = await lix.mergeVersionPreview({
-  sourceVersionId: draft.id,
+	sourceVersionId: draft.id,
 });
 ```
 
@@ -175,14 +204,14 @@ Result:
 
 ```ts
 type MergeVersionPreviewResult = {
-  outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
-  targetVersionId: string;
-  sourceVersionId: string;
-  baseCommitId: string;
-  targetHeadCommitId: string;
-  sourceHeadCommitId: string;
-  changeStats: MergeChangeStats;
-  conflicts: MergeConflict[];
+	outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
+	targetVersionId: string;
+	sourceVersionId: string;
+	baseCommitId: string;
+	targetHeadCommitId: string;
+	sourceHeadCommitId: string;
+	changeStats: MergeChangeStats;
+	conflicts: MergeConflict[];
 };
 ```
 
@@ -190,7 +219,7 @@ type MergeVersionPreviewResult = {
 
 ```ts
 const merge = await lix.mergeVersion({
-  sourceVersionId: draft.id,
+	sourceVersionId: draft.id,
 });
 ```
 
@@ -200,15 +229,15 @@ Result:
 
 ```ts
 type MergeVersionResult = {
-  outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
-  targetVersionId: string;
-  sourceVersionId: string;
-  baseCommitId: string;
-  targetHeadBeforeCommitId: string;
-  sourceHeadBeforeCommitId: string;
-  targetHeadAfterCommitId: string;
-  createdMergeCommitId: string | null;
-  changeStats: MergeChangeStats;
+	outcome: "alreadyUpToDate" | "fastForward" | "mergeCommitted";
+	targetVersionId: string;
+	sourceVersionId: string;
+	baseCommitId: string;
+	targetHeadBeforeCommitId: string;
+	sourceHeadBeforeCommitId: string;
+	targetHeadAfterCommitId: string;
+	createdMergeCommitId: string | null;
+	changeStats: MergeChangeStats;
 };
 ```
 
@@ -216,10 +245,10 @@ type MergeVersionResult = {
 
 ```ts
 type MergeChangeStats = {
-  total: number;
-  added: number;
-  modified: number;
-  removed: number;
+	total: number;
+	added: number;
+	modified: number;
+	removed: number;
 };
 ```
 
@@ -227,12 +256,12 @@ type MergeChangeStats = {
 
 ```ts
 type MergeConflict = {
-  kind: "sameEntityChanged";
-  schemaKey: string;
-  entityPk: string[];
-  fileId: string | null;
-  target: MergeConflictSide;
-  source: MergeConflictSide;
+	kind: "sameEntityChanged";
+	schemaKey: string;
+	entityPk: string[];
+	fileId: string | null;
+	target: MergeConflictSide;
+	source: MergeConflictSide;
 };
 ```
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,10 +1,10 @@
 ---
-description: Open Lix in memory for tests, or persist to a .lix SQLite file via SqliteBackend. For other storage targets, implement the backend interface.
+description: Open Lix in memory for tests, persist a filesystem workspace with FsBackend, or use SqliteBackend for a single .lix application file.
 ---
 
 # Persistence
 
-`openLix()` with no arguments opens an in-memory Lix that vanishes when the process exits. For anything that should survive a restart, pass a backend.
+`openLix()` with no arguments opens an in-memory Lix that vanishes when the process exits. For anything that should survive a restart, pass a backend. For local files and directories, `FsBackend` is the recommended backend.
 
 ## In-memory (tests, demos)
 
@@ -16,26 +16,26 @@ const lix = await openLix();
 await lix.close();
 ```
 
-## SQLite file (Node.js)
+## Filesystem workspace (persistent mode)
 
-Persist a Lix as a single `.lix` file using `SqliteBackend`:
+Persist a directory as a Lix workspace using `FsBackend`:
 
 ```bash
 npm install @lix-js/sdk
 ```
 
 ```ts
-import { openLix, SqliteBackend } from "@lix-js/sdk";
+import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  backend: new SqliteBackend({ path: "/var/data/app.lix" }),
+	backend: new FsBackend({ path: "/var/data/workspace" }),
 });
 
 // ... use it ...
 await lix.close();
 ```
 
-Reopening the same path resumes existing state. Don't open the file with raw SQLite tools; Lix manages its own schema and transactions.
+Reopening the same path resumes existing state. Lix stores its private repository data in `<workspace>/.lix/.internal/db.sqlite` and syncs workspace files through Lix.
 
 For tests, point at a temp directory so each run is isolated:
 
@@ -46,9 +46,53 @@ import path from "node:path";
 
 const dir = mkdtempSync(path.join(tmpdir(), "lix-"));
 const lix = await openLix({
-  backend: new SqliteBackend({ path: path.join(dir, "demo.lix") }),
+	backend: new FsBackend({ path: path.join(dir, "workspace") }),
 });
 ```
+
+## Filesystem sync without writing .lix metadata
+
+Use `storage: "memory"` when the directory should be read and synced through the filesystem backend, but the Lix repository itself should stay in memory:
+
+```ts
+import { FsBackend, openLix } from "@lix-js/sdk";
+
+const lix = await openLix({
+	backend: new FsBackend({ path: "/Users/me/Downloads", storage: "memory" }),
+});
+```
+
+This is useful for temporary workspaces, previews, and opening user folders that should not get a `.lix` folder.
+
+Add a filter when only specific files should participate in filesystem sync.
+`includePaths` entries are exact workspace-relative file paths, not directories
+or globs. They may be written with or without a leading slash, for example
+`"notes/today.md"` or `"/notes/today.md"`. The filter scopes disk import, file
+watching, and materialization; it does not filter unrelated Lix SQL state.
+
+```ts
+const lix = await openLix({
+	backend: new FsBackend({
+		path: "/Users/me/Downloads",
+		storage: "memory",
+		filter: { includePaths: ["notes/today.md"] },
+	}),
+});
+```
+
+## Single .lix application file
+
+Use `SqliteBackend` when the `.lix` SQLite file is the application document itself. This is useful if you are defining a new file format and want Lix to be the application's file format: a single portable file that contains the app's versioned state.
+
+```ts
+import { openLix, SqliteBackend } from "@lix-js/sdk";
+
+const lix = await openLix({
+	backend: new SqliteBackend({ path: "/var/data/app.lix" }),
+});
+```
+
+Reopening the same path resumes existing state. Don't open the file with raw SQLite tools; Lix manages its own schema and transactions.
 
 ## Closing
 

--- a/docs/what-is-lix.md
+++ b/docs/what-is-lix.md
@@ -50,7 +50,7 @@ Lix gives those files version-control primitives directly:
 - **Any file format** can be represented through parser plugins or custom schemas.
 - **Semantic changes** are stored per entity instead of only as whole-file snapshots.
 - **SQL** is the query interface for application code, AI agents, and tools.
-- **Pluggable storage.** Run in-memory, persist to a `.lix` SQLite file, or implement the [backend interface](./backend.md) to put Lix on Postgres, S3, Cloudflare, IndexedDB, OPFS, or anything transactional and key-value-shaped.
+- **Pluggable storage.** Run in-memory, sync a filesystem workspace with `FsBackend`, use a `.lix` SQLite file as an application file format, or implement the [backend interface](./backend.md) to put Lix on Postgres, S3, Cloudflare, IndexedDB, OPFS, or anything transactional and key-value-shaped.
 - **ACID transactions** work across files and entities.
 
 No daemon, no protocol, no remote.

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -11,19 +11,19 @@ npm install @lix-js/sdk
 ## Usage
 
 ```ts
-import { openLix, SqliteBackend } from "@lix-js/sdk";
+import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  backend: new SqliteBackend({ path: "app.lix" }),
+	backend: new FsBackend({ path: "./workspace" }),
 });
 
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-  ["/hello.txt", new TextEncoder().encode("world")],
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+	["/hello.txt", new TextEncoder().encode("world")],
 );
 
 const result = await lix.execute("SELECT data FROM lix_file WHERE path = $1", [
-  "/hello.txt",
+	"/hello.txt",
 ]);
 const bytes = result.rows[0]?.value("data").asBytes();
 
@@ -40,8 +40,8 @@ const draft = await lix.createBranch({ name: "Draft" });
 
 await lix.switchBranch({ branchId: draft.id });
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-  ["/status.txt", new TextEncoder().encode("draft")],
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+	["/status.txt", new TextEncoder().encode("draft")],
 );
 
 await lix.switchBranch({ branchId: main });
@@ -55,24 +55,27 @@ const merge = await lix.mergeBranch({ sourceBranchId: draft.id });
 const tx = await lix.beginTransaction();
 
 try {
-  await tx.execute(
-    "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-    ["/a.txt", new TextEncoder().encode("1")],
-  );
-  await tx.execute(
-    "INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-    ["/b.txt", new TextEncoder().encode("2")],
-  );
-  await tx.commit();
+	await tx.execute(
+		"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+		["/a.txt", new TextEncoder().encode("1")],
+	);
+	await tx.execute(
+		"INSERT INTO lix_file (path, data) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+		["/b.txt", new TextEncoder().encode("2")],
+	);
+	await tx.commit();
 } catch (error) {
-  await tx.rollback();
-  throw error;
+	await tx.rollback();
+	throw error;
 }
 ```
 
 ## Notes
 
-- `openLix()` opens a fresh in-memory Lix. Pass `new SqliteBackend({ path })` for a raw SQLite `.lix` file, `new FsBackend({ path })` for a filesystem workspace directory backed by `<path>/.lix/.internal/db.sqlite`, or `new FsEphemeralBackend({ path })` for filesystem sync backed by an in-memory repository.
+- `openLix()` opens a fresh in-memory Lix. Pass `new FsBackend({ path })` for a filesystem workspace directory backed by `<path>/.lix/.internal/db.sqlite`.
+- Use `new FsBackend({ path, storage: "memory" })` when you want to sync files from a directory but keep Lix repository storage in memory and avoid writing `.lix` metadata to that directory.
+- Add `filter: { includePaths: ["notes/today.md"] }` to sync only selected files from a filesystem backend. `includePaths` entries are exact workspace-relative file paths, not directories or globs. They may be written with or without a leading slash, and only affect filesystem sync.
+- Use `new SqliteBackend({ path })` when a single SQLite-backed `.lix` file is the application document itself, for example when defining a new file format and using Lix as the application's file format.
 - The SDK is Node/native only right now; it is not browser-compatible.
 - The package is ESM-only.
 - The native addon is built from Rust and loaded by the TypeScript wrapper.

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -1,6 +1,6 @@
 use lix_sdk::{
     CreateBranchOptions as RsCreateBranchOptions, CreateBranchReceipt,
-    ExecuteResult as RsExecuteResult, FsBackend, FsEphemeralBackend, InMemoryBackend, Lix as RsLix,
+    ExecuteResult as RsExecuteResult, FsBackend, FsBackendFilter, InMemoryBackend, Lix as RsLix,
     LixError, LixTransaction as RsLixTransaction, MergeBranchOptions as RsMergeBranchOptions,
     MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
     MergeChangeStats, MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide,
@@ -32,21 +32,18 @@ enum NativeLixInner {
     Memory(RsLix<InMemoryBackend>),
     Sqlite(RsLix<SqliteBackend>),
     Fs(RsLix<FsBackend>),
-    FsEphemeral(RsLix<FsEphemeralBackend>),
 }
 
 enum NativeLixTransactionInner {
     Memory(RsLixTransaction<InMemoryBackend>),
     Sqlite(RsLixTransaction<SqliteBackend>),
     Fs(RsLixTransaction<FsBackend>),
-    FsEphemeral(RsLixTransaction<FsEphemeralBackend>),
 }
 
 enum NativeObserveEventsInner {
     Memory(RsObserveEvents<InMemoryBackend>),
     Sqlite(RsObserveEvents<SqliteBackend>),
     Fs(RsObserveEvents<FsBackend>),
-    FsEphemeral(RsObserveEvents<FsEphemeralBackend>),
 }
 
 impl NativeLixInner {
@@ -59,7 +56,6 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.execute(sql, params).await,
             Self::Sqlite(lix) => lix.execute(sql, params).await,
             Self::Fs(lix) => lix.execute(sql, params).await,
-            Self::FsEphemeral(lix) => lix.execute(sql, params).await,
         }
     }
 
@@ -74,9 +70,6 @@ impl NativeLixInner {
             Self::Fs(lix) => Ok(NativeLixTransactionInner::Fs(
                 lix.begin_transaction().await?,
             )),
-            Self::FsEphemeral(lix) => Ok(NativeLixTransactionInner::FsEphemeral(
-                lix.begin_transaction().await?,
-            )),
         }
     }
 
@@ -89,9 +82,6 @@ impl NativeLixInner {
             Self::Memory(lix) => Ok(NativeObserveEventsInner::Memory(lix.observe(sql, params)?)),
             Self::Sqlite(lix) => Ok(NativeObserveEventsInner::Sqlite(lix.observe(sql, params)?)),
             Self::Fs(lix) => Ok(NativeObserveEventsInner::Fs(lix.observe(sql, params)?)),
-            Self::FsEphemeral(lix) => Ok(NativeObserveEventsInner::FsEphemeral(
-                lix.observe(sql, params)?,
-            )),
         }
     }
 
@@ -100,7 +90,6 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.active_branch_id().await,
             Self::Sqlite(lix) => lix.active_branch_id().await,
             Self::Fs(lix) => lix.active_branch_id().await,
-            Self::FsEphemeral(lix) => lix.active_branch_id().await,
         }
     }
 
@@ -112,7 +101,6 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.create_branch(options).await,
             Self::Sqlite(lix) => lix.create_branch(options).await,
             Self::Fs(lix) => lix.create_branch(options).await,
-            Self::FsEphemeral(lix) => lix.create_branch(options).await,
         }
     }
 
@@ -124,7 +112,6 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.switch_branch(options).await,
             Self::Sqlite(lix) => lix.switch_branch(options).await,
             Self::Fs(lix) => lix.switch_branch(options).await,
-            Self::FsEphemeral(lix) => lix.switch_branch(options).await,
         }
     }
 
@@ -136,7 +123,6 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.merge_branch_preview(options).await,
             Self::Sqlite(lix) => lix.merge_branch_preview(options).await,
             Self::Fs(lix) => lix.merge_branch_preview(options).await,
-            Self::FsEphemeral(lix) => lix.merge_branch_preview(options).await,
         }
     }
 
@@ -148,7 +134,6 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.merge_branch(options).await,
             Self::Sqlite(lix) => lix.merge_branch(options).await,
             Self::Fs(lix) => lix.merge_branch(options).await,
-            Self::FsEphemeral(lix) => lix.merge_branch(options).await,
         }
     }
 
@@ -157,7 +142,6 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.close().await,
             Self::Sqlite(lix) => lix.close().await,
             Self::Fs(lix) => lix.close().await,
-            Self::FsEphemeral(lix) => lix.close().await,
         }
     }
 }
@@ -172,7 +156,6 @@ impl NativeLixTransactionInner {
             Self::Memory(transaction) => transaction.execute(sql, params).await,
             Self::Sqlite(transaction) => transaction.execute(sql, params).await,
             Self::Fs(transaction) => transaction.execute(sql, params).await,
-            Self::FsEphemeral(transaction) => transaction.execute(sql, params).await,
         }
     }
 
@@ -181,7 +164,6 @@ impl NativeLixTransactionInner {
             Self::Memory(transaction) => transaction.commit().await,
             Self::Sqlite(transaction) => transaction.commit().await,
             Self::Fs(transaction) => transaction.commit().await,
-            Self::FsEphemeral(transaction) => transaction.commit().await,
         }
     }
 
@@ -190,7 +172,6 @@ impl NativeLixTransactionInner {
             Self::Memory(transaction) => transaction.rollback().await,
             Self::Sqlite(transaction) => transaction.rollback().await,
             Self::Fs(transaction) => transaction.rollback().await,
-            Self::FsEphemeral(transaction) => transaction.rollback().await,
         }
     }
 }
@@ -201,7 +182,6 @@ impl NativeObserveEventsInner {
             Self::Memory(events) => events.next().await,
             Self::Sqlite(events) => events.next().await,
             Self::Fs(events) => events.next().await,
-            Self::FsEphemeral(events) => events.next().await,
         }
     }
 
@@ -210,9 +190,46 @@ impl NativeObserveEventsInner {
             Self::Memory(events) => events.close(),
             Self::Sqlite(events) => events.close(),
             Self::Fs(events) => events.close(),
-            Self::FsEphemeral(events) => events.close(),
         }
     }
+}
+
+enum NativeFsBackendStorage {
+    Persistent,
+    Memory,
+}
+
+fn parse_fs_backend_storage(env: &Env, storage: Option<String>) -> Result<NativeFsBackendStorage> {
+    match storage.as_deref().unwrap_or("persistent") {
+        "persistent" => Ok(NativeFsBackendStorage::Persistent),
+        "memory" => Ok(NativeFsBackendStorage::Memory),
+        value => Err(throw_lix_error(
+            env,
+            LixError::new(
+                "LIX_INVALID_ARGUMENT",
+                format!("unsupported filesystem backend storage '{value}'"),
+            ),
+        )),
+    }
+}
+
+fn parse_fs_backend_filter(
+    env: &Env,
+    include_paths: Option<Vec<String>>,
+) -> Result<FsBackendFilter> {
+    let Some(include_paths) = include_paths else {
+        return Ok(FsBackendFilter::default());
+    };
+    if include_paths.is_empty() {
+        return Err(throw_lix_error(
+            env,
+            LixError::new(
+                "LIX_INVALID_ARGUMENT",
+                "filesystem backend filter.includePaths must contain at least one path",
+            ),
+        ));
+    }
+    Ok(FsBackendFilter::include_paths(include_paths))
 }
 
 #[napi]
@@ -250,13 +267,29 @@ impl NativeLix {
     }
 
     #[napi(factory, js_name = "openFs")]
-    pub fn open_fs(env: Env, path: String) -> Result<Self> {
+    pub fn open_fs(
+        env: Env,
+        path: String,
+        storage: Option<String>,
+        include_paths: Option<Vec<String>>,
+    ) -> Result<Self> {
         let rt = Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(to_napi_error)?;
+        let storage = parse_fs_backend_storage(&env, storage)?;
+        let filter = parse_fs_backend_filter(&env, include_paths)?;
         let backend = rt
-            .block_on(FsBackend::open(path))
+            .block_on(async {
+                match storage {
+                    NativeFsBackendStorage::Persistent => {
+                        FsBackend::open_with_filter(path, filter).await
+                    }
+                    NativeFsBackendStorage::Memory => {
+                        FsBackend::open_memory_with_filter(path, filter).await
+                    }
+                }
+            })
             .map_err(|error| throw_lix_error(&env, error))?;
         let lix = rt
             .block_on(open_lix_with_backend(backend))
@@ -264,24 +297,6 @@ impl NativeLix {
         Ok(Self {
             rt,
             lix: Some(NativeLixInner::Fs(lix)),
-        })
-    }
-
-    #[napi(factory, js_name = "openFsEphemeral")]
-    pub fn open_fs_ephemeral(env: Env, path: String) -> Result<Self> {
-        let rt = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(to_napi_error)?;
-        let backend = rt
-            .block_on(FsEphemeralBackend::open(path))
-            .map_err(|error| throw_lix_error(&env, error))?;
-        let lix = rt
-            .block_on(open_lix_with_backend(backend))
-            .map_err(|error| throw_lix_error(&env, error))?;
-        Ok(Self {
-            rt,
-            lix: Some(NativeLixInner::FsEphemeral(lix)),
         })
     }
 

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -4,7 +4,6 @@ export {
 	LixTransaction,
 	ObserveEvents,
 	openLix,
-	FsEphemeralBackend,
 	SqliteBackend,
 } from "./open-lix.js";
 export {
@@ -18,7 +17,6 @@ export type {
 	CreateBranchReceipt,
 	ExecuteResult,
 	FsBackendOptions,
-	FsEphemeralBackendOptions,
 	JsonValue,
 	LixValue,
 	MergeBranchOptions,

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -4,6 +4,7 @@ import {
 	readFileSync,
 	statSync,
 	symlinkSync,
+	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -12,7 +13,6 @@ import { expect, test } from "vitest";
 import {
 	bundledPluginArchives,
 	FsBackend,
-	FsEphemeralBackend,
 	openLix,
 	SqliteBackend,
 	Value,
@@ -249,12 +249,14 @@ test.each([
 	],
 	["fs", () => openLix({ backend: new FsBackend({ path: tempFsDir() }) })],
 	[
-		"fs-ephemeral",
+		"fs-memory",
 		() => {
 			const dir = tempFsDir();
 			mkdirSync(dir, { recursive: true });
 			writeFileSync(join(dir, "matrix.md"), "matrix");
-			return openLix({ backend: new FsEphemeralBackend({ path: dir }) });
+			return openLix({
+				backend: new FsBackend({ path: dir, storage: "memory" }),
+			});
 		},
 	],
 ] as const)("core native flow works with %s backend", async (_name, open) => {
@@ -320,7 +322,7 @@ test("fs backend imports local files and materializes lix_file writes", async ()
 	await reopened.close();
 });
 
-test("fs ephemeral backend imports the directory and writes normal files back", async () => {
+test("fs backend with memory storage imports the directory and writes normal files back", async () => {
 	const dir = tempFsDir();
 	const filePath = join(dir, "note.md");
 	const siblingPath = join(dir, "sibling.md");
@@ -329,7 +331,7 @@ test("fs ephemeral backend imports the directory and writes normal files back", 
 	writeFileSync(siblingPath, "sibling");
 
 	const lix = await openLix({
-		backend: new FsEphemeralBackend({ path: dir }),
+		backend: new FsBackend({ path: dir, storage: "memory" }),
 	});
 
 	const files = await lix.execute(
@@ -370,13 +372,214 @@ test("fs ephemeral backend imports the directory and writes normal files back", 
 	await lix.close();
 });
 
-test("fs ephemeral backend keeps lix storage paths in memory only", async () => {
+test("fs backend filter only syncs included paths", async () => {
+	const dir = tempFsDir();
+	const includedPath = join(dir, "docs", "note.md");
+	const excludedPath = join(dir, "docs", "sibling.md");
+	const generatedPath = join(dir, "generated.md");
+	mkdirSync(join(dir, "docs"), { recursive: true });
+	writeFileSync(includedPath, "included");
+	writeFileSync(excludedPath, "excluded");
+
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			storage: "memory",
+			filter: { includePaths: ["docs/note.md"] },
+		}),
+	});
+
+	const files = await lix.execute(
+		"SELECT path FROM lix_file WHERE path IN ($1, $2) ORDER BY path",
+		["/docs/note.md", "/docs/sibling.md"],
+	);
+	expect(files.rows.map((row) => row.get("path"))).toEqual(["/docs/note.md"]);
+
+	await lix.execute("UPDATE lix_file SET data = $1 WHERE path = $2", [
+		new TextEncoder().encode("updated"),
+		"/docs/note.md",
+	]);
+	expect(readFileSync(includedPath, "utf8")).toBe("updated");
+	expect(readFileSync(excludedPath, "utf8")).toBe("excluded");
+
+	await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
+		"/generated.md",
+		new TextEncoder().encode("generated"),
+	]);
+	expect(existsSync(generatedPath)).toBe(false);
+
+	writeFileSync(includedPath, "external");
+	await waitFor(async () => {
+		const bytes = await readFile(lix, "/docs/note.md");
+		return bytes ? new TextDecoder().decode(bytes) : undefined;
+	}, "external");
+
+	writeFileSync(excludedPath, "changed outside filter");
+	expect(await readFile(lix, "/docs/sibling.md")).toBeUndefined();
+
+	await lix.close();
+});
+
+test("fs backend filter requires explicit include paths", () => {
+	const dir = tempFsDir();
+	mkdirSync(dir, { recursive: true });
+
+	expect(
+		() =>
+			new FsBackend({ path: dir, filter: {} as { includePaths: string[] } }),
+	).toThrow("FsBackend filter.includePaths must be an array");
+	expect(
+		() => new FsBackend({ path: dir, filter: { includePaths: [] } }),
+	).toThrow("FsBackend filter.includePaths must contain at least one path");
+	expect(
+		() =>
+			new FsBackend({
+				path: dir,
+				filter: { includePaths: [""] },
+			}),
+	).toThrow("FsBackend filter.includePaths must contain non-empty strings");
+	expect(
+		() =>
+			new FsBackend({
+				path: dir,
+				filter: { includePaths: ["docs/"] },
+			}),
+	).toThrow(
+		"FsBackend filter.includePaths must contain file paths, not directory paths",
+	);
+});
+
+test("fs backend filter treats paths as exact filenames", async () => {
+	const dir = tempFsDir();
+	const filePath = join(dir, " spaced.md");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(filePath, "literal whitespace");
+
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			storage: "memory",
+			filter: { includePaths: [" spaced.md"] },
+		}),
+	});
+
+	const bytes = await readFile(lix, "/ spaced.md");
+	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe(
+		"literal whitespace",
+	);
+
+	await lix.close();
+});
+
+test("fs backend filter does not create directories for missing includes", async () => {
+	const dir = tempFsDir();
+	mkdirSync(dir, { recursive: true });
+
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			storage: "memory",
+			filter: { includePaths: ["missing/note.md"] },
+		}),
+	});
+
+	const directories = await lix.execute(
+		"SELECT path FROM lix_directory WHERE path = $1",
+		["/missing/"],
+	);
+	expect(directories.rows).toHaveLength(0);
+	expect(existsSync(join(dir, "missing"))).toBe(false);
+
+	await lix.close();
+});
+
+test("fs backend filter propagates deletion of included files", async () => {
+	const dir = tempFsDir();
+	const filePath = join(dir, "note.md");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(filePath, "local");
+
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			storage: "memory",
+			filter: { includePaths: ["note.md"] },
+		}),
+	});
+
+	expect(await readFile(lix, "/note.md")).toBeDefined();
+
+	unlinkSync(filePath);
+	await waitFor(async () => await readFile(lix, "/note.md"), undefined);
+
+	await lix.close();
+});
+
+test("fs backend filter does not delete excluded files through parent directories", async () => {
+	const dir = tempFsDir();
+	const includedPath = join(dir, "docs", "note.md");
+	mkdirSync(join(dir, "docs"), { recursive: true });
+	writeFileSync(includedPath, "local");
+
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			storage: "memory",
+			filter: { includePaths: ["docs/note.md"] },
+		}),
+	});
+
+	await writeFile(
+		lix,
+		"/docs/sibling.md",
+		new TextEncoder().encode("outside filter"),
+	);
+	expect(await readFile(lix, "/docs/sibling.md")).toBeDefined();
+
+	unlinkSync(includedPath);
+	await waitFor(async () => await readFile(lix, "/docs/note.md"), undefined);
+
+	const sibling = await readFile(lix, "/docs/sibling.md");
+	expect(sibling ? new TextDecoder().decode(sibling) : undefined).toBe(
+		"outside filter",
+	);
+
+	await lix.close();
+});
+
+test("fs backend filter matches directory paths by segment boundaries", async () => {
+	const dir = tempFsDir();
+	const includedPath = join(dir, "foo-bar", "note.md");
+	mkdirSync(join(dir, "foo-bar"), { recursive: true });
+	writeFileSync(includedPath, "local");
+
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			storage: "memory",
+			filter: { includePaths: ["foo-bar/note.md"] },
+		}),
+	});
+
+	await writeFile(
+		lix,
+		"/foo/file.md",
+		new TextEncoder().encode("outside filter"),
+	);
+
+	expect(existsSync(join(dir, "foo"))).toBe(false);
+	expect(readFileSync(includedPath, "utf8")).toBe("local");
+
+	await lix.close();
+});
+
+test("fs backend with memory storage keeps lix storage paths in memory only", async () => {
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "note.md"), "note");
 
 	const lix = await openLix({
-		backend: new FsEphemeralBackend({ path: dir }),
+		backend: new FsBackend({ path: dir, storage: "memory" }),
 	});
 
 	await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
@@ -389,13 +592,13 @@ test("fs ephemeral backend keeps lix storage paths in memory only", async () => 
 	await lix.close();
 });
 
-test("fs ephemeral backend reimports disk state on reopen without persisting lix storage", async () => {
+test("fs backend with memory storage reimports disk state on reopen without persisting lix storage", async () => {
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "note.md"), "first");
 
 	const lix = await openLix({
-		backend: new FsEphemeralBackend({ path: dir }),
+		backend: new FsBackend({ path: dir, storage: "memory" }),
 	});
 	await lix.execute("UPDATE lix_file SET data = $1 WHERE path = $2", [
 		new TextEncoder().encode("second"),
@@ -408,7 +611,7 @@ test("fs ephemeral backend reimports disk state on reopen without persisting lix
 	await lix.close();
 
 	const reopened = await openLix({
-		backend: new FsEphemeralBackend({ path: dir }),
+		backend: new FsBackend({ path: dir, storage: "memory" }),
 	});
 	const bytes = await readFile(reopened, "/note.md");
 	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe("second");

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -7,7 +7,6 @@ import type {
 	CreateBranchReceipt,
 	ExecuteResult,
 	FsBackendOptions,
-	FsEphemeralBackendOptions,
 	MergeBranchOptions,
 	MergeBranchPreview,
 	MergeBranchReceipt,
@@ -67,6 +66,8 @@ export class SqliteBackend {
 
 export class FsBackend {
 	readonly path: string;
+	readonly storage: "persistent" | "memory";
+	readonly filter: { includePaths: readonly string[] } | undefined;
 
 	constructor(options: FsBackendOptions) {
 		if (
@@ -76,22 +77,43 @@ export class FsBackend {
 		) {
 			throw new TypeError("FsBackend requires a non-empty path");
 		}
-		this.path = options.path;
-	}
-}
-
-export class FsEphemeralBackend {
-	readonly path: string;
-
-	constructor(options: FsEphemeralBackendOptions) {
 		if (
-			!options ||
-			typeof options.path !== "string" ||
-			options.path.length === 0
+			options.storage !== undefined &&
+			options.storage !== "persistent" &&
+			options.storage !== "memory"
 		) {
-			throw new TypeError("FsEphemeralBackend requires a non-empty path");
+			throw new TypeError('FsBackend storage must be "persistent" or "memory"');
+		}
+		if (options.filter !== undefined) {
+			if (!options.filter || typeof options.filter !== "object") {
+				throw new TypeError("FsBackend filter must be an object");
+			}
+			if (!Array.isArray(options.filter.includePaths)) {
+				throw new TypeError("FsBackend filter.includePaths must be an array");
+			}
+			if (options.filter.includePaths.length === 0) {
+				throw new TypeError(
+					"FsBackend filter.includePaths must contain at least one path",
+				);
+			}
+			for (const includePath of options.filter.includePaths) {
+				if (typeof includePath !== "string" || includePath.length === 0) {
+					throw new TypeError(
+						"FsBackend filter.includePaths must contain non-empty strings",
+					);
+				}
+				if (includePath.endsWith("/")) {
+					throw new TypeError(
+						"FsBackend filter.includePaths must contain file paths, not directory paths",
+					);
+				}
+			}
 		}
 		this.path = options.path;
+		this.storage = options.storage ?? "persistent";
+		this.filter = options.filter
+			? { includePaths: [...options.filter.includePaths] }
+			: undefined;
 	}
 }
 
@@ -106,13 +128,16 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 		return new Lix(addon.Lix.openSqlite(options.backend.path));
 	}
 	if (options.backend instanceof FsBackend) {
-		return new Lix(addon.Lix.openFs(options.backend.path));
-	}
-	if (options.backend instanceof FsEphemeralBackend) {
-		return new Lix(addon.Lix.openFsEphemeral(options.backend.path));
+		return new Lix(
+			addon.Lix.openFs(
+				options.backend.path,
+				options.backend.storage,
+				options.backend.filter?.includePaths,
+			),
+		);
 	}
 	throw new TypeError(
-		"openLix() requires { backend: new SqliteBackend({ path }) }, { backend: new FsBackend({ path }) }, or { backend: new FsEphemeralBackend({ path }) }",
+		"openLix() requires backend to be SqliteBackend or FsBackend",
 	);
 }
 

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -4,17 +4,16 @@ export type SqliteBackendOptions = {
 
 export type FsBackendOptions = {
 	path: string;
-};
-
-export type FsEphemeralBackendOptions = {
-	path: string;
+	storage?: "persistent" | "memory";
+	filter?: {
+		includePaths: readonly string[];
+	};
 };
 
 export type OpenLixOptions = {
 	backend?:
 		| import("./open-lix.js").SqliteBackend
-		| import("./open-lix.js").FsBackend
-		| import("./open-lix.js").FsEphemeralBackend;
+		| import("./open-lix.js").FsBackend;
 };
 
 export type LixValue =

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -7,8 +7,9 @@ use std::time::Duration;
 
 use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
-    Backend, BackendError, BackendWrite, CommitResult, Engine, InMemoryBackend, LixError, PutBatch,
-    ReadOptions, SessionContext, SpaceId, Value, WriteOptions,
+    Backend, BackendError, BackendRead, BackendWrite, CommitResult, Engine, GetOptions,
+    InMemoryBackend, Key, KeyRange, LixError, PointVisitor, PutBatch, ReadOptions, ScanOptions,
+    ScanResult, ScanVisitor, SessionContext, SpaceId, Value, WriteOptions,
 };
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
@@ -37,6 +38,23 @@ enum FilesystemMetadataMode {
     Ephemeral,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct FsBackendFilter {
+    pub include_paths: Vec<String>,
+}
+
+impl FsBackendFilter {
+    pub fn include_paths(include_paths: Vec<String>) -> Self {
+        Self { include_paths }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct FilesystemPathFilter {
+    include_files: BTreeSet<String>,
+}
+
 pub(crate) struct FilesystemWrite<'a, B>
 where
     B: Backend + Clone + Send + Sync + 'static,
@@ -51,24 +69,33 @@ where
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct FsBackend {
-    inner: FilesystemSync<SqliteBackend>,
+    inner: FsBackendInner,
+}
+
+#[cfg(feature = "sqlite")]
+#[derive(Clone)]
+enum FsBackendInner {
+    Persistent(FilesystemSync<SqliteBackend>),
+    Memory(FilesystemSync<InMemoryBackend>),
+}
+
+#[cfg(feature = "sqlite")]
+#[expect(missing_debug_implementations)]
+pub enum FsRead<'a> {
+    Persistent(crate::sqlite_backend::SqliteRead),
+    Memory(<InMemoryBackend as Backend>::Read<'a>),
 }
 
 #[cfg(feature = "sqlite")]
 #[expect(missing_debug_implementations)]
 pub struct FsWrite<'a> {
-    inner: FilesystemWrite<'a, SqliteBackend>,
+    inner: FsWriteInner<'a>,
 }
 
-#[derive(Clone)]
-#[expect(missing_debug_implementations)]
-pub struct FsEphemeralBackend {
-    inner: FilesystemSync<InMemoryBackend>,
-}
-
-#[expect(missing_debug_implementations)]
-pub struct FsEphemeralWrite<'a> {
-    inner: FilesystemWrite<'a, InMemoryBackend>,
+#[cfg(feature = "sqlite")]
+enum FsWriteInner<'a> {
+    Persistent(FilesystemWrite<'a, SqliteBackend>),
+    Memory(FilesystemWrite<'a, InMemoryBackend>),
 }
 
 #[derive(Clone)]
@@ -97,6 +124,7 @@ where
     session: SessionContext<B>,
     root: PathBuf,
     metadata_mode: FilesystemMetadataMode,
+    path_filter: FilesystemPathFilter,
     sync_lock: tokio::sync::Mutex<()>,
     last_materialized: Mutex<Option<MaterializedSnapshot>>,
 }
@@ -106,6 +134,84 @@ struct Snapshot {
     directories: BTreeSet<String>,
     files: BTreeMap<String, Vec<u8>>,
     unmanaged_paths: BTreeSet<String>,
+}
+
+impl Snapshot {
+    fn filtered(&self, path_filter: &FilesystemPathFilter) -> Self {
+        if path_filter.is_unfiltered() {
+            return self.clone();
+        }
+        Self {
+            directories: self
+                .directories
+                .iter()
+                .filter(|path| path_filter.includes_directory(path))
+                .cloned()
+                .collect(),
+            files: self
+                .files
+                .iter()
+                .filter(|(path, _)| path_filter.includes_file(path))
+                .map(|(path, data)| (path.clone(), data.clone()))
+                .collect(),
+            unmanaged_paths: self
+                .unmanaged_paths
+                .iter()
+                .filter(|path| path_filter.includes_path(path))
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+impl FilesystemPathFilter {
+    fn from_filter(filter: FsBackendFilter) -> Result<Self, LixError> {
+        let mut include_files = BTreeSet::new();
+        for path in filter.include_paths {
+            include_files.insert(normalize_filter_file_path(&path)?);
+        }
+        Ok(Self { include_files })
+    }
+
+    fn is_unfiltered(&self) -> bool {
+        self.include_files.is_empty()
+    }
+
+    fn includes_file(&self, path: &str) -> bool {
+        self.is_unfiltered() || self.include_files.contains(path)
+    }
+
+    fn includes_directory(&self, path: &str) -> bool {
+        if self.is_unfiltered() || path == "/" {
+            return true;
+        }
+        self.include_files.iter().any(|file_path| {
+            let directory = parent_lix_directory_path(file_path);
+            lix_directory_contains_directory(path, &directory)
+        })
+    }
+
+    fn includes_path(&self, path: &str) -> bool {
+        if path.ends_with('/') {
+            self.includes_directory(path)
+        } else {
+            self.includes_file(path)
+        }
+    }
+
+    fn local_watch_paths(&self, root: &Path) -> Result<Vec<PathBuf>, LixError> {
+        let mut paths = BTreeSet::new();
+        for path in &self.include_files {
+            let local_path = lix_path_to_local_path(root, path)?;
+            if local_path.exists() {
+                paths.insert(local_path.clone());
+            }
+            if let Some(parent) = local_path.parent() {
+                paths.insert(parent.to_path_buf());
+            }
+        }
+        Ok(paths.into_iter().collect())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,9 +247,53 @@ impl FsBackend {
     where
         P: AsRef<Path>,
     {
+        Self::open_with_filter(dir, FsBackendFilter::default()).await
+    }
+
+    pub async fn open_with_filter<P>(dir: P, filter: FsBackendFilter) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        FilesystemPathFilter::from_filter(filter.clone())?;
         let backend = open_filesystem_sqlite_backend(dir.as_ref())?;
-        let inner = FilesystemSync::open(backend, dir.as_ref()).await?;
-        Ok(Self { inner })
+        let inner = FilesystemSync::open_with_metadata_mode(
+            backend,
+            dir.as_ref(),
+            FilesystemMetadataMode::Persistent,
+            filter,
+        )
+        .await?;
+        Ok(Self {
+            inner: FsBackendInner::Persistent(inner),
+        })
+    }
+
+    pub async fn open_memory<P>(dir: P) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        Self::open_memory_with_filter(dir, FsBackendFilter::default()).await
+    }
+
+    pub async fn open_memory_with_filter<P>(
+        dir: P,
+        filter: FsBackendFilter,
+    ) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        FilesystemPathFilter::from_filter(filter.clone())?;
+        let backend = InMemoryBackend::new();
+        let inner = FilesystemSync::open_with_metadata_mode(
+            backend,
+            dir.as_ref(),
+            FilesystemMetadataMode::Ephemeral,
+            filter,
+        )
+        .await?;
+        Ok(Self {
+            inner: FsBackendInner::Memory(inner),
+        })
     }
 
     pub async fn open_with_wasm_runtime<P>(
@@ -156,14 +306,16 @@ impl FsBackend {
         let backend = open_filesystem_sqlite_backend(dir.as_ref())?;
         let inner =
             FilesystemSync::open_with_wasm_runtime(backend, dir.as_ref(), wasm_runtime).await?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: FsBackendInner::Persistent(inner),
+        })
     }
 }
 
 #[cfg(feature = "sqlite")]
 impl Backend for FsBackend {
     type Read<'a>
-        = crate::sqlite_backend::SqliteRead
+        = FsRead<'a>
     where
         Self: 'a;
 
@@ -173,112 +325,94 @@ impl Backend for FsBackend {
         Self: 'a;
 
     fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
-        self.inner.begin_read(opts)
+        match &self.inner {
+            FsBackendInner::Persistent(inner) => Ok(FsRead::Persistent(inner.begin_read(opts)?)),
+            FsBackendInner::Memory(inner) => Ok(FsRead::Memory(inner.begin_read(opts)?)),
+        }
     }
 
     fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
-        Ok(FsWrite {
-            inner: self.inner.begin_write(opts)?,
-        })
+        match &self.inner {
+            FsBackendInner::Persistent(inner) => Ok(FsWrite {
+                inner: FsWriteInner::Persistent(inner.begin_write(opts)?),
+            }),
+            FsBackendInner::Memory(inner) => Ok(FsWrite {
+                inner: FsWriteInner::Memory(inner.begin_write(opts)?),
+            }),
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl BackendRead for FsRead<'_> {
+    fn visit_keys<V>(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<(), BackendError>
+    where
+        V: PointVisitor + ?Sized,
+    {
+        match self {
+            Self::Persistent(read) => read.visit_keys(space, keys, opts, visitor),
+            Self::Memory(read) => read.visit_keys(space, keys, opts, visitor),
+        }
+    }
+
+    fn scan<V>(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<ScanResult, BackendError>
+    where
+        V: ScanVisitor + ?Sized,
+    {
+        match self {
+            Self::Persistent(read) => read.scan(space, range, opts, visitor),
+            Self::Memory(read) => read.scan(space, range, opts, visitor),
+        }
     }
 }
 
 #[cfg(feature = "sqlite")]
 impl BackendWrite for FsWrite<'_> {
     fn put_many(&mut self, space: SpaceId, entries: PutBatch) -> Result<(), BackendError> {
-        self.inner.put_many(space, entries)
+        match &mut self.inner {
+            FsWriteInner::Persistent(write) => write.put_many(space, entries),
+            FsWriteInner::Memory(write) => write.put_many(space, entries),
+        }
     }
 
-    fn delete_many(
-        &mut self,
-        space: SpaceId,
-        keys: &[lix_engine::Key],
-    ) -> Result<(), BackendError> {
-        self.inner.delete_many(space, keys)
+    fn delete_many(&mut self, space: SpaceId, keys: &[Key]) -> Result<(), BackendError> {
+        match &mut self.inner {
+            FsWriteInner::Persistent(write) => write.delete_many(space, keys),
+            FsWriteInner::Memory(write) => write.delete_many(space, keys),
+        }
     }
 
-    fn delete_range(
-        &mut self,
-        space: SpaceId,
-        range: lix_engine::KeyRange,
-    ) -> Result<(), BackendError> {
-        self.inner.delete_range(space, range)
-    }
-
-    fn commit(self) -> Result<CommitResult, BackendError> {
-        self.inner.commit()
-    }
-
-    fn rollback(self) -> Result<(), BackendError> {
-        self.inner.rollback()
-    }
-}
-
-impl FsEphemeralBackend {
-    pub async fn open<P>(dir: P) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        let backend = InMemoryBackend::new();
-        let inner = FilesystemSync::open_with_metadata_mode(
-            backend,
-            dir.as_ref(),
-            FilesystemMetadataMode::Ephemeral,
-        )
-        .await?;
-        Ok(Self { inner })
-    }
-}
-
-impl Backend for FsEphemeralBackend {
-    type Read<'a>
-        = <InMemoryBackend as Backend>::Read<'a>
-    where
-        Self: 'a;
-
-    type Write<'a>
-        = FsEphemeralWrite<'a>
-    where
-        Self: 'a;
-
-    fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
-        self.inner.begin_read(opts)
-    }
-
-    fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
-        Ok(FsEphemeralWrite {
-            inner: self.inner.begin_write(opts)?,
-        })
-    }
-}
-
-impl BackendWrite for FsEphemeralWrite<'_> {
-    fn put_many(&mut self, space: SpaceId, entries: PutBatch) -> Result<(), BackendError> {
-        self.inner.put_many(space, entries)
-    }
-
-    fn delete_many(
-        &mut self,
-        space: SpaceId,
-        keys: &[lix_engine::Key],
-    ) -> Result<(), BackendError> {
-        self.inner.delete_many(space, keys)
-    }
-
-    fn delete_range(
-        &mut self,
-        space: SpaceId,
-        range: lix_engine::KeyRange,
-    ) -> Result<(), BackendError> {
-        self.inner.delete_range(space, range)
+    fn delete_range(&mut self, space: SpaceId, range: KeyRange) -> Result<(), BackendError> {
+        match &mut self.inner {
+            FsWriteInner::Persistent(write) => write.delete_range(space, range),
+            FsWriteInner::Memory(write) => write.delete_range(space, range),
+        }
     }
 
     fn commit(self) -> Result<CommitResult, BackendError> {
-        self.inner.commit()
+        match self.inner {
+            FsWriteInner::Persistent(write) => write.commit(),
+            FsWriteInner::Memory(write) => write.commit(),
+        }
     }
 
     fn rollback(self) -> Result<(), BackendError> {
-        self.inner.rollback()
+        match self.inner {
+            FsWriteInner::Persistent(write) => write.rollback(),
+            FsWriteInner::Memory(write) => write.rollback(),
+        }
     }
 }
 
@@ -288,13 +422,6 @@ where
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
-    pub async fn open<P>(backend: B, root: P) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        Self::open_with_metadata_mode(backend, root, FilesystemMetadataMode::Persistent).await
-    }
-
     pub async fn open_with_wasm_runtime<P>(
         backend: B,
         root: P,
@@ -310,6 +437,7 @@ where
             engine,
             root.as_ref(),
             FilesystemMetadataMode::Persistent,
+            FsBackendFilter::default(),
         )
         .await
     }
@@ -318,12 +446,13 @@ where
         backend: B,
         root: P,
         metadata_mode: FilesystemMetadataMode,
+        filter: FsBackendFilter,
     ) -> Result<Self, LixError>
     where
         P: AsRef<Path>,
     {
         let engine = crate::lix::open_or_initialize_engine(backend.clone(), None).await?;
-        Self::open_with_engine(backend, engine, root.as_ref(), metadata_mode).await
+        Self::open_with_engine(backend, engine, root.as_ref(), metadata_mode, filter).await
     }
 
     async fn open_with_engine(
@@ -331,10 +460,11 @@ where
         engine: Engine<B>,
         root: &Path,
         metadata_mode: FilesystemMetadataMode,
+        filter: FsBackendFilter,
     ) -> Result<Self, LixError> {
         Ok(Self {
             inner: backend,
-            supervisor: FilesystemSupervisor::open(engine, root, metadata_mode).await?,
+            supervisor: FilesystemSupervisor::open(engine, root, metadata_mode, filter).await?,
         })
     }
 }
@@ -377,19 +507,11 @@ where
         self.inner.put_many(space, entries)
     }
 
-    fn delete_many(
-        &mut self,
-        space: SpaceId,
-        keys: &[lix_engine::Key],
-    ) -> Result<(), BackendError> {
+    fn delete_many(&mut self, space: SpaceId, keys: &[Key]) -> Result<(), BackendError> {
         self.inner.delete_many(space, keys)
     }
 
-    fn delete_range(
-        &mut self,
-        space: SpaceId,
-        range: lix_engine::KeyRange,
-    ) -> Result<(), BackendError> {
+    fn delete_range(&mut self, space: SpaceId, range: KeyRange) -> Result<(), BackendError> {
         self.inner.delete_range(space, range)
     }
 
@@ -414,10 +536,12 @@ where
         engine: Engine<B>,
         root: &Path,
         metadata_mode: FilesystemMetadataMode,
+        filter: FsBackendFilter,
     ) -> Result<Self, LixError> {
         ensure_filesystem_root_directory(root)?;
         let root = std::fs::canonicalize(root)
             .map_err(|error| io_error("canonicalize filesystem root", root, error))?;
+        let path_filter = FilesystemPathFilter::from_filter(filter)?;
         if metadata_mode == FilesystemMetadataMode::Persistent {
             ensure_filesystem_lix_directory(&root)?;
             migrate_legacy_filesystem_system_directory(&root)?;
@@ -427,6 +551,7 @@ where
             session,
             root,
             metadata_mode,
+            path_filter,
             sync_lock: tokio::sync::Mutex::new(()),
             last_materialized: Mutex::new(None),
         });
@@ -451,10 +576,7 @@ where
         )
         .ok()
         .and_then(|mut debouncer| {
-            if debouncer
-                .watch(state.root.as_path(), RecursiveMode::Recursive)
-                .is_ok()
-            {
+            if watch_filesystem_paths(&mut debouncer, &state.root, &state.path_filter).is_ok() {
                 Some(debouncer)
             } else {
                 debouncer.stop();
@@ -533,7 +655,7 @@ where
         let _guard = self.sync_lock.lock().await;
         let lix_revision = self.collect_lix_revision().await?;
         if self.is_last_materialized_lix_revision(&lix_revision) {
-            let local = collect_local_snapshot(&self.root, self.metadata_mode)?;
+            let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
             if self.is_last_materialized_disk(&local) {
                 return Ok(());
             }
@@ -546,7 +668,7 @@ where
 
     async fn sync_disk_to_lix(&self, skip_if_last_materialized: bool) -> Result<(), LixError> {
         let _guard = self.sync_lock.lock().await;
-        let local = collect_local_snapshot(&self.root, self.metadata_mode)?;
+        let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
         if skip_if_last_materialized && self.is_last_materialized_disk(&local) {
             let lix_revision = self.collect_lix_revision().await?;
             if self.is_last_materialized(&local, &lix_revision) {
@@ -689,6 +811,7 @@ where
 
         for path in lix.files.keys() {
             if !local.files.contains_key(path)
+                && self.path_filter.includes_file(path)
                 && !is_plugin_storage_path(path)
                 && !is_materialization_ignored_path(path, self.metadata_mode)
             {
@@ -712,35 +835,37 @@ where
             }
         }
 
-        let mut directories_to_remove = Vec::new();
-        for path in lix.directories.difference(&local.directories) {
-            if path.as_str() == "/"
-                || is_plugin_storage_path(path)
-                || is_materialization_ignored_path(path, self.metadata_mode)
-            {
-                continue;
+        if self.path_filter.is_unfiltered() {
+            let mut directories_to_remove = Vec::new();
+            for path in lix.directories.difference(&local.directories) {
+                if path.as_str() == "/"
+                    || is_plugin_storage_path(path)
+                    || is_materialization_ignored_path(path, self.metadata_mode)
+                {
+                    continue;
+                }
+                if previous
+                    .as_ref()
+                    .is_some_and(|snapshot| !snapshot.directories.contains(path))
+                {
+                    continue;
+                }
+                if lix_path_blocked_by_unmanaged(&self.root, path)?
+                    || snapshot_unmanaged_blocks_lix_path(previous, path)
+                {
+                    continue;
+                }
+                directories_to_remove.push(path.clone());
             }
-            if previous
-                .as_ref()
-                .is_some_and(|snapshot| !snapshot.directories.contains(path))
-            {
-                continue;
+            sort_directories_deepest_first(&mut directories_to_remove);
+            for path in directories_to_remove {
+                self.session
+                    .execute(
+                        "DELETE FROM lix_directory WHERE path = $1",
+                        &[Value::Text(path)],
+                    )
+                    .await?;
             }
-            if lix_path_blocked_by_unmanaged(&self.root, path)?
-                || snapshot_unmanaged_blocks_lix_path(previous, path)
-            {
-                continue;
-            }
-            directories_to_remove.push(path.clone());
-        }
-        sort_directories_deepest_first(&mut directories_to_remove);
-        for path in directories_to_remove {
-            self.session
-                .execute(
-                    "DELETE FROM lix_directory WHERE path = $1",
-                    &[Value::Text(path)],
-                )
-                .await?;
         }
 
         let mut directories_to_create = local
@@ -807,11 +932,12 @@ where
         base: Option<&Snapshot>,
     ) -> Result<Snapshot, LixError> {
         ensure_filesystem_root_directory(&self.root)?;
-        let local = collect_local_snapshot(&self.root, self.metadata_mode)?;
+        let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
         let previous = self.last_materialized_disk();
 
         for path in local.files.keys().filter(|path| {
-            !target.files.contains_key(*path)
+            self.path_filter.includes_file(path)
+                && !target.files.contains_key(*path)
                 && !is_materialization_ignored_path(path, self.metadata_mode)
                 && previous
                     .as_ref()
@@ -826,35 +952,41 @@ where
             remove_materialized_file(&self.root, path, self.metadata_mode)?;
         }
 
-        let mut directories_to_remove = local
-            .directories
-            .difference(&target.directories)
-            .filter(|path| {
-                path.as_str() != "/" && !is_materialization_ignored_path(path, self.metadata_mode)
-            })
-            .filter(|path| {
-                previous
-                    .as_ref()
-                    .is_none_or(|snapshot| snapshot.directories.contains(*path))
-            })
-            .filter(|path| {
-                base.is_none_or(|snapshot| {
-                    snapshot.directories.contains(*path)
-                        && local.directories.contains(*path) == snapshot.directories.contains(*path)
+        if self.path_filter.is_unfiltered() {
+            let mut directories_to_remove = local
+                .directories
+                .difference(&target.directories)
+                .filter(|path| {
+                    path.as_str() != "/"
+                        && !is_materialization_ignored_path(path, self.metadata_mode)
                 })
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        sort_directories_deepest_first(&mut directories_to_remove);
-        for path in directories_to_remove {
-            remove_materialized_directory(&self.root, &path, self.metadata_mode)?;
+                .filter(|path| {
+                    previous
+                        .as_ref()
+                        .is_none_or(|snapshot| snapshot.directories.contains(*path))
+                })
+                .filter(|path| {
+                    base.is_none_or(|snapshot| {
+                        snapshot.directories.contains(*path)
+                            && local.directories.contains(*path)
+                                == snapshot.directories.contains(*path)
+                    })
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            sort_directories_deepest_first(&mut directories_to_remove);
+            for path in directories_to_remove {
+                remove_materialized_directory(&self.root, &path, self.metadata_mode)?;
+            }
         }
 
         let mut directories_to_create = target
             .directories
             .iter()
             .filter(|path| {
-                path.as_str() != "/" && !is_materialization_ignored_path(path, self.metadata_mode)
+                path.as_str() != "/"
+                    && self.path_filter.includes_directory(path)
+                    && !is_materialization_ignored_path(path, self.metadata_mode)
             })
             .filter(|path| base.is_none_or(|snapshot| !snapshot.directories.contains(*path)))
             .filter(|path| {
@@ -869,11 +1001,10 @@ where
             create_materialized_directory(&self.root, &path, self.metadata_mode)?;
         }
 
-        for (path, data) in target
-            .files
-            .iter()
-            .filter(|(path, _)| !is_materialization_ignored_path(path, self.metadata_mode))
-        {
+        for (path, data) in target.files.iter().filter(|(path, _)| {
+            self.path_filter.includes_file(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
+        }) {
             if base.is_some_and(|snapshot| snapshot.files.get(path) == Some(data)) {
                 continue;
             }
@@ -885,8 +1016,9 @@ where
             }
         }
 
-        let materialized = collect_local_snapshot(&self.root, self.metadata_mode)?;
-        let mut remembered = target.clone();
+        let materialized =
+            collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
+        let mut remembered = target.filtered(&self.path_filter);
         remembered.unmanaged_paths = materialized.unmanaged_paths;
         Ok(remembered)
     }
@@ -1024,12 +1156,17 @@ fn sync_from_lix_for_replies<B>(
 fn collect_local_snapshot(
     root: &Path,
     metadata_mode: FilesystemMetadataMode,
+    path_filter: &FilesystemPathFilter,
 ) -> Result<Snapshot, LixError> {
     validate_filesystem_root_directory(root)?;
 
     let mut snapshot = Snapshot::default();
     snapshot.directories.insert("/".to_string());
-    collect_local_directory(root, root, metadata_mode, &mut snapshot)?;
+    if path_filter.is_unfiltered() {
+        collect_local_directory(root, root, metadata_mode, &mut snapshot)?;
+    } else {
+        collect_filtered_local_snapshot(root, metadata_mode, path_filter, &mut snapshot)?;
+    }
     Ok(snapshot)
 }
 
@@ -1077,6 +1214,47 @@ fn collect_local_directory(
     Ok(())
 }
 
+fn collect_filtered_local_snapshot(
+    root: &Path,
+    metadata_mode: FilesystemMetadataMode,
+    path_filter: &FilesystemPathFilter,
+    snapshot: &mut Snapshot,
+) -> Result<(), LixError> {
+    for lix_path in &path_filter.include_files {
+        if is_filesystem_sync_ignored_lix_path(lix_path, metadata_mode) {
+            continue;
+        }
+        let local_path = lix_path_to_local_path(root, lix_path)?;
+        if path_contains_unmanaged_entry(root, &local_path)? {
+            snapshot.unmanaged_paths.insert(lix_path.clone());
+            continue;
+        }
+        let metadata = match std::fs::symlink_metadata(&local_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(io_error(
+                    "read filesystem file metadata",
+                    &local_path,
+                    error,
+                ));
+            }
+        };
+        if is_unmanaged_file_type(&metadata.file_type()) {
+            snapshot.unmanaged_paths.insert(lix_path.clone());
+            continue;
+        }
+        if !metadata.is_file() {
+            continue;
+        }
+        insert_parent_lix_directories(lix_path, snapshot);
+        let data = std::fs::read(&local_path)
+            .map_err(|error| io_error("read filesystem file", &local_path, error))?;
+        snapshot.files.insert(lix_path.clone(), data);
+    }
+    Ok(())
+}
+
 fn remember_unmanaged_local_path(
     root: &Path,
     directory: &Path,
@@ -1090,6 +1268,23 @@ fn remember_unmanaged_local_path(
             snapshot.unmanaged_paths.insert(parent_path);
         }
     }
+}
+
+fn watch_filesystem_paths(
+    debouncer: &mut FilesystemDebouncer,
+    root: &Path,
+    path_filter: &FilesystemPathFilter,
+) -> Result<(), notify_debouncer_full::notify::Error> {
+    if path_filter.is_unfiltered() {
+        return debouncer.watch(root, RecursiveMode::Recursive);
+    }
+    for path in path_filter
+        .local_watch_paths(root)
+        .map_err(|error| notify_debouncer_full::notify::Error::generic(&error.format()))?
+    {
+        debouncer.watch(&path, RecursiveMode::NonRecursive)?;
+    }
+    Ok(())
 }
 
 fn ensure_filesystem_root_directory(root: &Path) -> Result<(), LixError> {
@@ -1490,6 +1685,67 @@ fn local_path_to_lix_path(
         lix_path.push('/');
     }
     Ok(lix_path)
+}
+
+fn normalize_filter_file_path(path: &str) -> Result<String, LixError> {
+    if path.is_empty() {
+        return Err(filesystem_error("filesystem filter path must not be empty"));
+    }
+    let normalized = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    if normalized.ends_with('/') {
+        return Err(filesystem_error(format!(
+            "filesystem filter path {path:?} must refer to a file"
+        )));
+    }
+    validate_lix_path(&normalized)?;
+    Ok(normalized)
+}
+
+fn validate_lix_path(path: &str) -> Result<(), LixError> {
+    let _ = lix_path_to_local_path(Path::new("/"), path)?;
+    Ok(())
+}
+
+fn parent_lix_directory_path(path: &str) -> String {
+    let Some(index) = path.rfind('/') else {
+        return "/".to_string();
+    };
+    if index == 0 {
+        "/".to_string()
+    } else {
+        format!("{}/", &path[..index])
+    }
+}
+
+fn lix_directory_contains_directory(parent: &str, child: &str) -> bool {
+    let parent = parent.trim_end_matches('/');
+    let child = child.trim_end_matches('/');
+    if parent.is_empty() {
+        return true;
+    }
+    child == parent
+        || child
+            .strip_prefix(parent)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn insert_parent_lix_directories(path: &str, snapshot: &mut Snapshot) {
+    let mut directory = parent_lix_directory_path(path);
+    let mut directories = Vec::new();
+    while directory != "/" {
+        directories.push(directory.clone());
+        let parent = parent_lix_directory_path(directory.trim_end_matches('/'));
+        if parent == directory {
+            break;
+        }
+        directory = parent;
+    }
+    directories.reverse();
+    snapshot.directories.extend(directories);
 }
 
 fn lix_path_to_local_path(root: &Path, path: &str) -> Result<PathBuf, LixError> {
@@ -1926,13 +2182,15 @@ mod tests {
             session: engine.open_workspace_session().await.unwrap(),
             root,
             metadata_mode: FilesystemMetadataMode::Persistent,
+            path_filter: FilesystemPathFilter::default(),
             sync_lock: tokio::sync::Mutex::new(()),
             last_materialized: Mutex::new(None),
         };
 
         state.sync_disk_to_lix(false).await.unwrap();
 
-        let local = collect_local_snapshot(&state.root, state.metadata_mode).unwrap();
+        let local =
+            collect_local_snapshot(&state.root, state.metadata_mode, &state.path_filter).unwrap();
         let lix_revision = state.collect_lix_revision().await.unwrap();
         assert!(
             state.is_last_materialized(&local, &lix_revision),
@@ -1955,6 +2213,7 @@ mod tests {
             session: engine.open_workspace_session().await.unwrap(),
             root,
             metadata_mode: FilesystemMetadataMode::Persistent,
+            path_filter: FilesystemPathFilter::default(),
             sync_lock: tokio::sync::Mutex::new(()),
             last_materialized: Mutex::new(None),
         };
@@ -2006,6 +2265,7 @@ mod tests {
             session: engine.open_workspace_session().await.unwrap(),
             root,
             metadata_mode: FilesystemMetadataMode::Persistent,
+            path_filter: FilesystemPathFilter::default(),
             sync_lock: tokio::sync::Mutex::new(()),
             last_materialized: Mutex::new(None),
         };
@@ -2046,6 +2306,7 @@ mod tests {
             session: engine.open_workspace_session().await.unwrap(),
             root,
             metadata_mode: FilesystemMetadataMode::Persistent,
+            path_filter: FilesystemPathFilter::default(),
             sync_lock: tokio::sync::Mutex::new(()),
             last_materialized: Mutex::new(None),
         };
@@ -2053,7 +2314,8 @@ mod tests {
         state.sync_disk_to_lix(false).await.unwrap();
         let disk_path = tempdir.path().join("disk.txt");
         std::fs::write(&disk_path, b"disk").unwrap();
-        let local = collect_local_snapshot(&state.root, state.metadata_mode).unwrap();
+        let local =
+            collect_local_snapshot(&state.root, state.metadata_mode, &state.path_filter).unwrap();
         let previous = state.last_materialized_disk();
         state
             .apply_local_snapshot_to_lix(&local, previous.as_ref())

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -13,9 +13,7 @@ mod lix;
 mod sqlite_backend;
 
 #[cfg(all(not(target_family = "wasm"), feature = "sqlite"))]
-pub use filesystem::FsBackend;
-#[cfg(not(target_family = "wasm"))]
-pub use filesystem::FsEphemeralBackend;
+pub use filesystem::{FsBackend, FsBackendFilter};
 pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_backend};
 pub use lix_engine::wasm::{
     WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,


### PR DESCRIPTION
## Summary
- consolidate filesystem backend behavior behind `FsBackend`, including memory storage mode
- add exact include-path filtering for filesystem sync so direct file opens can avoid indexing huge folders
- update Lix SDK docs to make `FsBackend` the default and clarify when the SQLite backend is useful
- add a minor changenote for the new filesystem backend API

## Root Cause
Opening a single Markdown file from a large directory caused the filesystem backend to eagerly crawl the surrounding folder. The crash report pointed at `lix_js_sdk.node` while collecting the local filesystem snapshot.

## Impact
Callers can now open a filesystem-backed Lix with `storage: "memory"` and an exact `filter.includePaths` list for single-file or selected-file workflows. The `.lix` folder is not synced back to the real filesystem in memory mode.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `pnpm -C submodule/lix/packages/js-sdk test`
- `pnpm -C submodule/lix/packages/js-sdk typecheck`
- `npm test` in `submodule/lix/website`
- `git -C submodule/lix diff --check`
- `node scripts/validate-changes.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a public backend type and changes filesystem sync semantics (filtered paths, directory deletion rules); well-covered by new tests but integrators must migrate and understand filter scope.
> 
> **Overview**
> **Removes `FsEphemeralBackend`** and folds ephemeral filesystem workflows into **`FsBackend`** via `storage: "memory"` (sync from disk without writing `.lix` metadata to the folder). Persistent workspaces stay the default with `storage: "persistent"` (or omitted).
> 
> Adds **`filter.includePaths`** on `FsBackend`: exact workspace-relative file paths (not globs or directories) that scope **disk import, file watching, and materialization** only—so opening a file in a large directory no longer crawls the whole tree. Rust `filesystem.rs` implements filtered snapshots, targeted watches, and stricter sync/delete behavior when a filter is active.
> 
> **Breaking:** callers must migrate `new FsEphemeralBackend({ path })` → `new FsBackend({ path, storage: "memory" })`. Docs and examples now lead with **`FsBackend`** for local workspaces and reserve **`SqliteBackend`** for a single `.lix` application file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab703730b3c9058dcc58b260cfbfea8518a5749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->