### PR TITLE
[codex] speed up simple lix_file writes

### DIFF
--- a/.changenotes/faster-lix-file-writes.md
+++ b/.changenotes/faster-lix-file-writes.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Improved large `lix_file` write performance for simple SQL file inserts and upserts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@
 - Added filesystem sync: a lix can mirror into a plain directory and back.
 
   Edits made in the directory with any tool flow into Lix with full history. Switching branches updates the directory contents.
-- Added the `lix.fs` file API for reading and writing files.
-
-  `lix.fs.writeFile` and `lix.fs.readFile` replace raw SQL on `lix_file` for the common path.
 - Added `lix.observe()` for subscribing to SQL query results.
 
   The Rust and JavaScript SDKs can now create observe streams that emit an initial result and re-run after Lix mutations, making it possible to build reactive views without manual polling.
@@ -25,16 +22,10 @@
 
 ### Patch
 
-- Added a typed file API for storing, reading, querying, and versioning file bytes in Lix:
-
-  ```js
-  await lix.fs.writeFile("/orders.xlsx", bytes);
-  const bytes = await lix.fs.readFile("/orders.xlsx");
-  await lix.fs.mkdir("/exports/");
-  await lix.fs.rm("/orders.xlsx");
-  ```
+- Added SQL file surfaces for storing, reading, querying, and versioning file bytes in Lix:
 
   ```sql
+  INSERT INTO lix_file (path, data) VALUES ('/orders.xlsx', $1);
   SELECT data FROM lix_file WHERE path = '/orders.xlsx';
   SELECT data FROM lix_file_history WHERE path = '/orders.xlsx';
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,5 +16,5 @@
 
 ## Opening a PR
 
-1. Run workspace checks and tests, for example `cargo check --workspace` and `cargo test --workspace`. Also run package-specific checks for any JavaScript or CLI package you changed.
+1. Run workspace checks and tests, for example `cargo check --workspace`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace`. Also run package-specific checks for any JavaScript or CLI package you changed.
 2. If the change affects a published core package, add a changenote in `.changenotes`. See `.changenotes/README.md` for the format and rules.

--- a/packages/engine/src/filesystem/mod.rs
+++ b/packages/engine/src/filesystem/mod.rs
@@ -5,7 +5,6 @@ mod read;
 mod visibility;
 
 pub(crate) use self::descriptor_path::{DirectoryPathRecord, derive_directory_paths};
-#[cfg(test)]
 pub(crate) use self::planner::directory_path_resolvers_from_state_rows;
 pub(crate) use self::planner::{
     BlobRefRowInput, DirectoryDescriptorWriteIntent, DirectoryPathResolver, FileDeleteInput,

--- a/packages/engine/src/filesystem/read.rs
+++ b/packages/engine/src/filesystem/read.rs
@@ -147,6 +147,13 @@ impl FilesystemIndex {
                 FilesystemEntry::Directory => None,
             })
     }
+
+    pub(crate) fn file_entry(&self, path: &str) -> Option<&FilesystemFileEntry> {
+        match self.entries_by_path.get(path) {
+            Some(FilesystemEntry::File(file)) => Some(file),
+            _ => None,
+        }
+    }
 }
 
 pub(crate) fn filesystem_schema_keys() -> Vec<String> {
@@ -180,7 +187,7 @@ pub(crate) struct RowScope {
 }
 
 impl RowScope {
-    fn context(&self, file_id: Option<String>) -> FilesystemRowContext {
+    pub(crate) fn context(&self, file_id: Option<String>) -> FilesystemRowContext {
         FilesystemRowContext {
             branch_id: self.branch_id.clone(),
             global: self.global,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -228,9 +228,7 @@ fn fast_file_path_conflict_shape(
 fn fast_file_value_expr_supported(expr: &BoundExpr) -> bool {
     matches!(
         expr,
-        BoundExpr::Param(_)
-            | BoundExpr::Literal(BoundLiteral::Text(_))
-            | BoundExpr::Literal(BoundLiteral::Blob(_))
+        BoundExpr::Param(_) | BoundExpr::Literal(BoundLiteral::Text(_) | BoundLiteral::Blob(_))
     )
 }
 

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -8,7 +8,7 @@ use crate::sql2::SqlWriteExecutionContext;
 use crate::sql2::bind::expr::{BoundExpr, BoundLiteral};
 use crate::sql2::bind::write::{
     BoundAssignment, BoundConflictAction, BoundInsertConflict, BoundInsertValues, BoundWriteInput,
-    BoundWriteOp, BoundWriteTarget, EntityWriteSurface,
+    BoundWriteOp, BoundWriteTarget, EntityWriteSurface, FileWriteSurface,
 };
 use crate::sql2::catalog::entity_surface::EntitySurfaceColumn;
 use crate::sql2::catalog::{
@@ -23,22 +23,40 @@ use crate::transaction::types::{
 };
 use crate::{LixError, Value, parse_row_metadata_value};
 
+#[cfg(test)]
 pub(crate) fn supports_bound_public_write(plan: &LogicalWritePlan) -> bool {
-    matches!(plan.bound.target, BoundWriteTarget::Entity(_))
-        && bound_public_write_shape_supported(plan)
+    match &plan.bound.target {
+        BoundWriteTarget::Entity(_) => bound_public_write_shape_supported(plan),
+        BoundWriteTarget::File(surface) => fast_file_path_write_shape(plan, surface).is_some(),
+        _ => false,
+    }
 }
 
-pub(crate) async fn execute_bound_public_write(
+pub(crate) enum BoundPublicWriteExecution {
+    Executed(u64),
+    Unsupported,
+}
+
+pub(crate) async fn try_execute_bound_public_write(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
     params: &[Value],
-) -> Result<u64, LixError> {
+) -> Result<BoundPublicWriteExecution, LixError> {
     match &plan.bound.target {
-        BoundWriteTarget::Entity(surface) => execute_entity_write(ctx, plan, surface, params).await,
-        _ => Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            "bound public write executor does not support this target yet",
-        )),
+        BoundWriteTarget::Entity(surface) if bound_public_write_shape_supported(plan) => {
+            execute_entity_write(ctx, plan, surface, params)
+                .await
+                .map(BoundPublicWriteExecution::Executed)
+        }
+        BoundWriteTarget::File(surface) => {
+            let Some(shape) = fast_file_path_write_shape(plan, surface) else {
+                return Ok(BoundPublicWriteExecution::Unsupported);
+            };
+            execute_file_path_write(ctx, plan, params, shape)
+                .await
+                .map(BoundPublicWriteExecution::Executed)
+        }
+        _ => Ok(BoundPublicWriteExecution::Unsupported),
     }
 }
 
@@ -109,6 +127,161 @@ async fn load_active_branch_commit_id(
                 "active branch",
             )
         })
+}
+
+#[derive(Clone, Copy)]
+struct FastFilePathWriteShape {
+    path_index: usize,
+    data_index: usize,
+    conflict: crate::sql2::providers::FastLixFilePathWriteConflict,
+}
+
+async fn execute_file_path_write(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    plan: &LogicalWritePlan,
+    params: &[Value],
+    shape: FastFilePathWriteShape,
+) -> Result<u64, LixError> {
+    let BoundWriteInput::Values(values) = &plan.bound.input else {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "bound lix_file fast write supports VALUES only",
+        ));
+    };
+    let mut affected = 0u64;
+    for row in &values.rows {
+        let path = eval_fast_file_text(&row[shape.path_index], params, "path")?;
+        let data = eval_fast_file_blob(&row[shape.data_index], params, "data")?;
+        affected += crate::sql2::providers::execute_fast_lix_file_path_write(
+            ctx,
+            path,
+            data,
+            shape.conflict,
+        )
+        .await?;
+    }
+    Ok(affected)
+}
+
+fn fast_file_path_write_shape(
+    plan: &LogicalWritePlan,
+    surface: &FileWriteSurface,
+) -> Option<FastFilePathWriteShape> {
+    if !matches!(surface, FileWriteSurface::Base) || plan.bound.op != BoundWriteOp::Insert {
+        return None;
+    }
+    let BoundWriteInput::Values(values) = &plan.bound.input else {
+        return None;
+    };
+    if values.rows.len() != 1 || values.columns.len() != 2 {
+        return None;
+    }
+    let path_index = values.column_index("path")?;
+    let data_index = values.column_index("data")?;
+    if values.rows.iter().any(|row| {
+        row.len() != values.columns.len()
+            || !fast_file_value_expr_supported(&row[path_index])
+            || !fast_file_value_expr_supported(&row[data_index])
+    }) {
+        return None;
+    }
+    let conflict = match &plan.bound.conflict {
+        None => crate::sql2::providers::FastLixFilePathWriteConflict::None,
+        Some(conflict) => fast_file_path_conflict_shape(conflict)?,
+    };
+    Some(FastFilePathWriteShape {
+        path_index,
+        data_index,
+        conflict,
+    })
+}
+
+fn fast_file_path_conflict_shape(
+    conflict: &BoundInsertConflict,
+) -> Option<crate::sql2::providers::FastLixFilePathWriteConflict> {
+    if conflict.target_columns.len() != 1 || conflict.target_columns[0].name != "path" {
+        return None;
+    }
+    match &conflict.action {
+        BoundConflictAction::DoNothing => {
+            Some(crate::sql2::providers::FastLixFilePathWriteConflict::DoNothing)
+        }
+        BoundConflictAction::DoUpdate { assignments } => {
+            if assignments.len() != 1 {
+                return None;
+            }
+            let assignment = &assignments[0];
+            if assignment.column.name != "data" {
+                return None;
+            }
+            let BoundExpr::ExcludedColumn(column) = &assignment.value else {
+                return None;
+            };
+            if column.name != "data" {
+                return None;
+            }
+            Some(crate::sql2::providers::FastLixFilePathWriteConflict::UpdateData)
+        }
+    }
+}
+
+fn fast_file_value_expr_supported(expr: &BoundExpr) -> bool {
+    matches!(
+        expr,
+        BoundExpr::Param(_)
+            | BoundExpr::Literal(BoundLiteral::Text(_))
+            | BoundExpr::Literal(BoundLiteral::Blob(_))
+    )
+}
+
+fn eval_fast_file_text(
+    expr: &BoundExpr,
+    params: &[Value],
+    column: &str,
+) -> Result<String, LixError> {
+    match expr {
+        BoundExpr::Literal(BoundLiteral::Text(value)) => Ok(value.clone()),
+        BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
+            Some(Value::Text(value)) => Ok(value.clone()),
+            Some(_) => Err(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!("lix_file fast write column '{column}' expects text"),
+            )),
+            None => Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                format!("missing SQL parameter ${}", param.index),
+            )),
+        },
+        _ => Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            format!("lix_file fast write column '{column}' supports params and literals only"),
+        )),
+    }
+}
+
+fn eval_fast_file_blob(
+    expr: &BoundExpr,
+    params: &[Value],
+    column: &str,
+) -> Result<Vec<u8>, LixError> {
+    match expr {
+        BoundExpr::Literal(BoundLiteral::Blob(value)) => Ok(value.clone()),
+        BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
+            Some(Value::Blob(value)) => Ok(value.clone()),
+            Some(_) => Err(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!("lix_file fast write column '{column}' expects blob data"),
+            )),
+            None => Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                format!("missing SQL parameter ${}", param.index),
+            )),
+        },
+        _ => Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            format!("lix_file fast write column '{column}' supports params and blob literals only"),
+        )),
+    }
 }
 
 async fn entity_insert(

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -115,14 +115,16 @@ async fn execute_write_logical_plan_with_mode_inner(
     let write_plan = resolve_parameterized_branch_scope(write_plan.plan, params)?;
     validate_write_parameter_count(&write_plan, params.len())?;
 
-    if mode != WriteExecutorModeInner::ForceDataFusion
-        && super::bound_public_write::supports_bound_public_write(&write_plan)
-    {
-        let rows_affected =
-            super::bound_public_write::execute_bound_public_write(ctx, &write_plan, params)
-                .await
-                .map_err(normalize_bound_public_write_error)?;
-        return Ok((rows_affected, WriteExecutorPath::Fast));
+    if mode != WriteExecutorModeInner::ForceDataFusion {
+        match super::bound_public_write::try_execute_bound_public_write(ctx, &write_plan, params)
+            .await
+            .map_err(normalize_bound_public_write_error)?
+        {
+            super::bound_public_write::BoundPublicWriteExecution::Executed(rows_affected) => {
+                return Ok((rows_affected, WriteExecutorPath::Fast));
+            }
+            super::bound_public_write::BoundPublicWriteExecution::Unsupported => {}
+        }
     }
 
     if mode != WriteExecutorModeInner::ForceDataFusion {

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1273,6 +1273,9 @@ pub(crate) async fn execute_fast_lix_file_path_write(
     let filesystem = FilesystemIndex::from_live_rows(live_rows.clone())?;
 
     if let Some(existing) = filesystem.file_entry(&parsed.path).cloned() {
+        if conflict != FastLixFilePathWriteConflict::None {
+            validate_fast_lix_file_path_conflict_pair(existing.scope.untracked, &parsed.path)?;
+        }
         return match conflict {
             FastLixFilePathWriteConflict::None => {
                 let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
@@ -1352,6 +1355,24 @@ pub(crate) async fn execute_fast_lix_file_path_write(
         }
     };
     stage_lix_file_fast_batch(ctx, mode, staged).await
+}
+
+fn validate_fast_lix_file_path_conflict_pair(
+    existing_untracked: bool,
+    path: &str,
+) -> Result<(), LixError> {
+    let proposed_untracked = false;
+    if existing_untracked == proposed_untracked {
+        return Ok(());
+    }
+    Err(LixError::new(
+        LixError::CODE_CONSTRAINT_VIOLATION,
+        format!(
+            "INSERT ON CONFLICT (path) on lix_file cannot write {} path {path:?} over existing {} file",
+            lane_name(proposed_untracked),
+            lane_name(existing_untracked)
+        ),
+    ))
 }
 
 async fn stage_lix_file_fast_batch(

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1289,7 +1289,13 @@ pub(crate) async fn execute_fast_lix_file_path_write(
                 let plan = plan_parsed_file_path_write_with_resolvers(
                     &mut path_resolvers,
                     parsed.parsed_path,
-                    Some(ctx.functions().call_uuid_v7().to_string()),
+                    Some(
+                        parsed
+                            .plugin_key
+                            .as_deref()
+                            .map(plugin_storage_archive_file_id)
+                            .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string()),
+                    ),
                     Some(data),
                     context,
                     &mut || ctx.functions().call_uuid_v7().to_string(),

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -34,7 +34,7 @@ use crate::binary_cas::{BlobDataReader, BlobHash};
 use crate::branch::BranchRefReader;
 use crate::common::{LixPath, compose_file_path};
 use crate::entity_pk::EntityPk;
-use crate::filesystem::FilesystemIndex;
+use crate::filesystem::{FilesystemIndex, filesystem_schema_keys};
 use crate::functions::FunctionProviderHandle;
 use crate::live_state::{
     LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection, LiveStateReader,
@@ -72,14 +72,16 @@ use crate::filesystem::{
     FileDescriptorRowInput, FileDescriptorWriteInput, FileDescriptorWriteIntent,
     FilesystemBlobRefKey, FilesystemDeletePlan, FilesystemDescriptorKey, FilesystemRowContext,
     blob_ref_row, blob_ref_tombstone_row, derive_directory_paths,
-    directory_path_resolvers_from_live_state, file_descriptor_row, file_descriptor_write_row,
-    filesystem_storage_scope_key, plan_file_delete, plan_file_descriptor_write,
-    plan_parsed_file_path_update_with_resolvers, plan_parsed_file_path_write_with_resolvers,
+    directory_path_resolvers_from_live_state, directory_path_resolvers_from_state_rows,
+    file_descriptor_row, file_descriptor_write_row, filesystem_storage_scope_key, plan_file_delete,
+    plan_file_descriptor_write, plan_parsed_file_path_update_with_resolvers,
+    plan_parsed_file_path_write_with_resolvers,
 };
 use crate::sql2::result_metadata::json_field;
 use crate::sql2::session::SqlWriteSessionOptions;
 use crate::sql2::{
-    SqlWriteContext, WriteAccess, WriteContextBranchRefReader, WriteContextLiveStateReader,
+    SqlWriteContext, SqlWriteExecutionContext, WriteAccess, WriteContextBranchRefReader,
+    WriteContextLiveStateReader,
 };
 use crate::transaction::types::{
     LogicalPrimaryKey, TransactionFileData, TransactionWrite, TransactionWriteMode,
@@ -1238,6 +1240,144 @@ impl LixFileStagedBatch {
         self.state_rows.extend(plan.rows);
         self.count += plan.count;
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FastLixFilePathWriteConflict {
+    None,
+    DoNothing,
+    UpdateData,
+}
+
+pub(crate) async fn execute_fast_lix_file_path_write(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    path: String,
+    data: Vec<u8>,
+    conflict: FastLixFilePathWriteConflict,
+) -> Result<u64, LixError> {
+    let active_branch_id = ctx.active_branch_id().to_string();
+    let parsed = parse_file_upsert_path(&path, TransactionWriteOperation::Insert)
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+
+    let live_rows = ctx
+        .scan_live_state(&LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: filesystem_schema_keys(),
+                branch_ids: vec![active_branch_id.clone()],
+                include_tombstones: false,
+                ..LiveStateFilter::default()
+            },
+            ..LiveStateScanRequest::default()
+        })
+        .await?;
+    let filesystem = FilesystemIndex::from_live_rows(live_rows.clone())?;
+
+    if let Some(existing) = filesystem.file_entry(&parsed.path).cloned() {
+        return match conflict {
+            FastLixFilePathWriteConflict::None => {
+                let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
+                let context = FilesystemRowContext {
+                    branch_id: active_branch_id.clone(),
+                    global: false,
+                    untracked: false,
+                    file_id: None,
+                    metadata: None,
+                };
+                let plan = plan_parsed_file_path_write_with_resolvers(
+                    &mut path_resolvers,
+                    parsed.parsed_path,
+                    Some(ctx.functions().call_uuid_v7().to_string()),
+                    Some(data),
+                    context,
+                    &mut || ctx.functions().call_uuid_v7().to_string(),
+                )?;
+                let mut staged = LixFileStagedBatch::default();
+                staged.extend_filesystem_plan(plan);
+                stage_lix_file_fast_batch(ctx, TransactionWriteMode::Insert, staged).await
+            }
+            FastLixFilePathWriteConflict::DoNothing => Ok(0),
+            FastLixFilePathWriteConflict::UpdateData => {
+                let mut staged = LixFileStagedBatch::default();
+                let mut context = existing.scope.context(Some(existing.id.clone()));
+                if context.global {
+                    context.branch_id = GLOBAL_BRANCH_ID.to_string();
+                }
+                stage_lix_file_data_update_write(
+                    &mut staged,
+                    existing.id.clone(),
+                    Some(parsed.path),
+                    Some(existing.name.clone()),
+                    data,
+                    context,
+                    existing.blob_hash.is_some(),
+                    None,
+                )
+                .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+                staged.count = 1;
+                stage_lix_file_fast_batch(ctx, TransactionWriteMode::Replace, staged).await
+            }
+        };
+    }
+
+    let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
+    let resolver_key = filesystem_storage_scope_key(&active_branch_id, false, false, None);
+    path_resolvers.entry(resolver_key).or_default();
+    let context = FilesystemRowContext {
+        branch_id: active_branch_id,
+        global: false,
+        untracked: false,
+        file_id: None,
+        metadata: None,
+    };
+    let file_id = parsed
+        .plugin_key
+        .as_deref()
+        .map(plugin_storage_archive_file_id)
+        .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string());
+    let mut plan = plan_parsed_file_path_write_with_resolvers(
+        &mut path_resolvers,
+        parsed.parsed_path,
+        Some(file_id.clone()),
+        Some(data),
+        context,
+        &mut || ctx.functions().call_uuid_v7().to_string(),
+    )?;
+    attach_lix_file_insert_origin(&mut plan.rows, "lix_file", &file_id);
+    let mut staged = LixFileStagedBatch::default();
+    staged.extend_filesystem_plan(plan);
+    let mode = match conflict {
+        FastLixFilePathWriteConflict::None => TransactionWriteMode::Insert,
+        FastLixFilePathWriteConflict::DoNothing | FastLixFilePathWriteConflict::UpdateData => {
+            TransactionWriteMode::Replace
+        }
+    };
+    stage_lix_file_fast_batch(ctx, mode, staged).await
+}
+
+async fn stage_lix_file_fast_batch(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    mode: TransactionWriteMode,
+    staged: LixFileStagedBatch,
+) -> Result<u64, LixError> {
+    let count = staged.count;
+    if staged.state_rows.is_empty() && staged.file_data_writes.is_empty() {
+        return Ok(count);
+    }
+    let write = if staged.file_data_writes.is_empty() {
+        TransactionWrite::Rows {
+            mode,
+            rows: staged.state_rows,
+        }
+    } else {
+        TransactionWrite::RowsWithFileData {
+            mode,
+            rows: staged.state_rows,
+            file_data: staged.file_data_writes,
+            count,
+        }
+    };
+    let outcome = ctx.stage_write(write).await?;
+    Ok(outcome.count)
 }
 
 #[cfg(test)]

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -29,6 +29,7 @@ use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
 use datafusion::catalog::TableProvider;
 
+pub(crate) use file::{FastLixFilePathWriteConflict, execute_fast_lix_file_path_write};
 pub(crate) use upsert::{UpsertAction, excluded_field_name};
 
 /// Execute an `INSERT ... ON CONFLICT` against a registered table provider.

--- a/packages/engine/src/sql2/test_support/differential.rs
+++ b/packages/engine/src/sql2/test_support/differential.rs
@@ -79,7 +79,12 @@ mod tests {
         if matches!(case.expected_execution, ExpectedExecution::Err { .. }) {
             assert_independent_no_mutation(case, &reference).await;
         } else if case.expectation == DifferentialExpectation::FastRequiredParity {
-            assert_independent_no_mutation(case, &reference).await;
+            if matches!(
+                reference.execution,
+                ExecutionSignature::Ok { rows_affected: 0 }
+            ) {
+                assert_independent_no_mutation(case, &reference).await;
+            }
             assert_eq!(
                 candidate.executor_path,
                 Some(WriteExecutorPath::Fast),
@@ -333,6 +338,8 @@ mod tests {
                         serde_json::from_str(value).expect("differential JSON param should parse");
                     Value::Json(value)
                 }
+                DifferentialParam::Text(value) => Value::Text((*value).to_string()),
+                DifferentialParam::Blob(value) => Value::Blob((*value).to_vec()),
             })
             .collect()
     }
@@ -518,6 +525,29 @@ mod tests {
                     ),
                     params,
                     branch_column_indexes: &[2],
+                }
+            }
+            DifferentialProbe::LixFileActive { paths } => {
+                let mut params = Vec::with_capacity(paths.len());
+                let placeholders = paths
+                    .iter()
+                    .enumerate()
+                    .map(|(index, path)| {
+                        params.push(Value::Text((*path).to_string()));
+                        format!("${}", index + 1)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ProbeQuery {
+                    name: format!("lix_file:{paths:?}"),
+                    sql: format!(
+                        "SELECT path, data \
+                         FROM lix_file \
+                         WHERE path IN ({placeholders}) \
+                         ORDER BY path"
+                    ),
+                    params,
+                    branch_column_indexes: &[],
                 }
             }
         }

--- a/packages/engine/src/sql2/test_support/generators.rs
+++ b/packages/engine/src/sql2/test_support/generators.rs
@@ -139,12 +139,18 @@ const SETUP_SEED_LIX_FILE_ROW: &[&str] = &[
 ];
 
 #[cfg(test)]
+const SETUP_SEED_UNTRACKED_LIX_FILE_ROW: &[&str] = &[
+    "INSERT INTO lix_file (id, path, data, lixcol_untracked) VALUES ('diff-untracked-file', '/diff/untracked.md', X'6f6c64', true)",
+];
+
+#[cfg(test)]
 const LIX_FILE_PROBE: &[DifferentialProbe] = &[DifferentialProbe::LixFileActive {
     paths: &[
         "/diff/insert.md",
         "/diff/param.md",
         "/diff/upsert-new.md",
         "/diff/existing.md",
+        "/diff/untracked.md",
         "/diff/multi-a.md",
         "/diff/multi-b.md",
     ],
@@ -391,6 +397,30 @@ pub(crate) fn generated_dml_cases() -> Vec<DifferentialSqlCase> {
             probes: LIX_FILE_PROBE,
             expectation: DifferentialExpectation::FastRequiredParity,
             expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/upsert-path-data-rejects-untracked-update".into(),
+            setup_sql: SETUP_SEED_UNTRACKED_LIX_FILE_ROW,
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/untracked.md', X'6e6577') ON CONFLICT (path) DO UPDATE SET data = excluded.data".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Err {
+                code: "LIX_CONSTRAINT_VIOLATION",
+            },
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/upsert-path-data-rejects-untracked-do-nothing".into(),
+            setup_sql: SETUP_SEED_UNTRACKED_LIX_FILE_ROW,
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/untracked.md', X'736b6970') ON CONFLICT (path) DO NOTHING".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Err {
+                code: "LIX_CONSTRAINT_VIOLATION",
+            },
         },
         DifferentialSqlCase {
             seed: "generated/lix-file/multi-row-path-data-falls-back".into(),

--- a/packages/engine/src/sql2/test_support/generators.rs
+++ b/packages/engine/src/sql2/test_support/generators.rs
@@ -38,6 +38,8 @@ pub(crate) enum ExpectedExecution {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DifferentialParam {
     Json(&'static str),
+    Text(&'static str),
+    Blob(&'static [u8]),
 }
 
 #[cfg(test)]
@@ -55,6 +57,9 @@ pub(crate) enum DifferentialProbe {
     RegisteredSchemaActive,
     RegisteredSchemaByBranch {
         branch_ids: &'static [&'static str],
+    },
+    LixFileActive {
+        paths: &'static [&'static str],
     },
 }
 
@@ -121,6 +126,29 @@ const PARAM_ENTITY_PK_AND_METADATA: &[DifferentialParam] = &[
     DifferentialParam::Json("[\"diff-key\"]"),
     DifferentialParam::Json("{\"seen\":\"param\"}"),
 ];
+
+#[cfg(test)]
+const PARAM_FILE_PATH_AND_DATA: &[DifferentialParam] = &[
+    DifferentialParam::Text("/diff/param.md"),
+    DifferentialParam::Blob(b"param data"),
+];
+
+#[cfg(test)]
+const SETUP_SEED_LIX_FILE_ROW: &[&str] = &[
+    "INSERT INTO lix_file (id, path, data) VALUES ('diff-existing-file', '/diff/existing.md', X'6f6c64')",
+];
+
+#[cfg(test)]
+const LIX_FILE_PROBE: &[DifferentialProbe] = &[DifferentialProbe::LixFileActive {
+    paths: &[
+        "/diff/insert.md",
+        "/diff/param.md",
+        "/diff/upsert-new.md",
+        "/diff/existing.md",
+        "/diff/multi-a.md",
+        "/diff/multi-b.md",
+    ],
+}];
 
 #[cfg(test)]
 pub(crate) fn deterministic_repro_cases() -> Vec<DifferentialSqlCase> {
@@ -314,6 +342,66 @@ pub(crate) fn generated_dml_cases() -> Vec<DifferentialSqlCase> {
     }
 
     cases.extend([
+        DifferentialSqlCase {
+            seed: "generated/lix-file/insert-path-data-literal".into(),
+            setup_sql: &[],
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/insert.md', X'696e73657274')".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/insert-path-data-params".into(),
+            setup_sql: &[],
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ($1, $2)".into(),
+            params: PARAM_FILE_PATH_AND_DATA,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/upsert-path-data-insert".into(),
+            setup_sql: &[],
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/upsert-new.md', X'6e6577') ON CONFLICT (path) DO UPDATE SET data = excluded.data".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/upsert-path-data-update".into(),
+            setup_sql: SETUP_SEED_LIX_FILE_ROW,
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/existing.md', X'6e6577') ON CONFLICT (path) DO UPDATE SET data = excluded.data".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/upsert-path-data-do-nothing".into(),
+            setup_sql: SETUP_SEED_LIX_FILE_ROW,
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/existing.md', X'736b6970') ON CONFLICT (path) DO NOTHING".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/multi-row-path-data-falls-back".into(),
+            setup_sql: &[],
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/multi-a.md', X'61'), ('/diff/multi-b.md', X'62')".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::SemanticParityMayFallback,
+            expected_execution: ExpectedExecution::Ok,
+        },
         DifferentialSqlCase {
             seed: "generated/lix-state-by-branch/update-explicit-miss".into(),
             setup_sql: SETUP_SEED_LIX_STATE_ROW,

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -151,6 +151,41 @@ async fn sql_plugin_archive_upsert_installs_and_updates_plugin() {
 }
 
 #[tokio::test]
+async fn sql_plugin_archive_plain_insert_reuses_deterministic_file_id() {
+    let backend = InMemoryBackend::new();
+    Engine::initialize(backend.clone())
+        .await
+        .expect("backend should initialize");
+    let engine = Engine::new(backend).await.expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    let archive = sentinel_plugin_archive();
+    let path = "/.lix/plugins/plugin_sentinel.lixplugin";
+
+    install_plugin(&session, "plugin_sentinel", &archive)
+        .await
+        .expect("plugin archive upsert should install plugin");
+
+    let error = session
+        .execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[Value::Text(path.to_string()), Value::Blob(archive.clone())],
+        )
+        .await
+        .expect_err("plain plugin archive insert should reject duplicate archive id");
+    assert_eq!(error.code, LixError::CODE_UNIQUE);
+    assert!(
+        error
+            .message
+            .contains("lix_plugin_archive::plugin_sentinel")
+    );
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
 async fn sql_plugin_archive_path_must_match_manifest_key() {
     let backend = InMemoryBackend::new();
     Engine::initialize(backend.clone())


### PR DESCRIPTION
## Summary

- Adds a pre-DataFusion fast path for single-row `lix_file(path, data)` inserts and path upserts.
- Reuses filesystem write planning/staging so plugin archive writes and blob bookkeeping stay on existing semantics.
- Narrows the fast path to one `VALUES` row and adds differential tests that prove the intended file writes use `WriteExecutorPath::Fast`.
- Removes stale changelog/docs references to the retired `lix.fs.writeFile` API and adds a patch changenote.

## Validation

- `cargo test -p lix_engine sql2::test_support::differential -- --nocapture`
- `cargo test -p lix_engine lix_file -- --nocapture`
- `cargo test -p lix_engine --test fs_api plugin -- --nocapture`
- `cargo fmt`
- `cargo check -p lix_engine`
- `LIX_NATIVE_PROFILE=debug npm run build:native` from `packages/js-sdk`
- Temp debug bench: 50 MB insert improved from ~17.5s to ~1.6s; upserts from ~17.7-19.0s to ~1.5-1.7s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the SQL write executor and `lix_file` mutation path, but semantics are delegated to existing filesystem staging and are heavily covered by differential and integration tests.
> 
> **Overview**
> Adds a **pre-DataFusion fast path** for single-row `INSERT INTO lix_file (path, data)` (literals or params) and matching **`ON CONFLICT (path)`** upserts (`DO NOTHING` or `DO UPDATE SET data = excluded.data`). Eligible plans run through `try_execute_bound_public_write` and `execute_fast_lix_file_path_write`, which reuse existing filesystem write planning and transaction staging (including plugin archive file IDs and blob bookkeeping). **Multi-row** or richer shapes **fall back** to the prior executors unchanged.
> 
> **Tests and docs:** differential cases assert `WriteExecutorPath::Fast` and `lix_file` probes; plugin archive plain insert still rejects duplicate IDs; changelog/docs drop stale `lix.fs.writeFile` references; CONTRIBUTING adds clippy; patch changenote for large-file write speedups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9014c6a722d7ae6b5e43ba4b3fc52e01044f1f21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->