### PR TITLE
Faster file writes ii

### DIFF
--- a/packages/engine/src/binary_cas/codec.rs
+++ b/packages/engine/src/binary_cas/codec.rs
@@ -61,7 +61,7 @@ impl BinaryCasManifest {
 
 #[cfg(test)]
 pub(crate) fn binary_blob_hash_hex(data: &[u8]) -> String {
-    crate::common::stable_content_fingerprint_hex(data)
+    hash_bytes_to_hex(&binary_blob_hash_bytes(data))
 }
 
 pub(crate) fn binary_blob_hash_bytes(data: &[u8]) -> [u8; HASH_BYTES] {

--- a/packages/engine/src/binary_cas/codec.rs
+++ b/packages/engine/src/binary_cas/codec.rs
@@ -11,13 +11,6 @@ pub(crate) enum BinaryChunkCodec {
     Raw,
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
-pub(crate) struct EncodedBinaryChunkPayload {
-    pub(crate) codec: BinaryChunkCodec,
-    #[musli(bytes)]
-    pub(crate) data: Vec<u8>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub(crate) enum BinaryCasManifest {
     Empty {
@@ -161,13 +154,6 @@ fn hex_value(byte: u8, label: &str) -> Result<u8, LixError> {
 
 fn codec_error(message: String) -> LixError {
     LixError::new("LIX_ERROR_UNKNOWN", message)
-}
-
-pub(crate) fn encode_binary_chunk_payload(chunk_data: &[u8]) -> EncodedBinaryChunkPayload {
-    EncodedBinaryChunkPayload {
-        codec: BinaryChunkCodec::Raw,
-        data: chunk_data.to_vec(),
-    }
 }
 
 #[cfg(test)]

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use crate::LixError;
-use crate::binary_cas::{BlobBytesBatch, BlobHash, BlobWrite, BlobWriteReceipt};
+use crate::binary_cas::{BlobBytesBatch, BlobHash, BlobPayload, BlobWriteReceipt};
 use crate::storage::{StorageRead, StorageWriteSet};
 use std::collections::HashSet;
 
@@ -90,12 +90,27 @@ impl<'a> BinaryCasWriter<'a> {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn stage_bytes(&mut self, bytes: &[u8]) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write(
             self.writes,
             &mut self.blob_hashes,
             &mut self.chunk_keys,
-            &BlobWrite { bytes },
+            bytes,
+            None,
+        )
+    }
+
+    pub(crate) fn stage_payload(
+        &mut self,
+        payload: &BlobPayload,
+    ) -> Result<BlobWriteReceipt, LixError> {
+        crate::binary_cas::kv::stage_blob_write(
+            self.writes,
+            &mut self.blob_hashes,
+            &mut self.chunk_keys,
+            payload.bytes(),
+            payload.hash(),
         )
     }
 }

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -8,8 +8,7 @@ use crate::binary_cas::codec::{
     encode_binary_cas_manifest_chunk, encode_binary_chunk_payload,
 };
 use crate::binary_cas::{
-    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWrite,
-    BlobWriteReceipt,
+    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWriteReceipt,
 };
 use crate::storage::{PointReadPlan, ScanPlan, StorageRead, StorageSpace, StorageWriteSet};
 use crate::storage::{
@@ -504,18 +503,32 @@ fn decode_and_verify_chunk(
     Ok(chunk_payload.to_vec())
 }
 
-pub(crate) fn stage_blob_write(
+pub(in crate::binary_cas) fn stage_blob_write(
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
     chunk_keys: &mut HashSet<Vec<u8>>,
-    write: &BlobWrite<'_>,
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
 ) -> Result<BlobWriteReceipt, LixError> {
-    let blob_hash = BlobHash::from_content(write.bytes);
-    let chunk_ranges = fastcdc_chunk_ranges(write.bytes);
+    let blob_hash = precomputed_hash.unwrap_or_else(|| BlobHash::from_content(bytes));
+    if cfg!(debug_assertions)
+        && precomputed_hash.is_some()
+        && BlobHash::from_content(bytes) != blob_hash
+    {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "binary CAS blob hash does not match blob contents".to_string(),
+        ));
+    }
+    let chunk_ranges = fastcdc_chunk_ranges(bytes);
     let layout = match chunk_ranges.as_slice() {
         [] => BlobLayout::Empty,
         [(start, end)] => BlobLayout::SingleChunk {
-            chunk_hash: BlobHash::from_content(&write.bytes[*start..*end]),
+            chunk_hash: if *start == 0 && *end == bytes.len() {
+                blob_hash
+            } else {
+                BlobHash::from_content(&bytes[*start..*end])
+            },
         },
         _ => BlobLayout::Chunked {
             chunk_count: u32::try_from(chunk_ranges.len()).map_err(|_| {
@@ -528,7 +541,7 @@ pub(crate) fn stage_blob_write(
     };
     let receipt = BlobWriteReceipt {
         hash: blob_hash,
-        size_bytes: write.bytes.len() as u64,
+        size_bytes: bytes.len() as u64,
         layout: layout.clone(),
     };
     if !blob_hashes.insert(blob_hash.into_bytes()) {
@@ -549,18 +562,18 @@ pub(crate) fn stage_blob_write(
                 writes,
                 blob_hash,
                 &BinaryCasManifest::SingleChunk {
-                    size_bytes: write.bytes.len() as u64,
+                    size_bytes: bytes.len() as u64,
                     chunk_hash: chunk_hash.into_bytes(),
                 },
             );
             if chunk_keys.insert(chunk_key(chunk_hash)) {
-                let encoded_chunk = encode_binary_chunk_payload(write.bytes);
+                let encoded_chunk = encode_binary_chunk_payload(bytes);
                 stage_chunk(
                     writes,
                     chunk_hash,
                     &KvChunk {
                         codec: encoded_chunk.codec,
-                        uncompressed_len: write.bytes.len() as u64,
+                        uncompressed_len: bytes.len() as u64,
                         data: encoded_chunk.data,
                     },
                 );
@@ -571,13 +584,13 @@ pub(crate) fn stage_blob_write(
                 writes,
                 blob_hash,
                 &BinaryCasManifest::Chunked {
-                    size_bytes: write.bytes.len() as u64,
+                    size_bytes: bytes.len() as u64,
                     chunk_count: *chunk_count,
                 },
             );
 
             for (chunk_index, (start, end)) in chunk_ranges.into_iter().enumerate() {
-                let chunk_data = &write.bytes[start..end];
+                let chunk_data = &bytes[start..end];
                 let chunk_hash = BlobHash::from_content(chunk_data);
                 let chunk_key = chunk_key(chunk_hash);
                 if chunk_keys.insert(chunk_key.clone()) {
@@ -670,6 +683,7 @@ fn persisted_size_to_usize(size: u64, label: &str) -> Result<usize, LixError> {
 mod tests {
     use super::*;
     use crate::binary_cas::BinaryCasContext;
+    use crate::binary_cas::BlobPayload;
     use crate::storage::StorageContext;
     use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
 
@@ -835,6 +849,47 @@ mod tests {
                 .await
                 .expect("single-chunk blob should not spill manifest chunks"),
             Vec::<KvBlobManifestChunk>::new()
+        );
+    }
+
+    #[tokio::test]
+    async fn public_kv_api_accepts_precomputed_blob_hash() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let data = b"hello precomputed hash";
+        let payload = BlobPayload::from_bytes(data.to_vec());
+        let blob_hash = payload
+            .hash()
+            .expect("non-empty payload should have blob hash");
+
+        {
+            let mut writes = storage.new_write_set();
+            let mut writer = BinaryCasContext::new().writer(&mut writes);
+            writer
+                .stage_payload(&payload)
+                .expect("blob write should stage with payload hash");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("blob write should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        assert_eq!(
+            load_bytes_many(&store, &[blob_hash])
+                .await
+                .expect("blob should load")
+                .into_vec(),
+            vec![Some(data.to_vec())]
+        );
+        assert_eq!(
+            load_manifest(&store, blob_hash)
+                .await
+                .expect("manifest should load"),
+            Some(BinaryCasManifest::SingleChunk {
+                size_bytes: data.len() as u64,
+                chunk_hash: blob_hash.into_bytes(),
+            })
         );
     }
 

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -5,7 +5,7 @@ use crate::binary_cas::chunking::fastcdc_chunk_ranges;
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
     decode_binary_cas_manifest_chunk, encode_binary_cas_chunk, encode_binary_cas_manifest,
-    encode_binary_cas_manifest_chunk, encode_binary_chunk_payload,
+    encode_binary_cas_manifest_chunk,
 };
 use crate::binary_cas::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWriteReceipt,
@@ -36,6 +36,7 @@ pub(crate) struct KvBlobManifestChunk {
     pub(crate) chunk_size: u64,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KvChunk {
     pub(crate) codec: BinaryChunkCodec,
@@ -120,15 +121,17 @@ async fn load_chunk(
     }))
 }
 
-pub(crate) fn stage_chunk(writes: &mut StorageWriteSet, chunk_hash: BlobHash, chunk: &KvChunk) {
+pub(crate) fn stage_chunk(
+    writes: &mut StorageWriteSet,
+    chunk_hash: BlobHash,
+    codec: BinaryChunkCodec,
+    uncompressed_len: u64,
+    payload: &[u8],
+) {
     writes.put(
         BINARY_CAS_CHUNK_SPACE,
         key(chunk_key(chunk_hash)),
-        value(encode_binary_cas_chunk(
-            chunk.codec,
-            chunk.uncompressed_len,
-            &chunk.data,
-        )),
+        value(encode_binary_cas_chunk(codec, uncompressed_len, payload)),
     );
 }
 
@@ -567,15 +570,12 @@ pub(in crate::binary_cas) fn stage_blob_write(
                 },
             );
             if chunk_keys.insert(chunk_key(chunk_hash)) {
-                let encoded_chunk = encode_binary_chunk_payload(bytes);
                 stage_chunk(
                     writes,
                     chunk_hash,
-                    &KvChunk {
-                        codec: encoded_chunk.codec,
-                        uncompressed_len: bytes.len() as u64,
-                        data: encoded_chunk.data,
-                    },
+                    BinaryChunkCodec::Raw,
+                    bytes.len() as u64,
+                    bytes,
                 );
             }
         }
@@ -594,15 +594,12 @@ pub(in crate::binary_cas) fn stage_blob_write(
                 let chunk_hash = BlobHash::from_content(chunk_data);
                 let chunk_key = chunk_key(chunk_hash);
                 if chunk_keys.insert(chunk_key.clone()) {
-                    let encoded_chunk = encode_binary_chunk_payload(chunk_data);
                     stage_chunk(
                         writes,
                         chunk_hash,
-                        &KvChunk {
-                            codec: encoded_chunk.codec,
-                            uncompressed_len: chunk_data.len() as u64,
-                            data: encoded_chunk.data,
-                        },
+                        BinaryChunkCodec::Raw,
+                        chunk_data.len() as u64,
+                        chunk_data,
                     );
                 }
 
@@ -771,7 +768,13 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            stage_chunk(&mut writes, chunk_hash, &chunk);
+            stage_chunk(
+                &mut writes,
+                chunk_hash,
+                chunk.codec,
+                chunk.uncompressed_len,
+                &chunk.data,
+            );
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .expect("chunk should commit");
@@ -969,11 +972,9 @@ mod tests {
             stage_chunk(
                 &mut writes,
                 substituted_chunk_hash,
-                &KvChunk {
-                    codec: BinaryChunkCodec::Raw,
-                    uncompressed_len: substituted.len() as u64,
-                    data: substituted.to_vec(),
-                },
+                BinaryChunkCodec::Raw,
+                substituted.len() as u64,
+                substituted,
             );
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -6,6 +6,6 @@ mod types;
 
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use types::{
-    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWrite,
+    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,
     BlobWriteReceipt,
 };

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -32,6 +32,35 @@ impl BlobHash {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BlobPayload {
+    bytes: Vec<u8>,
+    hash: Option<BlobHash>,
+}
+
+impl BlobPayload {
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
+        let hash = (!bytes.is_empty()).then(|| BlobHash::from_content(&bytes));
+        Self { bytes, hash }
+    }
+
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub(crate) fn hash(&self) -> Option<BlobHash> {
+        self.hash
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BlobLayout {
     Empty,
     SingleChunk { chunk_hash: BlobHash },
@@ -73,11 +102,6 @@ impl BlobBytesBatch {
     pub(crate) fn into_vec(self) -> Vec<Option<Vec<u8>>> {
         self.entries
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct BlobWrite<'a> {
-    pub(crate) bytes: &'a [u8],
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/engine/src/common/fingerprint.rs
+++ b/packages/engine/src/common/fingerprint.rs
@@ -1,3 +1,0 @@
-pub(crate) fn stable_content_fingerprint_hex(data: &[u8]) -> String {
-    blake3::hash(data).to_hex().to_string()
-}

--- a/packages/engine/src/common/mod.rs
+++ b/packages/engine/src/common/mod.rs
@@ -1,5 +1,4 @@
 pub(crate) mod error;
-pub(crate) mod fingerprint;
 pub(crate) mod identity;
 pub(crate) mod json_pointer;
 pub(crate) mod lix_path;
@@ -9,7 +8,6 @@ pub(crate) mod types;
 pub(crate) mod wire;
 
 pub use error::LixError;
-pub(crate) use fingerprint::stable_content_fingerprint_hex;
 pub use identity::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
 pub(crate) use identity::{json_pointer_get, validate_non_empty_identity_value};
 pub(crate) use json_pointer::{format_json_pointer, parse_json_pointer, top_level_property_name};

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -8,7 +8,8 @@ use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
-use crate::common::{LixPath, compose_file_path, stable_content_fingerprint_hex};
+use crate::binary_cas::BlobHash;
+use crate::common::{LixPath, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::live_state::{
     LiveStateFilter, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
@@ -192,7 +193,8 @@ pub(crate) struct FileDescriptorWriteIntent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobRefRowInput {
     pub(crate) file_id: String,
-    pub(crate) data: Vec<u8>,
+    pub(crate) blob_hash: BlobHash,
+    pub(crate) size_bytes: usize,
     pub(crate) context: FilesystemRowContext,
 }
 
@@ -805,7 +807,7 @@ pub(crate) fn file_descriptor_write_row(input: FileDescriptorWriteIntent) -> Tra
 }
 
 pub(crate) fn blob_ref_row(input: BlobRefRowInput) -> Result<TransactionWriteRow, LixError> {
-    let size_bytes = u64::try_from(input.data.len()).map_err(|_| {
+    let size_bytes = u64::try_from(input.size_bytes).map_err(|_| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!(
@@ -816,7 +818,7 @@ pub(crate) fn blob_ref_row(input: BlobRefRowInput) -> Result<TransactionWriteRow
     })?;
     let snapshot = json!({
         "id": input.file_id,
-        "blob_hash": stable_content_fingerprint_hex(&input.data),
+        "blob_hash": input.blob_hash.to_hex(),
         "size_bytes": size_bytes,
     });
 
@@ -912,10 +914,22 @@ fn plan_parsed_file_path_write_with_fallback(
 
     let mut file_data = Vec::new();
     if let Some(data) = data {
-        if !data.is_empty() {
+        let file_payload = TransactionFileData::new(
+            file_id.clone(),
+            Some(file_path),
+            Some(filename),
+            context.branch_id.clone(),
+            context.global,
+            context.untracked,
+            data,
+        );
+        if !file_payload.is_empty() {
             rows.push(blob_ref_row(BlobRefRowInput {
                 file_id: file_id.clone(),
-                data: data.clone(),
+                blob_hash: file_payload
+                    .blob_hash()
+                    .expect("non-empty payload should have blob hash"),
+                size_bytes: file_payload.len(),
                 context: FilesystemRowContext {
                     file_id: None,
                     metadata: None,
@@ -923,15 +937,7 @@ fn plan_parsed_file_path_write_with_fallback(
                 },
             })?);
         }
-        file_data.push(TransactionFileData {
-            file_id,
-            path: Some(file_path),
-            filename: Some(filename),
-            branch_id: context.branch_id,
-            global: context.global,
-            untracked: context.untracked,
-            data,
-        });
+        file_data.push(file_payload);
     }
 
     Ok(FilesystemWritePlan {
@@ -963,10 +969,22 @@ pub(crate) fn plan_file_descriptor_write(
 
     let mut file_data = Vec::new();
     if let Some(data) = input.data {
-        if !data.is_empty() {
+        let file_payload = TransactionFileData::new(
+            file_id.clone(),
+            Some(file_path),
+            Some(filename),
+            input.context.branch_id.clone(),
+            input.context.global,
+            input.context.untracked,
+            data,
+        );
+        if !file_payload.is_empty() {
             rows.push(blob_ref_row(BlobRefRowInput {
                 file_id: file_id.clone(),
-                data: data.clone(),
+                blob_hash: file_payload
+                    .blob_hash()
+                    .expect("non-empty payload should have blob hash"),
+                size_bytes: file_payload.len(),
                 context: FilesystemRowContext {
                     file_id: None,
                     metadata: None,
@@ -974,15 +992,7 @@ pub(crate) fn plan_file_descriptor_write(
                 },
             })?);
         }
-        file_data.push(TransactionFileData {
-            file_id,
-            path: Some(file_path),
-            filename: Some(filename),
-            branch_id: input.context.branch_id,
-            global: input.context.global,
-            untracked: input.context.untracked,
-            data,
-        });
+        file_data.push(file_payload);
     }
 
     Ok(FilesystemWritePlan {
@@ -1449,6 +1459,7 @@ mod tests {
     use serde_json::{Value as JsonValue, json};
 
     use crate::GLOBAL_BRANCH_ID;
+    use crate::binary_cas::BlobHash;
     use crate::changelog::{ChangeId, CommitId};
     use crate::filesystem::{FilesystemBlobRefKey, FilesystemDescriptorKey};
     use crate::transaction::types::TransactionJson;
@@ -1587,7 +1598,8 @@ mod tests {
     fn blob_ref_row_builds_state_row() {
         let row = blob_ref_row(BlobRefRowInput {
             file_id: "file-readme".to_string(),
-            data: b"Hello".to_vec(),
+            blob_hash: BlobHash::from_content(b"Hello"),
+            size_bytes: 5,
             context: FilesystemRowContext::active_branch("branch-a"),
         })
         .expect("blob ref row should build");
@@ -1601,10 +1613,9 @@ mod tests {
         let snapshot: JsonValue = row.snapshot.as_ref().unwrap().value().clone();
         assert_eq!(snapshot["id"], "file-readme");
         assert_eq!(snapshot["size_bytes"], 5);
-        assert!(
-            snapshot["blob_hash"]
-                .as_str()
-                .is_some_and(|hash| !hash.is_empty())
+        assert_eq!(
+            snapshot["blob_hash"].as_str(),
+            Some(BlobHash::from_content(b"Hello").to_hex().as_str())
         );
     }
 
@@ -1787,7 +1798,7 @@ mod tests {
         assert_eq!(plan.file_data.len(), 1);
         assert_eq!(plan.file_data[0].file_id, "file-readme");
         assert_eq!(plan.file_data[0].branch_id, "branch-a");
-        assert_eq!(plan.file_data[0].data, b"hello");
+        assert_eq!(plan.file_data[0].data(), b"hello");
         assert_eq!(plan.rows.len(), 4);
         assert_eq!(
             plan.rows
@@ -1871,7 +1882,7 @@ mod tests {
         assert_eq!(plan.file_data.len(), 1);
         assert_eq!(plan.file_data[0].file_id, "file-readme");
         assert_eq!(plan.file_data[0].path.as_deref(), Some("/docs/readme.md"));
-        assert_eq!(plan.file_data[0].data, b"hello");
+        assert_eq!(plan.file_data[0].data(), b"hello");
         assert_eq!(plan.rows.len(), 2);
         let file_row = plan
             .rows
@@ -2150,7 +2161,7 @@ mod tests {
         assert_eq!(plan.file_data[0].file_id, "file-readme");
         assert_eq!(plan.file_data[0].branch_id, "branch-a");
         assert_eq!(plan.file_data[0].untracked, true);
-        assert_eq!(plan.file_data[0].data, b"hello");
+        assert_eq!(plan.file_data[0].data(), b"hello");
     }
 
     #[test]
@@ -2170,7 +2181,7 @@ mod tests {
         assert_eq!(plan.count, 1);
         assert_eq!(plan.file_data.len(), 1);
         assert_eq!(plan.file_data[0].file_id, "file-empty");
-        assert!(plan.file_data[0].data.is_empty());
+        assert!(plan.file_data[0].is_empty());
         assert!(
             plan.rows
                 .iter()

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -925,7 +925,7 @@ fn plan_parsed_file_path_write_with_fallback(
         );
         if !file_payload.is_empty() {
             rows.push(blob_ref_row(BlobRefRowInput {
-                file_id: file_id.clone(),
+                file_id,
                 blob_hash: file_payload
                     .blob_hash()
                     .expect("non-empty payload should have blob hash"),
@@ -933,7 +933,7 @@ fn plan_parsed_file_path_write_with_fallback(
                 context: FilesystemRowContext {
                     file_id: None,
                     metadata: None,
-                    ..context.clone()
+                    ..context
                 },
             })?);
         }
@@ -980,7 +980,7 @@ pub(crate) fn plan_file_descriptor_write(
         );
         if !file_payload.is_empty() {
             rows.push(blob_ref_row(BlobRefRowInput {
-                file_id: file_id.clone(),
+                file_id,
                 blob_hash: file_payload
                     .blob_hash()
                     .expect("non-empty payload should have blob hash"),

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1978,7 +1978,7 @@ mod tests {
             snapshot_content: Some(
                 json!({
                     "id": entity_pk,
-                    "blob_hash": crate::common::stable_content_fingerprint_hex(bytes),
+                    "blob_hash": crate::binary_cas::BlobHash::from_content(bytes).to_hex(),
                     "size_bytes": bytes.len()
                 })
                 .to_string(),

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -2019,16 +2019,19 @@ fn stage_lix_file_data_insert_write(
     context: FilesystemRowContext,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
-    if !data.is_empty() {
-        stage_lix_file_data_blob_ref_write(
-            staged,
-            file_id.clone(),
-            data.clone(),
-            &context,
-            origin,
-        )?;
+    let file_payload = TransactionFileData::new(
+        file_id.clone(),
+        path,
+        filename,
+        context.branch_id.clone(),
+        context.global,
+        context.untracked,
+        data,
+    );
+    if !file_payload.is_empty() {
+        stage_lix_file_data_blob_ref_write(staged, &file_payload, &context, origin)?;
     }
-    stage_lix_file_data_payload_write(staged, file_id, path, filename, data, context);
+    staged.file_data_writes.push(file_payload);
     Ok(())
 }
 
@@ -2042,30 +2045,41 @@ fn stage_lix_file_data_update_write(
     has_blob_ref: bool,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
-    if data.is_empty() {
+    let file_payload = TransactionFileData::new(
+        file_id.clone(),
+        path,
+        filename,
+        context.branch_id.clone(),
+        context.global,
+        context.untracked,
+        data,
+    );
+    if file_payload.is_empty() {
         if has_blob_ref {
             let mut row = blob_ref_tombstone_row(file_id.clone(), context.clone());
             row.origin = origin;
             staged.state_rows.push(row);
         }
-        stage_lix_file_data_payload_write(staged, file_id, path, filename, data, context);
+        staged.file_data_writes.push(file_payload);
         return Ok(());
     }
-    stage_lix_file_data_blob_ref_write(staged, file_id.clone(), data.clone(), &context, origin)?;
-    stage_lix_file_data_payload_write(staged, file_id, path, filename, data, context);
+    stage_lix_file_data_blob_ref_write(staged, &file_payload, &context, origin)?;
+    staged.file_data_writes.push(file_payload);
     Ok(())
 }
 
 fn stage_lix_file_data_blob_ref_write(
     staged: &mut LixFileStagedBatch,
-    file_id: String,
-    data: Vec<u8>,
+    file_data: &TransactionFileData,
     context: &FilesystemRowContext,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
     let mut row = blob_ref_row(BlobRefRowInput {
-        file_id,
-        data,
+        file_id: file_data.file_id.clone(),
+        blob_hash: file_data
+            .blob_hash()
+            .expect("non-empty payload should have blob hash"),
+        size_bytes: file_data.len(),
         context: FilesystemRowContext {
             file_id: None,
             metadata: None,
@@ -2076,25 +2090,6 @@ fn stage_lix_file_data_blob_ref_write(
     row.origin = origin;
     staged.state_rows.push(row);
     Ok(())
-}
-
-fn stage_lix_file_data_payload_write(
-    staged: &mut LixFileStagedBatch,
-    file_id: String,
-    path: Option<String>,
-    filename: Option<String>,
-    data: Vec<u8>,
-    context: FilesystemRowContext,
-) {
-    staged.file_data_writes.push(TransactionFileData {
-        file_id,
-        path,
-        filename,
-        branch_id: context.branch_id,
-        global: context.global,
-        untracked: context.untracked,
-        data,
-    });
 }
 
 fn attach_lix_file_insert_origin(
@@ -4352,7 +4347,7 @@ mod tests {
         assert_eq!(staged.count, 1);
         assert_eq!(staged.file_data_writes.len(), 1);
         assert_eq!(staged.file_data_writes[0].file_id, "file-readme");
-        assert_eq!(staged.file_data_writes[0].data, b"hello");
+        assert_eq!(staged.file_data_writes[0].data(), b"hello");
         assert!(
             staged
                 .state_rows
@@ -4399,7 +4394,25 @@ mod tests {
             staged.file_data_writes[0].path.as_deref(),
             Some("/docs/readme.md")
         );
-        assert_eq!(staged.file_data_writes[0].data, b"hello");
+        assert_eq!(staged.file_data_writes[0].data(), b"hello");
+        let blob_ref_row = staged
+            .state_rows
+            .iter()
+            .find(|row| row.schema_key == "lix_binary_blob_ref")
+            .expect("data update should stage blob ref row");
+        let snapshot: serde_json::Value = blob_ref_row
+            .snapshot
+            .as_ref()
+            .expect("blob ref should carry snapshot")
+            .value()
+            .clone();
+        assert_eq!(
+            snapshot["blob_hash"].as_str(),
+            staged.file_data_writes[0]
+                .blob_hash()
+                .map(BlobHash::to_hex)
+                .as_deref()
+        );
     }
 
     #[test]
@@ -4474,7 +4487,20 @@ mod tests {
         assert_eq!(staged.file_data_writes.len(), 1);
         assert_eq!(staged.file_data_writes[0].file_id, "file-readme");
         assert_eq!(staged.file_data_writes[0].branch_id, "branch-b");
-        assert_eq!(staged.file_data_writes[0].data, b"hello");
+        assert_eq!(staged.file_data_writes[0].data(), b"hello");
+        let snapshot: serde_json::Value = blob_ref_row
+            .snapshot
+            .as_ref()
+            .expect("blob ref should carry snapshot")
+            .value()
+            .clone();
+        assert_eq!(
+            snapshot["blob_hash"].as_str(),
+            staged.file_data_writes[0]
+                .blob_hash()
+                .map(BlobHash::to_hex)
+                .as_deref()
+        );
     }
 
     #[test]
@@ -4693,7 +4719,7 @@ mod tests {
                 assert_eq!(file_data.len(), 1);
                 assert_eq!(file_data[0].file_id, "file-readme");
                 assert_eq!(file_data[0].path.as_deref(), Some("/docs/readme.md"));
-                assert_eq!(file_data[0].data, b"hello");
+                assert_eq!(file_data[0].data(), b"hello");
             }
             other => panic!("expected insert with file data staged write, got {other:?}"),
         }

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -2020,7 +2020,7 @@ fn stage_lix_file_data_insert_write(
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
     let file_payload = TransactionFileData::new(
-        file_id.clone(),
+        file_id,
         path,
         filename,
         context.branch_id.clone(),
@@ -2056,7 +2056,7 @@ fn stage_lix_file_data_update_write(
     );
     if file_payload.is_empty() {
         if has_blob_ref {
-            let mut row = blob_ref_tombstone_row(file_id.clone(), context.clone());
+            let mut row = blob_ref_tombstone_row(file_id, context.clone());
             row.origin = origin;
             staged.state_rows.push(row);
         }

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -47,7 +47,7 @@ pub(crate) async fn commit_prepared_writes(
     if !prepared_writes.file_data_writes.is_empty() {
         let mut blob_writer = binary_cas.writer(&mut writes);
         for write in &prepared_writes.file_data_writes {
-            blob_writer.stage_bytes(&write.data)?;
+            blob_writer.stage_payload(write.payload())?;
         }
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -461,8 +461,7 @@ where
                 let file_data = file_data
                     .into_iter()
                     .filter(|write| {
-                        !file_keys.contains(&PluginFileWriteKey::from(write))
-                            && !write.data.is_empty()
+                        !file_keys.contains(&PluginFileWriteKey::from(write)) && !write.is_empty()
                     })
                     .collect();
                 Ok(TransactionWrite::RowsWithFileData {
@@ -536,7 +535,7 @@ where
                 &active_state,
                 WasmPluginFile {
                     filename,
-                    data: write.data.clone(),
+                    data: write.data().to_vec(),
                 },
             )
             .await?;
@@ -1363,7 +1362,7 @@ fn plugin_archive_schema_rows_for_write(
     }
     Ok(Some(plugin_schema_rows_from_archive_path(
         path,
-        &write.data,
+        write.data(),
         &write.branch_id,
         write.global,
         write.untracked,

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -424,9 +424,12 @@ impl TransactionWriteBuffer {
         })?;
         let mut bytes_by_hash = BTreeMap::<BlobHash, Vec<u8>>::new();
         for write in file_data_guard.iter() {
+            let hash = write
+                .blob_hash()
+                .unwrap_or_else(|| BlobHash::from_content(write.data()));
             bytes_by_hash
-                .entry(BlobHash::from_content(&write.data))
-                .or_insert_with(|| write.data.clone());
+                .entry(hash)
+                .or_insert_with(|| write.data().to_vec());
         }
         Ok(BlobBytesBatch::new(
             hashes
@@ -1137,15 +1140,15 @@ mod tests {
             .stage_write(PreparedTransactionWrite::RowsWithFileData {
                 mode: TransactionWriteMode::Replace,
                 rows: vec![state_row("file-readme", "descriptor")],
-                file_data: vec![TransactionFileData {
-                    file_id: "file-readme".to_string(),
-                    path: Some("/readme.md".to_string()),
-                    filename: Some("readme.md".to_string()),
-                    branch_id: "global".to_string(),
-                    global: true,
-                    untracked: true,
-                    data: b"hello".to_vec(),
-                }],
+                file_data: vec![TransactionFileData::new(
+                    "file-readme".to_string(),
+                    Some("/readme.md".to_string()),
+                    Some("readme.md".to_string()),
+                    "global".to_string(),
+                    true,
+                    true,
+                    b"hello".to_vec(),
+                )],
                 count: 1,
             })
             .expect("staging rows with file data should succeed");
@@ -1155,7 +1158,7 @@ mod tests {
         assert_eq!(drained.state_rows.len(), 1);
         assert_eq!(drained.file_data_writes.len(), 1);
         assert_eq!(drained.file_data_writes[0].file_id, "file-readme");
-        assert_eq!(drained.file_data_writes[0].data, b"hello");
+        assert_eq!(drained.file_data_writes[0].data(), b"hello");
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeSet, fmt, ops::Deref, sync::Arc};
 
 use crate::LixError;
+use crate::binary_cas::{BlobHash, BlobPayload};
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::LixTimestamp;
@@ -181,7 +182,49 @@ pub(crate) struct TransactionFileData {
     pub(crate) branch_id: String,
     pub(crate) global: bool,
     pub(crate) untracked: bool,
-    pub(crate) data: Vec<u8>,
+    payload: BlobPayload,
+}
+
+impl TransactionFileData {
+    pub(crate) fn new(
+        file_id: String,
+        path: Option<String>,
+        filename: Option<String>,
+        branch_id: String,
+        global: bool,
+        untracked: bool,
+        data: Vec<u8>,
+    ) -> Self {
+        Self {
+            file_id,
+            path,
+            filename,
+            branch_id,
+            global,
+            untracked,
+            payload: BlobPayload::from_bytes(data),
+        }
+    }
+
+    pub(crate) fn data(&self) -> &[u8] {
+        self.payload.bytes()
+    }
+
+    pub(crate) fn blob_hash(&self) -> Option<BlobHash> {
+        self.payload.hash()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.payload.len()
+    }
+
+    pub(crate) fn payload(&self) -> &BlobPayload {
+        &self.payload
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.payload.is_empty()
+    }
 }
 
 /// One decoded write batch accepted by the transaction boundary.

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -63,6 +63,11 @@ path = "benches/profile_merge_10k.rs"
 harness = false
 required-features = ["sqlite"]
 
+[[example]]
+name = "profile_fs_open"
+path = "examples/profile_fs_open.rs"
+required-features = ["sqlite"]
+
 [[bench]]
 name = "sqlite_backend"
 path = "benches/sqlite_backend.rs"

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -59,7 +59,8 @@ fn main() {
             let initial_csv = csv_bytes_from_rows(&initial_rows);
             let start = Instant::now();
             write_file(&lix, CSV_PATH, initial_csv).await;
-            eprintln!("setup insert took {:?}", start.elapsed());
+            let elapsed = start.elapsed();
+            eprintln!("setup insert took {elapsed:?}");
             lix.close().await.unwrap();
         }),
         "merge" => runtime.block_on(async {
@@ -85,7 +86,8 @@ fn main() {
 
             let start = Instant::now();
             profile_merge_phase(&lix, updated_csv).await;
-            eprintln!("merge took {:?}", start.elapsed());
+            let elapsed = start.elapsed();
+            eprintln!("merge took {elapsed:?}");
             lix.close().await.unwrap();
         }),
         other => {

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -1,0 +1,77 @@
+// Cold-open profiling harness for the filesystem backend.
+//
+// Usage:
+//   cargo run --release --example profile_fs_open --features sqlite -- <src_dir>
+//
+// Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
+// FsBackend::open on the cold workspace.
+
+use std::path::Path;
+use std::time::Instant;
+
+use lix_sdk::FsBackend;
+
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        if name == ".lix" {
+            continue;
+        }
+        let from = entry.path();
+        let to = dst.join(&name);
+        if from.is_dir() {
+            copy_dir(&from, &to);
+        } else {
+            std::fs::copy(&from, &to).unwrap();
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let src = std::env::args()
+        .nth(1)
+        .expect("usage: profile_fs_open <src_dir>");
+    let src = Path::new(&src);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("workspace");
+
+    let t_copy = Instant::now();
+    copy_dir(src, &work);
+    eprintln!("copy: {:?}", t_copy.elapsed());
+
+    let repeat: usize = std::env::var("REPEAT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+
+    let t_open = Instant::now();
+    let backend = FsBackend::open(&work).await.unwrap();
+    let open_elapsed = t_open.elapsed();
+    eprintln!("cold open: {:?}", open_elapsed);
+    drop(backend);
+
+    // Warm reopen (now .lix exists).
+    let t_warm = Instant::now();
+    let backend = FsBackend::open(&work).await.unwrap();
+    eprintln!("warm reopen: {:?}", t_warm.elapsed());
+    drop(backend);
+
+    // Repeated cold opens into fresh temp dirs for profiling sample density.
+    for i in 0..repeat {
+        let tmp_i = tempfile::tempdir().unwrap();
+        let work_i = tmp_i.path().join("workspace");
+        copy_dir(src, &work_i);
+        let t = Instant::now();
+        let backend = FsBackend::open(&work_i).await.unwrap();
+        if i == repeat - 1 {
+            eprintln!("cold open (repeat {}): {:?}", repeat, t.elapsed());
+        }
+        drop(backend);
+    }
+
+    println!("COLD_OPEN_MS={}", open_elapsed.as_millis());
+}

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -41,7 +41,8 @@ async fn main() {
 
     let t_copy = Instant::now();
     copy_dir(src, &work);
-    eprintln!("copy: {:?}", t_copy.elapsed());
+    let copy_elapsed = t_copy.elapsed();
+    eprintln!("copy: {copy_elapsed:?}");
 
     let repeat: usize = std::env::var("REPEAT")
         .ok()
@@ -51,13 +52,14 @@ async fn main() {
     let t_open = Instant::now();
     let backend = FsBackend::open(&work).await.unwrap();
     let open_elapsed = t_open.elapsed();
-    eprintln!("cold open: {:?}", open_elapsed);
+    eprintln!("cold open: {open_elapsed:?}");
     drop(backend);
 
     // Warm reopen (now .lix exists).
     let t_warm = Instant::now();
     let backend = FsBackend::open(&work).await.unwrap();
-    eprintln!("warm reopen: {:?}", t_warm.elapsed());
+    let warm_elapsed = t_warm.elapsed();
+    eprintln!("warm reopen: {warm_elapsed:?}");
     drop(backend);
 
     // Repeated cold opens into fresh temp dirs for profiling sample density.
@@ -68,7 +70,8 @@ async fn main() {
         let t = Instant::now();
         let backend = FsBackend::open(&work_i).await.unwrap();
         if i == repeat - 1 {
-            eprintln!("cold open (repeat {}): {:?}", repeat, t.elapsed());
+            let elapsed = t.elapsed();
+            eprintln!("cold open (repeat {repeat}): {elapsed:?}");
         }
         drop(backend);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the file-write and binary CAS commit path where blob identity must stay consistent; mitigated by debug hash verification and broad test updates, but incorrect hash reuse would corrupt content addressing.
> 
> **Overview**
> Speeds up file writes by **hashing file bytes once** and carrying that identity through planning, blob-ref snapshots, and binary CAS staging instead of recomputing BLAKE3 at each layer.
> 
> Introduces **`BlobPayload`** (bytes + optional cached **`BlobHash`**) and wraps **`TransactionFileData`** around it. Filesystem planners and SQL file providers build blob-ref rows from the payload’s hash/size; commit calls **`BinaryCasWriter::stage_payload`**, which passes a **precomputed hash** into **`stage_blob_write`** (with debug checks that hash matches content). For a **single-chunk blob that spans the full payload**, the chunk hash is set to the blob hash to skip an extra content hash on that path.
> 
> Binary CAS staging is simplified: **`BlobWrite`** and **`encode_binary_chunk_payload`** are removed; **`stage_chunk`** takes raw codec/len/payload. **`stable_content_fingerprint_hex`** is dropped in favor of **`BlobHash`** at call sites.
> 
> Also adds an **`profile_fs_open`** example and small timing/logging tweaks in merge benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0aac8e5382c6e3ae7316a0ac4fa3cc87186bafd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->