### PR TITLE
[codex] Optimize filesystem folder open path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,7 @@ dependencies = [
  "lix_engine",
  "notify-debouncer-full",
  "rusqlite",
+ "serde_json",
  "tempfile",
  "tokio",
  "wasmtime",

--- a/packages/engine/src/binary_cas/codec.rs
+++ b/packages/engine/src/binary_cas/codec.rs
@@ -61,7 +61,7 @@ impl BinaryCasManifest {
 
 #[cfg(test)]
 pub(crate) fn binary_blob_hash_hex(data: &[u8]) -> String {
-    crate::common::stable_content_fingerprint_hex(data)
+    hash_bytes_to_hex(&binary_blob_hash_bytes(data))
 }
 
 pub(crate) fn binary_blob_hash_bytes(data: &[u8]) -> [u8; HASH_BYTES] {

--- a/packages/engine/src/binary_cas/codec.rs
+++ b/packages/engine/src/binary_cas/codec.rs
@@ -11,13 +11,6 @@ pub(crate) enum BinaryChunkCodec {
     Raw,
 }
 
-#[derive(Debug, Clone, Encode, Decode)]
-pub(crate) struct EncodedBinaryChunkPayload {
-    pub(crate) codec: BinaryChunkCodec,
-    #[musli(bytes)]
-    pub(crate) data: Vec<u8>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub(crate) enum BinaryCasManifest {
     Empty {
@@ -161,13 +154,6 @@ fn hex_value(byte: u8, label: &str) -> Result<u8, LixError> {
 
 fn codec_error(message: String) -> LixError {
     LixError::new("LIX_ERROR_UNKNOWN", message)
-}
-
-pub(crate) fn encode_binary_chunk_payload(chunk_data: &[u8]) -> EncodedBinaryChunkPayload {
-    EncodedBinaryChunkPayload {
-        codec: BinaryChunkCodec::Raw,
-        data: chunk_data.to_vec(),
-    }
 }
 
 #[cfg(test)]

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use crate::LixError;
-use crate::binary_cas::{BlobBytesBatch, BlobHash, BlobWrite, BlobWriteReceipt};
+use crate::binary_cas::{BlobBytesBatch, BlobHash, BlobPayload, BlobWriteReceipt};
 use crate::storage::{StorageRead, StorageWriteSet};
 use std::collections::HashSet;
 
@@ -90,12 +90,27 @@ impl<'a> BinaryCasWriter<'a> {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn stage_bytes(&mut self, bytes: &[u8]) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write(
             self.writes,
             &mut self.blob_hashes,
             &mut self.chunk_keys,
-            &BlobWrite { bytes },
+            bytes,
+            None,
+        )
+    }
+
+    pub(crate) fn stage_payload(
+        &mut self,
+        payload: &BlobPayload,
+    ) -> Result<BlobWriteReceipt, LixError> {
+        crate::binary_cas::kv::stage_blob_write(
+            self.writes,
+            &mut self.blob_hashes,
+            &mut self.chunk_keys,
+            payload.bytes(),
+            payload.hash(),
         )
     }
 }

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -8,8 +8,7 @@ use crate::binary_cas::codec::{
     encode_binary_cas_manifest_chunk, encode_binary_chunk_payload,
 };
 use crate::binary_cas::{
-    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWrite,
-    BlobWriteReceipt,
+    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWriteReceipt,
 };
 use crate::storage::{PointReadPlan, ScanPlan, StorageRead, StorageSpace, StorageWriteSet};
 use crate::storage::{
@@ -504,18 +503,32 @@ fn decode_and_verify_chunk(
     Ok(chunk_payload.to_vec())
 }
 
-pub(crate) fn stage_blob_write(
+pub(in crate::binary_cas) fn stage_blob_write(
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
     chunk_keys: &mut HashSet<Vec<u8>>,
-    write: &BlobWrite<'_>,
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
 ) -> Result<BlobWriteReceipt, LixError> {
-    let blob_hash = BlobHash::from_content(write.bytes);
-    let chunk_ranges = fastcdc_chunk_ranges(write.bytes);
+    let blob_hash = precomputed_hash.unwrap_or_else(|| BlobHash::from_content(bytes));
+    if cfg!(debug_assertions)
+        && precomputed_hash.is_some()
+        && BlobHash::from_content(bytes) != blob_hash
+    {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "binary CAS blob hash does not match blob contents".to_string(),
+        ));
+    }
+    let chunk_ranges = fastcdc_chunk_ranges(bytes);
     let layout = match chunk_ranges.as_slice() {
         [] => BlobLayout::Empty,
         [(start, end)] => BlobLayout::SingleChunk {
-            chunk_hash: BlobHash::from_content(&write.bytes[*start..*end]),
+            chunk_hash: if *start == 0 && *end == bytes.len() {
+                blob_hash
+            } else {
+                BlobHash::from_content(&bytes[*start..*end])
+            },
         },
         _ => BlobLayout::Chunked {
             chunk_count: u32::try_from(chunk_ranges.len()).map_err(|_| {
@@ -528,7 +541,7 @@ pub(crate) fn stage_blob_write(
     };
     let receipt = BlobWriteReceipt {
         hash: blob_hash,
-        size_bytes: write.bytes.len() as u64,
+        size_bytes: bytes.len() as u64,
         layout: layout.clone(),
     };
     if !blob_hashes.insert(blob_hash.into_bytes()) {
@@ -549,18 +562,18 @@ pub(crate) fn stage_blob_write(
                 writes,
                 blob_hash,
                 &BinaryCasManifest::SingleChunk {
-                    size_bytes: write.bytes.len() as u64,
+                    size_bytes: bytes.len() as u64,
                     chunk_hash: chunk_hash.into_bytes(),
                 },
             );
             if chunk_keys.insert(chunk_key(chunk_hash)) {
-                let encoded_chunk = encode_binary_chunk_payload(write.bytes);
+                let encoded_chunk = encode_binary_chunk_payload(bytes);
                 stage_chunk(
                     writes,
                     chunk_hash,
                     &KvChunk {
                         codec: encoded_chunk.codec,
-                        uncompressed_len: write.bytes.len() as u64,
+                        uncompressed_len: bytes.len() as u64,
                         data: encoded_chunk.data,
                     },
                 );
@@ -571,13 +584,13 @@ pub(crate) fn stage_blob_write(
                 writes,
                 blob_hash,
                 &BinaryCasManifest::Chunked {
-                    size_bytes: write.bytes.len() as u64,
+                    size_bytes: bytes.len() as u64,
                     chunk_count: *chunk_count,
                 },
             );
 
             for (chunk_index, (start, end)) in chunk_ranges.into_iter().enumerate() {
-                let chunk_data = &write.bytes[start..end];
+                let chunk_data = &bytes[start..end];
                 let chunk_hash = BlobHash::from_content(chunk_data);
                 let chunk_key = chunk_key(chunk_hash);
                 if chunk_keys.insert(chunk_key.clone()) {
@@ -670,6 +683,7 @@ fn persisted_size_to_usize(size: u64, label: &str) -> Result<usize, LixError> {
 mod tests {
     use super::*;
     use crate::binary_cas::BinaryCasContext;
+    use crate::binary_cas::BlobPayload;
     use crate::storage::StorageContext;
     use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
 
@@ -835,6 +849,47 @@ mod tests {
                 .await
                 .expect("single-chunk blob should not spill manifest chunks"),
             Vec::<KvBlobManifestChunk>::new()
+        );
+    }
+
+    #[tokio::test]
+    async fn public_kv_api_accepts_precomputed_blob_hash() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let data = b"hello precomputed hash";
+        let payload = BlobPayload::from_bytes(data.to_vec());
+        let blob_hash = payload
+            .hash()
+            .expect("non-empty payload should have blob hash");
+
+        {
+            let mut writes = storage.new_write_set();
+            let mut writer = BinaryCasContext::new().writer(&mut writes);
+            writer
+                .stage_payload(&payload)
+                .expect("blob write should stage with payload hash");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("blob write should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        assert_eq!(
+            load_bytes_many(&store, &[blob_hash])
+                .await
+                .expect("blob should load")
+                .into_vec(),
+            vec![Some(data.to_vec())]
+        );
+        assert_eq!(
+            load_manifest(&store, blob_hash)
+                .await
+                .expect("manifest should load"),
+            Some(BinaryCasManifest::SingleChunk {
+                size_bytes: data.len() as u64,
+                chunk_hash: blob_hash.into_bytes(),
+            })
         );
     }
 

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -5,7 +5,7 @@ use crate::binary_cas::chunking::fastcdc_chunk_ranges;
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
     decode_binary_cas_manifest_chunk, encode_binary_cas_chunk, encode_binary_cas_manifest,
-    encode_binary_cas_manifest_chunk, encode_binary_chunk_payload,
+    encode_binary_cas_manifest_chunk,
 };
 use crate::binary_cas::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWriteReceipt,
@@ -36,6 +36,7 @@ pub(crate) struct KvBlobManifestChunk {
     pub(crate) chunk_size: u64,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KvChunk {
     pub(crate) codec: BinaryChunkCodec,
@@ -120,15 +121,17 @@ async fn load_chunk(
     }))
 }
 
-pub(crate) fn stage_chunk(writes: &mut StorageWriteSet, chunk_hash: BlobHash, chunk: &KvChunk) {
+pub(crate) fn stage_chunk(
+    writes: &mut StorageWriteSet,
+    chunk_hash: BlobHash,
+    codec: BinaryChunkCodec,
+    uncompressed_len: u64,
+    payload: &[u8],
+) {
     writes.put(
         BINARY_CAS_CHUNK_SPACE,
         key(chunk_key(chunk_hash)),
-        value(encode_binary_cas_chunk(
-            chunk.codec,
-            chunk.uncompressed_len,
-            &chunk.data,
-        )),
+        value(encode_binary_cas_chunk(codec, uncompressed_len, payload)),
     );
 }
 
@@ -567,15 +570,12 @@ pub(in crate::binary_cas) fn stage_blob_write(
                 },
             );
             if chunk_keys.insert(chunk_key(chunk_hash)) {
-                let encoded_chunk = encode_binary_chunk_payload(bytes);
                 stage_chunk(
                     writes,
                     chunk_hash,
-                    &KvChunk {
-                        codec: encoded_chunk.codec,
-                        uncompressed_len: bytes.len() as u64,
-                        data: encoded_chunk.data,
-                    },
+                    BinaryChunkCodec::Raw,
+                    bytes.len() as u64,
+                    bytes,
                 );
             }
         }
@@ -594,15 +594,12 @@ pub(in crate::binary_cas) fn stage_blob_write(
                 let chunk_hash = BlobHash::from_content(chunk_data);
                 let chunk_key = chunk_key(chunk_hash);
                 if chunk_keys.insert(chunk_key.clone()) {
-                    let encoded_chunk = encode_binary_chunk_payload(chunk_data);
                     stage_chunk(
                         writes,
                         chunk_hash,
-                        &KvChunk {
-                            codec: encoded_chunk.codec,
-                            uncompressed_len: chunk_data.len() as u64,
-                            data: encoded_chunk.data,
-                        },
+                        BinaryChunkCodec::Raw,
+                        chunk_data.len() as u64,
+                        chunk_data,
                     );
                 }
 
@@ -771,7 +768,13 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            stage_chunk(&mut writes, chunk_hash, &chunk);
+            stage_chunk(
+                &mut writes,
+                chunk_hash,
+                chunk.codec,
+                chunk.uncompressed_len,
+                &chunk.data,
+            );
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .expect("chunk should commit");
@@ -969,11 +972,9 @@ mod tests {
             stage_chunk(
                 &mut writes,
                 substituted_chunk_hash,
-                &KvChunk {
-                    codec: BinaryChunkCodec::Raw,
-                    uncompressed_len: substituted.len() as u64,
-                    data: substituted.to_vec(),
-                },
+                BinaryChunkCodec::Raw,
+                substituted.len() as u64,
+                substituted,
             );
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -6,6 +6,6 @@ mod types;
 
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use types::{
-    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWrite,
+    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,
     BlobWriteReceipt,
 };

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -32,6 +32,35 @@ impl BlobHash {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BlobPayload {
+    bytes: Vec<u8>,
+    hash: Option<BlobHash>,
+}
+
+impl BlobPayload {
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
+        let hash = (!bytes.is_empty()).then(|| BlobHash::from_content(&bytes));
+        Self { bytes, hash }
+    }
+
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub(crate) fn hash(&self) -> Option<BlobHash> {
+        self.hash
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BlobLayout {
     Empty,
     SingleChunk { chunk_hash: BlobHash },
@@ -73,11 +102,6 @@ impl BlobBytesBatch {
     pub(crate) fn into_vec(self) -> Vec<Option<Vec<u8>>> {
         self.entries
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct BlobWrite<'a> {
-    pub(crate) bytes: &'a [u8],
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/engine/src/common/fingerprint.rs
+++ b/packages/engine/src/common/fingerprint.rs
@@ -1,3 +1,0 @@
-pub(crate) fn stable_content_fingerprint_hex(data: &[u8]) -> String {
-    blake3::hash(data).to_hex().to_string()
-}

--- a/packages/engine/src/common/mod.rs
+++ b/packages/engine/src/common/mod.rs
@@ -1,5 +1,4 @@
 pub(crate) mod error;
-pub(crate) mod fingerprint;
 pub(crate) mod identity;
 pub(crate) mod json_pointer;
 pub(crate) mod lix_path;
@@ -9,7 +8,6 @@ pub(crate) mod types;
 pub(crate) mod wire;
 
 pub use error::LixError;
-pub(crate) use fingerprint::stable_content_fingerprint_hex;
 pub use identity::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
 pub(crate) use identity::{json_pointer_get, validate_non_empty_identity_value};
 pub(crate) use json_pointer::{format_json_pointer, parse_json_pointer, top_level_property_name};

--- a/packages/engine/src/filesystem/mod.rs
+++ b/packages/engine/src/filesystem/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use self::planner::{
     plan_parsed_file_path_write_with_resolvers, plan_recursive_directory_delete,
 };
 pub(crate) use self::read::{FilesystemIndex, filesystem_schema_keys};
+pub use self::read::{LixFilesystemDirectoryEntry, LixFilesystemFileEntry, LixFilesystemInventory};
 pub(crate) use self::visibility::VisibleFilesystem;
 
 /// Public identity key for matching filesystem descriptors to their stored

--- a/packages/engine/src/filesystem/mod.rs
+++ b/packages/engine/src/filesystem/mod.rs
@@ -19,3 +19,134 @@ pub(crate) use self::planner::{
 };
 pub(crate) use self::read::{FilesystemIndex, filesystem_schema_keys};
 pub(crate) use self::visibility::VisibleFilesystem;
+
+/// Public identity key for matching filesystem descriptors to their stored
+/// blob reference rows without duplicating filesystem storage scope rules.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LixFilesystemBlobRefKey(FilesystemBlobRefKey);
+
+pub fn lix_filesystem_blob_ref_key_for_active_file_descriptor(
+    active_branch_id: &str,
+    global: bool,
+    untracked: bool,
+    descriptor_id: &str,
+) -> LixFilesystemBlobRefKey {
+    let context = FilesystemRowContext {
+        branch_id: if global {
+            crate::GLOBAL_BRANCH_ID.to_string()
+        } else {
+            active_branch_id.to_string()
+        },
+        global,
+        untracked,
+        file_id: None,
+        metadata: None,
+    };
+    LixFilesystemBlobRefKey(FilesystemBlobRefKey::from_context(&context, descriptor_id))
+}
+
+pub fn lix_filesystem_blob_ref_key_for_state_row(
+    branch_id: &str,
+    global: bool,
+    untracked: bool,
+    file_id: Option<String>,
+    blob_ref_id: &str,
+) -> LixFilesystemBlobRefKey {
+    LixFilesystemBlobRefKey(FilesystemBlobRefKey::from_parts(
+        branch_id,
+        global,
+        untracked,
+        file_id,
+        blob_ref_id,
+    ))
+}
+
+pub fn lix_filesystem_blob_ref_key_for_active_state_row(
+    active_branch_id: &str,
+    global: bool,
+    untracked: bool,
+    file_id: Option<String>,
+    blob_ref_id: &str,
+) -> LixFilesystemBlobRefKey {
+    lix_filesystem_blob_ref_key_for_state_row(
+        if global {
+            crate::GLOBAL_BRANCH_ID
+        } else {
+            active_branch_id
+        },
+        global,
+        untracked,
+        file_id,
+        blob_ref_id,
+    )
+}
+
+#[cfg(test)]
+mod public_key_tests {
+    use super::{
+        lix_filesystem_blob_ref_key_for_active_file_descriptor,
+        lix_filesystem_blob_ref_key_for_active_state_row,
+        lix_filesystem_blob_ref_key_for_state_row,
+    };
+
+    #[test]
+    fn active_descriptor_key_matches_file_scoped_blob_ref_key() {
+        let descriptor = lix_filesystem_blob_ref_key_for_active_file_descriptor(
+            "branch-a", false, false, "file-a",
+        );
+        let blob = lix_filesystem_blob_ref_key_for_state_row(
+            "branch-a",
+            false,
+            false,
+            Some("file-a".to_string()),
+            "file-a",
+        );
+
+        assert_eq!(descriptor, blob);
+    }
+
+    #[test]
+    fn active_descriptor_key_preserves_global_and_untracked_scope() {
+        let global_descriptor = lix_filesystem_blob_ref_key_for_active_file_descriptor(
+            "branch-a", true, false, "file-a",
+        );
+        let branch_blob = lix_filesystem_blob_ref_key_for_state_row(
+            "branch-a",
+            true,
+            false,
+            Some("file-a".to_string()),
+            "file-a",
+        );
+        let global_blob = lix_filesystem_blob_ref_key_for_state_row(
+            "global",
+            true,
+            false,
+            Some("file-a".to_string()),
+            "file-a",
+        );
+        let tracked_descriptor = lix_filesystem_blob_ref_key_for_active_file_descriptor(
+            "branch-a", false, false, "file-a",
+        );
+        let untracked_blob = lix_filesystem_blob_ref_key_for_state_row(
+            "branch-a",
+            false,
+            true,
+            Some("file-a".to_string()),
+            "file-a",
+        );
+
+        assert_ne!(global_descriptor, branch_blob);
+        assert_eq!(global_descriptor, global_blob);
+        assert_eq!(
+            global_descriptor,
+            lix_filesystem_blob_ref_key_for_active_state_row(
+                "branch-a",
+                true,
+                false,
+                Some("file-a".to_string()),
+                "file-a",
+            )
+        );
+        assert_ne!(tracked_descriptor, untracked_blob);
+    }
+}

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -8,7 +8,8 @@ use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
-use crate::common::{LixPath, compose_file_path, stable_content_fingerprint_hex};
+use crate::binary_cas::BlobHash;
+use crate::common::{LixPath, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::live_state::{
     LiveStateFilter, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
@@ -192,7 +193,8 @@ pub(crate) struct FileDescriptorWriteIntent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobRefRowInput {
     pub(crate) file_id: String,
-    pub(crate) data: Vec<u8>,
+    pub(crate) blob_hash: BlobHash,
+    pub(crate) size_bytes: usize,
     pub(crate) context: FilesystemRowContext,
 }
 
@@ -805,7 +807,7 @@ pub(crate) fn file_descriptor_write_row(input: FileDescriptorWriteIntent) -> Tra
 }
 
 pub(crate) fn blob_ref_row(input: BlobRefRowInput) -> Result<TransactionWriteRow, LixError> {
-    let size_bytes = u64::try_from(input.data.len()).map_err(|_| {
+    let size_bytes = u64::try_from(input.size_bytes).map_err(|_| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!(
@@ -816,7 +818,7 @@ pub(crate) fn blob_ref_row(input: BlobRefRowInput) -> Result<TransactionWriteRow
     })?;
     let snapshot = json!({
         "id": input.file_id,
-        "blob_hash": stable_content_fingerprint_hex(&input.data),
+        "blob_hash": input.blob_hash.to_hex(),
         "size_bytes": size_bytes,
     });
 
@@ -912,10 +914,22 @@ fn plan_parsed_file_path_write_with_fallback(
 
     let mut file_data = Vec::new();
     if let Some(data) = data {
-        if !data.is_empty() {
+        let file_payload = TransactionFileData::new(
+            file_id.clone(),
+            Some(file_path),
+            Some(filename),
+            context.branch_id.clone(),
+            context.global,
+            context.untracked,
+            data,
+        );
+        if !file_payload.is_empty() {
             rows.push(blob_ref_row(BlobRefRowInput {
                 file_id: file_id.clone(),
-                data: data.clone(),
+                blob_hash: file_payload
+                    .blob_hash()
+                    .expect("non-empty payload should have blob hash"),
+                size_bytes: file_payload.len(),
                 context: FilesystemRowContext {
                     file_id: None,
                     metadata: None,
@@ -923,15 +937,7 @@ fn plan_parsed_file_path_write_with_fallback(
                 },
             })?);
         }
-        file_data.push(TransactionFileData {
-            file_id,
-            path: Some(file_path),
-            filename: Some(filename),
-            branch_id: context.branch_id,
-            global: context.global,
-            untracked: context.untracked,
-            data,
-        });
+        file_data.push(file_payload);
     }
 
     Ok(FilesystemWritePlan {
@@ -963,10 +969,22 @@ pub(crate) fn plan_file_descriptor_write(
 
     let mut file_data = Vec::new();
     if let Some(data) = input.data {
-        if !data.is_empty() {
+        let file_payload = TransactionFileData::new(
+            file_id.clone(),
+            Some(file_path),
+            Some(filename),
+            input.context.branch_id.clone(),
+            input.context.global,
+            input.context.untracked,
+            data,
+        );
+        if !file_payload.is_empty() {
             rows.push(blob_ref_row(BlobRefRowInput {
                 file_id: file_id.clone(),
-                data: data.clone(),
+                blob_hash: file_payload
+                    .blob_hash()
+                    .expect("non-empty payload should have blob hash"),
+                size_bytes: file_payload.len(),
                 context: FilesystemRowContext {
                     file_id: None,
                     metadata: None,
@@ -974,15 +992,7 @@ pub(crate) fn plan_file_descriptor_write(
                 },
             })?);
         }
-        file_data.push(TransactionFileData {
-            file_id,
-            path: Some(file_path),
-            filename: Some(filename),
-            branch_id: input.context.branch_id,
-            global: input.context.global,
-            untracked: input.context.untracked,
-            data,
-        });
+        file_data.push(file_payload);
     }
 
     Ok(FilesystemWritePlan {
@@ -1449,6 +1459,7 @@ mod tests {
     use serde_json::{Value as JsonValue, json};
 
     use crate::GLOBAL_BRANCH_ID;
+    use crate::binary_cas::BlobHash;
     use crate::changelog::{ChangeId, CommitId};
     use crate::filesystem::{FilesystemBlobRefKey, FilesystemDescriptorKey};
     use crate::transaction::types::TransactionJson;
@@ -1587,7 +1598,8 @@ mod tests {
     fn blob_ref_row_builds_state_row() {
         let row = blob_ref_row(BlobRefRowInput {
             file_id: "file-readme".to_string(),
-            data: b"Hello".to_vec(),
+            blob_hash: BlobHash::from_content(b"Hello"),
+            size_bytes: 5,
             context: FilesystemRowContext::active_branch("branch-a"),
         })
         .expect("blob ref row should build");
@@ -1601,10 +1613,9 @@ mod tests {
         let snapshot: JsonValue = row.snapshot.as_ref().unwrap().value().clone();
         assert_eq!(snapshot["id"], "file-readme");
         assert_eq!(snapshot["size_bytes"], 5);
-        assert!(
-            snapshot["blob_hash"]
-                .as_str()
-                .is_some_and(|hash| !hash.is_empty())
+        assert_eq!(
+            snapshot["blob_hash"].as_str(),
+            Some(BlobHash::from_content(b"Hello").to_hex().as_str())
         );
     }
 
@@ -1787,7 +1798,7 @@ mod tests {
         assert_eq!(plan.file_data.len(), 1);
         assert_eq!(plan.file_data[0].file_id, "file-readme");
         assert_eq!(plan.file_data[0].branch_id, "branch-a");
-        assert_eq!(plan.file_data[0].data, b"hello");
+        assert_eq!(plan.file_data[0].data(), b"hello");
         assert_eq!(plan.rows.len(), 4);
         assert_eq!(
             plan.rows
@@ -1871,7 +1882,7 @@ mod tests {
         assert_eq!(plan.file_data.len(), 1);
         assert_eq!(plan.file_data[0].file_id, "file-readme");
         assert_eq!(plan.file_data[0].path.as_deref(), Some("/docs/readme.md"));
-        assert_eq!(plan.file_data[0].data, b"hello");
+        assert_eq!(plan.file_data[0].data(), b"hello");
         assert_eq!(plan.rows.len(), 2);
         let file_row = plan
             .rows
@@ -2150,7 +2161,7 @@ mod tests {
         assert_eq!(plan.file_data[0].file_id, "file-readme");
         assert_eq!(plan.file_data[0].branch_id, "branch-a");
         assert_eq!(plan.file_data[0].untracked, true);
-        assert_eq!(plan.file_data[0].data, b"hello");
+        assert_eq!(plan.file_data[0].data(), b"hello");
     }
 
     #[test]
@@ -2170,7 +2181,7 @@ mod tests {
         assert_eq!(plan.count, 1);
         assert_eq!(plan.file_data.len(), 1);
         assert_eq!(plan.file_data[0].file_id, "file-empty");
-        assert!(plan.file_data[0].data.is_empty());
+        assert!(plan.file_data[0].is_empty());
         assert!(
             plan.rows
                 .iter()

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -156,6 +156,22 @@ impl FilesystemBlobRefKey {
     ) -> Self {
         Self(FilesystemDescriptorKey::from_live_row(row, blob_ref_id))
     }
+
+    pub(crate) fn from_parts(
+        branch_id: impl Into<String>,
+        global: bool,
+        untracked: bool,
+        file_id: Option<String>,
+        blob_ref_id: impl Into<String>,
+    ) -> Self {
+        Self(FilesystemDescriptorKey {
+            branch_id: branch_id.into(),
+            global,
+            untracked,
+            file_id,
+            descriptor_id: blob_ref_id.into(),
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/engine/src/filesystem/read.rs
+++ b/packages/engine/src/filesystem/read.rs
@@ -16,12 +16,40 @@ pub(crate) struct FilesystemIndex {
     entries_by_path: BTreeMap<String, FilesystemEntry>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct LixFilesystemDirectoryEntry {
+    pub path: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct LixFilesystemFileEntry {
+    pub path: String,
+    pub id: String,
+    pub blob_hash: Option<String>,
+    pub metadata: Option<String>,
+    pub global: bool,
+    pub untracked: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct LixFilesystemInventory {
+    pub active_branch_id: String,
+    pub active_branch_commit_id: String,
+    pub storage_mutation_revision: Option<Vec<u8>>,
+    pub directories: Vec<LixFilesystemDirectoryEntry>,
+    pub files: Vec<LixFilesystemFileEntry>,
+}
+
 impl FilesystemIndex {
     pub(crate) fn from_live_rows(
         rows: Vec<crate::live_state::MaterializedLiveStateRow>,
     ) -> Result<Self, LixError> {
         let mut directory_rows = BTreeMap::<FilesystemDescriptorKey, DirectorySnapshot>::new();
-        let mut file_rows = Vec::<(FileSnapshot, RowScope)>::new();
+        let mut file_rows = Vec::<(FileSnapshot, RowScope, Option<String>)>::new();
         let mut blob_hashes_by_key = BTreeMap::<FilesystemBlobRefKey, String>::new();
 
         for row in rows {
@@ -54,7 +82,7 @@ impl FilesystemIndex {
                                 "invalid lix_file_descriptor snapshot JSON: {error}"
                             ))
                         })?;
-                    file_rows.push((snapshot, scope));
+                    file_rows.push((snapshot, scope, row.metadata.clone()));
                 }
                 BLOB_REF_SCHEMA_KEY => {
                     let snapshot: BlobRefSnapshot = serde_json::from_str(snapshot_content)
@@ -90,11 +118,13 @@ impl FilesystemIndex {
             insert_entry(
                 &mut entries_by_path,
                 path.clone(),
-                FilesystemEntry::Directory,
+                FilesystemEntry::Directory(FilesystemDirectoryEntry {
+                    id: snapshot.id.clone(),
+                }),
             )?;
         }
 
-        for (snapshot, scope) in file_rows {
+        for (snapshot, scope, metadata) in file_rows {
             let file_key =
                 FilesystemDescriptorKey::from_context(&scope.context(None), &snapshot.id);
             let path = match snapshot.directory_id.as_ref() {
@@ -127,6 +157,7 @@ impl FilesystemIndex {
                         &snapshot.id,
                     ))
                     .cloned(),
+                metadata,
                 scope,
             };
             insert_entry(
@@ -144,7 +175,18 @@ impl FilesystemIndex {
             .iter()
             .filter_map(|(path, entry)| match entry {
                 FilesystemEntry::File(file) => Some((path.as_str(), file)),
-                FilesystemEntry::Directory => None,
+                FilesystemEntry::Directory(_) => None,
+            })
+    }
+
+    pub(crate) fn directory_entries(
+        &self,
+    ) -> impl Iterator<Item = (&str, &FilesystemDirectoryEntry)> {
+        self.entries_by_path
+            .iter()
+            .filter_map(|(path, entry)| match entry {
+                FilesystemEntry::Directory(directory) => Some((path.as_str(), directory)),
+                FilesystemEntry::File(_) => None,
             })
     }
 
@@ -166,8 +208,13 @@ pub(crate) fn filesystem_schema_keys() -> Vec<String> {
 
 #[derive(Debug, Clone)]
 enum FilesystemEntry {
-    Directory,
+    Directory(FilesystemDirectoryEntry),
     File(FilesystemFileEntry),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FilesystemDirectoryEntry {
+    pub(crate) id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -175,6 +222,7 @@ pub(crate) struct FilesystemFileEntry {
     pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) blob_hash: Option<String>,
+    pub(crate) metadata: Option<String>,
     pub(crate) scope: RowScope,
 }
 
@@ -290,7 +338,7 @@ fn insert_entry(
 
 fn namespace_conflict_path(path: &str, entry: &FilesystemEntry) -> String {
     match entry {
-        FilesystemEntry::Directory => path
+        FilesystemEntry::Directory(_) => path
             .strip_suffix('/')
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| path.to_string()),
@@ -300,7 +348,7 @@ fn namespace_conflict_path(path: &str, entry: &FilesystemEntry) -> String {
 
 fn entry_label(entry: &FilesystemEntry) -> &'static str {
     match entry {
-        FilesystemEntry::Directory => "directory",
+        FilesystemEntry::Directory(_) => "directory",
         FilesystemEntry::File(_) => "file",
     }
 }
@@ -319,7 +367,7 @@ mod tests {
         BLOB_REF_SCHEMA_KEY, DIRECTORY_DESCRIPTOR_SCHEMA_KEY, FILE_DESCRIPTOR_SCHEMA_KEY,
         FilesystemIndex, insert_entry,
     };
-    use super::{FilesystemEntry, FilesystemFileEntry, RowScope};
+    use super::{FilesystemDirectoryEntry, FilesystemEntry, FilesystemFileEntry, RowScope};
 
     #[test]
     fn from_live_rows_rejects_file_directory_namespace_conflicts() {
@@ -354,7 +402,7 @@ mod tests {
         insert_entry(
             &mut entries,
             "/foo/".to_string(),
-            FilesystemEntry::Directory,
+            FilesystemEntry::Directory(directory_entry("dir-foo")),
         )
         .expect_err("directory should conflict with file namespace");
 
@@ -362,7 +410,7 @@ mod tests {
         insert_entry(
             &mut entries,
             "/foo/".to_string(),
-            FilesystemEntry::Directory,
+            FilesystemEntry::Directory(directory_entry("dir-foo")),
         )
         .expect("initial directory entry should insert");
         insert_entry(
@@ -493,8 +541,13 @@ mod tests {
             id: id.to_string(),
             name: "foo".to_string(),
             blob_hash: None,
+            metadata: None,
             scope: row_scope(),
         }
+    }
+
+    fn directory_entry(id: &str) -> FilesystemDirectoryEntry {
+        FilesystemDirectoryEntry { id: id.to_string() }
     }
 
     fn row_scope() -> RowScope {

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -78,6 +78,15 @@ pub use backend::{
 };
 pub use common::LixError;
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
+pub use filesystem::{
+    LixFilesystemBlobRefKey, lix_filesystem_blob_ref_key_for_active_file_descriptor,
+    lix_filesystem_blob_ref_key_for_active_state_row, lix_filesystem_blob_ref_key_for_state_row,
+};
+
+/// Returns the canonical content hash used by filesystem blob references.
+pub fn lix_file_data_hash_hex(data: &[u8]) -> String {
+    binary_cas::BlobHash::from_content(data).to_hex()
+}
 pub use common::{LixNotice, NullableKeyFilter, SqlQueryResult, Value};
 pub use common::{WireQueryResult, WireValue};
 pub(crate) use common::{parse_row_metadata, parse_row_metadata_value, serialize_row_metadata};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -79,7 +79,8 @@ pub use backend::{
 pub use common::LixError;
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
 pub use filesystem::{
-    LixFilesystemBlobRefKey, lix_filesystem_blob_ref_key_for_active_file_descriptor,
+    LixFilesystemBlobRefKey, LixFilesystemDirectoryEntry, LixFilesystemFileEntry,
+    LixFilesystemInventory, lix_filesystem_blob_ref_key_for_active_file_descriptor,
     lix_filesystem_blob_ref_key_for_active_state_row, lix_filesystem_blob_ref_key_for_state_row,
 };
 

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -14,6 +14,10 @@ use crate::branch::{
 use crate::catalog::CatalogContext;
 use crate::commit_graph::{CommitGraphContext, CommitGraphReader};
 use crate::entity_pk::EntityPk;
+use crate::filesystem::{
+    DirectoryDescriptorWriteIntent, FileDescriptorRowInput, FilesystemRowContext,
+    directory_descriptor_write_row, file_descriptor_row,
+};
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreContext;
 use crate::live_state::{LiveStateContext, LiveStateReader, LiveStateRowRequest};
@@ -393,6 +397,34 @@ where
         self.with_write_transaction_reserved(write_access, f).await
     }
 
+    #[doc(hidden)]
+    pub async fn import_unresolved_filesystem_inventory(
+        &self,
+        existing_directories: &[(String, String)],
+        directories: &[String],
+        files: &[String],
+    ) -> Result<(), LixError> {
+        let existing_directories = existing_directories.to_vec();
+        let directories = directories.to_vec();
+        let files = files.to_vec();
+        self.with_write_transaction(|transaction| {
+            Box::pin(async move {
+                let rows = unresolved_filesystem_inventory_rows(
+                    transaction.active_branch_id(),
+                    transaction.functions(),
+                    &existing_directories,
+                    &directories,
+                    &files,
+                )?;
+                if !rows.is_empty() {
+                    transaction.stage_rows(rows).await?;
+                }
+                Ok(())
+            })
+        })
+        .await
+    }
+
     pub(super) async fn with_write_transaction_reserved<T, F>(
         &self,
         write_access: SessionWriteAccess,
@@ -447,6 +479,118 @@ where
     ) -> crate::transaction::TransactionCommitBoundary {
         self.transaction_manager.transaction_commit_boundary()
     }
+}
+
+fn unresolved_filesystem_inventory_rows(
+    active_branch_id: &str,
+    functions: FunctionProviderHandle,
+    existing_directories: &[(String, String)],
+    directories: &[String],
+    files: &[String],
+) -> Result<Vec<crate::transaction::types::TransactionWriteRow>, LixError> {
+    let mut rows = Vec::new();
+    let mut directory_ids = std::collections::BTreeMap::<String, String>::new();
+    directory_ids.insert("/".to_string(), String::new());
+    directory_ids.extend(existing_directories.iter().cloned());
+
+    let mut directories = directories
+        .iter()
+        .filter(|path| path.as_str() != "/")
+        .cloned()
+        .collect::<Vec<_>>();
+    directories.sort_by(|left, right| {
+        filesystem_path_depth(left)
+            .cmp(&filesystem_path_depth(right))
+            .then_with(|| left.cmp(right))
+    });
+
+    for directory in directories {
+        let parent = filesystem_parent_directory_path(directory.trim_end_matches('/'));
+        let id = functions.call_uuid_v7().to_string();
+        let parent_id = directory_ids
+            .get(&parent)
+            .filter(|value| !value.is_empty())
+            .cloned();
+        let name = filesystem_leaf_name(&directory)?.to_string();
+        rows.push(directory_descriptor_write_row(
+            DirectoryDescriptorWriteIntent {
+                id: Some(id.clone()),
+                parent_id,
+                name,
+                context: FilesystemRowContext {
+                    branch_id: active_branch_id.to_string(),
+                    global: false,
+                    untracked: false,
+                    file_id: None,
+                    metadata: None,
+                },
+            },
+        ));
+        directory_ids.insert(directory, id);
+    }
+
+    for file in files {
+        let directory = filesystem_parent_directory_path(file);
+        let directory_id = if directory == "/" {
+            None
+        } else {
+            Some(
+                directory_ids
+                    .get(&directory)
+                    .filter(|value| !value.is_empty())
+                    .cloned()
+                    .ok_or_else(|| {
+                        LixError::new(
+                            "LIX_FILESYSTEM_ERROR",
+                            format!(
+                                "cannot import unresolved file {file:?}: missing directory {directory:?}"
+                            ),
+                        )
+                    })?,
+            )
+        };
+        let file_id = functions.call_uuid_v7().to_string();
+        rows.push(file_descriptor_row(FileDescriptorRowInput {
+            id: file_id,
+            directory_id,
+            name: filesystem_leaf_name(file)?.to_string(),
+            context: FilesystemRowContext {
+                branch_id: active_branch_id.to_string(),
+                global: false,
+                untracked: false,
+                file_id: None,
+                metadata: Some(crate::sql2::filesystem_unresolved_metadata()),
+            },
+        }));
+    }
+
+    Ok(rows)
+}
+
+fn filesystem_parent_directory_path(path: &str) -> String {
+    let path = path.trim_end_matches('/');
+    let Some(index) = path.rfind('/') else {
+        return "/".to_string();
+    };
+    if index == 0 {
+        "/".to_string()
+    } else {
+        format!("{}/", &path[..index])
+    }
+}
+
+fn filesystem_leaf_name(path: &str) -> Result<&str, LixError> {
+    path.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| LixError::new("LIX_FILESYSTEM_ERROR", format!("invalid path {path:?}")))
+}
+
+fn filesystem_path_depth(path: &str) -> usize {
+    path.split('/')
+        .filter(|segment| !segment.is_empty())
+        .count()
 }
 
 impl<B> PluginComponentHost for SessionContext<B>

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -15,12 +15,15 @@ use crate::catalog::CatalogContext;
 use crate::commit_graph::{CommitGraphContext, CommitGraphReader};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
-    DirectoryDescriptorWriteIntent, FileDescriptorRowInput, FilesystemRowContext,
-    directory_descriptor_write_row, file_descriptor_row,
+    DirectoryDescriptorWriteIntent, FileDescriptorRowInput, FilesystemIndex, FilesystemRowContext,
+    LixFilesystemDirectoryEntry, LixFilesystemFileEntry, LixFilesystemInventory,
+    directory_descriptor_write_row, file_descriptor_row, filesystem_schema_keys,
 };
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreContext;
-use crate::live_state::{LiveStateContext, LiveStateReader, LiveStateRowRequest};
+use crate::live_state::{
+    LiveStateContext, LiveStateFilter, LiveStateReader, LiveStateRowRequest, LiveStateScanRequest,
+};
 use crate::observe_coordinator::ObserveCoordinator;
 use crate::observe_invalidation::ObserveInvalidation;
 use crate::plugin::{PluginComponentHost, PluginRuntimeHost};
@@ -314,6 +317,69 @@ where
             .storage
             .load_mutation_revision()?
             .map(|revision| revision.to_vec()))
+    }
+
+    #[doc(hidden)]
+    pub async fn read_filesystem_inventory(&self) -> Result<LixFilesystemInventory, LixError> {
+        self.ensure_open()?;
+        let _operation_guard = self.begin_waitable_session_operation().await?;
+        let read_store =
+            SharedStorageRead::new(self.storage.begin_read(StorageReadOptions::default())?);
+        let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+        let active_branch_commit_id = self
+            .branch_ctx
+            .ref_reader(read_store.clone())
+            .load_head(&active_branch_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::branch_not_found(
+                    active_branch_id.clone(),
+                    "read filesystem inventory",
+                    "active branch",
+                )
+            })?
+            .commit_id
+            .to_string();
+        let storage_mutation_revision =
+            StorageContext::<B>::load_mutation_revision_from_read(&read_store)?
+                .map(|revision| revision.to_vec());
+        let live_state = self.live_state.reader(read_store);
+        let rows = live_state
+            .scan_rows(&LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: filesystem_schema_keys(),
+                    branch_ids: vec![active_branch_id.clone()],
+                    ..LiveStateFilter::default()
+                },
+                ..LiveStateScanRequest::default()
+            })
+            .await?;
+        let index = FilesystemIndex::from_live_rows(rows)?;
+        let directories = index
+            .directory_entries()
+            .map(|(path, directory)| LixFilesystemDirectoryEntry {
+                path: path.to_string(),
+                id: directory.id.clone(),
+            })
+            .collect();
+        let files = index
+            .file_entries()
+            .map(|(path, file)| LixFilesystemFileEntry {
+                path: path.to_string(),
+                id: file.id.clone(),
+                blob_hash: file.blob_hash.clone(),
+                metadata: file.metadata.clone(),
+                global: file.scope.global,
+                untracked: file.scope.untracked,
+            })
+            .collect();
+        Ok(LixFilesystemInventory {
+            active_branch_id,
+            active_branch_commit_id,
+            storage_mutation_revision,
+            directories,
+            files,
+        })
     }
 
     pub(super) async fn active_branch_id_from_reader<S>(

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -425,6 +425,7 @@ fn filesystem_columns(by_branch: bool) -> Vec<PublicColumn> {
         PublicColumn::public("directory_id"),
         PublicColumn::public("name"),
         PublicColumn::public("data"),
+        PublicColumn::public_read_only("lixcol_data_hash"),
     ];
     columns.extend(filesystem_hidden_columns(by_branch));
     columns

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use serde_json::Value as JsonValue;
 
 use crate::changelog::CommitId;
@@ -148,19 +150,14 @@ async fn execute_file_path_write(
             "bound lix_file fast write supports VALUES only",
         ));
     };
-    let mut affected = 0u64;
+    let mut writes = Vec::with_capacity(values.rows.len());
     for row in &values.rows {
-        let path = eval_fast_file_text(&row[shape.path_index], params, "path")?;
-        let data = eval_fast_file_blob(&row[shape.data_index], params, "data")?;
-        affected += crate::sql2::providers::execute_fast_lix_file_path_write(
-            ctx,
-            path,
-            data,
-            shape.conflict,
-        )
-        .await?;
+        writes.push((
+            eval_fast_file_text(&row[shape.path_index], params, "path")?,
+            eval_fast_file_blob(&row[shape.data_index], params, "data")?,
+        ));
     }
-    Ok(affected)
+    crate::sql2::providers::execute_fast_lix_file_path_writes(ctx, writes, shape.conflict).await
 }
 
 fn fast_file_path_write_shape(
@@ -173,7 +170,7 @@ fn fast_file_path_write_shape(
     let BoundWriteInput::Values(values) = &plan.bound.input else {
         return None;
     };
-    if values.rows.len() != 1 || values.columns.len() != 2 {
+    if values.rows.is_empty() || values.columns.len() != 2 {
         return None;
     }
     let path_index = values.column_index("path")?;
@@ -575,7 +572,7 @@ fn validate_insert_conflict_target(
             }
             Ok(path[0].clone())
         })
-        .collect::<Result<std::collections::BTreeSet<_>, LixError>>()?;
+        .collect::<Result<BTreeSet<_>, LixError>>()?;
     if matches!(
         plan.bound.target,
         BoundWriteTarget::Entity(EntityWriteSurface::ByBranch { .. })
@@ -587,7 +584,7 @@ fn validate_insert_conflict_target(
         .target_columns
         .iter()
         .map(|column| column.name.clone())
-        .collect::<std::collections::BTreeSet<_>>();
+        .collect::<BTreeSet<_>>();
     if actual != expected {
         return Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
@@ -654,8 +651,8 @@ async fn scan_entity_conflict_candidates(
     spec: &EntitySurfaceSpec,
     insert_rows: &[TransactionWriteRow],
 ) -> Result<Vec<crate::live_state::MaterializedLiveStateRow>, LixError> {
-    let mut branch_ids = std::collections::BTreeSet::new();
-    let mut untracked_values = std::collections::BTreeSet::new();
+    let mut branch_ids = BTreeSet::new();
+    let mut untracked_values = BTreeSet::new();
     for row in insert_rows {
         branch_ids.insert(row.branch_id.clone());
         untracked_values.insert(row.untracked);
@@ -723,7 +720,7 @@ enum InsertColumnTarget {
 impl InsertRowLayout {
     fn from_values(spec: &EntitySurfaceSpec, values: &BoundInsertValues) -> Result<Self, LixError> {
         let mut snapshot_capacity = 0;
-        let mut seen_columns = std::collections::BTreeSet::new();
+        let mut seen_columns = BTreeSet::new();
         let columns = values
             .columns
             .iter()

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1465,6 +1465,9 @@ mod tests {
         ChangelogQuerySource, HistoryQuerySource, SqlChangelogQuerySource, SqlHistoryQuerySource,
     };
     use crate::sql2::{
+        WriteExecutorMode, WriteExecutorPath, execute_write_logical_plan_with_mode_and_trace,
+    };
+    use crate::sql2::{
         bind_statement, create_write_logical_plan, execute_write_logical_plan, parse_statement,
         plan_write,
     };
@@ -1713,6 +1716,16 @@ mod tests {
             rows: vec![vec![Value::Integer(count as i64)]],
             notices: Vec::new(),
         })
+    }
+
+    async fn execute_write_sql_trace(
+        ctx: &mut dyn SqlWriteExecutionContext,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<(u64, WriteExecutorPath), LixError> {
+        let plan = create_write_logical_plan(ctx, sql).await?;
+        execute_write_logical_plan_with_mode_and_trace(ctx, plan, params, WriteExecutorMode::Auto)
+            .await
     }
 
     #[async_trait]
@@ -3994,6 +4007,244 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_data_insert_uses_fast_path() {
+        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
+        let live_state = Arc::new(RowsLiveStateReader { rows: vec![] });
+        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+        let mut ctx = DummySqlWriteExecutionContext {
+            active_branch_id: "branch-a",
+            blob_reader,
+            live_state,
+            staged_writes: Arc::clone(&staged_writes),
+            schema_definitions: vec![],
+        };
+
+        let (count, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) VALUES \
+             ('/multi-a.txt', X'61'), ('/multi-b.txt', X'62')",
+            &[],
+        )
+        .await
+        .expect("multi-row path/data INSERT should use fast path");
+
+        assert_eq!(count, 2);
+        assert_eq!(path, WriteExecutorPath::Fast);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        assert_eq!(
+            overlay
+                .visible_semantic_rows(false, "lix_file_descriptor")
+                .len(),
+            2
+        );
+        assert_eq!(
+            overlay
+                .visible_semantic_rows(false, "lix_binary_blob_ref")
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_do_nothing_uses_fast_path() {
+        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
+        let live_state = Arc::new(RowsLiveStateReader {
+            rows: vec![
+                live_file_row("file-existing", "branch-a", None, "existing.md"),
+                live_blob_ref_row("file-existing", "branch-a", b"old"),
+            ],
+        });
+        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+        let mut ctx = DummySqlWriteExecutionContext {
+            active_branch_id: "branch-a",
+            blob_reader,
+            live_state,
+            staged_writes: Arc::clone(&staged_writes),
+            schema_definitions: vec![],
+        };
+
+        let (count, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) VALUES \
+             ('/existing.md', X'78'), ('/fresh.md', X'79') \
+             ON CONFLICT (path) DO NOTHING",
+            &[],
+        )
+        .await
+        .expect("multi-row path/data INSERT DO NOTHING should use fast path");
+
+        assert_eq!(count, 1);
+        assert_eq!(path, WriteExecutorPath::Fast);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let descriptor_rows = overlay.visible_semantic_rows(false, "lix_file_descriptor");
+        assert_eq!(descriptor_rows.len(), 1);
+        assert_eq!(descriptor_rows[0].branch_id, "branch-a");
+        let snapshot: JsonValue =
+            serde_json::from_str(descriptor_rows[0].snapshot_content.as_deref().unwrap())
+                .expect("descriptor snapshot JSON");
+        assert_eq!(snapshot["name"], "fresh.md");
+        assert_eq!(
+            overlay
+                .visible_semantic_rows(false, "lix_binary_blob_ref")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_do_update_uses_fast_path() {
+        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
+        let live_state = Arc::new(RowsLiveStateReader {
+            rows: vec![
+                live_file_row("file-existing", "branch-a", None, "existing.md"),
+                live_blob_ref_row("file-existing", "branch-a", b"old"),
+            ],
+        });
+        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+        let mut ctx = DummySqlWriteExecutionContext {
+            active_branch_id: "branch-a",
+            blob_reader,
+            live_state,
+            staged_writes: Arc::clone(&staged_writes),
+            schema_definitions: vec![],
+        };
+
+        let (count, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) VALUES \
+             ('/existing.md', X'78'), ('/fresh.md', X'79') \
+             ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+            &[],
+        )
+        .await
+        .expect("multi-row path/data INSERT DO UPDATE should use fast path");
+
+        assert_eq!(count, 2);
+        assert_eq!(path, WriteExecutorPath::Fast);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        assert_eq!(
+            overlay
+                .visible_semantic_rows(false, "lix_file_descriptor")
+                .len(),
+            1
+        );
+        assert_eq!(
+            overlay
+                .visible_semantic_rows(false, "lix_binary_blob_ref")
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_plain_insert_rejects_duplicate_new_path() {
+        assert_duplicate_lix_file_path_values_rejected(
+            "INSERT INTO lix_file (path, data) VALUES \
+             ('/dup.md', X'61'), ('/dup.md', X'62')",
+            vec![],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_do_nothing_rejects_duplicate_new_path() {
+        assert_duplicate_lix_file_path_values_rejected(
+            "INSERT INTO lix_file (path, data) VALUES \
+             ('/dup.md', X'61'), ('/dup.md', X'62') \
+             ON CONFLICT (path) DO NOTHING",
+            vec![],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_do_update_rejects_duplicate_new_path() {
+        assert_duplicate_lix_file_path_values_rejected(
+            "INSERT INTO lix_file (path, data) VALUES \
+             ('/dup.md', X'61'), ('/dup.md', X'62') \
+             ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+            vec![],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_do_nothing_rejects_duplicate_existing_path() {
+        assert_duplicate_lix_file_path_values_rejected(
+            "INSERT INTO lix_file (path, data) VALUES \
+             ('/existing.md', X'61'), ('/existing.md', X'62') \
+             ON CONFLICT (path) DO NOTHING",
+            vec![
+                live_file_row("file-existing", "branch-a", None, "existing.md"),
+                live_blob_ref_row("file-existing", "branch-a", b"old"),
+            ],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn execute_sql_non_fast_lix_file_path_do_nothing_rejects_duplicate_new_path() {
+        assert_duplicate_lix_file_path_values_rejected(
+            "INSERT INTO lix_file (id, path, data) VALUES \
+             ('file-a', '/dup.md', X'61'), ('file-b', '/dup.md', X'62') \
+             ON CONFLICT (path) DO NOTHING",
+            vec![],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn execute_sql_non_fast_lix_file_path_do_update_rejects_duplicate_existing_path() {
+        assert_duplicate_lix_file_path_values_rejected(
+            "INSERT INTO lix_file (id, path, data) VALUES \
+             ('file-a', '/existing.md', X'61'), ('file-b', '/existing.md', X'62') \
+             ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+            vec![
+                live_file_row("file-existing", "branch-a", None, "existing.md"),
+                live_blob_ref_row("file-existing", "branch-a", b"old"),
+            ],
+        )
+        .await;
+    }
+
+    async fn assert_duplicate_lix_file_path_values_rejected(
+        sql: &str,
+        live_rows: Vec<MaterializedLiveStateRow>,
+    ) {
+        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
+        let live_state = Arc::new(RowsLiveStateReader { rows: live_rows });
+        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+        let mut ctx = DummySqlWriteExecutionContext {
+            active_branch_id: "branch-a",
+            blob_reader,
+            live_state,
+            staged_writes: Arc::clone(&staged_writes),
+            schema_definitions: vec![],
+        };
+
+        let err = execute_write_sql_trace(&mut ctx, sql, &[])
+            .await
+            .expect_err("duplicate paths in one VALUES list should be rejected");
+
+        assert_eq!(err.code, LixError::CODE_UNIQUE);
+        assert!(err.message.contains("duplicate lix_file VALUES path"));
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert!(staged_writes.deltas.is_empty());
+    }
+
+    #[tokio::test]
     async fn execute_sql_update_file_stages_rewritten_descriptor() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let live_state = Arc::new(RowsLiveStateReader {
@@ -4799,7 +5050,7 @@ mod tests {
             &mut ctx,
             plan,
             &[],
-            crate::sql2::WriteExecutorMode::ForceDataFusion,
+            WriteExecutorMode::ForceDataFusion,
         )
         .await
         .expect_err("unsupported reference writer target should not become a fast no-op");
@@ -4838,7 +5089,7 @@ mod tests {
             &mut ctx,
             plan,
             &[],
-            crate::sql2::WriteExecutorMode::ForceDataFusion,
+            WriteExecutorMode::ForceDataFusion,
         )
         .await
         .expect_err("unsupported target with empty scope should not become a no-op");

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1978,7 +1978,7 @@ mod tests {
             snapshot_content: Some(
                 json!({
                     "id": entity_pk,
-                    "blob_hash": crate::common::stable_content_fingerprint_hex(bytes),
+                    "blob_hash": crate::binary_cas::BlobHash::from_content(bytes).to_hex(),
                     "size_bytes": bytes.len()
                 })
                 .to_string(),

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -44,3 +44,4 @@ pub(crate) use exec::{
 };
 pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
+pub(crate) use providers::filesystem_unresolved_metadata;

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -2019,16 +2019,19 @@ fn stage_lix_file_data_insert_write(
     context: FilesystemRowContext,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
-    if !data.is_empty() {
-        stage_lix_file_data_blob_ref_write(
-            staged,
-            file_id.clone(),
-            data.clone(),
-            &context,
-            origin,
-        )?;
+    let file_payload = TransactionFileData::new(
+        file_id.clone(),
+        path,
+        filename,
+        context.branch_id.clone(),
+        context.global,
+        context.untracked,
+        data,
+    );
+    if !file_payload.is_empty() {
+        stage_lix_file_data_blob_ref_write(staged, &file_payload, &context, origin)?;
     }
-    stage_lix_file_data_payload_write(staged, file_id, path, filename, data, context);
+    staged.file_data_writes.push(file_payload);
     Ok(())
 }
 
@@ -2042,30 +2045,41 @@ fn stage_lix_file_data_update_write(
     has_blob_ref: bool,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
-    if data.is_empty() {
+    let file_payload = TransactionFileData::new(
+        file_id.clone(),
+        path,
+        filename,
+        context.branch_id.clone(),
+        context.global,
+        context.untracked,
+        data,
+    );
+    if file_payload.is_empty() {
         if has_blob_ref {
             let mut row = blob_ref_tombstone_row(file_id.clone(), context.clone());
             row.origin = origin;
             staged.state_rows.push(row);
         }
-        stage_lix_file_data_payload_write(staged, file_id, path, filename, data, context);
+        staged.file_data_writes.push(file_payload);
         return Ok(());
     }
-    stage_lix_file_data_blob_ref_write(staged, file_id.clone(), data.clone(), &context, origin)?;
-    stage_lix_file_data_payload_write(staged, file_id, path, filename, data, context);
+    stage_lix_file_data_blob_ref_write(staged, &file_payload, &context, origin)?;
+    staged.file_data_writes.push(file_payload);
     Ok(())
 }
 
 fn stage_lix_file_data_blob_ref_write(
     staged: &mut LixFileStagedBatch,
-    file_id: String,
-    data: Vec<u8>,
+    file_data: &TransactionFileData,
     context: &FilesystemRowContext,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
     let mut row = blob_ref_row(BlobRefRowInput {
-        file_id,
-        data,
+        file_id: file_data.file_id.clone(),
+        blob_hash: file_data
+            .blob_hash()
+            .expect("non-empty payload should have blob hash"),
+        size_bytes: file_data.len(),
         context: FilesystemRowContext {
             file_id: None,
             metadata: None,
@@ -2076,25 +2090,6 @@ fn stage_lix_file_data_blob_ref_write(
     row.origin = origin;
     staged.state_rows.push(row);
     Ok(())
-}
-
-fn stage_lix_file_data_payload_write(
-    staged: &mut LixFileStagedBatch,
-    file_id: String,
-    path: Option<String>,
-    filename: Option<String>,
-    data: Vec<u8>,
-    context: FilesystemRowContext,
-) {
-    staged.file_data_writes.push(TransactionFileData {
-        file_id,
-        path,
-        filename,
-        branch_id: context.branch_id,
-        global: context.global,
-        untracked: context.untracked,
-        data,
-    });
 }
 
 fn attach_lix_file_insert_origin(
@@ -4352,7 +4347,7 @@ mod tests {
         assert_eq!(staged.count, 1);
         assert_eq!(staged.file_data_writes.len(), 1);
         assert_eq!(staged.file_data_writes[0].file_id, "file-readme");
-        assert_eq!(staged.file_data_writes[0].data, b"hello");
+        assert_eq!(staged.file_data_writes[0].data(), b"hello");
         assert!(
             staged
                 .state_rows
@@ -4399,7 +4394,25 @@ mod tests {
             staged.file_data_writes[0].path.as_deref(),
             Some("/docs/readme.md")
         );
-        assert_eq!(staged.file_data_writes[0].data, b"hello");
+        assert_eq!(staged.file_data_writes[0].data(), b"hello");
+        let blob_ref_row = staged
+            .state_rows
+            .iter()
+            .find(|row| row.schema_key == "lix_binary_blob_ref")
+            .expect("data update should stage blob ref row");
+        let snapshot: serde_json::Value = blob_ref_row
+            .snapshot
+            .as_ref()
+            .expect("blob ref should carry snapshot")
+            .value()
+            .clone();
+        assert_eq!(
+            snapshot["blob_hash"].as_str(),
+            staged.file_data_writes[0]
+                .blob_hash()
+                .map(BlobHash::to_hex)
+                .as_deref()
+        );
     }
 
     #[test]
@@ -4474,7 +4487,20 @@ mod tests {
         assert_eq!(staged.file_data_writes.len(), 1);
         assert_eq!(staged.file_data_writes[0].file_id, "file-readme");
         assert_eq!(staged.file_data_writes[0].branch_id, "branch-b");
-        assert_eq!(staged.file_data_writes[0].data, b"hello");
+        assert_eq!(staged.file_data_writes[0].data(), b"hello");
+        let snapshot: serde_json::Value = blob_ref_row
+            .snapshot
+            .as_ref()
+            .expect("blob ref should carry snapshot")
+            .value()
+            .clone();
+        assert_eq!(
+            snapshot["blob_hash"].as_str(),
+            staged.file_data_writes[0]
+                .blob_hash()
+                .map(BlobHash::to_hex)
+                .as_deref()
+        );
     }
 
     #[test]
@@ -4693,7 +4719,7 @@ mod tests {
                 assert_eq!(file_data.len(), 1);
                 assert_eq!(file_data[0].file_id, "file-readme");
                 assert_eq!(file_data[0].path.as_deref(), Some("/docs/readme.md"));
-                assert_eq!(file_data[0].data, b"hello");
+                assert_eq!(file_data[0].data(), b"hello");
             }
             other => panic!("expected insert with file data staged write, got {other:?}"),
         }

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -307,12 +307,15 @@ impl LixFileSpec {
                 let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
                     .await
                     .map_err(lix_error_to_datafusion_error)?;
+                let needs_plugin_render =
+                    lix_file_rows_need_plugin_render(&rows, needs_data, needs_data_hash)
+                        .map_err(lix_error_to_datafusion_error)?;
                 let plugin_render = plugin_render_context_for_lix_file_scan(
                     live_state,
                     &blob_reader,
                     &request,
                     plugin_host,
-                    needs_data || needs_data_hash,
+                    needs_plugin_render,
                 )
                 .await
                 .map_err(|error| {
@@ -440,12 +443,15 @@ impl TableSpec for LixFileSpec {
                     })?;
                     let rows = filter_lix_file_live_rows_by_path(rows, &target_paths)
                         .map_err(lix_error_to_datafusion_error)?;
+                    let needs_plugin_render =
+                        lix_file_rows_need_plugin_render(&rows, needs_data, needs_data_hash)
+                            .map_err(lix_error_to_datafusion_error)?;
                     let plugin_render = plugin_render_context_for_lix_file_scan(
                         Arc::clone(&live_state),
                         &blob_reader,
                         &request,
                         plugin_host,
-                        needs_data || needs_data_hash,
+                        needs_plugin_render,
                     )
                     .await
                     .map_err(|error| {
@@ -2710,6 +2716,59 @@ async fn lix_file_record_batch(
     })
 }
 
+fn lix_file_rows_need_plugin_render(
+    rows: &[MaterializedLiveStateRow],
+    needs_data: bool,
+    needs_data_hash: bool,
+) -> Result<bool, LixError> {
+    if !needs_data && !needs_data_hash {
+        return Ok(false);
+    }
+
+    let mut blob_keys = BTreeSet::<FilesystemBlobRefKey>::new();
+    for row in rows {
+        if row.schema_key != BLOB_REF_SCHEMA_KEY {
+            continue;
+        }
+        let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+            continue;
+        };
+        let snapshot = match serde_json::from_str::<BlobRefSnapshot>(snapshot_content) {
+            Ok(snapshot) => snapshot,
+            Err(_) => return Ok(true),
+        };
+        blob_keys.insert(FilesystemBlobRefKey::from_live_row(row, snapshot.id));
+    }
+
+    for row in rows {
+        if row.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY {
+            continue;
+        }
+        let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+            continue;
+        };
+        let snapshot = match serde_json::from_str::<FileDescriptorSnapshot>(snapshot_content) {
+            Ok(snapshot) => snapshot,
+            Err(_) => return Ok(true),
+        };
+        if file_metadata_is_filesystem_unresolved(row.metadata.as_deref()) {
+            continue;
+        }
+        let context = FilesystemRowContext {
+            branch_id: row.branch_id.clone(),
+            global: row.global,
+            untracked: row.untracked,
+            file_id: row.file_id.clone(),
+            metadata: None,
+        };
+        if !blob_keys.contains(&FilesystemBlobRefKey::from_context(&context, &snapshot.id)) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 async fn render_plugin_file_for_sql(
     plugin_render: &PluginRenderContext,
     file: &FileDescriptorRecord,
@@ -4475,6 +4534,7 @@ mod tests {
             &blob_reader,
             None,
             true,
+            false,
             vec![live_file_row(
                 "file-readme",
                 "branch-b",
@@ -4502,6 +4562,7 @@ mod tests {
             &blob_reader,
             None,
             true,
+            false,
             vec![
                 live_file_row(
                     "file-readme",

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -280,6 +280,7 @@ impl LixFileSpec {
         request: LiveStateScanRequest,
         target_file_ids: FileIdConstraint,
         needs_data: bool,
+        needs_data_hash: bool,
     ) -> RowSource {
         row_source(
             (
@@ -290,6 +291,7 @@ impl LixFileSpec {
                 request,
                 target_file_ids,
                 needs_data,
+                needs_data_hash,
             ),
             |(
                 write_ctx,
@@ -299,6 +301,7 @@ impl LixFileSpec {
                 request,
                 target_file_ids,
                 needs_data,
+                needs_data_hash,
             )| async move {
                 let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
                 let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
@@ -309,7 +312,7 @@ impl LixFileSpec {
                     &blob_reader,
                     &request,
                     plugin_host,
-                    needs_data,
+                    needs_data || needs_data_hash,
                 )
                 .await
                 .map_err(|error| {
@@ -317,9 +320,16 @@ impl LixFileSpec {
                         "sql2 lix_file plugin discovery failed: {error}"
                     ))
                 })?;
-                lix_file_record_batch(&table_schema, &blob_reader, plugin_render, needs_data, rows)
-                    .await
-                    .map_err(lix_error_to_datafusion_error)
+                lix_file_record_batch(
+                    &table_schema,
+                    &blob_reader,
+                    plugin_render,
+                    needs_data,
+                    needs_data_hash,
+                    rows,
+                )
+                .await
+                .map_err(lix_error_to_datafusion_error)
             },
         )
     }
@@ -362,11 +372,13 @@ impl TableSpec for LixFileSpec {
         let scan_limit = if filters.is_empty() { limit } else { None };
         let filters = filters.to_vec();
         let needs_data = scan_needs_data(&self.schema, projection, &filters);
+        let needs_data_hash = scan_needs_data_hash(&self.schema, projection, &filters);
         let mut request = lix_file_scan_request(
             self.branch_binding.active_branch_id(),
             Some(projected_schema.as_ref()),
             scan_limit,
             needs_data,
+            needs_data_hash,
         );
         if matches!(self.branch_binding, BranchBinding::Explicit) {
             request.filter.branch_ids = explicit_branch_ids_from_dml_filters(&filters);
@@ -400,6 +412,7 @@ impl TableSpec for LixFileSpec {
                     target_paths,
                     physical_filters,
                     needs_data,
+                    needs_data_hash,
                     limit,
                 ),
                 |(
@@ -413,6 +426,7 @@ impl TableSpec for LixFileSpec {
                     target_paths,
                     filters,
                     needs_data,
+                    needs_data_hash,
                     limit,
                 )| async move {
                     let rows = scan_lix_file_live_rows(
@@ -431,7 +445,7 @@ impl TableSpec for LixFileSpec {
                         &blob_reader,
                         &request,
                         plugin_host,
-                        needs_data,
+                        needs_data || needs_data_hash,
                     )
                     .await
                     .map_err(|error| {
@@ -444,6 +458,7 @@ impl TableSpec for LixFileSpec {
                         &blob_reader,
                         plugin_render,
                         needs_data,
+                        needs_data_hash,
                         rows,
                     )
                     .await
@@ -503,9 +518,17 @@ impl TableSpec for LixFileSpec {
         filters: &[Expr],
     ) -> Result<PlannedDml> {
         let needs_data = filters.iter().any(|filter| contains_column(filter, "data"));
+        let needs_data_hash = filters
+            .iter()
+            .any(|filter| contains_column(filter, "lixcol_data_hash"));
         let target_file_ids = file_id_constraint_from_filters(filters)?;
-        let mut request =
-            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
+        let mut request = lix_file_scan_request(
+            self.branch_binding.active_branch_id(),
+            None,
+            None,
+            needs_data,
+            needs_data_hash,
+        );
         request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
@@ -520,6 +543,7 @@ impl TableSpec for LixFileSpec {
             request.clone(),
             target_file_ids.clone(),
             needs_data,
+            needs_data_hash,
         );
         let branch_binding = self.branch_binding.clone();
         let apply: DmlApply = Arc::new(move |matched_batch| {
@@ -568,9 +592,20 @@ impl TableSpec for LixFileSpec {
             || assignments.iter().any(|(column_name, expr)| {
                 column_name == "path" || physical_expr_contains_column(expr, "data")
             });
+        let needs_data_hash = filters
+            .iter()
+            .any(|filter| contains_column(filter, "lixcol_data_hash"))
+            || assignments
+                .iter()
+                .any(|(_, expr)| physical_expr_contains_column(expr, "lixcol_data_hash"));
         let target_file_ids = file_id_constraint_from_filters(filters)?;
-        let mut request =
-            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
+        let mut request = lix_file_scan_request(
+            self.branch_binding.active_branch_id(),
+            None,
+            None,
+            needs_data,
+            needs_data_hash,
+        );
         request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
@@ -585,6 +620,7 @@ impl TableSpec for LixFileSpec {
             request.clone(),
             target_file_ids.clone(),
             needs_data,
+            needs_data_hash,
         );
         let branch_binding = self.branch_binding.clone();
         let functions = self.functions.clone();
@@ -798,8 +834,13 @@ impl UpsertSupport for LixFileSpec {
                 FileIdConstraint::All
             }
         };
-        let mut request =
-            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
+        let mut request = lix_file_scan_request(
+            self.branch_binding.active_branch_id(),
+            None,
+            None,
+            false,
+            false,
+        );
         if matches!(self.branch_binding, BranchBinding::Explicit) {
             request.filter.branch_ids = match target.kind() {
                 UpsertConflictKind::Id => proposed_branch_ids(proposed)?,
@@ -829,9 +870,16 @@ impl UpsertSupport for LixFileSpec {
         .map_err(|error| {
             DataFusionError::Execution(format!("sql2 lix_file plugin discovery failed: {error}"))
         })?;
-        lix_file_record_batch(&self.schema, &self.blob_reader, plugin_render, true, rows)
-            .await
-            .map_err(lix_error_to_datafusion_error)
+        lix_file_record_batch(
+            &self.schema,
+            &self.blob_reader,
+            plugin_render,
+            true,
+            false,
+            rows,
+        )
+        .await
+        .map_err(lix_error_to_datafusion_error)
     }
 
     fn validate_conflict_pair(
@@ -879,8 +927,13 @@ impl UpsertSupport for LixFileSpec {
         // (needed to tombstone the old blob when `data` is replaced) and any
         // plugins installed for path-move rewrites.
         let target_file_ids = augmented_file_id_constraint(augmented)?;
-        let mut request =
-            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
+        let mut request = lix_file_scan_request(
+            self.branch_binding.active_branch_id(),
+            None,
+            None,
+            false,
+            false,
+        );
         if matches!(self.branch_binding, BranchBinding::Explicit) {
             request.filter.branch_ids = augmented_branch_ids(augmented)?;
         }
@@ -2055,6 +2108,7 @@ fn lix_file_stage_from_batch_with_options_and_path_resolvers(
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_created_at")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_updated_at")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_commit_id")?;
+            reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_data_hash")?;
         }
 
         let path = optional_string_value(batch, row_index, "path")?;
@@ -2416,6 +2470,7 @@ async fn lix_file_record_batch(
     blob_reader: &Arc<dyn BlobDataReader>,
     plugin_render: Option<PluginRenderContext>,
     load_data: bool,
+    load_data_hash: bool,
     rows: Vec<MaterializedLiveStateRow>,
 ) -> Result<RecordBatch, LixError> {
     let projected_columns = schema
@@ -2508,6 +2563,7 @@ async fn lix_file_record_batch(
     let mut created_ats = Vec::new();
     let mut updated_ats = Vec::new();
     let mut commit_ids = Vec::new();
+    let mut data_hashes = Vec::new();
     let mut untracked_values = Vec::new();
     let mut metadata_values = Vec::new();
     let mut branch_ids = Vec::new();
@@ -2537,18 +2593,45 @@ async fn lix_file_record_batch(
             None => None,
         };
         let path = compose_file_path(directory_path.as_deref(), &file.name)?;
-        let data = if needs_data {
-            let context = FilesystemRowContext {
+        let context = if needs_data || load_data_hash {
+            Some(FilesystemRowContext {
                 branch_id: file.live.branch_id.clone(),
                 global: file.live.global,
                 untracked: file.live.untracked,
                 file_id: file.live.file_id.clone(),
                 metadata: None,
-            };
-            match blob_rows.get(&FilesystemBlobRefKey::from_context(&context, &file.id)) {
+            })
+        } else {
+            None
+        };
+        let blob_ref = context.as_ref().and_then(|context| {
+            blob_rows.get(&FilesystemBlobRefKey::from_context(context, &file.id))
+        });
+        let is_unresolved = file_metadata_is_filesystem_unresolved(file.live.metadata.as_deref());
+        let rendered = if blob_ref.is_none() && !is_unresolved && (needs_data || load_data_hash) {
+            match &plugin_render {
+                Some(plugin_render) => {
+                    render_plugin_file_for_sql(plugin_render, &file, &path).await?
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+        let data_hash = if load_data_hash {
+            Some(match blob_ref {
+                Some(blob_ref) => blob_ref.blob_hash.clone(),
+                None if is_unresolved => format!("unresolved:{path}"),
+                None => BlobHash::from_content(rendered.as_deref().unwrap_or_default()).to_hex(),
+            })
+        } else {
+            None
+        };
+        let data = if needs_data {
+            match blob_ref {
                 Some(blob_ref) => load_single_blob_bytes(blob_reader, &blob_ref.blob_hash).await?,
                 None => {
-                    if file_metadata_is_filesystem_unresolved(file.live.metadata.as_deref()) {
+                    if is_unresolved {
                         return Err(LixError::new(
                             "LIX_FILESYSTEM_DATA_UNRESOLVED",
                             format!("filesystem data for path {path:?} has not been imported yet"),
@@ -2557,12 +2640,6 @@ async fn lix_file_record_batch(
                             "Hydrate the filesystem file data before selecting lix_file.data.",
                         ));
                     }
-                    let rendered = match &plugin_render {
-                        Some(plugin_render) => {
-                            render_plugin_file_for_sql(plugin_render, &file, &path).await?
-                        }
-                        None => None,
-                    };
                     Some(rendered.unwrap_or_default())
                 }
             }
@@ -2583,6 +2660,7 @@ async fn lix_file_record_batch(
         created_ats.push(file.live.created_at);
         updated_ats.push(file.live.updated_at);
         commit_ids.push(file.live.commit_id.map(|id| id.to_string()));
+        data_hashes.push(data_hash);
         untracked_values.push(Some(file.live.untracked));
         metadata_values.push(file.live.metadata.as_deref().map(serialize_row_metadata));
         branch_ids.push(Some(file.live.branch_id));
@@ -2609,6 +2687,7 @@ async fn lix_file_record_batch(
             "lixcol_created_at" => Arc::new(StringArray::from(created_ats.clone())),
             "lixcol_updated_at" => Arc::new(StringArray::from(updated_ats.clone())),
             "lixcol_commit_id" => Arc::new(StringArray::from(commit_ids.clone())),
+            "lixcol_data_hash" => Arc::new(StringArray::from(data_hashes.clone())),
             "lixcol_untracked" => Arc::new(BooleanArray::from(untracked_values.clone())),
             "lixcol_metadata" => Arc::new(StringArray::from(metadata_values.clone())),
             "lixcol_branch_id" => Arc::new(StringArray::from(branch_ids.clone())),
@@ -2753,11 +2832,29 @@ fn scan_needs_data(
     projected_needs_data || filters.iter().any(|filter| contains_column(filter, "data"))
 }
 
+fn scan_needs_data_hash(
+    base_schema: &SchemaRef,
+    projection: Option<&Vec<usize>>,
+    filters: &[Expr],
+) -> bool {
+    let projected_needs_data_hash = match projection {
+        Some(indices) => indices
+            .iter()
+            .any(|index| base_schema.field(*index).name() == "lixcol_data_hash"),
+        None => true,
+    };
+    projected_needs_data_hash
+        || filters
+            .iter()
+            .any(|filter| contains_column(filter, "lixcol_data_hash"))
+}
+
 fn lix_file_scan_request(
     branch_binding: Option<&str>,
     projected_schema: Option<&Schema>,
     limit: Option<usize>,
     needs_data: bool,
+    needs_data_hash: bool,
 ) -> LiveStateScanRequest {
     LiveStateScanRequest {
         filter: LiveStateFilter {
@@ -2771,7 +2868,7 @@ fn lix_file_scan_request(
                 .unwrap_or_default(),
             ..LiveStateFilter::default()
         },
-        projection: lix_file_live_state_projection(projected_schema, needs_data),
+        projection: lix_file_live_state_projection(projected_schema, needs_data, needs_data_hash),
         limit,
     }
 }
@@ -2779,12 +2876,14 @@ fn lix_file_scan_request(
 fn lix_file_live_state_projection(
     projected_schema: Option<&Schema>,
     needs_data: bool,
+    needs_data_hash: bool,
 ) -> LiveStateProjection {
     let Some(schema) = projected_schema else {
         return LiveStateProjection::default();
     };
     let mut columns = vec!["snapshot_content".to_string()];
     if needs_data
+        || needs_data_hash
         || schema
             .fields()
             .iter()
@@ -2807,7 +2906,13 @@ fn file_metadata_is_filesystem_unresolved(metadata: Option<&str>) -> bool {
                 .and_then(|object| object.get(FILESYSTEM_UNRESOLVED_METADATA_KEY))
                 .cloned()
         })
-        .is_some()
+        .is_some_and(|value| filesystem_unresolved_metadata_value_is_marker(&value))
+}
+
+fn filesystem_unresolved_metadata_value_is_marker(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        object.len() == 1 && object.get("version").and_then(serde_json::Value::as_u64) == Some(1)
+    })
 }
 
 async fn scan_lix_file_live_rows(
@@ -3598,6 +3703,7 @@ pub(super) fn lix_file_schema() -> SchemaRef {
         Field::new("lixcol_created_at", DataType::Utf8, true),
         Field::new("lixcol_updated_at", DataType::Utf8, true),
         Field::new("lixcol_commit_id", DataType::Utf8, true),
+        Field::new("lixcol_data_hash", DataType::Utf8, true),
         Field::new("lixcol_untracked", DataType::Boolean, true),
         json_field("lixcol_metadata", true),
     ]))

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -10,7 +10,7 @@
     clippy::useless_let_if_seq
 )]
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -29,6 +29,7 @@ use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 use datafusion::prelude::SessionContext;
 use futures_util::FutureExt;
 use serde::Deserialize;
+use serde_json::json;
 
 use crate::binary_cas::{BlobDataReader, BlobHash};
 use crate::branch::BranchRefReader;
@@ -66,6 +67,7 @@ use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value, serialize_row_
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
+const FILESYSTEM_UNRESOLVED_METADATA_KEY: &str = "lix_fs_unresolved";
 
 use crate::filesystem::{
     BlobRefRowInput, DirectoryPathRecord, DirectoryPathResolver, FileDeleteInput,
@@ -358,12 +360,14 @@ impl TableSpec for LixFileSpec {
     ) -> Result<PlannedScan> {
         let projected_schema = projected_schema(&self.schema, projection)?;
         let scan_limit = if filters.is_empty() { limit } else { None };
+        let filters = filters.to_vec();
+        let needs_data = scan_needs_data(&self.schema, projection, &filters);
         let mut request = lix_file_scan_request(
             self.branch_binding.active_branch_id(),
             Some(projected_schema.as_ref()),
             scan_limit,
+            needs_data,
         );
-        let filters = filters.to_vec();
         if matches!(self.branch_binding, BranchBinding::Explicit) {
             request.filter.branch_ids = explicit_branch_ids_from_dml_filters(&filters);
         }
@@ -374,8 +378,8 @@ impl TableSpec for LixFileSpec {
         )
         .await
         .map_err(lix_error_to_datafusion_error)?;
-        let needs_data = scan_needs_data(&self.schema, projection, &filters);
         let target_file_ids = file_id_constraint_from_filters(&filters)?;
+        let target_paths = file_path_constraint_from_filters(&filters)?;
         let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
         validate_json_predicate_filters(self.schema.as_ref(), &filters)?;
         let physical_filters = filters
@@ -393,6 +397,7 @@ impl TableSpec for LixFileSpec {
                     projection.cloned(),
                     request,
                     target_file_ids,
+                    target_paths,
                     physical_filters,
                     needs_data,
                     limit,
@@ -405,6 +410,7 @@ impl TableSpec for LixFileSpec {
                     projection,
                     request,
                     target_file_ids,
+                    target_paths,
                     filters,
                     needs_data,
                     limit,
@@ -418,6 +424,8 @@ impl TableSpec for LixFileSpec {
                     .map_err(|error| {
                         DataFusionError::Execution(format!("sql2 lix_file scan failed: {error}"))
                     })?;
+                    let rows = filter_lix_file_live_rows_by_path(rows, &target_paths)
+                        .map_err(lix_error_to_datafusion_error)?;
                     let plugin_render = plugin_render_context_for_lix_file_scan(
                         Arc::clone(&live_state),
                         &blob_reader,
@@ -496,7 +504,8 @@ impl TableSpec for LixFileSpec {
     ) -> Result<PlannedDml> {
         let needs_data = filters.iter().any(|filter| contains_column(filter, "data"));
         let target_file_ids = file_id_constraint_from_filters(filters)?;
-        let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
+        let mut request =
+            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
         request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
@@ -560,7 +569,8 @@ impl TableSpec for LixFileSpec {
                 column_name == "path" || physical_expr_contains_column(expr, "data")
             });
         let target_file_ids = file_id_constraint_from_filters(filters)?;
-        let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
+        let mut request =
+            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
         request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
@@ -761,6 +771,17 @@ impl UpsertSupport for LixFileSpec {
         ))
     }
 
+    fn validate_proposed_batches(
+        &self,
+        batches: &[RecordBatch],
+        target: &UpsertConflictTarget,
+    ) -> Result<()> {
+        if target.kind() == UpsertConflictKind::Path {
+            reject_duplicate_lix_file_path_conflict_identities(batches, target)?;
+        }
+        Ok(())
+    }
+
     async fn scan_conflict_candidates(
         &self,
         write_ctx: &SqlWriteContext,
@@ -777,7 +798,8 @@ impl UpsertSupport for LixFileSpec {
                 FileIdConstraint::All
             }
         };
-        let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
+        let mut request =
+            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
         if matches!(self.branch_binding, BranchBinding::Explicit) {
             request.filter.branch_ids = match target.kind() {
                 UpsertConflictKind::Id => proposed_branch_ids(proposed)?,
@@ -857,7 +879,8 @@ impl UpsertSupport for LixFileSpec {
         // (needed to tombstone the old blob when `data` is replaced) and any
         // plugins installed for path-move rewrites.
         let target_file_ids = augmented_file_id_constraint(augmented)?;
-        let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
+        let mut request =
+            lix_file_scan_request(self.branch_binding.active_branch_id(), None, None, false);
         if matches!(self.branch_binding, BranchBinding::Explicit) {
             request.filter.branch_ids = augmented_branch_ids(augmented)?;
         }
@@ -994,6 +1017,37 @@ fn validate_required_paths(batch: &RecordBatch, table_name: &str) -> Result<()> 
             return Err(DataFusionError::Execution(format!(
                 "INSERT ON CONFLICT (path) on {table_name} requires non-null path"
             )));
+        }
+    }
+    Ok(())
+}
+
+fn reject_duplicate_lix_file_path_conflict_identities(
+    batches: &[RecordBatch],
+    target: &UpsertConflictTarget,
+) -> Result<()> {
+    let mut seen = HashSet::new();
+    for batch in batches {
+        validate_required_paths(batch, "lix_file")?;
+        if target.columns().contains(&"lixcol_branch_id") {
+            let _ = required_proposed_branch_ids(batch, "lix_file")?;
+        }
+        for row_index in 0..batch.num_rows() {
+            let mut key = Vec::with_capacity(target.columns().len());
+            for column_name in target.columns() {
+                let column_index = batch.schema().index_of(column_name)?;
+                key.push(ScalarValue::try_from_array(
+                    batch.column(column_index).as_ref(),
+                    row_index,
+                )?);
+            }
+            if !seen.insert(key) {
+                let path = required_string_value(batch, row_index, "path")?;
+                return Err(lix_error_to_datafusion_error(LixError::new(
+                    LixError::CODE_UNIQUE,
+                    format!("duplicate lix_file VALUES path {path:?}"),
+                )));
+            }
         }
     }
     Ok(())
@@ -1249,16 +1303,17 @@ pub(crate) enum FastLixFilePathWriteConflict {
     UpdateData,
 }
 
-pub(crate) async fn execute_fast_lix_file_path_write(
+pub(crate) async fn execute_fast_lix_file_path_writes(
     ctx: &mut dyn SqlWriteExecutionContext,
-    path: String,
-    data: Vec<u8>,
+    writes: Vec<(String, Vec<u8>)>,
     conflict: FastLixFilePathWriteConflict,
 ) -> Result<u64, LixError> {
-    let active_branch_id = ctx.active_branch_id().to_string();
-    let parsed = parse_file_upsert_path(&path, TransactionWriteOperation::Insert)
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+    if writes.is_empty() {
+        return Ok(0);
+    }
+    reject_duplicate_fast_lix_file_paths(&writes)?;
 
+    let active_branch_id = ctx.active_branch_id().to_string();
     let live_rows = ctx
         .scan_live_state(&LiveStateScanRequest {
             filter: LiveStateFilter {
@@ -1271,89 +1326,121 @@ pub(crate) async fn execute_fast_lix_file_path_write(
         })
         .await?;
     let filesystem = FilesystemIndex::from_live_rows(live_rows.clone())?;
-
-    if let Some(existing) = filesystem.file_entry(&parsed.path).cloned() {
-        if conflict != FastLixFilePathWriteConflict::None {
-            validate_fast_lix_file_path_conflict_pair(existing.scope.untracked, &parsed.path)?;
-        }
-        return match conflict {
-            FastLixFilePathWriteConflict::None => {
-                let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
-                let context = FilesystemRowContext {
-                    branch_id: active_branch_id.clone(),
-                    global: false,
-                    untracked: false,
-                    file_id: None,
-                    metadata: None,
-                };
-                let plan = plan_parsed_file_path_write_with_resolvers(
-                    &mut path_resolvers,
-                    parsed.parsed_path,
-                    Some(
-                        parsed
-                            .plugin_key
-                            .as_deref()
-                            .map(plugin_storage_archive_file_id)
-                            .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string()),
-                    ),
-                    Some(data),
-                    context,
-                    &mut || ctx.functions().call_uuid_v7().to_string(),
-                )?;
-                let mut staged = LixFileStagedBatch::default();
-                staged.extend_filesystem_plan(plan);
-                stage_lix_file_fast_batch(ctx, TransactionWriteMode::Insert, staged).await
-            }
-            FastLixFilePathWriteConflict::DoNothing => Ok(0),
-            FastLixFilePathWriteConflict::UpdateData => {
-                let mut staged = LixFileStagedBatch::default();
-                let mut context = existing.scope.context(Some(existing.id.clone()));
-                if context.global {
-                    context.branch_id = GLOBAL_BRANCH_ID.to_string();
-                }
-                stage_lix_file_data_update_write(
-                    &mut staged,
-                    existing.id.clone(),
-                    Some(parsed.path),
-                    Some(existing.name.clone()),
-                    data,
-                    context,
-                    existing.blob_hash.is_some(),
-                    None,
-                )
-                .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
-                staged.count = 1;
-                stage_lix_file_fast_batch(ctx, TransactionWriteMode::Replace, staged).await
-            }
-        };
-    }
-
+    let descriptor_contexts = file_descriptor_contexts_from_live_rows(&live_rows)?;
     let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
     let resolver_key = filesystem_storage_scope_key(&active_branch_id, false, false, None);
     path_resolvers.entry(resolver_key).or_default();
-    let context = FilesystemRowContext {
-        branch_id: active_branch_id,
-        global: false,
-        untracked: false,
-        file_id: None,
-        metadata: None,
-    };
-    let file_id = parsed
-        .plugin_key
-        .as_deref()
-        .map(plugin_storage_archive_file_id)
-        .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string());
-    let mut plan = plan_parsed_file_path_write_with_resolvers(
-        &mut path_resolvers,
-        parsed.parsed_path,
-        Some(file_id.clone()),
-        Some(data),
-        context,
-        &mut || ctx.functions().call_uuid_v7().to_string(),
-    )?;
-    attach_lix_file_insert_origin(&mut plan.rows, "lix_file", &file_id);
     let mut staged = LixFileStagedBatch::default();
-    staged.extend_filesystem_plan(plan);
+
+    for (path, data) in writes {
+        let parsed = parse_file_upsert_path(&path, TransactionWriteOperation::Insert)
+            .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+
+        if let Some(existing) = filesystem.file_entry(&parsed.path).cloned() {
+            if conflict != FastLixFilePathWriteConflict::None {
+                validate_fast_lix_file_path_conflict_pair(existing.scope.untracked, &parsed.path)?;
+            }
+            match conflict {
+                FastLixFilePathWriteConflict::None => {
+                    let context = FilesystemRowContext {
+                        branch_id: active_branch_id.clone(),
+                        global: false,
+                        untracked: false,
+                        file_id: None,
+                        metadata: None,
+                    };
+                    let plan = plan_parsed_file_path_write_with_resolvers(
+                        &mut path_resolvers,
+                        parsed.parsed_path,
+                        Some(
+                            parsed
+                                .plugin_key
+                                .as_deref()
+                                .map(plugin_storage_archive_file_id)
+                                .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string()),
+                        ),
+                        Some(data),
+                        context,
+                        &mut || ctx.functions().call_uuid_v7().to_string(),
+                    )?;
+                    staged.extend_filesystem_plan(plan);
+                }
+                FastLixFilePathWriteConflict::DoNothing => {}
+                FastLixFilePathWriteConflict::UpdateData => {
+                    let descriptor_context = descriptor_contexts.get(&existing.id);
+                    let mut context = descriptor_context
+                        .map(|descriptor| descriptor.context.clone())
+                        .unwrap_or_else(|| existing.scope.context(None));
+                    if context.global {
+                        context.branch_id = GLOBAL_BRANCH_ID.to_string();
+                    }
+                    if file_metadata_is_filesystem_unresolved(
+                        context.metadata.as_ref().map(TransactionJson::normalized),
+                    ) {
+                        let Some(descriptor_context) = descriptor_context else {
+                            return Err(LixError::new(
+                                LixError::CODE_UNKNOWN,
+                                format!(
+                                    "missing descriptor context for unresolved file {:?}",
+                                    parsed.path
+                                ),
+                            ));
+                        };
+                        context = clear_filesystem_unresolved_metadata(&context);
+                        staged
+                            .state_rows
+                            .push(file_descriptor_row(FileDescriptorRowInput {
+                                id: existing.id.clone(),
+                                directory_id: descriptor_context.directory_id.clone(),
+                                name: descriptor_context.name.clone(),
+                                context: context.clone(),
+                            }));
+                    }
+                    stage_lix_file_data_update_write(
+                        &mut staged,
+                        existing.id.clone(),
+                        Some(parsed.path),
+                        Some(existing.name.clone()),
+                        data,
+                        context,
+                        existing.blob_hash.is_some(),
+                        None,
+                    )
+                    .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+                    staged.count = staged.count.checked_add(1).ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_UNSUPPORTED_SQL,
+                            "lix_file fast write row count overflow",
+                        )
+                    })?;
+                }
+            }
+        } else {
+            let context = FilesystemRowContext {
+                branch_id: active_branch_id.clone(),
+                global: false,
+                untracked: false,
+                file_id: None,
+                metadata: None,
+            };
+            let file_id = parsed
+                .plugin_key
+                .as_deref()
+                .map(plugin_storage_archive_file_id)
+                .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string());
+            let mut plan = plan_parsed_file_path_write_with_resolvers(
+                &mut path_resolvers,
+                parsed.parsed_path,
+                Some(file_id.clone()),
+                Some(data),
+                context,
+                &mut || ctx.functions().call_uuid_v7().to_string(),
+            )?;
+            attach_lix_file_insert_origin(&mut plan.rows, "lix_file", &file_id);
+            staged.extend_filesystem_plan(plan);
+        }
+    }
+
     let mode = match conflict {
         FastLixFilePathWriteConflict::None => TransactionWriteMode::Insert,
         FastLixFilePathWriteConflict::DoNothing | FastLixFilePathWriteConflict::UpdateData => {
@@ -1361,6 +1448,70 @@ pub(crate) async fn execute_fast_lix_file_path_write(
         }
     };
     stage_lix_file_fast_batch(ctx, mode, staged).await
+}
+
+fn reject_duplicate_fast_lix_file_paths(writes: &[(String, Vec<u8>)]) -> Result<(), LixError> {
+    let mut seen = BTreeSet::new();
+    for (path, _) in writes {
+        if !seen.insert(path.as_str()) {
+            return Err(LixError::new(
+                LixError::CODE_UNIQUE,
+                format!("duplicate lix_file VALUES path {path:?}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct FileDescriptorContext {
+    directory_id: Option<String>,
+    name: String,
+    context: FilesystemRowContext,
+}
+
+fn file_descriptor_contexts_from_live_rows(
+    rows: &[MaterializedLiveStateRow],
+) -> Result<BTreeMap<String, FileDescriptorContext>, LixError> {
+    let mut descriptors = BTreeMap::new();
+    for row in rows {
+        if row.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY {
+            continue;
+        }
+        let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+            continue;
+        };
+        let snapshot: FileDescriptorSnapshot =
+            serde_json::from_str(snapshot_content).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!("invalid lix_file_descriptor snapshot JSON: {error}"),
+                )
+            })?;
+        let metadata = row
+            .metadata
+            .as_deref()
+            .map(|metadata| {
+                let value = parse_row_metadata_value(metadata, "lix_file")?;
+                TransactionJson::from_value(value, "lix_file metadata")
+            })
+            .transpose()?;
+        descriptors.insert(
+            snapshot.id.clone(),
+            FileDescriptorContext {
+                directory_id: snapshot.directory_id,
+                name: snapshot.name,
+                context: FilesystemRowContext {
+                    branch_id: row.branch_id.clone(),
+                    global: row.global,
+                    untracked: row.untracked,
+                    file_id: row.file_id.clone(),
+                    metadata,
+                },
+            },
+        );
+    }
+    Ok(descriptors)
 }
 
 fn validate_fast_lix_file_path_conflict_pair(
@@ -1426,7 +1577,7 @@ fn lix_file_delete_stage_from_batch(
             parse_normal_write_file_path(&path, TransactionWriteOperation::Delete)?;
         }
         let file_id = required_string_value(batch, row_index, "id")?;
-        let context = file_row_context_from_batch(batch, row_index, branch_binding)?;
+        let context = file_row_context_from_existing_batch(batch, row_index, branch_binding)?;
         staged.extend_filesystem_delete_plan(plan_file_delete(FileDeleteInput {
             file_id: file_id.clone(),
             has_blob_ref: blob_ref_keys
@@ -1524,6 +1675,11 @@ fn lix_file_existing_update_stage_from_batch(
         let id = required_string_value(batch, row_index, "id")?;
         let context =
             file_row_context_from_update(batch, assignment_values, row_index, branch_binding)?;
+        let data_context = if include_data_writes {
+            clear_filesystem_unresolved_metadata(&context)
+        } else {
+            context.clone()
+        };
         let mut data_path = None;
         let mut data_filename = None;
         if include_descriptor_writes {
@@ -1548,12 +1704,24 @@ fn lix_file_existing_update_stage_from_batch(
                     id: id.clone(),
                     directory_id,
                     name,
-                    context: context.clone(),
+                    context: data_context.clone(),
                 }));
         }
 
         if include_data_writes {
             let data = update_required_binary_value(batch, assignment_values, row_index, "data")?;
+            if !include_descriptor_writes && context.metadata != data_context.metadata {
+                let directory_id = optional_string_value(batch, row_index, "directory_id")?;
+                let name = required_string_value(batch, row_index, "name")?;
+                staged
+                    .state_rows
+                    .push(file_descriptor_row(FileDescriptorRowInput {
+                        id: id.clone(),
+                        directory_id,
+                        name,
+                        context: data_context.clone(),
+                    }));
+            }
             let path = if include_descriptor_writes {
                 data_path
             } else {
@@ -1567,7 +1735,7 @@ fn lix_file_existing_update_stage_from_batch(
                 path,
                 data_filename,
                 data,
-                context,
+                data_context,
                 has_blob_ref,
                 None,
             )?;
@@ -1646,6 +1814,32 @@ fn reject_lix_file_update_plugin_storage_paths(
     Ok(())
 }
 
+fn reject_unresolved_metadata_update_without_data(
+    batch: &RecordBatch,
+    assignment_values: &UpdateAssignmentValues,
+    update_columns: LixFileUpdateColumns,
+) -> Result<()> {
+    if update_columns.data || !update_columns.descriptor {
+        return Ok(());
+    }
+    for row_index in 0..batch.num_rows() {
+        if !matches!(
+            assignment_values.assigned_cell(row_index, "lixcol_metadata")?,
+            UpdateCell::Assigned(_)
+        ) {
+            continue;
+        }
+        let metadata = optional_string_value(batch, row_index, "lixcol_metadata")?;
+        if file_metadata_is_filesystem_unresolved(metadata.as_deref()) {
+            return Err(lix_error_to_datafusion_error(LixError::new(
+                LixError::CODE_READ_ONLY,
+                "UPDATE lix_file cannot modify metadata for unresolved filesystem data without also assigning data",
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn lix_file_update_stage_from_batch(
     batch: &RecordBatch,
     assignment_values: &UpdateAssignmentValues,
@@ -1657,6 +1851,7 @@ fn lix_file_update_stage_from_batch(
     generate_directory_id: &mut dyn FnMut() -> String,
 ) -> Result<LixFileStagedBatch> {
     reject_lix_file_update_plugin_storage_paths(batch, assignment_values, update_columns)?;
+    reject_unresolved_metadata_update_without_data(batch, assignment_values, update_columns)?;
 
     if update_columns.path || update_columns.descriptor {
         let Some(path_resolvers) = path_resolvers else {
@@ -1722,6 +1917,11 @@ fn lix_file_path_update_stage_from_batch(
         } = parse_file_upsert_path(&path, TransactionWriteOperation::Update)?;
         let context =
             file_row_context_from_update(batch, assignment_values, row_index, branch_binding)?;
+        let data_context = if update_columns.data {
+            clear_filesystem_unresolved_metadata(&context)
+        } else {
+            context.clone()
+        };
         let assigned_data = if update_columns.data {
             Some(update_required_binary_value(
                 batch,
@@ -1737,7 +1937,7 @@ fn lix_file_path_update_stage_from_batch(
             path_resolvers,
             id.clone(),
             parsed_path,
-            context.clone(),
+            data_context.clone(),
             generate_directory_id,
         )
         .map_err(lix_error_to_datafusion_error)?;
@@ -1752,7 +1952,7 @@ fn lix_file_path_update_stage_from_batch(
                 Some(path),
                 Some(filename),
                 data,
-                context,
+                data_context,
                 has_blob_ref,
                 None,
             )?;
@@ -2139,6 +2339,34 @@ fn file_row_context_from_batch(
     })
 }
 
+fn file_row_context_from_existing_batch(
+    batch: &RecordBatch,
+    row_index: usize,
+    branch_binding: Option<&str>,
+) -> Result<FilesystemRowContext> {
+    let explicit_branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?;
+    let scope = resolve_write_branch_scope(
+        optional_bool_value(batch, row_index, "lixcol_global")?,
+        explicit_branch_id,
+        branch_binding,
+        "lix_file_by_branch",
+        "lix_file",
+    )?;
+
+    Ok(FilesystemRowContext {
+        branch_id: scope.branch_id,
+        global: scope.global,
+        untracked: optional_bool_value(batch, row_index, "lixcol_untracked")?.unwrap_or(false),
+        file_id: optional_string_value(batch, row_index, "lixcol_file_id")?,
+        metadata: optional_existing_metadata_value(
+            batch,
+            row_index,
+            "lixcol_metadata",
+            "lix_file",
+        )?,
+    })
+}
+
 fn file_row_context_from_update(
     batch: &RecordBatch,
     assignment_values: &UpdateAssignmentValues,
@@ -2320,6 +2548,15 @@ async fn lix_file_record_batch(
             match blob_rows.get(&FilesystemBlobRefKey::from_context(&context, &file.id)) {
                 Some(blob_ref) => load_single_blob_bytes(blob_reader, &blob_ref.blob_hash).await?,
                 None => {
+                    if file_metadata_is_filesystem_unresolved(file.live.metadata.as_deref()) {
+                        return Err(LixError::new(
+                            "LIX_FILESYSTEM_DATA_UNRESOLVED",
+                            format!("filesystem data for path {path:?} has not been imported yet"),
+                        )
+                        .with_hint(
+                            "Hydrate the filesystem file data before selecting lix_file.data.",
+                        ));
+                    }
                     let rendered = match &plugin_render {
                         Some(plugin_render) => {
                             render_plugin_file_for_sql(plugin_render, &file, &path).await?
@@ -2520,6 +2757,7 @@ fn lix_file_scan_request(
     branch_binding: Option<&str>,
     projected_schema: Option<&Schema>,
     limit: Option<usize>,
+    needs_data: bool,
 ) -> LiveStateScanRequest {
     LiveStateScanRequest {
         filter: LiveStateFilter {
@@ -2533,24 +2771,43 @@ fn lix_file_scan_request(
                 .unwrap_or_default(),
             ..LiveStateFilter::default()
         },
-        projection: lix_file_live_state_projection(projected_schema),
+        projection: lix_file_live_state_projection(projected_schema, needs_data),
         limit,
     }
 }
 
-fn lix_file_live_state_projection(projected_schema: Option<&Schema>) -> LiveStateProjection {
+fn lix_file_live_state_projection(
+    projected_schema: Option<&Schema>,
+    needs_data: bool,
+) -> LiveStateProjection {
     let Some(schema) = projected_schema else {
         return LiveStateProjection::default();
     };
     let mut columns = vec!["snapshot_content".to_string()];
-    if schema
-        .fields()
-        .iter()
-        .any(|field| field.name() == "lixcol_metadata")
+    if needs_data
+        || schema
+            .fields()
+            .iter()
+            .any(|field| field.name() == "lixcol_metadata")
     {
         columns.push("metadata".to_string());
     }
     LiveStateProjection { columns }
+}
+
+fn file_metadata_is_filesystem_unresolved(metadata: Option<&str>) -> bool {
+    let Some(metadata) = metadata else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(metadata)
+        .ok()
+        .and_then(|value| {
+            value
+                .as_object()
+                .and_then(|object| object.get(FILESYSTEM_UNRESOLVED_METADATA_KEY))
+                .cloned()
+        })
+        .is_some()
 }
 
 async fn scan_lix_file_live_rows(
@@ -2583,6 +2840,96 @@ async fn scan_lix_file_live_rows(
     rows.extend(live_state.scan_rows(&directory_request).await?);
 
     Ok(rows)
+}
+
+fn filter_lix_file_live_rows_by_path(
+    rows: Vec<MaterializedLiveStateRow>,
+    target_paths: &FileIdConstraint,
+) -> std::result::Result<Vec<MaterializedLiveStateRow>, LixError> {
+    if matches!(target_paths, FileIdConstraint::All) {
+        return Ok(rows);
+    }
+
+    let mut directory_rows = Vec::<DirectoryDescriptorRecord>::new();
+    let mut file_rows = Vec::<FileDescriptorRecord>::new();
+    for row in &rows {
+        let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+            continue;
+        };
+        match row.schema_key.as_str() {
+            FILE_DESCRIPTOR_SCHEMA_KEY => {
+                let snapshot: FileDescriptorSnapshot = serde_json::from_str(snapshot_content)
+                    .map_err(|error| {
+                        LixError::new(
+                            "LIX_ERROR_UNKNOWN",
+                            format!("invalid lix_file_descriptor snapshot JSON: {error}"),
+                        )
+                    })?;
+                file_rows.push(FileDescriptorRecord {
+                    id: snapshot.id.clone(),
+                    directory_id: snapshot.directory_id,
+                    name: snapshot.name,
+                    key: FilesystemDescriptorKey::from_live_row(row, snapshot.id),
+                    live: row.clone(),
+                });
+            }
+            DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
+                let snapshot: DirectoryDescriptorSnapshot = serde_json::from_str(snapshot_content)
+                    .map_err(|error| {
+                        LixError::new(
+                            "LIX_ERROR_UNKNOWN",
+                            format!("invalid lix_directory_descriptor snapshot JSON: {error}"),
+                        )
+                    })?;
+                directory_rows.push(DirectoryDescriptorRecord {
+                    key: FilesystemDescriptorKey::from_live_row(row, snapshot.id.clone()),
+                    parent_id: snapshot.parent_id,
+                    name: snapshot.name,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let directory_paths =
+        derive_directory_paths(directory_rows.iter().map(|row| (row.key.clone(), row)))?;
+    let mut keep_file_ids = BTreeSet::new();
+    for file in file_rows {
+        let directory_path = match file.directory_id.as_ref() {
+            Some(directory_id) => {
+                let parent_key = file
+                    .directory_parent_keys(directory_id)
+                    .into_iter()
+                    .find(|key| directory_paths.contains_key(key));
+                parent_key
+                    .as_ref()
+                    .and_then(|key| directory_paths.get(key))
+                    .cloned()
+            }
+            None => None,
+        };
+        let path = compose_file_path(directory_path.as_deref(), &file.name)?;
+        if target_paths.matches_value(&path) {
+            keep_file_ids.insert(file.id);
+        }
+    }
+
+    Ok(rows
+        .into_iter()
+        .filter(|row| {
+            if row.schema_key == DIRECTORY_DESCRIPTOR_SCHEMA_KEY {
+                return true;
+            }
+            if row.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY || row.schema_key == BLOB_REF_SCHEMA_KEY
+            {
+                return row
+                    .entity_pk
+                    .as_single_string()
+                    .is_ok_and(|file_id| keep_file_ids.contains(file_id));
+            }
+            true
+        })
+        .collect())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2627,10 +2974,29 @@ impl FileIdConstraint {
             }
         }
     }
+
+    fn matches_value(&self, value: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::None => false,
+            Self::Ids(values) => values.contains(value),
+        }
+    }
 }
 
 fn file_id_constraint_from_filters(filters: &[Expr]) -> Result<FileIdConstraint> {
     let analyzer = LixFileIdFilterAnalyzer;
+    let mut constraint = FileIdConstraint::All;
+    for filter in filters {
+        if let Some(filter_constraint) = analyzer.analyze(filter)? {
+            constraint = constraint.intersect(filter_constraint);
+        }
+    }
+    Ok(constraint)
+}
+
+fn file_path_constraint_from_filters(filters: &[Expr]) -> Result<FileIdConstraint> {
+    let analyzer = ExactStringColumnFilterAnalyzer::new("path");
     let mut constraint = FileIdConstraint::All;
     for filter in filters {
         if let Some(filter_constraint) = analyzer.analyze(filter)? {
@@ -2963,14 +3329,32 @@ fn update_optional_metadata_value(
     column_name: &str,
     context: &str,
 ) -> Result<Option<TransactionJson>> {
-    update_optional_string_value(batch, assignment_values, row_index, column_name)?
-        .map(|value| {
-            let metadata = parse_row_metadata_value(&value, context)
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
+    match assignment_values.assigned_cell(row_index, column_name)? {
+        UpdateCell::Assigned(SqlCell::Null) => Ok(None),
+        UpdateCell::Assigned(SqlCell::Value(
+            ScalarValue::Utf8(Some(value))
+            | ScalarValue::Utf8View(Some(value))
+            | ScalarValue::LargeUtf8(Some(value)),
+        )) => {
+            let metadata = parse_public_lix_file_metadata(&value, context)?;
             TransactionJson::from_value(metadata, &format!("{context} metadata"))
                 .map_err(crate::sql2::error::lix_error_to_datafusion_error)
-        })
-        .transpose()
+                .map(Some)
+        }
+        UpdateCell::Assigned(SqlCell::Value(other)) => Err(DataFusionError::Execution(format!(
+            "UPDATE lix_file expected text-compatible column '{column_name}', got {other:?}"
+        ))),
+        UpdateCell::Unassigned => {
+            update_optional_string_value(batch, assignment_values, row_index, column_name)?
+                .map(|value| {
+                    let metadata = parse_row_metadata_value(&value, context)
+                        .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
+                    TransactionJson::from_value(metadata, &format!("{context} metadata"))
+                        .map_err(crate::sql2::error::lix_error_to_datafusion_error)
+                })
+                .transpose()
+        }
+    }
 }
 
 fn update_required_binary_value(
@@ -3054,12 +3438,80 @@ fn optional_metadata_value(
 ) -> Result<Option<TransactionJson>> {
     optional_string_value(batch, row_index, column_name)?
         .map(|value| {
+            let metadata = parse_public_lix_file_metadata(&value, context)?;
+            TransactionJson::from_value(metadata, &format!("{context} metadata"))
+                .map_err(crate::sql2::error::lix_error_to_datafusion_error)
+        })
+        .transpose()
+}
+
+fn optional_existing_metadata_value(
+    batch: &RecordBatch,
+    row_index: usize,
+    column_name: &str,
+    context: &str,
+) -> Result<Option<TransactionJson>> {
+    optional_string_value(batch, row_index, column_name)?
+        .map(|value| {
             let metadata = parse_row_metadata_value(&value, context)
                 .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
             TransactionJson::from_value(metadata, &format!("{context} metadata"))
                 .map_err(crate::sql2::error::lix_error_to_datafusion_error)
         })
         .transpose()
+}
+
+fn parse_public_lix_file_metadata(value: &str, context: &str) -> Result<serde_json::Value> {
+    let metadata = parse_row_metadata_value(value, context)
+        .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
+    if metadata
+        .as_object()
+        .is_some_and(|object| object.contains_key(FILESYSTEM_UNRESOLVED_METADATA_KEY))
+    {
+        return Err(lix_error_to_datafusion_error(LixError::new(
+            LixError::CODE_READ_ONLY,
+            format!(
+                "{context} metadata key {FILESYSTEM_UNRESOLVED_METADATA_KEY:?} is reserved for filesystem backend inventory"
+            ),
+        )));
+    }
+    Ok(metadata)
+}
+
+fn clear_filesystem_unresolved_metadata(context: &FilesystemRowContext) -> FilesystemRowContext {
+    let Some(metadata) = context.metadata.as_ref() else {
+        return context.clone();
+    };
+    let Some(object) = metadata.value().as_object() else {
+        return context.clone();
+    };
+    if !object.contains_key(FILESYSTEM_UNRESOLVED_METADATA_KEY) {
+        return context.clone();
+    }
+
+    let mut value = metadata.value().clone();
+    let Some(object) = value.as_object_mut() else {
+        return context.clone();
+    };
+    object.remove(FILESYSTEM_UNRESOLVED_METADATA_KEY);
+
+    let metadata = if object.is_empty() {
+        None
+    } else {
+        Some(TransactionJson::from_value_unchecked(value))
+    };
+    FilesystemRowContext {
+        metadata,
+        ..context.clone()
+    }
+}
+
+pub(crate) fn filesystem_unresolved_metadata() -> TransactionJson {
+    TransactionJson::from_value_unchecked(json!({
+        FILESYSTEM_UNRESOLVED_METADATA_KEY: {
+            "version": 1
+        }
+    }))
 }
 
 fn optional_bool_value(
@@ -3698,6 +4150,31 @@ mod tests {
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("file insert batch")
     }
 
+    fn path_upsert_batch(path: &str) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("path", DataType::Utf8, false)])),
+            vec![string_column(vec![Some(path)])],
+        )
+        .expect("path upsert batch")
+    }
+
+    #[test]
+    fn path_upsert_duplicate_validation_spans_batches() {
+        let target = super::UpsertConflictTarget::path(super::LIX_FILE_PATH_IDENTITY);
+
+        let error = super::reject_duplicate_lix_file_path_conflict_identities(
+            &[path_upsert_batch("/dup.md"), path_upsert_batch("/dup.md")],
+            &target,
+        )
+        .expect_err("duplicate path in a later batch should be rejected");
+
+        assert!(
+            error
+                .strip_backtrace()
+                .contains("duplicate lix_file VALUES path \"/dup.md\"")
+        );
+    }
+
     fn data_insert_batch() -> RecordBatch {
         RecordBatch::try_new(
             Arc::new(Schema::new(vec![
@@ -3782,6 +4259,30 @@ mod tests {
             ],
         )
         .expect("file data update batch")
+    }
+
+    fn unresolved_data_update_batch() -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Utf8, false),
+                Field::new("path", DataType::Utf8, false),
+                Field::new("directory_id", DataType::Utf8, true),
+                Field::new("name", DataType::Utf8, false),
+                Field::new("data", DataType::Binary, true),
+                Field::new("lixcol_branch_id", DataType::Utf8, false),
+                crate::sql2::result_metadata::json_field("lixcol_metadata", true),
+            ])),
+            vec![
+                string_column(vec![Some("file-readme")]),
+                string_column(vec![Some("/docs/readme.md")]),
+                string_column(vec![Some("dir-docs")]),
+                string_column(vec![Some("readme.md")]),
+                Arc::new(BinaryArray::from_vec(vec![b"hello"])) as ArrayRef,
+                string_column(vec![Some("branch-b")]),
+                string_column(vec![Some(r#"{"lix_fs_unresolved":{"version":1}}"#)]),
+            ],
+        )
+        .expect("file unresolved data update batch")
     }
 
     fn descriptor_data_update_batch() -> RecordBatch {
@@ -4435,6 +4936,37 @@ mod tests {
         assert_eq!(staged.file_data_writes[0].file_id, "file-readme");
         assert_eq!(staged.state_rows.len(), 1);
         assert_eq!(staged.state_rows[0].schema_key, "lix_binary_blob_ref");
+    }
+
+    #[test]
+    fn file_data_update_clears_unresolved_metadata() {
+        let staged = lix_file_update_stage_from_batch_for_test(
+            &unresolved_data_update_batch(),
+            None,
+            super::LixFileUpdateColumns {
+                path: false,
+                data: true,
+                descriptor: false,
+            },
+            None,
+            &mut test_id_generator(&["should-not-be-used"]),
+        )
+        .expect("decode file data update");
+
+        assert_eq!(staged.count, 1);
+        assert_eq!(staged.file_data_writes.len(), 1);
+        let descriptor = staged
+            .state_rows
+            .iter()
+            .find(|row| row.schema_key == "lix_file_descriptor")
+            .expect("data hydration should restage the descriptor");
+        assert_eq!(descriptor.metadata, None);
+        assert!(
+            staged
+                .state_rows
+                .iter()
+                .any(|row| row.schema_key == "lix_binary_blob_ref")
+        );
     }
 
     #[test]

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -29,7 +29,9 @@ use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
 use datafusion::catalog::TableProvider;
 
-pub(crate) use file::{FastLixFilePathWriteConflict, execute_fast_lix_file_path_write};
+pub(crate) use file::{
+    FastLixFilePathWriteConflict, execute_fast_lix_file_path_writes, filesystem_unresolved_metadata,
+};
 pub(crate) use upsert::{UpsertAction, excluded_field_name};
 
 /// Execute an `INSERT ... ON CONFLICT` against a registered table provider.

--- a/packages/engine/src/sql2/providers/upsert.rs
+++ b/packages/engine/src/sql2/providers/upsert.rs
@@ -143,6 +143,15 @@ pub(super) trait UpsertSupport: Send + Sync {
         batch: &RecordBatch,
     ) -> Result<StagedUpsert>;
 
+    /// Validate all proposed rows before scanning existing conflict candidates.
+    fn validate_proposed_batches(
+        &self,
+        _batches: &[RecordBatch],
+        _target: &UpsertConflictTarget,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Scan existing rows whose identity matches a proposed row, returned as a
     /// batch in this table's column schema.
     async fn scan_conflict_candidates(
@@ -189,6 +198,8 @@ pub(super) async fn execute_upsert<S: UpsertSupport + ?Sized>(
     let conflict_columns = target.columns();
     let mut staged = StagedUpsert::default();
     let mut affected: u64 = 0;
+
+    spec.validate_proposed_batches(&proposed_batches, target)?;
 
     for batch in &proposed_batches {
         let existing = spec

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -47,7 +47,7 @@ pub(crate) async fn commit_prepared_writes(
     if !prepared_writes.file_data_writes.is_empty() {
         let mut blob_writer = binary_cas.writer(&mut writes);
         for write in &prepared_writes.file_data_writes {
-            blob_writer.stage_bytes(&write.data)?;
+            blob_writer.stage_payload(write.payload())?;
         }
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -461,8 +461,7 @@ where
                 let file_data = file_data
                     .into_iter()
                     .filter(|write| {
-                        !file_keys.contains(&PluginFileWriteKey::from(write))
-                            && !write.data.is_empty()
+                        !file_keys.contains(&PluginFileWriteKey::from(write)) && !write.is_empty()
                     })
                     .collect();
                 Ok(TransactionWrite::RowsWithFileData {
@@ -536,7 +535,7 @@ where
                 &active_state,
                 WasmPluginFile {
                     filename,
-                    data: write.data.clone(),
+                    data: write.data().to_vec(),
                 },
             )
             .await?;
@@ -1363,7 +1362,7 @@ fn plugin_archive_schema_rows_for_write(
     }
     Ok(Some(plugin_schema_rows_from_archive_path(
         path,
-        &write.data,
+        write.data(),
         &write.branch_id,
         write.global,
         write.untracked,

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -424,9 +424,12 @@ impl TransactionWriteBuffer {
         })?;
         let mut bytes_by_hash = BTreeMap::<BlobHash, Vec<u8>>::new();
         for write in file_data_guard.iter() {
+            let hash = write
+                .blob_hash()
+                .unwrap_or_else(|| BlobHash::from_content(write.data()));
             bytes_by_hash
-                .entry(BlobHash::from_content(&write.data))
-                .or_insert_with(|| write.data.clone());
+                .entry(hash)
+                .or_insert_with(|| write.data().to_vec());
         }
         Ok(BlobBytesBatch::new(
             hashes
@@ -1137,15 +1140,15 @@ mod tests {
             .stage_write(PreparedTransactionWrite::RowsWithFileData {
                 mode: TransactionWriteMode::Replace,
                 rows: vec![state_row("file-readme", "descriptor")],
-                file_data: vec![TransactionFileData {
-                    file_id: "file-readme".to_string(),
-                    path: Some("/readme.md".to_string()),
-                    filename: Some("readme.md".to_string()),
-                    branch_id: "global".to_string(),
-                    global: true,
-                    untracked: true,
-                    data: b"hello".to_vec(),
-                }],
+                file_data: vec![TransactionFileData::new(
+                    "file-readme".to_string(),
+                    Some("/readme.md".to_string()),
+                    Some("readme.md".to_string()),
+                    "global".to_string(),
+                    true,
+                    true,
+                    b"hello".to_vec(),
+                )],
                 count: 1,
             })
             .expect("staging rows with file data should succeed");
@@ -1155,7 +1158,7 @@ mod tests {
         assert_eq!(drained.state_rows.len(), 1);
         assert_eq!(drained.file_data_writes.len(), 1);
         assert_eq!(drained.file_data_writes[0].file_id, "file-readme");
-        assert_eq!(drained.file_data_writes[0].data, b"hello");
+        assert_eq!(drained.file_data_writes[0].data(), b"hello");
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeSet, fmt, ops::Deref, sync::Arc};
 
 use crate::LixError;
+use crate::binary_cas::{BlobHash, BlobPayload};
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::LixTimestamp;
@@ -181,7 +182,49 @@ pub(crate) struct TransactionFileData {
     pub(crate) branch_id: String,
     pub(crate) global: bool,
     pub(crate) untracked: bool,
-    pub(crate) data: Vec<u8>,
+    payload: BlobPayload,
+}
+
+impl TransactionFileData {
+    pub(crate) fn new(
+        file_id: String,
+        path: Option<String>,
+        filename: Option<String>,
+        branch_id: String,
+        global: bool,
+        untracked: bool,
+        data: Vec<u8>,
+    ) -> Self {
+        Self {
+            file_id,
+            path,
+            filename,
+            branch_id,
+            global,
+            untracked,
+            payload: BlobPayload::from_bytes(data),
+        }
+    }
+
+    pub(crate) fn data(&self) -> &[u8] {
+        self.payload.bytes()
+    }
+
+    pub(crate) fn blob_hash(&self) -> Option<BlobHash> {
+        self.payload.hash()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.payload.len()
+    }
+
+    pub(crate) fn payload(&self) -> &BlobPayload {
+        &self.payload
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.payload.is_empty()
+    }
 }
 
 /// One decoded write batch accepted by the transaction boundary.

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -63,6 +63,11 @@ path = "benches/profile_merge_10k.rs"
 harness = false
 required-features = ["sqlite"]
 
+[[example]]
+name = "profile_fs_open"
+path = "examples/profile_fs_open.rs"
+required-features = ["sqlite"]
+
 [[bench]]
 name = "sqlite_backend"
 path = "benches/sqlite_backend.rs"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -23,6 +23,7 @@ lix_engine = { workspace = true }
 async-trait = "0.1"
 bytes = "1"
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+serde_json = "1"
 tempfile = { version = "3", optional = true }
 wasmtime = { version = "45", default-features = false, features = ["component-model", "cranelift", "runtime", "std"], optional = true }
 wasmtime-wasi = { version = "45", default-features = false, features = ["p2"], optional = true }

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -1,0 +1,77 @@
+// Cold-open profiling harness for the filesystem backend.
+//
+// Usage:
+//   cargo run --release --example profile_fs_open --features sqlite -- <src_dir>
+//
+// Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
+// FsBackend::open on the cold workspace.
+
+use std::path::Path;
+use std::time::Instant;
+
+use lix_sdk::FsBackend;
+
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        if name == ".lix" {
+            continue;
+        }
+        let from = entry.path();
+        let to = dst.join(&name);
+        if from.is_dir() {
+            copy_dir(&from, &to);
+        } else {
+            std::fs::copy(&from, &to).unwrap();
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let src = std::env::args()
+        .nth(1)
+        .expect("usage: profile_fs_open <src_dir>");
+    let src = Path::new(&src);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let work = tmp.path().join("workspace");
+
+    let t_copy = Instant::now();
+    copy_dir(src, &work);
+    eprintln!("copy: {:?}", t_copy.elapsed());
+
+    let repeat: usize = std::env::var("REPEAT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+
+    let t_open = Instant::now();
+    let backend = FsBackend::open(&work).await.unwrap();
+    let open_elapsed = t_open.elapsed();
+    eprintln!("cold open: {:?}", open_elapsed);
+    drop(backend);
+
+    // Warm reopen (now .lix exists).
+    let t_warm = Instant::now();
+    let backend = FsBackend::open(&work).await.unwrap();
+    eprintln!("warm reopen: {:?}", t_warm.elapsed());
+    drop(backend);
+
+    // Repeated cold opens into fresh temp dirs for profiling sample density.
+    for i in 0..repeat {
+        let tmp_i = tempfile::tempdir().unwrap();
+        let work_i = tmp_i.path().join("workspace");
+        copy_dir(src, &work_i);
+        let t = Instant::now();
+        let backend = FsBackend::open(&work_i).await.unwrap();
+        if i == repeat - 1 {
+            eprintln!("cold open (repeat {}): {:?}", repeat, t.elapsed());
+        }
+        drop(backend);
+    }
+
+    println!("COLD_OPEN_MS={}", open_elapsed.as_millis());
+}

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -4,7 +4,8 @@
 //   cargo run --release --example profile_fs_open --features sqlite -- <src_dir>
 //
 // Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
-// FsBackend::open on the cold workspace.
+// FsBackend::open on the cold workspace. Pass --in-place to time an existing
+// workspace without copying.
 
 use std::path::Path;
 use std::time::Instant;
@@ -31,10 +32,25 @@ fn copy_dir(src: &Path, dst: &Path) {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let src = std::env::args()
-        .nth(1)
-        .expect("usage: profile_fs_open <src_dir>");
+    let mut args = std::env::args().skip(1).collect::<Vec<_>>();
+    let in_place = args.first().is_some_and(|arg| arg == "--in-place");
+    if in_place {
+        args.remove(0);
+    }
+    let src = args
+        .first()
+        .expect("usage: profile_fs_open [--in-place] <src_dir>");
     let src = Path::new(&src);
+
+    if in_place {
+        let t_open = Instant::now();
+        let backend = FsBackend::open(src).await.unwrap();
+        let open_elapsed = t_open.elapsed();
+        eprintln!("in-place open: {:?}", open_elapsed);
+        drop(backend);
+        println!("OPEN_MS={}", open_elapsed.as_millis());
+        return;
+    }
 
     let tmp = tempfile::tempdir().unwrap();
     let work = tmp.path().join("workspace");

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::marker::PhantomData;
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -12,6 +12,8 @@ use lix_engine::{
     Backend, BackendError, BackendRead, BackendWrite, CommitResult, Engine, GetOptions,
     InMemoryBackend, Key, KeyRange, LixError, PointVisitor, PutBatch, ReadOptions, ScanOptions,
     ScanResult, ScanVisitor, SessionContext, SessionTransaction, SpaceId, Value, WriteOptions,
+    lix_file_data_hash_hex, lix_filesystem_blob_ref_key_for_active_file_descriptor,
+    lix_filesystem_blob_ref_key_for_active_state_row,
 };
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
@@ -122,6 +124,7 @@ struct FilesystemSupervisorInner {
     event_tx: mpsc::Sender<FilesystemEvent>,
     debouncer: Mutex<Option<FilesystemDebouncer>>,
     worker: Mutex<Option<JoinHandle<()>>>,
+    shutdown: AtomicBool,
 }
 
 struct FilesystemState<B>
@@ -241,6 +244,7 @@ enum MaterializedState {
     Bytes(MaterializedSnapshot),
     Inventory {
         disk: InventorySnapshot,
+        resolved_data_hashes: BTreeMap<String, String>,
         disk_owned_unresolved_files: BTreeSet<String>,
         lix_revision: LixRevision,
     },
@@ -262,10 +266,35 @@ struct LixSnapshotRead {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LixInventoryRead {
     active_branch_id: String,
+    revision: LixRevision,
     directories: BTreeSet<String>,
     directory_ids: BTreeMap<String, String>,
     files: BTreeSet<String>,
+    blob_data_hash_by_path: BTreeMap<String, String>,
     unresolved_files: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct InventoryReconcileOutcome {
+    descriptors_changed: bool,
+}
+
+#[derive(Debug, Default)]
+struct InventoryMaterializeOutcome {
+    needs_disk_sync: bool,
+    skipped_deleted_files: BTreeSet<String>,
+    skipped_deleted_directories: BTreeSet<String>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct SyncFromLixOutcome {
+    needs_disk_sync: bool,
+}
+
+#[derive(Debug)]
+struct InventoryBlobRefSnapshot {
+    id: String,
+    blob_hash: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -276,6 +305,7 @@ enum DiskSyncOutcome {
 
 enum FilesystemEvent {
     DiskChanged,
+    WatcherInstalled,
     SyncFromLix {
         reply_tx: mpsc::SyncSender<Result<(), LixError>>,
     },
@@ -597,32 +627,43 @@ where
             last_materialized: Mutex::new(None),
         });
         let (event_tx, event_rx) = mpsc::channel();
-        let watcher_setup = state.path_filter.is_unfiltered().then(|| {
-            start_filesystem_watcher_setup(
-                state.root.clone(),
-                state.metadata_mode,
-                state.path_filter.clone(),
-                event_tx.clone(),
-            )
-        });
+        let watcher_setup = state
+            .path_filter
+            .is_unfiltered()
+            .then(|| {
+                start_filesystem_watcher_setup(
+                    state.root.clone(),
+                    state.metadata_mode,
+                    state.path_filter.clone(),
+                    event_tx.clone(),
+                )
+            })
+            .flatten();
 
         let initial_sync_result = async {
             if metadata_mode == FilesystemMetadataMode::Persistent {
                 state.migrate_legacy_lix_system_paths().await?;
             }
             if state.sync_disk_to_lix(false).await? == DiskSyncOutcome::NeedsMaterialization {
-                state.sync_from_lix().await?;
+                let _ = state.sync_from_lix().await?;
             }
             Ok::<(), LixError>(())
         }
         .await;
 
-        let debouncer = if let Some(watcher_setup) = watcher_setup.flatten() {
-            let debouncer = finish_filesystem_watcher_setup(Some(watcher_setup));
-            initial_sync_result?;
-            debouncer
+        if let Err(error) = initial_sync_result {
+            if let Some(watcher_setup) = watcher_setup {
+                if let Some(debouncer) = finish_filesystem_watcher_setup(Some(watcher_setup)) {
+                    debouncer.stop();
+                }
+            }
+            return Err(error);
+        }
+
+        let watcher_pending = watcher_setup.is_some();
+        let debouncer = if watcher_pending {
+            None
         } else {
-            initial_sync_result?;
             create_filesystem_debouncer(
                 &state.root,
                 state.metadata_mode,
@@ -642,12 +683,18 @@ where
                 )
             })?;
 
+        let inner = Arc::new(FilesystemSupervisorInner {
+            event_tx: event_tx.clone(),
+            debouncer: Mutex::new(debouncer),
+            worker: Mutex::new(Some(worker)),
+            shutdown: AtomicBool::new(false),
+        });
+        if let Some(watcher_setup) = watcher_setup {
+            start_filesystem_watcher_install(watcher_setup, Arc::downgrade(&inner));
+        }
+
         Ok(Self {
-            inner: Arc::new(FilesystemSupervisorInner {
-                event_tx,
-                debouncer: Mutex::new(debouncer),
-                worker: Mutex::new(Some(worker)),
-            }),
+            inner,
             _marker: PhantomData,
         })
     }
@@ -680,6 +727,7 @@ impl Drop for FilesystemSupervisorInner {
 
 impl FilesystemSupervisorInner {
     fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
         if let Ok(mut debouncer) = self.debouncer.lock() {
             let _ = debouncer.take().map(FilesystemDebouncer::stop);
         }
@@ -710,13 +758,43 @@ fn finish_filesystem_watcher_setup(
     watcher_setup.and_then(|handle| handle.join().ok().flatten())
 }
 
+fn start_filesystem_watcher_install(
+    watcher_setup: JoinHandle<Option<FilesystemDebouncer>>,
+    supervisor: std::sync::Weak<FilesystemSupervisorInner>,
+) {
+    let _ = std::thread::Builder::new()
+        .name("lix-sdk-filesystem-watch-install".to_string())
+        .spawn(move || {
+            let Some(debouncer) = finish_filesystem_watcher_setup(Some(watcher_setup)) else {
+                if let Some(inner) = supervisor.upgrade() {
+                    let _ = inner.event_tx.send(FilesystemEvent::WatcherInstalled);
+                }
+                return;
+            };
+            let Some(inner) = supervisor.upgrade() else {
+                debouncer.stop();
+                return;
+            };
+            let Ok(mut slot) = inner.debouncer.lock() else {
+                debouncer.stop();
+                return;
+            };
+            if inner.shutdown.load(Ordering::SeqCst) {
+                debouncer.stop();
+                return;
+            }
+            *slot = Some(debouncer);
+            let _ = inner.event_tx.send(FilesystemEvent::WatcherInstalled);
+        });
+}
+
 impl<B> FilesystemState<B>
 where
     B: Backend + Clone + Send + Sync + 'static,
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
-    async fn sync_from_lix(&self) -> Result<(), LixError> {
+    async fn sync_from_lix(&self) -> Result<SyncFromLixOutcome, LixError> {
         let _guard = self.sync_lock.lock().await;
         if let Some(lix_inventory) = self.lix_inventory_for_inventory_sync().await? {
             let resolved = self
@@ -724,32 +802,67 @@ where
                 .await?;
             let disk_owned_unresolved_files =
                 self.disk_owned_unresolved_files_for_lix_materialization(&lix_inventory)?;
-            self.materialize_inventory_snapshot(
+            let materialize_outcome = self.materialize_inventory_snapshot(
                 &resolved,
                 &lix_inventory,
                 &disk_owned_unresolved_files,
             )?;
+            let resolved_data_hashes = snapshot_data_hashes(&resolved);
             let lix_revision = self.collect_lix_revision().await?;
-            let materialized_inventory =
+            let mut materialized_inventory =
                 collect_local_inventory(&self.root, self.metadata_mode, &self.path_filter)?;
+            materialized_inventory
+                .files
+                .extend(materialize_outcome.skipped_deleted_files);
+            materialized_inventory
+                .directories
+                .extend(materialize_outcome.skipped_deleted_directories);
             self.remember_inventory(
                 materialized_inventory,
+                resolved_data_hashes,
                 disk_owned_unresolved_files,
                 lix_revision,
             );
-            return Ok(());
+            return Ok(SyncFromLixOutcome {
+                needs_disk_sync: materialize_outcome.needs_disk_sync,
+            });
         }
         let lix_revision = self.collect_lix_revision().await?;
         if self.is_last_materialized_lix_revision(&lix_revision) {
             let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
             if self.is_last_materialized_disk(&local) {
-                return Ok(());
+                return Ok(SyncFromLixOutcome::default());
             }
         }
         let lix = self.collect_lix_snapshot_read().await?;
+        let local_before_materialize =
+            collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
+        let previous_before_materialize = self.last_materialized_disk();
+        let previous_inventory_before_materialize = self.last_materialized_inventory();
+        let needs_disk_sync = previous_before_materialize
+            .as_ref()
+            .is_some_and(|previous| {
+                lix.snapshot.files.iter().any(|(path, data)| {
+                    previous.files.get(path) == Some(data)
+                        && local_before_materialize.files.get(path) != Some(data)
+                }) || lix.snapshot.directories.iter().any(|path| {
+                    path != "/"
+                        && previous.directories.contains(path)
+                        && !local_before_materialize.directories.contains(path)
+                })
+            })
+            || previous_inventory_before_materialize
+                .as_ref()
+                .is_some_and(|previous| {
+                    lix.snapshot.directories.iter().any(|path| {
+                        path != "/"
+                            && previous.directories.contains(path)
+                            && !local_before_materialize.directories.contains(path)
+                    })
+                });
         let disk = self.materialize_snapshot(&lix.snapshot)?;
         self.remember_materialized(disk, lix.revision);
-        Ok(())
+        Ok(SyncFromLixOutcome { needs_disk_sync })
     }
 
     async fn sync_disk_to_lix(
@@ -757,7 +870,8 @@ where
         skip_if_last_materialized: bool,
     ) -> Result<DiskSyncOutcome, LixError> {
         let _guard = self.sync_lock.lock().await;
-        if let Some(mut lix_inventory) = self.lix_inventory_for_inventory_sync().await? {
+        let lix_inventory_for_sync = self.lix_inventory_for_inventory_sync().await?;
+        if let Some(mut lix_inventory) = lix_inventory_for_sync {
             let mut inventory =
                 collect_local_inventory(&self.root, self.metadata_mode, &self.path_filter)?;
             let mut disk_owned_unresolved_files =
@@ -781,17 +895,26 @@ where
                     return Ok(DiskSyncOutcome::InventoryMaterialized);
                 }
             }
-            self.apply_local_inventory_to_lix(
-                &inventory,
-                &lix_inventory,
-                &disk_owned_unresolved_files,
-                !skip_if_last_materialized,
-            )
-            .await?;
-            lix_inventory = self.collect_lix_inventory_read().await?;
-            disk_owned_unresolved_files =
-                self.disk_owned_unresolved_files_for_inventory(&lix_inventory, Some(&inventory))?;
-            self.apply_plugin_local_file_data_to_lix(&inventory).await?;
+            let reconcile_outcome = self
+                .apply_local_inventory_to_lix(
+                    &inventory,
+                    &lix_inventory,
+                    &disk_owned_unresolved_files,
+                    !skip_if_last_materialized,
+                )
+                .await?;
+            let should_recollect_lix = if reconcile_outcome.descriptors_changed {
+                true
+            } else {
+                self.collect_lix_revision().await? != lix_inventory.revision
+            };
+            if should_recollect_lix {
+                lix_inventory = self.collect_lix_inventory_read().await?;
+                disk_owned_unresolved_files = self
+                    .disk_owned_unresolved_files_for_inventory(&lix_inventory, Some(&inventory))?;
+            }
+            self.apply_plugin_local_file_data_to_lix(&inventory, &lix_inventory)
+                .await?;
             self.materialize_missing_plugin_archives(&mut inventory, &lix_inventory)
                 .await?;
             self.apply_resolved_local_file_data_to_lix(
@@ -801,7 +924,12 @@ where
             )
             .await?;
             let lix_revision = self.collect_lix_revision().await?;
-            self.remember_inventory(inventory, disk_owned_unresolved_files, lix_revision);
+            self.remember_inventory(
+                inventory,
+                lix_inventory.blob_data_hash_by_path.clone(),
+                disk_owned_unresolved_files,
+                lix_revision,
+            );
             return Ok(DiskSyncOutcome::InventoryMaterialized);
         }
         let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
@@ -1063,11 +1191,18 @@ where
         let mut directories = BTreeSet::from(["/".to_string()]);
         let mut directory_ids = BTreeMap::new();
         let mut files = BTreeSet::new();
+        let mut blob_key_by_path = BTreeMap::new();
+        let mut blob_hash_by_key = BTreeMap::new();
         let mut unresolved_files = BTreeSet::new();
-        let statements: [(&str, &[Value]); 2] = [
+        let statements: [(&str, &[Value]); 3] = [
             ("SELECT path, id FROM lix_directory ORDER BY path", &[]),
             (
-                "SELECT path, lixcol_metadata FROM lix_file ORDER BY path",
+                "SELECT path, id, lixcol_metadata, lixcol_global, lixcol_untracked FROM lix_file ORDER BY path",
+                &[],
+            ),
+            (
+                "SELECT entity_pk, file_id, snapshot_content, global, untracked \
+                 FROM lix_state WHERE schema_key = 'lix_binary_blob_ref'",
                 &[],
             ),
         ];
@@ -1075,15 +1210,21 @@ where
             .session
             .execute_coherent_read_batch(&statements)
             .await?;
-        let [directory_rows, file_rows] = batch.results.try_into().map_err(|results: Vec<_>| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!(
-                    "coherent filesystem inventory read returned {} result sets",
-                    results.len()
-                ),
-            )
-        })?;
+        let revision = LixRevision {
+            active_branch_id: batch.active_branch_id.clone(),
+            active_branch_commit_id: batch.active_branch_commit_id.clone(),
+            storage_mutation_revision: batch.storage_mutation_revision.clone(),
+        };
+        let [directory_rows, file_rows, blob_ref_rows] =
+            batch.results.try_into().map_err(|results: Vec<_>| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "coherent filesystem inventory read returned {} result sets",
+                        results.len()
+                    ),
+                )
+            })?;
         for row in directory_rows.rows() {
             let path = row.get::<String>("path")?;
             if path != "/" {
@@ -1092,18 +1233,50 @@ where
             }
             directories.insert(path);
         }
+        for row in blob_ref_rows.rows() {
+            let Some(blob_ref_id) = single_string_entity_pk_value(row.value("entity_pk")?)? else {
+                continue;
+            };
+            let snapshot_content = json_or_text_value_to_string(row.value("snapshot_content")?)?;
+            let snapshot = inventory_blob_ref_snapshot_from_json(&snapshot_content)?;
+            if snapshot.id != blob_ref_id {
+                continue;
+            }
+            let key = lix_filesystem_blob_ref_key_for_active_state_row(
+                &revision.active_branch_id,
+                bool_value_or_false(row.value("global")?)?,
+                bool_value_or_false(row.value("untracked")?)?,
+                optional_text_value(row.value("file_id")?)?,
+                &blob_ref_id,
+            );
+            blob_hash_by_key.insert(key, snapshot.blob_hash);
+        }
         for row in file_rows.rows() {
             let path = row.get::<String>("path")?;
             if metadata_value_is_filesystem_unresolved(row.value("lixcol_metadata")?)? {
                 unresolved_files.insert(path.clone());
             }
+            let descriptor_id = row.get::<String>("id")?;
+            let key = lix_filesystem_blob_ref_key_for_active_file_descriptor(
+                &revision.active_branch_id,
+                bool_value_or_false(row.value("lixcol_global")?)?,
+                bool_value_or_false(row.value("lixcol_untracked")?)?,
+                &descriptor_id,
+            );
+            blob_key_by_path.insert(path.clone(), key);
             files.insert(path);
         }
+        let blob_data_hash_by_path = blob_key_by_path
+            .into_iter()
+            .filter_map(|(path, key)| blob_hash_by_key.get(&key).map(|hash| (path, hash.clone())))
+            .collect::<BTreeMap<_, _>>();
         Ok(LixInventoryRead {
-            active_branch_id: self.session.active_branch_id().await?,
+            active_branch_id: revision.active_branch_id.clone(),
+            revision,
             directories,
             directory_ids,
             files,
+            blob_data_hash_by_path,
             unresolved_files,
         })
     }
@@ -1196,8 +1369,9 @@ where
         lix: &LixInventoryRead,
         disk_owned_unresolved_files: &BTreeSet<String>,
         delete_all_missing: bool,
-    ) -> Result<(), LixError> {
+    ) -> Result<InventoryReconcileOutcome, LixError> {
         let previous_inventory = self.last_materialized_inventory();
+        let mut outcome = InventoryReconcileOutcome::default();
         let mut files_to_import = local
             .files
             .difference(&lix.files)
@@ -1241,8 +1415,11 @@ where
                     &files_to_import,
                 )
                 .await?;
+            outcome.descriptors_changed = true;
         }
 
+        let mut delete_transaction = None;
+        let mut remaining_lix_files = lix.files.clone();
         for path in lix.files.difference(&local.files) {
             if !delete_all_missing
                 && !previous_inventory
@@ -1262,12 +1439,21 @@ where
                 {
                     continue;
                 }
-                self.session
+                if delete_transaction.is_none() {
+                    delete_transaction = Some(self.session.begin_transaction().await?);
+                }
+                let result = delete_transaction
+                    .as_mut()
+                    .expect("delete transaction should be initialized")
                     .execute(
                         "DELETE FROM lix_file WHERE path = $1",
                         &[Value::Text(path.clone())],
                     )
                     .await?;
+                if result.rows_affected() > 0 {
+                    outcome.descriptors_changed = true;
+                    remaining_lix_files.remove(path);
+                }
             }
         }
 
@@ -1283,6 +1469,7 @@ where
                         || previous_inventory
                             .as_ref()
                             .is_some_and(|previous| previous.directories.contains(*path))
+                        || !directory_contains_path(path, &remaining_lix_files)
                 })
                 .cloned()
                 .collect::<Vec<_>>();
@@ -1293,16 +1480,27 @@ where
                 {
                     continue;
                 }
-                self.session
+                if delete_transaction.is_none() {
+                    delete_transaction = Some(self.session.begin_transaction().await?);
+                }
+                let result = delete_transaction
+                    .as_mut()
+                    .expect("delete transaction should be initialized")
                     .execute(
                         "DELETE FROM lix_directory WHERE path = $1",
-                        &[Value::Text(path)],
+                        &[Value::Text(path.clone())],
                     )
                     .await?;
+                if result.rows_affected() > 0 {
+                    outcome.descriptors_changed = true;
+                }
             }
         }
+        if let Some(transaction) = delete_transaction {
+            transaction.commit().await?;
+        }
 
-        Ok(())
+        Ok(outcome)
     }
 
     async fn apply_resolved_local_file_data_to_lix(
@@ -1319,6 +1517,7 @@ where
                     && !is_plugin_storage_path(path)
             }),
             true,
+            &lix.blob_data_hash_by_path,
         )
         .await
     }
@@ -1326,6 +1525,7 @@ where
     async fn apply_plugin_local_file_data_to_lix(
         &self,
         local: &InventorySnapshot,
+        lix: &LixInventoryRead,
     ) -> Result<(), LixError> {
         self.apply_selected_local_file_data_to_lix(
             local
@@ -1333,6 +1533,7 @@ where
                 .iter()
                 .filter(|path| is_valid_plugin_storage_archive_path(path)),
             true,
+            &lix.blob_data_hash_by_path,
         )
         .await
     }
@@ -1374,19 +1575,42 @@ where
         &self,
         paths: impl IntoIterator<Item = &'a String>,
         compare_existing: bool,
+        blob_data_hash_by_path: &BTreeMap<String, String>,
     ) -> Result<(), LixError> {
+        let paths = paths
+            .into_iter()
+            .filter(|path| !is_materialization_ignored_path(path, self.metadata_mode))
+            .cloned()
+            .collect::<Vec<_>>();
+        if paths.is_empty() {
+            return Ok(());
+        }
+        let fallback_paths = if compare_existing {
+            paths
+                .iter()
+                .filter(|path| !blob_data_hash_by_path.contains_key(*path))
+                .cloned()
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let fallback_hashes = if compare_existing && !fallback_paths.is_empty() {
+            self.lix_file_data_hashes(&fallback_paths).await?
+        } else {
+            BTreeMap::new()
+        };
         let mut file_upserts = Vec::with_capacity(FILESYSTEM_FILE_UPSERT_CHUNK_SIZE);
         let mut file_transaction = None;
         let mut file_transaction_bytes = 0usize;
 
-        for path in paths {
-            if is_materialization_ignored_path(path, self.metadata_mode) {
-                continue;
-            }
+        for path in &paths {
             let local_path = lix_path_to_local_path(&self.root, path)?;
             let data = std::fs::read(&local_path)
                 .map_err(|error| io_error("read resolved filesystem file", &local_path, error))?;
-            if compare_existing && self.lix_file_data_equals(path, &data).await? {
+            let existing_hash = blob_data_hash_by_path
+                .get(path)
+                .or_else(|| fallback_hashes.get(path));
+            if compare_existing && lix_file_data_hash_equals(existing_hash, &data) {
                 continue;
             }
             file_upserts.push((path.clone(), data));
@@ -1416,22 +1640,29 @@ where
         Ok(())
     }
 
-    async fn lix_file_data_equals(&self, path: &str, data: &[u8]) -> Result<bool, LixError> {
-        let rows = self
-            .session
-            .execute(
-                "SELECT data FROM lix_file WHERE path = $1",
-                &[Value::Text(path.to_string())],
-            )
-            .await?;
-        let Some(row) = rows.rows().first() else {
-            return Ok(false);
-        };
-        match row.get::<Vec<u8>>("data") {
-            Ok(existing) => Ok(existing == data),
-            Err(error) if error.code == "LIX_FILESYSTEM_DATA_UNRESOLVED" => Ok(false),
-            Err(error) => Err(error),
+    async fn lix_file_data_hashes(
+        &self,
+        paths: &[String],
+    ) -> Result<BTreeMap<String, String>, LixError> {
+        let mut hashes = BTreeMap::new();
+        for chunk in paths.chunks(FILESYSTEM_FILE_UPSERT_CHUNK_SIZE) {
+            let placeholders = (1..=chunk.len())
+                .map(|index| format!("${index}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT path, lixcol_data_hash FROM lix_file WHERE path IN ({placeholders})"
+            );
+            let values = chunk.iter().cloned().map(Value::Text).collect::<Vec<_>>();
+            let rows = self.session.execute(&sql, &values).await?;
+            for row in rows.rows() {
+                hashes.insert(
+                    row.get::<String>("path")?,
+                    row.get::<String>("lixcol_data_hash")?,
+                );
+            }
         }
+        Ok(hashes)
     }
 
     async fn collect_lix_revision(&self) -> Result<LixRevision, LixError> {
@@ -1697,9 +1928,11 @@ where
         target: &Snapshot,
         target_inventory: &LixInventoryRead,
         disk_owned_unresolved_files: &BTreeSet<String>,
-    ) -> Result<(), LixError> {
+    ) -> Result<InventoryMaterializeOutcome, LixError> {
         ensure_filesystem_root_directory(&self.root)?;
         let previous = self.last_materialized_inventory();
+        let previous_hashes = self.last_materialized_inventory_hashes();
+        let mut outcome = InventoryMaterializeOutcome::default();
 
         if let Some(previous) = previous.as_ref() {
             for path in previous
@@ -1744,6 +1977,16 @@ where
             .collect::<Vec<_>>();
         sort_directories_shallowest_first(&mut directories_to_create);
         for path in directories_to_create {
+            if previous.as_ref().is_some_and(|snapshot| {
+                snapshot.directories.contains(&path)
+                    && lix_path_to_local_path(&self.root, &path)
+                        .map(|local_path| !local_path.is_dir())
+                        .unwrap_or(false)
+            }) {
+                outcome.needs_disk_sync = true;
+                outcome.skipped_deleted_directories.insert(path);
+                continue;
+            }
             create_materialized_directory(&self.root, &path, self.metadata_mode)?;
         }
 
@@ -1753,12 +1996,25 @@ where
                 && !disk_owned_unresolved_files.contains(*path)
         }) {
             let local_path = lix_path_to_local_path(&self.root, path)?;
-            if std::fs::read(&local_path).ok().as_deref() != Some(data.as_slice()) {
+            let local_data = std::fs::read(&local_path).ok();
+            let target_hash = lix_file_data_hash_hex(data);
+            if previous_hashes.get(path) == Some(&target_hash)
+                && local_data
+                    .as_deref()
+                    .is_none_or(|local| !lix_file_data_hash_equals(Some(&target_hash), local))
+            {
+                outcome.needs_disk_sync = true;
+                if local_data.is_none() {
+                    outcome.skipped_deleted_files.insert(path.clone());
+                }
+                continue;
+            }
+            if local_data.as_deref() != Some(data.as_slice()) {
                 write_materialized_file(&self.root, path, data, self.metadata_mode)?;
             }
         }
 
-        Ok(())
+        Ok(outcome)
     }
 
     fn materialize_snapshot_with_base(
@@ -1769,6 +2025,8 @@ where
         ensure_filesystem_root_directory(&self.root)?;
         let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
         let previous = self.last_materialized_disk();
+        let previous_inventory = self.last_materialized_inventory();
+        let previous_inventory_hashes = self.last_materialized_inventory_hashes();
 
         for path in local.files.keys().filter(|path| {
             self.path_filter.includes_file(path)
@@ -1829,6 +2087,16 @@ where
                     local.directories.contains(*path) == snapshot.directories.contains(*path)
                 })
             })
+            .filter(|path| {
+                !previous.as_ref().is_some_and(|snapshot| {
+                    snapshot.directories.contains(*path) && !local.directories.contains(*path)
+                })
+            })
+            .filter(|path| {
+                !previous_inventory.as_ref().is_some_and(|snapshot| {
+                    snapshot.directories.contains(*path) && !local.directories.contains(*path)
+                })
+            })
             .cloned()
             .collect::<Vec<_>>();
         sort_directories_shallowest_first(&mut directories_to_create);
@@ -1840,6 +2108,19 @@ where
             self.path_filter.includes_file(path)
                 && !is_materialization_ignored_path(path, self.metadata_mode)
         }) {
+            let target_hash = lix_file_data_hash_hex(data);
+            if previous.as_ref().is_some_and(|snapshot| {
+                snapshot.files.get(path) == Some(data) && local.files.get(path) != Some(data)
+            }) {
+                continue;
+            }
+            if previous_inventory_hashes.get(path) == Some(&target_hash)
+                && local.files.get(path).is_none_or(|local_data| {
+                    !lix_file_data_hash_equals(Some(&target_hash), local_data)
+                })
+            {
+                continue;
+            }
             if base.is_some_and(|snapshot| snapshot.files.get(path) == Some(data)) {
                 continue;
             }
@@ -1872,6 +2153,7 @@ where
     fn remember_inventory(
         &self,
         disk: InventorySnapshot,
+        resolved_data_hashes: BTreeMap<String, String>,
         disk_owned_unresolved_files: BTreeSet<String>,
         lix_revision: LixRevision,
     ) {
@@ -1881,6 +2163,7 @@ where
             .expect("filesystem materialized snapshot lock should not poison") =
             Some(MaterializedState::Inventory {
                 disk,
+                resolved_data_hashes,
                 disk_owned_unresolved_files,
                 lix_revision,
             });
@@ -1906,6 +2189,21 @@ where
                 MaterializedState::Inventory { disk, .. } => Some(disk.clone()),
                 MaterializedState::Bytes(_) => None,
             })
+    }
+
+    fn last_materialized_inventory_hashes(&self) -> BTreeMap<String, String> {
+        self.last_materialized
+            .lock()
+            .expect("filesystem materialized snapshot lock should not poison")
+            .as_ref()
+            .and_then(|snapshot| match snapshot {
+                MaterializedState::Inventory {
+                    resolved_data_hashes,
+                    ..
+                } => Some(resolved_data_hashes.clone()),
+                MaterializedState::Bytes(_) => None,
+            })
+            .unwrap_or_default()
     }
 
     fn is_last_materialized_disk(&self, snapshot: &Snapshot) -> bool {
@@ -2006,8 +2304,20 @@ fn filesystem_worker<B>(
                     return;
                 }
             }
+            Ok(FilesystemEvent::WatcherInstalled) => {
+                if drain_filesystem_events(&runtime, &state, &event_rx, true) {
+                    return;
+                }
+            }
             Ok(FilesystemEvent::SyncFromLix { reply_tx }) => {
-                sync_from_lix_for_replies(&runtime, &state, vec![reply_tx]);
+                match sync_from_lix_for_replies(&runtime, &state, vec![reply_tx]) {
+                    Ok(outcome) => {
+                        if outcome.needs_disk_sync {
+                            let _ = runtime.block_on(state.sync_disk_to_lix(true));
+                        }
+                    }
+                    Err(_) => {}
+                }
                 if drain_filesystem_events(&runtime, &state, &event_rx, false) {
                     return;
                 }
@@ -2035,6 +2345,9 @@ where
     loop {
         match event_rx.try_recv() {
             Ok(FilesystemEvent::DiskChanged) => sync_disk = true,
+            Ok(FilesystemEvent::WatcherInstalled) => {
+                sync_disk = true;
+            }
             Ok(FilesystemEvent::SyncFromLix { reply_tx }) => sync_replies.push(reply_tx),
             Ok(FilesystemEvent::Shutdown) | Err(mpsc::TryRecvError::Disconnected) => {
                 let _ = runtime.block_on(state.close());
@@ -2043,11 +2356,18 @@ where
             Err(mpsc::TryRecvError::Empty) => break,
         }
     }
-    if sync_disk {
-        let _ = runtime.block_on(state.sync_disk_to_lix(true));
-    }
     if !sync_replies.is_empty() {
-        sync_from_lix_for_replies(runtime, state, sync_replies);
+        // If Lix materialization and disk changes are queued together,
+        // materialize first so committed Lix writes win same-path races.
+        // A successful follow-up disk sync still picks up unrelated local edits.
+        match sync_from_lix_for_replies(runtime, state, sync_replies) {
+            Ok(outcome) if sync_disk || outcome.needs_disk_sync => {
+                let _ = runtime.block_on(state.sync_disk_to_lix(true));
+            }
+            Ok(_) | Err(_) => {}
+        }
+    } else if sync_disk {
+        let _ = runtime.block_on(state.sync_disk_to_lix(true));
     }
     false
 }
@@ -2056,15 +2376,18 @@ fn sync_from_lix_for_replies<B>(
     runtime: &tokio::runtime::Runtime,
     state: &Arc<FilesystemState<B>>,
     replies: Vec<mpsc::SyncSender<Result<(), LixError>>>,
-) where
+) -> Result<SyncFromLixOutcome, LixError>
+where
     B: Backend + Clone + Send + Sync + 'static,
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
     let result = runtime.block_on(state.sync_from_lix());
+    let reply_result = result.clone().map(|_| ());
     for reply in replies {
-        let _ = reply.send(result.clone());
+        let _ = reply.send(reply_result.clone());
     }
+    result
 }
 
 fn file_upsert_chunk_bytes(file_upserts: &[(&String, &Vec<u8>)]) -> usize {
@@ -2105,6 +2428,101 @@ fn collect_local_inventory(
         collect_filtered_local_inventory(root, metadata_mode, path_filter, &mut snapshot)?;
     }
     Ok(snapshot)
+}
+
+fn snapshot_data_hashes(snapshot: &Snapshot) -> BTreeMap<String, String> {
+    snapshot
+        .files
+        .iter()
+        .map(|(path, data)| (path.clone(), lix_file_data_hash_hex(data)))
+        .collect()
+}
+
+fn optional_text_value(value: &Value) -> Result<Option<String>, LixError> {
+    match value {
+        Value::Null => Ok(None),
+        Value::Text(value) => Ok(Some(value.clone())),
+        other => Err(LixError::unknown(format!(
+            "expected nullable text value, got {other:?}"
+        ))),
+    }
+}
+
+fn bool_value_or_false(value: &Value) -> Result<bool, LixError> {
+    match value {
+        Value::Null => Ok(false),
+        Value::Boolean(value) => Ok(*value),
+        other => Err(LixError::unknown(format!(
+            "expected nullable boolean value, got {other:?}"
+        ))),
+    }
+}
+
+fn json_or_text_value_to_string(value: &Value) -> Result<String, LixError> {
+    match value {
+        Value::Text(value) => Ok(value.clone()),
+        Value::Json(value) => Ok(value.to_string()),
+        other => Err(LixError::unknown(format!(
+            "expected JSON or text value, got {other:?}"
+        ))),
+    }
+}
+
+fn single_string_entity_pk_value(value: &Value) -> Result<Option<String>, LixError> {
+    let entity_pk = match value {
+        Value::Json(value) => value.clone(),
+        Value::Text(value) => serde_json::from_str(value).map_err(|error| {
+            LixError::unknown(format!(
+                "invalid entity_pk JSON for filesystem blob ref: {error}"
+            ))
+        })?,
+        Value::Null => return Ok(None),
+        other => {
+            return Err(LixError::unknown(format!(
+                "expected entity_pk JSON array, got {other:?}"
+            )));
+        }
+    };
+    let serde_json::Value::Array(values) = entity_pk else {
+        return Ok(None);
+    };
+    let [serde_json::Value::String(value)] = values.as_slice() else {
+        return Ok(None);
+    };
+    Ok(Some(value.clone()))
+}
+
+fn inventory_blob_ref_snapshot_from_json(
+    snapshot_content: &str,
+) -> Result<InventoryBlobRefSnapshot, LixError> {
+    let value = serde_json::from_str::<serde_json::Value>(snapshot_content).map_err(|error| {
+        LixError::unknown(format!(
+            "invalid lix_binary_blob_ref snapshot JSON: {error}"
+        ))
+    })?;
+    let id = value
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| LixError::unknown("lix_binary_blob_ref snapshot is missing id"))?;
+    let blob_hash = value
+        .get("blob_hash")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| LixError::unknown("lix_binary_blob_ref snapshot is missing blob_hash"))?;
+    Ok(InventoryBlobRefSnapshot {
+        id: id.to_string(),
+        blob_hash: blob_hash.to_string(),
+    })
+}
+
+fn is_lix_file_data_hash_hex(value: &str) -> bool {
+    value.len() == 64 && value.as_bytes().iter().all(u8::is_ascii_hexdigit)
+}
+
+fn lix_file_data_hash_equals(existing_hash: Option<&String>, data: &[u8]) -> bool {
+    let Some(existing_hash) = existing_hash else {
+        return false;
+    };
+    is_lix_file_data_hash_hex(existing_hash) && existing_hash == &lix_file_data_hash_hex(data)
 }
 
 fn disk_owned_unresolved_registry_path(

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -9,7 +9,7 @@ use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
     Backend, BackendError, BackendRead, BackendWrite, CommitResult, Engine, GetOptions,
     InMemoryBackend, Key, KeyRange, LixError, PointVisitor, PutBatch, ReadOptions, ScanOptions,
-    ScanResult, ScanVisitor, SessionContext, SpaceId, Value, WriteOptions,
+    ScanResult, ScanVisitor, SessionContext, SessionTransaction, SpaceId, Value, WriteOptions,
 };
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
@@ -20,6 +20,11 @@ use crate::sqlite_backend::SqliteBackend;
 type FilesystemDebouncer = Debouncer<RecommendedWatcher, RecommendedCache>;
 const LIX_DIRECTORY_GITIGNORE: &[u8] = b"*\n";
 const FILESYSTEM_POLL_INTERVAL: Duration = Duration::from_secs(15);
+// Each file upsert uses two SQL parameters. 400 rows stays under SQLite's
+// historical 999-parameter floor while reducing per-chunk live-state scans.
+const FILESYSTEM_FILE_UPSERT_CHUNK_SIZE: usize = 400;
+const FILESYSTEM_FILE_UPSERT_TRANSACTION_BYTES: usize = 16 * 1024 * 1024;
+const FILESYSTEM_UNRESOLVED_METADATA_KEY: &str = "lix_fs_unresolved";
 
 #[derive(Clone)]
 pub(crate) struct FilesystemSync<B>
@@ -126,13 +131,20 @@ where
     metadata_mode: FilesystemMetadataMode,
     path_filter: FilesystemPathFilter,
     sync_lock: tokio::sync::Mutex<()>,
-    last_materialized: Mutex<Option<MaterializedSnapshot>>,
+    last_materialized: Mutex<Option<MaterializedState>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct Snapshot {
     directories: BTreeSet<String>,
     files: BTreeMap<String, Vec<u8>>,
+    unmanaged_paths: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct InventorySnapshot {
+    directories: BTreeSet<String>,
+    files: BTreeSet<String>,
     unmanaged_paths: BTreeSet<String>,
 }
 
@@ -220,6 +232,15 @@ struct MaterializedSnapshot {
     lix_revision: LixRevision,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MaterializedState {
+    Bytes(MaterializedSnapshot),
+    Inventory {
+        disk: InventorySnapshot,
+        lix_revision: LixRevision,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct LixRevision {
     active_branch_id: String,
@@ -231,6 +252,20 @@ struct LixRevision {
 struct LixSnapshotRead {
     snapshot: Snapshot,
     revision: LixRevision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LixInventoryRead {
+    directories: BTreeSet<String>,
+    directory_ids: BTreeMap<String, String>,
+    files: BTreeSet<String>,
+    unresolved_files: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiskSyncOutcome {
+    NeedsMaterialization,
+    InventoryMaterialized,
 }
 
 enum FilesystemEvent {
@@ -559,8 +594,9 @@ where
         if metadata_mode == FilesystemMetadataMode::Persistent {
             state.migrate_legacy_lix_system_paths().await?;
         }
-        state.sync_disk_to_lix(false).await?;
-        state.sync_from_lix().await?;
+        if state.sync_disk_to_lix(false).await? == DiskSyncOutcome::NeedsMaterialization {
+            state.sync_from_lix().await?;
+        }
 
         let (event_tx, event_rx) = mpsc::channel();
         let callback_tx = event_tx.clone();
@@ -653,6 +689,17 @@ where
 {
     async fn sync_from_lix(&self) -> Result<(), LixError> {
         let _guard = self.sync_lock.lock().await;
+        if let Some(lix_inventory) = self.lix_inventory_for_inventory_sync().await? {
+            let resolved = self
+                .collect_lix_resolved_snapshot_read(&lix_inventory)
+                .await?;
+            self.materialize_inventory_snapshot(&resolved, &lix_inventory)?;
+            let lix_revision = self.collect_lix_revision().await?;
+            let materialized_inventory =
+                collect_local_inventory(&self.root, self.metadata_mode, &self.path_filter)?;
+            self.remember_inventory(materialized_inventory, lix_revision);
+            return Ok(());
+        }
         let lix_revision = self.collect_lix_revision().await?;
         if self.is_last_materialized_lix_revision(&lix_revision) {
             let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
@@ -666,13 +713,51 @@ where
         Ok(())
     }
 
-    async fn sync_disk_to_lix(&self, skip_if_last_materialized: bool) -> Result<(), LixError> {
+    async fn sync_disk_to_lix(
+        &self,
+        skip_if_last_materialized: bool,
+    ) -> Result<DiskSyncOutcome, LixError> {
         let _guard = self.sync_lock.lock().await;
+        if let Some(lix_inventory) = self.lix_inventory_for_inventory_sync().await? {
+            let inventory =
+                collect_local_inventory(&self.root, self.metadata_mode, &self.path_filter)?;
+            let has_resolved_files = lix_inventory
+                .files
+                .difference(&lix_inventory.unresolved_files)
+                .next()
+                .is_some();
+            let has_plugin_files = inventory
+                .files
+                .iter()
+                .any(|path| is_plugin_storage_path(path));
+            if skip_if_last_materialized
+                && !has_resolved_files
+                && !has_plugin_files
+                && self.is_last_materialized_inventory(&inventory)
+            {
+                let lix_revision = self.collect_lix_revision().await?;
+                if self.is_last_materialized_inventory_with_revision(&inventory, &lix_revision) {
+                    return Ok(DiskSyncOutcome::InventoryMaterialized);
+                }
+            }
+            self.apply_local_inventory_to_lix(
+                &inventory,
+                &lix_inventory,
+                !skip_if_last_materialized,
+            )
+            .await?;
+            self.apply_plugin_local_file_data_to_lix(&inventory).await?;
+            self.apply_resolved_local_file_data_to_lix(&inventory, &lix_inventory)
+                .await?;
+            let lix_revision = self.collect_lix_revision().await?;
+            self.remember_inventory(inventory, lix_revision);
+            return Ok(DiskSyncOutcome::InventoryMaterialized);
+        }
         let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
         if skip_if_last_materialized && self.is_last_materialized_disk(&local) {
             let lix_revision = self.collect_lix_revision().await?;
             if self.is_last_materialized(&local, &lix_revision) {
-                return Ok(());
+                return Ok(DiskSyncOutcome::NeedsMaterialization);
             }
         }
         let previous = self.last_materialized_disk();
@@ -681,7 +766,7 @@ where
         let lix = self.collect_lix_snapshot_read().await?;
         let materialized = self.materialize_snapshot_after_disk_sync(&lix.snapshot, &local)?;
         self.remember_materialized(materialized, lix.revision);
-        Ok(())
+        Ok(DiskSyncOutcome::NeedsMaterialization)
     }
 
     async fn close(&self) -> Result<(), LixError> {
@@ -691,18 +776,46 @@ where
     async fn migrate_legacy_lix_system_paths(&self) -> Result<(), LixError> {
         let files = self
             .session
-            .execute("SELECT path, data FROM lix_file ORDER BY path", &[])
+            .execute(
+                "SELECT path FROM lix_file \
+                 WHERE path = '/.lix_system' OR path = '/.lix_system/' OR path LIKE '/.lix_system/%' \
+                 ORDER BY path",
+                &[],
+            )
             .await?;
         let legacy_files = files
             .rows()
             .iter()
-            .map(|row| Ok((row.get::<String>("path")?, row.get::<Vec<u8>>("data")?)))
+            .map(|row| row.get::<String>("path"))
             .collect::<Result<Vec<_>, LixError>>()?;
-        for (path, data) in legacy_files
+        for path in legacy_files
             .iter()
-            .filter(|(path, _)| is_legacy_lix_system_path(path))
+            .filter(|path| is_legacy_lix_system_path(path))
         {
             if let Some(new_path) = migrate_legacy_lix_system_path(path) {
+                let rows = self
+                    .session
+                    .execute(
+                        "SELECT data FROM lix_file WHERE path = $1",
+                        &[Value::Text(path.clone())],
+                    )
+                    .await?;
+                let Some(row) = rows.rows().first() else {
+                    continue;
+                };
+                let data = row.get::<Vec<u8>>("data").map_err(|error| {
+                    if error.code == "LIX_FILESYSTEM_DATA_UNRESOLVED" {
+                        LixError::new(
+                            "LIX_FILESYSTEM_LEGACY_UNRESOLVED",
+                            format!("legacy filesystem path {path:?} has unresolved data"),
+                        )
+                        .with_hint(
+                            "Hydrate or remove the legacy .lix_system file before filesystem open.",
+                        )
+                    } else {
+                        error
+                    }
+                })?;
                 self.session
                     .execute(
                         "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
@@ -710,7 +823,7 @@ where
                         &[Value::Text(new_path.clone()), Value::Blob(data.clone())],
                     )
                     .await?;
-                write_materialized_file(&self.root, &new_path, data, self.metadata_mode)?;
+                write_materialized_file(&self.root, &new_path, &data, self.metadata_mode)?;
             }
             self.session
                 .execute(
@@ -793,6 +906,289 @@ where
         })
     }
 
+    async fn collect_lix_inventory_read(&self) -> Result<LixInventoryRead, LixError> {
+        let mut directories = BTreeSet::from(["/".to_string()]);
+        let mut directory_ids = BTreeMap::new();
+        let mut files = BTreeSet::new();
+        let mut unresolved_files = BTreeSet::new();
+        let statements: [(&str, &[Value]); 2] = [
+            ("SELECT path, id FROM lix_directory ORDER BY path", &[]),
+            (
+                "SELECT path, lixcol_metadata FROM lix_file ORDER BY path",
+                &[],
+            ),
+        ];
+        let batch = self
+            .session
+            .execute_coherent_read_batch(&statements)
+            .await?;
+        let [directory_rows, file_rows] = batch.results.try_into().map_err(|results: Vec<_>| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                format!(
+                    "coherent filesystem inventory read returned {} result sets",
+                    results.len()
+                ),
+            )
+        })?;
+        for row in directory_rows.rows() {
+            let path = row.get::<String>("path")?;
+            if path != "/" {
+                let id = row.get::<String>("id")?;
+                directory_ids.insert(path.clone(), id);
+            }
+            directories.insert(path);
+        }
+        for row in file_rows.rows() {
+            let path = row.get::<String>("path")?;
+            if metadata_value_is_filesystem_unresolved(row.value("lixcol_metadata")?)? {
+                unresolved_files.insert(path.clone());
+            }
+            files.insert(path);
+        }
+        Ok(LixInventoryRead {
+            directories,
+            directory_ids,
+            files,
+            unresolved_files,
+        })
+    }
+
+    async fn collect_lix_resolved_snapshot_read(
+        &self,
+        inventory: &LixInventoryRead,
+    ) -> Result<Snapshot, LixError> {
+        let mut snapshot = Snapshot::default();
+        snapshot.directories = inventory.directories.clone();
+        for path in inventory.files.difference(&inventory.unresolved_files) {
+            if is_materialization_ignored_path(path, self.metadata_mode) {
+                continue;
+            }
+            let rows = self
+                .session
+                .execute(
+                    "SELECT data FROM lix_file WHERE path = $1",
+                    &[Value::Text(path.clone())],
+                )
+                .await?;
+            let Some(row) = rows.rows().first() else {
+                continue;
+            };
+            snapshot
+                .files
+                .insert(path.clone(), row.get::<Vec<u8>>("data")?);
+        }
+        Ok(snapshot)
+    }
+
+    async fn lix_inventory_for_inventory_sync(&self) -> Result<Option<LixInventoryRead>, LixError> {
+        let inventory = self.collect_lix_inventory_read().await?;
+        let should_sync = !inventory.unresolved_files.is_empty()
+            || (inventory.files.is_empty()
+                && inventory.directories.iter().all(|path| {
+                    path == "/" || is_materialization_ignored_path(path, self.metadata_mode)
+                }));
+        Ok(should_sync.then_some(inventory))
+    }
+
+    async fn apply_local_inventory_to_lix(
+        &self,
+        local: &InventorySnapshot,
+        lix: &LixInventoryRead,
+        delete_all_missing: bool,
+    ) -> Result<(), LixError> {
+        let previous_inventory = self.last_materialized_inventory();
+        let mut files_to_import = local
+            .files
+            .difference(&lix.files)
+            .filter(|path| !is_materialization_ignored_path(path, self.metadata_mode))
+            .filter(|path| {
+                delete_all_missing
+                    || !previous_inventory
+                        .as_ref()
+                        .is_some_and(|previous| previous.files.contains(*path))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        files_to_import.sort();
+        let mut directories_to_import = local
+            .directories
+            .difference(&lix.directories)
+            .filter(|path| path.as_str() != "/")
+            .filter(|path| !is_materialization_ignored_path(path, self.metadata_mode))
+            .filter(|path| {
+                delete_all_missing
+                    || !previous_inventory
+                        .as_ref()
+                        .is_some_and(|previous| previous.directories.contains(*path))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        sort_directories_shallowest_first(&mut directories_to_import);
+
+        if !directories_to_import.is_empty() || !files_to_import.is_empty() {
+            let existing_directory_ids = lix
+                .directory_ids
+                .iter()
+                .map(|(path, id)| (path.clone(), id.clone()))
+                .collect::<Vec<_>>();
+            self.session
+                .import_unresolved_filesystem_inventory(
+                    &existing_directory_ids,
+                    &directories_to_import,
+                    &files_to_import,
+                )
+                .await?;
+        }
+
+        for path in lix.files.difference(&local.files) {
+            if !delete_all_missing
+                && !previous_inventory
+                    .as_ref()
+                    .is_some_and(|previous| previous.files.contains(path))
+            {
+                continue;
+            }
+            if self.path_filter.includes_file(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
+            {
+                if inventory_unmanaged_blocks_lix_path(local, path)
+                    || lix_path_blocked_by_unmanaged(&self.root, path)?
+                {
+                    continue;
+                }
+                self.session
+                    .execute(
+                        "DELETE FROM lix_file WHERE path = $1",
+                        &[Value::Text(path.clone())],
+                    )
+                    .await?;
+            }
+        }
+
+        if self.path_filter.is_unfiltered() {
+            let mut directories_to_remove = lix
+                .directories
+                .difference(&local.directories)
+                .filter(|path| path.as_str() != "/")
+                .filter(|path| !is_materialization_ignored_path(path, self.metadata_mode))
+                .filter(|path| {
+                    delete_all_missing
+                        || previous_inventory
+                            .as_ref()
+                            .is_some_and(|previous| previous.directories.contains(*path))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            sort_directories_deepest_first(&mut directories_to_remove);
+            for path in directories_to_remove {
+                if inventory_unmanaged_blocks_lix_path(local, &path)
+                    || lix_path_blocked_by_unmanaged(&self.root, &path)?
+                {
+                    continue;
+                }
+                self.session
+                    .execute(
+                        "DELETE FROM lix_directory WHERE path = $1",
+                        &[Value::Text(path)],
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn apply_resolved_local_file_data_to_lix(
+        &self,
+        local: &InventorySnapshot,
+        lix: &LixInventoryRead,
+    ) -> Result<(), LixError> {
+        self.apply_selected_local_file_data_to_lix(
+            local.files.iter().filter(|path| {
+                lix.files.contains(*path)
+                    && !lix.unresolved_files.contains(*path)
+                    && !is_plugin_storage_path(path)
+            }),
+            true,
+        )
+        .await
+    }
+
+    async fn apply_plugin_local_file_data_to_lix(
+        &self,
+        local: &InventorySnapshot,
+    ) -> Result<(), LixError> {
+        self.apply_selected_local_file_data_to_lix(
+            local
+                .files
+                .iter()
+                .filter(|path| is_valid_plugin_storage_archive_path(path)),
+            false,
+        )
+        .await
+    }
+
+    async fn apply_selected_local_file_data_to_lix<'a>(
+        &self,
+        paths: impl IntoIterator<Item = &'a String>,
+        compare_existing: bool,
+    ) -> Result<(), LixError> {
+        let mut file_upserts = Vec::with_capacity(FILESYSTEM_FILE_UPSERT_CHUNK_SIZE);
+        let mut file_transaction = None;
+        let mut file_transaction_bytes = 0usize;
+
+        for path in paths {
+            if is_materialization_ignored_path(path, self.metadata_mode) {
+                continue;
+            }
+            let local_path = lix_path_to_local_path(&self.root, path)?;
+            let data = std::fs::read(&local_path)
+                .map_err(|error| io_error("read resolved filesystem file", &local_path, error))?;
+            if compare_existing && self.lix_file_data_equals(path, &data).await? {
+                continue;
+            }
+            file_upserts.push((path.clone(), data));
+            if file_upserts.len() == FILESYSTEM_FILE_UPSERT_CHUNK_SIZE {
+                self.execute_owned_file_upsert_chunk(
+                    &mut file_transaction,
+                    &mut file_transaction_bytes,
+                    &file_upserts,
+                )
+                .await?;
+                file_upserts.clear();
+            }
+        }
+
+        if !file_upserts.is_empty() {
+            self.execute_owned_file_upsert_chunk(
+                &mut file_transaction,
+                &mut file_transaction_bytes,
+                &file_upserts,
+            )
+            .await?;
+        }
+        if let Some(transaction) = file_transaction {
+            transaction.commit().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn lix_file_data_equals(&self, path: &str, data: &[u8]) -> Result<bool, LixError> {
+        let rows = self
+            .session
+            .execute(
+                "SELECT data FROM lix_file WHERE path = $1",
+                &[Value::Text(path.to_string())],
+            )
+            .await?;
+        let Some(row) = rows.rows().first() else {
+            return Ok(false);
+        };
+        Ok(row.get::<Vec<u8>>("data")? == data)
+    }
+
     async fn collect_lix_revision(&self) -> Result<LixRevision, LixError> {
         let batch = self.session.execute_coherent_read_batch(&[]).await?;
         Ok(LixRevision {
@@ -808,87 +1204,113 @@ where
         previous: Option<&Snapshot>,
     ) -> Result<(), LixError> {
         let lix = self.collect_lix_snapshot_read().await?.snapshot;
+        let mut transaction = self.session.begin_transaction().await?;
 
-        for path in lix.files.keys() {
-            if !local.files.contains_key(path)
-                && self.path_filter.includes_file(path)
-                && !is_plugin_storage_path(path)
-                && !is_materialization_ignored_path(path, self.metadata_mode)
-            {
-                if previous
-                    .as_ref()
-                    .is_some_and(|snapshot| !snapshot.files.contains_key(path))
+        let metadata_result = async {
+            let mut changed = false;
+            for path in lix.files.keys() {
+                if !local.files.contains_key(path)
+                    && self.path_filter.includes_file(path)
+                    && !is_plugin_storage_path(path)
+                    && !is_materialization_ignored_path(path, self.metadata_mode)
                 {
-                    continue;
+                    if previous
+                        .as_ref()
+                        .is_some_and(|snapshot| !snapshot.files.contains_key(path))
+                    {
+                        continue;
+                    }
+                    if lix_path_blocked_by_unmanaged(&self.root, path)?
+                        || snapshot_unmanaged_blocks_lix_path(previous, path)
+                    {
+                        continue;
+                    }
+                    transaction
+                        .execute(
+                            "DELETE FROM lix_file WHERE path = $1",
+                            &[Value::Text(path.clone())],
+                        )
+                        .await?;
+                    changed = true;
                 }
-                if lix_path_blocked_by_unmanaged(&self.root, path)?
-                    || snapshot_unmanaged_blocks_lix_path(previous, path)
-                {
-                    continue;
-                }
-                self.session
-                    .execute(
-                        "DELETE FROM lix_file WHERE path = $1",
-                        &[Value::Text(path.clone())],
-                    )
-                    .await?;
             }
-        }
 
-        if self.path_filter.is_unfiltered() {
-            let mut directories_to_remove = Vec::new();
-            for path in lix.directories.difference(&local.directories) {
-                if path.as_str() == "/"
-                    || is_plugin_storage_path(path)
-                    || is_materialization_ignored_path(path, self.metadata_mode)
-                {
-                    continue;
+            if self.path_filter.is_unfiltered() {
+                let mut directories_to_remove = Vec::new();
+                for path in lix.directories.difference(&local.directories) {
+                    if path.as_str() == "/"
+                        || is_plugin_storage_path(path)
+                        || is_materialization_ignored_path(path, self.metadata_mode)
+                    {
+                        continue;
+                    }
+                    if previous
+                        .as_ref()
+                        .is_some_and(|snapshot| !snapshot.directories.contains(path))
+                    {
+                        continue;
+                    }
+                    if lix_path_blocked_by_unmanaged(&self.root, path)?
+                        || snapshot_unmanaged_blocks_lix_path(previous, path)
+                    {
+                        continue;
+                    }
+                    directories_to_remove.push(path.clone());
                 }
-                if previous
-                    .as_ref()
-                    .is_some_and(|snapshot| !snapshot.directories.contains(path))
-                {
-                    continue;
+                sort_directories_deepest_first(&mut directories_to_remove);
+                for path in directories_to_remove {
+                    transaction
+                        .execute(
+                            "DELETE FROM lix_directory WHERE path = $1",
+                            &[Value::Text(path)],
+                        )
+                        .await?;
+                    changed = true;
                 }
-                if lix_path_blocked_by_unmanaged(&self.root, path)?
-                    || snapshot_unmanaged_blocks_lix_path(previous, path)
-                {
-                    continue;
-                }
-                directories_to_remove.push(path.clone());
             }
-            sort_directories_deepest_first(&mut directories_to_remove);
-            for path in directories_to_remove {
-                self.session
+
+            let mut directories_to_create = local
+                .directories
+                .difference(&lix.directories)
+                .filter(|path| path.as_str() != "/")
+                .filter(|path| {
+                    previous
+                        .as_ref()
+                        .is_none_or(|snapshot| !snapshot.directories.contains(*path))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            sort_directories_shallowest_first(&mut directories_to_create);
+            for path in directories_to_create {
+                transaction
                     .execute(
-                        "DELETE FROM lix_directory WHERE path = $1",
+                        "INSERT INTO lix_directory (path) VALUES ($1) ON CONFLICT (path) DO NOTHING",
                         &[Value::Text(path)],
                     )
                     .await?;
+                changed = true;
+            }
+
+            Ok(changed)
+        }
+        .await;
+
+        match metadata_result {
+            Ok(true) => {
+                transaction.commit().await?;
+            }
+            Ok(false) => {
+                transaction.rollback().await?;
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                return Err(error);
             }
         }
 
-        let mut directories_to_create = local
-            .directories
-            .difference(&lix.directories)
-            .filter(|path| path.as_str() != "/")
-            .filter(|path| {
-                previous
-                    .as_ref()
-                    .is_none_or(|snapshot| !snapshot.directories.contains(*path))
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        sort_directories_shallowest_first(&mut directories_to_create);
-        for path in directories_to_create {
-            self.session
-                .execute(
-                    "INSERT INTO lix_directory (path) VALUES ($1) ON CONFLICT (path) DO NOTHING",
-                    &[Value::Text(path)],
-                )
-                .await?;
-        }
-
+        let mut file_upserts = Vec::with_capacity(FILESYSTEM_FILE_UPSERT_CHUNK_SIZE);
+        let mut file_transaction = None;
+        let mut file_transaction_bytes = 0usize;
         for (path, data) in local
             .files
             .iter()
@@ -901,16 +1323,115 @@ where
                 continue;
             }
             if lix.files.get(path) != Some(data) {
-                self.session
-                    .execute(
-                        "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
-                         ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-                        &[Value::Text(path.clone()), Value::Blob(data.clone())],
+                file_upserts.push((path, data));
+                if file_upserts.len() == FILESYSTEM_FILE_UPSERT_CHUNK_SIZE {
+                    self.execute_file_upsert_chunk(
+                        &mut file_transaction,
+                        &mut file_transaction_bytes,
+                        &file_upserts,
                     )
                     .await?;
+                    file_upserts.clear();
+                }
             }
         }
+        if !file_upserts.is_empty() {
+            self.execute_file_upsert_chunk(
+                &mut file_transaction,
+                &mut file_transaction_bytes,
+                &file_upserts,
+            )
+            .await?;
+        }
+        if let Some(transaction) = file_transaction {
+            transaction.commit().await?;
+        }
 
+        Ok(())
+    }
+
+    async fn execute_file_upsert_chunk(
+        &self,
+        current_transaction: &mut Option<SessionTransaction<B>>,
+        current_transaction_bytes: &mut usize,
+        file_upserts: &[(&String, &Vec<u8>)],
+    ) -> Result<(), LixError> {
+        if file_upserts.is_empty() {
+            return Ok(());
+        }
+        if current_transaction.is_none() {
+            *current_transaction = Some(self.session.begin_transaction().await?);
+        }
+        let chunk_bytes = file_upsert_chunk_bytes(file_upserts);
+        let result = {
+            let transaction = current_transaction
+                .as_mut()
+                .expect("file upsert transaction should be open");
+            self.execute_file_upsert_chunk_in_transaction(transaction, file_upserts)
+                .await
+        };
+
+        match result {
+            Ok(()) => {
+                *current_transaction_bytes = current_transaction_bytes.saturating_add(chunk_bytes);
+                if *current_transaction_bytes >= FILESYSTEM_FILE_UPSERT_TRANSACTION_BYTES {
+                    let transaction = current_transaction
+                        .take()
+                        .expect("file upsert transaction should be open");
+                    transaction.commit().await?;
+                    *current_transaction_bytes = 0;
+                }
+                Ok(())
+            }
+            Err(error) => {
+                if let Some(transaction) = current_transaction.take() {
+                    let _ = transaction.rollback().await;
+                }
+                Err(error)
+            }
+        }
+    }
+
+    async fn execute_owned_file_upsert_chunk(
+        &self,
+        current_transaction: &mut Option<SessionTransaction<B>>,
+        current_transaction_bytes: &mut usize,
+        file_upserts: &[(String, Vec<u8>)],
+    ) -> Result<(), LixError> {
+        let file_upserts = file_upserts
+            .iter()
+            .map(|(path, data)| (path, data))
+            .collect::<Vec<_>>();
+        self.execute_file_upsert_chunk(
+            current_transaction,
+            current_transaction_bytes,
+            &file_upserts,
+        )
+        .await
+    }
+
+    async fn execute_file_upsert_chunk_in_transaction(
+        &self,
+        transaction: &mut SessionTransaction<B>,
+        file_upserts: &[(&String, &Vec<u8>)],
+    ) -> Result<(), LixError> {
+        if file_upserts.is_empty() {
+            return Ok(());
+        }
+        let mut sql = String::from("INSERT INTO lix_file (path, data) VALUES ");
+        let mut params = Vec::with_capacity(file_upserts.len() * 2);
+        for (index, (path, data)) in file_upserts.iter().enumerate() {
+            if index > 0 {
+                sql.push_str(", ");
+            }
+            let path_param = index * 2 + 1;
+            let data_param = path_param + 1;
+            sql.push_str(&format!("(${path_param}, ${data_param})"));
+            params.push(Value::Text((*path).clone()));
+            params.push(Value::Blob((*data).clone()));
+        }
+        sql.push_str(" ON CONFLICT (path) DO UPDATE SET data = excluded.data");
+        transaction.execute(&sql, &params).await?;
         Ok(())
     }
 
@@ -924,6 +1445,71 @@ where
         base: &Snapshot,
     ) -> Result<Snapshot, LixError> {
         self.materialize_snapshot_with_base(target, Some(base))
+    }
+
+    fn materialize_inventory_snapshot(
+        &self,
+        target: &Snapshot,
+        target_inventory: &LixInventoryRead,
+    ) -> Result<(), LixError> {
+        ensure_filesystem_root_directory(&self.root)?;
+        let previous = self.last_materialized_inventory();
+
+        if let Some(previous) = previous.as_ref() {
+            for path in previous
+                .files
+                .difference(&target_inventory.files)
+                .filter(|path| {
+                    self.path_filter.includes_file(path)
+                        && !is_materialization_ignored_path(path, self.metadata_mode)
+                })
+            {
+                remove_materialized_file(&self.root, path, self.metadata_mode)?;
+            }
+
+            if self.path_filter.is_unfiltered() {
+                let mut directories_to_remove = previous
+                    .directories
+                    .difference(&target_inventory.directories)
+                    .filter(|path| {
+                        path.as_str() != "/"
+                            && !is_materialization_ignored_path(path, self.metadata_mode)
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                sort_directories_deepest_first(&mut directories_to_remove);
+                for path in directories_to_remove {
+                    remove_materialized_directory(&self.root, &path, self.metadata_mode)?;
+                }
+            }
+        }
+
+        let mut directories_to_create = target
+            .directories
+            .iter()
+            .filter(|path| {
+                path.as_str() != "/"
+                    && self.path_filter.includes_directory(path)
+                    && !is_materialization_ignored_path(path, self.metadata_mode)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        sort_directories_shallowest_first(&mut directories_to_create);
+        for path in directories_to_create {
+            create_materialized_directory(&self.root, &path, self.metadata_mode)?;
+        }
+
+        for (path, data) in target.files.iter().filter(|(path, _)| {
+            self.path_filter.includes_file(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
+        }) {
+            let local_path = lix_path_to_local_path(&self.root, path)?;
+            if std::fs::read(&local_path).ok().as_deref() != Some(data.as_slice()) {
+                write_materialized_file(&self.root, path, data, self.metadata_mode)?;
+            }
+        }
+
+        Ok(())
     }
 
     fn materialize_snapshot_with_base(
@@ -941,7 +1527,7 @@ where
                 && !is_materialization_ignored_path(path, self.metadata_mode)
                 && previous
                     .as_ref()
-                    .is_none_or(|snapshot| snapshot.files.contains_key(*path))
+                    .is_some_and(|snapshot| snapshot.files.contains_key(*path))
         }) {
             if base.is_some_and(|snapshot| {
                 !snapshot.files.contains_key(path)
@@ -963,7 +1549,7 @@ where
                 .filter(|path| {
                     previous
                         .as_ref()
-                        .is_none_or(|snapshot| snapshot.directories.contains(*path))
+                        .is_some_and(|snapshot| snapshot.directories.contains(*path))
                 })
                 .filter(|path| {
                     base.is_none_or(|snapshot| {
@@ -1028,7 +1614,18 @@ where
             .last_materialized
             .lock()
             .expect("filesystem materialized snapshot lock should not poison") =
-            Some(MaterializedSnapshot { disk, lix_revision });
+            Some(MaterializedState::Bytes(MaterializedSnapshot {
+                disk,
+                lix_revision,
+            }));
+    }
+
+    fn remember_inventory(&self, disk: InventorySnapshot, lix_revision: LixRevision) {
+        *self
+            .last_materialized
+            .lock()
+            .expect("filesystem materialized snapshot lock should not poison") =
+            Some(MaterializedState::Inventory { disk, lix_revision });
     }
 
     fn last_materialized_disk(&self) -> Option<Snapshot> {
@@ -1036,7 +1633,21 @@ where
             .lock()
             .expect("filesystem materialized snapshot lock should not poison")
             .as_ref()
-            .map(|snapshot| snapshot.disk.clone())
+            .and_then(|snapshot| match snapshot {
+                MaterializedState::Bytes(snapshot) => Some(snapshot.disk.clone()),
+                MaterializedState::Inventory { .. } => None,
+            })
+    }
+
+    fn last_materialized_inventory(&self) -> Option<InventorySnapshot> {
+        self.last_materialized
+            .lock()
+            .expect("filesystem materialized snapshot lock should not poison")
+            .as_ref()
+            .and_then(|snapshot| match snapshot {
+                MaterializedState::Inventory { disk, .. } => Some(disk.clone()),
+                MaterializedState::Bytes(_) => None,
+            })
     }
 
     fn is_last_materialized_disk(&self, snapshot: &Snapshot) -> bool {
@@ -1044,7 +1655,39 @@ where
             .lock()
             .expect("filesystem materialized snapshot lock should not poison")
             .as_ref()
-            .is_some_and(|materialized| &materialized.disk == snapshot)
+            .is_some_and(|materialized| match materialized {
+                MaterializedState::Bytes(materialized) => &materialized.disk == snapshot,
+                MaterializedState::Inventory { .. } => false,
+            })
+    }
+
+    fn is_last_materialized_inventory(&self, snapshot: &InventorySnapshot) -> bool {
+        self.last_materialized
+            .lock()
+            .expect("filesystem materialized snapshot lock should not poison")
+            .as_ref()
+            .is_some_and(|materialized| match materialized {
+                MaterializedState::Inventory { disk, .. } => disk == snapshot,
+                MaterializedState::Bytes(_) => false,
+            })
+    }
+
+    fn is_last_materialized_inventory_with_revision(
+        &self,
+        disk: &InventorySnapshot,
+        lix_revision: &LixRevision,
+    ) -> bool {
+        self.last_materialized
+            .lock()
+            .expect("filesystem materialized snapshot lock should not poison")
+            .as_ref()
+            .is_some_and(|materialized| match materialized {
+                MaterializedState::Inventory {
+                    disk: materialized_disk,
+                    lix_revision: materialized_revision,
+                } => materialized_disk == disk && materialized_revision == lix_revision,
+                MaterializedState::Bytes(_) => false,
+            })
     }
 
     fn is_last_materialized_lix_revision(&self, lix_revision: &LixRevision) -> bool {
@@ -1052,7 +1695,15 @@ where
             .lock()
             .expect("filesystem materialized snapshot lock should not poison")
             .as_ref()
-            .is_some_and(|materialized| &materialized.lix_revision == lix_revision)
+            .is_some_and(|materialized| match materialized {
+                MaterializedState::Bytes(materialized) => {
+                    &materialized.lix_revision == lix_revision
+                }
+                MaterializedState::Inventory {
+                    lix_revision: materialized_revision,
+                    ..
+                } => materialized_revision == lix_revision,
+            })
     }
 
     fn is_last_materialized(&self, disk: &Snapshot, lix_revision: &LixRevision) -> bool {
@@ -1061,7 +1712,11 @@ where
             .expect("filesystem materialized snapshot lock should not poison")
             .as_ref()
             .is_some_and(|materialized| {
-                &materialized.disk == disk && &materialized.lix_revision == lix_revision
+                matches!(
+                    materialized,
+                    MaterializedState::Bytes(materialized)
+                        if &materialized.disk == disk && &materialized.lix_revision == lix_revision
+                )
             })
     }
 }
@@ -1153,6 +1808,12 @@ fn sync_from_lix_for_replies<B>(
     }
 }
 
+fn file_upsert_chunk_bytes(file_upserts: &[(&String, &Vec<u8>)]) -> usize {
+    file_upserts.iter().fold(0usize, |total, (path, data)| {
+        total.saturating_add(path.len()).saturating_add(data.len())
+    })
+}
+
 fn collect_local_snapshot(
     root: &Path,
     metadata_mode: FilesystemMetadataMode,
@@ -1168,6 +1829,146 @@ fn collect_local_snapshot(
         collect_filtered_local_snapshot(root, metadata_mode, path_filter, &mut snapshot)?;
     }
     Ok(snapshot)
+}
+
+fn collect_local_inventory(
+    root: &Path,
+    metadata_mode: FilesystemMetadataMode,
+    path_filter: &FilesystemPathFilter,
+) -> Result<InventorySnapshot, LixError> {
+    validate_filesystem_root_directory(root)?;
+
+    let mut snapshot = InventorySnapshot::default();
+    snapshot.directories.insert("/".to_string());
+    if path_filter.is_unfiltered() {
+        collect_local_inventory_directory(root, root, metadata_mode, &mut snapshot)?;
+    } else {
+        collect_filtered_local_inventory(root, metadata_mode, path_filter, &mut snapshot)?;
+    }
+    Ok(snapshot)
+}
+
+fn collect_local_inventory_directory(
+    root: &Path,
+    directory: &Path,
+    metadata_mode: FilesystemMetadataMode,
+    snapshot: &mut InventorySnapshot,
+) -> Result<(), LixError> {
+    let entries = std::fs::read_dir(directory)
+        .map_err(|error| io_error("read filesystem directory", directory, error))?;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| io_error("read filesystem directory entry", directory, error))?;
+        let path = entry.path();
+        if is_filesystem_sync_ignored_local_path(root, &path, metadata_mode) {
+            continue;
+        }
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(io_error("read filesystem entry type", &path, error)),
+        };
+        if is_unmanaged_file_type(&file_type) {
+            remember_unmanaged_inventory_path(root, directory, &path, snapshot);
+            continue;
+        }
+        if file_type.is_dir() {
+            let Ok(lix_path) = local_path_to_lix_path(root, &path, true) else {
+                remember_unmanaged_inventory_path(root, directory, &path, snapshot);
+                continue;
+            };
+            if is_invalid_plugin_storage_inventory_path(&lix_path, true) {
+                remember_unmanaged_inventory_path(root, directory, &path, snapshot);
+                continue;
+            }
+            snapshot.directories.insert(lix_path);
+            collect_local_inventory_directory(root, &path, metadata_mode, snapshot)?;
+        } else if file_type.is_file() {
+            let Ok(lix_path) = local_path_to_lix_path(root, &path, false) else {
+                remember_unmanaged_inventory_path(root, directory, &path, snapshot);
+                continue;
+            };
+            if is_invalid_plugin_storage_inventory_path(&lix_path, false) {
+                remember_unmanaged_inventory_path(root, directory, &path, snapshot);
+                continue;
+            }
+            snapshot.files.insert(lix_path);
+        }
+    }
+    Ok(())
+}
+
+fn collect_filtered_local_inventory(
+    root: &Path,
+    metadata_mode: FilesystemMetadataMode,
+    path_filter: &FilesystemPathFilter,
+    snapshot: &mut InventorySnapshot,
+) -> Result<(), LixError> {
+    for lix_path in &path_filter.include_files {
+        if is_filesystem_sync_ignored_lix_path(lix_path, metadata_mode) {
+            continue;
+        }
+        let local_path = lix_path_to_local_path(root, lix_path)?;
+        if path_contains_unmanaged_entry(root, &local_path)? {
+            snapshot.unmanaged_paths.insert(lix_path.clone());
+            continue;
+        }
+        let metadata = match std::fs::symlink_metadata(&local_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(io_error(
+                    "read filesystem file metadata",
+                    &local_path,
+                    error,
+                ));
+            }
+        };
+        if is_unmanaged_file_type(&metadata.file_type()) {
+            snapshot.unmanaged_paths.insert(lix_path.clone());
+            continue;
+        }
+        if !metadata.is_file() {
+            continue;
+        }
+        if is_invalid_plugin_storage_inventory_path(lix_path, false) {
+            snapshot.unmanaged_paths.insert(lix_path.clone());
+            continue;
+        }
+        insert_parent_inventory_directories(lix_path, snapshot);
+        snapshot.files.insert(lix_path.clone());
+    }
+    Ok(())
+}
+
+fn remember_unmanaged_inventory_path(
+    root: &Path,
+    directory: &Path,
+    path: &Path,
+    snapshot: &mut InventorySnapshot,
+) {
+    if let Ok(lix_path) = local_path_to_lix_path(root, path, false) {
+        snapshot.unmanaged_paths.insert(lix_path);
+    } else if directory != root {
+        if let Ok(parent_path) = local_path_to_lix_path(root, directory, true) {
+            snapshot.unmanaged_paths.insert(parent_path);
+        }
+    }
+}
+
+fn insert_parent_inventory_directories(path: &str, snapshot: &mut InventorySnapshot) {
+    let mut directory = parent_lix_directory_path(path);
+    let mut directories = Vec::new();
+    while directory != "/" {
+        directories.push(directory.clone());
+        let parent = parent_lix_directory_path(directory.trim_end_matches('/'));
+        if parent == directory {
+            break;
+        }
+        directory = parent;
+    }
+    directories.reverse();
+    snapshot.directories.extend(directories);
 }
 
 fn collect_local_directory(
@@ -1610,6 +2411,13 @@ fn snapshot_unmanaged_blocks_lix_path(snapshot: Option<&Snapshot>, path: &str) -
     })
 }
 
+fn inventory_unmanaged_blocks_lix_path(inventory: &InventorySnapshot, path: &str) -> bool {
+    inventory
+        .unmanaged_paths
+        .iter()
+        .any(|unmanaged_path| unmanaged_path_blocks_lix_path(unmanaged_path, path))
+}
+
 fn unmanaged_path_blocks_lix_path(unmanaged_path: &str, path: &str) -> bool {
     let unmanaged_path = unmanaged_path.strip_suffix('/').unwrap_or(unmanaged_path);
     let path = path.strip_suffix('/').unwrap_or(path);
@@ -1649,6 +2457,34 @@ fn path_contains_unmanaged_entry(root: &Path, local_path: &Path) -> Result<bool,
 
 fn is_unmanaged_file_type(file_type: &std::fs::FileType) -> bool {
     file_type.is_symlink() || (!file_type.is_file() && !file_type.is_dir())
+}
+
+fn metadata_is_filesystem_unresolved(metadata: Option<&str>) -> bool {
+    let Some(metadata) = metadata else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(metadata)
+        .ok()
+        .is_some_and(|value| json_metadata_is_filesystem_unresolved(&value))
+}
+
+fn metadata_value_is_filesystem_unresolved(value: &Value) -> Result<bool, LixError> {
+    match value {
+        Value::Null => Ok(false),
+        Value::Text(value) => Ok(metadata_is_filesystem_unresolved(Some(value))),
+        Value::Json(value) => Ok(json_metadata_is_filesystem_unresolved(value)),
+        other => Err(LixError::new(
+            "LIX_ERROR_VALUE_TYPE",
+            format!("expected nullable metadata, got {other:?}"),
+        )),
+    }
+}
+
+fn json_metadata_is_filesystem_unresolved(value: &serde_json::Value) -> bool {
+    value
+        .as_object()
+        .and_then(|object| object.get(FILESYSTEM_UNRESOLVED_METADATA_KEY))
+        .is_some()
 }
 
 fn local_path_to_lix_path(
@@ -1790,6 +2626,31 @@ fn push_lix_path_segment(local: &mut PathBuf, segment: &str, path: &str) -> Resu
 
 fn is_plugin_storage_path(path: &str) -> bool {
     path == "/.lix/plugins" || path.starts_with("/.lix/plugins/")
+}
+
+fn is_invalid_plugin_storage_inventory_path(path: &str, is_directory: bool) -> bool {
+    if !is_plugin_storage_path(path) {
+        return false;
+    }
+    if path == "/.lix/plugins" || path == "/.lix/plugins/" {
+        return false;
+    }
+    is_directory || !is_valid_plugin_storage_archive_path(path)
+}
+
+fn is_valid_plugin_storage_archive_path(path: &str) -> bool {
+    let Some(file_name) = path.strip_prefix("/.lix/plugins/") else {
+        return false;
+    };
+    let Some(plugin_key) = file_name.strip_suffix(".lixplugin") else {
+        return false;
+    };
+    if plugin_key.is_empty() || plugin_key.len() > 128 || plugin_key.contains('/') {
+        return false;
+    }
+    let mut bytes = plugin_key.bytes();
+    matches!(bytes.next(), Some(b'a'..=b'z'))
+        && bytes.all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'_' | b'-'))
 }
 
 fn is_filesystem_metadata_path(path: &str) -> bool {
@@ -2348,5 +3209,23 @@ mod tests {
         );
 
         state.close().await.unwrap();
+    }
+
+    #[test]
+    fn inventory_unmanaged_blocks_lix_path_descendants() {
+        let inventory = InventorySnapshot {
+            unmanaged_paths: BTreeSet::from(["/dir/".to_string()]),
+            ..InventorySnapshot::default()
+        };
+
+        assert!(inventory_unmanaged_blocks_lix_path(
+            &inventory,
+            "/dir/file.txt"
+        ));
+        assert!(inventory_unmanaged_blocks_lix_path(&inventory, "/dir/"));
+        assert!(!inventory_unmanaged_blocks_lix_path(
+            &inventory,
+            "/dir-adjacent/file.txt"
+        ));
     }
 }

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
-use std::thread::JoinHandle;
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use lix_engine::wasm::WasmRuntime;
@@ -12,8 +12,7 @@ use lix_engine::{
     Backend, BackendError, BackendRead, BackendWrite, CommitResult, Engine, GetOptions,
     InMemoryBackend, Key, KeyRange, LixError, PointVisitor, PutBatch, ReadOptions, ScanOptions,
     ScanResult, ScanVisitor, SessionContext, SessionTransaction, SpaceId, Value, WriteOptions,
-    lix_file_data_hash_hex, lix_filesystem_blob_ref_key_for_active_file_descriptor,
-    lix_filesystem_blob_ref_key_for_active_state_row,
+    lix_file_data_hash_hex,
 };
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
@@ -28,6 +27,9 @@ const FILESYSTEM_POLL_INTERVAL: Duration = Duration::from_secs(15);
 // historical 999-parameter floor while reducing per-chunk live-state scans.
 const FILESYSTEM_FILE_UPSERT_CHUNK_SIZE: usize = 400;
 const FILESYSTEM_FILE_UPSERT_TRANSACTION_BYTES: usize = 16 * 1024 * 1024;
+const FILESYSTEM_PARALLEL_INVENTORY_MIN_DIRS: usize = 8;
+// Bounds blocking filesystem metadata IO during folder open.
+const FILESYSTEM_PARALLEL_INVENTORY_MAX_WORKERS: usize = 8;
 const FILESYSTEM_UNRESOLVED_METADATA_KEY: &str = "lix_fs_unresolved";
 const FILESYSTEM_DISK_OWNED_UNRESOLVED_PATHS: &str = ".lix/.internal/fs_unresolved_disk_owned.json";
 static FILESYSTEM_UNRESOLVED_REGISTRY_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -274,6 +276,12 @@ struct LixInventoryRead {
     unresolved_files: BTreeSet<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct DiskOwnedUnresolvedFileOwners {
+    owners: BTreeMap<String, String>,
+    needs_writeback: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct InventoryReconcileOutcome {
     descriptors_changed: bool,
@@ -289,12 +297,6 @@ struct InventoryMaterializeOutcome {
 #[derive(Debug, Default, Clone, Copy)]
 struct SyncFromLixOutcome {
     needs_disk_sync: bool,
-}
-
-#[derive(Debug)]
-struct InventoryBlobRefSnapshot {
-    id: String,
-    blob_hash: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -673,7 +675,7 @@ where
         };
         let poll_filesystem = cfg!(target_os = "macos") || debouncer.is_none();
         let worker_state = Arc::clone(&state);
-        let worker = std::thread::Builder::new()
+        let worker = thread::Builder::new()
             .name("lix-sdk-filesystem-sync".to_string())
             .spawn(move || filesystem_worker(worker_state, event_rx, poll_filesystem))
             .map_err(|error| {
@@ -746,7 +748,7 @@ fn start_filesystem_watcher_setup(
     path_filter: FilesystemPathFilter,
     event_tx: mpsc::Sender<FilesystemEvent>,
 ) -> Option<JoinHandle<Option<FilesystemDebouncer>>> {
-    std::thread::Builder::new()
+    thread::Builder::new()
         .name("lix-sdk-filesystem-watch-setup".to_string())
         .spawn(move || create_filesystem_debouncer(&root, metadata_mode, &path_filter, event_tx))
         .ok()
@@ -762,7 +764,7 @@ fn start_filesystem_watcher_install(
     watcher_setup: JoinHandle<Option<FilesystemDebouncer>>,
     supervisor: std::sync::Weak<FilesystemSupervisorInner>,
 ) {
-    let _ = std::thread::Builder::new()
+    let _ = thread::Builder::new()
         .name("lix-sdk-filesystem-watch-install".to_string())
         .spawn(move || {
             let Some(debouncer) = finish_filesystem_watcher_setup(Some(watcher_setup)) else {
@@ -955,14 +957,14 @@ where
     fn read_disk_owned_unresolved_file_owners(
         &self,
         legacy_owner_branch_id: Option<&str>,
-    ) -> Result<BTreeMap<String, String>, LixError> {
+    ) -> Result<DiskOwnedUnresolvedFileOwners, LixError> {
         let Some(path) = disk_owned_unresolved_registry_path(&self.root, self.metadata_mode) else {
-            return Ok(BTreeMap::new());
+            return Ok(DiskOwnedUnresolvedFileOwners::default());
         };
         let data = match std::fs::read(&path) {
             Ok(data) => data,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(BTreeMap::new());
+                return Ok(DiskOwnedUnresolvedFileOwners::default());
             }
             Err(error) => {
                 return Err(io_error(
@@ -1188,88 +1190,34 @@ where
     }
 
     async fn collect_lix_inventory_read(&self) -> Result<LixInventoryRead, LixError> {
+        let inventory = self.session.read_filesystem_inventory().await?;
         let mut directories = BTreeSet::from(["/".to_string()]);
         let mut directory_ids = BTreeMap::new();
         let mut files = BTreeSet::new();
-        let mut blob_key_by_path = BTreeMap::new();
-        let mut blob_hash_by_key = BTreeMap::new();
+        let mut blob_data_hash_by_path = BTreeMap::new();
         let mut unresolved_files = BTreeSet::new();
-        let statements: [(&str, &[Value]); 3] = [
-            ("SELECT path, id FROM lix_directory ORDER BY path", &[]),
-            (
-                "SELECT path, id, lixcol_metadata, lixcol_global, lixcol_untracked FROM lix_file ORDER BY path",
-                &[],
-            ),
-            (
-                "SELECT entity_pk, file_id, snapshot_content, global, untracked \
-                 FROM lix_state WHERE schema_key = 'lix_binary_blob_ref'",
-                &[],
-            ),
-        ];
-        let batch = self
-            .session
-            .execute_coherent_read_batch(&statements)
-            .await?;
         let revision = LixRevision {
-            active_branch_id: batch.active_branch_id.clone(),
-            active_branch_commit_id: batch.active_branch_commit_id.clone(),
-            storage_mutation_revision: batch.storage_mutation_revision.clone(),
+            active_branch_id: inventory.active_branch_id.clone(),
+            active_branch_commit_id: inventory.active_branch_commit_id.clone(),
+            storage_mutation_revision: inventory.storage_mutation_revision.clone(),
         };
-        let [directory_rows, file_rows, blob_ref_rows] =
-            batch.results.try_into().map_err(|results: Vec<_>| {
-                LixError::new(
-                    "LIX_ERROR_UNKNOWN",
-                    format!(
-                        "coherent filesystem inventory read returned {} result sets",
-                        results.len()
-                    ),
-                )
-            })?;
-        for row in directory_rows.rows() {
-            let path = row.get::<String>("path")?;
+        for directory in inventory.directories {
+            let path = directory.path;
             if path != "/" {
-                let id = row.get::<String>("id")?;
-                directory_ids.insert(path.clone(), id);
+                directory_ids.insert(path.clone(), directory.id);
             }
             directories.insert(path);
         }
-        for row in blob_ref_rows.rows() {
-            let Some(blob_ref_id) = single_string_entity_pk_value(row.value("entity_pk")?)? else {
-                continue;
-            };
-            let snapshot_content = json_or_text_value_to_string(row.value("snapshot_content")?)?;
-            let snapshot = inventory_blob_ref_snapshot_from_json(&snapshot_content)?;
-            if snapshot.id != blob_ref_id {
-                continue;
-            }
-            let key = lix_filesystem_blob_ref_key_for_active_state_row(
-                &revision.active_branch_id,
-                bool_value_or_false(row.value("global")?)?,
-                bool_value_or_false(row.value("untracked")?)?,
-                optional_text_value(row.value("file_id")?)?,
-                &blob_ref_id,
-            );
-            blob_hash_by_key.insert(key, snapshot.blob_hash);
-        }
-        for row in file_rows.rows() {
-            let path = row.get::<String>("path")?;
-            if metadata_value_is_filesystem_unresolved(row.value("lixcol_metadata")?)? {
+        for file in inventory.files {
+            let path = file.path;
+            if metadata_is_filesystem_unresolved(file.metadata.as_deref()) {
                 unresolved_files.insert(path.clone());
             }
-            let descriptor_id = row.get::<String>("id")?;
-            let key = lix_filesystem_blob_ref_key_for_active_file_descriptor(
-                &revision.active_branch_id,
-                bool_value_or_false(row.value("lixcol_global")?)?,
-                bool_value_or_false(row.value("lixcol_untracked")?)?,
-                &descriptor_id,
-            );
-            blob_key_by_path.insert(path.clone(), key);
+            if let Some(blob_hash) = file.blob_hash {
+                blob_data_hash_by_path.insert(path.clone(), blob_hash);
+            }
             files.insert(path);
         }
-        let blob_data_hash_by_path = blob_key_by_path
-            .into_iter()
-            .filter_map(|(path, key)| blob_hash_by_key.get(&key).map(|hash| (path, hash.clone())))
-            .collect::<BTreeMap<_, _>>();
         Ok(LixInventoryRead {
             active_branch_id: revision.active_branch_id.clone(),
             revision,
@@ -1313,6 +1261,7 @@ where
         let should_sync = !inventory.unresolved_files.is_empty()
             || !self
                 .read_disk_owned_unresolved_file_owners(Some(&inventory.active_branch_id))?
+                .owners
                 .is_empty()
             || (inventory.files.is_empty()
                 && inventory.directories.iter().all(|path| {
@@ -1326,8 +1275,34 @@ where
         lix: &LixInventoryRead,
         local: Option<&InventorySnapshot>,
     ) -> Result<BTreeSet<String>, LixError> {
-        let mut disk_owned =
-            self.read_disk_owned_unresolved_file_owners(Some(&lix.active_branch_id))?;
+        let (disk_owned, needs_writeback) =
+            self.normalized_disk_owned_unresolved_file_owners(lix, local)?;
+        if needs_writeback {
+            self.write_disk_owned_unresolved_file_owners(&disk_owned)?;
+        }
+        Ok(disk_owned.into_keys().collect())
+    }
+
+    fn disk_owned_unresolved_files_for_lix_materialization(
+        &self,
+        lix: &LixInventoryRead,
+    ) -> Result<BTreeSet<String>, LixError> {
+        let (disk_owned, needs_writeback) =
+            self.normalized_disk_owned_unresolved_file_owners(lix, None)?;
+        if needs_writeback {
+            self.write_disk_owned_unresolved_file_owners(&disk_owned)?;
+        }
+        Ok(disk_owned.into_keys().collect())
+    }
+
+    fn normalized_disk_owned_unresolved_file_owners(
+        &self,
+        lix: &LixInventoryRead,
+        local: Option<&InventorySnapshot>,
+    ) -> Result<(BTreeMap<String, String>, bool), LixError> {
+        let read = self.read_disk_owned_unresolved_file_owners(Some(&lix.active_branch_id))?;
+        let original = read.owners.clone();
+        let mut disk_owned = read.owners;
         for path in &lix.unresolved_files {
             disk_owned
                 .entry(path.clone())
@@ -1339,28 +1314,8 @@ where
                 && !is_materialization_ignored_path(path, self.metadata_mode)
                 && local.is_none_or(|inventory| inventory.files.contains(path))
         });
-        self.write_disk_owned_unresolved_file_owners(&disk_owned)?;
-        Ok(disk_owned.into_keys().collect())
-    }
-
-    fn disk_owned_unresolved_files_for_lix_materialization(
-        &self,
-        lix: &LixInventoryRead,
-    ) -> Result<BTreeSet<String>, LixError> {
-        let mut disk_owned =
-            self.read_disk_owned_unresolved_file_owners(Some(&lix.active_branch_id))?;
-        for path in &lix.unresolved_files {
-            disk_owned
-                .entry(path.clone())
-                .or_insert_with(|| lix.active_branch_id.clone());
-        }
-        disk_owned.retain(|path, owner_branch_id| {
-            (lix.unresolved_files.contains(path) || owner_branch_id != &lix.active_branch_id)
-                && self.path_filter.includes_file(path)
-                && !is_materialization_ignored_path(path, self.metadata_mode)
-        });
-        self.write_disk_owned_unresolved_file_owners(&disk_owned)?;
-        Ok(disk_owned.into_keys().collect())
+        let needs_writeback = read.needs_writeback || disk_owned != original;
+        Ok((disk_owned, needs_writeback))
     }
 
     async fn apply_local_inventory_to_lix(
@@ -2423,7 +2378,7 @@ fn collect_local_inventory(
     let mut snapshot = InventorySnapshot::default();
     snapshot.directories.insert("/".to_string());
     if path_filter.is_unfiltered() {
-        collect_local_inventory_directory(root, root, metadata_mode, &mut snapshot)?;
+        collect_local_inventory_unfiltered(root, metadata_mode, &mut snapshot)?;
     } else {
         collect_filtered_local_inventory(root, metadata_mode, path_filter, &mut snapshot)?;
     }
@@ -2436,82 +2391,6 @@ fn snapshot_data_hashes(snapshot: &Snapshot) -> BTreeMap<String, String> {
         .iter()
         .map(|(path, data)| (path.clone(), lix_file_data_hash_hex(data)))
         .collect()
-}
-
-fn optional_text_value(value: &Value) -> Result<Option<String>, LixError> {
-    match value {
-        Value::Null => Ok(None),
-        Value::Text(value) => Ok(Some(value.clone())),
-        other => Err(LixError::unknown(format!(
-            "expected nullable text value, got {other:?}"
-        ))),
-    }
-}
-
-fn bool_value_or_false(value: &Value) -> Result<bool, LixError> {
-    match value {
-        Value::Null => Ok(false),
-        Value::Boolean(value) => Ok(*value),
-        other => Err(LixError::unknown(format!(
-            "expected nullable boolean value, got {other:?}"
-        ))),
-    }
-}
-
-fn json_or_text_value_to_string(value: &Value) -> Result<String, LixError> {
-    match value {
-        Value::Text(value) => Ok(value.clone()),
-        Value::Json(value) => Ok(value.to_string()),
-        other => Err(LixError::unknown(format!(
-            "expected JSON or text value, got {other:?}"
-        ))),
-    }
-}
-
-fn single_string_entity_pk_value(value: &Value) -> Result<Option<String>, LixError> {
-    let entity_pk = match value {
-        Value::Json(value) => value.clone(),
-        Value::Text(value) => serde_json::from_str(value).map_err(|error| {
-            LixError::unknown(format!(
-                "invalid entity_pk JSON for filesystem blob ref: {error}"
-            ))
-        })?,
-        Value::Null => return Ok(None),
-        other => {
-            return Err(LixError::unknown(format!(
-                "expected entity_pk JSON array, got {other:?}"
-            )));
-        }
-    };
-    let serde_json::Value::Array(values) = entity_pk else {
-        return Ok(None);
-    };
-    let [serde_json::Value::String(value)] = values.as_slice() else {
-        return Ok(None);
-    };
-    Ok(Some(value.clone()))
-}
-
-fn inventory_blob_ref_snapshot_from_json(
-    snapshot_content: &str,
-) -> Result<InventoryBlobRefSnapshot, LixError> {
-    let value = serde_json::from_str::<serde_json::Value>(snapshot_content).map_err(|error| {
-        LixError::unknown(format!(
-            "invalid lix_binary_blob_ref snapshot JSON: {error}"
-        ))
-    })?;
-    let id = value
-        .get("id")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| LixError::unknown("lix_binary_blob_ref snapshot is missing id"))?;
-    let blob_hash = value
-        .get("blob_hash")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| LixError::unknown("lix_binary_blob_ref snapshot is missing blob_hash"))?;
-    Ok(InventoryBlobRefSnapshot {
-        id: id.to_string(),
-        blob_hash: blob_hash.to_string(),
-    })
 }
 
 fn is_lix_file_data_hash_hex(value: &str) -> bool {
@@ -2545,7 +2424,7 @@ fn disk_owned_unresolved_registry_tmp_path(path: &Path) -> PathBuf {
 fn disk_owned_unresolved_owners_from_json(
     value: &serde_json::Value,
     legacy_owner_branch_id: Option<&str>,
-) -> Option<BTreeMap<String, String>> {
+) -> Option<DiskOwnedUnresolvedFileOwners> {
     match value {
         serde_json::Value::Array(paths) => {
             let owner_branch_id = legacy_owner_branch_id?;
@@ -2553,14 +2432,20 @@ fn disk_owned_unresolved_owners_from_json(
             for path in paths {
                 owners.insert(path.as_str()?.to_string(), owner_branch_id.to_string());
             }
-            Some(owners)
+            Some(DiskOwnedUnresolvedFileOwners {
+                owners,
+                needs_writeback: true,
+            })
         }
         serde_json::Value::Object(object) => {
             let mut owners = BTreeMap::new();
             for (path, owner_branch_id) in object {
                 owners.insert(path.clone(), owner_branch_id.as_str()?.to_string());
             }
-            Some(owners)
+            Some(DiskOwnedUnresolvedFileOwners {
+                owners,
+                needs_writeback: false,
+            })
         }
         _ => None,
     }
@@ -2580,6 +2465,95 @@ fn collect_local_inventory_directory(
     metadata_mode: FilesystemMetadataMode,
     snapshot: &mut InventorySnapshot,
 ) -> Result<(), LixError> {
+    let child_dirs =
+        collect_local_inventory_directory_entries(root, directory, metadata_mode, snapshot)?;
+    for child_dir in child_dirs {
+        collect_local_inventory_directory(root, &child_dir, metadata_mode, snapshot)?;
+    }
+    Ok(())
+}
+
+fn collect_local_inventory_unfiltered(
+    root: &Path,
+    metadata_mode: FilesystemMetadataMode,
+    snapshot: &mut InventorySnapshot,
+) -> Result<(), LixError> {
+    let child_dirs =
+        collect_local_inventory_directory_entries(root, root, metadata_mode, snapshot)?;
+    let child_snapshot =
+        collect_local_inventory_child_directories(root, child_dirs, metadata_mode)?;
+    merge_inventory_snapshot(snapshot, child_snapshot);
+    Ok(())
+}
+
+fn collect_local_inventory_child_directories(
+    root: &Path,
+    child_dirs: Vec<PathBuf>,
+    metadata_mode: FilesystemMetadataMode,
+) -> Result<InventorySnapshot, LixError> {
+    let available_workers = thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(FILESYSTEM_PARALLEL_INVENTORY_MAX_WORKERS)
+        .min(child_dirs.len());
+    if child_dirs.len() < FILESYSTEM_PARALLEL_INVENTORY_MIN_DIRS || available_workers <= 1 {
+        let mut snapshot = InventorySnapshot::default();
+        for child_dir in child_dirs {
+            collect_local_inventory_directory(root, &child_dir, metadata_mode, &mut snapshot)?;
+        }
+        return Ok(snapshot);
+    }
+
+    let chunk_size = child_dirs.len().div_ceil(available_workers);
+    let mut handles = Vec::new();
+    for chunk in child_dirs.chunks(chunk_size) {
+        let root = root.to_path_buf();
+        let child_dirs = chunk.to_vec();
+        handles.push(thread::spawn(move || {
+            let mut snapshot = InventorySnapshot::default();
+            for child_dir in child_dirs {
+                collect_local_inventory_directory(&root, &child_dir, metadata_mode, &mut snapshot)?;
+            }
+            Ok::<_, LixError>(snapshot)
+        }));
+    }
+
+    let mut snapshot = InventorySnapshot::default();
+    let mut first_error = None;
+    for handle in handles {
+        match handle.join() {
+            Ok(Ok(child_snapshot)) => merge_inventory_snapshot(&mut snapshot, child_snapshot),
+            Ok(Err(error)) => {
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+            Err(_) => {
+                if first_error.is_none() {
+                    first_error = Some(LixError::unknown("filesystem inventory worker panicked"));
+                }
+            }
+        }
+    }
+    if let Some(error) = first_error {
+        return Err(error);
+    }
+    Ok(snapshot)
+}
+
+fn merge_inventory_snapshot(target: &mut InventorySnapshot, source: InventorySnapshot) {
+    target.directories.extend(source.directories);
+    target.files.extend(source.files);
+    target.unmanaged_paths.extend(source.unmanaged_paths);
+}
+
+fn collect_local_inventory_directory_entries(
+    root: &Path,
+    directory: &Path,
+    metadata_mode: FilesystemMetadataMode,
+    snapshot: &mut InventorySnapshot,
+) -> Result<Vec<PathBuf>, LixError> {
+    let mut child_dirs = Vec::new();
     let entries = std::fs::read_dir(directory)
         .map_err(|error| io_error("read filesystem directory", directory, error))?;
     for entry in entries {
@@ -2608,7 +2582,7 @@ fn collect_local_inventory_directory(
                 continue;
             }
             snapshot.directories.insert(lix_path);
-            collect_local_inventory_directory(root, &path, metadata_mode, snapshot)?;
+            child_dirs.push(path);
         } else if file_type.is_file() {
             let Ok(lix_path) = local_path_to_lix_path(root, &path, false) else {
                 remember_unmanaged_inventory_path(root, directory, &path, snapshot);
@@ -2621,7 +2595,7 @@ fn collect_local_inventory_directory(
             snapshot.files.insert(lix_path);
         }
     }
-    Ok(())
+    Ok(child_dirs)
 }
 
 fn collect_filtered_local_inventory(
@@ -3242,18 +3216,6 @@ fn metadata_is_filesystem_unresolved(metadata: Option<&str>) -> bool {
     serde_json::from_str::<serde_json::Value>(metadata)
         .ok()
         .is_some_and(|value| json_metadata_is_filesystem_unresolved(&value))
-}
-
-fn metadata_value_is_filesystem_unresolved(value: &Value) -> Result<bool, LixError> {
-    match value {
-        Value::Null => Ok(false),
-        Value::Text(value) => Ok(metadata_is_filesystem_unresolved(Some(value))),
-        Value::Json(value) => Ok(json_metadata_is_filesystem_unresolved(value)),
-        other => Err(LixError::new(
-            "LIX_ERROR_VALUE_TYPE",
-            format!("expected nullable metadata, got {other:?}"),
-        )),
-    }
 }
 
 fn json_metadata_is_filesystem_unresolved(value: &serde_json::Value) -> bool {

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
 use std::marker::PhantomData;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -25,6 +27,8 @@ const FILESYSTEM_POLL_INTERVAL: Duration = Duration::from_secs(15);
 const FILESYSTEM_FILE_UPSERT_CHUNK_SIZE: usize = 400;
 const FILESYSTEM_FILE_UPSERT_TRANSACTION_BYTES: usize = 16 * 1024 * 1024;
 const FILESYSTEM_UNRESOLVED_METADATA_KEY: &str = "lix_fs_unresolved";
+const FILESYSTEM_DISK_OWNED_UNRESOLVED_PATHS: &str = ".lix/.internal/fs_unresolved_disk_owned.json";
+static FILESYSTEM_UNRESOLVED_REGISTRY_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone)]
 pub(crate) struct FilesystemSync<B>
@@ -237,6 +241,7 @@ enum MaterializedState {
     Bytes(MaterializedSnapshot),
     Inventory {
         disk: InventorySnapshot,
+        disk_owned_unresolved_files: BTreeSet<String>,
         lix_revision: LixRevision,
     },
 }
@@ -256,6 +261,7 @@ struct LixSnapshotRead {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LixInventoryRead {
+    active_branch_id: String,
     directories: BTreeSet<String>,
     directory_ids: BTreeMap<String, String>,
     files: BTreeSet<String>,
@@ -716,11 +722,21 @@ where
             let resolved = self
                 .collect_lix_resolved_snapshot_read(&lix_inventory)
                 .await?;
-            self.materialize_inventory_snapshot(&resolved, &lix_inventory)?;
+            let disk_owned_unresolved_files =
+                self.disk_owned_unresolved_files_for_lix_materialization(&lix_inventory)?;
+            self.materialize_inventory_snapshot(
+                &resolved,
+                &lix_inventory,
+                &disk_owned_unresolved_files,
+            )?;
             let lix_revision = self.collect_lix_revision().await?;
             let materialized_inventory =
                 collect_local_inventory(&self.root, self.metadata_mode, &self.path_filter)?;
-            self.remember_inventory(materialized_inventory, lix_revision);
+            self.remember_inventory(
+                materialized_inventory,
+                disk_owned_unresolved_files,
+                lix_revision,
+            );
             return Ok(());
         }
         let lix_revision = self.collect_lix_revision().await?;
@@ -741,9 +757,11 @@ where
         skip_if_last_materialized: bool,
     ) -> Result<DiskSyncOutcome, LixError> {
         let _guard = self.sync_lock.lock().await;
-        if let Some(lix_inventory) = self.lix_inventory_for_inventory_sync().await? {
-            let inventory =
+        if let Some(mut lix_inventory) = self.lix_inventory_for_inventory_sync().await? {
+            let mut inventory =
                 collect_local_inventory(&self.root, self.metadata_mode, &self.path_filter)?;
+            let mut disk_owned_unresolved_files =
+                self.disk_owned_unresolved_files_for_inventory(&lix_inventory, Some(&inventory))?;
             let has_resolved_files = lix_inventory
                 .files
                 .difference(&lix_inventory.unresolved_files)
@@ -766,14 +784,24 @@ where
             self.apply_local_inventory_to_lix(
                 &inventory,
                 &lix_inventory,
+                &disk_owned_unresolved_files,
                 !skip_if_last_materialized,
             )
             .await?;
+            lix_inventory = self.collect_lix_inventory_read().await?;
+            disk_owned_unresolved_files =
+                self.disk_owned_unresolved_files_for_inventory(&lix_inventory, Some(&inventory))?;
             self.apply_plugin_local_file_data_to_lix(&inventory).await?;
-            self.apply_resolved_local_file_data_to_lix(&inventory, &lix_inventory)
+            self.materialize_missing_plugin_archives(&mut inventory, &lix_inventory)
                 .await?;
+            self.apply_resolved_local_file_data_to_lix(
+                &inventory,
+                &lix_inventory,
+                &disk_owned_unresolved_files,
+            )
+            .await?;
             let lix_revision = self.collect_lix_revision().await?;
-            self.remember_inventory(inventory, lix_revision);
+            self.remember_inventory(inventory, disk_owned_unresolved_files, lix_revision);
             return Ok(DiskSyncOutcome::InventoryMaterialized);
         }
         let local = collect_local_snapshot(&self.root, self.metadata_mode, &self.path_filter)?;
@@ -794,6 +822,108 @@ where
 
     async fn close(&self) -> Result<(), LixError> {
         self.session.close().await
+    }
+
+    fn read_disk_owned_unresolved_file_owners(
+        &self,
+        legacy_owner_branch_id: Option<&str>,
+    ) -> Result<BTreeMap<String, String>, LixError> {
+        let Some(path) = disk_owned_unresolved_registry_path(&self.root, self.metadata_mode) else {
+            return Ok(BTreeMap::new());
+        };
+        let data = match std::fs::read(&path) {
+            Ok(data) => data,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(BTreeMap::new());
+            }
+            Err(error) => {
+                return Err(io_error(
+                    "read filesystem unresolved registry",
+                    &path,
+                    error,
+                ));
+            }
+        };
+        let value = serde_json::from_slice::<serde_json::Value>(&data).map_err(|error| {
+            LixError::new(
+                "LIX_FILESYSTEM_ERROR",
+                format!(
+                    "failed to parse filesystem unresolved registry {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        disk_owned_unresolved_owners_from_json(&value, legacy_owner_branch_id).ok_or_else(|| {
+            LixError::new(
+                "LIX_FILESYSTEM_ERROR",
+                format!(
+                    "filesystem unresolved registry {} has an invalid format",
+                    path.display()
+                ),
+            )
+        })
+    }
+
+    fn write_disk_owned_unresolved_file_owners(
+        &self,
+        paths: &BTreeMap<String, String>,
+    ) -> Result<(), LixError> {
+        let Some(path) = disk_owned_unresolved_registry_path(&self.root, self.metadata_mode) else {
+            return Ok(());
+        };
+        if paths.is_empty() {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(io_error(
+                        "remove filesystem unresolved registry",
+                        &path,
+                        error,
+                    ));
+                }
+            }
+            return Ok(());
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                io_error(
+                    "create filesystem unresolved registry parent",
+                    parent,
+                    error,
+                )
+            })?;
+        }
+        let data = serde_json::to_vec(paths).map_err(|error| {
+            LixError::new(
+                "LIX_FILESYSTEM_ERROR",
+                format!("failed to encode filesystem unresolved registry: {error}"),
+            )
+        })?;
+        if std::fs::read(&path).ok().as_deref() == Some(data.as_slice()) {
+            return Ok(());
+        }
+        let tmp_path = disk_owned_unresolved_registry_tmp_path(&path);
+        {
+            let mut file = std::fs::File::create(&tmp_path).map_err(|error| {
+                io_error("create filesystem unresolved registry", &tmp_path, error)
+            })?;
+            file.write_all(&data).map_err(|error| {
+                io_error("write filesystem unresolved registry", &tmp_path, error)
+            })?;
+            file.sync_all().map_err(|error| {
+                io_error("sync filesystem unresolved registry", &tmp_path, error)
+            })?;
+        }
+        std::fs::rename(&tmp_path, &path).map_err(|error| {
+            io_error("replace filesystem unresolved registry", &tmp_path, error)
+        })?;
+        if let Some(parent) = path.parent() {
+            if let Ok(parent_dir) = std::fs::File::open(parent) {
+                let _ = parent_dir.sync_all();
+            }
+        }
+        Ok(())
     }
 
     async fn migrate_legacy_lix_system_paths(&self) -> Result<(), LixError> {
@@ -970,6 +1100,7 @@ where
             files.insert(path);
         }
         Ok(LixInventoryRead {
+            active_branch_id: self.session.active_branch_id().await?,
             directories,
             directory_ids,
             files,
@@ -1007,6 +1138,9 @@ where
     async fn lix_inventory_for_inventory_sync(&self) -> Result<Option<LixInventoryRead>, LixError> {
         let inventory = self.collect_lix_inventory_read().await?;
         let should_sync = !inventory.unresolved_files.is_empty()
+            || !self
+                .read_disk_owned_unresolved_file_owners(Some(&inventory.active_branch_id))?
+                .is_empty()
             || (inventory.files.is_empty()
                 && inventory.directories.iter().all(|path| {
                     path == "/" || is_materialization_ignored_path(path, self.metadata_mode)
@@ -1014,10 +1148,53 @@ where
         Ok(should_sync.then_some(inventory))
     }
 
+    fn disk_owned_unresolved_files_for_inventory(
+        &self,
+        lix: &LixInventoryRead,
+        local: Option<&InventorySnapshot>,
+    ) -> Result<BTreeSet<String>, LixError> {
+        let mut disk_owned =
+            self.read_disk_owned_unresolved_file_owners(Some(&lix.active_branch_id))?;
+        for path in &lix.unresolved_files {
+            disk_owned
+                .entry(path.clone())
+                .or_insert_with(|| lix.active_branch_id.clone());
+        }
+        disk_owned.retain(|path, owner_branch_id| {
+            (lix.unresolved_files.contains(path) || owner_branch_id != &lix.active_branch_id)
+                && self.path_filter.includes_file(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
+                && local.is_none_or(|inventory| inventory.files.contains(path))
+        });
+        self.write_disk_owned_unresolved_file_owners(&disk_owned)?;
+        Ok(disk_owned.into_keys().collect())
+    }
+
+    fn disk_owned_unresolved_files_for_lix_materialization(
+        &self,
+        lix: &LixInventoryRead,
+    ) -> Result<BTreeSet<String>, LixError> {
+        let mut disk_owned =
+            self.read_disk_owned_unresolved_file_owners(Some(&lix.active_branch_id))?;
+        for path in &lix.unresolved_files {
+            disk_owned
+                .entry(path.clone())
+                .or_insert_with(|| lix.active_branch_id.clone());
+        }
+        disk_owned.retain(|path, owner_branch_id| {
+            (lix.unresolved_files.contains(path) || owner_branch_id != &lix.active_branch_id)
+                && self.path_filter.includes_file(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
+        });
+        self.write_disk_owned_unresolved_file_owners(&disk_owned)?;
+        Ok(disk_owned.into_keys().collect())
+    }
+
     async fn apply_local_inventory_to_lix(
         &self,
         local: &InventorySnapshot,
         lix: &LixInventoryRead,
+        disk_owned_unresolved_files: &BTreeSet<String>,
         delete_all_missing: bool,
     ) -> Result<(), LixError> {
         let previous_inventory = self.last_materialized_inventory();
@@ -1025,6 +1202,7 @@ where
             .files
             .difference(&lix.files)
             .filter(|path| !is_materialization_ignored_path(path, self.metadata_mode))
+            .filter(|path| !disk_owned_unresolved_files.contains(*path))
             .filter(|path| {
                 delete_all_missing
                     || !previous_inventory
@@ -1039,6 +1217,7 @@ where
             .difference(&lix.directories)
             .filter(|path| path.as_str() != "/")
             .filter(|path| !is_materialization_ignored_path(path, self.metadata_mode))
+            .filter(|path| !directory_contains_path(path, disk_owned_unresolved_files))
             .filter(|path| {
                 delete_all_missing
                     || !previous_inventory
@@ -1075,6 +1254,9 @@ where
             if self.path_filter.includes_file(path)
                 && !is_materialization_ignored_path(path, self.metadata_mode)
             {
+                if is_plugin_storage_path(path) {
+                    continue;
+                }
                 if inventory_unmanaged_blocks_lix_path(local, path)
                     || lix_path_blocked_by_unmanaged(&self.root, path)?
                 {
@@ -1095,6 +1277,7 @@ where
                 .difference(&local.directories)
                 .filter(|path| path.as_str() != "/")
                 .filter(|path| !is_materialization_ignored_path(path, self.metadata_mode))
+                .filter(|path| !is_plugin_storage_path(path))
                 .filter(|path| {
                     delete_all_missing
                         || previous_inventory
@@ -1126,11 +1309,13 @@ where
         &self,
         local: &InventorySnapshot,
         lix: &LixInventoryRead,
+        disk_owned_unresolved_files: &BTreeSet<String>,
     ) -> Result<(), LixError> {
         self.apply_selected_local_file_data_to_lix(
             local.files.iter().filter(|path| {
                 lix.files.contains(*path)
                     && !lix.unresolved_files.contains(*path)
+                    && !disk_owned_unresolved_files.contains(*path)
                     && !is_plugin_storage_path(path)
             }),
             true,
@@ -1147,9 +1332,42 @@ where
                 .files
                 .iter()
                 .filter(|path| is_valid_plugin_storage_archive_path(path)),
-            false,
+            true,
         )
         .await
+    }
+
+    async fn materialize_missing_plugin_archives(
+        &self,
+        local: &mut InventorySnapshot,
+        lix: &LixInventoryRead,
+    ) -> Result<(), LixError> {
+        let missing_plugin_archives = lix
+            .files
+            .difference(&local.files)
+            .filter(|path| {
+                !lix.unresolved_files.contains(*path) && is_valid_plugin_storage_archive_path(path)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for path in missing_plugin_archives {
+            let rows = self
+                .session
+                .execute(
+                    "SELECT data FROM lix_file WHERE path = $1",
+                    &[Value::Text(path.clone())],
+                )
+                .await?;
+            let Some(row) = rows.rows().first() else {
+                continue;
+            };
+            let data = row.get::<Vec<u8>>("data")?;
+            write_materialized_file(&self.root, &path, &data, self.metadata_mode)?;
+            insert_parent_inventory_directories(&path, local);
+            local.files.insert(path);
+        }
+        Ok(())
     }
 
     async fn apply_selected_local_file_data_to_lix<'a>(
@@ -1209,7 +1427,11 @@ where
         let Some(row) = rows.rows().first() else {
             return Ok(false);
         };
-        Ok(row.get::<Vec<u8>>("data")? == data)
+        match row.get::<Vec<u8>>("data") {
+            Ok(existing) => Ok(existing == data),
+            Err(error) if error.code == "LIX_FILESYSTEM_DATA_UNRESOLVED" => Ok(false),
+            Err(error) => Err(error),
+        }
     }
 
     async fn collect_lix_revision(&self) -> Result<LixRevision, LixError> {
@@ -1474,6 +1696,7 @@ where
         &self,
         target: &Snapshot,
         target_inventory: &LixInventoryRead,
+        disk_owned_unresolved_files: &BTreeSet<String>,
     ) -> Result<(), LixError> {
         ensure_filesystem_root_directory(&self.root)?;
         let previous = self.last_materialized_inventory();
@@ -1485,6 +1708,7 @@ where
                 .filter(|path| {
                     self.path_filter.includes_file(path)
                         && !is_materialization_ignored_path(path, self.metadata_mode)
+                        && !disk_owned_unresolved_files.contains(*path)
                 })
             {
                 remove_materialized_file(&self.root, path, self.metadata_mode)?;
@@ -1497,6 +1721,7 @@ where
                     .filter(|path| {
                         path.as_str() != "/"
                             && !is_materialization_ignored_path(path, self.metadata_mode)
+                            && !directory_contains_path(path, disk_owned_unresolved_files)
                     })
                     .cloned()
                     .collect::<Vec<_>>();
@@ -1525,6 +1750,7 @@ where
         for (path, data) in target.files.iter().filter(|(path, _)| {
             self.path_filter.includes_file(path)
                 && !is_materialization_ignored_path(path, self.metadata_mode)
+                && !disk_owned_unresolved_files.contains(*path)
         }) {
             let local_path = lix_path_to_local_path(&self.root, path)?;
             if std::fs::read(&local_path).ok().as_deref() != Some(data.as_slice()) {
@@ -1643,12 +1869,21 @@ where
             }));
     }
 
-    fn remember_inventory(&self, disk: InventorySnapshot, lix_revision: LixRevision) {
+    fn remember_inventory(
+        &self,
+        disk: InventorySnapshot,
+        disk_owned_unresolved_files: BTreeSet<String>,
+        lix_revision: LixRevision,
+    ) {
         *self
             .last_materialized
             .lock()
             .expect("filesystem materialized snapshot lock should not poison") =
-            Some(MaterializedState::Inventory { disk, lix_revision });
+            Some(MaterializedState::Inventory {
+                disk,
+                disk_owned_unresolved_files,
+                lix_revision,
+            });
     }
 
     fn last_materialized_disk(&self) -> Option<Snapshot> {
@@ -1708,6 +1943,7 @@ where
                 MaterializedState::Inventory {
                     disk: materialized_disk,
                     lix_revision: materialized_revision,
+                    ..
                 } => materialized_disk == disk && materialized_revision == lix_revision,
                 MaterializedState::Bytes(_) => false,
             })
@@ -1869,6 +2105,55 @@ fn collect_local_inventory(
         collect_filtered_local_inventory(root, metadata_mode, path_filter, &mut snapshot)?;
     }
     Ok(snapshot)
+}
+
+fn disk_owned_unresolved_registry_path(
+    root: &Path,
+    metadata_mode: FilesystemMetadataMode,
+) -> Option<PathBuf> {
+    (metadata_mode == FilesystemMetadataMode::Persistent)
+        .then(|| root.join(FILESYSTEM_DISK_OWNED_UNRESOLVED_PATHS))
+}
+
+fn disk_owned_unresolved_registry_tmp_path(path: &Path) -> PathBuf {
+    let next = FILESYSTEM_UNRESOLVED_REGISTRY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("fs_unresolved_disk_owned.json");
+    path.with_file_name(format!(".{filename}.{}.{}.tmp", std::process::id(), next))
+}
+
+fn disk_owned_unresolved_owners_from_json(
+    value: &serde_json::Value,
+    legacy_owner_branch_id: Option<&str>,
+) -> Option<BTreeMap<String, String>> {
+    match value {
+        serde_json::Value::Array(paths) => {
+            let owner_branch_id = legacy_owner_branch_id?;
+            let mut owners = BTreeMap::new();
+            for path in paths {
+                owners.insert(path.as_str()?.to_string(), owner_branch_id.to_string());
+            }
+            Some(owners)
+        }
+        serde_json::Value::Object(object) => {
+            let mut owners = BTreeMap::new();
+            for (path, owner_branch_id) in object {
+                owners.insert(path.clone(), owner_branch_id.as_str()?.to_string());
+            }
+            Some(owners)
+        }
+        _ => None,
+    }
+}
+
+fn directory_contains_path(directory: &str, paths: &BTreeSet<String>) -> bool {
+    let directory = directory.strip_suffix('/').unwrap_or(directory);
+    paths.iter().any(|path| {
+        path.strip_prefix(directory)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+    })
 }
 
 fn collect_local_inventory_directory(
@@ -2557,7 +2842,13 @@ fn json_metadata_is_filesystem_unresolved(value: &serde_json::Value) -> bool {
     value
         .as_object()
         .and_then(|object| object.get(FILESYSTEM_UNRESOLVED_METADATA_KEY))
-        .is_some()
+        .is_some_and(filesystem_unresolved_metadata_value_is_marker)
+}
+
+fn filesystem_unresolved_metadata_value_is_marker(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        object.len() == 1 && object.get("version").and_then(serde_json::Value::as_u64) == Some(1)
+    })
 }
 
 fn local_path_to_lix_path(

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -590,35 +590,40 @@ where
             sync_lock: tokio::sync::Mutex::new(()),
             last_materialized: Mutex::new(None),
         });
-
-        if metadata_mode == FilesystemMetadataMode::Persistent {
-            state.migrate_legacy_lix_system_paths().await?;
-        }
-        if state.sync_disk_to_lix(false).await? == DiskSyncOutcome::NeedsMaterialization {
-            state.sync_from_lix().await?;
-        }
-
         let (event_tx, event_rx) = mpsc::channel();
-        let callback_tx = event_tx.clone();
-        let watcher_config = Config::default().with_follow_symlinks(false);
-        let debouncer = new_debouncer_opt::<_, RecommendedWatcher, RecommendedCache>(
-            Duration::from_millis(500),
-            None,
-            move |_result: DebounceEventResult| {
-                let _ = callback_tx.send(FilesystemEvent::DiskChanged);
-            },
-            RecommendedCache::new(),
-            watcher_config,
-        )
-        .ok()
-        .and_then(|mut debouncer| {
-            if watch_filesystem_paths(&mut debouncer, &state.root, &state.path_filter).is_ok() {
-                Some(debouncer)
-            } else {
-                debouncer.stop();
-                None
-            }
+        let watcher_setup = state.path_filter.is_unfiltered().then(|| {
+            start_filesystem_watcher_setup(
+                state.root.clone(),
+                state.metadata_mode,
+                state.path_filter.clone(),
+                event_tx.clone(),
+            )
         });
+
+        let initial_sync_result = async {
+            if metadata_mode == FilesystemMetadataMode::Persistent {
+                state.migrate_legacy_lix_system_paths().await?;
+            }
+            if state.sync_disk_to_lix(false).await? == DiskSyncOutcome::NeedsMaterialization {
+                state.sync_from_lix().await?;
+            }
+            Ok::<(), LixError>(())
+        }
+        .await;
+
+        let debouncer = if let Some(watcher_setup) = watcher_setup.flatten() {
+            let debouncer = finish_filesystem_watcher_setup(Some(watcher_setup));
+            initial_sync_result?;
+            debouncer
+        } else {
+            initial_sync_result?;
+            create_filesystem_debouncer(
+                &state.root,
+                state.metadata_mode,
+                &state.path_filter,
+                event_tx.clone(),
+            )
+        };
         let poll_filesystem = cfg!(target_os = "macos") || debouncer.is_none();
         let worker_state = Arc::clone(&state);
         let worker = std::thread::Builder::new()
@@ -679,6 +684,24 @@ impl FilesystemSupervisorInner {
             }
         }
     }
+}
+
+fn start_filesystem_watcher_setup(
+    root: PathBuf,
+    metadata_mode: FilesystemMetadataMode,
+    path_filter: FilesystemPathFilter,
+    event_tx: mpsc::Sender<FilesystemEvent>,
+) -> Option<JoinHandle<Option<FilesystemDebouncer>>> {
+    std::thread::Builder::new()
+        .name("lix-sdk-filesystem-watch-setup".to_string())
+        .spawn(move || create_filesystem_debouncer(&root, metadata_mode, &path_filter, event_tx))
+        .ok()
+}
+
+fn finish_filesystem_watcher_setup(
+    watcher_setup: Option<JoinHandle<Option<FilesystemDebouncer>>>,
+) -> Option<FilesystemDebouncer> {
+    watcher_setup.and_then(|handle| handle.join().ok().flatten())
 }
 
 impl<B> FilesystemState<B>
@@ -2086,6 +2109,56 @@ fn watch_filesystem_paths(
         debouncer.watch(&path, RecursiveMode::NonRecursive)?;
     }
     Ok(())
+}
+
+fn create_filesystem_debouncer(
+    root: &Path,
+    metadata_mode: FilesystemMetadataMode,
+    path_filter: &FilesystemPathFilter,
+    event_tx: mpsc::Sender<FilesystemEvent>,
+) -> Option<FilesystemDebouncer> {
+    let watcher_config = Config::default().with_follow_symlinks(false);
+    let callback_root = root.to_path_buf();
+    new_debouncer_opt::<_, RecommendedWatcher, RecommendedCache>(
+        Duration::from_millis(500),
+        None,
+        move |result: DebounceEventResult| {
+            if debounce_result_should_sync(&result, &callback_root, metadata_mode) {
+                let _ = event_tx.send(FilesystemEvent::DiskChanged);
+            }
+        },
+        RecommendedCache::new(),
+        watcher_config,
+    )
+    .ok()
+    .and_then(|mut debouncer| {
+        if watch_filesystem_paths(&mut debouncer, root, path_filter).is_ok() {
+            Some(debouncer)
+        } else {
+            debouncer.stop();
+            None
+        }
+    })
+}
+
+fn debounce_result_should_sync(
+    result: &DebounceEventResult,
+    root: &Path,
+    metadata_mode: FilesystemMetadataMode,
+) -> bool {
+    let Ok(events) = result else {
+        return true;
+    };
+    let mut saw_path = false;
+    for event in events {
+        for path in &event.paths {
+            saw_path = true;
+            if !is_filesystem_sync_ignored_local_path(root, path, metadata_mode) {
+                return true;
+            }
+        }
+    }
+    !saw_path
 }
 
 fn ensure_filesystem_root_directory(root: &Path) -> Result<(), LixError> {

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -5,6 +5,8 @@ use lix_sdk::{
 #[cfg(feature = "sqlite")]
 use lix_sdk::{FsBackend, SqliteBackend, open_lix_with_backend};
 #[cfg(feature = "sqlite")]
+use std::io::{Cursor, Write};
+#[cfg(feature = "sqlite")]
 use std::path::Path;
 #[cfg(feature = "sqlite")]
 use std::time::{Duration, Instant};
@@ -340,6 +342,66 @@ async fn transaction_lix_file_data_reads_staged_file_bytes() {
 }
 
 #[tokio::test]
+async fn lix_file_data_hash_filters_work_in_destructive_dml() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    write_file(&lix, "/hash-a.txt", b"alpha".to_vec())
+        .await
+        .unwrap();
+    write_file(&lix, "/hash-b.txt", b"beta".to_vec())
+        .await
+        .unwrap();
+
+    let rows = lix
+        .execute(
+            "SELECT path, lixcol_data_hash FROM lix_file WHERE path IN ($1, $2) ORDER BY path",
+            &[
+                Value::Text("/hash-a.txt".to_string()),
+                Value::Text("/hash-b.txt".to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+    let hash_a = rows.rows()[0].get::<String>("lixcol_data_hash").unwrap();
+    let hash_b = rows.rows()[1].get::<String>("lixcol_data_hash").unwrap();
+    assert_ne!(hash_a, hash_b);
+
+    let update = lix
+        .execute(
+            "UPDATE lix_file SET data = $1 WHERE lixcol_data_hash = $2",
+            &[Value::Blob(b"updated".to_vec()), Value::Text(hash_a)],
+        )
+        .await
+        .unwrap();
+    assert_eq!(update.rows_affected(), 1);
+    assert_eq!(
+        read_file(&lix, "/hash-a.txt").await.unwrap().as_deref(),
+        Some(b"updated".as_slice())
+    );
+    assert_eq!(
+        read_file(&lix, "/hash-b.txt").await.unwrap().as_deref(),
+        Some(b"beta".as_slice())
+    );
+
+    let delete_null = lix
+        .execute("DELETE FROM lix_file WHERE lixcol_data_hash IS NULL", &[])
+        .await
+        .unwrap();
+    assert_eq!(delete_null.rows_affected(), 0);
+
+    let delete = lix
+        .execute(
+            "DELETE FROM lix_file WHERE lixcol_data_hash = $1",
+            &[Value::Text(hash_b)],
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete.rows_affected(), 1);
+    assert_eq!(read_file(&lix, "/hash-b.txt").await.unwrap(), None);
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn transaction_rollback_discards_staged_writes() {
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
     register_crm_task_schema(&lix).await;
@@ -465,6 +527,13 @@ async fn filesystem_initial_import_stages_descriptors_without_file_data() {
     write_file(&lix, "/docs/readme.txt", b"hydrated".to_vec())
         .await
         .unwrap();
+    assert!(
+        !tempdir
+            .path()
+            .join(".lix/.internal/fs_unresolved_disk_owned.json")
+            .exists(),
+        "hydrating the active unresolved file should release disk-owned protection"
+    );
     assert_eq!(
         read_file(&lix, "/docs/readme.txt")
             .await
@@ -472,6 +541,43 @@ async fn filesystem_initial_import_stages_descriptors_without_file_data() {
             .as_deref(),
         Some(b"hydrated".as_slice())
     );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_unresolved_file_exposes_data_hash_without_data() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("docs.md"), b"local").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    let rows = lix
+        .execute(
+            "SELECT lixcol_data_hash FROM lix_file WHERE path = $1",
+            &[Value::Text("/docs.md".to_string())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.rows()[0].get::<String>("lixcol_data_hash").unwrap(),
+        "unresolved:/docs.md"
+    );
+    assert_unresolved_file_data(&lix, "/docs.md").await;
+
+    write_file(&lix, "/docs.md", b"hydrated".to_vec())
+        .await
+        .unwrap();
+    let rows = lix
+        .execute(
+            "SELECT lixcol_data_hash FROM lix_file WHERE path = $1",
+            &[Value::Text("/docs.md".to_string())],
+        )
+        .await
+        .unwrap();
+    let hash = rows.rows()[0].get::<String>("lixcol_data_hash").unwrap();
+    assert!(!hash.is_empty());
+    assert_ne!(hash, "unresolved:/docs.md");
+
     lix.close().await.unwrap();
 }
 
@@ -960,6 +1066,211 @@ async fn filesystem_inventory_mode_syncs_resolved_disk_edits() {
     std::fs::write(tempdir.path().join("resolved.txt"), b"disk-change").unwrap();
     wait_for_lix_file(&lix, "/resolved.txt", Some(b"disk-change")).await;
     assert_unresolved_file_data(&lix, "/still-unresolved.txt").await;
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_inventory_mode_protects_unresolved_disk_bytes_from_resolved_branch() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("same.md"), b"disk-main").unwrap();
+    std::fs::write(tempdir.path().join("only-main.md"), b"only-main").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+    let main_branch_id = lix.active_branch_id().await.unwrap();
+    assert_unresolved_file_data(&lix, "/same.md").await;
+    assert!(
+        tempdir
+            .path()
+            .join(".lix/.internal/fs_unresolved_disk_owned.json")
+            .exists(),
+        "initial unresolved import should persist disk-owned protection"
+    );
+
+    let branch = lix
+        .create_branch(CreateBranchOptions {
+            id: Some("resolved-branch".to_string()),
+            name: "Resolved".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .unwrap();
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: branch.id.clone(),
+    })
+    .await
+    .unwrap();
+    lix.execute(
+        "DELETE FROM lix_file WHERE path = $1",
+        &[Value::Text("/only-main.md".to_string())],
+    )
+    .await
+    .unwrap();
+    write_file(&lix, "/same.md", b"branch-data".to_vec())
+        .await
+        .unwrap();
+
+    std::fs::write(tempdir.path().join("disk-trigger.txt"), b"trigger").unwrap();
+    wait_for_lix_unresolved_file(&lix, "/disk-trigger.txt").await;
+    assert_eq!(
+        read_file(&lix, "/same.md").await.unwrap().as_deref(),
+        Some(b"branch-data".as_slice())
+    );
+    assert_eq!(
+        std::fs::read(tempdir.path().join("same.md")).unwrap(),
+        b"disk-main"
+    );
+    assert_eq!(read_file(&lix, "/only-main.md").await.unwrap(), None);
+    assert_eq!(
+        std::fs::read(tempdir.path().join("only-main.md")).unwrap(),
+        b"only-main"
+    );
+
+    lix.close().await.unwrap();
+    let reopened = open_lix_with_filesystem(tempdir.path()).await;
+    reopened
+        .switch_branch(SwitchBranchOptions {
+            branch_id: branch.id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        read_file(&reopened, "/same.md").await.unwrap().as_deref(),
+        Some(b"branch-data".as_slice())
+    );
+    assert_eq!(
+        std::fs::read(tempdir.path().join("same.md")).unwrap(),
+        b"disk-main"
+    );
+    assert_eq!(read_file(&reopened, "/only-main.md").await.unwrap(), None);
+    assert_eq!(
+        std::fs::read(tempdir.path().join("only-main.md")).unwrap(),
+        b"only-main"
+    );
+    reopened
+        .switch_branch(SwitchBranchOptions {
+            branch_id: main_branch_id,
+        })
+        .await
+        .unwrap();
+    assert_unresolved_file_data(&reopened, "/same.md").await;
+    assert_unresolved_file_data(&reopened, "/only-main.md").await;
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_inventory_mode_rematerializes_missing_plugin_archive() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("normal.txt"), b"normal").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+    let plugin_archive = build_runtime_test_plugin_archive();
+    write_file(
+        &lix,
+        "/.lix/plugins/plugin_runtime_test.lixplugin",
+        plugin_archive.clone(),
+    )
+    .await
+    .unwrap();
+    wait_for_disk_file(
+        &tempdir
+            .path()
+            .join(".lix/plugins/plugin_runtime_test.lixplugin"),
+        Some(&plugin_archive),
+    );
+    lix.close().await.unwrap();
+
+    std::fs::remove_file(
+        tempdir
+            .path()
+            .join(".lix/plugins/plugin_runtime_test.lixplugin"),
+    )
+    .unwrap();
+    let reopened = open_lix_with_filesystem(tempdir.path()).await;
+    wait_for_disk_file(
+        &tempdir
+            .path()
+            .join(".lix/plugins/plugin_runtime_test.lixplugin"),
+        Some(&plugin_archive),
+    );
+    assert_unresolved_file_data(&reopened, "/normal.txt").await;
+    reopened.close().await.unwrap();
+}
+
+#[cfg(feature = "sqlite")]
+fn build_runtime_test_plugin_archive() -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        ("manifest.json", RUNTIME_TEST_PLUGIN_MANIFEST.as_bytes()),
+        (
+            "schema/test_plugin_doc.json",
+            RUNTIME_TEST_PLUGIN_SCHEMA.as_bytes(),
+        ),
+        ("plugin.wasm", b"\0asm\x01\0\0\0".as_slice()),
+    ] {
+        writer.start_file(path, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+#[cfg(feature = "sqlite")]
+const RUNTIME_TEST_PLUGIN_MANIFEST: &str = r#"{
+  "key": "plugin_runtime_test",
+  "runtime": "wasm-component-v1",
+  "api_version": "0.1.0",
+  "match": {
+    "path_glob": "*.runtime",
+    "content_type": "text"
+  },
+  "entry": "plugin.wasm",
+  "schemas": [
+    "schema/test_plugin_doc.json"
+  ]
+}"#;
+
+#[cfg(feature = "sqlite")]
+const RUNTIME_TEST_PLUGIN_SCHEMA: &str = r#"{
+  "x-lix-key": "test_plugin_doc",
+  "x-lix-primary-key": [
+    "/id"
+  ],
+  "type": "object",
+  "required": [
+    "id",
+    "content"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "content": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}"#;
+
+#[tokio::test]
+async fn lix_file_unresolved_metadata_key_stays_reserved() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    let error = lix
+        .execute(
+            "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ($1, $2, lix_json($3))",
+            &[
+                Value::Text("/marker-like.txt".to_string()),
+                Value::Blob(b"data".to_vec()),
+                Value::Text(r#"{"lix_fs_unresolved":{"version":2}}"#.to_string()),
+            ],
+        )
+        .await
+        .expect_err("filesystem unresolved metadata key should be reserved");
+    assert!(
+        error.message.contains("reserved for filesystem backend"),
+        "unexpected error: {error:?}"
+    );
 
     lix.close().await.unwrap();
 }

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -435,7 +435,7 @@ async fn transaction_blocks_session_execute_on_same_handle() {
 
 #[tokio::test]
 #[cfg(feature = "sqlite")]
-async fn filesystem_initial_import_uses_local_files_as_source_of_truth() {
+async fn filesystem_initial_import_stages_descriptors_without_file_data() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tempdir.path().join("docs")).unwrap();
     std::fs::create_dir_all(tempdir.path().join("empty")).unwrap();
@@ -443,18 +443,110 @@ async fn filesystem_initial_import_uses_local_files_as_source_of_truth() {
 
     let lix = open_lix_with_filesystem(tempdir.path()).await;
 
-    assert_eq!(
-        read_file(&lix, "/docs/readme.txt")
-            .await
-            .unwrap()
-            .as_deref(),
-        Some(b"local".as_slice())
+    assert_unresolved_file_data(&lix, "/docs/readme.txt").await;
+    let error = lix
+        .execute(
+            "UPDATE lix_file SET lixcol_metadata = lix_json('{}') WHERE path = $1",
+            &[Value::Text("/docs/readme.txt".to_string())],
+        )
+        .await
+        .expect_err("metadata-only update must not resolve file data");
+    assert!(
+        error
+            .message
+            .contains("cannot modify metadata for unresolved filesystem data"),
+        "unexpected error: {error:?}"
     );
     assert!(readdir(&lix, "/empty/").await.unwrap().unwrap().is_empty());
     assert_eq!(
         std::fs::read(tempdir.path().join("docs/readme.txt")).unwrap(),
         b"local"
     );
+    write_file(&lix, "/docs/readme.txt", b"hydrated".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        read_file(&lix, "/docs/readme.txt")
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(b"hydrated".as_slice())
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn lix_file_fast_upsert_preserves_public_metadata() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+
+    lix.execute(
+        "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ($1, $2, lix_json($3))",
+        &[
+            Value::Text("/metadata.txt".to_string()),
+            Value::Blob(b"old".to_vec()),
+            Value::Text(r#"{"owner":"user"}"#.to_string()),
+        ],
+    )
+    .await
+    .unwrap();
+    write_file(&lix, "/metadata.txt", b"new".to_vec())
+        .await
+        .unwrap();
+
+    let rows = lix
+        .execute(
+            "SELECT data, lixcol_metadata FROM lix_file WHERE path = $1",
+            &[Value::Text("/metadata.txt".to_string())],
+        )
+        .await
+        .unwrap();
+    let row = rows.rows().first().expect("metadata file should exist");
+    assert_eq!(row.get::<Vec<u8>>("data").unwrap(), b"new");
+    assert_eq!(
+        row.get::<serde_json::Value>("lixcol_metadata").unwrap(),
+        serde_json::json!({"owner": "user"})
+    );
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_initial_import_creates_nested_file() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tempdir.path().join("a/b/c")).unwrap();
+    std::fs::write(tempdir.path().join("a/b/c/file.txt"), b"nested").unwrap();
+
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    assert_unresolved_file_data(&lix, "/a/b/c/file.txt").await;
+    assert_eq!(
+        readdir(&lix, "/a/b/c/").await.unwrap(),
+        Some(vec!["file.txt".to_string()])
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_initial_import_handles_more_files_than_one_upsert_chunk() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tempdir.path().join("batch")).unwrap();
+    for index in 0..410 {
+        std::fs::write(
+            tempdir.path().join(format!("batch/file-{index:03}.txt")),
+            format!("content-{index:03}"),
+        )
+        .unwrap();
+    }
+
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    let entries = readdir(&lix, "/batch/").await.unwrap().unwrap();
+    assert_eq!(entries.len(), 410);
+    assert_eq!(entries.first().map(String::as_str), Some("file-000.txt"));
+    assert_eq!(entries.last().map(String::as_str), Some("file-409.txt"));
+    assert_unresolved_file_data(&lix, "/batch/file-409.txt").await;
     lix.close().await.unwrap();
 }
 
@@ -481,6 +573,21 @@ where
         .first()
         .map(|row| row.get::<Vec<u8>>("data"))
         .transpose()
+}
+
+async fn assert_unresolved_file_data<B>(lix: &Lix<B>, path: &str)
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    let error = read_file(lix, path)
+        .await
+        .expect_err("descriptor-only file data should be unresolved");
+    assert!(
+        error.message.contains("LIX_FILESYSTEM_DATA_UNRESOLVED"),
+        "unexpected error: {error:?}"
+    );
 }
 
 async fn write_file<B>(lix: &Lix<B>, path: &str, data: Vec<u8>) -> Result<(), LixError>
@@ -708,13 +815,7 @@ async fn filesystem_initial_import_ignores_git_entries() {
 
     let lix = open_lix_with_filesystem(tempdir.path()).await;
 
-    assert_eq!(
-        read_file(&lix, "/docs/readme.txt")
-            .await
-            .unwrap()
-            .as_deref(),
-        Some(b"normal".as_slice())
-    );
+    assert_unresolved_file_data(&lix, "/docs/readme.txt").await;
     assert_eq!(readdir(&lix, "/.git/").await.unwrap(), None);
     assert_eq!(read_file(&lix, "/.git/config").await.unwrap(), None);
     assert_eq!(readdir(&lix, "/nested/.git/").await.unwrap(), None);
@@ -845,6 +946,71 @@ async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
 
 #[tokio::test]
 #[cfg(feature = "sqlite")]
+async fn filesystem_inventory_mode_syncs_resolved_disk_edits() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("resolved.txt"), b"initial").unwrap();
+    std::fs::write(tempdir.path().join("still-unresolved.txt"), b"lazy").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    write_file(&lix, "/resolved.txt", b"hydrated".to_vec())
+        .await
+        .unwrap();
+    wait_for_disk_file(&tempdir.path().join("resolved.txt"), Some(b"hydrated"));
+
+    std::fs::write(tempdir.path().join("resolved.txt"), b"disk-change").unwrap();
+    wait_for_lix_file(&lix, "/resolved.txt", Some(b"disk-change")).await;
+    assert_unresolved_file_data(&lix, "/still-unresolved.txt").await;
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_inventory_mode_applies_lix_deletes_to_disk() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("deleted.txt"), b"delete me").unwrap();
+    std::fs::write(tempdir.path().join("still-unresolved.txt"), b"lazy").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    lix.execute(
+        "DELETE FROM lix_file WHERE path = $1",
+        &[Value::Text("/deleted.txt".to_string())],
+    )
+    .await
+    .unwrap();
+
+    wait_for_disk_file(&tempdir.path().join("deleted.txt"), None);
+    assert_eq!(read_file(&lix, "/deleted.txt").await.unwrap(), None);
+    assert_unresolved_file_data(&lix, "/still-unresolved.txt").await;
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_inventory_mode_does_not_resurrect_lix_delete_after_disk_event() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("deleted.txt"), b"delete me").unwrap();
+    std::fs::write(tempdir.path().join("still-unresolved.txt"), b"lazy").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    lix.execute(
+        "DELETE FROM lix_file WHERE path = $1",
+        &[Value::Text("/deleted.txt".to_string())],
+    )
+    .await
+    .unwrap();
+    std::fs::write(tempdir.path().join("local-add.txt"), b"local").unwrap();
+
+    wait_for_disk_file(&tempdir.path().join("deleted.txt"), None);
+    assert_eq!(read_file(&lix, "/deleted.txt").await.unwrap(), None);
+    wait_for_lix_unresolved_file(&lix, "/local-add.txt").await;
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
 async fn filesystem_materializes_untracked_sdk_sql_writes() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -948,6 +1114,61 @@ async fn filesystem_materialization_skips_git_entries() {
 
 #[tokio::test]
 #[cfg(feature = "sqlite")]
+async fn filesystem_inventory_ignores_invalid_plugin_descendants() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tempdir.path().join(".lix/plugins/nested")).unwrap();
+    std::fs::write(tempdir.path().join(".lix/plugins/nested/file.txt"), b"bad").unwrap();
+    std::fs::write(tempdir.path().join("normal.txt"), b"normal").unwrap();
+
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    assert_unresolved_file_data(&lix, "/normal.txt").await;
+    assert_eq!(readdir(&lix, "/.lix/plugins/nested/").await.unwrap(), None);
+    assert_eq!(
+        read_file(&lix, "/.lix/plugins/nested/file.txt")
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(
+        tempdir
+            .path()
+            .join(".lix/plugins/nested/file.txt")
+            .is_file()
+    );
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(all(unix, feature = "sqlite"))]
+async fn filesystem_inventory_mode_preserves_lix_entry_blocked_by_unmanaged_path() {
+    use std::os::unix::fs::symlink;
+
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("blocked.txt"), b"initial").unwrap();
+    std::fs::write(tempdir.path().join("still-unresolved.txt"), b"lazy").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+    write_file(&lix, "/blocked.txt", b"hydrated".to_vec())
+        .await
+        .unwrap();
+    wait_for_disk_file(&tempdir.path().join("blocked.txt"), Some(b"hydrated"));
+
+    std::fs::remove_file(tempdir.path().join("blocked.txt")).unwrap();
+    symlink("still-unresolved.txt", tempdir.path().join("blocked.txt")).unwrap();
+    std::fs::write(tempdir.path().join("local-trigger.txt"), b"local").unwrap();
+
+    wait_for_lix_unresolved_file(&lix, "/local-trigger.txt").await;
+    assert_eq!(
+        read_file(&lix, "/blocked.txt").await.unwrap().as_deref(),
+        Some(b"hydrated".as_slice())
+    );
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
 async fn filesystem_imports_opaque_lix_path_names() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::write(tempdir.path().join("bad%name.txt"), b"bad").unwrap();
@@ -955,14 +1176,8 @@ async fn filesystem_imports_opaque_lix_path_names() {
 
     let lix = open_lix_with_filesystem(tempdir.path()).await;
 
-    assert_eq!(
-        read_file(&lix, "/bad%name.txt").await.unwrap().as_deref(),
-        Some(b"bad".as_slice())
-    );
-    assert_eq!(
-        read_file(&lix, "/#hash.txt").await.unwrap().as_deref(),
-        Some(b"hash".as_slice())
-    );
+    assert_unresolved_file_data(&lix, "/bad%name.txt").await;
+    assert_unresolved_file_data(&lix, "/#hash.txt").await;
     write_file(&lix, "/written%23.txt", b"written".to_vec())
         .await
         .unwrap();
@@ -1000,17 +1215,8 @@ async fn filesystem_ignores_symlinks_on_initial_import() {
 
     let lix = open_lix_with_filesystem(tempdir.path()).await;
 
-    assert_eq!(
-        read_file(&lix, "/target.txt").await.unwrap().as_deref(),
-        Some(b"target".as_slice())
-    );
-    assert_eq!(
-        read_file(&lix, "/real-dir/file.txt")
-            .await
-            .unwrap()
-            .as_deref(),
-        Some(b"nested".as_slice())
-    );
+    assert_unresolved_file_data(&lix, "/target.txt").await;
+    assert_unresolved_file_data(&lix, "/real-dir/file.txt").await;
     assert_eq!(read_file(&lix, "/link.txt").await.unwrap(), None);
     assert_eq!(readdir(&lix, "/linked-dir/").await.unwrap(), None);
     assert_eq!(read_file(&lix, "/linked-dir/file.txt").await.unwrap(), None);
@@ -1226,6 +1432,25 @@ async fn wait_for_lix_file(lix: &Lix<FsBackend>, path: &str, expected: Option<&[
             Instant::now() < deadline,
             "timed out waiting for Lix file {path} to be {expected:?}, got {actual:?}"
         );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(feature = "sqlite")]
+async fn wait_for_lix_unresolved_file(lix: &Lix<FsBackend>, path: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match read_file(lix, path).await {
+            Err(error) if error.message.contains("LIX_FILESYSTEM_DATA_UNRESOLVED") => return,
+            Ok(actual) => assert!(
+                Instant::now() < deadline,
+                "timed out waiting for Lix file {path} to be unresolved, got {actual:?}"
+            ),
+            Err(error) => assert!(
+                Instant::now() < deadline,
+                "timed out waiting for Lix file {path} to be unresolved, got error {error:?}"
+            ),
+        }
         std::thread::sleep(Duration::from_millis(50));
     }
 }

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,3 +1,4 @@
+use lix_engine::lix_file_data_hash_hex;
 use lix_sdk::{
     Backend, CreateBranchOptions, InMemoryBackend, Lix, LixError, MergeBranchOptions,
     MergeBranchOutcome, OpenLixOptions, SwitchBranchOptions, Value, open_lix,
@@ -575,8 +576,20 @@ async fn filesystem_unresolved_file_exposes_data_hash_without_data() {
         .await
         .unwrap();
     let hash = rows.rows()[0].get::<String>("lixcol_data_hash").unwrap();
-    assert!(!hash.is_empty());
-    assert_ne!(hash, "unresolved:/docs.md");
+    assert_eq!(hash, lix_file_data_hash_hex(b"hydrated"));
+
+    write_file(&lix, "/empty.md", Vec::new()).await.unwrap();
+    let rows = lix
+        .execute(
+            "SELECT lixcol_data_hash FROM lix_file WHERE path = $1",
+            &[Value::Text("/empty.md".to_string())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.rows()[0].get::<String>("lixcol_data_hash").unwrap(),
+        lix_file_data_hash_hex(b"")
+    );
 
     lix.close().await.unwrap();
 }
@@ -1066,6 +1079,111 @@ async fn filesystem_inventory_mode_syncs_resolved_disk_edits() {
     std::fs::write(tempdir.path().join("resolved.txt"), b"disk-change").unwrap();
     wait_for_lix_file(&lix, "/resolved.txt", Some(b"disk-change")).await;
     assert_unresolved_file_data(&lix, "/still-unresolved.txt").await;
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_inventory_reopen_uses_blob_hash_and_still_syncs_changed_bytes() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("resolved.txt"), b"initial").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    write_file(&lix, "/resolved.txt", b"hydrated".to_vec())
+        .await
+        .unwrap();
+    wait_for_disk_file(&tempdir.path().join("resolved.txt"), Some(b"hydrated"));
+    lix.close().await.unwrap();
+
+    let reopened = open_lix_with_filesystem(tempdir.path()).await;
+    let rows = reopened
+        .execute(
+            "SELECT lixcol_data_hash FROM lix_file WHERE path = $1",
+            &[Value::Text("/resolved.txt".to_string())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.rows()[0].get::<String>("lixcol_data_hash").unwrap(),
+        lix_file_data_hash_hex(b"hydrated")
+    );
+
+    std::fs::write(tempdir.path().join("resolved.txt"), b"disk-change").unwrap();
+    wait_for_lix_file(&reopened, "/resolved.txt", Some(b"disk-change")).await;
+
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_materialization_preserves_unrelated_dirty_resolved_file() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("a.txt"), b"a-disk").unwrap();
+    std::fs::write(tempdir.path().join("b.txt"), b"b-disk").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    write_file(&lix, "/a.txt", b"a-lix".to_vec()).await.unwrap();
+    write_file(&lix, "/b.txt", b"b-lix".to_vec()).await.unwrap();
+    wait_for_disk_file(&tempdir.path().join("a.txt"), Some(b"a-lix"));
+    wait_for_disk_file(&tempdir.path().join("b.txt"), Some(b"b-lix"));
+
+    std::fs::write(tempdir.path().join("b.txt"), b"b-local").unwrap();
+    write_file(&lix, "/a.txt", b"a-new".to_vec()).await.unwrap();
+    wait_for_disk_file(&tempdir.path().join("a.txt"), Some(b"a-new"));
+    assert_eq!(
+        std::fs::read(tempdir.path().join("b.txt")).unwrap(),
+        b"b-local"
+    );
+    wait_for_lix_file(&lix, "/b.txt", Some(b"b-local")).await;
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_materialization_preserves_unrelated_deleted_resolved_file() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("a.txt"), b"a-disk").unwrap();
+    std::fs::write(tempdir.path().join("b.txt"), b"b-disk").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    write_file(&lix, "/a.txt", b"a-lix".to_vec()).await.unwrap();
+    write_file(&lix, "/b.txt", b"b-lix".to_vec()).await.unwrap();
+    wait_for_disk_file(&tempdir.path().join("a.txt"), Some(b"a-lix"));
+    wait_for_disk_file(&tempdir.path().join("b.txt"), Some(b"b-lix"));
+
+    std::fs::remove_file(tempdir.path().join("b.txt")).unwrap();
+    write_file(&lix, "/a.txt", b"a-new".to_vec()).await.unwrap();
+    wait_for_disk_file(&tempdir.path().join("a.txt"), Some(b"a-new"));
+    wait_for_disk_file(&tempdir.path().join("b.txt"), None);
+    wait_for_lix_file(&lix, "/b.txt", None).await;
+
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "sqlite")]
+async fn filesystem_materialization_preserves_unrelated_deleted_resolved_directory() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("a.txt"), b"a-disk").unwrap();
+    std::fs::create_dir_all(tempdir.path().join("dir")).unwrap();
+    std::fs::write(tempdir.path().join("dir/b.txt"), b"b-disk").unwrap();
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    write_file(&lix, "/a.txt", b"a-lix".to_vec()).await.unwrap();
+    write_file(&lix, "/dir/b.txt", b"b-lix".to_vec())
+        .await
+        .unwrap();
+    wait_for_disk_file(&tempdir.path().join("a.txt"), Some(b"a-lix"));
+    wait_for_disk_file(&tempdir.path().join("dir/b.txt"), Some(b"b-lix"));
+
+    std::fs::remove_dir_all(tempdir.path().join("dir")).unwrap();
+    write_file(&lix, "/a.txt", b"a-new".to_vec()).await.unwrap();
+    wait_for_disk_file(&tempdir.path().join("a.txt"), Some(b"a-new"));
+    wait_for_disk_file(&tempdir.path().join("dir/b.txt"), None);
+    wait_for_lix_file(&lix, "/dir/b.txt", None).await;
+    assert_eq!(readdir(&lix, "/dir/").await.unwrap(), None);
 
     lix.close().await.unwrap();
 }

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -388,6 +388,20 @@ async fn sqlite_backend_open_lix_options_supplies_plugin_wasm_runtime() {
     );
     assert_eq!(runtime.render_calls.load(Ordering::SeqCst), 1);
 
+    let hash_rows = lix
+        .execute(
+            "SELECT lixcol_data_hash FROM lix_file WHERE path = $1",
+            &[Value::Text("/custom.runtime".to_string())],
+        )
+        .await
+        .expect("plugin file data hash reads");
+    let data_hash = hash_rows.rows()[0]
+        .get::<String>("lixcol_data_hash")
+        .expect("data hash should decode");
+    assert!(!data_hash.is_empty());
+    assert!(!data_hash.starts_with("unresolved:"));
+    assert_eq!(runtime.render_calls.load(Ordering::SeqCst), 2);
+
     lix.close().await.expect("lix closes");
 }
 


### PR DESCRIPTION
## Summary

- add descriptor-first filesystem inventory and hash-backed sync optimizations for large folder opens
- add a typed filesystem inventory read path to avoid hot-path SQL/DataFusion descriptor queries
- bound unfiltered local descriptor walking across top-level directories and avoid no-op unresolved sidecar rewrites

## Impact

Flashtype can cold-open `/Users/samuel/Downloads` as a folder under 1 second without skipping descriptor sync. Final Electron samples from the consuming app were 876ms, 882ms, 936ms, 893ms, and 873ms total.

## Validation

- `cargo check -p lix_sdk --features sqlite`
- `cargo test -p lix_sdk --features sqlite filesystem_inventory_ -- --nocapture`
- `cargo test -p lix_sdk --features sqlite filesystem_materialization_preserves -- --nocapture`
- `cargo test -p lix_sdk --features sqlite filesystem_materializes_sdk_sql_and_transaction_writes -- --nocapture`
- `cargo test -p lix_sdk --features sqlite filesystem_unresolved_file_exposes_data_hash_without_data -- --nocapture`
- `cargo test -p lix_sdk --features sqlite lix_file_data_hash_filters_work_in_destructive_dml -- --nocapture`
- `cargo test -p lix_sdk --features sqlite sqlite_backend_open_lix_options_supplies_plugin_wasm_runtime -- --nocapture`
- `cargo test -p lix_engine public_key_tests -- --nocapture`
- `cargo run --release --example profile_fs_open --features sqlite -- --in-place /Users/samuel/Downloads`
- Flashtype Electron cold-open measurements against `/Users/samuel/Downloads`
