### PR TITLE
[codex] Batch lix_file filesystem upserts

### DIFF
--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -148,19 +148,14 @@ async fn execute_file_path_write(
             "bound lix_file fast write supports VALUES only",
         ));
     };
-    let mut affected = 0u64;
+    let mut writes = Vec::with_capacity(values.rows.len());
     for row in &values.rows {
-        let path = eval_fast_file_text(&row[shape.path_index], params, "path")?;
-        let data = eval_fast_file_blob(&row[shape.data_index], params, "data")?;
-        affected += crate::sql2::providers::execute_fast_lix_file_path_write(
-            ctx,
-            path,
-            data,
-            shape.conflict,
-        )
-        .await?;
+        writes.push((
+            eval_fast_file_text(&row[shape.path_index], params, "path")?,
+            eval_fast_file_blob(&row[shape.data_index], params, "data")?,
+        ));
     }
-    Ok(affected)
+    crate::sql2::providers::execute_fast_lix_file_path_writes(ctx, writes, shape.conflict).await
 }
 
 fn fast_file_path_write_shape(
@@ -173,7 +168,7 @@ fn fast_file_path_write_shape(
     let BoundWriteInput::Values(values) = &plan.bound.input else {
         return None;
     };
-    if values.rows.len() != 1 || values.columns.len() != 2 {
+    if values.rows.is_empty() || values.columns.len() != 2 {
         return None;
     }
     let path_index = values.column_index("path")?;

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1442,7 +1442,10 @@ fn string_scalar_to_lix_value(value: &str, field: Option<&Field>) -> Result<Valu
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     use async_trait::async_trait;
     use serde_json::Value as JsonValue;
@@ -1465,8 +1468,9 @@ mod tests {
         ChangelogQuerySource, HistoryQuerySource, SqlChangelogQuerySource, SqlHistoryQuerySource,
     };
     use crate::sql2::{
-        bind_statement, create_write_logical_plan, execute_write_logical_plan, parse_statement,
-        plan_write,
+        WriteExecutorMode, WriteExecutorPath, bind_statement, create_write_logical_plan,
+        execute_write_logical_plan, execute_write_logical_plan_with_mode_and_trace,
+        parse_statement, plan_write,
     };
     use crate::storage::{
         InMemoryStorageBackend, InMemoryStorageRead, SharedStorageRead, StorageContext,
@@ -1485,6 +1489,10 @@ mod tests {
     struct DummyLiveStateReader;
     struct RowsLiveStateReader {
         rows: Vec<MaterializedLiveStateRow>,
+    }
+    struct CountingRowsLiveStateReader {
+        rows: Vec<MaterializedLiveStateRow>,
+        scans: Arc<AtomicUsize>,
     }
     struct DummyCommitGraphReader;
     struct DummyBranchRefReader;
@@ -1715,6 +1723,25 @@ mod tests {
         })
     }
 
+    async fn execute_write_sql_trace(
+        ctx: &mut dyn SqlWriteExecutionContext,
+        sql: &str,
+        params: &[Value],
+        mode: WriteExecutorMode,
+    ) -> Result<(crate::SqlQueryResult, WriteExecutorPath), LixError> {
+        let plan = create_write_logical_plan(ctx, sql).await?;
+        let (count, path) =
+            execute_write_logical_plan_with_mode_and_trace(ctx, plan, params, mode).await?;
+        Ok((
+            crate::SqlQueryResult {
+                columns: vec!["count".to_string()],
+                rows: vec![vec![Value::Integer(count as i64)]],
+                notices: Vec::new(),
+            },
+            path,
+        ))
+    }
+
     #[async_trait]
     impl BranchRefReader for DummyBranchRefReader {
         async fn load_head(
@@ -1783,48 +1810,72 @@ mod tests {
         }
     }
 
+    fn filter_live_state_rows(
+        rows: &[MaterializedLiveStateRow],
+        request: &LiveStateScanRequest,
+    ) -> Vec<MaterializedLiveStateRow> {
+        if matches!(
+            request.filter.rows,
+            crate::live_state::LiveStateRowFilter::None
+        ) {
+            return Vec::new();
+        }
+        let mut rows = rows
+            .iter()
+            .filter(|row| {
+                (request.filter.schema_keys.is_empty()
+                    || request.filter.schema_keys.contains(&row.schema_key))
+                    && (request.filter.entity_pks.is_empty()
+                        || request.filter.entity_pks.contains(&row.entity_pk))
+                    && (request.filter.branch_ids.is_empty()
+                        || request.filter.branch_ids.contains(&row.branch_id))
+                    && request
+                        .filter
+                        .untracked
+                        .is_none_or(|untracked| row.untracked == untracked)
+                    && (request.filter.include_tombstones || !row.deleted)
+                    && (request.filter.file_ids.is_empty()
+                        || request.filter.file_ids.iter().any(|filter| match filter {
+                            NullableKeyFilter::Any => true,
+                            NullableKeyFilter::Null => row.file_id.is_none(),
+                            NullableKeyFilter::Value(file_id) => {
+                                row.file_id.as_ref() == Some(file_id)
+                            }
+                        }))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if let Some(limit) = request.limit {
+            rows.truncate(limit);
+        }
+        rows
+    }
+
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
         ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-            if matches!(
-                request.filter.rows,
-                crate::live_state::LiveStateRowFilter::None
-            ) {
-                return Ok(Vec::new());
-            }
-            let mut rows = self
-                .rows
-                .iter()
-                .filter(|row| {
-                    (request.filter.schema_keys.is_empty()
-                        || request.filter.schema_keys.contains(&row.schema_key))
-                        && (request.filter.entity_pks.is_empty()
-                            || request.filter.entity_pks.contains(&row.entity_pk))
-                        && (request.filter.branch_ids.is_empty()
-                            || request.filter.branch_ids.contains(&row.branch_id))
-                        && request
-                            .filter
-                            .untracked
-                            .is_none_or(|untracked| row.untracked == untracked)
-                        && (request.filter.include_tombstones || !row.deleted)
-                        && (request.filter.file_ids.is_empty()
-                            || request.filter.file_ids.iter().any(|filter| match filter {
-                                NullableKeyFilter::Any => true,
-                                NullableKeyFilter::Null => row.file_id.is_none(),
-                                NullableKeyFilter::Value(file_id) => {
-                                    row.file_id.as_ref() == Some(file_id)
-                                }
-                            }))
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            if let Some(limit) = request.limit {
-                rows.truncate(limit);
-            }
-            Ok(rows)
+            Ok(filter_live_state_rows(&self.rows, request))
+        }
+
+        async fn load_row(
+            &self,
+            _request: &LiveStateRowRequest,
+        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
+            Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl LiveStateReader for CountingRowsLiveStateReader {
+        async fn scan_rows(
+            &self,
+            request: &LiveStateScanRequest,
+        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            self.scans.fetch_add(1, Ordering::SeqCst);
+            Ok(filter_live_state_rows(&self.rows, request))
         }
 
         async fn load_row(
@@ -1997,6 +2048,52 @@ mod tests {
             created_at: "2026-04-23T00:00:00Z".to_string(),
             updated_at: "2026-04-23T01:00:00Z".to_string(),
         }
+    }
+
+    fn counting_write_context(
+        rows: Vec<MaterializedLiveStateRow>,
+    ) -> (
+        DummySqlWriteExecutionContext<'static>,
+        Arc<Mutex<CapturingStagedWrites>>,
+        Arc<AtomicUsize>,
+    ) {
+        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
+        let scans = Arc::new(AtomicUsize::new(0));
+        let live_state: Arc<dyn LiveStateReader> = Arc::new(CountingRowsLiveStateReader {
+            rows,
+            scans: Arc::clone(&scans),
+        });
+        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+        (
+            DummySqlWriteExecutionContext {
+                active_branch_id: "branch-a",
+                blob_reader,
+                live_state,
+                staged_writes: Arc::clone(&staged_writes),
+                schema_definitions: vec![],
+            },
+            staged_writes,
+            scans,
+        )
+    }
+
+    fn mark_untracked(mut row: MaterializedLiveStateRow) -> MaterializedLiveStateRow {
+        row.untracked = true;
+        row
+    }
+
+    fn descriptor_names(rows: &[CapturedStageRow]) -> Vec<String> {
+        let mut names = rows
+            .iter()
+            .map(|row| {
+                let snapshot: JsonValue =
+                    serde_json::from_str(row.snapshot_content.as_deref().unwrap())
+                        .expect("descriptor snapshot JSON");
+                snapshot["name"].as_str().unwrap().to_string()
+            })
+            .collect::<Vec<_>>();
+        names.sort();
+        names
     }
 
     #[tokio::test]
@@ -3994,6 +4091,323 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_data_uses_one_fast_stage() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/multi/a.md', X'61'), ('/multi/b.md', X'62')",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("multi-row path/data insert should use the fast writer");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(2)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let descriptor_rows = overlay.visible_semantic_rows(false, "lix_file_descriptor");
+        assert_eq!(descriptor_names(&descriptor_rows), vec!["a.md", "b.md"]);
+        let blob_ref_rows = overlay.visible_semantic_rows(false, "lix_binary_blob_ref");
+        assert_eq!(blob_ref_rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_data_params_use_fast_stage() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4)",
+            &[
+                Value::Text("/multi/param-a.md".to_string()),
+                Value::Blob(b"param-a".to_vec()),
+                Value::Text("/multi/param-b.md".to_string()),
+                Value::Blob(b"param-b".to_vec()),
+            ],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("parameterized multi-row path/data insert should use the fast writer");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(2)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_do_nothing_validates_and_skips_existing() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![
+            live_file_row("file-existing", "branch-a", None, "existing.md"),
+            live_blob_ref_row("file-existing", "branch-a", b"old"),
+        ]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/existing.md', X'6e6577'), ('/fresh.md', X'6672657368') \
+             ON CONFLICT (path) DO NOTHING",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("multi-row DO NOTHING should use the fast writer");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let descriptor_rows = overlay.visible_semantic_rows(false, "lix_file_descriptor");
+        assert_eq!(descriptor_names(&descriptor_rows), vec!["fresh.md"]);
+        let blob_ref_rows = overlay.visible_semantic_rows(false, "lix_binary_blob_ref");
+        assert_eq!(blob_ref_rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_update_existing_and_insert_fresh() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![
+            live_file_row("file-existing", "branch-a", None, "existing.md"),
+            live_blob_ref_row("file-existing", "branch-a", b"old"),
+        ]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/existing.md', X'6e6577'), ('/fresh.md', X'6672657368') \
+             ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("multi-row DO UPDATE should use the fast writer");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(2)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let descriptor_rows = overlay.visible_semantic_rows(false, "lix_file_descriptor");
+        assert_eq!(descriptor_names(&descriptor_rows), vec!["fresh.md"]);
+        let blob_ref_rows = overlay.visible_semantic_rows(false, "lix_binary_blob_ref");
+        assert_eq!(blob_ref_rows.len(), 2);
+        assert!(
+            blob_ref_rows
+                .iter()
+                .any(|row| row.entity_pk == "[\"file-existing\"]")
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_duplicate_insert_paths_reject_before_staging() {
+        for sql in [
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/dupe.md', X'61'), ('/dupe.md', X'62')",
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/dupe.md', X'61'), ('/dupe.md', X'62') \
+             ON CONFLICT (path) DO NOTHING",
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/dupe.md', X'61'), ('/dupe.md', X'62') \
+             ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+        ] {
+            let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+            let error = execute_write_sql_trace(&mut ctx, sql, &[], WriteExecutorMode::ForceFast)
+                .await
+                .expect_err("duplicate VALUES paths should fail");
+
+            assert_eq!(error.code, LixError::CODE_UNIQUE, "{sql}");
+            assert_eq!(scans.load(Ordering::SeqCst), 1, "{sql}");
+            assert!(
+                staged_writes
+                    .lock()
+                    .expect("staged writes lock")
+                    .deltas
+                    .is_empty(),
+                "{sql}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_duplicate_existing_do_nothing_skips_all() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![
+            live_file_row("file-existing", "branch-a", None, "existing.md"),
+            live_blob_ref_row("file-existing", "branch-a", b"old"),
+        ]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/existing.md', X'61'), ('/existing.md', X'62') \
+             ON CONFLICT (path) DO NOTHING",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("duplicate existing paths should follow DO NOTHING");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(0)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_namespace_conflict_leaves_no_stage() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        let error = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/folder', X'61'), ('/folder/file.md', X'62')",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect_err("batch should reject file/directory namespace conflicts");
+
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_invalid_later_row_leaves_no_stage() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/ok.md', X'6f6b'), ('relative.md', X'626164')",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect_err("invalid later path should fail before staging");
+
+        assert_eq!(scans.load(Ordering::SeqCst), 0);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_bad_data_param_leaves_no_stage() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        let error = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4)",
+            &[
+                Value::Text("/ok.md".to_string()),
+                Value::Blob(b"ok".to_vec()),
+                Value::Text("/bad.md".to_string()),
+                Value::Text("not a blob".to_string()),
+            ],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect_err("wrong data param type should fail before staging");
+
+        assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
+        assert_eq!(scans.load(Ordering::SeqCst), 0);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_do_nothing_rejects_untracked_collision() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![mark_untracked(
+            live_file_row("file-untracked", "branch-a", None, "untracked.md"),
+        )]);
+
+        let error = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data) \
+             VALUES ('/untracked.md', X'6e6577'), ('/fresh.md', X'6672657368') \
+             ON CONFLICT (path) DO NOTHING",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect_err("DO NOTHING should still reject tracked/untracked conflicts");
+
+        assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_id_path_data_is_not_path_data_fast_shape() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        let error = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (id, path, data) \
+             VALUES ('file-a', '/a.md', X'61'), ('file-b', '/b.md', X'62')",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect_err("id/path/data is outside the narrow path/data fast shape");
+
+        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
+        assert_eq!(scans.load(Ordering::SeqCst), 0);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
     async fn execute_sql_update_file_stages_rewritten_descriptor() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let live_state = Arc::new(RowsLiveStateReader {
@@ -4799,7 +5213,7 @@ mod tests {
             &mut ctx,
             plan,
             &[],
-            crate::sql2::WriteExecutorMode::ForceDataFusion,
+            WriteExecutorMode::ForceDataFusion,
         )
         .await
         .expect_err("unsupported reference writer target should not become a fast no-op");
@@ -4838,7 +5252,7 @@ mod tests {
             &mut ctx,
             plan,
             &[],
-            crate::sql2::WriteExecutorMode::ForceDataFusion,
+            WriteExecutorMode::ForceDataFusion,
         )
         .await
         .expect_err("unsupported target with empty scope should not become a no-op");

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1067,19 +1067,8 @@ impl InsertSink for LixFileInsertSink {
                 );
             }
             if record_batch_has_non_null_column(&batch, "path")? {
-                staged.extend(lix_file_insert_stage_from_batch_with_path_resolvers(
-                    &batch,
-                    self.branch_binding.active_branch_id(),
-                    self.surface_name,
-                    path_resolvers
-                        .as_mut()
-                        .expect("path resolver should be initialized"),
-                    &mut || self.functions.call_uuid_v7().to_string(),
-                    self.include_data_writes,
-                )?);
-            } else {
-                staged.extend(
-                    lix_file_insert_stage_from_batch_with_id_generator_and_path_resolvers(
+                staged
+                    .extend(lix_file_insert_stage_from_batch_with_path_resolvers(
                         &batch,
                         self.branch_binding.active_branch_id(),
                         self.surface_name,
@@ -1088,8 +1077,23 @@ impl InsertSink for LixFileInsertSink {
                             .expect("path resolver should be initialized"),
                         &mut || self.functions.call_uuid_v7().to_string(),
                         self.include_data_writes,
-                    )?,
-                );
+                    )?)
+                    .map_err(lix_error_to_datafusion_error)?;
+            } else {
+                staged
+                    .extend(
+                        lix_file_insert_stage_from_batch_with_id_generator_and_path_resolvers(
+                            &batch,
+                            self.branch_binding.active_branch_id(),
+                            self.surface_name,
+                            path_resolvers
+                                .as_mut()
+                                .expect("path resolver should be initialized"),
+                            &mut || self.functions.call_uuid_v7().to_string(),
+                            self.include_data_writes,
+                        )?,
+                    )
+                    .map_err(lix_error_to_datafusion_error)?;
             }
         }
 
@@ -1224,21 +1228,37 @@ struct LixFileStagedBatch {
 }
 
 impl LixFileStagedBatch {
-    fn extend(&mut self, other: Self) {
+    fn extend(&mut self, other: Self) -> std::result::Result<(), LixError> {
         self.state_rows.extend(other.state_rows);
         self.file_data_writes.extend(other.file_data_writes);
-        self.count += other.count;
+        self.add_count(other.count)
     }
 
-    fn extend_filesystem_plan(&mut self, plan: crate::filesystem::FilesystemWritePlan) {
+    fn extend_filesystem_plan(
+        &mut self,
+        plan: crate::filesystem::FilesystemWritePlan,
+    ) -> std::result::Result<(), LixError> {
         self.state_rows.extend(plan.rows);
         self.file_data_writes.extend(plan.file_data);
-        self.count += plan.count;
+        self.add_count(plan.count)
     }
 
-    fn extend_filesystem_delete_plan(&mut self, plan: FilesystemDeletePlan) {
+    fn extend_filesystem_delete_plan(
+        &mut self,
+        plan: FilesystemDeletePlan,
+    ) -> std::result::Result<(), LixError> {
         self.state_rows.extend(plan.rows);
-        self.count += plan.count;
+        self.add_count(plan.count)
+    }
+
+    fn add_count(&mut self, count: u64) -> std::result::Result<(), LixError> {
+        self.count = self.count.checked_add(count).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "lix_file fast write row count overflow",
+            )
+        })?;
+        Ok(())
     }
 }
 
@@ -1249,15 +1269,17 @@ pub(crate) enum FastLixFilePathWriteConflict {
     UpdateData,
 }
 
-pub(crate) async fn execute_fast_lix_file_path_write(
+pub(crate) async fn execute_fast_lix_file_path_writes(
     ctx: &mut dyn SqlWriteExecutionContext,
-    path: String,
-    data: Vec<u8>,
+    writes: Vec<(String, Vec<u8>)>,
     conflict: FastLixFilePathWriteConflict,
 ) -> Result<u64, LixError> {
+    if writes.is_empty() {
+        return Ok(0);
+    }
+
     let active_branch_id = ctx.active_branch_id().to_string();
-    let parsed = parse_file_upsert_path(&path, TransactionWriteOperation::Insert)
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+    let parsed_writes = parse_fast_lix_file_path_writes(writes)?;
 
     let live_rows = ctx
         .scan_live_state(&LiveStateScanRequest {
@@ -1271,89 +1293,92 @@ pub(crate) async fn execute_fast_lix_file_path_write(
         })
         .await?;
     let filesystem = FilesystemIndex::from_live_rows(live_rows.clone())?;
-
-    if let Some(existing) = filesystem.file_entry(&parsed.path).cloned() {
-        if conflict != FastLixFilePathWriteConflict::None {
-            validate_fast_lix_file_path_conflict_pair(existing.scope.untracked, &parsed.path)?;
-        }
-        return match conflict {
-            FastLixFilePathWriteConflict::None => {
-                let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
-                let context = FilesystemRowContext {
-                    branch_id: active_branch_id.clone(),
-                    global: false,
-                    untracked: false,
-                    file_id: None,
-                    metadata: None,
-                };
-                let plan = plan_parsed_file_path_write_with_resolvers(
-                    &mut path_resolvers,
-                    parsed.parsed_path,
-                    Some(
-                        parsed
-                            .plugin_key
-                            .as_deref()
-                            .map(plugin_storage_archive_file_id)
-                            .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string()),
-                    ),
-                    Some(data),
-                    context,
-                    &mut || ctx.functions().call_uuid_v7().to_string(),
-                )?;
-                let mut staged = LixFileStagedBatch::default();
-                staged.extend_filesystem_plan(plan);
-                stage_lix_file_fast_batch(ctx, TransactionWriteMode::Insert, staged).await
-            }
-            FastLixFilePathWriteConflict::DoNothing => Ok(0),
-            FastLixFilePathWriteConflict::UpdateData => {
-                let mut staged = LixFileStagedBatch::default();
-                let mut context = existing.scope.context(Some(existing.id.clone()));
-                if context.global {
-                    context.branch_id = GLOBAL_BRANCH_ID.to_string();
-                }
-                stage_lix_file_data_update_write(
-                    &mut staged,
-                    existing.id.clone(),
-                    Some(parsed.path),
-                    Some(existing.name.clone()),
-                    data,
-                    context,
-                    existing.blob_hash.is_some(),
-                    None,
-                )
-                .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
-                staged.count = 1;
-                stage_lix_file_fast_batch(ctx, TransactionWriteMode::Replace, staged).await
-            }
-        };
-    }
-
     let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
     let resolver_key = filesystem_storage_scope_key(&active_branch_id, false, false, None);
     path_resolvers.entry(resolver_key).or_default();
-    let context = FilesystemRowContext {
-        branch_id: active_branch_id,
-        global: false,
-        untracked: false,
-        file_id: None,
-        metadata: None,
-    };
-    let file_id = parsed
-        .plugin_key
-        .as_deref()
-        .map(plugin_storage_archive_file_id)
-        .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string());
-    let mut plan = plan_parsed_file_path_write_with_resolvers(
-        &mut path_resolvers,
-        parsed.parsed_path,
-        Some(file_id.clone()),
-        Some(data),
-        context,
-        &mut || ctx.functions().call_uuid_v7().to_string(),
-    )?;
-    attach_lix_file_insert_origin(&mut plan.rows, "lix_file", &file_id);
     let mut staged = LixFileStagedBatch::default();
-    staged.extend_filesystem_plan(plan);
+
+    for write in parsed_writes {
+        if let Some(existing) = filesystem.file_entry(&write.parsed.path).cloned() {
+            if conflict != FastLixFilePathWriteConflict::None {
+                validate_fast_lix_file_path_conflict_pair(
+                    existing.scope.untracked,
+                    &write.parsed.path,
+                )?;
+            }
+            match conflict {
+                FastLixFilePathWriteConflict::None => {
+                    let context = FilesystemRowContext {
+                        branch_id: active_branch_id.clone(),
+                        global: false,
+                        untracked: false,
+                        file_id: None,
+                        metadata: None,
+                    };
+                    let plan = plan_parsed_file_path_write_with_resolvers(
+                        &mut path_resolvers,
+                        write.parsed.parsed_path,
+                        Some(
+                            write
+                                .parsed
+                                .plugin_key
+                                .as_deref()
+                                .map(plugin_storage_archive_file_id)
+                                .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string()),
+                        ),
+                        Some(write.data),
+                        context,
+                        &mut || ctx.functions().call_uuid_v7().to_string(),
+                    )?;
+                    staged.extend_filesystem_plan(plan)?;
+                }
+                FastLixFilePathWriteConflict::DoNothing => {}
+                FastLixFilePathWriteConflict::UpdateData => {
+                    let mut context = existing.scope.context(Some(existing.id.clone()));
+                    if context.global {
+                        context.branch_id = GLOBAL_BRANCH_ID.to_string();
+                    }
+                    stage_lix_file_data_update_write(
+                        &mut staged,
+                        existing.id.clone(),
+                        Some(write.parsed.path),
+                        Some(existing.name.clone()),
+                        write.data,
+                        context,
+                        existing.blob_hash.is_some(),
+                        None,
+                    )
+                    .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+                    staged.add_count(1)?;
+                }
+            }
+        } else {
+            let context = FilesystemRowContext {
+                branch_id: active_branch_id.clone(),
+                global: false,
+                untracked: false,
+                file_id: None,
+                metadata: None,
+            };
+            let file_id = write
+                .parsed
+                .plugin_key
+                .as_deref()
+                .map(plugin_storage_archive_file_id)
+                .unwrap_or_else(|| ctx.functions().call_uuid_v7().to_string());
+            let mut plan = plan_parsed_file_path_write_with_resolvers(
+                &mut path_resolvers,
+                write.parsed.parsed_path,
+                Some(file_id.clone()),
+                Some(write.data),
+                context,
+                &mut || ctx.functions().call_uuid_v7().to_string(),
+            )?;
+            attach_lix_file_insert_origin(&mut plan.rows, "lix_file", &file_id);
+            staged.extend_filesystem_plan(plan)?;
+        }
+    }
+
     let mode = match conflict {
         FastLixFilePathWriteConflict::None => TransactionWriteMode::Insert,
         FastLixFilePathWriteConflict::DoNothing | FastLixFilePathWriteConflict::UpdateData => {
@@ -1361,6 +1386,26 @@ pub(crate) async fn execute_fast_lix_file_path_write(
         }
     };
     stage_lix_file_fast_batch(ctx, mode, staged).await
+}
+
+struct FastLixFilePathWrite {
+    parsed: ParsedFileWritePath,
+    data: Vec<u8>,
+}
+
+fn parse_fast_lix_file_path_writes(
+    writes: Vec<(String, Vec<u8>)>,
+) -> std::result::Result<Vec<FastLixFilePathWrite>, LixError> {
+    writes
+        .into_iter()
+        .map(|(path, data)| {
+            Ok(FastLixFilePathWrite {
+                parsed: parse_file_upsert_path(&path, TransactionWriteOperation::Insert)
+                    .map_err(crate::sql2::error::datafusion_error_to_lix_error)?,
+                data,
+            })
+        })
+        .collect()
 }
 
 fn validate_fast_lix_file_path_conflict_pair(
@@ -1427,12 +1472,14 @@ fn lix_file_delete_stage_from_batch(
         }
         let file_id = required_string_value(batch, row_index, "id")?;
         let context = file_row_context_from_batch(batch, row_index, branch_binding)?;
-        staged.extend_filesystem_delete_plan(plan_file_delete(FileDeleteInput {
-            file_id: file_id.clone(),
-            has_blob_ref: blob_ref_keys
-                .contains(&FilesystemBlobRefKey::from_context(&context, &file_id)),
-            context,
-        }));
+        staged
+            .extend_filesystem_delete_plan(plan_file_delete(FileDeleteInput {
+                file_id: file_id.clone(),
+                has_blob_ref: blob_ref_keys
+                    .contains(&FilesystemBlobRefKey::from_context(&context, &file_id)),
+                context,
+            }))
+            .map_err(lix_error_to_datafusion_error)?;
     }
     Ok(staged)
 }
@@ -1741,7 +1788,9 @@ fn lix_file_path_update_stage_from_batch(
             generate_directory_id,
         )
         .map_err(lix_error_to_datafusion_error)?;
-        staged.extend_filesystem_plan(plan);
+        staged
+            .extend_filesystem_plan(plan)
+            .map_err(lix_error_to_datafusion_error)?;
 
         if let Some(data) = assigned_data {
             let has_blob_ref =
@@ -1907,7 +1956,9 @@ fn lix_file_stage_from_batch_with_options_and_path_resolvers(
             )
             .map_err(lix_error_to_datafusion_error)?;
             attach_lix_file_insert_origin(&mut plan.rows, surface_name, &file_id);
-            staged.extend_filesystem_plan(plan);
+            staged
+                .extend_filesystem_plan(plan)
+                .map_err(lix_error_to_datafusion_error)?;
             continue;
         }
 
@@ -1951,7 +2002,9 @@ fn lix_file_stage_from_batch_with_options_and_path_resolvers(
                 )
                 .map_err(lix_error_to_datafusion_error)?;
                 attach_lix_file_insert_origin(&mut plan.rows, surface_name, &file_id);
-                staged.extend_filesystem_plan(plan);
+                staged
+                    .extend_filesystem_plan(plan)
+                    .map_err(lix_error_to_datafusion_error)?;
                 continue;
             }
         }

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -29,7 +29,7 @@ use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
 use datafusion::catalog::TableProvider;
 
-pub(crate) use file::{FastLixFilePathWriteConflict, execute_fast_lix_file_path_write};
+pub(crate) use file::{FastLixFilePathWriteConflict, execute_fast_lix_file_path_writes};
 pub(crate) use upsert::{UpsertAction, excluded_field_name};
 
 /// Execute an `INSERT ... ON CONFLICT` against a registered table provider.

--- a/packages/engine/src/sql2/test_support/generators.rs
+++ b/packages/engine/src/sql2/test_support/generators.rs
@@ -134,6 +134,14 @@ const PARAM_FILE_PATH_AND_DATA: &[DifferentialParam] = &[
 ];
 
 #[cfg(test)]
+const PARAM_MULTI_FILE_PATH_AND_DATA: &[DifferentialParam] = &[
+    DifferentialParam::Text("/diff/param-a.md"),
+    DifferentialParam::Blob(b"param a"),
+    DifferentialParam::Text("/diff/param-b.md"),
+    DifferentialParam::Blob(b"param b"),
+];
+
+#[cfg(test)]
 const SETUP_SEED_LIX_FILE_ROW: &[&str] = &[
     "INSERT INTO lix_file (id, path, data) VALUES ('diff-existing-file', '/diff/existing.md', X'6f6c64')",
 ];
@@ -148,6 +156,8 @@ const LIX_FILE_PROBE: &[DifferentialProbe] = &[DifferentialProbe::LixFileActive 
     paths: &[
         "/diff/insert.md",
         "/diff/param.md",
+        "/diff/param-a.md",
+        "/diff/param-b.md",
         "/diff/upsert-new.md",
         "/diff/existing.md",
         "/diff/untracked.md",
@@ -399,6 +409,16 @@ pub(crate) fn generated_dml_cases() -> Vec<DifferentialSqlCase> {
             expected_execution: ExpectedExecution::Ok,
         },
         DifferentialSqlCase {
+            seed: "generated/lix-file/upsert-path-data-do-nothing-duplicate-existing".into(),
+            setup_sql: SETUP_SEED_LIX_FILE_ROW,
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/existing.md', X'736b6970'), ('/diff/existing.md', X'736b6970') ON CONFLICT (path) DO NOTHING".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
             seed: "generated/lix-file/upsert-path-data-rejects-untracked-update".into(),
             setup_sql: SETUP_SEED_UNTRACKED_LIX_FILE_ROW,
             transaction_setup_sql: &[],
@@ -423,13 +443,43 @@ pub(crate) fn generated_dml_cases() -> Vec<DifferentialSqlCase> {
             },
         },
         DifferentialSqlCase {
-            seed: "generated/lix-file/multi-row-path-data-falls-back".into(),
+            seed: "generated/lix-file/multi-row-path-data-fast".into(),
             setup_sql: &[],
             transaction_setup_sql: &[],
             sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/multi-a.md', X'61'), ('/diff/multi-b.md', X'62')".into(),
             params: EMPTY_PARAMS,
             probes: LIX_FILE_PROBE,
-            expectation: DifferentialExpectation::SemanticParityMayFallback,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/multi-row-path-data-params-fast".into(),
+            setup_sql: &[],
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4)".into(),
+            params: PARAM_MULTI_FILE_PATH_AND_DATA,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/multi-row-upsert-path-data-update".into(),
+            setup_sql: SETUP_SEED_LIX_FILE_ROW,
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/existing.md', X'6e6577'), ('/diff/multi-a.md', X'61') ON CONFLICT (path) DO UPDATE SET data = excluded.data".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
+            expected_execution: ExpectedExecution::Ok,
+        },
+        DifferentialSqlCase {
+            seed: "generated/lix-file/multi-row-upsert-path-data-do-nothing".into(),
+            setup_sql: SETUP_SEED_LIX_FILE_ROW,
+            transaction_setup_sql: &[],
+            sql: "INSERT INTO lix_file (path, data) VALUES ('/diff/existing.md', X'736b6970'), ('/diff/multi-b.md', X'62') ON CONFLICT (path) DO NOTHING".into(),
+            params: EMPTY_PARAMS,
+            probes: LIX_FILE_PROBE,
+            expectation: DifferentialExpectation::FastRequiredParity,
             expected_execution: ExpectedExecution::Ok,
         },
         DifferentialSqlCase {

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
 use std::marker::PhantomData;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex, mpsc};
@@ -20,6 +21,8 @@ use crate::sqlite_backend::SqliteBackend;
 type FilesystemDebouncer = Debouncer<RecommendedWatcher, RecommendedCache>;
 const LIX_DIRECTORY_GITIGNORE: &[u8] = b"*\n";
 const FILESYSTEM_POLL_INTERVAL: Duration = Duration::from_secs(15);
+const FILE_UPSERT_BATCH_MAX_ROWS: usize = 500;
+const FILE_UPSERT_BATCH_MAX_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Clone)]
 pub(crate) struct FilesystemSync<B>
@@ -889,6 +892,7 @@ where
                 .await?;
         }
 
+        let mut files_to_upsert = Vec::new();
         for (path, data) in local
             .files
             .iter()
@@ -901,16 +905,33 @@ where
                 continue;
             }
             if lix.files.get(path) != Some(data) {
-                self.session
-                    .execute(
-                        "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
-                         ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-                        &[Value::Text(path.clone()), Value::Blob(data.clone())],
-                    )
-                    .await?;
+                files_to_upsert.push((path.as_str(), data.as_slice()));
             }
         }
+        self.upsert_local_files_to_lix(&files_to_upsert).await?;
 
+        Ok(())
+    }
+
+    async fn upsert_local_files_to_lix(&self, files: &[(&str, &[u8])]) -> Result<(), LixError> {
+        let mut start = 0;
+        while start < files.len() {
+            let end = lix_file_upsert_chunk_end(
+                files,
+                start,
+                FILE_UPSERT_BATCH_MAX_ROWS,
+                FILE_UPSERT_BATCH_MAX_BYTES,
+            );
+            let chunk = &files[start..end];
+            let sql = lix_file_upsert_sql(chunk.len());
+            let mut params = Vec::with_capacity(chunk.len() * 2);
+            for (path, data) in chunk {
+                params.push(Value::Text((*path).to_string()));
+                params.push(Value::Blob((*data).to_vec()));
+            }
+            self.session.execute(&sql, &params).await?;
+            start = end;
+        }
         Ok(())
     }
 
@@ -1594,6 +1615,41 @@ fn write_materialized_file(
         .map_err(|error| io_error("write filesystem file", &local_path, error))
 }
 
+fn lix_file_upsert_sql(row_count: usize) -> String {
+    debug_assert!(row_count > 0);
+    let mut sql = String::from("INSERT INTO lix_file (path, data) VALUES ");
+    for row in 0..row_count {
+        if row > 0 {
+            sql.push_str(", ");
+        }
+        let _ = write!(sql, "(${}, ${})", row * 2 + 1, row * 2 + 2);
+    }
+    sql.push_str(" ON CONFLICT (path) DO UPDATE SET data = excluded.data");
+    sql
+}
+
+fn lix_file_upsert_chunk_end(
+    files: &[(&str, &[u8])],
+    start: usize,
+    max_rows: usize,
+    max_bytes: usize,
+) -> usize {
+    debug_assert!(start < files.len());
+    let max_rows = max_rows.max(1);
+    let mut end = start;
+    let mut bytes = 0usize;
+    while end < files.len() && end - start < max_rows {
+        let (path, data) = files[end];
+        let file_bytes = path.len().saturating_add(data.len());
+        if end > start && bytes.saturating_add(file_bytes) > max_bytes {
+            break;
+        }
+        bytes = bytes.saturating_add(file_bytes);
+        end += 1;
+    }
+    end
+}
+
 fn lix_path_blocked_by_unmanaged(root: &Path, path: &str) -> Result<bool, LixError> {
     let Some(local_path) = materialization_local_path(root, path) else {
         return Ok(true);
@@ -2167,6 +2223,42 @@ mod tests {
             let error = lix_path_to_local_path(root, path).expect_err("path should fail");
             assert_eq!(error.code, "LIX_FILESYSTEM_ERROR");
         }
+    }
+
+    #[test]
+    fn lix_file_upsert_sql_batches_path_data_rows() {
+        assert_eq!(
+            lix_file_upsert_sql(3),
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4), ($5, $6) ON CONFLICT (path) DO UPDATE SET data = excluded.data"
+        );
+    }
+
+    #[test]
+    fn lix_file_upsert_chunk_end_respects_row_and_byte_budgets() {
+        let a = [0u8; 3];
+        let b = [0u8; 4];
+        let c = [0u8; 4];
+        let files = [
+            ("/a", a.as_slice()),
+            ("/b", b.as_slice()),
+            ("/c", c.as_slice()),
+        ];
+
+        assert_eq!(lix_file_upsert_chunk_end(&files, 0, 2, usize::MAX), 2);
+        assert_eq!(lix_file_upsert_chunk_end(&files, 0, 10, 11), 2);
+        assert_eq!(lix_file_upsert_chunk_end(&files, 1, 10, 6), 2);
+    }
+
+    #[test]
+    fn lix_file_upsert_chunk_end_allows_single_file_over_byte_budget() {
+        let large = [0u8; 16];
+        let small = [0u8; 1];
+        let files = [
+            ("/large.bin", large.as_slice()),
+            ("/small.bin", small.as_slice()),
+        ];
+
+        assert_eq!(lix_file_upsert_chunk_end(&files, 0, 10, 8), 1);
     }
 
     #[cfg(feature = "sqlite")]


### PR DESCRIPTION
## What changed

- Teach the `lix_file (path, data)` fast write path to accept multi-row `VALUES` and stage the whole batch together.
- Reuse one live-state scan, filesystem index, and directory resolver map across the batch.
- Update filesystem sync to upsert changed local files with multi-row `INSERT ... ON CONFLICT`, chunked by row count and byte budget.
- Add focused fast-path, conflict, differential-generator, SQL-builder, and chunking tests.

## Why

Filesystem sync was still issuing one `lix_file` upsert per changed file. Since the backend already has a `lix_file(path, data)` fast path, batching there keeps the abstraction simple and avoids repeated scans/staging work without changing public behavior or SQL semantics.

## Impact

- Public API, schema, and filesystem semantics are unchanged.
- Batches are bounded to 500 rows or 8 MiB of path+data payload, with oversized single files still allowed as their own chunk.
- Existing `DO NOTHING` / `DO UPDATE SET data = excluded.data` behavior is preserved for supported `path,data` shapes.

## Local validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

## Local benchmarks

- 1000-row `lix_file(path, data)` SQL insert, 64-byte blobs, repeat=5: median ~94.9 ms on `origin/main` to ~40.5 ms on this branch.
- 200-file filesystem sync sample: cold open ~782 ms on `origin/main` to ~207 ms on this branch; repeat cold ~762 ms to ~178 ms.
- Did not run the full Downloads-folder open benchmark.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `lix_file` write staging and filesystem sync SQL batching; semantics for conflicts and errors must stay aligned with single-row behavior, but public API is unchanged and coverage is broad.
> 
> **Overview**
> **Multi-row `lix_file (path, data)` fast path** — The bound public write shape now allows any non-empty multi-row `VALUES` (not only a single row). Execution collects all path/blob pairs and calls **`execute_fast_lix_file_path_writes`**, which does **one** live-state scan, builds a shared filesystem index and directory resolvers, applies per-row insert / `ON CONFLICT DO NOTHING` / `DO UPDATE SET data` semantics, and **stages a single batch**.
> 
> **Filesystem sync (rs-sdk)** — Changed local files are upserted via dynamically built multi-row `INSERT ... ON CONFLICT (path) DO UPDATE SET data`, split into chunks capped at **500 rows** or **8 MiB** of path+data payload (a lone oversized file can still be its own chunk).
> 
> **Supporting changes** — `LixFileStagedBatch` extend/count paths now return `LixError` on row-count overflow; differential SQL cases expect **fast required parity** for multi-row scenarios. Tests cover conflicts, duplicates, namespace clashes, validation-before-staging, and executor path tracing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c5bfe326479090bd0ad0c4cf680111d9cc449f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->