### PR TITLE
[codex] Reuse filesystem sync snapshot on no-op

### DIFF
--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -679,9 +679,9 @@ where
             }
         }
         let previous = self.last_materialized_disk();
-        self.apply_local_snapshot_to_lix(&local, previous.as_ref())
+        let lix = self
+            .apply_local_snapshot_to_lix(&local, previous.as_ref())
             .await?;
-        let lix = self.collect_lix_snapshot_read().await?;
         let materialized = self.materialize_snapshot_after_disk_sync(&lix.snapshot, &local)?;
         self.remember_materialized(materialized, lix.revision);
         Ok(())
@@ -809,10 +809,11 @@ where
         &self,
         local: &Snapshot,
         previous: Option<&Snapshot>,
-    ) -> Result<(), LixError> {
-        let lix = self.collect_lix_snapshot_read().await?.snapshot;
+    ) -> Result<LixSnapshotRead, LixError> {
+        let lix = self.collect_lix_snapshot_read().await?;
+        let mut needs_fresh_lix_read = false;
 
-        for path in lix.files.keys() {
+        for path in lix.snapshot.files.keys() {
             if !local.files.contains_key(path)
                 && self.path_filter.includes_file(path)
                 && !is_plugin_storage_path(path)
@@ -829,6 +830,7 @@ where
                 {
                     continue;
                 }
+                needs_fresh_lix_read = true;
                 self.session
                     .execute(
                         "DELETE FROM lix_file WHERE path = $1",
@@ -840,7 +842,7 @@ where
 
         if self.path_filter.is_unfiltered() {
             let mut directories_to_remove = Vec::new();
-            for path in lix.directories.difference(&local.directories) {
+            for path in lix.snapshot.directories.difference(&local.directories) {
                 if path.as_str() == "/"
                     || is_plugin_storage_path(path)
                     || is_materialization_ignored_path(path, self.metadata_mode)
@@ -862,6 +864,7 @@ where
             }
             sort_directories_deepest_first(&mut directories_to_remove);
             for path in directories_to_remove {
+                needs_fresh_lix_read = true;
                 self.session
                     .execute(
                         "DELETE FROM lix_directory WHERE path = $1",
@@ -873,7 +876,7 @@ where
 
         let mut directories_to_create = local
             .directories
-            .difference(&lix.directories)
+            .difference(&lix.snapshot.directories)
             .filter(|path| path.as_str() != "/")
             .filter(|path| {
                 previous
@@ -884,6 +887,7 @@ where
             .collect::<Vec<_>>();
         sort_directories_shallowest_first(&mut directories_to_create);
         for path in directories_to_create {
+            needs_fresh_lix_read = true;
             self.session
                 .execute(
                     "INSERT INTO lix_directory (path) VALUES ($1) ON CONFLICT (path) DO NOTHING",
@@ -904,13 +908,19 @@ where
             {
                 continue;
             }
-            if lix.files.get(path) != Some(data) {
+            if lix.snapshot.files.get(path) != Some(data) {
                 files_to_upsert.push((path.as_str(), data.as_slice()));
             }
         }
-        self.upsert_local_files_to_lix(&files_to_upsert).await?;
+        if !files_to_upsert.is_empty() {
+            needs_fresh_lix_read = true;
+            self.upsert_local_files_to_lix(&files_to_upsert).await?;
+        }
 
-        Ok(())
+        if needs_fresh_lix_read || self.collect_lix_revision().await? != lix.revision {
+            return self.collect_lix_snapshot_read().await;
+        }
+        Ok(lix)
     }
 
     async fn upsert_local_files_to_lix(&self, files: &[(&str, &[u8])]) -> Result<(), LixError> {


### PR DESCRIPTION
## What changed

- Reuse the Lix snapshot already read during filesystem disk-to-Lix reconciliation when no Lix write is planned.
- Keep the optimization internal to `apply_local_snapshot_to_lix()`: callers receive the current `LixSnapshotRead` directly.
- If reconciliation plans any write, or if the cheap revision check observes concurrent Lix changes, fall back to a fresh full Lix snapshot read.

## Why

Warm no-op filesystem opens were reading the full Lix filesystem snapshot twice: once to diff local disk against Lix, and again before materialization. On the no-op path, the first snapshot is already the right materialization target as long as the revision has not changed.

## Review notes

- Three sub-agents reviewed the prototype.
- The first draft tracked `rows_affected`; reviewers flagged that as the wrong freshness invariant under concurrent writes.
- This version tracks planned writes and performs a revision check before reusing the initial snapshot.

## Local validation

- `cargo fmt --check`
- `cargo check -p lix_sdk --features sqlite`
- `cargo test -p lix_sdk --features sqlite filesystem -- --nocapture`
- `cargo clippy -p lix_sdk --all-targets --features sqlite -- -D warnings`
- `git diff --check`

## Local benchmark

Synthetic fixture: 750 files / 76 dirs, `REPEAT=0 cargo run --release --example profile_fs_open --features sqlite`.

- Baseline warm no-op reopen median: 109.16 ms
- Patched warm no-op reopen median: 92.22 ms
- Scope: warm no-op reopen only; cold first import remains effectively unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core filesystem sync correctness (snapshot freshness under concurrent Lix writes); logic is guarded by planned-write tracking and revision checks but remains concurrency-sensitive.
> 
> **Overview**
> **Warm no-op disk→Lix sync** no longer performs a second full `collect_lix_snapshot_read` when reconciliation does not need to write anything and the Lix revision is unchanged.
> 
> `apply_local_snapshot_to_lix` now returns `LixSnapshotRead` instead of `()`. `sync_disk_to_lix` uses that value for materialization instead of reading Lix again. During reconciliation, planned deletes/inserts/upserts set a flag; if any write ran **or** a cheap `collect_lix_revision` differs from the initial read, the function still does a fresh coherent snapshot read so concurrent Lix changes are not missed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34105dc20648093376ccd47598180c511f329f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->