### PR TITLE
[codex] Batch lix_file blob reads

### DIFF
--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1145,6 +1145,17 @@ impl FileDescriptorRecord {
         }
         keys
     }
+
+    fn blob_ref_key(&self) -> FilesystemBlobRefKey {
+        let context = FilesystemRowContext {
+            branch_id: self.live.branch_id.clone(),
+            global: self.live.global,
+            untracked: self.live.untracked,
+            file_id: self.live.file_id.clone(),
+            metadata: None,
+        };
+        FilesystemBlobRefKey::from_context(&context, &self.id)
+    }
 }
 
 #[derive(Clone)]
@@ -2336,6 +2347,11 @@ async fn lix_file_record_batch(
     let mut untracked_values = Vec::new();
     let mut metadata_values = Vec::new();
     let mut branch_ids = Vec::new();
+    let mut blob_bytes = if needs_data {
+        load_blob_bytes_for_files(blob_reader, &file_rows, &blob_rows).await?
+    } else {
+        LoadedBlobBytes::default()
+    };
 
     for (_, file) in file_rows {
         let directory_path = match file.directory_id.as_ref() {
@@ -2363,15 +2379,9 @@ async fn lix_file_record_batch(
         };
         let path = compose_file_path(directory_path.as_deref(), &file.name)?;
         let data = if needs_data {
-            let context = FilesystemRowContext {
-                branch_id: file.live.branch_id.clone(),
-                global: file.live.global,
-                untracked: file.live.untracked,
-                file_id: file.live.file_id.clone(),
-                metadata: None,
-            };
-            match blob_rows.get(&FilesystemBlobRefKey::from_context(&context, &file.id)) {
-                Some(blob_ref) => load_single_blob_bytes(blob_reader, &blob_ref.blob_hash).await?,
+            let blob_key = file.blob_ref_key();
+            match blob_bytes.take(&blob_key) {
+                Some(data) => data,
                 None => {
                     let rendered = match &plugin_render {
                         Some(plugin_render) => {
@@ -2444,6 +2454,70 @@ async fn lix_file_record_batch(
             "LIX_ERROR_UNKNOWN",
             format!("sql2 failed to build lix_file record batch: {error}"),
         )
+    })
+}
+
+#[derive(Default)]
+struct LoadedBlobBytes {
+    bytes_by_key: BTreeMap<FilesystemBlobRefKey, Option<Vec<u8>>>,
+    remaining_by_key: BTreeMap<FilesystemBlobRefKey, usize>,
+}
+
+impl LoadedBlobBytes {
+    fn take(&mut self, key: &FilesystemBlobRefKey) -> Option<Option<Vec<u8>>> {
+        match self.remaining_by_key.get_mut(key) {
+            Some(remaining) if *remaining > 1 => {
+                *remaining -= 1;
+                self.bytes_by_key.get(key).cloned()
+            }
+            Some(_) => {
+                self.remaining_by_key.remove(key);
+                self.bytes_by_key.remove(key)
+            }
+            None => None,
+        }
+    }
+}
+
+async fn load_blob_bytes_for_files(
+    blob_reader: &Arc<dyn BlobDataReader>,
+    file_rows: &BTreeMap<FilesystemDescriptorKey, FileDescriptorRecord>,
+    blob_rows: &BTreeMap<FilesystemBlobRefKey, BlobRefRecord>,
+) -> Result<LoadedBlobBytes, LixError> {
+    if file_rows.is_empty() || blob_rows.is_empty() {
+        return Ok(LoadedBlobBytes::default());
+    }
+    let mut keys = Vec::new();
+    let mut hashes = Vec::new();
+    let mut remaining_by_key = BTreeMap::<FilesystemBlobRefKey, usize>::new();
+    for file in file_rows.values() {
+        let key = file.blob_ref_key();
+        if let Some(row) = blob_rows.get(&key) {
+            let remaining = remaining_by_key.entry(key.clone()).or_insert(0);
+            if *remaining == 0 {
+                keys.push(key);
+                hashes.push(BlobHash::from_hex(&row.blob_hash)?);
+            }
+            *remaining += 1;
+        }
+    }
+    if keys.is_empty() {
+        return Ok(LoadedBlobBytes::default());
+    }
+    let values = blob_reader.load_bytes_many(&hashes).await?.into_vec();
+    if values.len() != keys.len() {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!(
+                "blob reader returned {} values for {} requested hashes",
+                values.len(),
+                keys.len()
+            ),
+        ));
+    }
+    Ok(LoadedBlobBytes {
+        bytes_by_key: keys.into_iter().zip(values).collect(),
+        remaining_by_key,
     })
 }
 
@@ -3977,6 +4051,54 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(values.contains(&None));
         assert!(values.contains(&Some("owner-file".to_string())));
+    }
+
+    #[tokio::test]
+    async fn file_projection_reuses_loaded_blob_for_duplicate_blob_ref_keys() {
+        let data = b"shared data".to_vec();
+        let blob_hash = BlobHash::from_content(&data).to_hex();
+        let blob_reader =
+            Arc::new(StaticBlobReader::from_blobs(vec![data.clone()])) as Arc<dyn BlobDataReader>;
+        let mut scoped_file = live_file_row(
+            "file-readme",
+            "branch-b",
+            "{\"id\":\"file-readme\",\"directory_id\":null,\"name\":\"scoped.md\"}",
+        );
+        scoped_file.file_id = Some("owner-file".to_string());
+        let batch = super::lix_file_record_batch(
+            &super::lix_file_schema(),
+            &blob_reader,
+            None,
+            true,
+            vec![
+                live_file_row(
+                    "file-readme",
+                    "branch-b",
+                    "{\"id\":\"file-readme\",\"directory_id\":null,\"name\":\"root.md\"}",
+                ),
+                scoped_file,
+                live_blob_ref_row(
+                    "file-readme",
+                    "branch-b",
+                    "file-readme",
+                    &blob_hash,
+                    data.len(),
+                ),
+            ],
+        )
+        .await
+        .expect("duplicate blob-ref keys should project data for every descriptor");
+
+        let data_column = batch
+            .column(batch.schema().index_of("data").unwrap())
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("data should be binary array");
+        assert_eq!(batch.num_rows(), 2);
+        for index in 0..batch.num_rows() {
+            assert!(!data_column.is_null(index));
+            assert_eq!(data_column.value(index), data.as_slice());
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Batches `lix_file` blob reads when SQL projects `data`, using the existing CAS `BlobDataReader::load_bytes_many` API instead of issuing one singleton read per file row.

The provider now:
- derives blob-ref keys from the file descriptor record in one helper
- preloads blob bytes for selected file descriptors when `data` is needed
- preserves plugin-rendered fallback for files without blob refs
- preserves duplicate blob-ref-key behavior by tracking remaining uses instead of consuming the cached bytes too early
- checks that batch blob reads return one result per requested hash

## Why

`SELECT path, data FROM lix_file` previously paid per-row CAS read overhead. Filesystem sync and other SQL reads that materialize file data can benefit from using the CAS batch primitive directly.

## Validation

- `cargo fmt --check`
- `cargo test -p lix_engine file_projection_reuses_loaded_blob_for_duplicate_blob_ref_keys -- --nocapture`
- `cargo test -p lix_engine execute_sql_reads_lix_file -- --nocapture`
- `cargo test -p lix_sdk --features sqlite filesystem_initial_import_uses_local_files_as_source_of_truth -- --nocapture`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `npm test -- --run src/open-lix.test.ts`
- `git diff --check`

## Bench notes

Focused SQL read bench over 3,000 small files showed median `SELECT path, data FROM lix_file ORDER BY path` moving from about `58.0ms` baseline to `52.8ms` and `46.8ms` on two patched runs.

Memory check over `100 x 1MiB` files did not show a material peak RSS regression. The data-over-path RSS delta was about `101 MiB` baseline and about `98 MiB` patched on the local fixture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot read path for SQL file content materialization; behavior is intended to be equivalent but duplicate-key and batch-response edge cases are new logic on core storage reads.
> 
> **Overview**
> **SQL `lix_file` projection** now loads file bytes in one CAS batch when the query needs the `data` column, instead of calling the blob reader once per row.
> 
> Before building the record batch, the provider collects distinct blob-ref keys/hashes, calls `BlobDataReader::load_bytes_many`, and serves bytes from an in-memory cache. A `FileDescriptorRecord::blob_ref_key()` helper centralizes how keys are derived. **Duplicate blob-ref keys** (e.g. two descriptors sharing one blob) are handled with a per-key use count so every row still gets the same payload without re-fetching or dropping the cache too early.
> 
> **Unchanged behavior:** no blob ref still falls through to plugin rendering (or empty data); batch size mismatches from the reader are treated as an error. A new unit test covers the duplicate-key case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8427a93249957c1fb25980facfc833b793b7ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->