### PR TITLE
Experiment: RocksDB BlobDB filesystem backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
           BINSTALL_NO_CONFIRM=true
           EOF
 
+      - name: Install LLVM build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -76,6 +81,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install LLVM build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -94,6 +94,12 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install LLVM build dependencies
+        if: startsWith(matrix.suffix, 'linux-')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -167,6 +173,11 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Install LLVM build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,6 +3000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lix_fs_backend"
+version = "0.7.0"
+dependencies = [
+ "bytes",
+ "lix_engine",
+ "rocksdb",
+ "tempfile",
+]
+
+[[package]]
 name = "lix_js_sdk"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,20 +449,18 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
 ]
@@ -790,7 +788,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1055,7 +1052,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -2777,12 +2774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,16 +2844,6 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
-name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -2879,14 +2860,13 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
 ]
@@ -2986,7 +2966,7 @@ dependencies = [
  "redb",
  "rocksdb",
  "rusqlite",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "ruzstd",
  "serde",
  "serde_json",
@@ -3238,7 +3218,7 @@ dependencies = [
  "napi-build",
  "napi-sys",
  "nohash-hasher",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -3282,7 +3262,7 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
- "libloading 0.9.0",
+ "libloading",
 ]
 
 [[package]]
@@ -3948,7 +3928,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.1",
  "log",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -3989,9 +3969,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -4016,12 +3996,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "lix_backends",
  "lix_engine",
+ "lix_fs_backend",
  "notify-debouncer-full",
  "rusqlite",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust-version = "1.93"
 lix_cli = { path = "packages/cli", version = "0.7.0" }
 lix_backends = { path = "packages/backends", version = "0.7.0", default-features = false }
 lix_engine = { path = "packages/engine", version = "0.7.0" }
+lix_fs_backend = { path = "packages/fs-backend", version = "0.7.0", default-features = false }
 lix_js_sdk = { path = "packages/js-sdk", version = "0.7.0" }
 lix_order_key = { path = "plugins/order-key", version = "0.7.0" }
 lix_sdk = { path = "packages/rs-sdk", version = "0.7.0" }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -43,20 +43,17 @@ const lix = await openLix({
 
 Use `FsBackend` when the Lix should sync a local directory. This is the
 recommended persistent backend for filesystem workspaces. The backend stores
-its private SQLite database at `<workspace>/.lix/.internal/db.sqlite` and syncs
-workspace files, including user-editable files under `.lix/` such as plugin
-archives, through Lix.
+its private RocksDB data at `<workspace>/.lix/.internal/rocksdb` and syncs
+workspace files through Lix. The `.lix/.internal` directory is owned by Lix and
+is not materialized as a workspace file.
 
-```ts
-import { FsBackend, openLix } from "@lix-js/sdk";
+Older SQLite filesystem backend metadata is not migrated. When old SQLite
+metadata files are present in `.lix/.internal` and no RocksDB store exists, Lix
+clears `.lix/.internal` and initializes a fresh RocksDB store.
 
-const lix = await openLix({
-	backend: new FsBackend({ path: "/Users/me/Downloads", storage: "memory" }),
-});
-```
-
-Pass `storage: "memory"` when the filesystem should be synced but Lix should not
-write `.lix` repository metadata into that folder.
+For ephemeral filesystem sync, pass `storage: "memory"`. Workspace files are
+still imported, watched, and materialized, but the Lix repository itself stays
+in memory and no `.lix` directory is written.
 
 Use `SqliteBackend` when the `.lix` SQLite file is the application document
 itself. This is useful when defining a new file format and using Lix as the

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -26,8 +26,8 @@ Options:
 | --------- | ---------------------------- | -------------------------------------------------------------------- |
 | `backend` | `FsBackend \| SqliteBackend` | Optional storage backend. Omit it for the default in-memory backend. |
 
-Use `FsBackend` for a filesystem workspace directory backed by
-`<workspace>/.lix/.internal/db.sqlite`:
+Use `FsBackend` for a filesystem workspace directory backed by RocksDB at
+`<workspace>/.lix/.internal/rocksdb`:
 
 ```ts
 import { FsBackend, openLix } from "@lix-js/sdk";
@@ -37,12 +37,15 @@ const lix = await openLix({
 });
 ```
 
-Pass `storage: "memory"` to sync files from a directory without writing `.lix`
-repository metadata into that directory:
+Pass `storage: "memory"` for filesystem sync with an in-memory Lix repository.
+This does not write `<workspace>/.lix`:
 
 ```ts
 const lix = await openLix({
-	backend: new FsBackend({ path: "./workspace", storage: "memory" }),
+	backend: new FsBackend({
+		path: "./workspace",
+		storage: "memory",
+	}),
 });
 ```
 
@@ -56,7 +59,6 @@ watching, and materialization; it does not filter unrelated Lix SQL state.
 const lix = await openLix({
 	backend: new FsBackend({
 		path: "./workspace",
-		storage: "memory",
 		filter: { includePaths: ["notes/today.md"] },
 	}),
 });

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -35,7 +35,29 @@ const lix = await openLix({
 await lix.close();
 ```
 
-Reopening the same path resumes existing state. Lix stores its private repository data in `<workspace>/.lix/.internal/db.sqlite` and syncs workspace files through Lix.
+Reopening the same path resumes existing RocksDB filesystem backend state. Lix stores its private repository data in `<workspace>/.lix/.internal/rocksdb` and syncs workspace files through Lix.
+
+Older SQLite filesystem backend metadata is not migrated. If Lix detects the
+old SQLite metadata files in `<workspace>/.lix/.internal` before a RocksDB store
+exists, it clears `.lix/.internal` and initializes a fresh RocksDB backend.
+
+## Filesystem workspace (memory storage)
+
+Use `storage: "memory"` when you want filesystem sync without persisting the
+Lix repository metadata:
+
+```ts
+const lix = await openLix({
+	backend: new FsBackend({
+		path: "/var/data/workspace",
+		storage: "memory",
+	}),
+});
+```
+
+This imports, watches, and materializes workspace files, but the Lix repository
+state is kept in memory and no `.lix` directory is written. Reopening the same
+path reimports the files from disk instead of resuming prior Lix metadata.
 
 For tests, point at a temp directory so each run is isolated:
 
@@ -50,20 +72,6 @@ const lix = await openLix({
 });
 ```
 
-## Filesystem sync without writing .lix metadata
-
-Use `storage: "memory"` when the directory should be read and synced through the filesystem backend, but the Lix repository itself should stay in memory:
-
-```ts
-import { FsBackend, openLix } from "@lix-js/sdk";
-
-const lix = await openLix({
-	backend: new FsBackend({ path: "/Users/me/Downloads", storage: "memory" }),
-});
-```
-
-This is useful for temporary workspaces, previews, and opening user folders that should not get a `.lix` folder.
-
 Add a filter when only specific files should participate in filesystem sync.
 `includePaths` entries are exact workspace-relative file paths, not directories
 or globs. They may be written with or without a leading slash, for example
@@ -74,7 +82,6 @@ watching, and materialization; it does not filter unrelated Lix SQL state.
 const lix = await openLix({
 	backend: new FsBackend({
 		path: "/Users/me/Downloads",
-		storage: "memory",
 		filter: { includePaths: ["notes/today.md"] },
 	}),
 });
@@ -100,6 +107,6 @@ Always `await lix.close()` in scripts and tests. Long-lived servers can hold a s
 
 ## Other storage targets
 
-Postgres, S3, Cloudflare D1 / Durable Objects, IndexedDB, OPFS, RocksDB (anything transactional and key-value-shaped) are not shipped by the Lix team.
+Postgres, S3, Cloudflare D1 / Durable Objects, IndexedDB, OPFS, and other transactional key-value storage targets beyond the shipped backends are not shipped by the Lix team.
 
 The storage interface is public and small enough to implement yourself. The [Backends](./backend.md) page documents the full contract.

--- a/packages/backends/Cargo.toml
+++ b/packages/backends/Cargo.toml
@@ -27,6 +27,6 @@ lix_engine = { workspace = true }
 
 bytes = { version = "1", optional = true }
 redb = { version = "4.1.0", optional = true }
-rocksdb = { version = "0.22", default-features = false, optional = true }
+rocksdb = { version = "0.24", default-features = false, optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 tempfile = { version = "3", optional = true }

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -89,7 +89,7 @@ base64 = "0.22"
 bytes = "1"
 zip = { version = "8", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
-rocksdb = { version = "0.22", default-features = false, optional = true }
+rocksdb = { version = "0.24", default-features = false, optional = true }
 redb = { version = "4.1.0", optional = true }
 
 [dev-dependencies]

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,22 +1,41 @@
+use std::sync::OnceLock;
+
 const FASTCDC_MIN_CHUNK_BYTES: usize = 16 * 1024;
 const FASTCDC_AVG_CHUNK_BYTES: usize = 64 * 1024;
 const FASTCDC_MAX_CHUNK_BYTES: usize = 256 * 1024;
 const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
+
+// Experiment-only runtime overrides for filesystem backend benchmarking.
+const FASTCDC_MIN_CHUNK_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_MIN_BYTES";
+const FASTCDC_AVG_CHUNK_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_AVG_BYTES";
+const FASTCDC_MAX_CHUNK_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_MAX_BYTES";
+const SINGLE_CHUNK_FAST_PATH_MAX_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_SINGLE_BYTES";
+
+static FASTCDC_CONFIG: OnceLock<FastCdcConfig> = OnceLock::new();
+
+#[derive(Clone, Copy)]
+struct FastCdcConfig {
+    min_chunk_bytes: usize,
+    avg_chunk_bytes: usize,
+    max_chunk_bytes: usize,
+    single_chunk_fast_path_max_bytes: usize,
+}
 
 #[expect(clippy::cast_possible_truncation)]
 pub(crate) fn fastcdc_chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
     if data.is_empty() {
         return Vec::new();
     }
-    if data.len() <= SINGLE_CHUNK_FAST_PATH_MAX_BYTES {
+    let config = fastcdc_config();
+    if data.len() <= config.single_chunk_fast_path_max_bytes {
         return vec![(0, data.len())];
     }
 
     fastcdc::v2020::FastCDC::new(
         data,
-        FASTCDC_MIN_CHUNK_BYTES as u32,
-        FASTCDC_AVG_CHUNK_BYTES as u32,
-        FASTCDC_MAX_CHUNK_BYTES as u32,
+        config.min_chunk_bytes as u32,
+        config.avg_chunk_bytes as u32,
+        config.max_chunk_bytes as u32,
     )
     .map(|chunk| {
         let start = chunk.offset;
@@ -24,4 +43,61 @@ pub(crate) fn fastcdc_chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
         (start, end)
     })
     .collect()
+}
+
+fn fastcdc_config() -> FastCdcConfig {
+    *FASTCDC_CONFIG.get_or_init(load_fastcdc_config)
+}
+
+fn load_fastcdc_config() -> FastCdcConfig {
+    let config = FastCdcConfig {
+        min_chunk_bytes: env_usize(FASTCDC_MIN_CHUNK_BYTES_ENV).unwrap_or(FASTCDC_MIN_CHUNK_BYTES),
+        avg_chunk_bytes: env_usize(FASTCDC_AVG_CHUNK_BYTES_ENV).unwrap_or(FASTCDC_AVG_CHUNK_BYTES),
+        max_chunk_bytes: env_usize(FASTCDC_MAX_CHUNK_BYTES_ENV).unwrap_or(FASTCDC_MAX_CHUNK_BYTES),
+        single_chunk_fast_path_max_bytes: env_usize(SINGLE_CHUNK_FAST_PATH_MAX_BYTES_ENV)
+            .unwrap_or(SINGLE_CHUNK_FAST_PATH_MAX_BYTES),
+    };
+    assert!(
+        config.min_chunk_bytes > 0
+            && config.min_chunk_bytes <= config.avg_chunk_bytes
+            && config.avg_chunk_bytes <= config.max_chunk_bytes
+            && config.max_chunk_bytes <= u32::MAX as usize,
+        "invalid FastCDC experiment chunk sizes: min={}, avg={}, max={}",
+        config.min_chunk_bytes,
+        config.avg_chunk_bytes,
+        config.max_chunk_bytes
+    );
+    assert!(
+        config.single_chunk_fast_path_max_bytes > 0
+            && config.single_chunk_fast_path_max_bytes <= u32::MAX as usize,
+        "invalid FastCDC experiment single-chunk fast path size: {}",
+        config.single_chunk_fast_path_max_bytes
+    );
+    config
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn env_usize(name: &str) -> Option<usize> {
+    std::env::var(name).ok().map(|value| {
+        parse_size(&value).unwrap_or_else(|| panic!("{name} must be a positive byte size"))
+    })
+}
+
+#[cfg(target_family = "wasm")]
+fn env_usize(_name: &str) -> Option<usize> {
+    None
+}
+
+fn parse_size(value: &str) -> Option<usize> {
+    let trimmed = value.trim();
+    let last_digit = trimmed.rfind(|ch: char| ch.is_ascii_digit())?;
+    let (digits, suffix) = trimmed.split_at(last_digit + 1);
+    let base = digits.parse::<usize>().ok()?;
+    let multiplier = match suffix.to_ascii_lowercase().as_str() {
+        "" => 1,
+        "k" | "kb" | "kib" => 1024,
+        "m" | "mb" | "mib" => 1024 * 1024,
+        _ => return None,
+    };
+    base.checked_mul(multiplier)
 }

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,41 +1,52 @@
-use std::sync::OnceLock;
-
-const FASTCDC_MIN_CHUNK_BYTES: usize = 16 * 1024;
-const FASTCDC_AVG_CHUNK_BYTES: usize = 64 * 1024;
-const FASTCDC_MAX_CHUNK_BYTES: usize = 256 * 1024;
 const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 
-// Experiment-only runtime overrides for filesystem backend benchmarking.
-const FASTCDC_MIN_CHUNK_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_MIN_BYTES";
-const FASTCDC_AVG_CHUNK_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_AVG_BYTES";
-const FASTCDC_MAX_CHUNK_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_MAX_BYTES";
-const SINGLE_CHUNK_FAST_PATH_MAX_BYTES_ENV: &str = "LIX_EXPERIMENT_FASTCDC_SINGLE_BYTES";
-
-static FASTCDC_CONFIG: OnceLock<FastCdcConfig> = OnceLock::new();
-
-#[derive(Clone, Copy)]
-struct FastCdcConfig {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct BinaryCasChunking {
     min_chunk_bytes: usize,
     avg_chunk_bytes: usize,
     max_chunk_bytes: usize,
     single_chunk_fast_path_max_bytes: usize,
 }
 
-#[expect(clippy::cast_possible_truncation)]
+impl BinaryCasChunking {
+    pub(crate) const fn fastcdc_1m_v1() -> Self {
+        Self {
+            min_chunk_bytes: 256 * 1024,
+            avg_chunk_bytes: 1024 * 1024,
+            max_chunk_bytes: 4096 * 1024,
+            single_chunk_fast_path_max_bytes: SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
+        }
+    }
+}
+
+impl Default for BinaryCasChunking {
+    fn default() -> Self {
+        Self::fastcdc_1m_v1()
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn fastcdc_chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
+    fastcdc_chunk_ranges_with_chunking(data, BinaryCasChunking::default())
+}
+
+#[expect(clippy::cast_possible_truncation)]
+pub(crate) fn fastcdc_chunk_ranges_with_chunking(
+    data: &[u8],
+    chunking: BinaryCasChunking,
+) -> Vec<(usize, usize)> {
     if data.is_empty() {
         return Vec::new();
     }
-    let config = fastcdc_config();
-    if data.len() <= config.single_chunk_fast_path_max_bytes {
+    if data.len() <= chunking.single_chunk_fast_path_max_bytes {
         return vec![(0, data.len())];
     }
 
     fastcdc::v2020::FastCDC::new(
         data,
-        config.min_chunk_bytes as u32,
-        config.avg_chunk_bytes as u32,
-        config.max_chunk_bytes as u32,
+        chunking.min_chunk_bytes as u32,
+        chunking.avg_chunk_bytes as u32,
+        chunking.max_chunk_bytes as u32,
     )
     .map(|chunk| {
         let start = chunk.offset;
@@ -43,61 +54,4 @@ pub(crate) fn fastcdc_chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
         (start, end)
     })
     .collect()
-}
-
-fn fastcdc_config() -> FastCdcConfig {
-    *FASTCDC_CONFIG.get_or_init(load_fastcdc_config)
-}
-
-fn load_fastcdc_config() -> FastCdcConfig {
-    let config = FastCdcConfig {
-        min_chunk_bytes: env_usize(FASTCDC_MIN_CHUNK_BYTES_ENV).unwrap_or(FASTCDC_MIN_CHUNK_BYTES),
-        avg_chunk_bytes: env_usize(FASTCDC_AVG_CHUNK_BYTES_ENV).unwrap_or(FASTCDC_AVG_CHUNK_BYTES),
-        max_chunk_bytes: env_usize(FASTCDC_MAX_CHUNK_BYTES_ENV).unwrap_or(FASTCDC_MAX_CHUNK_BYTES),
-        single_chunk_fast_path_max_bytes: env_usize(SINGLE_CHUNK_FAST_PATH_MAX_BYTES_ENV)
-            .unwrap_or(SINGLE_CHUNK_FAST_PATH_MAX_BYTES),
-    };
-    assert!(
-        config.min_chunk_bytes > 0
-            && config.min_chunk_bytes <= config.avg_chunk_bytes
-            && config.avg_chunk_bytes <= config.max_chunk_bytes
-            && config.max_chunk_bytes <= u32::MAX as usize,
-        "invalid FastCDC experiment chunk sizes: min={}, avg={}, max={}",
-        config.min_chunk_bytes,
-        config.avg_chunk_bytes,
-        config.max_chunk_bytes
-    );
-    assert!(
-        config.single_chunk_fast_path_max_bytes > 0
-            && config.single_chunk_fast_path_max_bytes <= u32::MAX as usize,
-        "invalid FastCDC experiment single-chunk fast path size: {}",
-        config.single_chunk_fast_path_max_bytes
-    );
-    config
-}
-
-#[cfg(not(target_family = "wasm"))]
-fn env_usize(name: &str) -> Option<usize> {
-    std::env::var(name).ok().map(|value| {
-        parse_size(&value).unwrap_or_else(|| panic!("{name} must be a positive byte size"))
-    })
-}
-
-#[cfg(target_family = "wasm")]
-fn env_usize(_name: &str) -> Option<usize> {
-    None
-}
-
-fn parse_size(value: &str) -> Option<usize> {
-    let trimmed = value.trim();
-    let last_digit = trimmed.rfind(|ch: char| ch.is_ascii_digit())?;
-    let (digits, suffix) = trimmed.split_at(last_digit + 1);
-    let base = digits.parse::<usize>().ok()?;
-    let multiplier = match suffix.to_ascii_lowercase().as_str() {
-        "" => 1,
-        "k" | "kb" | "kib" => 1024,
-        "m" | "mb" | "mib" => 1024 * 1024,
-        _ => return None,
-    };
-    base.checked_mul(multiplier)
 }

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -55,3 +55,43 @@ pub(crate) fn fastcdc_chunk_ranges_with_chunking(
     })
     .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_chunking_is_fixed_fastcdc_1m_profile() {
+        let chunking = BinaryCasChunking::default();
+
+        assert_eq!(chunking.min_chunk_bytes, 256 * 1024);
+        assert_eq!(chunking.avg_chunk_bytes, 1024 * 1024);
+        assert_eq!(chunking.max_chunk_bytes, 4096 * 1024);
+        assert_eq!(chunking.single_chunk_fast_path_max_bytes, 64 * 1024);
+    }
+
+    #[test]
+    fn single_chunk_fast_path_applies_through_64kib() {
+        let at_boundary = vec![0; 64 * 1024];
+        assert_eq!(
+            fastcdc_chunk_ranges(&at_boundary),
+            vec![(0, at_boundary.len())]
+        );
+    }
+
+    #[test]
+    fn single_chunk_fast_path_does_not_apply_above_64kib() {
+        let above_boundary = vec![0; 64 * 1024 + 1];
+        let chunking = BinaryCasChunking {
+            min_chunk_bytes: 16 * 1024,
+            avg_chunk_bytes: 32 * 1024,
+            max_chunk_bytes: 64 * 1024,
+            single_chunk_fast_path_max_bytes: 64 * 1024,
+        };
+
+        assert_ne!(
+            fastcdc_chunk_ranges_with_chunking(&above_boundary, chunking),
+            vec![(0, above_boundary.len())]
+        );
+    }
+}

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -35,8 +35,21 @@ impl BinaryCasContext {
     }
 
     #[expect(clippy::unused_self)]
+    #[allow(dead_code)]
     pub(crate) fn writer<'a>(&self, writes: &'a mut StorageWriteSet) -> BinaryCasWriter<'a> {
         BinaryCasWriter::new(writes)
+    }
+
+    #[expect(clippy::unused_self)]
+    pub(crate) fn writer_skipping_existing_chunks<'a, S>(
+        &self,
+        store: &'a S,
+        writes: &'a mut StorageWriteSet,
+    ) -> ExistingChunkAwareBinaryCasWriter<'a, S>
+    where
+        S: StorageRead + ?Sized,
+    {
+        ExistingChunkAwareBinaryCasWriter::new(store, writes)
     }
 }
 
@@ -75,12 +88,26 @@ where
 ///
 /// This type does not begin, commit, or roll back transactions. It only writes
 /// CAS data into the transaction supplied by the caller.
+#[allow(dead_code)]
 pub(crate) struct BinaryCasWriter<'a> {
     writes: &'a mut StorageWriteSet,
     blob_hashes: HashSet<[u8; 32]>,
     chunk_keys: HashSet<Vec<u8>>,
 }
 
+/// Binary CAS writer that avoids re-putting chunk payload rows already present
+/// in the backing store.
+pub(crate) struct ExistingChunkAwareBinaryCasWriter<'a, S>
+where
+    S: StorageRead + ?Sized,
+{
+    store: &'a S,
+    writes: &'a mut StorageWriteSet,
+    blob_hashes: HashSet<[u8; 32]>,
+    chunk_keys: HashSet<Vec<u8>>,
+}
+
+#[allow(dead_code)]
 impl<'a> BinaryCasWriter<'a> {
     fn new(writes: &'a mut StorageWriteSet) -> Self {
         Self {
@@ -106,6 +133,34 @@ impl<'a> BinaryCasWriter<'a> {
         payload: &BlobPayload,
     ) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write(
+            self.writes,
+            &mut self.blob_hashes,
+            &mut self.chunk_keys,
+            payload.bytes(),
+            payload.hash(),
+        )
+    }
+}
+
+impl<'a, S> ExistingChunkAwareBinaryCasWriter<'a, S>
+where
+    S: StorageRead + ?Sized,
+{
+    fn new(store: &'a S, writes: &'a mut StorageWriteSet) -> Self {
+        Self {
+            store,
+            writes,
+            blob_hashes: HashSet::new(),
+            chunk_keys: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn stage_payload(
+        &mut self,
+        payload: &BlobPayload,
+    ) -> Result<BlobWriteReceipt, LixError> {
+        crate::binary_cas::kv::stage_blob_write_skipping_existing_chunks(
+            self.store,
             self.writes,
             &mut self.blob_hashes,
             &mut self.chunk_keys,

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::LixError;
+use crate::binary_cas::BinaryCasChunking;
 use crate::binary_cas::{BlobBytesBatch, BlobHash, BlobPayload, BlobWriteReceipt};
 use crate::storage::{StorageRead, StorageWriteSet};
 use std::collections::HashSet;
@@ -15,11 +16,15 @@ pub(crate) trait BlobDataReader: Send + Sync {
 /// The context does not own storage. Callers explicitly provide a KV store via
 /// `reader(...)` or `writer(...)`, keeping backend and transaction ownership at
 /// the execution layer.
-pub(crate) struct BinaryCasContext;
+pub(crate) struct BinaryCasContext {
+    chunking: BinaryCasChunking,
+}
 
 impl BinaryCasContext {
     pub(crate) fn new() -> Self {
-        Self
+        Self {
+            chunking: BinaryCasChunking::default(),
+        }
     }
 
     /// Creates a Binary CAS reader over any storage reader.
@@ -37,7 +42,7 @@ impl BinaryCasContext {
     #[expect(clippy::unused_self)]
     #[allow(dead_code)]
     pub(crate) fn writer<'a>(&self, writes: &'a mut StorageWriteSet) -> BinaryCasWriter<'a> {
-        BinaryCasWriter::new(writes)
+        BinaryCasWriter::new(writes, self.chunking)
     }
 
     #[expect(clippy::unused_self)]
@@ -49,7 +54,7 @@ impl BinaryCasContext {
     where
         S: StorageRead + ?Sized,
     {
-        ExistingChunkAwareBinaryCasWriter::new(store, writes)
+        ExistingChunkAwareBinaryCasWriter::new(store, writes, self.chunking)
     }
 }
 
@@ -91,6 +96,7 @@ where
 #[allow(dead_code)]
 pub(crate) struct BinaryCasWriter<'a> {
     writes: &'a mut StorageWriteSet,
+    chunking: BinaryCasChunking,
     blob_hashes: HashSet<[u8; 32]>,
     chunk_keys: HashSet<Vec<u8>>,
 }
@@ -103,15 +109,17 @@ where
 {
     store: &'a S,
     writes: &'a mut StorageWriteSet,
+    chunking: BinaryCasChunking,
     blob_hashes: HashSet<[u8; 32]>,
     chunk_keys: HashSet<Vec<u8>>,
 }
 
 #[allow(dead_code)]
 impl<'a> BinaryCasWriter<'a> {
-    fn new(writes: &'a mut StorageWriteSet) -> Self {
+    fn new(writes: &'a mut StorageWriteSet, chunking: BinaryCasChunking) -> Self {
         Self {
             writes,
+            chunking,
             blob_hashes: HashSet::new(),
             chunk_keys: HashSet::new(),
         }
@@ -120,6 +128,7 @@ impl<'a> BinaryCasWriter<'a> {
     #[cfg(test)]
     pub(crate) fn stage_bytes(&mut self, bytes: &[u8]) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write(
+            self.chunking,
             self.writes,
             &mut self.blob_hashes,
             &mut self.chunk_keys,
@@ -133,6 +142,7 @@ impl<'a> BinaryCasWriter<'a> {
         payload: &BlobPayload,
     ) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write(
+            self.chunking,
             self.writes,
             &mut self.blob_hashes,
             &mut self.chunk_keys,
@@ -146,10 +156,11 @@ impl<'a, S> ExistingChunkAwareBinaryCasWriter<'a, S>
 where
     S: StorageRead + ?Sized,
 {
-    fn new(store: &'a S, writes: &'a mut StorageWriteSet) -> Self {
+    fn new(store: &'a S, writes: &'a mut StorageWriteSet, chunking: BinaryCasChunking) -> Self {
         Self {
             store,
             writes,
+            chunking,
             blob_hashes: HashSet::new(),
             chunk_keys: HashSet::new(),
         }
@@ -160,6 +171,7 @@ where
         payload: &BlobPayload,
     ) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write_skipping_existing_chunks(
+            self.chunking,
             self.store,
             self.writes,
             &mut self.blob_hashes,

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -39,13 +39,11 @@ impl BinaryCasContext {
         BinaryCasStoreReader { store }
     }
 
-    #[expect(clippy::unused_self)]
     #[allow(dead_code)]
     pub(crate) fn writer<'a>(&self, writes: &'a mut StorageWriteSet) -> BinaryCasWriter<'a> {
         BinaryCasWriter::new(writes, self.chunking)
     }
 
-    #[expect(clippy::unused_self)]
     pub(crate) fn writer_skipping_existing_chunks<'a, S>(
         &self,
         store: &'a S,

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -1,14 +1,15 @@
 #![allow(clippy::cast_sign_loss)]
 
 use crate::LixError;
-use crate::binary_cas::chunking::fastcdc_chunk_ranges;
+use crate::binary_cas::chunking::fastcdc_chunk_ranges_with_chunking;
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
     decode_binary_cas_manifest_chunk, encode_binary_cas_chunk, encode_binary_cas_manifest,
     encode_binary_cas_manifest_chunk,
 };
 use crate::binary_cas::{
-    BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobWriteReceipt,
+    BinaryCasChunking, BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch,
+    BlobWriteReceipt,
 };
 use crate::storage::{PointReadPlan, ScanPlan, StorageRead, StorageSpace, StorageWriteSet};
 use crate::storage::{
@@ -517,18 +518,25 @@ fn decode_and_verify_chunk(
 
 #[allow(dead_code)]
 pub(in crate::binary_cas) fn stage_blob_write(
+    chunking: BinaryCasChunking,
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
     chunk_keys: &mut HashSet<Vec<u8>>,
     bytes: &[u8],
     precomputed_hash: Option<BlobHash>,
 ) -> Result<BlobWriteReceipt, LixError> {
-    stage_blob_write_with_chunk_filter(writes, blob_hashes, bytes, precomputed_hash, |chunk_hash| {
-        Ok(chunk_keys.insert(chunk_key(chunk_hash)))
-    })
+    stage_blob_write_with_chunk_filter(
+        chunking,
+        writes,
+        blob_hashes,
+        bytes,
+        precomputed_hash,
+        |chunk_hash| Ok(chunk_keys.insert(chunk_key(chunk_hash))),
+    )
 }
 
 pub(in crate::binary_cas) fn stage_blob_write_skipping_existing_chunks<S>(
+    chunking: BinaryCasChunking,
     store: &S,
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
@@ -539,7 +547,7 @@ pub(in crate::binary_cas) fn stage_blob_write_skipping_existing_chunks<S>(
 where
     S: StorageRead + ?Sized,
 {
-    let plan = prepare_blob_write(bytes, precomputed_hash)?;
+    let plan = prepare_blob_write(chunking, bytes, precomputed_hash)?;
     let receipt = plan.receipt.clone();
     if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
         return Ok(receipt);
@@ -553,13 +561,14 @@ where
 }
 
 fn stage_blob_write_with_chunk_filter(
+    chunking: BinaryCasChunking,
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
     bytes: &[u8],
     precomputed_hash: Option<BlobHash>,
     mut should_stage_chunk: impl FnMut(BlobHash) -> Result<bool, LixError>,
 ) -> Result<BlobWriteReceipt, LixError> {
-    let plan = prepare_blob_write(bytes, precomputed_hash)?;
+    let plan = prepare_blob_write(chunking, bytes, precomputed_hash)?;
     let receipt = plan.receipt.clone();
     if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
         return Ok(receipt);
@@ -572,6 +581,7 @@ fn stage_blob_write_with_chunk_filter(
 }
 
 fn prepare_blob_write(
+    chunking: BinaryCasChunking,
     bytes: &[u8],
     precomputed_hash: Option<BlobHash>,
 ) -> Result<BlobWritePlan, LixError> {
@@ -585,7 +595,7 @@ fn prepare_blob_write(
             "binary CAS blob hash does not match blob contents".to_string(),
         ));
     }
-    let chunk_ranges = fastcdc_chunk_ranges(bytes);
+    let chunk_ranges = fastcdc_chunk_ranges_with_chunking(bytes, chunking);
     let layout = match chunk_ranges.as_slice() {
         [] => BlobLayout::Empty,
         [(start, end)] => BlobLayout::SingleChunk {
@@ -827,6 +837,12 @@ fn persisted_size_to_usize(size: u64, label: &str) -> Result<usize, LixError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn definitely_multi_chunk_blob_bytes() -> Vec<u8> {
+        (0..5_000_000)
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>()
+    }
     use crate::binary_cas::BinaryCasContext;
     use crate::binary_cas::BlobPayload;
     use crate::storage::StorageContext;
@@ -1054,12 +1070,10 @@ mod tests {
     #[tokio::test]
     async fn existing_chunk_aware_writer_batches_persisted_chunk_checks() {
         let storage = StorageContext::new(InMemoryStorageBackend::new());
-        let data = (0..600_000)
-            .map(|index| (index % 251) as u8)
-            .collect::<Vec<_>>();
+        let data = definitely_multi_chunk_blob_bytes();
         let payload = BlobPayload::from_bytes(data.clone());
         let blob_hash = payload.hash().expect("payload should have a hash");
-        let chunk_ranges = fastcdc_chunk_ranges(&data);
+        let chunk_ranges = crate::binary_cas::chunking::fastcdc_chunk_ranges(&data);
         assert!(chunk_ranges.len() > 1);
         let chunk_hashes = chunk_ranges
             .iter()
@@ -1324,9 +1338,7 @@ mod tests {
     #[tokio::test]
     async fn public_kv_api_roundtrips_multi_chunk_blob() {
         let storage = StorageContext::new(InMemoryStorageBackend::new());
-        let data = (0..600_000)
-            .map(|index| (index % 251) as u8)
-            .collect::<Vec<_>>();
+        let data = definitely_multi_chunk_blob_bytes();
         let blob_hash = BlobHash::from_content(&data);
 
         {

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -1091,7 +1091,7 @@ mod tests {
                 .expect("initial blob write should commit");
         }
 
-        crate::binary_cas::reset_binary_cas_write_metrics();
+        crate::binary_cas::metrics::reset_binary_cas_write_metrics();
         let store = storage
             .begin_read(StorageReadOptions::default())
             .expect("read should open");
@@ -1106,7 +1106,7 @@ mod tests {
             writes.stats().staged_puts,
             1 + u64::try_from(chunk_ranges.len()).expect("chunk count should fit in u64")
         );
-        let metrics = crate::binary_cas::binary_cas_write_metrics_snapshot();
+        let metrics = crate::binary_cas::metrics::binary_cas_write_metrics_snapshot();
         assert_eq!(metrics.chunk_lookup_count, chunk_hashes.len() as u64);
         assert_eq!(metrics.chunk_lookup_batch_count, 1);
         assert_eq!(metrics.chunk_lookup_hit_count, chunk_hashes.len() as u64);

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -31,6 +31,14 @@ pub(crate) const BINARY_CAS_MANIFEST_CHUNK_SPACE: StorageSpace = StorageSpace::n
 pub(crate) const BINARY_CAS_CHUNK_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0005_0003), BINARY_CAS_CHUNK_NAMESPACE);
 
+#[derive(Debug)]
+struct BlobWritePlan {
+    blob_hash: BlobHash,
+    chunk_ranges: Vec<(usize, usize)>,
+    layout: BlobLayout,
+    receipt: BlobWriteReceipt,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KvBlobManifestChunk {
     pub(crate) chunk_hash: [u8; 32],
@@ -531,14 +539,17 @@ pub(in crate::binary_cas) fn stage_blob_write_skipping_existing_chunks<S>(
 where
     S: StorageRead + ?Sized,
 {
-    stage_blob_write_with_chunk_filter(writes, blob_hashes, bytes, precomputed_hash, |chunk_hash| {
-        let key = chunk_key(chunk_hash);
-        if !chunk_keys.insert(key.clone()) {
-            crate::binary_cas::metrics::record_binary_cas_transaction_duplicate_chunk();
-            return Ok(false);
-        }
-        Ok(!chunk_key_exists(store, key)?)
-    })
+    let plan = prepare_blob_write(bytes, precomputed_hash)?;
+    let receipt = plan.receipt.clone();
+    if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
+        return Ok(receipt);
+    }
+
+    let mut chunk_hashes_to_stage = missing_chunk_hashes(store, chunk_keys, bytes, &plan)?;
+    stage_prepared_blob_write(writes, bytes, &plan, |chunk_hash| {
+        Ok(chunk_hashes_to_stage.remove(&chunk_hash))
+    })?;
+    Ok(receipt)
 }
 
 fn stage_blob_write_with_chunk_filter(
@@ -548,6 +559,22 @@ fn stage_blob_write_with_chunk_filter(
     precomputed_hash: Option<BlobHash>,
     mut should_stage_chunk: impl FnMut(BlobHash) -> Result<bool, LixError>,
 ) -> Result<BlobWriteReceipt, LixError> {
+    let plan = prepare_blob_write(bytes, precomputed_hash)?;
+    let receipt = plan.receipt.clone();
+    if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
+        return Ok(receipt);
+    }
+
+    stage_prepared_blob_write(writes, bytes, &plan, |chunk_hash| {
+        should_stage_chunk(chunk_hash)
+    })?;
+    Ok(receipt)
+}
+
+fn prepare_blob_write(
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
+) -> Result<BlobWritePlan, LixError> {
     let blob_hash = precomputed_hash.unwrap_or_else(|| BlobHash::from_content(bytes));
     if cfg!(debug_assertions)
         && precomputed_hash.is_some()
@@ -582,15 +609,26 @@ fn stage_blob_write_with_chunk_filter(
         size_bytes: bytes.len() as u64,
         layout: layout.clone(),
     };
-    if !blob_hashes.insert(blob_hash.into_bytes()) {
-        return Ok(receipt);
-    }
 
-    match &layout {
+    Ok(BlobWritePlan {
+        blob_hash,
+        chunk_ranges,
+        layout,
+        receipt,
+    })
+}
+
+fn stage_prepared_blob_write(
+    writes: &mut StorageWriteSet,
+    bytes: &[u8],
+    plan: &BlobWritePlan,
+    mut should_stage_chunk: impl FnMut(BlobHash) -> Result<bool, LixError>,
+) -> Result<(), LixError> {
+    match &plan.layout {
         BlobLayout::Empty => {
             stage_manifest(
                 writes,
-                blob_hash,
+                plan.blob_hash,
                 &BinaryCasManifest::Empty { size_bytes: 0 },
             );
         }
@@ -598,7 +636,7 @@ fn stage_blob_write_with_chunk_filter(
             let chunk_hash = *chunk_hash;
             stage_manifest(
                 writes,
-                blob_hash,
+                plan.blob_hash,
                 &BinaryCasManifest::SingleChunk {
                     size_bytes: bytes.len() as u64,
                     chunk_hash: chunk_hash.into_bytes(),
@@ -617,14 +655,14 @@ fn stage_blob_write_with_chunk_filter(
         BlobLayout::Chunked { chunk_count } => {
             stage_manifest(
                 writes,
-                blob_hash,
+                plan.blob_hash,
                 &BinaryCasManifest::Chunked {
                     size_bytes: bytes.len() as u64,
                     chunk_count: *chunk_count,
                 },
             );
 
-            for (chunk_index, (start, end)) in chunk_ranges.into_iter().enumerate() {
+            for (chunk_index, (start, end)) in plan.chunk_ranges.iter().copied().enumerate() {
                 let chunk_data = &bytes[start..end];
                 let chunk_hash = BlobHash::from_content(chunk_data);
                 if should_stage_chunk(chunk_hash)? {
@@ -639,7 +677,7 @@ fn stage_blob_write_with_chunk_filter(
 
                 stage_manifest_chunk(
                     writes,
-                    blob_hash,
+                    plan.blob_hash,
                     chunk_index as u64,
                     &KvBlobManifestChunk {
                         chunk_hash: *chunk_hash.as_bytes(),
@@ -649,21 +687,82 @@ fn stage_blob_write_with_chunk_filter(
             }
         }
     }
-    Ok(receipt)
+    Ok(())
 }
 
-fn chunk_key_exists(store: &(impl StorageRead + ?Sized), key: Vec<u8>) -> Result<bool, LixError> {
-    let key = StorageKey(Bytes::from(key));
+fn missing_chunk_hashes(
+    store: &(impl StorageRead + ?Sized),
+    transaction_chunk_keys: &mut HashSet<Vec<u8>>,
+    bytes: &[u8],
+    plan: &BlobWritePlan,
+) -> Result<HashSet<BlobHash>, LixError> {
+    let mut candidates = Vec::<(BlobHash, StorageKey)>::new();
+    match &plan.layout {
+        BlobLayout::Empty => {}
+        BlobLayout::SingleChunk { chunk_hash } => {
+            collect_chunk_lookup_candidate(*chunk_hash, transaction_chunk_keys, &mut candidates);
+        }
+        BlobLayout::Chunked { .. } => {
+            for (start, end) in plan.chunk_ranges.iter().copied() {
+                let chunk_hash = BlobHash::from_content(&bytes[start..end]);
+                collect_chunk_lookup_candidate(chunk_hash, transaction_chunk_keys, &mut candidates);
+            }
+        }
+    }
+
+    if candidates.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let keys = candidates
+        .iter()
+        .map(|(_, key)| key.clone())
+        .collect::<Vec<_>>();
+    let existing = chunk_keys_exist(store, keys)?;
+    Ok(candidates
+        .into_iter()
+        .zip(existing)
+        .filter_map(|((chunk_hash, _), exists)| (!exists).then_some(chunk_hash))
+        .collect())
+}
+
+fn collect_chunk_lookup_candidate(
+    chunk_hash: BlobHash,
+    transaction_chunk_keys: &mut HashSet<Vec<u8>>,
+    candidates: &mut Vec<(BlobHash, StorageKey)>,
+) {
+    let key = chunk_key(chunk_hash);
+    if !transaction_chunk_keys.insert(key.clone()) {
+        crate::binary_cas::metrics::record_binary_cas_transaction_duplicate_chunk();
+        return;
+    }
+    candidates.push((chunk_hash, StorageKey(Bytes::from(key))));
+}
+
+fn chunk_keys_exist(
+    store: &(impl StorageRead + ?Sized),
+    keys: Vec<StorageKey>,
+) -> Result<Vec<bool>, LixError> {
     let started = Instant::now();
-    let result = PointReadPlan::new(BINARY_CAS_CHUNK_SPACE, &[key]).materialize(
+    let result = PointReadPlan::from_unique_keys(BINARY_CAS_CHUNK_SPACE, keys).materialize(
         store,
         StorageGetOptions {
             projection: StorageCoreProjection::KeyOnly,
             ..StorageGetOptions::default()
         },
     )?;
-    let exists = result.value.into_iter().next().flatten().is_some();
-    crate::binary_cas::metrics::record_binary_cas_chunk_lookup(exists, started.elapsed());
+    let exists = result
+        .value
+        .into_iter()
+        .map(|value| value.is_some())
+        .collect::<Vec<_>>();
+    let hit_count = exists.iter().filter(|&&exists| exists).count() as u64;
+    let miss_count = exists.len() as u64 - hit_count;
+    crate::binary_cas::metrics::record_binary_cas_chunk_lookup_batch(
+        hit_count,
+        miss_count,
+        started.elapsed(),
+    );
     Ok(exists)
 }
 
@@ -731,7 +830,9 @@ mod tests {
     use crate::binary_cas::BinaryCasContext;
     use crate::binary_cas::BlobPayload;
     use crate::storage::StorageContext;
-    use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
+    use crate::storage::{
+        InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
+    };
 
     #[tokio::test]
     async fn stores_manifest_chunks_in_scan_order() {
@@ -948,6 +1049,101 @@ mod tests {
                 .into_vec(),
             vec![Some(data.to_vec())]
         );
+    }
+
+    #[tokio::test]
+    async fn existing_chunk_aware_writer_batches_persisted_chunk_checks() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let data = (0..600_000)
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
+        let payload = BlobPayload::from_bytes(data.clone());
+        let blob_hash = payload.hash().expect("payload should have a hash");
+        let chunk_ranges = fastcdc_chunk_ranges(&data);
+        assert!(chunk_ranges.len() > 1);
+        let chunk_hashes = chunk_ranges
+            .iter()
+            .map(|(start, end)| BlobHash::from_content(&data[*start..*end]))
+            .collect::<HashSet<_>>();
+
+        {
+            let mut writes = storage.new_write_set();
+            let mut writer = BinaryCasContext::new().writer(&mut writes);
+            writer
+                .stage_payload(&payload)
+                .expect("initial blob write should stage");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("initial blob write should commit");
+        }
+
+        crate::binary_cas::reset_binary_cas_write_metrics();
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer =
+            BinaryCasContext::new().writer_skipping_existing_chunks(&store, &mut writes);
+        writer
+            .stage_payload(&payload)
+            .expect("repeat blob write should stage");
+
+        assert_eq!(
+            writes.stats().staged_puts,
+            1 + u64::try_from(chunk_ranges.len()).expect("chunk count should fit in u64")
+        );
+        let metrics = crate::binary_cas::binary_cas_write_metrics_snapshot();
+        assert_eq!(metrics.chunk_lookup_count, chunk_hashes.len() as u64);
+        assert_eq!(metrics.chunk_lookup_batch_count, 1);
+        assert_eq!(metrics.chunk_lookup_hit_count, chunk_hashes.len() as u64);
+        assert_eq!(metrics.chunk_lookup_miss_count, 0);
+        assert_eq!(
+            metrics.transaction_duplicate_chunk_count,
+            (chunk_ranges.len() - chunk_hashes.len()) as u64
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("repeat blob write should commit");
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        assert_eq!(
+            load_bytes_many(&store, &[blob_hash])
+                .await
+                .expect("blob should load")
+                .into_vec(),
+            vec![Some(data)]
+        );
+    }
+
+    #[test]
+    fn prepared_blob_write_stages_duplicate_chunk_payload_once() {
+        let data = b"abcabc";
+        let blob_hash = BlobHash::from_content(data);
+        let chunk_hash = BlobHash::from_content(b"abc");
+        let plan = BlobWritePlan {
+            blob_hash,
+            chunk_ranges: vec![(0, 3), (3, 6)],
+            layout: BlobLayout::Chunked { chunk_count: 2 },
+            receipt: BlobWriteReceipt {
+                hash: blob_hash,
+                size_bytes: data.len() as u64,
+                layout: BlobLayout::Chunked { chunk_count: 2 },
+            },
+        };
+        let mut writes = StorageWriteSet::new();
+        let mut chunk_hashes_to_stage = HashSet::from([chunk_hash]);
+
+        stage_prepared_blob_write(&mut writes, data, &plan, |chunk_hash| {
+            Ok(chunk_hashes_to_stage.remove(&chunk_hash))
+        })
+        .expect("duplicate chunk payload write should stage");
+
+        assert_eq!(writes.stats().staged_puts, 4);
+        writes
+            .validate()
+            .expect("duplicate chunk payload should be staged only once");
     }
 
     #[tokio::test]

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -17,6 +17,7 @@ use crate::storage::{
 };
 use bytes::Bytes;
 use std::collections::{HashMap, HashSet};
+use std::time::Instant;
 
 pub(crate) const BINARY_CAS_MANIFEST_NAMESPACE: &str = "binary_cas.manifest";
 pub(crate) const BINARY_CAS_MANIFEST_CHUNK_NAMESPACE: &str = "binary_cas.manifest_chunk";
@@ -533,6 +534,7 @@ where
     stage_blob_write_with_chunk_filter(writes, blob_hashes, bytes, precomputed_hash, |chunk_hash| {
         let key = chunk_key(chunk_hash);
         if !chunk_keys.insert(key.clone()) {
+            crate::binary_cas::metrics::record_binary_cas_transaction_duplicate_chunk();
             return Ok(false);
         }
         Ok(!chunk_key_exists(store, key)?)
@@ -652,6 +654,7 @@ fn stage_blob_write_with_chunk_filter(
 
 fn chunk_key_exists(store: &(impl StorageRead + ?Sized), key: Vec<u8>) -> Result<bool, LixError> {
     let key = StorageKey(Bytes::from(key));
+    let started = Instant::now();
     let result = PointReadPlan::new(BINARY_CAS_CHUNK_SPACE, &[key]).materialize(
         store,
         StorageGetOptions {
@@ -659,7 +662,9 @@ fn chunk_key_exists(store: &(impl StorageRead + ?Sized), key: Vec<u8>) -> Result
             ..StorageGetOptions::default()
         },
     )?;
-    Ok(result.value.into_iter().next().flatten().is_some())
+    let exists = result.value.into_iter().next().flatten().is_some();
+    crate::binary_cas::metrics::record_binary_cas_chunk_lookup(exists, started.elapsed());
+    Ok(exists)
 }
 
 fn metadata_from_manifest(

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -12,8 +12,8 @@ use crate::binary_cas::{
 };
 use crate::storage::{PointReadPlan, ScanPlan, StorageRead, StorageSpace, StorageWriteSet};
 use crate::storage::{
-    StorageGetOptions, StorageKey, StoragePrefix, StorageProjectedValue, StorageScanOptions,
-    StorageSpaceId, StorageValue,
+    StorageCoreProjection, StorageGetOptions, StorageKey, StoragePrefix, StorageProjectedValue,
+    StorageScanOptions, StorageSpaceId, StorageValue,
 };
 use bytes::Bytes;
 use std::collections::{HashMap, HashSet};
@@ -506,12 +506,45 @@ fn decode_and_verify_chunk(
     Ok(chunk_payload.to_vec())
 }
 
+#[allow(dead_code)]
 pub(in crate::binary_cas) fn stage_blob_write(
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
     chunk_keys: &mut HashSet<Vec<u8>>,
     bytes: &[u8],
     precomputed_hash: Option<BlobHash>,
+) -> Result<BlobWriteReceipt, LixError> {
+    stage_blob_write_with_chunk_filter(writes, blob_hashes, bytes, precomputed_hash, |chunk_hash| {
+        Ok(chunk_keys.insert(chunk_key(chunk_hash)))
+    })
+}
+
+pub(in crate::binary_cas) fn stage_blob_write_skipping_existing_chunks<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    blob_hashes: &mut HashSet<[u8; 32]>,
+    chunk_keys: &mut HashSet<Vec<u8>>,
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
+) -> Result<BlobWriteReceipt, LixError>
+where
+    S: StorageRead + ?Sized,
+{
+    stage_blob_write_with_chunk_filter(writes, blob_hashes, bytes, precomputed_hash, |chunk_hash| {
+        let key = chunk_key(chunk_hash);
+        if !chunk_keys.insert(key.clone()) {
+            return Ok(false);
+        }
+        Ok(!chunk_key_exists(store, key)?)
+    })
+}
+
+fn stage_blob_write_with_chunk_filter(
+    writes: &mut StorageWriteSet,
+    blob_hashes: &mut HashSet<[u8; 32]>,
+    bytes: &[u8],
+    precomputed_hash: Option<BlobHash>,
+    mut should_stage_chunk: impl FnMut(BlobHash) -> Result<bool, LixError>,
 ) -> Result<BlobWriteReceipt, LixError> {
     let blob_hash = precomputed_hash.unwrap_or_else(|| BlobHash::from_content(bytes));
     if cfg!(debug_assertions)
@@ -569,7 +602,7 @@ pub(in crate::binary_cas) fn stage_blob_write(
                     chunk_hash: chunk_hash.into_bytes(),
                 },
             );
-            if chunk_keys.insert(chunk_key(chunk_hash)) {
+            if should_stage_chunk(chunk_hash)? {
                 stage_chunk(
                     writes,
                     chunk_hash,
@@ -592,8 +625,7 @@ pub(in crate::binary_cas) fn stage_blob_write(
             for (chunk_index, (start, end)) in chunk_ranges.into_iter().enumerate() {
                 let chunk_data = &bytes[start..end];
                 let chunk_hash = BlobHash::from_content(chunk_data);
-                let chunk_key = chunk_key(chunk_hash);
-                if chunk_keys.insert(chunk_key.clone()) {
+                if should_stage_chunk(chunk_hash)? {
                     stage_chunk(
                         writes,
                         chunk_hash,
@@ -616,6 +648,18 @@ pub(in crate::binary_cas) fn stage_blob_write(
         }
     }
     Ok(receipt)
+}
+
+fn chunk_key_exists(store: &(impl StorageRead + ?Sized), key: Vec<u8>) -> Result<bool, LixError> {
+    let key = StorageKey(Bytes::from(key));
+    let result = PointReadPlan::new(BINARY_CAS_CHUNK_SPACE, &[key]).materialize(
+        store,
+        StorageGetOptions {
+            projection: StorageCoreProjection::KeyOnly,
+            ..StorageGetOptions::default()
+        },
+    )?;
+    Ok(result.value.into_iter().next().flatten().is_some())
 }
 
 fn metadata_from_manifest(
@@ -852,6 +896,52 @@ mod tests {
                 .await
                 .expect("single-chunk blob should not spill manifest chunks"),
             Vec::<KvBlobManifestChunk>::new()
+        );
+    }
+
+    #[tokio::test]
+    async fn existing_chunk_aware_writer_skips_persisted_chunk_payloads() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let data = b"hello chunked kv cas";
+        let payload = BlobPayload::from_bytes(data.to_vec());
+        let blob_hash = payload.hash().expect("payload should have a hash");
+
+        {
+            let mut writes = storage.new_write_set();
+            let mut writer = BinaryCasContext::new().writer(&mut writes);
+            writer
+                .stage_payload(&payload)
+                .expect("initial blob write should stage");
+            assert_eq!(writes.stats().staged_puts, 2);
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .expect("initial blob write should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer =
+            BinaryCasContext::new().writer_skipping_existing_chunks(&store, &mut writes);
+        writer
+            .stage_payload(&payload)
+            .expect("repeat blob write should stage");
+
+        assert_eq!(writes.stats().staged_puts, 1);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("repeat blob write should commit");
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        assert_eq!(
+            load_bytes_many(&store, &[blob_hash])
+                .await
+                .expect("blob should load")
+                .into_vec(),
+            vec![Some(data.to_vec())]
         );
     }
 

--- a/packages/engine/src/binary_cas/metrics.rs
+++ b/packages/engine/src/binary_cas/metrics.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BinaryCasWriteMetrics {
     pub chunk_lookup_count: u64,
+    pub chunk_lookup_batch_count: u64,
     pub chunk_lookup_hit_count: u64,
     pub chunk_lookup_miss_count: u64,
     pub chunk_lookup_elapsed_ns: u64,
@@ -11,6 +12,7 @@ pub struct BinaryCasWriteMetrics {
 }
 
 static CHUNK_LOOKUP_COUNT: AtomicU64 = AtomicU64::new(0);
+static CHUNK_LOOKUP_BATCH_COUNT: AtomicU64 = AtomicU64::new(0);
 static CHUNK_LOOKUP_HIT_COUNT: AtomicU64 = AtomicU64::new(0);
 static CHUNK_LOOKUP_MISS_COUNT: AtomicU64 = AtomicU64::new(0);
 static CHUNK_LOOKUP_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
@@ -18,6 +20,7 @@ static TRANSACTION_DUPLICATE_CHUNK_COUNT: AtomicU64 = AtomicU64::new(0);
 
 pub fn reset_binary_cas_write_metrics() {
     CHUNK_LOOKUP_COUNT.store(0, Ordering::Relaxed);
+    CHUNK_LOOKUP_BATCH_COUNT.store(0, Ordering::Relaxed);
     CHUNK_LOOKUP_HIT_COUNT.store(0, Ordering::Relaxed);
     CHUNK_LOOKUP_MISS_COUNT.store(0, Ordering::Relaxed);
     CHUNK_LOOKUP_ELAPSED_NS.store(0, Ordering::Relaxed);
@@ -27,6 +30,7 @@ pub fn reset_binary_cas_write_metrics() {
 pub fn binary_cas_write_metrics_snapshot() -> BinaryCasWriteMetrics {
     BinaryCasWriteMetrics {
         chunk_lookup_count: CHUNK_LOOKUP_COUNT.load(Ordering::Relaxed),
+        chunk_lookup_batch_count: CHUNK_LOOKUP_BATCH_COUNT.load(Ordering::Relaxed),
         chunk_lookup_hit_count: CHUNK_LOOKUP_HIT_COUNT.load(Ordering::Relaxed),
         chunk_lookup_miss_count: CHUNK_LOOKUP_MISS_COUNT.load(Ordering::Relaxed),
         chunk_lookup_elapsed_ns: CHUNK_LOOKUP_ELAPSED_NS.load(Ordering::Relaxed),
@@ -35,13 +39,15 @@ pub fn binary_cas_write_metrics_snapshot() -> BinaryCasWriteMetrics {
     }
 }
 
-pub(crate) fn record_binary_cas_chunk_lookup(exists: bool, elapsed: Duration) {
-    CHUNK_LOOKUP_COUNT.fetch_add(1, Ordering::Relaxed);
-    if exists {
-        CHUNK_LOOKUP_HIT_COUNT.fetch_add(1, Ordering::Relaxed);
-    } else {
-        CHUNK_LOOKUP_MISS_COUNT.fetch_add(1, Ordering::Relaxed);
-    }
+pub(crate) fn record_binary_cas_chunk_lookup_batch(
+    hit_count: u64,
+    miss_count: u64,
+    elapsed: Duration,
+) {
+    CHUNK_LOOKUP_BATCH_COUNT.fetch_add(1, Ordering::Relaxed);
+    CHUNK_LOOKUP_COUNT.fetch_add(hit_count + miss_count, Ordering::Relaxed);
+    CHUNK_LOOKUP_HIT_COUNT.fetch_add(hit_count, Ordering::Relaxed);
+    CHUNK_LOOKUP_MISS_COUNT.fetch_add(miss_count, Ordering::Relaxed);
     CHUNK_LOOKUP_ELAPSED_NS.fetch_add(duration_ns(elapsed), Ordering::Relaxed);
 }
 

--- a/packages/engine/src/binary_cas/metrics.rs
+++ b/packages/engine/src/binary_cas/metrics.rs
@@ -1,0 +1,54 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BinaryCasWriteMetrics {
+    pub chunk_lookup_count: u64,
+    pub chunk_lookup_hit_count: u64,
+    pub chunk_lookup_miss_count: u64,
+    pub chunk_lookup_elapsed_ns: u64,
+    pub transaction_duplicate_chunk_count: u64,
+}
+
+static CHUNK_LOOKUP_COUNT: AtomicU64 = AtomicU64::new(0);
+static CHUNK_LOOKUP_HIT_COUNT: AtomicU64 = AtomicU64::new(0);
+static CHUNK_LOOKUP_MISS_COUNT: AtomicU64 = AtomicU64::new(0);
+static CHUNK_LOOKUP_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
+static TRANSACTION_DUPLICATE_CHUNK_COUNT: AtomicU64 = AtomicU64::new(0);
+
+pub fn reset_binary_cas_write_metrics() {
+    CHUNK_LOOKUP_COUNT.store(0, Ordering::Relaxed);
+    CHUNK_LOOKUP_HIT_COUNT.store(0, Ordering::Relaxed);
+    CHUNK_LOOKUP_MISS_COUNT.store(0, Ordering::Relaxed);
+    CHUNK_LOOKUP_ELAPSED_NS.store(0, Ordering::Relaxed);
+    TRANSACTION_DUPLICATE_CHUNK_COUNT.store(0, Ordering::Relaxed);
+}
+
+pub fn binary_cas_write_metrics_snapshot() -> BinaryCasWriteMetrics {
+    BinaryCasWriteMetrics {
+        chunk_lookup_count: CHUNK_LOOKUP_COUNT.load(Ordering::Relaxed),
+        chunk_lookup_hit_count: CHUNK_LOOKUP_HIT_COUNT.load(Ordering::Relaxed),
+        chunk_lookup_miss_count: CHUNK_LOOKUP_MISS_COUNT.load(Ordering::Relaxed),
+        chunk_lookup_elapsed_ns: CHUNK_LOOKUP_ELAPSED_NS.load(Ordering::Relaxed),
+        transaction_duplicate_chunk_count: TRANSACTION_DUPLICATE_CHUNK_COUNT
+            .load(Ordering::Relaxed),
+    }
+}
+
+pub(crate) fn record_binary_cas_chunk_lookup(exists: bool, elapsed: Duration) {
+    CHUNK_LOOKUP_COUNT.fetch_add(1, Ordering::Relaxed);
+    if exists {
+        CHUNK_LOOKUP_HIT_COUNT.fetch_add(1, Ordering::Relaxed);
+    } else {
+        CHUNK_LOOKUP_MISS_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+    CHUNK_LOOKUP_ELAPSED_NS.fetch_add(duration_ns(elapsed), Ordering::Relaxed);
+}
+
+pub(crate) fn record_binary_cas_transaction_duplicate_chunk() {
+    TRANSACTION_DUPLICATE_CHUNK_COUNT.fetch_add(1, Ordering::Relaxed);
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    duration.as_nanos().min(u128::from(u64::MAX)) as u64
+}

--- a/packages/engine/src/binary_cas/metrics.rs
+++ b/packages/engine/src/binary_cas/metrics.rs
@@ -59,5 +59,5 @@ pub(crate) fn record_binary_cas_transaction_duplicate_chunk() {
 }
 
 fn duration_ns(duration: Duration) -> u64 {
-    duration.as_nanos().min(u128::from(u64::MAX)) as u64
+    u64::try_from(duration.as_nanos().min(u128::from(u64::MAX))).unwrap()
 }

--- a/packages/engine/src/binary_cas/metrics.rs
+++ b/packages/engine/src/binary_cas/metrics.rs
@@ -1,8 +1,9 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct BinaryCasWriteMetrics {
+pub(crate) struct BinaryCasWriteMetrics {
     pub chunk_lookup_count: u64,
     pub chunk_lookup_batch_count: u64,
     pub chunk_lookup_hit_count: u64,
@@ -18,7 +19,8 @@ static CHUNK_LOOKUP_MISS_COUNT: AtomicU64 = AtomicU64::new(0);
 static CHUNK_LOOKUP_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_DUPLICATE_CHUNK_COUNT: AtomicU64 = AtomicU64::new(0);
 
-pub fn reset_binary_cas_write_metrics() {
+#[cfg(test)]
+pub(crate) fn reset_binary_cas_write_metrics() {
     CHUNK_LOOKUP_COUNT.store(0, Ordering::Relaxed);
     CHUNK_LOOKUP_BATCH_COUNT.store(0, Ordering::Relaxed);
     CHUNK_LOOKUP_HIT_COUNT.store(0, Ordering::Relaxed);
@@ -27,7 +29,8 @@ pub fn reset_binary_cas_write_metrics() {
     TRANSACTION_DUPLICATE_CHUNK_COUNT.store(0, Ordering::Relaxed);
 }
 
-pub fn binary_cas_write_metrics_snapshot() -> BinaryCasWriteMetrics {
+#[cfg(test)]
+pub(crate) fn binary_cas_write_metrics_snapshot() -> BinaryCasWriteMetrics {
     BinaryCasWriteMetrics {
         chunk_lookup_count: CHUNK_LOOKUP_COUNT.load(Ordering::Relaxed),
         chunk_lookup_batch_count: CHUNK_LOOKUP_BATCH_COUNT.load(Ordering::Relaxed),

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -2,9 +2,11 @@ mod chunking;
 mod codec;
 mod context;
 pub(crate) mod kv;
+mod stats;
 mod types;
 
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
+pub use stats::{BinaryCasStorageStats, collect_binary_cas_storage_stats};
 pub(crate) use types::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,
     BlobWriteReceipt,

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -6,6 +6,7 @@ mod metrics;
 mod stats;
 mod types;
 
+pub(crate) use chunking::BinaryCasChunking;
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub use metrics::{
     BinaryCasWriteMetrics, binary_cas_write_metrics_snapshot, reset_binary_cas_write_metrics,

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -2,10 +2,14 @@ mod chunking;
 mod codec;
 mod context;
 pub(crate) mod kv;
+mod metrics;
 mod stats;
 mod types;
 
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
+pub use metrics::{
+    BinaryCasWriteMetrics, binary_cas_write_metrics_snapshot, reset_binary_cas_write_metrics,
+};
 pub use stats::{BinaryCasStorageStats, collect_binary_cas_storage_stats};
 pub(crate) use types::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -3,15 +3,12 @@ mod codec;
 mod context;
 pub(crate) mod kv;
 mod metrics;
+#[cfg(test)]
 mod stats;
 mod types;
 
 pub(crate) use chunking::BinaryCasChunking;
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
-pub use metrics::{
-    BinaryCasWriteMetrics, binary_cas_write_metrics_snapshot, reset_binary_cas_write_metrics,
-};
-pub use stats::{BinaryCasStorageStats, collect_binary_cas_storage_stats};
 pub(crate) use types::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,
     BlobWriteReceipt,

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn counts_binary_cas_storage_rows() {
         let backend = InMemoryStorageBackend::new();
-        let storage = StorageContext::new(backend.clone());
+        let storage = StorageContext::new(backend);
         let mut writes = storage.new_write_set();
 
         let empty_hash = BlobHash::from_content(b"empty");

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -11,7 +11,7 @@ use crate::binary_cas::kv::{
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct BinaryCasStorageStats {
+pub(crate) struct BinaryCasStorageStats {
     pub manifest_rows: u64,
     pub empty_blob_rows: u64,
     pub single_chunk_blob_rows: u64,
@@ -22,7 +22,9 @@ pub struct BinaryCasStorageStats {
     pub logical_blob_bytes: u64,
 }
 
-pub fn collect_binary_cas_storage_stats<R>(read: &R) -> Result<BinaryCasStorageStats, LixError>
+pub(crate) fn collect_binary_cas_storage_stats<R>(
+    read: &R,
+) -> Result<BinaryCasStorageStats, LixError>
 where
     R: BackendRead + ?Sized,
 {

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -1,0 +1,210 @@
+use std::ops::Bound;
+
+use crate::LixError;
+use crate::backend::{
+    BackendError, BackendRead, CoreProjection, KeyRange, KeyRef, ProjectedValueRef, ScanOptions,
+    SpaceId,
+};
+use crate::binary_cas::codec::{BinaryCasManifest, decode_binary_cas_manifest};
+use crate::binary_cas::kv::{
+    BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE, BINARY_CAS_MANIFEST_SPACE,
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BinaryCasStorageStats {
+    pub manifest_rows: u64,
+    pub empty_blob_rows: u64,
+    pub single_chunk_blob_rows: u64,
+    pub chunked_blob_rows: u64,
+    pub manifest_chunk_rows: u64,
+    pub chunk_rows: u64,
+    pub total_chunk_refs: u64,
+    pub logical_blob_bytes: u64,
+}
+
+pub fn collect_binary_cas_storage_stats<R>(read: &R) -> Result<BinaryCasStorageStats, LixError>
+where
+    R: BackendRead + ?Sized,
+{
+    let mut stats = BinaryCasStorageStats::default();
+    stats.manifest_rows = scan_space(
+        read,
+        BINARY_CAS_MANIFEST_SPACE.id,
+        CoreProjection::FullValue,
+        |value| {
+            let ProjectedValueRef::FullValue(bytes) = value else {
+                return Err(BackendError::Corruption(
+                    "binary CAS manifest scan returned key-only value".to_string(),
+                ));
+            };
+            let manifest = decode_binary_cas_manifest(bytes).map_err(|error| {
+                BackendError::Corruption(format!("invalid binary CAS manifest: {error}"))
+            })?;
+            stats.logical_blob_bytes += manifest.size_bytes();
+            match manifest {
+                BinaryCasManifest::Empty { .. } => stats.empty_blob_rows += 1,
+                BinaryCasManifest::SingleChunk { .. } => {
+                    stats.single_chunk_blob_rows += 1;
+                    stats.total_chunk_refs += 1;
+                }
+                BinaryCasManifest::Chunked { chunk_count, .. } => {
+                    stats.chunked_blob_rows += 1;
+                    stats.total_chunk_refs += u64::from(chunk_count);
+                }
+            }
+            Ok(())
+        },
+    )?;
+    stats.manifest_chunk_rows = count_space(read, BINARY_CAS_MANIFEST_CHUNK_SPACE.id)?;
+    stats.chunk_rows = count_space(read, BINARY_CAS_CHUNK_SPACE.id)?;
+    Ok(stats)
+}
+
+fn count_space<R>(read: &R, space: SpaceId) -> Result<u64, LixError>
+where
+    R: BackendRead + ?Sized,
+{
+    scan_space(read, space, CoreProjection::KeyOnly, |_| Ok(()))
+}
+
+fn scan_space<R, F>(
+    read: &R,
+    space: SpaceId,
+    projection: CoreProjection,
+    mut visit: F,
+) -> Result<u64, LixError>
+where
+    R: BackendRead + ?Sized,
+    F: for<'a> FnMut(ProjectedValueRef<'a>) -> Result<(), BackendError>,
+{
+    let range = KeyRange {
+        lower: Bound::Unbounded,
+        upper: Bound::Unbounded,
+    };
+    let mut resume_after = None;
+    let mut row_count = 0_u64;
+
+    loop {
+        let mut last_key = None;
+        let mut emitted = 0_u64;
+        let result = read.scan(
+            space,
+            range.clone(),
+            ScanOptions {
+                projection,
+                limit_rows: 4096,
+                resume_after: resume_after.as_ref(),
+            },
+            &mut |key: KeyRef<'_>, value: ProjectedValueRef<'_>| {
+                emitted += 1;
+                last_key = Some(key.to_owned_key());
+                visit(value)
+            },
+        )?;
+        row_count += emitted;
+        if !result.has_more || last_key.is_none() {
+            break;
+        }
+        resume_after = last_key;
+    }
+
+    Ok(row_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::{Backend, InMemoryBackend, ReadOptions, WriteOptions};
+    use crate::binary_cas::BlobHash;
+    use crate::binary_cas::codec::BinaryChunkCodec;
+    use crate::binary_cas::kv::{
+        KvBlobManifestChunk, stage_chunk, stage_manifest, stage_manifest_chunk,
+    };
+    use crate::storage::StorageContext;
+
+    #[test]
+    fn counts_binary_cas_storage_rows() {
+        let backend = InMemoryBackend::new();
+        let storage = StorageContext::new(backend.clone());
+        let mut writes = storage.new_write_set();
+
+        let empty_hash = BlobHash::from_content(b"empty");
+        stage_manifest(
+            &mut writes,
+            empty_hash,
+            &BinaryCasManifest::Empty { size_bytes: 0 },
+        );
+
+        let single_hash = BlobHash::from_content(b"single blob");
+        let single_chunk_hash = BlobHash::from_content(b"single");
+        stage_manifest(
+            &mut writes,
+            single_hash,
+            &BinaryCasManifest::SingleChunk {
+                size_bytes: 6,
+                chunk_hash: single_chunk_hash.into_bytes(),
+            },
+        );
+        stage_chunk(
+            &mut writes,
+            single_chunk_hash,
+            BinaryChunkCodec::Raw,
+            6,
+            b"single",
+        );
+
+        let chunked_hash = BlobHash::from_content(b"chunked blob");
+        stage_manifest(
+            &mut writes,
+            chunked_hash,
+            &BinaryCasManifest::Chunked {
+                size_bytes: 8,
+                chunk_count: 2,
+            },
+        );
+        for (index, payload) in [b"left".as_slice(), b"side".as_slice()]
+            .into_iter()
+            .enumerate()
+        {
+            let chunk_hash = BlobHash::from_content(payload);
+            stage_manifest_chunk(
+                &mut writes,
+                chunked_hash,
+                index as u64,
+                &KvBlobManifestChunk {
+                    chunk_hash: chunk_hash.into_bytes(),
+                    chunk_size: payload.len() as u64,
+                },
+            );
+            stage_chunk(
+                &mut writes,
+                chunk_hash,
+                BinaryChunkCodec::Raw,
+                payload.len() as u64,
+                payload,
+            );
+        }
+
+        storage
+            .commit_write_set(writes, WriteOptions::default())
+            .expect("CAS test rows should commit");
+        let read = backend
+            .begin_read(ReadOptions::default())
+            .expect("CAS test read should open");
+
+        let stats = collect_binary_cas_storage_stats(&read).expect("stats should collect");
+        assert_eq!(
+            stats,
+            BinaryCasStorageStats {
+                manifest_rows: 3,
+                empty_blob_rows: 1,
+                single_chunk_blob_rows: 1,
+                chunked_blob_rows: 1,
+                manifest_chunk_rows: 2,
+                chunk_rows: 3,
+                total_chunk_refs: 3,
+                logical_blob_bytes: 14,
+            }
+        );
+    }
+}

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -1,13 +1,13 @@
 use std::ops::Bound;
 
 use crate::LixError;
-use crate::backend::{
-    BackendError, BackendRead, CoreProjection, KeyRange, KeyRef, ProjectedValueRef, ScanOptions,
-    SpaceId,
-};
 use crate::binary_cas::codec::{BinaryCasManifest, decode_binary_cas_manifest};
 use crate::binary_cas::kv::{
     BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE, BINARY_CAS_MANIFEST_SPACE,
+};
+use crate::storage::{
+    StorageBackendError, StorageBackendRead, StorageCoreProjection, StorageKeyRange, StorageKeyRef,
+    StorageProjectedValueRef, StorageRead, StorageScanOptions, StorageSpaceId,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -26,60 +26,62 @@ pub(crate) fn collect_binary_cas_storage_stats<R>(
     read: &R,
 ) -> Result<BinaryCasStorageStats, LixError>
 where
-    R: BackendRead + ?Sized,
+    R: StorageRead + ?Sized,
 {
-    let mut stats = BinaryCasStorageStats::default();
-    stats.manifest_rows = scan_space(
-        read,
-        BINARY_CAS_MANIFEST_SPACE.id,
-        CoreProjection::FullValue,
-        |value| {
-            let ProjectedValueRef::FullValue(bytes) = value else {
-                return Err(BackendError::Corruption(
-                    "binary CAS manifest scan returned key-only value".to_string(),
-                ));
-            };
-            let manifest = decode_binary_cas_manifest(bytes).map_err(|error| {
-                BackendError::Corruption(format!("invalid binary CAS manifest: {error}"))
-            })?;
-            stats.logical_blob_bytes += manifest.size_bytes();
-            match manifest {
-                BinaryCasManifest::Empty { .. } => stats.empty_blob_rows += 1,
-                BinaryCasManifest::SingleChunk { .. } => {
-                    stats.single_chunk_blob_rows += 1;
-                    stats.total_chunk_refs += 1;
+    Ok(read.with_backend(|backend_read| {
+        let mut stats = BinaryCasStorageStats::default();
+        stats.manifest_rows = scan_space(
+            backend_read,
+            BINARY_CAS_MANIFEST_SPACE.id,
+            StorageCoreProjection::FullValue,
+            |value| {
+                let StorageProjectedValueRef::FullValue(bytes) = value else {
+                    return Err(StorageBackendError::Corruption(
+                        "binary CAS manifest scan returned key-only value".to_string(),
+                    ));
+                };
+                let manifest = decode_binary_cas_manifest(bytes).map_err(|error| {
+                    StorageBackendError::Corruption(format!("invalid binary CAS manifest: {error}"))
+                })?;
+                stats.logical_blob_bytes += manifest.size_bytes();
+                match manifest {
+                    BinaryCasManifest::Empty { .. } => stats.empty_blob_rows += 1,
+                    BinaryCasManifest::SingleChunk { .. } => {
+                        stats.single_chunk_blob_rows += 1;
+                        stats.total_chunk_refs += 1;
+                    }
+                    BinaryCasManifest::Chunked { chunk_count, .. } => {
+                        stats.chunked_blob_rows += 1;
+                        stats.total_chunk_refs += u64::from(chunk_count);
+                    }
                 }
-                BinaryCasManifest::Chunked { chunk_count, .. } => {
-                    stats.chunked_blob_rows += 1;
-                    stats.total_chunk_refs += u64::from(chunk_count);
-                }
-            }
-            Ok(())
-        },
-    )?;
-    stats.manifest_chunk_rows = count_space(read, BINARY_CAS_MANIFEST_CHUNK_SPACE.id)?;
-    stats.chunk_rows = count_space(read, BINARY_CAS_CHUNK_SPACE.id)?;
-    Ok(stats)
+                Ok(())
+            },
+        )?;
+        stats.manifest_chunk_rows = count_space(backend_read, BINARY_CAS_MANIFEST_CHUNK_SPACE.id)?;
+        stats.chunk_rows = count_space(backend_read, BINARY_CAS_CHUNK_SPACE.id)?;
+        Ok(stats)
+    })?)
 }
 
-fn count_space<R>(read: &R, space: SpaceId) -> Result<u64, LixError>
+fn count_space<R>(read: &R, space: StorageSpaceId) -> Result<u64, StorageBackendError>
 where
-    R: BackendRead + ?Sized,
+    R: StorageBackendRead + ?Sized,
 {
-    scan_space(read, space, CoreProjection::KeyOnly, |_| Ok(()))
+    scan_space(read, space, StorageCoreProjection::KeyOnly, |_| Ok(()))
 }
 
 fn scan_space<R, F>(
     read: &R,
-    space: SpaceId,
-    projection: CoreProjection,
+    space: StorageSpaceId,
+    projection: StorageCoreProjection,
     mut visit: F,
-) -> Result<u64, LixError>
+) -> Result<u64, StorageBackendError>
 where
-    R: BackendRead + ?Sized,
-    F: for<'a> FnMut(ProjectedValueRef<'a>) -> Result<(), BackendError>,
+    R: StorageBackendRead + ?Sized,
+    F: for<'a> FnMut(StorageProjectedValueRef<'a>) -> Result<(), StorageBackendError>,
 {
-    let range = KeyRange {
+    let range = StorageKeyRange {
         lower: Bound::Unbounded,
         upper: Bound::Unbounded,
     };
@@ -92,12 +94,12 @@ where
         let result = read.scan(
             space,
             range.clone(),
-            ScanOptions {
+            StorageScanOptions {
                 projection,
                 limit_rows: 4096,
                 resume_after: resume_after.as_ref(),
             },
-            &mut |key: KeyRef<'_>, value: ProjectedValueRef<'_>| {
+            &mut |key: StorageKeyRef<'_>, value: StorageProjectedValueRef<'_>| {
                 emitted += 1;
                 last_key = Some(key.to_owned_key());
                 visit(value)
@@ -116,17 +118,18 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::{Backend, InMemoryBackend, ReadOptions, WriteOptions};
     use crate::binary_cas::BlobHash;
     use crate::binary_cas::codec::BinaryChunkCodec;
     use crate::binary_cas::kv::{
         KvBlobManifestChunk, stage_chunk, stage_manifest, stage_manifest_chunk,
     };
-    use crate::storage::StorageContext;
+    use crate::storage::{
+        InMemoryStorageBackend, StorageContext, StorageReadOptions, StorageWriteOptions,
+    };
 
     #[test]
     fn counts_binary_cas_storage_rows() {
-        let backend = InMemoryBackend::new();
+        let backend = InMemoryStorageBackend::new();
         let storage = StorageContext::new(backend.clone());
         let mut writes = storage.new_write_set();
 
@@ -188,10 +191,10 @@ mod tests {
         }
 
         storage
-            .commit_write_set(writes, WriteOptions::default())
+            .commit_write_set(writes, StorageWriteOptions::default())
             .expect("CAS test rows should commit");
-        let read = backend
-            .begin_read(ReadOptions::default())
+        let read = storage
+            .begin_read(StorageReadOptions::default())
             .expect("CAS test read should open");
 
         let stats = collect_binary_cas_storage_stats(&read).expect("stats should collect");

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -60,7 +60,7 @@ where
     /// Creates a clean DataFusion-first engine over an initialized backend.
     ///
     /// SessionContext, execution, and transaction overlays are layered below the
-    /// instance instead of being hidden behind a legacy boot path.
+    /// instance instead of being hidden behind initialization side effects.
     ///
     /// Deterministic runtime sequencing is serialized within this Engine
     /// context. Independently constructing multiple Engine values over the same

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -76,10 +76,6 @@ pub use backend::{
     ScanOptions, ScanResult, ScanVisitor, SnapshotRef, SpaceId, StoredValue, Value as BackendValue,
     WriteOptions, WriteStats, get_many as backend_get_many,
 };
-pub use binary_cas::{
-    BinaryCasStorageStats, BinaryCasWriteMetrics, binary_cas_write_metrics_snapshot,
-    collect_binary_cas_storage_stats, reset_binary_cas_write_metrics,
-};
 pub use common::LixError;
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
 pub use common::{LixNotice, NullableKeyFilter, SqlQueryResult, Value};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -76,7 +76,10 @@ pub use backend::{
     ScanOptions, ScanResult, ScanVisitor, SnapshotRef, SpaceId, StoredValue, Value as BackendValue,
     WriteOptions, WriteStats, get_many as backend_get_many,
 };
-pub use binary_cas::{BinaryCasStorageStats, collect_binary_cas_storage_stats};
+pub use binary_cas::{
+    BinaryCasStorageStats, BinaryCasWriteMetrics, binary_cas_write_metrics_snapshot,
+    collect_binary_cas_storage_stats, reset_binary_cas_write_metrics,
+};
 pub use common::LixError;
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
 pub use common::{LixNotice, NullableKeyFilter, SqlQueryResult, Value};

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -76,6 +76,7 @@ pub use backend::{
     ScanOptions, ScanResult, ScanVisitor, SnapshotRef, SpaceId, StoredValue, Value as BackendValue,
     WriteOptions, WriteStats, get_many as backend_get_many,
 };
+pub use binary_cas::{BinaryCasStorageStats, collect_binary_cas_storage_stats};
 pub use common::LixError;
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
 pub use common::{LixNotice, NullableKeyFilter, SqlQueryResult, Value};

--- a/packages/engine/src/storage/mod.rs
+++ b/packages/engine/src/storage/mod.rs
@@ -31,7 +31,8 @@ pub use crate::backend::{
     BackendError as StorageBackendError, CoreProjection as StorageCoreProjection,
     GetOptions as StorageGetOptions, InMemoryBackend as InMemoryStorageBackend,
     InMemoryRead as InMemoryStorageRead, InMemoryWrite as InMemoryStorageWrite, Key as StorageKey,
-    KeyRange as StorageKeyRange, Prefix as StoragePrefix, ProjectedValue as StorageProjectedValue,
+    KeyRange as StorageKeyRange, KeyRef as StorageKeyRef, Prefix as StoragePrefix,
+    ProjectedValue as StorageProjectedValue, ProjectedValueRef as StorageProjectedValueRef,
     ReadOptions as StorageReadOptions, ScanOptions as StorageScanOptions,
     SpaceId as StorageSpaceId, StoredValue as StorageValue, WriteOptions as StorageWriteOptions,
 };

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -45,7 +45,7 @@ pub(crate) async fn commit_prepared_writes(
     let mut json_writer = JsonStoreContext::new().writer();
 
     if !prepared_writes.file_data_writes.is_empty() {
-        let mut blob_writer = binary_cas.writer(&mut writes);
+        let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
         for write in &prepared_writes.file_data_writes {
             blob_writer.stage_payload(write.payload())?;
         }

--- a/packages/fs-backend/Cargo.toml
+++ b/packages/fs-backend/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "lix_fs_backend"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = []
+rocksdb = ["dep:bytes", "dep:rocksdb", "dep:tempfile"]
+
+[dependencies]
+lix_engine = { workspace = true }
+
+bytes = { version = "1", optional = true }
+rocksdb = { version = "0.22", default-features = false, optional = true }
+tempfile = { version = "3", optional = true }
+
+[dev-dependencies]
+bytes = "1"
+tempfile = "3"

--- a/packages/fs-backend/Cargo.toml
+++ b/packages/fs-backend/Cargo.toml
@@ -24,7 +24,7 @@ rocksdb = ["dep:bytes", "dep:rocksdb", "dep:tempfile"]
 lix_engine = { workspace = true }
 
 bytes = { version = "1", optional = true }
-rocksdb = { version = "0.22", default-features = false, optional = true }
+rocksdb = { version = "0.24", default-features = false, optional = true }
 tempfile = { version = "3", optional = true }
 
 [dev-dependencies]

--- a/packages/fs-backend/Cargo.toml
+++ b/packages/fs-backend/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "lix_fs_backend"
 version.workspace = true
+publish = false
 authors.workspace = true
 edition.workspace = true
 description.workspace = true

--- a/packages/fs-backend/src/lib.rs
+++ b/packages/fs-backend/src/lib.rs
@@ -1,0 +1,13 @@
+//! Filesystem-specialized persistence backends for Lix.
+//!
+//! This crate intentionally owns filesystem backend experiments directly
+//! instead of routing RocksDB through the generic `lix_backends` crate.
+
+#[cfg(feature = "rocksdb")]
+mod rocksdb;
+
+#[cfg(feature = "rocksdb")]
+pub use rocksdb::{
+    RocksDbBlobOptions, RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions,
+    RocksDbFilesystemRead, RocksDbFilesystemWrite,
+};

--- a/packages/fs-backend/src/lib.rs
+++ b/packages/fs-backend/src/lib.rs
@@ -1,13 +1,10 @@
 //! Filesystem-specialized persistence backends for Lix.
 //!
-//! This crate intentionally owns filesystem backend experiments directly
-//! instead of routing RocksDB through the generic `lix_backends` crate.
+//! This internal crate owns the RocksDB implementation behind
+//! `lix_sdk::FsBackend`.
 
 #[cfg(feature = "rocksdb")]
 mod rocksdb;
 
 #[cfg(feature = "rocksdb")]
-pub use rocksdb::{
-    RocksDbBlobOptions, RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions,
-    RocksDbFilesystemRead, RocksDbFilesystemWrite,
-};
+pub use rocksdb::{RocksDbFilesystemBackend, RocksDbFilesystemRead, RocksDbFilesystemWrite};

--- a/packages/fs-backend/src/rocksdb.rs
+++ b/packages/fs-backend/src/rocksdb.rs
@@ -12,6 +12,10 @@ use lix_engine::backend::{
 use rocksdb::Snapshot;
 use rocksdb::{DB, Direction, IteratorMode, Options, WriteBatch};
 
+const DEFAULT_BLOB_MIN_SIZE: u64 = 32 * 1024;
+const DEFAULT_BLOB_FILE_SIZE: u64 = 256 * 1024 * 1024;
+const DEFAULT_BLOB_GC_AGE_CUTOFF: f64 = 0.25;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RocksDbFilesystemBackendOptions {
     pub path: PathBuf,
@@ -68,22 +72,40 @@ impl RocksDbFilesystemBackendOptions {
         }
     }
 
+    pub fn default_blob(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            blob: RocksDbBlobOptions::default(),
+        }
+    }
+
     pub fn blob(path: impl Into<PathBuf>, min_blob_size: u64) -> Self {
         Self {
             path: path.into(),
             blob: RocksDbBlobOptions::Enabled {
                 min_blob_size,
-                blob_file_size: 256 * 1024 * 1024,
+                blob_file_size: DEFAULT_BLOB_FILE_SIZE,
                 enable_gc: true,
-                gc_age_cutoff: 0.25,
+                gc_age_cutoff: DEFAULT_BLOB_GC_AGE_CUTOFF,
             },
+        }
+    }
+}
+
+impl Default for RocksDbBlobOptions {
+    fn default() -> Self {
+        Self::Enabled {
+            min_blob_size: DEFAULT_BLOB_MIN_SIZE,
+            blob_file_size: DEFAULT_BLOB_FILE_SIZE,
+            enable_gc: true,
+            gc_age_cutoff: DEFAULT_BLOB_GC_AGE_CUTOFF,
         }
     }
 }
 
 impl RocksDbFilesystemBackend {
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, BackendError> {
-        Self::open_with_options(RocksDbFilesystemBackendOptions::plain(path))
+        Self::open_with_options(RocksDbFilesystemBackendOptions::default_blob(path))
     }
 
     pub fn open_with_options(
@@ -748,7 +770,8 @@ mod tests {
     fn same_process_open_rejects_different_blob_options_for_open_database() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = temp_dir.path().join("fs.rocksdb");
-        let _plain = RocksDbFilesystemBackend::open(&path).expect("open plain backend");
+        let _default_blob =
+            RocksDbFilesystemBackend::open(&path).expect("open default blob backend");
 
         let error = match RocksDbFilesystemBackend::open_with_options(
             RocksDbFilesystemBackendOptions::blob(&path, 16),

--- a/packages/fs-backend/src/rocksdb.rs
+++ b/packages/fs-backend/src/rocksdb.rs
@@ -91,6 +91,12 @@ impl RocksDbFilesystemBackend {
     pub fn flush(&self) -> Result<(), BackendError> {
         self.db.flush().map_err(rocksdb_error)
     }
+
+    pub fn compact_all(&self) -> Result<(), BackendError> {
+        self.flush()?;
+        self.db.compact_range::<&[u8], &[u8]>(None, None);
+        self.flush()
+    }
 }
 
 impl Backend for RocksDbFilesystemBackend {

--- a/packages/fs-backend/src/rocksdb.rs
+++ b/packages/fs-backend/src/rocksdb.rs
@@ -16,23 +16,6 @@ const DEFAULT_BLOB_MIN_SIZE: u64 = 32 * 1024;
 const DEFAULT_BLOB_FILE_SIZE: u64 = 256 * 1024 * 1024;
 const DEFAULT_BLOB_GC_AGE_CUTOFF: f64 = 0.25;
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct RocksDbFilesystemBackendOptions {
-    pub path: PathBuf,
-    pub blob: RocksDbBlobOptions,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum RocksDbBlobOptions {
-    Disabled,
-    Enabled {
-        min_blob_size: u64,
-        blob_file_size: u64,
-        enable_gc: bool,
-        gc_age_cutoff: f64,
-    },
-}
-
 #[derive(Clone)]
 #[allow(missing_debug_implementations)]
 pub struct RocksDbFilesystemBackend {
@@ -41,8 +24,6 @@ pub struct RocksDbFilesystemBackend {
 
 #[allow(missing_debug_implementations)]
 struct RocksDbFilesystemInner {
-    path: PathBuf,
-    blob: RocksDbBlobOptions,
     db: DB,
     write_gate: WriteGate,
 }
@@ -64,70 +45,16 @@ pub struct RocksDbFilesystemWrite {
 static OPEN_DATABASES: OnceLock<Mutex<HashMap<PathBuf, Weak<RocksDbFilesystemInner>>>> =
     OnceLock::new();
 
-impl RocksDbFilesystemBackendOptions {
-    pub fn plain(path: impl Into<PathBuf>) -> Self {
-        Self {
-            path: path.into(),
-            blob: RocksDbBlobOptions::Disabled,
-        }
-    }
-
-    pub fn default_blob(path: impl Into<PathBuf>) -> Self {
-        Self {
-            path: path.into(),
-            blob: RocksDbBlobOptions::default(),
-        }
-    }
-
-    pub fn blob(path: impl Into<PathBuf>, min_blob_size: u64) -> Self {
-        Self {
-            path: path.into(),
-            blob: RocksDbBlobOptions::Enabled {
-                min_blob_size,
-                blob_file_size: DEFAULT_BLOB_FILE_SIZE,
-                enable_gc: true,
-                gc_age_cutoff: DEFAULT_BLOB_GC_AGE_CUTOFF,
-            },
-        }
-    }
-}
-
-impl Default for RocksDbBlobOptions {
-    fn default() -> Self {
-        Self::Enabled {
-            min_blob_size: DEFAULT_BLOB_MIN_SIZE,
-            blob_file_size: DEFAULT_BLOB_FILE_SIZE,
-            enable_gc: true,
-            gc_age_cutoff: DEFAULT_BLOB_GC_AGE_CUTOFF,
-        }
-    }
-}
-
 impl RocksDbFilesystemBackend {
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, BackendError> {
-        Self::open_with_options(RocksDbFilesystemBackendOptions::default_blob(path))
-    }
-
-    pub fn open_with_options(
-        options: RocksDbFilesystemBackendOptions,
-    ) -> Result<Self, BackendError> {
         Ok(Self {
-            inner: open_shared_rocksdb(options)?,
+            inner: open_shared_rocksdb(path.into())?,
         })
     }
 
-    pub fn path(&self) -> &Path {
-        &self.inner.path
-    }
-
-    pub fn flush(&self) -> Result<(), BackendError> {
+    #[cfg(test)]
+    fn flush(&self) -> Result<(), BackendError> {
         self.inner.db.flush().map_err(rocksdb_error)
-    }
-
-    pub fn compact_all(&self) -> Result<(), BackendError> {
-        self.flush()?;
-        self.inner.db.compact_range::<&[u8], &[u8]>(None, None);
-        self.flush()
     }
 }
 
@@ -323,10 +250,8 @@ impl BackendWrite for RocksDbFilesystemWrite {
     }
 }
 
-fn open_shared_rocksdb(
-    options: RocksDbFilesystemBackendOptions,
-) -> Result<Arc<RocksDbFilesystemInner>, BackendError> {
-    let path = registry_key(&options.path)?;
+fn open_shared_rocksdb(path: PathBuf) -> Result<Arc<RocksDbFilesystemInner>, BackendError> {
+    let path = registry_key(&path)?;
     let registry = OPEN_DATABASES.get_or_init(|| Mutex::new(HashMap::new()));
     let mut open_databases = registry
         .lock()
@@ -334,24 +259,12 @@ fn open_shared_rocksdb(
 
     if let Some(existing) = open_databases.get(&path) {
         if let Some(inner) = existing.upgrade() {
-            if inner.blob != options.blob {
-                return Err(BackendError::Io(format!(
-                    "rocksdb filesystem backend at {} is already open with different options",
-                    path.display()
-                )));
-            }
             return Ok(inner);
         }
     }
 
-    let open_options = RocksDbFilesystemBackendOptions {
-        path: path.clone(),
-        blob: options.blob,
-    };
-    let db = open_rocksdb(&open_options)?;
+    let db = open_rocksdb(&path)?;
     let inner = Arc::new(RocksDbFilesystemInner {
-        path: path.clone(),
-        blob: options.blob,
         db,
         write_gate: WriteGate::new(),
     });
@@ -398,28 +311,17 @@ fn registry_key(path: &Path) -> Result<PathBuf, BackendError> {
     Ok(canonical_parent.join(file_name))
 }
 
-fn open_rocksdb(options: &RocksDbFilesystemBackendOptions) -> Result<DB, BackendError> {
+fn open_rocksdb(path: &Path) -> Result<DB, BackendError> {
     let mut db_options = Options::default();
     db_options.create_if_missing(true);
     db_options.set_use_fsync(false);
     db_options.set_write_buffer_size(64 * 1024 * 1024);
-    match options.blob {
-        RocksDbBlobOptions::Disabled => {}
-        RocksDbBlobOptions::Enabled {
-            min_blob_size,
-            blob_file_size,
-            enable_gc,
-            gc_age_cutoff,
-        } => {
-            db_options.set_enable_blob_files(true);
-            db_options.set_min_blob_size(min_blob_size);
-            db_options.set_blob_file_size(blob_file_size);
-            db_options.set_enable_blob_gc(enable_gc);
-            db_options.set_blob_gc_age_cutoff(gc_age_cutoff);
-        }
-    }
-    DB::open(&db_options, &options.path)
-        .map_err(|error| rocksdb_open_error(error, options.path.as_path()))
+    db_options.set_enable_blob_files(true);
+    db_options.set_min_blob_size(DEFAULT_BLOB_MIN_SIZE);
+    db_options.set_blob_file_size(DEFAULT_BLOB_FILE_SIZE);
+    db_options.set_enable_blob_gc(true);
+    db_options.set_blob_gc_age_cutoff(DEFAULT_BLOB_GC_AGE_CUTOFF);
+    DB::open(&db_options, path).map_err(|error| rocksdb_open_error(error, path))
 }
 
 fn physical_key(space: SpaceId, key: &Key) -> Key {
@@ -653,15 +555,74 @@ mod tests {
         Backend, BackendWrite, Key, PutBatch, PutEntry, ReadOptions, SpaceId, StoredValue,
         WriteOptions, get_many,
     };
+    use lix_engine::{BackendFactory, BackendFixture, BackendTestConfig, run_backend_conformance};
     use std::env;
     use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc;
     use std::time::Duration;
+    use tempfile::TempDir;
 
-    use super::{RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions};
+    use super::RocksDbFilesystemBackend;
+
+    #[derive(Debug)]
+    struct RocksDbFilesystemBackendFactory {
+        temp_dir: TempDir,
+        next_database_id: AtomicU64,
+    }
+
+    #[derive(Clone, Debug)]
+    struct RocksDbFilesystemBackendFixture {
+        path: std::path::PathBuf,
+    }
+
+    impl RocksDbFilesystemBackendFactory {
+        fn new() -> Self {
+            Self {
+                temp_dir: tempfile::tempdir().expect("create rocksdb fs backend temp dir"),
+                next_database_id: AtomicU64::new(0),
+            }
+        }
+    }
+
+    impl BackendFactory for RocksDbFilesystemBackendFactory {
+        type Backend = RocksDbFilesystemBackend;
+        type Fixture = RocksDbFilesystemBackendFixture;
+
+        fn create_fixture(&self) -> Self::Fixture {
+            let database_id = self.next_database_id.fetch_add(1, Ordering::Relaxed);
+            RocksDbFilesystemBackendFixture {
+                path: self
+                    .temp_dir
+                    .path()
+                    .join(format!("fs-backend-{database_id}.rocksdb")),
+            }
+        }
+
+        fn config(&self) -> BackendTestConfig {
+            BackendTestConfig {
+                supports_concurrent_writers: false,
+                ..BackendTestConfig::default()
+            }
+        }
+    }
+
+    impl BackendFixture for RocksDbFilesystemBackendFixture {
+        type Backend = RocksDbFilesystemBackend;
+
+        fn open(&self) -> Self::Backend {
+            RocksDbFilesystemBackend::open(&self.path).expect("open rocksdb fs backend")
+        }
+    }
 
     #[test]
-    fn plain_backend_roundtrips_point_read_after_reopen() {
+    fn passes_backend_conformance() {
+        let report = run_backend_conformance(&RocksDbFilesystemBackendFactory::new());
+        report.assert_no_failures();
+    }
+
+    #[test]
+    fn blobdb_backend_roundtrips_point_read_after_reopen() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = temp_dir.path().join("fs.rocksdb");
         let key = Key(Bytes::from_static(b"file-chunk"));
@@ -767,24 +728,22 @@ mod tests {
     }
 
     #[test]
-    fn same_process_open_rejects_different_blob_options_for_open_database() {
+    fn writes_large_values_to_blob_files() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = temp_dir.path().join("fs.rocksdb");
-        let _default_blob =
-            RocksDbFilesystemBackend::open(&path).expect("open default blob backend");
-
-        let error = match RocksDbFilesystemBackend::open_with_options(
-            RocksDbFilesystemBackendOptions::blob(&path, 16),
-        ) {
-            Ok(_) => panic!("second open with different options should fail"),
-            Err(error) => error,
-        };
+        let backend = RocksDbFilesystemBackend::open(&path).expect("open blob backend");
+        put_one(
+            &backend,
+            SpaceId(0x0005_0003),
+            Key(Bytes::from_static(b"large-value")),
+            Bytes::from(vec![7; 128 * 1024]),
+        );
+        backend.flush().expect("flush blob backend");
+        drop(backend);
 
         assert!(
-            error
-                .to_string()
-                .contains("already open with different options"),
-            "error should explain option mismatch: {error}"
+            rocksdb_blob_file_count(&path) > 0,
+            "large values should be stored in RocksDB blob files"
         );
     }
 
@@ -831,15 +790,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn blob_options_open() {
-        let temp_dir = tempfile::tempdir().expect("create temp dir");
-        let options = RocksDbFilesystemBackendOptions::blob(temp_dir.path().join("fs.rocksdb"), 16);
-        let backend =
-            RocksDbFilesystemBackend::open_with_options(options).expect("open blob backend");
-        backend.flush().expect("flush blob backend");
-    }
-
     fn put_one(backend: &RocksDbFilesystemBackend, space: SpaceId, key: Key, value: Bytes) {
         let mut write = backend
             .begin_write(WriteOptions::default())
@@ -867,5 +817,18 @@ mod tests {
             lix_engine::backend::ProjectedValue::FullValue(bytes) => bytes,
             lix_engine::backend::ProjectedValue::KeyOnly => Bytes::new(),
         })
+    }
+
+    fn rocksdb_blob_file_count(path: &std::path::Path) -> usize {
+        std::fs::read_dir(path)
+            .expect("read rocksdb directory")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .path()
+                    .extension()
+                    .is_some_and(|extension| extension == "blob")
+            })
+            .count()
     }
 }

--- a/packages/fs-backend/src/rocksdb.rs
+++ b/packages/fs-backend/src/rocksdb.rs
@@ -552,8 +552,8 @@ impl Drop for WriterPermit {
 mod tests {
     use bytes::Bytes;
     use lix_engine::backend::{
-        Backend, BackendWrite, Key, PutBatch, PutEntry, ReadOptions, SpaceId, StoredValue,
-        WriteOptions, get_many,
+        Backend, BackendWrite, GetOptions, Key, PutBatch, PutEntry, ReadOptions, SpaceId,
+        StoredValue, WriteOptions, get_many,
     };
     use lix_engine::{BackendFactory, BackendFixture, BackendTestConfig, run_backend_conformance};
     use std::env;
@@ -654,8 +654,8 @@ mod tests {
         let read = backend
             .begin_read(ReadOptions::default())
             .expect("begin read");
-        let result =
-            get_many(&read, SpaceId(0x0005_0003), &[key], Default::default()).expect("read chunk");
+        let result = get_many(&read, SpaceId(0x0005_0003), &[key], GetOptions::default())
+            .expect("read chunk");
         assert_eq!(result.values.len(), 1);
         assert_eq!(
             result.values[0].as_ref().map(|value| value.as_ref()),
@@ -678,13 +678,13 @@ mod tests {
 
         put_one(&backend_a, space, key_a.clone(), Bytes::from_static(b"a"));
         assert_eq!(
-            read_one(&backend_b, space, key_a.clone()),
+            read_one(&backend_b, space, key_a),
             Some(Bytes::from_static(b"a"))
         );
 
         put_one(&backend_b, space, key_b.clone(), Bytes::from_static(b"b"));
         assert_eq!(
-            read_one(&backend_a, space, key_b.clone()),
+            read_one(&backend_a, space, key_b),
             Some(Bytes::from_static(b"b"))
         );
     }
@@ -777,9 +777,8 @@ mod tests {
             return;
         };
 
-        let error = match RocksDbFilesystemBackend::open(path) {
-            Ok(_) => panic!("child process should not open RocksDB while parent holds the DB lock"),
-            Err(error) => error,
+        let Err(error) = RocksDbFilesystemBackend::open(path) else {
+            panic!("child process should not open RocksDB while parent holds the DB lock");
         };
 
         assert!(
@@ -812,7 +811,7 @@ mod tests {
         let read = backend
             .begin_read(ReadOptions::default())
             .expect("begin read");
-        let result = get_many(&read, space, &[key], Default::default()).expect("read one row");
+        let result = get_many(&read, space, &[key], GetOptions::default()).expect("read one row");
         result.values[0].clone().map(|value| match value {
             lix_engine::backend::ProjectedValue::FullValue(bytes) => bytes,
             lix_engine::backend::ProjectedValue::KeyOnly => Bytes::new(),

--- a/packages/fs-backend/src/rocksdb.rs
+++ b/packages/fs-backend/src/rocksdb.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 
 use bytes::Bytes;
 use lix_engine::backend::{
@@ -31,8 +32,15 @@ pub enum RocksDbBlobOptions {
 #[derive(Clone)]
 #[allow(missing_debug_implementations)]
 pub struct RocksDbFilesystemBackend {
+    inner: Arc<RocksDbFilesystemInner>,
+}
+
+#[allow(missing_debug_implementations)]
+struct RocksDbFilesystemInner {
     path: PathBuf,
-    db: Arc<DB>,
+    blob: RocksDbBlobOptions,
+    db: DB,
+    write_gate: WriteGate,
 }
 
 #[allow(missing_debug_implementations)]
@@ -42,11 +50,15 @@ pub struct RocksDbFilesystemRead<'a> {
 
 #[allow(missing_debug_implementations)]
 pub struct RocksDbFilesystemWrite {
-    db: Arc<DB>,
+    inner: Arc<RocksDbFilesystemInner>,
+    _writer_permit: WriterPermit,
     batch: WriteBatch,
     staged_put_keys: Vec<Key>,
     stats: WriteStats,
 }
+
+static OPEN_DATABASES: OnceLock<Mutex<HashMap<PathBuf, Weak<RocksDbFilesystemInner>>>> =
+    OnceLock::new();
 
 impl RocksDbFilesystemBackendOptions {
     pub fn plain(path: impl Into<PathBuf>) -> Self {
@@ -77,24 +89,22 @@ impl RocksDbFilesystemBackend {
     pub fn open_with_options(
         options: RocksDbFilesystemBackendOptions,
     ) -> Result<Self, BackendError> {
-        let db = Arc::new(open_rocksdb(&options)?);
         Ok(Self {
-            path: options.path,
-            db,
+            inner: open_shared_rocksdb(options)?,
         })
     }
 
     pub fn path(&self) -> &Path {
-        &self.path
+        &self.inner.path
     }
 
     pub fn flush(&self) -> Result<(), BackendError> {
-        self.db.flush().map_err(rocksdb_error)
+        self.inner.db.flush().map_err(rocksdb_error)
     }
 
     pub fn compact_all(&self) -> Result<(), BackendError> {
         self.flush()?;
-        self.db.compact_range::<&[u8], &[u8]>(None, None);
+        self.inner.db.compact_range::<&[u8], &[u8]>(None, None);
         self.flush()
     }
 }
@@ -112,13 +122,15 @@ impl Backend for RocksDbFilesystemBackend {
 
     fn begin_read(&self, _opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
         Ok(RocksDbFilesystemRead {
-            snapshot: self.db.snapshot(),
+            snapshot: self.inner.db.snapshot(),
         })
     }
 
     fn begin_write(&self, _opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+        let writer_permit = self.inner.write_gate.acquire()?;
         Ok(RocksDbFilesystemWrite {
-            db: Arc::clone(&self.db),
+            inner: Arc::clone(&self.inner),
+            _writer_permit: writer_permit,
             batch: WriteBatch::default(),
             staged_put_keys: Vec::new(),
             stats: WriteStats::default(),
@@ -249,6 +261,7 @@ impl BackendWrite for RocksDbFilesystemWrite {
         } else {
             let bounds = EncodedBounds::new(range, None);
             for item in self
+                .inner
                 .db
                 .iterator(IteratorMode::From(&bounds.lower_seek, Direction::Forward))
             {
@@ -276,7 +289,7 @@ impl BackendWrite for RocksDbFilesystemWrite {
     }
 
     fn commit(self) -> Result<CommitResult, BackendError> {
-        self.db.write(self.batch).map_err(rocksdb_error)?;
+        self.inner.db.write(self.batch).map_err(rocksdb_error)?;
         Ok(CommitResult {
             commit_id: None,
             stats: self.stats,
@@ -286,6 +299,81 @@ impl BackendWrite for RocksDbFilesystemWrite {
     fn rollback(self) -> Result<(), BackendError> {
         Ok(())
     }
+}
+
+fn open_shared_rocksdb(
+    options: RocksDbFilesystemBackendOptions,
+) -> Result<Arc<RocksDbFilesystemInner>, BackendError> {
+    let path = registry_key(&options.path)?;
+    let registry = OPEN_DATABASES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut open_databases = registry
+        .lock()
+        .map_err(|error| BackendError::Io(format!("rocksdb registry lock poisoned: {error}")))?;
+
+    if let Some(existing) = open_databases.get(&path) {
+        if let Some(inner) = existing.upgrade() {
+            if inner.blob != options.blob {
+                return Err(BackendError::Io(format!(
+                    "rocksdb filesystem backend at {} is already open with different options",
+                    path.display()
+                )));
+            }
+            return Ok(inner);
+        }
+    }
+
+    let open_options = RocksDbFilesystemBackendOptions {
+        path: path.clone(),
+        blob: options.blob,
+    };
+    let db = open_rocksdb(&open_options)?;
+    let inner = Arc::new(RocksDbFilesystemInner {
+        path: path.clone(),
+        blob: options.blob,
+        db,
+        write_gate: WriteGate::new(),
+    });
+    open_databases.insert(path, Arc::downgrade(&inner));
+    Ok(inner)
+}
+
+fn registry_key(path: &Path) -> Result<PathBuf, BackendError> {
+    let absolute_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| BackendError::Io(format!("read current directory: {error}")))?
+            .join(path)
+    };
+
+    if absolute_path.exists() {
+        return std::fs::canonicalize(&absolute_path).map_err(|error| {
+            BackendError::Io(format!(
+                "canonicalize rocksdb filesystem backend path {}: {error}",
+                absolute_path.display()
+            ))
+        });
+    }
+
+    let parent = absolute_path.parent().ok_or_else(|| {
+        BackendError::Io(format!(
+            "rocksdb filesystem backend path has no parent: {}",
+            absolute_path.display()
+        ))
+    })?;
+    let file_name = absolute_path.file_name().ok_or_else(|| {
+        BackendError::Io(format!(
+            "rocksdb filesystem backend path has no final component: {}",
+            absolute_path.display()
+        ))
+    })?;
+    let canonical_parent = std::fs::canonicalize(parent).map_err(|error| {
+        BackendError::Io(format!(
+            "canonicalize rocksdb filesystem backend parent {}: {error}",
+            parent.display()
+        ))
+    })?;
+    Ok(canonical_parent.join(file_name))
 }
 
 fn open_rocksdb(options: &RocksDbFilesystemBackendOptions) -> Result<DB, BackendError> {
@@ -308,7 +396,8 @@ fn open_rocksdb(options: &RocksDbFilesystemBackendOptions) -> Result<DB, Backend
             db_options.set_blob_gc_age_cutoff(gc_age_cutoff);
         }
     }
-    DB::open(&db_options, &options.path).map_err(rocksdb_error)
+    DB::open(&db_options, &options.path)
+        .map_err(|error| rocksdb_open_error(error, options.path.as_path()))
 }
 
 fn physical_key(space: SpaceId, key: &Key) -> Key {
@@ -471,6 +560,70 @@ fn rocksdb_error(error: rocksdb::Error) -> BackendError {
     BackendError::Io(format!("rocksdb filesystem backend: {error}"))
 }
 
+fn rocksdb_open_error(error: rocksdb::Error, path: &Path) -> BackendError {
+    let message = error.to_string();
+    if message.to_ascii_lowercase().contains("lock") {
+        BackendError::Io(format!(
+            "rocksdb filesystem backend at {} is already open by another process: {message}",
+            path.display()
+        ))
+    } else {
+        BackendError::Io(format!(
+            "rocksdb filesystem backend failed to open {}: {message}",
+            path.display()
+        ))
+    }
+}
+
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+struct WriteGate {
+    state: Arc<WriteGateState>,
+}
+
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+struct WriteGateState {
+    active: Mutex<bool>,
+    available: Condvar,
+}
+
+#[allow(missing_debug_implementations)]
+struct WriterPermit {
+    state: Arc<WriteGateState>,
+}
+
+impl WriteGate {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn acquire(&self) -> Result<WriterPermit, BackendError> {
+        let mut active =
+            self.state.active.lock().map_err(|error| {
+                BackendError::Io(format!("rocksdb writer gate poisoned: {error}"))
+            })?;
+        while *active {
+            active = self.state.available.wait(active).map_err(|error| {
+                BackendError::Io(format!("rocksdb writer gate poisoned: {error}"))
+            })?;
+        }
+        *active = true;
+        Ok(WriterPermit {
+            state: Arc::clone(&self.state),
+        })
+    }
+}
+
+impl Drop for WriterPermit {
+    fn drop(&mut self) {
+        if let Ok(mut active) = self.state.active.lock() {
+            *active = false;
+            self.state.available.notify_one();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
@@ -478,6 +631,10 @@ mod tests {
         Backend, BackendWrite, Key, PutBatch, PutEntry, ReadOptions, SpaceId, StoredValue,
         WriteOptions, get_many,
     };
+    use std::env;
+    use std::process::Command;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     use super::{RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions};
 
@@ -526,11 +683,166 @@ mod tests {
     }
 
     #[test]
+    fn same_process_open_reuses_shared_database_handle() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("fs.rocksdb");
+        let key_a = Key(Bytes::from_static(b"from-a"));
+        let key_b = Key(Bytes::from_static(b"from-b"));
+        let space = SpaceId(0x0005_0003);
+
+        let backend_a = RocksDbFilesystemBackend::open(&path).expect("open first backend");
+        let backend_b = RocksDbFilesystemBackend::open(&path).expect("open second backend");
+
+        put_one(&backend_a, space, key_a.clone(), Bytes::from_static(b"a"));
+        assert_eq!(
+            read_one(&backend_b, space, key_a.clone()),
+            Some(Bytes::from_static(b"a"))
+        );
+
+        put_one(&backend_b, space, key_b.clone(), Bytes::from_static(b"b"));
+        assert_eq!(
+            read_one(&backend_a, space, key_b.clone()),
+            Some(Bytes::from_static(b"b"))
+        );
+    }
+
+    #[test]
+    fn same_process_writes_are_serialized_across_reopened_handles() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("fs.rocksdb");
+        let backend_a = RocksDbFilesystemBackend::open(&path).expect("open first backend");
+        let backend_b = RocksDbFilesystemBackend::open(&path).expect("open second backend");
+        let write_a = backend_a
+            .begin_write(WriteOptions::default())
+            .expect("begin first write");
+
+        let (attempt_tx, attempt_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            attempt_tx.send(()).expect("signal write attempt");
+            let write_b = backend_b
+                .begin_write(WriteOptions::default())
+                .expect("begin second write");
+            acquired_tx.send(()).expect("signal write acquired");
+            write_b.rollback().expect("rollback second write");
+        });
+
+        attempt_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("second write should be attempted");
+        assert!(
+            acquired_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err(),
+            "second write should wait while the first write is active"
+        );
+
+        write_a.rollback().expect("rollback first write");
+        acquired_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("second write should acquire after first write closes");
+        waiter.join().expect("writer thread should finish");
+    }
+
+    #[test]
+    fn same_process_open_rejects_different_blob_options_for_open_database() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("fs.rocksdb");
+        let _plain = RocksDbFilesystemBackend::open(&path).expect("open plain backend");
+
+        let error = match RocksDbFilesystemBackend::open_with_options(
+            RocksDbFilesystemBackendOptions::blob(&path, 16),
+        ) {
+            Ok(_) => panic!("second open with different options should fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("already open with different options"),
+            "error should explain option mismatch: {error}"
+        );
+    }
+
+    #[test]
+    fn cross_process_open_reports_locked_database() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("fs.rocksdb");
+        let _backend = RocksDbFilesystemBackend::open(&path).expect("open parent backend");
+        let test_binary = env::current_exe().expect("current test binary path should resolve");
+
+        let output = Command::new(test_binary)
+            .arg("--exact")
+            .arg("rocksdb::tests::cross_process_open_helper")
+            .arg("--nocapture")
+            .env("LIX_ROCKSDB_LOCK_HELPER_PATH", &path)
+            .output()
+            .expect("spawn rocksdb lock helper");
+
+        assert!(
+            output.status.success(),
+            "helper should observe locked RocksDB database\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn cross_process_open_helper() {
+        let Some(path) = env::var_os("LIX_ROCKSDB_LOCK_HELPER_PATH") else {
+            return;
+        };
+
+        let error = match RocksDbFilesystemBackend::open(path) {
+            Ok(_) => panic!("child process should not open RocksDB while parent holds the DB lock"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("already open by another process"),
+            "lock error should be mapped clearly: {error}"
+        );
+    }
+
+    #[test]
     fn blob_options_open() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let options = RocksDbFilesystemBackendOptions::blob(temp_dir.path().join("fs.rocksdb"), 16);
         let backend =
             RocksDbFilesystemBackend::open_with_options(options).expect("open blob backend");
         backend.flush().expect("flush blob backend");
+    }
+
+    fn put_one(backend: &RocksDbFilesystemBackend, space: SpaceId, key: Key, value: Bytes) {
+        let mut write = backend
+            .begin_write(WriteOptions::default())
+            .expect("begin write");
+        write
+            .put_many(
+                space,
+                PutBatch {
+                    entries: vec![PutEntry {
+                        key,
+                        value: StoredValue { bytes: value },
+                    }],
+                },
+            )
+            .expect("put one row");
+        write.commit().expect("commit write");
+    }
+
+    fn read_one(backend: &RocksDbFilesystemBackend, space: SpaceId, key: Key) -> Option<Bytes> {
+        let read = backend
+            .begin_read(ReadOptions::default())
+            .expect("begin read");
+        let result = get_many(&read, space, &[key], Default::default()).expect("read one row");
+        result.values[0].clone().map(|value| match value {
+            lix_engine::backend::ProjectedValue::FullValue(bytes) => bytes,
+            lix_engine::backend::ProjectedValue::KeyOnly => Bytes::new(),
+        })
     }
 }

--- a/packages/fs-backend/src/rocksdb.rs
+++ b/packages/fs-backend/src/rocksdb.rs
@@ -1,0 +1,530 @@
+use std::ops::Bound;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use bytes::Bytes;
+use lix_engine::backend::{
+    Backend, BackendError, BackendRead, BackendWrite, CommitResult, CoreProjection, GetOptions,
+    Key, KeyRange, KeyRef, PointVisitor, ProjectedValueRef, PutBatch, ReadOptions, ScanOptions,
+    ScanResult, ScanVisitor, SpaceId, StoredValue, WriteOptions, WriteStats,
+};
+use rocksdb::Snapshot;
+use rocksdb::{DB, Direction, IteratorMode, Options, WriteBatch};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RocksDbFilesystemBackendOptions {
+    pub path: PathBuf,
+    pub blob: RocksDbBlobOptions,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RocksDbBlobOptions {
+    Disabled,
+    Enabled {
+        min_blob_size: u64,
+        blob_file_size: u64,
+        enable_gc: bool,
+        gc_age_cutoff: f64,
+    },
+}
+
+#[derive(Clone)]
+#[allow(missing_debug_implementations)]
+pub struct RocksDbFilesystemBackend {
+    path: PathBuf,
+    db: Arc<DB>,
+}
+
+#[allow(missing_debug_implementations)]
+pub struct RocksDbFilesystemRead<'a> {
+    snapshot: Snapshot<'a>,
+}
+
+#[allow(missing_debug_implementations)]
+pub struct RocksDbFilesystemWrite {
+    db: Arc<DB>,
+    batch: WriteBatch,
+    staged_put_keys: Vec<Key>,
+    stats: WriteStats,
+}
+
+impl RocksDbFilesystemBackendOptions {
+    pub fn plain(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            blob: RocksDbBlobOptions::Disabled,
+        }
+    }
+
+    pub fn blob(path: impl Into<PathBuf>, min_blob_size: u64) -> Self {
+        Self {
+            path: path.into(),
+            blob: RocksDbBlobOptions::Enabled {
+                min_blob_size,
+                blob_file_size: 256 * 1024 * 1024,
+                enable_gc: true,
+                gc_age_cutoff: 0.25,
+            },
+        }
+    }
+}
+
+impl RocksDbFilesystemBackend {
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, BackendError> {
+        Self::open_with_options(RocksDbFilesystemBackendOptions::plain(path))
+    }
+
+    pub fn open_with_options(
+        options: RocksDbFilesystemBackendOptions,
+    ) -> Result<Self, BackendError> {
+        let db = Arc::new(open_rocksdb(&options)?);
+        Ok(Self {
+            path: options.path,
+            db,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn flush(&self) -> Result<(), BackendError> {
+        self.db.flush().map_err(rocksdb_error)
+    }
+}
+
+impl Backend for RocksDbFilesystemBackend {
+    type Read<'a>
+        = RocksDbFilesystemRead<'a>
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = RocksDbFilesystemWrite
+    where
+        Self: 'a;
+
+    fn begin_read(&self, _opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
+        Ok(RocksDbFilesystemRead {
+            snapshot: self.db.snapshot(),
+        })
+    }
+
+    fn begin_write(&self, _opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
+        Ok(RocksDbFilesystemWrite {
+            db: Arc::clone(&self.db),
+            batch: WriteBatch::default(),
+            staged_put_keys: Vec::new(),
+            stats: WriteStats::default(),
+        })
+    }
+}
+
+impl BackendRead for RocksDbFilesystemRead<'_> {
+    fn visit_keys<V>(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<(), BackendError>
+    where
+        V: PointVisitor + ?Sized,
+    {
+        let physical_keys = keys
+            .iter()
+            .map(|key| physical_key(space, key))
+            .collect::<Vec<_>>();
+        for (index, (key, value)) in keys
+            .iter()
+            .zip(
+                self.snapshot
+                    .multi_get(physical_keys.iter().map(|key| key.0.as_ref())),
+            )
+            .enumerate()
+        {
+            let value = value.map_err(rocksdb_error)?;
+            visitor.visit(
+                index,
+                key,
+                value
+                    .as_ref()
+                    .map(|value| project_value_ref(value.as_ref(), opts.projection)),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn scan<V>(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<ScanResult, BackendError>
+    where
+        V: ScanVisitor + ?Sized,
+    {
+        if opts.limit_rows == 0 {
+            return Ok(ScanResult {
+                emitted: 0,
+                has_more: false,
+            });
+        }
+
+        let resume_after = opts.resume_after.map(|key| physical_key(space, key));
+        let bounds = EncodedBounds::new(physical_range(space, range), resume_after.as_ref());
+        let mut emitted = 0usize;
+
+        for item in self
+            .snapshot
+            .iterator(IteratorMode::From(&bounds.lower_seek, Direction::Forward))
+        {
+            let (encoded_key, value) = item.map_err(rocksdb_error)?;
+            let encoded_key = encoded_key.as_ref();
+            if !bounds.after_lower(encoded_key) {
+                continue;
+            }
+            if !bounds.before_upper(encoded_key) {
+                break;
+            }
+            if emitted == opts.limit_rows {
+                return Ok(ScanResult {
+                    emitted,
+                    has_more: true,
+                });
+            }
+            match opts.projection {
+                CoreProjection::KeyOnly => {
+                    visitor.visit(KeyRef(&encoded_key[4..]), ProjectedValueRef::KeyOnly)?;
+                }
+                CoreProjection::FullValue => visitor.visit(
+                    KeyRef(&encoded_key[4..]),
+                    ProjectedValueRef::FullValue(value.as_ref()),
+                )?,
+            }
+            emitted += 1;
+        }
+
+        Ok(ScanResult {
+            emitted,
+            has_more: false,
+        })
+    }
+}
+
+impl BackendWrite for RocksDbFilesystemWrite {
+    fn put_many(&mut self, space: SpaceId, entries: PutBatch) -> Result<(), BackendError> {
+        for entry in entries.entries {
+            let key = physical_key(space, &entry.key);
+            let value = stored_value_bytes(entry.value);
+            self.stats.put_entries += 1;
+            self.stats.written_bytes += value.len() as u64;
+            self.staged_put_keys.push(key.clone());
+            self.batch.put(key.0.as_ref(), value.as_ref());
+        }
+        self.stats.backend_calls += 1;
+        Ok(())
+    }
+
+    fn delete_many(&mut self, space: SpaceId, keys: &[Key]) -> Result<(), BackendError> {
+        for key in keys {
+            self.batch.delete(physical_key(space, key).0.as_ref());
+        }
+        self.stats.deleted_entries += keys.len() as u64;
+        self.stats.backend_calls += 1;
+        Ok(())
+    }
+
+    fn delete_range(&mut self, space: SpaceId, range: KeyRange) -> Result<(), BackendError> {
+        let range = physical_range(space, range);
+        if let Some((lower, upper)) = rocksdb_delete_range_bounds(&range) {
+            self.batch.delete_range(lower.as_slice(), upper.as_slice());
+        } else {
+            let bounds = EncodedBounds::new(range, None);
+            for item in self
+                .db
+                .iterator(IteratorMode::From(&bounds.lower_seek, Direction::Forward))
+            {
+                let (encoded_key, _value) = item.map_err(rocksdb_error)?;
+                let encoded_key = encoded_key.as_ref();
+                if !bounds.after_lower(encoded_key) {
+                    continue;
+                }
+                if !bounds.before_upper(encoded_key) {
+                    break;
+                }
+                self.batch.delete(encoded_key);
+            }
+
+            for key in &self.staged_put_keys {
+                if bounds.contains(key.0.as_ref()) {
+                    self.batch.delete(key.0.as_ref());
+                }
+            }
+        }
+
+        self.stats.deleted_ranges += 1;
+        self.stats.backend_calls += 1;
+        Ok(())
+    }
+
+    fn commit(self) -> Result<CommitResult, BackendError> {
+        self.db.write(self.batch).map_err(rocksdb_error)?;
+        Ok(CommitResult {
+            commit_id: None,
+            stats: self.stats,
+        })
+    }
+
+    fn rollback(self) -> Result<(), BackendError> {
+        Ok(())
+    }
+}
+
+fn open_rocksdb(options: &RocksDbFilesystemBackendOptions) -> Result<DB, BackendError> {
+    let mut db_options = Options::default();
+    db_options.create_if_missing(true);
+    db_options.set_use_fsync(false);
+    db_options.set_write_buffer_size(64 * 1024 * 1024);
+    match options.blob {
+        RocksDbBlobOptions::Disabled => {}
+        RocksDbBlobOptions::Enabled {
+            min_blob_size,
+            blob_file_size,
+            enable_gc,
+            gc_age_cutoff,
+        } => {
+            db_options.set_enable_blob_files(true);
+            db_options.set_min_blob_size(min_blob_size);
+            db_options.set_blob_file_size(blob_file_size);
+            db_options.set_enable_blob_gc(enable_gc);
+            db_options.set_blob_gc_age_cutoff(gc_age_cutoff);
+        }
+    }
+    DB::open(&db_options, &options.path).map_err(rocksdb_error)
+}
+
+fn physical_key(space: SpaceId, key: &Key) -> Key {
+    let mut bytes = Vec::with_capacity(4 + key.0.len());
+    bytes.extend_from_slice(&space.0.to_be_bytes());
+    bytes.extend_from_slice(&key.0);
+    Key(Bytes::from(bytes))
+}
+
+fn physical_range(space: SpaceId, range: KeyRange) -> KeyRange {
+    let map = |bound: Bound<Key>, unbounded: Bound<Key>| match bound {
+        Bound::Included(key) => Bound::Included(physical_key(space, &key)),
+        Bound::Excluded(key) => Bound::Excluded(physical_key(space, &key)),
+        Bound::Unbounded => unbounded,
+    };
+    KeyRange {
+        lower: map(
+            range.lower,
+            Bound::Included(Key(Bytes::copy_from_slice(&space.0.to_be_bytes()))),
+        ),
+        upper: map(
+            range.upper,
+            space.0.checked_add(1).map_or(Bound::Unbounded, |next| {
+                Bound::Excluded(Key(Bytes::copy_from_slice(&next.to_be_bytes())))
+            }),
+        ),
+    }
+}
+
+struct EncodedBounds {
+    lower_seek: Vec<u8>,
+    lower: Bound<Vec<u8>>,
+    upper: Bound<Vec<u8>>,
+}
+
+impl EncodedBounds {
+    fn new(range: KeyRange, resume_after: Option<&Key>) -> Self {
+        let range_lower = match range.lower {
+            Bound::Included(key) => Bound::Included(key.0.to_vec()),
+            Bound::Excluded(key) => Bound::Excluded(key.0.to_vec()),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let lower = match resume_after {
+            Some(resume_after) => {
+                max_lower_bound(range_lower, Bound::Excluded(resume_after.0.to_vec()))
+            }
+            None => range_lower,
+        };
+
+        let upper = match range.upper {
+            Bound::Included(key) => Bound::Included(key.0.to_vec()),
+            Bound::Excluded(key) => Bound::Excluded(key.0.to_vec()),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+
+        let lower_seek = match &lower {
+            Bound::Included(key) | Bound::Excluded(key) => key.clone(),
+            Bound::Unbounded => Vec::new(),
+        };
+
+        Self {
+            lower_seek,
+            lower,
+            upper,
+        }
+    }
+
+    fn after_lower(&self, encoded_key: &[u8]) -> bool {
+        match &self.lower {
+            Bound::Included(lower) if encoded_key < lower.as_slice() => false,
+            Bound::Excluded(lower) if encoded_key <= lower.as_slice() => false,
+            _ => true,
+        }
+    }
+
+    fn before_upper(&self, encoded_key: &[u8]) -> bool {
+        match &self.upper {
+            Bound::Included(upper) => encoded_key <= upper.as_slice(),
+            Bound::Excluded(upper) => encoded_key < upper.as_slice(),
+            Bound::Unbounded => true,
+        }
+    }
+
+    fn contains(&self, encoded_key: &[u8]) -> bool {
+        if !self.after_lower(encoded_key) {
+            return false;
+        }
+        match &self.upper {
+            Bound::Included(upper) => encoded_key <= upper.as_slice(),
+            Bound::Excluded(upper) => encoded_key < upper.as_slice(),
+            Bound::Unbounded => true,
+        }
+    }
+}
+
+fn max_lower_bound(left: Bound<Vec<u8>>, right: Bound<Vec<u8>>) -> Bound<Vec<u8>> {
+    match (left, right) {
+        (Bound::Unbounded, bound) | (bound, Bound::Unbounded) => bound,
+        (Bound::Included(left), Bound::Included(right)) => {
+            Bound::Included(if left >= right { left } else { right })
+        }
+        (Bound::Included(left), Bound::Excluded(right)) => {
+            if left > right {
+                Bound::Included(left)
+            } else {
+                Bound::Excluded(right)
+            }
+        }
+        (Bound::Excluded(left), Bound::Included(right)) => {
+            if left >= right {
+                Bound::Excluded(left)
+            } else {
+                Bound::Included(right)
+            }
+        }
+        (Bound::Excluded(left), Bound::Excluded(right)) => {
+            Bound::Excluded(if left >= right { left } else { right })
+        }
+    }
+}
+
+fn rocksdb_delete_range_bounds(range: &KeyRange) -> Option<(Vec<u8>, Vec<u8>)> {
+    let lower = match &range.lower {
+        Bound::Included(key) => key.0.to_vec(),
+        Bound::Excluded(key) => next_lexicographic_key(key)?,
+        Bound::Unbounded => Vec::new(),
+    };
+    let upper = match &range.upper {
+        Bound::Included(key) => next_lexicographic_key(key)?,
+        Bound::Excluded(key) => key.0.to_vec(),
+        Bound::Unbounded => return None,
+    };
+
+    if lower >= upper {
+        None
+    } else {
+        Some((lower, upper))
+    }
+}
+
+#[expect(clippy::unnecessary_wraps)]
+fn next_lexicographic_key(key: &Key) -> Option<Vec<u8>> {
+    let mut bytes = key.0.to_vec();
+    bytes.push(0);
+    Some(bytes)
+}
+
+fn stored_value_bytes(value: StoredValue) -> Bytes {
+    value.bytes
+}
+
+fn project_value_ref(value: &[u8], projection: CoreProjection) -> ProjectedValueRef<'_> {
+    match projection {
+        CoreProjection::KeyOnly => ProjectedValueRef::KeyOnly,
+        CoreProjection::FullValue => ProjectedValueRef::FullValue(value),
+    }
+}
+
+fn rocksdb_error(error: rocksdb::Error) -> BackendError {
+    BackendError::Io(format!("rocksdb filesystem backend: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use lix_engine::backend::{
+        Backend, BackendWrite, Key, PutBatch, PutEntry, ReadOptions, SpaceId, StoredValue,
+        WriteOptions, get_many,
+    };
+
+    use super::{RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions};
+
+    #[test]
+    fn plain_backend_roundtrips_point_read_after_reopen() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("fs.rocksdb");
+        let key = Key(Bytes::from_static(b"file-chunk"));
+        let value = Bytes::from_static(b"chunk bytes");
+
+        {
+            let backend = RocksDbFilesystemBackend::open(&path).expect("open backend");
+            let mut write = backend
+                .begin_write(WriteOptions::default())
+                .expect("begin write");
+            write
+                .put_many(
+                    SpaceId(0x0005_0003),
+                    PutBatch {
+                        entries: vec![PutEntry {
+                            key: key.clone(),
+                            value: StoredValue {
+                                bytes: value.clone(),
+                            },
+                        }],
+                    },
+                )
+                .expect("put chunk");
+            write.commit().expect("commit write");
+            backend.flush().expect("flush backend");
+        }
+
+        let backend = RocksDbFilesystemBackend::open(&path).expect("reopen backend");
+        let read = backend
+            .begin_read(ReadOptions::default())
+            .expect("begin read");
+        let result =
+            get_many(&read, SpaceId(0x0005_0003), &[key], Default::default()).expect("read chunk");
+        assert_eq!(result.values.len(), 1);
+        assert_eq!(
+            result.values[0].as_ref().map(|value| value.as_ref()),
+            Some(lix_engine::backend::ProjectedValueRef::FullValue(
+                value.as_ref()
+            ))
+        );
+    }
+
+    #[test]
+    fn blob_options_open() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let options = RocksDbFilesystemBackendOptions::blob(temp_dir.path().join("fs.rocksdb"), 16);
+        let backend =
+            RocksDbFilesystemBackend::open_with_options(options).expect("open blob backend");
+        backend.flush().expect("flush blob backend");
+    }
+}

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-lix_sdk = { path = "../rs-sdk", version = "0.7.0", default-features = false, features = ["default_wasm_runtime", "sqlite"] }
+lix_sdk = { path = "../rs-sdk", version = "0.7.0", default-features = false, features = ["default_wasm_runtime", "fs_backend", "sqlite"] }
 
 napi = { version = "3.9.0", default-features = false, features = ["napi6", "serde-json"] }
 napi-derive = "3.5.6"

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -72,8 +72,8 @@ try {
 
 ## Notes
 
-- `openLix()` opens a fresh in-memory Lix. Pass `new FsBackend({ path })` for a filesystem workspace directory backed by `<path>/.lix/.internal/db.sqlite`.
-- Use `new FsBackend({ path, storage: "memory" })` when you want to sync files from a directory but keep Lix repository storage in memory and avoid writing `.lix` metadata to that directory.
+- `openLix()` opens a fresh in-memory Lix. Pass `new FsBackend({ path })` for a filesystem workspace directory backed by `<path>/.lix/.internal/rocksdb`.
+- Pass `new FsBackend({ path, storage: "memory" })` for filesystem sync with an in-memory Lix repository and no `.lix` directory on disk.
 - Add `filter: { includePaths: ["notes/today.md"] }` to sync only selected files from a filesystem backend. `includePaths` entries are exact workspace-relative file paths, not directories or globs. They may be written with or without a leading slash, and only affect filesystem sync.
 - Use `new SqliteBackend({ path })` when a single SQLite-backed `.lix` file is the application document itself, for example when defining a new file format and using Lix as the application's file format.
 - The SDK is Node/native only right now; it is not browser-compatible.

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -291,7 +291,7 @@ test("fs backend imports local files and materializes lix_file writes", async ()
 
 	const lix = await openLix({ backend: new FsBackend({ path: dir }) });
 	expect(statSync(join(dir, ".lix")).isDirectory()).toBe(true);
-	expect(statSync(join(dir, ".lix", ".internal", "db.sqlite")).isFile()).toBe(
+	expect(statSync(join(dir, ".lix", ".internal", "rocksdb")).isDirectory()).toBe(
 		true,
 	);
 
@@ -346,7 +346,6 @@ test("fs backend with memory storage imports the directory and writes normal fil
 		"local",
 	);
 	expect(existsSync(join(dir, ".lix"))).toBe(false);
-	expect(existsSync(join(dir, ".lix_system"))).toBe(false);
 
 	await lix.execute("UPDATE lix_file SET data = $1 WHERE path = $2", [
 		new TextEncoder().encode("updated"),
@@ -361,7 +360,6 @@ test("fs backend with memory storage imports the directory and writes normal fil
 	]);
 	expect(readFileSync(join(dir, "generated.md"), "utf8")).toBe("generated");
 	expect(existsSync(join(dir, ".lix"))).toBe(false);
-	expect(existsSync(join(dir, ".lix_system"))).toBe(false);
 
 	writeFileSync(filePath, "external");
 	await waitFor(async () => {
@@ -587,7 +585,6 @@ test("fs backend with memory storage keeps lix storage paths in memory only", as
 		new TextEncoder().encode("ephemeral"),
 	]);
 	expect(existsSync(join(dir, ".lix"))).toBe(false);
-	expect(existsSync(join(dir, ".lix_system"))).toBe(false);
 
 	await lix.close();
 });
@@ -618,7 +615,6 @@ test("fs backend with memory storage reimports disk state on reopen without pers
 	const ephemeral = await readFile(reopened, "/.lix/ephemeral.txt");
 	expect(ephemeral).toBeUndefined();
 	expect(existsSync(join(dir, ".lix"))).toBe(false);
-	expect(existsSync(join(dir, ".lix_system"))).toBe(false);
 
 	await reopened.close();
 });

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.93"
 publish = false
 
 [dependencies]
-lix_sdk = { path = "../rs-sdk", version = "0.7.0", default-features = false, features = ["default_wasm_runtime", "sqlite"] }
+lix_sdk = { path = "../rs-sdk", version = "0.7.0", default-features = false, features = ["default_wasm_runtime", "fs_backend", "sqlite"] }
 
 [dev-dependencies]
 plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -41,7 +41,7 @@ zip = { version = "8", default-features = false }
 [features]
 default = ["default_wasm_runtime"]
 default_wasm_runtime = ["dep:wasmtime", "dep:wasmtime-wasi"]
-rocksdb = ["dep:lix_fs_backend", "lix_fs_backend/rocksdb"]
+fs_backend = ["dep:lix_fs_backend", "lix_fs_backend/rocksdb"]
 sqlite = ["dep:lix_backends", "lix_backends/sqlite", "dep:rusqlite", "dep:tempfile"]
 
 [[example]]
@@ -68,7 +68,7 @@ required-features = ["sqlite"]
 [[example]]
 name = "profile_fs_open"
 path = "examples/profile_fs_open.rs"
-required-features = ["rocksdb"]
+required-features = ["fs_backend"]
 
 [[bench]]
 name = "sqlite_backend"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -68,7 +68,7 @@ required-features = ["sqlite"]
 [[example]]
 name = "profile_fs_open"
 path = "examples/profile_fs_open.rs"
-required-features = ["sqlite"]
+required-features = ["rocksdb"]
 
 [[bench]]
 name = "sqlite_backend"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 lix_backends = { workspace = true, optional = true }
 lix_engine = { workspace = true }
+lix_fs_backend = { workspace = true, optional = true }
 
 async-trait = "0.1"
 bytes = "1"
@@ -40,6 +41,7 @@ zip = { version = "8", default-features = false }
 [features]
 default = ["default_wasm_runtime"]
 default_wasm_runtime = ["dep:wasmtime", "dep:wasmtime-wasi"]
+rocksdb = ["dep:lix_fs_backend", "lix_fs_backend/rocksdb"]
 sqlite = ["dep:lix_backends", "lix_backends/sqlite", "dep:rusqlite", "dep:tempfile"]
 
 [[example]]

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -428,11 +428,13 @@ fn print_result(
                     "\"cold_open_ms\":{},",
                     "\"warm_reopen_ms\":{},",
                     "\"cold_binary_cas_chunk_lookup_count\":{},",
+                    "\"cold_binary_cas_chunk_lookup_batch_count\":{},",
                     "\"cold_binary_cas_chunk_lookup_hit_count\":{},",
                     "\"cold_binary_cas_chunk_lookup_miss_count\":{},",
                     "\"cold_binary_cas_chunk_lookup_time_us\":{},",
                     "\"cold_binary_cas_transaction_duplicate_chunk_count\":{},",
                     "\"warm_binary_cas_chunk_lookup_count\":{},",
+                    "\"warm_binary_cas_chunk_lookup_batch_count\":{},",
                     "\"warm_binary_cas_chunk_lookup_hit_count\":{},",
                     "\"warm_binary_cas_chunk_lookup_miss_count\":{},",
                     "\"warm_binary_cas_chunk_lookup_time_us\":{},",
@@ -470,12 +472,16 @@ fn print_result(
                 duration_ms(open_elapsed),
                 duration_ms(warm_elapsed),
                 open_metrics.chunk_lookup_count,
+                open_metrics.chunk_lookup_batch_count,
                 open_metrics.chunk_lookup_hit_count,
                 open_metrics.chunk_lookup_miss_count,
                 metric_duration_us(open_metrics.chunk_lookup_elapsed_ns),
                 open_metrics.transaction_duplicate_chunk_count,
                 warm_metrics
                     .map(|metrics| metrics.chunk_lookup_count)
+                    .unwrap_or_default(),
+                warm_metrics
+                    .map(|metrics| metrics.chunk_lookup_batch_count)
                     .unwrap_or_default(),
                 warm_metrics
                     .map(|metrics| metrics.chunk_lookup_hit_count)
@@ -522,6 +528,7 @@ fn print_result(
                     "\"blob_min_size\":{},",
                     "\"open_ms\":{},",
                     "\"open_binary_cas_chunk_lookup_count\":{},",
+                    "\"open_binary_cas_chunk_lookup_batch_count\":{},",
                     "\"open_binary_cas_chunk_lookup_hit_count\":{},",
                     "\"open_binary_cas_chunk_lookup_miss_count\":{},",
                     "\"open_binary_cas_chunk_lookup_time_us\":{},",
@@ -557,6 +564,7 @@ fn print_result(
                 blob_min_json,
                 duration_ms(open_elapsed),
                 open_metrics.chunk_lookup_count,
+                open_metrics.chunk_lookup_batch_count,
                 open_metrics.chunk_lookup_hit_count,
                 open_metrics.chunk_lookup_miss_count,
                 metric_duration_us(open_metrics.chunk_lookup_elapsed_ns),
@@ -613,6 +621,10 @@ fn print_open_metrics(prefix: &str, metrics: &BinaryCasWriteMetrics) {
     println!(
         "{prefix}_BINARY_CAS_CHUNK_LOOKUP_COUNT={}",
         metrics.chunk_lookup_count
+    );
+    println!(
+        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_BATCH_COUNT={}",
+        metrics.chunk_lookup_batch_count
     );
     println!(
         "{prefix}_BINARY_CAS_CHUNK_LOOKUP_HIT_COUNT={}",

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -15,6 +15,7 @@ use lix_engine::Value;
 use lix_sdk::{FsBackend, open_lix_with_backend};
 
 #[derive(Debug)]
+#[expect(clippy::struct_excessive_bools)]
 struct Args {
     in_place: bool,
     json: bool,
@@ -77,14 +78,14 @@ fn copy_dir(src: &Path, dst: &Path) {
 }
 
 fn parse_args() -> Args {
-    let mut raw = std::env::args().skip(1);
+    let raw = std::env::args().skip(1);
     let mut in_place = false;
     let mut json = false;
     let mut keep_workspace = false;
     let mut read_bench = false;
     let mut src = None;
 
-    while let Some(arg) = raw.next() {
+    for arg in raw {
         match arg.as_str() {
             "--in-place" => in_place = true,
             "--json" => json = true,
@@ -92,9 +93,10 @@ fn parse_args() -> Args {
             "--read-bench" => read_bench = true,
             _ if arg.starts_with("--") => panic!("unknown option '{arg}'"),
             _ => {
-                if src.replace(arg).is_some() {
-                    panic!("profile_fs_open accepts exactly one source directory");
-                }
+                assert!(
+                    src.replace(arg).is_none(),
+                    "profile_fs_open accepts exactly one source directory"
+                );
             }
         }
     }

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -33,6 +33,7 @@ enum ProfileBackend {
 #[derive(Debug)]
 struct Args {
     backend: ProfileBackend,
+    compact_before_stats: bool,
     in_place: bool,
     json: bool,
     keep_workspace: bool,
@@ -130,6 +131,7 @@ fn copy_dir(src: &Path, dst: &Path) {
 fn parse_args() -> Args {
     let mut raw = std::env::args().skip(1);
     let mut backend = ProfileBackend::Sqlite;
+    let mut compact_before_stats = false;
     let mut in_place = false;
     let mut json = false;
     let mut keep_workspace = false;
@@ -179,6 +181,7 @@ fn parse_args() -> Args {
                     panic!("profile_fs_open was built without the rocksdb feature")
                 }
             }
+            "--compact-before-stats" => compact_before_stats = true,
             "--in-place" => in_place = true,
             "--json" => json = true,
             "--keep-workspace" => keep_workspace = true,
@@ -193,6 +196,7 @@ fn parse_args() -> Args {
 
     Args {
         backend,
+        compact_before_stats,
         in_place,
         json,
         keep_workspace,
@@ -218,6 +222,25 @@ fn parse_size(value: &str) -> u64 {
 
 fn duration_ms(duration: Duration) -> u128 {
     duration.as_micros() / 1000
+}
+
+fn compact_backend_if_requested(args: &Args, backend: &FsBackend) -> Option<Duration> {
+    if !args.compact_before_stats {
+        return None;
+    }
+    #[cfg(feature = "rocksdb")]
+    {
+        let t_compact = Instant::now();
+        backend
+            .compact_rocksdb()
+            .expect("profile RocksDB compact should succeed");
+        Some(t_compact.elapsed())
+    }
+    #[cfg(not(feature = "rocksdb"))]
+    {
+        let _ = backend;
+        panic!("profile_fs_open was built without the rocksdb feature")
+    }
 }
 
 fn collect_profile_stats(workspace: &Path) -> ProfileStats {
@@ -361,6 +384,7 @@ fn print_result(
     copy_elapsed: Option<Duration>,
     open_elapsed: Duration,
     warm_elapsed: Option<Duration>,
+    compact_elapsed: Option<Duration>,
     stats: &ProfileStats,
     workspace_path: Option<&Path>,
 ) {
@@ -372,6 +396,9 @@ fn print_result(
         let workspace_json = workspace_path.map_or("null".to_string(), |path| {
             json_string(&path.display().to_string())
         });
+        let compact_ms_json = compact_elapsed
+            .map(|duration| duration_ms(duration).to_string())
+            .unwrap_or_else(|| "null".to_string());
         match (copy_elapsed, warm_elapsed) {
             (Some(copy_elapsed), Some(warm_elapsed)) => println!(
                 concat!(
@@ -381,6 +408,7 @@ fn print_result(
                     "\"copy_ms\":{},",
                     "\"cold_open_ms\":{},",
                     "\"warm_reopen_ms\":{},",
+                    "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
                     "\"corpus_bytes\":{},",
@@ -412,6 +440,7 @@ fn print_result(
                 duration_ms(copy_elapsed),
                 duration_ms(open_elapsed),
                 duration_ms(warm_elapsed),
+                compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
                 stats.corpus_bytes,
@@ -443,6 +472,7 @@ fn print_result(
                     "\"backend\":\"{}\",",
                     "\"blob_min_size\":{},",
                     "\"open_ms\":{},",
+                    "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
                     "\"corpus_bytes\":{},",
@@ -472,6 +502,7 @@ fn print_result(
                 args.backend.name(),
                 blob_min_json,
                 duration_ms(open_elapsed),
+                compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
                 stats.corpus_bytes,
@@ -500,9 +531,15 @@ fn print_result(
         }
     } else if args.in_place {
         println!("OPEN_MS={}", duration_ms(open_elapsed));
+        if let Some(compact_elapsed) = compact_elapsed {
+            println!("COMPACT_MS={}", duration_ms(compact_elapsed));
+        }
         print_text_stats(stats, workspace_path);
     } else {
         println!("COLD_OPEN_MS={}", duration_ms(open_elapsed));
+        if let Some(compact_elapsed) = compact_elapsed {
+            println!("COMPACT_MS={}", duration_ms(compact_elapsed));
+        }
         print_text_stats(stats, workspace_path);
     }
 }
@@ -567,10 +604,19 @@ async fn main() {
         let backend = args.backend.open(src).await;
         let open_elapsed = t_open.elapsed();
         eprintln!("{} in-place open: {open_elapsed:?}", args.backend.name());
+        let compact_elapsed = compact_backend_if_requested(&args, &backend);
         let mut stats = collect_profile_stats(src);
         collect_backend_profile_stats(&backend, &mut stats);
         drop(backend);
-        print_result(&args, None, open_elapsed, None, &stats, Some(src));
+        print_result(
+            &args,
+            None,
+            open_elapsed,
+            None,
+            compact_elapsed,
+            &stats,
+            Some(src),
+        );
         return;
     }
 
@@ -598,6 +644,7 @@ async fn main() {
     let backend = args.backend.open(&work).await;
     let warm_elapsed = t_warm.elapsed();
     eprintln!("{} warm reopen: {warm_elapsed:?}", args.backend.name());
+    let compact_elapsed = compact_backend_if_requested(&args, &backend);
     let mut stats = collect_profile_stats(&work);
     collect_backend_profile_stats(&backend, &mut stats);
     drop(backend);
@@ -625,6 +672,7 @@ async fn main() {
         Some(copy_elapsed),
         open_elapsed,
         Some(warm_elapsed),
+        compact_elapsed,
         &stats,
         workspace_path,
     );

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -11,6 +11,10 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use lix_engine::{
+    Backend as _, BackendRead as _, BinaryCasStorageStats, ReadOptions,
+    collect_binary_cas_storage_stats,
+};
 use lix_sdk::FsBackend;
 #[cfg(feature = "rocksdb")]
 use lix_sdk::{FsBackendFilter, RocksDbBlobOptions};
@@ -52,6 +56,14 @@ struct ProfileStats {
     rocksdb_manifest_bytes: u64,
     rocksdb_options_bytes: u64,
     rocksdb_other_bytes: u64,
+    binary_cas_manifest_rows: u64,
+    binary_cas_empty_blob_rows: u64,
+    binary_cas_single_chunk_blob_rows: u64,
+    binary_cas_chunked_blob_rows: u64,
+    binary_cas_manifest_chunk_rows: u64,
+    binary_cas_chunk_rows: u64,
+    binary_cas_total_chunk_refs: u64,
+    binary_cas_logical_blob_bytes: u64,
 }
 
 impl ProfileBackend {
@@ -215,6 +227,27 @@ fn collect_profile_stats(workspace: &Path) -> ProfileStats {
     stats
 }
 
+fn collect_backend_profile_stats(backend: &FsBackend, stats: &mut ProfileStats) {
+    let read = backend
+        .begin_read(ReadOptions::default())
+        .expect("profile backend read should open");
+    let binary_cas =
+        collect_binary_cas_storage_stats(&read).expect("profile binary CAS stats should collect");
+    read.close().expect("profile backend read should close");
+    apply_binary_cas_stats(stats, binary_cas);
+}
+
+fn apply_binary_cas_stats(stats: &mut ProfileStats, binary_cas: BinaryCasStorageStats) {
+    stats.binary_cas_manifest_rows = binary_cas.manifest_rows;
+    stats.binary_cas_empty_blob_rows = binary_cas.empty_blob_rows;
+    stats.binary_cas_single_chunk_blob_rows = binary_cas.single_chunk_blob_rows;
+    stats.binary_cas_chunked_blob_rows = binary_cas.chunked_blob_rows;
+    stats.binary_cas_manifest_chunk_rows = binary_cas.manifest_chunk_rows;
+    stats.binary_cas_chunk_rows = binary_cas.chunk_rows;
+    stats.binary_cas_total_chunk_refs = binary_cas.total_chunk_refs;
+    stats.binary_cas_logical_blob_bytes = binary_cas.logical_blob_bytes;
+}
+
 fn collect_corpus_stats(root: &Path, stats: &mut ProfileStats) {
     let Ok(entries) = std::fs::read_dir(root) else {
         return;
@@ -363,7 +396,15 @@ fn print_result(
                     "\"rocksdb_log_bytes\":{},",
                     "\"rocksdb_manifest_bytes\":{},",
                     "\"rocksdb_options_bytes\":{},",
-                    "\"rocksdb_other_bytes\":{}",
+                    "\"rocksdb_other_bytes\":{},",
+                    "\"binary_cas_manifest_rows\":{},",
+                    "\"binary_cas_empty_blob_rows\":{},",
+                    "\"binary_cas_single_chunk_blob_rows\":{},",
+                    "\"binary_cas_chunked_blob_rows\":{},",
+                    "\"binary_cas_manifest_chunk_rows\":{},",
+                    "\"binary_cas_chunk_rows\":{},",
+                    "\"binary_cas_total_chunk_refs\":{},",
+                    "\"binary_cas_logical_blob_bytes\":{}",
                     "}}"
                 ),
                 args.backend.name(),
@@ -386,7 +427,15 @@ fn print_result(
                 stats.rocksdb_log_bytes,
                 stats.rocksdb_manifest_bytes,
                 stats.rocksdb_options_bytes,
-                stats.rocksdb_other_bytes
+                stats.rocksdb_other_bytes,
+                stats.binary_cas_manifest_rows,
+                stats.binary_cas_empty_blob_rows,
+                stats.binary_cas_single_chunk_blob_rows,
+                stats.binary_cas_chunked_blob_rows,
+                stats.binary_cas_manifest_chunk_rows,
+                stats.binary_cas_chunk_rows,
+                stats.binary_cas_total_chunk_refs,
+                stats.binary_cas_logical_blob_bytes
             ),
             _ => println!(
                 concat!(
@@ -409,7 +458,15 @@ fn print_result(
                     "\"rocksdb_log_bytes\":{},",
                     "\"rocksdb_manifest_bytes\":{},",
                     "\"rocksdb_options_bytes\":{},",
-                    "\"rocksdb_other_bytes\":{}",
+                    "\"rocksdb_other_bytes\":{},",
+                    "\"binary_cas_manifest_rows\":{},",
+                    "\"binary_cas_empty_blob_rows\":{},",
+                    "\"binary_cas_single_chunk_blob_rows\":{},",
+                    "\"binary_cas_chunked_blob_rows\":{},",
+                    "\"binary_cas_manifest_chunk_rows\":{},",
+                    "\"binary_cas_chunk_rows\":{},",
+                    "\"binary_cas_total_chunk_refs\":{},",
+                    "\"binary_cas_logical_blob_bytes\":{}",
                     "}}"
                 ),
                 args.backend.name(),
@@ -430,7 +487,15 @@ fn print_result(
                 stats.rocksdb_log_bytes,
                 stats.rocksdb_manifest_bytes,
                 stats.rocksdb_options_bytes,
-                stats.rocksdb_other_bytes
+                stats.rocksdb_other_bytes,
+                stats.binary_cas_manifest_rows,
+                stats.binary_cas_empty_blob_rows,
+                stats.binary_cas_single_chunk_blob_rows,
+                stats.binary_cas_chunked_blob_rows,
+                stats.binary_cas_manifest_chunk_rows,
+                stats.binary_cas_chunk_rows,
+                stats.binary_cas_total_chunk_refs,
+                stats.binary_cas_logical_blob_bytes
             ),
         }
     } else if args.in_place {
@@ -461,6 +526,35 @@ fn print_text_stats(stats: &ProfileStats, workspace_path: Option<&Path>) {
     println!("ROCKSDB_MANIFEST_BYTES={}", stats.rocksdb_manifest_bytes);
     println!("ROCKSDB_OPTIONS_BYTES={}", stats.rocksdb_options_bytes);
     println!("ROCKSDB_OTHER_BYTES={}", stats.rocksdb_other_bytes);
+    println!(
+        "BINARY_CAS_MANIFEST_ROWS={}",
+        stats.binary_cas_manifest_rows
+    );
+    println!(
+        "BINARY_CAS_EMPTY_BLOB_ROWS={}",
+        stats.binary_cas_empty_blob_rows
+    );
+    println!(
+        "BINARY_CAS_SINGLE_CHUNK_BLOB_ROWS={}",
+        stats.binary_cas_single_chunk_blob_rows
+    );
+    println!(
+        "BINARY_CAS_CHUNKED_BLOB_ROWS={}",
+        stats.binary_cas_chunked_blob_rows
+    );
+    println!(
+        "BINARY_CAS_MANIFEST_CHUNK_ROWS={}",
+        stats.binary_cas_manifest_chunk_rows
+    );
+    println!("BINARY_CAS_CHUNK_ROWS={}", stats.binary_cas_chunk_rows);
+    println!(
+        "BINARY_CAS_TOTAL_CHUNK_REFS={}",
+        stats.binary_cas_total_chunk_refs
+    );
+    println!(
+        "BINARY_CAS_LOGICAL_BLOB_BYTES={}",
+        stats.binary_cas_logical_blob_bytes
+    );
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -473,8 +567,9 @@ async fn main() {
         let backend = args.backend.open(src).await;
         let open_elapsed = t_open.elapsed();
         eprintln!("{} in-place open: {open_elapsed:?}", args.backend.name());
+        let mut stats = collect_profile_stats(src);
+        collect_backend_profile_stats(&backend, &mut stats);
         drop(backend);
-        let stats = collect_profile_stats(src);
         print_result(&args, None, open_elapsed, None, &stats, Some(src));
         return;
     }
@@ -503,8 +598,9 @@ async fn main() {
     let backend = args.backend.open(&work).await;
     let warm_elapsed = t_warm.elapsed();
     eprintln!("{} warm reopen: {warm_elapsed:?}", args.backend.name());
+    let mut stats = collect_profile_stats(&work);
+    collect_backend_profile_stats(&backend, &mut stats);
     drop(backend);
-    let stats = collect_profile_stats(&work);
 
     // Repeated cold opens into fresh temp dirs for profiling sample density.
     for i in 0..repeat {

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -5,9 +5,10 @@
 //     --backend sqlite <src_dir>
 //
 // Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
-// FsBackend::open on the cold workspace.
+// FsBackend::open on the cold workspace. Pass --keep-workspace to preserve the
+// copied temp workspace for inspection.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use lix_sdk::FsBackend;
@@ -30,7 +31,27 @@ struct Args {
     backend: ProfileBackend,
     in_place: bool,
     json: bool,
+    keep_workspace: bool,
     src: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ProfileStats {
+    corpus_file_count: u64,
+    corpus_bytes: u64,
+    lix_total_bytes: u64,
+    sqlite_db_bytes: u64,
+    sqlite_wal_bytes: u64,
+    sqlite_shm_bytes: u64,
+    sqlite_other_bytes: u64,
+    rocksdb_total_bytes: u64,
+    rocksdb_sst_bytes: u64,
+    rocksdb_blob_bytes: u64,
+    rocksdb_wal_bytes: u64,
+    rocksdb_log_bytes: u64,
+    rocksdb_manifest_bytes: u64,
+    rocksdb_options_bytes: u64,
+    rocksdb_other_bytes: u64,
 }
 
 impl ProfileBackend {
@@ -99,6 +120,7 @@ fn parse_args() -> Args {
     let mut backend = ProfileBackend::Sqlite;
     let mut in_place = false;
     let mut json = false;
+    let mut keep_workspace = false;
     let mut src = None;
 
     while let Some(arg) = raw.next() {
@@ -147,6 +169,7 @@ fn parse_args() -> Args {
             }
             "--in-place" => in_place = true,
             "--json" => json = true,
+            "--keep-workspace" => keep_workspace = true,
             _ if arg.starts_with("--") => panic!("unknown option '{arg}'"),
             _ => {
                 if src.replace(arg).is_some() {
@@ -160,8 +183,9 @@ fn parse_args() -> Args {
         backend,
         in_place,
         json,
+        keep_workspace,
         src: src.expect(
-            "usage: profile_fs_open [--json] [--in-place] [--backend sqlite|rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
+            "usage: profile_fs_open [--json] [--in-place] [--keep-workspace] [--backend sqlite|rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
         ),
     }
 }
@@ -184,38 +208,259 @@ fn duration_ms(duration: Duration) -> u128 {
     duration.as_micros() / 1000
 }
 
+fn collect_profile_stats(workspace: &Path) -> ProfileStats {
+    let mut stats = ProfileStats::default();
+    collect_corpus_stats(workspace, &mut stats);
+    collect_lix_stats(workspace, &mut stats);
+    stats
+}
+
+fn collect_corpus_stats(root: &Path, stats: &mut ProfileStats) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if entry.file_name() == ".lix" {
+            continue;
+        }
+        let metadata = entry.metadata().unwrap();
+        if metadata.is_dir() {
+            collect_corpus_stats(&path, stats);
+        } else if metadata.is_file() {
+            stats.corpus_file_count += 1;
+            stats.corpus_bytes += metadata.len();
+        }
+    }
+}
+
+fn collect_lix_stats(workspace: &Path, stats: &mut ProfileStats) {
+    let lix_dir = workspace.join(".lix");
+    if !lix_dir.exists() {
+        return;
+    }
+    let internal_dir = lix_dir.join(".internal");
+    let rocksdb_dir = internal_dir.join("rocksdb");
+    collect_lix_stats_recursive(&lix_dir, &internal_dir, &rocksdb_dir, stats);
+}
+
+fn collect_lix_stats_recursive(
+    dir: &Path,
+    internal_dir: &Path,
+    rocksdb_dir: &Path,
+    stats: &mut ProfileStats,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let metadata = entry.metadata().unwrap();
+        if metadata.is_dir() {
+            collect_lix_stats_recursive(&path, internal_dir, rocksdb_dir, stats);
+            continue;
+        }
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let bytes = metadata.len();
+        stats.lix_total_bytes += bytes;
+        if path.strip_prefix(rocksdb_dir).is_ok() {
+            classify_rocksdb_file(&path, bytes, stats);
+        } else if path.strip_prefix(internal_dir).is_ok() {
+            classify_sqlite_file(&path, bytes, stats);
+        }
+    }
+}
+
+fn classify_sqlite_file(path: &Path, bytes: u64, stats: &mut ProfileStats) {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some("db.sqlite") => stats.sqlite_db_bytes += bytes,
+        Some("db.sqlite-wal") => stats.sqlite_wal_bytes += bytes,
+        Some("db.sqlite-shm") => stats.sqlite_shm_bytes += bytes,
+        _ => stats.sqlite_other_bytes += bytes,
+    }
+}
+
+fn classify_rocksdb_file(path: &Path, bytes: u64, stats: &mut ProfileStats) {
+    stats.rocksdb_total_bytes += bytes;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("sst") => stats.rocksdb_sst_bytes += bytes,
+        Some("blob") => stats.rocksdb_blob_bytes += bytes,
+        Some("log") => stats.rocksdb_wal_bytes += bytes,
+        _ if file_name.starts_with("LOG") => stats.rocksdb_log_bytes += bytes,
+        _ if file_name.starts_with("MANIFEST") => stats.rocksdb_manifest_bytes += bytes,
+        _ if file_name.starts_with("OPTIONS") => stats.rocksdb_options_bytes += bytes,
+        _ => stats.rocksdb_other_bytes += bytes,
+    }
+}
+
+fn json_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if ch.is_control() => {
+                use std::fmt::Write as _;
+                write!(&mut out, "\\u{:04x}", ch as u32).unwrap();
+            }
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
 fn print_result(
     args: &Args,
     copy_elapsed: Option<Duration>,
     open_elapsed: Duration,
     warm_elapsed: Option<Duration>,
+    stats: &ProfileStats,
+    workspace_path: Option<&Path>,
 ) {
     if args.json {
         let blob_min_json = args
             .backend
             .blob_min_size()
             .map_or("null".to_string(), |size| size.to_string());
+        let workspace_json = workspace_path.map_or("null".to_string(), |path| {
+            json_string(&path.display().to_string())
+        });
         match (copy_elapsed, warm_elapsed) {
             (Some(copy_elapsed), Some(warm_elapsed)) => println!(
-                "{{\"backend\":\"{}\",\"blob_min_size\":{},\"copy_ms\":{},\"cold_open_ms\":{},\"warm_reopen_ms\":{}}}",
+                concat!(
+                    "{{",
+                    "\"backend\":\"{}\",",
+                    "\"blob_min_size\":{},",
+                    "\"copy_ms\":{},",
+                    "\"cold_open_ms\":{},",
+                    "\"warm_reopen_ms\":{},",
+                    "\"workspace_path\":{},",
+                    "\"corpus_file_count\":{},",
+                    "\"corpus_bytes\":{},",
+                    "\"lix_total_bytes\":{},",
+                    "\"sqlite_db_bytes\":{},",
+                    "\"sqlite_wal_bytes\":{},",
+                    "\"sqlite_shm_bytes\":{},",
+                    "\"sqlite_other_bytes\":{},",
+                    "\"rocksdb_total_bytes\":{},",
+                    "\"rocksdb_sst_bytes\":{},",
+                    "\"rocksdb_blob_bytes\":{},",
+                    "\"rocksdb_wal_bytes\":{},",
+                    "\"rocksdb_log_bytes\":{},",
+                    "\"rocksdb_manifest_bytes\":{},",
+                    "\"rocksdb_options_bytes\":{},",
+                    "\"rocksdb_other_bytes\":{}",
+                    "}}"
+                ),
                 args.backend.name(),
                 blob_min_json,
                 duration_ms(copy_elapsed),
                 duration_ms(open_elapsed),
-                duration_ms(warm_elapsed)
+                duration_ms(warm_elapsed),
+                workspace_json,
+                stats.corpus_file_count,
+                stats.corpus_bytes,
+                stats.lix_total_bytes,
+                stats.sqlite_db_bytes,
+                stats.sqlite_wal_bytes,
+                stats.sqlite_shm_bytes,
+                stats.sqlite_other_bytes,
+                stats.rocksdb_total_bytes,
+                stats.rocksdb_sst_bytes,
+                stats.rocksdb_blob_bytes,
+                stats.rocksdb_wal_bytes,
+                stats.rocksdb_log_bytes,
+                stats.rocksdb_manifest_bytes,
+                stats.rocksdb_options_bytes,
+                stats.rocksdb_other_bytes
             ),
             _ => println!(
-                "{{\"backend\":\"{}\",\"blob_min_size\":{},\"open_ms\":{}}}",
+                concat!(
+                    "{{",
+                    "\"backend\":\"{}\",",
+                    "\"blob_min_size\":{},",
+                    "\"open_ms\":{},",
+                    "\"workspace_path\":{},",
+                    "\"corpus_file_count\":{},",
+                    "\"corpus_bytes\":{},",
+                    "\"lix_total_bytes\":{},",
+                    "\"sqlite_db_bytes\":{},",
+                    "\"sqlite_wal_bytes\":{},",
+                    "\"sqlite_shm_bytes\":{},",
+                    "\"sqlite_other_bytes\":{},",
+                    "\"rocksdb_total_bytes\":{},",
+                    "\"rocksdb_sst_bytes\":{},",
+                    "\"rocksdb_blob_bytes\":{},",
+                    "\"rocksdb_wal_bytes\":{},",
+                    "\"rocksdb_log_bytes\":{},",
+                    "\"rocksdb_manifest_bytes\":{},",
+                    "\"rocksdb_options_bytes\":{},",
+                    "\"rocksdb_other_bytes\":{}",
+                    "}}"
+                ),
                 args.backend.name(),
                 blob_min_json,
-                duration_ms(open_elapsed)
+                duration_ms(open_elapsed),
+                workspace_json,
+                stats.corpus_file_count,
+                stats.corpus_bytes,
+                stats.lix_total_bytes,
+                stats.sqlite_db_bytes,
+                stats.sqlite_wal_bytes,
+                stats.sqlite_shm_bytes,
+                stats.sqlite_other_bytes,
+                stats.rocksdb_total_bytes,
+                stats.rocksdb_sst_bytes,
+                stats.rocksdb_blob_bytes,
+                stats.rocksdb_wal_bytes,
+                stats.rocksdb_log_bytes,
+                stats.rocksdb_manifest_bytes,
+                stats.rocksdb_options_bytes,
+                stats.rocksdb_other_bytes
             ),
         }
     } else if args.in_place {
         println!("OPEN_MS={}", duration_ms(open_elapsed));
+        print_text_stats(stats, workspace_path);
     } else {
         println!("COLD_OPEN_MS={}", duration_ms(open_elapsed));
+        print_text_stats(stats, workspace_path);
     }
+}
+
+fn print_text_stats(stats: &ProfileStats, workspace_path: Option<&Path>) {
+    if let Some(workspace_path) = workspace_path {
+        println!("WORKSPACE_PATH={}", workspace_path.display());
+    }
+    println!("CORPUS_FILE_COUNT={}", stats.corpus_file_count);
+    println!("CORPUS_BYTES={}", stats.corpus_bytes);
+    println!("LIX_TOTAL_BYTES={}", stats.lix_total_bytes);
+    println!("SQLITE_DB_BYTES={}", stats.sqlite_db_bytes);
+    println!("SQLITE_WAL_BYTES={}", stats.sqlite_wal_bytes);
+    println!("SQLITE_SHM_BYTES={}", stats.sqlite_shm_bytes);
+    println!("SQLITE_OTHER_BYTES={}", stats.sqlite_other_bytes);
+    println!("ROCKSDB_TOTAL_BYTES={}", stats.rocksdb_total_bytes);
+    println!("ROCKSDB_SST_BYTES={}", stats.rocksdb_sst_bytes);
+    println!("ROCKSDB_BLOB_BYTES={}", stats.rocksdb_blob_bytes);
+    println!("ROCKSDB_WAL_BYTES={}", stats.rocksdb_wal_bytes);
+    println!("ROCKSDB_LOG_BYTES={}", stats.rocksdb_log_bytes);
+    println!("ROCKSDB_MANIFEST_BYTES={}", stats.rocksdb_manifest_bytes);
+    println!("ROCKSDB_OPTIONS_BYTES={}", stats.rocksdb_options_bytes);
+    println!("ROCKSDB_OTHER_BYTES={}", stats.rocksdb_other_bytes);
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -229,7 +474,8 @@ async fn main() {
         let open_elapsed = t_open.elapsed();
         eprintln!("{} in-place open: {open_elapsed:?}", args.backend.name());
         drop(backend);
-        print_result(&args, None, open_elapsed, None);
+        let stats = collect_profile_stats(src);
+        print_result(&args, None, open_elapsed, None, &stats, Some(src));
         return;
     }
 
@@ -258,6 +504,7 @@ async fn main() {
     let warm_elapsed = t_warm.elapsed();
     eprintln!("{} warm reopen: {warm_elapsed:?}", args.backend.name());
     drop(backend);
+    let stats = collect_profile_stats(&work);
 
     // Repeated cold opens into fresh temp dirs for profiling sample density.
     for i in 0..repeat {
@@ -276,5 +523,17 @@ async fn main() {
         drop(backend);
     }
 
-    print_result(&args, Some(copy_elapsed), open_elapsed, Some(warm_elapsed));
+    let workspace_path = args.keep_workspace.then_some(work.as_path());
+    print_result(
+        &args,
+        Some(copy_elapsed),
+        open_elapsed,
+        Some(warm_elapsed),
+        &stats,
+        workspace_path,
+    );
+    if args.keep_workspace {
+        let _kept_root: PathBuf = tmp.keep();
+        eprintln!("kept workspace: {}", work.display());
+    }
 }

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -1,8 +1,8 @@
 // Cold-open profiling harness for the filesystem backend.
 //
 // Usage:
-//   cargo run --release --example profile_fs_open --features rocksdb -- \
-//     --backend rocksdb-blob <src_dir>
+//   cargo run --release --example profile_fs_open --features fs_backend -- \
+//     <src_dir>
 //
 // Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
 // FsBackend::open on the cold workspace. Pass --keep-workspace to preserve the
@@ -11,26 +11,11 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use lix_engine::{
-    Backend as _, BackendRead as _, BinaryCasStorageStats, BinaryCasWriteMetrics, ReadOptions,
-    Value, binary_cas_write_metrics_snapshot, collect_binary_cas_storage_stats,
-    reset_binary_cas_write_metrics,
-};
-use lix_fs_backend::RocksDbBlobOptions;
-use lix_sdk::{FsBackend, FsBackendFilter, open_lix_with_backend};
-
-const DEFAULT_BLOB_MIN_SIZE: u64 = 32 * 1024;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ProfileBackend {
-    RocksDb,
-    RocksDbBlob { min_blob_size: u64 },
-}
+use lix_engine::Value;
+use lix_sdk::{FsBackend, open_lix_with_backend};
 
 #[derive(Debug)]
 struct Args {
-    backend: ProfileBackend,
-    compact_before_stats: bool,
     in_place: bool,
     json: bool,
     keep_workspace: bool,
@@ -51,14 +36,6 @@ struct ProfileStats {
     rocksdb_manifest_bytes: u64,
     rocksdb_options_bytes: u64,
     rocksdb_other_bytes: u64,
-    binary_cas_manifest_rows: u64,
-    binary_cas_empty_blob_rows: u64,
-    binary_cas_single_chunk_blob_rows: u64,
-    binary_cas_chunked_blob_rows: u64,
-    binary_cas_manifest_chunk_rows: u64,
-    binary_cas_chunk_rows: u64,
-    binary_cas_total_chunk_refs: u64,
-    binary_cas_logical_blob_bytes: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -81,49 +58,6 @@ struct BenchFile {
     size_bytes: u64,
 }
 
-impl ProfileBackend {
-    fn name(self) -> &'static str {
-        match self {
-            Self::RocksDb => "rocksdb",
-            Self::RocksDbBlob { .. } => "rocksdb-blob",
-        }
-    }
-
-    fn blob_min_size(self) -> Option<u64> {
-        match self {
-            Self::RocksDbBlob { min_blob_size } => Some(min_blob_size),
-            Self::RocksDb => None,
-        }
-    }
-
-    async fn open(self, path: &Path) -> FsBackend {
-        match self {
-            Self::RocksDb => FsBackend::open_with_rocksdb_blob_options(
-                path,
-                FsBackendFilter::default(),
-                RocksDbBlobOptions::Disabled,
-            )
-            .await
-            .unwrap(),
-            Self::RocksDbBlob {
-                min_blob_size: DEFAULT_BLOB_MIN_SIZE,
-            } => FsBackend::open(path).await.unwrap(),
-            Self::RocksDbBlob { min_blob_size } => FsBackend::open_with_rocksdb_blob_options(
-                path,
-                FsBackendFilter::default(),
-                RocksDbBlobOptions::Enabled {
-                    min_blob_size,
-                    blob_file_size: 256 * 1024 * 1024,
-                    enable_gc: true,
-                    gc_age_cutoff: 0.25,
-                },
-            )
-            .await
-            .unwrap(),
-        }
-    }
-}
-
 fn copy_dir(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).unwrap();
     for entry in std::fs::read_dir(src).unwrap() {
@@ -144,10 +78,6 @@ fn copy_dir(src: &Path, dst: &Path) {
 
 fn parse_args() -> Args {
     let mut raw = std::env::args().skip(1);
-    let mut backend = ProfileBackend::RocksDbBlob {
-        min_blob_size: DEFAULT_BLOB_MIN_SIZE,
-    };
-    let mut compact_before_stats = false;
     let mut in_place = false;
     let mut json = false;
     let mut keep_workspace = false;
@@ -156,22 +86,6 @@ fn parse_args() -> Args {
 
     while let Some(arg) = raw.next() {
         match arg.as_str() {
-            "--backend" => {
-                let value = raw.next().expect("--backend requires a value");
-                backend = match value.as_str() {
-                    "rocksdb" => ProfileBackend::RocksDb,
-                    "rocksdb-blob" => ProfileBackend::RocksDbBlob {
-                        min_blob_size: DEFAULT_BLOB_MIN_SIZE,
-                    },
-                    other => panic!("unknown backend '{other}'"),
-                };
-            }
-            "--blob-min" => {
-                let value = raw.next().expect("--blob-min requires a value");
-                let min_blob_size = parse_size(&value);
-                backend = ProfileBackend::RocksDbBlob { min_blob_size };
-            }
-            "--compact-before-stats" => compact_before_stats = true,
             "--in-place" => in_place = true,
             "--json" => json = true,
             "--keep-workspace" => keep_workspace = true,
@@ -186,29 +100,13 @@ fn parse_args() -> Args {
     }
 
     Args {
-        backend,
-        compact_before_stats,
         in_place,
         json,
         keep_workspace,
         read_bench,
         src: src.expect(
-            "usage: profile_fs_open [--json] [--in-place] [--keep-workspace] [--read-bench] [--backend rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
+            "usage: profile_fs_open [--json] [--in-place] [--keep-workspace] [--read-bench] <src_dir>",
         ),
-    }
-}
-
-fn parse_size(value: &str) -> u64 {
-    let Some(last_digit) = value.rfind(|ch: char| ch.is_ascii_digit()) else {
-        panic!("size must include digits");
-    };
-    let (digits, suffix) = value.split_at(last_digit + 1);
-    let base = digits.parse::<u64>().expect("size digits must parse");
-    match suffix.to_ascii_lowercase().as_str() {
-        "" => base,
-        "k" | "kb" | "kib" => base * 1024,
-        "m" | "mb" | "mib" => base * 1024 * 1024,
-        other => panic!("unknown size suffix '{other}'"),
     }
 }
 
@@ -216,39 +114,11 @@ fn duration_ms(duration: Duration) -> u128 {
     duration.as_micros() / 1000
 }
 
-fn metric_duration_us(ns: u64) -> u64 {
-    ns / 1000
-}
-
-async fn open_with_metrics(
-    backend: ProfileBackend,
-    path: &Path,
-) -> (FsBackend, Duration, BinaryCasWriteMetrics) {
-    reset_binary_cas_write_metrics();
+async fn open_with_timing(path: &Path) -> (FsBackend, Duration) {
     let started = Instant::now();
-    let opened = backend.open(path).await;
+    let opened = FsBackend::open(path).await.unwrap();
     let elapsed = started.elapsed();
-    let metrics = binary_cas_write_metrics_snapshot();
-    (opened, elapsed, metrics)
-}
-
-fn compact_backend_if_requested(args: &Args, backend: &FsBackend) -> Option<Duration> {
-    if !args.compact_before_stats {
-        return None;
-    }
-    #[cfg(feature = "rocksdb")]
-    {
-        let t_compact = Instant::now();
-        backend
-            .compact_rocksdb()
-            .expect("profile RocksDB compact should succeed");
-        Some(t_compact.elapsed())
-    }
-    #[cfg(not(feature = "rocksdb"))]
-    {
-        let _ = backend;
-        panic!("profile_fs_open was built without the rocksdb feature")
-    }
+    (opened, elapsed)
 }
 
 fn collect_profile_stats(workspace: &Path) -> ProfileStats {
@@ -256,16 +126,6 @@ fn collect_profile_stats(workspace: &Path) -> ProfileStats {
     collect_corpus_stats(workspace, &mut stats);
     collect_lix_stats(workspace, &mut stats);
     stats
-}
-
-fn collect_backend_profile_stats(backend: &FsBackend, stats: &mut ProfileStats) {
-    let read = backend
-        .begin_read(ReadOptions::default())
-        .expect("profile backend read should open");
-    let binary_cas =
-        collect_binary_cas_storage_stats(&read).expect("profile binary CAS stats should collect");
-    read.close().expect("profile backend read should close");
-    apply_binary_cas_stats(stats, binary_cas);
 }
 
 async fn run_read_benchmark(backend: &FsBackend, workspace: &Path) -> ReadBenchStats {
@@ -427,17 +287,6 @@ fn stable_path_hash(path: &str) -> u64 {
     hash
 }
 
-fn apply_binary_cas_stats(stats: &mut ProfileStats, binary_cas: BinaryCasStorageStats) {
-    stats.binary_cas_manifest_rows = binary_cas.manifest_rows;
-    stats.binary_cas_empty_blob_rows = binary_cas.empty_blob_rows;
-    stats.binary_cas_single_chunk_blob_rows = binary_cas.single_chunk_blob_rows;
-    stats.binary_cas_chunked_blob_rows = binary_cas.chunked_blob_rows;
-    stats.binary_cas_manifest_chunk_rows = binary_cas.manifest_chunk_rows;
-    stats.binary_cas_chunk_rows = binary_cas.chunk_rows;
-    stats.binary_cas_total_chunk_refs = binary_cas.total_chunk_refs;
-    stats.binary_cas_logical_blob_bytes = binary_cas.logical_blob_bytes;
-}
-
 fn collect_corpus_stats(root: &Path, stats: &mut ProfileStats) {
     let Ok(entries) = std::fs::read_dir(root) else {
         return;
@@ -533,47 +382,23 @@ fn print_result(
     args: &Args,
     copy_elapsed: Option<Duration>,
     open_elapsed: Duration,
-    open_metrics: &BinaryCasWriteMetrics,
     warm_elapsed: Option<Duration>,
-    warm_metrics: Option<&BinaryCasWriteMetrics>,
-    compact_elapsed: Option<Duration>,
     read_bench: Option<&ReadBenchStats>,
     stats: &ProfileStats,
     workspace_path: Option<&Path>,
 ) {
     if args.json {
-        let blob_min_json = args
-            .backend
-            .blob_min_size()
-            .map_or("null".to_string(), |size| size.to_string());
         let workspace_json = workspace_path.map_or("null".to_string(), |path| {
             json_string(&path.display().to_string())
         });
-        let compact_ms_json = compact_elapsed
-            .map(|duration| duration_ms(duration).to_string())
-            .unwrap_or_else(|| "null".to_string());
         let read_bench = read_bench.copied().unwrap_or_default();
         match (copy_elapsed, warm_elapsed) {
             (Some(copy_elapsed), Some(warm_elapsed)) => println!(
                 concat!(
                     "{{",
-                    "\"backend\":\"{}\",",
-                    "\"blob_min_size\":{},",
                     "\"copy_ms\":{},",
                     "\"cold_open_ms\":{},",
                     "\"warm_reopen_ms\":{},",
-                    "\"cold_binary_cas_chunk_lookup_count\":{},",
-                    "\"cold_binary_cas_chunk_lookup_batch_count\":{},",
-                    "\"cold_binary_cas_chunk_lookup_hit_count\":{},",
-                    "\"cold_binary_cas_chunk_lookup_miss_count\":{},",
-                    "\"cold_binary_cas_chunk_lookup_time_us\":{},",
-                    "\"cold_binary_cas_transaction_duplicate_chunk_count\":{},",
-                    "\"warm_binary_cas_chunk_lookup_count\":{},",
-                    "\"warm_binary_cas_chunk_lookup_batch_count\":{},",
-                    "\"warm_binary_cas_chunk_lookup_hit_count\":{},",
-                    "\"warm_binary_cas_chunk_lookup_miss_count\":{},",
-                    "\"warm_binary_cas_chunk_lookup_time_us\":{},",
-                    "\"warm_binary_cas_transaction_duplicate_chunk_count\":{},",
                     "\"read_all_files_ms\":{},",
                     "\"read_all_files_count\":{},",
                     "\"read_all_files_bytes\":{},",
@@ -584,7 +409,6 @@ fn print_result(
                     "\"read_small_sample_ms\":{},",
                     "\"read_small_sample_count\":{},",
                     "\"read_small_sample_bytes\":{},",
-                    "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
                     "\"corpus_bytes\":{},",
@@ -596,46 +420,12 @@ fn print_result(
                     "\"rocksdb_log_bytes\":{},",
                     "\"rocksdb_manifest_bytes\":{},",
                     "\"rocksdb_options_bytes\":{},",
-                    "\"rocksdb_other_bytes\":{},",
-                    "\"binary_cas_manifest_rows\":{},",
-                    "\"binary_cas_empty_blob_rows\":{},",
-                    "\"binary_cas_single_chunk_blob_rows\":{},",
-                    "\"binary_cas_chunked_blob_rows\":{},",
-                    "\"binary_cas_manifest_chunk_rows\":{},",
-                    "\"binary_cas_chunk_rows\":{},",
-                    "\"binary_cas_total_chunk_refs\":{},",
-                    "\"binary_cas_logical_blob_bytes\":{}",
+                    "\"rocksdb_other_bytes\":{}",
                     "}}"
                 ),
-                args.backend.name(),
-                blob_min_json,
                 duration_ms(copy_elapsed),
                 duration_ms(open_elapsed),
                 duration_ms(warm_elapsed),
-                open_metrics.chunk_lookup_count,
-                open_metrics.chunk_lookup_batch_count,
-                open_metrics.chunk_lookup_hit_count,
-                open_metrics.chunk_lookup_miss_count,
-                metric_duration_us(open_metrics.chunk_lookup_elapsed_ns),
-                open_metrics.transaction_duplicate_chunk_count,
-                warm_metrics
-                    .map(|metrics| metrics.chunk_lookup_count)
-                    .unwrap_or_default(),
-                warm_metrics
-                    .map(|metrics| metrics.chunk_lookup_batch_count)
-                    .unwrap_or_default(),
-                warm_metrics
-                    .map(|metrics| metrics.chunk_lookup_hit_count)
-                    .unwrap_or_default(),
-                warm_metrics
-                    .map(|metrics| metrics.chunk_lookup_miss_count)
-                    .unwrap_or_default(),
-                warm_metrics
-                    .map(|metrics| metric_duration_us(metrics.chunk_lookup_elapsed_ns))
-                    .unwrap_or_default(),
-                warm_metrics
-                    .map(|metrics| metrics.transaction_duplicate_chunk_count)
-                    .unwrap_or_default(),
                 read_bench.all_files_ms,
                 read_bench.all_files_count,
                 read_bench.all_files_bytes,
@@ -646,7 +436,6 @@ fn print_result(
                 read_bench.small_sample_ms,
                 read_bench.small_sample_count,
                 read_bench.small_sample_bytes,
-                compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
                 stats.corpus_bytes,
@@ -658,28 +447,12 @@ fn print_result(
                 stats.rocksdb_log_bytes,
                 stats.rocksdb_manifest_bytes,
                 stats.rocksdb_options_bytes,
-                stats.rocksdb_other_bytes,
-                stats.binary_cas_manifest_rows,
-                stats.binary_cas_empty_blob_rows,
-                stats.binary_cas_single_chunk_blob_rows,
-                stats.binary_cas_chunked_blob_rows,
-                stats.binary_cas_manifest_chunk_rows,
-                stats.binary_cas_chunk_rows,
-                stats.binary_cas_total_chunk_refs,
-                stats.binary_cas_logical_blob_bytes
+                stats.rocksdb_other_bytes
             ),
             _ => println!(
                 concat!(
                     "{{",
-                    "\"backend\":\"{}\",",
-                    "\"blob_min_size\":{},",
                     "\"open_ms\":{},",
-                    "\"open_binary_cas_chunk_lookup_count\":{},",
-                    "\"open_binary_cas_chunk_lookup_batch_count\":{},",
-                    "\"open_binary_cas_chunk_lookup_hit_count\":{},",
-                    "\"open_binary_cas_chunk_lookup_miss_count\":{},",
-                    "\"open_binary_cas_chunk_lookup_time_us\":{},",
-                    "\"open_binary_cas_transaction_duplicate_chunk_count\":{},",
                     "\"read_all_files_ms\":{},",
                     "\"read_all_files_count\":{},",
                     "\"read_all_files_bytes\":{},",
@@ -690,7 +463,6 @@ fn print_result(
                     "\"read_small_sample_ms\":{},",
                     "\"read_small_sample_count\":{},",
                     "\"read_small_sample_bytes\":{},",
-                    "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
                     "\"corpus_bytes\":{},",
@@ -702,26 +474,10 @@ fn print_result(
                     "\"rocksdb_log_bytes\":{},",
                     "\"rocksdb_manifest_bytes\":{},",
                     "\"rocksdb_options_bytes\":{},",
-                    "\"rocksdb_other_bytes\":{},",
-                    "\"binary_cas_manifest_rows\":{},",
-                    "\"binary_cas_empty_blob_rows\":{},",
-                    "\"binary_cas_single_chunk_blob_rows\":{},",
-                    "\"binary_cas_chunked_blob_rows\":{},",
-                    "\"binary_cas_manifest_chunk_rows\":{},",
-                    "\"binary_cas_chunk_rows\":{},",
-                    "\"binary_cas_total_chunk_refs\":{},",
-                    "\"binary_cas_logical_blob_bytes\":{}",
+                    "\"rocksdb_other_bytes\":{}",
                     "}}"
                 ),
-                args.backend.name(),
-                blob_min_json,
                 duration_ms(open_elapsed),
-                open_metrics.chunk_lookup_count,
-                open_metrics.chunk_lookup_batch_count,
-                open_metrics.chunk_lookup_hit_count,
-                open_metrics.chunk_lookup_miss_count,
-                metric_duration_us(open_metrics.chunk_lookup_elapsed_ns),
-                open_metrics.transaction_duplicate_chunk_count,
                 read_bench.all_files_ms,
                 read_bench.all_files_count,
                 read_bench.all_files_bytes,
@@ -732,7 +488,6 @@ fn print_result(
                 read_bench.small_sample_ms,
                 read_bench.small_sample_count,
                 read_bench.small_sample_bytes,
-                compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
                 stats.corpus_bytes,
@@ -744,69 +499,25 @@ fn print_result(
                 stats.rocksdb_log_bytes,
                 stats.rocksdb_manifest_bytes,
                 stats.rocksdb_options_bytes,
-                stats.rocksdb_other_bytes,
-                stats.binary_cas_manifest_rows,
-                stats.binary_cas_empty_blob_rows,
-                stats.binary_cas_single_chunk_blob_rows,
-                stats.binary_cas_chunked_blob_rows,
-                stats.binary_cas_manifest_chunk_rows,
-                stats.binary_cas_chunk_rows,
-                stats.binary_cas_total_chunk_refs,
-                stats.binary_cas_logical_blob_bytes
+                stats.rocksdb_other_bytes
             ),
         }
     } else if args.in_place {
         println!("OPEN_MS={}", duration_ms(open_elapsed));
-        print_open_metrics("OPEN", open_metrics);
-        if let Some(compact_elapsed) = compact_elapsed {
-            println!("COMPACT_MS={}", duration_ms(compact_elapsed));
-        }
         if let Some(read_bench) = read_bench {
             print_read_bench(read_bench);
         }
         print_text_stats(stats, workspace_path);
     } else {
         println!("COLD_OPEN_MS={}", duration_ms(open_elapsed));
-        print_open_metrics("COLD", open_metrics);
-        if let (Some(warm_elapsed), Some(warm_metrics)) = (warm_elapsed, warm_metrics) {
+        if let Some(warm_elapsed) = warm_elapsed {
             println!("WARM_REOPEN_MS={}", duration_ms(warm_elapsed));
-            print_open_metrics("WARM", warm_metrics);
-        }
-        if let Some(compact_elapsed) = compact_elapsed {
-            println!("COMPACT_MS={}", duration_ms(compact_elapsed));
         }
         if let Some(read_bench) = read_bench {
             print_read_bench(read_bench);
         }
         print_text_stats(stats, workspace_path);
     }
-}
-
-fn print_open_metrics(prefix: &str, metrics: &BinaryCasWriteMetrics) {
-    println!(
-        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_COUNT={}",
-        metrics.chunk_lookup_count
-    );
-    println!(
-        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_BATCH_COUNT={}",
-        metrics.chunk_lookup_batch_count
-    );
-    println!(
-        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_HIT_COUNT={}",
-        metrics.chunk_lookup_hit_count
-    );
-    println!(
-        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_MISS_COUNT={}",
-        metrics.chunk_lookup_miss_count
-    );
-    println!(
-        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_TIME_US={}",
-        metric_duration_us(metrics.chunk_lookup_elapsed_ns)
-    );
-    println!(
-        "{prefix}_BINARY_CAS_TRANSACTION_DUPLICATE_CHUNK_COUNT={}",
-        metrics.transaction_duplicate_chunk_count
-    );
 }
 
 fn print_read_bench(read_bench: &ReadBenchStats) {
@@ -846,35 +557,6 @@ fn print_text_stats(stats: &ProfileStats, workspace_path: Option<&Path>) {
     println!("ROCKSDB_MANIFEST_BYTES={}", stats.rocksdb_manifest_bytes);
     println!("ROCKSDB_OPTIONS_BYTES={}", stats.rocksdb_options_bytes);
     println!("ROCKSDB_OTHER_BYTES={}", stats.rocksdb_other_bytes);
-    println!(
-        "BINARY_CAS_MANIFEST_ROWS={}",
-        stats.binary_cas_manifest_rows
-    );
-    println!(
-        "BINARY_CAS_EMPTY_BLOB_ROWS={}",
-        stats.binary_cas_empty_blob_rows
-    );
-    println!(
-        "BINARY_CAS_SINGLE_CHUNK_BLOB_ROWS={}",
-        stats.binary_cas_single_chunk_blob_rows
-    );
-    println!(
-        "BINARY_CAS_CHUNKED_BLOB_ROWS={}",
-        stats.binary_cas_chunked_blob_rows
-    );
-    println!(
-        "BINARY_CAS_MANIFEST_CHUNK_ROWS={}",
-        stats.binary_cas_manifest_chunk_rows
-    );
-    println!("BINARY_CAS_CHUNK_ROWS={}", stats.binary_cas_chunk_rows);
-    println!(
-        "BINARY_CAS_TOTAL_CHUNK_REFS={}",
-        stats.binary_cas_total_chunk_refs
-    );
-    println!(
-        "BINARY_CAS_LOGICAL_BLOB_BYTES={}",
-        stats.binary_cas_logical_blob_bytes
-    );
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -883,25 +565,20 @@ async fn main() {
     let src = Path::new(&args.src);
 
     if args.in_place {
-        let (backend, open_elapsed, open_metrics) = open_with_metrics(args.backend, src).await;
-        eprintln!("{} in-place open: {open_elapsed:?}", args.backend.name());
+        let (backend, open_elapsed) = open_with_timing(src).await;
+        eprintln!("in-place open: {open_elapsed:?}");
         let read_bench = if args.read_bench {
             Some(run_read_benchmark(&backend, src).await)
         } else {
             None
         };
-        let compact_elapsed = compact_backend_if_requested(&args, &backend);
-        let mut stats = collect_profile_stats(src);
-        collect_backend_profile_stats(&backend, &mut stats);
+        let stats = collect_profile_stats(src);
         drop(backend);
         print_result(
             &args,
             None,
             open_elapsed,
-            &open_metrics,
             None,
-            None,
-            compact_elapsed,
             read_bench.as_ref(),
             &stats,
             Some(src),
@@ -922,21 +599,19 @@ async fn main() {
         .and_then(|v| v.parse().ok())
         .unwrap_or(1);
 
-    let (backend, open_elapsed, open_metrics) = open_with_metrics(args.backend, &work).await;
-    eprintln!("{} cold open: {open_elapsed:?}", args.backend.name());
+    let (backend, open_elapsed) = open_with_timing(&work).await;
+    eprintln!("cold open: {open_elapsed:?}");
     drop(backend);
 
     // Warm reopen (now .lix exists).
-    let (backend, warm_elapsed, warm_metrics) = open_with_metrics(args.backend, &work).await;
-    eprintln!("{} warm reopen: {warm_elapsed:?}", args.backend.name());
+    let (backend, warm_elapsed) = open_with_timing(&work).await;
+    eprintln!("warm reopen: {warm_elapsed:?}");
     let read_bench = if args.read_bench {
         Some(run_read_benchmark(&backend, &work).await)
     } else {
         None
     };
-    let compact_elapsed = compact_backend_if_requested(&args, &backend);
-    let mut stats = collect_profile_stats(&work);
-    collect_backend_profile_stats(&backend, &mut stats);
+    let stats = collect_profile_stats(&work);
     drop(backend);
 
     // Repeated cold opens into fresh temp dirs for profiling sample density.
@@ -945,13 +620,10 @@ async fn main() {
         let work_i = tmp_i.path().join("workspace");
         copy_dir(src, &work_i);
         let t = Instant::now();
-        let backend = args.backend.open(&work_i).await;
+        let backend = FsBackend::open(&work_i).await.unwrap();
         if i == repeat - 1 {
             let elapsed = t.elapsed();
-            eprintln!(
-                "{} cold open (repeat {repeat}): {elapsed:?}",
-                args.backend.name()
-            );
+            eprintln!("cold open (repeat {repeat}): {elapsed:?}");
         }
         drop(backend);
     }
@@ -961,10 +633,7 @@ async fn main() {
         &args,
         Some(copy_elapsed),
         open_elapsed,
-        &open_metrics,
         Some(warm_elapsed),
-        Some(&warm_metrics),
-        compact_elapsed,
         read_bench.as_ref(),
         &stats,
         workspace_path,

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -1,15 +1,80 @@
 // Cold-open profiling harness for the filesystem backend.
 //
 // Usage:
-//   cargo run --release --example profile_fs_open --features sqlite -- <src_dir>
+//   cargo run --release --example profile_fs_open --features sqlite,rocksdb -- \
+//     --backend sqlite <src_dir>
 //
 // Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
 // FsBackend::open on the cold workspace.
 
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use lix_sdk::FsBackend;
+#[cfg(feature = "rocksdb")]
+use lix_sdk::{FsBackendFilter, RocksDbBlobOptions};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProfileBackend {
+    Sqlite,
+    #[cfg(feature = "rocksdb")]
+    RocksDb,
+    #[cfg(feature = "rocksdb")]
+    RocksDbBlob {
+        min_blob_size: u64,
+    },
+}
+
+#[derive(Debug)]
+struct Args {
+    backend: ProfileBackend,
+    in_place: bool,
+    json: bool,
+    src: String,
+}
+
+impl ProfileBackend {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDb => "rocksdb",
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDbBlob { .. } => "rocksdb-blob",
+        }
+    }
+
+    fn blob_min_size(self) -> Option<u64> {
+        match self {
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDbBlob { min_blob_size } => Some(min_blob_size),
+            Self::Sqlite => None,
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDb => None,
+        }
+    }
+
+    async fn open(self, path: &Path) -> FsBackend {
+        match self {
+            Self::Sqlite => FsBackend::open(path).await.unwrap(),
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDb => FsBackend::open_rocksdb(path).await.unwrap(),
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDbBlob { min_blob_size } => FsBackend::open_rocksdb_with_blob_options(
+                path,
+                FsBackendFilter::default(),
+                RocksDbBlobOptions::Enabled {
+                    min_blob_size,
+                    blob_file_size: 256 * 1024 * 1024,
+                    enable_gc: true,
+                    gc_age_cutoff: 0.25,
+                },
+            )
+            .await
+            .unwrap(),
+        }
+    }
+}
 
 fn copy_dir(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).unwrap();
@@ -29,12 +94,144 @@ fn copy_dir(src: &Path, dst: &Path) {
     }
 }
 
+fn parse_args() -> Args {
+    let mut raw = std::env::args().skip(1);
+    let mut backend = ProfileBackend::Sqlite;
+    let mut in_place = false;
+    let mut json = false;
+    let mut src = None;
+
+    while let Some(arg) = raw.next() {
+        match arg.as_str() {
+            "--backend" => {
+                let value = raw.next().expect("--backend requires a value");
+                backend = match value.as_str() {
+                    "sqlite" => ProfileBackend::Sqlite,
+                    "rocksdb" => {
+                        #[cfg(feature = "rocksdb")]
+                        {
+                            ProfileBackend::RocksDb
+                        }
+                        #[cfg(not(feature = "rocksdb"))]
+                        {
+                            panic!("profile_fs_open was built without the rocksdb feature")
+                        }
+                    }
+                    "rocksdb-blob" => {
+                        #[cfg(feature = "rocksdb")]
+                        {
+                            ProfileBackend::RocksDbBlob {
+                                min_blob_size: 64 * 1024,
+                            }
+                        }
+                        #[cfg(not(feature = "rocksdb"))]
+                        {
+                            panic!("profile_fs_open was built without the rocksdb feature")
+                        }
+                    }
+                    other => panic!("unknown backend '{other}'"),
+                };
+            }
+            "--blob-min" => {
+                let value = raw.next().expect("--blob-min requires a value");
+                let min_blob_size = parse_size(&value);
+                #[cfg(feature = "rocksdb")]
+                {
+                    backend = ProfileBackend::RocksDbBlob { min_blob_size };
+                }
+                #[cfg(not(feature = "rocksdb"))]
+                {
+                    let _ = min_blob_size;
+                    panic!("profile_fs_open was built without the rocksdb feature")
+                }
+            }
+            "--in-place" => in_place = true,
+            "--json" => json = true,
+            _ if arg.starts_with("--") => panic!("unknown option '{arg}'"),
+            _ => {
+                if src.replace(arg).is_some() {
+                    panic!("profile_fs_open accepts exactly one source directory");
+                }
+            }
+        }
+    }
+
+    Args {
+        backend,
+        in_place,
+        json,
+        src: src.expect(
+            "usage: profile_fs_open [--json] [--in-place] [--backend sqlite|rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
+        ),
+    }
+}
+
+fn parse_size(value: &str) -> u64 {
+    let Some(last_digit) = value.rfind(|ch: char| ch.is_ascii_digit()) else {
+        panic!("size must include digits");
+    };
+    let (digits, suffix) = value.split_at(last_digit + 1);
+    let base = digits.parse::<u64>().expect("size digits must parse");
+    match suffix.to_ascii_lowercase().as_str() {
+        "" => base,
+        "k" | "kb" | "kib" => base * 1024,
+        "m" | "mb" | "mib" => base * 1024 * 1024,
+        other => panic!("unknown size suffix '{other}'"),
+    }
+}
+
+fn duration_ms(duration: Duration) -> u128 {
+    duration.as_micros() / 1000
+}
+
+fn print_result(
+    args: &Args,
+    copy_elapsed: Option<Duration>,
+    open_elapsed: Duration,
+    warm_elapsed: Option<Duration>,
+) {
+    if args.json {
+        let blob_min_json = args
+            .backend
+            .blob_min_size()
+            .map_or("null".to_string(), |size| size.to_string());
+        match (copy_elapsed, warm_elapsed) {
+            (Some(copy_elapsed), Some(warm_elapsed)) => println!(
+                "{{\"backend\":\"{}\",\"blob_min_size\":{},\"copy_ms\":{},\"cold_open_ms\":{},\"warm_reopen_ms\":{}}}",
+                args.backend.name(),
+                blob_min_json,
+                duration_ms(copy_elapsed),
+                duration_ms(open_elapsed),
+                duration_ms(warm_elapsed)
+            ),
+            _ => println!(
+                "{{\"backend\":\"{}\",\"blob_min_size\":{},\"open_ms\":{}}}",
+                args.backend.name(),
+                blob_min_json,
+                duration_ms(open_elapsed)
+            ),
+        }
+    } else if args.in_place {
+        println!("OPEN_MS={}", duration_ms(open_elapsed));
+    } else {
+        println!("COLD_OPEN_MS={}", duration_ms(open_elapsed));
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let src = std::env::args()
-        .nth(1)
-        .expect("usage: profile_fs_open <src_dir>");
-    let src = Path::new(&src);
+    let args = parse_args();
+    let src = Path::new(&args.src);
+
+    if args.in_place {
+        let t_open = Instant::now();
+        let backend = args.backend.open(src).await;
+        let open_elapsed = t_open.elapsed();
+        eprintln!("{} in-place open: {open_elapsed:?}", args.backend.name());
+        drop(backend);
+        print_result(&args, None, open_elapsed, None);
+        return;
+    }
 
     let tmp = tempfile::tempdir().unwrap();
     let work = tmp.path().join("workspace");
@@ -50,16 +247,16 @@ async fn main() {
         .unwrap_or(1);
 
     let t_open = Instant::now();
-    let backend = FsBackend::open(&work).await.unwrap();
+    let backend = args.backend.open(&work).await;
     let open_elapsed = t_open.elapsed();
-    eprintln!("cold open: {open_elapsed:?}");
+    eprintln!("{} cold open: {open_elapsed:?}", args.backend.name());
     drop(backend);
 
     // Warm reopen (now .lix exists).
     let t_warm = Instant::now();
-    let backend = FsBackend::open(&work).await.unwrap();
+    let backend = args.backend.open(&work).await;
     let warm_elapsed = t_warm.elapsed();
-    eprintln!("warm reopen: {warm_elapsed:?}");
+    eprintln!("{} warm reopen: {warm_elapsed:?}", args.backend.name());
     drop(backend);
 
     // Repeated cold opens into fresh temp dirs for profiling sample density.
@@ -68,13 +265,16 @@ async fn main() {
         let work_i = tmp_i.path().join("workspace");
         copy_dir(src, &work_i);
         let t = Instant::now();
-        let backend = FsBackend::open(&work_i).await.unwrap();
+        let backend = args.backend.open(&work_i).await;
         if i == repeat - 1 {
             let elapsed = t.elapsed();
-            eprintln!("cold open (repeat {repeat}): {elapsed:?}");
+            eprintln!(
+                "{} cold open (repeat {repeat}): {elapsed:?}",
+                args.backend.name()
+            );
         }
         drop(backend);
     }
 
-    println!("COLD_OPEN_MS={}", open_elapsed.as_millis());
+    print_result(&args, Some(copy_elapsed), open_elapsed, Some(warm_elapsed));
 }

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -12,8 +12,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use lix_engine::{
-    Backend as _, BackendRead as _, BinaryCasStorageStats, ReadOptions,
-    collect_binary_cas_storage_stats,
+    Backend as _, BackendRead as _, BinaryCasStorageStats, BinaryCasWriteMetrics, ReadOptions,
+    binary_cas_write_metrics_snapshot, collect_binary_cas_storage_stats,
+    reset_binary_cas_write_metrics,
 };
 use lix_sdk::FsBackend;
 #[cfg(feature = "rocksdb")]
@@ -224,6 +225,22 @@ fn duration_ms(duration: Duration) -> u128 {
     duration.as_micros() / 1000
 }
 
+fn metric_duration_us(ns: u64) -> u64 {
+    ns / 1000
+}
+
+async fn open_with_metrics(
+    backend: ProfileBackend,
+    path: &Path,
+) -> (FsBackend, Duration, BinaryCasWriteMetrics) {
+    reset_binary_cas_write_metrics();
+    let started = Instant::now();
+    let opened = backend.open(path).await;
+    let elapsed = started.elapsed();
+    let metrics = binary_cas_write_metrics_snapshot();
+    (opened, elapsed, metrics)
+}
+
 fn compact_backend_if_requested(args: &Args, backend: &FsBackend) -> Option<Duration> {
     if !args.compact_before_stats {
         return None;
@@ -383,7 +400,9 @@ fn print_result(
     args: &Args,
     copy_elapsed: Option<Duration>,
     open_elapsed: Duration,
+    open_metrics: &BinaryCasWriteMetrics,
     warm_elapsed: Option<Duration>,
+    warm_metrics: Option<&BinaryCasWriteMetrics>,
     compact_elapsed: Option<Duration>,
     stats: &ProfileStats,
     workspace_path: Option<&Path>,
@@ -408,6 +427,16 @@ fn print_result(
                     "\"copy_ms\":{},",
                     "\"cold_open_ms\":{},",
                     "\"warm_reopen_ms\":{},",
+                    "\"cold_binary_cas_chunk_lookup_count\":{},",
+                    "\"cold_binary_cas_chunk_lookup_hit_count\":{},",
+                    "\"cold_binary_cas_chunk_lookup_miss_count\":{},",
+                    "\"cold_binary_cas_chunk_lookup_time_us\":{},",
+                    "\"cold_binary_cas_transaction_duplicate_chunk_count\":{},",
+                    "\"warm_binary_cas_chunk_lookup_count\":{},",
+                    "\"warm_binary_cas_chunk_lookup_hit_count\":{},",
+                    "\"warm_binary_cas_chunk_lookup_miss_count\":{},",
+                    "\"warm_binary_cas_chunk_lookup_time_us\":{},",
+                    "\"warm_binary_cas_transaction_duplicate_chunk_count\":{},",
                     "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
@@ -440,6 +469,26 @@ fn print_result(
                 duration_ms(copy_elapsed),
                 duration_ms(open_elapsed),
                 duration_ms(warm_elapsed),
+                open_metrics.chunk_lookup_count,
+                open_metrics.chunk_lookup_hit_count,
+                open_metrics.chunk_lookup_miss_count,
+                metric_duration_us(open_metrics.chunk_lookup_elapsed_ns),
+                open_metrics.transaction_duplicate_chunk_count,
+                warm_metrics
+                    .map(|metrics| metrics.chunk_lookup_count)
+                    .unwrap_or_default(),
+                warm_metrics
+                    .map(|metrics| metrics.chunk_lookup_hit_count)
+                    .unwrap_or_default(),
+                warm_metrics
+                    .map(|metrics| metrics.chunk_lookup_miss_count)
+                    .unwrap_or_default(),
+                warm_metrics
+                    .map(|metrics| metric_duration_us(metrics.chunk_lookup_elapsed_ns))
+                    .unwrap_or_default(),
+                warm_metrics
+                    .map(|metrics| metrics.transaction_duplicate_chunk_count)
+                    .unwrap_or_default(),
                 compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
@@ -472,6 +521,11 @@ fn print_result(
                     "\"backend\":\"{}\",",
                     "\"blob_min_size\":{},",
                     "\"open_ms\":{},",
+                    "\"open_binary_cas_chunk_lookup_count\":{},",
+                    "\"open_binary_cas_chunk_lookup_hit_count\":{},",
+                    "\"open_binary_cas_chunk_lookup_miss_count\":{},",
+                    "\"open_binary_cas_chunk_lookup_time_us\":{},",
+                    "\"open_binary_cas_transaction_duplicate_chunk_count\":{},",
                     "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
@@ -502,6 +556,11 @@ fn print_result(
                 args.backend.name(),
                 blob_min_json,
                 duration_ms(open_elapsed),
+                open_metrics.chunk_lookup_count,
+                open_metrics.chunk_lookup_hit_count,
+                open_metrics.chunk_lookup_miss_count,
+                metric_duration_us(open_metrics.chunk_lookup_elapsed_ns),
+                open_metrics.transaction_duplicate_chunk_count,
                 compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
@@ -531,17 +590,46 @@ fn print_result(
         }
     } else if args.in_place {
         println!("OPEN_MS={}", duration_ms(open_elapsed));
+        print_open_metrics("OPEN", open_metrics);
         if let Some(compact_elapsed) = compact_elapsed {
             println!("COMPACT_MS={}", duration_ms(compact_elapsed));
         }
         print_text_stats(stats, workspace_path);
     } else {
         println!("COLD_OPEN_MS={}", duration_ms(open_elapsed));
+        print_open_metrics("COLD", open_metrics);
+        if let (Some(warm_elapsed), Some(warm_metrics)) = (warm_elapsed, warm_metrics) {
+            println!("WARM_REOPEN_MS={}", duration_ms(warm_elapsed));
+            print_open_metrics("WARM", warm_metrics);
+        }
         if let Some(compact_elapsed) = compact_elapsed {
             println!("COMPACT_MS={}", duration_ms(compact_elapsed));
         }
         print_text_stats(stats, workspace_path);
     }
+}
+
+fn print_open_metrics(prefix: &str, metrics: &BinaryCasWriteMetrics) {
+    println!(
+        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_COUNT={}",
+        metrics.chunk_lookup_count
+    );
+    println!(
+        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_HIT_COUNT={}",
+        metrics.chunk_lookup_hit_count
+    );
+    println!(
+        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_MISS_COUNT={}",
+        metrics.chunk_lookup_miss_count
+    );
+    println!(
+        "{prefix}_BINARY_CAS_CHUNK_LOOKUP_TIME_US={}",
+        metric_duration_us(metrics.chunk_lookup_elapsed_ns)
+    );
+    println!(
+        "{prefix}_BINARY_CAS_TRANSACTION_DUPLICATE_CHUNK_COUNT={}",
+        metrics.transaction_duplicate_chunk_count
+    );
 }
 
 fn print_text_stats(stats: &ProfileStats, workspace_path: Option<&Path>) {
@@ -600,9 +688,7 @@ async fn main() {
     let src = Path::new(&args.src);
 
     if args.in_place {
-        let t_open = Instant::now();
-        let backend = args.backend.open(src).await;
-        let open_elapsed = t_open.elapsed();
+        let (backend, open_elapsed, open_metrics) = open_with_metrics(args.backend, src).await;
         eprintln!("{} in-place open: {open_elapsed:?}", args.backend.name());
         let compact_elapsed = compact_backend_if_requested(&args, &backend);
         let mut stats = collect_profile_stats(src);
@@ -612,6 +698,8 @@ async fn main() {
             &args,
             None,
             open_elapsed,
+            &open_metrics,
+            None,
             None,
             compact_elapsed,
             &stats,
@@ -633,16 +721,12 @@ async fn main() {
         .and_then(|v| v.parse().ok())
         .unwrap_or(1);
 
-    let t_open = Instant::now();
-    let backend = args.backend.open(&work).await;
-    let open_elapsed = t_open.elapsed();
+    let (backend, open_elapsed, open_metrics) = open_with_metrics(args.backend, &work).await;
     eprintln!("{} cold open: {open_elapsed:?}", args.backend.name());
     drop(backend);
 
     // Warm reopen (now .lix exists).
-    let t_warm = Instant::now();
-    let backend = args.backend.open(&work).await;
-    let warm_elapsed = t_warm.elapsed();
+    let (backend, warm_elapsed, warm_metrics) = open_with_metrics(args.backend, &work).await;
     eprintln!("{} warm reopen: {warm_elapsed:?}", args.backend.name());
     let compact_elapsed = compact_backend_if_requested(&args, &backend);
     let mut stats = collect_profile_stats(&work);
@@ -671,7 +755,9 @@ async fn main() {
         &args,
         Some(copy_elapsed),
         open_elapsed,
+        &open_metrics,
         Some(warm_elapsed),
+        Some(&warm_metrics),
         compact_elapsed,
         &stats,
         workspace_path,

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -1,8 +1,8 @@
 // Cold-open profiling harness for the filesystem backend.
 //
 // Usage:
-//   cargo run --release --example profile_fs_open --features sqlite,rocksdb -- \
-//     --backend sqlite <src_dir>
+//   cargo run --release --example profile_fs_open --features rocksdb -- \
+//     --backend rocksdb-blob <src_dir>
 //
 // Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
 // FsBackend::open on the cold workspace. Pass --keep-workspace to preserve the
@@ -16,19 +16,15 @@ use lix_engine::{
     Value, binary_cas_write_metrics_snapshot, collect_binary_cas_storage_stats,
     reset_binary_cas_write_metrics,
 };
-use lix_sdk::{FsBackend, open_lix_with_backend};
-#[cfg(feature = "rocksdb")]
-use lix_sdk::{FsBackendFilter, RocksDbBlobOptions};
+use lix_fs_backend::RocksDbBlobOptions;
+use lix_sdk::{FsBackend, FsBackendFilter, open_lix_with_backend};
+
+const DEFAULT_BLOB_MIN_SIZE: u64 = 32 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ProfileBackend {
-    Sqlite,
-    #[cfg(feature = "rocksdb")]
     RocksDb,
-    #[cfg(feature = "rocksdb")]
-    RocksDbBlob {
-        min_blob_size: u64,
-    },
+    RocksDbBlob { min_blob_size: u64 },
 }
 
 #[derive(Debug)]
@@ -47,10 +43,6 @@ struct ProfileStats {
     corpus_file_count: u64,
     corpus_bytes: u64,
     lix_total_bytes: u64,
-    sqlite_db_bytes: u64,
-    sqlite_wal_bytes: u64,
-    sqlite_shm_bytes: u64,
-    sqlite_other_bytes: u64,
     rocksdb_total_bytes: u64,
     rocksdb_sst_bytes: u64,
     rocksdb_blob_bytes: u64,
@@ -92,31 +84,31 @@ struct BenchFile {
 impl ProfileBackend {
     fn name(self) -> &'static str {
         match self {
-            Self::Sqlite => "sqlite",
-            #[cfg(feature = "rocksdb")]
             Self::RocksDb => "rocksdb",
-            #[cfg(feature = "rocksdb")]
             Self::RocksDbBlob { .. } => "rocksdb-blob",
         }
     }
 
     fn blob_min_size(self) -> Option<u64> {
         match self {
-            #[cfg(feature = "rocksdb")]
             Self::RocksDbBlob { min_blob_size } => Some(min_blob_size),
-            Self::Sqlite => None,
-            #[cfg(feature = "rocksdb")]
             Self::RocksDb => None,
         }
     }
 
     async fn open(self, path: &Path) -> FsBackend {
         match self {
-            Self::Sqlite => FsBackend::open(path).await.unwrap(),
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb => FsBackend::open_rocksdb(path).await.unwrap(),
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDbBlob { min_blob_size } => FsBackend::open_rocksdb_with_blob_options(
+            Self::RocksDb => FsBackend::open_with_rocksdb_blob_options(
+                path,
+                FsBackendFilter::default(),
+                RocksDbBlobOptions::Disabled,
+            )
+            .await
+            .unwrap(),
+            Self::RocksDbBlob {
+                min_blob_size: DEFAULT_BLOB_MIN_SIZE,
+            } => FsBackend::open(path).await.unwrap(),
+            Self::RocksDbBlob { min_blob_size } => FsBackend::open_with_rocksdb_blob_options(
                 path,
                 FsBackendFilter::default(),
                 RocksDbBlobOptions::Enabled {
@@ -152,7 +144,9 @@ fn copy_dir(src: &Path, dst: &Path) {
 
 fn parse_args() -> Args {
     let mut raw = std::env::args().skip(1);
-    let mut backend = ProfileBackend::Sqlite;
+    let mut backend = ProfileBackend::RocksDbBlob {
+        min_blob_size: DEFAULT_BLOB_MIN_SIZE,
+    };
     let mut compact_before_stats = false;
     let mut in_place = false;
     let mut json = false;
@@ -165,44 +159,17 @@ fn parse_args() -> Args {
             "--backend" => {
                 let value = raw.next().expect("--backend requires a value");
                 backend = match value.as_str() {
-                    "sqlite" => ProfileBackend::Sqlite,
-                    "rocksdb" => {
-                        #[cfg(feature = "rocksdb")]
-                        {
-                            ProfileBackend::RocksDb
-                        }
-                        #[cfg(not(feature = "rocksdb"))]
-                        {
-                            panic!("profile_fs_open was built without the rocksdb feature")
-                        }
-                    }
-                    "rocksdb-blob" => {
-                        #[cfg(feature = "rocksdb")]
-                        {
-                            ProfileBackend::RocksDbBlob {
-                                min_blob_size: 64 * 1024,
-                            }
-                        }
-                        #[cfg(not(feature = "rocksdb"))]
-                        {
-                            panic!("profile_fs_open was built without the rocksdb feature")
-                        }
-                    }
+                    "rocksdb" => ProfileBackend::RocksDb,
+                    "rocksdb-blob" => ProfileBackend::RocksDbBlob {
+                        min_blob_size: DEFAULT_BLOB_MIN_SIZE,
+                    },
                     other => panic!("unknown backend '{other}'"),
                 };
             }
             "--blob-min" => {
                 let value = raw.next().expect("--blob-min requires a value");
                 let min_blob_size = parse_size(&value);
-                #[cfg(feature = "rocksdb")]
-                {
-                    backend = ProfileBackend::RocksDbBlob { min_blob_size };
-                }
-                #[cfg(not(feature = "rocksdb"))]
-                {
-                    let _ = min_blob_size;
-                    panic!("profile_fs_open was built without the rocksdb feature")
-                }
+                backend = ProfileBackend::RocksDbBlob { min_blob_size };
             }
             "--compact-before-stats" => compact_before_stats = true,
             "--in-place" => in_place = true,
@@ -226,7 +193,7 @@ fn parse_args() -> Args {
         keep_workspace,
         read_bench,
         src: src.expect(
-            "usage: profile_fs_open [--json] [--in-place] [--keep-workspace] [--read-bench] [--backend sqlite|rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
+            "usage: profile_fs_open [--json] [--in-place] [--keep-workspace] [--read-bench] [--backend rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
         ),
     }
 }
@@ -496,17 +463,11 @@ fn collect_lix_stats(workspace: &Path, stats: &mut ProfileStats) {
     if !lix_dir.exists() {
         return;
     }
-    let internal_dir = lix_dir.join(".internal");
-    let rocksdb_dir = internal_dir.join("rocksdb");
-    collect_lix_stats_recursive(&lix_dir, &internal_dir, &rocksdb_dir, stats);
+    let rocksdb_dir = lix_dir.join(".internal/rocksdb");
+    collect_lix_stats_recursive(&lix_dir, &rocksdb_dir, stats);
 }
 
-fn collect_lix_stats_recursive(
-    dir: &Path,
-    internal_dir: &Path,
-    rocksdb_dir: &Path,
-    stats: &mut ProfileStats,
-) {
+fn collect_lix_stats_recursive(dir: &Path, rocksdb_dir: &Path, stats: &mut ProfileStats) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -515,7 +476,7 @@ fn collect_lix_stats_recursive(
         let path = entry.path();
         let metadata = entry.metadata().unwrap();
         if metadata.is_dir() {
-            collect_lix_stats_recursive(&path, internal_dir, rocksdb_dir, stats);
+            collect_lix_stats_recursive(&path, rocksdb_dir, stats);
             continue;
         }
         if !metadata.is_file() {
@@ -526,18 +487,7 @@ fn collect_lix_stats_recursive(
         stats.lix_total_bytes += bytes;
         if path.strip_prefix(rocksdb_dir).is_ok() {
             classify_rocksdb_file(&path, bytes, stats);
-        } else if path.strip_prefix(internal_dir).is_ok() {
-            classify_sqlite_file(&path, bytes, stats);
         }
-    }
-}
-
-fn classify_sqlite_file(path: &Path, bytes: u64, stats: &mut ProfileStats) {
-    match path.file_name().and_then(|name| name.to_str()) {
-        Some("db.sqlite") => stats.sqlite_db_bytes += bytes,
-        Some("db.sqlite-wal") => stats.sqlite_wal_bytes += bytes,
-        Some("db.sqlite-shm") => stats.sqlite_shm_bytes += bytes,
-        _ => stats.sqlite_other_bytes += bytes,
     }
 }
 
@@ -639,10 +589,6 @@ fn print_result(
                     "\"corpus_file_count\":{},",
                     "\"corpus_bytes\":{},",
                     "\"lix_total_bytes\":{},",
-                    "\"sqlite_db_bytes\":{},",
-                    "\"sqlite_wal_bytes\":{},",
-                    "\"sqlite_shm_bytes\":{},",
-                    "\"sqlite_other_bytes\":{},",
                     "\"rocksdb_total_bytes\":{},",
                     "\"rocksdb_sst_bytes\":{},",
                     "\"rocksdb_blob_bytes\":{},",
@@ -705,10 +651,6 @@ fn print_result(
                 stats.corpus_file_count,
                 stats.corpus_bytes,
                 stats.lix_total_bytes,
-                stats.sqlite_db_bytes,
-                stats.sqlite_wal_bytes,
-                stats.sqlite_shm_bytes,
-                stats.sqlite_other_bytes,
                 stats.rocksdb_total_bytes,
                 stats.rocksdb_sst_bytes,
                 stats.rocksdb_blob_bytes,
@@ -753,10 +695,6 @@ fn print_result(
                     "\"corpus_file_count\":{},",
                     "\"corpus_bytes\":{},",
                     "\"lix_total_bytes\":{},",
-                    "\"sqlite_db_bytes\":{},",
-                    "\"sqlite_wal_bytes\":{},",
-                    "\"sqlite_shm_bytes\":{},",
-                    "\"sqlite_other_bytes\":{},",
                     "\"rocksdb_total_bytes\":{},",
                     "\"rocksdb_sst_bytes\":{},",
                     "\"rocksdb_blob_bytes\":{},",
@@ -799,10 +737,6 @@ fn print_result(
                 stats.corpus_file_count,
                 stats.corpus_bytes,
                 stats.lix_total_bytes,
-                stats.sqlite_db_bytes,
-                stats.sqlite_wal_bytes,
-                stats.sqlite_shm_bytes,
-                stats.sqlite_other_bytes,
                 stats.rocksdb_total_bytes,
                 stats.rocksdb_sst_bytes,
                 stats.rocksdb_blob_bytes,
@@ -904,10 +838,6 @@ fn print_text_stats(stats: &ProfileStats, workspace_path: Option<&Path>) {
     println!("CORPUS_FILE_COUNT={}", stats.corpus_file_count);
     println!("CORPUS_BYTES={}", stats.corpus_bytes);
     println!("LIX_TOTAL_BYTES={}", stats.lix_total_bytes);
-    println!("SQLITE_DB_BYTES={}", stats.sqlite_db_bytes);
-    println!("SQLITE_WAL_BYTES={}", stats.sqlite_wal_bytes);
-    println!("SQLITE_SHM_BYTES={}", stats.sqlite_shm_bytes);
-    println!("SQLITE_OTHER_BYTES={}", stats.sqlite_other_bytes);
     println!("ROCKSDB_TOTAL_BYTES={}", stats.rocksdb_total_bytes);
     println!("ROCKSDB_SST_BYTES={}", stats.rocksdb_sst_bytes);
     println!("ROCKSDB_BLOB_BYTES={}", stats.rocksdb_blob_bytes);

--- a/packages/rs-sdk/examples/profile_fs_open.rs
+++ b/packages/rs-sdk/examples/profile_fs_open.rs
@@ -13,10 +13,10 @@ use std::time::{Duration, Instant};
 
 use lix_engine::{
     Backend as _, BackendRead as _, BinaryCasStorageStats, BinaryCasWriteMetrics, ReadOptions,
-    binary_cas_write_metrics_snapshot, collect_binary_cas_storage_stats,
+    Value, binary_cas_write_metrics_snapshot, collect_binary_cas_storage_stats,
     reset_binary_cas_write_metrics,
 };
-use lix_sdk::FsBackend;
+use lix_sdk::{FsBackend, open_lix_with_backend};
 #[cfg(feature = "rocksdb")]
 use lix_sdk::{FsBackendFilter, RocksDbBlobOptions};
 
@@ -38,6 +38,7 @@ struct Args {
     in_place: bool,
     json: bool,
     keep_workspace: bool,
+    read_bench: bool,
     src: String,
 }
 
@@ -66,6 +67,26 @@ struct ProfileStats {
     binary_cas_chunk_rows: u64,
     binary_cas_total_chunk_refs: u64,
     binary_cas_logical_blob_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ReadBenchStats {
+    all_files_ms: u128,
+    all_files_count: u64,
+    all_files_bytes: u64,
+    largest_files_ms: u128,
+    largest_files_repeat_ms: u128,
+    largest_files_count: u64,
+    largest_files_bytes: u64,
+    small_sample_ms: u128,
+    small_sample_count: u64,
+    small_sample_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct BenchFile {
+    lix_path: String,
+    size_bytes: u64,
 }
 
 impl ProfileBackend {
@@ -136,6 +157,7 @@ fn parse_args() -> Args {
     let mut in_place = false;
     let mut json = false;
     let mut keep_workspace = false;
+    let mut read_bench = false;
     let mut src = None;
 
     while let Some(arg) = raw.next() {
@@ -186,6 +208,7 @@ fn parse_args() -> Args {
             "--in-place" => in_place = true,
             "--json" => json = true,
             "--keep-workspace" => keep_workspace = true,
+            "--read-bench" => read_bench = true,
             _ if arg.starts_with("--") => panic!("unknown option '{arg}'"),
             _ => {
                 if src.replace(arg).is_some() {
@@ -201,8 +224,9 @@ fn parse_args() -> Args {
         in_place,
         json,
         keep_workspace,
+        read_bench,
         src: src.expect(
-            "usage: profile_fs_open [--json] [--in-place] [--keep-workspace] [--backend sqlite|rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
+            "usage: profile_fs_open [--json] [--in-place] [--keep-workspace] [--read-bench] [--backend sqlite|rocksdb|rocksdb-blob] [--blob-min bytes] <src_dir>",
         ),
     }
 }
@@ -275,6 +299,165 @@ fn collect_backend_profile_stats(backend: &FsBackend, stats: &mut ProfileStats) 
         collect_binary_cas_storage_stats(&read).expect("profile binary CAS stats should collect");
     read.close().expect("profile backend read should close");
     apply_binary_cas_stats(stats, binary_cas);
+}
+
+async fn run_read_benchmark(backend: &FsBackend, workspace: &Path) -> ReadBenchStats {
+    let files = collect_bench_files(workspace);
+    let largest = files.iter().take(4).collect::<Vec<_>>();
+    let small_sample = select_small_sample(&files, 16);
+    let lix = open_lix_with_backend(backend.clone())
+        .await
+        .expect("profile read benchmark should open lix");
+
+    let all_started = Instant::now();
+    let all_files = lix
+        .execute("SELECT path, data FROM lix_file ORDER BY path", &[])
+        .await
+        .expect("profile read benchmark should read all files");
+    let all_files_ms = duration_ms(all_started.elapsed());
+    let mut all_files_count = 0u64;
+    let mut all_files_bytes = 0u64;
+    for row in all_files.rows() {
+        let _path = row
+            .get::<String>("path")
+            .expect("profile read benchmark path should decode");
+        let data = row
+            .get::<Vec<u8>>("data")
+            .expect("profile read benchmark data should decode");
+        all_files_count += 1;
+        all_files_bytes += data.len() as u64;
+    }
+
+    let (largest_files_ms, largest_files_bytes) = time_read_paths(&lix, &largest).await;
+    let (largest_files_repeat_ms, repeat_largest_bytes) = time_read_paths(&lix, &largest).await;
+    assert_eq!(
+        largest_files_bytes, repeat_largest_bytes,
+        "profile read benchmark repeated largest reads should return the same bytes"
+    );
+    let (small_sample_ms, small_sample_bytes) = time_read_paths(&lix, &small_sample).await;
+    lix.close()
+        .await
+        .expect("profile read benchmark should close lix");
+
+    ReadBenchStats {
+        all_files_ms,
+        all_files_count,
+        all_files_bytes,
+        largest_files_ms,
+        largest_files_repeat_ms,
+        largest_files_count: largest.len() as u64,
+        largest_files_bytes,
+        small_sample_ms,
+        small_sample_count: small_sample.len() as u64,
+        small_sample_bytes,
+    }
+}
+
+async fn time_read_paths(lix: &lix_sdk::Lix<FsBackend>, files: &[&BenchFile]) -> (u128, u64) {
+    let started = Instant::now();
+    let mut bytes = 0u64;
+    for file in files {
+        let result = lix
+            .execute(
+                "SELECT data FROM lix_file WHERE path = $1",
+                &[Value::Text(file.lix_path.clone())],
+            )
+            .await
+            .expect("profile read benchmark should read file");
+        let row = result
+            .rows()
+            .first()
+            .unwrap_or_else(|| panic!("missing lix_file row for {}", file.lix_path));
+        let data = row
+            .get::<Vec<u8>>("data")
+            .expect("profile read benchmark data should decode");
+        assert_eq!(
+            data.len() as u64,
+            file.size_bytes,
+            "profile read benchmark byte count mismatch for {}",
+            file.lix_path
+        );
+        bytes += data.len() as u64;
+    }
+    (duration_ms(started.elapsed()), bytes)
+}
+
+fn collect_bench_files(workspace: &Path) -> Vec<BenchFile> {
+    let mut files = Vec::new();
+    collect_bench_files_recursive(workspace, workspace, &mut files);
+    files.sort_by(|left, right| {
+        right
+            .size_bytes
+            .cmp(&left.size_bytes)
+            .then_with(|| left.lix_path.cmp(&right.lix_path))
+    });
+    files
+}
+
+fn collect_bench_files_recursive(root: &Path, dir: &Path, files: &mut Vec<BenchFile>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries {
+        let entry = entry.expect("profile read benchmark should read directory entry");
+        if entry.file_name() == ".lix" {
+            continue;
+        }
+        let path = entry.path();
+        let metadata = entry
+            .metadata()
+            .expect("profile read benchmark should read metadata");
+        if metadata.is_dir() {
+            collect_bench_files_recursive(root, &path, files);
+        } else if metadata.is_file() {
+            files.push(BenchFile {
+                lix_path: local_path_to_lix_path(root, &path),
+                size_bytes: metadata.len(),
+            });
+        }
+    }
+}
+
+fn local_path_to_lix_path(root: &Path, path: &Path) -> String {
+    let relative = path
+        .strip_prefix(root)
+        .expect("profile read benchmark file should be under workspace");
+    let mut lix_path = String::from("/");
+    for (index, component) in relative.components().enumerate() {
+        if index > 0 {
+            lix_path.push('/');
+        }
+        match component {
+            std::path::Component::Normal(segment) => {
+                lix_path.push_str(&segment.to_string_lossy());
+            }
+            _ => panic!("profile read benchmark only supports normal path components"),
+        }
+    }
+    lix_path
+}
+
+fn select_small_sample(files: &[BenchFile], count: usize) -> Vec<&BenchFile> {
+    let mut small = files
+        .iter()
+        .filter(|file| file.size_bytes <= 64 * 1024)
+        .collect::<Vec<_>>();
+    small.sort_by(|left, right| {
+        stable_path_hash(&left.lix_path)
+            .cmp(&stable_path_hash(&right.lix_path))
+            .then_with(|| left.lix_path.cmp(&right.lix_path))
+    });
+    small.truncate(count);
+    small
+}
+
+fn stable_path_hash(path: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in path.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
 }
 
 fn apply_binary_cas_stats(stats: &mut ProfileStats, binary_cas: BinaryCasStorageStats) {
@@ -404,6 +587,7 @@ fn print_result(
     warm_elapsed: Option<Duration>,
     warm_metrics: Option<&BinaryCasWriteMetrics>,
     compact_elapsed: Option<Duration>,
+    read_bench: Option<&ReadBenchStats>,
     stats: &ProfileStats,
     workspace_path: Option<&Path>,
 ) {
@@ -418,6 +602,7 @@ fn print_result(
         let compact_ms_json = compact_elapsed
             .map(|duration| duration_ms(duration).to_string())
             .unwrap_or_else(|| "null".to_string());
+        let read_bench = read_bench.copied().unwrap_or_default();
         match (copy_elapsed, warm_elapsed) {
             (Some(copy_elapsed), Some(warm_elapsed)) => println!(
                 concat!(
@@ -439,6 +624,16 @@ fn print_result(
                     "\"warm_binary_cas_chunk_lookup_miss_count\":{},",
                     "\"warm_binary_cas_chunk_lookup_time_us\":{},",
                     "\"warm_binary_cas_transaction_duplicate_chunk_count\":{},",
+                    "\"read_all_files_ms\":{},",
+                    "\"read_all_files_count\":{},",
+                    "\"read_all_files_bytes\":{},",
+                    "\"read_largest_files_ms\":{},",
+                    "\"read_largest_files_repeat_ms\":{},",
+                    "\"read_largest_files_count\":{},",
+                    "\"read_largest_files_bytes\":{},",
+                    "\"read_small_sample_ms\":{},",
+                    "\"read_small_sample_count\":{},",
+                    "\"read_small_sample_bytes\":{},",
                     "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
@@ -495,6 +690,16 @@ fn print_result(
                 warm_metrics
                     .map(|metrics| metrics.transaction_duplicate_chunk_count)
                     .unwrap_or_default(),
+                read_bench.all_files_ms,
+                read_bench.all_files_count,
+                read_bench.all_files_bytes,
+                read_bench.largest_files_ms,
+                read_bench.largest_files_repeat_ms,
+                read_bench.largest_files_count,
+                read_bench.largest_files_bytes,
+                read_bench.small_sample_ms,
+                read_bench.small_sample_count,
+                read_bench.small_sample_bytes,
                 compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
@@ -533,6 +738,16 @@ fn print_result(
                     "\"open_binary_cas_chunk_lookup_miss_count\":{},",
                     "\"open_binary_cas_chunk_lookup_time_us\":{},",
                     "\"open_binary_cas_transaction_duplicate_chunk_count\":{},",
+                    "\"read_all_files_ms\":{},",
+                    "\"read_all_files_count\":{},",
+                    "\"read_all_files_bytes\":{},",
+                    "\"read_largest_files_ms\":{},",
+                    "\"read_largest_files_repeat_ms\":{},",
+                    "\"read_largest_files_count\":{},",
+                    "\"read_largest_files_bytes\":{},",
+                    "\"read_small_sample_ms\":{},",
+                    "\"read_small_sample_count\":{},",
+                    "\"read_small_sample_bytes\":{},",
                     "\"compact_ms\":{},",
                     "\"workspace_path\":{},",
                     "\"corpus_file_count\":{},",
@@ -569,6 +784,16 @@ fn print_result(
                 open_metrics.chunk_lookup_miss_count,
                 metric_duration_us(open_metrics.chunk_lookup_elapsed_ns),
                 open_metrics.transaction_duplicate_chunk_count,
+                read_bench.all_files_ms,
+                read_bench.all_files_count,
+                read_bench.all_files_bytes,
+                read_bench.largest_files_ms,
+                read_bench.largest_files_repeat_ms,
+                read_bench.largest_files_count,
+                read_bench.largest_files_bytes,
+                read_bench.small_sample_ms,
+                read_bench.small_sample_count,
+                read_bench.small_sample_bytes,
                 compact_ms_json,
                 workspace_json,
                 stats.corpus_file_count,
@@ -602,6 +827,9 @@ fn print_result(
         if let Some(compact_elapsed) = compact_elapsed {
             println!("COMPACT_MS={}", duration_ms(compact_elapsed));
         }
+        if let Some(read_bench) = read_bench {
+            print_read_bench(read_bench);
+        }
         print_text_stats(stats, workspace_path);
     } else {
         println!("COLD_OPEN_MS={}", duration_ms(open_elapsed));
@@ -612,6 +840,9 @@ fn print_result(
         }
         if let Some(compact_elapsed) = compact_elapsed {
             println!("COMPACT_MS={}", duration_ms(compact_elapsed));
+        }
+        if let Some(read_bench) = read_bench {
+            print_read_bench(read_bench);
         }
         print_text_stats(stats, workspace_path);
     }
@@ -642,6 +873,28 @@ fn print_open_metrics(prefix: &str, metrics: &BinaryCasWriteMetrics) {
         "{prefix}_BINARY_CAS_TRANSACTION_DUPLICATE_CHUNK_COUNT={}",
         metrics.transaction_duplicate_chunk_count
     );
+}
+
+fn print_read_bench(read_bench: &ReadBenchStats) {
+    println!("READ_ALL_FILES_MS={}", read_bench.all_files_ms);
+    println!("READ_ALL_FILES_COUNT={}", read_bench.all_files_count);
+    println!("READ_ALL_FILES_BYTES={}", read_bench.all_files_bytes);
+    println!("READ_LARGEST_FILES_MS={}", read_bench.largest_files_ms);
+    println!(
+        "READ_LARGEST_FILES_REPEAT_MS={}",
+        read_bench.largest_files_repeat_ms
+    );
+    println!(
+        "READ_LARGEST_FILES_COUNT={}",
+        read_bench.largest_files_count
+    );
+    println!(
+        "READ_LARGEST_FILES_BYTES={}",
+        read_bench.largest_files_bytes
+    );
+    println!("READ_SMALL_SAMPLE_MS={}", read_bench.small_sample_ms);
+    println!("READ_SMALL_SAMPLE_COUNT={}", read_bench.small_sample_count);
+    println!("READ_SMALL_SAMPLE_BYTES={}", read_bench.small_sample_bytes);
 }
 
 fn print_text_stats(stats: &ProfileStats, workspace_path: Option<&Path>) {
@@ -702,6 +955,11 @@ async fn main() {
     if args.in_place {
         let (backend, open_elapsed, open_metrics) = open_with_metrics(args.backend, src).await;
         eprintln!("{} in-place open: {open_elapsed:?}", args.backend.name());
+        let read_bench = if args.read_bench {
+            Some(run_read_benchmark(&backend, src).await)
+        } else {
+            None
+        };
         let compact_elapsed = compact_backend_if_requested(&args, &backend);
         let mut stats = collect_profile_stats(src);
         collect_backend_profile_stats(&backend, &mut stats);
@@ -714,6 +972,7 @@ async fn main() {
             None,
             None,
             compact_elapsed,
+            read_bench.as_ref(),
             &stats,
             Some(src),
         );
@@ -740,6 +999,11 @@ async fn main() {
     // Warm reopen (now .lix exists).
     let (backend, warm_elapsed, warm_metrics) = open_with_metrics(args.backend, &work).await;
     eprintln!("{} warm reopen: {warm_elapsed:?}", args.backend.name());
+    let read_bench = if args.read_bench {
+        Some(run_read_benchmark(&backend, &work).await)
+    } else {
+        None
+    };
     let compact_elapsed = compact_backend_if_requested(&args, &backend);
     let mut stats = collect_profile_stats(&work);
     collect_backend_profile_stats(&backend, &mut stats);
@@ -771,6 +1035,7 @@ async fn main() {
         Some(warm_elapsed),
         Some(&warm_metrics),
         compact_elapsed,
+        read_bench.as_ref(),
         &stats,
         workspace_path,
     );

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -1612,11 +1612,27 @@ fn is_plugin_storage_path(path: &str) -> bool {
 }
 
 fn is_filesystem_metadata_path(path: &str) -> bool {
-    path == "/.lix/.gitignore" || path == "/.lix/.gitignore/" || is_filesystem_internal_path(path)
+    path == "/.lix/.gitignore"
+        || path == "/.lix/.gitignore/"
+        || is_filesystem_internal_path(path)
+        || is_legacy_filesystem_metadata_path(path)
 }
 
 fn is_filesystem_internal_path(path: &str) -> bool {
     path == "/.lix/.internal" || path.starts_with("/.lix/.internal/")
+}
+
+fn is_legacy_filesystem_metadata_path(path: &str) -> bool {
+    let path = path.strip_suffix('/').unwrap_or(path);
+    path == "/.lix_system"
+        || path.starts_with("/.lix_system/")
+        || path
+            .strip_prefix("/.lix/")
+            .is_some_and(is_legacy_filesystem_sqlite_metadata_name)
+}
+
+fn is_legacy_filesystem_sqlite_metadata_name(name: &str) -> bool {
+    LEGACY_FILESYSTEM_SQLITE_METADATA_NAMES.contains(&name)
 }
 
 fn is_filesystem_sync_ignored_local_path(
@@ -1644,6 +1660,12 @@ fn is_filesystem_sync_ignored_local_path(
         {
             return true;
         }
+        if metadata_mode == FilesystemMetadataMode::Persistent
+            && depth == 1
+            && segment == Some(".lix_system")
+        {
+            return true;
+        }
         if depth == 1 && segment == Some(".lix") {
             first_segment_is_lix = true;
         }
@@ -1651,6 +1673,13 @@ fn is_filesystem_sync_ignored_local_path(
             return true;
         }
         if depth == 2 && first_segment_is_lix && segment == Some(".internal") {
+            return true;
+        }
+        if metadata_mode == FilesystemMetadataMode::Persistent
+            && depth == 2
+            && first_segment_is_lix
+            && segment.is_some_and(is_legacy_filesystem_sqlite_metadata_name)
+        {
             return true;
         }
     }
@@ -1729,12 +1758,21 @@ fn open_filesystem_rocksdb_backend(dir: &Path) -> Result<RocksDbFilesystemBacken
 #[cfg(feature = "fs_backend")]
 fn ensure_filesystem_rocksdb_metadata_directory(dir: &Path) -> Result<PathBuf, LixError> {
     let lix_dir = ensure_filesystem_lix_directory(dir)?;
+    remove_legacy_filesystem_root_metadata(dir, &lix_dir)?;
     let internal_dir = lix_dir.join(".internal");
     reset_legacy_filesystem_internal_directory(&internal_dir)?;
     ensure_metadata_directory(&internal_dir, "filesystem metadata directory")?;
     let metadata_dir = internal_dir.join("rocksdb");
     ensure_metadata_directory(&metadata_dir, "filesystem RocksDB metadata directory")?;
     Ok(metadata_dir)
+}
+
+#[cfg(feature = "fs_backend")]
+fn remove_legacy_filesystem_root_metadata(root: &Path, lix_dir: &Path) -> Result<(), LixError> {
+    for name in LEGACY_FILESYSTEM_SQLITE_METADATA_NAMES {
+        remove_legacy_metadata_file(&lix_dir.join(name))?;
+    }
+    remove_legacy_metadata_path(&root.join(".lix_system"))
 }
 
 #[cfg(feature = "fs_backend")]
@@ -1777,14 +1815,71 @@ fn reset_legacy_filesystem_internal_directory(internal_dir: &Path) -> Result<(),
 
 #[cfg(feature = "fs_backend")]
 fn legacy_filesystem_sqlite_metadata_exists(internal_dir: &Path) -> bool {
-    [
-        "db.sqlite",
-        "db.sqlite-wal",
-        "db.sqlite-shm",
-        "db.sqlite-journal",
-    ]
-    .iter()
-    .any(|name| internal_dir.join(name).exists())
+    LEGACY_FILESYSTEM_SQLITE_METADATA_NAMES
+        .iter()
+        .any(|name| internal_dir.join(name).exists())
+}
+
+#[cfg(feature = "fs_backend")]
+fn remove_legacy_metadata_file(path: &Path) -> Result<(), LixError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(io_error(
+                "read legacy filesystem metadata file",
+                path,
+                error,
+            ));
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        let display = path.display();
+        return Err(filesystem_error(format!(
+            "legacy filesystem metadata file {display} must not be a symlink"
+        )));
+    }
+    if !metadata.is_file() {
+        let display = path.display();
+        return Err(filesystem_error(format!(
+            "legacy filesystem metadata path {display} must be a file"
+        )));
+    }
+    std::fs::remove_file(path)
+        .map_err(|error| io_error("remove legacy filesystem metadata file", path, error))
+}
+
+#[cfg(feature = "fs_backend")]
+fn remove_legacy_metadata_path(path: &Path) -> Result<(), LixError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(io_error(
+                "read legacy filesystem metadata path",
+                path,
+                error,
+            ));
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        let display = path.display();
+        return Err(filesystem_error(format!(
+            "legacy filesystem metadata path {display} must not be a symlink"
+        )));
+    }
+    if metadata.is_dir() {
+        return std::fs::remove_dir_all(path)
+            .map_err(|error| io_error("remove legacy filesystem metadata directory", path, error));
+    }
+    if metadata.is_file() {
+        return std::fs::remove_file(path)
+            .map_err(|error| io_error("remove legacy filesystem metadata file", path, error));
+    }
+    let display = path.display();
+    Err(filesystem_error(format!(
+        "legacy filesystem metadata path {display} must be a file or directory"
+    )))
 }
 
 #[cfg(feature = "fs_backend")]
@@ -1825,6 +1920,13 @@ fn ensure_gitignore(directory: &Path, content: &[u8]) -> Result<(), LixError> {
     std::fs::write(&gitignore, content)
         .map_err(|error| io_error("write filesystem .gitignore", &gitignore, error))
 }
+
+const LEGACY_FILESYSTEM_SQLITE_METADATA_NAMES: &[&str] = &[
+    "db.sqlite",
+    "db.sqlite-wal",
+    "db.sqlite-shm",
+    "db.sqlite-journal",
+];
 
 #[cfg(feature = "fs_backend")]
 fn rocksdb_backend_error(error: BackendError) -> LixError {

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -355,6 +355,23 @@ impl FsBackend {
         })
     }
 
+    #[cfg(feature = "rocksdb")]
+    pub fn compact_rocksdb(&self) -> Result<(), LixError> {
+        match &self.inner {
+            FsBackendInner::RocksDb(inner) => {
+                inner.inner.compact_all().map_err(rocksdb_backend_error)
+            }
+            #[cfg(feature = "sqlite")]
+            FsBackendInner::Sqlite(_) | FsBackendInner::Memory(_) => Err(filesystem_error(
+                "compact_rocksdb requires a RocksDB filesystem backend",
+            )),
+            #[cfg(not(feature = "sqlite"))]
+            FsBackendInner::Memory(_) => Err(filesystem_error(
+                "compact_rocksdb requires a RocksDB filesystem backend",
+            )),
+        }
+    }
+
     #[cfg(feature = "sqlite")]
     pub async fn open_with_wasm_runtime<P>(
         dir: P,

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -7,16 +7,15 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use lix_engine::{
-    Backend, BackendError, BackendWrite, CommitResult, Engine, Key, KeyRange, LixError, PutBatch,
-    ReadOptions, SessionContext, SpaceId, Value, WriteOptions,
+    Backend, BackendError, BackendRead, BackendWrite, CommitResult, Engine, GetOptions,
+    InMemoryBackend, Key, KeyRange, LixError, PointVisitor, PutBatch, ReadOptions, ScanOptions,
+    ScanResult, ScanVisitor, SessionContext, SpaceId, Value, WriteOptions,
 };
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
 
-#[cfg(feature = "rocksdb")]
-use lix_fs_backend::{
-    RocksDbBlobOptions, RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions,
-};
+#[cfg(feature = "fs_backend")]
+use lix_fs_backend::RocksDbFilesystemBackend;
 
 type FilesystemDebouncer = Debouncer<RecommendedWatcher, RecommendedCache>;
 const LIX_DIRECTORY_GITIGNORE: &[u8] = b"*\n";
@@ -38,6 +37,7 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FilesystemMetadataMode {
     Persistent,
+    Ephemeral,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -67,17 +67,37 @@ where
     supervisor: FilesystemSupervisor<B>,
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct FsBackend {
-    inner: FilesystemSync<RocksDbFilesystemBackend>,
+    inner: FsBackendInner,
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
+#[derive(Clone)]
+enum FsBackendInner {
+    Persistent(FilesystemSync<RocksDbFilesystemBackend>),
+    Memory(FilesystemSync<InMemoryBackend>),
+}
+
+#[cfg(feature = "fs_backend")]
+#[expect(missing_debug_implementations)]
+pub enum FsRead<'a> {
+    Persistent(lix_fs_backend::RocksDbFilesystemRead<'a>),
+    Memory(<InMemoryBackend as Backend>::Read<'a>),
+}
+
+#[cfg(feature = "fs_backend")]
 #[expect(missing_debug_implementations)]
 pub struct FsWrite<'a> {
-    inner: FilesystemWrite<'a, RocksDbFilesystemBackend>,
+    inner: FsWriteInner<'a>,
+}
+
+#[cfg(feature = "fs_backend")]
+enum FsWriteInner<'a> {
+    Persistent(FilesystemWrite<'a, RocksDbFilesystemBackend>),
+    Memory(FilesystemWrite<'a, InMemoryBackend>),
 }
 
 #[derive(Clone)]
@@ -223,7 +243,7 @@ enum FilesystemEvent {
     Shutdown,
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 impl FsBackend {
     pub async fn open<P>(dir: P) -> Result<Self, LixError>
     where
@@ -236,20 +256,8 @@ impl FsBackend {
     where
         P: AsRef<Path>,
     {
-        Self::open_with_rocksdb_blob_options(dir, filter, default_rocksdb_blob_options()).await
-    }
-
-    #[doc(hidden)]
-    pub async fn open_with_rocksdb_blob_options<P>(
-        dir: P,
-        filter: FsBackendFilter,
-        blob: RocksDbBlobOptions,
-    ) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
         FilesystemPathFilter::from_filter(filter.clone())?;
-        let backend = open_filesystem_rocksdb_backend(dir.as_ref(), blob)?;
+        let backend = open_filesystem_rocksdb_backend(dir.as_ref())?;
         let inner = FilesystemSync::open_filesystem(
             backend,
             dir.as_ref(),
@@ -257,21 +265,44 @@ impl FsBackend {
             filter,
         )
         .await?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner: FsBackendInner::Persistent(inner),
+        })
     }
 
-    pub fn compact_rocksdb(&self) -> Result<(), LixError> {
-        self.inner
-            .inner
-            .compact_all()
-            .map_err(rocksdb_backend_error)
+    pub async fn open_memory<P>(dir: P) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        Self::open_memory_with_filter(dir, FsBackendFilter::default()).await
+    }
+
+    pub async fn open_memory_with_filter<P>(
+        dir: P,
+        filter: FsBackendFilter,
+    ) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        FilesystemPathFilter::from_filter(filter.clone())?;
+        let backend = InMemoryBackend::new();
+        let inner = FilesystemSync::open_filesystem(
+            backend,
+            dir.as_ref(),
+            FilesystemMetadataMode::Ephemeral,
+            filter,
+        )
+        .await?;
+        Ok(Self {
+            inner: FsBackendInner::Memory(inner),
+        })
     }
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 impl Backend for FsBackend {
     type Read<'a>
-        = lix_fs_backend::RocksDbFilesystemRead<'a>
+        = FsRead<'a>
     where
         Self: 'a;
 
@@ -281,36 +312,94 @@ impl Backend for FsBackend {
         Self: 'a;
 
     fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
-        self.inner.begin_read(opts)
+        match &self.inner {
+            FsBackendInner::Persistent(inner) => Ok(FsRead::Persistent(inner.begin_read(opts)?)),
+            FsBackendInner::Memory(inner) => Ok(FsRead::Memory(inner.begin_read(opts)?)),
+        }
     }
 
     fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
-        Ok(FsWrite {
-            inner: self.inner.begin_write(opts)?,
-        })
+        match &self.inner {
+            FsBackendInner::Persistent(inner) => Ok(FsWrite {
+                inner: FsWriteInner::Persistent(inner.begin_write(opts)?),
+            }),
+            FsBackendInner::Memory(inner) => Ok(FsWrite {
+                inner: FsWriteInner::Memory(inner.begin_write(opts)?),
+            }),
+        }
     }
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
+impl BackendRead for FsRead<'_> {
+    fn visit_keys<V>(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<(), BackendError>
+    where
+        V: PointVisitor + ?Sized,
+    {
+        match self {
+            Self::Persistent(read) => read.visit_keys(space, keys, opts, visitor),
+            Self::Memory(read) => read.visit_keys(space, keys, opts, visitor),
+        }
+    }
+
+    fn scan<V>(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions<'_>,
+        visitor: &mut V,
+    ) -> Result<ScanResult, BackendError>
+    where
+        V: ScanVisitor + ?Sized,
+    {
+        match self {
+            Self::Persistent(read) => read.scan(space, range, opts, visitor),
+            Self::Memory(read) => read.scan(space, range, opts, visitor),
+        }
+    }
+}
+
+#[cfg(feature = "fs_backend")]
 impl BackendWrite for FsWrite<'_> {
     fn put_many(&mut self, space: SpaceId, entries: PutBatch) -> Result<(), BackendError> {
-        self.inner.put_many(space, entries)
+        match &mut self.inner {
+            FsWriteInner::Persistent(write) => write.put_many(space, entries),
+            FsWriteInner::Memory(write) => write.put_many(space, entries),
+        }
     }
 
     fn delete_many(&mut self, space: SpaceId, keys: &[Key]) -> Result<(), BackendError> {
-        self.inner.delete_many(space, keys)
+        match &mut self.inner {
+            FsWriteInner::Persistent(write) => write.delete_many(space, keys),
+            FsWriteInner::Memory(write) => write.delete_many(space, keys),
+        }
     }
 
     fn delete_range(&mut self, space: SpaceId, range: KeyRange) -> Result<(), BackendError> {
-        self.inner.delete_range(space, range)
+        match &mut self.inner {
+            FsWriteInner::Persistent(write) => write.delete_range(space, range),
+            FsWriteInner::Memory(write) => write.delete_range(space, range),
+        }
     }
 
     fn commit(self) -> Result<CommitResult, BackendError> {
-        self.inner.commit()
+        match self.inner {
+            FsWriteInner::Persistent(write) => write.commit(),
+            FsWriteInner::Memory(write) => write.commit(),
+        }
     }
 
     fn rollback(self) -> Result<(), BackendError> {
-        self.inner.rollback()
+        match self.inner {
+            FsWriteInner::Persistent(write) => write.rollback(),
+            FsWriteInner::Memory(write) => write.rollback(),
+        }
     }
 }
 
@@ -320,7 +409,7 @@ where
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     async fn open_filesystem<P>(
         backend: B,
         root: P,
@@ -422,7 +511,9 @@ where
         let root = std::fs::canonicalize(root)
             .map_err(|error| io_error("canonicalize filesystem root", root, error))?;
         let path_filter = FilesystemPathFilter::from_filter(filter)?;
-        ensure_filesystem_lix_directory(&root)?;
+        if metadata_mode == FilesystemMetadataMode::Persistent {
+            ensure_filesystem_lix_directory(&root)?;
+        }
         let session = engine.open_workspace_session().await?;
         let state = Arc::new(FilesystemState {
             session,
@@ -621,7 +712,7 @@ where
             if !local.files.contains_key(path)
                 && self.path_filter.includes_file(path)
                 && !is_plugin_storage_path(path)
-                && !is_materialization_ignored_path(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
             {
                 if previous
                     .as_ref()
@@ -648,7 +739,7 @@ where
             for path in lix.directories.difference(&local.directories) {
                 if path.as_str() == "/"
                     || is_plugin_storage_path(path)
-                    || is_materialization_ignored_path(path)
+                    || is_materialization_ignored_path(path, self.metadata_mode)
                 {
                     continue;
                 }
@@ -701,7 +792,7 @@ where
         for (path, data) in local
             .files
             .iter()
-            .filter(|(path, _)| !is_materialization_ignored_path(path))
+            .filter(|(path, _)| !is_materialization_ignored_path(path, self.metadata_mode))
         {
             if previous
                 .as_ref()
@@ -764,7 +855,7 @@ where
         for path in local.files.keys().filter(|path| {
             self.path_filter.includes_file(path)
                 && !target.files.contains_key(*path)
-                && !is_materialization_ignored_path(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
                 && previous
                     .as_ref()
                     .is_none_or(|snapshot| snapshot.files.contains_key(*path))
@@ -782,7 +873,10 @@ where
             let mut directories_to_remove = local
                 .directories
                 .difference(&target.directories)
-                .filter(|path| path.as_str() != "/" && !is_materialization_ignored_path(path))
+                .filter(|path| {
+                    path.as_str() != "/"
+                        && !is_materialization_ignored_path(path, self.metadata_mode)
+                })
                 .filter(|path| {
                     previous
                         .as_ref()
@@ -809,7 +903,7 @@ where
             .filter(|path| {
                 path.as_str() != "/"
                     && self.path_filter.includes_directory(path)
-                    && !is_materialization_ignored_path(path)
+                    && !is_materialization_ignored_path(path, self.metadata_mode)
             })
             .filter(|path| base.is_none_or(|snapshot| !snapshot.directories.contains(*path)))
             .filter(|path| {
@@ -825,7 +919,8 @@ where
         }
 
         for (path, data) in target.files.iter().filter(|(path, _)| {
-            self.path_filter.includes_file(path) && !is_materialization_ignored_path(path)
+            self.path_filter.includes_file(path)
+                && !is_materialization_ignored_path(path, self.metadata_mode)
         }) {
             if base.is_some_and(|snapshot| snapshot.files.get(path) == Some(data)) {
                 continue;
@@ -1527,7 +1622,7 @@ fn is_filesystem_internal_path(path: &str) -> bool {
 fn is_filesystem_sync_ignored_local_path(
     root: &Path,
     path: &Path,
-    _metadata_mode: FilesystemMetadataMode,
+    metadata_mode: FilesystemMetadataMode,
 ) -> bool {
     let Ok(relative) = path.strip_prefix(root) else {
         return true;
@@ -1543,6 +1638,12 @@ fn is_filesystem_sync_ignored_local_path(
         if segment == Some(".git") {
             return true;
         }
+        if metadata_mode == FilesystemMetadataMode::Ephemeral
+            && depth == 1
+            && segment == Some(".lix")
+        {
+            return true;
+        }
         if depth == 1 && segment == Some(".lix") {
             first_segment_is_lix = true;
         }
@@ -1556,12 +1657,20 @@ fn is_filesystem_sync_ignored_local_path(
     false
 }
 
-fn is_materialization_ignored_path(path: &str) -> bool {
-    is_filesystem_metadata_path(path)
+fn is_materialization_ignored_path(path: &str, metadata_mode: FilesystemMetadataMode) -> bool {
+    match metadata_mode {
+        FilesystemMetadataMode::Persistent => is_filesystem_metadata_path(path),
+        FilesystemMetadataMode::Ephemeral => is_lix_storage_path(path),
+    }
 }
 
-fn is_filesystem_sync_ignored_lix_path(path: &str, _metadata_mode: FilesystemMetadataMode) -> bool {
-    lix_path_contains_segment(path, ".git") || is_materialization_ignored_path(path)
+fn is_filesystem_sync_ignored_lix_path(path: &str, metadata_mode: FilesystemMetadataMode) -> bool {
+    lix_path_contains_segment(path, ".git") || is_materialization_ignored_path(path, metadata_mode)
+}
+
+fn is_lix_storage_path(path: &str) -> bool {
+    let path = path.strip_suffix('/').unwrap_or(path);
+    path == "/.lix" || path.starts_with("/.lix/")
 }
 
 fn lix_path_contains_segment(path: &str, segment: &str) -> bool {
@@ -1610,36 +1719,75 @@ fn filesystem_error(message: impl Into<String>) -> LixError {
     LixError::new("LIX_FILESYSTEM_ERROR", message)
 }
 
-#[cfg(feature = "rocksdb")]
-fn open_filesystem_rocksdb_backend(
-    dir: &Path,
-    blob: RocksDbBlobOptions,
-) -> Result<RocksDbFilesystemBackend, LixError> {
+#[cfg(feature = "fs_backend")]
+fn open_filesystem_rocksdb_backend(dir: &Path) -> Result<RocksDbFilesystemBackend, LixError> {
     ensure_filesystem_root_directory(dir)?;
     let metadata_dir = ensure_filesystem_rocksdb_metadata_directory(dir)?;
-    RocksDbFilesystemBackend::open_with_options(RocksDbFilesystemBackendOptions {
-        path: metadata_dir,
-        blob,
-    })
-    .map_err(rocksdb_backend_error)
+    RocksDbFilesystemBackend::open(metadata_dir).map_err(rocksdb_backend_error)
 }
 
-#[cfg(feature = "rocksdb")]
-fn default_rocksdb_blob_options() -> RocksDbBlobOptions {
-    RocksDbBlobOptions::default()
-}
-
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 fn ensure_filesystem_rocksdb_metadata_directory(dir: &Path) -> Result<PathBuf, LixError> {
     let lix_dir = ensure_filesystem_lix_directory(dir)?;
     let internal_dir = lix_dir.join(".internal");
+    reset_legacy_filesystem_internal_directory(&internal_dir)?;
     ensure_metadata_directory(&internal_dir, "filesystem metadata directory")?;
     let metadata_dir = internal_dir.join("rocksdb");
     ensure_metadata_directory(&metadata_dir, "filesystem RocksDB metadata directory")?;
     Ok(metadata_dir)
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
+fn reset_legacy_filesystem_internal_directory(internal_dir: &Path) -> Result<(), LixError> {
+    if internal_dir.join("rocksdb").exists() {
+        return Ok(());
+    }
+    if !legacy_filesystem_sqlite_metadata_exists(internal_dir) {
+        return Ok(());
+    }
+
+    let metadata = std::fs::symlink_metadata(internal_dir).map_err(|error| {
+        io_error(
+            "read legacy filesystem metadata directory",
+            internal_dir,
+            error,
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
+        let display = internal_dir.display();
+        return Err(filesystem_error(format!(
+            "legacy filesystem metadata directory {display} must not be a symlink"
+        )));
+    }
+    if !metadata.is_dir() {
+        let display = internal_dir.display();
+        return Err(filesystem_error(format!(
+            "legacy filesystem metadata path {display} must be a directory"
+        )));
+    }
+
+    std::fs::remove_dir_all(internal_dir).map_err(|error| {
+        io_error(
+            "remove legacy filesystem metadata directory",
+            internal_dir,
+            error,
+        )
+    })
+}
+
+#[cfg(feature = "fs_backend")]
+fn legacy_filesystem_sqlite_metadata_exists(internal_dir: &Path) -> bool {
+    [
+        "db.sqlite",
+        "db.sqlite-wal",
+        "db.sqlite-shm",
+        "db.sqlite-journal",
+    ]
+    .iter()
+    .any(|name| internal_dir.join(name).exists())
+}
+
+#[cfg(feature = "fs_backend")]
 fn ensure_metadata_directory(path: &Path, label: &str) -> Result<(), LixError> {
     match std::fs::create_dir(path) {
         Ok(()) => {}
@@ -1678,7 +1826,7 @@ fn ensure_gitignore(directory: &Path, content: &[u8]) -> Result<(), LixError> {
         .map_err(|error| io_error("write filesystem .gitignore", &gitignore, error))
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 fn rocksdb_backend_error(error: BackendError) -> LixError {
     LixError::new(
         LixError::CODE_STORAGE_ERROR,
@@ -1689,10 +1837,10 @@ fn rocksdb_backend_error(error: BackendError) -> LixError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     use lix_engine::Value;
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     async fn lix_read_file<B>(
         session: &SessionContext<B>,
         path: &str,
@@ -1715,7 +1863,7 @@ mod tests {
             .transpose()
     }
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     async fn lix_write_file<B>(
         session: &SessionContext<B>,
         path: &str,
@@ -1829,13 +1977,11 @@ mod tests {
         assert_eq!(lix_file_upsert_chunk_end(&files, 0, 10, 8), 1);
     }
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     #[tokio::test]
     async fn disk_sync_remembers_canonical_snapshot_for_idle_skip() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend =
-            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
-                .unwrap();
+        let backend = open_filesystem_rocksdb_backend(tempdir.path()).unwrap();
         let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();
@@ -1862,13 +2008,11 @@ mod tests {
         state.close().await.unwrap();
     }
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     #[tokio::test]
     async fn disk_sync_does_not_reimport_unchanged_materialized_file_deleted_in_lix() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend =
-            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
-                .unwrap();
+        let backend = open_filesystem_rocksdb_backend(tempdir.path()).unwrap();
         let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();
@@ -1916,13 +2060,11 @@ mod tests {
         state.close().await.unwrap();
     }
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     #[tokio::test]
     async fn disk_sync_does_not_skip_lix_side_file_data_change() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend =
-            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
-                .unwrap();
+        let backend = open_filesystem_rocksdb_backend(tempdir.path()).unwrap();
         let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();
@@ -1959,13 +2101,11 @@ mod tests {
         state.close().await.unwrap();
     }
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(feature = "fs_backend")]
     #[tokio::test]
     async fn disk_sync_materialization_preserves_file_changed_after_import() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend =
-            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
-                .unwrap();
+        let backend = open_filesystem_rocksdb_backend(tempdir.path()).unwrap();
         let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -6,17 +6,13 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
-    Backend, BackendError, BackendRead, BackendWrite, CommitResult, Engine, GetOptions,
-    InMemoryBackend, Key, KeyRange, LixError, PointVisitor, PutBatch, ReadOptions, ScanOptions,
-    ScanResult, ScanVisitor, SessionContext, SpaceId, Value, WriteOptions,
+    Backend, BackendError, BackendWrite, CommitResult, Engine, Key, KeyRange, LixError, PutBatch,
+    ReadOptions, SessionContext, SpaceId, Value, WriteOptions,
 };
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
 
-#[cfg(feature = "sqlite")]
-use crate::sqlite_backend::SqliteBackend;
 #[cfg(feature = "rocksdb")]
 use lix_fs_backend::{
     RocksDbBlobOptions, RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions,
@@ -42,7 +38,6 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FilesystemMetadataMode {
     Persistent,
-    Ephemeral,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -72,46 +67,17 @@ where
     supervisor: FilesystemSupervisor<B>,
 }
 
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
+#[cfg(feature = "rocksdb")]
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct FsBackend {
-    inner: FsBackendInner,
+    inner: FilesystemSync<RocksDbFilesystemBackend>,
 }
 
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
-#[derive(Clone)]
-enum FsBackendInner {
-    #[cfg(feature = "sqlite")]
-    Sqlite(FilesystemSync<SqliteBackend>),
-    #[cfg(feature = "rocksdb")]
-    RocksDb(FilesystemSync<RocksDbFilesystemBackend>),
-    Memory(FilesystemSync<InMemoryBackend>),
-}
-
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
-#[expect(missing_debug_implementations)]
-pub enum FsRead<'a> {
-    #[cfg(feature = "sqlite")]
-    Sqlite(crate::sqlite_backend::SqliteRead),
-    #[cfg(feature = "rocksdb")]
-    RocksDb(lix_fs_backend::RocksDbFilesystemRead<'a>),
-    Memory(<InMemoryBackend as Backend>::Read<'a>),
-}
-
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
+#[cfg(feature = "rocksdb")]
 #[expect(missing_debug_implementations)]
 pub struct FsWrite<'a> {
-    inner: FsWriteInner<'a>,
-}
-
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
-enum FsWriteInner<'a> {
-    #[cfg(feature = "sqlite")]
-    Sqlite(FilesystemWrite<'a, SqliteBackend>),
-    #[cfg(feature = "rocksdb")]
-    RocksDb(FilesystemWrite<'a, RocksDbFilesystemBackend>),
-    Memory(FilesystemWrite<'a, InMemoryBackend>),
+    inner: FilesystemWrite<'a, RocksDbFilesystemBackend>,
 }
 
 #[derive(Clone)]
@@ -257,9 +223,8 @@ enum FilesystemEvent {
     Shutdown,
 }
 
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
+#[cfg(feature = "rocksdb")]
 impl FsBackend {
-    #[cfg(feature = "sqlite")]
     pub async fn open<P>(dir: P) -> Result<Self, LixError>
     where
         P: AsRef<Path>,
@@ -267,46 +232,15 @@ impl FsBackend {
         Self::open_with_filter(dir, FsBackendFilter::default()).await
     }
 
-    #[cfg(feature = "sqlite")]
     pub async fn open_with_filter<P>(dir: P, filter: FsBackendFilter) -> Result<Self, LixError>
     where
         P: AsRef<Path>,
     {
-        FilesystemPathFilter::from_filter(filter.clone())?;
-        let backend = open_filesystem_sqlite_backend(dir.as_ref())?;
-        let inner = FilesystemSync::open_with_metadata_mode(
-            backend,
-            dir.as_ref(),
-            FilesystemMetadataMode::Persistent,
-            filter,
-        )
-        .await?;
-        Ok(Self {
-            inner: FsBackendInner::Sqlite(inner),
-        })
+        Self::open_with_rocksdb_blob_options(dir, filter, default_rocksdb_blob_options()).await
     }
 
-    #[cfg(feature = "rocksdb")]
-    pub async fn open_rocksdb<P>(dir: P) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        Self::open_rocksdb_with_filter(dir, FsBackendFilter::default()).await
-    }
-
-    #[cfg(feature = "rocksdb")]
-    pub async fn open_rocksdb_with_filter<P>(
-        dir: P,
-        filter: FsBackendFilter,
-    ) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        Self::open_rocksdb_with_blob_options(dir, filter, RocksDbBlobOptions::Disabled).await
-    }
-
-    #[cfg(feature = "rocksdb")]
-    pub async fn open_rocksdb_with_blob_options<P>(
+    #[doc(hidden)]
+    pub async fn open_with_rocksdb_blob_options<P>(
         dir: P,
         filter: FsBackendFilter,
         blob: RocksDbBlobOptions,
@@ -316,84 +250,28 @@ impl FsBackend {
     {
         FilesystemPathFilter::from_filter(filter.clone())?;
         let backend = open_filesystem_rocksdb_backend(dir.as_ref(), blob)?;
-        let inner = FilesystemSync::open_with_metadata_mode(
+        let inner = FilesystemSync::open_filesystem(
             backend,
             dir.as_ref(),
             FilesystemMetadataMode::Persistent,
             filter,
         )
         .await?;
-        Ok(Self {
-            inner: FsBackendInner::RocksDb(inner),
-        })
+        Ok(Self { inner })
     }
 
-    pub async fn open_memory<P>(dir: P) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        Self::open_memory_with_filter(dir, FsBackendFilter::default()).await
-    }
-
-    pub async fn open_memory_with_filter<P>(
-        dir: P,
-        filter: FsBackendFilter,
-    ) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        FilesystemPathFilter::from_filter(filter.clone())?;
-        let backend = InMemoryBackend::new();
-        let inner = FilesystemSync::open_with_metadata_mode(
-            backend,
-            dir.as_ref(),
-            FilesystemMetadataMode::Ephemeral,
-            filter,
-        )
-        .await?;
-        Ok(Self {
-            inner: FsBackendInner::Memory(inner),
-        })
-    }
-
-    #[cfg(feature = "rocksdb")]
     pub fn compact_rocksdb(&self) -> Result<(), LixError> {
-        match &self.inner {
-            FsBackendInner::RocksDb(inner) => {
-                inner.inner.compact_all().map_err(rocksdb_backend_error)
-            }
-            #[cfg(feature = "sqlite")]
-            FsBackendInner::Sqlite(_) | FsBackendInner::Memory(_) => Err(filesystem_error(
-                "compact_rocksdb requires a RocksDB filesystem backend",
-            )),
-            #[cfg(not(feature = "sqlite"))]
-            FsBackendInner::Memory(_) => Err(filesystem_error(
-                "compact_rocksdb requires a RocksDB filesystem backend",
-            )),
-        }
-    }
-
-    #[cfg(feature = "sqlite")]
-    pub async fn open_with_wasm_runtime<P>(
-        dir: P,
-        wasm_runtime: Arc<dyn WasmRuntime>,
-    ) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        let backend = open_filesystem_sqlite_backend(dir.as_ref())?;
-        let inner =
-            FilesystemSync::open_with_wasm_runtime(backend, dir.as_ref(), wasm_runtime).await?;
-        Ok(Self {
-            inner: FsBackendInner::Sqlite(inner),
-        })
+        self.inner
+            .inner
+            .compact_all()
+            .map_err(rocksdb_backend_error)
     }
 }
 
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
+#[cfg(feature = "rocksdb")]
 impl Backend for FsBackend {
     type Read<'a>
-        = FsRead<'a>
+        = lix_fs_backend::RocksDbFilesystemRead<'a>
     where
         Self: 'a;
 
@@ -403,123 +281,36 @@ impl Backend for FsBackend {
         Self: 'a;
 
     fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
-        match &self.inner {
-            #[cfg(feature = "sqlite")]
-            FsBackendInner::Sqlite(inner) => Ok(FsRead::Sqlite(inner.begin_read(opts)?)),
-            #[cfg(feature = "rocksdb")]
-            FsBackendInner::RocksDb(inner) => Ok(FsRead::RocksDb(inner.begin_read(opts)?)),
-            FsBackendInner::Memory(inner) => Ok(FsRead::Memory(inner.begin_read(opts)?)),
-        }
+        self.inner.begin_read(opts)
     }
 
     fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
-        match &self.inner {
-            #[cfg(feature = "sqlite")]
-            FsBackendInner::Sqlite(inner) => Ok(FsWrite {
-                inner: FsWriteInner::Sqlite(inner.begin_write(opts)?),
-            }),
-            #[cfg(feature = "rocksdb")]
-            FsBackendInner::RocksDb(inner) => Ok(FsWrite {
-                inner: FsWriteInner::RocksDb(inner.begin_write(opts)?),
-            }),
-            FsBackendInner::Memory(inner) => Ok(FsWrite {
-                inner: FsWriteInner::Memory(inner.begin_write(opts)?),
-            }),
-        }
+        Ok(FsWrite {
+            inner: self.inner.begin_write(opts)?,
+        })
     }
 }
 
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
-impl BackendRead for FsRead<'_> {
-    fn visit_keys<V>(
-        &self,
-        space: SpaceId,
-        keys: &[Key],
-        opts: GetOptions<'_>,
-        visitor: &mut V,
-    ) -> Result<(), BackendError>
-    where
-        V: PointVisitor + ?Sized,
-    {
-        match self {
-            #[cfg(feature = "sqlite")]
-            Self::Sqlite(read) => read.visit_keys(space, keys, opts, visitor),
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(read) => read.visit_keys(space, keys, opts, visitor),
-            Self::Memory(read) => read.visit_keys(space, keys, opts, visitor),
-        }
-    }
-
-    fn scan<V>(
-        &self,
-        space: SpaceId,
-        range: KeyRange,
-        opts: ScanOptions<'_>,
-        visitor: &mut V,
-    ) -> Result<ScanResult, BackendError>
-    where
-        V: ScanVisitor + ?Sized,
-    {
-        match self {
-            #[cfg(feature = "sqlite")]
-            Self::Sqlite(read) => read.scan(space, range, opts, visitor),
-            #[cfg(feature = "rocksdb")]
-            Self::RocksDb(read) => read.scan(space, range, opts, visitor),
-            Self::Memory(read) => read.scan(space, range, opts, visitor),
-        }
-    }
-}
-
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
+#[cfg(feature = "rocksdb")]
 impl BackendWrite for FsWrite<'_> {
     fn put_many(&mut self, space: SpaceId, entries: PutBatch) -> Result<(), BackendError> {
-        match &mut self.inner {
-            #[cfg(feature = "sqlite")]
-            FsWriteInner::Sqlite(write) => write.put_many(space, entries),
-            #[cfg(feature = "rocksdb")]
-            FsWriteInner::RocksDb(write) => write.put_many(space, entries),
-            FsWriteInner::Memory(write) => write.put_many(space, entries),
-        }
+        self.inner.put_many(space, entries)
     }
 
     fn delete_many(&mut self, space: SpaceId, keys: &[Key]) -> Result<(), BackendError> {
-        match &mut self.inner {
-            #[cfg(feature = "sqlite")]
-            FsWriteInner::Sqlite(write) => write.delete_many(space, keys),
-            #[cfg(feature = "rocksdb")]
-            FsWriteInner::RocksDb(write) => write.delete_many(space, keys),
-            FsWriteInner::Memory(write) => write.delete_many(space, keys),
-        }
+        self.inner.delete_many(space, keys)
     }
 
     fn delete_range(&mut self, space: SpaceId, range: KeyRange) -> Result<(), BackendError> {
-        match &mut self.inner {
-            #[cfg(feature = "sqlite")]
-            FsWriteInner::Sqlite(write) => write.delete_range(space, range),
-            #[cfg(feature = "rocksdb")]
-            FsWriteInner::RocksDb(write) => write.delete_range(space, range),
-            FsWriteInner::Memory(write) => write.delete_range(space, range),
-        }
+        self.inner.delete_range(space, range)
     }
 
     fn commit(self) -> Result<CommitResult, BackendError> {
-        match self.inner {
-            #[cfg(feature = "sqlite")]
-            FsWriteInner::Sqlite(write) => write.commit(),
-            #[cfg(feature = "rocksdb")]
-            FsWriteInner::RocksDb(write) => write.commit(),
-            FsWriteInner::Memory(write) => write.commit(),
-        }
+        self.inner.commit()
     }
 
     fn rollback(self) -> Result<(), BackendError> {
-        match self.inner {
-            #[cfg(feature = "sqlite")]
-            FsWriteInner::Sqlite(write) => write.rollback(),
-            #[cfg(feature = "rocksdb")]
-            FsWriteInner::RocksDb(write) => write.rollback(),
-            FsWriteInner::Memory(write) => write.rollback(),
-        }
+        self.inner.rollback()
     }
 }
 
@@ -529,27 +320,8 @@ where
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
-    pub async fn open_with_wasm_runtime<P>(
-        backend: B,
-        root: P,
-        wasm_runtime: Arc<dyn WasmRuntime>,
-    ) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        let engine =
-            crate::lix::open_or_initialize_engine(backend.clone(), Some(wasm_runtime)).await?;
-        Self::open_with_engine(
-            backend,
-            engine,
-            root.as_ref(),
-            FilesystemMetadataMode::Persistent,
-            FsBackendFilter::default(),
-        )
-        .await
-    }
-
-    async fn open_with_metadata_mode<P>(
+    #[cfg(feature = "rocksdb")]
+    async fn open_filesystem<P>(
         backend: B,
         root: P,
         metadata_mode: FilesystemMetadataMode,
@@ -558,7 +330,8 @@ where
     where
         P: AsRef<Path>,
     {
-        let engine = crate::lix::open_or_initialize_engine(backend.clone(), None).await?;
+        let engine =
+            crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None).await?;
         Self::open_with_engine(backend, engine, root.as_ref(), metadata_mode, filter).await
     }
 
@@ -649,10 +422,7 @@ where
         let root = std::fs::canonicalize(root)
             .map_err(|error| io_error("canonicalize filesystem root", root, error))?;
         let path_filter = FilesystemPathFilter::from_filter(filter)?;
-        if metadata_mode == FilesystemMetadataMode::Persistent {
-            ensure_filesystem_lix_directory(&root)?;
-            migrate_legacy_filesystem_system_directory(&root)?;
-        }
+        ensure_filesystem_lix_directory(&root)?;
         let session = engine.open_workspace_session().await?;
         let state = Arc::new(FilesystemState {
             session,
@@ -663,9 +433,6 @@ where
             last_materialized: Mutex::new(None),
         });
 
-        if metadata_mode == FilesystemMetadataMode::Persistent {
-            state.migrate_legacy_lix_system_paths().await?;
-        }
         state.sync_disk_to_lix(false).await?;
         state.sync_from_lix().await?;
 
@@ -795,72 +562,6 @@ where
         self.session.close().await
     }
 
-    async fn migrate_legacy_lix_system_paths(&self) -> Result<(), LixError> {
-        let files = self
-            .session
-            .execute("SELECT path, data FROM lix_file ORDER BY path", &[])
-            .await?;
-        let legacy_files = files
-            .rows()
-            .iter()
-            .map(|row| Ok((row.get::<String>("path")?, row.get::<Vec<u8>>("data")?)))
-            .collect::<Result<Vec<_>, LixError>>()?;
-        for (path, data) in legacy_files
-            .iter()
-            .filter(|(path, _)| is_legacy_lix_system_path(path))
-        {
-            if let Some(new_path) = migrate_legacy_lix_system_path(path) {
-                self.session
-                    .execute(
-                        "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
-                         ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-                        &[Value::Text(new_path.clone()), Value::Blob(data.clone())],
-                    )
-                    .await?;
-                write_materialized_file(&self.root, &new_path, data, self.metadata_mode)?;
-            }
-            self.session
-                .execute(
-                    "DELETE FROM lix_file WHERE path = $1",
-                    &[Value::Text(path.clone())],
-                )
-                .await?;
-        }
-
-        let directories = self
-            .session
-            .execute("SELECT path FROM lix_directory ORDER BY path", &[])
-            .await?;
-        let mut directory_paths = directories
-            .rows()
-            .iter()
-            .map(|row| row.get::<String>("path"))
-            .collect::<Result<Vec<_>, _>>()?;
-        directory_paths.retain(|path| is_legacy_lix_system_path(path));
-        sort_directories_shallowest_first(&mut directory_paths);
-        for path in &directory_paths {
-            if let Some(new_path) = migrate_legacy_lix_system_path(path) {
-                self.session
-                    .execute(
-                        "INSERT INTO lix_directory (path) VALUES ($1) ON CONFLICT (path) DO NOTHING",
-                        &[Value::Text(new_path.clone())],
-                    )
-                    .await?;
-                create_materialized_directory(&self.root, &new_path, self.metadata_mode)?;
-            }
-        }
-        sort_directories_deepest_first(&mut directory_paths);
-        for path in directory_paths {
-            self.session
-                .execute(
-                    "DELETE FROM lix_directory WHERE path = $1",
-                    &[Value::Text(path)],
-                )
-                .await?;
-        }
-        Ok(())
-    }
-
     async fn collect_lix_snapshot_read(&self) -> Result<LixSnapshotRead, LixError> {
         let mut snapshot = Snapshot::default();
         snapshot.directories.insert("/".to_string());
@@ -920,7 +621,7 @@ where
             if !local.files.contains_key(path)
                 && self.path_filter.includes_file(path)
                 && !is_plugin_storage_path(path)
-                && !is_materialization_ignored_path(path, self.metadata_mode)
+                && !is_materialization_ignored_path(path)
             {
                 if previous
                     .as_ref()
@@ -947,7 +648,7 @@ where
             for path in lix.directories.difference(&local.directories) {
                 if path.as_str() == "/"
                     || is_plugin_storage_path(path)
-                    || is_materialization_ignored_path(path, self.metadata_mode)
+                    || is_materialization_ignored_path(path)
                 {
                     continue;
                 }
@@ -1000,7 +701,7 @@ where
         for (path, data) in local
             .files
             .iter()
-            .filter(|(path, _)| !is_materialization_ignored_path(path, self.metadata_mode))
+            .filter(|(path, _)| !is_materialization_ignored_path(path))
         {
             if previous
                 .as_ref()
@@ -1063,7 +764,7 @@ where
         for path in local.files.keys().filter(|path| {
             self.path_filter.includes_file(path)
                 && !target.files.contains_key(*path)
-                && !is_materialization_ignored_path(path, self.metadata_mode)
+                && !is_materialization_ignored_path(path)
                 && previous
                     .as_ref()
                     .is_none_or(|snapshot| snapshot.files.contains_key(*path))
@@ -1081,10 +782,7 @@ where
             let mut directories_to_remove = local
                 .directories
                 .difference(&target.directories)
-                .filter(|path| {
-                    path.as_str() != "/"
-                        && !is_materialization_ignored_path(path, self.metadata_mode)
-                })
+                .filter(|path| path.as_str() != "/" && !is_materialization_ignored_path(path))
                 .filter(|path| {
                     previous
                         .as_ref()
@@ -1111,7 +809,7 @@ where
             .filter(|path| {
                 path.as_str() != "/"
                     && self.path_filter.includes_directory(path)
-                    && !is_materialization_ignored_path(path, self.metadata_mode)
+                    && !is_materialization_ignored_path(path)
             })
             .filter(|path| base.is_none_or(|snapshot| !snapshot.directories.contains(*path)))
             .filter(|path| {
@@ -1127,8 +825,7 @@ where
         }
 
         for (path, data) in target.files.iter().filter(|(path, _)| {
-            self.path_filter.includes_file(path)
-                && !is_materialization_ignored_path(path, self.metadata_mode)
+            self.path_filter.includes_file(path) && !is_materialization_ignored_path(path)
         }) {
             if base.is_some_and(|snapshot| snapshot.files.get(path) == Some(data)) {
                 continue;
@@ -1467,139 +1164,6 @@ fn ensure_filesystem_lix_directory(root: &Path) -> Result<PathBuf, LixError> {
 
     ensure_gitignore(&lix_dir, LIX_DIRECTORY_GITIGNORE)?;
     Ok(lix_dir)
-}
-
-fn migrate_legacy_filesystem_system_directory(root: &Path) -> Result<(), LixError> {
-    let legacy_dir = root.join(".lix_system");
-    let metadata = match std::fs::symlink_metadata(&legacy_dir) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => {
-            return Err(io_error(
-                "read legacy filesystem system directory",
-                &legacy_dir,
-                error,
-            ));
-        }
-    };
-    if metadata.is_dir() && !metadata.file_type().is_symlink() {
-        merge_legacy_directory_contents(root, &legacy_dir, &root.join(".lix"))?;
-        std::fs::remove_dir_all(&legacy_dir).map_err(|error| {
-            io_error(
-                "remove legacy filesystem system directory",
-                &legacy_dir,
-                error,
-            )
-        })
-    } else {
-        std::fs::remove_file(&legacy_dir)
-            .map_err(|error| io_error("remove legacy filesystem system path", &legacy_dir, error))
-    }
-}
-
-fn merge_legacy_directory_contents(
-    root: &Path,
-    source: &Path,
-    target: &Path,
-) -> Result<(), LixError> {
-    let entries = std::fs::read_dir(source)
-        .map_err(|error| io_error("read legacy filesystem system directory", source, error))?;
-    for entry in entries {
-        let entry = entry.map_err(|error| {
-            io_error(
-                "read legacy filesystem system directory entry",
-                source,
-                error,
-            )
-        })?;
-        let source_path = entry.path();
-        let file_name = entry.file_name();
-        if is_discarded_legacy_system_entry_name(&file_name) {
-            remove_legacy_system_entry(&source_path)?;
-            continue;
-        }
-        let target_path = target.join(&file_name);
-        let Ok(target_lix_path) = local_path_to_lix_path(root, &target_path, false) else {
-            remove_legacy_system_entry(&source_path)?;
-            continue;
-        };
-        if is_filesystem_metadata_path(&target_lix_path) {
-            remove_legacy_system_entry(&source_path)?;
-            continue;
-        }
-        let file_type = entry.file_type().map_err(|error| {
-            io_error(
-                "read legacy filesystem system entry type",
-                &source_path,
-                error,
-            )
-        })?;
-        if file_type.is_dir() {
-            match std::fs::symlink_metadata(&target_path) {
-                Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
-                    merge_legacy_directory_contents(root, &source_path, &target_path)?;
-                    std::fs::remove_dir(&source_path).map_err(|error| {
-                        io_error(
-                            "remove migrated legacy filesystem system directory",
-                            &source_path,
-                            error,
-                        )
-                    })?;
-                }
-                Ok(_) => {
-                    return Err(filesystem_error(format!(
-                        "cannot migrate legacy filesystem system directory {} to {} because the target exists",
-                        source_path.display(),
-                        target_path.display()
-                    )));
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    std::fs::rename(&source_path, &target_path).map_err(|error| {
-                        io_error(
-                            "move legacy filesystem system directory",
-                            &source_path,
-                            error,
-                        )
-                    })?;
-                }
-                Err(error) => {
-                    return Err(io_error(
-                        "read legacy filesystem system target",
-                        &target_path,
-                        error,
-                    ));
-                }
-            }
-        } else {
-            if target_path.exists() {
-                return Err(filesystem_error(format!(
-                    "cannot migrate legacy filesystem system file {} to {} because the target exists",
-                    source_path.display(),
-                    target_path.display()
-                )));
-            }
-            std::fs::rename(&source_path, &target_path).map_err(|error| {
-                io_error("move legacy filesystem system file", &source_path, error)
-            })?;
-        }
-    }
-    Ok(())
-}
-
-fn is_discarded_legacy_system_entry_name(name: &std::ffi::OsStr) -> bool {
-    matches!(name.to_str(), Some(".gitignore" | ".DS_Store"))
-}
-
-fn remove_legacy_system_entry(path: &Path) -> Result<(), LixError> {
-    let metadata = std::fs::symlink_metadata(path)
-        .map_err(|error| io_error("read legacy filesystem system entry", path, error))?;
-    if metadata.is_dir() && !metadata.file_type().is_symlink() {
-        std::fs::remove_dir_all(path)
-            .map_err(|error| io_error("remove legacy filesystem system entry", path, error))
-    } else {
-        std::fs::remove_file(path)
-            .map_err(|error| io_error("remove legacy filesystem system entry", path, error))
-    }
 }
 
 fn remove_materialized_file(
@@ -1953,49 +1517,17 @@ fn is_plugin_storage_path(path: &str) -> bool {
 }
 
 fn is_filesystem_metadata_path(path: &str) -> bool {
-    path == "/.lix/.gitignore"
-        || path == "/.lix/.gitignore/"
-        || is_filesystem_internal_path(path)
-        || is_legacy_filesystem_sqlite_metadata_path(path)
+    path == "/.lix/.gitignore" || path == "/.lix/.gitignore/" || is_filesystem_internal_path(path)
 }
 
 fn is_filesystem_internal_path(path: &str) -> bool {
     path == "/.lix/.internal" || path.starts_with("/.lix/.internal/")
 }
 
-fn is_legacy_lix_system_path(path: &str) -> bool {
-    let path = path.strip_suffix('/').unwrap_or(path);
-    path == "/.lix_system" || path.starts_with("/.lix_system/")
-}
-
-fn migrate_legacy_lix_system_path(path: &str) -> Option<String> {
-    if path == "/.lix_system" {
-        return Some("/.lix".to_string());
-    }
-    if path == "/.lix_system/" {
-        return Some("/.lix/".to_string());
-    }
-    let new_path = path
-        .strip_prefix("/.lix_system/")
-        .map(|suffix| format!("/.lix/{suffix}"))?;
-    if is_filesystem_metadata_path(&new_path) {
-        None
-    } else {
-        Some(new_path)
-    }
-}
-
-fn is_legacy_filesystem_sqlite_metadata_path(path: &str) -> bool {
-    matches!(
-        path.strip_prefix("/.lix/"),
-        Some("db.sqlite" | "db.sqlite-wal" | "db.sqlite-shm" | "db.sqlite-journal")
-    )
-}
-
 fn is_filesystem_sync_ignored_local_path(
     root: &Path,
     path: &Path,
-    metadata_mode: FilesystemMetadataMode,
+    _metadata_mode: FilesystemMetadataMode,
 ) -> bool {
     let Ok(relative) = path.strip_prefix(root) else {
         return true;
@@ -2011,12 +1543,6 @@ fn is_filesystem_sync_ignored_local_path(
         if segment == Some(".git") {
             return true;
         }
-        if metadata_mode == FilesystemMetadataMode::Ephemeral
-            && depth == 1
-            && matches!(segment, Some(".lix" | ".lix_system"))
-        {
-            return true;
-        }
         if depth == 1 && segment == Some(".lix") {
             first_segment_is_lix = true;
         }
@@ -2026,35 +1552,16 @@ fn is_filesystem_sync_ignored_local_path(
         if depth == 2 && first_segment_is_lix && segment == Some(".internal") {
             return true;
         }
-        if depth == 2
-            && first_segment_is_lix
-            && matches!(
-                segment,
-                Some("db.sqlite" | "db.sqlite-wal" | "db.sqlite-shm" | "db.sqlite-journal")
-            )
-        {
-            return true;
-        }
     }
     false
 }
 
-fn is_materialization_ignored_path(path: &str, metadata_mode: FilesystemMetadataMode) -> bool {
-    match metadata_mode {
-        FilesystemMetadataMode::Persistent => is_filesystem_metadata_path(path),
-        FilesystemMetadataMode::Ephemeral => {
-            is_lix_storage_path(path) || is_legacy_lix_system_path(path)
-        }
-    }
+fn is_materialization_ignored_path(path: &str) -> bool {
+    is_filesystem_metadata_path(path)
 }
 
-fn is_filesystem_sync_ignored_lix_path(path: &str, metadata_mode: FilesystemMetadataMode) -> bool {
-    lix_path_contains_segment(path, ".git") || is_materialization_ignored_path(path, metadata_mode)
-}
-
-fn is_lix_storage_path(path: &str) -> bool {
-    let path = path.strip_suffix('/').unwrap_or(path);
-    path == "/.lix" || path.starts_with("/.lix/")
+fn is_filesystem_sync_ignored_lix_path(path: &str, _metadata_mode: FilesystemMetadataMode) -> bool {
+    lix_path_contains_segment(path, ".git") || is_materialization_ignored_path(path)
 }
 
 fn lix_path_contains_segment(path: &str, segment: &str) -> bool {
@@ -2103,13 +1610,6 @@ fn filesystem_error(message: impl Into<String>) -> LixError {
     LixError::new("LIX_FILESYSTEM_ERROR", message)
 }
 
-#[cfg(feature = "sqlite")]
-fn open_filesystem_sqlite_backend(dir: &Path) -> Result<SqliteBackend, LixError> {
-    ensure_filesystem_root_directory(dir)?;
-    let metadata_dir = ensure_filesystem_sqlite_metadata_directory(dir)?;
-    SqliteBackend::open(metadata_dir.join("db.sqlite")).map_err(sqlite_backend_error)
-}
-
 #[cfg(feature = "rocksdb")]
 fn open_filesystem_rocksdb_backend(
     dir: &Path,
@@ -2124,44 +1624,9 @@ fn open_filesystem_rocksdb_backend(
     .map_err(rocksdb_backend_error)
 }
 
-#[cfg(feature = "sqlite")]
-fn ensure_filesystem_sqlite_metadata_directory(dir: &Path) -> Result<PathBuf, LixError> {
-    let lix_dir = ensure_filesystem_lix_directory(dir)?;
-    let metadata_dir = lix_dir.join(".internal");
-    match std::fs::create_dir(&metadata_dir) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
-        Err(error) => {
-            return Err(io_error(
-                "create filesystem SQLite metadata directory",
-                &metadata_dir,
-                error,
-            ));
-        }
-    }
-
-    let metadata = std::fs::symlink_metadata(&metadata_dir).map_err(|error| {
-        io_error(
-            "read filesystem SQLite metadata directory",
-            &metadata_dir,
-            error,
-        )
-    })?;
-    if metadata.file_type().is_symlink() {
-        let path = metadata_dir.display();
-        return Err(filesystem_error(format!(
-            "filesystem SQLite metadata path {path} must not be a symlink"
-        )));
-    }
-    if !metadata.is_dir() {
-        let path = metadata_dir.display();
-        return Err(filesystem_error(format!(
-            "filesystem SQLite metadata path {path} must be a directory"
-        )));
-    }
-
-    move_legacy_filesystem_sqlite_metadata(&lix_dir, &metadata_dir)?;
-    Ok(metadata_dir)
+#[cfg(feature = "rocksdb")]
+fn default_rocksdb_blob_options() -> RocksDbBlobOptions {
+    RocksDbBlobOptions::default()
 }
 
 #[cfg(feature = "rocksdb")]
@@ -2199,58 +1664,6 @@ fn ensure_metadata_directory(path: &Path, label: &str) -> Result<(), LixError> {
     Ok(())
 }
 
-fn move_legacy_filesystem_sqlite_metadata(
-    lix_dir: &Path,
-    metadata_dir: &Path,
-) -> Result<(), LixError> {
-    let mut files_to_move = Vec::new();
-    for file_name in [
-        "db.sqlite",
-        "db.sqlite-wal",
-        "db.sqlite-shm",
-        "db.sqlite-journal",
-    ] {
-        let legacy_path = lix_dir.join(file_name);
-        let target_path = metadata_dir.join(file_name);
-        let legacy_metadata = match std::fs::symlink_metadata(&legacy_path) {
-            Ok(metadata) => metadata,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => {
-                return Err(io_error(
-                    "read legacy filesystem SQLite metadata",
-                    &legacy_path,
-                    error,
-                ));
-            }
-        };
-        if !legacy_metadata.is_file() {
-            return Err(filesystem_error(format!(
-                "legacy filesystem SQLite metadata {} must be a regular file",
-                legacy_path.display()
-            )));
-        }
-        if target_path.exists() {
-            return Err(filesystem_error(format!(
-                "cannot move legacy filesystem SQLite metadata {} to {} because the target already exists",
-                legacy_path.display(),
-                target_path.display()
-            )));
-        }
-        files_to_move.push((legacy_path, target_path));
-    }
-
-    for (legacy_path, target_path) in files_to_move {
-        std::fs::rename(&legacy_path, &target_path).map_err(|error| {
-            io_error(
-                "move legacy filesystem SQLite metadata",
-                &legacy_path,
-                error,
-            )
-        })?;
-    }
-    Ok(())
-}
-
 fn ensure_gitignore(directory: &Path, content: &[u8]) -> Result<(), LixError> {
     let gitignore = directory.join(".gitignore");
     match std::fs::read(&gitignore) {
@@ -2265,14 +1678,6 @@ fn ensure_gitignore(directory: &Path, content: &[u8]) -> Result<(), LixError> {
         .map_err(|error| io_error("write filesystem .gitignore", &gitignore, error))
 }
 
-#[cfg(feature = "sqlite")]
-fn sqlite_backend_error(error: BackendError) -> LixError {
-    LixError::new(
-        LixError::CODE_STORAGE_ERROR,
-        format!("failed to open filesystem SQLite backend: {error}"),
-    )
-}
-
 #[cfg(feature = "rocksdb")]
 fn rocksdb_backend_error(error: BackendError) -> LixError {
     LixError::new(
@@ -2284,9 +1689,10 @@ fn rocksdb_backend_error(error: BackendError) -> LixError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "sqlite")]
+    #[cfg(feature = "rocksdb")]
     use lix_engine::Value;
 
+    #[cfg(feature = "rocksdb")]
     async fn lix_read_file<B>(
         session: &SessionContext<B>,
         path: &str,
@@ -2309,6 +1715,7 @@ mod tests {
             .transpose()
     }
 
+    #[cfg(feature = "rocksdb")]
     async fn lix_write_file<B>(
         session: &SessionContext<B>,
         path: &str,
@@ -2422,12 +1829,14 @@ mod tests {
         assert_eq!(lix_file_upsert_chunk_end(&files, 0, 10, 8), 1);
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(feature = "rocksdb")]
     #[tokio::test]
     async fn disk_sync_remembers_canonical_snapshot_for_idle_skip() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
-        let engine = crate::lix::open_or_initialize_engine(backend, None)
+        let backend =
+            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
+                .unwrap();
+        let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();
         let root = std::fs::canonicalize(tempdir.path()).unwrap();
@@ -2453,12 +1862,14 @@ mod tests {
         state.close().await.unwrap();
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(feature = "rocksdb")]
     #[tokio::test]
     async fn disk_sync_does_not_reimport_unchanged_materialized_file_deleted_in_lix() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
-        let engine = crate::lix::open_or_initialize_engine(backend, None)
+        let backend =
+            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
+                .unwrap();
+        let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();
         let root = std::fs::canonicalize(tempdir.path()).unwrap();
@@ -2505,12 +1916,14 @@ mod tests {
         state.close().await.unwrap();
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(feature = "rocksdb")]
     #[tokio::test]
     async fn disk_sync_does_not_skip_lix_side_file_data_change() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
-        let engine = crate::lix::open_or_initialize_engine(backend, None)
+        let backend =
+            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
+                .unwrap();
+        let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();
         let root = std::fs::canonicalize(tempdir.path()).unwrap();
@@ -2546,12 +1959,14 @@ mod tests {
         state.close().await.unwrap();
     }
 
-    #[cfg(feature = "sqlite")]
+    #[cfg(feature = "rocksdb")]
     #[tokio::test]
     async fn disk_sync_materialization_preserves_file_changed_after_import() {
         let tempdir = tempfile::tempdir().unwrap();
-        let backend = open_filesystem_sqlite_backend(tempdir.path()).unwrap();
-        let engine = crate::lix::open_or_initialize_engine(backend, None)
+        let backend =
+            open_filesystem_rocksdb_backend(tempdir.path(), default_rocksdb_blob_options())
+                .unwrap();
+        let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
             .await
             .unwrap();
         let root = std::fs::canonicalize(tempdir.path()).unwrap();

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -17,6 +17,10 @@ use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, ne
 
 #[cfg(feature = "sqlite")]
 use crate::sqlite_backend::SqliteBackend;
+#[cfg(feature = "rocksdb")]
+use lix_fs_backend::{
+    RocksDbBlobOptions, RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions,
+};
 
 type FilesystemDebouncer = Debouncer<RecommendedWatcher, RecommendedCache>;
 const LIX_DIRECTORY_GITIGNORE: &[u8] = b"*\n";
@@ -68,36 +72,45 @@ where
     supervisor: FilesystemSupervisor<B>,
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct FsBackend {
     inner: FsBackendInner,
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 #[derive(Clone)]
 enum FsBackendInner {
-    Persistent(FilesystemSync<SqliteBackend>),
+    #[cfg(feature = "sqlite")]
+    Sqlite(FilesystemSync<SqliteBackend>),
+    #[cfg(feature = "rocksdb")]
+    RocksDb(FilesystemSync<RocksDbFilesystemBackend>),
     Memory(FilesystemSync<InMemoryBackend>),
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 #[expect(missing_debug_implementations)]
 pub enum FsRead<'a> {
-    Persistent(crate::sqlite_backend::SqliteRead),
+    #[cfg(feature = "sqlite")]
+    Sqlite(crate::sqlite_backend::SqliteRead),
+    #[cfg(feature = "rocksdb")]
+    RocksDb(lix_fs_backend::RocksDbFilesystemRead<'a>),
     Memory(<InMemoryBackend as Backend>::Read<'a>),
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 #[expect(missing_debug_implementations)]
 pub struct FsWrite<'a> {
     inner: FsWriteInner<'a>,
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 enum FsWriteInner<'a> {
-    Persistent(FilesystemWrite<'a, SqliteBackend>),
+    #[cfg(feature = "sqlite")]
+    Sqlite(FilesystemWrite<'a, SqliteBackend>),
+    #[cfg(feature = "rocksdb")]
+    RocksDb(FilesystemWrite<'a, RocksDbFilesystemBackend>),
     Memory(FilesystemWrite<'a, InMemoryBackend>),
 }
 
@@ -244,8 +257,9 @@ enum FilesystemEvent {
     Shutdown,
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 impl FsBackend {
+    #[cfg(feature = "sqlite")]
     pub async fn open<P>(dir: P) -> Result<Self, LixError>
     where
         P: AsRef<Path>,
@@ -267,7 +281,49 @@ impl FsBackend {
         )
         .await?;
         Ok(Self {
-            inner: FsBackendInner::Persistent(inner),
+            inner: FsBackendInner::Sqlite(inner),
+        })
+    }
+
+    #[cfg(feature = "rocksdb")]
+    pub async fn open_rocksdb<P>(dir: P) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        Self::open_rocksdb_with_filter(dir, FsBackendFilter::default()).await
+    }
+
+    #[cfg(feature = "rocksdb")]
+    pub async fn open_rocksdb_with_filter<P>(
+        dir: P,
+        filter: FsBackendFilter,
+    ) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        Self::open_rocksdb_with_blob_options(dir, filter, RocksDbBlobOptions::Disabled).await
+    }
+
+    #[cfg(feature = "rocksdb")]
+    pub async fn open_rocksdb_with_blob_options<P>(
+        dir: P,
+        filter: FsBackendFilter,
+        blob: RocksDbBlobOptions,
+    ) -> Result<Self, LixError>
+    where
+        P: AsRef<Path>,
+    {
+        FilesystemPathFilter::from_filter(filter.clone())?;
+        let backend = open_filesystem_rocksdb_backend(dir.as_ref(), blob)?;
+        let inner = FilesystemSync::open_with_metadata_mode(
+            backend,
+            dir.as_ref(),
+            FilesystemMetadataMode::Persistent,
+            filter,
+        )
+        .await?;
+        Ok(Self {
+            inner: FsBackendInner::RocksDb(inner),
         })
     }
 
@@ -299,6 +355,7 @@ impl FsBackend {
         })
     }
 
+    #[cfg(feature = "sqlite")]
     pub async fn open_with_wasm_runtime<P>(
         dir: P,
         wasm_runtime: Arc<dyn WasmRuntime>,
@@ -310,12 +367,12 @@ impl FsBackend {
         let inner =
             FilesystemSync::open_with_wasm_runtime(backend, dir.as_ref(), wasm_runtime).await?;
         Ok(Self {
-            inner: FsBackendInner::Persistent(inner),
+            inner: FsBackendInner::Sqlite(inner),
         })
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 impl Backend for FsBackend {
     type Read<'a>
         = FsRead<'a>
@@ -329,15 +386,23 @@ impl Backend for FsBackend {
 
     fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
         match &self.inner {
-            FsBackendInner::Persistent(inner) => Ok(FsRead::Persistent(inner.begin_read(opts)?)),
+            #[cfg(feature = "sqlite")]
+            FsBackendInner::Sqlite(inner) => Ok(FsRead::Sqlite(inner.begin_read(opts)?)),
+            #[cfg(feature = "rocksdb")]
+            FsBackendInner::RocksDb(inner) => Ok(FsRead::RocksDb(inner.begin_read(opts)?)),
             FsBackendInner::Memory(inner) => Ok(FsRead::Memory(inner.begin_read(opts)?)),
         }
     }
 
     fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
         match &self.inner {
-            FsBackendInner::Persistent(inner) => Ok(FsWrite {
-                inner: FsWriteInner::Persistent(inner.begin_write(opts)?),
+            #[cfg(feature = "sqlite")]
+            FsBackendInner::Sqlite(inner) => Ok(FsWrite {
+                inner: FsWriteInner::Sqlite(inner.begin_write(opts)?),
+            }),
+            #[cfg(feature = "rocksdb")]
+            FsBackendInner::RocksDb(inner) => Ok(FsWrite {
+                inner: FsWriteInner::RocksDb(inner.begin_write(opts)?),
             }),
             FsBackendInner::Memory(inner) => Ok(FsWrite {
                 inner: FsWriteInner::Memory(inner.begin_write(opts)?),
@@ -346,7 +411,7 @@ impl Backend for FsBackend {
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 impl BackendRead for FsRead<'_> {
     fn visit_keys<V>(
         &self,
@@ -359,7 +424,10 @@ impl BackendRead for FsRead<'_> {
         V: PointVisitor + ?Sized,
     {
         match self {
-            Self::Persistent(read) => read.visit_keys(space, keys, opts, visitor),
+            #[cfg(feature = "sqlite")]
+            Self::Sqlite(read) => read.visit_keys(space, keys, opts, visitor),
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDb(read) => read.visit_keys(space, keys, opts, visitor),
             Self::Memory(read) => read.visit_keys(space, keys, opts, visitor),
         }
     }
@@ -375,45 +443,63 @@ impl BackendRead for FsRead<'_> {
         V: ScanVisitor + ?Sized,
     {
         match self {
-            Self::Persistent(read) => read.scan(space, range, opts, visitor),
+            #[cfg(feature = "sqlite")]
+            Self::Sqlite(read) => read.scan(space, range, opts, visitor),
+            #[cfg(feature = "rocksdb")]
+            Self::RocksDb(read) => read.scan(space, range, opts, visitor),
             Self::Memory(read) => read.scan(space, range, opts, visitor),
         }
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
 impl BackendWrite for FsWrite<'_> {
     fn put_many(&mut self, space: SpaceId, entries: PutBatch) -> Result<(), BackendError> {
         match &mut self.inner {
-            FsWriteInner::Persistent(write) => write.put_many(space, entries),
+            #[cfg(feature = "sqlite")]
+            FsWriteInner::Sqlite(write) => write.put_many(space, entries),
+            #[cfg(feature = "rocksdb")]
+            FsWriteInner::RocksDb(write) => write.put_many(space, entries),
             FsWriteInner::Memory(write) => write.put_many(space, entries),
         }
     }
 
     fn delete_many(&mut self, space: SpaceId, keys: &[Key]) -> Result<(), BackendError> {
         match &mut self.inner {
-            FsWriteInner::Persistent(write) => write.delete_many(space, keys),
+            #[cfg(feature = "sqlite")]
+            FsWriteInner::Sqlite(write) => write.delete_many(space, keys),
+            #[cfg(feature = "rocksdb")]
+            FsWriteInner::RocksDb(write) => write.delete_many(space, keys),
             FsWriteInner::Memory(write) => write.delete_many(space, keys),
         }
     }
 
     fn delete_range(&mut self, space: SpaceId, range: KeyRange) -> Result<(), BackendError> {
         match &mut self.inner {
-            FsWriteInner::Persistent(write) => write.delete_range(space, range),
+            #[cfg(feature = "sqlite")]
+            FsWriteInner::Sqlite(write) => write.delete_range(space, range),
+            #[cfg(feature = "rocksdb")]
+            FsWriteInner::RocksDb(write) => write.delete_range(space, range),
             FsWriteInner::Memory(write) => write.delete_range(space, range),
         }
     }
 
     fn commit(self) -> Result<CommitResult, BackendError> {
         match self.inner {
-            FsWriteInner::Persistent(write) => write.commit(),
+            #[cfg(feature = "sqlite")]
+            FsWriteInner::Sqlite(write) => write.commit(),
+            #[cfg(feature = "rocksdb")]
+            FsWriteInner::RocksDb(write) => write.commit(),
             FsWriteInner::Memory(write) => write.commit(),
         }
     }
 
     fn rollback(self) -> Result<(), BackendError> {
         match self.inner {
-            FsWriteInner::Persistent(write) => write.rollback(),
+            #[cfg(feature = "sqlite")]
+            FsWriteInner::Sqlite(write) => write.rollback(),
+            #[cfg(feature = "rocksdb")]
+            FsWriteInner::RocksDb(write) => write.rollback(),
             FsWriteInner::Memory(write) => write.rollback(),
         }
     }
@@ -2006,6 +2092,20 @@ fn open_filesystem_sqlite_backend(dir: &Path) -> Result<SqliteBackend, LixError>
     SqliteBackend::open(metadata_dir.join("db.sqlite")).map_err(sqlite_backend_error)
 }
 
+#[cfg(feature = "rocksdb")]
+fn open_filesystem_rocksdb_backend(
+    dir: &Path,
+    blob: RocksDbBlobOptions,
+) -> Result<RocksDbFilesystemBackend, LixError> {
+    ensure_filesystem_root_directory(dir)?;
+    let metadata_dir = ensure_filesystem_rocksdb_metadata_directory(dir)?;
+    RocksDbFilesystemBackend::open_with_options(RocksDbFilesystemBackendOptions {
+        path: metadata_dir,
+        blob,
+    })
+    .map_err(rocksdb_backend_error)
+}
+
 #[cfg(feature = "sqlite")]
 fn ensure_filesystem_sqlite_metadata_directory(dir: &Path) -> Result<PathBuf, LixError> {
     let lix_dir = ensure_filesystem_lix_directory(dir)?;
@@ -2044,6 +2144,41 @@ fn ensure_filesystem_sqlite_metadata_directory(dir: &Path) -> Result<PathBuf, Li
 
     move_legacy_filesystem_sqlite_metadata(&lix_dir, &metadata_dir)?;
     Ok(metadata_dir)
+}
+
+#[cfg(feature = "rocksdb")]
+fn ensure_filesystem_rocksdb_metadata_directory(dir: &Path) -> Result<PathBuf, LixError> {
+    let lix_dir = ensure_filesystem_lix_directory(dir)?;
+    let internal_dir = lix_dir.join(".internal");
+    ensure_metadata_directory(&internal_dir, "filesystem metadata directory")?;
+    let metadata_dir = internal_dir.join("rocksdb");
+    ensure_metadata_directory(&metadata_dir, "filesystem RocksDB metadata directory")?;
+    Ok(metadata_dir)
+}
+
+#[cfg(feature = "rocksdb")]
+fn ensure_metadata_directory(path: &Path, label: &str) -> Result<(), LixError> {
+    match std::fs::create_dir(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(io_error(&format!("create {label}"), path, error)),
+    }
+
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| io_error(&format!("read {label}"), path, error))?;
+    if metadata.file_type().is_symlink() {
+        let display = path.display();
+        return Err(filesystem_error(format!(
+            "{label} {display} must not be a symlink"
+        )));
+    }
+    if !metadata.is_dir() {
+        let display = path.display();
+        return Err(filesystem_error(format!(
+            "{label} {display} must be a directory"
+        )));
+    }
+    Ok(())
 }
 
 fn move_legacy_filesystem_sqlite_metadata(
@@ -2117,6 +2252,14 @@ fn sqlite_backend_error(error: BackendError) -> LixError {
     LixError::new(
         LixError::CODE_STORAGE_ERROR,
         format!("failed to open filesystem SQLite backend: {error}"),
+    )
+}
+
+#[cfg(feature = "rocksdb")]
+fn rocksdb_backend_error(error: BackendError) -> LixError {
+    LixError::new(
+        LixError::CODE_STORAGE_ERROR,
+        format!("failed to open filesystem RocksDB backend: {error}"),
     )
 }
 

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -267,6 +267,7 @@ impl FsBackend {
         Self::open_with_filter(dir, FsBackendFilter::default()).await
     }
 
+    #[cfg(feature = "sqlite")]
     pub async fn open_with_filter<P>(dir: P, filter: FsBackendFilter) -> Result<Self, LixError>
     where
         P: AsRef<Path>,

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -6,16 +6,13 @@
 
 #[cfg(feature = "default_wasm_runtime")]
 mod default_wasm_runtime;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
 mod filesystem;
 mod lix;
 #[cfg(feature = "sqlite")]
 mod sqlite_backend;
 
-#[cfg(all(
-    not(target_family = "wasm"),
-    any(feature = "sqlite", feature = "rocksdb")
-))]
+#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
 pub use filesystem::{FsBackend, FsBackendFilter};
 pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_backend};
 pub use lix_engine::wasm::{
@@ -36,8 +33,6 @@ pub use lix_engine::{
     SwitchBranchOptions, SwitchBranchReceipt, SwitchBranchReceipt as SwitchBranchResult,
     TryFromValue, Value, WriteOptions, WriteStats, run_backend_conformance,
 };
-#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
-pub use lix_fs_backend::{RocksDbBlobOptions, RocksDbFilesystemBackend};
 #[cfg(feature = "sqlite")]
 pub use sqlite_backend::{
     SQLITE_FORMAT_VERSION, SqliteBackend, SqliteBackendFactory, SqliteBackendFixture,

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -6,13 +6,13 @@
 
 #[cfg(feature = "default_wasm_runtime")]
 mod default_wasm_runtime;
-#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
+#[cfg(all(not(target_family = "wasm"), feature = "fs_backend"))]
 mod filesystem;
 mod lix;
 #[cfg(feature = "sqlite")]
 mod sqlite_backend;
 
-#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
+#[cfg(all(not(target_family = "wasm"), feature = "fs_backend"))]
 pub use filesystem::{FsBackend, FsBackendFilter};
 pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_backend};
 pub use lix_engine::wasm::{

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -12,7 +12,10 @@ mod lix;
 #[cfg(feature = "sqlite")]
 mod sqlite_backend;
 
-#[cfg(all(not(target_family = "wasm"), feature = "sqlite"))]
+#[cfg(all(
+    not(target_family = "wasm"),
+    any(feature = "sqlite", feature = "rocksdb")
+))]
 pub use filesystem::{FsBackend, FsBackendFilter};
 pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_backend};
 pub use lix_engine::wasm::{
@@ -33,6 +36,8 @@ pub use lix_engine::{
     SwitchBranchOptions, SwitchBranchReceipt, SwitchBranchReceipt as SwitchBranchResult,
     TryFromValue, Value, WriteOptions, WriteStats, run_backend_conformance,
 };
+#[cfg(all(not(target_family = "wasm"), feature = "rocksdb"))]
+pub use lix_fs_backend::{RocksDbBlobOptions, RocksDbFilesystemBackend};
 #[cfg(feature = "sqlite")]
 pub use sqlite_backend::{
     SQLITE_FORMAT_VERSION, SqliteBackend, SqliteBackendFactory, SqliteBackendFixture,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -200,6 +200,26 @@ where
     }
 }
 
+#[cfg(feature = "rocksdb")]
+pub(crate) async fn open_or_initialize_filesystem_engine<B>(
+    backend: B,
+    wasm_runtime: Option<Arc<dyn WasmRuntime>>,
+) -> Result<Engine<B>, LixError>
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    match new_engine(backend.clone(), wasm_runtime.clone()).await {
+        Ok(engine) => Ok(engine),
+        Err(error) if error.code == "LIX_ERROR_NOT_INITIALIZED" => {
+            Engine::initialize(backend.clone()).await?;
+            new_engine(backend, wasm_runtime).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
 async fn new_engine<B>(
     backend: B,
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -200,7 +200,7 @@ where
     }
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 pub(crate) async fn open_or_initialize_filesystem_engine<B>(
     backend: B,
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,

--- a/packages/rs-sdk/src/sqlite_backend.rs
+++ b/packages/rs-sdk/src/sqlite_backend.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use lix_backends::{
     SQLITE_FORMAT_VERSION, SqliteBackend, SqliteBackendFactory, SqliteBackendFixture,
     SqliteBackendOptions, SqliteRead,

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,16 +1,12 @@
-#[cfg(feature = "rocksdb")]
-use lix_fs_backend::{
-    RocksDbBlobOptions, RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions,
-};
 use lix_sdk::{
     Backend, CreateBranchOptions, InMemoryBackend, Lix, LixError, MergeBranchOptions,
     MergeBranchOutcome, OpenLixOptions, SwitchBranchOptions, Value, open_lix,
 };
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 use lix_sdk::{FsBackend, open_lix_with_backend};
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 use std::path::Path;
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 use std::time::{Duration, Instant};
 
 #[tokio::test]
@@ -438,7 +434,7 @@ async fn transaction_blocks_session_execute_on_same_handle() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_initial_import_uses_local_files_as_source_of_truth() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tempdir.path().join("docs")).unwrap();
@@ -462,25 +458,43 @@ async fn filesystem_initial_import_uses_local_files_as_source_of_truth() {
     lix.close().await.unwrap();
 }
 
-#[cfg(feature = "rocksdb")]
+#[tokio::test]
+#[cfg(feature = "fs_backend")]
+async fn filesystem_initialization_wipes_legacy_sqlite_internal_metadata() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let internal_dir = tempdir.path().join(".lix/.internal");
+    std::fs::create_dir_all(&internal_dir).unwrap();
+    std::fs::write(internal_dir.join("db.sqlite"), b"legacy sqlite metadata").unwrap();
+    std::fs::write(internal_dir.join("old-cache"), b"legacy internal data").unwrap();
+    std::fs::write(tempdir.path().join("note.txt"), b"workspace").unwrap();
+
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    assert!(!internal_dir.join("db.sqlite").exists());
+    assert!(!internal_dir.join("old-cache").exists());
+    assert!(internal_dir.join("rocksdb").is_dir());
+    assert_eq!(
+        read_file(&lix, "/.lix/.internal/db.sqlite")
+            .await
+            .unwrap()
+            .as_deref(),
+        None
+    );
+    assert_eq!(
+        read_file(&lix, "/note.txt").await.unwrap().as_deref(),
+        Some(b"workspace".as_slice())
+    );
+    lix.close().await.unwrap();
+}
+
+#[cfg(feature = "fs_backend")]
 async fn open_lix_with_filesystem(path: &Path) -> Lix<FsBackend> {
     let backend = FsBackend::open(path).await.unwrap();
     open_lix_with_backend(backend).await.unwrap()
 }
 
-#[cfg(feature = "rocksdb")]
-async fn open_lix_with_seeded_filesystem_metadata(path: &Path) -> Lix<RocksDbFilesystemBackend> {
-    let metadata_dir = path.join(".lix/.internal/rocksdb");
-    std::fs::create_dir_all(&metadata_dir).unwrap();
-    let backend = RocksDbFilesystemBackend::open_with_options(
-        RocksDbFilesystemBackendOptions::blob(metadata_dir, 32 * 1024),
-    )
-    .unwrap();
-    open_lix_with_backend(backend).await.unwrap()
-}
-
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn rocksdb_filesystem_backend_allows_same_process_multi_open() {
     let tempdir = tempfile::tempdir().unwrap();
     let backend_a = FsBackend::open(tempdir.path())
@@ -514,46 +528,6 @@ async fn rocksdb_filesystem_backend_allows_same_process_multi_open() {
 
     lix_a.close().await.unwrap();
     lix_b.close().await.unwrap();
-}
-
-#[tokio::test]
-#[cfg(feature = "rocksdb")]
-async fn fs_backend_open_uses_blobdb_32kib_by_default() {
-    let tempdir = tempfile::tempdir().unwrap();
-    let default = FsBackend::open(tempdir.path())
-        .await
-        .expect("default fs backend opens");
-
-    let same_options = FsBackend::open_with_rocksdb_blob_options(
-        tempdir.path(),
-        Default::default(),
-        RocksDbBlobOptions::Enabled {
-            min_blob_size: 32 * 1024,
-            blob_file_size: 256 * 1024 * 1024,
-            enable_gc: true,
-            gc_age_cutoff: 0.25,
-        },
-    )
-    .await
-    .expect("explicit default BlobDB options should match FsBackend::open");
-    drop(same_options);
-
-    let Err(error) = FsBackend::open_with_rocksdb_blob_options(
-        tempdir.path(),
-        Default::default(),
-        RocksDbBlobOptions::Disabled,
-    )
-    .await
-    else {
-        panic!("plain RocksDB options should not match FsBackend::open");
-    };
-    assert!(
-        error
-            .message
-            .contains("already open with different options"),
-        "error should explain option mismatch: {error:?}"
-    );
-    drop(default);
 }
 
 async fn read_file<B>(lix: &Lix<B>, path: &str) -> Result<Option<Vec<u8>>, LixError>
@@ -672,7 +646,7 @@ where
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_creates_gitignore_files_for_lix_metadata() {
     let tempdir = tempfile::tempdir().unwrap();
 
@@ -692,7 +666,7 @@ async fn filesystem_creates_gitignore_files_for_lix_metadata() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_initial_import_ignores_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tempdir.path().join(".git/objects")).unwrap();
@@ -724,10 +698,10 @@ async fn filesystem_initial_import_ignores_git_entries() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
-    let seed = open_lix_with_seeded_filesystem_metadata(tempdir.path()).await;
+    let seed = open_lix_with_filesystem(tempdir.path()).await;
     write_file(&seed, "/.git/config", b"old".to_vec())
         .await
         .unwrap();
@@ -746,15 +720,17 @@ async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_initial_import_deletes_lix_entries_missing_locally() {
     let tempdir = tempfile::tempdir().unwrap();
-    let seed = open_lix_with_seeded_filesystem_metadata(tempdir.path()).await;
+    let seed = open_lix_with_filesystem(tempdir.path()).await;
     write_file(&seed, "/old.txt", b"old".to_vec())
         .await
         .unwrap();
     mkdir(&seed, "/old-empty/").await.unwrap();
     seed.close().await.unwrap();
+    std::fs::remove_file(tempdir.path().join("old.txt")).unwrap();
+    std::fs::remove_dir(tempdir.path().join("old-empty")).unwrap();
 
     let lix = open_lix_with_filesystem(tempdir.path()).await;
 
@@ -766,7 +742,7 @@ async fn filesystem_initial_import_deletes_lix_entries_missing_locally() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -833,7 +809,7 @@ async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_materializes_untracked_sdk_sql_writes() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -868,7 +844,7 @@ async fn filesystem_materializes_untracked_sdk_sql_writes() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_watcher_syncs_disk_changes_to_lix() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -891,7 +867,7 @@ async fn filesystem_watcher_syncs_disk_changes_to_lix() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_watcher_ignores_git_entries_created_after_open() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -910,7 +886,7 @@ async fn filesystem_watcher_ignores_git_entries_created_after_open() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_materialization_skips_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -936,7 +912,7 @@ async fn filesystem_materialization_skips_git_entries() {
 }
 
 #[tokio::test]
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn filesystem_imports_opaque_lix_path_names() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::write(tempdir.path().join("bad%name.txt"), b"bad").unwrap();
@@ -960,7 +936,7 @@ async fn filesystem_imports_opaque_lix_path_names() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "fs_backend"))]
 async fn filesystem_rejects_symlink_root() {
     use std::os::unix::fs::symlink;
 
@@ -976,7 +952,7 @@ async fn filesystem_rejects_symlink_root() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "fs_backend"))]
 async fn filesystem_ignores_symlinks_on_initial_import() {
     use std::os::unix::fs::symlink;
 
@@ -1019,7 +995,7 @@ async fn filesystem_ignores_symlinks_on_initial_import() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "fs_backend"))]
 async fn filesystem_ignores_special_and_invalid_utf8_entries() {
     use std::ffi::OsString;
     use std::os::unix::ffi::OsStringExt;
@@ -1057,7 +1033,7 @@ async fn filesystem_ignores_special_and_invalid_utf8_entries() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "fs_backend"))]
 async fn filesystem_watcher_ignores_symlinks_created_after_open() {
     use std::os::unix::fs::symlink;
 
@@ -1079,7 +1055,7 @@ async fn filesystem_watcher_ignores_symlinks_created_after_open() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "fs_backend"))]
 async fn filesystem_materialization_skips_symlink_collisions() {
     use std::os::unix::fs::symlink;
 
@@ -1146,7 +1122,7 @@ async fn filesystem_materialization_skips_symlink_collisions() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "rocksdb"))]
+#[cfg(all(unix, feature = "fs_backend"))]
 async fn filesystem_materialization_skips_special_file_collisions() {
     use std::os::unix::fs::FileTypeExt;
     use std::os::unix::net::UnixListener;
@@ -1179,13 +1155,13 @@ async fn filesystem_materialization_skips_special_file_collisions() {
     lix.close().await.unwrap();
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 #[track_caller]
 fn wait_for_disk_file(path: &Path, expected: Option<&[u8]>) {
     wait_for_disk_file_with_timeout(path, expected, Duration::from_secs(5));
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 #[track_caller]
 fn wait_for_disk_file_with_timeout(path: &Path, expected: Option<&[u8]>, timeout: Duration) {
     let deadline = Instant::now() + timeout;
@@ -1203,7 +1179,7 @@ fn wait_for_disk_file_with_timeout(path: &Path, expected: Option<&[u8]>, timeout
     }
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn wait_for_lix_file(lix: &Lix<FsBackend>, path: &str, expected: Option<&[u8]>) {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
@@ -1219,7 +1195,7 @@ async fn wait_for_lix_file(lix: &Lix<FsBackend>, path: &str, expected: Option<&[
     }
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(feature = "fs_backend")]
 async fn wait_for_lix_directory(lix: &Lix<FsBackend>, path: &str, expected: bool) {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "sqlite")]
+use lix_sdk::SqliteBackend;
 use lix_sdk::{
     Backend, CreateBranchOptions, InMemoryBackend, Lix, LixError, MergeBranchOptions,
     MergeBranchOutcome, OpenLixOptions, SwitchBranchOptions, Value, open_lix,
 };
-#[cfg(feature = "sqlite")]
-use lix_sdk::{FsBackend, SqliteBackend, open_lix_with_backend};
+#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
+use lix_sdk::{FsBackend, open_lix_with_backend};
 #[cfg(feature = "sqlite")]
 use std::path::Path;
 #[cfg(feature = "sqlite")]
@@ -462,6 +464,43 @@ async fn filesystem_initial_import_uses_local_files_as_source_of_truth() {
 async fn open_lix_with_filesystem(path: &Path) -> Lix<FsBackend> {
     let backend = FsBackend::open(path).await.unwrap();
     open_lix_with_backend(backend).await.unwrap()
+}
+
+#[tokio::test]
+#[cfg(feature = "rocksdb")]
+async fn rocksdb_filesystem_backend_allows_same_process_multi_open() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let backend_a = FsBackend::open_rocksdb(tempdir.path())
+        .await
+        .expect("first rocksdb fs backend opens");
+    let backend_b = FsBackend::open_rocksdb(tempdir.path())
+        .await
+        .expect("second rocksdb fs backend reuses process-local DB");
+    let lix_a = open_lix_with_backend(backend_a)
+        .await
+        .expect("first lix opens");
+    let lix_b = open_lix_with_backend(backend_b)
+        .await
+        .expect("second lix opens");
+
+    write_file(&lix_a, "/from-a.txt", b"a".to_vec())
+        .await
+        .expect("first lix writes");
+    assert_eq!(
+        read_file(&lix_b, "/from-a.txt").await.unwrap().as_deref(),
+        Some(b"a".as_slice())
+    );
+
+    write_file(&lix_b, "/from-b.txt", b"b".to_vec())
+        .await
+        .expect("second lix writes");
+    assert_eq!(
+        read_file(&lix_a, "/from-b.txt").await.unwrap().as_deref(),
+        Some(b"b".as_slice())
+    );
+
+    lix_a.close().await.unwrap();
+    lix_b.close().await.unwrap();
 }
 
 async fn read_file<B>(lix: &Lix<B>, path: &str) -> Result<Option<Vec<u8>>, LixError>

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,14 +1,16 @@
-#[cfg(feature = "sqlite")]
-use lix_sdk::SqliteBackend;
+#[cfg(feature = "rocksdb")]
+use lix_fs_backend::{
+    RocksDbBlobOptions, RocksDbFilesystemBackend, RocksDbFilesystemBackendOptions,
+};
 use lix_sdk::{
     Backend, CreateBranchOptions, InMemoryBackend, Lix, LixError, MergeBranchOptions,
     MergeBranchOutcome, OpenLixOptions, SwitchBranchOptions, Value, open_lix,
 };
-#[cfg(any(feature = "sqlite", feature = "rocksdb"))]
+#[cfg(feature = "rocksdb")]
 use lix_sdk::{FsBackend, open_lix_with_backend};
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 use std::path::Path;
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 use std::time::{Duration, Instant};
 
 #[tokio::test]
@@ -436,7 +438,7 @@ async fn transaction_blocks_session_execute_on_same_handle() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_initial_import_uses_local_files_as_source_of_truth() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tempdir.path().join("docs")).unwrap();
@@ -460,9 +462,20 @@ async fn filesystem_initial_import_uses_local_files_as_source_of_truth() {
     lix.close().await.unwrap();
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn open_lix_with_filesystem(path: &Path) -> Lix<FsBackend> {
     let backend = FsBackend::open(path).await.unwrap();
+    open_lix_with_backend(backend).await.unwrap()
+}
+
+#[cfg(feature = "rocksdb")]
+async fn open_lix_with_seeded_filesystem_metadata(path: &Path) -> Lix<RocksDbFilesystemBackend> {
+    let metadata_dir = path.join(".lix/.internal/rocksdb");
+    std::fs::create_dir_all(&metadata_dir).unwrap();
+    let backend = RocksDbFilesystemBackend::open_with_options(
+        RocksDbFilesystemBackendOptions::blob(metadata_dir, 32 * 1024),
+    )
+    .unwrap();
     open_lix_with_backend(backend).await.unwrap()
 }
 
@@ -470,10 +483,10 @@ async fn open_lix_with_filesystem(path: &Path) -> Lix<FsBackend> {
 #[cfg(feature = "rocksdb")]
 async fn rocksdb_filesystem_backend_allows_same_process_multi_open() {
     let tempdir = tempfile::tempdir().unwrap();
-    let backend_a = FsBackend::open_rocksdb(tempdir.path())
+    let backend_a = FsBackend::open(tempdir.path())
         .await
         .expect("first rocksdb fs backend opens");
-    let backend_b = FsBackend::open_rocksdb(tempdir.path())
+    let backend_b = FsBackend::open(tempdir.path())
         .await
         .expect("second rocksdb fs backend reuses process-local DB");
     let lix_a = open_lix_with_backend(backend_a)
@@ -501,6 +514,46 @@ async fn rocksdb_filesystem_backend_allows_same_process_multi_open() {
 
     lix_a.close().await.unwrap();
     lix_b.close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "rocksdb")]
+async fn fs_backend_open_uses_blobdb_32kib_by_default() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let default = FsBackend::open(tempdir.path())
+        .await
+        .expect("default fs backend opens");
+
+    let same_options = FsBackend::open_with_rocksdb_blob_options(
+        tempdir.path(),
+        Default::default(),
+        RocksDbBlobOptions::Enabled {
+            min_blob_size: 32 * 1024,
+            blob_file_size: 256 * 1024 * 1024,
+            enable_gc: true,
+            gc_age_cutoff: 0.25,
+        },
+    )
+    .await
+    .expect("explicit default BlobDB options should match FsBackend::open");
+    drop(same_options);
+
+    let Err(error) = FsBackend::open_with_rocksdb_blob_options(
+        tempdir.path(),
+        Default::default(),
+        RocksDbBlobOptions::Disabled,
+    )
+    .await
+    else {
+        panic!("plain RocksDB options should not match FsBackend::open");
+    };
+    assert!(
+        error
+            .message
+            .contains("already open with different options"),
+        "error should explain option mismatch: {error:?}"
+    );
+    drop(default);
 }
 
 async fn read_file<B>(lix: &Lix<B>, path: &str) -> Result<Option<Vec<u8>>, LixError>
@@ -619,7 +672,7 @@ where
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_creates_gitignore_files_for_lix_metadata() {
     let tempdir = tempfile::tempdir().unwrap();
 
@@ -639,102 +692,7 @@ async fn filesystem_creates_gitignore_files_for_lix_metadata() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
-async fn filesystem_removes_legacy_lix_system_directory() {
-    let tempdir = tempfile::tempdir().unwrap();
-    let metadata_dir = tempdir.path().join(".lix/.internal");
-    std::fs::create_dir_all(&metadata_dir).unwrap();
-    let seed = open_lix_with_backend(SqliteBackend::open(metadata_dir.join("db.sqlite")).unwrap())
-        .await
-        .unwrap();
-    write_file(
-        &seed,
-        "/.lix_system/settings.json",
-        b"stored legacy".to_vec(),
-    )
-    .await
-    .unwrap();
-    write_file(&seed, "/.lix_system/db.sqlite", b"legacy db".to_vec())
-        .await
-        .unwrap();
-    write_file(
-        &seed,
-        "/.lix_system/.internal/private",
-        b"legacy private".to_vec(),
-    )
-    .await
-    .unwrap();
-    seed.close().await.unwrap();
-
-    std::fs::create_dir_all(tempdir.path().join(".lix_system/app_data")).unwrap();
-    std::fs::write(
-        tempdir.path().join(".lix_system/app_data/legacy.txt"),
-        b"disk legacy",
-    )
-    .unwrap();
-    std::fs::write(tempdir.path().join(".lix_system/.gitignore"), b"*\n").unwrap();
-    std::fs::write(tempdir.path().join(".lix_system/.DS_Store"), b"ds-store").unwrap();
-    std::fs::write(
-        tempdir.path().join(".lix_system/db.sqlite"),
-        b"disk legacy db",
-    )
-    .unwrap();
-    std::fs::create_dir_all(tempdir.path().join(".lix_system/.internal")).unwrap();
-    std::fs::write(
-        tempdir.path().join(".lix_system/.internal/private"),
-        b"disk private",
-    )
-    .unwrap();
-
-    let lix = open_lix_with_filesystem(tempdir.path()).await;
-
-    assert!(!tempdir.path().join(".lix_system").exists());
-    assert_eq!(
-        std::fs::read(tempdir.path().join(".lix/app_data/legacy.txt")).unwrap(),
-        b"disk legacy"
-    );
-    assert!(!tempdir.path().join(".lix/.DS_Store").exists());
-    assert_eq!(readdir(&lix, "/.lix_system/").await.unwrap(), None);
-    assert_eq!(
-        read_file(&lix, "/.lix_system/settings.json").await.unwrap(),
-        None
-    );
-    assert_eq!(
-        read_file(&lix, "/.lix_system/db.sqlite").await.unwrap(),
-        None
-    );
-    assert_eq!(read_file(&lix, "/.lix/db.sqlite").await.unwrap(), None);
-    assert!(!tempdir.path().join(".lix/db.sqlite").exists());
-    assert_eq!(
-        read_file(&lix, "/.lix_system/.internal/private")
-            .await
-            .unwrap(),
-        None
-    );
-    assert_eq!(
-        read_file(&lix, "/.lix/.internal/private").await.unwrap(),
-        None
-    );
-    assert!(!tempdir.path().join(".lix/.internal/private").exists());
-    assert_eq!(
-        read_file(&lix, "/.lix/settings.json")
-            .await
-            .unwrap()
-            .as_deref(),
-        Some(b"stored legacy".as_slice())
-    );
-    assert_eq!(
-        read_file(&lix, "/.lix/app_data/legacy.txt")
-            .await
-            .unwrap()
-            .as_deref(),
-        Some(b"disk legacy".as_slice())
-    );
-    lix.close().await.unwrap();
-}
-
-#[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_initial_import_ignores_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tempdir.path().join(".git/objects")).unwrap();
@@ -766,14 +724,10 @@ async fn filesystem_initial_import_ignores_git_entries() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
-    let metadata_dir = tempdir.path().join(".lix/.internal");
-    std::fs::create_dir_all(&metadata_dir).unwrap();
-    let seed = open_lix_with_backend(SqliteBackend::open(metadata_dir.join("db.sqlite")).unwrap())
-        .await
-        .unwrap();
+    let seed = open_lix_with_seeded_filesystem_metadata(tempdir.path()).await;
     write_file(&seed, "/.git/config", b"old".to_vec())
         .await
         .unwrap();
@@ -792,14 +746,10 @@ async fn filesystem_reconciliation_removes_previously_imported_git_entries() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_initial_import_deletes_lix_entries_missing_locally() {
     let tempdir = tempfile::tempdir().unwrap();
-    let metadata_dir = tempdir.path().join(".lix/.internal");
-    std::fs::create_dir_all(&metadata_dir).unwrap();
-    let seed = open_lix_with_backend(SqliteBackend::open(metadata_dir.join("db.sqlite")).unwrap())
-        .await
-        .unwrap();
+    let seed = open_lix_with_seeded_filesystem_metadata(tempdir.path()).await;
     write_file(&seed, "/old.txt", b"old".to_vec())
         .await
         .unwrap();
@@ -816,7 +766,7 @@ async fn filesystem_initial_import_deletes_lix_entries_missing_locally() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -883,7 +833,7 @@ async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_materializes_untracked_sdk_sql_writes() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -918,7 +868,7 @@ async fn filesystem_materializes_untracked_sdk_sql_writes() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_watcher_syncs_disk_changes_to_lix() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -941,7 +891,7 @@ async fn filesystem_watcher_syncs_disk_changes_to_lix() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_watcher_ignores_git_entries_created_after_open() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -960,7 +910,7 @@ async fn filesystem_watcher_ignores_git_entries_created_after_open() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_materialization_skips_git_entries() {
     let tempdir = tempfile::tempdir().unwrap();
     let lix = open_lix_with_filesystem(tempdir.path()).await;
@@ -986,7 +936,7 @@ async fn filesystem_materialization_skips_git_entries() {
 }
 
 #[tokio::test]
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn filesystem_imports_opaque_lix_path_names() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::write(tempdir.path().join("bad%name.txt"), b"bad").unwrap();
@@ -1010,7 +960,7 @@ async fn filesystem_imports_opaque_lix_path_names() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "sqlite"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 async fn filesystem_rejects_symlink_root() {
     use std::os::unix::fs::symlink;
 
@@ -1026,7 +976,7 @@ async fn filesystem_rejects_symlink_root() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "sqlite"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 async fn filesystem_ignores_symlinks_on_initial_import() {
     use std::os::unix::fs::symlink;
 
@@ -1069,7 +1019,7 @@ async fn filesystem_ignores_symlinks_on_initial_import() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "sqlite"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 async fn filesystem_ignores_special_and_invalid_utf8_entries() {
     use std::ffi::OsString;
     use std::os::unix::ffi::OsStringExt;
@@ -1107,7 +1057,7 @@ async fn filesystem_ignores_special_and_invalid_utf8_entries() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "sqlite"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 async fn filesystem_watcher_ignores_symlinks_created_after_open() {
     use std::os::unix::fs::symlink;
 
@@ -1129,7 +1079,7 @@ async fn filesystem_watcher_ignores_symlinks_created_after_open() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "sqlite"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 async fn filesystem_materialization_skips_symlink_collisions() {
     use std::os::unix::fs::symlink;
 
@@ -1196,7 +1146,7 @@ async fn filesystem_materialization_skips_symlink_collisions() {
 }
 
 #[tokio::test]
-#[cfg(all(unix, feature = "sqlite"))]
+#[cfg(all(unix, feature = "rocksdb"))]
 async fn filesystem_materialization_skips_special_file_collisions() {
     use std::os::unix::fs::FileTypeExt;
     use std::os::unix::net::UnixListener;
@@ -1229,13 +1179,13 @@ async fn filesystem_materialization_skips_special_file_collisions() {
     lix.close().await.unwrap();
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 #[track_caller]
 fn wait_for_disk_file(path: &Path, expected: Option<&[u8]>) {
     wait_for_disk_file_with_timeout(path, expected, Duration::from_secs(5));
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 #[track_caller]
 fn wait_for_disk_file_with_timeout(path: &Path, expected: Option<&[u8]>, timeout: Duration) {
     let deadline = Instant::now() + timeout;
@@ -1253,7 +1203,7 @@ fn wait_for_disk_file_with_timeout(path: &Path, expected: Option<&[u8]>, timeout
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn wait_for_lix_file(lix: &Lix<FsBackend>, path: &str, expected: Option<&[u8]>) {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
@@ -1269,7 +1219,7 @@ async fn wait_for_lix_file(lix: &Lix<FsBackend>, path: &str, expected: Option<&[
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(feature = "rocksdb")]
 async fn wait_for_lix_directory(lix: &Lix<FsBackend>, path: &str, expected: bool) {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -487,6 +487,49 @@ async fn filesystem_initialization_wipes_legacy_sqlite_internal_metadata() {
     lix.close().await.unwrap();
 }
 
+#[tokio::test]
+#[cfg(feature = "fs_backend")]
+async fn filesystem_initialization_wipes_legacy_root_sqlite_and_system_metadata() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let lix_dir = tempdir.path().join(".lix");
+    let system_dir = tempdir.path().join(".lix_system");
+    std::fs::create_dir_all(&lix_dir).unwrap();
+    std::fs::create_dir_all(&system_dir).unwrap();
+    std::fs::write(lix_dir.join("db.sqlite"), b"legacy sqlite metadata").unwrap();
+    std::fs::write(lix_dir.join("db.sqlite-wal"), b"legacy sqlite wal").unwrap();
+    std::fs::write(system_dir.join("cache"), b"legacy system data").unwrap();
+    std::fs::write(tempdir.path().join("note.txt"), b"workspace").unwrap();
+
+    let lix = open_lix_with_filesystem(tempdir.path()).await;
+
+    assert!(!lix_dir.join("db.sqlite").exists());
+    assert!(!lix_dir.join("db.sqlite-wal").exists());
+    assert!(!system_dir.exists());
+    assert_eq!(
+        read_file(&lix, "/.lix/db.sqlite").await.unwrap().as_deref(),
+        None
+    );
+    assert_eq!(
+        read_file(&lix, "/.lix/db.sqlite-wal")
+            .await
+            .unwrap()
+            .as_deref(),
+        None
+    );
+    assert_eq!(
+        read_file(&lix, "/.lix_system/cache")
+            .await
+            .unwrap()
+            .as_deref(),
+        None
+    );
+    assert_eq!(
+        read_file(&lix, "/note.txt").await.unwrap().as_deref(),
+        Some(b"workspace".as_slice())
+    );
+    lix.close().await.unwrap();
+}
+
 #[cfg(feature = "fs_backend")]
 async fn open_lix_with_filesystem(path: &Path) -> Lix<FsBackend> {
     let backend = FsBackend::open(path).await.unwrap();

--- a/packages/rs-sdk/tests/sqlite_backend.rs
+++ b/packages/rs-sdk/tests/sqlite_backend.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "sqlite")]
 use lix_engine::run_backend_conformance;
 use lix_sdk::{
-    Backend, FsBackend, Lix, LixError, OpenLixOptions, SQLITE_FORMAT_VERSION, SqliteBackend,
+    Backend, Lix, LixError, OpenLixOptions, SQLITE_FORMAT_VERSION, SqliteBackend,
     SqliteBackendFactory, Value, WasmComponentInstance, WasmLimits, WasmPluginDetectedChange,
     WasmPluginEntityState, WasmPluginFile, WasmRuntime, open_lix, open_lix_with_backend,
 };
@@ -9,7 +9,6 @@ use rusqlite::Connection;
 use std::io::{Cursor, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
 
 #[test]
 fn sqlite_backend_passes_backend_conformance() {
@@ -103,255 +102,6 @@ async fn sqlite_backend_persists_lix_data_across_reopen() {
 }
 
 #[tokio::test]
-async fn fs_backend_uses_dir_lix_and_materializes_across_reopen() {
-    let tempdir = tempfile::tempdir().expect("tempdir should create");
-    let filesystem_path = tempdir.path().join("filesystem");
-
-    {
-        let backend = FsBackend::open(&filesystem_path)
-            .await
-            .expect("fs backend opens");
-        let lix = open_lix_with_backend(backend)
-            .await
-            .expect("lix opens on fs backend");
-        let sqlite_dir = filesystem_path.join(".lix/.internal");
-        let sqlite_path = sqlite_dir.join("db.sqlite");
-        assert!(
-            sqlite_dir.is_dir(),
-            "fs backend should store SQLite in dir/.lix/.internal"
-        );
-        assert!(
-            sqlite_path.is_file(),
-            "fs backend should store SQLite at dir/.lix/.internal/db.sqlite"
-        );
-        assert_eq!(
-            read_file(&lix, "/.lix")
-                .await
-                .expect(".lix file path reads"),
-            None,
-            "dir/.lix should not be imported into Lix as a file"
-        );
-        assert_eq!(
-            readdir(&lix, "/.lix/")
-                .await
-                .expect(".lix directory path reads"),
-            Some(Vec::new()),
-            "dir/.lix should be visible but private children should not"
-        );
-        assert_eq!(
-            readdir(&lix, "/.lix/.internal/")
-                .await
-                .expect(".lix/.internal directory path reads"),
-            None,
-            "dir/.lix/.internal should not be visible as a synced Lix directory"
-        );
-        write_file(&lix, "/persisted.txt", b"persisted".to_vec())
-            .await
-            .expect("file write succeeds");
-        wait_for_disk_file(
-            &filesystem_path.join("persisted.txt"),
-            Some(b"persisted".as_slice()),
-        );
-        lix.close().await.expect("lix closes");
-    }
-
-    {
-        let plain = open_lix_with_backend(
-            SqliteBackend::open(filesystem_path.join(".lix/.internal").join("db.sqlite"))
-                .expect("sqlite backend reopens"),
-        )
-        .await
-        .expect("plain lix opens on sqlite backend");
-        assert_eq!(
-            read_file(&plain, "/persisted.txt")
-                .await
-                .expect("persisted file reads")
-                .as_deref(),
-            Some(b"persisted".as_slice())
-        );
-        plain.close().await.expect("plain lix closes");
-    }
-
-    let backend = FsBackend::open(&filesystem_path)
-        .await
-        .expect("fs backend reopens");
-    let lix = open_lix_with_backend(backend)
-        .await
-        .expect("lix reopens on fs backend");
-    assert_eq!(
-        read_file(&lix, "/persisted.txt")
-            .await
-            .expect("persisted file reads after reopen")
-            .as_deref(),
-        Some(b"persisted".as_slice())
-    );
-    write_file(&lix, "/second.txt", b"second".to_vec())
-        .await
-        .expect("second file write succeeds");
-    wait_for_disk_file(
-        &filesystem_path.join("second.txt"),
-        Some(b"second".as_slice()),
-    );
-    lix.close().await.expect("lix closes");
-}
-
-#[tokio::test]
-async fn fs_backend_moves_legacy_root_sqlite_metadata_into_internal_dir() {
-    let tempdir = tempfile::tempdir().expect("tempdir should create");
-    let filesystem_path = tempdir.path().join("filesystem");
-    let legacy_sqlite_dir = filesystem_path.join(".lix");
-    let legacy_sqlite_path = legacy_sqlite_dir.join("db.sqlite");
-    std::fs::create_dir_all(&legacy_sqlite_dir).expect("legacy sqlite dir creates");
-
-    {
-        let lix = open_lix_with_backend(
-            SqliteBackend::open(&legacy_sqlite_path).expect("legacy sqlite backend opens"),
-        )
-        .await
-        .expect("legacy lix opens");
-        lix.execute(
-            "INSERT INTO lix_key_value (key, value) VALUES ('legacy-key', 'legacy-value')",
-            &[],
-        )
-        .await
-        .expect("legacy key value write succeeds");
-        lix.close().await.expect("legacy lix closes");
-    }
-    for name in ["db.sqlite-wal", "db.sqlite-shm", "db.sqlite-journal"] {
-        std::fs::write(legacy_sqlite_dir.join(name), b"legacy-sidecar")
-            .expect("legacy sidecar writes");
-    }
-
-    let lix = open_lix_with_backend(
-        FsBackend::open(&filesystem_path)
-            .await
-            .expect("fs backend opens"),
-    )
-    .await
-    .expect("lix opens on fs backend");
-
-    assert!(
-        !legacy_sqlite_path.exists(),
-        "legacy SQLite path should move"
-    );
-    for name in ["db.sqlite-wal", "db.sqlite-shm", "db.sqlite-journal"] {
-        assert!(
-            !legacy_sqlite_dir.join(name).exists(),
-            "legacy {name} should move"
-        );
-    }
-    for name in ["db.sqlite-wal", "db.sqlite-shm"] {
-        assert!(
-            filesystem_path.join(".lix/.internal").join(name).is_file(),
-            "{name} should move into .lix/.internal"
-        );
-    }
-    assert!(
-        filesystem_path.join(".lix/.internal/db.sqlite").is_file(),
-        "SQLite file should move into .lix/.internal"
-    );
-    let rows = lix
-        .execute(
-            "SELECT key FROM lix_key_value WHERE key = 'legacy-key' AND value = lix_json('\"legacy-value\"')",
-            &[],
-        )
-        .await
-        .expect("legacy key value reads");
-    assert_eq!(rows.len(), 1, "moved SQLite database should be reused");
-    assert_eq!(
-        read_file(&lix, "/.lix/db.sqlite")
-            .await
-            .expect("legacy metadata file path reads"),
-        None,
-        "legacy SQLite file should not be imported as a Lix file"
-    );
-
-    lix.close().await.expect("lix closes");
-}
-
-#[tokio::test]
-async fn fs_backend_legacy_sqlite_metadata_conflict_does_not_partially_move() {
-    let tempdir = tempfile::tempdir().expect("tempdir should create");
-    let filesystem_path = tempdir.path().join("filesystem");
-    let legacy_sqlite_dir = filesystem_path.join(".lix");
-    let internal_sqlite_dir = filesystem_path.join(".lix/.internal");
-    std::fs::create_dir_all(&legacy_sqlite_dir).expect("legacy sqlite dir creates");
-    std::fs::create_dir_all(&internal_sqlite_dir).expect("internal sqlite dir creates");
-    std::fs::write(legacy_sqlite_dir.join("db.sqlite"), b"legacy").expect("legacy sqlite writes");
-    std::fs::write(legacy_sqlite_dir.join("db.sqlite-wal"), b"legacy-wal")
-        .expect("legacy wal writes");
-    std::fs::write(internal_sqlite_dir.join("db.sqlite-wal"), b"target-wal")
-        .expect("target wal writes");
-
-    let Err(error) = FsBackend::open(&filesystem_path).await else {
-        panic!("conflicting legacy metadata should fail");
-    };
-
-    assert!(
-        error.message.contains("target already exists"),
-        "error should explain metadata conflict: {error:?}"
-    );
-    assert!(
-        legacy_sqlite_dir.join("db.sqlite").is_file(),
-        "legacy db.sqlite should remain in place after preflight failure"
-    );
-    assert!(
-        legacy_sqlite_dir.join("db.sqlite-wal").is_file(),
-        "legacy db.sqlite-wal should remain in place after preflight failure"
-    );
-}
-
-#[tokio::test]
-async fn fs_backend_ignores_sqlite_sidecar_paths() {
-    let tempdir = tempfile::tempdir().expect("tempdir should create");
-    let filesystem_path = tempdir.path().join("filesystem");
-    std::fs::create_dir_all(filesystem_path.join(".lix")).expect("legacy .lix dir creates");
-    for name in ["db.sqlite-wal", "db.sqlite-shm", "db.sqlite-journal"] {
-        std::fs::write(filesystem_path.join(".lix").join(name), b"legacy")
-            .expect("legacy sqlite sidecar writes");
-    }
-    let lix = open_lix_with_backend(
-        FsBackend::open(&filesystem_path)
-            .await
-            .expect("fs backend opens"),
-    )
-    .await
-    .expect("lix opens on fs backend");
-
-    for path in [
-        "/.lix/.internal",
-        "/.lix/.internal/db.sqlite",
-        "/.lix/.internal/db.sqlite-wal",
-        "/.lix/.internal/db.sqlite-shm",
-        "/.lix/.internal/db.sqlite-journal",
-        "/.lix/db.sqlite",
-        "/.lix/db.sqlite-wal",
-        "/.lix/db.sqlite-shm",
-        "/.lix/db.sqlite-journal",
-    ] {
-        assert_eq!(
-            read_file(&lix, path).await.expect("metadata path reads"),
-            None,
-            "{path} should not be visible as a synced Lix file"
-        );
-    }
-    assert_eq!(
-        readdir(&lix, "/.lix/.internal/")
-            .await
-            .expect("internal directory reads"),
-        None,
-        "/.lix/.internal should not be visible as a synced Lix directory"
-    );
-    assert_eq!(
-        readdir(&lix, "/.lix/").await.expect(".lix directory reads"),
-        Some(Vec::new()),
-        "legacy root SQLite sidecars should not appear in /.lix/"
-    );
-
-    lix.close().await.expect("lix closes");
-}
-
-#[tokio::test]
 async fn sqlite_backend_open_lix_options_supplies_plugin_wasm_runtime() {
     let tempdir = tempfile::tempdir().expect("tempdir should create");
     let path = tempdir.path().join("workspace.lix");
@@ -395,22 +145,6 @@ fn sqlite_journal_mode(path: &std::path::Path) -> String {
     let conn = Connection::open(path).expect("sqlite file should open");
     conn.pragma_query_value(None, "journal_mode", |row| row.get(0))
         .expect("journal_mode should read")
-}
-
-fn wait_for_disk_file(path: &std::path::Path, expected: Option<&[u8]>) {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let path_display = path.display();
-    loop {
-        let actual = std::fs::read(path).ok();
-        if actual.as_deref() == expected {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for disk file {path_display} to be {expected:?}, got {actual:?}"
-        );
-        std::thread::sleep(Duration::from_millis(50));
-    }
 }
 
 async fn install_plugin<B>(lix: &Lix<B>, key: &str, archive: &[u8]) -> Result<(), LixError>
@@ -459,40 +193,6 @@ where
         .first()
         .map(|row| row.get::<Vec<u8>>("data"))
         .transpose()
-}
-
-async fn readdir<B>(lix: &Lix<B>, path: &str) -> Result<Option<Vec<String>>, LixError>
-where
-    B: Backend + Clone + Send + Sync + 'static,
-    for<'backend> B::Read<'backend>: Send,
-    for<'backend> B::Write<'backend>: Send,
-{
-    let directory = lix
-        .execute(
-            "SELECT id FROM lix_directory WHERE path = $1",
-            &[Value::Text(path.to_string())],
-        )
-        .await?;
-    let Some(directory) = directory.rows().first() else {
-        return Ok(None);
-    };
-    let directory_id = directory.get::<String>("id")?;
-    let entries = lix
-        .execute(
-            "SELECT name FROM lix_directory WHERE parent_id = $1 \
-             UNION ALL \
-             SELECT name FROM lix_file WHERE directory_id = $1 \
-             ORDER BY name",
-            &[Value::Text(directory_id)],
-        )
-        .await?;
-    Ok(Some(
-        entries
-            .rows()
-            .iter()
-            .map(|row| row.get::<String>("name"))
-            .collect::<Result<Vec<_>, _>>()?,
-    ))
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary

This draft PR contains the RocksDB/BlobDB filesystem backend experiment for the Lix filesystem path.

What changed:

- Added a filesystem-specialized `lix_fs_backend` crate with a RocksDB backend and BlobDB options.
- Wired the RocksDB filesystem backend into `lix_sdk` behind the `rocksdb` feature.
- Extended `profile_fs_open` with backend selection, BlobDB thresholds, JSON output, disk/CAS stats, compaction profiling, FastCDC experiment overrides, and read benchmarks.
- Added skip-existing CAS chunk payload writes, then batched CAS chunk existence checks.
- Upgraded the Rust RocksDB wrapper to `rocksdb 0.24` / `librocksdb-sys 0.17.3+10.4.2`.

## Experiment Result

On the sanitized Downloads sample, current SQLite chunking versus the candidate:

| Backend/config | Cold | Warm | Read all | Read 4 largest | Repeat 4 largest | Read 16 small | `.lix` total | CAS chunks |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| SQLite current `16/64/256` | 17232 ms | 11506 ms | 3231 ms | 12570 ms | 12230 ms | 50196 ms | 1.636 GB | 20,223 |
| BlobDB 32 KiB + `256/1024/4096` | 6431 ms | 3772 ms | 799 ms | 2609 ms | 2206 ms | 9543 ms | 1.602 GB | 1,745 |

Current experiment winner: BlobDB 32 KiB plus FastCDC `256/1024/4096 KiB`.

## Validation

Ran during the experiment:

- `cargo fmt -p lix_engine -p lix_sdk`
- `cargo test -p lix_engine binary_cas --lib`
- `cargo check -p lix_sdk --features sqlite,rocksdb --example profile_fs_open`
- `cargo build --release -p lix_sdk --features sqlite,rocksdb --example profile_fs_open`
- `cargo test -p lix_sdk --features sqlite,rocksdb filesystem::tests:: -- --nocapture`
- `cargo check -p lix_sdk --features sqlite --example profile_fs_open`
- Read/import/rewrite/delete benchmark matrices recorded in the parent experiment log.

Note: local RocksDB builds required `DYLD_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib LIBCLANG_PATH=/opt/homebrew/opt/llvm/lib` because the newer `librocksdb-sys` bindgen runtime needs `libclang.dylib`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking on-disk format for existing filesystem workspaces (legacy SQLite wiped, not migrated) and a large change to persistence, CAS chunking, and native build/CI dependencies.
> 
> **Overview**
> **Filesystem persistence** moves from SQLite under `.lix/.internal/db.sqlite` to a new `lix_fs_backend` crate with RocksDB (BlobDB) at `.lix/.internal/rocksdb`. `FsBackend` is gated behind the `fs_backend` feature (JS SDK and tests enable it). Legacy SQLite metadata and `.lix_system` are **not migrated**—when old internal SQLite files exist and no RocksDB store is present, `.lix/.internal` is cleared and a fresh RocksDB store is created.
> 
> **Binary CAS** switches the default FastCDC profile to **256 KiB / 1 MiB / 4 MiB** (from 16/64/256 KiB), adds chunking configuration on `BinaryCasContext`, and on commit uses **`writer_skipping_existing_chunks`** so persisted chunk payloads are not rewritten (batched key-only existence checks plus metrics/stats helpers).
> 
> **Tooling & deps:** CI/publish workflows install `llvm-dev` / `libclang-dev` / `clang` for RocksDB bindgen; `rocksdb` is bumped to **0.24** (`librocksdb-sys` 0.17). Docs and `profile_fs_open` are updated for RocksDB paths, optional read benchmarks, and corpus/RocksDB byte breakdowns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d2eabc603556cf76f488eb93cc5e99a097eb77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->