### PR TITLE
[codex] Make JS native bindings truly async

### DIFF
--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -12,10 +12,11 @@ use lix_sdk::{
 use napi::JsDeferred;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use std::collections::HashMap;
 use std::sync::mpsc::{self, Sender};
 use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use std::thread;
 use tokio::runtime::{Builder, Runtime};
@@ -24,8 +25,7 @@ use tokio::sync::watch;
 #[expect(missing_debug_implementations)]
 #[napi(js_name = "Lix")]
 pub struct NativeLix {
-    rt: Runtime,
-    lix: Option<NativeLixInner>,
+    actor: NativeLixActor,
 }
 
 enum NativeLixInner {
@@ -44,6 +44,400 @@ enum NativeObserveEventsInner {
     Memory(RsObserveEvents<InMemoryBackend>),
     Sqlite(RsObserveEvents<SqliteBackend>),
     Fs(RsObserveEvents<FsBackend>),
+}
+
+#[derive(Clone)]
+struct NativeLixActor {
+    commands: Sender<LixCommand>,
+    closed: Arc<AtomicBool>,
+    send_lock: Arc<Mutex<()>>,
+    next_transaction_id: Arc<AtomicU64>,
+}
+
+struct NativeLixActorState {
+    lix: NativeLixInner,
+    transactions: HashMap<u64, NativeLixTransactionInner>,
+}
+
+type NativeResult<T> = std::result::Result<T, LixError>;
+type NativeResolver<T> = Box<dyn FnOnce(Env) -> Result<T> + Send>;
+type NativeDeferred<T> = JsDeferred<T, NativeResolver<T>>;
+type NativeExecuteDeferred = NativeDeferred<ExecuteResult>;
+type NativeTransactionDeferred = NativeDeferred<NativeLixTransaction>;
+type NativeStringDeferred = NativeDeferred<String>;
+type NativeCreateBranchDeferred = NativeDeferred<CreateBranchReceiptDto>;
+type NativeSwitchBranchDeferred = NativeDeferred<SwitchBranchReceiptDto>;
+type NativeMergePreviewDeferred = NativeDeferred<MergeBranchPreviewDto>;
+type NativeMergeReceiptDeferred = NativeDeferred<MergeBranchReceiptDto>;
+type NativeUnitDeferred = NativeDeferred<()>;
+
+enum LixCommand {
+    Execute {
+        sql: String,
+        params: Vec<Value>,
+        deferred: NativeExecuteDeferred,
+    },
+    BeginTransaction {
+        transaction_id: u64,
+        actor: NativeLixActor,
+        deferred: NativeTransactionDeferred,
+    },
+    ActiveBranchId(NativeStringDeferred),
+    CreateBranch {
+        options: RsCreateBranchOptions,
+        deferred: NativeCreateBranchDeferred,
+    },
+    SwitchBranch {
+        options: RsSwitchBranchOptions,
+        deferred: NativeSwitchBranchDeferred,
+    },
+    MergeBranchPreview {
+        options: MergeBranchPreviewOptions,
+        deferred: NativeMergePreviewDeferred,
+    },
+    MergeBranch {
+        options: RsMergeBranchOptions,
+        deferred: NativeMergeReceiptDeferred,
+    },
+    Close(NativeUnitDeferred),
+    Observe {
+        sql: String,
+        params: Vec<Value>,
+        deferred: NativeDeferred<NativeObserveEvents>,
+    },
+    TransactionExecute {
+        transaction_id: u64,
+        sql: String,
+        params: Vec<Value>,
+        deferred: NativeExecuteDeferred,
+    },
+    TransactionCommit {
+        transaction_id: u64,
+        deferred: NativeUnitDeferred,
+    },
+    TransactionRollback {
+        transaction_id: u64,
+        deferred: NativeUnitDeferred,
+    },
+    TransactionAbandon {
+        transaction_id: u64,
+    },
+}
+
+impl NativeLixActor {
+    fn start(lix: NativeLixInner) -> Result<Self> {
+        let (commands, receiver) = mpsc::channel();
+        let actor = Self {
+            commands,
+            closed: Arc::new(AtomicBool::new(false)),
+            send_lock: Arc::new(Mutex::new(())),
+            next_transaction_id: Arc::new(AtomicU64::new(1)),
+        };
+        let actor_closed = Arc::clone(&actor.closed);
+        let actor_send_lock = Arc::clone(&actor.send_lock);
+        thread::Builder::new()
+            .name("lix-native".to_string())
+            .spawn(move || run_lix_actor(lix, receiver, actor_closed, actor_send_lock))
+            .map_err(to_napi_error)?;
+        Ok(actor)
+    }
+
+    fn next_transaction_id(&self) -> u64 {
+        self.next_transaction_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn send_with_deferred<T>(
+        &self,
+        deferred: NativeDeferred<T>,
+        command: impl FnOnce(NativeDeferred<T>) -> LixCommand,
+    ) where
+        T: ToNapiValue + Send + 'static,
+    {
+        let Ok(_send_guard) = self.send_lock.lock() else {
+            settle_deferred(deferred, Err(lix_closed_error()));
+            return;
+        };
+        if self.closed.load(Ordering::SeqCst) {
+            settle_deferred(deferred, Err(lix_closed_error()));
+            return;
+        }
+        let command = command(deferred);
+        match self.commands.send(command) {
+            Ok(()) => {}
+            Err(error) => {
+                settle_command_after_close(error.0);
+            }
+        }
+    }
+}
+
+impl NativeLixActor {
+    fn abandon_transaction(&self, transaction_id: u64) {
+        let _ = self
+            .commands
+            .send(LixCommand::TransactionAbandon { transaction_id });
+    }
+}
+
+fn settle_deferred<T>(deferred: NativeDeferred<T>, result: NativeResult<T>)
+where
+    T: ToNapiValue + Send + 'static,
+{
+    deferred.resolve(Box::new(move |env| {
+        result.map_err(|error| lix_error_to_napi_error(&env, error))
+    }));
+}
+
+fn run_lix_actor(
+    lix: NativeLixInner,
+    receiver: mpsc::Receiver<LixCommand>,
+    closed: Arc<AtomicBool>,
+    send_lock: Arc<Mutex<()>>,
+) {
+    let rt = match Builder::new_current_thread().enable_all().build() {
+        Ok(rt) => rt,
+        Err(error) => {
+            closed.store(true, Ordering::SeqCst);
+            reject_pending_lix_commands(receiver, error);
+            return;
+        }
+    };
+    let mut state = Some(NativeLixActorState {
+        lix,
+        transactions: HashMap::new(),
+    });
+
+    while let Ok(command) = receiver.recv() {
+        let Some(open_state) = state.as_mut() else {
+            settle_command_after_close(command);
+            continue;
+        };
+        if closed.load(Ordering::SeqCst) {
+            drop(state.take());
+            settle_command_after_close(command);
+            drain_commands_after_close(&receiver, &send_lock);
+            break;
+        }
+        if handle_lix_command(&rt, open_state, &closed, command) {
+            drop(state.take());
+            drain_commands_after_close(&receiver, &send_lock);
+            break;
+        }
+    }
+    closed.store(true, Ordering::SeqCst);
+}
+
+fn drain_commands_after_close(receiver: &mpsc::Receiver<LixCommand>, send_lock: &Mutex<()>) {
+    let Ok(_send_guard) = send_lock.lock() else {
+        return;
+    };
+    for command in receiver.try_iter() {
+        settle_command_after_close(command);
+    }
+}
+
+fn reject_pending_lix_commands(receiver: mpsc::Receiver<LixCommand>, error: std::io::Error) {
+    while let Ok(command) = receiver.recv() {
+        match command {
+            LixCommand::Execute { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::BeginTransaction { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::ActiveBranchId(deferred) => deferred.reject(to_napi_error(&error)),
+            LixCommand::CreateBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::SwitchBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::MergeBranchPreview { deferred, .. } => {
+                deferred.reject(to_napi_error(&error));
+            }
+            LixCommand::MergeBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::Close(deferred) => deferred.reject(to_napi_error(&error)),
+            LixCommand::Observe { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::TransactionExecute { deferred, .. } => {
+                deferred.reject(to_napi_error(&error));
+            }
+            LixCommand::TransactionCommit { deferred, .. }
+            | LixCommand::TransactionRollback { deferred, .. } => {
+                deferred.reject(to_napi_error(&error));
+            }
+            LixCommand::TransactionAbandon { .. } => {}
+        }
+    }
+}
+
+fn handle_lix_command(
+    rt: &Runtime,
+    state: &mut NativeLixActorState,
+    closed: &AtomicBool,
+    command: LixCommand,
+) -> bool {
+    match command {
+        LixCommand::Execute {
+            sql,
+            params,
+            deferred,
+        } => {
+            let result = rt
+                .block_on(state.lix.execute(&sql, &params))
+                .and_then(ExecuteResult::try_from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::BeginTransaction {
+            transaction_id,
+            actor,
+            deferred,
+        } => {
+            let result = rt
+                .block_on(state.lix.begin_transaction())
+                .map(|transaction| {
+                    state.transactions.insert(transaction_id, transaction);
+                    NativeLixTransaction::new(actor, transaction_id)
+                });
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::ActiveBranchId(deferred) => {
+            let result = rt.block_on(state.lix.active_branch_id());
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::CreateBranch { options, deferred } => {
+            let result = rt
+                .block_on(state.lix.create_branch(options))
+                .map(CreateBranchReceiptDto::from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::SwitchBranch { options, deferred } => {
+            let result = rt
+                .block_on(state.lix.switch_branch(options))
+                .map(SwitchBranchReceiptDto::from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::MergeBranchPreview { options, deferred } => {
+            let result = rt
+                .block_on(state.lix.merge_branch_preview(options))
+                .map(MergeBranchPreviewDto::from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::MergeBranch { options, deferred } => {
+            let result = rt
+                .block_on(state.lix.merge_branch(options))
+                .map(MergeBranchReceiptDto::from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::Close(deferred) => {
+            let result = rt.block_on(state.lix.close());
+            let should_drop_state = result.is_ok();
+            if result.is_ok() {
+                closed.store(true, Ordering::SeqCst);
+            }
+            settle_deferred(deferred, result);
+            should_drop_state
+        }
+        LixCommand::Observe {
+            sql,
+            params,
+            deferred,
+        } => {
+            let result = state.lix.observe(&sql, &params).and_then(|events| {
+                NativeObserveEvents::new(events).map_err(|error| {
+                    LixError::unknown(format!("failed to start observe actor: {error}"))
+                })
+            });
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::TransactionExecute {
+            transaction_id,
+            sql,
+            params,
+            deferred,
+        } => {
+            let result = state.transactions.get_mut(&transaction_id).map_or_else(
+                || Err(transaction_closed_error()),
+                |transaction| {
+                    rt.block_on(transaction.execute(&sql, &params))
+                        .and_then(ExecuteResult::try_from)
+                },
+            );
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::TransactionCommit {
+            transaction_id,
+            deferred,
+        } => {
+            let result = state.transactions.remove(&transaction_id).map_or_else(
+                || Err(transaction_closed_error()),
+                |transaction| rt.block_on(transaction.commit()),
+            );
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::TransactionRollback {
+            transaction_id,
+            deferred,
+        } => {
+            let result = state.transactions.remove(&transaction_id).map_or_else(
+                || Err(transaction_closed_error()),
+                |transaction| rt.block_on(transaction.rollback()),
+            );
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::TransactionAbandon { transaction_id } => {
+            if let Some(transaction) = state.transactions.remove(&transaction_id) {
+                let _ = rt.block_on(transaction.rollback());
+            }
+            false
+        }
+    }
+}
+
+fn settle_command_after_close(command: LixCommand) {
+    match command {
+        LixCommand::Close(deferred) => settle_deferred(deferred, Ok(())),
+        LixCommand::Execute { deferred, .. } | LixCommand::TransactionExecute { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::BeginTransaction { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::ActiveBranchId(deferred) => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::CreateBranch { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::SwitchBranch { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::MergeBranchPreview { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::MergeBranch { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::Observe { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::TransactionCommit { deferred, .. }
+        | LixCommand::TransactionRollback { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
+        LixCommand::TransactionAbandon { .. } => {}
+    }
+}
+
+fn lix_closed_error() -> LixError {
+    LixError::new(LixError::CODE_CLOSED, "Lix handle is closed")
+        .with_hint("Open a new Lix handle before calling this method.")
+}
+
+fn transaction_closed_error() -> LixError {
+    LixError::new("LIX_INVALID_TRANSACTION_STATE", "Lix transaction is closed")
 }
 
 impl NativeLixInner {
@@ -207,6 +601,14 @@ pub struct OpenFsTask {
     filter: FsBackendFilter,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct OpenMemoryTask;
+
+#[derive(Debug)]
+pub struct OpenSqliteTask {
+    path: String,
+}
+
 fn parse_fs_backend_storage(env: &Env, storage: Option<String>) -> Result<NativeFsBackendStorage> {
     match storage.as_deref().unwrap_or("persistent") {
         "persistent" => Ok(NativeFsBackendStorage::Persistent),
@@ -257,6 +659,51 @@ impl Task for OpenFsTask {
     }
 }
 
+impl Task for OpenMemoryTask {
+    type Output = std::result::Result<NativeLix, LixError>;
+    type JsValue = NativeLix;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        Ok(open_memory_native())
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        output.map_err(|error| lix_error_to_napi_error(&env, error))
+    }
+}
+
+impl Task for OpenSqliteTask {
+    type Output = std::result::Result<NativeLix, LixError>;
+    type JsValue = NativeLix;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        Ok(open_sqlite_native(std::mem::take(&mut self.path)))
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        output.map_err(|error| lix_error_to_napi_error(&env, error))
+    }
+}
+
+fn open_memory_native() -> std::result::Result<NativeLix, LixError> {
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
+    let lix = rt.block_on(open_lix(RsOpenLixOptions::default()))?;
+    NativeLix::new(NativeLixInner::Memory(lix))
+}
+
+fn open_sqlite_native(path: String) -> std::result::Result<NativeLix, LixError> {
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
+    let backend = SqliteBackend::new(SqliteBackendOptions { path: path.into() })?;
+    let lix = rt.block_on(open_lix_with_backend(backend))?;
+    NativeLix::new(NativeLixInner::Sqlite(lix))
+}
+
 fn open_fs_native(
     path: String,
     storage: NativeFsBackendStorage,
@@ -275,44 +722,19 @@ fn open_fs_native(
         }
     })?;
     let lix = rt.block_on(open_lix_with_backend(backend))?;
-    Ok(NativeLix {
-        rt,
-        lix: Some(NativeLixInner::Fs(lix)),
-    })
+    NativeLix::new(NativeLixInner::Fs(lix))
 }
 
 #[napi]
 impl NativeLix {
-    #[napi(factory, js_name = "openMemory")]
-    pub fn open_memory(env: Env) -> Result<Self> {
-        let rt = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(to_napi_error)?;
-        let lix = rt
-            .block_on(open_lix(RsOpenLixOptions::default()))
-            .map_err(|error| throw_lix_error(&env, error))?;
-        Ok(Self {
-            rt,
-            lix: Some(NativeLixInner::Memory(lix)),
-        })
+    #[napi(js_name = "openMemory")]
+    pub fn open_memory() -> AsyncTask<OpenMemoryTask> {
+        AsyncTask::new(OpenMemoryTask)
     }
 
-    #[napi(factory, js_name = "openSqlite")]
-    pub fn open_sqlite(env: Env, path: String) -> Result<Self> {
-        let rt = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(to_napi_error)?;
-        let backend = SqliteBackend::new(SqliteBackendOptions { path: path.into() })
-            .map_err(|error| throw_lix_error(&env, error.into()))?;
-        let lix = rt
-            .block_on(open_lix_with_backend(backend))
-            .map_err(|error| throw_lix_error(&env, error))?;
-        Ok(Self {
-            rt,
-            lix: Some(NativeLixInner::Sqlite(lix)),
-        })
+    #[napi(js_name = "openSqlite")]
+    pub fn open_sqlite(path: String) -> AsyncTask<OpenSqliteTask> {
+        AsyncTask::new(OpenSqliteTask { path })
     }
 
     #[napi(js_name = "openFs")]
@@ -332,156 +754,152 @@ impl NativeLix {
     }
 
     #[napi]
-    pub fn execute(
+    pub fn execute<'env>(
         &self,
-        env: Env,
+        env: &'env Env,
         sql: String,
         params: Option<Vec<LixValue>>,
-    ) -> Result<ExecuteResult> {
+    ) -> Result<Object<'env>> {
         let params = match params {
             Some(params) => params
                 .into_iter()
                 .map(Value::try_from)
                 .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|error| throw_lix_error(&env, error))?,
+                .map_err(|error| throw_lix_error(env, error))?,
             None => Vec::new(),
         };
-        let result = self
-            .rt
-            .block_on(
-                self.lix()
-                    .map_err(|error| throw_lix_error(&env, error))?
-                    .execute(&sql, &params),
-            )
-            .map_err(|error| throw_lix_error(&env, error))?;
-        ExecuteResult::try_from(result).map_err(|error| throw_lix_error(&env, error))
+        let (deferred, promise): (NativeExecuteDeferred, Object<'env>) = env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::Execute {
+                sql,
+                params,
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi]
-    pub fn observe(
+    pub fn observe<'env>(
         &self,
-        env: Env,
+        env: &'env Env,
         sql: String,
         params: Option<Vec<LixValue>>,
-    ) -> Result<NativeObserveEvents> {
+    ) -> Result<Object<'env>> {
         let params = match params {
             Some(params) => params
                 .into_iter()
                 .map(Value::try_from)
                 .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|error| throw_lix_error(&env, error))?,
+                .map_err(|error| throw_lix_error(env, error))?,
             None => Vec::new(),
         };
-        let events = self
-            .lix()
-            .map_err(|error| throw_lix_error(&env, error))?
-            .observe(&sql, &params)
-            .map_err(|error| throw_lix_error(&env, error))?;
-        NativeObserveEvents::new(events)
+        let (deferred, promise): (NativeDeferred<NativeObserveEvents>, Object<'env>) =
+            env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::Observe {
+                sql,
+                params,
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi(js_name = "beginTransaction")]
-    pub fn begin_transaction(&self, env: Env) -> Result<NativeLixTransaction> {
-        let transaction = self
-            .rt
-            .block_on(
-                self.lix()
-                    .map_err(|error| throw_lix_error(&env, error))?
-                    .begin_transaction(),
-            )
-            .map_err(|error| throw_lix_error(&env, error))?;
-        NativeLixTransaction::new(transaction)
+    pub fn begin_transaction<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
+        let transaction_id = self.actor.next_transaction_id();
+        let (deferred, promise): (NativeTransactionDeferred, Object<'env>) =
+            env.create_deferred()?;
+        let actor = self.actor.clone();
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::BeginTransaction {
+                transaction_id,
+                actor,
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi(js_name = "activeBranchId")]
-    pub fn active_branch_id(&self, env: Env) -> Result<String> {
-        self.rt
-            .block_on(
-                self.lix()
-                    .map_err(|error| throw_lix_error(&env, error))?
-                    .active_branch_id(),
-            )
-            .map_err(|error| throw_lix_error(&env, error))
+    pub fn active_branch_id<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeStringDeferred, Object<'env>) = env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, LixCommand::ActiveBranchId);
+        Ok(promise)
     }
 
     #[napi(js_name = "createBranch")]
-    pub fn create_branch(
+    pub fn create_branch<'env>(
         &self,
-        env: Env,
+        env: &'env Env,
         options: CreateBranchOptions,
-    ) -> Result<CreateBranchReceiptDto> {
-        let receipt = self
-            .rt
-            .block_on(
-                self.lix()
-                    .map_err(|error| throw_lix_error(&env, error))?
-                    .create_branch(options.into()),
-            )
-            .map_err(|error| throw_lix_error(&env, error))?;
-        Ok(CreateBranchReceiptDto::from(receipt))
+    ) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeCreateBranchDeferred, Object<'env>) =
+            env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::CreateBranch {
+                options: options.into(),
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi(js_name = "switchBranch")]
-    pub fn switch_branch(
+    pub fn switch_branch<'env>(
         &self,
-        env: Env,
+        env: &'env Env,
         options: SwitchBranchOptions,
-    ) -> Result<SwitchBranchReceiptDto> {
-        let receipt = self
-            .rt
-            .block_on(
-                self.lix()
-                    .map_err(|error| throw_lix_error(&env, error))?
-                    .switch_branch(options.into()),
-            )
-            .map_err(|error| throw_lix_error(&env, error))?;
-        Ok(SwitchBranchReceiptDto::from(receipt))
+    ) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeSwitchBranchDeferred, Object<'env>) =
+            env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::SwitchBranch {
+                options: options.into(),
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi(js_name = "mergeBranchPreview")]
-    pub fn merge_branch_preview(
+    pub fn merge_branch_preview<'env>(
         &self,
-        env: Env,
+        env: &'env Env,
         options: MergeBranchOptions,
-    ) -> Result<MergeBranchPreviewDto> {
-        let preview = self
-            .rt
-            .block_on(
-                self.lix()
-                    .map_err(|error| throw_lix_error(&env, error))?
-                    .merge_branch_preview(options.into_preview()),
-            )
-            .map_err(|error| throw_lix_error(&env, error))?;
-        Ok(MergeBranchPreviewDto::from(preview))
+    ) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeMergePreviewDeferred, Object<'env>) =
+            env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::MergeBranchPreview {
+                options: options.into_preview(),
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi(js_name = "mergeBranch")]
-    pub fn merge_branch(
+    pub fn merge_branch<'env>(
         &self,
-        env: Env,
+        env: &'env Env,
         options: MergeBranchOptions,
-    ) -> Result<MergeBranchReceiptDto> {
-        let receipt = self
-            .rt
-            .block_on(
-                self.lix()
-                    .map_err(|error| throw_lix_error(&env, error))?
-                    .merge_branch(options.into()),
-            )
-            .map_err(|error| throw_lix_error(&env, error))?;
-        Ok(MergeBranchReceiptDto::from(receipt))
+    ) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeMergeReceiptDeferred, Object<'env>) =
+            env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::MergeBranch {
+                options: options.into(),
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi]
-    pub fn close(&mut self, env: Env) -> Result<()> {
-        let Some(lix) = self.lix.as_ref() else {
-            return Ok(());
-        };
-        self.rt
-            .block_on(lix.close())
-            .map_err(|error| throw_lix_error(&env, error))?;
-        self.lix = None;
-        Ok(())
+    pub fn close<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeUnitDeferred, Object<'env>) = env.create_deferred()?;
+        if self.actor.closed.load(Ordering::SeqCst) {
+            settle_deferred(deferred, Ok(()));
+            return Ok(promise);
+        }
+        self.actor.send_with_deferred(deferred, LixCommand::Close);
+        Ok(promise)
     }
 }
 
@@ -727,88 +1145,104 @@ fn close_observe_events(
 }
 
 impl NativeLix {
-    fn lix(&self) -> std::result::Result<&NativeLixInner, LixError> {
-        self.lix.as_ref().ok_or_else(|| {
-            LixError::new(LixError::CODE_CLOSED, "Lix handle is closed")
-                .with_hint("Open a new Lix handle before calling this method.")
-        })
+    fn new(lix: NativeLixInner) -> std::result::Result<Self, LixError> {
+        let actor = NativeLixActor::start(lix)
+            .map_err(|error| LixError::unknown(format!("failed to start native actor: {error}")))?;
+        Ok(Self { actor })
     }
 }
 
 #[expect(missing_debug_implementations)]
 #[napi(js_name = "LixTransaction")]
 pub struct NativeLixTransaction {
-    rt: Runtime,
-    transaction: Option<NativeLixTransactionInner>,
+    actor: NativeLixActor,
+    transaction_id: u64,
+    closed: Arc<AtomicBool>,
 }
 
 #[napi]
 impl NativeLixTransaction {
-    fn new(transaction: NativeLixTransactionInner) -> Result<Self> {
-        let rt = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(to_napi_error)?;
-        Ok(Self {
-            rt,
-            transaction: Some(transaction),
-        })
+    fn new(actor: NativeLixActor, transaction_id: u64) -> Self {
+        Self {
+            actor,
+            transaction_id,
+            closed: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     #[napi]
-    pub fn execute(
-        &mut self,
-        env: Env,
+    pub fn execute<'env>(
+        &self,
+        env: &'env Env,
         sql: String,
         params: Option<Vec<LixValue>>,
-    ) -> Result<ExecuteResult> {
+    ) -> Result<Object<'env>> {
         let params = match params {
             Some(params) => params
                 .into_iter()
                 .map(Value::try_from)
                 .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|error| throw_lix_error(&env, error))?,
+                .map_err(|error| throw_lix_error(env, error))?,
             None => Vec::new(),
         };
-        let mut transaction = self
-            .take_transaction()
-            .map_err(|error| throw_lix_error(&env, error))?;
-        let result = self.rt.block_on(transaction.execute(&sql, &params));
-        self.transaction = Some(transaction);
-        let result = result.map_err(|error| throw_lix_error(&env, error))?;
-        ExecuteResult::try_from(result).map_err(|error| throw_lix_error(&env, error))
+        let (deferred, promise): (NativeExecuteDeferred, Object<'env>) = env.create_deferred()?;
+        if self.closed.load(Ordering::SeqCst) {
+            settle_deferred(deferred, Err(transaction_closed_error()));
+            return Ok(promise);
+        }
+        let transaction_id = self.transaction_id;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::TransactionExecute {
+                transaction_id,
+                sql,
+                params,
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi]
-    pub fn commit(&mut self, env: Env) -> Result<()> {
-        let transaction = self
-            .take_transaction()
-            .map_err(|error| throw_lix_error(&env, error))?;
-        self.rt
-            .block_on(transaction.commit())
-            .map_err(|error| throw_lix_error(&env, error))
+    pub fn commit<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeUnitDeferred, Object<'env>) = env.create_deferred()?;
+        if self.closed.swap(true, Ordering::SeqCst) {
+            settle_deferred(deferred, Err(transaction_closed_error()));
+            return Ok(promise);
+        }
+        let transaction_id = self.transaction_id;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::TransactionCommit {
+                transaction_id,
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi]
-    pub fn rollback(&mut self, env: Env) -> Result<()> {
-        let transaction = self
-            .take_transaction()
-            .map_err(|error| throw_lix_error(&env, error))?;
-        self.rt
-            .block_on(transaction.rollback())
-            .map_err(|error| throw_lix_error(&env, error))
+    pub fn rollback<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeUnitDeferred, Object<'env>) = env.create_deferred()?;
+        if self.closed.swap(true, Ordering::SeqCst) {
+            settle_deferred(deferred, Err(transaction_closed_error()));
+            return Ok(promise);
+        }
+        let transaction_id = self.transaction_id;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::TransactionRollback {
+                transaction_id,
+                deferred,
+            });
+        Ok(promise)
     }
 }
 
-impl NativeLixTransaction {
-    fn take_transaction(&mut self) -> std::result::Result<NativeLixTransactionInner, LixError> {
-        self.transaction.take().ok_or_else(|| {
-            LixError::new("LIX_INVALID_TRANSACTION_STATE", "Lix transaction is closed")
-        })
+impl Drop for NativeLixTransaction {
+    fn drop(&mut self) {
+        if !self.closed.swap(true, Ordering::SeqCst) {
+            self.actor.abandon_transaction(self.transaction_id);
+        }
     }
 }
 
-#[expect(missing_debug_implementations)]
+#[derive(Debug)]
 #[napi(object)]
 pub struct CreateBranchOptions {
     pub id: Option<String>,
@@ -826,7 +1260,6 @@ impl From<CreateBranchOptions> for RsCreateBranchOptions {
     }
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct CreateBranchReceiptDto {
     pub id: String,
@@ -846,7 +1279,7 @@ impl From<CreateBranchReceipt> for CreateBranchReceiptDto {
     }
 }
 
-#[expect(missing_debug_implementations)]
+#[derive(Debug)]
 #[napi(object)]
 pub struct SwitchBranchOptions {
     pub branch_id: String,
@@ -860,7 +1293,6 @@ impl From<SwitchBranchOptions> for RsSwitchBranchOptions {
     }
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct SwitchBranchReceiptDto {
     pub branch_id: String,
@@ -896,7 +1328,6 @@ impl From<MergeBranchOptions> for RsMergeBranchOptions {
     }
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct MergeBranchReceiptDto {
     pub outcome: String,
@@ -926,7 +1357,6 @@ impl From<MergeBranchReceipt> for MergeBranchReceiptDto {
     }
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct MergeBranchPreviewDto {
     pub outcome: String,
@@ -963,7 +1393,6 @@ fn merge_branch_outcome_to_string(outcome: MergeBranchOutcome) -> String {
     .to_string()
 }
 
-#[expect(missing_copy_implementations, missing_debug_implementations)]
 #[napi(object)]
 pub struct MergeChangeStatsDto {
     pub total: u32,
@@ -984,7 +1413,6 @@ impl From<MergeChangeStats> for MergeChangeStatsDto {
     }
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct MergeConflictDto {
     pub kind: String,
@@ -1015,7 +1443,6 @@ fn merge_conflict_kind_to_string(kind: MergeConflictKind) -> String {
     .to_string()
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct MergeConflictSideDto {
     pub kind: String,
@@ -1162,7 +1589,6 @@ impl TryFrom<&Value> for LixValue {
     }
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct ExecuteResult {
     pub columns: Vec<String>,
@@ -1221,7 +1647,6 @@ impl TryFrom<RsObserveEvent> for ObserveEventDto {
     }
 }
 
-#[expect(missing_debug_implementations)]
 #[napi(object)]
 pub struct LixNotice {
     pub code: String,

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -293,7 +293,78 @@ test("native fs open returns a promise", async () => {
 	const native = addon.Lix.openFs(dir, "memory", undefined);
 	expect(native).toBeInstanceOf(Promise);
 	const lix = await native;
-	lix.close();
+	await lix.close();
+});
+
+test("native awaited APIs return promises", async () => {
+	const opened = addon.Lix.openMemory();
+	expect(opened).toBeInstanceOf(Promise);
+	const lix = await opened;
+
+	const execute = lix.execute("SELECT 1 AS ok", []);
+	expect(execute).toBeInstanceOf(Promise);
+	expect((await execute).rows).toHaveLength(1);
+
+	const activeBranchId = lix.activeBranchId();
+	expect(activeBranchId).toBeInstanceOf(Promise);
+	expect(await activeBranchId).toEqual(expect.any(String));
+
+	const transaction = lix.beginTransaction();
+	expect(transaction).toBeInstanceOf(Promise);
+	const tx = await transaction;
+
+	const txExecute = tx.execute("SELECT 2 AS ok", []);
+	expect(txExecute).toBeInstanceOf(Promise);
+	expect((await txExecute).rows).toHaveLength(1);
+
+	const rollback = tx.rollback();
+	expect(rollback).toBeInstanceOf(Promise);
+	await rollback;
+
+	const close = lix.close();
+	expect(close).toBeInstanceOf(Promise);
+	await close;
+});
+
+test("native actor preserves queued execution order", async () => {
+	const lix = await openLix();
+	await registerCrmTaskSchema(lix);
+
+	const first = lix.execute(
+		"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
+		["queued-1", "Queued 1", false, "{}"],
+	);
+	const second = lix.execute(
+		"UPDATE crm_task SET title = $1 WHERE id = $2",
+		["Queued 2", "queued-1"],
+	);
+	const third = lix.execute("SELECT title FROM crm_task WHERE id = $1", [
+		"queued-1",
+	]);
+
+	await first;
+	await second;
+	expect(get(await third, "title")).toBe("Queued 2");
+	await lix.close();
+});
+
+test("native actor settles commands queued behind close", async () => {
+	const lix = await openLix();
+
+	const firstClose = lix.close();
+	const readAfterClose = lix.execute("SELECT 1 AS ok");
+	const secondClose = lix.close();
+
+	const settled = await settlesWithin(
+		Promise.allSettled([firstClose, readAfterClose, secondClose]),
+		1000,
+	);
+	expect(settled[0].status).toBe("fulfilled");
+	expect(settled[1]).toMatchObject({
+		status: "rejected",
+		reason: { code: "LIX_ERROR_CLOSED" },
+	});
+	expect(settled[2].status).toBe("fulfilled");
 });
 
 test("fs backend imports local files and materializes lix_file writes", async () => {
@@ -1565,6 +1636,10 @@ async function withTimeout<T>(promise: Promise<T>, ms = 1_000): Promise<T> {
 			clearTimeout(timeout);
 		}
 	}
+}
+
+async function settlesWithin<T>(promise: Promise<T>, ms = 1_000): Promise<T> {
+	return withTimeout(promise, ms);
 }
 
 async function waitFor<T>(

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -27,21 +27,21 @@ type NativeObserveEvent = {
 type NativeParam = ReturnType<typeof toNativeValue>;
 
 type NativeLix = {
-	execute(sql: string, params: NativeParam[]): NativeExecuteResult;
-	observe(sql: string, params: NativeParam[]): NativeObserveEvents;
-	beginTransaction(): NativeLixTransaction;
-	activeBranchId(): string;
-	createBranch(options: CreateBranchOptions): CreateBranchReceipt;
-	switchBranch(options: SwitchBranchOptions): SwitchBranchReceipt;
-	mergeBranchPreview(options: MergeBranchOptions): MergeBranchPreview;
-	mergeBranch(options: MergeBranchOptions): MergeBranchReceipt;
-	close(): void;
+	execute(sql: string, params: NativeParam[]): Promise<NativeExecuteResult>;
+	observe(sql: string, params: NativeParam[]): Promise<NativeObserveEvents>;
+	beginTransaction(): Promise<NativeLixTransaction>;
+	activeBranchId(): Promise<string>;
+	createBranch(options: CreateBranchOptions): Promise<CreateBranchReceipt>;
+	switchBranch(options: SwitchBranchOptions): Promise<SwitchBranchReceipt>;
+	mergeBranchPreview(options: MergeBranchOptions): Promise<MergeBranchPreview>;
+	mergeBranch(options: MergeBranchOptions): Promise<MergeBranchReceipt>;
+	close(): Promise<void>;
 };
 
 type NativeLixTransaction = {
-	execute(sql: string, params: NativeParam[]): NativeExecuteResult;
-	commit(): void;
-	rollback(): void;
+	execute(sql: string, params: NativeParam[]): Promise<NativeExecuteResult>;
+	commit(): Promise<void>;
+	rollback(): Promise<void>;
 };
 
 type NativeObserveEvents = {
@@ -122,10 +122,10 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 		throw new TypeError("openLix() options must be an object");
 	}
 	if (options.backend === undefined) {
-		return new Lix(addon.Lix.openMemory());
+		return new Lix(await addon.Lix.openMemory());
 	}
 	if (options.backend instanceof SqliteBackend) {
-		return new Lix(addon.Lix.openSqlite(options.backend.path));
+		return new Lix(await addon.Lix.openSqlite(options.backend.path));
 	}
 	if (options.backend instanceof FsBackend) {
 		return new Lix(
@@ -147,7 +147,7 @@ export class Lix {
 	async execute(sql: string, params: SqlParam[] = []): Promise<ExecuteResult> {
 		assertExecuteArgs("lix", sql, params);
 		return wrapExecuteResult(
-			this.native.execute(
+			await this.native.execute(
 				sql,
 				params.map((param, index) =>
 					toNativeValue(normalizeParam(param, index)),
@@ -169,7 +169,7 @@ export class Lix {
 	}
 
 	async beginTransaction(): Promise<LixTransaction> {
-		return new LixTransaction(this.native.beginTransaction());
+		return new LixTransaction(await this.native.beginTransaction());
 	}
 
 	async activeBranchId(): Promise<string> {
@@ -191,11 +191,11 @@ export class Lix {
 	async mergeBranchPreview(
 		options: MergeBranchOptions,
 	): Promise<MergeBranchPreview> {
-		return normalizeOptionals(this.native.mergeBranchPreview(options));
+		return normalizeOptionals(await this.native.mergeBranchPreview(options));
 	}
 
 	async mergeBranch(options: MergeBranchOptions): Promise<MergeBranchReceipt> {
-		const receipt = normalizeOptionals(this.native.mergeBranch(options));
+		const receipt = normalizeOptionals(await this.native.mergeBranch(options));
 		receipt.createdMergeCommitId ??= null;
 		return receipt;
 	}
@@ -206,10 +206,22 @@ export class Lix {
 }
 
 export class ObserveEvents {
-	constructor(private readonly native: NativeObserveEvents) {}
+	private setupError: unknown;
+	private readonly native: Promise<NativeObserveEvents | undefined>;
+
+	constructor(native: Promise<NativeObserveEvents>) {
+		this.native = native.catch((error: unknown) => {
+			this.setupError = error;
+			return undefined;
+		});
+	}
 
 	async next(): Promise<ObserveEvent | undefined> {
-		const event = await this.native.next();
+		const native = await this.native;
+		if (native === undefined) {
+			throw this.setupError;
+		}
+		const event = await native.next();
 		if (event == null) {
 			return undefined;
 		}
@@ -221,7 +233,7 @@ export class ObserveEvents {
 	}
 
 	close(): void {
-		this.native.close();
+		void this.native.then((native) => native?.close());
 	}
 }
 
@@ -231,7 +243,7 @@ export class LixTransaction {
 	async execute(sql: string, params: SqlParam[] = []): Promise<ExecuteResult> {
 		assertExecuteArgs("lixTransaction", sql, params);
 		return wrapExecuteResult(
-			this.native.execute(
+			await this.native.execute(
 				sql,
 				params.map((param, index) =>
 					toNativeValue(normalizeParam(param, index)),


### PR DESCRIPTION
## What changed

- Move awaited JS native methods onto a per-`NativeLix` actor so they return promises before Rust async work runs.
- Make memory/sqlite/fs open paths, `execute`, branch/merge methods, `close`, and transaction methods real async at the native boundary.
- Keep transaction state actor-owned by ID, including stale-handle rejection and best-effort rollback on dropped transaction handles.
- Preserve the synchronous public `lix.observe(...)` shape while doing native observer setup asynchronously and safely handling setup rejection.
- Harden close lifecycle so queued commands settle, resources are dropped, the actor exits, and close/send races do not strand promises.

## Why

The TypeScript API exposed many awaited methods, but most native bindings still called `block_on(...)` before returning to JS. In Electron this can freeze the main process even though callers are using `await`.

## Validation

- `cargo clippy -p lix_js_sdk --all-targets --all-features -- -D warnings`
- `npm run typecheck`
- `npx vitest run src/open-lix.test.ts --testTimeout=15000`
- Reviewed by sub-agents for simplicity, first-principles abstraction, lifecycle correctness, transaction ordering, and N-API safety until no HIGH/MEDIUM findings remained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large architectural change to the native boundary affecting all DB operations, transactions, and close ordering; regressions could cause deadlocks, wrong serialization, or data loss on abandoned transactions.
> 
> **Overview**
> Replaces synchronous `block_on` N-API calls with a **per-`NativeLix` background actor** that serializes work on a dedicated thread and resolves **N-API deferred promises** for `execute`, branch/merge APIs, `close`, transactions, and observer setup.
> 
> **Open paths** (`openMemory`, `openSqlite`, and existing `openFs`) now return **`AsyncTask` promises** instead of blocking during open; the TypeScript `openLix` wrapper awaits those before constructing `Lix`.
> 
> **Transactions** are tracked by ID on the actor (not per-handle Tokio runtimes). Commit/rollback close the JS handle; dropped handles send **`TransactionAbandon`** for best-effort rollback. Stale or post-close calls get structured closed errors.
> 
> **Close lifecycle** drains the command queue: work after close rejects with `LIX_ERROR_CLOSED`, duplicate `close()` still fulfills, and a send lock avoids stranded promises.
> 
> **`observe`** stays synchronous at the public TS API but native setup is async; `ObserveEvents` defers `next()` until setup completes and surfaces setup failures on first `next()`.
> 
> Tests add coverage for promise shapes, FIFO execution order, and close-vs-queued-command settlement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8deaf2e14f74984e4acc635b958bc674fa6f2a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->