### PR TITLE
Add on-demand filesystem sync for FsBackend

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -37,7 +37,10 @@ talks to the outside system where Lix data lives, it is a backend.
 import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	backend: new FsBackend({ path: "/var/data/workspace" }),
+	backend: new FsBackend({
+		path: "/var/data/workspace",
+		syncAllFiles: true,
+	}),
 });
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,10 @@ const lix = await openLix();
 import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	backend: new FsBackend({ path: "./workspace" }),
+	backend: new FsBackend({
+		path: "./workspace",
+		syncAllFiles: true,
+	}),
 });
 ```
 

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -33,7 +33,10 @@ Use `FsBackend` for a filesystem workspace directory backed by RocksDB at
 import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	backend: new FsBackend({ path: "./workspace" }),
+	backend: new FsBackend({
+		path: "./workspace",
+		syncAllFiles: true,
+	}),
 });
 ```
 
@@ -45,23 +48,26 @@ const lix = await openLix({
 	backend: new FsBackend({
 		path: "./workspace",
 		lixDir: "/tmp/session/.lix",
+		syncAllFiles: true,
 	}),
 });
 ```
 
-Add `filter.includePaths` to limit filesystem sync to selected files.
-`includePaths` entries are exact workspace-relative file paths, not directories
-or globs. They may be written with or without a leading slash, for example
-`"notes/today.md"` or `"/notes/today.md"`. The filter scopes disk import, file
-watching, and materialization; it does not filter unrelated Lix SQL state.
+Set `syncAllFiles: false` to start filesystem sync with no regular workspace
+files, then import selected files with `importFilesystemPaths()`. Imported paths are
+exact workspace-relative file paths, not directories or globs. They may be
+written with or without a leading slash, for example `"notes/today.md"` or
+`"/notes/today.md"`. This scopes disk import, file watching, and
+materialization; it does not filter unrelated Lix SQL state.
 
 ```ts
 const lix = await openLix({
 	backend: new FsBackend({
 		path: "./workspace",
-		filter: { includePaths: ["notes/today.md"] },
+		syncAllFiles: false,
 	}),
 });
+await lix.importFilesystemPaths(["notes/today.md"]);
 ```
 
 Use `SqliteBackend` when a single `.lix` SQLite file is the application document

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -28,7 +28,10 @@ npm install @lix-js/sdk
 import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	backend: new FsBackend({ path: "/var/data/workspace" }),
+	backend: new FsBackend({
+		path: "/var/data/workspace",
+		syncAllFiles: true,
+	}),
 });
 
 // ... use it ...
@@ -51,6 +54,7 @@ const lix = await openLix({
 	backend: new FsBackend({
 		path: "/var/data/workspace",
 		lixDir: "/tmp/session/.lix",
+		syncAllFiles: true,
 	}),
 });
 ```
@@ -69,23 +73,28 @@ import path from "node:path";
 
 const dir = mkdtempSync(path.join(tmpdir(), "lix-"));
 const lix = await openLix({
-	backend: new FsBackend({ path: path.join(dir, "workspace") }),
+	backend: new FsBackend({
+		path: path.join(dir, "workspace"),
+		syncAllFiles: true,
+	}),
 });
 ```
 
-Add a filter when only specific files should participate in filesystem sync.
-`includePaths` entries are exact workspace-relative file paths, not directories
-or globs. They may be written with or without a leading slash, for example
-`"notes/today.md"` or `"/notes/today.md"`. The filter scopes disk import, file
-watching, and materialization; it does not filter unrelated Lix SQL state.
+Set `syncAllFiles: false` when filesystem sync should start with no regular
+workspace files, then import selected files with `importFilesystemPaths()`. Imported paths
+are exact workspace-relative file paths, not directories or globs. They may be
+written with or without a leading slash, for example `"notes/today.md"` or
+`"/notes/today.md"`. This scopes disk import, file watching, and
+materialization; it does not filter unrelated Lix SQL state.
 
 ```ts
 const lix = await openLix({
 	backend: new FsBackend({
 		path: "/Users/me/Downloads",
-		filter: { includePaths: ["notes/today.md"] },
+		syncAllFiles: false,
 	}),
 });
+await lix.importFilesystemPaths(["notes/today.md"]);
 ```
 
 ## Single .lix application file

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -14,7 +14,10 @@ npm install @lix-js/sdk
 import { FsBackend, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-	backend: new FsBackend({ path: "./workspace" }),
+	backend: new FsBackend({
+		path: "./workspace",
+		syncAllFiles: true,
+	}),
 });
 
 await lix.execute(
@@ -72,9 +75,9 @@ try {
 
 ## Notes
 
-- `openLix()` opens a fresh in-memory Lix. Pass `new FsBackend({ path })` for a filesystem workspace directory backed by `<path>/.lix/.internal/rocksdb`.
-- Pass `new FsBackend({ path, lixDir })` for filesystem sync with repository metadata in an external `.lix` directory and no workspace `.lix` directory.
-- Add `filter: { includePaths: ["notes/today.md"] }` to sync only selected files from a filesystem backend. `includePaths` entries are exact workspace-relative file paths, not directories or globs. They may be written with or without a leading slash, and only affect filesystem sync.
+- `openLix()` opens a fresh in-memory Lix. Pass `new FsBackend({ path, syncAllFiles: true })` for a filesystem workspace directory backed by `<path>/.lix/.internal/rocksdb`.
+- Pass `new FsBackend({ path, lixDir, syncAllFiles: true })` for filesystem sync with repository metadata in an external `.lix` directory and no workspace `.lix` directory.
+- Pass `syncAllFiles: false` to start filesystem sync with no regular workspace files, then call `lix.importFilesystemPaths(["notes/today.md"])` to sync selected files. Imported paths are exact workspace-relative file paths, not directories or globs.
 - Use `new SqliteBackend({ path })` when a single SQLite-backed `.lix` file is the application document itself, for example when defining a new file format and using Lix as the application's file format.
 - The SDK is Node/native only right now; it is not browser-compatible.
 - The package is ESM-only.

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -1,7 +1,7 @@
 use lix_sdk::{
     CreateBranchOptions as RsCreateBranchOptions, CreateBranchReceipt,
-    ExecuteResult as RsExecuteResult, FsBackend, FsBackendFilter, FsBackendOpenOptions,
-    InMemoryBackend, Lix as RsLix, LixError, LixTransaction as RsLixTransaction,
+    ExecuteResult as RsExecuteResult, FsBackend, FsBackendOpenOptions, InMemoryBackend,
+    Lix as RsLix, LixError, LixTransaction as RsLixTransaction,
     MergeBranchOptions as RsMergeBranchOptions, MergeBranchOutcome, MergeBranchPreview,
     MergeBranchPreviewOptions, MergeBranchReceipt, MergeChangeStats, MergeConflict,
     MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, ObserveEvent as RsObserveEvent,
@@ -90,6 +90,10 @@ enum LixCommand {
     SwitchBranch {
         options: RsSwitchBranchOptions,
         deferred: NativeSwitchBranchDeferred,
+    },
+    ImportFilesystemPaths {
+        paths: Vec<String>,
+        deferred: NativeUnitDeferred,
     },
     MergeBranchPreview {
         options: MergeBranchPreviewOptions,
@@ -253,7 +257,8 @@ fn reject_pending_lix_commands(receiver: mpsc::Receiver<LixCommand>, error: std:
             LixCommand::TransactionExecute { deferred, .. } => {
                 deferred.reject(to_napi_error(&error));
             }
-            LixCommand::TransactionCommit { deferred, .. }
+            LixCommand::ImportFilesystemPaths { deferred, .. }
+            | LixCommand::TransactionCommit { deferred, .. }
             | LixCommand::TransactionRollback { deferred, .. } => {
                 deferred.reject(to_napi_error(&error));
             }
@@ -310,6 +315,11 @@ fn handle_lix_command(
             let result = rt
                 .block_on(state.lix.switch_branch(options))
                 .map(SwitchBranchReceiptDto::from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::ImportFilesystemPaths { paths, deferred } => {
+            let result = rt.block_on(state.lix.import_filesystem_paths(paths));
             settle_deferred(deferred, result);
             false
         }
@@ -423,7 +433,8 @@ fn settle_command_after_close(command: LixCommand) {
         LixCommand::Observe { deferred, .. } => {
             settle_deferred(deferred, Err(lix_closed_error()));
         }
-        LixCommand::TransactionCommit { deferred, .. }
+        LixCommand::ImportFilesystemPaths { deferred, .. }
+        | LixCommand::TransactionCommit { deferred, .. }
         | LixCommand::TransactionRollback { deferred, .. } => {
             settle_deferred(deferred, Err(lix_closed_error()));
         }
@@ -506,6 +517,19 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.switch_branch(options).await,
             Self::Sqlite(lix) => lix.switch_branch(options).await,
             Self::Fs(lix) => lix.switch_branch(options).await,
+        }
+    }
+
+    async fn import_filesystem_paths(
+        &self,
+        paths: Vec<String>,
+    ) -> std::result::Result<(), LixError> {
+        match self {
+            Self::Fs(lix) => lix.import_filesystem_paths(paths).await,
+            Self::Memory(_) | Self::Sqlite(_) => Err(LixError::new(
+                "LIX_UNSUPPORTED_BACKEND",
+                "importFilesystemPaths requires a filesystem backend",
+            )),
         }
     }
 
@@ -592,7 +616,7 @@ impl NativeObserveEventsInner {
 pub struct OpenFsTask {
     path: String,
     lix_dir: Option<String>,
-    filter: FsBackendFilter,
+    sync_all_files: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -611,7 +635,7 @@ impl Task for OpenFsTask {
         Ok(open_fs_native(
             std::mem::take(&mut self.path),
             self.lix_dir.take(),
-            std::mem::take(&mut self.filter),
+            std::mem::take(&mut self.sync_all_files),
         ))
     }
 
@@ -668,15 +692,14 @@ fn open_sqlite_native(path: String) -> std::result::Result<NativeLix, LixError> 
 fn open_fs_native(
     path: String,
     lix_dir: Option<String>,
-    filter: FsBackendFilter,
+    sync_all_files: bool,
 ) -> std::result::Result<NativeLix, LixError> {
     let rt = Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
-    let mut options = FsBackendOpenOptions::new(path);
+    let mut options = FsBackendOpenOptions::new(path, sync_all_files);
     options.lix_dir = lix_dir.map(Into::into);
-    options.filter = filter;
     let backend = rt.block_on(FsBackend::open_with_options(options))?;
     let lix = rt.block_on(open_lix_with_backend(backend))?;
     NativeLix::new(NativeLixInner::Fs(lix))
@@ -698,12 +721,12 @@ impl NativeLix {
     pub fn open_fs(
         path: String,
         lix_dir: Option<String>,
-        include_paths: Option<Vec<String>>,
+        sync_all_files: bool,
     ) -> AsyncTask<OpenFsTask> {
         AsyncTask::new(OpenFsTask {
             path,
             lix_dir,
-            filter: FsBackendFilter::new(include_paths),
+            sync_all_files,
         })
     }
 
@@ -808,6 +831,21 @@ impl NativeLix {
         self.actor
             .send_with_deferred(deferred, |deferred| LixCommand::SwitchBranch {
                 options: options.into(),
+                deferred,
+            });
+        Ok(promise)
+    }
+
+    #[napi(js_name = "importFilesystemPaths")]
+    pub fn import_filesystem_paths<'env>(
+        &self,
+        env: &'env Env,
+        paths: Vec<String>,
+    ) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeUnitDeferred, Object<'env>) = env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::ImportFilesystemPaths {
+                paths,
                 deferred,
             });
         Ok(promise)

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -248,7 +248,16 @@ test.each([
 		"sqlite",
 		() => openLix({ backend: new SqliteBackend({ path: tempLixPath() }) }),
 	],
-	["fs", () => openLix({ backend: new FsBackend({ path: tempFsDir() }) })],
+	[
+		"fs",
+		() =>
+			openLix({
+				backend: new FsBackend({
+					path: tempFsDir(),
+					syncAllFiles: true,
+				}),
+			}),
+	],
 	[
 		"fs-external-lix",
 		() => {
@@ -256,7 +265,11 @@ test.each([
 			mkdirSync(dir, { recursive: true });
 			writeFileSync(join(dir, "matrix.md"), "matrix");
 			return openLix({
-				backend: new FsBackend({ path: dir, lixDir: tempExternalLixDir() }),
+				backend: new FsBackend({
+					path: dir,
+					lixDir: tempExternalLixDir(),
+					syncAllFiles: true,
+				}),
 			});
 		},
 	],
@@ -290,7 +303,7 @@ test("native fs open returns a promise", async () => {
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "note.md"), "local");
 
-	const native = addon.Lix.openFs(dir, undefined, undefined);
+	const native = addon.Lix.openFs(dir, undefined, true);
 	expect(native).toBeInstanceOf(Promise);
 	const lix = await native;
 	await lix.close();
@@ -372,7 +385,9 @@ test("fs backend imports local files and materializes lix_file writes", async ()
 	mkdirSync(join(dir, "docs"), { recursive: true });
 	writeFileSync(join(dir, "docs", "readme.md"), "local");
 
-	const lix = await openLix({ backend: new FsBackend({ path: dir }) });
+	const lix = await openLix({
+		backend: new FsBackend({ path: dir, syncAllFiles: true }),
+	});
 	expect(statSync(join(dir, ".lix")).isDirectory()).toBe(true);
 	expect(
 		statSync(join(dir, ".lix", ".internal", "rocksdb")).isDirectory(),
@@ -394,7 +409,9 @@ test("fs backend imports local files and materializes lix_file writes", async ()
 	expect(readFileSync(join(dir, "generated.md"), "utf8")).toBe("generated");
 	await lix.close();
 
-	const reopened = await openLix({ backend: new FsBackend({ path: dir }) });
+	const reopened = await openLix({
+		backend: new FsBackend({ path: dir, syncAllFiles: true }),
+	});
 	const persisted = await reopened.execute(
 		"SELECT data FROM lix_file WHERE directory_id IS NULL AND name = $1",
 		["generated.md"],
@@ -414,7 +431,11 @@ test("fs backend with external lixDir imports the directory and writes normal fi
 	writeFileSync(siblingPath, "sibling");
 
 	const lix = await openLix({
-		backend: new FsBackend({ path: dir, lixDir: tempExternalLixDir() }),
+		backend: new FsBackend({
+			path: dir,
+			lixDir: tempExternalLixDir(),
+			syncAllFiles: true,
+		}),
 	});
 
 	const files = await lix.execute(
@@ -453,7 +474,7 @@ test("fs backend with external lixDir imports the directory and writes normal fi
 	await lix.close();
 });
 
-test("fs backend filter syncs included paths and lix-created files", async () => {
+test("fs backend on-demand sync imports selected paths and lix-created files", async () => {
 	const dir = tempFsDir();
 	const includedPath = join(dir, "docs", "note.md");
 	const excludedPath = join(dir, "docs", "sibling.md");
@@ -466,9 +487,10 @@ test("fs backend filter syncs included paths and lix-created files", async () =>
 		backend: new FsBackend({
 			path: dir,
 			lixDir: tempExternalLixDir(),
-			filter: { includePaths: ["docs/note.md"] },
+			syncAllFiles: false,
 		}),
 	});
+	await lix.importFilesystemPaths(["docs/note.md"]);
 
 	const files = await lix.execute(
 		"SELECT path FROM lix_file WHERE path IN ($1, $2) ORDER BY path",
@@ -501,7 +523,61 @@ test("fs backend filter syncs included paths and lix-created files", async () =>
 	await lix.close();
 });
 
-test("fs backend filter validates include paths", () => {
+test("fs backend imports existing files into a filtered filesystem", async () => {
+	const dir = tempFsDir();
+	const importedPath = join(dir, "docs", "opened.md");
+	mkdirSync(join(dir, "docs"), { recursive: true });
+	writeFileSync(importedPath, "opened");
+
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			lixDir: tempExternalLixDir(),
+			syncAllFiles: false,
+		}),
+	});
+
+	expect(await readFile(lix, "/docs/opened.md")).toBeUndefined();
+
+	await lix.importFilesystemPaths(["docs/opened.md"]);
+	expect(
+		new TextDecoder().decode((await readFile(lix, "/docs/opened.md"))!),
+	).toBe("opened");
+
+	writeFileSync(importedPath, "edited");
+	await waitFor(async () => {
+		const bytes = await readFile(lix, "/docs/opened.md");
+		return bytes ? new TextDecoder().decode(bytes) : undefined;
+	}, "edited");
+
+	await lix.close();
+});
+
+test("importFilesystemPaths validates paths and requires a filesystem backend", async () => {
+	const memory = await openLix();
+	await expect(memory.importFilesystemPaths(["note.md"])).rejects.toThrow(
+		"filesystem backend",
+	);
+	await memory.close();
+
+	const dir = tempFsDir();
+	const lix = await openLix({
+		backend: new FsBackend({
+			path: dir,
+			lixDir: tempExternalLixDir(),
+			syncAllFiles: false,
+		}),
+	});
+	await expect(lix.importFilesystemPaths([""])).rejects.toThrow(
+		"non-empty strings",
+	);
+	await expect(lix.importFilesystemPaths(["docs/"])).rejects.toThrow(
+		"file paths, not directory paths",
+	);
+	await lix.close();
+});
+
+test("fs backend syncAllFiles validates option shape", () => {
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 
@@ -512,32 +588,21 @@ test("fs backend filter validates include paths", () => {
 				storage: "memory",
 			} as never),
 	).toThrow("FsBackend storage is no longer supported");
-	expect(
-		() =>
-			new FsBackend({ path: dir, filter: {} as { includePaths: string[] } }),
-	).toThrow("FsBackend filter.includePaths must be an array");
-	expect(
-		() => new FsBackend({ path: dir, filter: { includePaths: [] } }),
-	).not.toThrow();
-	expect(
-		() =>
-			new FsBackend({
-				path: dir,
-				filter: { includePaths: [""] },
-			}),
-	).toThrow("FsBackend filter.includePaths must contain non-empty strings");
-	expect(
-		() =>
-			new FsBackend({
-				path: dir,
-				filter: { includePaths: ["docs/"] },
-			}),
-	).toThrow(
-		"FsBackend filter.includePaths must contain file paths, not directory paths",
+	expect(() => new FsBackend({ path: dir } as never)).toThrow(
+		"FsBackend syncAllFiles must be a boolean",
 	);
+	expect(() => new FsBackend({ path: dir, syncAllFiles: true })).not.toThrow();
+	expect(() => new FsBackend({ path: dir, syncAllFiles: false })).not.toThrow();
+	expect(
+		() =>
+			new FsBackend({
+				path: dir,
+				syncAllFiles: {} as boolean,
+			}),
+	).toThrow("FsBackend syncAllFiles must be a boolean");
 });
 
-test("fs backend empty filter imports no regular workspace files", async () => {
+test("fs backend on-demand sync imports no regular workspace files initially", async () => {
 	const dir = tempFsDir();
 	const lixDir = tempExternalLixDir();
 	mkdirSync(dir, { recursive: true });
@@ -547,7 +612,7 @@ test("fs backend empty filter imports no regular workspace files", async () => {
 		backend: new FsBackend({
 			path: dir,
 			lixDir,
-			filter: { includePaths: [] },
+			syncAllFiles: false,
 		}),
 	});
 
@@ -565,7 +630,7 @@ test("fs backend empty filter imports no regular workspace files", async () => {
 	await lix.close();
 });
 
-test("fs backend filter treats paths as exact filenames", async () => {
+test("fs backend on-demand sync treats paths as exact filenames", async () => {
 	const dir = tempFsDir();
 	const filePath = join(dir, " spaced.md");
 	mkdirSync(dir, { recursive: true });
@@ -575,9 +640,10 @@ test("fs backend filter treats paths as exact filenames", async () => {
 		backend: new FsBackend({
 			path: dir,
 			lixDir: tempExternalLixDir(),
-			filter: { includePaths: [" spaced.md"] },
+			syncAllFiles: false,
 		}),
 	});
+	await lix.importFilesystemPaths([" spaced.md"]);
 
 	const bytes = await readFile(lix, "/ spaced.md");
 	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe(
@@ -587,7 +653,7 @@ test("fs backend filter treats paths as exact filenames", async () => {
 	await lix.close();
 });
 
-test("fs backend filter does not create directories for missing includes", async () => {
+test("fs backend on-demand sync does not create directories for missing imports", async () => {
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 
@@ -595,9 +661,10 @@ test("fs backend filter does not create directories for missing includes", async
 		backend: new FsBackend({
 			path: dir,
 			lixDir: tempExternalLixDir(),
-			filter: { includePaths: ["missing/note.md"] },
+			syncAllFiles: false,
 		}),
 	});
+	await lix.importFilesystemPaths(["missing/note.md"]);
 
 	const directories = await lix.execute(
 		"SELECT path FROM lix_directory WHERE path = $1",
@@ -609,7 +676,7 @@ test("fs backend filter does not create directories for missing includes", async
 	await lix.close();
 });
 
-test("fs backend filter propagates deletion of included files", async () => {
+test("fs backend on-demand sync propagates deletion of imported files", async () => {
 	const dir = tempFsDir();
 	const filePath = join(dir, "note.md");
 	mkdirSync(dir, { recursive: true });
@@ -619,9 +686,10 @@ test("fs backend filter propagates deletion of included files", async () => {
 		backend: new FsBackend({
 			path: dir,
 			lixDir: tempExternalLixDir(),
-			filter: { includePaths: ["note.md"] },
+			syncAllFiles: false,
 		}),
 	});
+	await lix.importFilesystemPaths(["note.md"]);
 
 	expect(await readFile(lix, "/note.md")).toBeDefined();
 
@@ -631,7 +699,7 @@ test("fs backend filter propagates deletion of included files", async () => {
 	await lix.close();
 });
 
-test("fs backend filter does not delete excluded files through parent directories", async () => {
+test("fs backend on-demand sync does not delete excluded files through parent directories", async () => {
 	const dir = tempFsDir();
 	const includedPath = join(dir, "docs", "note.md");
 	mkdirSync(join(dir, "docs"), { recursive: true });
@@ -641,9 +709,10 @@ test("fs backend filter does not delete excluded files through parent directorie
 		backend: new FsBackend({
 			path: dir,
 			lixDir: tempExternalLixDir(),
-			filter: { includePaths: ["docs/note.md"] },
+			syncAllFiles: false,
 		}),
 	});
+	await lix.importFilesystemPaths(["docs/note.md"]);
 
 	await writeFile(
 		lix,
@@ -663,7 +732,7 @@ test("fs backend filter does not delete excluded files through parent directorie
 	await lix.close();
 });
 
-test("fs backend filter matches directory paths by segment boundaries", async () => {
+test("fs backend on-demand sync matches directory paths by segment boundaries", async () => {
 	const dir = tempFsDir();
 	const excludedPath = join(dir, "foo", "file.md");
 	const includedPath = join(dir, "foo-bar", "note.md");
@@ -676,9 +745,10 @@ test("fs backend filter matches directory paths by segment boundaries", async ()
 		backend: new FsBackend({
 			path: dir,
 			lixDir: tempExternalLixDir(),
-			filter: { includePaths: ["foo-bar/note.md"] },
+			syncAllFiles: false,
 		}),
 	});
+	await lix.importFilesystemPaths(["foo-bar/note.md"]);
 
 	expect(await readFile(lix, "/foo/file.md")).toBeUndefined();
 	expect(readFileSync(excludedPath, "utf8")).toBe("outside filter");
@@ -694,7 +764,7 @@ test("fs backend with external lixDir materializes lix storage outside the works
 	writeFileSync(join(dir, "note.md"), "note");
 
 	const lix = await openLix({
-		backend: new FsBackend({ path: dir, lixDir }),
+		backend: new FsBackend({ path: dir, lixDir, syncAllFiles: true }),
 	});
 
 	await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
@@ -716,7 +786,7 @@ test("fs backend with external lixDir persists lix storage when reused", async (
 	writeFileSync(join(dir, "note.md"), "first");
 
 	const lix = await openLix({
-		backend: new FsBackend({ path: dir, lixDir }),
+		backend: new FsBackend({ path: dir, lixDir, syncAllFiles: true }),
 	});
 	await lix.execute("UPDATE lix_file SET data = $1 WHERE path = $2", [
 		new TextEncoder().encode("second"),
@@ -729,7 +799,7 @@ test("fs backend with external lixDir persists lix storage when reused", async (
 	await lix.close();
 
 	const reopened = await openLix({
-		backend: new FsBackend({ path: dir, lixDir }),
+		backend: new FsBackend({ path: dir, lixDir, syncAllFiles: true }),
 	});
 	const bytes = await readFile(reopened, "/note.md");
 	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe("second");
@@ -748,7 +818,11 @@ test("fs backend with a fresh external lixDir reimports disk state without old l
 	writeFileSync(join(dir, "note.md"), "first");
 
 	const lix = await openLix({
-		backend: new FsBackend({ path: dir, lixDir: tempExternalLixDir() }),
+		backend: new FsBackend({
+			path: dir,
+			lixDir: tempExternalLixDir(),
+			syncAllFiles: true,
+		}),
 	});
 	await lix.execute("UPDATE lix_file SET data = $1 WHERE path = $2", [
 		new TextEncoder().encode("second"),
@@ -761,7 +835,11 @@ test("fs backend with a fresh external lixDir reimports disk state without old l
 	await lix.close();
 
 	const reopened = await openLix({
-		backend: new FsBackend({ path: dir, lixDir: tempExternalLixDir() }),
+		backend: new FsBackend({
+			path: dir,
+			lixDir: tempExternalLixDir(),
+			syncAllFiles: true,
+		}),
 	});
 	const bytes = await readFile(reopened, "/note.md");
 	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe("second");
@@ -782,7 +860,9 @@ test.skipIf(process.platform === "win32")(
 		symlinkSync("target.txt", join(dir, "link.txt"));
 		symlinkSync("docs", join(dir, "linked-docs"));
 
-		const lix = await openLix({ backend: new FsBackend({ path: dir }) });
+		const lix = await openLix({
+			backend: new FsBackend({ path: dir, syncAllFiles: true }),
+		});
 		const files = await lix.execute(
 			"SELECT path FROM lix_file WHERE path IN ($1, $2, $3) ORDER BY path",
 			["/target.txt", "/link.txt", "/linked-docs/readme.md"],

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -33,6 +33,7 @@ type NativeLix = {
 	activeBranchId(): Promise<string>;
 	createBranch(options: CreateBranchOptions): Promise<CreateBranchReceipt>;
 	switchBranch(options: SwitchBranchOptions): Promise<SwitchBranchReceipt>;
+	importFilesystemPaths(paths: string[]): Promise<void>;
 	mergeBranchPreview(options: MergeBranchOptions): Promise<MergeBranchPreview>;
 	mergeBranch(options: MergeBranchOptions): Promise<MergeBranchReceipt>;
 	close(): Promise<void>;
@@ -67,7 +68,7 @@ export class SqliteBackend {
 export class FsBackend {
 	readonly path: string;
 	readonly lixDir: string | undefined;
-	readonly filter: { includePaths: readonly string[] } | undefined;
+	readonly syncAllFiles: boolean;
 
 	constructor(options: FsBackendOptions) {
 		if (
@@ -86,31 +87,12 @@ export class FsBackend {
 		) {
 			throw new TypeError("FsBackend lixDir must be a non-empty string");
 		}
-		if (options.filter !== undefined) {
-			if (!options.filter || typeof options.filter !== "object") {
-				throw new TypeError("FsBackend filter must be an object");
-			}
-			if (!Array.isArray(options.filter.includePaths)) {
-				throw new TypeError("FsBackend filter.includePaths must be an array");
-			}
-			for (const includePath of options.filter.includePaths) {
-				if (typeof includePath !== "string" || includePath.length === 0) {
-					throw new TypeError(
-						"FsBackend filter.includePaths must contain non-empty strings",
-					);
-				}
-				if (includePath.endsWith("/")) {
-					throw new TypeError(
-						"FsBackend filter.includePaths must contain file paths, not directory paths",
-					);
-				}
-			}
+		if (typeof options.syncAllFiles !== "boolean") {
+			throw new TypeError("FsBackend syncAllFiles must be a boolean");
 		}
 		this.path = options.path;
 		this.lixDir = options.lixDir;
-		this.filter = options.filter
-			? { includePaths: [...options.filter.includePaths] }
-			: undefined;
+		this.syncAllFiles = options.syncAllFiles;
 	}
 }
 
@@ -129,7 +111,7 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			await addon.Lix.openFs(
 				options.backend.path,
 				options.backend.lixDir,
-				options.backend.filter?.includePaths,
+				options.backend.syncAllFiles,
 			),
 		);
 	}
@@ -183,6 +165,25 @@ export class Lix {
 		options: SwitchBranchOptions,
 	): Promise<SwitchBranchReceipt> {
 		return this.native.switchBranch(options);
+	}
+
+	async importFilesystemPaths(paths: readonly string[]): Promise<void> {
+		if (!Array.isArray(paths)) {
+			throw new TypeError("importFilesystemPaths() paths must be an array");
+		}
+		for (const path of paths) {
+			if (typeof path !== "string" || path.length === 0) {
+				throw new TypeError(
+					"importFilesystemPaths() paths must contain non-empty strings",
+				);
+			}
+			if (path.endsWith("/")) {
+				throw new TypeError(
+					"importFilesystemPaths() paths must contain file paths, not directory paths",
+				);
+			}
+		}
+		await this.native.importFilesystemPaths([...paths]);
 	}
 
 	async mergeBranchPreview(

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -5,9 +5,7 @@ export type SqliteBackendOptions = {
 export type FsBackendOptions = {
 	path: string;
 	lixDir?: string;
-	filter?: {
-		includePaths: readonly string[];
-	};
+	syncAllFiles: boolean;
 };
 
 export type OpenLixOptions = {

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -43,18 +43,6 @@ struct FilesystemLayout {
     lix_dir_is_default: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[non_exhaustive]
-pub struct FsBackendFilter {
-    pub include_paths: Option<Vec<String>>,
-}
-
-impl FsBackendFilter {
-    pub fn new(include_paths: Option<Vec<String>>) -> Self {
-        Self { include_paths }
-    }
-}
-
 impl FilesystemLayout {
     fn lix_path_to_local_path(&self, path: &str) -> Result<PathBuf, LixError> {
         if path == "/.lix" {
@@ -102,19 +90,19 @@ impl FilesystemLayout {
 pub struct FsBackendOpenOptions {
     pub root: PathBuf,
     pub lix_dir: Option<PathBuf>,
-    pub filter: FsBackendFilter,
+    pub sync_all_files: bool,
 }
 
 #[cfg(feature = "fs_backend")]
 impl FsBackendOpenOptions {
-    pub fn new<P>(root: P) -> Self
+    pub fn new<P>(root: P, sync_all_files: bool) -> Self
     where
         P: Into<PathBuf>,
     {
         Self {
             root: root.into(),
             lix_dir: None,
-            filter: FsBackendFilter::default(),
+            sync_all_files,
         }
     }
 }
@@ -226,17 +214,13 @@ impl Snapshot {
 }
 
 impl FilesystemPathFilter {
-    fn from_filter(filter: FsBackendFilter) -> Result<Self, LixError> {
-        let include_files = filter
-            .include_paths
-            .map(|include_paths| {
-                include_paths
-                    .into_iter()
-                    .map(|path| normalize_filter_file_path(&path))
-                    .collect::<Result<BTreeSet<_>, LixError>>()
-            })
-            .transpose()?;
-        Ok(Self { include_files })
+    fn from_sync_all_files(sync_all_files: bool) -> Self {
+        let include_files = if sync_all_files {
+            None
+        } else {
+            Some(BTreeSet::new())
+        };
+        Self { include_files }
     }
 
     fn is_unfiltered(&self) -> bool {
@@ -338,6 +322,10 @@ enum FilesystemEvent {
     SyncFromLix {
         reply_tx: mpsc::SyncSender<Result<(), LixError>>,
     },
+    ImportPaths {
+        paths: Vec<String>,
+        reply_tx: mpsc::SyncSender<Result<(), LixError>>,
+    },
     Shutdown,
 }
 
@@ -350,17 +338,25 @@ impl FsBackend {
         Self::open_with_options(FsBackendOpenOptions {
             root: dir.as_ref().to_path_buf(),
             lix_dir: None,
-            filter: FsBackendFilter::default(),
+            sync_all_files: true,
         })
         .await
     }
 
     pub async fn open_with_options(options: FsBackendOpenOptions) -> Result<Self, LixError> {
-        FilesystemPathFilter::from_filter(options.filter.clone())?;
         let layout = prepare_filesystem_layout(&options.root, options.lix_dir.as_deref())?;
         let backend = open_filesystem_rocksdb_backend(&layout)?;
-        let inner = FilesystemSync::open_filesystem(backend, layout, options.filter).await?;
+        let inner =
+            FilesystemSync::open_filesystem(backend, layout, options.sync_all_files).await?;
         Ok(Self { inner })
+    }
+
+    pub async fn import_paths<I, S>(&self, paths: I) -> Result<(), LixError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.inner.import_paths(paths).await
     }
 }
 
@@ -420,23 +416,36 @@ where
     async fn open_filesystem(
         backend: B,
         layout: FilesystemLayout,
-        filter: FsBackendFilter,
+        sync_all_files: bool,
     ) -> Result<Self, LixError> {
         let engine =
             crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None).await?;
-        Self::open_with_engine(backend, engine, layout, filter).await
+        Self::open_with_engine(backend, engine, layout, sync_all_files).await
     }
 
     async fn open_with_engine(
         backend: B,
         engine: Engine<B>,
         layout: FilesystemLayout,
-        filter: FsBackendFilter,
+        sync_all_files: bool,
     ) -> Result<Self, LixError> {
         Ok(Self {
             inner: backend,
-            supervisor: FilesystemSupervisor::open(engine, layout, filter).await?,
+            supervisor: FilesystemSupervisor::open(engine, layout, sync_all_files).await?,
         })
+    }
+
+    async fn import_paths<I, S>(&self, paths: I) -> Result<(), LixError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.supervisor.import_paths_blocking(
+            paths
+                .into_iter()
+                .map(|path| path.as_ref().to_string())
+                .collect(),
+        )
     }
 }
 
@@ -506,11 +515,11 @@ where
     async fn open(
         engine: Engine<B>,
         layout: FilesystemLayout,
-        filter: FsBackendFilter,
+        sync_all_files: bool,
     ) -> Result<Self, LixError> {
         validate_filesystem_root_directory(&layout.root)?;
         validate_filesystem_lix_directory(&layout.lix_dir)?;
-        let path_filter = FilesystemPathFilter::from_filter(filter)?;
+        let path_filter = FilesystemPathFilter::from_sync_all_files(sync_all_files);
         let session = engine.open_workspace_session().await?;
         let state = Arc::new(FilesystemState {
             session,
@@ -585,6 +594,24 @@ where
             Ok(Err(error)) => Err(filesystem_sync_backend_error(error)),
             Err(error) => Err(BackendError::Io(format!(
                 "filesystem sync failed: filesystem worker stopped: {error}"
+            ))),
+        }
+    }
+
+    fn import_paths_blocking(&self, paths: Vec<String>) -> Result<(), LixError> {
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.inner
+            .event_tx
+            .send(FilesystemEvent::ImportPaths { paths, reply_tx })
+            .map_err(|error| {
+                filesystem_error(format!(
+                    "filesystem import failed: filesystem worker stopped: {error}"
+                ))
+            })?;
+        match reply_rx.recv() {
+            Ok(result) => result,
+            Err(error) => Err(filesystem_error(format!(
+                "filesystem import failed: filesystem worker stopped: {error}"
             ))),
         }
     }
@@ -706,6 +733,26 @@ where
             self.materialize_snapshot_with_filter(&lix.snapshot, Some(&local), &path_filter)?;
         self.remember_materialized(materialized, lix.revision, lix_file_paths(&lix.snapshot));
         Ok(())
+    }
+
+    async fn import_paths(&self, paths: Vec<String>) -> Result<(), LixError> {
+        if paths.is_empty() {
+            return Ok(());
+        }
+        let normalized_paths = paths
+            .into_iter()
+            .map(|path| normalize_filter_file_path(&path))
+            .collect::<Result<Vec<_>, LixError>>()?;
+        {
+            let mut path_filter = self
+                .path_filter
+                .lock()
+                .expect("filesystem path filter lock should not poison");
+            for path in normalized_paths {
+                path_filter.add_file(&path);
+            }
+        }
+        self.sync_disk_to_lix(true).await
     }
 
     async fn close(&self) -> Result<(), LixError> {
@@ -1116,6 +1163,25 @@ fn filesystem_worker<B>(
                     return;
                 }
             }
+            Ok(FilesystemEvent::ImportPaths { paths, reply_tx }) => {
+                let _ = import_paths_for_replies(
+                    &runtime,
+                    &state,
+                    vec![(paths, reply_tx)],
+                    &mut debouncer,
+                    &mut poll_filesystem,
+                );
+                if drain_filesystem_events(
+                    &runtime,
+                    &state,
+                    &event_rx,
+                    false,
+                    &mut debouncer,
+                    &mut poll_filesystem,
+                ) {
+                    return;
+                }
+            }
             Ok(FilesystemEvent::Shutdown) | Err(mpsc::RecvTimeoutError::Disconnected) => {
                 let _ = runtime.block_on(state.close());
                 return;
@@ -1138,10 +1204,14 @@ where
     for<'backend> B::Write<'backend>: Send,
 {
     let mut sync_replies = Vec::new();
+    let mut import_replies = Vec::new();
     loop {
         match event_rx.try_recv() {
             Ok(FilesystemEvent::DiskChanged) => sync_disk = true,
             Ok(FilesystemEvent::SyncFromLix { reply_tx }) => sync_replies.push(reply_tx),
+            Ok(FilesystemEvent::ImportPaths { paths, reply_tx }) => {
+                import_replies.push((paths, reply_tx));
+            }
             Ok(FilesystemEvent::Shutdown) | Err(mpsc::TryRecvError::Disconnected) => {
                 let _ = runtime.block_on(state.close());
                 return true;
@@ -1157,7 +1227,36 @@ where
     if !sync_replies.is_empty() {
         let _ = sync_from_lix_for_replies(runtime, state, sync_replies, debouncer, poll_filesystem);
     }
+    if !import_replies.is_empty() {
+        let _ =
+            import_paths_for_replies(runtime, state, import_replies, debouncer, poll_filesystem);
+    }
     false
+}
+
+fn import_paths_for_replies<B>(
+    runtime: &tokio::runtime::Runtime,
+    state: &Arc<FilesystemState<B>>,
+    replies: Vec<(Vec<String>, mpsc::SyncSender<Result<(), LixError>>)>,
+    debouncer: &mut Option<FilesystemWatcher>,
+    poll_filesystem: &mut bool,
+) -> Result<(), LixError>
+where
+    B: Backend + Clone + Send + Sync + 'static,
+    for<'backend> B::Read<'backend>: Send,
+    for<'backend> B::Write<'backend>: Send,
+{
+    let mut first_error = None;
+    for (paths, reply) in replies {
+        let result = runtime.block_on(state.import_paths(paths));
+        if result.is_ok() {
+            refresh_filesystem_watcher(state, debouncer, poll_filesystem);
+        } else if first_error.is_none() {
+            first_error = result.clone().err();
+        }
+        let _ = reply.send(result);
+    }
+    first_error.map_or(Ok(()), Err)
 }
 
 fn sync_from_lix_for_replies<B>(
@@ -2502,8 +2601,7 @@ mod tests {
             b"internal",
         )
         .unwrap();
-        let path_filter =
-            FilesystemPathFilter::from_filter(FsBackendFilter::new(Some(vec![]))).unwrap();
+        let path_filter = FilesystemPathFilter::from_sync_all_files(false);
 
         let snapshot = collect_local_snapshot(&layout, &path_filter).unwrap();
 
@@ -2707,7 +2805,7 @@ mod tests {
         let backend = FsBackend::open_with_options(FsBackendOpenOptions {
             root: root.path().to_path_buf(),
             lix_dir: Some(lix_dir.clone()),
-            filter: FsBackendFilter::default(),
+            sync_all_files: true,
         })
         .await
         .unwrap();

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -13,7 +13,7 @@ mod lix;
 mod sqlite_backend;
 
 #[cfg(all(not(target_family = "wasm"), feature = "fs_backend"))]
-pub use filesystem::{FsBackend, FsBackendFilter, FsBackendOpenOptions};
+pub use filesystem::{FsBackend, FsBackendOpenOptions};
 pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_backend};
 pub use lix_engine::wasm::{
     WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -46,6 +46,7 @@ where
     for<'backend> B::Write<'backend>: Send,
 {
     _engine: Engine<B>,
+    backend: B,
     session: SessionContext<B>,
 }
 
@@ -60,10 +61,12 @@ where
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
-    let engine = open_or_initialize_engine(options.backend, options.wasm_runtime).await?;
+    let backend = options.backend;
+    let engine = open_or_initialize_engine(backend.clone(), options.wasm_runtime).await?;
     let session = engine.open_workspace_session().await?;
     Ok(Lix {
         _engine: engine,
+        backend,
         session,
     })
 }
@@ -141,6 +144,17 @@ where
 
     pub async fn close(&self) -> Result<(), LixError> {
         self.session.close().await
+    }
+}
+
+#[cfg(all(not(target_family = "wasm"), feature = "fs_backend"))]
+impl Lix<crate::FsBackend> {
+    pub async fn import_filesystem_paths<I, S>(&self, paths: I) -> Result<(), LixError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.backend.import_paths(paths).await
     }
 }
 

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -3,7 +3,7 @@ use lix_sdk::{
     MergeBranchOutcome, OpenLixOptions, SwitchBranchOptions, Value, open_lix,
 };
 #[cfg(feature = "fs_backend")]
-use lix_sdk::{FsBackend, FsBackendFilter, FsBackendOpenOptions, open_lix_with_backend};
+use lix_sdk::{FsBackend, FsBackendOpenOptions, open_lix_with_backend};
 #[cfg(feature = "fs_backend")]
 use std::path::Path;
 #[cfg(feature = "fs_backend")]
@@ -537,16 +537,14 @@ async fn open_lix_with_filesystem(path: &Path) -> Lix<FsBackend> {
 }
 
 #[cfg(feature = "fs_backend")]
-async fn open_lix_with_filtered_filesystem(path: &Path, include_paths: &[&str]) -> Lix<FsBackend> {
-    let mut options = FsBackendOpenOptions::new(path.to_path_buf());
-    options.filter = FsBackendFilter::new(Some(
-        include_paths
-            .iter()
-            .map(|path| (*path).to_string())
-            .collect(),
-    ));
+async fn open_lix_with_on_demand_filesystem(path: &Path, file_paths: &[&str]) -> Lix<FsBackend> {
+    let options = FsBackendOpenOptions::new(path.to_path_buf(), false);
     let backend = FsBackend::open_with_options(options).await.unwrap();
-    open_lix_with_backend(backend).await.unwrap()
+    let lix = open_lix_with_backend(backend).await.unwrap();
+    lix.import_filesystem_paths(file_paths.iter().copied())
+        .await
+        .unwrap();
+    lix
 }
 
 #[tokio::test]
@@ -866,10 +864,10 @@ async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
 
 #[tokio::test]
 #[cfg(feature = "fs_backend")]
-async fn filtered_filesystem_materializes_lix_created_file_outside_initial_filter() {
+async fn on_demand_filesystem_materializes_lix_created_file_outside_initial_imports() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::write(tempdir.path().join("initial.md"), b"initial").unwrap();
-    let lix = open_lix_with_filtered_filesystem(tempdir.path(), &["initial.md"]).await;
+    let lix = open_lix_with_on_demand_filesystem(tempdir.path(), &["initial.md"]).await;
 
     write_file(&lix, "/new-file.md", b"new".to_vec())
         .await
@@ -881,10 +879,10 @@ async fn filtered_filesystem_materializes_lix_created_file_outside_initial_filte
 
 #[tokio::test]
 #[cfg(feature = "fs_backend")]
-async fn filtered_filesystem_watches_nested_lix_created_file_after_materialization() {
+async fn on_demand_filesystem_watches_nested_lix_created_file_after_materialization() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::write(tempdir.path().join("initial.md"), b"initial").unwrap();
-    let lix = open_lix_with_filtered_filesystem(tempdir.path(), &["initial.md"]).await;
+    let lix = open_lix_with_on_demand_filesystem(tempdir.path(), &["initial.md"]).await;
 
     write_file(&lix, "/nested/new-file.md", b"new".to_vec())
         .await
@@ -899,10 +897,10 @@ async fn filtered_filesystem_watches_nested_lix_created_file_after_materializati
 
 #[tokio::test]
 #[cfg(feature = "fs_backend")]
-async fn filtered_filesystem_lix_delete_removes_path_from_active_filter() {
+async fn on_demand_filesystem_lix_delete_removes_path_from_active_imports() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::write(tempdir.path().join("initial.md"), b"initial").unwrap();
-    let lix = open_lix_with_filtered_filesystem(tempdir.path(), &["initial.md"]).await;
+    let lix = open_lix_with_on_demand_filesystem(tempdir.path(), &["initial.md"]).await;
 
     write_file(&lix, "/new-file.md", b"new".to_vec())
         .await
@@ -927,10 +925,10 @@ async fn filtered_filesystem_lix_delete_removes_path_from_active_filter() {
 
 #[tokio::test]
 #[cfg(feature = "fs_backend")]
-async fn filtered_filesystem_lix_rename_replaces_tracked_path() {
+async fn on_demand_filesystem_lix_rename_replaces_tracked_path() {
     let tempdir = tempfile::tempdir().unwrap();
     std::fs::write(tempdir.path().join("old.md"), b"old").unwrap();
-    let lix = open_lix_with_filtered_filesystem(tempdir.path(), &["old.md"]).await;
+    let lix = open_lix_with_on_demand_filesystem(tempdir.path(), &["old.md"]).await;
 
     lix.execute(
         "UPDATE lix_file SET path = $1 WHERE path = $2",


### PR DESCRIPTION
- Replace `filter.includePaths` / `FsBackendFilter` with required `syncAllFiles` option.
- Add `importFilesystemPaths()` across Rust, native, and JS SDK layers for importing selected files after opening a `syncAllFiles: false` / `sync_all_files: false` filesystem backend.
- Use `syncAllFiles: false` / `sync_all_files: false` for on-demand sync, and `true` for full workspace sync.
- Update filesystem watcher/materialization tests and docs for the new API.