### PR TITLE
v0.8 changenotes and FsBackend API cleanup

### DIFF
--- a/.changenotes/async-js-bindings.md
+++ b/.changenotes/async-js-bindings.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Made the JavaScript SDK's native bindings fully asynchronous.
+
+Awaited methods previously blocked the calling thread inside the native binding, which could freeze an Electron main process. Opening a lix, `execute`, transactions, branch and merge calls, observers, and `close` now return real promises and run their work off-thread.

--- a/.changenotes/faster-entity-upserts.md
+++ b/.changenotes/faster-entity-upserts.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Sped up `INSERT ... ON CONFLICT` entity upserts by scanning only the inserted identity for conflicts instead of the full entity state.

--- a/.changenotes/faster-lix-file-writes.md
+++ b/.changenotes/faster-lix-file-writes.md
@@ -2,4 +2,6 @@
 type: patch
 ---
 
-Improved large `lix_file` write performance for simple SQL file inserts and upserts.
+Improved `lix_file` read and write performance.
+
+Simple single- and multi-row `lix_file (path, data)` inserts and upserts take a fast path that makes large file writes roughly 10x faster. File bytes are hashed once per write, unchanged chunks skip re-writes, and filesystem sync batches its upserts: in repository benchmarks, a 1,000-row `lix_file` insert dropped from ~95 ms to ~41 ms and a 200-file filesystem cold open from ~780 ms to ~210 ms. `SELECT` queries that project `data` now batch their blob reads.

--- a/.changenotes/filesystem-sync-barrier.md
+++ b/.changenotes/filesystem-sync-barrier.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added `lix.syncDiskToLix()` as an awaitable filesystem sync barrier.
+
+The filesystem backend picks up disk edits in the background with debouncing. `syncDiskToLix()` flushes pending on-disk changes into Lix and resolves once they are materialized, so subsequent queries reflect the current disk state.

--- a/.changenotes/filesystem-sync-barrier.md
+++ b/.changenotes/filesystem-sync-barrier.md
@@ -2,6 +2,6 @@
 type: minor
 ---
 
-Added `lix.syncDiskToLix()` as an awaitable filesystem sync barrier.
+Added `FsBackend.syncDiskToLix()` as an awaitable filesystem sync barrier.
 
-The filesystem backend picks up disk edits in the background with debouncing. `syncDiskToLix()` flushes pending on-disk changes into Lix and resolves once they are materialized, so subsequent queries reflect the current disk state.
+The filesystem backend picks up disk edits in the background with debouncing. `backend.syncDiskToLix()` flushes pending on-disk changes into Lix and resolves once they are materialized, so subsequent queries reflect the current disk state.

--- a/.changenotes/fs-backend-external-lix-dir.md
+++ b/.changenotes/fs-backend-external-lix-dir.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added a `lixDir` option to `FsBackend` for storing lix state outside the workspace.
+
+By default, state lives in `<workspace>/.lix`. Passing `lixDir` keeps repository metadata in an external `.lix` directory and writes no `.lix` directory into the workspace. Pointing `lixDir` at a temporary directory gives ephemeral filesystem sync: workspace files are imported and watched without persisting lix state.

--- a/.changenotes/fs-backend-on-demand-sync.md
+++ b/.changenotes/fs-backend-on-demand-sync.md
@@ -1,0 +1,7 @@
+---
+type: major
+---
+
+`FsBackend` now requires an explicit `syncAllFiles` option and supports on-demand file sync.
+
+`new FsBackend({ path, syncAllFiles: true })` syncs the full workspace as before. With `syncAllFiles: false`, the lix opens without workspace files and `lix.importFilesystemPaths(["notes/today.md"])` syncs selected files on demand. Imported paths are exact workspace-relative file paths, not directories or globs. In Rust, use `FsBackendOpenOptions::new(root, sync_all_files)` and `import_paths()`.

--- a/.changenotes/fs-backend-on-demand-sync.md
+++ b/.changenotes/fs-backend-on-demand-sync.md
@@ -4,4 +4,4 @@ type: minor
 
 `FsBackend` now requires an explicit `syncAllFiles` option and supports on-demand file sync.
 
-`new FsBackend({ path, syncAllFiles: true })` syncs the full workspace as before. With `syncAllFiles: false`, the lix opens without workspace files and `lix.importFilesystemPaths(["notes/today.md"])` syncs selected files on demand. Imported paths are exact workspace-relative file paths, not directories or globs. In Rust, use `FsBackendOpenOptions::new(root, sync_all_files)` and `import_paths()`.
+`new FsBackend({ path, syncAllFiles: true })` syncs the full workspace as before. With `syncAllFiles: false`, the lix opens without workspace files and `backend.importPaths(["notes/today.md"])` syncs selected files on demand. Imported paths are exact workspace-relative file paths, not directories or globs. In Rust, use `FsBackendOpenOptions::new(root, sync_all_files)` and `FsBackend::import_paths()`.

--- a/.changenotes/fs-backend-on-demand-sync.md
+++ b/.changenotes/fs-backend-on-demand-sync.md
@@ -1,5 +1,5 @@
 ---
-type: major
+type: minor
 ---
 
 `FsBackend` now requires an explicit `syncAllFiles` option and supports on-demand file sync.

--- a/.changenotes/fs-backend-state-not-migrated.md
+++ b/.changenotes/fs-backend-state-not-migrated.md
@@ -1,0 +1,7 @@
+---
+type: major
+---
+
+The filesystem backend replaced its internal state store; existing v0.7 filesystem workspace state is not migrated.
+
+When old metadata is present in `.lix/.internal` and no new store exists, Lix clears `.lix/.internal` and initializes fresh state from the workspace files. Workspace files are untouched; recorded lix history for that workspace is not carried over.

--- a/.changenotes/fs-backend-state-not-migrated.md
+++ b/.changenotes/fs-backend-state-not-migrated.md
@@ -1,7 +1,0 @@
----
-type: major
----
-
-The filesystem backend replaced its internal state store; existing v0.7 filesystem workspace state is not migrated.
-
-When old metadata is present in `.lix/.internal` and no new store exists, Lix clears `.lix/.internal` and initializes fresh state from the workspace files. Workspace files are untouched; recorded lix history for that workspace is not carried over.

--- a/.changenotes/large-file-data-surfaces.md
+++ b/.changenotes/large-file-data-surfaces.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Removed a 2 GB size ceiling on file data read through SQL.
+
+The `data` column on `lix_file`, `lix_file_by_branch`, and `lix_file_history` now uses a large binary representation, so reads no longer fail when file bytes in a result exceed Arrow's 32-bit offset limit.

--- a/.changenotes/mit-license.md
+++ b/.changenotes/mit-license.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Lix is now MIT licensed.
+
+The Rust crates and the JavaScript SDK npm package declare the MIT license, replacing the previous proprietary license reference.

--- a/.changenotes/origin-keys.md
+++ b/.changenotes/origin-keys.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added optional origin keys for tagging Lix writes.
+
+`lix.execute(sql, params, { originKey })` in JavaScript and `execute_with_options(sql, params, options)` in Rust stamp the change records a write produces. The key is exposed as `origin_key` on `lix_change` and as `lixcol_origin_key` on state, file, and history surfaces; writes without an origin key stay `NULL`.

--- a/.changenotes/simplify-fs-backend-memory-storage.md
+++ b/.changenotes/simplify-fs-backend-memory-storage.md
@@ -1,7 +1,0 @@
----
-type: minor
----
-
-Simplified filesystem-backed Lix storage around `FsBackend`.
-
-Use `new FsBackend({ path: "./workspace" })` for persistent filesystem-backed storage, or `new FsBackend({ path: "./workspace", storage: "memory" })` when the workspace should be synced into an in-memory Lix without writing `.lix` state back to disk. Filesystem sync can now be limited to exact workspace-relative paths with `filter.includePaths`.

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -54,20 +54,19 @@ const lix = await openLix({
 ```
 
 Set `syncAllFiles: false` to start filesystem sync with no regular workspace
-files, then import selected files with `importFilesystemPaths()`. Imported paths are
+files, then import selected files with `backend.importPaths()`. Imported paths are
 exact workspace-relative file paths, not directories or globs. They may be
 written with or without a leading slash, for example `"notes/today.md"` or
 `"/notes/today.md"`. This scopes disk import, file watching, and
 materialization; it does not filter unrelated Lix SQL state.
 
 ```ts
-const lix = await openLix({
-	backend: new FsBackend({
-		path: "./workspace",
-		syncAllFiles: false,
-	}),
+const backend = new FsBackend({
+	path: "./workspace",
+	syncAllFiles: false,
 });
-await lix.importFilesystemPaths(["notes/today.md"]);
+const lix = await openLix({ backend });
+await backend.importPaths(["notes/today.md"]);
 ```
 
 Use `SqliteBackend` when a single `.lix` SQLite file is the application document

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -81,20 +81,19 @@ const lix = await openLix({
 ```
 
 Set `syncAllFiles: false` when filesystem sync should start with no regular
-workspace files, then import selected files with `importFilesystemPaths()`. Imported paths
+workspace files, then import selected files with `backend.importPaths()`. Imported paths
 are exact workspace-relative file paths, not directories or globs. They may be
 written with or without a leading slash, for example `"notes/today.md"` or
 `"/notes/today.md"`. This scopes disk import, file watching, and
 materialization; it does not filter unrelated Lix SQL state.
 
 ```ts
-const lix = await openLix({
-	backend: new FsBackend({
-		path: "/Users/me/Downloads",
-		syncAllFiles: false,
-	}),
+const backend = new FsBackend({
+	path: "/Users/me/Downloads",
+	syncAllFiles: false,
 });
-await lix.importFilesystemPaths(["notes/today.md"]);
+const lix = await openLix({ backend });
+await backend.importPaths(["notes/today.md"]);
 ```
 
 ## Single .lix application file

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -77,7 +77,7 @@ try {
 
 - `openLix()` opens a fresh in-memory Lix. Pass `new FsBackend({ path, syncAllFiles: true })` for a filesystem workspace directory backed by `<path>/.lix/.internal/rocksdb`.
 - Pass `new FsBackend({ path, lixDir, syncAllFiles: true })` for filesystem sync with repository metadata in an external `.lix` directory and no workspace `.lix` directory.
-- Pass `syncAllFiles: false` to start filesystem sync with no regular workspace files, then call `lix.importFilesystemPaths(["notes/today.md"])` to sync selected files. Imported paths are exact workspace-relative file paths, not directories or globs.
+- Pass `syncAllFiles: false` to start filesystem sync with no regular workspace files, then call `backend.importPaths(["notes/today.md"])` on the `FsBackend` instance to sync selected files. Imported paths are exact workspace-relative file paths, not directories or globs.
 - Use `new SqliteBackend({ path })` when a single SQLite-backed `.lix` file is the application document itself, for example when defining a new file format and using Lix as the application's file format.
 - The SDK is Node/native only right now; it is not browser-compatible.
 - The package is ESM-only.

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -32,7 +32,7 @@ pub struct NativeLix {
 enum NativeLixInner {
     Memory(RsLix<InMemoryBackend>),
     Sqlite(RsLix<SqliteBackend>),
-    Fs(RsLix<FsBackend>),
+    Fs(RsLix<FsBackend>, FsBackend),
 }
 
 enum NativeLixTransactionInner {
@@ -489,7 +489,7 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.execute_with_options(sql, params, options).await,
             Self::Sqlite(lix) => lix.execute_with_options(sql, params, options).await,
-            Self::Fs(lix) => lix.execute_with_options(sql, params, options).await,
+            Self::Fs(lix, _) => lix.execute_with_options(sql, params, options).await,
         }
     }
 
@@ -501,7 +501,7 @@ impl NativeLixInner {
             Self::Sqlite(lix) => Ok(NativeLixTransactionInner::Sqlite(
                 lix.begin_transaction().await?,
             )),
-            Self::Fs(lix) => Ok(NativeLixTransactionInner::Fs(
+            Self::Fs(lix, _) => Ok(NativeLixTransactionInner::Fs(
                 lix.begin_transaction().await?,
             )),
         }
@@ -515,7 +515,7 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => Ok(NativeObserveEventsInner::Memory(lix.observe(sql, params)?)),
             Self::Sqlite(lix) => Ok(NativeObserveEventsInner::Sqlite(lix.observe(sql, params)?)),
-            Self::Fs(lix) => Ok(NativeObserveEventsInner::Fs(lix.observe(sql, params)?)),
+            Self::Fs(lix, _) => Ok(NativeObserveEventsInner::Fs(lix.observe(sql, params)?)),
         }
     }
 
@@ -523,7 +523,7 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.active_branch_id().await,
             Self::Sqlite(lix) => lix.active_branch_id().await,
-            Self::Fs(lix) => lix.active_branch_id().await,
+            Self::Fs(lix, _) => lix.active_branch_id().await,
         }
     }
 
@@ -534,7 +534,7 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.create_branch(options).await,
             Self::Sqlite(lix) => lix.create_branch(options).await,
-            Self::Fs(lix) => lix.create_branch(options).await,
+            Self::Fs(lix, _) => lix.create_branch(options).await,
         }
     }
 
@@ -545,7 +545,7 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.switch_branch(options).await,
             Self::Sqlite(lix) => lix.switch_branch(options).await,
-            Self::Fs(lix) => lix.switch_branch(options).await,
+            Self::Fs(lix, _) => lix.switch_branch(options).await,
         }
     }
 
@@ -554,7 +554,7 @@ impl NativeLixInner {
         paths: Vec<String>,
     ) -> std::result::Result<(), LixError> {
         match self {
-            Self::Fs(lix) => lix.import_filesystem_paths(paths).await,
+            Self::Fs(_, backend) => backend.import_paths(paths).await,
             Self::Memory(_) | Self::Sqlite(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_BACKEND",
                 "importFilesystemPaths requires a filesystem backend",
@@ -569,7 +569,7 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.merge_branch_preview(options).await,
             Self::Sqlite(lix) => lix.merge_branch_preview(options).await,
-            Self::Fs(lix) => lix.merge_branch_preview(options).await,
+            Self::Fs(lix, _) => lix.merge_branch_preview(options).await,
         }
     }
 
@@ -580,13 +580,13 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.merge_branch(options).await,
             Self::Sqlite(lix) => lix.merge_branch(options).await,
-            Self::Fs(lix) => lix.merge_branch(options).await,
+            Self::Fs(lix, _) => lix.merge_branch(options).await,
         }
     }
 
     async fn sync_disk_to_lix(&self) -> std::result::Result<(), LixError> {
         match self {
-            Self::Fs(lix) => lix.sync_disk_to_lix().await,
+            Self::Fs(_, backend) => backend.sync_disk_to_lix().await,
             Self::Memory(_) | Self::Sqlite(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_BACKEND",
                 "syncDiskToLix requires a filesystem backend",
@@ -598,7 +598,7 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.close().await,
             Self::Sqlite(lix) => lix.close().await,
-            Self::Fs(lix) => lix.close().await,
+            Self::Fs(lix, _) => lix.close().await,
         }
     }
 }
@@ -745,8 +745,8 @@ fn open_fs_native(
     let mut options = FsBackendOpenOptions::new(path, sync_all_files);
     options.lix_dir = lix_dir.map(Into::into);
     let backend = rt.block_on(FsBackend::open_with_options(options))?;
-    let lix = rt.block_on(open_lix_with_backend(backend))?;
-    NativeLix::new(NativeLixInner::Fs(lix))
+    let lix = rt.block_on(open_lix_with_backend(backend.clone()))?;
+    NativeLix::new(NativeLixInner::Fs(lix, backend))
 }
 
 #[napi]

--- a/packages/js-sdk/src/errors.ts
+++ b/packages/js-sdk/src/errors.ts
@@ -36,3 +36,22 @@ export function invalidParam(
 	};
 	return error;
 }
+
+export function fsBackendNotOpen(operation: string): LixJsError {
+	const error = new Error(
+		`FsBackend.${operation}() requires the backend to be opened with openLix() first`,
+	) as LixJsError;
+	error.name = "LixError";
+	error.code = "LIX_FS_BACKEND_NOT_OPEN";
+	error.details = { operation };
+	return error;
+}
+
+export function fsBackendAlreadyOpen(): LixJsError {
+	const error = new Error(
+		"openLix() FsBackend is already open; close the existing Lix or create a new FsBackend",
+	) as LixJsError;
+	error.name = "LixError";
+	error.code = "LIX_FS_BACKEND_IN_USE";
+	return error;
+}

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -548,14 +548,13 @@ test("fs backend on-demand sync imports selected paths and lix-created files", a
 	writeFileSync(includedPath, "included");
 	writeFileSync(excludedPath, "excluded");
 
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
-	await lix.importFilesystemPaths(["docs/note.md"]);
+	const lix = await openLix({ backend });
+	await backend.importPaths(["docs/note.md"]);
 
 	const files = await lix.execute(
 		"SELECT path FROM lix_file WHERE path IN ($1, $2) ORDER BY path",
@@ -594,17 +593,16 @@ test("fs backend imports existing files into a filtered filesystem", async () =>
 	mkdirSync(join(dir, "docs"), { recursive: true });
 	writeFileSync(importedPath, "opened");
 
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
+	const lix = await openLix({ backend });
 
 	expect(await readFile(lix, "/docs/opened.md")).toBeUndefined();
 
-	await lix.importFilesystemPaths(["docs/opened.md"]);
+	await backend.importPaths(["docs/opened.md"]);
 	expect(
 		new TextDecoder().decode((await readFile(lix, "/docs/opened.md"))!),
 	).toBe("opened");
@@ -618,28 +616,44 @@ test("fs backend imports existing files into a filtered filesystem", async () =>
 	await lix.close();
 });
 
-test("importFilesystemPaths validates paths and requires a filesystem backend", async () => {
-	const memory = await openLix();
-	await expect(memory.importFilesystemPaths(["note.md"])).rejects.toThrow(
-		"filesystem backend",
+test("importPaths validates paths and requires an opened backend", async () => {
+	const unopened = new FsBackend({ path: tempFsDir(), syncAllFiles: false });
+	await expect(unopened.importPaths(["note.md"])).rejects.toThrow(
+		"opened with openLix()",
 	);
-	await memory.close();
 
 	const dir = tempFsDir();
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
-	await expect(lix.importFilesystemPaths([""])).rejects.toThrow(
-		"non-empty strings",
-	);
-	await expect(lix.importFilesystemPaths(["docs/"])).rejects.toThrow(
+	const lix = await openLix({ backend });
+	await expect(backend.importPaths([""])).rejects.toThrow("non-empty strings");
+	await expect(backend.importPaths(["docs/"])).rejects.toThrow(
 		"file paths, not directory paths",
 	);
 	await lix.close();
+	await expect(backend.importPaths(["note.md"])).rejects.toThrow(
+		"opened with openLix()",
+	);
+});
+
+test("fs backend binds to one open lix at a time", async () => {
+	const dir = tempFsDir();
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "note.md"), "note");
+
+	const backend = new FsBackend({ path: dir, syncAllFiles: true });
+	const lix = await openLix({ backend });
+	await expect(openLix({ backend })).rejects.toThrow("already open");
+
+	await backend.syncDiskToLix();
+
+	await lix.close();
+	const reopened = await openLix({ backend });
+	await backend.syncDiskToLix();
+	await reopened.close();
 });
 
 test("fs backend syncAllFiles validates option shape", () => {
@@ -701,14 +715,13 @@ test("fs backend on-demand sync treats paths as exact filenames", async () => {
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(filePath, "literal whitespace");
 
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
-	await lix.importFilesystemPaths([" spaced.md"]);
+	const lix = await openLix({ backend });
+	await backend.importPaths([" spaced.md"]);
 
 	const bytes = await readFile(lix, "/ spaced.md");
 	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe(
@@ -722,14 +735,13 @@ test("fs backend on-demand sync does not create directories for missing imports"
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
-	await lix.importFilesystemPaths(["missing/note.md"]);
+	const lix = await openLix({ backend });
+	await backend.importPaths(["missing/note.md"]);
 
 	const directories = await lix.execute(
 		"SELECT path FROM lix_directory WHERE path = $1",
@@ -747,14 +759,13 @@ test("fs backend on-demand sync propagates deletion of imported files", async ()
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(filePath, "local");
 
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
-	await lix.importFilesystemPaths(["note.md"]);
+	const lix = await openLix({ backend });
+	await backend.importPaths(["note.md"]);
 
 	expect(await readFile(lix, "/note.md")).toBeDefined();
 
@@ -770,14 +781,13 @@ test("fs backend on-demand sync does not delete excluded files through parent di
 	mkdirSync(join(dir, "docs"), { recursive: true });
 	writeFileSync(includedPath, "local");
 
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
-	await lix.importFilesystemPaths(["docs/note.md"]);
+	const lix = await openLix({ backend });
+	await backend.importPaths(["docs/note.md"]);
 
 	await writeFile(
 		lix,
@@ -806,14 +816,13 @@ test("fs backend on-demand sync matches directory paths by segment boundaries", 
 	writeFileSync(excludedPath, "outside filter");
 	writeFileSync(includedPath, "local");
 
-	const lix = await openLix({
-		backend: new FsBackend({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: false,
-		}),
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
 	});
-	await lix.importFilesystemPaths(["foo-bar/note.md"]);
+	const lix = await openLix({ backend });
+	await backend.importPaths(["foo-bar/note.md"]);
 
 	expect(await readFile(lix, "/foo/file.md")).toBeUndefined();
 	expect(readFileSync(excludedPath, "utf8")).toBe("outside filter");

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -1,4 +1,8 @@
-import { invalidArgument } from "./errors.js";
+import {
+	fsBackendAlreadyOpen,
+	fsBackendNotOpen,
+	invalidArgument,
+} from "./errors.js";
 import { addon } from "./native.js";
 import { normalizeOptionals, wrapExecuteResult } from "./result.js";
 import { normalizeParam, toNativeValue } from "./value.js";
@@ -75,6 +79,8 @@ export class SqliteBackend {
 	}
 }
 
+const openFsBackends = new WeakMap<FsBackend, NativeLix | null>();
+
 export class FsBackend {
 	readonly path: string;
 	readonly lixDir: string | undefined;
@@ -104,6 +110,37 @@ export class FsBackend {
 		this.lixDir = options.lixDir;
 		this.syncAllFiles = options.syncAllFiles;
 	}
+
+	async importPaths(paths: readonly string[]): Promise<void> {
+		if (!Array.isArray(paths)) {
+			throw new TypeError("importPaths() paths must be an array");
+		}
+		for (const path of paths) {
+			if (typeof path !== "string" || path.length === 0) {
+				throw new TypeError(
+					"importPaths() paths must contain non-empty strings",
+				);
+			}
+			if (path.endsWith("/")) {
+				throw new TypeError(
+					"importPaths() paths must contain file paths, not directory paths",
+				);
+			}
+		}
+		await this.native("importPaths").importFilesystemPaths([...paths]);
+	}
+
+	async syncDiskToLix(): Promise<void> {
+		return this.native("syncDiskToLix").syncDiskToLix();
+	}
+
+	private native(operation: string): NativeLix {
+		const native = openFsBackends.get(this);
+		if (!native) {
+			throw fsBackendNotOpen(operation);
+		}
+		return native;
+	}
 }
 
 export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
@@ -117,13 +154,23 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 		return new Lix(await addon.Lix.openSqlite(options.backend.path));
 	}
 	if (options.backend instanceof FsBackend) {
-		return new Lix(
-			await addon.Lix.openFs(
-				options.backend.path,
-				options.backend.lixDir,
-				options.backend.syncAllFiles,
-			),
-		);
+		const backend = options.backend;
+		if (openFsBackends.has(backend)) {
+			throw fsBackendAlreadyOpen();
+		}
+		openFsBackends.set(backend, null);
+		try {
+			const native = await addon.Lix.openFs(
+				backend.path,
+				backend.lixDir,
+				backend.syncAllFiles,
+			);
+			openFsBackends.set(backend, native);
+			return new Lix(native, () => openFsBackends.delete(backend));
+		} catch (error) {
+			openFsBackends.delete(backend);
+			throw error;
+		}
 	}
 	throw new TypeError(
 		"openLix() requires backend to be SqliteBackend or FsBackend",
@@ -131,7 +178,10 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 }
 
 export class Lix {
-	constructor(private readonly native: NativeLix) {}
+	constructor(
+		private readonly native: NativeLix,
+		private readonly onClose?: () => void,
+	) {}
 
 	async execute(
 		sql: string,
@@ -182,25 +232,6 @@ export class Lix {
 		return this.native.switchBranch(options);
 	}
 
-	async importFilesystemPaths(paths: readonly string[]): Promise<void> {
-		if (!Array.isArray(paths)) {
-			throw new TypeError("importFilesystemPaths() paths must be an array");
-		}
-		for (const path of paths) {
-			if (typeof path !== "string" || path.length === 0) {
-				throw new TypeError(
-					"importFilesystemPaths() paths must contain non-empty strings",
-				);
-			}
-			if (path.endsWith("/")) {
-				throw new TypeError(
-					"importFilesystemPaths() paths must contain file paths, not directory paths",
-				);
-			}
-		}
-		await this.native.importFilesystemPaths([...paths]);
-	}
-
 	async mergeBranchPreview(
 		options: MergeBranchOptions,
 	): Promise<MergeBranchPreview> {
@@ -213,12 +244,9 @@ export class Lix {
 		return receipt;
 	}
 
-	async syncDiskToLix(): Promise<void> {
-		return this.native.syncDiskToLix();
-	}
-
 	async close(): Promise<void> {
-		return this.native.close();
+		await this.native.close();
+		this.onClose?.();
 	}
 }
 

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -425,8 +425,7 @@ where
         layout: FilesystemLayout,
         sync_all_files: bool,
     ) -> Result<Self, LixError> {
-        let engine =
-            crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None).await?;
+        let engine = crate::lix::open_or_initialize_engine(backend.clone(), None).await?;
         Self::open_with_engine(backend, engine, layout, sync_all_files).await
     }
 
@@ -2539,7 +2538,7 @@ mod tests {
         path_filter: FilesystemPathFilter,
     ) -> FilesystemState<RocksDbFilesystemBackend> {
         let backend = open_filesystem_rocksdb_backend(&layout).unwrap();
-        let engine = crate::lix::open_or_initialize_filesystem_engine(backend.clone(), None)
+        let engine = crate::lix::open_or_initialize_engine(backend.clone(), None)
             .await
             .unwrap();
         FilesystemState {

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -2885,13 +2885,15 @@ mod tests {
         })
         .await
         .unwrap();
-        let lix = crate::lix::open_lix_with_backend(backend).await.unwrap();
-        lix.import_filesystem_paths(["tracked.md"]).await.unwrap();
+        let lix = crate::lix::open_lix_with_backend(backend.clone())
+            .await
+            .unwrap();
+        backend.import_paths(["tracked.md"]).await.unwrap();
 
         std::fs::write(tempdir.path().join("tracked.md"), b"changed").unwrap();
         std::fs::write(tempdir.path().join("ignored.md"), b"changed").unwrap();
 
-        lix.sync_disk_to_lix().await.unwrap();
+        backend.sync_disk_to_lix().await.unwrap();
 
         let tracked = lix
             .execute(
@@ -2924,7 +2926,7 @@ mod tests {
 
     #[cfg(feature = "fs_backend")]
     #[tokio::test]
-    async fn fs_backend_sync_disk_to_lix_after_close_returns_closed() {
+    async fn fs_backend_sync_disk_to_lix_outlives_lix_session() {
         let tempdir = tempfile::tempdir().unwrap();
         std::fs::write(tempdir.path().join("tracked.md"), b"initial").unwrap();
 
@@ -2935,16 +2937,33 @@ mod tests {
         })
         .await
         .unwrap();
-        let lix = crate::lix::open_lix_with_backend(backend).await.unwrap();
+        let lix = crate::lix::open_lix_with_backend(backend.clone())
+            .await
+            .unwrap();
 
         lix.close().await.unwrap();
         std::fs::write(tempdir.path().join("tracked.md"), b"changed").unwrap();
 
-        let error = lix
-            .sync_disk_to_lix()
+        backend.sync_disk_to_lix().await.unwrap();
+
+        let lix = crate::lix::open_lix_with_backend(backend).await.unwrap();
+        let tracked = lix
+            .execute(
+                "SELECT data FROM lix_file WHERE path = $1",
+                &[Value::Text("/tracked.md".to_string())],
+            )
             .await
-            .expect_err("sync after close should fail closed");
-        assert_eq!(error.code, LixError::CODE_CLOSED);
+            .unwrap();
+        assert_eq!(
+            tracked
+                .rows()
+                .first()
+                .unwrap()
+                .get::<Vec<u8>>("data")
+                .unwrap(),
+            b"changed"
+        );
+        lix.close().await.unwrap();
     }
 
     #[cfg(feature = "fs_backend")]

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -46,7 +46,6 @@ where
     for<'backend> B::Write<'backend>: Send,
 {
     _engine: Engine<B>,
-    backend: B,
     session: SessionContext<B>,
 }
 
@@ -61,12 +60,10 @@ where
     for<'backend> B::Read<'backend>: Send,
     for<'backend> B::Write<'backend>: Send,
 {
-    let backend = options.backend;
-    let engine = open_or_initialize_engine(backend.clone(), options.wasm_runtime).await?;
+    let engine = open_or_initialize_engine(options.backend, options.wasm_runtime).await?;
     let session = engine.open_workspace_session().await?;
     Ok(Lix {
         _engine: engine,
-        backend,
         session,
     })
 }
@@ -156,36 +153,6 @@ where
     pub async fn close(&self) -> Result<(), LixError> {
         self.session.close().await
     }
-}
-
-#[cfg(all(not(target_family = "wasm"), feature = "fs_backend"))]
-impl Lix<crate::FsBackend> {
-    pub async fn import_filesystem_paths<I, S>(&self, paths: I) -> Result<(), LixError>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        self.ensure_open()?;
-        self.backend.import_paths(paths).await
-    }
-
-    pub async fn sync_disk_to_lix(&self) -> Result<(), LixError> {
-        self.ensure_open()?;
-        self.backend.sync_disk_to_lix().await
-    }
-
-    fn ensure_open(&self) -> Result<(), LixError> {
-        if self.session.is_closed() {
-            return Err(lix_closed_error());
-        }
-        Ok(())
-    }
-}
-
-#[cfg(all(not(target_family = "wasm"), feature = "fs_backend"))]
-fn lix_closed_error() -> LixError {
-    LixError::new(LixError::CODE_CLOSED, "Lix handle is closed")
-        .with_hint("Open a new Lix handle before calling this method.")
 }
 
 #[expect(missing_debug_implementations)]

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -220,26 +220,6 @@ where
     }
 }
 
-#[cfg(feature = "fs_backend")]
-pub(crate) async fn open_or_initialize_filesystem_engine<B>(
-    backend: B,
-    wasm_runtime: Option<Arc<dyn WasmRuntime>>,
-) -> Result<Engine<B>, LixError>
-where
-    B: Backend + Clone + Send + Sync + 'static,
-    for<'backend> B::Read<'backend>: Send,
-    for<'backend> B::Write<'backend>: Send,
-{
-    match new_engine(backend.clone(), wasm_runtime.clone()).await {
-        Ok(engine) => Ok(engine),
-        Err(error) if error.code == "LIX_ERROR_NOT_INITIALIZED" => {
-            Engine::initialize(backend.clone()).await?;
-            new_engine(backend, wasm_runtime).await
-        }
-        Err(error) => Err(error),
-    }
-}
-
 async fn new_engine<B>(
     backend: B,
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -540,8 +540,9 @@ async fn open_lix_with_filesystem(path: &Path) -> Lix<FsBackend> {
 async fn open_lix_with_on_demand_filesystem(path: &Path, file_paths: &[&str]) -> Lix<FsBackend> {
     let options = FsBackendOpenOptions::new(path.to_path_buf(), false);
     let backend = FsBackend::open_with_options(options).await.unwrap();
-    let lix = open_lix_with_backend(backend).await.unwrap();
-    lix.import_filesystem_paths(file_paths.iter().copied())
+    let lix = open_lix_with_backend(backend.clone()).await.unwrap();
+    backend
+        .import_paths(file_paths.iter().copied())
         .await
         .unwrap();
     lix


### PR DESCRIPTION
## What changed

**v0.8 changenotes** — one fragment per user-facing engine/SDK change since v0.7.0, all `minor`/`patch`:

- `FsBackend` requires an explicit `syncAllFiles` option; `syncAllFiles: false` + `backend.importPaths()` gives on-demand file sync
- `lixDir` option stores lix state outside the workspace (enables ephemeral sync)
- `FsBackend.syncDiskToLix()` awaitable filesystem sync barrier
- Origin keys for tagging writes (`originKey` / `execute_with_options`, exposed as `origin_key` on `lix_change` and history surfaces)
- Truly async JS native bindings (no more event-loop blocking in Electron)
- Faster `lix_file` reads/writes with benchmark numbers, faster `ON CONFLICT` entity upserts
- LargeBinary file data surfaces (removes the 2 GB Arrow offset ceiling)
- MIT license

Also removes the stale `simplify-fs-backend-memory-storage` note, which described an intermediate API (`storage: "memory"`, `filter.includePaths`) that never shipped.

**Move filesystem sync methods from `Lix` to `FsBackend`** — `importFilesystemPaths()` and `syncDiskToLix()` were backend-specific operations on every `Lix` handle, failing at runtime for memory/SQLite backends:

- rs-sdk: removed the `impl Lix<FsBackend>` convenience block; `FsBackend::import_paths()` / `FsBackend::sync_disk_to_lix()` are the only surface. The napi bridge holds a backend clone alongside the `Lix` handle.
- js-sdk: `FsBackend` gains `importPaths()` and `syncDiskToLix()`, bound to the native handle by `openLix()` and released on `close()`. An `FsBackend` instance opens at most one Lix at a time (`LIX_FS_BACKEND_IN_USE`), is reusable after close, and throws `LIX_FS_BACKEND_NOT_OPEN` while unbound.
- Behavior note: in Rust, `backend.sync_disk_to_lix()` now works independently of the session lifecycle (consistent with the background watcher); the old `CODE_CLOSED`-after-close test was repurposed to pin this down. JS still errors after close via the native actor guard.

**Dead code**: removed `open_or_initialize_filesystem_engine`, a byte-identical duplicate of `open_or_initialize_engine`.

## Validation

- `cargo clippy --all-targets -D warnings` clean on `lix_sdk` and `lix_js_sdk`
- rs-sdk filesystem lib tests 16/16, e2e 32/32
- js-sdk: `tsc` typecheck clean, `open-lix.test.ts` 61/61 against a freshly built native addon
- `node scripts/validate-changes.mjs` validates all 9 fragments
- Docs updated: `docs/js-api-reference.md`, `docs/persistence.md`, js-sdk README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API for filesystem sync (`Lix` → `FsBackend`) affects all FS-backed integrations; behavior changes around post-close sync in Rust warrant careful consumer updates.
> 
> **Overview**
> Adds **v0.8 changenotes** for engine/SDK changes since v0.7 (async JS bindings, `FsBackend` options, origin keys, performance, large file reads, MIT license) and drops a stale note about an unreleased `storage: "memory"` API.
> 
> **Breaking JS/Rust surface:** filesystem sync moves off `Lix` onto **`FsBackend`**. Callers use `backend.importPaths()` (was `lix.importFilesystemPaths()`) and `backend.syncDiskToLix()` (was on `Lix`). Rust drops `Lix<FsBackend>` helpers; `FsBackend::import_paths` / `sync_disk_to_lix` are canonical, and in Rust **`sync_disk_to_lix` can run after the session is closed** (tests updated accordingly).
> 
> **js-sdk:** `openLix()` binds one native handle per `FsBackend` via a `WeakMap`; an instance allows **at most one open Lix** (`LIX_FS_BACKEND_IN_USE`), methods error when unbound (`LIX_FS_BACKEND_NOT_OPEN`), and binding clears on `close()`. NAPI keeps a cloned `FsBackend` next to the `Lix` handle for these calls.
> 
> **Cleanup:** removes duplicate `open_or_initialize_filesystem_engine`; docs/README examples follow the new `FsBackend` flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc50377e1e92696c5d7fc24c435a0812d4ffb8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->