### PR TITLE
Use Node WebAssembly for JS SDK plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,6 +3198,7 @@ dependencies = [
 name = "lix_js_sdk"
 version = "0.7.0"
 dependencies = [
+ "async-trait",
  "lix_sdk",
  "napi",
  "napi-derive",

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -21,8 +21,9 @@ crate-type = ["cdylib"]
 path = "native/lib.rs"
 
 [dependencies]
-lix_sdk = { path = "../rs-sdk", version = "0.7.0", default-features = false, features = ["default_wasm_runtime", "fs_backend", "sqlite"] }
+lix_sdk = { path = "../rs-sdk", version = "0.7.0", default-features = false, features = ["fs_backend", "sqlite"] }
 
+async-trait = "0.1"
 napi = { version = "3.9.0", default-features = false, features = ["napi6", "serde-json"] }
 napi-derive = "3.5.6"
 serde = { version = "1", features = ["derive"] }

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -82,5 +82,6 @@ try {
 - The SDK is Node/native only right now; it is not browser-compatible.
 - The package is ESM-only.
 - The native addon is built from Rust and loaded by the TypeScript wrapper.
+- Installed WASM plugin components are transpiled with JCO and executed by Node's built-in WebAssembly runtime.
 - SQL parameters use normal JavaScript values: `string`, finite `number`, `boolean`, `Uint8Array`, `null`, JSON-compatible arrays, and JSON-compatible plain objects.
 - Use `Value.integer(...)`, `Value.real(...)`, `Value.text(...)`, `Value.json(...)`, or `Value.blob(...)` only when you need to pass an explicit native Lix value.

--- a/packages/js-sdk/native/js_wasm_runtime.rs
+++ b/packages/js-sdk/native/js_wasm_runtime.rs
@@ -1,0 +1,315 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use lix_sdk::{
+    LixError, WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime,
+};
+use napi::Status;
+use napi::bindgen_prelude::{Buffer, CallbackContext, PromiseRaw, Unknown};
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use napi_derive::napi;
+
+pub(crate) type JsWasmRuntimeDispatch = ThreadsafeFunction<
+    JsWasmRuntimeRequest,
+    PromiseRaw<'static, JsWasmRuntimeResponse>,
+    JsWasmRuntimeRequest,
+    Status,
+    false,
+>;
+pub(crate) type SharedJsWasmRuntimeDispatch = Arc<JsWasmRuntimeDispatch>;
+
+pub(crate) struct JsWasmRuntime {
+    dispatch: SharedJsWasmRuntimeDispatch,
+}
+
+impl JsWasmRuntime {
+    pub(crate) fn new(dispatch: SharedJsWasmRuntimeDispatch) -> Self {
+        Self { dispatch }
+    }
+
+    async fn dispatch(
+        &self,
+        operation: &'static str,
+        request: JsWasmRuntimeRequest,
+    ) -> Result<JsWasmRuntimeResponse, LixError> {
+        dispatch_request(&self.dispatch, operation, request).await
+    }
+}
+
+#[async_trait]
+impl WasmRuntime for JsWasmRuntime {
+    async fn init_component(
+        &self,
+        bytes: Vec<u8>,
+        limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
+        let response = self
+            .dispatch(
+                "init-component",
+                JsWasmRuntimeRequest {
+                    operation: "initComponent".to_string(),
+                    component_id: None,
+                    component_bytes: Some(bytes.into()),
+                    max_memory_bytes: Some(limits.max_memory_bytes.to_string()),
+                    max_fuel: limits.max_fuel.map(|value| value.to_string()),
+                    timeout_ms: limits.timeout_ms.map(|value| value.to_string()),
+                    state: None,
+                    file: None,
+                },
+            )
+            .await?;
+        let component_id = response.component_id.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "JavaScript WASM runtime did not return a component id",
+            )
+        })?;
+        Ok(Arc::new(JsWasmComponent {
+            component_id,
+            dispatch: Arc::clone(&self.dispatch),
+        }))
+    }
+}
+
+struct JsWasmComponent {
+    component_id: u32,
+    dispatch: SharedJsWasmRuntimeDispatch,
+}
+
+impl JsWasmComponent {
+    async fn dispatch(
+        &self,
+        operation: &'static str,
+        request: JsWasmRuntimeRequest,
+    ) -> Result<JsWasmRuntimeResponse, LixError> {
+        dispatch_request(&self.dispatch, operation, request).await
+    }
+}
+
+#[async_trait]
+impl WasmComponentInstance for JsWasmComponent {
+    async fn detect_changes(
+        &self,
+        state: Vec<WasmPluginEntityState>,
+        file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+        let response = self
+            .dispatch(
+                "detect-changes",
+                JsWasmRuntimeRequest {
+                    operation: "detectChanges".to_string(),
+                    component_id: Some(self.component_id),
+                    component_bytes: None,
+                    max_memory_bytes: None,
+                    max_fuel: None,
+                    timeout_ms: None,
+                    state: Some(state.into_iter().map(Into::into).collect()),
+                    file: Some(file.into()),
+                },
+            )
+            .await?;
+        Ok(response
+            .changes
+            .unwrap_or_default()
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
+    async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
+        let response = self
+            .dispatch(
+                "render",
+                JsWasmRuntimeRequest {
+                    operation: "render".to_string(),
+                    component_id: Some(self.component_id),
+                    component_bytes: None,
+                    max_memory_bytes: None,
+                    max_fuel: None,
+                    timeout_ms: None,
+                    state: Some(state.into_iter().map(Into::into).collect()),
+                    file: None,
+                },
+            )
+            .await?;
+        response.bytes.map(Into::into).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "JavaScript WASM runtime did not return rendered bytes",
+            )
+        })
+    }
+}
+
+impl Drop for JsWasmComponent {
+    fn drop(&mut self) {
+        let _ = self.dispatch.call(
+            JsWasmRuntimeRequest {
+                operation: "closeComponent".to_string(),
+                component_id: Some(self.component_id),
+                component_bytes: None,
+                max_memory_bytes: None,
+                max_fuel: None,
+                timeout_ms: None,
+                state: None,
+                file: None,
+            },
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
+    }
+}
+
+async fn dispatch_request(
+    dispatch: &JsWasmRuntimeDispatch,
+    operation: &'static str,
+    request: JsWasmRuntimeRequest,
+) -> Result<JsWasmRuntimeResponse, LixError> {
+    type DispatchResult = Result<JsWasmRuntimeResponse, String>;
+    let (sender, receiver) = tokio::sync::oneshot::channel::<DispatchResult>();
+    let sender = Arc::new(Mutex::new(Some(sender)));
+    let callback_sender = Arc::clone(&sender);
+    let status = dispatch.call_with_return_value(
+        request,
+        ThreadsafeFunctionCallMode::NonBlocking,
+        move |promise, _env| {
+            let promise = match promise {
+                Ok(promise) => promise,
+                Err(error) => {
+                    settle_dispatch(&callback_sender, Err(error.to_string()));
+                    return Ok(());
+                }
+            };
+            let resolve_sender = Arc::clone(&callback_sender);
+            let reject_sender = Arc::clone(&callback_sender);
+            promise
+                .then(move |context| {
+                    settle_dispatch(&resolve_sender, Ok(context.value));
+                    Ok(())
+                })?
+                .catch(move |_context: CallbackContext<Unknown>| {
+                    settle_dispatch(
+                        &reject_sender,
+                        Err("JavaScript runtime promise rejected".to_string()),
+                    );
+                    Ok(())
+                })?;
+            Ok(())
+        },
+    );
+    if status != Status::Ok {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("JavaScript WASM runtime {operation} dispatch failed: {status:?}"),
+        ));
+    }
+    let response = receiver
+        .await
+        .map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("JavaScript WASM runtime {operation} response channel closed"),
+            )
+        })?
+        .map_err(|message| js_runtime_error(operation, message))?;
+    if let Some(message) = response.error_message.as_deref() {
+        return Err(js_runtime_error(operation, message));
+    }
+    Ok(response)
+}
+
+fn settle_dispatch(
+    sender: &Mutex<Option<tokio::sync::oneshot::Sender<Result<JsWasmRuntimeResponse, String>>>>,
+    result: Result<JsWasmRuntimeResponse, String>,
+) {
+    if let Ok(mut sender) = sender.lock()
+        && let Some(sender) = sender.take()
+    {
+        let _ = sender.send(result);
+    }
+}
+
+fn js_runtime_error(operation: &str, error: impl std::fmt::Display) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("JavaScript WASM runtime {operation} failed: {error}"),
+    )
+}
+
+#[expect(missing_debug_implementations)]
+#[napi(object)]
+pub struct JsWasmRuntimeRequest {
+    pub operation: String,
+    pub component_id: Option<u32>,
+    pub component_bytes: Option<Buffer>,
+    pub max_memory_bytes: Option<String>,
+    pub max_fuel: Option<String>,
+    pub timeout_ms: Option<String>,
+    pub state: Option<Vec<JsWasmPluginEntityState>>,
+    pub file: Option<JsWasmPluginFile>,
+}
+
+#[expect(missing_debug_implementations)]
+#[napi(object)]
+pub struct JsWasmRuntimeResponse {
+    pub component_id: Option<u32>,
+    pub changes: Option<Vec<JsWasmPluginDetectedChange>>,
+    pub bytes: Option<Buffer>,
+    pub error_message: Option<String>,
+}
+
+#[expect(missing_debug_implementations)]
+#[napi(object)]
+pub struct JsWasmPluginFile {
+    pub filename: Option<String>,
+    pub data: Buffer,
+}
+
+impl From<WasmPluginFile> for JsWasmPluginFile {
+    fn from(file: WasmPluginFile) -> Self {
+        Self {
+            filename: file.filename,
+            data: file.data.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+#[napi(object)]
+pub struct JsWasmPluginEntityState {
+    pub entity_pk: Vec<String>,
+    pub schema_key: String,
+    pub snapshot_content: String,
+    pub metadata: Option<String>,
+}
+
+impl From<WasmPluginEntityState> for JsWasmPluginEntityState {
+    fn from(state: WasmPluginEntityState) -> Self {
+        Self {
+            entity_pk: state.entity_pk,
+            schema_key: state.schema_key,
+            snapshot_content: state.snapshot_content,
+            metadata: state.metadata,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[napi(object)]
+pub struct JsWasmPluginDetectedChange {
+    pub entity_pk: Vec<String>,
+    pub schema_key: String,
+    pub snapshot_content: Option<String>,
+    pub metadata: Option<String>,
+}
+
+impl From<JsWasmPluginDetectedChange> for WasmPluginDetectedChange {
+    fn from(change: JsWasmPluginDetectedChange) -> Self {
+        Self {
+            entity_pk: change.entity_pk,
+            schema_key: change.schema_key,
+            snapshot_content: change.snapshot_content,
+            metadata: change.metadata,
+        }
+    }
+}

--- a/packages/js-sdk/native/lib.rs
+++ b/packages/js-sdk/native/lib.rs
@@ -1,1 +1,2 @@
+mod js_wasm_runtime;
 mod napi;

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -8,7 +8,6 @@ use lix_sdk::{
     ObserveEvent as RsObserveEvent, ObserveEvents as RsObserveEvents,
     OpenLixOptions as RsOpenLixOptions, SqliteBackend, SqliteBackendOptions,
     SwitchBranchOptions as RsSwitchBranchOptions, SwitchBranchReceipt, Value, open_lix,
-    open_lix_with_backend,
 };
 use napi::JsDeferred;
 use napi::bindgen_prelude::*;
@@ -22,6 +21,8 @@ use std::sync::{
 use std::thread;
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::watch;
+
+use crate::js_wasm_runtime::{JsWasmRuntime, SharedJsWasmRuntimeDispatch};
 
 #[expect(missing_debug_implementations)]
 #[napi(js_name = "Lix")]
@@ -656,19 +657,23 @@ impl NativeObserveEventsInner {
     }
 }
 
-#[derive(Debug)]
+#[expect(missing_debug_implementations)]
 pub struct OpenFsTask {
     path: String,
     lix_dir: Option<String>,
     sync_all_files: bool,
+    wasm_runtime_dispatch: Option<SharedJsWasmRuntimeDispatch>,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct OpenMemoryTask;
+#[expect(missing_debug_implementations)]
+pub struct OpenMemoryTask {
+    wasm_runtime_dispatch: Option<SharedJsWasmRuntimeDispatch>,
+}
 
-#[derive(Debug)]
+#[expect(missing_debug_implementations)]
 pub struct OpenSqliteTask {
     path: String,
+    wasm_runtime_dispatch: Option<SharedJsWasmRuntimeDispatch>,
 }
 
 impl Task for OpenFsTask {
@@ -676,10 +681,12 @@ impl Task for OpenFsTask {
     type JsValue = NativeLix;
 
     fn compute(&mut self) -> Result<Self::Output> {
+        let wasm_runtime_dispatch = take_wasm_runtime_dispatch(&mut self.wasm_runtime_dispatch)?;
         Ok(open_fs_native(
             std::mem::take(&mut self.path),
             self.lix_dir.take(),
             std::mem::take(&mut self.sync_all_files),
+            wasm_runtime_dispatch,
         ))
     }
 
@@ -693,7 +700,8 @@ impl Task for OpenMemoryTask {
     type JsValue = NativeLix;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        Ok(open_memory_native())
+        let wasm_runtime_dispatch = take_wasm_runtime_dispatch(&mut self.wasm_runtime_dispatch)?;
+        Ok(open_memory_native(wasm_runtime_dispatch))
     }
 
     fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -706,7 +714,11 @@ impl Task for OpenSqliteTask {
     type JsValue = NativeLix;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        Ok(open_sqlite_native(std::mem::take(&mut self.path)))
+        let wasm_runtime_dispatch = take_wasm_runtime_dispatch(&mut self.wasm_runtime_dispatch)?;
+        Ok(open_sqlite_native(
+            std::mem::take(&mut self.path),
+            wasm_runtime_dispatch,
+        ))
     }
 
     fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -714,22 +726,42 @@ impl Task for OpenSqliteTask {
     }
 }
 
-fn open_memory_native() -> std::result::Result<NativeLix, LixError> {
+fn take_wasm_runtime_dispatch(
+    dispatch: &mut Option<SharedJsWasmRuntimeDispatch>,
+) -> Result<SharedJsWasmRuntimeDispatch> {
+    dispatch.take().ok_or_else(|| {
+        Error::new(
+            Status::GenericFailure,
+            "JavaScript WASM runtime dispatch was already consumed",
+        )
+    })
+}
+
+fn open_memory_native(
+    wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+) -> std::result::Result<NativeLix, LixError> {
     let rt = Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
-    let lix = rt.block_on(open_lix(RsOpenLixOptions::default()))?;
+    let options = RsOpenLixOptions::default()
+        .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
+    let lix = rt.block_on(open_lix(options))?;
     NativeLix::new(NativeLixInner::Memory(lix))
 }
 
-fn open_sqlite_native(path: String) -> std::result::Result<NativeLix, LixError> {
+fn open_sqlite_native(
+    path: String,
+    wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+) -> std::result::Result<NativeLix, LixError> {
     let rt = Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
     let backend = SqliteBackend::new(SqliteBackendOptions { path: path.into() })?;
-    let lix = rt.block_on(open_lix_with_backend(backend))?;
+    let options = RsOpenLixOptions::new(backend)
+        .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
+    let lix = rt.block_on(open_lix(options))?;
     NativeLix::new(NativeLixInner::Sqlite(lix))
 }
 
@@ -737,6 +769,7 @@ fn open_fs_native(
     path: String,
     lix_dir: Option<String>,
     sync_all_files: bool,
+    wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
 ) -> std::result::Result<NativeLix, LixError> {
     let rt = Builder::new_current_thread()
         .enable_all()
@@ -745,20 +778,32 @@ fn open_fs_native(
     let mut options = FsBackendOpenOptions::new(path, sync_all_files);
     options.lix_dir = lix_dir.map(Into::into);
     let backend = rt.block_on(FsBackend::open_with_options(options))?;
-    let lix = rt.block_on(open_lix_with_backend(backend.clone()))?;
+    let options = RsOpenLixOptions::new(backend.clone())
+        .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
+    let lix = rt.block_on(open_lix(options))?;
     NativeLix::new(NativeLixInner::Fs(lix, backend))
 }
 
 #[napi]
 impl NativeLix {
     #[napi(js_name = "openMemory")]
-    pub fn open_memory() -> AsyncTask<OpenMemoryTask> {
-        AsyncTask::new(OpenMemoryTask)
+    pub fn open_memory(
+        wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+    ) -> AsyncTask<OpenMemoryTask> {
+        AsyncTask::new(OpenMemoryTask {
+            wasm_runtime_dispatch: Some(wasm_runtime_dispatch),
+        })
     }
 
     #[napi(js_name = "openSqlite")]
-    pub fn open_sqlite(path: String) -> AsyncTask<OpenSqliteTask> {
-        AsyncTask::new(OpenSqliteTask { path })
+    pub fn open_sqlite(
+        path: String,
+        wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+    ) -> AsyncTask<OpenSqliteTask> {
+        AsyncTask::new(OpenSqliteTask {
+            path,
+            wasm_runtime_dispatch: Some(wasm_runtime_dispatch),
+        })
     }
 
     #[napi(js_name = "openFs")]
@@ -766,11 +811,13 @@ impl NativeLix {
         path: String,
         lix_dir: Option<String>,
         sync_all_files: bool,
+        wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
     ) -> AsyncTask<OpenFsTask> {
         AsyncTask::new(OpenFsTask {
             path,
             lix_dir,
             sync_all_files,
+            wasm_runtime_dispatch: Some(wasm_runtime_dispatch),
         })
     }
 

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -8,6 +8,11 @@
 			"name": "@lix-js/sdk",
 			"version": "0.7.0",
 			"license": "MIT",
+			"dependencies": {
+				"@bytecodealliance/jco-transpile": "0.4.2",
+				"@bytecodealliance/preview2-shim": "0.19.0",
+				"fflate": "^0.8.3"
+			},
 			"devDependencies": {
 				"@types/node": "^24.10.2",
 				"typescript": "^5.5.4",
@@ -20,11 +25,37 @@
 				"@lix-js/sdk-win32-x64": "0.7.0"
 			}
 		},
+		"node_modules/@bytecodealliance/jco-transpile": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@bytecodealliance/jco-transpile/-/jco-transpile-0.4.2.tgz",
+			"integrity": "sha512-45aeQsUSJsrru1FY1EU47T6kREUkQ7QC1EwIqb5Vi3yakrl6cyqOTRG005k/BWq/fNR0i0n3QtTZQRoF4fi88g==",
+			"license": "(Apache-2.0 WITH LLVM-exception)",
+			"dependencies": {
+				"@bytecodealliance/preview2-shim": "^0.19.0",
+				"@bytecodealliance/preview3-shim": "^0.2.0",
+				"binaryen": "^130.0.0",
+				"oxc-minify": "^0.136.0"
+			}
+		},
+		"node_modules/@bytecodealliance/preview2-shim": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.19.0.tgz",
+			"integrity": "sha512-OSUlcM62fXLuzYP0DjBn/SwjKMZ/y/2PMXZ8v5cRiiFcroauntlPRl/oCnx0xYjYiqdYvE0PY50VCNutll0xOw==",
+			"license": "(Apache-2.0 WITH LLVM-exception)"
+		},
+		"node_modules/@bytecodealliance/preview3-shim": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@bytecodealliance/preview3-shim/-/preview3-shim-0.2.0.tgz",
+			"integrity": "sha512-44zSPzlOyF/hWTNK32odet+Jt/nVXgtboSvgvZqMEJKP9GuM+Ln3L6js31WAakDEe+TYgG4iNEBk39rByINZkA==",
+			"license": "(Apache-2.0 WITH LLVM-exception)",
+			"dependencies": {
+				"@bytecodealliance/preview2-shim": "^0.19.0"
+			}
+		},
 		"node_modules/@emnapi/core": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
 			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -36,7 +67,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
 			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -47,11 +77,48 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
 			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
@@ -61,15 +128,75 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@lix-js/sdk-darwin-arm64": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-darwin-arm64/-/sdk-darwin-arm64-0.7.0.tgz",
+			"integrity": "sha512-Cfwypl8JGoDFvbubcc2ekiOgEazFQOXlnjX2uP60XEOd0AXAPFAbxgWf2ii+ekyRxmboSouRej6w4MBNXaRacw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@lix-js/sdk-linux-arm64": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-arm64/-/sdk-linux-arm64-0.7.0.tgz",
+			"integrity": "sha512-DskfAJPeNQoNFLtI56Upu9sFtlu2+dnr7b84f8K6ovSGmDFkUTHppMRHsVd975AbdhO0R3Y1ZZSRrFxBX/3Oqw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lix-js/sdk-linux-x64": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-x64/-/sdk-linux-x64-0.7.0.tgz",
+			"integrity": "sha512-BBgAxTNM/h+i6oVtGKqEnnrUglLQgnO3iKtzbOdN/c+SbFIt/13+tMF/X7XyOsQmjgkcj2/hIqAZY6oGtwsB2g==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lix-js/sdk-win32-x64": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk-win32-x64/-/sdk-win32-x64-0.7.0.tgz",
+			"integrity": "sha512-O1ECA2fOoCLDarbzKVbOCI13x/2a0GgFtrwHwcQTzEJLbrT1dkWNOAAhaN5AJm4L553sCtPDtWWxiVlYkVg7yw==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.3"
 			},
 			"funding": {
 				"type": "github",
@@ -78,6 +205,359 @@
 			"peerDependencies": {
 				"@emnapi/core": "^1.7.1",
 				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@oxc-minify/binding-android-arm-eabi": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.136.0.tgz",
+			"integrity": "sha512-gk1jzky1vLeOcK7w9Ib2RT/UooZ7O21s8YSeXCsy4tzsmguKb3Cbsv/Ra2fKhMp4mKeKCzvC1Xa41OfSBWfWdQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-android-arm64": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.136.0.tgz",
+			"integrity": "sha512-5GIYanqud/ohXEcg2dsdn0+eSKXqclw5qlRUkvSM1sKEa4ZQ7hqOk8XPJBNPh3LXXw+Qw85B6jkmOFLKsCHp5w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-darwin-arm64": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.136.0.tgz",
+			"integrity": "sha512-QAMpHKXWOoMCTenSZjQjVT5YmMooujlCKAf1T3PHFl2LuaA6ukQFXba0bgSLgAxRrAeX/itkwi4lzVQXtYmnRg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-darwin-x64": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.136.0.tgz",
+			"integrity": "sha512-rDnoPj8hztiU8C1VNKuzujh7SgTJlgiUvUCiWQjTnVSLsABsLW9ZWd1l1Ji0VN3UW39wGpptgvahIWTrHnGH/A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-freebsd-x64": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.136.0.tgz",
+			"integrity": "sha512-9fGSgP7uyPLCTjMx9z3AUV4UjnfOVoGTH5JzamLegPwGLJ97Gr1jht1437CRk8ZNabGmxQR6qNn3e+Tox2lswg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.136.0.tgz",
+			"integrity": "sha512-k0QvZS+x6ROI4O5Ikqn9dDU2dmkEJ46Yh6baZJI/eUk/a1k1GOs9/vyXItLZrKlwYrSgdEx2BFXbKgyd1NyRPw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.136.0.tgz",
+			"integrity": "sha512-iRFxUc8ubotVfuyq3e4LPGbHrjvWd1/B3499a55GueMLc1EDJ0fHzNXJiCx2eMQGfzHtHodjmvrJ2BSvSXBNhQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm64-gnu": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.136.0.tgz",
+			"integrity": "sha512-hbKxNCXJsULrb6EyG5SumzJKuPfP8Y0UQ/TElRgXVUhyyPf6cBPlF8HMq+MAylF98ACBzV8jBp2Mm62lJyTo+w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-arm64-musl": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.136.0.tgz",
+			"integrity": "sha512-T+u/CGKW0UXemJeVux4ix6rK+ug3bQCUEbu5hFlX9K61KQNd44rOcrM15mDK99L7USaXwmiwHeIkEDvmmyDMSA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.136.0.tgz",
+			"integrity": "sha512-WNPTN2F448tb49BoqjV9IMRzZWa0WB8GHzrB+bnxKQPOyzz07T6rmDKrr4Hjl81ADGjDYSsr1fgXcjyLQFdMdw==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.136.0.tgz",
+			"integrity": "sha512-MvcCfu8OeabrmNN9wqhh8Gqizg68RQ3iOvXBJmlLMy5p1PC6az9bAwqOk98lsCmKI4I5LpULekOlfxRYh3o5Kw==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-riscv64-musl": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.136.0.tgz",
+			"integrity": "sha512-rwJXFUFFA0egAULtOOgfW8YhhLhtWrr2qFxftvZ7/U6Xtxiev8i+eCwSNW1RpHiX74QMsJVpRE3ykoefqb1MtQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-s390x-gnu": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.136.0.tgz",
+			"integrity": "sha512-qizAxHmj7VHm5/D5qiIlvzxAS2tlmadDOJ5XFI7zx/wfnk/+fdk5iVaHOv+C4tDE/4wLQyMoBYVIs6R1LeN91w==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-x64-gnu": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.136.0.tgz",
+			"integrity": "sha512-gcyLAad0UblkEhGjVfx5Mwq63OSx8r04IbcfwzpZYpHisO/vioMsrs4GkDsQZ2Ejc8cdUk6YMIrf9FwNBzh+Dw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-linux-x64-musl": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.136.0.tgz",
+			"integrity": "sha512-QAK6kwBjljX6luYzeppVdRP3gTaFNFfp9iS/V0cCvU43wUZay5xFXBgmzBHYrzZV2MhzURNnXfEZRo9poAxyvA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-openharmony-arm64": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.136.0.tgz",
+			"integrity": "sha512-nIGxkTOnN9GwslmooxbZ3Ti2RgbX9QLHy0X9uO0pslOT+4dsNVUawBU/6r4M5cWM+ZdRD2tOF4V+n0l8tS59nQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-wasm32-wasi": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.136.0.tgz",
+			"integrity": "sha512-YB3G8AHT6PpDS8/DfjlJrQjywj+/6gCkNBcAJdYzcYbQRIZE6SaTNowiGuZPR1m1jOl1WjcjefniKSmVxzhvRA==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.5"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-win32-arm64-msvc": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.136.0.tgz",
+			"integrity": "sha512-UVRH3BlNc2rmla+sbSd5xTF/u+esCqZS6VSWPolZybcBh3TlVe1Sf5MOuHQWUaFoyv5uFOvee4hOfS/14nPvZw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-win32-ia32-msvc": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.136.0.tgz",
+			"integrity": "sha512-zFGkUd82jci0E+isc2O36lVmmXVUDXyEMN2RYIyez+MBNqhdjPLIGx62FCsrJtLKeuiPf/8XkFv977aUtndUng==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-minify/binding-win32-x64-msvc": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.136.0.tgz",
+			"integrity": "sha512-VHgPwd5xibC9UYxBeq7nURTjY+wxhdumllij6JaCIUVfD9IRcrA66SVlJ5fPNoUXcRp8ZXhJfoIZwVz9wAEGJw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@oxc-project/types": {
@@ -362,10 +842,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-			"dev": true,
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -520,6 +999,21 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/acorn": {
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -529,6 +1023,32 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/binaryen": {
+			"version": "130.0.0",
+			"resolved": "https://registry.npmjs.org/binaryen/-/binaryen-130.0.0.tgz",
+			"integrity": "sha512-XDrb+zql0RbFPKgj7MuH9zOc78R3Fa/P/VSGnnpdwYsvNZPWjcMYMdAkKCOQEL2A7yqgjSMTDRFp6gfSDW+/QQ==",
+			"license": "Apache-2.0",
+			"bin": {
+				"wasm-as": "bin/wasm-as",
+				"wasm-ctor-eval": "bin/wasm-ctor-eval",
+				"wasm-dis": "bin/wasm-dis",
+				"wasm-merge": "bin/wasm-merge",
+				"wasm-metadce": "bin/wasm-metadce",
+				"wasm-opt": "bin/wasm-opt",
+				"wasm-reduce": "bin/wasm-reduce",
+				"wasm-shell": "bin/wasm-shell",
+				"wasm2js": "bin/wasm2js"
+			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/chai": {
 			"version": "6.2.2",
@@ -601,6 +1121,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+			"license": "MIT"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -918,6 +1444,40 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/oxc-minify": {
+			"version": "0.136.0",
+			"resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.136.0.tgz",
+			"integrity": "sha512-u9UvPFTYVwQ/i1kpp/c20S/SbvLaLV0Ngzyhgi0YV4B1SlxM7RgnnePl4vY9N3Z9sTRcozL1MRStI3PlUN9RFA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-minify/binding-android-arm-eabi": "0.136.0",
+				"@oxc-minify/binding-android-arm64": "0.136.0",
+				"@oxc-minify/binding-darwin-arm64": "0.136.0",
+				"@oxc-minify/binding-darwin-x64": "0.136.0",
+				"@oxc-minify/binding-freebsd-x64": "0.136.0",
+				"@oxc-minify/binding-linux-arm-gnueabihf": "0.136.0",
+				"@oxc-minify/binding-linux-arm-musleabihf": "0.136.0",
+				"@oxc-minify/binding-linux-arm64-gnu": "0.136.0",
+				"@oxc-minify/binding-linux-arm64-musl": "0.136.0",
+				"@oxc-minify/binding-linux-ppc64-gnu": "0.136.0",
+				"@oxc-minify/binding-linux-riscv64-gnu": "0.136.0",
+				"@oxc-minify/binding-linux-riscv64-musl": "0.136.0",
+				"@oxc-minify/binding-linux-s390x-gnu": "0.136.0",
+				"@oxc-minify/binding-linux-x64-gnu": "0.136.0",
+				"@oxc-minify/binding-linux-x64-musl": "0.136.0",
+				"@oxc-minify/binding-openharmony-arm64": "0.136.0",
+				"@oxc-minify/binding-wasm32-wasi": "0.136.0",
+				"@oxc-minify/binding-win32-arm64-msvc": "0.136.0",
+				"@oxc-minify/binding-win32-ia32-msvc": "0.136.0",
+				"@oxc-minify/binding-win32-x64-msvc": "0.136.0"
+			}
+		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1015,6 +1575,18 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1023,6 +1595,19 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/stackback": {
@@ -1038,6 +1623,36 @@
 			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/terser": {
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+			"integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.15.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -1087,7 +1702,6 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
 			"license": "0BSD",
 			"optional": true
 		},

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -39,6 +39,8 @@
 		"vitest": "^4.0.18"
 	},
 	"dependencies": {
+		"@bytecodealliance/jco-transpile": "0.4.2",
+		"@bytecodealliance/preview2-shim": "0.19.0",
 		"fflate": "^0.8.3"
 	}
 }

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -20,6 +20,7 @@ import {
 	type Lix,
 } from "./index.js";
 import { addon } from "./native.js";
+import { createPluginRuntimeDispatch } from "./plugin-runtime.js";
 
 test("openLix exposes the lix-sdk e2e flow", async () => {
 	const lix = await openLix();
@@ -303,14 +304,19 @@ test("native fs open returns a promise", async () => {
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "note.md"), "local");
 
-	const native = addon.Lix.openFs(dir, undefined, true);
+	const native = addon.Lix.openFs(
+		dir,
+		undefined,
+		true,
+		createPluginRuntimeDispatch(),
+	);
 	expect(native).toBeInstanceOf(Promise);
 	const lix = await native;
 	await lix.close();
 });
 
 test("native awaited APIs return promises", async () => {
-	const opened = addon.Lix.openMemory();
+	const opened = addon.Lix.openMemory(createPluginRuntimeDispatch());
 	expect(opened).toBeInstanceOf(Promise);
 	const lix = await opened;
 
@@ -1045,6 +1051,65 @@ test("SQL plugin archive upsert stores the archive and installs schemas", async 
 		"csv_row",
 		"csv_table",
 	]);
+
+	await lix.close();
+});
+
+test("bundled CSV plugin executes detect-changes and render", async () => {
+	const lix = await openLix();
+	const csvPlugin = (await bundledPluginArchives()).find(
+		(plugin) => plugin.key === "plugin_csv",
+	);
+	if (!csvPlugin) {
+		throw new Error("expected bundled CSV plugin");
+	}
+
+	await upsertPluginArchive(lix, csvPlugin.key, csvPlugin.archiveBytes);
+	const source = "name,age\nAda,36\nGrace,37\n";
+	await writeFile(lix, "/people.csv", new TextEncoder().encode(source));
+
+	const result = await lix.execute(
+		"SELECT cells FROM csv_row ORDER BY order_key",
+	);
+	expect(result.rows.map((row) => row.get("cells"))).toEqual([
+		["name", "age"],
+		["Ada", "36"],
+		["Grace", "37"],
+	]);
+
+	const rendered = await readFile(lix, "/people.csv");
+	expect(rendered && new TextDecoder().decode(rendered)).toBe(source);
+
+	await lix.close();
+});
+
+test("bundled Markdown plugin executes detect-changes and render", async () => {
+	const lix = await openLix();
+	const markdownPlugin = (await bundledPluginArchives()).find(
+		(plugin) => plugin.key === "plugin_md_v2",
+	);
+	if (!markdownPlugin) {
+		throw new Error("expected bundled Markdown plugin");
+	}
+
+	await upsertPluginArchive(
+		lix,
+		markdownPlugin.key,
+		markdownPlugin.archiveBytes,
+	);
+	const source = "# Heading\n\nParagraph with **bold** text.\n";
+	await writeFile(lix, "/notes.md", new TextEncoder().encode(source));
+
+	const blocks = await lix.execute(
+		"SELECT block FROM markdown_block ORDER BY order_key",
+	);
+	expect(blocks.rows.map((row) => row.get("block"))).toEqual([
+		"# Heading",
+		"Paragraph with **bold** text.",
+	]);
+
+	const rendered = await readFile(lix, "/notes.md");
+	expect(rendered && new TextDecoder().decode(rendered)).toBe(source);
 
 	await lix.close();
 });

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -4,6 +4,7 @@ import {
 	invalidArgument,
 } from "./errors.js";
 import { addon } from "./native.js";
+import { createPluginRuntimeDispatch } from "./plugin-runtime.js";
 import { normalizeOptionals, wrapExecuteResult } from "./result.js";
 import { normalizeParam, toNativeValue } from "./value.js";
 import type {
@@ -147,11 +148,17 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 	if (!options || typeof options !== "object") {
 		throw new TypeError("openLix() options must be an object");
 	}
+	const pluginRuntimeDispatch = createPluginRuntimeDispatch();
 	if (options.backend === undefined) {
-		return new Lix(await addon.Lix.openMemory());
+		return new Lix(await addon.Lix.openMemory(pluginRuntimeDispatch));
 	}
 	if (options.backend instanceof SqliteBackend) {
-		return new Lix(await addon.Lix.openSqlite(options.backend.path));
+		return new Lix(
+			await addon.Lix.openSqlite(
+				options.backend.path,
+				pluginRuntimeDispatch,
+			),
+		);
 	}
 	if (options.backend instanceof FsBackend) {
 		const backend = options.backend;
@@ -164,6 +171,7 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 				backend.path,
 				backend.lixDir,
 				backend.syncAllFiles,
+				pluginRuntimeDispatch,
 			);
 			openFsBackends.set(backend, native);
 			return new Lix(native, () => openFsBackends.delete(backend));

--- a/packages/js-sdk/src/plugin-runtime.ts
+++ b/packages/js-sdk/src/plugin-runtime.ts
@@ -52,9 +52,17 @@ type PluginApi = {
 	render(state: PluginEntityState[]): Uint8Array;
 };
 
+type WebAssemblyHost = {
+	compile(bytes: ArrayBuffer): Promise<object>;
+};
+
+const webAssembly = (
+	globalThis as typeof globalThis & { WebAssembly: WebAssemblyHost }
+).WebAssembly;
+
 type InstantiationModule = {
 	instantiate(
-		getCoreModule: (path: string) => Promise<WebAssembly.Module>,
+		getCoreModule: (path: string) => Promise<object>,
 		imports: Record<string, unknown>,
 	): Promise<{ api?: PluginApi }>;
 };
@@ -113,7 +121,7 @@ class NodeWasmPluginRuntime {
 		});
 		const instance = await generatedModule.instantiate(
 			async (path) =>
-				await WebAssembly.compile(copyArrayBuffer(requiredFile(files, path))),
+				await webAssembly.compile(copyArrayBuffer(requiredFile(files, path))),
 			wasi.getImportObject() as Record<string, unknown>,
 		);
 		if (!instance.api) {

--- a/packages/js-sdk/src/plugin-runtime.ts
+++ b/packages/js-sdk/src/plugin-runtime.ts
@@ -1,0 +1,193 @@
+import { transpileBytes } from "@bytecodealliance/jco-transpile";
+import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
+
+type PluginRuntimeOperation =
+	| "initComponent"
+	| "detectChanges"
+	| "render"
+	| "closeComponent";
+
+export type PluginRuntimeRequest = {
+	operation: PluginRuntimeOperation;
+	componentId?: number;
+	componentBytes?: Uint8Array;
+	maxMemoryBytes?: string;
+	maxFuel?: string;
+	timeoutMs?: string;
+	state?: PluginEntityState[];
+	file?: PluginFile;
+};
+
+export type PluginRuntimeResponse = {
+	componentId?: number;
+	changes?: PluginDetectedChange[];
+	bytes?: Uint8Array;
+	errorMessage?: string;
+};
+
+type PluginFile = {
+	filename?: string;
+	data: Uint8Array;
+};
+
+type PluginEntityState = {
+	entityPk: string[];
+	schemaKey: string;
+	snapshotContent: string;
+	metadata?: string;
+};
+
+type PluginDetectedChange = {
+	entityPk: string[];
+	schemaKey: string;
+	snapshotContent?: string;
+	metadata?: string;
+};
+
+type PluginApi = {
+	detectChanges(
+		state: PluginEntityState[],
+		file: PluginFile,
+	): PluginDetectedChange[];
+	render(state: PluginEntityState[]): Uint8Array;
+};
+
+type InstantiationModule = {
+	instantiate(
+		getCoreModule: (path: string) => Promise<WebAssembly.Module>,
+		imports: Record<string, unknown>,
+	): Promise<{ api?: PluginApi }>;
+};
+
+class NodeWasmPluginRuntime {
+	private nextComponentId = 1;
+	private readonly components = new Map<number, PluginApi>();
+
+	readonly dispatch = async (
+		request: PluginRuntimeRequest,
+	): Promise<PluginRuntimeResponse> => {
+		try {
+			switch (request.operation) {
+				case "initComponent":
+					return await this.initComponent(request);
+				case "detectChanges":
+					return this.detectChanges(request);
+				case "render":
+					return this.render(request);
+				case "closeComponent":
+					return this.closeComponent(request);
+			}
+		} catch (cause) {
+			return {
+				errorMessage: `Lix plugin runtime ${request.operation} failed: ${errorMessage(cause)}`,
+			};
+		}
+	};
+
+	private async initComponent(
+		request: PluginRuntimeRequest,
+	): Promise<PluginRuntimeResponse> {
+		if (!request.componentBytes) {
+			throw new TypeError("initComponent requires componentBytes");
+		}
+		const componentId = this.nextComponentId;
+		this.nextComponentId += 1;
+		const name = "lix_plugin";
+		const transpiled = await transpileBytes(request.componentBytes, {
+			name,
+			emitTypescriptDeclarations: false,
+			instantiation: "async",
+			nodejsCompat: false,
+		});
+		const files = new Map(Object.entries(transpiled.files));
+		const moduleSource = requiredFile(files, `${name}.js`);
+		const moduleUrl = `data:text/javascript;base64,${Buffer.from(moduleSource).toString("base64")}`;
+		const generatedModule = (await import(moduleUrl)) as InstantiationModule;
+		const wasi = new WASIShim({
+			sandbox: {
+				preopens: {},
+				env: {},
+				args: ["lix-plugin"],
+				enableNetwork: false,
+			},
+		});
+		const instance = await generatedModule.instantiate(
+			async (path) =>
+				await WebAssembly.compile(copyArrayBuffer(requiredFile(files, path))),
+			wasi.getImportObject() as Record<string, unknown>,
+		);
+		if (!instance.api) {
+			throw new Error("component does not export lix:plugin/api");
+		}
+		this.components.set(componentId, instance.api);
+		return { componentId };
+	}
+
+	private detectChanges(request: PluginRuntimeRequest): PluginRuntimeResponse {
+		const component = this.requiredComponent(request.componentId);
+		if (!request.file) {
+			throw new TypeError("detectChanges requires file");
+		}
+		return {
+			changes: component.detectChanges(request.state ?? [], request.file),
+		};
+	}
+
+	private render(request: PluginRuntimeRequest): PluginRuntimeResponse {
+		const component = this.requiredComponent(request.componentId);
+		return { bytes: component.render(request.state ?? []) };
+	}
+
+	private closeComponent(request: PluginRuntimeRequest): PluginRuntimeResponse {
+		if (request.componentId !== undefined) {
+			this.components.delete(request.componentId);
+		}
+		return {};
+	}
+
+	private requiredComponent(componentId: number | undefined): PluginApi {
+		if (componentId === undefined) {
+			throw new TypeError("plugin runtime operation requires componentId");
+		}
+		const component = this.components.get(componentId);
+		if (!component) {
+			throw new Error(`unknown plugin component ${componentId}`);
+		}
+		return component;
+	}
+}
+
+export function createPluginRuntimeDispatch(): NodeWasmPluginRuntime["dispatch"] {
+	return new NodeWasmPluginRuntime().dispatch;
+}
+
+function requiredFile(
+	files: ReadonlyMap<string, Uint8Array>,
+	path: string,
+): Uint8Array {
+	const file = files.get(path);
+	if (!file) {
+		throw new Error(`JCO output is missing ${path}`);
+	}
+	return file;
+}
+
+function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	return copy.buffer;
+}
+
+function errorMessage(cause: unknown): string {
+	if (cause instanceof Error) {
+		return cause.message;
+	}
+	if (cause && typeof cause === "object") {
+		const tag = "tag" in cause ? String(cause.tag) : undefined;
+		const value = "val" in cause ? String(cause.val) : undefined;
+		if (tag || value) {
+			return [tag, value].filter(Boolean).join(": ");
+		}
+	}
+	return String(cause);
+}

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-		"lib": ["ES2024"],
+		"lib": ["ES2024", "DOM"],
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
 		"outDir": "dist",

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-		"lib": ["ES2024", "DOM"],
+		"lib": ["ES2024"],
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
 		"outDir": "dist",


### PR DESCRIPTION
## Summary

- remove the JS SDK's dependency on the Rust SDK's default Wasmtime runtime
- bridge the engine's WASM component runtime interface to JavaScript through N-API
- transpile installed components at runtime with JCO and execute them with Node's built-in WebAssembly engine
- cover bundled CSV and Markdown plugin detection and rendering end to end

## Why

The Node JS SDK already runs inside V8, so bundling Wasmtime solely for plugin execution duplicates the WASM runtime and increases the native artifact and dependency surface. This keeps the Rust engine/runtime interface intact while letting the JavaScript host provide component execution.

## Impact

The public JS SDK API is unchanged. Memory, SQLite, and filesystem-backed Lix instances all receive the JavaScript plugin runtime. Installed CSV and Markdown plugins now materialize and render through Node WebAssembly.

This PR is intentionally Node-only. It does not add browser support or worker isolation. Plugin calls currently run synchronously on the JavaScript thread, and the adapter does not enforce the engine's fuel, timeout, or memory-limit fields; worker-based isolation can be evaluated separately if untrusted plugin execution becomes part of the scope.

## Validation

- `npm test` — 63 tests passed
- `npm run typecheck`
- `cargo clippy -p lix_js_sdk --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the plugin execution stack and Rust/JS threading boundary for all backends; limits from the engine (fuel, timeout, memory) are passed through but not enforced in the JS adapter, and plugin work can block the JS thread.
> 
> **Overview**
> Replaces the JS SDK’s bundled **Wasmtime** path with a **JavaScript-hosted WASM runtime**: the Rust native addon implements `WasmRuntime` by dispatching `initComponent`, `detectChanges`, `render`, and `closeComponent` to Node through an N-API threadsafe function, and every `openLix` / native open path injects that dispatch via `OpenLixOptions::with_wasm_runtime`.
> 
> On the TypeScript side, **`plugin-runtime.ts`** transpiles installed component bytes with **JCO**, instantiates them with Node’s built-in **WebAssembly** and **preview2 WASI** shims, and keeps component instances in a map keyed by id. **`lix_sdk`** no longer enables `default_wasm_runtime`; runtime deps add `@bytecodealliance/jco-transpile` and `@bytecodealliance/preview2-shim`.
> 
> The public **`openLix()`** API is unchanged. New e2e tests assert bundled **CSV** and **Markdown** plugins detect changes and round-trip render after archive install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63ae93e254e53e5de165625d401ca0c0e803312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->