### PR TITLE
Unify SQL partition coalescing across runtimes

### DIFF
--- a/packages/engine/src/sql2/runtime.rs
+++ b/packages/engine/src/sql2/runtime.rs
@@ -1,11 +1,22 @@
+use std::any::Any;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::{DataFusionError, internal_err};
 use datafusion::dataframe::DataFrame;
 use datafusion::error::Result;
 use datafusion::execution::TaskContext;
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
-use futures_util::TryStreamExt;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::execution_plan::CardinalityEffect;
+use datafusion::physical_plan::limit::LimitStream;
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    SendableRecordBatchStream, Statistics,
+};
+use futures_util::{StreamExt, TryStreamExt, stream};
 
 pub(crate) async fn collect_dataframe(dataframe: DataFrame) -> Result<Vec<RecordBatch>> {
     let task_ctx = Arc::new(dataframe.task_ctx());
@@ -17,7 +28,7 @@ pub(crate) async fn collect_input_plan(
     plan: Arc<dyn ExecutionPlan>,
     task_ctx: Arc<TaskContext>,
 ) -> Result<Vec<RecordBatch>> {
-    validate_physical_plan(&plan)?;
+    let plan = adapt_runtime_plan(plan)?;
     let partition_count = plan.output_partitioning().partition_count();
     let mut batches = Vec::new();
     for partition in 0..partition_count {
@@ -30,32 +41,154 @@ pub(crate) async fn collect_input_plan(
     Ok(batches)
 }
 
-#[cfg(not(target_family = "wasm"))]
-#[expect(clippy::unnecessary_wraps)]
-fn validate_physical_plan(_plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
-    Ok(())
-}
-
-#[cfg(target_family = "wasm")]
-fn validate_physical_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
-    let operator_name = plan.name();
-    if is_wasm_unsafe_operator(operator_name) {
-        return Err(datafusion::error::DataFusionError::Plan(format!(
-            "SQL physical operator '{operator_name}' is not supported by the WebAssembly runtime yet"
-        )));
-    }
-
+fn adapt_runtime_plan(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    let mut children_changed = false;
+    let mut children = Vec::new();
     for child in plan.children() {
-        validate_physical_plan(child)?;
+        let original = Arc::clone(child);
+        let adapted = adapt_runtime_plan(Arc::clone(child))?;
+        children_changed |= !Arc::ptr_eq(&original, &adapted);
+        children.push(adapted);
     }
+    let plan = if children_changed {
+        plan.with_new_children(children)?
+    } else {
+        plan
+    };
 
-    Ok(())
+    let Some(coalesce) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() else {
+        return Ok(plan);
+    };
+    Ok(Arc::new(SerialCoalescePartitionsExec::new(
+        Arc::clone(coalesce.input()),
+        coalesce.fetch(),
+    )))
 }
 
-#[cfg(target_family = "wasm")]
-fn is_wasm_unsafe_operator(operator_name: &str) -> bool {
-    matches!(
-        operator_name,
-        "CoalescePartitionsExec" | "RepartitionExec" | "SortPreservingMergeExec"
-    )
+/// Runtime-neutral partition coalescing.
+///
+/// DataFusion's coalescer spawns one task per input partition. Lix deliberately
+/// uses a single-partition SQL session and can merge the structural partitions
+/// produced by operators such as `UNION ALL` serially instead. Keeping this
+/// adapter target-independent gives native and WebAssembly the same SQL plan
+/// semantics without relying on runtime-specific task spawning.
+#[derive(Debug)]
+struct SerialCoalescePartitionsExec {
+    input: Arc<dyn ExecutionPlan>,
+    fetch: Option<usize>,
+    metrics: ExecutionPlanMetricsSet,
+    properties: Arc<PlanProperties>,
+}
+
+impl SerialCoalescePartitionsExec {
+    fn new(input: Arc<dyn ExecutionPlan>, fetch: Option<usize>) -> Self {
+        let datafusion_plan = CoalescePartitionsExec::new(Arc::clone(&input)).with_fetch(fetch);
+        Self {
+            input,
+            fetch,
+            metrics: ExecutionPlanMetricsSet::new(),
+            properties: Arc::clone(datafusion_plan.properties()),
+        }
+    }
+}
+
+impl DisplayAs for SerialCoalescePartitionsExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SerialCoalescePartitionsExec")?;
+        if let Some(fetch) = self.fetch {
+            write!(f, ": fetch={fetch}")?;
+        }
+        Ok(())
+    }
+}
+
+impl ExecutionPlan for SerialCoalescePartitionsExec {
+    fn name(&self) -> &'static str {
+        "SerialCoalescePartitionsExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Plan(format!(
+                "SerialCoalescePartitionsExec expects one child, got {}",
+                children.len()
+            )));
+        }
+        Ok(Arc::new(Self::new(children.swap_remove(0), self.fetch)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        if partition != 0 {
+            return internal_err!(
+                "SerialCoalescePartitionsExec only exposes partition 0, got {partition}"
+            );
+        }
+        let partition_count = self.input.output_partitioning().partition_count();
+        if partition_count == 0 {
+            return internal_err!(
+                "SerialCoalescePartitionsExec requires at least one input partition"
+            );
+        }
+
+        let streams = (0..partition_count)
+            .map(|input_partition| self.input.execute(input_partition, Arc::clone(&context)))
+            .collect::<Result<Vec<_>>>()?;
+        let schema = self.schema();
+        let serial_stream = stream::iter(streams).flatten();
+        let adapted: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            serial_stream,
+        ));
+
+        if self.fetch.is_none() {
+            return Ok(adapted);
+        }
+        Ok(Box::pin(LimitStream::new(
+            adapted,
+            0,
+            self.fetch,
+            BaselineMetrics::new(&self.metrics, partition),
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Statistics> {
+        self.input
+            .partition_statistics(None)?
+            .with_fetch(self.fetch, 0, 1)
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
 }

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -41,3 +41,34 @@ test("loads and executes the engine outside the browser main thread", async () =
 		for (const [name, original] of originals) wasm[name] = original;
 	}
 });
+
+test("executes a globally ordered union plan in browser WASM", async () => {
+	const { openLix } = await import("@lix-js/sdk");
+	const lix = await openLix();
+	try {
+		await lix.execute("INSERT INTO lix_directory (path) VALUES ($1)", [
+			"/docs/",
+		]);
+		await lix.execute("INSERT INTO lix_file (path, data) VALUES ($1, $2)", [
+			"/README.md",
+			new Uint8Array(),
+		]);
+
+		const result = await lix.execute(`
+			SELECT path, 'directory' AS kind FROM lix_directory
+			UNION ALL
+			SELECT path, 'file' AS kind FROM lix_file
+			ORDER BY path ASC
+		`);
+		const rows = result.rows
+			.map((row) => row.toObject() as { path: string; kind: string })
+			.filter((row) => !row.path.startsWith("/.lix/"));
+
+		expect(rows).toEqual([
+			{ path: "/README.md", kind: "file" },
+			{ path: "/docs/", kind: "directory" },
+		]);
+	} finally {
+		await lix.close();
+	}
+});


### PR DESCRIPTION
## Summary

- replace the WASM-only physical-plan blocklist with a target-independent serial partition coalescer
- preserve DataFusion coalescing semantics, fetch limits, metrics, and statistics without runtime-specific task spawning
- add a real Chromium regression for globally ordered `UNION ALL` queries

## Root cause

DataFusion plans ordered unions with `CoalescePartitionsExec`. Its default implementation spawns one task per input partition, which traps in the browser WASM worker. Lix previously rejected the operator only on WASM, creating different SQL behavior between native and browser runtimes.

This change adapts that operator to a serial implementation in every runtime. Valid SQL therefore follows the same execution path in native and browser builds, while avoiding unsupported browser task spawning. This also restores the Files view query used by the Atelier browser host.

## Validation

- `corepack pnpm --dir packages/js-sdk test:browser -- src/open-lix.browser.test.ts` (9 passed)
- `cargo test -p lix_engine --lib execute_sql_collects_union_all_partitions` (1 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SQL physical-plan execution for all runtimes (not only WASM); behavior should match DataFusion coalescing but any gap in fetch, stats, or ordering would affect query results broadly.
> 
> **Overview**
> Replaces the **WASM-only physical-plan blocklist** with a **runtime-wide plan adapter** that swaps DataFusion’s `CoalescePartitionsExec` for a custom **`SerialCoalescePartitionsExec`** before SQL results are collected.
> 
> The serial coalescer walks input partitions one after another (with optional **fetch/limit** handling) instead of spawning a task per partition, so ordered **`UNION ALL`** plans work in the browser worker without diverging from native behavior.
> 
> Adds a **Chromium regression test** that runs a globally ordered union over `lix_directory` and `lix_file` in browser WASM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f57fbf5978a74b1bd778c0b78e012094594328b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->