### PR TITLE
perf(sql): cache branch refs per statement

### DIFF
--- a/packages/engine/src/sql2/branch_ref.rs
+++ b/packages/engine/src/sql2/branch_ref.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::LixError;
+use crate::branch::{BranchHead, BranchRefReader};
+
+/// Statement-scoped branch-ref reader that avoids resolving the same branch
+/// head through the backend more than once.
+pub(super) struct CachingBranchRefReader {
+    inner: Arc<dyn BranchRefReader>,
+    heads: Mutex<HashMap<String, Option<BranchHead>>>,
+}
+
+impl CachingBranchRefReader {
+    pub(super) fn new(inner: Arc<dyn BranchRefReader>) -> Self {
+        Self {
+            inner,
+            heads: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl BranchRefReader for CachingBranchRefReader {
+    async fn load_head(&self, branch_id: &str) -> Result<Option<BranchHead>, LixError> {
+        let mut heads = self.heads.lock().await;
+        if let Some(head) = heads.get(branch_id) {
+            return Ok(head.clone());
+        }
+
+        let head = self.inner.load_head(branch_id).await?;
+        heads.insert(branch_id.to_string(), head.clone());
+        Ok(head)
+    }
+
+    async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
+        let mut cache = self.heads.lock().await;
+        let heads = self.inner.scan_heads().await?;
+        for head in &heads {
+            cache.insert(head.branch_id.clone(), Some(head.clone()));
+        }
+        Ok(heads)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::changelog::CommitId;
+
+    struct CountingBranchRefReader {
+        heads: Vec<BranchHead>,
+        load_count: AtomicUsize,
+        scan_count: AtomicUsize,
+    }
+
+    impl CountingBranchRefReader {
+        fn new(heads: Vec<BranchHead>) -> Self {
+            Self {
+                heads,
+                load_count: AtomicUsize::new(0),
+                scan_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BranchRefReader for CountingBranchRefReader {
+        async fn load_head(&self, branch_id: &str) -> Result<Option<BranchHead>, LixError> {
+            self.load_count.fetch_add(1, Ordering::Relaxed);
+            Ok(self
+                .heads
+                .iter()
+                .find(|head| head.branch_id == branch_id)
+                .cloned())
+        }
+
+        async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
+            self.scan_count.fetch_add(1, Ordering::Relaxed);
+            Ok(self.heads.clone())
+        }
+    }
+
+    fn head(branch_id: &str, commit_id: &str) -> BranchHead {
+        BranchHead {
+            branch_id: branch_id.to_string(),
+            commit_id: CommitId::for_test_label(commit_id),
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_load_head_uses_underlying_reader_once() {
+        let inner = Arc::new(CountingBranchRefReader::new(vec![head(
+            "branch-a", "commit-a",
+        )]));
+        let cached = CachingBranchRefReader::new(inner.clone());
+
+        assert_eq!(
+            cached.load_head("branch-a").await.unwrap(),
+            Some(head("branch-a", "commit-a"))
+        );
+        assert_eq!(
+            cached.load_head("branch-a").await.unwrap(),
+            Some(head("branch-a", "commit-a"))
+        );
+        assert_eq!(inner.load_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn missing_load_head_is_cached_as_none() {
+        let inner = Arc::new(CountingBranchRefReader::new(Vec::new()));
+        let cached = CachingBranchRefReader::new(inner.clone());
+
+        assert_eq!(cached.load_head("missing").await.unwrap(), None);
+        assert_eq!(cached.load_head("missing").await.unwrap(), None);
+        assert_eq!(inner.load_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn scan_heads_seeds_load_head_cache() {
+        let inner = Arc::new(CountingBranchRefReader::new(vec![head(
+            "branch-a", "commit-a",
+        )]));
+        let cached = CachingBranchRefReader::new(inner.clone());
+
+        assert_eq!(
+            cached.scan_heads().await.unwrap(),
+            vec![head("branch-a", "commit-a")]
+        );
+        assert_eq!(
+            cached.load_head("branch-a").await.unwrap(),
+            Some(head("branch-a", "commit-a"))
+        );
+        assert_eq!(inner.scan_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner.load_count.load(Ordering::Relaxed), 0);
+    }
+}

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -1,4 +1,5 @@
 mod bind;
+mod branch_ref;
 mod branch_scope;
 mod catalog;
 mod change_materialization;

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -23,9 +23,7 @@ use crate::live_state::{
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::write_normalization::{InsertCell, SqlCell, UpdateAssignmentValues};
-use crate::sql2::{
-    SqlWriteContext, WriteAccess, WriteContextBranchRefReader, WriteContextLiveStateReader,
-};
+use crate::sql2::{SqlWriteContext, WriteAccess, WriteContextLiveStateReader};
 use crate::transaction::types::{
     LogicalPrimaryKey, TransactionWrite, TransactionWriteMode, TransactionWriteOperation,
     TransactionWriteOrigin, TransactionWriteRow,
@@ -61,9 +59,9 @@ pub(super) async fn register_write_provider(
     session: &datafusion::prelude::SessionContext,
     surface_name: &str,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
 ) -> Result<(), LixError> {
     let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-    let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
     register_spec_table(
         session,
         surface_name,
@@ -128,10 +126,12 @@ impl TableSpec for BranchSpec {
         write_ctx: &SqlWriteContext,
         batches: Vec<RecordBatch>,
     ) -> Result<u64> {
-        let default_commit_id = write_ctx
-            .load_branch_head(&write_ctx.active_branch_id())
+        let default_commit_id = self
+            .branch_ref
+            .load_head(&write_ctx.active_branch_id())
             .await
             .map_err(lix_error_to_datafusion_error)?
+            .map(|head| head.commit_id)
             .ok_or_else(|| {
                 DataFusionError::Execution(
                     "INSERT into lix_branch could not resolve active branch head".to_string(),
@@ -280,10 +280,12 @@ impl UpsertSupport for BranchSpec {
         write_ctx: &SqlWriteContext,
         batch: &RecordBatch,
     ) -> Result<StagedUpsert> {
-        let default_commit_id = write_ctx
-            .load_branch_head(&write_ctx.active_branch_id())
+        let default_commit_id = self
+            .branch_ref
+            .load_head(&write_ctx.active_branch_id())
             .await
             .map_err(lix_error_to_datafusion_error)?
+            .map(|head| head.commit_id)
             .ok_or_else(|| {
                 DataFusionError::Execution(
                     "INSERT into lix_branch could not resolve active branch head".to_string(),

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -51,9 +51,7 @@ use crate::filesystem::{
     plan_recursive_directory_delete,
 };
 use crate::sql2::result_metadata::json_field;
-use crate::sql2::{
-    SqlWriteContext, WriteAccess, WriteContextBranchRefReader, WriteContextLiveStateReader,
-};
+use crate::sql2::{SqlWriteContext, WriteAccess, WriteContextLiveStateReader};
 use crate::transaction::types::{TransactionWrite, TransactionWriteMode};
 
 use super::spec::{
@@ -116,10 +114,10 @@ pub(super) async fn register_by_branch_write_provider(
     session: &SessionContext,
     surface_name: &str,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
 ) -> Result<(), LixError> {
     let functions = write_ctx.functions();
     let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-    let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
     register_spec_table(
         session,
         surface_name,
@@ -134,11 +132,11 @@ pub(super) async fn register_active_write_provider(
     session: &SessionContext,
     surface_name: &str,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
 ) -> Result<(), LixError> {
     let active_branch_id = write_ctx.active_branch_id();
     let functions = write_ctx.functions();
     let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-    let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
     register_spec_table(
         session,
         surface_name,

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -29,8 +29,7 @@ use crate::sql2::catalog::{
 use crate::sql2::error::lix_error_to_datafusion_error;
 
 use crate::sql2::{
-    SqlHistoryQuerySource, SqlWriteContext, WriteAccess, WriteContextBranchRefReader,
-    WriteContextLiveStateReader,
+    SqlHistoryQuerySource, SqlWriteContext, WriteAccess, WriteContextLiveStateReader,
 };
 
 use super::entity_history::register_entity_history_surface;
@@ -105,6 +104,7 @@ where
 pub(crate) async fn register_entity_write_providers(
     ctx: &SessionContext,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
     catalog: &PublicCatalog,
 ) -> Result<(), LixError> {
     for surface in catalog.surfaces() {
@@ -114,7 +114,11 @@ pub(crate) async fn register_entity_write_providers(
                 register_spec_table(
                     ctx,
                     &surface.name,
-                    Arc::new(EntitySpec::active_with_write(spec, write_ctx.clone())),
+                    Arc::new(EntitySpec::active_with_write(
+                        spec,
+                        write_ctx.clone(),
+                        Arc::clone(&branch_ref),
+                    )),
                     WriteAccess::write(write_ctx.clone()),
                 )?;
             }
@@ -123,7 +127,11 @@ pub(crate) async fn register_entity_write_providers(
                 register_spec_table(
                     ctx,
                     &surface.name,
-                    Arc::new(EntitySpec::by_branch_with_write(spec, write_ctx.clone())),
+                    Arc::new(EntitySpec::by_branch_with_write(
+                        spec,
+                        write_ctx.clone(),
+                        Arc::clone(&branch_ref),
+                    )),
                     WriteAccess::write(write_ctx.clone()),
                 )?;
             }
@@ -179,10 +187,13 @@ impl EntitySpec {
         }
     }
 
-    fn active_with_write(spec: Arc<EntitySurfaceSpec>, write_ctx: SqlWriteContext) -> Self {
+    fn active_with_write(
+        spec: Arc<EntitySurfaceSpec>,
+        write_ctx: SqlWriteContext,
+        branch_ref: Arc<dyn BranchRefReader>,
+    ) -> Self {
         let active_branch_id = write_ctx.active_branch_id();
-        let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-        let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx));
+        let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx));
         Self::active(spec, live_state, branch_ref, active_branch_id)
     }
 
@@ -201,9 +212,12 @@ impl EntitySpec {
         }
     }
 
-    fn by_branch_with_write(spec: Arc<EntitySurfaceSpec>, write_ctx: SqlWriteContext) -> Self {
-        let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-        let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx));
+    fn by_branch_with_write(
+        spec: Arc<EntitySurfaceSpec>,
+        write_ctx: SqlWriteContext,
+        branch_ref: Arc<dyn BranchRefReader>,
+    ) -> Self {
+        let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx));
         Self::by_branch(spec, live_state, branch_ref)
     }
 
@@ -1304,6 +1318,7 @@ mod tests {
             Arc::new(super::EntitySpec::active_with_write(
                 entity_insert_spec_with_primary_key(),
                 write_ctx.clone(),
+                empty_branch_ref(),
             )),
             WriteAccess::write(write_ctx),
         );

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -80,8 +80,7 @@ use crate::filesystem::{
 use crate::sql2::result_metadata::json_field;
 use crate::sql2::session::SqlWriteSessionOptions;
 use crate::sql2::{
-    SqlWriteContext, SqlWriteExecutionContext, WriteAccess, WriteContextBranchRefReader,
-    WriteContextLiveStateReader,
+    SqlWriteContext, SqlWriteExecutionContext, WriteAccess, WriteContextLiveStateReader,
 };
 use crate::transaction::types::{
     LogicalPrimaryKey, TransactionFileData, TransactionWrite, TransactionWriteMode,
@@ -148,6 +147,7 @@ pub(super) async fn register_by_branch_write_provider(
     session: &SessionContext,
     surface_name: &str,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
 ) -> Result<(), LixError> {
     register_spec_table(
@@ -155,6 +155,7 @@ pub(super) async fn register_by_branch_write_provider(
         surface_name,
         Arc::new(LixFileSpec::by_branch_with_write(
             write_ctx.clone(),
+            branch_ref,
             options,
         )),
         WriteAccess::write(write_ctx),
@@ -165,6 +166,7 @@ pub(super) async fn register_active_write_provider(
     session: &SessionContext,
     surface_name: &str,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
 ) -> Result<(), LixError> {
     register_spec_table(
@@ -172,6 +174,7 @@ pub(super) async fn register_active_write_provider(
         surface_name,
         Arc::new(LixFileSpec::active_branch_with_write(
             write_ctx.clone(),
+            branch_ref,
             options,
         )),
         WriteAccess::write(write_ctx),
@@ -212,12 +215,12 @@ impl LixFileSpec {
 
     fn active_branch_with_write(
         write_ctx: SqlWriteContext,
+        branch_ref: Arc<dyn BranchRefReader>,
         options: SqlWriteSessionOptions,
     ) -> Self {
         let active_branch_id = write_ctx.active_branch_id();
         let functions = write_ctx.functions();
         let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-        let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
         let blob_reader = write_ctx.blob_reader();
         let plugin_host = write_ctx.plugin_host();
         Self {
@@ -251,10 +254,13 @@ impl LixFileSpec {
         }
     }
 
-    fn by_branch_with_write(write_ctx: SqlWriteContext, options: SqlWriteSessionOptions) -> Self {
+    fn by_branch_with_write(
+        write_ctx: SqlWriteContext,
+        branch_ref: Arc<dyn BranchRefReader>,
+        options: SqlWriteSessionOptions,
+    ) -> Self {
         let functions = write_ctx.functions();
         let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-        let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
         let blob_reader = write_ctx.blob_reader();
         let plugin_host = write_ctx.plugin_host();
         Self {

--- a/packages/engine/src/sql2/providers/lix_state.rs
+++ b/packages/engine/src/sql2/providers/lix_state.rs
@@ -33,9 +33,7 @@ use crate::sql2::write_normalization::{InsertCell, SqlCell, UpdateAssignmentValu
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 use crate::{LixError, NullableKeyFilter, parse_row_metadata_value};
 
-use crate::sql2::{
-    SqlWriteContext, WriteAccess, WriteContextBranchRefReader, WriteContextLiveStateReader,
-};
+use crate::sql2::{SqlWriteContext, WriteAccess, WriteContextLiveStateReader};
 use crate::transaction::types::{TransactionWrite, TransactionWriteMode};
 
 use crate::sql2::predicate_typecheck::{
@@ -88,9 +86,9 @@ pub(super) async fn register_lix_state_by_branch_write_provider(
     session: &SessionContext,
     surface_name: &str,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
 ) -> Result<(), LixError> {
     let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-    let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
     register_spec_table(
         session,
         surface_name,
@@ -103,10 +101,10 @@ pub(super) async fn register_lix_state_active_write_provider(
     session: &SessionContext,
     surface_name: &str,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
 ) -> Result<(), LixError> {
     let active_branch_id = write_ctx.active_branch_id();
     let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-    let branch_ref = Arc::new(WriteContextBranchRefReader::new(write_ctx.clone()));
     register_spec_table(
         session,
         surface_name,
@@ -1137,8 +1135,7 @@ mod tests {
     use crate::functions::FunctionProviderHandle;
     use crate::sql2::dml::InsertExec;
     use crate::sql2::{
-        SqlWriteContext, SqlWriteExecutionContext, WriteAccess, WriteContextBranchRefReader,
-        WriteContextLiveStateReader,
+        SqlWriteContext, SqlWriteExecutionContext, WriteAccess, WriteContextLiveStateReader,
     };
     use crate::transaction::types::{
         TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
@@ -1324,7 +1321,9 @@ mod tests {
         LixStateSpec::active_branch(
             write_ctx.active_branch_id(),
             Arc::new(WriteContextLiveStateReader::new(write_ctx.clone())),
-            Arc::new(WriteContextBranchRefReader::new(write_ctx.clone())),
+            Arc::new(crate::sql2::WriteContextBranchRefReader::new(
+                write_ctx.clone(),
+            )),
         )
     }
 
@@ -1700,13 +1699,26 @@ mod tests {
         let session = SessionContext::new();
         let mut write_context = DummyWriteContext::default();
         let write_ctx = SqlWriteContext::new(&mut write_context);
+        let branch_ref = Arc::new(crate::sql2::WriteContextBranchRefReader::new(
+            write_ctx.clone(),
+        ));
 
-        register_lix_state_active_write_provider(&session, "lix_state", write_ctx.clone())
-            .await
-            .expect("lix_state provider should register");
-        register_lix_state_by_branch_write_provider(&session, "lix_state_by_branch", write_ctx)
-            .await
-            .expect("lix_state_by_branch provider should register");
+        register_lix_state_active_write_provider(
+            &session,
+            "lix_state",
+            write_ctx.clone(),
+            branch_ref.clone(),
+        )
+        .await
+        .expect("lix_state provider should register");
+        register_lix_state_by_branch_write_provider(
+            &session,
+            "lix_state_by_branch",
+            write_ctx,
+            branch_ref,
+        )
+        .await
+        .expect("lix_state_by_branch provider should register");
 
         let lix_state = session
             .table_provider("lix_state")

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -6,6 +6,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 
 use crate::LixError;
+use crate::branch::BranchRefReader;
 
 mod branch;
 mod change;
@@ -78,11 +79,14 @@ pub(crate) async fn validate_spec_upsert(
     Ok(())
 }
 
-pub(crate) async fn register_read<C>(session: &SessionContext, ctx: &C) -> Result<(), LixError>
+pub(crate) async fn register_read<C>(
+    session: &SessionContext,
+    ctx: &C,
+    branch_ref: Arc<dyn BranchRefReader>,
+) -> Result<(), LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let branch_ref = ctx.branch_ref();
     let history_query_source = ctx.history_query_source();
     let changelog_query_source = ctx.changelog_query_source();
     let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
@@ -221,6 +225,7 @@ where
 pub(crate) async fn register_write(
     session: &SessionContext,
     write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
 ) -> Result<(), LixError> {
     let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
@@ -232,6 +237,7 @@ pub(crate) async fn register_write(
                     session,
                     &surface.name,
                     write_ctx.clone(),
+                    Arc::clone(&branch_ref),
                 )
                 .await?;
             }
@@ -241,12 +247,19 @@ pub(crate) async fn register_write(
                     session,
                     &surface.name,
                     write_ctx.clone(),
+                    Arc::clone(&branch_ref),
                 )
                 .await?;
             }
             PublicSurfaceKind::Branch => {
                 replace_registered_table(session, &surface.name)?;
-                branch::register_write_provider(session, &surface.name, write_ctx.clone()).await?;
+                branch::register_write_provider(
+                    session,
+                    &surface.name,
+                    write_ctx.clone(),
+                    Arc::clone(&branch_ref),
+                )
+                .await?;
             }
             PublicSurfaceKind::File => {
                 replace_registered_table(session, &surface.name)?;
@@ -254,6 +267,7 @@ pub(crate) async fn register_write(
                     session,
                     &surface.name,
                     write_ctx.clone(),
+                    Arc::clone(&branch_ref),
                     options.clone(),
                 )
                 .await?;
@@ -264,6 +278,7 @@ pub(crate) async fn register_write(
                     session,
                     &surface.name,
                     write_ctx.clone(),
+                    Arc::clone(&branch_ref),
                     options.clone(),
                 )
                 .await?;
@@ -274,6 +289,7 @@ pub(crate) async fn register_write(
                     session,
                     &surface.name,
                     write_ctx.clone(),
+                    Arc::clone(&branch_ref),
                 )
                 .await?;
             }
@@ -283,6 +299,7 @@ pub(crate) async fn register_write(
                     session,
                     &surface.name,
                     write_ctx.clone(),
+                    Arc::clone(&branch_ref),
                 )
                 .await?;
             }
@@ -303,7 +320,8 @@ pub(crate) async fn register_write(
             replace_registered_table(session, &surface.name)?;
         }
     }
-    entity::register_entity_write_providers(session, write_ctx.clone(), &catalog).await?;
+    entity::register_entity_write_providers(session, write_ctx.clone(), branch_ref, &catalog)
+        .await?;
     Ok(())
 }
 

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -1,8 +1,11 @@
 use datafusion::prelude::{SessionConfig, SessionContext};
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use crate::LixError;
+use crate::branch::BranchRefReader;
 
+use super::branch_ref::CachingBranchRefReader;
 use super::providers;
 use super::udfs::register_sql2_functions;
 use super::{SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext};
@@ -12,13 +15,14 @@ where
     C: SqlExecutionContext + ?Sized,
 {
     let session = new_sql_session_context();
-    let branch_ref = ctx.branch_ref();
+    let branch_ref: Arc<dyn BranchRefReader> =
+        Arc::new(CachingBranchRefReader::new(ctx.branch_ref()));
     let active_branch_commit_id = branch_ref
         .load_head(ctx.active_branch_id())
         .await?
         .map(|head| head.commit_id.to_string());
     register_sql2_functions(&session, ctx.functions(), active_branch_commit_id);
-    providers::register_read(&session, ctx).await?;
+    providers::register_read(&session, ctx, branch_ref).await?;
 
     Ok(session)
 }
@@ -30,9 +34,26 @@ pub(crate) async fn build_transaction_read_session<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let session = build_read_session(read_ctx).await?;
+    let session = new_sql_session_context();
+    let read_branch_ref: Arc<dyn BranchRefReader> =
+        Arc::new(CachingBranchRefReader::new(read_ctx.branch_ref()));
+    let active_branch_commit_id = read_branch_ref
+        .load_head(read_ctx.active_branch_id())
+        .await?
+        .map(|head| head.commit_id.to_string());
+    register_sql2_functions(&session, read_ctx.functions(), active_branch_commit_id);
+    providers::register_read(&session, read_ctx, read_branch_ref).await?;
     let write_ctx = SqlWriteContext::new(write_ctx);
-    providers::register_write(&session, write_ctx, SqlWriteSessionOptions::default()).await?;
+    let write_branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(
+        Arc::new(super::WriteContextBranchRefReader::new(write_ctx.clone())),
+    ));
+    providers::register_write(
+        &session,
+        write_ctx,
+        write_branch_ref,
+        SqlWriteSessionOptions::default(),
+    )
+    .await?;
     Ok(session)
 }
 
@@ -48,22 +69,26 @@ pub(crate) async fn build_write_session_with_options(
     let session = new_sql_session_context();
     let write_ctx = SqlWriteContext::new(ctx);
     let active_branch_id = write_ctx.active_branch_id();
-    let active_branch_commit_id = write_ctx
-        .load_branch_head(&active_branch_id)
-        .await?
-        .ok_or_else(|| {
-            LixError::branch_not_found(
-                active_branch_id.clone(),
-                "build SQL write session",
-                "active branch",
-            )
-        })?;
+    let branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(Arc::new(
+        super::WriteContextBranchRefReader::new(write_ctx.clone()),
+    )));
+    let active_branch_commit_id =
+        branch_ref
+            .load_head(&active_branch_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::branch_not_found(
+                    active_branch_id.clone(),
+                    "build SQL write session",
+                    "active branch",
+                )
+            })?;
     register_sql2_functions(
         &session,
         write_ctx.functions(),
-        Some(active_branch_commit_id.to_string()),
+        Some(active_branch_commit_id.commit_id.to_string()),
     );
-    providers::register_write(&session, write_ctx, options).await?;
+    providers::register_write(&session, write_ctx, branch_ref, options).await?;
 
     Ok(session)
 }


### PR DESCRIPTION
## Stack

1 of 4. Base: `main`.

## What

- Add a statement-scoped `BranchRefReader` cache shared by SQL UDF resolution and SQL table providers.
- Keep committed-read and transaction-overlay caches separate so transaction visibility semantics do not change.

## Why

SQL session construction and providers can resolve the same branch head more than once. With SlateDB those duplicate point reads cross the network boundary. Successful and missing head lookups are now stable for the lifetime of one SQL statement.

## Before / after

Measured with a local, uncommitted `CountingBackend<InMemoryBackend>` harness, 5 samples per read; fixture setup and `EXPLAIN VERBOSE` excluded. Counts were stable; elapsed time is a noisy median.

| Atelier case | Backend reads | Point calls | Requested keys | Median ms |
| --- | ---: | ---: | ---: | ---: |
| Q04 file by ID | 78 -> 77 | 62 -> 61 | 139 -> 138 | 0.649 -> 0.670 |
| Q18 branch listing | 42 -> 41 | 37 -> 36 | 93 -> 92 | 0.683 -> 1.236 |
| `SELECT 1` session baseline | 32 -> 32 | 28 -> 28 | 81 -> 81 | 0.506 -> 0.522 |

Q13 and Q22 were unchanged, as expected: those paths do not repeat a branch-head backend read in the measured statement. Logical filter pushdown is unchanged; this removes duplicate physical branch-ref reads below the providers.

One backend `visit_keys` call can fan out to multiple SlateDB/object-store reads, so the scorecard reports both calls and requested keys.

## Validation

- Local workload smoke: baseline + all 42 Atelier forms passed (harness is not part of this PR).
- `sql2::branch_ref::tests`: 3 passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed on the technical-only stack.
- `cargo fmt --all -- --check` passed.
