### PR TITLE
perf(sql): batch branch head scans

### DIFF
--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -402,10 +402,10 @@ async fn load_branch_rows(
     match head_read_strategy {
         BranchHeadReadStrategy::Batch => {
             // A read session has already resolved and cached the active branch.
-            // Keep the zero/one-descriptor case on point lookup so an empty or
-            // brand-new workspace does not add a ref scan; batch once there is
-            // actual fanout to collapse.
-            if descriptors.len() <= 1 {
+            // Keep the zero-to-two-descriptor case on point lookup: the active
+            // head is already cached, so at most one backend read remains.
+            // Batch once there is actual fanout to collapse.
+            if descriptors.len() <= 2 {
                 return load_branch_rows_with_point_lookups(descriptors, branch_ref).await;
             }
             let heads = branch_ref.scan_heads().await?;
@@ -857,11 +857,12 @@ mod tests {
         let live_state = Arc::new(RowsLiveStateReader {
             rows: vec![
                 descriptor_row("branch-a", "Branch A"),
+                descriptor_row("branch-b", "Branch B"),
                 descriptor_row("descriptor-only", "Descriptor only"),
             ],
         });
         let branch_ref = Arc::new(CountingBranchRefReader {
-            heads: vec![head("branch-a"), head("ref-only")],
+            heads: vec![head("branch-a"), head("branch-b"), head("ref-only")],
             point_reads: AtomicUsize::new(0),
             scans: AtomicUsize::new(0),
         });
@@ -876,12 +877,20 @@ mod tests {
 
         assert_eq!(
             rows,
-            vec![BranchRow {
-                id: "branch-a".to_string(),
-                name: "Branch A".to_string(),
-                hidden: false,
-                commit_id: head("branch-a").commit_id,
-            }]
+            vec![
+                BranchRow {
+                    id: "branch-a".to_string(),
+                    name: "Branch A".to_string(),
+                    hidden: false,
+                    commit_id: head("branch-a").commit_id,
+                },
+                BranchRow {
+                    id: "branch-b".to_string(),
+                    name: "Branch B".to_string(),
+                    hidden: false,
+                    commit_id: head("branch-b").commit_id,
+                },
+            ]
         );
         assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 1);
         assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 0);

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -13,7 +14,7 @@ use serde_json::Value as JsonValue;
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::branch::{
-    BranchRefReader, branch_descriptor_stage_row, branch_descriptor_tombstone_row,
+    BranchHead, BranchRefReader, branch_descriptor_stage_row, branch_descriptor_tombstone_row,
     branch_ref_stage_row, branch_ref_tombstone_row,
 };
 use crate::changelog::CommitId;
@@ -50,6 +51,7 @@ pub(super) async fn register_lix_branch_read_provider(
         Arc::new(BranchSpec {
             live_state,
             branch_ref,
+            head_read_strategy: BranchHeadReadStrategy::Batch,
         }),
         WriteAccess::read_only(),
     )
@@ -68,6 +70,7 @@ pub(super) async fn register_write_provider(
         Arc::new(BranchSpec {
             live_state,
             branch_ref,
+            head_read_strategy: BranchHeadReadStrategy::Point,
         }),
         WriteAccess::write(write_ctx),
     )
@@ -76,6 +79,13 @@ pub(super) async fn register_write_provider(
 struct BranchSpec {
     live_state: Arc<dyn LiveStateReader>,
     branch_ref: Arc<dyn BranchRefReader>,
+    head_read_strategy: BranchHeadReadStrategy,
+}
+
+#[derive(Clone, Copy)]
+enum BranchHeadReadStrategy {
+    Batch,
+    Point,
 }
 
 #[async_trait]
@@ -108,9 +118,10 @@ impl TableSpec for BranchSpec {
                     Arc::clone(&self.live_state),
                     Arc::clone(&self.branch_ref),
                     schema,
+                    self.head_read_strategy,
                 ),
-                |(live_state, branch_ref, schema)| async move {
-                    let rows = load_branch_rows(live_state, branch_ref)
+                |(live_state, branch_ref, schema, head_read_strategy)| async move {
+                    let rows = load_branch_rows(live_state, branch_ref, head_read_strategy)
                         .await
                         .map_err(lix_error_to_datafusion_error)?;
                     LIX_BRANCH_COLS
@@ -254,7 +265,7 @@ impl BranchSpec {
         row_source(
             (Arc::clone(&self.live_state), Arc::clone(&self.branch_ref)),
             |(live_state, branch_ref)| async move {
-                let rows = load_branch_rows(live_state, branch_ref)
+                let rows = load_branch_rows(live_state, branch_ref, BranchHeadReadStrategy::Point)
                     .await
                     .map_err(lix_error_to_datafusion_error)?;
                 LIX_BRANCH_COLS
@@ -305,9 +316,13 @@ impl UpsertSupport for BranchSpec {
         _proposed: &RecordBatch,
         _target: &super::upsert::UpsertConflictTarget,
     ) -> Result<RecordBatch> {
-        let rows = load_branch_rows(Arc::clone(&self.live_state), Arc::clone(&self.branch_ref))
-            .await
-            .map_err(lix_error_to_datafusion_error)?;
+        let rows = load_branch_rows(
+            Arc::clone(&self.live_state),
+            Arc::clone(&self.branch_ref),
+            BranchHeadReadStrategy::Point,
+        )
+        .await
+        .map_err(lix_error_to_datafusion_error)?;
         LIX_BRANCH_COLS
             .build(lix_branch_schema(), &rows)
             .map_err(branch_batch_error)
@@ -365,6 +380,7 @@ fn branch_batch_error(error: ColumnTableError) -> DataFusionError {
 async fn load_branch_rows(
     live_state: Arc<dyn LiveStateReader>,
     branch_ref: Arc<dyn BranchRefReader>,
+    head_read_strategy: BranchHeadReadStrategy,
 ) -> Result<Vec<BranchRow>, LixError> {
     let descriptor_rows = live_state
         .scan_rows(&LiveStateScanRequest {
@@ -378,9 +394,35 @@ async fn load_branch_rows(
         })
         .await?;
 
+    let descriptors = descriptor_rows
+        .iter()
+        .map(parse_descriptor)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    match head_read_strategy {
+        BranchHeadReadStrategy::Batch => {
+            // A read session has already resolved and cached the active branch.
+            // Keep the zero/one-descriptor case on point lookup so an empty or
+            // brand-new workspace does not add a ref scan; batch once there is
+            // actual fanout to collapse.
+            if descriptors.len() <= 1 {
+                return load_branch_rows_with_point_lookups(descriptors, branch_ref).await;
+            }
+            let heads = branch_ref.scan_heads().await?;
+            Ok(join_branch_descriptors_with_heads(descriptors, heads))
+        }
+        BranchHeadReadStrategy::Point => {
+            load_branch_rows_with_point_lookups(descriptors, branch_ref).await
+        }
+    }
+}
+
+async fn load_branch_rows_with_point_lookups(
+    descriptors: Vec<BranchDescriptor>,
+    branch_ref: Arc<dyn BranchRefReader>,
+) -> Result<Vec<BranchRow>, LixError> {
     let mut out = Vec::new();
-    for descriptor_row in descriptor_rows {
-        let descriptor = parse_descriptor(&descriptor_row)?;
+    for descriptor in descriptors {
         let Some(commit_id) = branch_ref.load_head_commit_id(&descriptor.id).await? else {
             continue;
         };
@@ -392,6 +434,28 @@ async fn load_branch_rows(
         });
     }
     Ok(out)
+}
+
+fn join_branch_descriptors_with_heads(
+    descriptors: Vec<BranchDescriptor>,
+    heads: Vec<BranchHead>,
+) -> Vec<BranchRow> {
+    let commit_ids_by_branch = heads
+        .into_iter()
+        .map(|head| (head.branch_id, head.commit_id))
+        .collect::<HashMap<_, _>>();
+    descriptors
+        .into_iter()
+        .filter_map(|descriptor| {
+            let commit_id = commit_ids_by_branch.get(&descriptor.id).copied()?;
+            Some(BranchRow {
+                commit_id,
+                id: descriptor.id,
+                name: descriptor.name,
+                hidden: descriptor.hidden,
+            })
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -707,4 +771,143 @@ pub(super) fn lix_branch_schema() -> SchemaRef {
         Field::new("hidden", DataType::Boolean, false),
         Field::new("commit_id", DataType::Utf8, false),
     ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::entity_pk::EntityPk;
+    use crate::live_state::LiveStateRowRequest;
+
+    struct RowsLiveStateReader {
+        rows: Vec<MaterializedLiveStateRow>,
+    }
+
+    #[async_trait]
+    impl LiveStateReader for RowsLiveStateReader {
+        async fn scan_rows(
+            &self,
+            _request: &LiveStateScanRequest,
+        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            Ok(self.rows.clone())
+        }
+
+        async fn load_row(
+            &self,
+            _request: &LiveStateRowRequest,
+        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
+            Ok(None)
+        }
+    }
+
+    struct CountingBranchRefReader {
+        heads: Vec<BranchHead>,
+        point_reads: AtomicUsize,
+        scans: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl BranchRefReader for CountingBranchRefReader {
+        async fn load_head(&self, branch_id: &str) -> Result<Option<BranchHead>, LixError> {
+            self.point_reads.fetch_add(1, Ordering::Relaxed);
+            Ok(self
+                .heads
+                .iter()
+                .find(|head| head.branch_id == branch_id)
+                .cloned())
+        }
+
+        async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
+            self.scans.fetch_add(1, Ordering::Relaxed);
+            Ok(self.heads.clone())
+        }
+    }
+
+    fn descriptor_row(id: &str, name: &str) -> MaterializedLiveStateRow {
+        MaterializedLiveStateRow {
+            entity_pk: EntityPk::single(id),
+            schema_key: "lix_branch_descriptor".to_string(),
+            file_id: None,
+            snapshot_content: Some(
+                serde_json::json!({ "id": id, "name": name, "hidden": false }).to_string(),
+            ),
+            metadata: None,
+            deleted: false,
+            created_at: "2026-07-12T00:00:00Z".to_string(),
+            updated_at: "2026-07-12T00:00:00Z".to_string(),
+            global: true,
+            change_id: None,
+            commit_id: None,
+            untracked: false,
+            branch_id: GLOBAL_BRANCH_ID.to_string(),
+        }
+    }
+
+    fn head(branch_id: &str) -> BranchHead {
+        BranchHead {
+            branch_id: branch_id.to_string(),
+            commit_id: CommitId::for_test_label(&format!("commit-{branch_id}")),
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_head_read_joins_matching_descriptors_with_one_scan() {
+        let live_state = Arc::new(RowsLiveStateReader {
+            rows: vec![
+                descriptor_row("branch-a", "Branch A"),
+                descriptor_row("descriptor-only", "Descriptor only"),
+            ],
+        });
+        let branch_ref = Arc::new(CountingBranchRefReader {
+            heads: vec![head("branch-a"), head("ref-only")],
+            point_reads: AtomicUsize::new(0),
+            scans: AtomicUsize::new(0),
+        });
+
+        let rows = load_branch_rows(
+            live_state,
+            branch_ref.clone(),
+            BranchHeadReadStrategy::Batch,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![BranchRow {
+                id: "branch-a".to_string(),
+                name: "Branch A".to_string(),
+                hidden: false,
+                commit_id: head("branch-a").commit_id,
+            }]
+        );
+        assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 1);
+        assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn batch_head_read_avoids_scan_for_single_descriptor() {
+        let live_state = Arc::new(RowsLiveStateReader {
+            rows: vec![descriptor_row("branch-a", "Branch A")],
+        });
+        let branch_ref = Arc::new(CountingBranchRefReader {
+            heads: vec![head("branch-a")],
+            point_reads: AtomicUsize::new(0),
+            scans: AtomicUsize::new(0),
+        });
+
+        let rows = load_branch_rows(
+            live_state,
+            branch_ref.clone(),
+            BranchHeadReadStrategy::Batch,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 0);
+        assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 1);
+    }
 }

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -408,8 +408,17 @@ async fn load_branch_rows(
             if descriptors.len() <= 2 {
                 return load_branch_rows_with_point_lookups(descriptors, branch_ref).await;
             }
-            let heads = branch_ref.scan_heads().await?;
-            Ok(join_branch_descriptors_with_heads(descriptors, heads))
+            match branch_ref.scan_heads().await {
+                Ok(heads) => Ok(join_branch_descriptors_with_heads(descriptors, heads)),
+                // A full scan can encounter a malformed ref unrelated to the
+                // descriptors being listed. Preserve point-read semantics in
+                // that case while keeping the one-scan fast path for valid
+                // branch-ref state.
+                Err(error) if error.code != LixError::CODE_STORAGE_ERROR => {
+                    load_branch_rows_with_point_lookups(descriptors, branch_ref).await
+                }
+                Err(error) => Err(error),
+            }
         }
         BranchHeadReadStrategy::Point => {
             load_branch_rows_with_point_lookups(descriptors, branch_ref).await
@@ -806,12 +815,20 @@ mod tests {
         heads: Vec<BranchHead>,
         point_reads: AtomicUsize,
         scans: AtomicUsize,
+        scan_error: Option<LixError>,
+        point_error_branch: Option<String>,
     }
 
     #[async_trait]
     impl BranchRefReader for CountingBranchRefReader {
         async fn load_head(&self, branch_id: &str) -> Result<Option<BranchHead>, LixError> {
             self.point_reads.fetch_add(1, Ordering::Relaxed);
+            if self.point_error_branch.as_deref() == Some(branch_id) {
+                return Err(LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!("branch ref for '{branch_id}' is malformed"),
+                ));
+            }
             Ok(self
                 .heads
                 .iter()
@@ -821,6 +838,9 @@ mod tests {
 
         async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
             self.scans.fetch_add(1, Ordering::Relaxed);
+            if let Some(error) = &self.scan_error {
+                return Err(error.clone());
+            }
             Ok(self.heads.clone())
         }
     }
@@ -865,6 +885,8 @@ mod tests {
             heads: vec![head("branch-a"), head("branch-b"), head("ref-only")],
             point_reads: AtomicUsize::new(0),
             scans: AtomicUsize::new(0),
+            scan_error: None,
+            point_error_branch: None,
         });
 
         let rows = load_branch_rows(
@@ -905,6 +927,8 @@ mod tests {
             heads: vec![head("branch-a")],
             point_reads: AtomicUsize::new(0),
             scans: AtomicUsize::new(0),
+            scan_error: None,
+            point_error_branch: None,
         });
 
         let rows = load_branch_rows(
@@ -918,5 +942,104 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 0);
         assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn batch_head_read_falls_back_to_point_reads_when_scan_fails() {
+        let live_state = Arc::new(RowsLiveStateReader {
+            rows: vec![
+                descriptor_row("branch-a", "Branch A"),
+                descriptor_row("branch-b", "Branch B"),
+                descriptor_row("branch-c", "Branch C"),
+            ],
+        });
+        let branch_ref = Arc::new(CountingBranchRefReader {
+            heads: vec![head("branch-a"), head("branch-b"), head("branch-c")],
+            point_reads: AtomicUsize::new(0),
+            scans: AtomicUsize::new(0),
+            scan_error: Some(LixError::new(
+                LixError::CODE_UNKNOWN,
+                "unrelated branch ref is malformed",
+            )),
+            point_error_branch: None,
+        });
+
+        let rows = load_branch_rows(
+            live_state,
+            branch_ref.clone(),
+            BranchHeadReadStrategy::Batch,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 1);
+        assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn batch_head_read_still_rejects_a_malformed_selected_ref() {
+        let live_state = Arc::new(RowsLiveStateReader {
+            rows: vec![
+                descriptor_row("branch-a", "Branch A"),
+                descriptor_row("branch-b", "Branch B"),
+                descriptor_row("branch-c", "Branch C"),
+            ],
+        });
+        let branch_ref = Arc::new(CountingBranchRefReader {
+            heads: vec![head("branch-a"), head("branch-b"), head("branch-c")],
+            point_reads: AtomicUsize::new(0),
+            scans: AtomicUsize::new(0),
+            scan_error: Some(LixError::new(
+                LixError::CODE_UNKNOWN,
+                "a branch ref is malformed",
+            )),
+            point_error_branch: Some("branch-b".to_string()),
+        });
+
+        let error = load_branch_rows(
+            live_state,
+            branch_ref.clone(),
+            BranchHeadReadStrategy::Batch,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.message.contains("branch-b"));
+        assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 1);
+        assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn batch_head_read_does_not_amplify_storage_errors() {
+        let live_state = Arc::new(RowsLiveStateReader {
+            rows: vec![
+                descriptor_row("branch-a", "Branch A"),
+                descriptor_row("branch-b", "Branch B"),
+                descriptor_row("branch-c", "Branch C"),
+            ],
+        });
+        let branch_ref = Arc::new(CountingBranchRefReader {
+            heads: vec![head("branch-a"), head("branch-b"), head("branch-c")],
+            point_reads: AtomicUsize::new(0),
+            scans: AtomicUsize::new(0),
+            scan_error: Some(LixError::new(
+                LixError::CODE_STORAGE_ERROR,
+                "branch-ref scan failed",
+            )),
+            point_error_branch: None,
+        });
+
+        let error = load_branch_rows(
+            live_state,
+            branch_ref.clone(),
+            BranchHeadReadStrategy::Batch,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.code, LixError::CODE_STORAGE_ERROR);
+        assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 1);
+        assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 0);
     }
 }


### PR DESCRIPTION
## Stack

3 of 4. Base: `codex/atelier-sql-file-history-reuse`.

## What

For read-only `lix_branch` scans with three or more descriptors, scan branch heads once and join them to descriptors in memory. Zero-to-two-descriptor listings retain point reads because the active head is already statement-cached. SQL write/update/upsert paths also retain point reads because the write-context reader does not support `scan_heads`.

## Why

Atelier Q18/Q19 list every branch. The SQL provider previously loaded one ref per descriptor, creating an N+1 pattern across the SlateDB boundary.

## Before / after

Four-branch fixture in a local, uncommitted `CountingBackend<InMemoryBackend>` harness, 5-sample medians. The hidden predicate remains a DataFusion residual; the optimization changes physical ref access only.

| Atelier case | Backend reads | Point calls | Scan calls | Keys | Scan rows | Median ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Q18 visible branches + hidden | 41 -> 39 | 36 -> 33 | 5 -> 6 | 92 -> 89 | 1 -> 5 | 1.176 -> 0.996 |
| Q19 visible branches | 41 -> 39 | 36 -> 33 | 5 -> 6 | 92 -> 89 | 1 -> 5 | 0.837 -> 1.118 |

This trades three point calls for one range scan: two fewer backend calls and three fewer requested keys. Read volume is essentially flat (`34.69 -> 34.86 KiB`); elapsed results show the expected local-run noise.

## Validation

- Batch join and small-list regression tests: 2 passed.
- Tests cover descriptor-only/ref-only rows, one scan/zero point loads for batch mode, and no scan for a single descriptor.
- Local all-Atelier workload smoke passed; the harness is not part of this PR. Formatting and diff checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how branch heads are loaded for read queries and adds error-handling branches around scan_heads; write paths are unchanged but listing semantics must stay aligned with point-read fallback behavior.
> 
> **Overview**
> Read-only **`lix_branch`** SQL scans now resolve branch heads with a **`Batch`** strategy instead of one **`load_head_commit_id`** call per descriptor, cutting the N+1 pattern when listing many branches (e.g. Atelier Q18/Q19).
> 
> **`load_branch_rows`** parses descriptors first, then for **`Batch`**: uses point lookups when there are ≤2 descriptors; otherwise calls **`branch_ref.scan_heads()`** once and joins heads to descriptors in memory via **`join_branch_descriptors_with_heads`**. If **`scan_heads`** fails with a non-storage error, it falls back to point reads so unrelated malformed refs do not change listing semantics; storage errors propagate without fallback. Write paths (**`register_write_provider`**, UPDATE/DELETE/upsert candidate scans) keep **`Point`** because the write-context reader does not support **`scan_heads`**.
> 
> Unit tests cover one-scan joins, small-list point reads, scan failure fallback, malformed selected refs, and storage-error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5594e647ebba721465db2a7649d7ab1045e53e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->