### PR TITLE
perf: reduce SlateDB backend latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 name = "lix_backends"
 version = "0.8.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "futures-util",
  "lix_engine",
@@ -3176,6 +3177,7 @@ dependencies = [
  "jiff",
  "jsonschema",
  "lix_backends",
+ "lru",
  "musli",
  "object_store 0.14.0",
  "paste",

--- a/packages/backends/Cargo.toml
+++ b/packages/backends/Cargo.toml
@@ -34,4 +34,7 @@ rocksdb = { version = "0.24", default-features = false, features = ["bindgen-run
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 slatedb = { version = "0.14.1", default-features = false, features = ["moka"], optional = true }
 tempfile = { version = "3", optional = true }
-tokio = { version = "1", features = ["rt"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
+
+[dev-dependencies]
+async-trait = "0.1"

--- a/packages/backends/src/slatedb.rs
+++ b/packages/backends/src/slatedb.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::future::Future;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::JoinHandle;
 
@@ -186,8 +186,14 @@ impl SlateDbBackend {
     }
 
     pub fn flush(&self) -> Result<(), BackendError> {
-        self.worker
-            .call(|db| async move { db.flush().await.map_err(slatedb_error) })
+        self.worker.ensure_usable()?;
+        let durability_failed = Arc::clone(&self.worker.inner.durability_failed);
+        self.worker.call(move |db| async move {
+            db.flush().await.map_err(|error| {
+                durability_failed.store(true, Ordering::Release);
+                slatedb_error(error)
+            })
+        })
     }
 }
 
@@ -214,6 +220,7 @@ impl Backend for SlateDbBackend {
 
     fn begin_write(&self, _opts: WriteOptions) -> Result<Self::Write<'_>, BackendError> {
         let writer_permit = self.write_gate.acquire()?;
+        self.worker.ensure_usable()?;
         let base = self
             .worker
             .call(|db| async move { db.snapshot().await.map_err(slatedb_error) })?;
@@ -403,6 +410,7 @@ impl BackendWrite for SlateDbWrite {
             });
         }
 
+        let durability_failed = Arc::clone(&self.worker.inner.durability_failed);
         self.worker.call_with_visibility_lock(move |db| async move {
             let mut batch = WriteBatch::new();
             for (key, value) in self.overlay {
@@ -419,14 +427,20 @@ impl BackendWrite for SlateDbWrite {
                 },
             )
             .await
-            .map_err(slatedb_error)?;
+            .map_err(|error| {
+                durability_failed.store(true, Ordering::Release);
+                slatedb_error(error)
+            })?;
             // SlateDB's default durable write waits for its periodic WAL
             // flush (100 ms by default). The backend already serializes
             // writers, so separate commits cannot benefit from that group
             // commit window. Request and await the WAL flush immediately to
             // preserve the existing durability contract without the timer
             // latency floor.
-            db.flush().await.map_err(slatedb_error)?;
+            db.flush().await.map_err(|error| {
+                durability_failed.store(true, Ordering::Release);
+                slatedb_error(error)
+            })?;
             Ok(CommitResult {
                 commit_id: None,
                 stats,
@@ -453,6 +467,10 @@ struct SlateDbWorkerInner {
     // snapshots share this lock with that write-plus-flush window; operations
     // on already-pinned snapshots remain fully concurrent.
     visibility_lock: Arc<AsyncMutex<()>>,
+    // SlateDB applies writes to its visible memtable before WAL durability.
+    // Publish a terminal failure before releasing the visibility lock so a
+    // failed commit can never be captured by a later backend snapshot.
+    durability_failed: Arc<AtomicBool>,
     #[cfg(test)]
     next_visibility_wait: Mutex<Option<mpsc::Sender<()>>>,
     shutdown: mpsc::Sender<()>,
@@ -483,6 +501,7 @@ impl SlateDbWorker {
                     runtime,
                     db,
                     visibility_lock: Arc::new(AsyncMutex::new(())),
+                    durability_failed: Arc::new(AtomicBool::new(false)),
                     #[cfg(test)]
                     next_visibility_wait: Mutex::new(None),
                     shutdown,
@@ -503,6 +522,14 @@ impl SlateDbWorker {
         Fut: Future<Output = Result<R, BackendError>> + Send + 'static,
     {
         self.call_inner(None, operation)
+    }
+
+    fn ensure_usable(&self) -> Result<(), BackendError> {
+        if self.inner.durability_failed.load(Ordering::Acquire) {
+            Err(BackendError::Durability)
+        } else {
+            Ok(())
+        }
     }
 
     fn call_with_visibility_lock<R, F, Fut>(&self, operation: F) -> Result<R, BackendError>
@@ -526,6 +553,9 @@ impl SlateDbWorker {
     {
         let (reply_tx, reply_rx) = mpsc::channel();
         let db = Arc::clone(&self.inner.db);
+        let durability_failed = visibility_lock
+            .as_ref()
+            .map(|_| Arc::clone(&self.inner.durability_failed));
         #[cfg(test)]
         let visibility_wait = if visibility_lock.is_some() {
             self.inner
@@ -547,7 +577,11 @@ impl SlateDbWorker {
                 }
                 None => None,
             };
-            let result = operation(db).await;
+            let result = if durability_failed.is_some_and(|failed| failed.load(Ordering::Acquire)) {
+                Err(BackendError::Durability)
+            } else {
+                operation(db).await
+            };
             let _ = reply_tx.send(result);
         });
         reply_rx
@@ -992,12 +1026,11 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path as ObjectPath;
     use object_store::{
-        CopyOptions, GetOptions as ObjectStoreGetOptions, GetResult, ListResult, MultipartUpload,
-        ObjectMeta, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
-        Result as ObjectStoreResult,
+        CopyOptions, Error as ObjectStoreError, GetOptions as ObjectStoreGetOptions, GetResult,
+        ListResult, MultipartUpload, ObjectMeta, PutMultipartOptions, PutOptions, PutPayload,
+        PutResult, RenameOptions, Result as ObjectStoreResult,
     };
     use std::ops::Range;
-    use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -1110,6 +1143,71 @@ mod tests {
     }
 
     #[test]
+    fn failed_commit_rejects_queued_readers_and_future_writers() {
+        let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
+        let backend = SlateDbBackend::open_object_store("test-failed-commit", store.clone())
+            .expect("open failed commit backend");
+        let space = SpaceId(9);
+        let key = Key(Bytes::from_static(b"rejected"));
+
+        let blocked_write = store.block_next_write();
+        store.fail_writes();
+        let commit_backend = backend.clone();
+        let commit = std::thread::spawn(move || {
+            let mut write = commit_backend
+                .begin_write(WriteOptions::default())
+                .expect("begin failing write");
+            write
+                .put_many(
+                    space,
+                    PutBatch {
+                        entries: vec![PutEntry {
+                            key,
+                            value: StoredValue {
+                                bytes: Bytes::from_static(b"not-durable"),
+                            },
+                        }],
+                    },
+                )
+                .expect("stage failing write");
+            write.commit()
+        });
+        blocked_write.wait_for_entries(1, "failing SlateDB WAL write");
+
+        let visibility_wait = backend.worker.observe_next_visibility_wait();
+        let read_backend = backend.clone();
+        let reader =
+            std::thread::spawn(move || read_backend.begin_read(ReadOptions::default()).map(|_| ()));
+        visibility_wait
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reader should queue on the visibility lock");
+
+        drop(blocked_write);
+        let commit_error = commit
+            .join()
+            .expect("join failing commit")
+            .expect_err("WAL failure must fail commit");
+        assert!(
+            matches!(commit_error, BackendError::Io(message) if message.contains("injected write failure")),
+            "commit should preserve the SlateDB write error"
+        );
+        assert_eq!(
+            reader
+                .join()
+                .expect("join queued reader")
+                .expect_err("queued reader must reject a failed commit"),
+            BackendError::Durability
+        );
+        assert_eq!(
+            backend
+                .begin_write(WriteOptions::default())
+                .map(|_| ())
+                .expect_err("future writers must reject a failed commit"),
+            BackendError::Durability
+        );
+    }
+
+    #[test]
     fn independent_backend_reads_overlap() {
         let inner = Arc::new(InMemory::new());
         let db_path = "test-concurrent-reads";
@@ -1190,6 +1288,7 @@ mod tests {
     struct BlockingStore {
         inner: Arc<InMemory>,
         next_write: Arc<AtomicBool>,
+        fail_writes: Arc<AtomicBool>,
         writes: Arc<OperationBlock>,
         block_reads: Arc<AtomicBool>,
         reads: Arc<OperationBlock>,
@@ -1200,6 +1299,7 @@ mod tests {
             Self {
                 inner,
                 next_write: Arc::new(AtomicBool::new(false)),
+                fail_writes: Arc::new(AtomicBool::new(false)),
                 writes: Arc::new(OperationBlock::default()),
                 block_reads: Arc::new(AtomicBool::new(false)),
                 reads: Arc::new(OperationBlock::default()),
@@ -1210,6 +1310,10 @@ mod tests {
             OperationBlockGuard::arm(Arc::clone(&self.next_write), Arc::clone(&self.writes))
         }
 
+        fn fail_writes(&self) {
+            self.fail_writes.store(true, Ordering::Release);
+        }
+
         fn block_sst_reads(&self) -> OperationBlockGuard {
             OperationBlockGuard::arm(Arc::clone(&self.block_reads), Arc::clone(&self.reads))
         }
@@ -1217,6 +1321,16 @@ mod tests {
         fn maybe_block_write(&self) {
             if self.next_write.swap(false, Ordering::AcqRel) {
                 self.writes.enter();
+            }
+        }
+
+        fn maybe_fail_write(&self) -> ObjectStoreResult<()> {
+            if self.fail_writes.load(Ordering::Acquire) {
+                Err(ObjectStoreError::NotSupported {
+                    source: Box::new(std::io::Error::other("injected write failure")),
+                })
+            } else {
+                Ok(())
             }
         }
 
@@ -1320,6 +1434,7 @@ mod tests {
             options: PutOptions,
         ) -> ObjectStoreResult<PutResult> {
             self.maybe_block_write();
+            self.maybe_fail_write()?;
             self.inner.put_opts(location, payload, options).await
         }
 

--- a/packages/backends/src/slatedb.rs
+++ b/packages/backends/src/slatedb.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -17,16 +18,19 @@ use object_store::ObjectStore;
 use object_store::local::LocalFileSystem;
 use slatedb::config::{
     ObjectStoreCacheOptions, PreloadLevel, ScanOptions as SlateDbScanOptions, Settings,
+    WriteOptions as SlateDbWriteOptions,
 };
 use slatedb::db_cache::moka::{MokaCache, MokaCacheOptions};
 use slatedb::db_cache::{DbCache, SplitCache};
 use slatedb::{Db, DbIterator, DbSnapshot, WriteBatch};
 use tempfile::TempDir;
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::{Builder, Handle, Runtime};
+use tokio::sync::Mutex as AsyncMutex;
 
 const DB_PATH: &str = "db";
 const SPACE_PREFIX_LEN: usize = 4;
 const MAX_SLATEDB_KEY_LEN: usize = u16::MAX as usize;
+const RUNTIME_WORKER_THREADS: usize = 2;
 const POINT_READ_CONCURRENCY: usize = 64;
 const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
@@ -183,7 +187,7 @@ impl SlateDbBackend {
 
     pub fn flush(&self) -> Result<(), BackendError> {
         self.worker
-            .call(|runtime, db| runtime.block_on(db.flush()).map_err(slatedb_error))
+            .call(|db| async move { db.flush().await.map_err(slatedb_error) })
     }
 }
 
@@ -199,9 +203,9 @@ impl Backend for SlateDbBackend {
         Self: 'a;
 
     fn begin_read(&self, _opts: ReadOptions) -> Result<Self::Read<'_>, BackendError> {
-        let snapshot = self
-            .worker
-            .call(|runtime, db| runtime.block_on(db.snapshot()).map_err(slatedb_error))?;
+        let snapshot = self.worker.call_with_visibility_lock(|db| async move {
+            db.snapshot().await.map_err(slatedb_error)
+        })?;
         Ok(SlateDbRead {
             worker: self.worker.clone(),
             snapshot,
@@ -212,7 +216,7 @@ impl Backend for SlateDbBackend {
         let writer_permit = self.write_gate.acquire()?;
         let base = self
             .worker
-            .call(|runtime, db| runtime.block_on(db.snapshot()).map_err(slatedb_error))?;
+            .call(|db| async move { db.snapshot().await.map_err(slatedb_error) })?;
         Ok(SlateDbWrite {
             worker: self.worker.clone(),
             _writer_permit: writer_permit,
@@ -245,7 +249,7 @@ impl BackendRead for SlateDbRead {
         let snapshot = Arc::clone(&self.snapshot);
         let values = self
             .worker
-            .call(move |runtime, _db| get_snapshot_values(runtime, snapshot, physical_keys))?;
+            .call(move |_db| get_snapshot_values(snapshot, physical_keys))?;
 
         for (index, (key, value)) in keys.iter().zip(values.iter()).enumerate() {
             visitor.visit(
@@ -286,7 +290,7 @@ impl BackendRead for SlateDbRead {
         let snapshot = Arc::clone(&self.snapshot);
         let mut iter = Some(
             self.worker
-                .call(move |runtime, _db| open_snapshot_scan(runtime, &snapshot, bounds))?,
+                .call(move |_db| open_snapshot_scan(snapshot, bounds))?,
         );
         let mut emitted = 0usize;
 
@@ -298,8 +302,8 @@ impl BackendRead for SlateDbRead {
                 .take()
                 .expect("slatedb scan iterator is present until scan returns");
             let projection = opts.projection;
-            let batch = self.worker.call(move |runtime, _db| {
-                scan_snapshot_batch(runtime, current_iter, batch_limit, projection, lookahead)
+            let batch = self.worker.call(move |_db| {
+                scan_snapshot_batch(current_iter, batch_limit, projection, lookahead)
             })?;
             let ScanBatch {
                 iter: next_iter,
@@ -367,7 +371,7 @@ impl BackendWrite for SlateDbWrite {
         let base = Arc::clone(&self.base);
         let base_keys = self
             .worker
-            .call(move |runtime, _db| collect_snapshot_keys(runtime, &base, bounds))?;
+            .call(move |_db| collect_snapshot_keys(base, bounds))?;
 
         let overlay_keys = self
             .overlay
@@ -399,7 +403,7 @@ impl BackendWrite for SlateDbWrite {
             });
         }
 
-        self.worker.call(move |runtime, db| {
+        self.worker.call_with_visibility_lock(move |db| async move {
             let mut batch = WriteBatch::new();
             for (key, value) in self.overlay {
                 match value {
@@ -407,7 +411,22 @@ impl BackendWrite for SlateDbWrite {
                     None => batch.delete(key.0),
                 }
             }
-            runtime.block_on(db.write(batch)).map_err(slatedb_error)?;
+            db.write_with_options(
+                batch,
+                &SlateDbWriteOptions {
+                    await_durable: false,
+                    ..SlateDbWriteOptions::default()
+                },
+            )
+            .await
+            .map_err(slatedb_error)?;
+            // SlateDB's default durable write waits for its periodic WAL
+            // flush (100 ms by default). The backend already serializes
+            // writers, so separate commits cannot benefit from that group
+            // commit window. Request and await the WAL flush immediately to
+            // preserve the existing durability contract without the timer
+            // latency floor.
+            db.flush().await.map_err(slatedb_error)?;
             Ok(CommitResult {
                 commit_id: None,
                 stats,
@@ -428,13 +447,16 @@ struct SlateDbWorker {
 
 #[allow(missing_debug_implementations)]
 struct SlateDbWorkerInner {
-    commands: mpsc::Sender<SlateDbCommand>,
-    thread: Mutex<Option<JoinHandle<()>>>,
-}
-
-enum SlateDbCommand {
-    Run(Box<dyn FnOnce(&Runtime, &Db) + Send + 'static>),
-    Shutdown,
+    runtime: Handle,
+    db: Arc<Db>,
+    // A commit becomes visible before its explicit WAL flush completes. New
+    // snapshots share this lock with that write-plus-flush window; operations
+    // on already-pinned snapshots remain fully concurrent.
+    visibility_lock: Arc<AsyncMutex<()>>,
+    #[cfg(test)]
+    next_visibility_wait: Mutex<Option<mpsc::Sender<()>>>,
+    shutdown: mpsc::Sender<()>,
+    manager: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl SlateDbWorker {
@@ -443,12 +465,12 @@ impl SlateDbWorker {
         object_store: Arc<dyn ObjectStore>,
         options: SlateDbObjectStoreOptions,
     ) -> Result<Self, BackendError> {
-        let (commands, receiver) = mpsc::channel();
-        let (opened_tx, opened_rx) = mpsc::channel();
+        let (shutdown, shutdown_rx) = mpsc::channel();
+        let (opened_tx, opened_rx) = mpsc::channel::<Result<(Handle, Arc<Db>), BackendError>>();
         let thread = std::thread::Builder::new()
-            .name("lix-slatedb".to_string())
+            .name("lix-slatedb-manager".to_string())
             .spawn(move || {
-                run_slatedb_worker(db_path, object_store, options, receiver, opened_tx);
+                run_slatedb_manager(db_path, object_store, options, shutdown_rx, opened_tx);
             })
             .map_err(|error| BackendError::Io(format!("spawn slatedb worker: {error}")))?;
 
@@ -456,10 +478,15 @@ impl SlateDbWorker {
             .recv()
             .map_err(|error| BackendError::Io(format!("slatedb worker did not open: {error}")))?
         {
-            Ok(()) => Ok(Self {
+            Ok((runtime, db)) => Ok(Self {
                 inner: Arc::new(SlateDbWorkerInner {
-                    commands,
-                    thread: Mutex::new(Some(thread)),
+                    runtime,
+                    db,
+                    visibility_lock: Arc::new(AsyncMutex::new(())),
+                    #[cfg(test)]
+                    next_visibility_wait: Mutex::new(None),
+                    shutdown,
+                    manager: Mutex::new(Some(thread)),
                 }),
             }),
             Err(error) => {
@@ -469,46 +496,101 @@ impl SlateDbWorker {
         }
     }
 
-    fn call<R>(
+    fn call<R, F, Fut>(&self, operation: F) -> Result<R, BackendError>
+    where
+        R: Send + 'static,
+        F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<R, BackendError>> + Send + 'static,
+    {
+        self.call_inner(None, operation)
+    }
+
+    fn call_with_visibility_lock<R, F, Fut>(&self, operation: F) -> Result<R, BackendError>
+    where
+        R: Send + 'static,
+        F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<R, BackendError>> + Send + 'static,
+    {
+        self.call_inner(Some(Arc::clone(&self.inner.visibility_lock)), operation)
+    }
+
+    fn call_inner<R, F, Fut>(
         &self,
-        operation: impl FnOnce(&Runtime, &Db) -> Result<R, BackendError> + Send + 'static,
+        visibility_lock: Option<Arc<AsyncMutex<()>>>,
+        operation: F,
     ) -> Result<R, BackendError>
     where
         R: Send + 'static,
+        F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<R, BackendError>> + Send + 'static,
     {
         let (reply_tx, reply_rx) = mpsc::channel();
-        self.inner
-            .commands
-            .send(SlateDbCommand::Run(Box::new(move |runtime, db| {
-                let _ = reply_tx.send(operation(runtime, db));
-            })))
-            .map_err(|error| BackendError::Io(format!("send slatedb worker command: {error}")))?;
+        let db = Arc::clone(&self.inner.db);
+        #[cfg(test)]
+        let visibility_wait = if visibility_lock.is_some() {
+            self.inner
+                .next_visibility_wait
+                .lock()
+                .expect("lock visibility wait probe")
+                .take()
+        } else {
+            None
+        };
+        self.inner.runtime.spawn(async move {
+            let _visibility_guard = match visibility_lock {
+                Some(visibility_lock) => {
+                    #[cfg(test)]
+                    if let Some(visibility_wait) = visibility_wait {
+                        let _ = visibility_wait.send(());
+                    }
+                    Some(visibility_lock.lock_owned().await)
+                }
+                None => None,
+            };
+            let result = operation(db).await;
+            let _ = reply_tx.send(result);
+        });
         reply_rx
             .recv()
             .map_err(|error| BackendError::Io(format!("receive slatedb worker reply: {error}")))?
+    }
+
+    #[cfg(test)]
+    fn observe_next_visibility_wait(&self) -> mpsc::Receiver<()> {
+        let (wait_tx, wait_rx) = mpsc::channel();
+        *self
+            .inner
+            .next_visibility_wait
+            .lock()
+            .expect("lock visibility wait probe") = Some(wait_tx);
+        wait_rx
     }
 }
 
 impl Drop for SlateDbWorkerInner {
     fn drop(&mut self) {
-        let _ = self.commands.send(SlateDbCommand::Shutdown);
-        let Ok(mut thread) = self.thread.lock() else {
+        let _ = self.shutdown.send(());
+        let Ok(mut manager) = self.manager.lock() else {
             return;
         };
-        if let Some(thread) = thread.take() {
-            let _ = thread.join();
+        if let Some(manager) = manager.take() {
+            let _ = manager.join();
         }
     }
 }
 
-fn run_slatedb_worker(
+fn run_slatedb_manager(
     db_path: String,
     object_store: Arc<dyn ObjectStore>,
     options: SlateDbObjectStoreOptions,
-    receiver: mpsc::Receiver<SlateDbCommand>,
-    opened: mpsc::Sender<Result<(), BackendError>>,
+    shutdown: mpsc::Receiver<()>,
+    opened: mpsc::Sender<Result<(Handle, Arc<Db>), BackendError>>,
 ) {
-    let runtime = match Builder::new_current_thread().enable_all().build() {
+    let runtime = match Builder::new_multi_thread()
+        .worker_threads(RUNTIME_WORKER_THREADS)
+        .enable_all()
+        .build()
+    {
         Ok(runtime) => runtime,
         Err(error) => {
             let _ = opened.send(Err(BackendError::Io(format!(
@@ -526,15 +608,15 @@ fn run_slatedb_worker(
         }
     };
 
-    let _ = opened.send(Ok(()));
-
-    while let Ok(command) = receiver.recv() {
-        match command {
-            SlateDbCommand::Run(operation) => operation(&runtime, &db),
-            SlateDbCommand::Shutdown => break,
-        }
+    let db = Arc::new(db);
+    if opened
+        .send(Ok((runtime.handle().clone(), Arc::clone(&db))))
+        .is_err()
+    {
+        let _ = runtime.block_on(db.close());
+        return;
     }
-
+    let _ = shutdown.recv();
     let _ = runtime.block_on(db.close());
 }
 
@@ -673,21 +755,18 @@ impl EncodedBounds {
     }
 }
 
-fn get_snapshot_values(
-    runtime: &Runtime,
+async fn get_snapshot_values(
     snapshot: Arc<DbSnapshot>,
     keys: Vec<Key>,
 ) -> Result<Vec<Option<Bytes>>, BackendError> {
-    runtime.block_on(async move {
-        stream::iter(keys)
-            .map(|key| {
-                let snapshot = Arc::clone(&snapshot);
-                async move { snapshot.get(key.0).await.map_err(slatedb_error) }
-            })
-            .buffered(POINT_READ_CONCURRENCY)
-            .try_collect()
-            .await
-    })
+    stream::iter(keys)
+        .map(|key| {
+            let snapshot = Arc::clone(&snapshot);
+            async move { snapshot.get(key.0).await.map_err(slatedb_error) }
+        })
+        .buffered(POINT_READ_CONCURRENCY)
+        .try_collect()
+        .await
 }
 
 struct ScanBatch {
@@ -703,85 +782,76 @@ enum ScanBatchState {
     HasMore,
 }
 
-fn open_snapshot_scan(
-    runtime: &Runtime,
-    snapshot: &DbSnapshot,
+async fn open_snapshot_scan(
+    snapshot: Arc<DbSnapshot>,
     bounds: EncodedBounds,
 ) -> Result<DbIterator, BackendError> {
-    runtime.block_on(async {
-        let scan_options = slatedb_scan_options();
-        snapshot
-            .scan_with_options(bounds.range(), &scan_options)
-            .await
-            .map_err(slatedb_error)
-    })
+    let scan_options = slatedb_scan_options();
+    snapshot
+        .scan_with_options(bounds.range(), &scan_options)
+        .await
+        .map_err(slatedb_error)
 }
 
-fn scan_snapshot_batch(
-    runtime: &Runtime,
+async fn scan_snapshot_batch(
     mut iter: DbIterator,
     limit_rows: usize,
     projection: CoreProjection,
     lookahead: bool,
 ) -> Result<ScanBatch, BackendError> {
-    runtime.block_on(async {
-        let mut entries = Vec::with_capacity(limit_rows);
-        while entries.len() < limit_rows {
-            let Some(row) = iter.next().await.map_err(slatedb_error)? else {
-                return Ok(ScanBatch {
-                    iter,
-                    entries,
-                    state: ScanBatchState::Exhausted,
-                });
-            };
-            if row.key.len() < SPACE_PREFIX_LEN {
-                return Err(BackendError::Corruption(format!(
-                    "slatedb key was shorter than space prefix: {:?}",
-                    row.key
-                )));
-            }
-            let key = Key(Bytes::copy_from_slice(&row.key[SPACE_PREFIX_LEN..]));
-            let value = match projection {
-                CoreProjection::KeyOnly => ProjectedValue::KeyOnly,
-                CoreProjection::FullValue => ProjectedValue::FullValue(row.value),
-            };
-            entries.push((key, value));
-        }
-
-        let state = if lookahead {
-            if iter.next().await.map_err(slatedb_error)?.is_some() {
-                ScanBatchState::HasMore
-            } else {
-                ScanBatchState::Exhausted
-            }
-        } else {
-            ScanBatchState::MoreUnknown
+    let mut entries = Vec::with_capacity(limit_rows);
+    while entries.len() < limit_rows {
+        let Some(row) = iter.next().await.map_err(slatedb_error)? else {
+            return Ok(ScanBatch {
+                iter,
+                entries,
+                state: ScanBatchState::Exhausted,
+            });
         };
-        Ok(ScanBatch {
-            iter,
-            entries,
-            state,
-        })
+        if row.key.len() < SPACE_PREFIX_LEN {
+            return Err(BackendError::Corruption(format!(
+                "slatedb key was shorter than space prefix: {:?}",
+                row.key
+            )));
+        }
+        let key = Key(Bytes::copy_from_slice(&row.key[SPACE_PREFIX_LEN..]));
+        let value = match projection {
+            CoreProjection::KeyOnly => ProjectedValue::KeyOnly,
+            CoreProjection::FullValue => ProjectedValue::FullValue(row.value),
+        };
+        entries.push((key, value));
+    }
+
+    let state = if lookahead {
+        if iter.next().await.map_err(slatedb_error)?.is_some() {
+            ScanBatchState::HasMore
+        } else {
+            ScanBatchState::Exhausted
+        }
+    } else {
+        ScanBatchState::MoreUnknown
+    };
+    Ok(ScanBatch {
+        iter,
+        entries,
+        state,
     })
 }
 
-fn collect_snapshot_keys(
-    runtime: &Runtime,
-    snapshot: &DbSnapshot,
+async fn collect_snapshot_keys(
+    snapshot: Arc<DbSnapshot>,
     bounds: EncodedBounds,
 ) -> Result<Vec<Key>, BackendError> {
-    runtime.block_on(async {
-        let scan_options = slatedb_scan_options();
-        let mut iter = snapshot
-            .scan_with_options(bounds.range(), &scan_options)
-            .await
-            .map_err(slatedb_error)?;
-        let mut keys = Vec::new();
-        while let Some(row) = iter.next().await.map_err(slatedb_error)? {
-            keys.push(Key(row.key));
-        }
-        Ok(keys)
-    })
+    let scan_options = slatedb_scan_options();
+    let mut iter = snapshot
+        .scan_with_options(bounds.range(), &scan_options)
+        .await
+        .map_err(slatedb_error)?;
+    let mut keys = Vec::new();
+    while let Some(row) = iter.next().await.map_err(slatedb_error)? {
+        keys.push(Key(row.key));
+    }
+    Ok(keys)
 }
 
 fn slatedb_scan_options() -> SlateDbScanOptions {
@@ -913,11 +983,22 @@ impl Drop for WriterPermit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use futures_util::stream::BoxStream;
     use lix_engine::backend::{
         Backend, BackendWrite, GetOptions, ProjectedValue, PutEntry, ReadOptions, StoredValue,
         WriteOptions, get_many,
     };
     use object_store::memory::InMemory;
+    use object_store::path::Path as ObjectPath;
+    use object_store::{
+        CopyOptions, GetOptions as ObjectStoreGetOptions, GetResult, ListResult, MultipartUpload,
+        ObjectMeta, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
+        Result as ObjectStoreResult,
+    };
+    use std::ops::Range;
+    use std::sync::atomic::AtomicBool;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn open_object_store_round_trips_with_memory_store() {
@@ -952,5 +1033,367 @@ mod tests {
         let result = get_many(&read, space, &[key], GetOptions::default()).expect("read row");
 
         assert_eq!(result.values, vec![Some(ProjectedValue::FullValue(value))]);
+    }
+
+    #[test]
+    fn begin_read_waits_for_commit_wal_durability() {
+        let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
+        let backend = SlateDbBackend::open_object_store("test-commit-visibility", store.clone())
+            .expect("open commit visibility backend");
+        let space = SpaceId(8);
+        let key = Key(Bytes::from_static(b"visible-after-durable"));
+
+        let blocked_write = store.block_next_write();
+        let commit_backend = backend.clone();
+        let commit_key = key.clone();
+        let commit = std::thread::spawn(move || {
+            let mut write = commit_backend
+                .begin_write(WriteOptions::default())
+                .expect("begin visibility write");
+            write
+                .put_many(
+                    space,
+                    PutBatch {
+                        entries: vec![PutEntry {
+                            key: commit_key,
+                            value: StoredValue {
+                                bytes: Bytes::from_static(b"value"),
+                            },
+                        }],
+                    },
+                )
+                .expect("stage visibility write");
+            write.commit()
+        });
+        blocked_write.wait_for_entries(1, "SlateDB WAL write");
+
+        let visibility_wait = backend.worker.observe_next_visibility_wait();
+        let read_backend = backend;
+        let read_key = key;
+        let (read_result_tx, read_result_rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            let result = (|| {
+                let read = read_backend.begin_read(ReadOptions::default())?;
+                get_many(&read, space, &[read_key], GetOptions::default())
+                    .map(|result| result.values)
+            })();
+            let _ = read_result_tx.send(result);
+        });
+
+        visibility_wait
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reader should reach the visibility lock");
+        assert!(
+            matches!(
+                read_result_rx.recv_timeout(Duration::from_millis(50)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "begin_read must remain queued until the WAL write is durable"
+        );
+
+        drop(blocked_write);
+        commit
+            .join()
+            .expect("join visibility commit")
+            .expect("commit visibility value");
+        let values = read_result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("visibility read should finish after WAL durability")
+            .expect("read visibility value");
+        assert_eq!(
+            values,
+            vec![Some(ProjectedValue::FullValue(Bytes::from_static(
+                b"value"
+            )))]
+        );
+        reader.join().expect("join visibility reader");
+    }
+
+    #[test]
+    fn independent_backend_reads_overlap() {
+        let inner = Arc::new(InMemory::new());
+        let db_path = "test-concurrent-reads";
+        let space = SpaceId(9);
+        let left_key = Key(Bytes::from_static(b"left"));
+        let right_key = Key(Bytes::from_static(b"right"));
+        let value = Bytes::from(vec![b'x'; 128 * 1024]);
+
+        {
+            let backend = SlateDbBackend::open_object_store(db_path, inner.clone())
+                .expect("open concurrent-read seed backend");
+            let mut write = backend
+                .begin_write(WriteOptions::default())
+                .expect("begin concurrent-read seed write");
+            write
+                .put_many(
+                    space,
+                    PutBatch {
+                        entries: vec![
+                            PutEntry {
+                                key: left_key.clone(),
+                                value: StoredValue {
+                                    bytes: value.clone(),
+                                },
+                            },
+                            PutEntry {
+                                key: right_key.clone(),
+                                value: StoredValue {
+                                    bytes: value.clone(),
+                                },
+                            },
+                        ],
+                    },
+                )
+                .expect("stage concurrent-read seed values");
+            write.commit().expect("commit concurrent-read seed values");
+        }
+
+        let store = Arc::new(BlockingStore::new(inner));
+        let backend = SlateDbBackend::open_object_store(db_path, store.clone())
+            .expect("reopen concurrent-read backend");
+        let left_read = backend
+            .begin_read(ReadOptions::default())
+            .expect("begin left read");
+        let right_read = backend
+            .begin_read(ReadOptions::default())
+            .expect("begin right read");
+        let blocked_reads = store.block_sst_reads();
+
+        let left = std::thread::spawn(move || {
+            get_many(&left_read, space, &[left_key], GetOptions::default())
+        });
+        blocked_reads.wait_for_entries(1, "first SST read");
+        let right = std::thread::spawn(move || {
+            get_many(&right_read, space, &[right_key], GetOptions::default())
+        });
+        blocked_reads.wait_for_entries(2, "second concurrent SST read");
+        drop(blocked_reads);
+
+        assert_eq!(
+            left.join()
+                .expect("join left read")
+                .expect("read left value")
+                .values,
+            vec![Some(ProjectedValue::FullValue(value.clone()))]
+        );
+        assert_eq!(
+            right
+                .join()
+                .expect("join right read")
+                .expect("read right value")
+                .values,
+            vec![Some(ProjectedValue::FullValue(value))]
+        );
+    }
+
+    #[derive(Clone, Debug)]
+    struct BlockingStore {
+        inner: Arc<InMemory>,
+        next_write: Arc<AtomicBool>,
+        writes: Arc<OperationBlock>,
+        block_reads: Arc<AtomicBool>,
+        reads: Arc<OperationBlock>,
+    }
+
+    impl BlockingStore {
+        fn new(inner: Arc<InMemory>) -> Self {
+            Self {
+                inner,
+                next_write: Arc::new(AtomicBool::new(false)),
+                writes: Arc::new(OperationBlock::default()),
+                block_reads: Arc::new(AtomicBool::new(false)),
+                reads: Arc::new(OperationBlock::default()),
+            }
+        }
+
+        fn block_next_write(&self) -> OperationBlockGuard {
+            OperationBlockGuard::arm(Arc::clone(&self.next_write), Arc::clone(&self.writes))
+        }
+
+        fn block_sst_reads(&self) -> OperationBlockGuard {
+            OperationBlockGuard::arm(Arc::clone(&self.block_reads), Arc::clone(&self.reads))
+        }
+
+        fn maybe_block_write(&self) {
+            if self.next_write.swap(false, Ordering::AcqRel) {
+                self.writes.enter();
+            }
+        }
+
+        fn maybe_block_read(&self, location: &ObjectPath) {
+            if self.block_reads.load(Ordering::Acquire)
+                && location
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("sst"))
+            {
+                self.reads.enter();
+            }
+        }
+    }
+
+    impl std::fmt::Display for BlockingStore {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("BlockingStore")
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct OperationBlock {
+        state: Mutex<OperationBlockState>,
+        available: Condvar,
+    }
+
+    #[derive(Debug, Default)]
+    struct OperationBlockState {
+        entries: usize,
+        released: bool,
+    }
+
+    impl OperationBlock {
+        fn reset(&self) {
+            let mut state = self.state.lock().expect("lock operation block");
+            state.entries = 0;
+            state.released = false;
+        }
+
+        fn enter(&self) {
+            let mut state = self.state.lock().expect("lock operation block");
+            state.entries += 1;
+            self.available.notify_all();
+            while !state.released {
+                state = self
+                    .available
+                    .wait(state)
+                    .expect("wait for operation release");
+            }
+        }
+
+        fn release(&self) {
+            let mut state = self.state.lock().expect("lock operation block");
+            state.released = true;
+            self.available.notify_all();
+        }
+    }
+
+    #[derive(Debug)]
+    struct OperationBlockGuard {
+        enabled: Arc<AtomicBool>,
+        block: Arc<OperationBlock>,
+    }
+
+    impl OperationBlockGuard {
+        fn arm(enabled: Arc<AtomicBool>, block: Arc<OperationBlock>) -> Self {
+            block.reset();
+            enabled.store(true, Ordering::Release);
+            Self { enabled, block }
+        }
+
+        fn wait_for_entries(&self, expected: usize, description: &str) {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let mut state = self.block.state.lock().expect("lock operation block");
+            while state.entries < expected {
+                let now = Instant::now();
+                assert!(now < deadline, "timed out waiting for {description}");
+                let (next_state, _) = self
+                    .block
+                    .available
+                    .wait_timeout(state, deadline - now)
+                    .expect("wait for blocked operation");
+                state = next_state;
+            }
+        }
+    }
+
+    impl Drop for OperationBlockGuard {
+        fn drop(&mut self) {
+            self.enabled.store(false, Ordering::Release);
+            self.block.release();
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for BlockingStore {
+        async fn put_opts(
+            &self,
+            location: &ObjectPath,
+            payload: PutPayload,
+            options: PutOptions,
+        ) -> ObjectStoreResult<PutResult> {
+            self.maybe_block_write();
+            self.inner.put_opts(location, payload, options).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjectPath,
+            options: PutMultipartOptions,
+        ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, options).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &ObjectPath,
+            options: ObjectStoreGetOptions,
+        ) -> ObjectStoreResult<GetResult> {
+            self.maybe_block_read(location);
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(
+            &self,
+            location: &ObjectPath,
+            ranges: &[Range<u64>],
+        ) -> ObjectStoreResult<Vec<Bytes>> {
+            self.maybe_block_read(location);
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, ObjectStoreResult<ObjectPath>>,
+        ) -> BoxStream<'static, ObjectStoreResult<ObjectPath>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&ObjectPath>,
+            offset: &ObjectPath,
+        ) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> ObjectStoreResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjectPath,
+            to: &ObjectPath,
+            options: CopyOptions,
+        ) -> ObjectStoreResult<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+
+        async fn rename_opts(
+            &self,
+            from: &ObjectPath,
+            to: &ObjectPath,
+            options: RenameOptions,
+        ) -> ObjectStoreResult<()> {
+            self.inner.rename_opts(from, to, options).await
+        }
     }
 }

--- a/packages/backends/src/slatedb.rs
+++ b/packages/backends/src/slatedb.rs
@@ -403,6 +403,7 @@ impl BackendWrite for SlateDbWrite {
     fn commit(self) -> Result<CommitResult, BackendError> {
         let stats = self.stats;
         if self.overlay.is_empty() {
+            self.worker.ensure_usable()?;
             return Ok(CommitResult {
                 commit_id: None,
                 stats,
@@ -1224,6 +1225,31 @@ mod tests {
                 .begin_write(WriteOptions::default())
                 .map(|_| ())
                 .expect_err("future writers must reject a failed commit"),
+            BackendError::Durability
+        );
+    }
+
+    #[test]
+    fn empty_commit_observes_prior_durability_failure() {
+        let backend = SlateDbBackend::open_object_store(
+            "test-empty-failed-commit",
+            Arc::new(InMemory::new()),
+        )
+        .expect("open empty failed commit backend");
+        let write = backend
+            .begin_write(WriteOptions::default())
+            .expect("begin empty write before failure");
+
+        backend
+            .worker
+            .inner
+            .durability_failed
+            .store(true, Ordering::Release);
+
+        assert_eq!(
+            write
+                .commit()
+                .expect_err("empty commit must observe prior durability failure"),
             BackendError::Durability
         );
     }

--- a/packages/backends/src/slatedb.rs
+++ b/packages/backends/src/slatedb.rs
@@ -186,9 +186,8 @@ impl SlateDbBackend {
     }
 
     pub fn flush(&self) -> Result<(), BackendError> {
-        self.worker.ensure_usable()?;
         let durability_failed = Arc::clone(&self.worker.inner.durability_failed);
-        self.worker.call(move |db| async move {
+        self.worker.call_with_visibility_lock(move |db| async move {
             db.flush().await.map_err(|error| {
                 durability_failed.store(true, Ordering::Release);
                 slatedb_error(error)
@@ -1069,7 +1068,7 @@ mod tests {
     }
 
     #[test]
-    fn begin_read_waits_for_commit_wal_durability() {
+    fn visibility_operations_wait_for_commit_wal_durability() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let backend = SlateDbBackend::open_object_store("test-commit-visibility", store.clone())
             .expect("open commit visibility backend");
@@ -1101,7 +1100,7 @@ mod tests {
         blocked_write.wait_for_entries(1, "SlateDB WAL write");
 
         let visibility_wait = backend.worker.observe_next_visibility_wait();
-        let read_backend = backend;
+        let read_backend = backend.clone();
         let read_key = key;
         let (read_result_tx, read_result_rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
@@ -1124,6 +1123,23 @@ mod tests {
             "begin_read must remain queued until the WAL write is durable"
         );
 
+        let flush_wait = backend.worker.observe_next_visibility_wait();
+        let flush_backend = backend;
+        let (flush_result_tx, flush_result_rx) = mpsc::channel();
+        let flusher = std::thread::spawn(move || {
+            let _ = flush_result_tx.send(flush_backend.flush());
+        });
+        flush_wait
+            .recv_timeout(Duration::from_secs(2))
+            .expect("flush should reach the visibility lock");
+        assert!(
+            matches!(
+                flush_result_rx.recv_timeout(Duration::from_millis(50)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "flush must remain queued until the commit WAL write finishes"
+        );
+
         drop(blocked_write);
         commit
             .join()
@@ -1140,6 +1156,11 @@ mod tests {
             )))]
         );
         reader.join().expect("join visibility reader");
+        flush_result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("flush should finish after commit WAL durability")
+            .expect("flush committed database");
+        flusher.join().expect("join queued flusher");
     }
 
     #[test]

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -84,6 +84,7 @@ serde_json = "1"
 jsonschema = { version = "0.17", default-features = false, features = ["draft202012"] }
 globset = "0.4"
 jiff = { version = "0.2.27", default-features = false, features = ["std"] }
+lru = "0.18"
 uuid = { version = "1", features = ["v7", "std", "js", "fast-rng"] }
 unicode-normalization = "0.1"
 precis-profiles = "0.1.13"

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 use std::ops::Range;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Barrier};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -10,6 +10,10 @@ use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_ma
 use futures_util::StreamExt;
 use futures_util::stream::{self, BoxStream};
 use lix_backends::{SlateDbBackend, SlateDbCacheOptions, SlateDbObjectStoreOptions};
+use lix_engine::backend::{
+    Backend, BackendWrite, GetOptions as BackendGetOptions, Key, ProjectedValue, PutBatch,
+    PutEntry, ReadOptions, SpaceId, StoredValue, WriteOptions, get_many,
+};
 use lix_engine::{Engine, SessionContext, Value};
 use object_store::memory::InMemory;
 use object_store::path::Path;
@@ -28,7 +32,11 @@ const UPLOAD_BATCH_SIZE: usize = 10;
 const BENCH_DISK_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const BENCH_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
 const BENCH_METADATA_CACHE_BYTES: u64 = 4 * 1024 * 1024;
-const MAX_UPLOAD_REMOTE_WRITE_OPS: u64 = 8;
+const FRESH_ENGINE_DELAYS_MS: &[u64] = &[0, 25];
+const CONCURRENCY_DELAY_MS: u64 = 10;
+const CONCURRENCY_REQUESTS: usize = 4;
+const CONCURRENCY_VALUE_BYTES: usize = 16 * 1024;
+const CONCURRENCY_SPACE: SpaceId = SpaceId(0x00ff_0001);
 
 static NEXT_DB_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -37,7 +45,7 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
         .enable_all()
         .build()
         .expect("create tokio runtime for slatedb_file_api benchmarks");
-    let mut group = c.benchmark_group("slatedb_file_api");
+    let mut group = c.benchmark_group("slatedb_file_api_warm_cache");
     group.sample_size(10);
 
     for &delay_ms in DELAYS_MS {
@@ -45,62 +53,75 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
         let delay_label = format!("{delay_ms}ms");
 
         group.bench_with_input(
-            BenchmarkId::new("upload_overwrite_file", &delay_label),
+            BenchmarkId::new("upload_overwrite_file_after_preload", &delay_label),
             &delay,
             |b, &delay| {
                 b.iter_custom(|iterations| {
                     let fixture = runtime.block_on(UploadBenchFixture::seeded(delay));
+                    black_box(runtime.block_on(fixture.upload_overwrite_file()));
                     measure_iterations(iterations, || {
-                        fixture.object_store.reset_counts();
-                        let result = runtime.block_on(fixture.upload_overwrite_file());
-                        let counts = fixture.object_store.counts();
-                        assert_eq!(counts.reads, 0, "cached upload issued remote reads");
-                        assert!(
-                            counts.writes <= MAX_UPLOAD_REMOTE_WRITE_OPS,
-                            "cached upload issued {} remote writes",
-                            counts.writes
-                        );
-                        black_box(counts);
-                        result
+                        runtime.block_on(fixture.upload_overwrite_file())
                     })
                 });
             },
         );
 
         group.bench_with_input(
-            BenchmarkId::new("list_root_directory", &delay_label),
+            BenchmarkId::new("list_root_directory_after_preload", &delay_label),
             &delay,
             |b, &delay| {
                 b.iter_custom(|iterations| {
                     let fixture = runtime.block_on(ReadBenchFixture::seeded(delay));
+                    black_box(runtime.block_on(fixture.list_root_directory()));
                     measure_iterations(iterations, || {
-                        fixture.object_store.reset_counts();
-                        let result = runtime.block_on(fixture.list_root_directory());
-                        let counts = fixture.object_store.counts();
-                        assert_eq!(counts.reads, 0, "cached directory list issued remote reads");
-                        assert_eq!(counts.writes, 0, "directory list issued remote writes");
-                        black_box(counts);
-                        result
+                        runtime.block_on(fixture.list_root_directory())
                     })
                 });
             },
         );
 
         group.bench_with_input(
-            BenchmarkId::new("download_file", delay_label),
+            BenchmarkId::new("download_file_after_preload", delay_label),
             &delay,
             |b, &delay| {
                 b.iter_custom(|iterations| {
                     let fixture = runtime.block_on(ReadBenchFixture::seeded(delay));
-                    measure_iterations(iterations, || {
-                        fixture.object_store.reset_counts();
-                        let result = runtime.block_on(fixture.download_file());
-                        let counts = fixture.object_store.counts();
-                        assert_eq!(counts.reads, 0, "cached download issued remote reads");
-                        assert_eq!(counts.writes, 0, "download issued remote writes");
-                        black_box(counts);
-                        result
-                    })
+                    black_box(runtime.block_on(fixture.download_file()));
+                    measure_iterations(iterations, || runtime.block_on(fixture.download_file()))
+                });
+            },
+        );
+    }
+
+    group.finish();
+
+    fresh_engine_select_benches(c, &runtime);
+    backend_concurrency_benches(c);
+}
+
+fn fresh_engine_select_benches(c: &mut Criterion, runtime: &tokio::runtime::Runtime) {
+    let mut group = c.benchmark_group("slatedb_file_api_fresh_engine_select");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &delay_ms in FRESH_ENGINE_DELAYS_MS {
+        let delay = Duration::from_millis(delay_ms);
+
+        group.bench_with_input(
+            BenchmarkId::new("download_file", format!("{delay_ms}ms")),
+            &delay,
+            |b, &delay| {
+                b.iter_custom(|iterations| {
+                    let fixture = runtime.block_on(FreshEngineSelectBenchFixture::seeded(delay));
+                    // Constructing the Engine and session can itself fetch
+                    // repository state. Prepare each fresh session outside the
+                    // manual timer so this measures only its first SELECT.
+                    measure_prepared_iterations(
+                        iterations,
+                        || runtime.block_on(fixture.open_session()),
+                        |session| runtime.block_on(download_file(session, &fixture.file_id)),
+                    )
                 });
             },
         );
@@ -109,12 +130,61 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
     group.finish();
 }
 
+fn backend_concurrency_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("slatedb_backend_concurrency");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    group.bench_function("one_point_read", |b| {
+        b.iter_custom(|iterations| {
+            let fixture =
+                BackendConcurrencyFixture::seeded(Duration::from_millis(CONCURRENCY_DELAY_MS));
+            measure_iterations(iterations, || fixture.read_sequential(1))
+        });
+    });
+
+    group.bench_function("four_sequential_point_reads", |b| {
+        b.iter_custom(|iterations| {
+            let fixture =
+                BackendConcurrencyFixture::seeded(Duration::from_millis(CONCURRENCY_DELAY_MS));
+            measure_iterations(iterations, || fixture.read_sequential(CONCURRENCY_REQUESTS))
+        });
+    });
+
+    group.bench_function("four_parallel_point_reads", |b| {
+        b.iter_custom(|iterations| {
+            let fixture =
+                BackendConcurrencyFixture::seeded(Duration::from_millis(CONCURRENCY_DELAY_MS));
+            measure_iterations(iterations, || fixture.read_parallel(CONCURRENCY_REQUESTS))
+        });
+    });
+
+    group.finish();
+}
+
 fn measure_iterations<T>(iterations: u64, mut operation: impl FnMut() -> T) -> Duration {
     let mut elapsed = Duration::ZERO;
     for _ in 0..iterations {
-        let start = Instant::now();
+        let started = Instant::now();
         let result = operation();
-        elapsed += start.elapsed();
+        elapsed += started.elapsed();
+        black_box(result);
+    }
+    elapsed
+}
+
+fn measure_prepared_iterations<P, T>(
+    iterations: u64,
+    mut prepare: impl FnMut() -> P,
+    mut operation: impl FnMut(&P) -> T,
+) -> Duration {
+    let mut elapsed = Duration::ZERO;
+    for _ in 0..iterations {
+        let prepared = prepare();
+        let started = Instant::now();
+        let result = operation(&prepared);
+        elapsed += started.elapsed();
         black_box(result);
     }
     elapsed
@@ -129,7 +199,7 @@ struct SeededStore {
 }
 
 impl SeededStore {
-    async fn create(delay: Duration) -> Self {
+    async fn create() -> Self {
         let db_id = NEXT_DB_ID.fetch_add(1, Ordering::Relaxed);
         let db_path = format!("slatedb-file-api-bench-{}-{db_id}", std::process::id());
         let seed_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -151,7 +221,7 @@ impl SeededStore {
         let upload_path = file_path(0);
         let file_id = lookup_file_id(&session, &upload_path).await;
         backend.flush().expect("flush seeded file benchmark store");
-        let object_store = Arc::new(DelayedObjectStore::new(seed_object_store, delay));
+        let object_store = Arc::new(DelayedObjectStore::new(seed_object_store, Duration::ZERO));
 
         Self {
             object_store,
@@ -182,9 +252,7 @@ impl SeededStore {
 }
 
 struct UploadBenchFixture {
-    backend: SlateDbBackend,
     session: SessionContext<SlateDbBackend>,
-    object_store: Arc<DelayedObjectStore>,
     _cache_dir: TempDir,
     next_upload_version: AtomicU64,
     upload_path: String,
@@ -192,7 +260,7 @@ struct UploadBenchFixture {
 
 impl UploadBenchFixture {
     async fn seeded(delay: Duration) -> Self {
-        let seeded = SeededStore::create(Duration::ZERO).await;
+        let seeded = SeededStore::create().await;
         let cache_dir = tempfile::tempdir().expect("create SlateDB upload cache directory");
         let backend = SlateDbBackend::open_object_store_with_options(
             seeded.db_path.clone(),
@@ -200,7 +268,7 @@ impl UploadBenchFixture {
             cached_object_store_options(&cache_dir),
         )
         .expect("reopen delayed SlateDB backend for upload benchmark");
-        let engine = Engine::new(backend.clone())
+        let engine = Engine::new(backend)
             .await
             .expect("open SlateDB upload benchmark engine");
         let session = engine
@@ -208,12 +276,9 @@ impl UploadBenchFixture {
             .await
             .expect("open SlateDB upload benchmark session");
         seeded.object_store.set_delay(delay);
-        seeded.object_store.reset_counts();
 
         Self {
-            backend,
             session,
-            object_store: seeded.object_store,
             _cache_dir: cache_dir,
             next_upload_version: AtomicU64::new(0),
             upload_path: seeded.upload_path,
@@ -236,30 +301,24 @@ impl UploadBenchFixture {
             )
             .await
             .expect("overwrite benchmark file");
-        self.backend
-            .flush()
-            .expect("flush overwritten benchmark file");
         result.rows_affected()
     }
 }
 
 struct ReadBenchFixture {
     session: SessionContext<SlateDbBackend>,
-    object_store: Arc<DelayedObjectStore>,
     _cache_dir: TempDir,
     file_id: String,
 }
 
 impl ReadBenchFixture {
     async fn seeded(delay: Duration) -> Self {
-        let seeded = SeededStore::create(Duration::ZERO).await;
+        let seeded = SeededStore::create().await;
         let (session, cache_dir) = seeded.open_session().await;
         seeded.object_store.set_delay(delay);
-        seeded.object_store.reset_counts();
 
         Self {
             session,
-            object_store: seeded.object_store,
             _cache_dir: cache_dir,
             file_id: seeded.file_id,
         }
@@ -288,23 +347,222 @@ impl ReadBenchFixture {
     }
 
     async fn download_file(&self) -> usize {
-        let result = self
-            .session
-            .execute(
-                "SELECT data FROM lix_file WHERE id = $1",
-                &[Value::Text(self.file_id.clone())],
-            )
-            .await
-            .expect("download benchmark file");
-        let value = result
-            .rows()
-            .first()
-            .and_then(|row| row.values().first())
-            .expect("download query should return one data value");
-        match value {
-            Value::Blob(bytes) => bytes.len(),
-            other => panic!("download query returned non-blob value: {other:?}"),
+        download_file(&self.session, &self.file_id).await
+    }
+}
+
+struct FreshEngineSelectBenchFixture {
+    backend: SlateDbBackend,
+    main_branch_id: String,
+    file_id: String,
+}
+
+impl FreshEngineSelectBenchFixture {
+    async fn seeded(delay: Duration) -> Self {
+        let seeded = SeededStore::create().await;
+        let backend = SlateDbBackend::open_object_store(
+            seeded.db_path.clone(),
+            object_store_handle(&seeded.object_store),
+        )
+        .expect("reopen uncached SlateDB file benchmark backend");
+        seeded.object_store.set_delay(delay);
+
+        Self {
+            backend,
+            main_branch_id: seeded.main_branch_id,
+            file_id: seeded.file_id,
         }
+    }
+
+    async fn open_session(&self) -> SessionContext<SlateDbBackend> {
+        // A fresh Engine owns a fresh immutable-node cache. The benchmark
+        // creates this session before starting its manual request timer.
+        let engine = Engine::new(self.backend.clone())
+            .await
+            .expect("open fresh-engine SlateDB benchmark engine");
+        engine
+            .open_session(self.main_branch_id.clone())
+            .await
+            .expect("open fresh-engine SlateDB benchmark session")
+    }
+}
+
+async fn download_file(session: &SessionContext<SlateDbBackend>, file_id: &str) -> usize {
+    let result = session
+        .execute(
+            "SELECT data FROM lix_file WHERE id = $1",
+            &[Value::Text(file_id.to_string())],
+        )
+        .await
+        .expect("download benchmark file");
+    let value = result
+        .rows()
+        .first()
+        .and_then(|row| row.values().first())
+        .expect("download query should return one data value");
+    match value {
+        Value::Blob(bytes) => bytes.len(),
+        other => panic!("download query returned non-blob value: {other:?}"),
+    }
+}
+
+struct BackendConcurrencyFixture {
+    readers: BackendReadWorkers,
+}
+
+struct BackendReadRequest {
+    barrier: Arc<Barrier>,
+    result: std::sync::mpsc::Sender<usize>,
+}
+
+struct BackendReadWorkers {
+    commands: Vec<std::sync::mpsc::Sender<BackendReadRequest>>,
+    threads: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl BackendConcurrencyFixture {
+    fn seeded(delay: Duration) -> Self {
+        let db_id = NEXT_DB_ID.fetch_add(1, Ordering::Relaxed);
+        let db_path = format!("slatedb-concurrency-bench-{}-{db_id}", std::process::id());
+        let seed_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let keys = (0..CONCURRENCY_REQUESTS)
+            .map(|index| Key(Bytes::from(format!("concurrency-key-{index}"))))
+            .collect::<Vec<_>>();
+
+        {
+            let backend =
+                SlateDbBackend::open_object_store(db_path.clone(), Arc::clone(&seed_object_store))
+                    .expect("open SlateDB concurrency seed backend");
+            let mut write = backend
+                .begin_write(WriteOptions::default())
+                .expect("begin SlateDB concurrency seed write");
+            write
+                .put_many(
+                    CONCURRENCY_SPACE,
+                    PutBatch {
+                        entries: keys
+                            .iter()
+                            .cloned()
+                            .map(|key| PutEntry {
+                                key,
+                                value: StoredValue {
+                                    bytes: Bytes::from(vec![0x5a; CONCURRENCY_VALUE_BYTES]),
+                                },
+                            })
+                            .collect(),
+                    },
+                )
+                .expect("stage SlateDB concurrency seed value");
+            write
+                .commit()
+                .expect("commit SlateDB concurrency seed value");
+        }
+
+        let object_store = Arc::new(DelayedObjectStore::new(seed_object_store, Duration::ZERO));
+        let backend =
+            SlateDbBackend::open_object_store(db_path, object_store_handle(&object_store))
+                .expect("reopen SlateDB concurrency benchmark backend");
+        let readers = BackendReadWorkers::new(&backend, &keys);
+        object_store.set_delay(delay);
+
+        Self { readers }
+    }
+
+    fn read_sequential(&self, request_count: usize) -> usize {
+        self.readers.read_sequential(request_count)
+    }
+
+    fn read_parallel(&self, request_count: usize) -> usize {
+        self.readers.read_parallel(request_count)
+    }
+}
+
+impl BackendReadWorkers {
+    fn new(backend: &SlateDbBackend, keys: &[Key]) -> Self {
+        let mut commands = Vec::with_capacity(keys.len());
+        let mut threads = Vec::with_capacity(keys.len());
+        for key in keys {
+            let (command_tx, command_rx) = std::sync::mpsc::channel::<BackendReadRequest>();
+            let backend = backend.clone();
+            let key = key.clone();
+            threads.push(std::thread::spawn(move || {
+                while let Ok(request) = command_rx.recv() {
+                    request.barrier.wait();
+                    let result = read_backend_key(&backend, &key);
+                    let _ = request.result.send(result);
+                }
+            }));
+            commands.push(command_tx);
+        }
+        Self { commands, threads }
+    }
+
+    fn read_sequential(&self, request_count: usize) -> usize {
+        assert!(
+            request_count > 0 && request_count <= self.commands.len(),
+            "benchmark request count must fit the persistent reader pool"
+        );
+        let barrier = Arc::new(Barrier::new(1));
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let mut result = 0;
+        for command in self.commands.iter().take(request_count) {
+            command
+                .send(BackendReadRequest {
+                    barrier: Arc::clone(&barrier),
+                    result: result_tx.clone(),
+                })
+                .expect("dispatch sequential SlateDB point read");
+            result += result_rx
+                .recv()
+                .expect("receive sequential SlateDB point read");
+        }
+        result
+    }
+
+    fn read_parallel(&self, request_count: usize) -> usize {
+        assert!(
+            request_count > 0 && request_count <= self.commands.len(),
+            "benchmark request count must fit the persistent reader pool"
+        );
+        let barrier = Arc::new(Barrier::new(request_count));
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        for command in self.commands.iter().take(request_count) {
+            command
+                .send(BackendReadRequest {
+                    barrier: Arc::clone(&barrier),
+                    result: result_tx.clone(),
+                })
+                .expect("dispatch parallel SlateDB point read");
+        }
+        drop(result_tx);
+        result_rx.into_iter().sum()
+    }
+}
+
+impl Drop for BackendReadWorkers {
+    fn drop(&mut self) {
+        self.commands.clear();
+        for thread in self.threads.drain(..) {
+            thread.join().expect("join persistent SlateDB reader");
+        }
+    }
+}
+
+fn read_backend_key(backend: &SlateDbBackend, key: &Key) -> usize {
+    let read = backend
+        .begin_read(ReadOptions::default())
+        .expect("begin SlateDB concurrency read");
+    let result = get_many(
+        &read,
+        CONCURRENCY_SPACE,
+        std::slice::from_ref(key),
+        BackendGetOptions::default(),
+    )
+    .expect("read SlateDB concurrency key");
+    match result.values.into_iter().next().flatten() {
+        Some(ProjectedValue::FullValue(value)) => value.len(),
+        Some(ProjectedValue::KeyOnly) => panic!("concurrency read returned key-only value"),
+        None => panic!("concurrency read did not find seeded key"),
     }
 }
 
@@ -399,18 +657,10 @@ fn cached_object_store_options(cache_dir: &TempDir) -> SlateDbObjectStoreOptions
     }
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-struct ObjectStoreOperationCounts {
-    reads: u64,
-    writes: u64,
-}
-
 #[derive(Clone, Debug)]
 struct DelayedObjectStore {
     inner: Arc<dyn ObjectStore>,
     delay_nanos: Arc<AtomicU64>,
-    read_ops: Arc<AtomicU64>,
-    write_ops: Arc<AtomicU64>,
 }
 
 impl DelayedObjectStore {
@@ -418,8 +668,6 @@ impl DelayedObjectStore {
         Self {
             inner,
             delay_nanos: Arc::new(AtomicU64::new(duration_nanos(delay))),
-            read_ops: Arc::new(AtomicU64::new(0)),
-            write_ops: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -430,18 +678,6 @@ impl DelayedObjectStore {
 
     fn delay(&self) -> Duration {
         Duration::from_nanos(self.delay_nanos.load(Ordering::Relaxed))
-    }
-
-    fn reset_counts(&self) {
-        self.read_ops.store(0, Ordering::Relaxed);
-        self.write_ops.store(0, Ordering::Relaxed);
-    }
-
-    fn counts(&self) -> ObjectStoreOperationCounts {
-        ObjectStoreOperationCounts {
-            reads: self.read_ops.load(Ordering::Relaxed),
-            writes: self.write_ops.load(Ordering::Relaxed),
-        }
     }
 }
 
@@ -464,7 +700,6 @@ impl ObjectStore for DelayedObjectStore {
         payload: PutPayload,
         opts: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
-        self.write_ops.fetch_add(1, Ordering::Relaxed);
         delay_once(self.delay()).await;
         self.inner.put_opts(location, payload, opts).await
     }
@@ -474,13 +709,11 @@ impl ObjectStore for DelayedObjectStore {
         location: &Path,
         opts: PutMultipartOptions,
     ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
-        self.write_ops.fetch_add(1, Ordering::Relaxed);
         delay_once(self.delay()).await;
         self.inner.put_multipart_opts(location, opts).await
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> ObjectStoreResult<GetResult> {
-        self.read_ops.fetch_add(1, Ordering::Relaxed);
         delay_once(self.delay()).await;
         self.inner.get_opts(location, options).await
     }
@@ -490,7 +723,6 @@ impl ObjectStore for DelayedObjectStore {
         location: &Path,
         ranges: &[Range<u64>],
     ) -> ObjectStoreResult<Vec<Bytes>> {
-        self.read_ops.fetch_add(1, Ordering::Relaxed);
         delay_once(self.delay()).await;
         self.inner.get_ranges(location, ranges).await
     }
@@ -501,7 +733,6 @@ impl ObjectStore for DelayedObjectStore {
     ) -> BoxStream<'static, ObjectStoreResult<Path>> {
         let inner = Arc::clone(&self.inner);
         let delay_nanos = Arc::clone(&self.delay_nanos);
-        self.write_ops.fetch_add(1, Ordering::Relaxed);
         stream::once(async move {
             delay_once(current_delay(&delay_nanos)).await;
             inner.delete_stream(locations)
@@ -514,7 +745,6 @@ impl ObjectStore for DelayedObjectStore {
         let inner = Arc::clone(&self.inner);
         let prefix = prefix.cloned();
         let delay_nanos = Arc::clone(&self.delay_nanos);
-        self.read_ops.fetch_add(1, Ordering::Relaxed);
         stream::once(async move {
             delay_once(current_delay(&delay_nanos)).await;
             inner.list(prefix.as_ref())
@@ -532,7 +762,6 @@ impl ObjectStore for DelayedObjectStore {
         let prefix = prefix.cloned();
         let offset = offset.clone();
         let delay_nanos = Arc::clone(&self.delay_nanos);
-        self.read_ops.fetch_add(1, Ordering::Relaxed);
         stream::once(async move {
             delay_once(current_delay(&delay_nanos)).await;
             inner.list_with_offset(prefix.as_ref(), &offset)
@@ -542,7 +771,6 @@ impl ObjectStore for DelayedObjectStore {
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
-        self.read_ops.fetch_add(1, Ordering::Relaxed);
         delay_once(self.delay()).await;
         self.inner.list_with_delimiter(prefix).await
     }
@@ -553,7 +781,6 @@ impl ObjectStore for DelayedObjectStore {
         to: &Path,
         options: CopyOptions,
     ) -> ObjectStoreResult<()> {
-        self.write_ops.fetch_add(1, Ordering::Relaxed);
         delay_once(self.delay()).await;
         self.inner.copy_opts(from, to, options).await
     }
@@ -564,7 +791,6 @@ impl ObjectStore for DelayedObjectStore {
         to: &Path,
         options: RenameOptions,
     ) -> ObjectStoreResult<()> {
-        self.write_ops.fetch_add(1, Ordering::Relaxed);
         delay_once(self.delay()).await;
         self.inner.rename_opts(from, to, options).await
     }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -111,14 +111,22 @@ pub(crate) fn verify_chunk_hash(
     expected: &[u8; TRACKED_STATE_HASH_BYTES],
     bytes: &[u8],
 ) -> Result<(), LixError> {
+    let actual = crate::tracked_state::codec::hash_bytes(bytes);
+    if &actual != expected {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state chunk hash mismatch",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn debug_verify_chunk_hash(
+    expected: &[u8; TRACKED_STATE_HASH_BYTES],
+    bytes: &[u8],
+) -> Result<(), LixError> {
     if cfg!(debug_assertions) {
-        let actual = crate::tracked_state::codec::hash_bytes(bytes);
-        if &actual != expected {
-            return Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "tracked-state chunk hash mismatch",
-            ));
-        }
+        verify_chunk_hash(expected, bytes)?;
     }
     Ok(())
 }
@@ -143,15 +151,8 @@ impl TrackedStateChunkOverlay {
         Self::default()
     }
 
-    pub(crate) async fn read_chunk(
-        &self,
-        store: &(impl StorageRead + ?Sized),
-        hash: &[u8; TRACKED_STATE_HASH_BYTES],
-    ) -> Result<Option<Vec<u8>>, LixError> {
-        if let Some(bytes) = self.chunks.get(hash) {
-            return Ok(Some(bytes.clone()));
-        }
-        read_chunk(store, hash).await
+    pub(crate) fn staged_chunk(&self, hash: &[u8; TRACKED_STATE_HASH_BYTES]) -> Option<&[u8]> {
+        self.chunks.get(hash).map(Vec::as_slice)
     }
 
     pub(crate) fn stage_chunks(

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -1,9 +1,13 @@
 use std::{
     collections::{BTreeMap, VecDeque},
     future::Future,
+    num::NonZeroUsize,
     ops::Range,
     pin::Pin,
+    sync::{Arc, Mutex},
 };
+
+use lru::LruCache;
 
 use crate::storage::{StorageRead, StorageWriteSet};
 use crate::tracked_state::codec::{
@@ -21,6 +25,13 @@ use crate::tracked_state::types::{
     TrackedStateTreeScanRequest,
 };
 use crate::{LixError, NullableKeyFilter};
+
+// Nodes are immutable and addressed by their BLAKE3 content hash, so verified
+// bytes are safe to share across tree clones. Nodes larger than the configured
+// maximum chunk size bypass the cache, bounding production payload bytes at
+// about 64 MiB (excluding cache metadata and live Arcs held by callers).
+const TRACKED_STATE_NODE_CACHE_CAPACITY: usize = 4096;
+type TrackedStateNodeCache = LruCache<[u8; TRACKED_STATE_HASH_BYTES], Arc<[u8]>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TrackedStateTreeOptions {
@@ -51,18 +62,27 @@ impl Default for TrackedStateTreeOptions {
 #[derive(Debug, Clone)]
 pub(crate) struct TrackedStateTree {
     options: TrackedStateTreeOptions,
+    node_cache: Arc<Mutex<TrackedStateNodeCache>>,
 }
 
 impl TrackedStateTree {
     pub(crate) fn new() -> Self {
-        Self {
-            options: TrackedStateTreeOptions::default(),
-        }
+        Self::with_options_inner(TrackedStateTreeOptions::default())
     }
 
     #[cfg(test)]
     pub(crate) fn with_options(options: TrackedStateTreeOptions) -> Self {
-        Self { options }
+        Self::with_options_inner(options)
+    }
+
+    fn with_options_inner(options: TrackedStateTreeOptions) -> Self {
+        Self {
+            options,
+            node_cache: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(TRACKED_STATE_NODE_CACHE_CAPACITY)
+                    .expect("tracked-state node cache capacity must be non-zero"),
+            ))),
+        }
     }
 
     pub(crate) async fn load_root(
@@ -1657,11 +1677,30 @@ impl TrackedStateTree {
         &self,
         store: &(impl StorageRead + Send + Sync + ?Sized),
         hash: &[u8; TRACKED_STATE_HASH_BYTES],
-    ) -> Result<Vec<u8>, LixError> {
+    ) -> Result<Arc<[u8]>, LixError> {
+        let cached = {
+            let mut cache = self
+                .node_cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            cache.get(hash).cloned()
+        };
+        if let Some(bytes) = cached {
+            return Ok(bytes);
+        }
+
         let bytes = storage::read_chunk(store, hash).await?.ok_or_else(|| {
             LixError::new("LIX_ERROR_UNKNOWN", "tracked-state tree chunk is missing")
         })?;
+        // Verify once on a durable-store miss before making the bytes reusable.
         storage::verify_chunk_hash(hash, &bytes)?;
+        let bytes: Arc<[u8]> = bytes.into();
+        if bytes.len() <= self.options.max_chunk_bytes {
+            self.node_cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .put(*hash, Arc::clone(&bytes));
+        }
         Ok(bytes)
     }
 
@@ -1671,10 +1710,12 @@ impl TrackedStateTree {
         overlay: &storage::TrackedStateChunkOverlay,
         hash: &[u8; TRACKED_STATE_HASH_BYTES],
     ) -> Result<DecodedNode, LixError> {
-        let bytes = overlay.read_chunk(store, hash).await?.ok_or_else(|| {
-            LixError::new("LIX_ERROR_UNKNOWN", "tracked-state tree chunk is missing")
-        })?;
-        storage::verify_chunk_hash(hash, &bytes)?;
+        if let Some(bytes) = overlay.staged_chunk(hash) {
+            // Overlay chunks are not cached until a later durable-store read.
+            storage::debug_verify_chunk_hash(hash, bytes)?;
+            return decode_node(bytes);
+        }
+        let bytes = self.load_node_bytes(store, hash).await?;
         decode_node(&bytes)
     }
 }
@@ -2373,11 +2414,151 @@ fn scan_limit_reached(request: &TrackedStateTreeScanRequest, row_count: usize) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::backend::{
+        BackendError, BackendRead, GetOptions, Key, KeyRange, PointVisitor, ProjectedValueRef,
+        ScanOptions, ScanResult, ScanVisitor, SpaceId,
+    };
     use crate::changelog::{ChangeId, CommitId};
     use crate::entity_pk::EntityPk;
-    use crate::storage::StorageContext;
     use crate::storage::{InMemoryStorageBackend, StorageReadOptions, StorageWriteOptions};
-    use crate::tracked_state::codec::encode_value;
+    use crate::storage::{StorageContext, StorageReadScope};
+    use crate::tracked_state::codec::{encode_value, hash_bytes};
+
+    struct CountingChunkRead {
+        hash: [u8; TRACKED_STATE_HASH_BYTES],
+        bytes: Vec<u8>,
+        backend_reads: Arc<AtomicUsize>,
+        corrupt_first_read: bool,
+    }
+
+    impl BackendRead for CountingChunkRead {
+        fn visit_keys<V>(
+            &self,
+            space: SpaceId,
+            keys: &[Key],
+            _opts: GetOptions<'_>,
+            visitor: &mut V,
+        ) -> Result<(), BackendError>
+        where
+            V: PointVisitor + ?Sized,
+        {
+            assert_eq!(space, storage::TRACKED_STATE_TREE_CHUNK_SPACE.id);
+            let read_index = self.backend_reads.fetch_add(1, Ordering::Relaxed);
+            let bytes = if self.corrupt_first_read && read_index == 0 {
+                b"corrupt tracked-state node".as_slice()
+            } else {
+                self.bytes.as_slice()
+            };
+            for (index, key) in keys.iter().enumerate() {
+                let value =
+                    (key.0.as_ref() == self.hash).then_some(ProjectedValueRef::FullValue(bytes));
+                visitor.visit(index, key, value)?;
+            }
+            Ok(())
+        }
+
+        fn scan<V>(
+            &self,
+            _space: SpaceId,
+            _range: KeyRange,
+            _opts: ScanOptions<'_>,
+            _visitor: &mut V,
+        ) -> Result<ScanResult, BackendError>
+        where
+            V: ScanVisitor + ?Sized,
+        {
+            unreachable!("tracked-state node cache test only performs point reads")
+        }
+    }
+
+    #[tokio::test]
+    async fn repeated_node_loads_from_tree_clones_avoid_backend_reads() {
+        let bytes = encode_leaf_node(&[]);
+        let hash = hash_bytes(&bytes);
+        let backend_reads = Arc::new(AtomicUsize::new(0));
+        let store = StorageReadScope::new(CountingChunkRead {
+            hash,
+            bytes,
+            backend_reads: Arc::clone(&backend_reads),
+            corrupt_first_read: false,
+        });
+        let tree = TrackedStateTree::new();
+        let cloned_tree = tree.clone();
+
+        assert!(matches!(
+            tree.load_node(&store, &hash)
+                .await
+                .expect("first node load should succeed"),
+            DecodedNode::Leaf(_)
+        ));
+        assert!(matches!(
+            cloned_tree
+                .load_node(&store, &hash)
+                .await
+                .expect("cached node load should succeed"),
+            DecodedNode::Leaf(_)
+        ));
+
+        assert_eq!(backend_reads.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn oversized_node_loads_are_not_cached() {
+        let bytes = encode_leaf_node(&[]);
+        assert!(bytes.len() > 1, "test node must have an encoded body");
+        let hash = hash_bytes(&bytes);
+        let backend_reads = Arc::new(AtomicUsize::new(0));
+        let store = StorageReadScope::new(CountingChunkRead {
+            hash,
+            bytes: bytes.clone(),
+            backend_reads: Arc::clone(&backend_reads),
+            corrupt_first_read: false,
+        });
+        let tree = TrackedStateTree::with_options(TrackedStateTreeOptions {
+            target_chunk_bytes: bytes.len() - 1,
+            min_chunk_bytes: 1,
+            max_chunk_bytes: bytes.len() - 1,
+        });
+
+        tree.load_node(&store, &hash)
+            .await
+            .expect("first oversized node load should succeed");
+        tree.load_node(&store, &hash)
+            .await
+            .expect("second oversized node load should succeed");
+
+        assert_eq!(backend_reads.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn corrupt_node_miss_does_not_poison_cache() {
+        let bytes = encode_leaf_node(&[]);
+        let hash = hash_bytes(&bytes);
+        let backend_reads = Arc::new(AtomicUsize::new(0));
+        let store = StorageReadScope::new(CountingChunkRead {
+            hash,
+            bytes,
+            backend_reads: Arc::clone(&backend_reads),
+            corrupt_first_read: true,
+        });
+        let tree = TrackedStateTree::new();
+
+        let error = tree
+            .load_node(&store, &hash)
+            .await
+            .expect_err("corrupt node load should fail");
+        assert!(error.message.contains("chunk hash mismatch"));
+        tree.load_node(&store, &hash)
+            .await
+            .expect("valid retry should succeed");
+        tree.load_node(&store, &hash)
+            .await
+            .expect("validated node should be cached");
+
+        assert_eq!(backend_reads.load(Ordering::Relaxed), 2);
+    }
 
     #[tokio::test]
     async fn exact_read_roundtrips_from_applied_root() {

--- a/packages/engine/tests/backend/slatedb.rs
+++ b/packages/engine/tests/backend/slatedb.rs
@@ -227,6 +227,32 @@ fn cached_slatedb_backend_does_not_acknowledge_failed_remote_writes() {
     );
 }
 
+#[test]
+fn slatedb_commit_flushes_one_wal_write_immediately() {
+    let object_store = Arc::new(InMemory::new());
+    let counting_store = Arc::new(FaultStore::new(object_store));
+    let backend =
+        SlateDbBackend::open_object_store("slatedb-immediate-wal-flush", counting_store.clone())
+            .expect("open immediate WAL flush backend");
+    counting_store.reset_write_count();
+
+    write_one(
+        &backend,
+        SpaceId(13),
+        Key(Bytes::from_static(b"durable")),
+        b"value",
+    )
+    .expect("commit immediately durable value");
+
+    assert_eq!(counting_store.write_count(), 1);
+    backend.flush().expect("flush already durable backend");
+    assert_eq!(
+        counting_store.write_count(),
+        1,
+        "an explicit flush after commit should not issue another remote write"
+    );
+}
+
 fn write_one(
     backend: &SlateDbBackend,
     space: SpaceId,
@@ -375,6 +401,7 @@ impl BackendFixture for CachedSlateDbBackendFixture {
 struct FaultStore {
     inner: Arc<InMemory>,
     fail_writes: Arc<AtomicBool>,
+    write_ops: Arc<AtomicU64>,
 }
 
 impl FaultStore {
@@ -382,11 +409,20 @@ impl FaultStore {
         Self {
             inner,
             fail_writes: Arc::new(AtomicBool::new(false)),
+            write_ops: Arc::new(AtomicU64::new(0)),
         }
     }
 
     fn should_fail_writes(&self) -> bool {
         self.fail_writes.load(Ordering::Relaxed)
+    }
+
+    fn reset_write_count(&self) {
+        self.write_ops.store(0, Ordering::Relaxed);
+    }
+
+    fn write_count(&self) -> u64 {
+        self.write_ops.load(Ordering::Relaxed)
     }
 }
 
@@ -404,6 +440,7 @@ impl ObjectStore for FaultStore {
         payload: PutPayload,
         options: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
+        self.write_ops.fetch_add(1, Ordering::Relaxed);
         if self.should_fail_writes() {
             return Err(fault_error());
         }
@@ -415,6 +452,7 @@ impl ObjectStore for FaultStore {
         location: &Path,
         options: PutMultipartOptions,
     ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.write_ops.fetch_add(1, Ordering::Relaxed);
         if self.should_fail_writes() {
             return Err(fault_error());
         }
@@ -441,6 +479,7 @@ impl ObjectStore for FaultStore {
         &self,
         locations: BoxStream<'static, ObjectStoreResult<Path>>,
     ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+        self.write_ops.fetch_add(1, Ordering::Relaxed);
         if self.should_fail_writes() {
             return Box::pin(stream::once(async { Err(fault_error()) }));
         }
@@ -469,6 +508,7 @@ impl ObjectStore for FaultStore {
         to: &Path,
         options: CopyOptions,
     ) -> ObjectStoreResult<()> {
+        self.write_ops.fetch_add(1, Ordering::Relaxed);
         if self.should_fail_writes() {
             return Err(fault_error());
         }
@@ -481,6 +521,7 @@ impl ObjectStore for FaultStore {
         to: &Path,
         options: RenameOptions,
     ) -> ObjectStoreResult<()> {
+        self.write_ops.fetch_add(1, Ordering::Relaxed);
         if self.should_fail_writes() {
             return Err(fault_error());
         }


### PR DESCRIPTION
## Summary

- run SlateDB operations directly on a manager-owned two-thread Tokio runtime so independent backend reads can overlap without four extra command threads
- preserve commit durability while removing SlateDB's periodic WAL-flush latency floor by explicitly flushing after each backend commit
- protect only snapshot capture and the visible-but-not-yet-durable write window with a fair async mutex
- add a bounded, content-addressed tracked-state node cache shared across engine sessions
- add warm-cache, fresh-engine SELECT, and measured sequential-vs-parallel SlateDB benchmarks

## Why

Lix's local backends hid a latency-amplification problem: one SQL query fans out into many storage operations. With SlateDB over an object store, serialized requests and the default WAL flush interval made that latency directly visible. The backend also lacked an engine-level immutable-node cache, so repeated tree walks continued through storage.

## Measurements

Using a synthetic 10 ms object-store delay:

- one point read: 23.63 ms
- four sequential point reads: 130.72 ms
- four parallel point reads: 35.68 ms (3.66x faster than measured sequential)

Fresh-Engine SELECT validation:

- 0 ms synthetic RTT: 9.36 ms
- 25 ms synthetic RTT: 3.168 s

The benchmark host was under load, so these runs validate the workload and relative concurrency behavior; an idle-host run should establish release thresholds.

## Correctness

- commits acknowledge only after the WAL object-store write completes
- new snapshots cannot observe a write between visibility and durability
- already-pinned snapshots remain concurrent with commits
- oversized or corrupt tracked-state nodes cannot poison or unbound the cache
- blocked-I/O tests use positive handshakes and RAII release to avoid timeout-only false passes or teardown hangs

## Validation

- `cargo fmt --check`
- `cargo check -p lix_engine --bench slatedb_file_api --features slatedb`
- `cargo test -p lix_backends --features slatedb --lib`
- `cargo test -p lix_engine --test backend --features slatedb -- slatedb`
- `cargo test -p lix_engine tracked_state::tree::tests --lib`
- clippy with warnings denied for the backend, backend integration test, and benchmark
- Lixray smoke test compiled and ran against these local Lix packages

## Related

Companion Lixray runtime/cancellation PR: https://github.com/opral/lixray/pull/8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes SlateDB concurrency, commit durability ordering, and snapshot visibility semantics—core storage paths where bugs could cause data loss or stale reads; mitigated by targeted blocking-I/O and durability tests.
> 
> **Overview**
> **SlateDB backend** stops serializing every operation through a single-thread command queue and instead runs work on a manager-owned **two-worker Tokio runtime**, so independent reads (and buffered point gets) can overlap. Snapshot creation, commit, and `flush` still go through a **visibility lock** so new snapshots cannot observe writes before WAL durability; a **terminal `durability_failed` flag** rejects later writers and visibility-gated readers after a failed commit/flush.
> 
> Commits now use **`write_with_options` with `await_durable: false`** followed by an **immediate `flush`**, avoiding SlateDB’s default periodic WAL flush latency while keeping one remote WAL write per commit (covered by integration tests).
> 
> **Tracked-state** adds a **bounded LRU cache** (4096 entries, shared across `TrackedStateTree` clones) for verified content-addressed node bytes, with hash verification on durable misses and no caching for oversized nodes or corrupt first reads. Chunk overlay reads use **`staged_chunk`** instead of async storage fallback.
> 
> **Benchmarks** split warm-cache file API runs, add fresh-engine first-`SELECT` timing, and add sequential vs parallel backend point-read concurrency cases; extensive **blocking object-store tests** exercise visibility ordering and overlapping SST reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91521987e31c16fbe059a27a6fd2ed83d5f306b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->