### PR TITLE
bench: measure cached SlateDB cold lifecycle

### DIFF
--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -152,9 +152,9 @@ fn cached_preloaded_request_benches(c: &mut Criterion, runtime: &tokio::runtime:
                         measure_prepared_iterations(
                             iterations,
                             || runtime.block_on(fixture.prepare_request(stage)),
-                            |prepared| {
+                            |engine| {
                                 runtime.block_on(lixray_download_file(
-                                    &prepared.engine,
+                                    engine,
                                     &fixture.main_branch_id,
                                     &fixture.file_id,
                                 ))
@@ -482,11 +482,6 @@ struct CachedRequestBenchFixture {
     file_id: String,
 }
 
-struct PreparedCachedRequest {
-    engine: Engine<SlateDbBackend>,
-    _backend: SlateDbBackend,
-}
-
 impl CachedLifecycleBenchFixture {
     async fn seeded(delay: Duration) -> Self {
         let seeded = SeededStore::create().await;
@@ -572,23 +567,20 @@ impl CachedRequestBenchFixture {
         }
     }
 
-    async fn prepare_request(&self, stage: CachedRequestStage) -> PreparedCachedRequest {
+    async fn prepare_request(&self, stage: CachedRequestStage) -> Engine<SlateDbBackend> {
         let backend = SlateDbBackend::open_object_store_with_options(
             self.db_path.clone(),
             object_store_handle(&self.object_store),
             cached_object_store_options(&self.cache_dir),
         )
         .expect("reopen cached preloaded request backend");
-        let engine = Engine::new(backend.clone())
+        let engine = Engine::new(backend)
             .await
             .expect("open cached preloaded request engine");
         if matches!(stage, CachedRequestStage::Second) {
             black_box(lixray_download_file(&engine, &self.main_branch_id, &self.file_id).await);
         }
-        PreparedCachedRequest {
-            engine,
-            _backend: backend,
-        }
+        engine
     }
 }
 

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -95,8 +95,78 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
 
     group.finish();
 
+    cached_cold_lifecycle_benches(c, &runtime);
+    cached_preloaded_request_benches(c, &runtime);
     fresh_engine_select_benches(c, &runtime);
     backend_concurrency_benches(c);
+}
+
+fn cached_cold_lifecycle_benches(c: &mut Criterion, runtime: &tokio::runtime::Runtime) {
+    let mut group = c.benchmark_group("slatedb_file_api_cached_cold_lifecycle");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &delay_ms in FRESH_ENGINE_DELAYS_MS {
+        let delay = Duration::from_millis(delay_ms);
+        for stage in CachedLifecycleStage::ALL {
+            group.bench_with_input(
+                BenchmarkId::new(stage.label(), format!("{delay_ms}ms")),
+                &(delay, stage),
+                |b, &(delay, stage)| {
+                    b.iter_custom(|iterations| {
+                        let fixture = runtime.block_on(CachedLifecycleBenchFixture::seeded(delay));
+                        measure_prepared_iterations(
+                            iterations,
+                            // Keep cache-directory creation and teardown outside the
+                            // cumulative startup interval.
+                            || tempfile::tempdir().expect("create lifecycle cache directory"),
+                            |cache_dir| runtime.block_on(fixture.run(stage, cache_dir)),
+                        )
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn cached_preloaded_request_benches(c: &mut Criterion, runtime: &tokio::runtime::Runtime) {
+    let mut group = c.benchmark_group("slatedb_file_api_cached_preloaded_request");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &delay_ms in FRESH_ENGINE_DELAYS_MS {
+        let delay = Duration::from_millis(delay_ms);
+        for stage in CachedRequestStage::ALL {
+            group.bench_with_input(
+                BenchmarkId::new(stage.label(), format!("{delay_ms}ms")),
+                &(delay, stage),
+                |b, &(delay, stage)| {
+                    b.iter_custom(|iterations| {
+                        let fixture = runtime.block_on(CachedRequestBenchFixture::seeded(delay));
+                        // Reuse the preloaded backend while starting each sample with
+                        // a fresh Engine to isolate request-serving latency.
+                        measure_prepared_iterations(
+                            iterations,
+                            || runtime.block_on(fixture.prepare_engine(stage)),
+                            |engine| {
+                                runtime.block_on(lixray_download_file(
+                                    engine,
+                                    &fixture.main_branch_id,
+                                    &fixture.file_id,
+                                ))
+                            },
+                        )
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
 }
 
 fn fresh_engine_select_benches(c: &mut Criterion, runtime: &tokio::runtime::Runtime) {
@@ -357,6 +427,154 @@ struct FreshEngineSelectBenchFixture {
     file_id: String,
 }
 
+#[derive(Clone, Copy)]
+enum CachedLifecycleStage {
+    BackendOpen,
+    EngineOpen,
+    FirstRequest,
+    SecondRequest,
+}
+
+impl CachedLifecycleStage {
+    const ALL: [Self; 4] = [
+        Self::BackendOpen,
+        Self::EngineOpen,
+        Self::FirstRequest,
+        Self::SecondRequest,
+    ];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::BackendOpen => "startup_through_backend_open",
+            Self::EngineOpen => "startup_through_engine_open",
+            Self::FirstRequest => "startup_through_first_request",
+            Self::SecondRequest => "startup_through_second_request",
+        }
+    }
+}
+
+struct CachedLifecycleBenchFixture {
+    seeded: SeededStore,
+}
+
+#[derive(Clone, Copy)]
+enum CachedRequestStage {
+    First,
+    Second,
+}
+
+impl CachedRequestStage {
+    const ALL: [Self; 2] = [Self::First, Self::Second];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::First => "first_request",
+            Self::Second => "second_request",
+        }
+    }
+}
+
+struct CachedRequestBenchFixture {
+    backend: SlateDbBackend,
+    _cache_dir: TempDir,
+    main_branch_id: String,
+    file_id: String,
+}
+
+impl CachedLifecycleBenchFixture {
+    async fn seeded(delay: Duration) -> Self {
+        let seeded = SeededStore::create().await;
+        seeded.object_store.set_delay(delay);
+        Self { seeded }
+    }
+
+    async fn run(
+        &self,
+        stage: CachedLifecycleStage,
+        cache_dir: &TempDir,
+    ) -> CachedLifecycleBenchResult {
+        let backend = SlateDbBackend::open_object_store_with_options(
+            self.seeded.db_path.clone(),
+            object_store_handle(&self.seeded.object_store),
+            cached_object_store_options(cache_dir),
+        )
+        .expect("open cached lifecycle backend");
+        if matches!(stage, CachedLifecycleStage::BackendOpen) {
+            return CachedLifecycleBenchResult {
+                _value: 1,
+                _backend: backend,
+                _engine: None,
+            };
+        }
+
+        let engine = Engine::new(backend.clone())
+            .await
+            .expect("open cached lifecycle engine");
+        if matches!(stage, CachedLifecycleStage::EngineOpen) {
+            return CachedLifecycleBenchResult {
+                _value: 1,
+                _backend: backend,
+                _engine: Some(engine),
+            };
+        }
+
+        let first =
+            lixray_download_file(&engine, &self.seeded.main_branch_id, &self.seeded.file_id).await;
+        if matches!(stage, CachedLifecycleStage::FirstRequest) {
+            return CachedLifecycleBenchResult {
+                _value: first,
+                _backend: backend,
+                _engine: Some(engine),
+            };
+        }
+
+        let second =
+            lixray_download_file(&engine, &self.seeded.main_branch_id, &self.seeded.file_id).await;
+        CachedLifecycleBenchResult {
+            _value: first + second,
+            _backend: backend,
+            _engine: Some(engine),
+        }
+    }
+}
+
+struct CachedLifecycleBenchResult {
+    _value: usize,
+    _engine: Option<Engine<SlateDbBackend>>,
+    _backend: SlateDbBackend,
+}
+
+impl CachedRequestBenchFixture {
+    async fn seeded(delay: Duration) -> Self {
+        let seeded = SeededStore::create().await;
+        seeded.object_store.set_delay(delay);
+        let cache_dir = tempfile::tempdir().expect("create preloaded request cache directory");
+        let backend = SlateDbBackend::open_object_store_with_options(
+            seeded.db_path,
+            object_store_handle(&seeded.object_store),
+            cached_object_store_options(&cache_dir),
+        )
+        .expect("open cached preloaded request backend");
+
+        Self {
+            backend,
+            _cache_dir: cache_dir,
+            main_branch_id: seeded.main_branch_id,
+            file_id: seeded.file_id,
+        }
+    }
+
+    async fn prepare_engine(&self, stage: CachedRequestStage) -> Engine<SlateDbBackend> {
+        let engine = Engine::new(self.backend.clone())
+            .await
+            .expect("open cached preloaded request engine");
+        if matches!(stage, CachedRequestStage::Second) {
+            black_box(lixray_download_file(&engine, &self.main_branch_id, &self.file_id).await);
+        }
+        engine
+    }
+}
+
 impl FreshEngineSelectBenchFixture {
     async fn seeded(delay: Duration) -> Self {
         let seeded = SeededStore::create().await;
@@ -404,6 +622,26 @@ async fn download_file(session: &SessionContext<SlateDbBackend>, file_id: &str) 
         Value::Blob(bytes) => bytes.len(),
         other => panic!("download query returned non-blob value: {other:?}"),
     }
+}
+
+async fn lixray_download_file(
+    engine: &Engine<SlateDbBackend>,
+    branch_id: &str,
+    file_id: &str,
+) -> usize {
+    assert!(
+        engine
+            .load_branch_head_commit_id(branch_id)
+            .await
+            .expect("validate lifecycle branch")
+            .is_some(),
+        "seeded lifecycle branch should exist"
+    );
+    let session = engine
+        .open_session(branch_id.to_string())
+        .await
+        .expect("open lifecycle session");
+    download_file(&session, file_id).await
 }
 
 struct BackendConcurrencyFixture {

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -147,14 +147,14 @@ fn cached_preloaded_request_benches(c: &mut Criterion, runtime: &tokio::runtime:
                 |b, &(delay, stage)| {
                     b.iter_custom(|iterations| {
                         let fixture = runtime.block_on(CachedRequestBenchFixture::seeded(delay));
-                        // Reuse the preloaded backend while starting each sample with
-                        // a fresh Engine to isolate request-serving latency.
+                        // Reuse only the populated disk cache. Each iteration gets a
+                        // fresh backend so its in-memory caches start empty.
                         measure_prepared_iterations(
                             iterations,
-                            || runtime.block_on(fixture.prepare_engine(stage)),
-                            |engine| {
+                            || runtime.block_on(fixture.prepare_request(stage)),
+                            |prepared| {
                                 runtime.block_on(lixray_download_file(
-                                    engine,
+                                    &prepared.engine,
                                     &fixture.main_branch_id,
                                     &fixture.file_id,
                                 ))
@@ -475,10 +475,16 @@ impl CachedRequestStage {
 }
 
 struct CachedRequestBenchFixture {
-    backend: SlateDbBackend,
-    _cache_dir: TempDir,
+    object_store: Arc<DelayedObjectStore>,
+    db_path: String,
+    cache_dir: TempDir,
     main_branch_id: String,
     file_id: String,
+}
+
+struct PreparedCachedRequest {
+    engine: Engine<SlateDbBackend>,
+    _backend: SlateDbBackend,
 }
 
 impl CachedLifecycleBenchFixture {
@@ -550,28 +556,39 @@ impl CachedRequestBenchFixture {
         seeded.object_store.set_delay(delay);
         let cache_dir = tempfile::tempdir().expect("create preloaded request cache directory");
         let backend = SlateDbBackend::open_object_store_with_options(
-            seeded.db_path,
+            seeded.db_path.clone(),
             object_store_handle(&seeded.object_store),
             cached_object_store_options(&cache_dir),
         )
         .expect("open cached preloaded request backend");
+        drop(backend);
 
         Self {
-            backend,
-            _cache_dir: cache_dir,
+            object_store: seeded.object_store,
+            db_path: seeded.db_path,
+            cache_dir,
             main_branch_id: seeded.main_branch_id,
             file_id: seeded.file_id,
         }
     }
 
-    async fn prepare_engine(&self, stage: CachedRequestStage) -> Engine<SlateDbBackend> {
-        let engine = Engine::new(self.backend.clone())
+    async fn prepare_request(&self, stage: CachedRequestStage) -> PreparedCachedRequest {
+        let backend = SlateDbBackend::open_object_store_with_options(
+            self.db_path.clone(),
+            object_store_handle(&self.object_store),
+            cached_object_store_options(&self.cache_dir),
+        )
+        .expect("reopen cached preloaded request backend");
+        let engine = Engine::new(backend.clone())
             .await
             .expect("open cached preloaded request engine");
         if matches!(stage, CachedRequestStage::Second) {
             black_box(lixray_download_file(&engine, &self.main_branch_id, &self.file_id).await);
         }
-        engine
+        PreparedCachedRequest {
+            engine,
+            _backend: backend,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- add cache-enabled cold lifecycle benchmarks for backend preload, Engine open, and the first two Lixray-shaped requests
- add direct first/second request benchmarks over an already-preloaded backend
- keep cache-directory setup, SlateDB shutdown, and cache cleanup outside the timed intervals
- exercise Lixray's branch validation, pinned session creation, and file download path

## Why

The existing fresh-Engine benchmark intentionally disables SlateDB's object-store caches, while Lixray uses bounded disk/block/metadata caches with `AllSst` preload. That made its ~3.17 s result useful as a worst case, but not representative of Lixray's long-lived production backend.

This benchmark separates the one-time cold preload cost from post-ready request latency. The results do not justify another request-path optimization: once preload completes, requests do not inherit the simulated 25 ms object-store RTT.

## Baseline results

Criterion mean and 95% confidence interval on this machine:

| Cumulative cold lifecycle stage | 0 ms RTT | 25 ms RTT |
| --- | ---: | ---: |
| backend open/preload | 15.7 ms [15.3, 16.0] | 687.2 ms [685.7, 688.7] |
| through Engine open | 18.7 ms [15.9, 23.6] | 703.2 ms [693.7, 713.6] |
| through first request | 26.6 ms [23.0, 30.4] | 734.6 ms [711.6, 759.1] |
| through second request | 28.6 ms [25.7, 32.1] | 732.1 ms [713.3, 754.0] |

The lifecycle stages are independently sampled cumulative milestones, so their point estimates should not be subtracted. The overlapping 25 ms request-stage intervals are expected measurement noise.

| Request on preloaded backend | 0 ms RTT | 25 ms RTT |
| --- | ---: | ---: |
| first request on fresh backend and Engine | 20.1 ms [11.6, 34.2] | 13.6 ms [7.0, 24.1] |
| second request on same backend and Engine | 8.9 ms [6.5, 11.7] | 5.0 ms [3.9, 6.5] |

Each direct-request iteration reuses only the populated disk cache and reopens a fresh backend, resetting SlateDB's block and metadata caches. The intervals are noisy, but the 25 ms cases remain below one remote RTT. The remaining measured cold cost is backend open/preload, which Lixray's long-lived container amortizes.

## Validation

- `cargo bench -p lix_engine --bench slatedb_file_api --features slatedb -- 'slatedb_file_api_cached_cold_lifecycle' --noplot`
- `cargo bench -p lix_engine --bench slatedb_file_api --features slatedb -- 'slatedb_file_api_cached_preloaded_request' --noplot`
- `cargo check -p lix_engine --bench slatedb_file_api --features slatedb`
- `cargo clippy -p lix_engine --bench slatedb_file_api --features slatedb -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Follow-up to #581, which has now merged into `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the `slatedb_file_api` Criterion bench; no production engine or API behavior is modified.
> 
> **Overview**
> Adds **cache-enabled** SlateDB file API benchmarks that better match Lixray’s long-lived, disk-cached backend than the existing uncached fresh-Engine path.
> 
> **`slatedb_file_api_cached_cold_lifecycle`** times cumulative cold startup at four milestones (backend open/preload through Engine open and the first two requests), using `cached_object_store_options` and a **new temp cache directory per iteration** so setup/teardown stays outside the timed window.
> 
> **`slatedb_file_api_cached_preloaded_request`** measures first vs second file download on a **pre-populated disk cache**, reopening a fresh backend each iteration so block/metadata caches reset while SST data stays on disk. Downloads go through **`lixray_download_file`** (branch head check, session open, then the existing `download_file` SELECT) instead of a pre-opened session.
> 
> Both groups sweep **0 ms and 25 ms** simulated object-store RTT via the existing delayed store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487b28d62d60def3b66518d64863665d63dd03eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->