### PR TITLE
perf(sql): skip unprojected change payloads

### DIFF
--- a/packages/engine/src/sql2/change_materialization.rs
+++ b/packages/engine/src/sql2/change_materialization.rs
@@ -22,6 +22,24 @@ pub(crate) struct MaterializedChange {
     pub(crate) origin_key: Option<String>,
 }
 
+/// JSON payloads that a change scan must resolve for its output or filters.
+///
+/// The durable change record keeps these fields as inline JSON or content
+/// references. Callers that only need identity columns can leave both flags
+/// disabled and avoid crossing the JSON-store boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ChangePayloadProjection {
+    pub(crate) snapshot_content: bool,
+    pub(crate) metadata: bool,
+}
+
+impl ChangePayloadProjection {
+    pub(crate) const ALL: Self = Self {
+        snapshot_content: true,
+        metadata: true,
+    };
+}
+
 pub(crate) async fn materialize_located_history_change<S>(
     json_reader: &mut JsonStoreReader<S>,
     change: crate::commit_graph::CommitGraphChange,
@@ -29,12 +47,13 @@ pub(crate) async fn materialize_located_history_change<S>(
 where
     S: StorageRead,
 {
-    materialize_commit_graph_change(json_reader, change).await
+    materialize_commit_graph_change(json_reader, change, ChangePayloadProjection::ALL).await
 }
 
 pub(crate) async fn materialize_changelog_change_record<S>(
     json_reader: &mut JsonStoreReader<S>,
     change: ChangeRecord,
+    payload_projection: ChangePayloadProjection,
 ) -> Result<MaterializedChange, LixError>
 where
     S: StorageRead,
@@ -51,6 +70,7 @@ where
             created_at: change.created_at,
             origin_key: change.origin_key,
         },
+        payload_projection,
     )
     .await
 }
@@ -58,16 +78,23 @@ where
 pub(crate) async fn materialize_commit_graph_change<S>(
     json_reader: &mut JsonStoreReader<S>,
     change: crate::commit_graph::CommitGraphChange,
+    payload_projection: ChangePayloadProjection,
 ) -> Result<MaterializedChange, LixError>
 where
     S: StorageRead,
 {
-    let snapshot_content =
-        load_changelog_json_slot(json_reader, &change.snapshot, "snapshot").await?;
-    let metadata = match load_changelog_json_slot(json_reader, &change.metadata, "metadata").await?
-    {
-        Some(value) => Some(parse_row_metadata(&value, "changelog change metadata_ref")?),
-        None => None,
+    let snapshot_content = if payload_projection.snapshot_content {
+        load_changelog_json_slot(json_reader, &change.snapshot, "snapshot").await?
+    } else {
+        None
+    };
+    let metadata = if payload_projection.metadata {
+        match load_changelog_json_slot(json_reader, &change.metadata, "metadata").await? {
+            Some(value) => Some(parse_row_metadata(&value, "changelog change metadata_ref")?),
+            None => None,
+        }
+    } else {
+        None
     };
     Ok(MaterializedChange {
         id: change.id.to_string(),
@@ -115,4 +142,123 @@ where
             format!("changelog change {field} is not UTF-8 JSON: {error}"),
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::changelog::ChangeId;
+    use crate::commit_graph::CommitGraphChange;
+    use crate::common::LixTimestamp;
+    use crate::entity_pk::EntityPk;
+    use crate::json_store::{
+        JsonRef, JsonSlot, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef,
+    };
+    use crate::storage::{
+        InMemoryStorageBackend, StorageContext, StorageReadOptions, StorageWriteOptions,
+    };
+
+    use super::{ChangePayloadProjection, materialize_commit_graph_change};
+
+    fn change(snapshot: JsonSlot, metadata: JsonSlot) -> CommitGraphChange {
+        CommitGraphChange {
+            id: ChangeId::for_test_label("change-projection"),
+            entity_pk: EntityPk::single("entity-1"),
+            schema_key: "example".to_string(),
+            file_id: Some("file-1".to_string()),
+            snapshot,
+            metadata,
+            created_at: LixTimestamp::expect_parse("created_at", "2026-01-01T00:00:00Z"),
+            origin_key: Some("origin-1".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn unprojected_json_refs_are_not_loaded() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("begin read");
+        let mut json_reader = JsonStoreContext::new().reader(read);
+        let row = materialize_commit_graph_change(
+            &mut json_reader,
+            change(
+                JsonSlot::Ref(JsonRef::for_content(b"missing snapshot")),
+                JsonSlot::Ref(JsonRef::for_content(b"missing metadata")),
+            ),
+            ChangePayloadProjection {
+                snapshot_content: false,
+                metadata: false,
+            },
+        )
+        .await
+        .expect("unprojected missing refs should not be read");
+
+        assert_eq!(
+            row.id,
+            ChangeId::for_test_label("change-projection").to_string()
+        );
+        assert_eq!(row.origin_key.as_deref(), Some("origin-1"));
+        assert_eq!(row.snapshot_content, None);
+        assert_eq!(row.metadata, None);
+    }
+
+    #[tokio::test]
+    async fn projected_json_ref_still_reports_missing_payload() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("begin read");
+        let mut json_reader = JsonStoreContext::new().reader(read);
+        let missing_ref = JsonRef::for_content(b"missing snapshot");
+        let error = materialize_commit_graph_change(
+            &mut json_reader,
+            change(JsonSlot::Ref(missing_ref), JsonSlot::None),
+            ChangePayloadProjection {
+                snapshot_content: true,
+                metadata: false,
+            },
+        )
+        .await
+        .expect_err("projected missing ref should fail");
+
+        assert!(error.message.contains(&missing_ref.to_hex()));
+        assert!(error.message.contains("snapshot"));
+    }
+
+    #[tokio::test]
+    async fn projected_json_refs_are_materialized() {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let snapshot = "{\"value\":1}";
+        let metadata = "{\"source\":\"test\"}";
+        let mut writes = storage.new_write_set();
+        let refs = JsonStoreContext::new()
+            .writer()
+            .stage_batch(
+                &mut writes,
+                JsonWritePlacementRef::OutOfBand,
+                [
+                    NormalizedJsonRef::new(snapshot),
+                    NormalizedJsonRef::new(metadata),
+                ],
+            )
+            .expect("stage json payloads");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .expect("commit json payloads");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("begin read");
+        let mut json_reader = JsonStoreContext::new().reader(read);
+        let row = materialize_commit_graph_change(
+            &mut json_reader,
+            change(JsonSlot::Ref(refs[0]), JsonSlot::Ref(refs[1])),
+            ChangePayloadProjection::ALL,
+        )
+        .await
+        .expect("projected refs should materialize");
+
+        assert_eq!(row.snapshot_content.as_deref(), Some(snapshot));
+        assert_eq!(row.metadata.as_deref(), Some(metadata));
+    }
 }

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -16,7 +16,8 @@ use crate::serialize_row_metadata;
 use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::WriteAccess;
 use crate::sql2::change_materialization::{
-    MaterializedChange, materialize_changelog_change_record, materialize_commit_graph_change,
+    ChangePayloadProjection, MaterializedChange, materialize_changelog_change_record,
+    materialize_commit_graph_change,
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::result_metadata::json_field;
@@ -74,6 +75,7 @@ where
     ) -> Result<PlannedScan> {
         let pushed_limit = if filters.is_empty() { limit } else { None };
         let schema = projected_schema(&lix_change_schema(), projection);
+        let payload_projection = change_payload_projection(schema.as_ref(), filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             load: row_source(
@@ -88,14 +90,22 @@ where
                     for change in canonical_changes {
                         match change {
                             LixChangeRow::Direct(change) => changes.push(
-                                materialize_changelog_change_record(&mut json_reader, change)
-                                    .await
-                                    .map_err(lix_error_to_datafusion_error)?,
+                                materialize_changelog_change_record(
+                                    &mut json_reader,
+                                    change,
+                                    payload_projection,
+                                )
+                                .await
+                                .map_err(lix_error_to_datafusion_error)?,
                             ),
                             LixChangeRow::DerivedCommit(change) => changes.push(
-                                materialize_commit_graph_change(&mut json_reader, change)
-                                    .await
-                                    .map_err(lix_error_to_datafusion_error)?,
+                                materialize_commit_graph_change(
+                                    &mut json_reader,
+                                    change,
+                                    payload_projection,
+                                )
+                                .await
+                                .map_err(lix_error_to_datafusion_error)?,
                             ),
                         }
                     }
@@ -105,6 +115,22 @@ where
                 },
             ),
         })
+    }
+}
+
+fn change_payload_projection(schema: &Schema, filters: &[Expr]) -> ChangePayloadProjection {
+    let needs = |column_name: &str| {
+        schema.field_with_name(column_name).is_ok()
+            || filters.iter().any(|filter| {
+                filter
+                    .column_refs()
+                    .iter()
+                    .any(|column| column.name.as_str() == column_name)
+            })
+    };
+    ChangePayloadProjection {
+        snapshot_content: needs("snapshot_content"),
+        metadata: needs("metadata"),
     }
 }
 
@@ -242,5 +268,42 @@ fn change_batch_error(error: ColumnTableError) -> DataFusionError {
             DataFusionError::Execution(format!("failed to build lix_change batch: {error}"))
         }
         ColumnTableError::Row(error) => lix_error_to_datafusion_error(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::datatypes::Schema;
+    use datafusion::logical_expr::{Expr, col};
+
+    use super::{change_payload_projection, lix_change_schema};
+
+    #[test]
+    fn identity_projection_skips_json_payloads() {
+        let full_schema = lix_change_schema();
+        let projected = Schema::new(vec![
+            full_schema.field_with_name("id").expect("id").clone(),
+            full_schema
+                .field_with_name("origin_key")
+                .expect("origin_key")
+                .clone(),
+        ]);
+
+        let projection = change_payload_projection(&projected, &[]);
+
+        assert!(!projection.snapshot_content);
+        assert!(!projection.metadata);
+    }
+
+    #[test]
+    fn payload_filter_requires_materialization() {
+        let full_schema = lix_change_schema();
+        let projected = Schema::new(vec![full_schema.field_with_name("id").expect("id").clone()]);
+        let filters = vec![Expr::IsNotNull(Box::new(col("metadata")))];
+
+        let projection = change_payload_projection(&projected, &filters);
+
+        assert!(!projection.snapshot_content);
+        assert!(projection.metadata);
     }
 }


### PR DESCRIPTION
## Stack

3 of 6. Base: `codex/atelier-sql-history-hydration`. Next: `codex/atelier-sql-file-data-fast-update`.

## What changed

Make `lix_change` materialization projection-aware so JSON payloads are loaded only when projected columns require them. History/changelog surfaces retain full payload materialization.

## Backend smoke results

Incremental parent/child measurements with a local `CountingBackend<InMemoryBackend>` harness. Elapsed values are medians of five samples and are expected to be noisy.

| Atelier query | Read calls | Point calls | Scan calls | Keys | Read KiB | Median ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Q07 file/change join | 64 → 50 | 52 → 38 | 12 → 12 | 111 → 97 | 43.357 → 34.609 | 2.790 → 0.846 |
| Q11 file/change join | 64 → 50 | 52 → 38 | 12 → 12 | 111 → 97 | 43.357 → 34.609 | 3.348 → 0.956 |

The physical plan and filter pushdown are unchanged; the 14-call reduction is unused JSON hydration.

## Validation

- Projected payload, metadata, origin, and history full-payload parity tests
- `cargo fmt --all -- --check`
- Full Atelier SQL smoke catalog on the final stacked branch
- Full `sql2` unit-test sweep on the final stacked branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path optimization with explicit full-payload behavior preserved for history; behavior change is limited to when JSON is loaded, not what rows are returned for equivalent full-column queries.
> 
> **Overview**
> **`lix_change` scans now hydrate `snapshot_content` and `metadata` only when the query needs them**, cutting JSON-store reads for identity-only or narrow projections (e.g. file/change joins).
> 
> A new `ChangePayloadProjection` gates `load_changelog_json_slot` in change materialization. The `lix_change` provider derives flags from the projected schema and pushed filters (a filter on `metadata` still forces metadata load even if that column is not selected). **History paths keep full hydration** via `ChangePayloadProjection::ALL` on `materialize_located_history_change`.
> 
> Unit tests cover skipped loads for missing refs when unprojected, errors when projected refs are missing, and full materialization when both flags are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc0ba4fddf5c180575a23958675568508f09827d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->