### PR TITLE
perf(sql): skip unused history commit metadata walk

### DIFF
--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::ScalarValue;
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::{Expr, Operator};
@@ -165,6 +166,39 @@ pub(crate) enum HistoryColumnStyle {
     Prefixed,
 }
 
+/// Commit metadata that a history scan must materialize for its projected
+/// columns and residual filters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct HistoryMetadataProjection {
+    commit_created_at: bool,
+}
+
+impl HistoryMetadataProjection {
+    pub(crate) fn from_scan(
+        projected_schema: &SchemaRef,
+        filters: &[Expr],
+        column_style: HistoryColumnStyle,
+    ) -> Self {
+        let column_name = match column_style {
+            HistoryColumnStyle::Bare => "commit_created_at",
+            HistoryColumnStyle::Prefixed => HISTORY_COL_COMMIT_CREATED_AT,
+        };
+        let commit_created_at = projected_schema.field_with_name(column_name).is_ok()
+            || filters.iter().any(|filter| {
+                filter
+                    .column_refs()
+                    .iter()
+                    .any(|column| column.name == column_name)
+            });
+        Self { commit_created_at }
+    }
+
+    #[cfg(test)]
+    fn commit_created_at(self) -> bool {
+        self.commit_created_at
+    }
+}
+
 /// Shaped history views expose delete events as tombstone rows.
 ///
 /// If the current event is the descriptor tombstone itself, the provider must
@@ -213,6 +247,7 @@ pub(crate) async fn load_history_entries<S>(
     mut json_reader: SqlJsonReader<S>,
     route: &HistoryRoute,
     schema_keys: Vec<String>,
+    metadata_projection: HistoryMetadataProjection,
 ) -> Result<Vec<HistoryEntry>, LixError>
 where
     S: StorageRead + Clone + Send + Sync + 'static,
@@ -245,7 +280,11 @@ where
             let entries = guard
                 .change_history_from_commit(&start_commit_id, &request)
                 .await?;
-            let reachable_commits = guard.reachable_commits(&start_commit_id).await?;
+            let reachable_commits = if metadata_projection.commit_created_at {
+                guard.reachable_commits(&start_commit_id).await?
+            } else {
+                Vec::new()
+            };
             (entries, reachable_commits)
         };
         let commit_created_at_by_id = reachable_commits
@@ -591,10 +630,31 @@ fn scalar_i64_literal(expr: &Expr) -> Option<i64> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::common::{Column, ScalarValue};
     use datafusion::logical_expr::{BinaryExpr, Expr, Like, Operator};
+    use tokio::sync::Mutex;
 
-    use super::{HistoryColumnStyle, HistoryRoute, parse_history_filter};
+    use crate::LixError;
+    use crate::changelog::{ChangeId, CommitId};
+    use crate::commit_graph::{
+        CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
+        CommitGraphCommit, CommitGraphReader, ReachableCommitGraphCommit,
+    };
+    use crate::entity_pk::EntityPk;
+    use crate::json_store::{JsonSlot, JsonStoreContext};
+    use crate::storage::{
+        InMemoryStorageBackend, InMemoryStorageRead, SharedStorageRead, StorageContext,
+        StorageReadOptions,
+    };
+
+    use super::{
+        HistoryColumnStyle, HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor,
+        load_history_entries, parse_history_filter,
+    };
 
     #[test]
     fn route_extraction_keeps_supported_terms_from_mixed_and_filter() {
@@ -636,6 +696,190 @@ mod tests {
             route.start_commit_ids.is_empty(),
             "partial OR pushdown would change SQL semantics"
         );
+    }
+
+    #[test]
+    fn commit_metadata_projection_tracks_projection_and_filters() {
+        let unrelated_schema = Arc::new(Schema::new(vec![Field::new(
+            "depth",
+            DataType::Int64,
+            false,
+        )]));
+        assert!(
+            !HistoryMetadataProjection::from_scan(
+                &unrelated_schema,
+                &[],
+                HistoryColumnStyle::Bare,
+            )
+            .commit_created_at()
+        );
+
+        let projected_schema = Arc::new(Schema::new(vec![Field::new(
+            "lixcol_commit_created_at",
+            DataType::Utf8,
+            false,
+        )]));
+        assert!(
+            HistoryMetadataProjection::from_scan(
+                &projected_schema,
+                &[],
+                HistoryColumnStyle::Prefixed,
+            )
+            .commit_created_at()
+        );
+
+        let residual_filter = eq(col("commit_created_at"), str_lit("2026-07-12T00:00:00Z"));
+        assert!(
+            HistoryMetadataProjection::from_scan(
+                &unrelated_schema,
+                &[residual_filter],
+                HistoryColumnStyle::Bare,
+            )
+            .commit_created_at()
+        );
+    }
+
+    #[tokio::test]
+    async fn history_loader_skips_unprojected_commit_metadata_walk() {
+        let reachable_calls = Arc::new(AtomicUsize::new(0));
+        let start_commit_id = CommitId::for_test_label("start");
+        let rows = load_history_entries(
+            HistoryViewDescriptor {
+                view_name: "test_history",
+                start_commit_column: "start_commit_id",
+            },
+            test_commit_graph(Arc::clone(&reachable_calls), start_commit_id),
+            empty_json_reader().await,
+            &HistoryRoute {
+                start_commit_ids: vec![start_commit_id.to_string()],
+                ..HistoryRoute::default()
+            },
+            vec!["message".to_string()],
+            HistoryMetadataProjection::default(),
+        )
+        .await
+        .expect("history load should succeed without commit metadata");
+
+        assert_eq!(reachable_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn history_loader_preserves_projected_commit_timestamp() {
+        let reachable_calls = Arc::new(AtomicUsize::new(0));
+        let start_commit_id = CommitId::for_test_label("start");
+        let metadata_schema = Arc::new(Schema::new(vec![Field::new(
+            "commit_created_at",
+            DataType::Utf8,
+            false,
+        )]));
+        let rows = load_history_entries(
+            HistoryViewDescriptor {
+                view_name: "test_history",
+                start_commit_column: "start_commit_id",
+            },
+            test_commit_graph(Arc::clone(&reachable_calls), start_commit_id),
+            empty_json_reader().await,
+            &HistoryRoute {
+                start_commit_ids: vec![start_commit_id.to_string()],
+                ..HistoryRoute::default()
+            },
+            vec!["message".to_string()],
+            HistoryMetadataProjection::from_scan(&metadata_schema, &[], HistoryColumnStyle::Bare),
+        )
+        .await
+        .expect("history load should enrich commit metadata");
+
+        assert_eq!(reachable_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].commit_created_at, commit_timestamp().to_string());
+    }
+
+    struct CountingCommitGraphReader {
+        reachable_calls: Arc<AtomicUsize>,
+        start_commit_id: CommitId,
+    }
+
+    #[async_trait::async_trait]
+    impl CommitGraphReader for CountingCommitGraphReader {
+        async fn load_commit(
+            &mut self,
+            _commit_id: &CommitId,
+        ) -> Result<Option<CommitGraphCommit>, LixError> {
+            Ok(None)
+        }
+
+        async fn reachable_commits(
+            &mut self,
+            _head_commit_id: &CommitId,
+        ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
+            self.reachable_calls.fetch_add(1, Ordering::SeqCst);
+            let change = test_change("commit-change", commit_timestamp());
+            Ok(vec![ReachableCommitGraphCommit {
+                commit: CommitGraphCommit {
+                    canonical_change: change.clone(),
+                    change,
+                    commit_id: self.start_commit_id,
+                    change_ids: vec![ChangeId::for_test_label("entity-change")],
+                    author_account_ids: Vec::new(),
+                    parent_commit_ids: Vec::new(),
+                },
+                depth: 0,
+            }])
+        }
+
+        async fn change_history_from_commit(
+            &mut self,
+            _start_commit_id: &CommitId,
+            _request: &CommitGraphChangeHistoryRequest,
+        ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
+            Ok(vec![CommitGraphChangeHistoryEntry {
+                change: test_change("entity-change", event_timestamp()),
+                observed_commit_id: self.start_commit_id,
+                start_commit_id: self.start_commit_id,
+                depth: 0,
+            }])
+        }
+    }
+
+    fn test_commit_graph(
+        reachable_calls: Arc<AtomicUsize>,
+        start_commit_id: CommitId,
+    ) -> Arc<Mutex<Box<dyn CommitGraphReader>>> {
+        Arc::new(Mutex::new(Box::new(CountingCommitGraphReader {
+            reachable_calls,
+            start_commit_id,
+        })))
+    }
+
+    fn test_change(label: &str, created_at: crate::common::LixTimestamp) -> CommitGraphChange {
+        CommitGraphChange {
+            id: ChangeId::for_test_label(label),
+            entity_pk: EntityPk::single("entity-1"),
+            schema_key: "message".to_string(),
+            file_id: None,
+            snapshot: JsonSlot::None,
+            metadata: JsonSlot::None,
+            created_at,
+            origin_key: None,
+        }
+    }
+
+    fn event_timestamp() -> crate::common::LixTimestamp {
+        crate::common::LixTimestamp::expect_parse("event timestamp", "2026-07-11T00:00:00Z")
+    }
+
+    fn commit_timestamp() -> crate::common::LixTimestamp {
+        crate::common::LixTimestamp::expect_parse("commit timestamp", "2026-07-12T00:00:00Z")
+    }
+
+    async fn empty_json_reader()
+    -> crate::sql2::SqlJsonReader<SharedStorageRead<InMemoryStorageRead>> {
+        let storage = StorageContext::new(InMemoryStorageBackend::new());
+        let read_scope = storage
+            .begin_read(StorageReadOptions::default())
+            .expect("read should open");
+        JsonStoreContext::new().reader(SharedStorageRead::new(read_scope))
     }
 
     fn and(left: Expr, right: Expr) -> Expr {

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -23,8 +23,8 @@ use crate::sql2::history_route::{
     HISTORY_COL_CHANGE_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
     HISTORY_COL_FILE_ID, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
     HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
-    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryEntry, HistoryRoute,
-    HistoryViewDescriptor, history_descriptor_event_matches, load_history_entries,
+    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection,
+    HistoryRoute, HistoryViewDescriptor, history_descriptor_event_matches, load_history_entries,
     parse_history_filter,
 };
 use crate::sql2::providers::filesystem_history_path::{
@@ -101,6 +101,8 @@ where
     ) -> Result<PlannedScan> {
         let schema = projected_schema(&self.schema, projection);
         let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Prefixed);
+        let metadata_projection =
+            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             load: row_source(
@@ -110,11 +112,17 @@ where
                     schema,
                     route,
                     limit,
+                    metadata_projection,
                 ),
-                |(commit_graph, query_source, schema, route, limit)| async move {
-                    let mut rows = load_directory_history_rows(commit_graph, query_source, &route)
-                        .await
-                        .map_err(lix_error_to_datafusion_error)?;
+                |(commit_graph, query_source, schema, route, limit, metadata_projection)| async move {
+                    let mut rows = load_directory_history_rows(
+                        commit_graph,
+                        query_source,
+                        &route,
+                        metadata_projection,
+                    )
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
                     if let Some(limit) = limit {
                         rows.truncate(limit);
                     }
@@ -186,6 +194,7 @@ async fn load_directory_history_rows<S>(
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
     route: &HistoryRoute,
+    metadata_projection: HistoryMetadataProjection,
 ) -> Result<Vec<DirectoryHistoryOutputRow>, LixError>
 where
     S: StorageRead + Clone + Send + Sync + 'static,
@@ -200,6 +209,7 @@ where
         query_source.json_reader.clone(),
         &event_route,
         vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+        metadata_projection,
     )
     .await?;
     let context_route = route.starts_only();
@@ -212,6 +222,7 @@ where
         query_source.json_reader,
         &context_route,
         vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+        metadata_projection,
     )
     .await?;
     let event_descriptors = parse_directory_history_records(&event_entries)?;

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -25,8 +25,8 @@ use crate::sql2::catalog::{
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
 use crate::sql2::history_route::{
-    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryRoute, HistoryViewDescriptor,
-    load_history_entries, parse_history_filter,
+    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryMetadataProjection, HistoryRoute,
+    HistoryViewDescriptor, load_history_entries, parse_history_filter,
 };
 use crate::sql2::providers::entity::{
     entity_f64_value, entity_i64_value, entity_json_text_value, parse_snapshot,
@@ -107,6 +107,8 @@ where
     ) -> Result<PlannedScan> {
         let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Prefixed);
         let schema = projected_schema(&self.schema, projection);
+        let metadata_projection =
+            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             load: row_source(
@@ -116,12 +118,19 @@ where
                     self.query_source.clone(),
                     route,
                     schema,
+                    metadata_projection,
                 ),
-                move |(spec, commit_graph, query_source, route, schema)| async move {
-                    let rows =
-                        load_entity_history_rows(&spec, commit_graph, query_source, &route, limit)
-                            .await
-                            .map_err(lix_error_to_datafusion_error)?;
+                move |(spec, commit_graph, query_source, route, schema, metadata_projection)| async move {
+                    let rows = load_entity_history_rows(
+                        &spec,
+                        commit_graph,
+                        query_source,
+                        &route,
+                        limit,
+                        metadata_projection,
+                    )
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
                     entity_history_record_batch(&schema, &spec, &rows)
                 },
             ),
@@ -144,6 +153,7 @@ async fn load_entity_history_rows<S>(
     query_source: SqlHistoryQuerySource<S>,
     route: &HistoryRoute,
     limit: Option<usize>,
+    metadata_projection: HistoryMetadataProjection,
 ) -> Result<Vec<EntityHistoryRow>, LixError>
 where
     S: StorageRead + Clone + Send + Sync + 'static,
@@ -158,6 +168,7 @@ where
         query_source.json_reader,
         route,
         vec![spec.schema_key.clone()],
+        metadata_projection,
     )
     .await?;
     let mut rows = entries

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -34,8 +34,8 @@ use crate::sql2::history_route::{
     HISTORY_COL_CHANGE_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
     HISTORY_COL_FILE_ID, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
     HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
-    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryEntry, HistoryRoute,
-    HistoryViewDescriptor, history_descriptor_event_matches, load_history_entries,
+    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection,
+    HistoryRoute, HistoryViewDescriptor, history_descriptor_event_matches, load_history_entries,
     parse_history_filter,
 };
 use crate::sql2::providers::filesystem_history_path::{
@@ -134,6 +134,8 @@ where
             })
         });
         let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Prefixed);
+        let metadata_projection =
+            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             load: row_source(
@@ -144,8 +146,17 @@ where
                     self.plugin_host.clone(),
                     route,
                     schema,
+                    metadata_projection,
                 ),
-                move |(commit_graph, query_source, blob_reader, plugin_host, route, schema)| async move {
+                move |(
+                    commit_graph,
+                    query_source,
+                    blob_reader,
+                    plugin_host,
+                    route,
+                    schema,
+                    metadata_projection,
+                )| async move {
                     let mut rows = load_file_history_rows(
                         commit_graph,
                         query_source,
@@ -153,6 +164,7 @@ where
                         plugin_host,
                         &route,
                         needs_data,
+                        metadata_projection,
                     )
                     .await
                     .map_err(lix_error_to_datafusion_error)?;
@@ -275,6 +287,7 @@ async fn load_file_history_rows<S>(
     plugin_host: PluginRuntimeHost,
     route: &HistoryRoute,
     needs_data: bool,
+    metadata_projection: HistoryMetadataProjection,
 ) -> Result<Vec<FileHistoryOutputRow>, LixError>
 where
     S: StorageRead + Clone + Send + Sync + 'static,
@@ -295,6 +308,7 @@ where
         query_source.clone(),
         &event_route,
         &context_route,
+        metadata_projection,
     )
     .await?;
     let mut installed_plugins_cache = BTreeMap::<(String, u32, String), InstalledPlugin>::new();
@@ -322,6 +336,7 @@ where
             &event_route,
             &context_route,
             plugin_schema_keys,
+            metadata_projection,
         )
         .await?
     };
@@ -422,6 +437,7 @@ async fn load_file_history_filesystem_context<S>(
     query_source: SqlHistoryQuerySource<S>,
     event_route: &HistoryRoute,
     context_route: &HistoryRoute,
+    metadata_projection: HistoryMetadataProjection,
 ) -> Result<FileHistoryFilesystemContext, LixError>
 where
     S: StorageRead + Clone + Send + Sync + 'static,
@@ -442,6 +458,7 @@ where
                     json_reader,
                     &route,
                     schema_keys,
+                    metadata_projection,
                 )
                 .await
             }
@@ -464,6 +481,7 @@ async fn load_file_history_plugin_state<S>(
     event_route: &HistoryRoute,
     context_route: &HistoryRoute,
     plugin_schema_keys: Vec<String>,
+    metadata_projection: HistoryMetadataProjection,
 ) -> Result<
     (
         Vec<FileHistoryPluginStateRecord>,
@@ -489,6 +507,7 @@ where
                     json_reader,
                     &route,
                     schema_keys,
+                    metadata_projection,
                 )
                 .await
             }

--- a/packages/engine/src/sql2/providers/history.rs
+++ b/packages/engine/src/sql2/providers/history.rs
@@ -16,8 +16,8 @@ use crate::sql2::SqlHistoryQuerySource;
 use crate::sql2::WriteAccess;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_route::{
-    HistoryColumnStyle, HistoryRoute, HistoryViewDescriptor, load_history_entries,
-    parse_history_filter,
+    HistoryColumnStyle, HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor,
+    load_history_entries, parse_history_filter,
 };
 use crate::sql2::result_metadata::json_field;
 use crate::storage::StorageRead;
@@ -89,6 +89,8 @@ where
     ) -> Result<PlannedScan> {
         let schema = projected_schema(&lix_state_history_schema(), projection);
         let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Bare);
+        let metadata_projection =
+            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Bare);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             load: row_source(
@@ -97,14 +99,20 @@ where
                     self.query_source.clone(),
                     route,
                     schema,
+                    metadata_projection,
                 ),
-                move |(commit_graph, query_source, route, schema)| async move {
+                move |(commit_graph, query_source, route, schema, metadata_projection)| async move {
                     let rows = if route.is_contradictory() {
                         Vec::new()
                     } else {
-                        load_state_history_rows(commit_graph, query_source, &route)
-                            .await
-                            .map_err(lix_error_to_datafusion_error)?
+                        load_state_history_rows(
+                            commit_graph,
+                            query_source,
+                            &route,
+                            metadata_projection,
+                        )
+                        .await
+                        .map_err(lix_error_to_datafusion_error)?
                     };
                     let rows = if let Some(limit) = limit {
                         rows.into_iter().take(limit).collect::<Vec<_>>()
@@ -210,6 +218,7 @@ async fn load_state_history_rows<S>(
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
     route: &HistoryRoute,
+    metadata_projection: HistoryMetadataProjection,
 ) -> Result<Vec<StateHistorySqlRow>, LixError>
 where
     S: StorageRead + Clone + Send + Sync + 'static,
@@ -223,6 +232,7 @@ where
         query_source.json_reader,
         route,
         Vec::new(),
+        metadata_projection,
     )
     .await?;
     let mut rows = entries


### PR DESCRIPTION
## Stack

1 of 6. Base: `main`. Next: `codex/atelier-sql-history-hydration`.

## What changed

Propagate history projection requirements into `HistoryRoute` and skip the reachable-commit metadata walk when `commit_created_at` is neither projected nor filtered. Queries that need the timestamp retain the existing traversal and value semantics.

## Backend smoke results

Measured with a local `CountingBackend<InMemoryBackend>` harness over the Atelier fixture. Elapsed values are medians of five read samples and are expected to be noisy.

| Atelier query | Read calls | Point calls | Scan calls | Keys | Median ms |
| --- | ---: | ---: | ---: | ---: | ---: |
| Q03a one history start | 153 → 119 | 115 → 98 | 38 → 21 | 168 → 151 | 2.578 → 11.724 |
| Q03b two history starts | 268 → 204 | 200 → 168 | 68 → 36 | 253 → 221 | 2.829 → 3.507 |
| Q12 two-start state history | 242 → 178 | 174 → 142 | 68 → 36 | 227 → 195 | 2.485 → 2.761 |
| Q20 root commit history | 143 → 109 | 102 → 85 | 41 → 24 | 155 → 138 | 2.869 → 2.540 |

Q05, Q08, Q21, and Q22 also move from 153 to 119 read calls. This removes 34 backend calls per history start, or 64 calls for the two-start forms. The Q03a timing regression is not accompanied by additional backend work and illustrates the expected timing noise.

## Validation

- Projection and timestamp-filter parity tests across all history providers
- `cargo fmt --all -- --check`
- Full Atelier SQL smoke catalog on the final stacked branch
- Full `sql2` unit-test sweep on the final stacked branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared history loading semantics when `commit_created_at` is omitted (fallback uses change time, not commit time), but projected/filtered queries retain the full walk; core commit-graph read path is affected across all history surfaces.
> 
> **Overview**
> SQL history scans now derive **`HistoryMetadataProjection`** from the projected schema and residual filters so the loader knows whether **`commit_created_at`** must be materialized (bare vs `lixcol_*` naming per surface).
> 
> **`load_history_entries`** only calls **`reachable_commits`** when that flag is set; otherwise it skips the per–start-commit graph walk that maps observed commits to commit timestamps. Entity, file, directory, and state history providers compute the projection in **`plan_scan`** and pass it through every **`load_history_entries`** call (including file history’s event/context and plugin loads).
> 
> Queries that project or filter on **`commit_created_at`** keep the prior enrichment path; tests assert zero vs one reachable-commit calls and timestamp parity when the column is projected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf71fbdf9be36571ff91bb290629e6c780f9fdbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->