### PR TITLE
perf(sql): fast path file data updates by id

### DIFF
--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -16,7 +16,7 @@ use crate::sql2::catalog::{
 };
 use crate::sql2::plan::LogicalWritePlan;
 use crate::sql2::plan::branch_scope::BranchScope;
-use crate::sql2::plan::predicate::FilterSet;
+use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
 use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::transaction::types::{
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteRow,
@@ -27,7 +27,10 @@ use crate::{LixError, NullableKeyFilter, Value, parse_row_metadata_value};
 pub(crate) fn supports_bound_public_write(plan: &LogicalWritePlan) -> bool {
     match &plan.bound.target {
         BoundWriteTarget::Entity(_) => bound_public_write_shape_supported(plan),
-        BoundWriteTarget::File(surface) => fast_file_path_write_shape(plan, surface).is_some(),
+        BoundWriteTarget::File(surface) => {
+            fast_file_path_write_shape(plan, surface).is_some()
+                || fast_file_data_update_shape(plan, surface).is_some()
+        }
         _ => false,
     }
 }
@@ -49,15 +52,94 @@ pub(crate) async fn try_execute_bound_public_write(
                 .map(BoundPublicWriteExecution::Executed)
         }
         BoundWriteTarget::File(surface) => {
-            let Some(shape) = fast_file_path_write_shape(plan, surface) else {
-                return Ok(BoundPublicWriteExecution::Unsupported);
-            };
-            execute_file_path_write(ctx, plan, params, shape)
-                .await
-                .map(BoundPublicWriteExecution::Executed)
+            if let Some(shape) = fast_file_path_write_shape(plan, surface) {
+                execute_file_path_write(ctx, plan, params, shape)
+                    .await
+                    .map(BoundPublicWriteExecution::Executed)
+            } else if let Some(shape) = fast_file_data_update_shape(plan, surface) {
+                execute_file_data_update(ctx, params, &shape)
+                    .await
+                    .map(BoundPublicWriteExecution::Executed)
+            } else {
+                Ok(BoundPublicWriteExecution::Unsupported)
+            }
         }
         _ => Ok(BoundPublicWriteExecution::Unsupported),
     }
+}
+
+struct FastFileDataUpdateShape {
+    id: BoundExpr,
+    data: BoundExpr,
+}
+
+async fn execute_file_data_update(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    params: &[Value],
+    shape: &FastFileDataUpdateShape,
+) -> Result<u64, LixError> {
+    let id = eval_fast_file_nullable_text(&shape.id, params, "id")?;
+    let data = eval_fast_file_blob(&shape.data, params, "data")?;
+    crate::sql2::providers::execute_fast_lix_file_data_update_by_id(ctx, id, data).await
+}
+
+fn fast_file_data_update_shape(
+    plan: &LogicalWritePlan,
+    surface: &FileWriteSurface,
+) -> Option<FastFileDataUpdateShape> {
+    if !matches!(surface, FileWriteSurface::Base)
+        || plan.bound.op != BoundWriteOp::Update
+        || !matches!(plan.bound.input, BoundWriteInput::None)
+        || plan.bound.conflict.is_some()
+        || !matches!(plan.bound.branch_scope, BranchScope::Active { .. })
+        || plan.bound.assignments.len() != 1
+    {
+        return None;
+    }
+    let assignment = &plan.bound.assignments[0];
+    if assignment.column.name != "data" || !fast_file_blob_expr_supported(&assignment.value) {
+        return None;
+    }
+    let id = fast_file_id_predicate_value(&plan.bound.predicate)?;
+    Some(FastFileDataUpdateShape {
+        id: id.clone(),
+        data: assignment.value.clone(),
+    })
+}
+
+fn fast_file_id_predicate_value(predicate: &BoundPredicate) -> Option<&BoundExpr> {
+    let BoundPredicate::Eq(left, right) = predicate else {
+        return None;
+    };
+    fast_file_id_column_value(left, right).or_else(|| fast_file_id_column_value(right, left))
+}
+
+fn fast_file_id_column_value<'a>(
+    column_expr: &BoundExpr,
+    value_expr: &'a BoundExpr,
+) -> Option<&'a BoundExpr> {
+    let BoundExpr::Column(column) = column_expr else {
+        return None;
+    };
+    if column.name == "id" && fast_file_text_expr_supported(value_expr) {
+        Some(value_expr)
+    } else {
+        None
+    }
+}
+
+fn fast_file_text_expr_supported(expr: &BoundExpr) -> bool {
+    matches!(
+        expr,
+        BoundExpr::Param(_) | BoundExpr::Literal(BoundLiteral::Text(_))
+    )
+}
+
+fn fast_file_blob_expr_supported(expr: &BoundExpr) -> bool {
+    matches!(
+        expr,
+        BoundExpr::Param(_) | BoundExpr::Literal(BoundLiteral::Blob(_))
+    )
 }
 
 async fn execute_entity_write(
@@ -250,6 +332,19 @@ fn eval_fast_file_text(
             format!("lix_file fast write column '{column}' supports params and literals only"),
         )),
     }
+}
+
+fn eval_fast_file_nullable_text(
+    expr: &BoundExpr,
+    params: &[Value],
+    column: &str,
+) -> Result<Option<String>, LixError> {
+    if let BoundExpr::Param(param) = expr
+        && matches!(params.get(param.index.saturating_sub(1)), Some(Value::Null))
+    {
+        return Ok(None);
+    }
+    eval_fast_file_text(expr, params, column).map(Some)
 }
 
 fn eval_fast_file_blob(
@@ -1173,7 +1268,7 @@ fn eval_expr_value(
 }
 
 fn predicate_matches(
-    predicate: &crate::sql2::plan::predicate::BoundPredicate,
+    predicate: &BoundPredicate,
     context: &EntityEvalContext<'_>,
     spec: &EntitySurfaceSpec,
     ctx: &mut dyn SqlWriteExecutionContext,
@@ -1375,9 +1470,7 @@ fn bound_public_write_shape_supported(plan: &LogicalWritePlan) -> bool {
         })
 }
 
-fn validate_predicate_supported(
-    predicate: &crate::sql2::plan::predicate::BoundPredicate,
-) -> Result<(), LixError> {
+fn validate_predicate_supported(predicate: &BoundPredicate) -> Result<(), LixError> {
     use crate::sql2::plan::predicate::BoundPredicate;
     match predicate {
         BoundPredicate::True | BoundPredicate::False => Ok(()),
@@ -1405,7 +1498,7 @@ fn validate_predicate_supported(
 }
 
 fn validate_json_predicate_types(
-    predicate: &crate::sql2::plan::predicate::BoundPredicate,
+    predicate: &BoundPredicate,
     spec: &EntitySurfaceSpec,
 ) -> Result<(), LixError> {
     use crate::sql2::plan::predicate::BoundPredicate;

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1556,6 +1556,7 @@ mod tests {
         }
     }
 
+    #[derive(Debug, PartialEq, Eq)]
     struct CapturedStageRow {
         entity_pk: String,
         schema_key: String,
@@ -4566,6 +4567,321 @@ mod tests {
             rows[0].metadata.as_deref(),
             Some("{\"source\":\"file-update\"}")
         );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_fast_path_matches_datafusion() {
+        let rows = vec![
+            live_directory_row("dir-docs", "branch-a", None, "docs"),
+            live_file_row("file-readme", "branch-a", Some("dir-docs"), "readme.md"),
+            live_blob_ref_row("file-readme", "branch-a", b"old"),
+        ];
+        let (mut fast_ctx, fast_staged, fast_scans) = counting_write_context(rows.clone());
+        let (mut datafusion_ctx, datafusion_staged, datafusion_scans) =
+            counting_write_context(rows);
+        let sql = "UPDATE lix_file SET data = X'4142' WHERE id = 'file-readme'";
+
+        let (fast_result, fast_path) =
+            execute_write_sql_trace(&mut fast_ctx, sql, &[], WriteExecutorMode::ForceFast)
+                .await
+                .expect("file data update should use the bound fast path");
+        let (datafusion_result, datafusion_path) = execute_write_sql_trace(
+            &mut datafusion_ctx,
+            sql,
+            &[],
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect("reference file data update should succeed");
+
+        assert_eq!(fast_path, WriteExecutorPath::Fast);
+        assert_eq!(datafusion_path, WriteExecutorPath::DataFusion);
+        assert_eq!(fast_result.rows, datafusion_result.rows);
+        assert_eq!(fast_scans.load(Ordering::SeqCst), 2);
+        assert_eq!(datafusion_scans.load(Ordering::SeqCst), 4);
+
+        let fast_rows = fast_staged.lock().expect("fast writes lock").deltas[0]
+            .pending_write_overlay()
+            .expect("fast staged delta should project")
+            .visible_all_semantic_rows();
+        let datafusion_rows = datafusion_staged
+            .lock()
+            .expect("DataFusion writes lock")
+            .deltas[0]
+            .pending_write_overlay()
+            .expect("DataFusion staged delta should project")
+            .visible_all_semantic_rows();
+        assert_eq!(fast_rows, datafusion_rows);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_updates_same_path_in_every_matching_scope() {
+        let root = live_file_row("file-readme", "branch-a", None, "shared.md");
+        let mut scoped = live_file_row("file-readme", "branch-a", None, "shared.md");
+        scoped.file_id = Some("owner-file".to_string());
+        let rows = vec![root, scoped];
+        let (mut fast_ctx, fast_staged, _) = counting_write_context(rows.clone());
+        let (mut datafusion_ctx, datafusion_staged, _) = counting_write_context(rows);
+        let sql = "UPDATE lix_file SET data = X'4142' WHERE id = 'file-readme'";
+
+        let (fast_result, fast_path) =
+            execute_write_sql_trace(&mut fast_ctx, sql, &[], WriteExecutorMode::ForceFast)
+                .await
+                .expect("scoped file data update should use the fast path");
+        let (datafusion_result, datafusion_path) = execute_write_sql_trace(
+            &mut datafusion_ctx,
+            sql,
+            &[],
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect("reference scoped file data update should succeed");
+
+        assert_eq!(fast_path, WriteExecutorPath::Fast);
+        assert_eq!(datafusion_path, WriteExecutorPath::DataFusion);
+        assert_eq!(fast_result.rows, vec![vec![Value::Integer(2)]]);
+        assert_eq!(fast_result.rows, datafusion_result.rows);
+        let fast_rows = fast_staged.lock().expect("fast writes lock").deltas[0]
+            .pending_write_overlay()
+            .expect("fast staged delta should project")
+            .visible_all_semantic_rows();
+        let datafusion_rows = datafusion_staged
+            .lock()
+            .expect("DataFusion writes lock")
+            .deltas[0]
+            .pending_write_overlay()
+            .expect("DataFusion staged delta should project")
+            .visible_all_semantic_rows();
+        assert_eq!(fast_rows, datafusion_rows);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_validates_active_branch() {
+        let make_context = || {
+            let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+            DummySqlWriteExecutionContext {
+                active_branch_id: "missing-branch",
+                blob_reader: Arc::new(DummyBlobReader),
+                live_state: Arc::new(RowsLiveStateReader { rows: Vec::new() }),
+                staged_writes,
+                schema_definitions: vec![],
+            }
+        };
+        let sql = "UPDATE lix_file SET data = X'41' WHERE id = 'file-readme'";
+        let mut fast_ctx = make_context();
+        let mut datafusion_ctx = make_context();
+
+        let fast_error =
+            execute_write_sql_trace(&mut fast_ctx, sql, &[], WriteExecutorMode::ForceFast)
+                .await
+                .expect_err("fast update must reject a missing active branch");
+        let datafusion_error = execute_write_sql_trace(
+            &mut datafusion_ctx,
+            sql,
+            &[],
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect_err("DataFusion update must reject a missing active branch");
+
+        assert_eq!(fast_error.code, datafusion_error.code);
+        assert_eq!(fast_error.code, LixError::CODE_BRANCH_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_validates_orphan_blob_refs() {
+        let mut malformed = live_blob_ref_row("file-readme", "branch-a", b"old");
+        malformed.snapshot_content = Some("not-json".to_string());
+        let (mut fast_ctx, _, _) = counting_write_context(vec![malformed.clone()]);
+        let (mut datafusion_ctx, _, _) = counting_write_context(vec![malformed]);
+        let sql = "UPDATE lix_file SET data = X'41' WHERE id = 'file-readme'";
+
+        let fast_error =
+            execute_write_sql_trace(&mut fast_ctx, sql, &[], WriteExecutorMode::ForceFast)
+                .await
+                .expect_err("fast update must validate targeted orphan blob refs");
+        let datafusion_error = execute_write_sql_trace(
+            &mut datafusion_ctx,
+            sql,
+            &[],
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect_err("DataFusion update must validate targeted orphan blob refs");
+
+        assert_eq!(fast_error.code, datafusion_error.code);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_supports_params() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![live_file_row(
+            "file-readme",
+            "branch-a",
+            None,
+            "readme.md",
+        )]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "UPDATE lix_file SET data = $1 WHERE id = $2",
+            &[
+                Value::Blob(b"parameterized".to_vec()),
+                Value::Text("file-readme".to_string()),
+            ],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("parameterized file data update should use the fast path");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 2);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let blob_refs = overlay.visible_semantic_rows(false, "lix_binary_blob_ref");
+        assert_eq!(blob_refs.len(), 1);
+        let snapshot: JsonValue = serde_json::from_str(
+            blob_refs[0]
+                .snapshot_content
+                .as_deref()
+                .expect("blob ref snapshot"),
+        )
+        .expect("blob ref snapshot JSON");
+        assert_eq!(snapshot["size_bytes"], 13);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_treats_null_id_as_no_match() {
+        let rows = vec![live_file_row("file-readme", "branch-a", None, "readme.md")];
+        let (mut fast_ctx, fast_staged, fast_scans) = counting_write_context(rows);
+        let sql = "UPDATE lix_file SET data = $1 WHERE id = $2";
+        let params = [Value::Blob(b"parameterized".to_vec()), Value::Null];
+
+        let (fast_result, fast_path) =
+            execute_write_sql_trace(&mut fast_ctx, sql, &params, WriteExecutorMode::ForceFast)
+                .await
+                .expect("NULL file id should be a fast no-op");
+        assert_eq!(fast_path, WriteExecutorPath::Fast);
+        assert_eq!(fast_result.rows, vec![vec![Value::Integer(0)]]);
+        assert_eq!(fast_scans.load(Ordering::SeqCst), 0);
+        assert!(
+            fast_staged
+                .lock()
+                .expect("fast writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_tombstones_blob_ref_for_empty_data() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![
+            live_file_row("file-readme", "branch-a", None, "readme.md"),
+            live_blob_ref_row("file-readme", "branch-a", b"old"),
+        ]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "UPDATE lix_file SET data = X'' WHERE id = 'file-readme'",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("empty file data update should use the fast path");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 2);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let blob_refs = overlay.visible_semantic_rows(true, "lix_binary_blob_ref");
+        assert_eq!(blob_refs.len(), 1);
+        assert!(blob_refs[0].tombstone);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_returns_zero_for_missing_file() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(Vec::new());
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "UPDATE lix_file SET data = X'41' WHERE id = 'missing'",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("missing file update should still use the fast path");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(0)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 2);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_file_data_update_by_id_preserves_plugin_path_restrictions() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![
+            live_directory_row("dir-lix", "branch-a", None, ".lix"),
+            live_directory_row("dir-plugins", "branch-a", Some("dir-lix"), "plugins"),
+            live_directory_row("dir-nested", "branch-a", Some("dir-plugins"), "nested"),
+            live_file_row(
+                "file-plugin",
+                "branch-a",
+                Some("dir-nested"),
+                "plugin_sentinel.lixplugin",
+            ),
+        ]);
+
+        let error = execute_write_sql_trace(
+            &mut ctx,
+            "UPDATE lix_file SET data = X'41' WHERE id = 'file-plugin'",
+            &[],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect_err("nested plugin archive path should remain invalid");
+
+        assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert_eq!(scans.load(Ordering::SeqCst), 2);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn bound_file_data_update_fast_path_rejects_broader_shapes() {
+        let (mut ctx, _, _) = counting_write_context(Vec::new());
+        for sql in [
+            "UPDATE lix_file SET data = X'41' WHERE path = '/readme.md'",
+            "UPDATE lix_file SET data = X'41', name = 'renamed.md' WHERE id = 'file-readme'",
+            "UPDATE lix_file SET data = data WHERE id = 'file-readme'",
+            "UPDATE lix_file_by_branch SET data = X'41' WHERE id = 'file-readme' AND lixcol_branch_id = 'branch-a'",
+        ] {
+            let plan = create_write_logical_plan(&mut ctx, sql)
+                .await
+                .unwrap_or_else(|error| panic!("{sql} should plan: {error}"));
+            let crate::sql2::exec::SqlLogicalPlan::Write(plan) = plan else {
+                panic!("{sql} should produce a write plan");
+            };
+            assert!(
+                !crate::sql2::exec::bound_public_write::supports_bound_public_write(&plan.plan),
+                "broader shape should fall back: {sql}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1157,6 +1157,16 @@ struct FileDescriptorRecord {
 }
 
 impl FileDescriptorRecord {
+    fn row_context(&self) -> FilesystemRowContext {
+        FilesystemRowContext {
+            branch_id: self.live.branch_id.clone(),
+            global: self.live.global,
+            untracked: self.live.untracked,
+            file_id: self.live.file_id.clone(),
+            metadata: None,
+        }
+    }
+
     fn directory_parent_keys(&self, directory_id: &str) -> Vec<FilesystemDescriptorKey> {
         let mut keys = vec![self.key.in_same_scope(directory_id)];
         if self.key.is_untracked() {
@@ -1166,14 +1176,7 @@ impl FileDescriptorRecord {
     }
 
     fn blob_ref_key(&self) -> FilesystemBlobRefKey {
-        let context = FilesystemRowContext {
-            branch_id: self.live.branch_id.clone(),
-            global: self.live.global,
-            untracked: self.live.untracked,
-            file_id: self.live.file_id.clone(),
-            metadata: None,
-        };
-        FilesystemBlobRefKey::from_context(&context, &self.id)
+        FilesystemBlobRefKey::from_context(&self.row_context(), &self.id)
     }
 }
 
@@ -1417,6 +1420,81 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
         }
     };
     stage_lix_file_fast_batch(ctx, mode, staged).await
+}
+
+pub(crate) async fn execute_fast_lix_file_data_update_by_id(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    file_id: Option<String>,
+    data: Vec<u8>,
+) -> Result<u64, LixError> {
+    let active_branch_id = ctx.active_branch_id().to_string();
+    ctx.load_branch_head(&active_branch_id)
+        .await?
+        .ok_or_else(|| {
+            LixError::branch_not_found(
+                active_branch_id.clone(),
+                "execute bound public write",
+                "active branch",
+            )
+        })?;
+    let Some(file_id) = file_id else {
+        return Ok(0);
+    };
+    let mut file_request = lix_file_scan_request(Some(&active_branch_id), None, None);
+    file_request.filter.schema_keys = vec![
+        FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+        BLOB_REF_SCHEMA_KEY.to_string(),
+    ];
+    file_request.filter.entity_pks = vec![EntityPk::single(file_id.clone())];
+    let mut rows = ctx.scan_live_state(&file_request).await?;
+
+    let mut directory_request = lix_file_scan_request(Some(&active_branch_id), None, None);
+    directory_request.filter.schema_keys = vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()];
+    rows.extend(ctx.scan_live_state(&directory_request).await?);
+
+    let PreparedLixFileRows {
+        file_rows,
+        blob_rows,
+        file_paths,
+    } = prepare_lix_file_rows(rows, &FilePathPredicate::All)?;
+    let existing = file_rows
+        .into_iter()
+        .filter(|(_, file)| file.id == file_id)
+        .map(|(key, file)| {
+            let path = file_paths
+                .get(&key)
+                .cloned()
+                .expect("prepared lix_file descriptor should have a path");
+            let has_blob_ref = blob_rows.contains_key(&file.blob_ref_key());
+            (path, file, has_blob_ref)
+        })
+        .collect::<Vec<_>>();
+    if existing.is_empty() {
+        return Ok(0);
+    }
+
+    let mut staged = LixFileStagedBatch::default();
+    for (path, existing, has_blob_ref) in existing {
+        parse_file_upsert_path(&path, TransactionWriteOperation::Update)
+            .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+        let mut context = existing.row_context();
+        if context.global {
+            context.branch_id = GLOBAL_BRANCH_ID.to_string();
+        }
+        stage_lix_file_data_update_write(
+            &mut staged,
+            existing.id,
+            Some(path),
+            None,
+            data.clone(),
+            context,
+            has_blob_ref,
+            None,
+        )
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+        staged.add_count(1)?;
+    }
+    stage_lix_file_fast_batch(ctx, TransactionWriteMode::Replace, staged).await
 }
 
 struct FastLixFilePathWrite {

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -30,7 +30,10 @@ use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
 use datafusion::catalog::TableProvider;
 
-pub(crate) use file::{FastLixFilePathWriteConflict, execute_fast_lix_file_path_writes};
+pub(crate) use file::{
+    FastLixFilePathWriteConflict, execute_fast_lix_file_data_update_by_id,
+    execute_fast_lix_file_path_writes,
+};
 pub(crate) use upsert::{UpsertAction, excluded_field_name};
 
 /// Execute an `INSERT ... ON CONFLICT` against a registered table provider.


### PR DESCRIPTION
## Stack

4 of 6. Base: `codex/atelier-sql-change-projection`. Next: `codex/atelier-sql-file-dml-reuse`.

## What changed

Add a bound SQL fast path for the exact active-branch shape `UPDATE lix_file SET data = ? WHERE id = ?`. It bypasses DataFusion construction and stages the targeted file-data update directly while preserving branch validation, malformed-state errors, plugin restrictions, tombstones, missing-file counts, and multiple descriptors with the same public ID in distinct scopes. Broader update shapes continue through DataFusion.

## Backend smoke results

Measured with a local `CountingBackend<InMemoryBackend>` harness. Mutation timing is one isolated fixture sample and is expected to be noisy.

| Atelier query | Begin reads | Read calls | Point calls | Scan calls | Keys | Read KiB | Median ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Q37a data by ID | 15 → 12 | 135 → 112 | 109 → 92 | 26 → 20 | 300 → 277 | 88.996 → 85.663 | 1.541 → 1.780 |

The candidate live-state scan count in the focused executor fixture moves from four to two. The isolated timing sample is noisy; backend work drops across every measured counter.

## Validation

- Forced fast/DataFusion staged-write parity
- Parameters, empty-data tombstones, missing IDs, multiple scopes, missing active branch, malformed orphan blob refs, plugin restrictions, and unsupported-shape fallback
- `cargo fmt --all -- --check`
- Full Atelier SQL smoke catalog on the final stacked branch
- Full `sql2` unit-test sweep on the final stacked branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches file blob staging and live-state scans for a hot mutation path; behavior is heavily parity-tested but incorrect fast-path matching could diverge from DataFusion on edge cases.
> 
> **Overview**
> Adds a **bound public-write fast path** for the exact active-branch shape `UPDATE lix_file SET data = ? WHERE id = ?`, alongside the existing path-based file insert fast path.
> 
> **`bound_public_write`** recognizes that narrow plan (base `lix_file`, single `data` assignment, equality on `id`, params/literals only) and routes execution to **`execute_fast_lix_file_data_update_by_id`** instead of building a DataFusion plan. NULL `id` parameters are treated as a no-op; broader updates still fall back to DataFusion.
> 
> The **file provider** loads matching descriptors and directories via targeted live-state scans, applies path/plugin validation, and stages blob updates through the same **`stage_lix_file_data_update_write`** path used elsewhere (including multi-scope rows sharing one public id). **`FileDescriptorRecord::row_context`** centralizes row context for blob-ref keys.
> 
> **Tests** force fast vs DataFusion parity on staged writes, scan counts, parameters, tombstones for empty data, missing files/branches, malformed blob refs, plugin path restrictions, and unsupported shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d784a068ca0281c9f31d9540be8a1f67f057860c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->