### PR TITLE
Allow entity writes to filter by lixcol_file_id

### DIFF
--- a/packages/engine/src/sql2/bind/table.rs
+++ b/packages/engine/src/sql2/bind/table.rs
@@ -247,6 +247,19 @@ mod tests {
         assert!(require_public_column(&table, "lixcol_snapshot_content").is_ok());
     }
 
+    #[test]
+    fn dynamic_entity_file_id_is_public_and_insert_only() {
+        let catalog = catalog();
+        let table = bind_public_table(&catalog, &table_name("SELECT * FROM test_state_schema"))
+            .expect("entity surface should bind");
+
+        assert!(require_public_column(&table, "lixcol_file_id").is_ok());
+        assert!(require_writable_column(&table, "lixcol_file_id", BoundWriteOp::Insert).is_ok());
+        let error = require_writable_column(&table, "lixcol_file_id", BoundWriteOp::Update)
+            .expect_err("entity file id should remain immutable after insert");
+        assert!(error.message.contains("is not writable"));
+    }
+
     fn catalog() -> PublicCatalog {
         PublicCatalog::from_visible_schemas(&[json!({
             "x-lix-key": "test_state_schema",

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -488,9 +488,8 @@ fn entity_system_columns(variant: EntitySurfaceShape) -> Vec<PublicColumn> {
             | "lixcol_updated_at" | "lixcol_commit_id" => {
                 PublicColumn::public_read_only(field.name().as_str())
             }
-            "lixcol_entity_pk" | "lixcol_global" | "lixcol_untracked" | "lixcol_branch_id" => {
-                PublicColumn::public_insert_only(field.name().as_str())
-            }
+            "lixcol_entity_pk" | "lixcol_file_id" | "lixcol_global" | "lixcol_untracked"
+            | "lixcol_branch_id" => PublicColumn::public_insert_only(field.name().as_str()),
             "lixcol_metadata" => PublicColumn::public(field.name().as_str()),
             _ => PublicColumn::hidden(field.name().as_str()),
         })

--- a/packages/engine/tests/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/sql/lix_registered_schema.rs
@@ -1141,6 +1141,92 @@ simulation_test!(
 );
 
 simulation_test!(
+    typed_entity_update_accepts_file_id_predicate,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"engine_file_scoped_entity_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES \
+                 ('file-1', '/file-1.txt', X'31'), \
+                 ('file-2', '/file-2.txt', X'32')",
+                &[],
+            )
+            .await
+            .expect("file inserts should succeed");
+
+        session
+            .execute(
+                "INSERT INTO engine_file_scoped_entity_schema \
+                 (id, name, lixcol_file_id, lixcol_global, lixcol_untracked) \
+                 VALUES \
+                 ('row-1', 'before-1', 'file-1', false, false), \
+                 ('row-2', 'before-2', 'file-2', false, false)",
+                &[],
+            )
+            .await
+            .expect("typed entity inserts with file ids should succeed");
+
+        let update = session
+            .execute(
+                "UPDATE engine_file_scoped_entity_schema \
+                 SET name = 'after' \
+                 WHERE lixcol_file_id = 'file-1'",
+                &[],
+            )
+            .await
+            .expect("file id should be accepted in an entity write predicate");
+        assert_eq!(update, ExecuteResult::from_rows_affected(1));
+
+        let result = session
+            .execute(
+                "SELECT id, name, lixcol_file_id \
+                 FROM engine_file_scoped_entity_schema \
+                 ORDER BY id",
+                &[],
+            )
+            .await
+            .expect("entity file id should be readable");
+        assert_rows_eq(
+            result,
+            vec![
+                vec![
+                    Value::Text("row-1".to_string()),
+                    Value::Text("after".to_string()),
+                    Value::Text("file-1".to_string()),
+                ],
+                vec![
+                    Value::Text("row-2".to_string()),
+                    Value::Text("before-2".to_string()),
+                    Value::Text("file-2".to_string()),
+                ],
+            ],
+        );
+    }
+);
+
+simulation_test!(
     typed_entity_update_accepts_parseable_json_text_identity_predicate,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## Summary

- expose `lixcol_file_id` as a public, insert-only entity-surface column
- allow entity `UPDATE` and `DELETE` predicates to bind against `lixcol_file_id`
- keep direct `SET lixcol_file_id = ...` assignments rejected because file ID is part of row identity
- add binder and end-to-end simulation coverage

## Why

Entity surfaces already projected and evaluated `lixcol_file_id`, but the public catalog marked it hidden. As a result, write predicates such as `UPDATE my_entity SET value = 'next' WHERE lixcol_file_id = 'file-1'` failed during binding.

Making the column public and insert-only aligns the catalog with the existing executor behavior while preserving identity immutability.

## Validation

- `cargo test -p lix_engine --lib dynamic_entity_file_id_is_public_and_insert_only`
- `cargo test -p lix_engine --test sql typed_entity_update_accepts_file_id_predicate`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog/binding-only change aligned with existing executor behavior; insert-only rules preserve row identity.
> 
> **Overview**
> Entity SQL surfaces now treat **`lixcol_file_id`** as a **public, insert-only** system column in the catalog (same class as `lixcol_entity_pk` and `lixcol_branch_id`), instead of a hidden column that failed binding in `WHERE` clauses.
> 
> **`UPDATE`** / **`DELETE`** on typed entity tables can filter with `WHERE lixcol_file_id = ...`; **`SET lixcol_file_id`** stays rejected because file ID is fixed at insert. Coverage adds a binder unit test and a simulation that updates only rows tied to a given file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8883af0d670f44e56f8a79a4a3c76332a4b404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->