### PR TITLE
Add compact filesystem path index

### DIFF
--- a/packages/engine/src/filesystem/mod.rs
+++ b/packages/engine/src/filesystem/mod.rs
@@ -1,10 +1,17 @@
 mod descriptor_path;
 mod keys;
+mod path_index;
 mod planner;
 mod read;
 mod visibility;
 
 pub(crate) use self::descriptor_path::{DirectoryPathRecord, derive_directory_paths};
+pub(crate) use self::path_index::{
+    FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
+    FilesystemPathIndexRequest, FilesystemPathKind, FilesystemPathSelection,
+    UncachedFilesystemPathIndexReader, build_path_index, load_path_index_revision,
+    stage_path_index_revision,
+};
 pub(crate) use self::planner::directory_path_resolvers_from_state_rows;
 pub(crate) use self::planner::{
     BlobRefRowInput, DirectoryDescriptorWriteIntent, DirectoryPathResolver, FileDeleteInput,
@@ -12,10 +19,11 @@ pub(crate) use self::planner::{
     FilesystemBlobRefKey, FilesystemDeletePlan, FilesystemDescriptorKey, FilesystemRowContext,
     FilesystemWritePlan, blob_ref_row, blob_ref_tombstone_row,
     create_directory_path_with_leaf_id_with_resolvers, directory_descriptor_write_row,
-    directory_path_resolvers_from_live_state, file_descriptor_row, file_descriptor_write_row,
-    filesystem_storage_scope_key, plan_file_delete, plan_file_descriptor_write,
-    plan_parsed_directory_path_update_with_resolvers, plan_parsed_file_path_update_with_resolvers,
-    plan_parsed_file_path_write_with_resolvers, plan_recursive_directory_delete,
+    directory_path_resolvers_from_live_state, directory_path_resolvers_from_path_index,
+    file_descriptor_row, file_descriptor_write_row, filesystem_storage_scope_key, plan_file_delete,
+    plan_file_descriptor_write, plan_parsed_directory_path_update_with_resolvers,
+    plan_parsed_file_path_update_with_resolvers, plan_parsed_file_path_write_with_resolvers,
+    plan_recursive_directory_delete,
 };
 pub(crate) use self::read::{FilesystemIndex, filesystem_schema_keys};
 pub(crate) use self::visibility::VisibleFilesystem;

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -505,7 +505,7 @@ impl FilesystemPathIndexCache {
     }
 }
 
-pub(crate) fn load_path_index_revision(
+pub(crate) async fn load_path_index_revision(
     store: &(impl StorageRead + ?Sized),
 ) -> Result<Option<Vec<u8>>, LixError> {
     let result = PointReadPlan::new(
@@ -516,9 +516,9 @@ pub(crate) fn load_path_index_revision(
         store,
         StorageGetOptions {
             projection: StorageCoreProjection::FullValue,
-            ..StorageGetOptions::default()
         },
-    )?;
+    )
+    .await?;
     Ok(result
         .value
         .into_iter()

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -1,0 +1,733 @@
+use std::collections::BTreeMap;
+use std::mem::size_of;
+use std::ops::Bound;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde::Deserialize;
+
+use crate::LixError;
+use crate::changelog::{ChangeId, CommitId};
+use crate::common::compose_file_path;
+use crate::entity_pk::EntityPk;
+use crate::live_state::{
+    LiveStateFilter, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
+};
+use crate::storage::{
+    PointReadPlan, StorageCoreProjection, StorageGetOptions, StorageKey, StorageProjectedValue,
+    StorageRead, StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+};
+
+use super::descriptor_path::{DirectoryPathRecord, derive_directory_paths};
+use super::keys::{DIRECTORY_DESCRIPTOR_SCHEMA_KEY, FILE_DESCRIPTOR_SCHEMA_KEY};
+use super::planner::FilesystemDescriptorKey;
+
+const FILESYSTEM_PATH_REVISION_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0007_0002),
+    "filesystem.path_index_revision",
+);
+const FILESYSTEM_PATH_REVISION_KEY: &[u8] = b"global";
+const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum FilesystemPathKind {
+    File,
+    Directory,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FilesystemPathEntry {
+    pub(crate) path: String,
+    pub(crate) kind: FilesystemPathKind,
+    pub(crate) parent_id: Option<String>,
+    pub(crate) name: String,
+    pub(crate) key: FilesystemDescriptorKey,
+    metadata: Option<String>,
+    created_at: String,
+    updated_at: String,
+    change_id: Option<ChangeId>,
+    commit_id: Option<CommitId>,
+}
+
+impl FilesystemPathEntry {
+    pub(crate) fn id(&self) -> &str {
+        self.key.descriptor_id()
+    }
+
+    pub(crate) fn live_row(&self) -> MaterializedLiveStateRow {
+        let snapshot_content = match self.kind {
+            FilesystemPathKind::File => serde_json::json!({
+                "id": self.id(),
+                "directory_id": &self.parent_id,
+                "name": &self.name,
+            }),
+            FilesystemPathKind::Directory => serde_json::json!({
+                "id": self.id(),
+                "parent_id": &self.parent_id,
+                "name": &self.name,
+            }),
+        };
+        MaterializedLiveStateRow {
+            entity_pk: EntityPk::single(self.id()),
+            schema_key: match self.kind {
+                FilesystemPathKind::File => FILE_DESCRIPTOR_SCHEMA_KEY,
+                FilesystemPathKind::Directory => DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
+            }
+            .to_string(),
+            file_id: self.key.file_id().map(str::to_string),
+            snapshot_content: Some(snapshot_content.to_string()),
+            metadata: self.metadata.clone(),
+            deleted: false,
+            created_at: self.created_at.clone(),
+            updated_at: self.updated_at.clone(),
+            global: self.key.global(),
+            change_id: self.change_id,
+            commit_id: self.commit_id,
+            untracked: self.key.is_untracked(),
+            branch_id: self.key.branch_id().to_string(),
+        }
+    }
+
+    fn estimated_heap_bytes(&self) -> usize {
+        self.path.capacity()
+            + self.parent_id.as_ref().map_or(0, String::capacity)
+            + self.name.capacity()
+            + self.key.estimated_heap_bytes()
+            + self.metadata.as_ref().map_or(0, String::capacity)
+            + self.created_at.capacity()
+            + self.updated_at.capacity()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FilesystemPathSelection {
+    index: Arc<FilesystemPathIndex>,
+    indices: Arc<[usize]>,
+}
+
+impl FilesystemPathSelection {
+    pub(crate) fn new(index: Arc<FilesystemPathIndex>, indices: Vec<usize>) -> Self {
+        Self {
+            index,
+            indices: indices.into(),
+        }
+    }
+
+    pub(crate) fn entries(&self) -> impl Iterator<Item = &FilesystemPathEntry> {
+        self.indices.iter().map(|index| &self.index.entries[*index])
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.indices.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+
+    pub(crate) fn index(&self) -> &FilesystemPathIndex {
+        &self.index
+    }
+}
+
+/// Ordered, descriptor-only index over one effective live filesystem view.
+///
+/// Duplicate paths remain adjacent because Lix path uniqueness is storage-scope
+/// local. Distinct branch/global lanes can legally render the same path and SQL
+/// predicates must retain every visible candidate.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FilesystemPathIndex {
+    entries: Vec<FilesystemPathEntry>,
+    file_count: usize,
+    directory_count: usize,
+    estimated_heap_bytes: usize,
+}
+
+impl FilesystemPathIndex {
+    pub(crate) fn from_live_rows(rows: Vec<MaterializedLiveStateRow>) -> Result<Self, LixError> {
+        let mut directory_rows = BTreeMap::<FilesystemDescriptorKey, DirectoryRecord>::new();
+        let mut file_rows = Vec::<(FilesystemDescriptorKey, FileRecord)>::new();
+
+        for row in rows {
+            let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+                continue;
+            };
+            match row.schema_key.as_str() {
+                DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
+                    let snapshot: DirectorySnapshot = serde_json::from_str(snapshot_content)
+                        .map_err(|error| {
+                            LixError::unknown(format!(
+                                "invalid lix_directory_descriptor snapshot JSON: {error}"
+                            ))
+                        })?;
+                    let key = FilesystemDescriptorKey::from_live_row(&row, snapshot.id.clone());
+                    directory_rows.insert(
+                        key.clone(),
+                        DirectoryRecord {
+                            key,
+                            id: snapshot.id,
+                            parent_id: snapshot.parent_id,
+                            name: snapshot.name,
+                            metadata: row.metadata,
+                            created_at: row.created_at,
+                            updated_at: row.updated_at,
+                            change_id: row.change_id,
+                            commit_id: row.commit_id,
+                        },
+                    );
+                }
+                FILE_DESCRIPTOR_SCHEMA_KEY => {
+                    let snapshot: FileSnapshot =
+                        serde_json::from_str(snapshot_content).map_err(|error| {
+                            LixError::unknown(format!(
+                                "invalid lix_file_descriptor snapshot JSON: {error}"
+                            ))
+                        })?;
+                    let key = FilesystemDescriptorKey::from_live_row(&row, snapshot.id.clone());
+                    file_rows.push((
+                        key,
+                        FileRecord {
+                            id: snapshot.id,
+                            directory_id: snapshot.directory_id,
+                            name: snapshot.name,
+                            metadata: row.metadata,
+                            created_at: row.created_at,
+                            updated_at: row.updated_at,
+                            change_id: row.change_id,
+                            commit_id: row.commit_id,
+                        },
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        let directory_paths = derive_directory_paths(
+            directory_rows
+                .iter()
+                .map(|(key, record)| (key.clone(), record)),
+        )?;
+        let mut entries = Vec::<FilesystemPathEntry>::with_capacity(
+            directory_rows.len().saturating_add(file_rows.len()),
+        );
+
+        for (key, record) in &directory_rows {
+            let path = directory_paths.get(key).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    format!("directory {:?} is not reachable from root", record.id),
+                )
+            })?;
+            entries.push(FilesystemPathEntry {
+                path: path.clone(),
+                kind: FilesystemPathKind::Directory,
+                parent_id: record.parent_id.clone(),
+                name: record.name.clone(),
+                key: record.key.clone(),
+                metadata: record.metadata.clone(),
+                created_at: record.created_at.clone(),
+                updated_at: record.updated_at.clone(),
+                change_id: record.change_id,
+                commit_id: record.commit_id,
+            });
+        }
+
+        for (key, record) in file_rows {
+            let directory_path = match record.directory_id.as_deref() {
+                Some(directory_id) => {
+                    let parent_key = file_directory_parent_keys(&key, directory_id)
+                        .into_iter()
+                        .find(|candidate| directory_paths.contains_key(candidate));
+                    let Some(path) = parent_key
+                        .as_ref()
+                        .and_then(|candidate| directory_paths.get(candidate))
+                    else {
+                        return Err(LixError::new(
+                            LixError::CODE_FOREIGN_KEY,
+                            format!(
+                                "lix_file_descriptor '{}' references missing directory_id '{}' in branch '{}'",
+                                record.id,
+                                directory_id,
+                                key.branch_id()
+                            ),
+                        ));
+                    };
+                    Some(path.as_str())
+                }
+                None => None,
+            };
+            let path = compose_file_path(directory_path, &record.name)?;
+            entries.push(FilesystemPathEntry {
+                path,
+                kind: FilesystemPathKind::File,
+                parent_id: record.directory_id,
+                name: record.name,
+                key,
+                metadata: record.metadata,
+                created_at: record.created_at,
+                updated_at: record.updated_at,
+                change_id: record.change_id,
+                commit_id: record.commit_id,
+            });
+        }
+
+        entries.sort_unstable_by(|left, right| {
+            left.path
+                .cmp(&right.path)
+                .then_with(|| left.key.cmp(&right.key))
+                .then_with(|| left.kind.cmp(&right.kind))
+        });
+        let file_count = entries
+            .iter()
+            .filter(|entry| entry.kind == FilesystemPathKind::File)
+            .count();
+        let directory_count = entries.len().saturating_sub(file_count);
+        let estimated_heap_bytes = size_of::<Self>()
+            + entries.capacity() * size_of::<FilesystemPathEntry>()
+            + entries
+                .iter()
+                .map(FilesystemPathEntry::estimated_heap_bytes)
+                .sum::<usize>();
+        Ok(Self {
+            entries,
+            file_count,
+            directory_count,
+            estimated_heap_bytes,
+        })
+    }
+
+    pub(crate) fn exact_indices(&self, path: &str) -> std::ops::Range<usize> {
+        let start = self
+            .entries
+            .partition_point(|entry| entry.path.as_str() < path);
+        let end = self
+            .entries
+            .partition_point(|entry| entry.path.as_str() <= path);
+        start..end
+    }
+
+    pub(crate) fn range_indices(
+        &self,
+        lower: Bound<&str>,
+        upper: Bound<&str>,
+    ) -> std::ops::Range<usize> {
+        let start = match lower {
+            Bound::Unbounded => 0,
+            Bound::Included(path) => self
+                .entries
+                .partition_point(|entry| entry.path.as_str() < path),
+            Bound::Excluded(path) => self
+                .entries
+                .partition_point(|entry| entry.path.as_str() <= path),
+        };
+        let end = match upper {
+            Bound::Unbounded => self.entries.len(),
+            Bound::Included(path) => self
+                .entries
+                .partition_point(|entry| entry.path.as_str() <= path),
+            Bound::Excluded(path) => self
+                .entries
+                .partition_point(|entry| entry.path.as_str() < path),
+        };
+        start..end
+    }
+
+    pub(crate) fn all_indices(&self) -> std::ops::Range<usize> {
+        0..self.entries.len()
+    }
+
+    pub(crate) fn entry(&self, index: usize) -> &FilesystemPathEntry {
+        &self.entries[index]
+    }
+
+    pub(crate) fn entries(&self) -> impl Iterator<Item = &FilesystemPathEntry> {
+        self.entries.iter()
+    }
+
+    pub(crate) fn kind_count(&self, kind: FilesystemPathKind) -> usize {
+        match kind {
+            FilesystemPathKind::File => self.file_count,
+            FilesystemPathKind::Directory => self.directory_count,
+        }
+    }
+
+    pub(crate) fn estimated_heap_bytes(&self) -> usize {
+        self.estimated_heap_bytes
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FilesystemPathIndexRequest {
+    pub(crate) branch_ids: Vec<String>,
+}
+
+impl FilesystemPathIndexRequest {
+    pub(crate) fn new(mut branch_ids: Vec<String>) -> Self {
+        branch_ids.sort();
+        branch_ids.dedup();
+        Self { branch_ids }
+    }
+
+    pub(crate) fn live_state_request(&self) -> LiveStateScanRequest {
+        LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: vec![
+                    DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                    FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                ],
+                branch_ids: self.branch_ids.clone(),
+                ..LiveStateFilter::default()
+            },
+            ..LiveStateScanRequest::default()
+        }
+    }
+}
+
+#[async_trait]
+pub(crate) trait FilesystemPathIndexReader: Send + Sync {
+    async fn path_index(
+        &self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<Arc<FilesystemPathIndex>, LixError>;
+}
+
+pub(crate) struct UncachedFilesystemPathIndexReader {
+    live_state: Arc<dyn LiveStateReader>,
+}
+
+impl UncachedFilesystemPathIndexReader {
+    pub(crate) fn new(live_state: Arc<dyn LiveStateReader>) -> Self {
+        Self { live_state }
+    }
+}
+
+#[async_trait]
+impl FilesystemPathIndexReader for UncachedFilesystemPathIndexReader {
+    async fn path_index(
+        &self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<Arc<FilesystemPathIndex>, LixError> {
+        build_path_index(self.live_state.as_ref(), request).await
+    }
+}
+
+pub(crate) async fn build_path_index(
+    live_state: &dyn LiveStateReader,
+    request: &FilesystemPathIndexRequest,
+) -> Result<Arc<FilesystemPathIndex>, LixError> {
+    let rows = live_state.scan_rows(&request.live_state_request()).await?;
+    Ok(Arc::new(FilesystemPathIndex::from_live_rows(rows)?))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CacheKey {
+    branch_ids: Vec<String>,
+    revision: Option<Vec<u8>>,
+}
+
+impl CacheKey {
+    fn estimated_heap_bytes(&self) -> usize {
+        self.branch_ids.capacity() * size_of::<String>()
+            + self.branch_ids.iter().map(String::capacity).sum::<usize>()
+            + self.revision.as_ref().map_or(0, Vec::capacity)
+    }
+}
+
+#[derive(Debug)]
+struct CachedIndex {
+    key: CacheKey,
+    index: Arc<FilesystemPathIndex>,
+    bytes: usize,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct FilesystemPathIndexCache {
+    entries: Mutex<Vec<CachedIndex>>,
+}
+
+impl FilesystemPathIndexCache {
+    pub(crate) fn get(
+        &self,
+        request: &FilesystemPathIndexRequest,
+        revision: Option<&[u8]>,
+    ) -> Option<Arc<FilesystemPathIndex>> {
+        let key = CacheKey {
+            branch_ids: request.branch_ids.clone(),
+            revision: revision.map(<[u8]>::to_vec),
+        };
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("filesystem path cache lock poisoned");
+        let index = entries.iter().position(|candidate| candidate.key == key)?;
+        let entry = entries.remove(index);
+        let result = Arc::clone(&entry.index);
+        entries.push(entry);
+        Some(result)
+    }
+
+    pub(crate) fn insert(
+        &self,
+        request: &FilesystemPathIndexRequest,
+        revision: Option<&[u8]>,
+        index: Arc<FilesystemPathIndex>,
+    ) -> Arc<FilesystemPathIndex> {
+        let key = CacheKey {
+            branch_ids: request.branch_ids.clone(),
+            revision: revision.map(<[u8]>::to_vec),
+        };
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("filesystem path cache lock poisoned");
+        if let Some(position) = entries.iter().position(|candidate| candidate.key == key) {
+            return Arc::clone(&entries[position].index);
+        }
+        entries.retain(|candidate| candidate.key.branch_ids != key.branch_ids);
+        let bytes =
+            size_of::<CachedIndex>() + key.estimated_heap_bytes() + index.estimated_heap_bytes();
+        entries.push(CachedIndex {
+            key,
+            index: Arc::clone(&index),
+            bytes,
+        });
+        while entries.len() > 1
+            && entries
+                .iter()
+                .map(|candidate| candidate.bytes)
+                .sum::<usize>()
+                > MAX_CACHE_BYTES
+        {
+            entries.remove(0);
+        }
+        index
+    }
+}
+
+pub(crate) fn load_path_index_revision(
+    store: &(impl StorageRead + ?Sized),
+) -> Result<Option<Vec<u8>>, LixError> {
+    let result = PointReadPlan::new(
+        FILESYSTEM_PATH_REVISION_SPACE,
+        &[StorageKey(Bytes::from_static(FILESYSTEM_PATH_REVISION_KEY))],
+    )
+    .materialize(
+        store,
+        StorageGetOptions {
+            projection: StorageCoreProjection::FullValue,
+            ..StorageGetOptions::default()
+        },
+    )?;
+    Ok(result
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .and_then(|value| match value {
+            StorageProjectedValue::FullValue(bytes) => Some(bytes.to_vec()),
+            StorageProjectedValue::KeyOnly => None,
+        }))
+}
+
+pub(crate) fn stage_path_index_revision(writes: &mut StorageWriteSet) {
+    writes.put(
+        FILESYSTEM_PATH_REVISION_SPACE,
+        StorageKey(Bytes::from_static(FILESYSTEM_PATH_REVISION_KEY)),
+        StorageValue {
+            bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
+        },
+    );
+}
+
+fn file_directory_parent_keys(
+    file_key: &FilesystemDescriptorKey,
+    directory_id: &str,
+) -> Vec<FilesystemDescriptorKey> {
+    let mut keys = vec![file_key.in_same_scope(directory_id)];
+    if file_key.is_untracked() {
+        keys.push(file_key.in_tracked_scope(directory_id));
+    }
+    keys
+}
+
+#[derive(Debug, Deserialize)]
+struct DirectorySnapshot {
+    id: String,
+    parent_id: Option<String>,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FileSnapshot {
+    id: String,
+    directory_id: Option<String>,
+    name: String,
+}
+
+#[derive(Debug)]
+struct DirectoryRecord {
+    key: FilesystemDescriptorKey,
+    id: String,
+    parent_id: Option<String>,
+    name: String,
+    metadata: Option<String>,
+    created_at: String,
+    updated_at: String,
+    change_id: Option<ChangeId>,
+    commit_id: Option<CommitId>,
+}
+
+impl DirectoryPathRecord for DirectoryRecord {
+    type Key = FilesystemDescriptorKey;
+
+    fn parent_key(&self, key: &Self::Key) -> Option<Self::Key> {
+        self.parent_id
+            .as_deref()
+            .map(|parent_id| key.in_same_scope(parent_id))
+    }
+
+    fn parent_keys(&self, key: &Self::Key) -> Vec<Self::Key> {
+        let Some(parent_id) = self.parent_id.as_deref() else {
+            return Vec::new();
+        };
+        let mut keys = vec![key.in_same_scope(parent_id)];
+        if key.is_untracked() {
+            keys.push(key.in_tracked_scope(parent_id));
+        }
+        keys
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[derive(Debug)]
+struct FileRecord {
+    id: String,
+    directory_id: Option<String>,
+    name: String,
+    metadata: Option<String>,
+    created_at: String,
+    updated_at: String,
+    change_id: Option<ChangeId>,
+    commit_id: Option<CommitId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::changelog::{ChangeId, CommitId};
+    use crate::entity_pk::EntityPk;
+
+    #[test]
+    fn exact_range_and_order_preserve_path_buckets() {
+        let index = FilesystemPathIndex::from_live_rows(vec![
+            directory_row("dir-docs", None, "docs", "branch-a", false),
+            file_row("file-a", Some("dir-docs"), "a.md", "branch-a", false),
+            file_row("file-b", Some("dir-docs"), "b.md", "branch-a", false),
+            file_row(
+                "file-a-global",
+                Some("dir-docs-global"),
+                "a.md",
+                "branch-a",
+                true,
+            ),
+            directory_row("dir-docs-global", None, "docs", "branch-a", true),
+        ])
+        .expect("path index should build");
+
+        assert_eq!(index.exact_indices("/docs/a.md").len(), 2);
+        assert!(index.exact_indices("/docs/missing.md").is_empty());
+        let range =
+            index.range_indices(Bound::Included("/docs/a.md"), Bound::Excluded("/docs/c.md"));
+        assert_eq!(
+            range
+                .map(|entry| index.entry(entry).path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/docs/a.md", "/docs/a.md", "/docs/b.md"]
+        );
+        assert_eq!(
+            index
+                .all_indices()
+                .map(|entry| index.entry(entry).path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/docs/", "/docs/", "/docs/a.md", "/docs/a.md", "/docs/b.md"]
+        );
+        assert!(index.estimated_heap_bytes() > 0);
+    }
+
+    #[test]
+    fn cache_supersedes_older_revision_for_the_same_scope() {
+        let cache = FilesystemPathIndexCache::default();
+        let request = FilesystemPathIndexRequest::new(vec!["branch-a".to_string()]);
+        let first = Arc::new(FilesystemPathIndex::default());
+        let second = Arc::new(FilesystemPathIndex::default());
+
+        cache.insert(&request, Some(&[1]), Arc::clone(&first));
+        cache.insert(&request, Some(&[2]), Arc::clone(&second));
+
+        assert!(cache.get(&request, Some(&[1])).is_none());
+        assert!(Arc::ptr_eq(
+            &cache.get(&request, Some(&[2])).expect("new revision"),
+            &second
+        ));
+    }
+
+    fn directory_row(
+        id: &str,
+        parent_id: Option<&str>,
+        name: &str,
+        branch_id: &str,
+        global: bool,
+    ) -> MaterializedLiveStateRow {
+        live_row(
+            id,
+            DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
+            serde_json::json!({"id": id, "parent_id": parent_id, "name": name}).to_string(),
+            branch_id,
+            global,
+        )
+    }
+
+    fn file_row(
+        id: &str,
+        directory_id: Option<&str>,
+        name: &str,
+        branch_id: &str,
+        global: bool,
+    ) -> MaterializedLiveStateRow {
+        live_row(
+            id,
+            FILE_DESCRIPTOR_SCHEMA_KEY,
+            serde_json::json!({"id": id, "directory_id": directory_id, "name": name}).to_string(),
+            branch_id,
+            global,
+        )
+    }
+
+    fn live_row(
+        id: &str,
+        schema_key: &str,
+        snapshot_content: String,
+        branch_id: &str,
+        global: bool,
+    ) -> MaterializedLiveStateRow {
+        MaterializedLiveStateRow {
+            entity_pk: EntityPk::single(id),
+            schema_key: schema_key.to_string(),
+            file_id: None,
+            snapshot_content: Some(snapshot_content),
+            metadata: None,
+            deleted: false,
+            created_at: "2026-01-01T00:00:00.000Z".to_string(),
+            updated_at: "2026-01-01T00:00:00.000Z".to_string(),
+            global,
+            change_id: Some(ChangeId::for_test_label(id)),
+            commit_id: Some(CommitId::for_test_label(id)),
+            untracked: false,
+            branch_id: branch_id.to_string(),
+        }
+    }
+}

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -128,6 +128,28 @@ impl FilesystemDescriptorKey {
     pub(crate) fn is_untracked(&self) -> bool {
         self.untracked
     }
+
+    pub(crate) fn branch_id(&self) -> &str {
+        &self.branch_id
+    }
+
+    pub(crate) fn global(&self) -> bool {
+        self.global
+    }
+
+    pub(crate) fn file_id(&self) -> Option<&str> {
+        self.file_id.as_deref()
+    }
+
+    pub(crate) fn descriptor_id(&self) -> &str {
+        &self.descriptor_id
+    }
+
+    pub(crate) fn estimated_heap_bytes(&self) -> usize {
+        self.branch_id.capacity()
+            + self.file_id.as_ref().map_or(0, String::capacity)
+            + self.descriptor_id.capacity()
+    }
 }
 
 /// Storage identity of a `lix_binary_blob_ref` row for a filesystem file.
@@ -1326,6 +1348,67 @@ pub(crate) async fn directory_path_resolvers_from_live_state(
         })
         .await?;
     let mut resolvers = directory_path_resolvers_from_state_rows(rows)?;
+    if let Some(branch_id) = branch_binding {
+        let key = filesystem_storage_scope_key(branch_id, false, false, None);
+        resolvers.entry(key).or_default();
+    }
+    Ok(resolvers)
+}
+
+pub(crate) fn directory_path_resolvers_from_path_index(
+    index: &super::path_index::FilesystemPathIndex,
+    branch_binding: Option<&str>,
+) -> Result<BTreeMap<String, DirectoryPathResolver>, LixError> {
+    let mut directory_rows = BTreeMap::<String, BTreeMap<String, DirectoryDescriptorSeed>>::new();
+    let mut file_rows = BTreeMap::<String, Vec<(Option<String>, String, String)>>::new();
+    for entry in index.entries() {
+        let key = &entry.key;
+        let storage_branch_id = if key.global() {
+            GLOBAL_BRANCH_ID
+        } else {
+            key.branch_id()
+        };
+        let resolver_key = filesystem_storage_scope_key(
+            storage_branch_id,
+            key.global(),
+            key.is_untracked(),
+            key.file_id(),
+        );
+        match entry.kind {
+            super::path_index::FilesystemPathKind::Directory => {
+                directory_rows.entry(resolver_key).or_default().insert(
+                    entry.id().to_string(),
+                    DirectoryDescriptorSeed {
+                        id: entry.id().to_string(),
+                        parent_id: entry.parent_id.clone(),
+                        name: entry.name.clone(),
+                    },
+                );
+            }
+            super::path_index::FilesystemPathKind::File => {
+                file_rows.entry(resolver_key).or_default().push((
+                    entry.parent_id.clone(),
+                    entry.name.clone(),
+                    entry.id().to_string(),
+                ));
+            }
+        }
+    }
+
+    let mut resolvers = BTreeMap::new();
+    for (resolver_key, records) in directory_rows {
+        let files = file_rows.remove(&resolver_key).unwrap_or_default();
+        resolvers.insert(
+            resolver_key,
+            DirectoryPathResolver::from_existing_descriptors(records.into_values(), files)?,
+        );
+    }
+    for (resolver_key, files) in file_rows {
+        resolvers.insert(
+            resolver_key,
+            DirectoryPathResolver::from_existing_descriptors(std::iter::empty(), files)?,
+        );
+    }
     if let Some(branch_id) = branch_binding {
         let key = filesystem_storage_scope_key(branch_id, false, false, None);
         resolvers.entry(key).or_default();

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -9,6 +9,10 @@ use crate::NullableKeyFilter;
 use crate::branch::BRANCH_REF_SCHEMA_KEY;
 use crate::commit_graph::CommitGraphContext;
 use crate::entity_pk::EntityPk;
+use crate::filesystem::{
+    FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
+    FilesystemPathIndexRequest, build_path_index, load_path_index_revision,
+};
 use crate::live_state::{
     LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
     VisibilityBranchScope, VisibilityRequest, expanded_branch_ids, resolve_visible_rows,
@@ -36,6 +40,7 @@ pub(crate) struct LiveStateContext {
     tracked_state: TrackedStateContext,
     untracked_state: UntrackedStateContext,
     commit_graph: CommitGraphContext,
+    filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
 }
 
 impl LiveStateContext {
@@ -48,6 +53,7 @@ impl LiveStateContext {
             tracked_state,
             untracked_state,
             commit_graph,
+            filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
         }
     }
 
@@ -61,6 +67,7 @@ impl LiveStateContext {
             tracked_state: self.tracked_state.clone(),
             untracked_state: self.untracked_state,
             commit_graph: self.commit_graph.clone(),
+            filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
         }
     }
 }
@@ -71,6 +78,7 @@ pub(crate) struct LiveStateStoreReader<S> {
     tracked_state: TrackedStateContext,
     untracked_state: UntrackedStateContext,
     commit_graph: CommitGraphContext,
+    filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
 }
 
 impl<S> LiveStateStoreReader<S>
@@ -203,6 +211,32 @@ where
         request: &LiveStateRowRequest,
     ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
         Self::load_row(self, request).await
+    }
+}
+
+#[async_trait]
+impl<S> FilesystemPathIndexReader for LiveStateStoreReader<S>
+where
+    S: StorageRead + Send + Sync,
+{
+    async fn path_index(
+        &self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<std::sync::Arc<FilesystemPathIndex>, LixError> {
+        let revision = {
+            let store = self.store.lock().await;
+            load_path_index_revision(&*store)?
+        };
+        if let Some(index) = self
+            .filesystem_path_index_cache
+            .get(request, revision.as_deref())
+        {
+            return Ok(index);
+        }
+        let index = build_path_index(self, request).await?;
+        Ok(self
+            .filesystem_path_index_cache
+            .insert(request, revision.as_deref(), index))
     }
 }
 

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -223,10 +223,7 @@ where
         &self,
         request: &FilesystemPathIndexRequest,
     ) -> Result<std::sync::Arc<FilesystemPathIndex>, LixError> {
-        let revision = {
-            let store = self.store.lock().await;
-            load_path_index_revision(&*store)?
-        };
+        let revision = load_path_index_revision(&self.store).await?;
         if let Some(index) = self
             .filesystem_path_index_cache
             .get(request, revision.as_deref())

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -14,6 +14,7 @@ use crate::branch::{
 use crate::catalog::CatalogContext;
 use crate::commit_graph::{CommitGraphContext, CommitGraphReader};
 use crate::entity_pk::EntityPk;
+use crate::filesystem::FilesystemPathIndexReader;
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreContext;
 use crate::live_state::{LiveStateContext, LiveStateReader, LiveStateRowRequest};
@@ -510,6 +511,12 @@ where
     #[expect(trivial_casts)]
     fn live_state(&self) -> Arc<dyn LiveStateReader> {
         Arc::new(self.live_state.reader(self.read_store.clone())) as Arc<dyn LiveStateReader>
+    }
+
+    fn filesystem_path_index(&self) -> Arc<dyn FilesystemPathIndexReader> {
+        let reader: Arc<dyn FilesystemPathIndexReader> =
+            Arc::new(self.live_state.reader(self.read_store.clone()));
+        reader
     }
 
     fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore> {

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -10,6 +10,10 @@ use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobHash};
 use crate::branch::{BranchHead, BranchRefReader};
 use crate::changelog::CommitId;
 use crate::commit_graph::CommitGraphReader;
+use crate::filesystem::{
+    FilesystemPathIndex, FilesystemPathIndexReader, FilesystemPathIndexRequest,
+    UncachedFilesystemPathIndexReader,
+};
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreReader;
 use crate::live_state::{
@@ -50,6 +54,9 @@ pub(crate) trait SqlExecutionContext {
 
     fn active_branch_id(&self) -> &str;
     fn live_state(&self) -> Arc<dyn LiveStateReader>;
+    fn filesystem_path_index(&self) -> Arc<dyn FilesystemPathIndexReader> {
+        Arc::new(UncachedFilesystemPathIndexReader::new(self.live_state()))
+    }
     fn functions(&self) -> FunctionProviderHandle;
     fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore>;
     fn changelog_query_source(&self) -> SqlChangelogQuerySource<Self::ReadStore>;
@@ -70,7 +77,7 @@ pub(crate) trait SqlExecutionContext {
 /// payloads stay in the existing engine forms so this boundary centralizes
 /// authority without adding another translation layer.
 #[async_trait]
-pub(crate) trait SqlWriteExecutionContext {
+pub(crate) trait SqlWriteExecutionContext: Send {
     fn active_branch_id(&self) -> &str;
     fn functions(&self) -> FunctionProviderHandle;
     fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError>;
@@ -84,6 +91,14 @@ pub(crate) trait SqlWriteExecutionContext {
         &mut self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
+
+    async fn filesystem_path_index(
+        &mut self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<Arc<FilesystemPathIndex>, LixError> {
+        let rows = self.scan_live_state(&request.live_state_request()).await?;
+        Ok(Arc::new(FilesystemPathIndex::from_live_rows(rows)?))
+    }
 
     async fn load_branch_head(&mut self, branch_id: &str) -> Result<Option<CommitId>, LixError>;
 
@@ -186,6 +201,22 @@ impl SqlWriteContext {
                 .as_mut()
                 .unwrap()
                 .load_branch_head(branch_id)
+                .await
+        }
+    }
+
+    pub(crate) async fn filesystem_path_index(
+        &self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<Arc<FilesystemPathIndex>, LixError> {
+        let _guard = self.gate.lock().await;
+        unsafe {
+            self.ptr
+                .0
+                .as_ptr()
+                .as_mut()
+                .unwrap()
+                .filesystem_path_index(request)
                 .await
         }
     }
@@ -294,6 +325,16 @@ impl LiveStateReader for WriteContextLiveStateReader {
             })
             .await?;
         Ok(rows.pop())
+    }
+}
+
+#[async_trait]
+impl FilesystemPathIndexReader for WriteContextLiveStateReader {
+    async fn path_index(
+        &self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<Arc<FilesystemPathIndex>, LixError> {
+        self.ctx.filesystem_path_index(request).await
     }
 }
 

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1610,6 +1610,12 @@ mod tests {
             Arc::clone(&self.live_state)
         }
 
+        fn filesystem_path_index(&self) -> Arc<dyn crate::filesystem::FilesystemPathIndexReader> {
+            Arc::new(crate::filesystem::UncachedFilesystemPathIndexReader::new(
+                Arc::clone(&self.live_state),
+            ))
+        }
+
         fn functions(&self) -> FunctionProviderHandle {
             test_functions()
         }

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -115,6 +115,7 @@ impl TableSpec for BranchSpec {
         let schema = projected_schema(&lix_branch_schema(), projection);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (
                     Arc::clone(&self.live_state),

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -78,6 +78,7 @@ where
         let payload_projection = change_payload_projection(schema.as_ref(), filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (self.query_source.clone(), schema),
                 move |(query_source, schema)| async move {

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -22,6 +22,10 @@ use futures_util::FutureExt;
 use serde::Deserialize;
 
 use crate::branch::BranchRefReader;
+use crate::filesystem::{
+    FilesystemPathIndexReader, FilesystemPathIndexRequest, FilesystemPathKind,
+    FilesystemPathSelection,
+};
 use crate::functions::FunctionProviderHandle;
 use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{
@@ -54,6 +58,7 @@ use crate::sql2::result_metadata::json_field;
 use crate::sql2::{SqlWriteContext, WriteAccess, WriteContextLiveStateReader};
 use crate::transaction::types::{TransactionWrite, TransactionWriteMode};
 
+use super::file::{FilePathPredicate, file_path_predicate_from_filters, indexed_path_matches};
 use super::spec::{
     PlannedDml, PlannedScan, RowSource, TableSpec, finish_scan_batch, projected_schema,
     register_spec_table, row_source,
@@ -77,6 +82,7 @@ pub(super) async fn register_lix_directory_active_provider(
     surface_name: &str,
     active_branch_id: &str,
     live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
     branch_ref: Arc<dyn BranchRefReader>,
     functions: FunctionProviderHandle,
 ) -> Result<(), LixError> {
@@ -86,6 +92,7 @@ pub(super) async fn register_lix_directory_active_provider(
         Arc::new(LixDirectorySpec::active_branch(
             active_branch_id,
             live_state,
+            filesystem_path_index,
             branch_ref,
             functions,
         )),
@@ -97,6 +104,7 @@ pub(super) async fn register_lix_directory_by_branch_provider(
     session: &SessionContext,
     surface_name: &str,
     live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
     branch_ref: Arc<dyn BranchRefReader>,
     functions: FunctionProviderHandle,
 ) -> Result<(), LixError> {
@@ -104,7 +112,10 @@ pub(super) async fn register_lix_directory_by_branch_provider(
         session,
         surface_name,
         Arc::new(LixDirectorySpec::by_branch(
-            live_state, branch_ref, functions,
+            live_state,
+            filesystem_path_index,
+            branch_ref,
+            functions,
         )),
         WriteAccess::read_only(),
     )
@@ -118,11 +129,15 @@ pub(super) async fn register_by_branch_write_provider(
 ) -> Result<(), LixError> {
     let functions = write_ctx.functions();
     let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
+    let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = live_state.clone();
     register_spec_table(
         session,
         surface_name,
         Arc::new(LixDirectorySpec::by_branch(
-            live_state, branch_ref, functions,
+            live_state,
+            filesystem_path_index,
+            branch_ref,
+            functions,
         )),
         WriteAccess::write(write_ctx),
     )
@@ -137,12 +152,14 @@ pub(super) async fn register_active_write_provider(
     let active_branch_id = write_ctx.active_branch_id();
     let functions = write_ctx.functions();
     let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
+    let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = live_state.clone();
     register_spec_table(
         session,
         surface_name,
         Arc::new(LixDirectorySpec::active_branch(
             active_branch_id,
             live_state,
+            filesystem_path_index,
             branch_ref,
             functions,
         )),
@@ -153,21 +170,53 @@ pub(super) async fn register_active_write_provider(
 struct LixDirectorySpec {
     schema: SchemaRef,
     live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
     branch_ref: Arc<dyn BranchRefReader>,
     functions: FunctionProviderHandle,
     branch_binding: BranchBinding,
 }
 
 impl LixDirectorySpec {
+    async fn indexed_path_matches(
+        &self,
+        request: &LiveStateScanRequest,
+        filters: &[Expr],
+    ) -> Result<Option<(FilesystemPathSelection, FilesystemPathSelection)>> {
+        let predicate = file_path_predicate_from_filters(filters);
+        if predicate == FilePathPredicate::All {
+            return Ok(None);
+        }
+        let index = self
+            .filesystem_path_index
+            .path_index(&FilesystemPathIndexRequest::new(
+                request.filter.branch_ids.clone(),
+            ))
+            .await
+            .map_err(lix_error_to_datafusion_error)?;
+        let selected = indexed_path_matches(
+            Arc::clone(&index),
+            &predicate,
+            FilesystemPathKind::Directory,
+        );
+        let all = indexed_path_matches(
+            index,
+            &FilePathPredicate::All,
+            FilesystemPathKind::Directory,
+        );
+        Ok(Some((selected, all)))
+    }
+
     fn active_branch(
         active_branch_id: impl Into<String>,
         live_state: Arc<dyn LiveStateReader>,
+        filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
         branch_ref: Arc<dyn BranchRefReader>,
         functions: FunctionProviderHandle,
     ) -> Self {
         Self {
             schema: lix_directory_schema(),
             live_state,
+            filesystem_path_index,
             branch_ref,
             functions,
             branch_binding: BranchBinding::active(active_branch_id),
@@ -176,12 +225,14 @@ impl LixDirectorySpec {
 
     fn by_branch(
         live_state: Arc<dyn LiveStateReader>,
+        filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
         branch_ref: Arc<dyn BranchRefReader>,
         functions: FunctionProviderHandle,
     ) -> Self {
         Self {
             schema: lix_directory_by_branch_schema(),
             live_state,
+            filesystem_path_index,
             branch_ref,
             functions,
             branch_binding: BranchBinding::explicit(),
@@ -211,23 +262,36 @@ impl LixDirectorySpec {
         &self,
         write_ctx: &SqlWriteContext,
         request: LiveStateScanRequest,
+        indexed_matches: Option<(FilesystemPathSelection, FilesystemPathSelection)>,
         captured: Arc<Mutex<Option<RecordBatch>>>,
     ) -> RowSource {
         row_source(
             (
                 write_ctx.clone(),
                 request,
+                indexed_matches,
                 Arc::clone(&self.schema),
                 captured,
             ),
-            |(write_ctx, request, table_schema, captured)| async move {
-                let rows = write_ctx
-                    .scan_live_state(&request)
-                    .await
-                    .map_err(lix_error_to_datafusion_error)?;
-                let source_batch = lix_directory_record_batch(&table_schema, rows)
-                    .map_err(lix_error_to_datafusion_error)?;
-                *captured.lock().expect("dml source mutex poisoned") = Some(source_batch.clone());
+            |(write_ctx, request, indexed_matches, table_schema, captured)| async move {
+                let (source_batch, all_directories_batch) =
+                    if let Some((selected, all)) = indexed_matches.as_ref() {
+                        (
+                            indexed_lix_directory_record_batch(&table_schema, selected)
+                                .map_err(lix_error_to_datafusion_error)?,
+                            indexed_lix_directory_record_batch(&table_schema, all)
+                                .map_err(lix_error_to_datafusion_error)?,
+                        )
+                    } else {
+                        let rows = write_ctx
+                            .scan_live_state(&request)
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?;
+                        let batch = lix_directory_record_batch(&table_schema, rows)
+                            .map_err(lix_error_to_datafusion_error)?;
+                        (batch.clone(), batch)
+                    };
+                *captured.lock().expect("dml source mutex poisoned") = Some(all_directories_batch);
                 Ok(source_batch)
             },
         )
@@ -274,6 +338,25 @@ impl TableSpec for LixDirectorySpec {
         .await
         .map_err(lix_error_to_datafusion_error)?;
         let filters = filters.to_vec();
+        let mut indexed_matches = self
+            .indexed_path_matches(&request, &filters)
+            .await?
+            .map(|(selected, _)| selected);
+        if indexed_matches.is_none() && filters.is_empty() && output_schema.index_of("path").is_ok()
+        {
+            let index = self
+                .filesystem_path_index
+                .path_index(&FilesystemPathIndexRequest::new(
+                    request.filter.branch_ids.clone(),
+                ))
+                .await
+                .map_err(lix_error_to_datafusion_error)?;
+            indexed_matches = Some(indexed_path_matches(
+                index,
+                &FilePathPredicate::All,
+                FilesystemPathKind::Directory,
+            ));
+        }
         let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
         validate_json_predicate_filters(self.schema.as_ref(), &filters)?;
         let physical_filters = filters
@@ -281,8 +364,10 @@ impl TableSpec for LixDirectorySpec {
             .map(|expr| create_physical_expr(expr, &df_schema, props))
             .collect::<Result<Vec<_>>>()?;
 
+        let ordering = indexed_matches.as_ref().map(|_| "path".to_string());
         Ok(PlannedScan {
             schema: Arc::clone(&output_schema),
+            ordering,
             load: row_source(
                 (
                     Arc::clone(&self.live_state),
@@ -290,6 +375,7 @@ impl TableSpec for LixDirectorySpec {
                     output_schema,
                     projection.cloned(),
                     request,
+                    indexed_matches,
                     physical_filters,
                     limit,
                 ),
@@ -299,20 +385,25 @@ impl TableSpec for LixDirectorySpec {
                     _output_schema,
                     projection,
                     request,
+                    indexed_matches,
                     physical_filters,
                     limit,
                 )| async move {
-                    let rows = live_state.scan_rows(&request).await.map_err(|error| {
-                        DataFusionError::Execution(format!(
-                            "sql2 lix_directory scan failed: {error}"
-                        ))
-                    })?;
-                    let batch =
-                        lix_directory_record_batch(&batch_schema, rows).map_err(|error| {
+                    let batch = if let Some(indexed_matches) = indexed_matches.as_ref() {
+                        indexed_lix_directory_record_batch(&batch_schema, indexed_matches)
+                    } else {
+                        let rows = live_state.scan_rows(&request).await.map_err(|error| {
                             DataFusionError::Execution(format!(
-                                "sql2 lix_directory batch build failed: {error}"
+                                "sql2 lix_directory scan failed: {error}"
                             ))
                         })?;
+                        lix_directory_record_batch(&batch_schema, rows)
+                    }
+                    .map_err(|error| {
+                        DataFusionError::Execution(format!(
+                            "sql2 lix_directory batch build failed: {error}"
+                        ))
+                    })?;
                     finish_scan_batch(
                         batch,
                         &physical_filters,
@@ -403,10 +494,11 @@ impl TableSpec for LixDirectorySpec {
         filters: &[Expr],
     ) -> Result<PlannedDml> {
         let request = self.dml_scan_request(filters).await?;
+        let indexed_matches = self.indexed_path_matches(&request, filters).await?;
         let captured: Arc<Mutex<Option<RecordBatch>>> = Arc::new(Mutex::new(None));
         let branch_binding = self.branch_binding.clone();
         Ok(PlannedDml {
-            source: self.dml_source(&write_ctx, request, Arc::clone(&captured)),
+            source: self.dml_source(&write_ctx, request, indexed_matches, Arc::clone(&captured)),
             apply: Arc::new(move |matched_batch| {
                 let write_ctx = write_ctx.clone();
                 let branch_binding = branch_binding.clone();
@@ -469,11 +561,12 @@ impl TableSpec for LixDirectorySpec {
         filters: &[Expr],
     ) -> Result<PlannedDml> {
         let request = self.dml_scan_request(filters).await?;
+        let indexed_matches = self.indexed_path_matches(&request, filters).await?;
         let captured: Arc<Mutex<Option<RecordBatch>>> = Arc::new(Mutex::new(None));
         let branch_binding = self.branch_binding.clone();
         let functions = self.functions.clone();
         Ok(PlannedDml {
-            source: self.dml_source(&write_ctx, request, captured),
+            source: self.dml_source(&write_ctx, request, indexed_matches, captured),
             apply: Arc::new(move |matched_batch| {
                 let write_ctx = write_ctx.clone();
                 let branch_binding = branch_binding.clone();
@@ -1265,6 +1358,43 @@ fn lix_directory_record_batch(
 
     let directory_paths =
         derive_directory_paths(directory_rows.iter().map(|row| (row.key.clone(), row)))?;
+    let directory_rows = directory_rows
+        .into_iter()
+        .map(|row| {
+            let path = directory_paths.get(&row.key).cloned();
+            (row, path)
+        })
+        .collect();
+    lix_directory_record_batch_from_rendered(schema, directory_rows)
+}
+
+fn indexed_lix_directory_record_batch(
+    schema: &SchemaRef,
+    matches: &FilesystemPathSelection,
+) -> Result<RecordBatch, LixError> {
+    let rows = matches
+        .entries()
+        .filter(|entry| entry.kind == FilesystemPathKind::Directory)
+        .map(|entry| {
+            (
+                DirectoryDescriptorRecord {
+                    id: entry.id().to_string(),
+                    parent_id: entry.parent_id.clone(),
+                    name: entry.name.clone(),
+                    key: entry.key.clone(),
+                    live: entry.live_row(),
+                },
+                Some(entry.path.clone()),
+            )
+        })
+        .collect();
+    lix_directory_record_batch_from_rendered(schema, rows)
+}
+
+fn lix_directory_record_batch_from_rendered(
+    schema: &SchemaRef,
+    directory_rows: Vec<(DirectoryDescriptorRecord, Option<String>)>,
+) -> Result<RecordBatch, LixError> {
     let mut ids = Vec::new();
     let mut paths = Vec::new();
     let mut parent_ids = Vec::new();
@@ -1281,9 +1411,9 @@ fn lix_directory_record_batch(
     let mut metadata_values = Vec::new();
     let mut branch_ids = Vec::new();
 
-    for directory in directory_rows {
+    for (directory, path) in directory_rows {
         ids.push(Some(directory.id.clone()));
-        paths.push(directory_paths.get(&directory.key).cloned());
+        paths.push(path);
         parent_ids.push(directory.parent_id);
         names.push(Some(directory.name));
         entity_pks.push(Some(directory.live.entity_pk.as_json_array_text()?));
@@ -1664,16 +1794,22 @@ mod tests {
         let branch_ref = Arc::new(crate::sql2::WriteContextBranchRefReader::new(
             write_ctx.clone(),
         ));
+        let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
+            live_state.clone();
         let spec = match branch_binding {
             BranchBinding::Active { .. } => LixDirectorySpec::active_branch(
                 write_ctx.active_branch_id(),
                 live_state,
+                filesystem_path_index,
                 branch_ref,
                 test_functions(),
             ),
-            BranchBinding::Explicit => {
-                LixDirectorySpec::by_branch(live_state, branch_ref, test_functions())
-            }
+            BranchBinding::Explicit => LixDirectorySpec::by_branch(
+                live_state,
+                filesystem_path_index,
+                branch_ref,
+                test_functions(),
+            ),
         };
         spec.stage_insert(&write_ctx, vec![batch]).await
     }
@@ -2193,10 +2329,13 @@ mod tests {
         let branch_ref = Arc::new(crate::sql2::WriteContextBranchRefReader::new(
             write_ctx.clone(),
         ));
+        let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
+            live_state.clone();
         let provider = SpecTableProvider::new(
             Arc::new(LixDirectorySpec::active_branch(
                 write_ctx.active_branch_id(),
                 live_state,
+                filesystem_path_index,
                 branch_ref,
                 test_functions(),
             )),

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -105,6 +105,7 @@ where
             HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (
                     Arc::clone(&self.commit_graph),

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -286,6 +286,7 @@ impl TableSpec for EntitySpec {
             self.plan_scan_parts(projection, filters, limit).await?;
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (
                     Arc::clone(&self.spec),

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -111,6 +111,7 @@ where
             HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (
                     Arc::clone(&self.spec),

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -35,6 +35,10 @@ use crate::branch::BranchRefReader;
 use crate::common::{LixPath, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{FilesystemIndex, filesystem_schema_keys};
+use crate::filesystem::{
+    FilesystemPathIndexReader, FilesystemPathIndexRequest, FilesystemPathKind,
+    FilesystemPathSelection,
+};
 use crate::functions::FunctionProviderHandle;
 use crate::live_state::{
     LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection, LiveStateReader,
@@ -72,10 +76,10 @@ use crate::filesystem::{
     FileDescriptorRowInput, FileDescriptorWriteInput, FileDescriptorWriteIntent,
     FilesystemBlobRefKey, FilesystemDeletePlan, FilesystemDescriptorKey, FilesystemRowContext,
     blob_ref_row, blob_ref_tombstone_row, derive_directory_paths,
-    directory_path_resolvers_from_live_state, directory_path_resolvers_from_state_rows,
-    file_descriptor_row, file_descriptor_write_row, filesystem_storage_scope_key, plan_file_delete,
-    plan_file_descriptor_write, plan_parsed_file_path_update_with_resolvers,
-    plan_parsed_file_path_write_with_resolvers,
+    directory_path_resolvers_from_live_state, directory_path_resolvers_from_path_index,
+    directory_path_resolvers_from_state_rows, file_descriptor_row, file_descriptor_write_row,
+    filesystem_storage_scope_key, plan_file_delete, plan_file_descriptor_write,
+    plan_parsed_file_path_update_with_resolvers, plan_parsed_file_path_write_with_resolvers,
 };
 use crate::sql2::result_metadata::json_field;
 use crate::sql2::session::SqlWriteSessionOptions;
@@ -100,6 +104,7 @@ pub(super) async fn register_lix_file_active_provider(
     surface_name: &str,
     active_branch_id: &str,
     live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
     branch_ref: Arc<dyn BranchRefReader>,
     blob_reader: Arc<dyn BlobDataReader>,
     plugin_host: PluginRuntimeHost,
@@ -111,6 +116,7 @@ pub(super) async fn register_lix_file_active_provider(
         Arc::new(LixFileSpec::active_branch(
             active_branch_id,
             live_state,
+            filesystem_path_index,
             branch_ref,
             blob_reader,
             plugin_host,
@@ -124,6 +130,7 @@ pub(super) async fn register_lix_file_by_branch_provider(
     session: &SessionContext,
     surface_name: &str,
     live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
     branch_ref: Arc<dyn BranchRefReader>,
     blob_reader: Arc<dyn BlobDataReader>,
     plugin_host: PluginRuntimeHost,
@@ -134,6 +141,7 @@ pub(super) async fn register_lix_file_by_branch_provider(
         surface_name,
         Arc::new(LixFileSpec::by_branch(
             live_state,
+            filesystem_path_index,
             branch_ref,
             blob_reader,
             plugin_host,
@@ -184,6 +192,7 @@ pub(super) async fn register_active_write_provider(
 struct LixFileSpec {
     schema: SchemaRef,
     live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
     branch_ref: Arc<dyn BranchRefReader>,
     blob_reader: Arc<dyn BlobDataReader>,
     plugin_host: PluginRuntimeHost,
@@ -196,14 +205,35 @@ struct LixFileDmlSourceState {
     blob_ref_keys: BTreeSet<FilesystemBlobRefKey>,
     plugin_render: Option<PluginRenderContext>,
     path_resolver_rows: Option<Vec<MaterializedLiveStateRow>>,
+    path_index: Option<FilesystemPathSelection>,
 }
 
 type SharedLixFileDmlSourceState = Arc<Mutex<Option<LixFileDmlSourceState>>>;
 
 impl LixFileSpec {
+    async fn indexed_path_matches(
+        &self,
+        request: &LiveStateScanRequest,
+        filters: &[Expr],
+    ) -> Result<Option<FilesystemPathSelection>> {
+        let predicate = file_path_predicate_from_filters(filters);
+        if predicate == FilePathPredicate::All {
+            return Ok(None);
+        }
+        let index = self
+            .filesystem_path_index
+            .path_index(&FilesystemPathIndexRequest::new(
+                request.filter.branch_ids.clone(),
+            ))
+            .await
+            .map_err(lix_error_to_datafusion_error)?;
+        Ok(Some(indexed_file_matches(index, &predicate)))
+    }
+
     fn active_branch(
         active_branch_id: impl Into<String>,
         live_state: Arc<dyn LiveStateReader>,
+        filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
         branch_ref: Arc<dyn BranchRefReader>,
         blob_reader: Arc<dyn BlobDataReader>,
         plugin_host: PluginRuntimeHost,
@@ -212,6 +242,7 @@ impl LixFileSpec {
         Self {
             schema: lix_file_schema(),
             live_state,
+            filesystem_path_index,
             branch_ref,
             blob_reader,
             plugin_host,
@@ -229,11 +260,13 @@ impl LixFileSpec {
         let active_branch_id = write_ctx.active_branch_id();
         let functions = write_ctx.functions();
         let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
+        let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = live_state.clone();
         let blob_reader = write_ctx.blob_reader();
         let plugin_host = write_ctx.plugin_host();
         Self {
             schema: lix_file_schema(),
             live_state,
+            filesystem_path_index,
             branch_ref,
             blob_reader,
             plugin_host,
@@ -245,6 +278,7 @@ impl LixFileSpec {
 
     fn by_branch(
         live_state: Arc<dyn LiveStateReader>,
+        filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
         branch_ref: Arc<dyn BranchRefReader>,
         blob_reader: Arc<dyn BlobDataReader>,
         plugin_host: PluginRuntimeHost,
@@ -253,6 +287,7 @@ impl LixFileSpec {
         Self {
             schema: lix_file_by_branch_schema(),
             live_state,
+            filesystem_path_index,
             branch_ref,
             blob_reader,
             plugin_host,
@@ -269,11 +304,13 @@ impl LixFileSpec {
     ) -> Self {
         let functions = write_ctx.functions();
         let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
+        let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = live_state.clone();
         let blob_reader = write_ctx.blob_reader();
         let plugin_host = write_ctx.plugin_host();
         Self {
             schema: lix_file_by_branch_schema(),
             live_state,
+            filesystem_path_index,
             branch_ref,
             blob_reader,
             plugin_host,
@@ -291,6 +328,7 @@ impl LixFileSpec {
         write_ctx: &SqlWriteContext,
         request: LiveStateScanRequest,
         target_file_ids: FileIdConstraint,
+        indexed_matches: Option<FilesystemPathSelection>,
         needs_data: bool,
         capture_path_resolver_rows: bool,
         captured: SharedLixFileDmlSourceState,
@@ -303,6 +341,7 @@ impl LixFileSpec {
                 Arc::clone(&self.schema),
                 request,
                 target_file_ids,
+                indexed_matches,
                 needs_data,
                 capture_path_resolver_rows,
                 captured,
@@ -314,31 +353,55 @@ impl LixFileSpec {
                 table_schema,
                 request,
                 target_file_ids,
+                indexed_matches,
                 needs_data,
                 capture_path_resolver_rows,
                 captured,
             )| async move {
                 *captured.lock().expect("lix_file DML source mutex poisoned") = None;
                 let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-                let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
+                let (prepared, path_resolver_rows, path_index) = if let Some(indexed_matches) =
+                    indexed_matches.as_ref()
+                {
+                    let rows =
+                        scan_indexed_file_rows(live_state.clone(), &request, indexed_matches, true)
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?;
+                    (
+                        prepare_indexed_lix_file_rows(indexed_matches, rows),
+                        None,
+                        capture_path_resolver_rows.then(|| indexed_matches.clone()),
+                    )
+                } else {
+                    let rows =
+                        scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?;
+                    let path_resolver_rows = capture_path_resolver_rows.then(|| rows.clone());
+                    (
+                        prepare_lix_file_rows(rows, &FilePathPredicate::All),
+                        path_resolver_rows,
+                        None,
+                    )
+                };
+                let prepared = prepared.map_err(lix_error_to_datafusion_error)?;
+                let plugin_render = if prepared.needs_plugin_render(needs_data) {
+                    plugin_render_context_for_lix_file_scan(
+                        live_state,
+                        &blob_reader,
+                        &request,
+                        plugin_host,
+                        needs_data,
+                    )
                     .await
-                    .map_err(lix_error_to_datafusion_error)?;
-                let plugin_render = plugin_render_context_for_lix_file_scan(
-                    live_state,
-                    &blob_reader,
-                    &request,
-                    plugin_host,
-                    needs_data,
-                )
-                .await
-                .map_err(|error| {
-                    DataFusionError::Execution(format!(
-                        "sql2 lix_file plugin discovery failed: {error}"
-                    ))
-                })?;
-                let path_resolver_rows = capture_path_resolver_rows.then(|| rows.clone());
-                let prepared = prepare_lix_file_rows(rows, &FilePathPredicate::All)
-                    .map_err(lix_error_to_datafusion_error)?;
+                    .map_err(|error| {
+                        DataFusionError::Execution(format!(
+                            "sql2 lix_file plugin discovery failed: {error}"
+                        ))
+                    })?
+                } else {
+                    None
+                };
                 let blob_ref_keys = prepared.blob_rows.keys().cloned().collect();
                 let source_batch = lix_file_record_batch_from_prepared(
                     &table_schema,
@@ -354,6 +417,7 @@ impl LixFileSpec {
                         blob_ref_keys,
                         plugin_render,
                         path_resolver_rows,
+                        path_index,
                     });
                 Ok(source_batch)
             },
@@ -436,16 +500,42 @@ impl TableSpec for LixFileSpec {
         .await
         .map_err(lix_error_to_datafusion_error)?;
         let needs_data = scan_needs_data(&self.schema, projection, &filters);
+        let needs_blob_rows = scan_needs_blob_rows(&self.schema, projection, &filters);
         let target_file_ids = file_id_constraint_from_filters(&filters)?;
         let path_predicate = file_path_predicate_from_filters(&filters);
+        let use_path_index = path_predicate != FilePathPredicate::All
+            || (filters.is_empty()
+                && projected_schema.index_of("path").is_ok()
+                && !needs_blob_rows);
+        let indexed_matches = if !use_path_index {
+            None
+        } else {
+            let index = self
+                .filesystem_path_index
+                .path_index(&FilesystemPathIndexRequest::new(
+                    request.filter.branch_ids.clone(),
+                ))
+                .await
+                .map_err(lix_error_to_datafusion_error)?;
+            let matches = indexed_file_matches(Arc::clone(&index), &path_predicate);
+            let index_scan_threshold =
+                2_048_usize.max(index.kind_count(FilesystemPathKind::File) / 1_000);
+            if needs_blob_rows && matches.len() > index_scan_threshold {
+                None
+            } else {
+                Some(matches)
+            }
+        };
         let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
         validate_json_predicate_filters(self.schema.as_ref(), &filters)?;
         let physical_filters = filters
             .iter()
             .map(|expr| create_physical_expr(expr, &df_schema, props))
             .collect::<Result<Vec<_>>>()?;
+        let ordering = indexed_matches.as_ref().map(|_| "path".to_string());
         Ok(PlannedScan {
             schema: Arc::clone(&projected_schema),
+            ordering,
             load: row_source(
                 (
                     Arc::clone(&self.live_state),
@@ -456,8 +546,10 @@ impl TableSpec for LixFileSpec {
                     request,
                     target_file_ids,
                     path_predicate,
+                    indexed_matches,
                     physical_filters,
                     needs_data,
+                    needs_blob_rows,
                     limit,
                 ),
                 |(
@@ -469,25 +561,45 @@ impl TableSpec for LixFileSpec {
                     request,
                     target_file_ids,
                     path_predicate,
+                    indexed_matches,
                     filters,
                     needs_data,
+                    needs_blob_rows,
                     limit,
                 )| async move {
-                    let rows = scan_lix_file_live_rows(
-                        Arc::clone(&live_state),
-                        &request,
-                        &target_file_ids,
-                    )
-                    .await
-                    .map_err(|error| {
-                        DataFusionError::Execution(format!("sql2 lix_file scan failed: {error}"))
-                    })?;
-                    let prepared =
-                        prepare_lix_file_rows(rows, &path_predicate).map_err(|error| {
+                    let prepared = if let Some(indexed_matches) = indexed_matches.as_ref() {
+                        let rows = scan_indexed_file_rows(
+                            Arc::clone(&live_state),
+                            &request,
+                            indexed_matches,
+                            needs_blob_rows,
+                        )
+                        .await
+                        .map_err(|error| {
                             DataFusionError::Execution(format!(
-                                "sql2 lix_file row preparation failed: {error}"
+                                "sql2 indexed lix_file scan failed: {error}"
                             ))
                         })?;
+                        prepare_indexed_lix_file_rows(indexed_matches, rows)
+                    } else {
+                        let rows = scan_lix_file_live_rows(
+                            Arc::clone(&live_state),
+                            &request,
+                            &target_file_ids,
+                        )
+                        .await
+                        .map_err(|error| {
+                            DataFusionError::Execution(format!(
+                                "sql2 lix_file scan failed: {error}"
+                            ))
+                        })?;
+                        prepare_lix_file_rows(rows, &path_predicate)
+                    }
+                    .map_err(|error| {
+                        DataFusionError::Execution(format!(
+                            "sql2 lix_file row preparation failed: {error}"
+                        ))
+                    })?;
                     let plugin_render = if prepared.needs_plugin_render(needs_data) {
                         plugin_render_context_for_lix_file_scan(
                             Arc::clone(&live_state),
@@ -579,12 +691,14 @@ impl TableSpec for LixFileSpec {
         )
         .await
         .map_err(lix_error_to_datafusion_error)?;
+        let indexed_matches = self.indexed_path_matches(&request, filters).await?;
 
         let captured: SharedLixFileDmlSourceState = Arc::new(Mutex::new(None));
         let source = self.dml_source(
             &write_ctx,
             request,
             target_file_ids,
+            indexed_matches,
             needs_data,
             false,
             Arc::clone(&captured),
@@ -640,6 +754,7 @@ impl TableSpec for LixFileSpec {
         )
         .await
         .map_err(lix_error_to_datafusion_error)?;
+        let indexed_matches = self.indexed_path_matches(&request, filters).await?;
 
         let update_columns = LixFileUpdateColumns::from_assignments(&assignments);
         let capture_path_resolver_rows = (update_columns.path || update_columns.descriptor)
@@ -652,6 +767,7 @@ impl TableSpec for LixFileSpec {
             &write_ctx,
             request,
             target_file_ids,
+            indexed_matches,
             needs_data,
             capture_path_resolver_rows,
             Arc::clone(&captured),
@@ -669,6 +785,7 @@ impl TableSpec for LixFileSpec {
                     blob_ref_keys,
                     plugin_render,
                     path_resolver_rows,
+                    path_index,
                 } = lix_file_dml_source_state(&captured, "UPDATE")?;
                 let assignment_values =
                     UpdateAssignmentValues::evaluate(&matched_batch, &assignments)?;
@@ -684,21 +801,25 @@ impl TableSpec for LixFileSpec {
                 };
                 let mut path_resolvers = None;
                 if update_columns.path || update_columns.descriptor {
-                    path_resolvers = Some(
-                        if let (Some(rows), Some(active_branch_id)) =
-                            (path_resolver_rows, branch_binding.active_branch_id())
-                        {
-                            path_resolvers_from_dml_source_rows(rows, active_branch_id)
-                                .map_err(lix_error_to_datafusion_error)?
-                        } else {
-                            directory_path_resolvers_from_live_state(
-                                Arc::new(WriteContextLiveStateReader::new(write_ctx.clone())),
-                                branch_binding.active_branch_id(),
-                            )
-                            .await
+                    path_resolvers = Some(if let Some(path_index) = path_index {
+                        directory_path_resolvers_from_path_index(
+                            path_index.index(),
+                            branch_binding.active_branch_id(),
+                        )
+                        .map_err(lix_error_to_datafusion_error)?
+                    } else if let (Some(rows), Some(active_branch_id)) =
+                        (path_resolver_rows, branch_binding.active_branch_id())
+                    {
+                        path_resolvers_from_dml_source_rows(rows, active_branch_id)
                             .map_err(lix_error_to_datafusion_error)?
-                        },
-                    );
+                    } else {
+                        directory_path_resolvers_from_live_state(
+                            Arc::new(WriteContextLiveStateReader::new(write_ctx.clone())),
+                            branch_binding.active_branch_id(),
+                        )
+                        .await
+                        .map_err(lix_error_to_datafusion_error)?
+                    });
                 }
                 let staged = lix_file_update_stage_from_batch(
                     &matched_batch,
@@ -1504,6 +1625,7 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
         file_rows,
         blob_rows,
         file_paths,
+        ..
     } = prepare_lix_file_rows(rows, &FilePathPredicate::All)?;
     let existing = file_rows
         .into_iter()
@@ -2409,6 +2531,7 @@ struct PreparedLixFileRows {
     file_rows: BTreeMap<FilesystemDescriptorKey, FileDescriptorRecord>,
     blob_rows: BTreeMap<FilesystemBlobRefKey, BlobRefRecord>,
     file_paths: BTreeMap<FilesystemDescriptorKey, String>,
+    path_ordered_file_keys: Option<Vec<FilesystemDescriptorKey>>,
 }
 
 impl PreparedLixFileRows {
@@ -2532,6 +2655,65 @@ fn prepare_lix_file_rows(
         file_rows,
         blob_rows,
         file_paths,
+        path_ordered_file_keys: None,
+    })
+}
+
+fn prepare_indexed_lix_file_rows(
+    matches: &FilesystemPathSelection,
+    rows: Vec<MaterializedLiveStateRow>,
+) -> Result<PreparedLixFileRows, LixError> {
+    let mut file_rows = BTreeMap::<FilesystemDescriptorKey, FileDescriptorRecord>::new();
+    let mut file_paths = BTreeMap::<FilesystemDescriptorKey, String>::new();
+    let mut path_ordered_file_keys = Vec::with_capacity(matches.len());
+    for entry in matches.entries() {
+        if entry.kind != FilesystemPathKind::File {
+            continue;
+        }
+        let key = entry.key.clone();
+        path_ordered_file_keys.push(key.clone());
+        file_paths.insert(key.clone(), entry.path.clone());
+        file_rows.insert(
+            key.clone(),
+            FileDescriptorRecord {
+                id: entry.id().to_string(),
+                directory_id: entry.parent_id.clone(),
+                name: entry.name.clone(),
+                key,
+                live: entry.live_row(),
+            },
+        );
+    }
+
+    let mut blob_rows = BTreeMap::<FilesystemBlobRefKey, BlobRefRecord>::new();
+    for row in rows {
+        if row.schema_key != BLOB_REF_SCHEMA_KEY {
+            continue;
+        }
+        let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+            continue;
+        };
+        let snapshot: BlobRefSnapshot =
+            serde_json::from_str(snapshot_content).map_err(|error| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!("invalid lix_binary_blob_ref snapshot JSON: {error}"),
+                )
+            })?;
+        blob_rows.insert(
+            FilesystemBlobRefKey::from_live_row(&row, snapshot.id),
+            BlobRefRecord {
+                blob_hash: snapshot.blob_hash,
+                live: row,
+            },
+        );
+    }
+
+    Ok(PreparedLixFileRows {
+        file_rows,
+        blob_rows,
+        file_paths,
+        path_ordered_file_keys: Some(path_ordered_file_keys),
     })
 }
 
@@ -2549,9 +2731,10 @@ async fn lix_file_record_batch_from_prepared(
         .collect::<Vec<_>>();
     let needs_data = load_data && projected_columns.contains(&"data");
     let PreparedLixFileRows {
-        file_rows,
+        mut file_rows,
         blob_rows,
         mut file_paths,
+        path_ordered_file_keys,
     } = prepared;
     let mut ids = Vec::new();
     let mut paths = Vec::new();
@@ -2575,7 +2758,12 @@ async fn lix_file_record_batch_from_prepared(
         LoadedBlobBytes::default()
     };
 
-    for (key, file) in file_rows {
+    let file_keys =
+        path_ordered_file_keys.unwrap_or_else(|| file_rows.keys().cloned().collect::<Vec<_>>());
+    for key in file_keys {
+        let file = file_rows
+            .remove(&key)
+            .expect("prepared lix_file order should reference a descriptor");
         let path = file_paths
             .remove(&key)
             .expect("prepared lix_file descriptor should have a path");
@@ -2834,6 +3022,26 @@ fn scan_needs_data(
     projected_needs_data || filters.iter().any(|filter| contains_column(filter, "data"))
 }
 
+fn scan_needs_blob_rows(
+    base_schema: &SchemaRef,
+    projection: Option<&Vec<usize>>,
+    filters: &[Expr],
+) -> bool {
+    let projects_blob_column = match projection {
+        Some(indices) => indices.iter().any(|index| {
+            matches!(
+                base_schema.field(*index).name().as_str(),
+                "data" | "lixcol_change_id"
+            )
+        }),
+        None => true,
+    };
+    projects_blob_column
+        || filters.iter().any(|filter| {
+            contains_column(filter, "data") || contains_column(filter, "lixcol_change_id")
+        })
+}
+
 fn lix_file_scan_request(
     branch_binding: Option<&str>,
     projected_schema: Option<&Schema>,
@@ -2903,6 +3111,37 @@ async fn scan_lix_file_live_rows(
     Ok(rows)
 }
 
+async fn scan_indexed_file_rows(
+    live_state: Arc<dyn LiveStateReader>,
+    request: &LiveStateScanRequest,
+    matches: &FilesystemPathSelection,
+    needs_blob_rows: bool,
+) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+    if matches.is_empty() || !needs_blob_rows {
+        return Ok(Vec::new());
+    }
+    let file_ids = matches
+        .entries()
+        .filter(|entry| entry.kind == FilesystemPathKind::File)
+        .map(|entry| entry.id().to_string())
+        .collect::<BTreeSet<_>>();
+    if file_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut blob_request = request.clone();
+    blob_request.filter.schema_keys = vec![BLOB_REF_SCHEMA_KEY.to_string()];
+    blob_request.filter.entity_pks = file_ids
+        .iter()
+        .map(|file_id| EntityPk::single(file_id.clone()))
+        .collect();
+    blob_request.filter.file_ids = file_ids
+        .into_iter()
+        .map(crate::NullableKeyFilter::Value)
+        .collect();
+    blob_request.limit = None;
+    live_state.scan_rows(&blob_request).await
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum FileIdConstraint {
     All,
@@ -2959,7 +3198,7 @@ fn file_id_constraint_from_filters(filters: &[Expr]) -> Result<FileIdConstraint>
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum FilePathPredicate {
+pub(super) enum FilePathPredicate {
     All,
     Comparison {
         operation: FilePathComparison,
@@ -2997,7 +3236,7 @@ impl FilePathPredicate {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FilePathComparison {
+pub(super) enum FilePathComparison {
     Equal,
     LessThan,
     LessThanOrEqual,
@@ -3027,7 +3266,7 @@ impl FilePathComparison {
     }
 }
 
-fn file_path_predicate_from_filters(filters: &[Expr]) -> FilePathPredicate {
+pub(super) fn file_path_predicate_from_filters(filters: &[Expr]) -> FilePathPredicate {
     filters
         .iter()
         .fold(FilePathPredicate::All, |predicate, filter| {
@@ -3051,6 +3290,70 @@ fn file_path_predicate_from_expr(expr: &Expr) -> FilePathPredicate {
         Expr::InList(in_list) => file_path_in_predicate(in_list),
         _ => FilePathPredicate::All,
     }
+}
+
+pub(super) fn indexed_path_matches(
+    index: Arc<crate::filesystem::FilesystemPathIndex>,
+    predicate: &FilePathPredicate,
+    kind: FilesystemPathKind,
+) -> FilesystemPathSelection {
+    fn indices(
+        index: &crate::filesystem::FilesystemPathIndex,
+        predicate: &FilePathPredicate,
+        kind: FilesystemPathKind,
+    ) -> BTreeSet<usize> {
+        let candidate_indices: Box<dyn Iterator<Item = usize>> = match predicate {
+            FilePathPredicate::All => Box::new(index.all_indices()),
+            FilePathPredicate::Comparison { operation, value } => {
+                let range = match operation {
+                    FilePathComparison::Equal => index.exact_indices(value),
+                    FilePathComparison::LessThan => index.range_indices(
+                        std::ops::Bound::Unbounded,
+                        std::ops::Bound::Excluded(value.as_str()),
+                    ),
+                    FilePathComparison::LessThanOrEqual => index.range_indices(
+                        std::ops::Bound::Unbounded,
+                        std::ops::Bound::Included(value.as_str()),
+                    ),
+                    FilePathComparison::GreaterThan => index.range_indices(
+                        std::ops::Bound::Excluded(value.as_str()),
+                        std::ops::Bound::Unbounded,
+                    ),
+                    FilePathComparison::GreaterThanOrEqual => index.range_indices(
+                        std::ops::Bound::Included(value.as_str()),
+                        std::ops::Bound::Unbounded,
+                    ),
+                };
+                Box::new(range)
+            }
+            FilePathPredicate::In(values) => {
+                Box::new(values.iter().flat_map(|value| index.exact_indices(value)))
+            }
+            FilePathPredicate::And(left, right) => {
+                let left = indices(index, left, kind);
+                let right = indices(index, right, kind);
+                return left.intersection(&right).copied().collect();
+            }
+            FilePathPredicate::Or(left, right) => {
+                let mut matches = indices(index, left, kind);
+                matches.extend(indices(index, right, kind));
+                return matches;
+            }
+        };
+        candidate_indices
+            .filter(|candidate| index.entry(*candidate).kind == kind)
+            .collect()
+    }
+
+    let indices = indices(&index, predicate, kind).into_iter().collect();
+    FilesystemPathSelection::new(index, indices)
+}
+
+fn indexed_file_matches(
+    index: Arc<crate::filesystem::FilesystemPathIndex>,
+    predicate: &FilePathPredicate,
+) -> FilesystemPathSelection {
+    indexed_path_matches(index, predicate, FilesystemPathKind::File)
 }
 
 fn file_path_comparison_from_binary_filter(binary_expr: &BinaryExpr) -> Option<FilePathPredicate> {

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -145,6 +145,7 @@ where
         let public_predicate = FileHistoryPublicPredicate::from_filters(filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (
                     Arc::clone(&self.commit_graph),

--- a/packages/engine/src/sql2/providers/history.rs
+++ b/packages/engine/src/sql2/providers/history.rs
@@ -93,6 +93,7 @@ where
             HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Bare);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (
                     Arc::clone(&self.commit_graph),

--- a/packages/engine/src/sql2/providers/lix_state.rs
+++ b/packages/engine/src/sql2/providers/lix_state.rs
@@ -336,6 +336,7 @@ impl TableSpec for LixStateSpec {
 
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
+            ordering: None,
             load: row_source(
                 (Arc::clone(&self.live_state), schema, request),
                 |(live_state, schema, request)| async move {

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -146,6 +146,7 @@ where
                     &surface.name,
                     ctx.active_branch_id(),
                     ctx.live_state(),
+                    ctx.filesystem_path_index(),
                     Arc::clone(&branch_ref),
                     ctx.blob_reader(),
                     ctx.plugin_host(),
@@ -158,6 +159,7 @@ where
                     session,
                     &surface.name,
                     ctx.live_state(),
+                    ctx.filesystem_path_index(),
                     Arc::clone(&branch_ref),
                     ctx.blob_reader(),
                     ctx.plugin_host(),
@@ -182,6 +184,7 @@ where
                     &surface.name,
                     ctx.active_branch_id(),
                     ctx.live_state(),
+                    ctx.filesystem_path_index(),
                     Arc::clone(&branch_ref),
                     ctx.functions(),
                 )
@@ -192,6 +195,7 @@ where
                     session,
                     &surface.name,
                     ctx.live_state(),
+                    ctx.filesystem_path_index(),
                     Arc::clone(&branch_ref),
                     ctx.functions(),
                 )

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::arrow::array::{ArrayRef, BooleanArray, UInt64Array};
-use datafusion::arrow::compute::{and, filter_record_batch};
+use datafusion::arrow::compute::{SortOptions, and, filter_record_batch};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::{Session, TableProvider};
@@ -25,7 +25,10 @@ use datafusion::execution::TaskContext;
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
-use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr, create_physical_expr};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{
+    EquivalenceProperties, PhysicalExpr, PhysicalSortExpr, create_physical_expr,
+};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType, PlanProperties};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
@@ -76,6 +79,7 @@ pub(super) type InsertApply =
 pub(super) struct PlannedScan {
     pub(super) schema: SchemaRef,
     pub(super) load: RowSource,
+    pub(super) ordering: Option<String>,
 }
 
 /// A planned UPDATE/DELETE: the candidate-row source the filters run against,
@@ -490,8 +494,30 @@ struct SpecScanExec {
 
 impl SpecScanExec {
     fn new(table: Arc<str>, planned: PlannedScan) -> Self {
+        let equivalence_properties = planned
+            .ordering
+            .as_deref()
+            .and_then(|column_name| {
+                planned
+                    .schema
+                    .index_of(column_name)
+                    .ok()
+                    .map(|column_index| {
+                        EquivalenceProperties::new_with_orderings(
+                            Arc::clone(&planned.schema),
+                            [vec![PhysicalSortExpr {
+                                expr: Arc::new(Column::new(column_name, column_index)),
+                                options: SortOptions {
+                                    descending: false,
+                                    nulls_first: false,
+                                },
+                            }]],
+                        )
+                    })
+            })
+            .unwrap_or_else(|| EquivalenceProperties::new(Arc::clone(&planned.schema)));
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(Arc::clone(&planned.schema)),
+            equivalence_properties,
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -6,7 +6,7 @@
 
 use crate::LixError;
 use crate::binary_cas::BinaryCasContext;
-use crate::branch::{BranchContext, BranchRefReader};
+use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader};
 use crate::changelog::{
     ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitChangeRefSet,
     CommitId, CommitRecord,
@@ -53,10 +53,10 @@ pub(crate) async fn commit_prepared_writes(
     }
 
     let state_rows = prepared_writes.state_rows;
-    let filesystem_paths_changed = state_rows.iter().any(|row| {
+    let filesystem_view_changed = state_rows.iter().any(|row| {
         matches!(
             row.schema_key.as_str(),
-            "lix_file_descriptor" | "lix_directory_descriptor"
+            "lix_file_descriptor" | "lix_directory_descriptor" | BRANCH_REF_SCHEMA_KEY
         )
     });
     let finalized = finalize_commit_rows(
@@ -146,7 +146,7 @@ pub(crate) async fn commit_prepared_writes(
         branch_ctx.stage_canonical_ref_rows(&mut writes, &[canonical_row.row])?;
     }
 
-    if filesystem_paths_changed {
+    if filesystem_view_changed {
         stage_path_index_revision(&mut writes);
     }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -13,6 +13,7 @@ use crate::changelog::{
 };
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
+use crate::filesystem::stage_path_index_revision;
 use crate::functions::FunctionContext;
 use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::storage::{StorageRead, StorageWriteSet};
@@ -52,6 +53,12 @@ pub(crate) async fn commit_prepared_writes(
     }
 
     let state_rows = prepared_writes.state_rows;
+    let filesystem_paths_changed = state_rows.iter().any(|row| {
+        matches!(
+            row.schema_key.as_str(),
+            "lix_file_descriptor" | "lix_directory_descriptor"
+        )
+    });
     let finalized = finalize_commit_rows(
         prepared_writes.commit_change_refs_by_branch,
         prepared_writes.extra_commit_parents_by_branch,
@@ -137,6 +144,10 @@ pub(crate) async fn commit_prepared_writes(
         let canonical_row =
             prepare_branch_ref_row(&branch_head.branch_id, &branch_head.commit_id, &timestamp)?;
         branch_ctx.stage_canonical_ref_rows(&mut writes, &[canonical_row.row])?;
+    }
+
+    if filesystem_paths_changed {
+        stage_path_index_revision(&mut writes);
     }
 
     Ok(writes)

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1360,8 +1360,11 @@ where
         request: &FilesystemPathIndexRequest,
     ) -> Result<Arc<FilesystemPathIndex>, LixError> {
         if !self.staged_writes.has_staged_filesystem_descriptors()? {
-            let read =
-                SharedStorageRead::new(self.storage.begin_read(StorageReadOptions::default())?);
+            let read = SharedStorageRead::new(
+                self.storage
+                    .begin_read(StorageReadOptions::default())
+                    .await?,
+            );
             return self.live_state.reader(read).path_index(request).await;
         }
         let rows = self

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -23,7 +23,8 @@ use crate::common::LixTimestamp;
 use crate::domain::Domain;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
-    FilesystemIndex, FilesystemRowContext, blob_ref_tombstone_row, filesystem_schema_keys,
+    FilesystemIndex, FilesystemPathIndex, FilesystemPathIndexReader, FilesystemPathIndexRequest,
+    FilesystemRowContext, blob_ref_tombstone_row, build_path_index, filesystem_schema_keys,
 };
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::live_state::{
@@ -1006,6 +1007,13 @@ where
         })
     }
 
+    fn filesystem_path_index(&self) -> Arc<dyn FilesystemPathIndexReader> {
+        Arc::new(TransactionReadLiveStateReader {
+            base: self.live_state.reader(self.read_store.clone()),
+            staged: self.staged.clone(),
+        })
+    }
+
     fn functions(&self) -> FunctionProviderHandle {
         self.functions.clone()
     }
@@ -1139,6 +1147,19 @@ where
             .await?
             .into_iter()
             .next())
+    }
+}
+
+#[async_trait]
+impl<R> FilesystemPathIndexReader for TransactionReadLiveStateReader<R>
+where
+    R: crate::storage::StorageBackendRead + Send + 'static,
+{
+    async fn path_index(
+        &self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<Arc<FilesystemPathIndex>, LixError> {
+        build_path_index(self, request).await
     }
 }
 
@@ -1332,6 +1353,21 @@ where
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
         self.scan_visible_live_state(request).await
+    }
+
+    async fn filesystem_path_index(
+        &mut self,
+        request: &FilesystemPathIndexRequest,
+    ) -> Result<Arc<FilesystemPathIndex>, LixError> {
+        if !self.staged_writes.has_staged_filesystem_descriptors()? {
+            let read =
+                SharedStorageRead::new(self.storage.begin_read(StorageReadOptions::default())?);
+            return self.live_state.reader(read).path_index(request).await;
+        }
+        let rows = self
+            .scan_visible_live_state(&request.live_state_request())
+            .await?;
+        Ok(Arc::new(FilesystemPathIndex::from_live_rows(rows)?))
     }
 
     async fn load_branch_head(&mut self, branch_id: &str) -> Result<Option<CommitId>, LixError> {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -403,6 +403,21 @@ impl TransactionWriteBuffer {
         })
     }
 
+    pub(crate) fn has_staged_filesystem_descriptors(&self) -> Result<bool, LixError> {
+        let rows = self.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        Ok(rows.iter().flatten().any(|row| {
+            matches!(
+                row.schema_key.as_str(),
+                "lix_file_descriptor" | "lix_directory_descriptor"
+            )
+        }))
+    }
+
     /// Returns transaction-local file bytes addressed by their eventual CAS hash.
     ///
     /// File data is flushed into the binary CAS only during commit, while SQL reads

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -1689,6 +1689,104 @@ simulation_test!(
 );
 
 simulation_test!(
+    lix_file_path_index_invalidates_when_branch_head_moves,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('branch-head-file', '/branch-head.txt', X'68656164')",
+                &[],
+            )
+            .await
+            .expect("file fixture should insert");
+        let current_head = session
+            .execute(
+                &format!(
+                    "SELECT commit_id FROM lix_branch WHERE id = '{}'",
+                    sim.main_branch_id()
+                ),
+                &[],
+            )
+            .await
+            .expect("current branch head should query")
+            .rows()[0]
+            .values()[0]
+            .clone();
+
+        let warm = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/branch-head.txt'",
+                &[],
+            )
+            .await
+            .expect("exact path lookup should warm the filesystem index");
+        assert_rows_eq(
+            warm,
+            vec![vec![Value::Text("branch-head-file".to_string())]],
+        );
+
+        let reset = session
+            .execute(
+                &format!(
+                    "UPDATE lix_branch SET commit_id = '{}' WHERE id = '{}'",
+                    sim.initial_commit_id(),
+                    sim.main_branch_id()
+                ),
+                &[],
+            )
+            .await
+            .expect("branch head should reset to the initial commit");
+        assert_eq!(reset, ExecuteResult::from_rows_affected(1));
+
+        let old_head_lookup = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/branch-head.txt'",
+                &[],
+            )
+            .await
+            .expect("path lookup after branch reset should succeed");
+        assert_eq!(old_head_lookup.len(), 0);
+
+        let current_head = match current_head {
+            Value::Text(commit_id) => commit_id,
+            other => panic!("expected text commit id, got {other:?}"),
+        };
+        let restore = session
+            .execute(
+                &format!(
+                    "UPDATE lix_branch SET commit_id = '{current_head}' WHERE id = '{}'",
+                    sim.main_branch_id()
+                ),
+                &[],
+            )
+            .await
+            .expect("branch head should restore to the file commit");
+        assert_eq!(restore, ExecuteResult::from_rows_affected(1));
+
+        let restored_lookup = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/branch-head.txt'",
+                &[],
+            )
+            .await
+            .expect("path lookup after branch restore should succeed");
+        assert_rows_eq(
+            restored_lookup,
+            vec![vec![Value::Text("branch-head-file".to_string())]],
+        );
+    }
+);
+
+simulation_test!(
     atelier_current_path_range_and_order_workloads,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -1599,6 +1599,199 @@ simulation_test!(lix_file_path_update_preserves_data, |sim| async move {
 });
 
 simulation_test!(
+    lix_file_path_update_by_path_uses_fresh_index,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES \
+             ('file-target', '/docs/target.md', X'746172676574'), \
+             ('file-other', '/docs/other.md', X'6F74686572')",
+                &[],
+            )
+            .await
+            .expect("file fixtures should insert");
+
+        let warm = session
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("exact path lookup should warm the filesystem index");
+        assert_rows_eq(
+            warm,
+            vec![vec![
+                Value::Text("file-target".to_string()),
+                Value::Text("/docs/target.md".to_string()),
+            ]],
+        );
+
+        let update = session
+            .execute(
+                "UPDATE lix_file \
+             SET path = '/archive/renamed.md' \
+             WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("path-filtered file rename should succeed");
+        assert_eq!(update, ExecuteResult::from_rows_affected(1));
+
+        let old = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("old path lookup should succeed as a miss");
+        assert_eq!(old.len(), 0);
+
+        let renamed = session
+            .execute(
+                "SELECT id, path, data FROM lix_file WHERE path = '/archive/renamed.md'",
+                &[],
+            )
+            .await
+            .expect("renamed path should be visible through a fresh index");
+        assert_rows_eq(
+            renamed,
+            vec![vec![
+                Value::Text("file-target".to_string()),
+                Value::Text("/archive/renamed.md".to_string()),
+                Value::Blob(b"target".to_vec()),
+            ]],
+        );
+
+        let unrelated = session
+            .execute(
+                "SELECT path, data FROM lix_file WHERE id = 'file-other'",
+                &[],
+            )
+            .await
+            .expect("unrelated file should remain unchanged");
+        assert_rows_eq(
+            unrelated,
+            vec![vec![
+                Value::Text("/docs/other.md".to_string()),
+                Value::Blob(b"other".to_vec()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    atelier_current_path_range_and_order_workloads,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES \
+             ('extension-a', '/.lix/app_data/atelier/extensions/demo/a.js', X'61'), \
+             ('extension-b', '/.lix/app_data/atelier/extensions/demo/b.js', X'62'), \
+             ('extension-upper', '/.lix/app_data/atelier/extensions0/out.js', X'78'), \
+             ('unrelated', '/docs/readme.md', X'72')",
+                &[],
+            )
+            .await
+            .expect("Atelier path fixtures should insert");
+
+        let range = session
+            .execute(
+                "SELECT path, data FROM lix_file \
+             WHERE path >= '/.lix/app_data/atelier/extensions/' \
+               AND path < '/.lix/app_data/atelier/extensions0' \
+             ORDER BY path",
+                &[],
+            )
+            .await
+            .expect("Atelier extension prefix range should query");
+        assert_rows_eq(
+            range,
+            vec![
+                vec![
+                    Value::Text("/.lix/app_data/atelier/extensions/demo/a.js".to_string()),
+                    Value::Blob(b"a".to_vec()),
+                ],
+                vec![
+                    Value::Text("/.lix/app_data/atelier/extensions/demo/b.js".to_string()),
+                    Value::Blob(b"b".to_vec()),
+                ],
+            ],
+        );
+
+        let listing = session
+            .execute(
+                "SELECT path, kind FROM (\
+               SELECT path, 'directory' AS kind FROM lix_directory \
+               UNION ALL \
+               SELECT path, 'file' AS kind FROM lix_file\
+             ) ORDER BY path",
+                &[],
+            )
+            .await
+            .expect("Atelier ordered filesystem listing should query");
+        let paths = listing
+            .rows()
+            .iter()
+            .map(|row| match &row.values()[0] {
+                Value::Text(path) => path.clone(),
+                other => panic!("expected text path, got {other:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert!(paths.windows(2).all(|pair| pair[0] <= pair[1]));
+        assert!(paths.contains(&"/docs/readme.md".to_string()));
+        assert!(paths.contains(&"/.lix/app_data/atelier/extensions0/out.js".to_string()));
+
+        let explain = session
+            .execute(
+                "EXPLAIN SELECT path, kind FROM (\
+                   SELECT path, 'directory' AS kind FROM lix_directory \
+                   UNION ALL \
+                   SELECT path, 'file' AS kind FROM lix_file\
+                 ) ORDER BY path",
+                &[],
+            )
+            .await
+            .expect("Atelier ordered listing should explain");
+        let plan = explain
+            .rows()
+            .iter()
+            .flat_map(|row| row.values().iter())
+            .map(|value| match value {
+                Value::Text(value) => value.clone(),
+                other => format!("{other:?}"),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !plan.contains("SortExec"),
+            "path-ordered providers should avoid a physical sort:\n{plan}"
+        );
+        assert!(
+            plan.contains("SortPreservingMergeExec"),
+            "the file/directory union should merge ordered inputs:\n{plan}"
+        );
+    }
+);
+
+simulation_test!(
     lix_file_update_rejects_null_data_and_preserves_existing_data,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## Summary

- add a compact, revision-scoped filesystem path index for tracked and untracked files and directories
- use ordered path selections for exact/range predicates, path-ordered scans, and update/delete candidate discovery
- avoid blob scans and physical sorting when path-only queries can be covered by the index
- cap cached index storage by estimated bytes and invalidate it through filesystem revision changes

## Why

Atelier's production SQL workload repeatedly resolves files and directories by path, including ordered filesystem listings and `UPDATE lix_file ... WHERE path = ...`. Those operations previously reconstructed paths from broad live-state scans and could read blob references or sort rows unnecessarily.

The sorted index keeps one compact descriptor entry per visible filesystem object. It gives logarithmic exact lookup, efficient contiguous range scans, naturally ordered output, and a single representation that serves both reads and path-based writes without duplicating a hash and ordered index.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p lix_engine`
- `cargo test -p lix_engine --quiet` (981 library tests and 496 SQL simulations passed before rebasing onto current `main`)
- focused filesystem index, Atelier Q01/Q02, and Q31 simulations
- plan-shape regression verifies ordered filesystem listings avoid `SortExec`

GitHub Actions is the authoritative post-rebase all-workspace, all-targets, all-features clippy and test run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SQL filesystem read/write and commit invalidation paths; incorrect index staleness or predicate mapping could change query results or DML candidate sets.
> 
> **Overview**
> Introduces a **sorted, descriptor-only filesystem path index** built from live file/directory rows, with revision-keyed caching on committed reads and invalidation when commits touch descriptors or branch refs.
> 
> **`lix_file` / `lix_directory` SQL providers** now route path equality, ranges, and unfiltered path projections through the index when possible—returning **path-ordered** batches (via `PlannedScan.ordering`) so unions/listings can merge without a physical `SortExec`. Path-only scans skip full descriptor scans and, for files, often skip blob refs unless `data` / change metadata is needed (with a size threshold to fall back).
> 
> **DML** uses indexed candidates for path-filtered UPDATE/DELETE; file path updates can build directory resolvers from the index instead of rescanning live state. Transaction reads rebuild the index from the visible overlay when staged filesystem descriptors exist.
> 
> Adds simulation coverage for path renames, branch-head cache invalidation, and Atelier-style range/order workloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07c88b7cbd3b57f56f5b09cf1a6f5afa5ed98c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->