### PR TITLE
Configure WASM runtime for filesystem sync

### DIFF
--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -7,7 +7,8 @@ use lix_sdk::{
     MergeChangeStats, MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide,
     ObserveEvent as RsObserveEvent, ObserveEvents as RsObserveEvents,
     OpenLixOptions as RsOpenLixOptions, SqliteBackend, SqliteBackendOptions,
-    SwitchBranchOptions as RsSwitchBranchOptions, SwitchBranchReceipt, Value, open_lix,
+    SwitchBranchOptions as RsSwitchBranchOptions, SwitchBranchReceipt, Value, WasmRuntime,
+    open_lix,
 };
 use napi::JsDeferred;
 use napi::bindgen_prelude::*;
@@ -777,9 +778,12 @@ fn open_fs_native(
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
     let mut options = FsBackendOpenOptions::new(path, sync_all_files);
     options.lix_dir = lix_dir.map(Into::into);
-    let backend = rt.block_on(FsBackend::open_with_options(options))?;
-    let options = RsOpenLixOptions::new(backend.clone())
-        .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
+    let wasm_runtime: Arc<dyn WasmRuntime> = Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch));
+    let backend = rt.block_on(FsBackend::open_with_options_and_wasm_runtime(
+        options,
+        Arc::clone(&wasm_runtime),
+    ))?;
+    let options = RsOpenLixOptions::new(backend.clone()).with_wasm_runtime(wasm_runtime);
     let lix = rt.block_on(open_lix(options))?;
     NativeLix::new(NativeLixInner::Fs(lix, backend))
 }

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -563,6 +563,38 @@ test("importPaths validates paths and requires an opened backend", async () => {
 	);
 });
 
+test("fs backend imports files through installed WASM plugins", async () => {
+	const dir = tempFsDir();
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "note.md"), "# Imported\n");
+	const backend = new FsBackend({
+		path: dir,
+		lixDir: tempExternalLixDir(),
+		syncAllFiles: false,
+	});
+	const lix = await openLix({ backend });
+	const markdownPlugin = (await bundledPluginArchives()).find(
+		(plugin) => plugin.key === "plugin_md_v2",
+	);
+	if (!markdownPlugin) throw new Error("expected bundled Markdown plugin");
+
+	await upsertPluginArchive(
+		lix,
+		markdownPlugin.key,
+		markdownPlugin.archiveBytes,
+	);
+	await backend.importPaths(["note.md"]);
+
+	const nodes = await lix.execute(
+		"SELECT kind FROM markdown_node ORDER BY kind",
+	);
+	expect(nodes.rows.map((row) => row.get("kind"))).toEqual([
+		"document",
+		"heading",
+	]);
+	await lix.close();
+});
+
 test("fs backend binds to one open lix at a time", async () => {
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
     Backend, BackendError, BackendWrite, CommitResult, Engine, Key, KeyRange, LixError, PutBatch,
     ReadOptions, SessionContext, SpaceId, Value, WriteOptions,
@@ -346,10 +347,28 @@ impl FsBackend {
     }
 
     pub async fn open_with_options(options: FsBackendOpenOptions) -> Result<Self, LixError> {
+        Self::open_with_options_and_runtime(options, None).await
+    }
+
+    /// Opens a filesystem backend whose disk-sync supervisor uses the same
+    /// component runtime as the Lix session that owns it.
+    pub async fn open_with_options_and_wasm_runtime(
+        options: FsBackendOpenOptions,
+        wasm_runtime: Arc<dyn WasmRuntime>,
+    ) -> Result<Self, LixError> {
+        Self::open_with_options_and_runtime(options, Some(wasm_runtime)).await
+    }
+
+    async fn open_with_options_and_runtime(
+        options: FsBackendOpenOptions,
+        wasm_runtime: Option<Arc<dyn WasmRuntime>>,
+    ) -> Result<Self, LixError> {
         let layout = prepare_filesystem_layout(&options.root, options.lix_dir.as_deref())?;
         let backend = open_filesystem_rocksdb_backend(&layout)?;
+        let engine = crate::lix::open_or_initialize_engine(backend.clone(), wasm_runtime).await?;
         let inner =
-            FilesystemSync::open_filesystem(backend, layout, options.sync_all_files).await?;
+            FilesystemSync::open_with_engine(backend, engine, layout, options.sync_all_files)
+                .await?;
         Ok(Self { inner })
     }
 
@@ -436,16 +455,6 @@ impl<B> FilesystemSync<B>
 where
     B: Backend + Clone + Send + Sync + 'static,
 {
-    #[cfg(feature = "fs_backend")]
-    async fn open_filesystem(
-        backend: B,
-        layout: FilesystemLayout,
-        sync_all_files: bool,
-    ) -> Result<Self, LixError> {
-        let engine = crate::lix::open_or_initialize_engine(backend.clone(), None).await?;
-        Self::open_with_engine(backend, engine, layout, sync_all_files).await
-    }
-
     async fn open_with_engine(
         backend: B,
         engine: Engine<B>,


### PR DESCRIPTION
## Summary

- open the filesystem sync supervisor with the same WASM component runtime as its Lix session
- share the JS runtime between filesystem imports and normal Lix operations
- cover importing Markdown through an installed WASM plugin

## Verification

- `pnpm --filter @lix-js/sdk build`
- `pnpm --filter @lix-js/sdk typecheck`
- focused native filesystem/WASM regression test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the filesystem backend initializes its engine and WASM runtime during disk import/sync, which is on the plugin execution path but is narrowly scoped and regression-tested.
> 
> **Overview**
> Filesystem-backed Lix sessions now wire the **same WASM component runtime** into the disk-sync supervisor as into normal `openLix` execution, so imports and sync can run installed plugins instead of using a separate engine with no runtime.
> 
> `FsBackend` gains `open_with_options_and_wasm_runtime` and builds its supervisor via `open_or_initialize_engine` with an optional `Arc<dyn WasmRuntime>`; the native `openFs` path constructs one shared `JsWasmRuntime` and passes it to both the backend open and `OpenLixOptions`. A JS SDK test covers importing a Markdown file after installing `plugin_md_v2` and asserts `markdown_node` rows are created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b7c2453eda8400cb3fe625332b83545486e2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->