### PR TITLE
Release v0.8.1

### DIFF
--- a/.changenotes/workerd-memory-snapshots.md
+++ b/.changenotes/workerd-memory-snapshots.md
@@ -1,6 +1,0 @@
----
-type: patch
----
-Added deterministic in-memory snapshot import and export to the Workerd JavaScript SDK entry point.
-
-Cloudflare Workers and other Workerd hosts can persist the complete physical Lix state outside an isolate and reopen it without changing branch, commit, or revision identities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.8.1 - 2026-07-13
+
+### Patch
+
+- Added deterministic in-memory snapshot import and export to the Workerd JavaScript SDK entry point.
+
+  Cloudflare Workers and other Workerd hosts can persist the complete physical Lix state outside an isolate and reopen it without changing branch, commit, or revision identities.
+
 ## 0.8.0 - 2026-07-09
 
 ### Minor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,7 +3125,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lix_backends"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "lix_cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "lix_engine"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "lix_fs_backend"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bytes",
  "lix_engine",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "lix_js_sdk"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
@@ -3233,11 +3233,11 @@ dependencies = [
 
 [[package]]
 name = "lix_order_key"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "lix_sdk"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "lix_sdk_tests"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_csv"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bytecount",
  "chardetng 1.0.0",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_json_v2"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "serde",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "plugin_md_v2"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chardetng 1.0.0",
  "encoding_rs",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "text_plugin"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chardetng 1.0.0",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Opral"]
 edition = "2024"
 description = "Embeddable version control for apps and AI agents."
@@ -20,17 +20,17 @@ categories = ["development-tools", "artificial-intelligence", "filesystem"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-lix_cli = { path = "packages/cli", version = "0.8.0" }
-lix_backends = { path = "packages/backends", version = "0.8.0", default-features = false }
-lix_engine = { path = "packages/engine", version = "0.8.0" }
-lix_fs_backend = { path = "packages/fs-backend", version = "0.8.0", default-features = false }
-lix_js_sdk = { path = "packages/js-sdk", version = "0.8.0" }
-lix_order_key = { path = "plugins/order-key", version = "0.8.0" }
-lix_sdk = { path = "packages/rs-sdk", version = "0.8.0" }
-plugin_csv = { path = "plugins/csv", version = "0.8.0" }
-plugin_json_v2 = { path = "plugins/json", version = "0.8.0" }
-plugin_md_v2 = { path = "plugins/markdown", version = "0.8.0" }
-text_plugin = { path = "plugins/text", version = "0.8.0" }
+lix_cli = { path = "packages/cli", version = "0.8.1" }
+lix_backends = { path = "packages/backends", version = "0.8.1", default-features = false }
+lix_engine = { path = "packages/engine", version = "0.8.1" }
+lix_fs_backend = { path = "packages/fs-backend", version = "0.8.1", default-features = false }
+lix_js_sdk = { path = "packages/js-sdk", version = "0.8.1" }
+lix_order_key = { path = "plugins/order-key", version = "0.8.1" }
+lix_sdk = { path = "packages/rs-sdk", version = "0.8.1" }
+plugin_csv = { path = "plugins/csv", version = "0.8.1" }
+plugin_json_v2 = { path = "plugins/json", version = "0.8.1" }
+plugin_md_v2 = { path = "plugins/markdown", version = "0.8.1" }
+text_plugin = { path = "plugins/text", version = "0.8.1" }
 
 [workspace.lints.rust]
 missing_copy_implementations = "warn"

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -26,13 +26,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-lix_sdk = { path = "../rs-sdk", version = "0.8.0", default-features = false, features = ["fs_backend", "sqlite"] }
+lix_sdk = { path = "../rs-sdk", version = "0.8.1", default-features = false, features = ["fs_backend", "sqlite"] }
 napi = { version = "3.9.0", default-features = false, features = ["napi6", "serde-json"] }
 napi-derive = "3.5.6"
 tokio = { version = "1", features = ["rt", "sync"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-lix_sdk = { path = "../rs-sdk", version = "0.8.0", default-features = false }
+lix_sdk = { path = "../rs-sdk", version = "0.8.1", default-features = false }
 console_error_panic_hook = "0.1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@lix-js/sdk",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@lix-js/sdk",
-			"version": "0.8.0",
+			"version": "0.8.1",
 			"license": "MIT",
 			"dependencies": {
 				"@bytecodealliance/jco-transpile": "0.4.2",
@@ -21,10 +21,10 @@
 				"vitest": "^4.0.18"
 			},
 			"optionalDependencies": {
-				"@lix-js/sdk-darwin-arm64": "0.8.0",
-				"@lix-js/sdk-linux-arm64": "0.8.0",
-				"@lix-js/sdk-linux-x64": "0.8.0",
-				"@lix-js/sdk-win32-x64": "0.8.0"
+				"@lix-js/sdk-darwin-arm64": "0.8.1",
+				"@lix-js/sdk-linux-arm64": "0.8.1",
+				"@lix-js/sdk-linux-x64": "0.8.1",
+				"@lix-js/sdk-win32-x64": "0.8.1"
 			}
 		},
 		"node_modules/@bytecodealliance/jco-transpile": {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@lix-js/sdk",
 	"type": "module",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -53,10 +53,10 @@
 		"typecheck": "tsc -p tsconfig.test.json --noEmit"
 	},
 	"optionalDependencies": {
-		"@lix-js/sdk-darwin-arm64": "0.8.0",
-		"@lix-js/sdk-linux-arm64": "0.8.0",
-		"@lix-js/sdk-linux-x64": "0.8.0",
-		"@lix-js/sdk-win32-x64": "0.8.0"
+		"@lix-js/sdk-darwin-arm64": "0.8.1",
+		"@lix-js/sdk-linux-arm64": "0.8.1",
+		"@lix-js/sdk-linux-x64": "0.8.1",
+		"@lix-js/sdk-win32-x64": "0.8.1"
 	},
 	"devDependencies": {
 		"@vitest/browser-playwright": "4.0.18",

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lix_sdk_tests"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Integration tests and benchmarks for the Lix Rust SDK."
 license = "MIT"
@@ -10,7 +10,7 @@ rust-version = "1.93"
 publish = false
 
 [dependencies]
-lix_sdk = { path = "../rs-sdk", version = "0.8.0", default-features = false, features = ["default_wasm_runtime", "fs_backend", "sqlite"] }
+lix_sdk = { path = "../rs-sdk", version = "0.8.1", default-features = false, features = ["default_wasm_runtime", "fs_backend", "sqlite"] }
 
 [dev-dependencies]
 plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }


### PR DESCRIPTION
Publishes the Workerd memory snapshot API as the requested patch release.

- bumps the workspace and `@lix-js/sdk` from 0.8.0 to 0.8.1
- consumes the snapshot changenote
- updates lockfiles and the changelog