### PR TITLE
fix(markdown): preserve YAML frontmatter

### DIFF
--- a/.changenotes/fix-markdown-frontmatter.md
+++ b/.changenotes/fix-markdown-frontmatter.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Preserved YAML and TOML frontmatter when Lix tracks Markdown files.
+
+Markdown frontmatter now remains a single editable block instead of being rewritten as thematic breaks and list content.

--- a/plugins/markdown/schema/markdown_node.json
+++ b/plugins/markdown/schema/markdown_node.json
@@ -22,6 +22,7 @@
       "type": "string",
       "enum": [
         "document",
+        "frontmatter",
         "paragraph",
         "heading",
         "thematic_break",

--- a/plugins/markdown/src/markdown_file.rs
+++ b/plugins/markdown/src/markdown_file.rs
@@ -58,6 +58,7 @@ pub(crate) fn parse_markdown_source(source: &str) -> Result<ParsedMarkdown, Plug
 
 fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginError> {
     let mut options = SyntaxOptions::gfm();
+    options.constructs.frontmatter = true;
     options.parse.preserve_character_escapes = true;
     options.parse.preserve_character_references = true;
     let mut output = options.parse(source);
@@ -264,6 +265,17 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
                     md::ThematicBreakMarker::Dash => "dash",
                     md::ThematicBreakMarker::Asterisk => "asterisk",
                     md::ThematicBreakMarker::Underscore => "underscore",
+                },
+            }),
+            Vec::new(),
+        )),
+        md::Block::Frontmatter(node) => Ok(new_tree(
+            NodeKind::Frontmatter,
+            json!({ "value": node.value }),
+            json!({
+                "kind": match node.kind {
+                    md::FrontmatterKind::Yaml => "yaml",
+                    md::FrontmatterKind::Toml => "toml",
                 },
             }),
             Vec::new(),
@@ -743,6 +755,15 @@ fn block_from_tree(tree: &NodeTree) -> Result<md::Block, PluginError> {
                 "underscore" => md::ThematicBreakMarker::Underscore,
                 value => return Err(invalid_field(&tree.node, "marker", value)),
             },
+        })),
+        NodeKind::Frontmatter => Ok(md::Block::Frontmatter(md::Frontmatter {
+            meta,
+            kind: match string_field(&tree.node.format, "kind")? {
+                "yaml" => md::FrontmatterKind::Yaml,
+                "toml" => md::FrontmatterKind::Toml,
+                value => return Err(invalid_field(&tree.node, "kind", value)),
+            },
+            value: owned_string_field(&tree.node.payload, "value")?,
         })),
         NodeKind::BlockQuote => Ok(md::Block::BlockQuote(md::BlockQuote {
             meta,
@@ -1498,6 +1519,7 @@ fn invalid_inline_field(node: &InlineNode, field: &str, value: &str) -> PluginEr
 fn kind_name(kind: NodeKind) -> &'static str {
     match kind {
         NodeKind::Document => "document",
+        NodeKind::Frontmatter => "frontmatter",
         NodeKind::Paragraph => "paragraph",
         NodeKind::Heading => "heading",
         NodeKind::ThematicBreak => "thematic_break",

--- a/plugins/markdown/src/markdown_file.rs
+++ b/plugins/markdown/src/markdown_file.rs
@@ -271,13 +271,14 @@ fn tree_from_block(block: &md::Block, source: &str) -> Result<NodeTree, PluginEr
         )),
         md::Block::Frontmatter(node) => Ok(new_tree(
             NodeKind::Frontmatter,
-            json!({ "value": node.value }),
             json!({
                 "kind": match node.kind {
                     md::FrontmatterKind::Yaml => "yaml",
                     md::FrontmatterKind::Toml => "toml",
                 },
+                "value": node.value,
             }),
+            empty(),
             Vec::new(),
         )),
         md::Block::BlockQuote(node) => Ok(new_tree(
@@ -758,7 +759,7 @@ fn block_from_tree(tree: &NodeTree) -> Result<md::Block, PluginError> {
         })),
         NodeKind::Frontmatter => Ok(md::Block::Frontmatter(md::Frontmatter {
             meta,
-            kind: match string_field(&tree.node.format, "kind")? {
+            kind: match string_field(&tree.node.payload, "kind")? {
                 "yaml" => md::FrontmatterKind::Yaml,
                 "toml" => md::FrontmatterKind::Toml,
                 value => return Err(invalid_field(&tree.node, "kind", value)),

--- a/plugins/markdown/src/model.rs
+++ b/plugins/markdown/src/model.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 #[serde(rename_all = "snake_case")]
 pub(crate) enum NodeKind {
     Document,
+    Frontmatter,
     Paragraph,
     Heading,
     ThematicBreak,

--- a/plugins/markdown/tests/diffing.rs
+++ b/plugins/markdown/tests/diffing.rs
@@ -151,6 +151,70 @@ fn editing_frontmatter_updates_one_durable_node_and_renders_yaml() {
 }
 
 #[test]
+fn changing_frontmatter_dialect_is_a_content_change() {
+    let yaml_source = concat!(
+        "---\n",
+        "title = \"Tokyo Packing List\"\n",
+        "---\n",
+        "\n",
+        "# Tokyo Packing List\n",
+    );
+    let toml_source = yaml_source
+        .replacen("---", "+++", 1)
+        .replacen("---", "+++", 1);
+    let before = state_from_source(yaml_source);
+    let frontmatter_id = ids_of_kind(&before, "frontmatter")[0].clone();
+
+    let delta = changes(before.clone(), &toml_source);
+    assert_eq!(delta.len(), 1, "{delta:#?}");
+    assert_eq!(change_snapshot(&delta[0])["kind"], "frontmatter");
+    assert_eq!(change_snapshot(&delta[0])["payload"]["kind"], "toml");
+    assert_eq!(delta[0].metadata, None);
+
+    let after = evolve(before, &toml_source);
+    assert_eq!(ids_of_kind(&after, "frontmatter"), vec![frontmatter_id]);
+    assert_eq!(support::render(after), toml_source);
+}
+
+#[test]
+fn adding_and_removing_frontmatter_is_local_and_preserves_heading_identity() {
+    let body_source = "# Tokyo Packing List\n";
+    let frontmatter_source = concat!(
+        "---\n",
+        "title: Tokyo Packing List\n",
+        "---\n",
+        "\n",
+        "# Tokyo Packing List\n",
+    );
+    let body = state_from_source(body_source);
+    let heading_id = ids_of_kind(&body, "heading")[0].clone();
+
+    let added = changes(body.clone(), frontmatter_source);
+    assert_eq!(added.len(), 1, "{added:#?}");
+    assert_eq!(change_snapshot(&added[0])["kind"], "frontmatter");
+
+    let with_frontmatter = evolve(body, frontmatter_source);
+    let frontmatter_id = ids_of_kind(&with_frontmatter, "frontmatter")[0].clone();
+    assert_eq!(
+        ids_of_kind(&with_frontmatter, "heading"),
+        vec![heading_id.clone()]
+    );
+    assert_eq!(
+        support::render(with_frontmatter.clone()),
+        frontmatter_source
+    );
+
+    let removed = changes(with_frontmatter.clone(), body_source);
+    assert_eq!(removed.len(), 1, "{removed:#?}");
+    assert_eq!(removed[0].entity_pk, vec![frontmatter_id]);
+    assert!(removed[0].snapshot_content.is_none());
+
+    let body_again = evolve(with_frontmatter, body_source);
+    assert_eq!(ids_of_kind(&body_again, "heading"), vec![heading_id]);
+    assert_eq!(support::render(body_again), body_source);
+}
+
+#[test]
 fn list_style_edit_updates_only_the_list_container() {
     let before_source = (0..100)
         .map(|index| format!("- Item {index:03}"))

--- a/plugins/markdown/tests/diffing.rs
+++ b/plugins/markdown/tests/diffing.rs
@@ -128,6 +128,29 @@ fn one_edit_in_a_thousand_paragraphs_is_one_row_update() {
 }
 
 #[test]
+fn editing_frontmatter_updates_one_durable_node_and_renders_yaml() {
+    let before_source = concat!(
+        "---\n",
+        "title: Tokyo Packing List\n",
+        "status: draft\n",
+        "---\n",
+        "\n",
+        "# Tokyo Packing List\n",
+    );
+    let after_source = before_source.replace("status: draft", "status: in-progress");
+    let before = state_from_source(before_source);
+    let frontmatter_id = ids_of_kind(&before, "frontmatter")[0].clone();
+
+    let delta = changes(before.clone(), &after_source);
+    assert_eq!(delta.len(), 1, "{delta:#?}");
+    assert_eq!(change_snapshot(&delta[0])["kind"], "frontmatter");
+
+    let after = evolve(before, &after_source);
+    assert_eq!(ids_of_kind(&after, "frontmatter"), vec![frontmatter_id]);
+    assert_eq!(support::render(after), after_source);
+}
+
+#[test]
 fn list_style_edit_updates_only_the_list_container() {
     let before_source = (0..100)
         .map(|index| format!("- Item {index:03}"))

--- a/plugins/markdown/tests/roundtrip.rs
+++ b/plugins/markdown/tests/roundtrip.rs
@@ -8,6 +8,18 @@ use support::{file, render, rows_of_kind, semantic_html, snapshot, state_from_so
 fn promised_format_tier_round_trips_exactly() {
     let fixtures = [
         ("empty", ""),
+        (
+            "yaml-frontmatter",
+            "---\ntitle: Tokyo Packing List\ntags:\n  - travel\n  - checklist\n---\n\n# Tokyo Packing List\n",
+        ),
+        (
+            "toml-frontmatter",
+            "+++\ntitle = \"Tokyo Packing List\"\n+++\n\n# Tokyo Packing List\n",
+        ),
+        (
+            "crlf-yaml-frontmatter",
+            "---\r\ntitle: Tokyo Packing List\r\n---\r\n\r\n# Tokyo Packing List\r\n",
+        ),
         ("no-final-newline", "paragraph"),
         ("final-newline", "paragraph\n"),
         ("crlf", "# A\r\n\r\nB\r\n"),
@@ -61,6 +73,47 @@ fn promised_format_tier_round_trips_exactly() {
         }
     }
     assert!(failures.is_empty(), "{}", failures.join("\n\n"));
+}
+
+#[test]
+fn yaml_frontmatter_is_structured_and_idempotent() {
+    let source = concat!(
+        "---\n",
+        "title: Tokyo Packing List\n",
+        "date: 2026-07-15\n",
+        "tags:\n",
+        "  - travel\n",
+        "  - checklist\n",
+        "---\n",
+        "\n",
+        "# Tokyo Packing List\n",
+    );
+
+    let state = state_from_source(source);
+    let frontmatter = rows_of_kind(&state, "frontmatter");
+    assert_eq!(frontmatter.len(), 1);
+    assert_eq!(snapshot(frontmatter[0])["format"]["kind"], "yaml");
+    assert_eq!(
+        snapshot(frontmatter[0])["payload"]["value"],
+        "title: Tokyo Packing List\ndate: 2026-07-15\ntags:\n  - travel\n  - checklist"
+    );
+    assert_eq!(rows_of_kind(&state, "thematic_break").len(), 0);
+    assert_eq!(render(state.clone()), source);
+    assert!(
+        MarkdownPlugin::detect_changes(state, file(source))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn a_leading_thematic_break_is_not_frontmatter() {
+    let source = "---\n\nBody\n";
+    let state = state_from_source(source);
+
+    assert_eq!(rows_of_kind(&state, "frontmatter").len(), 0);
+    assert_eq!(rows_of_kind(&state, "thematic_break").len(), 1);
+    assert_eq!(render(state), "- - -\n\nBody\n");
 }
 
 #[test]

--- a/plugins/markdown/tests/roundtrip.rs
+++ b/plugins/markdown/tests/roundtrip.rs
@@ -20,6 +20,14 @@ fn promised_format_tier_round_trips_exactly() {
             "crlf-yaml-frontmatter",
             "---\r\ntitle: Tokyo Packing List\r\n---\r\n\r\n# Tokyo Packing List\r\n",
         ),
+        (
+            "empty-yaml-frontmatter",
+            "---\n\n---\n\n# Tokyo Packing List\n",
+        ),
+        (
+            "yaml-frontmatter-with-block-scalar",
+            "---\nsummary: |\n  first\n  ---\n  last\n---\n\n# Tokyo Packing List\n",
+        ),
         ("no-final-newline", "paragraph"),
         ("final-newline", "paragraph\n"),
         ("crlf", "# A\r\n\r\nB\r\n"),
@@ -92,7 +100,7 @@ fn yaml_frontmatter_is_structured_and_idempotent() {
     let state = state_from_source(source);
     let frontmatter = rows_of_kind(&state, "frontmatter");
     assert_eq!(frontmatter.len(), 1);
-    assert_eq!(snapshot(frontmatter[0])["format"]["kind"], "yaml");
+    assert_eq!(snapshot(frontmatter[0])["payload"]["kind"], "yaml");
     assert_eq!(
         snapshot(frontmatter[0])["payload"]["value"],
         "title: Tokyo Packing List\ndate: 2026-07-15\ntags:\n  - travel\n  - checklist"
@@ -107,6 +115,22 @@ fn yaml_frontmatter_is_structured_and_idempotent() {
 }
 
 #[test]
+fn frontmatter_before_a_heading_canonicalizes_to_one_blank_separator() {
+    let source = "---\ntitle: Tokyo Packing List\n---\n# Tokyo Packing List\n";
+    let canonical = "---\ntitle: Tokyo Packing List\n---\n\n# Tokyo Packing List\n";
+    let state = state_from_source(source);
+
+    assert_eq!(rows_of_kind(&state, "frontmatter").len(), 1);
+    assert_eq!(rows_of_kind(&state, "heading").len(), 1);
+    assert_eq!(render(state.clone()), canonical);
+    assert!(
+        MarkdownPlugin::detect_changes(state, file(canonical))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn a_leading_thematic_break_is_not_frontmatter() {
     let source = "---\n\nBody\n";
     let state = state_from_source(source);
@@ -114,6 +138,23 @@ fn a_leading_thematic_break_is_not_frontmatter() {
     assert_eq!(rows_of_kind(&state, "frontmatter").len(), 0);
     assert_eq!(rows_of_kind(&state, "thematic_break").len(), 1);
     assert_eq!(render(state), "- - -\n\nBody\n");
+}
+
+#[test]
+fn incomplete_frontmatter_opener_remains_ordinary_markdown() {
+    let source = "---\ntitle: Tokyo Packing List\n";
+    let canonical = "- - -\n\ntitle: Tokyo Packing List\n";
+    let state = state_from_source(source);
+
+    assert_eq!(rows_of_kind(&state, "frontmatter").len(), 0);
+    assert_eq!(rows_of_kind(&state, "thematic_break").len(), 1);
+    assert_eq!(render(state.clone()), canonical);
+    assert_eq!(semantic_html(source), semantic_html(canonical));
+    assert!(
+        MarkdownPlugin::detect_changes(state, file(canonical))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]

--- a/plugins/markdown/tests/roundtrip_corpus.rs
+++ b/plugins/markdown/tests/roundtrip_corpus.rs
@@ -69,10 +69,11 @@ fn evaluate(input: &[u8]) -> Outcome {
 
 fn semantic_html(input: &[u8]) -> String {
     let source = decode_like_plugin(input);
-    let options = markdown::Options {
+    let mut options = markdown::Options {
         parse: markdown::ParseOptions::gfm(),
         compile: markdown::CompileOptions::gfm(),
     };
+    options.parse.constructs.frontmatter = true;
     markdown::to_html_with_options(&source, &options)
         .expect("fixture should compile as GFM")
         .trim_end_matches(['\r', '\n'])
@@ -222,6 +223,12 @@ fn fixtures() -> Vec<Fixture> {
         case(
             "yaml_frontmatter",
             b"---\ntitle: Test\n---\n\nBody\n",
+            true,
+            true,
+        ),
+        case(
+            "toml_frontmatter",
+            b"+++\ntitle = \"Test\"\n+++\n\nBody\n",
             true,
             true,
         ),

--- a/plugins/markdown/tests/roundtrip_corpus.rs
+++ b/plugins/markdown/tests/roundtrip_corpus.rs
@@ -220,9 +220,9 @@ fn fixtures() -> Vec<Fixture> {
         ),
         case("loose_list_extra_blank", b"- one\n\n- two\n", true, true),
         case(
-            "frontmatter_like",
+            "yaml_frontmatter",
             b"---\ntitle: Test\n---\n\nBody\n",
-            false,
+            true,
             true,
         ),
         case("mdx_jsx_like", b"<Component foo={1} />\n", true, true),

--- a/plugins/markdown/tests/schema.rs
+++ b/plugins/markdown/tests/schema.rs
@@ -20,6 +20,7 @@ fn exposes_one_self_referencing_markdown_node_schema() {
     );
     let raw = node_schema_json();
     assert!(raw.contains("\"document\""));
+    assert!(raw.contains("\"frontmatter\""));
     assert!(raw.contains("\"table_column\""));
     assert!(raw.contains("\"table_cell\""));
     assert!(raw.contains("\"parent_id\""));

--- a/plugins/markdown/tests/support/mod.rs
+++ b/plugins/markdown/tests/support/mod.rs
@@ -95,10 +95,11 @@ pub fn ids_of_kind(state: &[EntityState], kind: &str) -> Vec<String> {
 }
 
 pub fn semantic_html(source: &str) -> String {
-    let options = markdown::Options {
+    let mut options = markdown::Options {
         parse: markdown::ParseOptions::gfm(),
         compile: markdown::CompileOptions::gfm(),
     };
+    options.parse.constructs.frontmatter = true;
     markdown::to_html_with_options(source, &options)
         .expect("fixture should compile as GFM")
         .trim_end_matches(['\r', '\n'])


### PR DESCRIPTION
## Summary

- parse leading YAML and TOML frontmatter as a durable Markdown block
- preserve frontmatter through plugin rendering and the Markdown node schema
- cover exact round trips, CRLF, thematic-break boundaries, and frontmatter diffs

## Verification

- `cargo test -p plugin_md_v2`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- SDK/WASM in-memory round trip using the fixed plugin archive
- Markdown review-model tests for frontmatter replacement and undo

The full workspace test suite is running locally as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Markdown parse/serialize and the public node schema; behavior changes for any file with leading `---`/`+++`, though boundaries and non-frontmatter `---` are explicitly tested.
> 
> **Overview**
> Leading **YAML** (`---`) and **TOML** (`+++`) frontmatter is now parsed as a single durable **`frontmatter`** node (payload: dialect + raw body) instead of being split into thematic breaks and list/paragraph content.
> 
> The Markdown plugin turns on the parser’s frontmatter construct, wires **`frontmatter`** through the node schema and parse/render path, and keeps stable node IDs for edits, add/remove, and YAML↔TOML dialect changes. Tests cover exact round trips (CRLF, block scalars, empty blocks), diff granularity, and cases where `---` must stay a thematic break or ordinary markdown when the block is incomplete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e7cfbc49bc899283ad7e4b47f47195f4f3a9fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->