### PR TITLE
Add unified remote Lix HTTP mode

### DIFF
--- a/.changenotes/add-remote-lix-client.md
+++ b/.changenotes/add-remote-lix-client.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Lix can now open a workspace as a thin remote client.
+
+Use `openLix({ server: { mode: "remote", url } })` to execute SQL and manage branches through the versioned Lix HTTP protocol without loading a local engine.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -16,6 +16,10 @@
 			"types": "./dist/workerd.d.ts",
 			"workerd": "./dist/workerd.js",
 			"default": "./dist/workerd.js"
+		},
+		"./remote-protocol": {
+			"types": "./dist/remote/protocol.d.ts",
+			"default": "./dist/remote/protocol.js"
 		}
 	},
 	"imports": {

--- a/packages/js-sdk/scripts/test-packed-vite.js
+++ b/packages/js-sdk/scripts/test-packed-vite.js
@@ -95,11 +95,15 @@ try {
 		/^js-component-bindgen-component\.core2-.*\.wasm$/,
 		"JCO core2 WASM",
 	);
-	const mainSource = await readFile(join(assetsDir, mainBundle), "utf8");
 	const workerSource = await readFile(join(assetsDir, browserWorker), "utf8");
+	const browserJavaScriptSources = await Promise.all(
+		builtAssets
+			.filter((file) => file.endsWith(".js"))
+			.map((file) => readFile(join(assetsDir, file), "utf8")),
+	);
 	assert.ok(
-		mainSource.includes(browserWorker),
-		"The main bundle does not reference the emitted browser worker",
+		browserJavaScriptSources.some((source) => source.includes(browserWorker)),
+		"The browser bundle does not reference the emitted browser worker",
 	);
 	assert.ok(
 		workerSource.includes(engineWasm),
@@ -121,13 +125,7 @@ try {
 		builtAssets.every((file) => !file.endsWith(".node")),
 		"Vite emitted a native Node binding in the browser build",
 	);
-	const browserJavaScript = (
-		await Promise.all(
-			builtAssets
-				.filter((file) => file.endsWith(".js"))
-				.map((file) => readFile(join(assetsDir, file), "utf8")),
-		)
-	).join("\n");
+	const browserJavaScript = browserJavaScriptSources.join("\n");
 	for (const [label, nodeRuntimeMarker] of [
 		["Node worker module", "entry.node"],
 		["Node worker implementation", "Lix worker requires a parent port"],

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -29,6 +29,8 @@ export type {
 	MergeConflictSide,
 	ObserveEvent,
 	OpenLixOptions,
+	RemoteLixFetch,
+	RemoteLixServerOptions,
 	SqlParam,
 	SQLiteOptions,
 	SwitchBranchOptions,

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -11,7 +11,6 @@ import type {
 } from "./binding-types.js";
 import { normalizeOptionals, wrapExecuteResult } from "./result.js";
 import { normalizeParam, toNativeValue } from "./value.js";
-import { openLixWorkerBinding } from "./worker/client.js";
 import type {
 	CreateBranchOptions,
 	CreateBranchReceipt,
@@ -127,6 +126,16 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			"openLix() option 'backend' was removed; use 'storage' instead",
 		);
 	}
+	if (options.server !== undefined) {
+		if (options.storage !== undefined) {
+			throw new TypeError(
+				"openLix() remote mode cannot be combined with client storage",
+			);
+		}
+		const { openRemoteLixBinding } = await import("./remote/client.js");
+		return new Lix(await openRemoteLixBinding(options.server));
+	}
+	const { openLixWorkerBinding } = await import("./worker/client.js");
 	if (options.storage === undefined) {
 		return new Lix(await openLixWorkerBinding({ kind: "memory" }));
 	}

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -1,0 +1,300 @@
+import { expect, test, vi } from "vitest";
+import { openLix } from "../index.js";
+
+test("remote mode uses the workspace protocol without loading a local engine", async () => {
+	const requests: Request[] = [];
+	let headerCalls = 0;
+	const remoteFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const request = new Request(input, init);
+		requests.push(request);
+		if (new URL(request.url).pathname.endsWith("/.lix/v1/")) {
+			return Response.json({ protocolVersion: 1, activeBranchId: "main-id" });
+		}
+		if (new URL(request.url).pathname.endsWith("/.lix/v1/execute")) {
+			return Response.json({
+				columns: ["n", "bytes", "json"],
+				rows: [
+					[
+						{ kind: "int", value: 42 },
+						{ kind: "blob", base64: "AQID" },
+						{ kind: "json", value: { ok: true } },
+					],
+				],
+				rowsAffected: 0,
+				notices: [],
+			});
+		}
+		throw new Error(`Unexpected request: ${request.url}`);
+	});
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: remoteFetch as typeof fetch,
+			headers: () => {
+				headerCalls += 1;
+				return { Authorization: `Bearer token-${headerCalls}` };
+			},
+		},
+	});
+
+	expect(await lix.activeBranchId()).toBe("main-id");
+	const result = await lix.execute(
+		"SELECT $1, $2, $3, $4, $5, $6, $7",
+		[
+			null,
+			true,
+			7,
+			1.5,
+			"text",
+			{ nested: [1, false] },
+			new Uint8Array([1, 2, 3]),
+		],
+		{ originKey: "remote-test" },
+	);
+
+	expect(result.rows[0]?.get("n")).toBe(42);
+	expect(result.rows[0]?.value("bytes").asBytes()).toEqual(
+		new Uint8Array([1, 2, 3]),
+	);
+	expect(result.rows[0]?.get("json")).toEqual({ ok: true });
+	expect(headerCalls).toBe(2);
+	expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
+		"/@acme/workspace/.lix/v1/",
+		"/@acme/workspace/.lix/v1/execute",
+	]);
+	expect(requests[1]?.headers.get("authorization")).toBe("Bearer token-2");
+	expect(await requests[1]?.json()).toEqual({
+		branchId: "main-id",
+		sql: "SELECT $1, $2, $3, $4, $5, $6, $7",
+		params: [
+			{ kind: "null", value: null },
+			{ kind: "bool", value: true },
+			{ kind: "int", value: 7 },
+			{ kind: "float", value: 1.5 },
+			{ kind: "text", value: "text" },
+			{ kind: "json", value: { nested: [1, false] } },
+			{ kind: "blob", base64: "AQID" },
+		],
+		options: { originKey: "remote-test" },
+	});
+
+	await lix.close();
+});
+
+test("remote branches preserve local Lix branch semantics", async () => {
+	const requests: Request[] = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: new URL("https://lixray.test/@acme/workspace/"),
+			branchId: "requested-id",
+			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = new Request(input, init);
+				requests.push(request.clone());
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/.lix/v1/")) {
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId: "main-id",
+					});
+				}
+				if (pathname.endsWith("/branch/switch")) {
+					const body = (await request.json()) as { branchId: string };
+					return Response.json({ branchId: body.branchId });
+				}
+				if (pathname.endsWith("/branch/create")) {
+					return Response.json({
+						id: "draft-id",
+						name: "Draft",
+						hidden: false,
+						commitId: "commit-id",
+					});
+				}
+				throw new Error(`Unexpected request: ${pathname}`);
+			}) as typeof fetch,
+		},
+	});
+
+	expect(await lix.activeBranchId()).toBe("requested-id");
+	const created = await lix.createBranch({ name: "Draft" });
+	expect(created.id).toBe("draft-id");
+	expect(await lix.activeBranchId()).toBe("requested-id");
+	await lix.switchBranch({ branchId: created.id });
+	expect(await lix.activeBranchId()).toBe("draft-id");
+	expect(
+		await Promise.all(requests.slice(1).map((request) => request.clone().json())),
+	).toEqual([
+		{ branchId: "requested-id" },
+		{ branchId: "requested-id", name: "Draft" },
+		{ branchId: "draft-id" },
+	]);
+
+	await lix.close();
+});
+
+test("a failed remote branch switch leaves the active branch unchanged", async () => {
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: (async (input: RequestInfo | URL) => {
+				const pathname = new URL(input.toString()).pathname;
+				return pathname.endsWith("/.lix/v1/")
+					? Response.json({ protocolVersion: 1, activeBranchId: "main-id" })
+					: Response.json(
+							{
+								error: {
+									code: "LIX_BRANCH_NOT_FOUND",
+									message: "Branch not found",
+									hint: "Choose an existing branch",
+									details: { branchId: "missing" },
+								},
+							},
+							{ status: 404 },
+						);
+			}) as typeof fetch,
+		},
+	});
+
+	await expect(lix.switchBranch({ branchId: "missing" })).rejects.toMatchObject({
+		name: "LixError",
+		code: "LIX_BRANCH_NOT_FOUND",
+		message: "Branch not found",
+		hint: "Choose an existing branch",
+		details: { branchId: "missing" },
+		status: 404,
+	});
+	expect(await lix.activeBranchId()).toBe("main-id");
+
+	await lix.close();
+});
+
+test("remote operations preserve normal Lix call ordering", async () => {
+	let finishSwitch: (() => void) | undefined;
+	const switchGate = new Promise<void>((resolve) => {
+		finishSwitch = resolve;
+	});
+	const requestOrder: string[] = [];
+	let executeBranchId = "";
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/.lix/v1/")) {
+					return Response.json({ protocolVersion: 1, activeBranchId: "main-id" });
+				}
+				if (pathname.endsWith("/branch/switch")) {
+					requestOrder.push("switch");
+					await switchGate;
+					return Response.json({ branchId: "draft-id" });
+				}
+				if (pathname.endsWith("/execute")) {
+					requestOrder.push("execute");
+					executeBranchId = ((await request.json()) as { branchId: string })
+						.branchId;
+					return Response.json({
+						columns: [],
+						rows: [],
+						rowsAffected: 0,
+						notices: [],
+					});
+				}
+				throw new Error(`Unexpected request: ${pathname}`);
+			},
+		},
+	});
+
+	const switching = lix.switchBranch({ branchId: "draft-id" });
+	const executing = lix.execute("SELECT 1");
+	await Promise.resolve();
+	await Promise.resolve();
+	expect(requestOrder).toEqual(["switch"]);
+	finishSwitch?.();
+	await Promise.all([switching, executing]);
+	expect(requestOrder).toEqual(["switch", "execute"]);
+	expect(executeBranchId).toBe("draft-id");
+
+	await lix.close();
+});
+
+test("remote responses reject malformed rows and non-JSON HTTP errors", async () => {
+	let executeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input) => {
+				const pathname = new URL(input.toString()).pathname;
+				if (pathname.endsWith("/.lix/v1/")) {
+					return Response.json({ protocolVersion: 1, activeBranchId: "main-id" });
+				}
+				executeCalls += 1;
+				return executeCalls === 1
+					? Response.json({
+							columns: ["a", "b"],
+							rows: [[{ kind: "int", value: 1 }]],
+							rowsAffected: 0,
+							notices: [],
+						})
+					: new Response("upstream unavailable", { status: 502 });
+			},
+		},
+	});
+
+	await expect(lix.execute("SELECT malformed")).rejects.toMatchObject({
+		code: "LIX_REMOTE_PROTOCOL_ERROR",
+	});
+	await expect(lix.execute("SELECT unavailable")).rejects.toMatchObject({
+		code: "LIX_REMOTE_REQUEST_FAILED",
+		status: 502,
+		details: { body: "upstream unavailable" },
+	});
+
+	await lix.close();
+});
+
+test("remote mode rejects unsupported local-only operations honestly", async () => {
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: (async () =>
+				Response.json({
+					protocolVersion: 1,
+					activeBranchId: "main-id",
+				})) as typeof fetch,
+		},
+	});
+
+	await expect(lix.beginTransaction()).rejects.toMatchObject({
+		code: "LIX_UNSUPPORTED_REMOTE_OPERATION",
+	});
+	await expect(
+		lix.mergeBranch({ sourceBranchId: "source" }),
+	).rejects.toMatchObject({ code: "LIX_UNSUPPORTED_REMOTE_OPERATION" });
+	await lix.close();
+	await expect(lix.execute("SELECT 1")).rejects.toMatchObject({
+		code: "LIX_ERROR_CLOSED",
+	});
+});
+
+test("remote mode rejects incompatible protocol versions", async () => {
+	await expect(
+		openLix({
+			storage: undefined,
+			server: {
+				mode: "remote",
+				url: "https://lixray.test/workspace",
+				fetch: (async () =>
+					Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+					})) as typeof fetch,
+			},
+		}),
+	).rejects.toMatchObject({ code: "LIX_REMOTE_PROTOCOL_ERROR" });
+});

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -1,0 +1,312 @@
+import type {
+	BindingExecuteResult,
+	LixBinding,
+	LixTransactionBinding,
+	ObserveEventsBinding,
+} from "../binding-types.js";
+import type {
+	CreateBranchOptions,
+	CreateBranchReceipt,
+	ExecuteOptions,
+	MergeBranchOptions,
+	MergeBranchPreview,
+	MergeBranchReceipt,
+	RemoteLixServerOptions,
+	SwitchBranchOptions,
+	SwitchBranchReceipt,
+} from "../types.js";
+import type { NativeLixValue } from "../value.js";
+import {
+	decodeExecuteResult,
+	decodeHandshake,
+	encodeWireValue,
+	errorFromResponseBody,
+	protocolError,
+	record,
+	remoteError,
+} from "./protocol.js";
+
+export async function openRemoteLixBinding(
+	options: RemoteLixServerOptions,
+): Promise<LixBinding> {
+	const client = new RemoteLixBinding(options);
+	await client.open();
+	return client;
+}
+
+class RemoteLixBinding implements LixBinding {
+	readonly #baseUrl: URL;
+	readonly #fetch: NonNullable<RemoteLixServerOptions["fetch"]>;
+	readonly #headers: RemoteLixServerOptions["headers"];
+	readonly #initialBranchId: string | undefined;
+	#activeBranchId = "";
+	#acceptingOperations = true;
+	#operationQueue: Promise<void> = Promise.resolve();
+
+	constructor(options: RemoteLixServerOptions) {
+		if (!options || typeof options !== "object") {
+			throw new TypeError("openLix() remote server must be an object");
+		}
+		if (options.mode !== "remote") {
+			throw new TypeError("openLix() remote server mode must be 'remote'");
+		}
+		this.#baseUrl = protocolBaseUrl(options.url);
+		const remoteFetch = options.fetch ?? globalThis.fetch?.bind(globalThis);
+		if (typeof remoteFetch !== "function") {
+			throw new TypeError("openLix() remote mode requires fetch");
+		}
+		this.#fetch = remoteFetch;
+		if (
+			options.branchId !== undefined &&
+			(typeof options.branchId !== "string" || options.branchId.length === 0)
+		) {
+			throw new TypeError(
+				"openLix() remote server branchId must be a non-empty string",
+			);
+		}
+		if (
+			options.headers !== undefined &&
+			typeof options.headers !== "function" &&
+			!isHeadersInit(options.headers)
+		) {
+			throw new TypeError(
+				"openLix() remote server headers must be HeadersInit or a function",
+			);
+		}
+		this.#headers = options.headers;
+		this.#initialBranchId = options.branchId;
+	}
+
+	async open(): Promise<void> {
+		const handshake = decodeHandshake(await this.#requestJson("", { method: "GET" }));
+		this.#activeBranchId = handshake.activeBranchId;
+		if (this.#initialBranchId !== undefined) {
+			await this.switchBranch({ branchId: this.#initialBranchId });
+		}
+	}
+
+	async execute(
+		sql: string,
+		params: NativeLixValue[],
+		options?: ExecuteOptions,
+	): Promise<BindingExecuteResult> {
+		this.#assertOpen();
+		return this.#enqueue(async () =>
+			decodeExecuteResult(
+				await this.#requestJson("execute", {
+					method: "POST",
+					body: JSON.stringify({
+						branchId: this.#activeBranchId,
+						sql,
+						params: params.map(encodeWireValue),
+						...(options === undefined ? {} : { options }),
+					}),
+				}),
+			),
+		);
+	}
+
+	async observe(
+		_sql: string,
+		_params: NativeLixValue[],
+	): Promise<ObserveEventsBinding> {
+		this.#assertOpen();
+		throw unsupportedRemoteOperation("observe");
+	}
+
+	async beginTransaction(): Promise<LixTransactionBinding> {
+		this.#assertOpen();
+		throw unsupportedRemoteOperation("beginTransaction");
+	}
+
+	async activeBranchId(): Promise<string> {
+		this.#assertOpen();
+		return this.#enqueue(async () => this.#activeBranchId);
+	}
+
+	async createBranch(
+		options: CreateBranchOptions,
+	): Promise<CreateBranchReceipt> {
+		this.#assertOpen();
+		return this.#enqueue(async () => {
+			const value = record(
+				await this.#requestJson("branch/create", {
+					method: "POST",
+					body: JSON.stringify({
+						branchId: this.#activeBranchId,
+						...options,
+					}),
+				}),
+				"create branch response",
+			);
+			if (
+				typeof value.id !== "string" ||
+				typeof value.name !== "string" ||
+				typeof value.hidden !== "boolean" ||
+				typeof value.commitId !== "string"
+			) {
+				throw protocolError("create branch response is invalid");
+			}
+			return {
+				id: value.id,
+				name: value.name,
+				hidden: value.hidden,
+				commitId: value.commitId,
+			};
+		});
+	}
+
+	async switchBranch(
+		options: SwitchBranchOptions,
+	): Promise<SwitchBranchReceipt> {
+		this.#assertOpen();
+		return this.#enqueue(async () => {
+			const value = record(
+				await this.#requestJson("branch/switch", {
+					method: "POST",
+					body: JSON.stringify(options),
+				}),
+				"switch branch response",
+			);
+			if (value.branchId !== options.branchId) {
+				throw protocolError("switch branch response is invalid");
+			}
+			this.#activeBranchId = options.branchId;
+			return { branchId: options.branchId };
+		});
+	}
+
+	async importFilesystemPaths(_paths: string[]): Promise<void> {
+		this.#assertOpen();
+		throw unsupportedRemoteOperation("importFilesystemPaths");
+	}
+
+	async mergeBranchPreview(
+		_options: MergeBranchOptions,
+	): Promise<MergeBranchPreview> {
+		this.#assertOpen();
+		throw unsupportedRemoteOperation("mergeBranchPreview");
+	}
+
+	async mergeBranch(
+		_options: MergeBranchOptions,
+	): Promise<MergeBranchReceipt> {
+		this.#assertOpen();
+		throw unsupportedRemoteOperation("mergeBranch");
+	}
+
+	async syncDiskToLix(): Promise<void> {
+		this.#assertOpen();
+		throw unsupportedRemoteOperation("syncDiskToLix");
+	}
+
+	async close(): Promise<void> {
+		if (!this.#acceptingOperations) return this.#operationQueue;
+		this.#acceptingOperations = false;
+		return this.#enqueue(async () => undefined);
+	}
+
+	async #requestJson(path: string, init: RequestInit): Promise<unknown> {
+		const headers = new Headers(await resolveHeaders(this.#headers));
+		headers.set("accept", "application/json");
+		if (init.body !== undefined) headers.set("content-type", "application/json");
+		let response: Response;
+		try {
+			response = await this.#fetch(new URL(path, this.#baseUrl), {
+				...init,
+				headers,
+			});
+		} catch (cause) {
+			throw remoteError(
+				"LIX_REMOTE_UNAVAILABLE",
+				"The remote Lix server is unavailable",
+				{ details: { cause: errorMessage(cause) } },
+			);
+		}
+		const text = await response.text();
+		if (!response.ok) {
+			let body: unknown;
+			try {
+				body = JSON.parse(text);
+			} catch {
+				throw remoteError(
+					"LIX_REMOTE_REQUEST_FAILED",
+					`Remote Lix request failed with status ${response.status}`,
+					{
+						status: response.status,
+						details: text.length === 0 ? undefined : { body: text.slice(0, 1000) },
+					},
+				);
+			}
+			throw errorFromResponseBody(body, response.status);
+		}
+		try {
+			return JSON.parse(text);
+		} catch {
+			throw protocolError(
+				`remote response ${response.status} did not contain valid JSON`,
+			);
+		}
+	}
+
+	#assertOpen(): void {
+		if (!this.#acceptingOperations) {
+			throw remoteError("LIX_ERROR_CLOSED", "Lix is closed");
+		}
+	}
+
+	#enqueue<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.#operationQueue.then(operation, operation);
+		this.#operationQueue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+}
+
+async function resolveHeaders(
+	headers: RemoteLixServerOptions["headers"],
+): Promise<HeadersInit | undefined> {
+	return typeof headers === "function" ? await headers() : headers;
+}
+
+function protocolBaseUrl(value: string | URL): URL {
+	let workspaceUrl: URL;
+	try {
+		workspaceUrl = new URL(value);
+	} catch {
+		throw new TypeError("openLix() remote server url must be an absolute URL");
+	}
+	if (workspaceUrl.protocol !== "http:" && workspaceUrl.protocol !== "https:") {
+		throw new TypeError("openLix() remote server url must use http or https");
+	}
+	if (workspaceUrl.search || workspaceUrl.hash) {
+		throw new TypeError(
+			"openLix() remote server url must not contain a query or fragment",
+		);
+	}
+	workspaceUrl.pathname = `${workspaceUrl.pathname.replace(/\/$/, "")}/.lix/v1/`;
+	return workspaceUrl;
+}
+
+function unsupportedRemoteOperation(operation: string): Error & { code: string } {
+	return remoteError(
+		"LIX_UNSUPPORTED_REMOTE_OPERATION",
+		`${operation} is not supported in remote mode`,
+		{ details: { operation } },
+	);
+}
+
+function isHeadersInit(value: unknown): value is HeadersInit {
+	try {
+		new Headers(value as HeadersInit);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function errorMessage(value: unknown): string {
+	return value instanceof Error ? value.message : String(value);
+}

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -1,0 +1,310 @@
+import type { BindingExecuteResult } from "../binding-types.js";
+import type { NativeLixValue } from "../value.js";
+
+export const REMOTE_PROTOCOL_VERSION = 1;
+export const REMOTE_PROTOCOL_PATH = "/.lix/v1/";
+
+export type WireValue =
+	| { kind: "null"; value: null }
+	| { kind: "bool"; value: boolean }
+	| { kind: "int"; value: number }
+	| { kind: "float"; value: number }
+	| { kind: "text"; value: string }
+	| { kind: "json"; value: unknown }
+	| { kind: "blob"; base64: string };
+
+export type RemoteHandshake = {
+	protocolVersion: number;
+	activeBranchId: string;
+};
+
+export type RemoteExecuteRequest = {
+	branchId: string;
+	sql: string;
+	params: WireValue[];
+	options?: { originKey?: string };
+};
+
+export type RemoteExecuteResponse = {
+	columns: string[];
+	rows: WireValue[][];
+	rowsAffected: number;
+	notices: Array<{ code: string; message: string; hint?: string }>;
+};
+
+export type RemoteObserveRequest = Omit<RemoteExecuteRequest, "options">;
+
+export type RemoteObserveEvent = {
+	sequence: number;
+	mutationSequence: number;
+	result: RemoteExecuteResponse;
+};
+
+export type RemoteCreateBranchRequest = {
+	branchId: string;
+	id?: string;
+	name: string;
+	fromCommitId?: string;
+};
+
+export type RemoteCreateBranchResponse = {
+	id: string;
+	name: string;
+	hidden: boolean;
+	commitId: string;
+};
+
+export type RemoteSwitchBranchRequest = { branchId: string };
+export type RemoteSwitchBranchResponse = { branchId: string };
+
+export type RemoteErrorBody = {
+	error: {
+		code?: string;
+		message?: string;
+		hint?: string;
+		details?: unknown;
+	};
+};
+
+export function encodeWireValue(value: NativeLixValue): WireValue {
+	switch (value.kind) {
+		case "null":
+			return { kind: "null", value: null };
+		case "boolean":
+			return { kind: "bool", value: value.value };
+		case "integer":
+			return { kind: "int", value: value.value };
+		case "real":
+			return { kind: "float", value: value.value };
+		case "text":
+			return { kind: "text", value: value.value };
+		case "json":
+			return { kind: "json", value: value.value };
+		case "blob":
+			return { kind: "blob", base64: bytesToBase64(value.blob) };
+	}
+}
+
+export function decodeExecuteResult(value: unknown): BindingExecuteResult {
+	const result = record(value, "execute result");
+	const columns = stringArray(result.columns, "execute result columns");
+	if (!Array.isArray(result.rows)) {
+		throw protocolError("execute result rows must be an array");
+	}
+	const rows = result.rows.map((row, rowIndex) => {
+		if (!Array.isArray(row)) {
+			throw protocolError(`execute result row ${rowIndex} must be an array`);
+		}
+		if (row.length !== columns.length) {
+			throw protocolError(
+				`execute result row ${rowIndex} has ${row.length} values for ${columns.length} columns`,
+			);
+		}
+		return row.map((entry) => decodeWireValue(entry));
+	});
+	if (
+		typeof result.rowsAffected !== "number" ||
+		!Number.isSafeInteger(result.rowsAffected) ||
+		result.rowsAffected < 0
+	) {
+		throw protocolError(
+			"execute result rowsAffected must be a non-negative safe integer",
+		);
+	}
+	if (!Array.isArray(result.notices)) {
+		throw protocolError("execute result notices must be an array");
+	}
+	const notices = result.notices.map((notice, index) => {
+		const item = record(notice, `execute result notice ${index}`);
+		if (typeof item.code !== "string" || typeof item.message !== "string") {
+			throw protocolError(
+				`execute result notice ${index} requires code and message`,
+			);
+		}
+		if (item.hint !== undefined && typeof item.hint !== "string") {
+			throw protocolError(
+				`execute result notice ${index} hint must be a string`,
+			);
+		}
+		return {
+			code: item.code,
+			message: item.message,
+			...(item.hint === undefined ? {} : { hint: item.hint }),
+		};
+	});
+	return { columns, rows, rowsAffected: result.rowsAffected, notices };
+}
+
+export function decodeHandshake(value: unknown): RemoteHandshake {
+	const handshake = record(value, "remote handshake");
+	if (handshake.protocolVersion !== REMOTE_PROTOCOL_VERSION) {
+		throw protocolError(
+			`unsupported remote protocol version: ${String(handshake.protocolVersion)}`,
+		);
+	}
+	if (
+		typeof handshake.activeBranchId !== "string" ||
+		handshake.activeBranchId.length === 0
+	) {
+		throw protocolError("remote handshake requires activeBranchId");
+	}
+	return {
+		protocolVersion: REMOTE_PROTOCOL_VERSION,
+		activeBranchId: handshake.activeBranchId,
+	};
+}
+
+export function remoteError(
+	code: string,
+	message: string,
+	options: { hint?: string; details?: unknown; status?: number } = {},
+): Error & {
+	code: string;
+	hint?: string;
+	details?: unknown;
+	status?: number;
+} {
+	const error = new Error(message) as Error & {
+		code: string;
+		hint?: string;
+		details?: unknown;
+		status?: number;
+	};
+	error.name = "LixError";
+	error.code = code;
+	error.hint = options.hint;
+	error.details = options.details;
+	error.status = options.status;
+	return error;
+}
+
+export function protocolError(message: string): Error & { code: string } {
+	return remoteError("LIX_REMOTE_PROTOCOL_ERROR", message);
+}
+
+export function errorFromResponseBody(
+	value: unknown,
+	status: number,
+): Error & { code: string } {
+	const body = record(value, "remote error response");
+	const rawError = record(body.error, "remote error response error");
+	return remoteError(
+		typeof rawError.code === "string"
+			? rawError.code
+			: "LIX_REMOTE_REQUEST_FAILED",
+		typeof rawError.message === "string"
+			? rawError.message
+			: `Remote Lix request failed with status ${status}`,
+		{
+			hint: typeof rawError.hint === "string" ? rawError.hint : undefined,
+			details: rawError.details,
+			status,
+		},
+	);
+}
+
+export function record(
+	value: unknown,
+	description: string,
+): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw protocolError(`${description} must be an object`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function decodeWireValue(value: unknown): NativeLixValue {
+	const wire = record(value, "wire value");
+	switch (wire.kind) {
+		case "null":
+			if (wire.value !== null) throw protocolError("null wire value is invalid");
+			return { kind: "null", value: null };
+		case "bool":
+			if (typeof wire.value !== "boolean") {
+				throw protocolError("bool wire value is invalid");
+			}
+			return { kind: "boolean", value: wire.value };
+		case "int":
+			if (typeof wire.value !== "number" || !Number.isSafeInteger(wire.value)) {
+				throw protocolError("int wire value is invalid");
+			}
+			return { kind: "integer", value: wire.value };
+		case "float":
+			if (typeof wire.value !== "number" || !Number.isFinite(wire.value)) {
+				throw protocolError("float wire value is invalid");
+			}
+			return { kind: "real", value: wire.value };
+		case "text":
+			if (typeof wire.value !== "string") {
+				throw protocolError("text wire value is invalid");
+			}
+			return { kind: "text", value: wire.value };
+		case "json":
+			assertJsonValue(wire.value, "json wire value");
+			return { kind: "json", value: wire.value };
+		case "blob":
+			if (typeof wire.base64 !== "string") {
+				throw protocolError("blob wire value is invalid");
+			}
+			return { kind: "blob", value: null, blob: base64ToBytes(wire.base64) };
+		default:
+			throw protocolError(`unknown wire value kind: ${String(wire.kind)}`);
+	}
+}
+
+function stringArray(value: unknown, description: string): string[] {
+	if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+		throw protocolError(`${description} must be an array of strings`);
+	}
+	return [...value];
+}
+
+function assertJsonValue(
+	value: unknown,
+	description: string,
+): asserts value is import("../types.js").JsonValue {
+	if (
+		value === null ||
+		typeof value === "boolean" ||
+		(typeof value === "number" &&
+			Number.isFinite(value) &&
+			(!Number.isInteger(value) || Number.isSafeInteger(value))) ||
+		(typeof value === "string" && value.isWellFormed())
+	) {
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const entry of value) assertJsonValue(entry, description);
+		return;
+	}
+	if (value && typeof value === "object") {
+		for (const entry of Object.values(value)) {
+			assertJsonValue(entry, description);
+		}
+		return;
+	}
+	throw protocolError(`${description} is not valid Lix JSON`);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+	let binary = "";
+	const chunkSize = 0x8000;
+	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+		binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+	}
+	return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+	let binary: string;
+	try {
+		binary = atob(base64);
+	} catch {
+		throw protocolError("blob wire value contains invalid base64");
+	}
+	const bytes = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index += 1) {
+		bytes[index] = binary.charCodeAt(index);
+	}
+	return bytes;
+}

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -8,11 +8,30 @@ export type LocalFilesystemOptions = {
 	syncAllFiles: boolean;
 };
 
-export type OpenLixOptions = {
-	storage?:
-		| import("./open-lix.js").SQLite
-		| import("./open-lix.js").LocalFilesystem;
+export type RemoteLixFetch = (
+	input: RequestInfo | URL,
+	init?: RequestInit,
+) => Promise<Response>;
+
+export type RemoteLixServerOptions = {
+	mode: "remote";
+	url: string | URL;
+	branchId?: string;
+	headers?: HeadersInit | (() => HeadersInit | Promise<HeadersInit>);
+	fetch?: RemoteLixFetch;
 };
+
+export type OpenLixOptions =
+	| {
+			storage?:
+				| import("./open-lix.js").SQLite
+				| import("./open-lix.js").LocalFilesystem;
+			server?: never;
+	  }
+	| {
+			storage?: never;
+			server: RemoteLixServerOptions;
+	  };
 
 export type LixValue =
 	| { kind: "null"; value: null }


### PR DESCRIPTION
## What changed

- add unified `openLix({ server: { mode: "remote", url } })` support
- define the versioned `/.lix/v1/` handshake, execute, and branch contract in Lix
- support dynamic headers and an injected `fetch` for browser and service-binding callers
- serialize remote operations to preserve normal Lix call ordering
- lazy-load the local worker path only when local mode is selected
- expose the pure remote protocol as `@lix-js/sdk/remote-protocol`

## Why

Lix consumers should use the normal client against a server instead of maintaining application-specific HTTP facades. This is the finite-operation layer; remote observation is the next stacked PR.

Remote mode is deliberately thin and does not use client storage. A local `storage` plus a server belongs to the future sync mode rather than this MVP.

## Validation

- `npx vitest run src/remote/client.test.ts src/open-lix.test.ts` (72 tests)
- `npm run build:ts`
- `npm run typecheck`
- `git diff --check`

## Stack

- base: #610
- next: remote `lix.observe()`
