### PR TITLE
Support remote Lix observations

### DIFF
--- a/.changenotes/add-remote-lix-observe.md
+++ b/.changenotes/add-remote-lix-observe.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Remote Lix clients now support live query observations.
+
+`lix.observe()` streams server-side Lix results, reconnects transient failures, follows successful branch switches, and closes with the normal Lix lifecycle.

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -22,6 +22,39 @@ console.log(result.rows[0]?.get("message"));
 await lix.close();
 ```
 
+## Remote workspaces
+
+Use the same Lix client as a thin client against a hosted workspace:
+
+```ts
+const lix = await openLix({
+	server: {
+		mode: "remote",
+		url: "https://lixray.com/@namespace/workspace",
+		headers: async () => ({
+			Authorization: `Bearer ${await accessToken()}`,
+		}),
+	},
+});
+
+const files = lix.observe("SELECT path FROM lix_file ORDER BY path");
+const initial = await files.next();
+
+await lix.execute(
+	"INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+	["/hello.txt", new TextEncoder().encode("hello")],
+);
+const update = await files.next();
+
+files.close();
+await lix.close();
+```
+
+Remote mode uses the server for persistence and does not open a local engine,
+so it does not take a client `storage`. Dynamic headers are resolved for every
+request and observation reconnect. An injected `fetch` can route requests
+through a service binding or another authorized server-side transport.
+
 Filesystem sync and SQLite persistence use native Node.js dependencies:
 
 ```ts

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -1,5 +1,6 @@
 import type {
 	BindingExecuteResult,
+	BindingObserveEvent,
 	LixBinding,
 	LixTransactionBinding,
 	ObserveEventsBinding,
@@ -19,12 +20,17 @@ import type { NativeLixValue } from "../value.js";
 import {
 	decodeExecuteResult,
 	decodeHandshake,
+	decodeObserveEvent,
 	encodeWireValue,
 	errorFromResponseBody,
 	protocolError,
 	record,
 	remoteError,
 } from "./protocol.js";
+import { readSseEvents } from "./sse.js";
+
+const OBSERVE_RETRY_BASE_MS = 100;
+const OBSERVE_RETRY_MAX_MS = 5_000;
 
 export async function openRemoteLixBinding(
 	options: RemoteLixServerOptions,
@@ -39,6 +45,7 @@ class RemoteLixBinding implements LixBinding {
 	readonly #fetch: NonNullable<RemoteLixServerOptions["fetch"]>;
 	readonly #headers: RemoteLixServerOptions["headers"];
 	readonly #initialBranchId: string | undefined;
+	readonly #observations = new Set<RemoteObservation>();
 	#activeBranchId = "";
 	#acceptingOperations = true;
 	#operationQueue: Promise<void> = Promise.resolve();
@@ -107,11 +114,27 @@ class RemoteLixBinding implements LixBinding {
 	}
 
 	async observe(
-		_sql: string,
-		_params: NativeLixValue[],
+		sql: string,
+		params: NativeLixValue[],
 	): Promise<ObserveEventsBinding> {
 		this.#assertOpen();
-		throw unsupportedRemoteOperation("observe");
+		return this.#enqueue(async () => {
+			const wireParams = params.map(encodeWireValue);
+			const observation = new RemoteObservation({
+				activeBranchId: () => this.#activeBranchId,
+				openStream: (branchId, signal) =>
+					this.#requestObserveStream(
+						branchId,
+						sql,
+						wireParams,
+						signal,
+					),
+				onClose: () => this.#observations.delete(observation),
+			});
+			this.#observations.add(observation);
+			observation.start();
+			return observation;
+		});
 	}
 
 	async beginTransaction(): Promise<LixTransactionBinding> {
@@ -172,6 +195,7 @@ class RemoteLixBinding implements LixBinding {
 				throw protocolError("switch branch response is invalid");
 			}
 			this.#activeBranchId = options.branchId;
+			for (const observation of this.#observations) observation.restart();
 			return { branchId: options.branchId };
 		});
 	}
@@ -203,7 +227,8 @@ class RemoteLixBinding implements LixBinding {
 	async close(): Promise<void> {
 		if (!this.#acceptingOperations) return this.#operationQueue;
 		this.#acceptingOperations = false;
-		return this.#enqueue(async () => undefined);
+		this.#closeObservations();
+		return this.#enqueue(async () => this.#closeObservations());
 	}
 
 	async #requestJson(path: string, init: RequestInit): Promise<unknown> {
@@ -223,23 +248,8 @@ class RemoteLixBinding implements LixBinding {
 				{ details: { cause: errorMessage(cause) } },
 			);
 		}
+		if (!response.ok) throw await errorFromHttpResponse(response);
 		const text = await response.text();
-		if (!response.ok) {
-			let body: unknown;
-			try {
-				body = JSON.parse(text);
-			} catch {
-				throw remoteError(
-					"LIX_REMOTE_REQUEST_FAILED",
-					`Remote Lix request failed with status ${response.status}`,
-					{
-						status: response.status,
-						details: text.length === 0 ? undefined : { body: text.slice(0, 1000) },
-					},
-				);
-			}
-			throw errorFromResponseBody(body, response.status);
-		}
 		try {
 			return JSON.parse(text);
 		} catch {
@@ -249,10 +259,50 @@ class RemoteLixBinding implements LixBinding {
 		}
 	}
 
+	async #requestObserveStream(
+		branchId: string,
+		sql: string,
+		params: ReturnType<typeof encodeWireValue>[],
+		signal: AbortSignal,
+	): Promise<Response> {
+		let headers: Headers;
+		try {
+			headers = new Headers(await resolveHeaders(this.#headers));
+		} catch (cause) {
+			throw remoteError(
+				"LIX_REMOTE_CONFIGURATION_ERROR",
+				"Remote Lix observation headers could not be resolved",
+				{ details: { cause: errorMessage(cause) } },
+			);
+		}
+		headers.set("accept", "text/event-stream");
+		headers.set("content-type", "application/json");
+		try {
+			return await this.#fetch(new URL("observe", this.#baseUrl), {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ branchId, sql, params }),
+				signal,
+			});
+		} catch (cause) {
+			if (signal.aborted) throw cause;
+			throw remoteError(
+				"LIX_REMOTE_UNAVAILABLE",
+				"The remote Lix observation stream is unavailable",
+				{ details: { cause: errorMessage(cause) } },
+			);
+		}
+	}
+
 	#assertOpen(): void {
 		if (!this.#acceptingOperations) {
 			throw remoteError("LIX_ERROR_CLOSED", "Lix is closed");
 		}
+	}
+
+	#closeObservations(): void {
+		for (const observation of [...this.#observations]) observation.close();
+		this.#observations.clear();
 	}
 
 	#enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -265,10 +315,402 @@ class RemoteLixBinding implements LixBinding {
 	}
 }
 
+type ObserveWaiter = {
+	resolve(value: BindingObserveEvent | undefined): void;
+	reject(error: unknown): void;
+};
+
+type ObserveOutcome =
+	| { ok: true; event: BindingObserveEvent }
+	| { ok: false; error: unknown };
+
+type RemoteObservationOptions = {
+	activeBranchId(): string;
+	openStream(branchId: string, signal: AbortSignal): Promise<Response>;
+	onClose(): void;
+};
+
+class RemoteObservation implements ObserveEventsBinding {
+	readonly #activeBranchId: () => string;
+	readonly #openStream: RemoteObservationOptions["openStream"];
+	readonly #onClose: () => void;
+	#outcomes: ObserveOutcome[] = [];
+	#waiters: ObserveWaiter[] = [];
+	#terminalError: unknown;
+	#lastRows: BindingExecuteResult | undefined;
+	#lastSequence = -1;
+	#controller: AbortController | undefined;
+	#retryTimer: ReturnType<typeof setTimeout> | undefined;
+	#retryAttempt = 0;
+	#serverRetryMs: number | undefined;
+	#generation = 0;
+	#closed = false;
+
+	constructor(options: RemoteObservationOptions) {
+		this.#activeBranchId = options.activeBranchId;
+		this.#openStream = options.openStream;
+		this.#onClose = options.onClose;
+	}
+
+	start(): void {
+		if (
+			this.#closed ||
+			this.#terminalError !== undefined ||
+			this.#controller !== undefined ||
+			this.#retryTimer !== undefined
+		) {
+			return;
+		}
+		const generation = this.#generation;
+		const branchId = this.#activeBranchId();
+		const controller = new AbortController();
+		this.#controller = controller;
+		void this.#consume(generation, branchId, controller);
+	}
+
+	next(): Promise<BindingObserveEvent | undefined> {
+		const outcome = this.#outcomes.shift();
+		if (outcome?.ok) return Promise.resolve(outcome.event);
+		if (outcome) return Promise.reject(outcome.error);
+		if (this.#terminalError !== undefined) {
+			return Promise.reject(this.#terminalError);
+		}
+		if (this.#closed) return Promise.resolve(undefined);
+		return new Promise((resolve, reject) => {
+			this.#waiters.push({ resolve, reject });
+		});
+	}
+
+	restart(): void {
+		if (this.#closed) return;
+		this.#generation += 1;
+		this.#controller?.abort();
+		this.#controller = undefined;
+		if (this.#retryTimer !== undefined) clearTimeout(this.#retryTimer);
+		this.#retryTimer = undefined;
+		this.#retryAttempt = 0;
+		this.#serverRetryMs = undefined;
+		this.#terminalError = undefined;
+		this.#outcomes = [];
+		this.start();
+	}
+
+	close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#generation += 1;
+		this.#controller?.abort();
+		this.#controller = undefined;
+		if (this.#retryTimer !== undefined) clearTimeout(this.#retryTimer);
+		this.#retryTimer = undefined;
+		this.#outcomes = [];
+		this.#terminalError = undefined;
+		for (const waiter of this.#waiters.splice(0)) waiter.resolve(undefined);
+		this.#onClose();
+	}
+
+	async #consume(
+		generation: number,
+		branchId: string,
+		controller: AbortController,
+	): Promise<void> {
+		let reconnect = false;
+		let streamOpened = false;
+		try {
+			const response = await this.#openStream(branchId, controller.signal);
+			if (!this.#isCurrent(generation, controller)) return;
+			streamOpened = true;
+			if (!response.ok) {
+				if (isRetryableObserveStatus(response.status)) {
+					void response.body?.cancel();
+					reconnect = true;
+					return;
+				}
+				const error = await errorFromHttpResponse(response);
+				if (this.#isCurrent(generation, controller)) this.#fail(error);
+				return;
+			}
+			if (!response.body) {
+				this.#fail(protocolError("remote observe response has no body"));
+				return;
+			}
+			const contentType = response.headers.get("content-type") ?? "";
+			if (
+				contentType.split(";", 1)[0]?.trim().toLowerCase() !==
+				"text/event-stream"
+			) {
+				this.#fail(
+					protocolError("remote observe response must be text/event-stream"),
+				);
+				return;
+			}
+			for await (const frame of readSseEvents(response.body)) {
+				if (!this.#isCurrent(generation, controller)) return;
+				if (frame.retry !== undefined) this.#serverRetryMs = frame.retry;
+				if (frame.event === "next") {
+					let event: BindingObserveEvent;
+					try {
+						event = decodeObserveEvent(JSON.parse(frame.data));
+					} catch (error) {
+						this.#fail(asObserveProtocolError(error, "next"));
+						return;
+					}
+					this.#retryAttempt = 0;
+					this.#accept(event);
+				} else if (frame.event === "error") {
+					try {
+						const payload = record(
+							JSON.parse(frame.data),
+							"remote observe error event",
+						);
+						if (
+							payload.retryable !== undefined &&
+							typeof payload.retryable !== "boolean"
+						) {
+							throw protocolError(
+								"remote observe error retryable must be a boolean",
+							);
+						}
+						const error = errorFromResponseBody(payload);
+						if (payload.retryable === true) {
+							this.#pushRecoverableError(error);
+							reconnect = true;
+							controller.abort();
+						} else {
+							this.#fail(error);
+						}
+					} catch (error) {
+						this.#fail(asObserveProtocolError(error, "error"));
+					}
+					return;
+				} else if (frame.event !== "message" || frame.data.length > 0) {
+					this.#fail(
+						protocolError(`unknown remote observe event: ${frame.event}`),
+					);
+					return;
+				}
+			}
+			if (this.#isCurrent(generation, controller)) reconnect = true;
+		} catch (error) {
+			if (
+				!this.#isCurrent(generation, controller) ||
+				controller.signal.aborted
+			) {
+				return;
+			}
+			if (streamOpened || isRetryableObserveError(error)) reconnect = true;
+			else this.#fail(error);
+		} finally {
+			if (this.#isCurrent(generation, controller)) {
+				this.#controller = undefined;
+				if (reconnect) this.#scheduleReconnect(generation);
+			}
+		}
+	}
+
+	#accept(event: BindingObserveEvent): void {
+		if (this.#closed || this.#terminalError !== undefined) return;
+		if (
+			this.#lastRows !== undefined &&
+			executeResultsEqual(this.#lastRows, event.rows)
+		) {
+			return;
+		}
+		const normalized = {
+			sequence: this.#lastSequence + 1,
+			mutationSequence: event.mutationSequence,
+			rows: event.rows,
+		};
+		this.#lastRows = event.rows;
+		this.#lastSequence = normalized.sequence;
+		const waiter = this.#waiters.shift();
+		if (waiter) waiter.resolve(normalized);
+		else {
+			this.#outcomes = this.#outcomes.filter((outcome) => !outcome.ok);
+			this.#outcomes.push({ ok: true, event: normalized });
+		}
+	}
+
+	#pushRecoverableError(error: unknown): void {
+		if (this.#closed || this.#terminalError !== undefined) return;
+		const waiter = this.#waiters.shift();
+		if (waiter) waiter.reject(error);
+		else if (!this.#outcomes.some((outcome) => !outcome.ok)) {
+			this.#outcomes.push({ ok: false, error });
+		}
+	}
+
+	#fail(error: unknown): void {
+		if (this.#closed || this.#terminalError !== undefined) return;
+		this.#terminalError = error;
+		this.#controller?.abort();
+		for (const waiter of this.#waiters.splice(0)) waiter.reject(error);
+	}
+
+	#scheduleReconnect(generation: number): void {
+		if (
+			this.#closed ||
+			this.#terminalError !== undefined ||
+			generation !== this.#generation ||
+			this.#controller !== undefined ||
+			this.#retryTimer !== undefined
+		) {
+			return;
+		}
+		const delay =
+			this.#serverRetryMs === undefined
+				? Math.min(
+						OBSERVE_RETRY_BASE_MS * 2 ** this.#retryAttempt,
+						OBSERVE_RETRY_MAX_MS,
+					)
+				: Math.min(
+						Math.max(this.#serverRetryMs, OBSERVE_RETRY_BASE_MS),
+						OBSERVE_RETRY_MAX_MS,
+					);
+		this.#retryAttempt += 1;
+		this.#retryTimer = setTimeout(() => {
+			this.#retryTimer = undefined;
+			if (generation === this.#generation) this.start();
+		}, delay);
+	}
+
+	#isCurrent(generation: number, controller: AbortController): boolean {
+		return (
+			!this.#closed &&
+			generation === this.#generation &&
+			controller === this.#controller
+		);
+	}
+}
+
 async function resolveHeaders(
 	headers: RemoteLixServerOptions["headers"],
 ): Promise<HeadersInit | undefined> {
 	return typeof headers === "function" ? await headers() : headers;
+}
+
+async function errorFromHttpResponse(response: Response): Promise<Error> {
+	const text = await response.text();
+	try {
+		return errorFromResponseBody(JSON.parse(text), response.status);
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			"status" in error &&
+			(error as { status?: number }).status === response.status
+		) {
+			return error;
+		}
+		return remoteError(
+			"LIX_REMOTE_REQUEST_FAILED",
+			`Remote Lix request failed with status ${response.status}`,
+			{
+				status: response.status,
+				details: text.length === 0 ? undefined : { body: text.slice(0, 1000) },
+			},
+		);
+	}
+}
+
+function isRetryableObserveStatus(status: number): boolean {
+	return status === 408 || status === 429 || status >= 500;
+}
+
+function isRetryableObserveError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		"code" in error &&
+		(error as { code?: string }).code === "LIX_REMOTE_UNAVAILABLE"
+	);
+}
+
+function asObserveProtocolError(error: unknown, event: string): Error {
+	if (
+		error instanceof Error &&
+		"code" in error &&
+		(error as { code?: string }).code === "LIX_REMOTE_PROTOCOL_ERROR"
+	) {
+		return error;
+	}
+	return protocolError(
+		`remote observe ${event} event contains invalid data: ${errorMessage(error)}`,
+	);
+}
+
+function executeResultsEqual(
+	left: BindingExecuteResult,
+	right: BindingExecuteResult,
+): boolean {
+	return (
+		left.rowsAffected === right.rowsAffected &&
+		stringArraysEqual(left.columns, right.columns) &&
+		left.rows.length === right.rows.length &&
+		left.rows.every(
+			(row, rowIndex) =>
+				row.length === right.rows[rowIndex]?.length &&
+				row.every((value, valueIndex) =>
+					nativeValuesEqual(value, right.rows[rowIndex]?.[valueIndex]),
+				),
+		) &&
+		left.notices.length === right.notices.length &&
+		left.notices.every((notice, index) => {
+			const other = right.notices[index];
+			return (
+				notice.code === other?.code &&
+				notice.message === other.message &&
+				notice.hint === other.hint
+			);
+		})
+	);
+}
+
+function nativeValuesEqual(
+	left: NativeLixValue,
+	right: NativeLixValue | undefined,
+): boolean {
+	if (!right || left.kind !== right.kind) return false;
+	switch (left.kind) {
+		case "blob":
+			return (
+				right.kind === "blob" &&
+				left.blob.length === right.blob.length &&
+				left.blob.every((byte, index) => byte === right.blob[index])
+			);
+		case "json":
+			return right.kind === "json" && jsonValuesEqual(left.value, right.value);
+		default:
+			return left.value === right.value;
+	}
+}
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+	if (left === right) return true;
+	if (Array.isArray(left) || Array.isArray(right)) {
+		return (
+			Array.isArray(left) &&
+			Array.isArray(right) &&
+			left.length === right.length &&
+			left.every((value, index) => jsonValuesEqual(value, right[index]))
+		);
+	}
+	if (!left || !right || typeof left !== "object" || typeof right !== "object") {
+		return false;
+	}
+	const leftRecord = left as Record<string, unknown>;
+	const rightRecord = right as Record<string, unknown>;
+	const leftKeys = Object.keys(leftRecord).sort();
+	const rightKeys = Object.keys(rightRecord).sort();
+	return (
+		stringArraysEqual(leftKeys, rightKeys) &&
+		leftKeys.every((key) => jsonValuesEqual(leftRecord[key], rightRecord[key]))
+	);
+}
+
+function stringArraysEqual(left: string[], right: string[]): boolean {
+	return (
+		left.length === right.length &&
+		left.every((value, index) => value === right[index])
+	);
 }
 
 function protocolBaseUrl(value: string | URL): URL {

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -1,0 +1,413 @@
+import { expect, test, vi } from "vitest";
+import { openLix } from "../index.js";
+
+test("remote observe streams native Lix results", async () => {
+	const requests: Request[] = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				requests.push(request.clone());
+				return new URL(request.url).pathname.endsWith("/.lix/v1/")
+					? handshake()
+					: sseResponse(
+							sseFrame("next", observePayload("hello", 0, 7)),
+						);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT $1 AS value", ["hello"]);
+	const initial = await events.next();
+	expect(initial?.sequence).toBe(0);
+	expect(initial?.mutationSequence).toBe(7);
+	expect(initial?.result.rows[0]?.get("value")).toBe("hello");
+	expect(requests[1]?.headers.get("accept")).toBe("text/event-stream");
+	expect(await requests[1]?.json()).toEqual({
+		branchId: "main-id",
+		sql: "SELECT $1 AS value",
+		params: [{ kind: "text", value: "hello" }],
+	});
+
+	events.close();
+	expect(await events.next()).toBeUndefined();
+	await lix.close();
+});
+
+test("remote observe can continue after a semantic SSE error", async () => {
+	vi.useFakeTimers();
+	try {
+		let observeRequests = 0;
+		const lix = await openLix({
+			server: {
+				mode: "remote",
+				url: "https://lixray.test/@acme/workspace",
+				fetch: async (input, init) => {
+					const request = new Request(input, init);
+					if (new URL(request.url).pathname.endsWith("/.lix/v1/")) {
+						return handshake();
+					}
+					observeRequests += 1;
+					return observeRequests === 1
+						? sseResponse(
+								sseFrame("error", {
+									retryable: true,
+									error: {
+										code: "LIX_OBSERVE_RUNTIME",
+										message: "temporary observation failure",
+										hint: "Retry the observation",
+										details: { transient: true },
+									},
+								}),
+							)
+						: heldSseResponse(
+								sseFrame("next", observePayload("recovered", 0, 2)),
+								request.signal,
+							);
+				},
+			},
+		});
+
+		const events = lix.observe("SELECT value");
+		await expect(events.next()).rejects.toMatchObject({
+			name: "LixError",
+			code: "LIX_OBSERVE_RUNTIME",
+			message: "temporary observation failure",
+			hint: "Retry the observation",
+			details: { transient: true },
+		});
+		const recovered = events.next();
+		await vi.advanceTimersByTimeAsync(100);
+		expect((await recovered)?.result.rows[0]?.get("value")).toBe("recovered");
+		expect(observeRequests).toBe(2);
+
+		events.close();
+		await lix.close();
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("remote observe treats unmarked semantic errors as terminal", async () => {
+	let observeRequests = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input) => {
+				if (new URL(input.toString()).pathname.endsWith("/.lix/v1/")) {
+					return handshake();
+				}
+				observeRequests += 1;
+				return sseResponse(
+					sseFrame("error", {
+						error: {
+							code: "LIX_INVALID_SQL",
+							message: "invalid observed query",
+						},
+					}),
+				);
+			},
+		},
+	});
+
+	const events = lix.observe("INVALID");
+	await expect(events.next()).rejects.toMatchObject({
+		code: "LIX_INVALID_SQL",
+	});
+	await expect(events.next()).rejects.toMatchObject({
+		code: "LIX_INVALID_SQL",
+	});
+	expect(observeRequests).toBe(1);
+
+	events.close();
+	await lix.close();
+});
+
+test("a successful branch switch restarts existing remote observations", async () => {
+	const observedBranches: string[] = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/.lix/v1/")) return handshake();
+				if (pathname.endsWith("/branch/switch")) {
+					const body = (await request.json()) as { branchId: string };
+					return body.branchId === "missing-id"
+						? Response.json(
+								{
+									error: {
+										code: "LIX_BRANCH_NOT_FOUND",
+										message: "Branch not found",
+									},
+								},
+								{ status: 404 },
+							)
+						: Response.json({ branchId: body.branchId });
+				}
+				const body = (await request.clone().json()) as { branchId: string };
+				observedBranches.push(body.branchId);
+				return heldSseResponse(
+					sseFrame("next", observePayload(body.branchId, 0, 0)),
+					request.signal,
+				);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT active_branch");
+	expect((await events.next())?.result.rows[0]?.get("value")).toBe("main-id");
+	const afterSwitch = events.next();
+	await lix.switchBranch({ branchId: "draft-id" });
+	const switched = await afterSwitch;
+	expect(switched?.result.rows[0]?.get("value")).toBe("draft-id");
+	expect(switched?.sequence).toBe(1);
+	expect(observedBranches).toEqual(["main-id", "draft-id"]);
+	await expect(
+		lix.switchBranch({ branchId: "missing-id" }),
+	).rejects.toMatchObject({ code: "LIX_BRANCH_NOT_FOUND" });
+	expect(observedBranches).toEqual(["main-id", "draft-id"]);
+
+	events.close();
+	await lix.close();
+});
+
+test("a stale pre-switch HTTP error cannot fail the restarted observation", async () => {
+	const firstObserveOpened = deferred<void>();
+	let staleBody: ReadableStreamDefaultController<Uint8Array> | undefined;
+	let observeRequests = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/.lix/v1/")) return handshake();
+				if (pathname.endsWith("/branch/switch")) {
+					return Response.json({ branchId: "draft-id" });
+				}
+				observeRequests += 1;
+				if (observeRequests === 1) {
+					firstObserveOpened.resolve();
+					return new Response(
+						new ReadableStream<Uint8Array>({
+							start(controller) {
+								staleBody = controller;
+							},
+						}),
+						{
+							status: 400,
+							headers: { "content-type": "application/json" },
+						},
+					);
+				}
+				return heldSseResponse(
+					sseFrame("next", observePayload("draft", 0, 1)),
+					request.signal,
+				);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT value");
+	const first = events.next();
+	await firstObserveOpened.promise;
+	await lix.switchBranch({ branchId: "draft-id" });
+	expect((await first)?.result.rows[0]?.get("value")).toBe("draft");
+	staleBody?.enqueue(
+		new TextEncoder().encode(
+			JSON.stringify({
+				error: { code: "LIX_STALE", message: "stale main error" },
+			}),
+		),
+	);
+	staleBody?.close();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	const later = events.next();
+	const state = await Promise.race([
+		later.then(
+			() => "resolved",
+			() => "rejected",
+		),
+		new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 0)),
+	]);
+	expect(state).toBe("pending");
+	events.close();
+	expect(await later).toBeUndefined();
+	await lix.close();
+});
+
+test("remote observe reconnects retryable failures with fresh headers", async () => {
+	vi.useFakeTimers();
+	try {
+		let headerCalls = 0;
+		let observeRequests = 0;
+		const observedAuthorization: Array<string | null> = [];
+		const lix = await openLix({
+			server: {
+				mode: "remote",
+				url: "https://lixray.test/@acme/workspace",
+				headers: () => ({ Authorization: `Bearer token-${++headerCalls}` }),
+				fetch: async (input, init) => {
+					const request = new Request(input, init);
+					if (new URL(request.url).pathname.endsWith("/.lix/v1/")) {
+						return handshake();
+					}
+					observeRequests += 1;
+					observedAuthorization.push(request.headers.get("authorization"));
+					if (observeRequests <= 2) {
+						return sseResponse(
+							sseFrame("next", observePayload("first", 0, 0), 25),
+						);
+					}
+					return heldSseResponse(
+						sseFrame("next", observePayload("second", 0, 0)),
+						request.signal,
+					);
+				},
+			},
+		});
+
+		const events = lix.observe("SELECT value");
+		expect((await events.next())?.result.rows[0]?.get("value")).toBe("first");
+		const afterReconnect = events.next();
+		await Promise.resolve();
+		await Promise.resolve();
+		await vi.advanceTimersByTimeAsync(200);
+		const reconnected = await afterReconnect;
+		expect(reconnected?.result.rows[0]?.get("value")).toBe("second");
+		expect(reconnected?.sequence).toBe(1);
+		expect(reconnected?.mutationSequence).toBe(0);
+		expect(observedAuthorization).toEqual([
+			"Bearer token-2",
+			"Bearer token-3",
+			"Bearer token-4",
+		]);
+
+		events.close();
+		await lix.close();
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test("closing Lix resolves pending remote observation reads", async () => {
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				return new URL(request.url).pathname.endsWith("/.lix/v1/")
+					? handshake()
+					: heldSseResponse("", request.signal);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT value");
+	const pending = events.next();
+	await lix.close();
+	expect(await pending).toBeUndefined();
+	expect(await events.next()).toBeUndefined();
+});
+
+test("closing Lix stops observations before an earlier finite request settles", async () => {
+	const executeStarted = deferred<void>();
+	const releaseExecute = deferred<void>();
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/.lix/v1/")) return handshake();
+				if (pathname.endsWith("/observe")) {
+					return heldSseResponse("", request.signal);
+				}
+				executeStarted.resolve();
+				await releaseExecute.promise;
+				return Response.json({
+					columns: [],
+					rows: [],
+					rowsAffected: 0,
+					notices: [],
+				});
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT value");
+	const pendingEvent = events.next();
+	const executing = lix.execute("SELECT blocked");
+	await executeStarted.promise;
+	const closing = lix.close();
+	expect(await pendingEvent).toBeUndefined();
+	releaseExecute.resolve();
+	await Promise.all([executing, closing]);
+});
+
+function handshake(): Response {
+	return Response.json({ protocolVersion: 1, activeBranchId: "main-id" });
+}
+
+function observePayload(value: string, sequence: number, mutationSequence: number) {
+	return {
+		sequence,
+		mutationSequence,
+		result: {
+			columns: ["value"],
+			rows: [[{ kind: "text", value }]],
+			rowsAffected: 0,
+			notices: [],
+		},
+	};
+}
+
+function sseFrame(event: string, value: unknown, retry?: number): string {
+	return `${retry === undefined ? "" : `retry: ${retry}\n`}event: ${event}\ndata: ${JSON.stringify(value)}\n\n`;
+}
+
+function sseResponse(body: string): Response {
+	return new Response(body, {
+		headers: { "content-type": "text/event-stream; charset=utf-8" },
+	});
+}
+
+function heldSseResponse(body: string, signal: AbortSignal): Response {
+	const encoded = new TextEncoder().encode(body);
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				if (encoded.length > 0) controller.enqueue(encoded);
+				const abort = () => {
+					try {
+						controller.error(new DOMException("Aborted", "AbortError"));
+					} catch {
+						// The consumer already released the stream.
+					}
+				};
+				if (signal.aborted) abort();
+				else signal.addEventListener("abort", abort, { once: true });
+			},
+		}),
+		{ headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -1,4 +1,7 @@
-import type { BindingExecuteResult } from "../binding-types.js";
+import type {
+	BindingExecuteResult,
+	BindingObserveEvent,
+} from "../binding-types.js";
 import type { NativeLixValue } from "../value.js";
 
 export const REMOTE_PROTOCOL_VERSION = 1;
@@ -64,6 +67,10 @@ export type RemoteErrorBody = {
 		hint?: string;
 		details?: unknown;
 	};
+};
+
+export type RemoteObserveErrorEvent = RemoteErrorBody & {
+	retryable?: boolean;
 };
 
 export function encodeWireValue(value: NativeLixValue): WireValue {
@@ -154,6 +161,33 @@ export function decodeHandshake(value: unknown): RemoteHandshake {
 	};
 }
 
+export function decodeObserveEvent(value: unknown): BindingObserveEvent {
+	const event = record(value, "observe event");
+	if (
+		typeof event.sequence !== "number" ||
+		!Number.isSafeInteger(event.sequence) ||
+		event.sequence < 0
+	) {
+		throw protocolError(
+			"observe event sequence must be a non-negative safe integer",
+		);
+	}
+	if (
+		typeof event.mutationSequence !== "number" ||
+		!Number.isSafeInteger(event.mutationSequence) ||
+		event.mutationSequence < 0
+	) {
+		throw protocolError(
+			"observe event mutationSequence must be a non-negative safe integer",
+		);
+	}
+	return {
+		sequence: event.sequence,
+		mutationSequence: event.mutationSequence,
+		rows: decodeExecuteResult(event.result),
+	};
+}
+
 export function remoteError(
 	code: string,
 	message: string,
@@ -184,7 +218,7 @@ export function protocolError(message: string): Error & { code: string } {
 
 export function errorFromResponseBody(
 	value: unknown,
-	status: number,
+	status?: number,
 ): Error & { code: string } {
 	const body = record(value, "remote error response");
 	const rawError = record(body.error, "remote error response error");
@@ -194,7 +228,9 @@ export function errorFromResponseBody(
 			: "LIX_REMOTE_REQUEST_FAILED",
 		typeof rawError.message === "string"
 			? rawError.message
-			: `Remote Lix request failed with status ${status}`,
+			: status === undefined
+				? "Remote Lix operation failed"
+				: `Remote Lix request failed with status ${status}`,
 		{
 			hint: typeof rawError.hint === "string" ? rawError.hint : undefined,
 			details: rawError.details,

--- a/packages/js-sdk/src/remote/sse.test.ts
+++ b/packages/js-sdk/src/remote/sse.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "vitest";
+import { readSseEvents } from "./sse.js";
+
+test("parses SSE fields and ignores comments, IDs, and unknown fields", async () => {
+	const events = await collect(
+		streamFromText(
+			": connected\n" +
+				"id: invisible\n" +
+				"event: next\n" +
+				"retry: 1500\n" +
+				"data: first line\n" +
+				"data:second line\n" +
+				"extension: ignored\n" +
+				"\n" +
+				": keepalive\n\n" +
+				"data\n\n" +
+				"event: custom\r\n" +
+				"retry: nope\r\n" +
+				"retry: -1\r\n" +
+				"data: last\r\n\r\n",
+		),
+	);
+
+	expect(events).toEqual([
+		{
+			event: "next",
+			data: "first line\nsecond line",
+			retry: 1500,
+		},
+		{ event: "message", data: "" },
+		{ event: "custom", data: "last" },
+	]);
+});
+
+test("handles CRLF, UTF-8, and every possible byte chunk boundary", async () => {
+	const bytes = new TextEncoder().encode(
+		"event: unicode\r\ndata: café 😀\r\ndata: tail\r\n\r\n",
+	);
+	const events = await collect(
+		streamFromBytes(Array.from(bytes, (byte) => new Uint8Array([byte]))),
+	);
+
+	expect(events).toEqual([
+		{ event: "unicode", data: "café 😀\ntail" },
+	]);
+});
+
+test("discards an unterminated final event at EOF", async () => {
+	const events = await collect(
+		streamFromText(
+			": comment\nid: ignored\nevent: final\ndata: one\ndata: two",
+		),
+	);
+
+	expect(events).toEqual([]);
+});
+
+test("does not dispatch comments, keepalives, or field-only blocks", async () => {
+	const events = await collect(
+		streamFromText(
+			": one\n\n: two\r\n\r\nid: ignored\n\nevent: unused\n\nretry: 20\n\n",
+		),
+	);
+
+	expect(events).toEqual([]);
+});
+
+async function collect(
+	stream: ReadableStream<Uint8Array>,
+): Promise<Array<{ event: string; data: string; retry?: number }>> {
+	const events = [];
+	for await (const event of readSseEvents(stream)) events.push(event);
+	return events;
+}
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+	return streamFromBytes([new TextEncoder().encode(text)]);
+}
+
+function streamFromBytes(
+	chunks: Uint8Array[],
+): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}

--- a/packages/js-sdk/src/remote/sse.ts
+++ b/packages/js-sdk/src/remote/sse.ts
@@ -1,0 +1,96 @@
+export type SseEvent = {
+	event: string;
+	data: string;
+	retry?: number;
+};
+
+/**
+ * Parses a fetch response body as a stream of server-sent events.
+ *
+ * The caller remains responsible for validating the response status and
+ * content type before passing its body here.
+ */
+export async function* readSseEvents(
+	stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<SseEvent, void, void> {
+	const decoder = new TextDecoder();
+	const reader = stream.getReader();
+	let bufferedText = "";
+	let eventName = "";
+	let retry: number | undefined;
+	let dataLines: string[] = [];
+
+	function processLine(line: string): SseEvent | undefined {
+		if (line.length === 0) {
+			return dispatchEvent();
+		}
+		if (line.startsWith(":")) {
+			return undefined;
+		}
+
+		const colonIndex = line.indexOf(":");
+		const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+		let value = colonIndex === -1 ? "" : line.slice(colonIndex + 1);
+		if (value.startsWith(" ")) value = value.slice(1);
+
+		switch (field) {
+			case "event":
+				eventName = value;
+				break;
+			case "data":
+				dataLines.push(value);
+				break;
+			case "retry": {
+				if (/^\d+$/.test(value)) {
+					const parsed = Number(value);
+					if (Number.isSafeInteger(parsed)) retry = parsed;
+				}
+				break;
+			}
+			// Event IDs and extension fields are intentionally ignored. Remote Lix
+			// observations use their payload sequence for resumption instead.
+			default:
+				break;
+		}
+		return undefined;
+	}
+
+	function dispatchEvent(): SseEvent | undefined {
+		const hasData = dataLines.length !== 0;
+		const event: SseEvent | undefined = hasData
+			? {
+					event: eventName.length === 0 ? "message" : eventName,
+					data: dataLines.join("\n"),
+					...(retry === undefined ? {} : { retry }),
+				}
+			: undefined;
+		eventName = "";
+		retry = undefined;
+		dataLines = [];
+		return event;
+	}
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			bufferedText += decoder.decode(value, { stream: true });
+
+			let newlineIndex = bufferedText.indexOf("\n");
+			while (newlineIndex !== -1) {
+				let line = bufferedText.slice(0, newlineIndex);
+				bufferedText = bufferedText.slice(newlineIndex + 1);
+				if (line.endsWith("\r")) line = line.slice(0, -1);
+				const event = processLine(line);
+				if (event !== undefined) yield event;
+				newlineIndex = bufferedText.indexOf("\n");
+			}
+		}
+
+		decoder.decode();
+		// SSE dispatches only at a blank line. An incomplete final frame indicates
+		// a truncated connection and is deliberately left for the caller to retry.
+	} finally {
+		reader.releaseLock();
+	}
+}


### PR DESCRIPTION
## Summary
- stream remote query observations over the canonical SSE endpoint
- reconnect transient failures with fresh authentication headers and deduplicate snapshots
- restart observations after successful branch switches and close them with the Lix instance
- distinguish terminal query errors from explicitly retryable server errors

## Validation
- npm run build:ts
- npm run typecheck
- npx vitest run src/open-lix.test.ts src/remote/observe.test.ts src/remote/sse.test.ts src/remote/client.test.ts (84 tests)
- git diff --check

## Stack
- depends on #611
