### PR TITLE
Multiplex remote Lix observations

### DIFF
--- a/.changenotes/multiplex-remote-lix-observe.md
+++ b/.changenotes/multiplex-remote-lix-observe.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Remote Lix clients now multiplex live query observations over one server stream.
+
+Multiple `lix.observe()` calls no longer consume one HTTP connection each, so thin clients can keep executing queries while many observations are active.

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -26,6 +26,7 @@ import {
 	protocolError,
 	record,
 	remoteError,
+	type RemoteObserveSubscription,
 } from "./protocol.js";
 import { readSseEvents } from "./sse.js";
 
@@ -45,7 +46,7 @@ class RemoteLixBinding implements LixBinding {
 	readonly #fetch: NonNullable<RemoteLixServerOptions["fetch"]>;
 	readonly #headers: RemoteLixServerOptions["headers"];
 	readonly #initialBranchId: string | undefined;
-	readonly #observations = new Set<RemoteObservation>();
+	readonly #observationHub: RemoteObservationHub;
 	#activeBranchId = "";
 	#acceptingOperations = true;
 	#operationQueue: Promise<void> = Promise.resolve();
@@ -82,6 +83,11 @@ class RemoteLixBinding implements LixBinding {
 		}
 		this.#headers = options.headers;
 		this.#initialBranchId = options.branchId;
+		this.#observationHub = new RemoteObservationHub({
+			activeBranchId: () => this.#activeBranchId,
+			openStream: (branchId, subscriptions, signal) =>
+				this.#requestObserveStream(branchId, subscriptions, signal),
+		});
 	}
 
 	async open(): Promise<void> {
@@ -118,23 +124,9 @@ class RemoteLixBinding implements LixBinding {
 		params: NativeLixValue[],
 	): Promise<ObserveEventsBinding> {
 		this.#assertOpen();
-		return this.#enqueue(async () => {
-			const wireParams = params.map(encodeWireValue);
-			const observation = new RemoteObservation({
-				activeBranchId: () => this.#activeBranchId,
-				openStream: (branchId, signal) =>
-					this.#requestObserveStream(
-						branchId,
-						sql,
-						wireParams,
-						signal,
-					),
-				onClose: () => this.#observations.delete(observation),
-			});
-			this.#observations.add(observation);
-			observation.start();
-			return observation;
-		});
+		return this.#enqueue(async () =>
+			this.#observationHub.observe(sql, params.map(encodeWireValue)),
+		);
 	}
 
 	async beginTransaction(): Promise<LixTransactionBinding> {
@@ -195,7 +187,7 @@ class RemoteLixBinding implements LixBinding {
 				throw protocolError("switch branch response is invalid");
 			}
 			this.#activeBranchId = options.branchId;
-			for (const observation of this.#observations) observation.restart();
+			this.#observationHub.restart();
 			return { branchId: options.branchId };
 		});
 	}
@@ -227,8 +219,8 @@ class RemoteLixBinding implements LixBinding {
 	async close(): Promise<void> {
 		if (!this.#acceptingOperations) return this.#operationQueue;
 		this.#acceptingOperations = false;
-		this.#closeObservations();
-		return this.#enqueue(async () => this.#closeObservations());
+		this.#observationHub.close();
+		return this.#enqueue(async () => this.#observationHub.close());
 	}
 
 	async #requestJson(path: string, init: RequestInit): Promise<unknown> {
@@ -261,8 +253,7 @@ class RemoteLixBinding implements LixBinding {
 
 	async #requestObserveStream(
 		branchId: string,
-		sql: string,
-		params: ReturnType<typeof encodeWireValue>[],
+		subscriptions: RemoteObserveSubscription[],
 		signal: AbortSignal,
 	): Promise<Response> {
 		let headers: Headers;
@@ -278,10 +269,10 @@ class RemoteLixBinding implements LixBinding {
 		headers.set("accept", "text/event-stream");
 		headers.set("content-type", "application/json");
 		try {
-			return await this.#fetch(new URL("observe", this.#baseUrl), {
+			return await this.#fetch(new URL("observe/multiplex", this.#baseUrl), {
 				method: "POST",
 				headers,
-				body: JSON.stringify({ branchId, sql, params }),
+				body: JSON.stringify({ branchId, subscriptions }),
 				signal,
 			});
 		} catch (cause) {
@@ -298,11 +289,6 @@ class RemoteLixBinding implements LixBinding {
 		if (!this.#acceptingOperations) {
 			throw remoteError("LIX_ERROR_CLOSED", "Lix is closed");
 		}
-	}
-
-	#closeObservations(): void {
-		for (const observation of [...this.#observations]) observation.close();
-		this.#observations.clear();
 	}
 
 	#enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -324,21 +310,20 @@ type ObserveOutcome =
 	| { ok: true; event: BindingObserveEvent }
 	| { ok: false; error: unknown };
 
-type RemoteObservationOptions = {
+type RemoteObservationHubOptions = {
 	activeBranchId(): string;
-	openStream(branchId: string, signal: AbortSignal): Promise<Response>;
-	onClose(): void;
+	openStream(
+		branchId: string,
+		subscriptions: RemoteObserveSubscription[],
+		signal: AbortSignal,
+	): Promise<Response>;
 };
 
-class RemoteObservation implements ObserveEventsBinding {
+class RemoteObservationHub {
 	readonly #activeBranchId: () => string;
-	readonly #openStream: RemoteObservationOptions["openStream"];
-	readonly #onClose: () => void;
-	#outcomes: ObserveOutcome[] = [];
-	#waiters: ObserveWaiter[] = [];
-	#terminalError: unknown;
-	#lastRows: BindingExecuteResult | undefined;
-	#lastSequence = -1;
+	readonly #openStream: RemoteObservationHubOptions["openStream"];
+	readonly #observations = new Map<string, RemoteObservation>();
+	#nextObservationId = 0;
 	#controller: AbortController | undefined;
 	#retryTimer: ReturnType<typeof setTimeout> | undefined;
 	#retryAttempt = 0;
@@ -346,26 +331,295 @@ class RemoteObservation implements ObserveEventsBinding {
 	#generation = 0;
 	#closed = false;
 
-	constructor(options: RemoteObservationOptions) {
+	constructor(options: RemoteObservationHubOptions) {
 		this.#activeBranchId = options.activeBranchId;
 		this.#openStream = options.openStream;
-		this.#onClose = options.onClose;
 	}
 
-	start(): void {
+	observe(
+		sql: string,
+		params: RemoteObserveSubscription["params"],
+	): RemoteObservation {
+		const id = `observe-${++this.#nextObservationId}`;
+		const observation = new RemoteObservation({
+			id,
+			sql,
+			params,
+			onClose: () => {
+				this.#observations.delete(id);
+				this.#restartStream();
+			},
+		});
+		this.#observations.set(id, observation);
+		this.#restartStream();
+		return observation;
+	}
+
+	restart(): void {
+		if (this.#closed) return;
+		for (const observation of this.#observations.values()) {
+			observation.restart();
+		}
+		this.#restartStream();
+	}
+
+	close(): void {
+		if (!this.#closed) {
+			this.#closed = true;
+			this.#stopStream();
+		}
+		for (const observation of [...this.#observations.values()]) {
+			observation.close();
+		}
+		this.#observations.clear();
+	}
+
+	#restartStream(): void {
+		this.#stopStream();
+		this.#startStream();
+	}
+
+	#startStream(): void {
 		if (
 			this.#closed ||
-			this.#terminalError !== undefined ||
+			this.#observations.size === 0 ||
 			this.#controller !== undefined ||
 			this.#retryTimer !== undefined
 		) {
 			return;
 		}
 		const generation = this.#generation;
-		const branchId = this.#activeBranchId();
 		const controller = new AbortController();
 		this.#controller = controller;
-		void this.#consume(generation, branchId, controller);
+		void this.#consume(generation, controller);
+	}
+
+	#stopStream(): void {
+		this.#generation += 1;
+		this.#controller?.abort();
+		this.#controller = undefined;
+		if (this.#retryTimer !== undefined) clearTimeout(this.#retryTimer);
+		this.#retryTimer = undefined;
+		this.#retryAttempt = 0;
+		this.#serverRetryMs = undefined;
+	}
+
+	async #consume(
+		generation: number,
+		controller: AbortController,
+	): Promise<void> {
+		let reconnect = false;
+		let streamOpened = false;
+		try {
+			const response = await this.#openStream(
+				this.#activeBranchId(),
+				[...this.#observations.values()].map((observation) =>
+					observation.request(),
+				),
+				controller.signal,
+			);
+			if (!this.#isCurrent(generation, controller)) return;
+			streamOpened = true;
+			if (!response.ok) {
+				if (isRetryableObserveStatus(response.status)) {
+					void response.body?.cancel();
+					reconnect = true;
+					return;
+				}
+				const error = await errorFromHttpResponse(response);
+				if (this.#isCurrent(generation, controller)) {
+					this.#failStream(error, controller);
+				}
+				return;
+			}
+			if (!response.body) {
+				this.#failStream(
+					protocolError("remote observe response has no body"),
+					controller,
+				);
+				return;
+			}
+			const contentType = response.headers.get("content-type") ?? "";
+			if (
+				contentType.split(";", 1)[0]?.trim().toLowerCase() !==
+				"text/event-stream"
+			) {
+				this.#failStream(
+					protocolError("remote observe response must be text/event-stream"),
+					controller,
+				);
+				return;
+			}
+			for await (const frame of readSseEvents(response.body)) {
+				if (!this.#isCurrent(generation, controller)) return;
+				if (frame.retry !== undefined) this.#serverRetryMs = frame.retry;
+				if (frame.event === "next") {
+					try {
+						const payload = record(
+							JSON.parse(frame.data),
+							"remote multiplex observe next event",
+						);
+						const observation = this.#observation(payload.subscriptionId);
+						observation.accept(decodeObserveEvent(payload));
+						this.#retryAttempt = 0;
+					} catch (error) {
+						this.#failStream(
+							asObserveProtocolError(error, "next"),
+							controller,
+						);
+						return;
+					}
+				} else if (frame.event === "error") {
+					try {
+						const payload = record(
+							JSON.parse(frame.data),
+							"remote multiplex observe error event",
+						);
+						if (
+							payload.retryable !== undefined &&
+							typeof payload.retryable !== "boolean"
+						) {
+							throw protocolError(
+								"remote observe error retryable must be a boolean",
+							);
+						}
+						const error = errorFromResponseBody(payload);
+						if (payload.subscriptionId !== undefined) {
+							const observation = this.#observation(payload.subscriptionId);
+							if (payload.retryable === true) {
+								observation.recover(error);
+								reconnect = true;
+								controller.abort();
+								return;
+							}
+							observation.fail(error);
+							continue;
+						}
+						if (payload.retryable === true) {
+							for (const observation of this.#observations.values()) {
+								observation.recover(error);
+							}
+							reconnect = true;
+							controller.abort();
+						} else {
+							this.#failStream(error, controller);
+						}
+					} catch (error) {
+						this.#failStream(
+							asObserveProtocolError(error, "error"),
+							controller,
+						);
+					}
+					return;
+				} else if (frame.event !== "message" || frame.data.length > 0) {
+					this.#failStream(
+						protocolError(`unknown remote observe event: ${frame.event}`),
+						controller,
+					);
+					return;
+				}
+			}
+			if (this.#isCurrent(generation, controller)) reconnect = true;
+		} catch (error) {
+			if (
+				!this.#isCurrent(generation, controller) ||
+				controller.signal.aborted
+			) {
+				return;
+			}
+			if (streamOpened || isRetryableObserveError(error)) reconnect = true;
+			else this.#failStream(error, controller);
+		} finally {
+			if (this.#isCurrent(generation, controller)) {
+				this.#controller = undefined;
+				if (reconnect) this.#scheduleReconnect(generation);
+			}
+		}
+	}
+
+	#observation(id: unknown): RemoteObservation {
+		if (typeof id !== "string" || id.length === 0) {
+			throw protocolError("remote observe event requires subscriptionId");
+		}
+		const observation = this.#observations.get(id);
+		if (!observation) {
+			throw protocolError(`unknown remote observe subscription: ${id}`);
+		}
+		return observation;
+	}
+
+	#failAll(error: unknown): void {
+		for (const observation of this.#observations.values()) {
+			observation.fail(error);
+		}
+	}
+
+	#failStream(error: unknown, controller: AbortController): void {
+		this.#failAll(error);
+		controller.abort();
+	}
+
+	#scheduleReconnect(generation: number): void {
+		if (
+			this.#closed ||
+			this.#observations.size === 0 ||
+			generation !== this.#generation ||
+			this.#controller !== undefined ||
+			this.#retryTimer !== undefined
+		) {
+			return;
+		}
+		const delay =
+			this.#serverRetryMs === undefined
+				? Math.min(
+						OBSERVE_RETRY_BASE_MS * 2 ** this.#retryAttempt,
+						OBSERVE_RETRY_MAX_MS,
+					)
+				: Math.min(
+						Math.max(this.#serverRetryMs, OBSERVE_RETRY_BASE_MS),
+						OBSERVE_RETRY_MAX_MS,
+					);
+		this.#retryAttempt += 1;
+		this.#retryTimer = setTimeout(() => {
+			this.#retryTimer = undefined;
+			if (generation === this.#generation) this.#startStream();
+		}, delay);
+	}
+
+	#isCurrent(generation: number, controller: AbortController): boolean {
+		return (
+			!this.#closed &&
+			generation === this.#generation &&
+			controller === this.#controller
+		);
+	}
+}
+
+type RemoteObservationOptions = RemoteObserveSubscription & {
+	onClose(): void;
+};
+
+class RemoteObservation implements ObserveEventsBinding {
+	readonly #id: string;
+	readonly #sql: string;
+	readonly #params: RemoteObserveSubscription["params"];
+	readonly #onClose: () => void;
+	#outcomes: ObserveOutcome[] = [];
+	#waiters: ObserveWaiter[] = [];
+	#terminalError: unknown;
+	#lastRows: BindingExecuteResult | undefined;
+	#lastSequence = -1;
+	#closed = false;
+
+	constructor(options: RemoteObservationOptions) {
+		this.#id = options.id;
+		this.#sql = options.sql;
+		this.#params = options.params;
+		this.#onClose = options.onClose;
+	}
+
+	request(): RemoteObserveSubscription {
+		return { id: this.#id, sql: this.#sql, params: this.#params };
 	}
 
 	next(): Promise<BindingObserveEvent | undefined> {
@@ -383,132 +637,20 @@ class RemoteObservation implements ObserveEventsBinding {
 
 	restart(): void {
 		if (this.#closed) return;
-		this.#generation += 1;
-		this.#controller?.abort();
-		this.#controller = undefined;
-		if (this.#retryTimer !== undefined) clearTimeout(this.#retryTimer);
-		this.#retryTimer = undefined;
-		this.#retryAttempt = 0;
-		this.#serverRetryMs = undefined;
 		this.#terminalError = undefined;
 		this.#outcomes = [];
-		this.start();
 	}
 
 	close(): void {
 		if (this.#closed) return;
 		this.#closed = true;
-		this.#generation += 1;
-		this.#controller?.abort();
-		this.#controller = undefined;
-		if (this.#retryTimer !== undefined) clearTimeout(this.#retryTimer);
-		this.#retryTimer = undefined;
 		this.#outcomes = [];
 		this.#terminalError = undefined;
 		for (const waiter of this.#waiters.splice(0)) waiter.resolve(undefined);
 		this.#onClose();
 	}
 
-	async #consume(
-		generation: number,
-		branchId: string,
-		controller: AbortController,
-	): Promise<void> {
-		let reconnect = false;
-		let streamOpened = false;
-		try {
-			const response = await this.#openStream(branchId, controller.signal);
-			if (!this.#isCurrent(generation, controller)) return;
-			streamOpened = true;
-			if (!response.ok) {
-				if (isRetryableObserveStatus(response.status)) {
-					void response.body?.cancel();
-					reconnect = true;
-					return;
-				}
-				const error = await errorFromHttpResponse(response);
-				if (this.#isCurrent(generation, controller)) this.#fail(error);
-				return;
-			}
-			if (!response.body) {
-				this.#fail(protocolError("remote observe response has no body"));
-				return;
-			}
-			const contentType = response.headers.get("content-type") ?? "";
-			if (
-				contentType.split(";", 1)[0]?.trim().toLowerCase() !==
-				"text/event-stream"
-			) {
-				this.#fail(
-					protocolError("remote observe response must be text/event-stream"),
-				);
-				return;
-			}
-			for await (const frame of readSseEvents(response.body)) {
-				if (!this.#isCurrent(generation, controller)) return;
-				if (frame.retry !== undefined) this.#serverRetryMs = frame.retry;
-				if (frame.event === "next") {
-					let event: BindingObserveEvent;
-					try {
-						event = decodeObserveEvent(JSON.parse(frame.data));
-					} catch (error) {
-						this.#fail(asObserveProtocolError(error, "next"));
-						return;
-					}
-					this.#retryAttempt = 0;
-					this.#accept(event);
-				} else if (frame.event === "error") {
-					try {
-						const payload = record(
-							JSON.parse(frame.data),
-							"remote observe error event",
-						);
-						if (
-							payload.retryable !== undefined &&
-							typeof payload.retryable !== "boolean"
-						) {
-							throw protocolError(
-								"remote observe error retryable must be a boolean",
-							);
-						}
-						const error = errorFromResponseBody(payload);
-						if (payload.retryable === true) {
-							this.#pushRecoverableError(error);
-							reconnect = true;
-							controller.abort();
-						} else {
-							this.#fail(error);
-						}
-					} catch (error) {
-						this.#fail(asObserveProtocolError(error, "error"));
-					}
-					return;
-				} else if (frame.event !== "message" || frame.data.length > 0) {
-					this.#fail(
-						protocolError(`unknown remote observe event: ${frame.event}`),
-					);
-					return;
-				}
-			}
-			if (this.#isCurrent(generation, controller)) reconnect = true;
-		} catch (error) {
-			if (
-				!this.#isCurrent(generation, controller) ||
-				controller.signal.aborted
-			) {
-				return;
-			}
-			if (streamOpened || isRetryableObserveError(error)) reconnect = true;
-			else this.#fail(error);
-		} finally {
-			if (this.#isCurrent(generation, controller)) {
-				this.#controller = undefined;
-				if (reconnect) this.#scheduleReconnect(generation);
-			}
-		}
-	}
-
-	#accept(event: BindingObserveEvent): void {
+	accept(event: BindingObserveEvent): void {
 		if (this.#closed || this.#terminalError !== undefined) return;
 		if (
 			this.#lastRows !== undefined &&
@@ -531,7 +673,7 @@ class RemoteObservation implements ObserveEventsBinding {
 		}
 	}
 
-	#pushRecoverableError(error: unknown): void {
+	recover(error: unknown): void {
 		if (this.#closed || this.#terminalError !== undefined) return;
 		const waiter = this.#waiters.shift();
 		if (waiter) waiter.reject(error);
@@ -540,46 +682,10 @@ class RemoteObservation implements ObserveEventsBinding {
 		}
 	}
 
-	#fail(error: unknown): void {
+	fail(error: unknown): void {
 		if (this.#closed || this.#terminalError !== undefined) return;
 		this.#terminalError = error;
-		this.#controller?.abort();
 		for (const waiter of this.#waiters.splice(0)) waiter.reject(error);
-	}
-
-	#scheduleReconnect(generation: number): void {
-		if (
-			this.#closed ||
-			this.#terminalError !== undefined ||
-			generation !== this.#generation ||
-			this.#controller !== undefined ||
-			this.#retryTimer !== undefined
-		) {
-			return;
-		}
-		const delay =
-			this.#serverRetryMs === undefined
-				? Math.min(
-						OBSERVE_RETRY_BASE_MS * 2 ** this.#retryAttempt,
-						OBSERVE_RETRY_MAX_MS,
-					)
-				: Math.min(
-						Math.max(this.#serverRetryMs, OBSERVE_RETRY_BASE_MS),
-						OBSERVE_RETRY_MAX_MS,
-					);
-		this.#retryAttempt += 1;
-		this.#retryTimer = setTimeout(() => {
-			this.#retryTimer = undefined;
-			if (generation === this.#generation) this.start();
-		}, delay);
-	}
-
-	#isCurrent(generation: number, controller: AbortController): boolean {
-		return (
-			!this.#closed &&
-			generation === this.#generation &&
-			controller === this.#controller
-		);
 	}
 }
 

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -13,7 +13,10 @@ test("remote observe streams native Lix results", async () => {
 				return new URL(request.url).pathname.endsWith("/.lix/v1/")
 					? handshake()
 					: sseResponse(
-							sseFrame("next", observePayload("hello", 0, 7)),
+							sseFrame(
+								"next",
+								multiplexObservePayload("observe-1", "hello", 0, 7),
+							),
 						);
 			},
 		},
@@ -25,15 +28,159 @@ test("remote observe streams native Lix results", async () => {
 	expect(initial?.mutationSequence).toBe(7);
 	expect(initial?.result.rows[0]?.get("value")).toBe("hello");
 	expect(requests[1]?.headers.get("accept")).toBe("text/event-stream");
+	expect(new URL(requests[1]?.url ?? "").pathname).toBe(
+		"/@acme/workspace/.lix/v1/observe/multiplex",
+	);
 	expect(await requests[1]?.json()).toEqual({
 		branchId: "main-id",
-		sql: "SELECT $1 AS value",
-		params: [{ kind: "text", value: "hello" }],
+		subscriptions: [
+			{
+				id: "observe-1",
+				sql: "SELECT $1 AS value",
+				params: [{ kind: "text", value: "hello" }],
+			},
+		],
 	});
 
 	events.close();
 	expect(await events.next()).toBeUndefined();
 	await lix.close();
+});
+
+test("remote observe multiplexes more than six subscriptions without blocking execute", async () => {
+	const observeRequests: Request[] = [];
+	let liveObserveRequests = 0;
+	let maximumLiveObserveRequests = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/.lix/v1/")) return handshake();
+				if (pathname.endsWith("/execute")) {
+					return Response.json({
+						columns: ["value"],
+						rows: [[{ kind: "text", value: "executed" }]],
+						rowsAffected: 0,
+						notices: [],
+					});
+				}
+
+				observeRequests.push(request.clone());
+				liveObserveRequests += 1;
+				maximumLiveObserveRequests = Math.max(
+					maximumLiveObserveRequests,
+					liveObserveRequests,
+				);
+				let released = false;
+				const release = () => {
+					if (released) return;
+					released = true;
+					liveObserveRequests -= 1;
+				};
+				request.signal.addEventListener("abort", release, { once: true });
+				await Promise.resolve();
+				if (request.signal.aborted) {
+					release();
+					throw new DOMException("Aborted", "AbortError");
+				}
+				const body = (await request.clone().json()) as {
+					subscriptions: Array<{ id: string }>;
+				};
+				return heldSseResponse(
+					body.subscriptions
+						.map((subscription, index) =>
+							sseFrame(
+								"next",
+								multiplexObservePayload(
+									subscription.id,
+									`value-${index}`,
+									0,
+									0,
+								),
+							),
+						)
+						.join(""),
+					request.signal,
+				);
+			},
+		},
+	});
+
+	const observations = Array.from({ length: 8 }, (_, index) =>
+		lix.observe(`SELECT ${index} AS value`),
+	);
+	const initial = await Promise.all(
+		observations.map((observation) => observation.next()),
+	);
+	expect(initial.map((event) => event?.result.rows[0]?.get("value"))).toEqual(
+		Array.from({ length: 8 }, (_, index) => `value-${index}`),
+	);
+	expect(liveObserveRequests).toBe(1);
+	expect(maximumLiveObserveRequests).toBe(1);
+	expect(
+		observeRequests.every((request) =>
+			new URL(request.url).pathname.endsWith("/observe/multiplex"),
+		),
+	).toBe(true);
+	const latestBody = (await observeRequests.at(-1)?.json()) as {
+		subscriptions: unknown[];
+	};
+	expect(latestBody.subscriptions).toHaveLength(8);
+
+	const executed = await lix.execute("SELECT 'executed' AS value");
+	expect(executed.rows[0]?.get("value")).toBe("executed");
+	expect(liveObserveRequests).toBe(1);
+
+	await lix.close();
+	expect(liveObserveRequests).toBe(0);
+});
+
+test("hub-wide protocol failures abort a held multiplex stream without reconnecting", async () => {
+	vi.useFakeTimers();
+	try {
+		let observeRequests = 0;
+		let liveObserveRequests = 0;
+		const lix = await openLix({
+			server: {
+				mode: "remote",
+				url: "https://lixray.test/@acme/workspace",
+				fetch: async (input, init) => {
+					const request = new Request(input, init);
+					if (new URL(request.url).pathname.endsWith("/.lix/v1/")) {
+						return handshake();
+					}
+					observeRequests += 1;
+					liveObserveRequests += 1;
+					request.signal.addEventListener(
+						"abort",
+						() => {
+							liveObserveRequests -= 1;
+						},
+						{ once: true },
+					);
+					return heldSseResponse(
+						sseFrame("next", observePayload("missing subscription id", 0, 0)),
+						request.signal,
+					);
+				},
+			},
+		});
+
+		const events = lix.observe("SELECT value");
+		await expect(events.next()).rejects.toMatchObject({
+			code: "LIX_REMOTE_PROTOCOL_ERROR",
+		});
+		expect(liveObserveRequests).toBe(0);
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(observeRequests).toBe(1);
+
+		await lix.close();
+	} finally {
+		vi.useRealTimers();
+	}
 });
 
 test("remote observe can continue after a semantic SSE error", async () => {
@@ -53,6 +200,7 @@ test("remote observe can continue after a semantic SSE error", async () => {
 					return observeRequests === 1
 						? sseResponse(
 								sseFrame("error", {
+									subscriptionId: "observe-1",
 									retryable: true,
 									error: {
 										code: "LIX_OBSERVE_RUNTIME",
@@ -63,7 +211,10 @@ test("remote observe can continue after a semantic SSE error", async () => {
 								}),
 							)
 						: heldSseResponse(
-								sseFrame("next", observePayload("recovered", 0, 2)),
+								sseFrame(
+									"next",
+									multiplexObservePayload("observe-1", "recovered", 0, 2),
+								),
 								request.signal,
 							);
 				},
@@ -103,6 +254,7 @@ test("remote observe treats unmarked semantic errors as terminal", async () => {
 				observeRequests += 1;
 				return sseResponse(
 					sseFrame("error", {
+						subscriptionId: "observe-1",
 						error: {
 							code: "LIX_INVALID_SQL",
 							message: "invalid observed query",
@@ -153,7 +305,10 @@ test("a successful branch switch restarts existing remote observations", async (
 				const body = (await request.clone().json()) as { branchId: string };
 				observedBranches.push(body.branchId);
 				return heldSseResponse(
-					sseFrame("next", observePayload(body.branchId, 0, 0)),
+					sseFrame(
+						"next",
+						multiplexObservePayload("observe-1", body.branchId, 0, 0),
+					),
 					request.signal,
 				);
 			},
@@ -208,7 +363,7 @@ test("a stale pre-switch HTTP error cannot fail the restarted observation", asyn
 					);
 				}
 				return heldSseResponse(
-					sseFrame("next", observePayload("draft", 0, 1)),
+					sseFrame("next", multiplexObservePayload("observe-1", "draft", 0, 1)),
 					request.signal,
 				);
 			},
@@ -265,11 +420,18 @@ test("remote observe reconnects retryable failures with fresh headers", async ()
 					observedAuthorization.push(request.headers.get("authorization"));
 					if (observeRequests <= 2) {
 						return sseResponse(
-							sseFrame("next", observePayload("first", 0, 0), 25),
+							sseFrame(
+								"next",
+								multiplexObservePayload("observe-1", "first", 0, 0),
+								25,
+							),
 						);
 					}
 					return heldSseResponse(
-						sseFrame("next", observePayload("second", 0, 0)),
+						sseFrame(
+							"next",
+							multiplexObservePayload("observe-1", "second", 0, 0),
+						),
 						request.signal,
 					);
 				},
@@ -331,7 +493,7 @@ test("closing Lix stops observations before an earlier finite request settles", 
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/.lix/v1/")) return handshake();
-				if (pathname.endsWith("/observe")) {
+				if (pathname.endsWith("/observe/multiplex")) {
 					return heldSseResponse("", request.signal);
 				}
 				executeStarted.resolve();
@@ -370,6 +532,18 @@ function observePayload(value: string, sequence: number, mutationSequence: numbe
 			rowsAffected: 0,
 			notices: [],
 		},
+	};
+}
+
+function multiplexObservePayload(
+	subscriptionId: string,
+	value: string,
+	sequence: number,
+	mutationSequence: number,
+) {
+	return {
+		subscriptionId,
+		...observePayload(value, sequence, mutationSequence),
 	};
 }
 

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -37,10 +37,26 @@ export type RemoteExecuteResponse = {
 
 export type RemoteObserveRequest = Omit<RemoteExecuteRequest, "options">;
 
+export type RemoteObserveSubscription = Omit<
+	RemoteObserveRequest,
+	"branchId"
+> & {
+	id: string;
+};
+
+export type RemoteMultiplexObserveRequest = {
+	branchId: string;
+	subscriptions: RemoteObserveSubscription[];
+};
+
 export type RemoteObserveEvent = {
 	sequence: number;
 	mutationSequence: number;
 	result: RemoteExecuteResponse;
+};
+
+export type RemoteMultiplexObserveEvent = RemoteObserveEvent & {
+	subscriptionId: string;
 };
 
 export type RemoteCreateBranchRequest = {
@@ -71,6 +87,10 @@ export type RemoteErrorBody = {
 
 export type RemoteObserveErrorEvent = RemoteErrorBody & {
 	retryable?: boolean;
+};
+
+export type RemoteMultiplexObserveErrorEvent = RemoteObserveErrorEvent & {
+	subscriptionId?: string;
 };
 
 export function encodeWireValue(value: NativeLixValue): WireValue {


### PR DESCRIPTION
## Summary
- multiplex all remote `lix.observe()` subscriptions over one canonical SSE request
- restart that shared stream when subscriptions or the active branch change
- route subscription-scoped errors without failing healthy observations
- abort terminal streams and preserve retry/backoff behavior without leaking connections

## Why this is stacked
This PR is based on `codex/remote-lix-entrypoint` (#613). It keeps the public `lix.observe()` API unchanged while fixing browser HTTP/1.1 connection exhaustion discovered when LixRay opened more than six observations.

The server must expose `POST /.lix/v1/observe/multiplex`. Merge and deploy LixRay protocol PR #50 before releasing or consuming this SDK layer because protocol v1 has no capability negotiation or legacy fallback.

## Validation
- focused remote SDK suite (4 files, 23 tests)
- `npm run typecheck`
- regression with 8 live observations + a concurrent execute call
- scoped retryable reconnect regression
- held terminal stream abort/no-reconnect regression
- `git diff --check`