### PR TITLE
feat: add atomic executeBatch

### DIFF
--- a/.changenotes/atomic-sql-batches.md
+++ b/.changenotes/atomic-sql-batches.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Lix now supports `executeBatch()` for sequential SQL statements that commit atomically.
+
+Each statement keeps its own parameters and result, and a failed statement rolls back the complete batch.

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -68,8 +68,8 @@ pub(crate) use common::{parse_row_metadata, parse_row_metadata_value, serialize_
 pub use engine::Engine;
 pub use init::InitReceipt;
 pub use session::{
-    CoherentReadBatch, ExecuteOptions, ExecuteResult, ObserveEvent, ObserveEvents, Row, RowRef,
-    TryFromValue,
+    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ObserveEvent,
+    ObserveEvents, Row, RowRef, TryFromValue,
 };
 pub use session::{
     CreateBranchOptions, CreateBranchReceipt, MergeBranchOptions, MergeBranchOutcome,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
 use crate::branch::BranchRefReader;
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::sql2;
@@ -308,6 +310,13 @@ pub struct ExecuteOptions {
     pub origin_key: Option<String>,
 }
 
+/// One SQL statement to execute as part of an atomic batch.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExecuteBatchStatement {
+    pub sql: String,
+    pub params: Vec<Value>,
+}
+
 impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -412,6 +421,66 @@ where
             self.observe_invalidation.bump_if_storage_changed(&stats);
         }
         Ok(ExecuteResult::from_sql_query_result(read_result.query))
+    }
+
+    /// Executes SQL statements sequentially in one atomic transaction.
+    ///
+    /// Each statement receives its own parameter list. The transaction commits
+    /// only after every statement succeeds, so reads can observe earlier
+    /// staged writes while observers see only the final committed state.
+    pub async fn execute_batch(
+        &self,
+        statements: &[ExecuteBatchStatement],
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.execute_batch_with_options(statements, ExecuteOptions::default())
+            .await
+    }
+
+    pub async fn execute_batch_with_options(
+        &self,
+        statements: &[ExecuteBatchStatement],
+        options: ExecuteOptions,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.ensure_open()?;
+        if statements.is_empty() {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "execute_batch requires at least one statement",
+            )
+            .with_details(serde_json::json!({
+                "operation": "executeBatch",
+                "argument": "statements",
+                "expected": "non-empty array",
+            })));
+        }
+
+        let statements = statements.to_vec();
+        self.with_write_transaction(move |transaction| {
+            Box::pin(async move {
+                let mut results = Vec::with_capacity(statements.len());
+                for (statement_index, statement) in statements.iter().enumerate() {
+                    let parsed = sql2::parse_statement(&statement.sql)
+                        .map_err(|error| with_batch_statement_index(error, statement_index))?;
+                    let result = execute_transaction_statement(
+                        transaction,
+                        &statement.sql,
+                        parsed,
+                        &statement.params,
+                        options.clone(),
+                    )
+                    .await
+                    .map_err(|error| {
+                        with_batch_statement_index(
+                            normalize_sql_surface_error(error, &statement.sql),
+                            statement_index,
+                        )
+                    })?;
+                    results.push(result);
+                }
+                Ok(results)
+            })
+        })
+        .await
     }
 
     #[doc(hidden)]
@@ -702,20 +771,9 @@ where
         let _operation_guard = self.begin_session_operation()?;
         let statement = sql2::parse_statement(sql)?;
         let transaction = self.transaction_mut()?;
-        match sql2::bind_statement_route(&statement)? {
-            sql2::BoundStatementRoute::Write => {
-                execute_transaction_write_auto(transaction, statement, params, options)
-                    .await
-                    .map_err(|error| normalize_sql_surface_error(error, sql))
-            }
-            sql2::BoundStatementRoute::Read => {
-                let result = transaction
-                    .execute_read_sql_statement(sql, statement, params)
-                    .await
-                    .map_err(|error| normalize_sql_surface_error(error, sql))?;
-                Ok(ExecuteResult::from_sql_query_result(result))
-            }
-        }
+        execute_transaction_statement(transaction, sql, statement, params, options)
+            .await
+            .map_err(|error| normalize_sql_surface_error(error, sql))
     }
 
     #[cfg(test)]
@@ -794,6 +852,45 @@ where
     .await;
     transaction.replace_origin_key(previous_origin_key);
     result
+}
+
+async fn execute_transaction_statement<StorageImpl>(
+    transaction: &mut crate::transaction::Transaction<StorageImpl>,
+    sql: &str,
+    statement: datafusion::sql::parser::Statement,
+    params: &[Value],
+    options: ExecuteOptions,
+) -> Result<ExecuteResult, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    match sql2::bind_statement_route(&statement)? {
+        sql2::BoundStatementRoute::Write => {
+            execute_transaction_write_auto(transaction, statement, params, options).await
+        }
+        sql2::BoundStatementRoute::Read => transaction
+            .execute_read_sql_statement(sql, statement, params)
+            .await
+            .map(ExecuteResult::from_sql_query_result),
+    }
+}
+
+fn with_batch_statement_index(mut error: LixError, statement_index: usize) -> LixError {
+    let mut details = match error.details.take() {
+        Some(JsonValue::Object(details)) => details,
+        Some(details) => {
+            let mut wrapped = JsonMap::new();
+            wrapped.insert("cause".to_string(), details);
+            wrapped
+        }
+        None => JsonMap::new(),
+    };
+    details.insert(
+        "statementIndex".to_string(),
+        JsonValue::from(statement_index),
+    );
+    error.details = Some(JsonValue::Object(details));
+    error
 }
 
 #[cfg(test)]

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -21,7 +21,10 @@ mod transaction;
 pub use context::SessionContext;
 pub(crate) use context::{SessionMode, WORKSPACE_BRANCH_KEY};
 pub use create_branch::{CreateBranchOptions, CreateBranchReceipt};
-pub use execute::{CoherentReadBatch, ExecuteOptions, ExecuteResult, Row, RowRef, TryFromValue};
+pub use execute::{
+    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, Row, RowRef,
+    TryFromValue,
+};
 pub use merge::{
     MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions,
     MergeBranchReceipt, MergeChangeStats, MergeConflict, MergeConflictChangeKind,

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -1,7 +1,8 @@
 use lix_sdk::{
     CreateBranchOptions as RsCreateBranchOptions, CreateBranchReceipt,
-    ExecuteOptions as RsExecuteOptions, ExecuteResult as RsExecuteResult, Lix as RsLix, LixError,
-    LixTransaction as RsLixTransaction, LocalFilesystem, LocalFilesystemOpenOptions, Memory,
+    ExecuteBatchStatement as RsExecuteBatchStatement, ExecuteOptions as RsExecuteOptions,
+    ExecuteResult as RsExecuteResult, Lix as RsLix, LixError, LixTransaction as RsLixTransaction,
+    LocalFilesystem, LocalFilesystemOpenOptions, Memory,
     MergeBranchOptions as RsMergeBranchOptions, MergeBranchOutcome, MergeBranchPreview,
     MergeBranchPreviewOptions, MergeBranchReceipt, MergeChangeStats, MergeConflict,
     MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, ObserveEvent as RsObserveEvent,
@@ -63,6 +64,13 @@ impl From<NativeExecuteOptions> for RsExecuteOptions {
     }
 }
 
+#[napi(object)]
+#[expect(missing_debug_implementations)]
+pub struct NativeExecuteBatchStatement {
+    pub sql: String,
+    pub params: Option<Vec<LixValue>>,
+}
+
 #[derive(Clone)]
 struct NativeLixActor {
     commands: Sender<LixCommand>,
@@ -80,6 +88,7 @@ type NativeResult<T> = std::result::Result<T, LixError>;
 type NativeResolver<T> = Box<dyn FnOnce(Env) -> Result<T> + Send>;
 type NativeDeferred<T> = JsDeferred<T, NativeResolver<T>>;
 type NativeExecuteDeferred = NativeDeferred<ExecuteResult>;
+type NativeExecuteBatchDeferred = NativeDeferred<Vec<ExecuteResult>>;
 type NativeTransactionDeferred = NativeDeferred<NativeLixTransaction>;
 type NativeStringDeferred = NativeDeferred<String>;
 type NativeCreateBranchDeferred = NativeDeferred<CreateBranchReceiptDto>;
@@ -94,6 +103,11 @@ enum LixCommand {
         params: Vec<Value>,
         options: RsExecuteOptions,
         deferred: NativeExecuteDeferred,
+    },
+    ExecuteBatch {
+        statements: Vec<RsExecuteBatchStatement>,
+        options: RsExecuteOptions,
+        deferred: NativeExecuteBatchDeferred,
     },
     BeginTransaction {
         transaction_id: u64,
@@ -264,6 +278,7 @@ fn reject_pending_lix_commands(receiver: mpsc::Receiver<LixCommand>, error: std:
     while let Ok(command) = receiver.recv() {
         match command {
             LixCommand::Execute { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::ExecuteBatch { deferred, .. } => deferred.reject(to_napi_error(&error)),
             LixCommand::BeginTransaction { deferred, .. } => deferred.reject(to_napi_error(&error)),
             LixCommand::ActiveBranchId(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::CreateBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
@@ -304,6 +319,22 @@ fn handle_lix_command(
             let result = rt
                 .block_on(state.lix.execute(&sql, &params, options))
                 .and_then(ExecuteResult::try_from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::ExecuteBatch {
+            statements,
+            options,
+            deferred,
+        } => {
+            let result = rt
+                .block_on(state.lix.execute_batch(&statements, options))
+                .and_then(|results| {
+                    results
+                        .into_iter()
+                        .map(ExecuteResult::try_from)
+                        .collect::<std::result::Result<Vec<_>, _>>()
+                });
             settle_deferred(deferred, result);
             false
         }
@@ -440,6 +471,9 @@ fn settle_command_after_close(command: LixCommand) {
         LixCommand::Execute { deferred, .. } | LixCommand::TransactionExecute { deferred, .. } => {
             settle_deferred(deferred, Err(lix_closed_error()));
         }
+        LixCommand::ExecuteBatch { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
         LixCommand::BeginTransaction { deferred, .. } => {
             settle_deferred(deferred, Err(lix_closed_error()));
         }
@@ -491,6 +525,20 @@ impl NativeLixInner {
             Self::Memory(lix) => lix.execute_with_options(sql, params, options).await,
             Self::SQLite(lix) => lix.execute_with_options(sql, params, options).await,
             Self::LocalFilesystem(lix, _) => lix.execute_with_options(sql, params, options).await,
+        }
+    }
+
+    async fn execute_batch(
+        &self,
+        statements: &[RsExecuteBatchStatement],
+        options: RsExecuteOptions,
+    ) -> std::result::Result<Vec<RsExecuteResult>, LixError> {
+        match self {
+            Self::Memory(lix) => lix.execute_batch_with_options(statements, options).await,
+            Self::SQLite(lix) => lix.execute_batch_with_options(statements, options).await,
+            Self::LocalFilesystem(lix, _) => {
+                lix.execute_batch_with_options(statements, options).await
+            }
         }
     }
 
@@ -850,6 +898,41 @@ impl NativeLix {
             .send_with_deferred(deferred, |deferred| LixCommand::Execute {
                 sql,
                 params,
+                options,
+                deferred,
+            });
+        Ok(promise)
+    }
+
+    #[napi(js_name = "executeBatch")]
+    pub fn execute_batch<'env>(
+        &self,
+        env: &'env Env,
+        statements: Vec<NativeExecuteBatchStatement>,
+        options: Option<NativeExecuteOptions>,
+    ) -> Result<Object<'env>> {
+        let statements = statements
+            .into_iter()
+            .map(|statement| {
+                let params = statement
+                    .params
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(Value::try_from)
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(RsExecuteBatchStatement {
+                    sql: statement.sql,
+                    params,
+                })
+            })
+            .collect::<std::result::Result<Vec<_>, LixError>>()
+            .map_err(|error| throw_lix_error(env, error))?;
+        let options = options.map(RsExecuteOptions::from).unwrap_or_default();
+        let (deferred, promise): (NativeExecuteBatchDeferred, Object<'env>) =
+            env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::ExecuteBatch {
+                statements,
                 options,
                 deferred,
             });

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -10,10 +10,10 @@ use async_trait::async_trait;
 use futures_util::future::{AbortHandle, Abortable};
 use js_sys::{Function, Promise, Reflect};
 use lix_sdk::{
-    CreateBranchOptions as RsCreateBranchOptions, ExecuteOptions as RsExecuteOptions,
-    ExecuteResult as RsExecuteResult, Lix as RsLix, LixError, LixTransaction as RsLixTransaction,
-    Memory, MergeBranchOptions as RsMergeBranchOptions, MergeBranchOutcome,
-    MergeBranchPreviewOptions, ObserveEvents as RsObserveEvents,
+    CreateBranchOptions as RsCreateBranchOptions, ExecuteBatchStatement as RsExecuteBatchStatement,
+    ExecuteOptions as RsExecuteOptions, ExecuteResult as RsExecuteResult, Lix as RsLix, LixError,
+    LixTransaction as RsLixTransaction, Memory, MergeBranchOptions as RsMergeBranchOptions,
+    MergeBranchOutcome, MergeBranchPreviewOptions, ObserveEvents as RsObserveEvents,
     OpenLixOptions as RsOpenLixOptions, SqlScriptPlan,
     SwitchBranchOptions as RsSwitchBranchOptions, Value, WasmComponentInstance, WasmLimits,
     WasmPluginDetectedChange, WasmPluginEntityState, WasmPluginFile, WasmRuntime, open_lix,
@@ -99,6 +99,42 @@ impl WasmLix {
             .await
             .map_err(lix_error_to_js)?;
         execute_result_to_js(result)
+    }
+
+    #[wasm_bindgen(js_name = executeBatch)]
+    pub async fn execute_batch(
+        &self,
+        statements: JsValue,
+        options: Option<JsValue>,
+    ) -> Result<JsValue, JsValue> {
+        let statements: Vec<ExecuteBatchStatementDto> = from_js(statements)?;
+        let statements = statements
+            .into_iter()
+            .map(|statement| {
+                let params = statement
+                    .params
+                    .into_iter()
+                    .map(Value::try_from)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(RsExecuteBatchStatement {
+                    sql: statement.sql,
+                    params,
+                })
+            })
+            .collect::<Result<Vec<_>, LixError>>()
+            .map_err(lix_error_to_js)?;
+        let options = execute_options_from_js(options)?;
+        let results = self
+            .inner
+            .execute_batch_with_options(&statements, options)
+            .await
+            .map_err(lix_error_to_js)?;
+        let results = results
+            .into_iter()
+            .map(ExecuteResultDto::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(lix_error_to_js)?;
+        to_js(&results)
     }
 
     #[wasm_bindgen(js_name = observe)]
@@ -496,6 +532,14 @@ struct LixValueDto {
     kind: String,
     value: Option<serde_json::Value>,
     blob: Option<ByteBuf>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExecuteBatchStatementDto {
+    sql: String,
+    #[serde(default)]
+    params: Vec<LixValueDto>,
 }
 
 fn values_from_js(value: JsValue) -> Result<Vec<Value>, JsValue> {

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -2,6 +2,7 @@ import type {
 	CreateBranchOptions,
 	CreateBranchReceipt,
 	ExecuteOptions,
+	LixBatchOptions,
 	MergeBranchOptions,
 	MergeBranchPreview,
 	MergeBranchReceipt,
@@ -29,12 +30,21 @@ export type BindingObserveEvent = {
 
 export type BindingParam = NativeLixValue;
 
+export type BindingBatchStatement = {
+	sql: string;
+	params: BindingParam[];
+};
+
 export type LixBinding = {
 	execute(
 		sql: string,
 		params: BindingParam[],
 		options?: ExecuteOptions,
 	): Promise<BindingExecuteResult>;
+	executeBatch(
+		statements: BindingBatchStatement[],
+		options?: LixBatchOptions,
+	): Promise<BindingExecuteResult[]>;
 	observe(sql: string, params: BindingParam[]): Promise<ObserveEventsBinding>;
 	beginTransaction(): Promise<LixTransactionBinding>;
 	activeBranchId(): Promise<string>;

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -17,6 +17,8 @@ export type {
 	CreateBranchReceipt,
 	ExecuteOptions,
 	ExecuteResult,
+	LixBatchOptions,
+	LixBatchStatement,
 	LocalFilesystemOptions,
 	JsonValue,
 	LixValue,

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -411,6 +411,44 @@ test("execute originKey is exposed on change and history surfaces without metada
 	await lix.close();
 });
 
+test("executeBatch propagates originKey to every write", async () => {
+	const lix = await openLix();
+	const firstFileId = "batch-origin-file-1";
+	const secondFileId = "batch-origin-file-2";
+
+	const results = await lix.executeBatch(
+		[
+			{
+				sql: "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+				params: [
+					firstFileId,
+					"/batch-origin-one.md",
+					new TextEncoder().encode("one\n"),
+				],
+			},
+			{
+				sql: "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+				params: [
+					secondFileId,
+					"/batch-origin-two.md",
+					new TextEncoder().encode("two\n"),
+				],
+			},
+		],
+		{ originKey: "batch-origin" },
+	);
+
+	expect(results.map((result) => result.rowsAffected)).toEqual([1, 1]);
+	expect(get(await currentFileChange(lix, firstFileId), "origin_key")).toBe(
+		"batch-origin",
+	);
+	expect(get(await currentFileChange(lix, secondFileId), "origin_key")).toBe(
+		"batch-origin",
+	);
+
+	await lix.close();
+});
+
 test("fs storage with external lixDir imports the directory and writes normal files back", async () => {
 	const dir = tempFsDir();
 	const filePath = join(dir, "note.md");

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -13,6 +13,8 @@ import { LixWorkerClient, openLixWorker } from "./worker/client.js";
 import type {
 	CreateBranchOptions,
 	CreateBranchReceipt,
+	LixBatchOptions,
+	LixBatchStatement,
 	ExecuteOptions,
 	ExecuteResult,
 	LocalFilesystemOptions,
@@ -187,6 +189,19 @@ export class Lix {
 				options,
 			}),
 		);
+	}
+
+	async executeBatch(
+		statements: readonly LixBatchStatement[],
+		options?: LixBatchOptions,
+	): Promise<readonly ExecuteResult[]> {
+		const normalizedStatements = normalizeBatchStatements(statements, options);
+		const results = await this.client.request<BindingExecuteResult[]>({
+			kind: "executeBatch",
+			statements: normalizedStatements,
+			options,
+		});
+		return results.map(wrapExecuteResult);
 	}
 
 	observe(sql: string, params: SqlParam[] = []): ObserveEvents {
@@ -407,4 +422,103 @@ function assertSqlArgs(
 			receiver,
 		);
 	}
+}
+
+function normalizeBatchStatements(
+	statements: readonly LixBatchStatement[],
+	options?: LixBatchOptions,
+) {
+	if (!Array.isArray(statements)) {
+		throw invalidArgument(
+			"executeBatch",
+			"statements",
+			"array",
+			typeof statements,
+		);
+	}
+	if (statements.length === 0) {
+		throw invalidArgument(
+			"executeBatch",
+			"statements",
+			"non-empty array",
+			"empty array",
+		);
+	}
+	assertBatchOptions(options);
+	return statements.map((statement, statementIndex) => {
+		try {
+			if (
+				!statement ||
+				typeof statement !== "object" ||
+				Array.isArray(statement)
+			) {
+				throw invalidArgument(
+					"executeBatch",
+					`statements[${statementIndex}]`,
+					"object",
+					Array.isArray(statement) ? "array" : typeof statement,
+				);
+			}
+			if (typeof statement.sql !== "string") {
+				throw invalidArgument(
+					"executeBatch",
+					`statements[${statementIndex}].sql`,
+					"string",
+					typeof statement.sql,
+				);
+			}
+			const params = statement.params ?? [];
+			if (!Array.isArray(params)) {
+				throw invalidArgument(
+					"executeBatch",
+					`statements[${statementIndex}].params`,
+					"array",
+					typeof params,
+				);
+			}
+			return {
+				sql: statement.sql,
+				params: params.map((param, parameterIndex) =>
+					toNativeValue(normalizeParam(param, parameterIndex)),
+				),
+			};
+		} catch (error) {
+			throw withBatchStatementIndex(error, statementIndex);
+		}
+	});
+}
+
+function assertBatchOptions(options?: LixBatchOptions) {
+	if (options === undefined) return;
+	if (!options || typeof options !== "object" || Array.isArray(options)) {
+		throw invalidArgument(
+			"executeBatch",
+			"options",
+			"object",
+			typeof options,
+		);
+	}
+	if (options.originKey !== undefined && typeof options.originKey !== "string") {
+		throw invalidArgument(
+			"executeBatch",
+			"options.originKey",
+			"string",
+			typeof options.originKey,
+		);
+	}
+}
+
+function withBatchStatementIndex(error: unknown, statementIndex: number): unknown {
+	if (!error || typeof error !== "object") return error;
+	const lixError = error as { details?: unknown };
+	const details = lixError.details;
+	lixError.details = {
+		...(details && typeof details === "object" && !Array.isArray(details)
+			? details
+			: details === undefined
+				? {}
+				: { cause: details }),
+		statementIndex,
+	};
+	return error;
 }

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -37,6 +37,15 @@ export type ExecuteOptions = {
 	originKey?: string;
 };
 
+export type LixBatchStatement = {
+	sql: string;
+	params?: readonly SqlParam[];
+};
+
+export type LixBatchOptions = {
+	originKey?: string;
+};
+
 export type ExecuteResult = {
 	columns: string[];
 	rows: RowLike[];

--- a/packages/js-sdk/src/worker/host.ts
+++ b/packages/js-sdk/src/worker/host.ts
@@ -86,6 +86,11 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 					operation.params,
 					operation.options,
 				);
+			case "executeBatch":
+				return requiredLix().executeBatch(
+					operation.statements,
+					operation.options,
+				);
 			case "beginTransaction": {
 				const transaction = await requiredLix().beginTransaction();
 				const transactionId = nextTransactionId++;

--- a/packages/js-sdk/src/worker/protocol.ts
+++ b/packages/js-sdk/src/worker/protocol.ts
@@ -1,10 +1,12 @@
 import type {
+	BindingBatchStatement,
 	BindingParam,
 	LixStorageConfig,
 } from "../binding-types.js";
 import type {
 	CreateBranchOptions,
 	ExecuteOptions,
+	LixBatchOptions,
 	MergeBranchOptions,
 	SwitchBranchOptions,
 } from "../types.js";
@@ -21,6 +23,11 @@ export type WorkerOperation =
 			sql: string;
 			params: BindingParam[];
 			options?: ExecuteOptions;
+	  }
+	| {
+			kind: "executeBatch";
+			statements: BindingBatchStatement[];
+			options?: LixBatchOptions;
 	  }
 	| { kind: "beginTransaction" }
 	| {

--- a/packages/js-sdk/tests/memory-storage-contract.ts
+++ b/packages/js-sdk/tests/memory-storage-contract.ts
@@ -113,6 +113,88 @@ export function registerMemoryStorageContract({
 			await lix.close();
 		});
 
+		test("executes ordered atomic batches with per-statement parameters", async () => {
+			const { openLix } = await loadSdk();
+			const lix = await wait(openLix(), "open memory Lix");
+
+			try {
+				const oneStatement = await lix.executeBatch([
+					{ sql: "SELECT $1 AS value", params: ["one statement"] },
+				]);
+				expect(oneStatement).toHaveLength(1);
+				expect(oneStatement[0]?.rows[0]?.get("value")).toBe(
+					"one statement",
+				);
+
+				const results = await lix.executeBatch([
+					{
+						sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+						params: ["batch-a", "first"],
+					},
+					{
+						sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+						params: ["batch-b", "second"],
+					},
+					{
+						sql: "SELECT key, value FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key",
+						params: ["batch-a", "batch-b"],
+					},
+				]);
+				expect(results).toHaveLength(3);
+				expect(results[0]?.rowsAffected).toBe(1);
+				expect(results[1]?.rowsAffected).toBe(1);
+				expect(
+					results[2]?.rows.map((row) => row.toObject()),
+				).toEqual([
+					{ key: "batch-a", value: "first" },
+					{ key: "batch-b", value: "second" },
+				]);
+
+				const executeResult = await lix.execute("SELECT $1 AS value", [
+					"execute remains unchanged",
+				]);
+				expect(executeResult.rows[0]?.get("value")).toBe(
+					"execute remains unchanged",
+				);
+
+				await expect(lix.executeBatch([])).rejects.toMatchObject({
+					name: "LixError",
+					code: "LIX_INVALID_ARGUMENT",
+					details: {
+						operation: "executeBatch",
+						argument: "statements",
+						expected: "non-empty array",
+						actual: "empty array",
+					},
+				});
+
+				await expect(
+					lix.executeBatch([
+						{
+							sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+							params: ["batch-rolled-back", "before failure"],
+						},
+						{ sql: "SELECT entity_pk FROM lix_state_history" },
+						{
+							sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+							params: ["batch-not-run", "after failure"],
+						},
+					]),
+				).rejects.toMatchObject({
+					name: "LixError",
+					code: "LIX_HISTORY_FILTER_REQUIRED",
+					details: { statementIndex: 1 },
+				});
+				const rolledBack = await lix.execute(
+					"SELECT key FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key",
+					["batch-rolled-back", "batch-not-run"],
+				);
+				expect(rolledBack.rows).toHaveLength(0);
+			} finally {
+				await lix.close();
+			}
+		});
+
 		test("creates, switches, previews, and merges branches", async () => {
 			const { openLix } = await loadSdk();
 			const lix = await wait(openLix(), "open memory Lix");
@@ -167,6 +249,55 @@ export function registerMemoryStorageContract({
 			});
 			events.close();
 			await lix.close();
+		});
+
+		test("observe reports only the final committed batch state", async () => {
+			const { openLix } = await loadSdk();
+			const lix = await wait(openLix(), "open memory Lix");
+			const events = lix.observe(
+				"SELECT key, value FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key",
+				["batch-observe-a", "batch-observe-b"],
+			);
+
+			try {
+				const initial = await wait(events.next(), "initial batch observation");
+				expect(initial?.result.rows).toHaveLength(0);
+
+				const updatePromise = events.next();
+				const batch = lix.executeBatch([
+					{
+						sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+						params: ["batch-observe-a", "first"],
+					},
+					{
+						sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+						params: ["batch-observe-b", "second"],
+					},
+				]);
+				const update = await wait(updatePromise, "batch observation");
+				await wait(batch, "atomic batch");
+				expect(update?.sequence).toBe(1);
+				expect(update?.result.rows.map((row) => row.toObject())).toEqual([
+					{ key: "batch-observe-a", value: "first" },
+					{ key: "batch-observe-b", value: "second" },
+				]);
+
+				const noIntermediateUpdate = events.next();
+				await expect(
+					withTimeout(
+						noIntermediateUpdate,
+						"intermediate batch observation",
+						100,
+					),
+				).rejects.toThrow(/timed out/);
+				events.close();
+				await expect(
+					wait(noIntermediateUpdate, "closed batch observation"),
+				).resolves.toBeUndefined();
+			} finally {
+				events.close();
+				await lix.close();
+			}
 		});
 
 		test("observe rejects concurrent next and close resolves the pending next", async () => {

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -21,18 +21,18 @@ pub use lix_engine::wasm::{
 };
 pub use lix_engine::{
     CommitResult, CoreProjection, CreateBranchOptions, CreateBranchReceipt,
-    CreateBranchReceipt as CreateBranchResult, ExecuteOptions, ExecuteResult, GetManyResult,
-    GetOptions, Key, KeyRange, LixError, LixNotice, MAX_SCAN_PAGE_ROWS, Memory, MemoryRead,
-    MemoryWrite, MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview,
-    MergeBranchPreviewOptions, MergeBranchReceipt, MergeBranchReceipt as MergeBranchResult,
-    MergeChangeStats, MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide,
-    ObserveEvent, ObserveEvents, ProjectedValue, PutBatch, ReadEntry, ReadOptions, Row, ScanChunk,
-    ScanOptions, SpaceId, SqlQueryResult, SqlScriptPlan, SqlScriptStatement, Storage,
-    StorageConformanceReport, StorageConformanceResult, StorageConformanceStatus,
-    StorageConformanceTest, StorageError, StorageFactory, StorageFixture, StorageRead,
-    StorageTestConfig, StorageWrite, StoredValue, SwitchBranchOptions, SwitchBranchReceipt,
-    SwitchBranchReceipt as SwitchBranchResult, TryFromValue, Value, WriteOptions, WriteStats,
-    parse_sql_script, run_storage_conformance,
+    CreateBranchReceipt as CreateBranchResult, ExecuteBatchStatement, ExecuteOptions,
+    ExecuteResult, GetManyResult, GetOptions, Key, KeyRange, LixError, LixNotice,
+    MAX_SCAN_PAGE_ROWS, Memory, MemoryRead, MemoryWrite, MergeBranchOptions, MergeBranchOutcome,
+    MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
+    MergeBranchReceipt as MergeBranchResult, MergeChangeStats, MergeConflict,
+    MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, ObserveEvent, ObserveEvents,
+    ProjectedValue, PutBatch, ReadEntry, ReadOptions, Row, ScanChunk, ScanOptions, SpaceId,
+    SqlQueryResult, SqlScriptPlan, SqlScriptStatement, Storage, StorageConformanceReport,
+    StorageConformanceResult, StorageConformanceStatus, StorageConformanceTest, StorageError,
+    StorageFactory, StorageFixture, StorageRead, StorageTestConfig, StorageWrite, StoredValue,
+    SwitchBranchOptions, SwitchBranchReceipt, SwitchBranchReceipt as SwitchBranchResult,
+    TryFromValue, Value, WriteOptions, WriteStats, parse_sql_script, run_storage_conformance,
 };
 #[cfg(feature = "sqlite")]
 pub use sqlite::{SQLITE_FORMAT_VERSION, SQLite, SQLiteFactory, SQLiteFixture, SQLiteOptions};

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -1,8 +1,9 @@
 use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
-    CreateBranchOptions, CreateBranchReceipt, Engine, ExecuteOptions, ExecuteResult, LixError,
-    Memory, MergeBranchOptions, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
-    ObserveEvents, SessionContext, Storage, SwitchBranchOptions, SwitchBranchReceipt, Value,
+    CreateBranchOptions, CreateBranchReceipt, Engine, ExecuteBatchStatement, ExecuteOptions,
+    ExecuteResult, LixError, Memory, MergeBranchOptions, MergeBranchPreview,
+    MergeBranchPreviewOptions, MergeBranchReceipt, ObserveEvents, SessionContext, Storage,
+    SwitchBranchOptions, SwitchBranchReceipt, Value,
 };
 use std::sync::Arc;
 
@@ -99,6 +100,24 @@ where
     ) -> Result<ExecuteResult, LixError> {
         self.session
             .execute_with_options(sql, params, options)
+            .await
+    }
+
+    /// Executes statements sequentially in one atomic transaction.
+    pub async fn execute_batch(
+        &self,
+        statements: &[ExecuteBatchStatement],
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.session.execute_batch(statements).await
+    }
+
+    pub async fn execute_batch_with_options(
+        &self,
+        statements: &[ExecuteBatchStatement],
+        options: ExecuteOptions,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        self.session
+            .execute_batch_with_options(statements, options)
             .await
     }
 

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,6 +1,6 @@
 use lix_sdk::{
-    CreateBranchOptions, Lix, LixError, Memory, MergeBranchOptions, MergeBranchOutcome,
-    OpenLixOptions, Storage, SwitchBranchOptions, Value, open_lix,
+    CreateBranchOptions, ExecuteBatchStatement, Lix, LixError, Memory, MergeBranchOptions,
+    MergeBranchOutcome, OpenLixOptions, Storage, SwitchBranchOptions, Value, open_lix,
 };
 #[cfg(feature = "local_filesystem")]
 use lix_sdk::{LocalFilesystem, LocalFilesystemOpenOptions, open_lix_with_storage};
@@ -260,6 +260,100 @@ async fn transaction_commits_multiple_statements_together() {
         .await
         .unwrap();
     assert_eq!(committed.len(), 2);
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn execute_batch_is_atomic_and_returns_ordered_results() {
+    let lix = open_lix(OpenLixOptions::default()).await.unwrap();
+    let results = lix
+        .execute_batch(&[
+            ExecuteBatchStatement {
+                sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)".to_string(),
+                params: vec![
+                    Value::Text("batch-rs-a".to_string()),
+                    Value::Text("first".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)".to_string(),
+                params: vec![
+                    Value::Text("batch-rs-b".to_string()),
+                    Value::Text("second".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: "SELECT key, value FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key"
+                    .to_string(),
+                params: vec![
+                    Value::Text("batch-rs-a".to_string()),
+                    Value::Text("batch-rs-b".to_string()),
+                ],
+            },
+        ])
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].rows_affected(), 1);
+    assert_eq!(results[1].rows_affected(), 1);
+    assert_eq!(
+        results[2]
+            .rows()
+            .iter()
+            .map(|row| row.values().to_vec())
+            .collect::<Vec<_>>(),
+        vec![
+            vec![
+                Value::Text("batch-rs-a".to_string()),
+                Value::Json("first".into()),
+            ],
+            vec![
+                Value::Text("batch-rs-b".to_string()),
+                Value::Json("second".into()),
+            ],
+        ]
+    );
+
+    let error = lix
+        .execute_batch(&[
+            ExecuteBatchStatement {
+                sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)".to_string(),
+                params: vec![
+                    Value::Text("batch-rs-rollback".to_string()),
+                    Value::Text("before failure".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                sql: "SELECT entity_pk FROM lix_state_history".to_string(),
+                params: Vec::new(),
+            },
+        ])
+        .await
+        .expect_err("middle batch statement should fail");
+    assert_eq!(error.code, LixError::CODE_HISTORY_FILTER_REQUIRED);
+    assert_eq!(
+        error
+            .details
+            .as_ref()
+            .and_then(|details| details.get("statementIndex"))
+            .and_then(|value| value.as_u64()),
+        Some(1),
+    );
+
+    let rolled_back = lix
+        .execute(
+            "SELECT key FROM lix_key_value WHERE key = $1",
+            &[Value::Text("batch-rs-rollback".to_string())],
+        )
+        .await
+        .unwrap();
+    assert!(rolled_back.is_empty());
+
+    let empty_error = lix
+        .execute_batch(&[])
+        .await
+        .expect_err("empty batch should be rejected");
+    assert_eq!(empty_error.code, LixError::CODE_INVALID_PARAM);
     lix.close().await.unwrap();
 }
 

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -331,13 +331,12 @@ async fn execute_batch_is_atomic_and_returns_ordered_results() {
         .await
         .expect_err("middle batch statement should fail");
     assert_eq!(error.code, LixError::CODE_HISTORY_FILTER_REQUIRED);
-    assert_eq!(
+    assert!(
         error
             .details
             .as_ref()
             .and_then(|details| details.get("statementIndex"))
-            .and_then(|value| value.as_u64()),
-        Some(1),
+            .is_some_and(|value| value.as_u64() == Some(1)),
     );
 
     let rolled_back = lix


### PR DESCRIPTION
## Summary
- Add `lix.executeBatch()` with per-statement parameters and ordered results.
- Execute local batches in one engine-owned transaction, with complete rollback, `statementIndex` error details, and one observer invalidation.
- Wire the local N-API and WASM bindings, add regression coverage, and include a changenote.

## Validation
- `cargo fmt --all --check`
- `npm run typecheck`
- `npm test`
- `npm run test:browser:built`
- `cargo test --workspace --all-features`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API on the core SQL execution path with all-or-nothing transaction semantics; behavior is well covered by tests but touches session writes and observer invalidation.
> 
> **Overview**
> Adds **`executeBatch()`** / **`execute_batch()`** so callers can run multiple SQL statements in one **atomic** write transaction, with **per-statement** `params` and an **ordered** array of `ExecuteResult`s.
> 
> The engine runs the batch inside **`with_write_transaction`**: statements execute sequentially on one transaction handle (later reads see earlier staged writes), and **any failure rolls back the whole batch**. Errors include **`statementIndex`** in `details`; batch-level options such as **`originKey`** apply to writes in the batch. Single-statement transaction execution is refactored through shared **`execute_transaction_statement`**.
> 
> The **JS SDK** exposes `lix.executeBatch()` (types `LixBatchStatement` / `LixBatchOptions`), with validation and worker protocol support. **N-API** and **WASM** bindings mirror the API. **rs-sdk** re-exports `ExecuteBatchStatement` and adds `Lix::execute_batch*`. Tests cover atomicity, rollback, `originKey`, and observe emitting **one** update after the full batch commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4d4e19435f55021b9174f950a977d05d7ddcab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->