### PR TITLE
perf(engine): reuse plugin reconciliation state per batch

### DIFF
--- a/.changenotes/reuse-plugin-reconciliation.md
+++ b/.changenotes/reuse-plugin-reconciliation.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved the speed of batched file updates in workspaces with many files.
+
+Lix now reuses the plugin reconciliation view for files in the same write batch, avoiding repeated full filesystem scans during common multi-file uploads.

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -487,6 +487,13 @@ where
         file_data: &[TransactionFileData],
     ) -> Result<PluginFileDataReconciliation, LixError> {
         let mut reconciliation = PluginFileDataReconciliation::default();
+        // A single staged write can contain many ordinary files for the same
+        // branch. Reconciliation reads the pre-write filesystem each time, so
+        // retain that immutable view for this invocation rather than rebuilding
+        // it once per file. Nothing from this write is staged until this method
+        // returns, which keeps the cached snapshot equivalent to the previous
+        // per-file reads.
+        let mut contexts = BTreeMap::<String, PluginReconciliationContext>::new();
         for write in file_data {
             if let Some(rows) = plugin_archive_schema_rows_for_write(write)? {
                 reconciliation.rows.extend(rows);
@@ -498,20 +505,43 @@ where
             if !is_plugin_reconciliation_candidate_path(write_path) {
                 continue;
             }
-            let filesystem = self.filesystem_index_for_branch(&write.branch_id).await?;
-            let installed_plugins = self.installed_plugins_for_filesystem(&filesystem).await?;
-            let existing_file = filesystem.file_entries().find(|(_, file)| {
-                file.id == write.file_id
-                    && file.scope.global == write.global
-                    && file.scope.untracked == write.untracked
-            });
-            let existing_plugin = existing_file
-                .and_then(|(path, _)| select_plugin_for_path(&installed_plugins, path));
-            let selected_plugin = select_plugin_for_path(&installed_plugins, write_path);
-            let filename = write
-                .filename
-                .clone()
-                .or_else(|| existing_file.map(|(_, file)| file.name.clone()));
+            if !contexts.contains_key(&write.branch_id) {
+                let filesystem = self.filesystem_index_for_branch(&write.branch_id).await?;
+                let installed_plugins = self.installed_plugins_for_filesystem(&filesystem).await?;
+                contexts.insert(
+                    write.branch_id.clone(),
+                    PluginReconciliationContext {
+                        filesystem,
+                        installed_plugins,
+                    },
+                );
+            }
+            let (existing_plugin, selected_plugin, filename, existing_file_has_blob) = {
+                let context = contexts
+                    .get(&write.branch_id)
+                    .expect("plugin reconciliation context should be cached");
+                let existing_file = context.filesystem.file_entries().find(|(_, file)| {
+                    file.id == write.file_id
+                        && file.scope.global == write.global
+                        && file.scope.untracked == write.untracked
+                });
+                let existing_plugin = existing_file
+                    .and_then(|(path, _)| select_plugin_for_path(&context.installed_plugins, path));
+                let selected_plugin =
+                    select_plugin_for_path(&context.installed_plugins, write_path);
+                let filename = write
+                    .filename
+                    .clone()
+                    .or_else(|| existing_file.map(|(_, file)| file.name.clone()));
+                let existing_file_has_blob =
+                    existing_file.is_some_and(|(_, file)| file.blob_hash.is_some());
+                (
+                    existing_plugin,
+                    selected_plugin,
+                    filename,
+                    existing_file_has_blob,
+                )
+            };
             let context = FilesystemRowContext {
                 branch_id: write.branch_id.clone(),
                 global: write.global,
@@ -547,7 +577,7 @@ where
                 },
             )
             .await?;
-            if existing_file.is_some_and(|(_, file)| file.blob_hash.is_some()) {
+            if existing_file_has_blob {
                 reconciliation.rows.push(blob_ref_tombstone_row(
                     write.file_id.clone(),
                     context.clone(),
@@ -1426,6 +1456,13 @@ impl From<&TransactionFileData> for PluginFileWriteKey {
 struct PluginFileDataReconciliation {
     file_keys: BTreeSet<PluginFileWriteKey>,
     rows: Vec<TransactionWriteRow>,
+}
+
+/// The pre-write filesystem and plugin set for one branch during a single
+/// `RowsWithFileData` reconciliation pass.
+struct PluginReconciliationContext {
+    filesystem: FilesystemIndex,
+    installed_plugins: Vec<InstalledPlugin>,
 }
 
 fn plugin_archive_schema_rows_for_write(

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -11,6 +11,7 @@ use lix_engine::wasm::{
     WasmPluginFile, WasmRuntime,
 };
 use lix_engine::{Engine, ExecuteResult, LixError, Memory, SessionContext, Value};
+use serde_json::json;
 
 simulation_test!(
     sql_file_write_read_and_readdir_roundtrip,
@@ -398,6 +399,63 @@ async fn plugin_detect_changes_receives_descriptor_filename() {
         .expect("detect filename lock should not be poisoned")
         .clone();
     assert_eq!(filenames, vec![Some("raw.sentinel".to_string())]);
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn multi_value_file_upsert_reconciles_each_plugin_file() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let runtime = Arc::new(SentinelPluginRuntime::default());
+    let engine = Engine::new_with_wasm_runtime(storage, runtime.clone())
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(&session, "plugin_sentinel", &sentinel_plugin_archive())
+        .await
+        .expect("plugin install should succeed");
+    let sql = "INSERT INTO lix_file (path, data, lixcol_metadata) \
+               VALUES ($1, $2, $3), ($4, $5, $6) \
+               ON CONFLICT (path) DO UPDATE SET \
+                 data = excluded.data, lixcol_metadata = excluded.lixcol_metadata";
+    let params = [
+        Value::Text("/nested/first.sentinel".to_string()),
+        Value::Blob(b"first".to_vec()),
+        Value::Json(json!({"size": 5})),
+        Value::Text("/nested/second.sentinel".to_string()),
+        Value::Blob(b"second".to_vec()),
+        Value::Json(json!({"size": 6})),
+    ];
+    session
+        .execute(sql, &params)
+        .await
+        .expect("multi-value plugin file upsert should succeed");
+    session
+        .execute(sql, &params)
+        .await
+        .expect("multi-value plugin file overwrite should succeed");
+
+    let filenames = runtime
+        .detect_filenames
+        .lock()
+        .expect("detect filename lock should not be poisoned")
+        .clone();
+    assert_eq!(
+        filenames,
+        vec![
+            Some("first.sentinel".to_string()),
+            Some("second.sentinel".to_string()),
+            Some("first.sentinel".to_string()),
+            Some("second.sentinel".to_string()),
+        ]
+    );
 
     session.close().await.expect("session should close");
 }


### PR DESCRIPTION
## Summary

- Reuse the immutable filesystem and installed-plugin view once per branch within one `RowsWithFileData` reconciliation pass.
- Add a regression test for the exact multi-value `INSERT … ON CONFLICT(path) DO UPDATE` shape used by LixRay uploads, covering both insert and overwrite paths.
- Add a patch changenote.

## Root cause

A ten-file LixRay upload reaches one `stage_write` with ten file-data values. Plugin reconciliation rebuilt the full filesystem view and loaded installed plugins once **per file**, even though every item observes the same pre-write snapshot. That multiplied workspace-sized scans by batch size.

## Performance

Docker LixRay E2E, nested workspace with 2,500 files / 500 directories; exact ten-value file-explorer upsert with 1 KiB blobs:

| Run | p50 | p95 | Change vs. #620 baseline |
| --- | ---: | ---: | ---: |
| Baseline | 426.85 ms | 465.83 ms | — |
| This branch | 166.61 ms | 181.71 ms | **-61.0%** |
| Repeat | 170.76 ms | 185.15 ms | **-60.0%** |

This clears the required 20% performance gate on two runs.

## Correctness and scope

- The cache is a local variable scoped to one reconciliation call and branch, not persistent storage or a process-wide cache.
- Reconciliation runs before current input rows are staged, so cached items see the same pre-write filesystem snapshot as before.
- Archive writes, missing paths, plugin-storage handling, and active plugin state reads remain per-file where required.
- Plugin values are borrowed from the cached context; the change does not clone plugin WASM bytes.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --release --package lix_engine --lib transaction::context::tests`
- `cargo test --release --package lix_engine --test fs_api multi_value_file_upsert_reconciles_each_plugin_file -- --nocapture`
- `cargo test --workspace --all-features` reached two pre-existing macOS-only rs-sdk filesystem e2e permission failures while all affected engine tests passed; the repaired stack’s Linux CI is green and this PR’s CI is the authoritative full-suite gate.

## Design rationale

This follows the same practical principle as [Turso's batching guidance](https://turso.tech/blog/batches-in-sqlite-838e0961): amortize repeated setup across one batch. It avoids a persistent secondary index and its write/storage cost, consistent with the tradeoffs documented by [Dolt](https://www.dolthub.com/docs/concepts/dolt/sql/indexes/). The cache is deliberately batch-local rather than unbounded, aligning with [Sapling's scale discussion](https://sapling-scm.com/docs/scale/overview/), while keeping the change much smaller than a general optimizer/cache architecture such as [DuckDB's](https://duckdb.org/docs/stable/internals/overview.html).

## Stack

Base: `codex/directory-parent-index-scan` (#620).