### PR TITLE
perf(engine): index root directory listings

### DIFF
--- a/.changenotes/index-root-directory-listings.md
+++ b/.changenotes/index-root-directory-listings.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+Improved root-directory listings in workspaces with many directories.
+
+Lix now uses its filesystem path index for `lix_directory` queries filtered by
+`parent_id IS NULL`, avoiding an unnecessary full descriptor scan.

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -342,12 +342,24 @@ impl TableSpec for LixDirectorySpec {
         .map_err(lix_error_to_datafusion_error)?;
         let filters = filters.to_vec();
         let target_parent_ids = exact_string_column_constraint_from_filters(&filters, "parent_id")?;
+        let root_parent_filter = filters
+            .iter()
+            .any(|filter| is_null_column_filter(filter, "parent_id"));
         let mut indexed_matches = self
             .indexed_path_matches(&request, &filters)
             .await?
             .map(|(selected, _)| selected);
         if indexed_matches.is_none() {
-            if let FileIdConstraint::Ids(parent_ids) = &target_parent_ids {
+            if root_parent_filter {
+                let index = self
+                    .filesystem_path_index
+                    .path_index(&FilesystemPathIndexRequest::new(
+                        request.filter.branch_ids.clone(),
+                    ))
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
+                indexed_matches = Some(indexed_directory_root_matches(index));
+            } else if let FileIdConstraint::Ids(parent_ids) = &target_parent_ids {
                 let index = self
                     .filesystem_path_index
                     .path_index(&FilesystemPathIndexRequest::new(
@@ -1426,6 +1438,28 @@ fn indexed_directory_parent_matches(
     FilesystemPathSelection::new(index, indices)
 }
 
+fn indexed_directory_root_matches(
+    index: Arc<crate::filesystem::FilesystemPathIndex>,
+) -> FilesystemPathSelection {
+    let indices = index
+        .entries()
+        .enumerate()
+        .filter(|(_, entry)| {
+            entry.kind == FilesystemPathKind::Directory && entry.parent_id.is_none()
+        })
+        .map(|(index, _)| index)
+        .collect();
+    FilesystemPathSelection::new(index, indices)
+}
+
+fn is_null_column_filter(expr: &Expr, column_name: &str) -> bool {
+    matches!(
+        expr,
+        Expr::IsNull(inner)
+            if matches!(inner.as_ref(), Expr::Column(column) if column.name == column_name)
+    )
+}
+
 fn lix_directory_record_batch_from_rendered(
     schema: &SchemaRef,
     directory_rows: Vec<(DirectoryDescriptorRecord, Option<String>)>,
@@ -2273,6 +2307,76 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(paths.value(0), "/docs/guides/");
         assert_eq!(paths.value(1), "/docs/reference/");
+        assert_eq!(path_index_requests.load(Ordering::SeqCst), 1);
+        assert_eq!(live_state_scans.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn directory_root_scan_uses_indexed_descriptors() {
+        let live_state_scans = Arc::new(AtomicUsize::new(0));
+        let path_index_requests = Arc::new(AtomicUsize::new(0));
+        let index = Arc::new(
+            FilesystemPathIndex::from_live_rows(vec![
+                live_row(
+                    "dir-docs",
+                    "branch-a",
+                    r#"{"id":"dir-docs","parent_id":null,"name":"docs"}"#,
+                ),
+                live_row(
+                    "dir-guides",
+                    "branch-a",
+                    r#"{"id":"dir-guides","parent_id":"dir-docs","name":"guides"}"#,
+                ),
+                live_row(
+                    "dir-other",
+                    "branch-a",
+                    r#"{"id":"dir-other","parent_id":null,"name":"other"}"#,
+                ),
+            ])
+            .expect("filesystem path index should build"),
+        );
+        let spec = LixDirectorySpec::active_branch(
+            "branch-a",
+            Arc::new(RejectingLiveStateReader {
+                scan_count: Arc::clone(&live_state_scans),
+            }),
+            Arc::new(StaticFilesystemPathIndexReader {
+                index,
+                request_count: Arc::clone(&path_index_requests),
+            }),
+            Arc::new(TestBranchRefReader),
+            test_functions(),
+        );
+        let projection = vec![
+            spec.schema().index_of("path").expect("path column"),
+            spec.schema().index_of("name").expect("name column"),
+            spec.schema()
+                .index_of("lixcol_change_id")
+                .expect("change-id column"),
+            spec.schema()
+                .index_of("lixcol_updated_at")
+                .expect("updated-at column"),
+        ];
+        let filters = vec![Expr::IsNull(Box::new(Expr::Column(Column::from_name(
+            "parent_id",
+        ))))];
+
+        let planned = spec
+            .plan_scan(Some(&projection), &filters, None, &ExecutionProps::new())
+            .await
+            .expect("root-directory scan should plan");
+        let batch = (planned.load)()
+            .await
+            .expect("root-directory scan should load");
+
+        let paths = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("path column should be string data");
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(paths.value(0), "/docs/");
+        assert_eq!(paths.value(1), "/other/");
         assert_eq!(path_index_requests.load(Ordering::SeqCst), 1);
         assert_eq!(live_state_scans.load(Ordering::SeqCst), 0);
     }


### PR DESCRIPTION
## Summary

- Push the direct `lix_directory.parent_id IS NULL` predicate into Lix's existing filesystem path index.
- Select only root-directory descriptors rather than scanning every directory descriptor and deriving every path.
- Retain the existing physical-filter evaluation and recognize only a direct top-level null predicate, so compound/noncanonical expressions safely retain the current behavior.

This is a stackable follow-up to #622. It also inherits the requested cross-cutting-only `observations.md` living document.

## Measured impact

Production `lix-server` Docker images, fresh in-memory workspaces, 2,500 nested files under 500 directories. The isolated SQL exactly matches LixRay's root-directory query:

```sql
SELECT path, name, lixcol_change_id, lixcol_updated_at
FROM lix_directory
WHERE parent_id IS NULL
ORDER BY name
```

| Workload | Baseline (#622) | Candidate | Change |
| --- | --- | --- | --- |
| Isolated root-directory read, p50 | 5.77 ms | 3.35 ms | **−41.9%** |
| Isolated root-directory read, p95 | 15.48 ms | 4.45 ms | −71.3% |
| Actual warmed LixRay root-list pair (directory then file), p50 | 8.69 ms | 5.73 ms | **−34.1%** |
| Actual warmed LixRay root-list pair, p95 | 18.35 ms | 10.09 ms | −45.0% |

A fresh root-list pair also improved from 32.37 ms to 26.57 ms, so the new index path does not introduce a cold-path regression.

## Correctness and scope

- Adds a regression test with root and nested directories. It uses LixRay's exact projection, verifies the root-only paths, one index request, and no live-state scan.
- No persistent index, storage allocation, query rewrite, or cache-contract change. The selection reuses the existing in-memory `FilesystemPathIndex`.
- The direct predicate is intentionally scoped; all other filter shapes preserve today’s behavior.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --release --package lix_engine --lib directory_root_scan_uses_indexed_descriptors`
- Controlled production Docker comparison above

## Design references

This follows [Turso's guidance to avoid unnecessary row scans](https://docs.turso.tech/help/usage-and-billing), [DuckDB's filter-pushdown design](https://duckdb.org/docs/current/internals/overview), [Dolt's index-backed SQL approach](https://www.dolthub.com/docs/concepts/dolt/sql/indexes/), and [Sapling's warning that O(files) work becomes unaffordable at workspace scale](https://sapling-scm.com/docs/scale/overview/).