### PR TITLE
perf(engine): narrow path upsert conflict candidates

### DIFF
--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -3886,6 +3886,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_sql_file_path_upsert_uses_indexed_conflict_candidates() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(StaticBlobReader {
+            bytes: b"old".to_vec(),
+        });
+        let live_state = Arc::new(CapturingRowsLiveStateReader {
+            rows: vec![
+                live_file_row("target", "branch-a", None, "target.md"),
+                live_file_row("other", "branch-a", None, "other.md"),
+                live_blob_ref_row("target", "branch-a", b"old"),
+                live_blob_ref_row("other", "branch-a", b"skip"),
+            ],
+            requests: Arc::clone(&requests),
+        });
+        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
+        let mut ctx = DummySqlWriteExecutionContext {
+            active_branch_id: "branch-a",
+            blob_reader,
+            live_state,
+            staged_writes,
+            schema_definitions: vec![],
+        };
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data, lixcol_metadata) \
+             VALUES ('/target.md', X'6E6577', '{\"size\":3}') \
+             ON CONFLICT (path) DO UPDATE \
+             SET data = excluded.data, lixcol_metadata = excluded.lixcol_metadata",
+            &[],
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect("path upsert should update the matching file");
+
+        assert_eq!(path, WriteExecutorPath::DataFusion);
+        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+
+        let requests = requests.lock().expect("captured requests lock");
+        assert!(requests.iter().any(|request| {
+            request.filter.schema_keys
+                == vec![
+                    "lix_directory_descriptor".to_string(),
+                    "lix_file_descriptor".to_string(),
+                ]
+        }));
+        let blob_requests = requests
+            .iter()
+            .filter(|request| request.filter.schema_keys == vec!["lix_binary_blob_ref".to_string()])
+            .collect::<Vec<_>>();
+        assert_eq!(blob_requests.len(), 1);
+        assert_eq!(
+            blob_requests[0].filter.entity_pks,
+            vec![crate::entity_pk::EntityPk::single("target")]
+        );
+        assert_eq!(
+            blob_requests[0].filter.file_ids,
+            vec![NullableKeyFilter::Value("target".to_string())]
+        );
+    }
+
+    #[tokio::test]
     async fn execute_sql_insert_into_directory_by_branch_stages_write() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let live_state = Arc::new(DummyLiveStateReader);

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -990,15 +990,19 @@ impl UpsertSupport for LixFileSpec {
         proposed: &RecordBatch,
         target: &UpsertConflictTarget,
     ) -> Result<RecordBatch> {
-        // Existing rows whose `id` matches a proposed row, rendered as a full
-        // `lix_file` batch (with materialized `data`) so the driver can build
-        // the augmented `excluded.*` batch the conflict assignments run over.
-        let target_file_ids = match target.kind() {
-            UpsertConflictKind::Id => proposed_file_id_constraint(proposed)?,
-            UpsertConflictKind::Path => {
-                validate_required_paths(proposed, "lix_file")?;
-                FileIdConstraint::All
-            }
+        // Existing rows matching the proposed conflict identity, rendered as
+        // a full `lix_file` batch (with materialized `data`) so the driver can
+        // build the augmented `excluded.*` batch the conflict assignments run
+        // over.
+        let (target_file_ids, path_predicate) = match target.kind() {
+            UpsertConflictKind::Id => (
+                proposed_file_id_constraint(proposed)?,
+                FilePathPredicate::All,
+            ),
+            UpsertConflictKind::Path => (
+                FileIdConstraint::All,
+                proposed_file_path_predicate(proposed)?,
+            ),
         };
         let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
         if matches!(self.branch_binding, BranchBinding::Explicit) {
@@ -1016,23 +1020,56 @@ impl UpsertSupport for LixFileSpec {
         .map_err(lix_error_to_datafusion_error)?;
 
         let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-        let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
+        let prepared = if target.kind() == UpsertConflictKind::Path {
+            // Path conflicts only need the proposed paths. Use the filesystem
+            // index for descriptor matching, then fetch blob refs solely for
+            // matching files instead of materializing the complete file/blob
+            // candidate batch.
+            let index = self
+                .filesystem_path_index
+                .path_index(&FilesystemPathIndexRequest::new(
+                    request.filter.branch_ids.clone(),
+                ))
+                .await
+                .map_err(lix_error_to_datafusion_error)?;
+            let indexed_matches = indexed_file_matches(index, &path_predicate);
+            let rows = scan_indexed_file_rows(live_state.clone(), &request, &indexed_matches, true)
+                .await
+                .map_err(lix_error_to_datafusion_error)?;
+            prepare_indexed_lix_file_rows(&indexed_matches, rows)
+        } else {
+            let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
+                .await
+                .map_err(lix_error_to_datafusion_error)?;
+            prepare_lix_file_rows(rows, &FilePathPredicate::All)
+        }
+        .map_err(lix_error_to_datafusion_error)?;
+        let plugin_render = if prepared.needs_plugin_render(true) {
+            plugin_render_context_for_lix_file_scan(
+                live_state,
+                &self.blob_reader,
+                &request,
+                self.plugin_host.clone(),
+                true,
+            )
             .await
-            .map_err(lix_error_to_datafusion_error)?;
-        let plugin_render = plugin_render_context_for_lix_file_scan(
-            live_state,
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "sql2 lix_file plugin discovery failed: {error}"
+                ))
+            })?
+        } else {
+            None
+        };
+        lix_file_record_batch_from_prepared(
+            &self.schema,
             &self.blob_reader,
-            &request,
-            self.plugin_host.clone(),
+            plugin_render,
             true,
+            prepared,
         )
         .await
-        .map_err(|error| {
-            DataFusionError::Execution(format!("sql2 lix_file plugin discovery failed: {error}"))
-        })?;
-        lix_file_record_batch(&self.schema, &self.blob_reader, plugin_render, true, rows)
-            .await
-            .map_err(lix_error_to_datafusion_error)
+        .map_err(lix_error_to_datafusion_error)
     }
 
     fn validate_conflict_pair(
@@ -1168,6 +1205,16 @@ fn proposed_file_id_constraint(batch: &RecordBatch) -> Result<FileIdConstraint> 
         return Ok(FileIdConstraint::None);
     }
     Ok(FileIdConstraint::from_ids(ids))
+}
+
+/// The exact paths whose existing rows can conflict with a proposed
+/// `INSERT .. ON CONFLICT (path)` batch.
+fn proposed_file_path_predicate(batch: &RecordBatch) -> Result<FilePathPredicate> {
+    validate_required_paths(batch, "lix_file")?;
+    let paths = (0..batch.num_rows())
+        .map(|row_index| required_string_value(batch, row_index, "path"))
+        .collect::<Result<BTreeSet<_>>>()?;
+    Ok(FilePathPredicate::In(paths))
 }
 
 /// The `id` constraint of an augmented conflict batch (existing-row columns).
@@ -2550,6 +2597,7 @@ fn file_path_resolver_key(context: &FilesystemRowContext) -> String {
     )
 }
 
+#[cfg(test)]
 async fn lix_file_record_batch(
     schema: &SchemaRef,
     blob_reader: &Arc<dyn BlobDataReader>,


### PR DESCRIPTION
## Summary

- Reuse the existing filesystem path index for `INSERT INTO lix_file ... ON CONFLICT (path)` candidate discovery.
- Fetch blob references only for the proposed paths instead of materializing every file and blob in the workspace.
- Keep duplicate visible path lanes so the existing active/global and tracked/untracked conflict validation remains unchanged.
- Add a DataFusion-route regression test for LixRay's real metadata upload-upsert shape.

## Benchmark

Isolated Docker loop, 2,500 files / 500 nested directories / 1 KiB files; the real LixRay 10-row metadata overwrite workload, with two alternating runs:

| Run | Baseline p50 / p95 | Candidate p50 / p95 | Delta |
| --- | ---: | ---: | ---: |
| 1 | 165.73 / 173.08 ms | 113.92 / 116.43 ms | -31.3% / -32.7% |
| 2 | 165.94 / 179.19 ms | 122.81 / 126.03 ms | -26.0% / -29.7% |

Both fixtures retained 2,500 files and 10 updated metadata rows after the loop.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Focused DataFusion regression test
- 10 existing path-upsert integration tests, including global and tracked/untracked collision semantics

## Design references

This is a selective in-memory lookup, not a new persistent index or a storage-format change. It follows the same practical guidance as [Turso's query-planner indexes](https://docs.turso.tech/sql-reference/statements/create-index), [DuckDB's selective equality/IN index scans and index-maintenance trade-offs](https://duckdb.org/docs/current/guides/performance/indexing), and [Dolt's explicit secondary-index trade-offs](https://www.dolthub.com/docs/concepts/dolt/sql/indexes/). Reusing the bounded existing path index also aligns with [Sapling's warning that O(files) work becomes unaffordable at scale](https://sapling-scm.com/docs/scale/overview/).
