### PR TITLE
Add opt-in SQL telemetry across SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,6 +3324,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
  "unicode-normalization",
  "uuid",
  "web-time",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -90,6 +90,7 @@ precis-profiles = "0.1.13"
 web-time = "1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tokio = { version = "1", features = ["rt"] }
+tracing = "0.1"
 blake3 = "1"
 fastcdc = "3"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -17,6 +17,7 @@ use crate::session::SessionContext;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{SharedStorageAdapterRead, StorageReadOptions, StorageWriteOptions};
 use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
+use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
 use crate::wasm::{UnsupportedWasmRuntime, WasmRuntime};
 use crate::{LixError, NullableKeyFilter};
@@ -34,6 +35,30 @@ pub struct Engine<StorageImpl: Storage = crate::storage_adapter::Memory> {
     observe_coordinator: Arc<ObserveCoordinator>,
     observe_invalidation: Arc<ObserveInvalidation>,
     plugin_host: PluginRuntimeHost,
+    telemetry: Option<Arc<dyn TelemetrySink>>,
+}
+
+#[derive(Default)]
+#[expect(missing_debug_implementations)]
+pub struct EngineOptions {
+    wasm_runtime: Option<Arc<dyn WasmRuntime>>,
+    telemetry: Option<Arc<dyn TelemetrySink>>,
+}
+
+impl EngineOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_wasm_runtime(mut self, wasm_runtime: Arc<dyn WasmRuntime>) -> Self {
+        self.wasm_runtime = Some(wasm_runtime);
+        self
+    }
+
+    pub fn with_telemetry(mut self, telemetry: Arc<dyn TelemetrySink>) -> Self {
+        self.telemetry = Some(telemetry);
+        self
+    }
 }
 
 impl<StorageImpl> Engine<StorageImpl>
@@ -65,7 +90,7 @@ where
     /// context. Independently constructing multiple Engine values over the same
     /// cloned storage is outside that MVP runtime-sharing boundary.
     pub async fn new(storage: StorageImpl) -> Result<Self, LixError> {
-        Self::new_with_wasm_runtime(storage, Arc::new(UnsupportedWasmRuntime)).await
+        Self::new_with_options(storage, EngineOptions::new()).await
     }
 
     /// Creates an engine with a WASM component runtime for installed plugins.
@@ -73,7 +98,21 @@ where
         storage: StorageImpl,
         wasm_runtime: Arc<dyn WasmRuntime>,
     ) -> Result<Self, LixError> {
+        Self::new_with_options(
+            storage,
+            EngineOptions::new().with_wasm_runtime(wasm_runtime),
+        )
+        .await
+    }
+
+    pub async fn new_with_options(
+        storage: StorageImpl,
+        options: EngineOptions,
+    ) -> Result<Self, LixError> {
         let storage = StorageAdapter::new(storage);
+        let wasm_runtime = options
+            .wasm_runtime
+            .unwrap_or_else(|| Arc::new(UnsupportedWasmRuntime));
 
         let tracked_state = Arc::new(TrackedStateContext::new());
         let live_index = LiveStateIndexContext::new();
@@ -101,6 +140,7 @@ where
             observe_coordinator: Arc::new(ObserveCoordinator::new()),
             observe_invalidation: Arc::new(ObserveInvalidation::new()),
             plugin_host: PluginRuntimeHost::new(wasm_runtime),
+            telemetry: options.telemetry,
         })
     }
 
@@ -147,6 +187,7 @@ where
             Arc::clone(&self.observe_coordinator),
             Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),
+            self.telemetry.clone(),
         )
         .await
     }
@@ -163,6 +204,7 @@ where
             Arc::clone(&self.observe_coordinator),
             Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),
+            self.telemetry.clone(),
         )
         .await
     }

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -37,12 +37,14 @@ pub(crate) mod plugin;
 mod schema;
 pub mod session;
 pub(crate) mod sql2;
+mod sql_telemetry;
 pub mod storage;
 #[allow(unused_imports)]
 pub mod storage_adapter;
 #[cfg(feature = "storage-benches")]
 pub mod storage_bench;
 pub(crate) mod storage_codec;
+pub mod telemetry;
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) mod test_support;
 #[cfg(feature = "storage-benches")]
@@ -65,7 +67,7 @@ pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, Fil
 pub use common::{LixNotice, NullableKeyFilter, SqlQueryResult, Value};
 pub use common::{WireQueryResult, WireValue};
 pub(crate) use common::{parse_row_metadata, parse_row_metadata_value, serialize_row_metadata};
-pub use engine::Engine;
+pub use engine::{Engine, EngineOptions};
 pub use init::InitReceipt;
 pub use session::{
     CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ObserveEvent,

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -28,6 +28,7 @@ use crate::sql2::{
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{Memory, StorageReadOptions};
 use crate::storage_adapter::{SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead};
+use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
 use crate::transaction::{Transaction, open_transaction};
 use crate::{LixError, NullableKeyFilter};
@@ -63,6 +64,7 @@ pub struct SessionContext<StorageImpl: Storage = Memory> {
     pub(super) observe_coordinator: Arc<ObserveCoordinator>,
     pub(super) observe_invalidation: Arc<ObserveInvalidation>,
     pub(super) plugin_host: PluginRuntimeHost,
+    pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
     transaction_manager: SessionTransactionManager,
 }
 
@@ -81,6 +83,7 @@ where
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
+        telemetry: Option<Arc<dyn TelemetrySink>>,
     ) -> Result<Self, LixError> {
         let session = Self::new(
             SessionMode::Workspace,
@@ -94,6 +97,7 @@ where
             observe_coordinator,
             observe_invalidation,
             plugin_host,
+            telemetry,
         );
         session.active_branch_id().await?;
         Ok(session)
@@ -111,6 +115,7 @@ where
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
+        telemetry: Option<Arc<dyn TelemetrySink>>,
     ) -> Result<Self, LixError> {
         Ok(Self::new(
             SessionMode::Pinned {
@@ -126,6 +131,7 @@ where
             observe_coordinator,
             observe_invalidation,
             plugin_host,
+            telemetry,
         ))
     }
 
@@ -141,6 +147,7 @@ where
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
+        telemetry: Option<Arc<dyn TelemetrySink>>,
     ) -> Self {
         Self::new_with_transaction_manager(
             mode,
@@ -154,6 +161,7 @@ where
             observe_coordinator,
             observe_invalidation,
             plugin_host,
+            telemetry,
             SessionTransactionManager::new(),
         )
     }
@@ -170,6 +178,7 @@ where
         observe_coordinator: Arc<ObserveCoordinator>,
         observe_invalidation: Arc<ObserveInvalidation>,
         plugin_host: PluginRuntimeHost,
+        telemetry: Option<Arc<dyn TelemetrySink>>,
         transaction_manager: SessionTransactionManager,
     ) -> Self {
         Self {
@@ -184,6 +193,7 @@ where
             observe_coordinator,
             observe_invalidation,
             plugin_host,
+            telemetry,
             transaction_manager,
         }
     }

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1,18 +1,19 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use serde_json::{Map as JsonMap, Value as JsonValue};
-
 use crate::branch::BranchRefReader;
 use crate::functions::{FunctionContext, FunctionProviderHandle};
+use crate::sql_telemetry::{SqlStatementTelemetry, finish_operation, start_batch};
 use crate::sql2;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageAdapterReadScope, StorageReadOptions,
     StorageWriteOptions, StorageWriteSet,
 };
+use crate::telemetry::TelemetrySpanKind;
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
 use crate::{LixError, LixNotice, SqlQueryResult, Value};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use super::context::{SessionContext, SessionSqlExecutionContext, SessionWriteAccess};
 use super::transaction::SessionTransaction;
@@ -339,6 +340,45 @@ where
         params: &[Value],
         options: ExecuteOptions,
     ) -> Result<ExecuteResult, LixError> {
+        self.execute_with_kind(sql, params, options, "execute")
+            .await
+    }
+
+    pub(crate) async fn execute_for_observe(
+        &self,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<ExecuteResult, LixError> {
+        self.execute_with_kind(sql, params, ExecuteOptions::default(), "observe")
+            .await
+    }
+
+    async fn execute_with_kind(
+        &self,
+        sql: &str,
+        params: &[Value],
+        options: ExecuteOptions,
+        execution_kind: &'static str,
+    ) -> Result<ExecuteResult, LixError> {
+        let telemetry =
+            SqlStatementTelemetry::start(self.telemetry.as_ref(), sql, execution_kind, None);
+        let operation = self.execute_with_options_inner(sql, params, options);
+        let result = match telemetry.as_ref() {
+            Some(telemetry) => telemetry.instrument(operation).await,
+            None => operation.await,
+        };
+        if let Some(telemetry) = telemetry {
+            telemetry.finish(&result);
+        }
+        result
+    }
+
+    async fn execute_with_options_inner(
+        &self,
+        sql: &str,
+        params: &[Value],
+        options: ExecuteOptions,
+    ) -> Result<ExecuteResult, LixError> {
         self.ensure_open()?;
         let statement = sql2::parse_statement(sql)?;
         if sql2::bind_statement_route(&statement)? == sql2::BoundStatementRoute::Write {
@@ -441,6 +481,27 @@ where
         statements: &[ExecuteBatchStatement],
         options: ExecuteOptions,
     ) -> Result<Vec<ExecuteResult>, LixError> {
+        let telemetry = start_batch(
+            self.telemetry.as_ref(),
+            TelemetrySpanKind::SqlBatch,
+            statements.len(),
+        );
+        let operation = self.execute_batch_with_options_inner(statements, options);
+        let result = match telemetry.as_ref() {
+            Some(telemetry) => telemetry.instrument(operation).await,
+            None => operation.await,
+        };
+        if let Some(telemetry) = telemetry {
+            finish_operation(telemetry, &result);
+        }
+        result
+    }
+
+    async fn execute_batch_with_options_inner(
+        &self,
+        statements: &[ExecuteBatchStatement],
+        options: ExecuteOptions,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
         self.ensure_open()?;
         if statements.is_empty() {
             return Err(LixError::new(
@@ -455,26 +516,43 @@ where
         }
 
         let statements = statements.to_vec();
+        let telemetry_sink = self.telemetry.clone();
         self.with_write_transaction(move |transaction| {
             Box::pin(async move {
                 let mut results = Vec::with_capacity(statements.len());
                 for (statement_index, statement) in statements.iter().enumerate() {
-                    let parsed = sql2::parse_statement(&statement.sql)
-                        .map_err(|error| with_batch_statement_index(error, statement_index))?;
-                    let result = execute_transaction_statement(
-                        transaction,
+                    let telemetry = SqlStatementTelemetry::start(
+                        telemetry_sink.as_ref(),
                         &statement.sql,
-                        parsed,
-                        &statement.params,
-                        options.clone(),
-                    )
-                    .await
-                    .map_err(|error| {
-                        with_batch_statement_index(
-                            normalize_sql_surface_error(error, &statement.sql),
-                            statement_index,
+                        "batch",
+                        Some(statement_index),
+                    );
+                    let operation = async {
+                        let parsed = sql2::parse_statement(&statement.sql)
+                            .map_err(|error| with_batch_statement_index(error, statement_index))?;
+                        execute_transaction_statement(
+                            transaction,
+                            &statement.sql,
+                            parsed,
+                            &statement.params,
+                            options.clone(),
                         )
-                    })?;
+                        .await
+                        .map_err(|error| {
+                            with_batch_statement_index(
+                                normalize_sql_surface_error(error, &statement.sql),
+                                statement_index,
+                            )
+                        })
+                    };
+                    let result = match telemetry.as_ref() {
+                        Some(telemetry) => telemetry.instrument(operation).await,
+                        None => operation.await,
+                    };
+                    if let Some(telemetry) = telemetry {
+                        telemetry.finish(&result);
+                    }
+                    let result = result?;
                     results.push(result);
                 }
                 Ok(results)
@@ -485,6 +563,26 @@ where
 
     #[doc(hidden)]
     pub async fn execute_coherent_read_batch(
+        &self,
+        statements: &[(&str, &[Value])],
+    ) -> Result<CoherentReadBatch, LixError> {
+        let telemetry = start_batch(
+            self.telemetry.as_ref(),
+            TelemetrySpanKind::SqlCoherentReadBatch,
+            statements.len(),
+        );
+        let operation = self.execute_coherent_read_batch_inner(statements);
+        let result = match telemetry.as_ref() {
+            Some(telemetry) => telemetry.instrument(operation).await,
+            None => operation.await,
+        };
+        if let Some(telemetry) = telemetry {
+            finish_operation(telemetry, &result);
+        }
+        result
+    }
+
+    async fn execute_coherent_read_batch_inner(
         &self,
         statements: &[(&str, &[Value])],
     ) -> Result<CoherentReadBatch, LixError> {
@@ -559,11 +657,29 @@ where
                 plugin_host: self.plugin_host.clone(),
             };
             let mut results = Vec::with_capacity(statements.len());
-            for ((sql, params), statement) in statements.iter().zip(parsed) {
-                let query = sql2::execute_read_statement_from_parsed(&ctx, sql, statement, params)
-                    .await
-                    .map_err(|error| normalize_sql_surface_error(error, sql))?;
-                results.push(ExecuteResult::from_sql_query_result(query));
+            for (statement_index, ((sql, params), statement)) in
+                statements.iter().zip(parsed).enumerate()
+            {
+                let telemetry = SqlStatementTelemetry::start(
+                    self.telemetry.as_ref(),
+                    sql,
+                    "coherent_read_batch",
+                    Some(statement_index),
+                );
+                let operation = async {
+                    sql2::execute_read_statement_from_parsed(&ctx, sql, statement, params)
+                        .await
+                        .map(ExecuteResult::from_sql_query_result)
+                        .map_err(|error| normalize_sql_surface_error(error, sql))
+                };
+                let result = match telemetry.as_ref() {
+                    Some(telemetry) => telemetry.instrument(operation).await,
+                    None => operation.await,
+                };
+                if let Some(telemetry) = telemetry {
+                    telemetry.finish(&result);
+                }
+                results.push(result?);
             }
             drop(ctx);
             drop(live_state);
@@ -768,12 +884,24 @@ where
         params: &[Value],
         options: ExecuteOptions,
     ) -> Result<ExecuteResult, LixError> {
-        let _operation_guard = self.begin_session_operation()?;
-        let statement = sql2::parse_statement(sql)?;
-        let transaction = self.transaction_mut()?;
-        execute_transaction_statement(transaction, sql, statement, params, options)
-            .await
-            .map_err(|error| normalize_sql_surface_error(error, sql))
+        let telemetry =
+            SqlStatementTelemetry::start(self.telemetry.as_ref(), sql, "transaction", None);
+        let operation = async {
+            let _operation_guard = self.begin_session_operation()?;
+            let statement = sql2::parse_statement(sql)?;
+            let transaction = self.transaction_mut()?;
+            execute_transaction_statement(transaction, sql, statement, params, options)
+                .await
+                .map_err(|error| normalize_sql_surface_error(error, sql))
+        };
+        let result = match telemetry.as_ref() {
+            Some(telemetry) => telemetry.instrument(operation).await,
+            None => operation.await,
+        };
+        if let Some(telemetry) = telemetry {
+            telemetry.finish(&result);
+        }
+        result
     }
 
     #[cfg(test)]

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -144,14 +144,14 @@ where
         let Some(shared_state) = &self.query.shared_state else {
             return self
                 .session
-                .execute(&self.query.sql, &self.query.params)
+                .execute_for_observe(&self.query.sql, &self.query.params)
                 .await;
         };
 
         shared_state
             .evaluate(generation, || async {
                 self.session
-                    .execute(&self.query.sql, &self.query.params)
+                    .execute_for_observe(&self.query.sql, &self.query.params)
                     .await
             })
             .await

--- a/packages/engine/src/session/switch_branch.rs
+++ b/packages/engine/src/session/switch_branch.rs
@@ -81,6 +81,7 @@ where
             Arc::clone(&self.observe_coordinator),
             Arc::clone(&self.observe_invalidation),
             self.plugin_host.clone(),
+            self.telemetry.clone(),
             self.transaction_manager(),
         );
         Ok((

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -4,6 +4,7 @@ use crate::functions::{DeterministicRuntimeGuard, FunctionContext};
 use crate::observe_invalidation::ObserveInvalidation;
 use crate::storage_adapter::Memory;
 use crate::storage_adapter::Storage;
+use crate::telemetry::TelemetrySink;
 use tokio::sync::Notify;
 
 use crate::LixError;
@@ -24,6 +25,7 @@ pub struct SessionTransaction<StorageImpl: Storage = Memory> {
     observe_invalidation: Arc<ObserveInvalidation>,
     _deterministic_runtime_guard: Option<DeterministicRuntimeGuard>,
     write_access: Option<SessionWriteAccess>,
+    pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -68,6 +70,7 @@ where
             observe_invalidation: Arc::clone(&self.observe_invalidation),
             _deterministic_runtime_guard: deterministic_runtime_guard,
             write_access: Some(write_access),
+            telemetry: self.telemetry.clone(),
         })
     }
 }

--- a/packages/engine/src/sql_telemetry.rs
+++ b/packages/engine/src/sql_telemetry.rs
@@ -190,10 +190,11 @@ fn query_operation(query_text: &str) -> String {
 fn sanitize_query_text(sql: &str) -> String {
     let characters = sql.chars().collect::<Vec<_>>();
     let mut output = String::with_capacity(sql.len().min(MAX_QUERY_TEXT_CHARS));
+    let mut output_chars = 0;
     let mut index = 0;
     let mut pending_space = false;
 
-    while index < characters.len() && output.chars().count() < MAX_QUERY_TEXT_CHARS {
+    'query: while index < characters.len() {
         let character = characters[index];
         if character.is_whitespace() {
             pending_space = true;
@@ -228,25 +229,35 @@ fn sanitize_query_text(sql: &str) -> String {
             continue;
         }
 
-        push_pending_space(&mut output, &mut pending_space);
+        if !push_pending_space(&mut output, &mut output_chars, &mut pending_space) {
+            break;
+        }
 
         if character == '\'' {
-            output.push('?');
+            if !push_query_text_char(&mut output, &mut output_chars, '?') {
+                break;
+            }
             index = skip_single_quoted_literal(&characters, index + 1);
             continue;
         }
         if character == '$' {
             if characters.get(index + 1).is_some_and(char::is_ascii_digit) {
-                output.push('$');
+                if !push_query_text_char(&mut output, &mut output_chars, '$') {
+                    break;
+                }
                 index += 1;
                 while index < characters.len() && characters[index].is_ascii_digit() {
-                    output.push(characters[index]);
+                    if !push_query_text_char(&mut output, &mut output_chars, characters[index]) {
+                        break 'query;
+                    }
                     index += 1;
                 }
                 continue;
             }
             if let Some((delimiter, body_start)) = dollar_quote_delimiter(&characters, index) {
-                output.push('?');
+                if !push_query_text_char(&mut output, &mut output_chars, '?') {
+                    break;
+                }
                 index = skip_dollar_quoted_literal(&characters, body_start, &delimiter);
                 continue;
             }
@@ -256,21 +267,29 @@ fn sanitize_query_text(sql: &str) -> String {
                 .get(index.wrapping_sub(1))
                 .is_some_and(|previous| previous.is_ascii_alphanumeric() || *previous == '_')
         {
-            output.push('?');
+            if !push_query_text_char(&mut output, &mut output_chars, '?') {
+                break;
+            }
             index = skip_numeric_literal(&characters, index + 1);
             continue;
         }
         if matches!(character, '"' | '`' | '[') {
             let closing = if character == '[' { ']' } else { character };
-            output.push(character);
+            if !push_query_text_char(&mut output, &mut output_chars, character) {
+                break;
+            }
             index += 1;
             while index < characters.len() {
                 let current = characters[index];
-                output.push(current);
+                if !push_query_text_char(&mut output, &mut output_chars, current) {
+                    break 'query;
+                }
                 index += 1;
                 if current == closing {
                     if characters.get(index) == Some(&closing) {
-                        output.push(closing);
+                        if !push_query_text_char(&mut output, &mut output_chars, closing) {
+                            break 'query;
+                        }
                         index += 1;
                     } else {
                         break;
@@ -280,18 +299,36 @@ fn sanitize_query_text(sql: &str) -> String {
             continue;
         }
 
-        output.push(character);
+        if !push_query_text_char(&mut output, &mut output_chars, character) {
+            break;
+        }
         index += 1;
     }
 
     output.trim().to_string()
 }
 
-fn push_pending_space(output: &mut String, pending_space: &mut bool) {
+fn push_query_text_char(output: &mut String, output_chars: &mut usize, character: char) -> bool {
+    if *output_chars >= MAX_QUERY_TEXT_CHARS {
+        return false;
+    }
+    output.push(character);
+    *output_chars += 1;
+    true
+}
+
+fn push_pending_space(
+    output: &mut String,
+    output_chars: &mut usize,
+    pending_space: &mut bool,
+) -> bool {
     if *pending_space && !output.is_empty() && !output.ends_with(' ') {
-        output.push(' ');
+        if !push_query_text_char(output, output_chars, ' ') {
+            return false;
+        }
     }
     *pending_space = false;
+    true
 }
 
 fn skip_single_quoted_literal(characters: &[char], mut index: usize) -> usize {
@@ -371,6 +408,15 @@ mod tests {
             sanitize_query_text("SELECT \"odd table\".value FROM \"odd table\" WHERE id = 9"),
             "SELECT \"odd table\".value FROM \"odd table\" WHERE id = ?"
         );
+    }
+
+    #[test]
+    fn caps_query_text_inside_quoted_identifiers() {
+        let oversized_identifier = format!("SELECT \"{}", "a".repeat(MAX_QUERY_TEXT_CHARS * 2));
+        let sanitized = sanitize_query_text(&oversized_identifier);
+
+        assert_eq!(sanitized.chars().count(), MAX_QUERY_TEXT_CHARS);
+        assert!(sanitized.starts_with("SELECT \""));
     }
 
     #[test]

--- a/packages/engine/src/sql_telemetry.rs
+++ b/packages/engine/src/sql_telemetry.rs
@@ -1,0 +1,390 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::telemetry::{
+    ActiveTelemetrySpan, TelemetryAttribute, TelemetrySink, TelemetrySpanKind, TelemetrySpanStart,
+    TelemetrySpanStatus, unix_time_ms,
+};
+use crate::{ExecuteResult, LixError};
+
+const MAX_QUERY_TEXT_CHARS: usize = 4_096;
+
+pub(crate) struct SqlStatementTelemetry {
+    span: ActiveTelemetrySpan,
+}
+
+impl SqlStatementTelemetry {
+    pub(crate) fn start(
+        sink: Option<&Arc<dyn TelemetrySink>>,
+        sql: &str,
+        execution_kind: &'static str,
+        batch_index: Option<usize>,
+    ) -> Option<Self> {
+        let sink = sink?;
+        if !sink.enabled(TelemetrySpanKind::SqlQuery) {
+            return None;
+        }
+        Some(Self {
+            span: ActiveTelemetrySpan::start(
+                sink,
+                statement_start(sql, execution_kind, batch_index),
+            ),
+        })
+    }
+
+    pub(crate) async fn instrument<F>(&self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        self.span.instrument(future).await
+    }
+
+    pub(crate) fn finish(self, result: &Result<ExecuteResult, LixError>) {
+        let (status, attributes) = statement_end(result);
+        self.span.finish(status, attributes);
+    }
+}
+
+fn statement_start(
+    sql: &str,
+    execution_kind: &'static str,
+    batch_index: Option<usize>,
+) -> TelemetrySpanStart {
+    let query_text = sanitize_query_text(sql);
+    let operation = query_operation(&query_text);
+    let fingerprint = blake3::hash(query_text.as_bytes()).to_hex().to_string();
+    let mut attributes = vec![
+        TelemetryAttribute::string("otel.name", operation.clone()),
+        TelemetryAttribute::string("otel.kind", "internal"),
+        TelemetryAttribute::string("db.system.name", "lix"),
+        TelemetryAttribute::string("db.operation.name", operation.clone()),
+        TelemetryAttribute::string("db.query.summary", operation),
+        TelemetryAttribute::string("db.query.text", query_text),
+        TelemetryAttribute::string("lix.sql.fingerprint", fingerprint),
+        TelemetryAttribute::string("lix.execution.kind", execution_kind),
+    ];
+    if let Some(batch_index) = batch_index {
+        attributes.push(TelemetryAttribute::u64(
+            "lix.batch.index",
+            u64::try_from(batch_index).unwrap_or(u64::MAX),
+        ));
+    }
+    TelemetrySpanStart {
+        kind: TelemetrySpanKind::SqlQuery,
+        name: "lix.sql.query",
+        started_at_unix_ms: unix_time_ms(),
+        attributes,
+    }
+}
+
+fn statement_end(
+    result: &Result<ExecuteResult, LixError>,
+) -> (TelemetrySpanStatus, Vec<TelemetryAttribute>) {
+    match result {
+        Ok(result) => (
+            TelemetrySpanStatus::Ok,
+            vec![
+                TelemetryAttribute::u64(
+                    "db.response.returned_rows",
+                    u64::try_from(result.len()).unwrap_or(u64::MAX),
+                ),
+                TelemetryAttribute::u64("lix.rows_affected", result.rows_affected()),
+                TelemetryAttribute::string("otel.status_code", "OK"),
+            ],
+        ),
+        Err(error) => (
+            TelemetrySpanStatus::Error,
+            vec![
+                TelemetryAttribute::string("error.type", error.code.clone()),
+                TelemetryAttribute::string("otel.status_code", "ERROR"),
+            ],
+        ),
+    }
+}
+
+pub(crate) fn start_batch(
+    sink: Option<&Arc<dyn TelemetrySink>>,
+    kind: TelemetrySpanKind,
+    size: usize,
+) -> Option<ActiveTelemetrySpan> {
+    let sink = sink?;
+    if !sink.enabled(kind) {
+        return None;
+    }
+    let (name, display_name, execution_kind) = match kind {
+        TelemetrySpanKind::SqlBatch => ("lix.sql.batch", "SQL batch", "batch"),
+        TelemetrySpanKind::SqlCoherentReadBatch => (
+            "lix.sql.coherent_read_batch",
+            "SQL coherent read batch",
+            "coherent_read_batch",
+        ),
+        TelemetrySpanKind::SqlQuery => return None,
+    };
+    Some(ActiveTelemetrySpan::start(
+        sink,
+        TelemetrySpanStart {
+            kind,
+            name,
+            started_at_unix_ms: unix_time_ms(),
+            attributes: vec![
+                TelemetryAttribute::string("otel.name", display_name),
+                TelemetryAttribute::string("otel.kind", "internal"),
+                TelemetryAttribute::string("db.system.name", "lix"),
+                TelemetryAttribute::u64(
+                    "db.operation.batch.size",
+                    u64::try_from(size).unwrap_or(u64::MAX),
+                ),
+                TelemetryAttribute::string("lix.execution.kind", execution_kind),
+            ],
+        },
+    ))
+}
+
+pub(crate) fn finish_operation<T>(span: ActiveTelemetrySpan, result: &Result<T, LixError>) {
+    match result {
+        Ok(_) => span.finish(
+            TelemetrySpanStatus::Ok,
+            vec![TelemetryAttribute::string("otel.status_code", "OK")],
+        ),
+        Err(error) => span.finish(
+            TelemetrySpanStatus::Error,
+            vec![
+                TelemetryAttribute::string("error.type", error.code.clone()),
+                TelemetryAttribute::string("otel.status_code", "ERROR"),
+            ],
+        ),
+    }
+}
+
+#[cfg(test)]
+fn statement_fingerprint(sql: &str) -> String {
+    statement_start(sql, "execute", None)
+        .attributes
+        .into_iter()
+        .find_map(|attribute| {
+            if attribute.key == "lix.sql.fingerprint"
+                && let crate::telemetry::TelemetryValue::String(value) = attribute.value
+            {
+                Some(value)
+            } else {
+                None
+            }
+        })
+        .expect("statement telemetry includes a fingerprint")
+}
+fn query_operation(query_text: &str) -> String {
+    const OPERATIONS: &[&str] = &[
+        "SELECT", "INSERT", "UPDATE", "DELETE", "MERGE", "CREATE", "ALTER", "DROP", "TRUNCATE",
+        "EXPLAIN", "SHOW", "DESCRIBE", "SET",
+    ];
+    query_text
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '_')
+        .map(str::to_ascii_uppercase)
+        .find(|token| OPERATIONS.contains(&token.as_str()))
+        .unwrap_or_else(|| "SQL".to_string())
+}
+
+/// Removes SQL comments and literal values while preserving statement shape and
+/// placeholders. If a construct is ambiguous, it is redacted rather than
+/// copied so telemetry cannot become a side channel for query parameters.
+fn sanitize_query_text(sql: &str) -> String {
+    let characters = sql.chars().collect::<Vec<_>>();
+    let mut output = String::with_capacity(sql.len().min(MAX_QUERY_TEXT_CHARS));
+    let mut index = 0;
+    let mut pending_space = false;
+
+    while index < characters.len() && output.chars().count() < MAX_QUERY_TEXT_CHARS {
+        let character = characters[index];
+        if character.is_whitespace() {
+            pending_space = true;
+            index += 1;
+            continue;
+        }
+        if character == '-' && characters.get(index + 1) == Some(&'-') {
+            index += 2;
+            while index < characters.len() && characters[index] != '\n' {
+                index += 1;
+            }
+            pending_space = true;
+            continue;
+        }
+        if character == '/' && characters.get(index + 1) == Some(&'*') {
+            index += 2;
+            let mut depth = 1_u32;
+            while index < characters.len() && depth > 0 {
+                if characters.get(index) == Some(&'/') && characters.get(index + 1) == Some(&'*') {
+                    depth = depth.saturating_add(1);
+                    index += 2;
+                } else if characters.get(index) == Some(&'*')
+                    && characters.get(index + 1) == Some(&'/')
+                {
+                    depth -= 1;
+                    index += 2;
+                } else {
+                    index += 1;
+                }
+            }
+            pending_space = true;
+            continue;
+        }
+
+        push_pending_space(&mut output, &mut pending_space);
+
+        if character == '\'' {
+            output.push('?');
+            index = skip_single_quoted_literal(&characters, index + 1);
+            continue;
+        }
+        if character == '$' {
+            if characters.get(index + 1).is_some_and(char::is_ascii_digit) {
+                output.push('$');
+                index += 1;
+                while index < characters.len() && characters[index].is_ascii_digit() {
+                    output.push(characters[index]);
+                    index += 1;
+                }
+                continue;
+            }
+            if let Some((delimiter, body_start)) = dollar_quote_delimiter(&characters, index) {
+                output.push('?');
+                index = skip_dollar_quoted_literal(&characters, body_start, &delimiter);
+                continue;
+            }
+        }
+        if character.is_ascii_digit()
+            && !characters
+                .get(index.wrapping_sub(1))
+                .is_some_and(|previous| previous.is_ascii_alphanumeric() || *previous == '_')
+        {
+            output.push('?');
+            index = skip_numeric_literal(&characters, index + 1);
+            continue;
+        }
+        if matches!(character, '"' | '`' | '[') {
+            let closing = if character == '[' { ']' } else { character };
+            output.push(character);
+            index += 1;
+            while index < characters.len() {
+                let current = characters[index];
+                output.push(current);
+                index += 1;
+                if current == closing {
+                    if characters.get(index) == Some(&closing) {
+                        output.push(closing);
+                        index += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        output.push(character);
+        index += 1;
+    }
+
+    output.trim().to_string()
+}
+
+fn push_pending_space(output: &mut String, pending_space: &mut bool) {
+    if *pending_space && !output.is_empty() && !output.ends_with(' ') {
+        output.push(' ');
+    }
+    *pending_space = false;
+}
+
+fn skip_single_quoted_literal(characters: &[char], mut index: usize) -> usize {
+    while index < characters.len() {
+        if characters[index] == '\'' {
+            if characters.get(index + 1) == Some(&'\'') {
+                index += 2;
+                continue;
+            }
+            return index + 1;
+        }
+        if characters[index] == '\\' && index + 1 < characters.len() {
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+    index
+}
+
+fn dollar_quote_delimiter(characters: &[char], start: usize) -> Option<(Vec<char>, usize)> {
+    let mut index = start + 1;
+    while index < characters.len()
+        && (characters[index].is_ascii_alphanumeric() || characters[index] == '_')
+    {
+        index += 1;
+    }
+    if characters.get(index) != Some(&'$') {
+        return None;
+    }
+    if index > start + 1 && characters[start + 1].is_ascii_digit() {
+        return None;
+    }
+    Some((characters[start..=index].to_vec(), index + 1))
+}
+
+fn skip_dollar_quoted_literal(characters: &[char], mut index: usize, delimiter: &[char]) -> usize {
+    while index + delimiter.len() <= characters.len() {
+        if &characters[index..index + delimiter.len()] == delimiter {
+            return index + delimiter.len();
+        }
+        index += 1;
+    }
+    characters.len()
+}
+
+fn skip_numeric_literal(characters: &[char], mut index: usize) -> usize {
+    while index < characters.len()
+        && matches!(characters[index], '0'..='9' | '.' | 'e' | 'E' | '+' | '-' | 'x' | 'X' | 'a'..='f' | 'A'..='F' | '_')
+    {
+        index += 1;
+    }
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_sink_disables_statement_telemetry() {
+        assert!(SqlStatementTelemetry::start(None, "SELECT 'private'", "execute", None).is_none());
+    }
+
+    #[test]
+    fn sanitizes_literals_comments_and_preserves_placeholders() {
+        let sql = "SELECT value, 'private'' value', 42, $tag$secret$tag$ FROM lix_key_value -- hidden\n WHERE key = $1 AND other = ?";
+        assert_eq!(
+            sanitize_query_text(sql),
+            "SELECT value, ?, ?, ? FROM lix_key_value WHERE key = $1 AND other = ?"
+        );
+    }
+
+    #[test]
+    fn preserves_quoted_identifiers() {
+        assert_eq!(
+            sanitize_query_text("SELECT \"odd table\".value FROM \"odd table\" WHERE id = 9"),
+            "SELECT \"odd table\".value FROM \"odd table\" WHERE id = ?"
+        );
+    }
+
+    #[test]
+    fn nested_comments_cannot_leak_text() {
+        assert_eq!(
+            sanitize_query_text("SELECT 1 /* outer /* private */ still-private */ FROM t"),
+            "SELECT ? FROM t"
+        );
+    }
+
+    #[test]
+    fn fingerprint_depends_on_shape_not_literal_values() {
+        let first = statement_fingerprint("SELECT * FROM t WHERE id = 1");
+        let second = statement_fingerprint("SELECT * FROM t WHERE id = 999");
+        assert_eq!(first, second);
+    }
+}

--- a/packages/engine/src/telemetry.rs
+++ b/packages/engine/src/telemetry.rs
@@ -12,7 +12,7 @@ pub enum TelemetrySpanKind {
 }
 
 /// One vendor-neutral telemetry attribute.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TelemetryAttribute {
     pub key: &'static str,
     pub value: TelemetryValue,
@@ -34,7 +34,7 @@ impl TelemetryAttribute {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TelemetryValue {
     String(String),
     U64(u64),
@@ -42,7 +42,7 @@ pub enum TelemetryValue {
 }
 
 /// Information available when an engine operation begins.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TelemetrySpanStart {
     pub kind: TelemetrySpanKind,
     pub name: &'static str,
@@ -57,7 +57,7 @@ pub enum TelemetrySpanStatus {
 }
 
 /// Information available when an engine operation finishes.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TelemetrySpanEnd {
     pub duration_ns: u64,
     pub status: TelemetrySpanStatus,
@@ -65,7 +65,7 @@ pub struct TelemetrySpanEnd {
 }
 
 /// A completed span used by callback and cross-runtime adapters.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompletedTelemetrySpan {
     pub start: TelemetrySpanStart,
     pub end: TelemetrySpanEnd,

--- a/packages/engine/src/telemetry.rs
+++ b/packages/engine/src/telemetry.rs
@@ -1,0 +1,294 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+/// A stable category that lets sinks filter spans before Lix builds attributes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetrySpanKind {
+    SqlQuery,
+    SqlBatch,
+    SqlCoherentReadBatch,
+}
+
+/// One vendor-neutral telemetry attribute.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TelemetryAttribute {
+    pub key: &'static str,
+    pub value: TelemetryValue,
+}
+
+impl TelemetryAttribute {
+    pub fn string(key: &'static str, value: impl Into<String>) -> Self {
+        Self {
+            key,
+            value: TelemetryValue::String(value.into()),
+        }
+    }
+
+    pub fn u64(key: &'static str, value: u64) -> Self {
+        Self {
+            key,
+            value: TelemetryValue::U64(value),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TelemetryValue {
+    String(String),
+    U64(u64),
+    Boolean(bool),
+}
+
+/// Information available when an engine operation begins.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TelemetrySpanStart {
+    pub kind: TelemetrySpanKind,
+    pub name: &'static str,
+    pub started_at_unix_ms: u64,
+    pub attributes: Vec<TelemetryAttribute>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetrySpanStatus {
+    Ok,
+    Error,
+}
+
+/// Information available when an engine operation finishes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TelemetrySpanEnd {
+    pub duration_ns: u64,
+    pub status: TelemetrySpanStatus,
+    pub attributes: Vec<TelemetryAttribute>,
+}
+
+/// A completed span used by callback and cross-runtime adapters.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompletedTelemetrySpan {
+    pub start: TelemetrySpanStart,
+    pub end: TelemetrySpanEnd,
+}
+
+/// Per-engine telemetry destination. Lix never installs a global exporter.
+pub trait TelemetrySink: Send + Sync {
+    /// Called before Lix sanitizes or fingerprints SQL. Returning false makes
+    /// the disabled path avoid all telemetry-specific work.
+    fn enabled(&self, _kind: TelemetrySpanKind) -> bool {
+        true
+    }
+
+    fn start_span(&self, start: TelemetrySpanStart) -> Box<dyn TelemetrySpanHandle>;
+}
+
+/// A live span. `enter` is used on every future poll so native tracing keeps
+/// correct async parentage without holding an entered span across an await.
+pub trait TelemetrySpanHandle: Send + Sync {
+    fn enter(&self) -> Box<dyn TelemetrySpanEnterGuard + '_>;
+    fn finish(self: Box<Self>, end: TelemetrySpanEnd);
+}
+
+pub trait TelemetrySpanEnterGuard {}
+
+impl TelemetrySpanEnterGuard for () {}
+
+/// Sink adapter for hosts that consume completed spans through a callback.
+#[expect(missing_debug_implementations)]
+pub struct CallbackTelemetrySink {
+    callback: Arc<dyn Fn(CompletedTelemetrySpan) + Send + Sync>,
+}
+
+impl CallbackTelemetrySink {
+    pub fn new(callback: impl Fn(CompletedTelemetrySpan) + Send + Sync + 'static) -> Self {
+        Self {
+            callback: Arc::new(callback),
+        }
+    }
+}
+
+impl TelemetrySink for CallbackTelemetrySink {
+    fn start_span(&self, start: TelemetrySpanStart) -> Box<dyn TelemetrySpanHandle> {
+        Box::new(CallbackTelemetrySpan {
+            callback: Arc::clone(&self.callback),
+            start,
+        })
+    }
+}
+
+struct CallbackTelemetrySpan {
+    callback: Arc<dyn Fn(CompletedTelemetrySpan) + Send + Sync>,
+    start: TelemetrySpanStart,
+}
+
+impl TelemetrySpanHandle for CallbackTelemetrySpan {
+    fn enter(&self) -> Box<dyn TelemetrySpanEnterGuard + '_> {
+        Box::new(())
+    }
+
+    fn finish(self: Box<Self>, end: TelemetrySpanEnd) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (self.callback)(CompletedTelemetrySpan {
+                start: self.start,
+                end,
+            });
+        }));
+    }
+}
+
+/// Explicit adapter from engine telemetry into the Rust `tracing` ecosystem.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TracingTelemetrySink;
+
+impl TracingTelemetrySink {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl TelemetrySink for TracingTelemetrySink {
+    fn enabled(&self, _kind: TelemetrySpanKind) -> bool {
+        tracing::enabled!(target: "lix_sql", tracing::Level::INFO)
+    }
+
+    fn start_span(&self, start: TelemetrySpanStart) -> Box<dyn TelemetrySpanHandle> {
+        let span = tracing_span(&start);
+        Box::new(TracingTelemetrySpan { span })
+    }
+}
+
+struct TracingTelemetrySpan {
+    span: tracing::Span,
+}
+
+struct TracingTelemetrySpanEnterGuard<'a>(#[allow(dead_code)] tracing::span::Entered<'a>);
+
+impl TelemetrySpanEnterGuard for TracingTelemetrySpanEnterGuard<'_> {}
+
+impl TelemetrySpanHandle for TracingTelemetrySpan {
+    fn enter(&self) -> Box<dyn TelemetrySpanEnterGuard + '_> {
+        Box::new(TracingTelemetrySpanEnterGuard(self.span.enter()))
+    }
+
+    fn finish(self: Box<Self>, end: TelemetrySpanEnd) {
+        for attribute in &end.attributes {
+            record_attribute(&self.span, attribute);
+        }
+        drop(self);
+    }
+}
+
+fn tracing_span(start: &TelemetrySpanStart) -> tracing::Span {
+    let span = match start.kind {
+        TelemetrySpanKind::SqlQuery => tracing::info_span!(
+            target: "lix_sql",
+            "lix.sql.query",
+            "otel.name" = tracing::field::Empty,
+            "otel.kind" = tracing::field::Empty,
+            "db.system.name" = tracing::field::Empty,
+            "db.operation.name" = tracing::field::Empty,
+            "db.query.summary" = tracing::field::Empty,
+            "db.query.text" = tracing::field::Empty,
+            "lix.sql.fingerprint" = tracing::field::Empty,
+            "lix.execution.kind" = tracing::field::Empty,
+            "lix.batch.index" = tracing::field::Empty,
+            "db.response.returned_rows" = tracing::field::Empty,
+            "lix.rows_affected" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        TelemetrySpanKind::SqlBatch => tracing::info_span!(
+            target: "lix_sql",
+            "lix.sql.batch",
+            "otel.name" = tracing::field::Empty,
+            "otel.kind" = tracing::field::Empty,
+            "db.system.name" = tracing::field::Empty,
+            "db.operation.batch.size" = tracing::field::Empty,
+            "lix.execution.kind" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        TelemetrySpanKind::SqlCoherentReadBatch => tracing::info_span!(
+            target: "lix_sql",
+            "lix.sql.coherent_read_batch",
+            "otel.name" = tracing::field::Empty,
+            "otel.kind" = tracing::field::Empty,
+            "db.system.name" = tracing::field::Empty,
+            "db.operation.batch.size" = tracing::field::Empty,
+            "lix.execution.kind" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+    };
+    for attribute in &start.attributes {
+        record_attribute(&span, attribute);
+    }
+    span
+}
+
+fn record_attribute(span: &tracing::Span, attribute: &TelemetryAttribute) {
+    match &attribute.value {
+        TelemetryValue::String(value) => span.record(attribute.key, value.as_str()),
+        TelemetryValue::U64(value) => span.record(attribute.key, *value),
+        TelemetryValue::Boolean(value) => span.record(attribute.key, *value),
+    };
+}
+
+pub(crate) struct ActiveTelemetrySpan {
+    handle: Box<dyn TelemetrySpanHandle>,
+    started: web_time::Instant,
+}
+
+impl ActiveTelemetrySpan {
+    pub(crate) fn start(sink: &Arc<dyn TelemetrySink>, start: TelemetrySpanStart) -> Self {
+        Self {
+            handle: sink.start_span(start),
+            started: web_time::Instant::now(),
+        }
+    }
+
+    pub(crate) async fn instrument<F>(&self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        TelemetryInstrumentedFuture {
+            future: Box::pin(future),
+            handle: self.handle.as_ref(),
+        }
+        .await
+    }
+
+    pub(crate) fn finish(self, status: TelemetrySpanStatus, attributes: Vec<TelemetryAttribute>) {
+        let duration_ns = u64::try_from(self.started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        self.handle.finish(TelemetrySpanEnd {
+            duration_ns,
+            status,
+            attributes,
+        });
+    }
+}
+
+struct TelemetryInstrumentedFuture<'a, F> {
+    future: Pin<Box<F>>,
+    handle: &'a dyn TelemetrySpanHandle,
+}
+
+impl<F> Future for TelemetryInstrumentedFuture<'_, F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let _entered = self.handle.enter();
+        self.future.as_mut().poll(context)
+    }
+}
+
+pub(crate) fn unix_time_ms() -> u64 {
+    web_time::SystemTime::now()
+        .duration_since(web_time::SystemTime::UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| u64::try_from(duration.as_millis()).ok())
+        .unwrap_or(0)
+}

--- a/packages/js-sdk/native/lib.rs
+++ b/packages/js-sdk/native/lib.rs
@@ -2,5 +2,6 @@
 mod js_wasm_runtime;
 #[cfg(not(target_family = "wasm"))]
 mod napi;
+mod telemetry;
 #[cfg(target_family = "wasm")]
 mod wasm;

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -1,5 +1,5 @@
 use lix_sdk::{
-    CreateBranchOptions as RsCreateBranchOptions, CreateBranchReceipt,
+    CallbackTelemetrySink, CreateBranchOptions as RsCreateBranchOptions, CreateBranchReceipt,
     ExecuteBatchStatement as RsExecuteBatchStatement, ExecuteOptions as RsExecuteOptions,
     ExecuteResult as RsExecuteResult, Lix as RsLix, LixError, LixTransaction as RsLixTransaction,
     LocalFilesystem, LocalFilesystemOpenOptions, Memory,
@@ -7,11 +7,12 @@ use lix_sdk::{
     MergeBranchPreviewOptions, MergeBranchReceipt, MergeChangeStats, MergeConflict,
     MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, ObserveEvent as RsObserveEvent,
     ObserveEvents as RsObserveEvents, OpenLixOptions as RsOpenLixOptions, SQLite, SQLiteOptions,
-    SwitchBranchOptions as RsSwitchBranchOptions, SwitchBranchReceipt, Value, WasmRuntime,
-    open_lix,
+    SwitchBranchOptions as RsSwitchBranchOptions, SwitchBranchReceipt, TelemetrySink, Value,
+    WasmRuntime, open_lix,
 };
 use napi::JsDeferred;
 use napi::bindgen_prelude::*;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use std::collections::HashMap;
 use std::sync::mpsc::{self, Sender};
@@ -24,6 +25,9 @@ use tokio::runtime::{Builder, Runtime};
 use tokio::sync::watch;
 
 use crate::js_wasm_runtime::{JsWasmRuntime, SharedJsWasmRuntimeDispatch};
+
+type JsTelemetryDispatch = ThreadsafeFunction<String, (), String, Status, false>;
+type SharedJsTelemetryDispatch = Arc<JsTelemetryDispatch>;
 
 #[expect(missing_debug_implementations)]
 #[napi(js_name = "Lix")]
@@ -715,17 +719,20 @@ pub struct OpenLocalFilesystemTask {
     lix_dir: Option<String>,
     sync_all_files: bool,
     wasm_runtime_dispatch: Option<SharedJsWasmRuntimeDispatch>,
+    telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 }
 
 #[expect(missing_debug_implementations)]
 pub struct OpenMemoryTask {
     wasm_runtime_dispatch: Option<SharedJsWasmRuntimeDispatch>,
+    telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 }
 
 #[expect(missing_debug_implementations)]
 pub struct OpenSQLiteTask {
     path: String,
     wasm_runtime_dispatch: Option<SharedJsWasmRuntimeDispatch>,
+    telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 }
 
 impl Task for OpenLocalFilesystemTask {
@@ -739,6 +746,7 @@ impl Task for OpenLocalFilesystemTask {
             self.lix_dir.take(),
             std::mem::take(&mut self.sync_all_files),
             wasm_runtime_dispatch,
+            self.telemetry_dispatch.take(),
         ))
     }
 
@@ -753,7 +761,10 @@ impl Task for OpenMemoryTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         let wasm_runtime_dispatch = take_wasm_runtime_dispatch(&mut self.wasm_runtime_dispatch)?;
-        Ok(open_memory_native(wasm_runtime_dispatch))
+        Ok(open_memory_native(
+            wasm_runtime_dispatch,
+            self.telemetry_dispatch.take(),
+        ))
     }
 
     fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -770,6 +781,7 @@ impl Task for OpenSQLiteTask {
         Ok(open_sqlite_native(
             std::mem::take(&mut self.path),
             wasm_runtime_dispatch,
+            self.telemetry_dispatch.take(),
         ))
     }
 
@@ -789,15 +801,32 @@ fn take_wasm_runtime_dispatch(
     })
 }
 
+fn telemetry_sink(dispatch: Option<SharedJsTelemetryDispatch>) -> Option<Arc<dyn TelemetrySink>> {
+    dispatch.map(|dispatch| {
+        let sink: Arc<dyn TelemetrySink> = Arc::new(CallbackTelemetrySink::new(move |span| {
+            let Ok(json) = serde_json::to_string(&crate::telemetry::TelemetrySpanDto::from(span))
+            else {
+                return;
+            };
+            let _ = dispatch.call(json, ThreadsafeFunctionCallMode::NonBlocking);
+        }));
+        sink
+    })
+}
+
 fn open_memory_native(
     wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+    telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 ) -> std::result::Result<NativeLix, LixError> {
     let rt = Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
-    let options = RsOpenLixOptions::default()
+    let mut options = RsOpenLixOptions::default()
         .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
+    if let Some(telemetry) = telemetry_sink(telemetry_dispatch) {
+        options = options.with_telemetry(telemetry);
+    }
     let lix = rt.block_on(open_lix(options))?;
     NativeLix::new(NativeLixInner::Memory(lix))
 }
@@ -805,14 +834,18 @@ fn open_memory_native(
 fn open_sqlite_native(
     path: String,
     wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+    telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 ) -> std::result::Result<NativeLix, LixError> {
     let rt = Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
     let storage = SQLite::new(SQLiteOptions { path: path.into() })?;
-    let options = RsOpenLixOptions::new(storage)
+    let mut options = RsOpenLixOptions::new(storage)
         .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
+    if let Some(telemetry) = telemetry_sink(telemetry_dispatch) {
+        options = options.with_telemetry(telemetry);
+    }
     let lix = rt.block_on(open_lix(options))?;
     NativeLix::new(NativeLixInner::SQLite(lix))
 }
@@ -822,6 +855,7 @@ fn open_local_filesystem_native(
     lix_dir: Option<String>,
     sync_all_files: bool,
     wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+    telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 ) -> std::result::Result<NativeLix, LixError> {
     let rt = Builder::new_current_thread()
         .enable_all()
@@ -834,7 +868,10 @@ fn open_local_filesystem_native(
         options,
         Arc::clone(&wasm_runtime),
     ))?;
-    let options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(wasm_runtime);
+    let mut options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(wasm_runtime);
+    if let Some(telemetry) = telemetry_sink(telemetry_dispatch) {
+        options = options.with_telemetry(telemetry);
+    }
     let lix = rt.block_on(open_lix(options))?;
     NativeLix::new(NativeLixInner::LocalFilesystem(lix, storage))
 }
@@ -844,9 +881,11 @@ impl NativeLix {
     #[napi(js_name = "openMemory")]
     pub fn open_memory(
         wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+        telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
     ) -> AsyncTask<OpenMemoryTask> {
         AsyncTask::new(OpenMemoryTask {
             wasm_runtime_dispatch: Some(wasm_runtime_dispatch),
+            telemetry_dispatch,
         })
     }
 
@@ -854,10 +893,12 @@ impl NativeLix {
     pub fn open_sqlite(
         path: String,
         wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+        telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
     ) -> AsyncTask<OpenSQLiteTask> {
         AsyncTask::new(OpenSQLiteTask {
             path,
             wasm_runtime_dispatch: Some(wasm_runtime_dispatch),
+            telemetry_dispatch,
         })
     }
 
@@ -867,12 +908,14 @@ impl NativeLix {
         lix_dir: Option<String>,
         sync_all_files: bool,
         wasm_runtime_dispatch: SharedJsWasmRuntimeDispatch,
+        telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
     ) -> AsyncTask<OpenLocalFilesystemTask> {
         AsyncTask::new(OpenLocalFilesystemTask {
             path,
             lix_dir,
             sync_all_files,
             wasm_runtime_dispatch: Some(wasm_runtime_dispatch),
+            telemetry_dispatch,
         })
     }
 

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -8,7 +8,7 @@ use lix_sdk::{
     MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, ObserveEvent as RsObserveEvent,
     ObserveEvents as RsObserveEvents, OpenLixOptions as RsOpenLixOptions, SQLite, SQLiteOptions,
     SwitchBranchOptions as RsSwitchBranchOptions, SwitchBranchReceipt, TelemetrySink, Value,
-    WasmRuntime, open_lix,
+    WasmRuntime, open_lix, open_lix_with_telemetry,
 };
 use napi::JsDeferred;
 use napi::bindgen_prelude::*;
@@ -801,17 +801,14 @@ fn take_wasm_runtime_dispatch(
     })
 }
 
-fn telemetry_sink(dispatch: Option<SharedJsTelemetryDispatch>) -> Option<Arc<dyn TelemetrySink>> {
-    dispatch.map(|dispatch| {
-        let sink: Arc<dyn TelemetrySink> = Arc::new(CallbackTelemetrySink::new(move |span| {
-            let Ok(json) = serde_json::to_string(&crate::telemetry::TelemetrySpanDto::from(span))
-            else {
-                return;
-            };
-            let _ = dispatch.call(json, ThreadsafeFunctionCallMode::NonBlocking);
-        }));
-        sink
-    })
+fn telemetry_sink(dispatch: SharedJsTelemetryDispatch) -> Arc<dyn TelemetrySink> {
+    Arc::new(CallbackTelemetrySink::new(move |span| {
+        let Ok(json) = serde_json::to_string(&crate::telemetry::TelemetrySpanDto::from(span))
+        else {
+            return;
+        };
+        let _ = dispatch.call(json, ThreadsafeFunctionCallMode::NonBlocking);
+    }))
 }
 
 fn open_memory_native(
@@ -822,12 +819,12 @@ fn open_memory_native(
         .enable_all()
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
-    let mut options = RsOpenLixOptions::default()
+    let options = RsOpenLixOptions::default()
         .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
-    if let Some(telemetry) = telemetry_sink(telemetry_dispatch) {
-        options = options.with_telemetry(telemetry);
-    }
-    let lix = rt.block_on(open_lix(options))?;
+    let lix = match telemetry_dispatch.map(telemetry_sink) {
+        Some(telemetry) => rt.block_on(open_lix_with_telemetry(options, telemetry))?,
+        None => rt.block_on(open_lix(options))?,
+    };
     NativeLix::new(NativeLixInner::Memory(lix))
 }
 
@@ -841,12 +838,12 @@ fn open_sqlite_native(
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
     let storage = SQLite::new(SQLiteOptions { path: path.into() })?;
-    let mut options = RsOpenLixOptions::new(storage)
+    let options = RsOpenLixOptions::new(storage)
         .with_wasm_runtime(Arc::new(JsWasmRuntime::new(wasm_runtime_dispatch)));
-    if let Some(telemetry) = telemetry_sink(telemetry_dispatch) {
-        options = options.with_telemetry(telemetry);
-    }
-    let lix = rt.block_on(open_lix(options))?;
+    let lix = match telemetry_dispatch.map(telemetry_sink) {
+        Some(telemetry) => rt.block_on(open_lix_with_telemetry(options, telemetry))?,
+        None => rt.block_on(open_lix(options))?,
+    };
     NativeLix::new(NativeLixInner::SQLite(lix))
 }
 
@@ -868,11 +865,11 @@ fn open_local_filesystem_native(
         options,
         Arc::clone(&wasm_runtime),
     ))?;
-    let mut options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(wasm_runtime);
-    if let Some(telemetry) = telemetry_sink(telemetry_dispatch) {
-        options = options.with_telemetry(telemetry);
-    }
-    let lix = rt.block_on(open_lix(options))?;
+    let options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(wasm_runtime);
+    let lix = match telemetry_dispatch.map(telemetry_sink) {
+        Some(telemetry) => rt.block_on(open_lix_with_telemetry(options, telemetry))?,
+        None => rt.block_on(open_lix(options))?,
+    };
     NativeLix::new(NativeLixInner::LocalFilesystem(lix, storage))
 }
 

--- a/packages/js-sdk/native/telemetry.rs
+++ b/packages/js-sdk/native/telemetry.rs
@@ -1,0 +1,40 @@
+use std::collections::BTreeMap;
+
+use lix_sdk::{CompletedTelemetrySpan, TelemetrySpanStatus, TelemetryValue};
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TelemetrySpanDto {
+    schema_version: u8,
+    name: &'static str,
+    started_at_unix_ms: f64,
+    duration_ms: f64,
+    status: &'static str,
+    attributes: BTreeMap<&'static str, serde_json::Value>,
+}
+
+impl From<CompletedTelemetrySpan> for TelemetrySpanDto {
+    fn from(span: CompletedTelemetrySpan) -> Self {
+        let mut attributes = BTreeMap::new();
+        for attribute in span.start.attributes.into_iter().chain(span.end.attributes) {
+            let value = match attribute.value {
+                TelemetryValue::String(value) => serde_json::Value::String(value),
+                TelemetryValue::U64(value) => serde_json::Value::from(value),
+                TelemetryValue::Boolean(value) => serde_json::Value::Bool(value),
+            };
+            attributes.insert(attribute.key, value);
+        }
+        Self {
+            schema_version: 1,
+            name: span.start.name,
+            started_at_unix_ms: span.start.started_at_unix_ms as f64,
+            duration_ms: span.end.duration_ns as f64 / 1_000_000.0,
+            status: match span.end.status {
+                TelemetrySpanStatus::Ok => "ok",
+                TelemetrySpanStatus::Error => "error",
+            },
+            attributes,
+        }
+    }
+}

--- a/packages/js-sdk/native/telemetry.rs
+++ b/packages/js-sdk/native/telemetry.rs
@@ -14,6 +14,10 @@ pub(crate) struct TelemetrySpanDto {
     attributes: BTreeMap<&'static str, serde_json::Value>,
 }
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "JavaScript telemetry timestamps and durations are represented as Number"
+)]
 impl From<CompletedTelemetrySpan> for TelemetrySpanDto {
     fn from(span: CompletedTelemetrySpan) -> Self {
         let mut attributes = BTreeMap::new();

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -10,14 +10,15 @@ use async_trait::async_trait;
 use futures_util::future::{AbortHandle, Abortable};
 use js_sys::{Array, Function, Promise, Reflect};
 use lix_sdk::{
-    CreateBranchOptions as RsCreateBranchOptions, ExecuteBatchStatement as RsExecuteBatchStatement,
-    ExecuteOptions as RsExecuteOptions, ExecuteResult as RsExecuteResult, Lix as RsLix, LixError,
-    LixTransaction as RsLixTransaction, Memory, MergeBranchOptions as RsMergeBranchOptions,
-    MergeBranchOutcome, MergeBranchPreviewOptions, ObserveEvents as RsObserveEvents,
+    CallbackTelemetrySink, CreateBranchOptions as RsCreateBranchOptions,
+    ExecuteBatchStatement as RsExecuteBatchStatement, ExecuteOptions as RsExecuteOptions,
+    ExecuteResult as RsExecuteResult, Lix as RsLix, LixError, LixTransaction as RsLixTransaction,
+    Memory, MergeBranchOptions as RsMergeBranchOptions, MergeBranchOutcome,
+    MergeBranchPreviewOptions, ObserveEvents as RsObserveEvents,
     OpenLixOptions as RsOpenLixOptions, SqlScriptPlan,
-    SwitchBranchOptions as RsSwitchBranchOptions, Value, WasmComponentInstance, WasmLimits,
-    WasmPluginDetectedChange, WasmPluginEntityState, WasmPluginFile, WasmRuntime, open_lix,
-    parse_sql_script as parse_rs_sql_script,
+    SwitchBranchOptions as RsSwitchBranchOptions, TelemetrySink, Value, WasmComponentInstance,
+    WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState, WasmPluginFile, WasmRuntime,
+    open_lix, parse_sql_script as parse_rs_sql_script,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_bytes::ByteBuf;
@@ -47,13 +48,17 @@ pub struct WasmObserveEvents {
 }
 
 #[wasm_bindgen(js_name = openMemory)]
-pub async fn open_memory(plugin_runtime_dispatch: Function) -> Result<WasmLix, JsValue> {
-    open_memory_from_snapshot(plugin_runtime_dispatch, None).await
+pub async fn open_memory(
+    plugin_runtime_dispatch: Function,
+    telemetry_dispatch: Option<Function>,
+) -> Result<WasmLix, JsValue> {
+    open_memory_from_snapshot(plugin_runtime_dispatch, telemetry_dispatch, None).await
 }
 
 #[wasm_bindgen(js_name = openMemoryFromSnapshot)]
 pub async fn open_memory_from_snapshot(
     plugin_runtime_dispatch: Function,
+    telemetry_dispatch: Option<Function>,
     snapshot: Option<Vec<u8>>,
 ) -> Result<WasmLix, JsValue> {
     console_error_panic_hook::set_once();
@@ -64,10 +69,29 @@ pub async fn open_memory_from_snapshot(
         }
         None => Memory::new(),
     };
-    let options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(runtime);
+    let mut options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(runtime);
+    if let Some(dispatch) = telemetry_dispatch {
+        let dispatch = BrowserTelemetryDispatch(dispatch);
+        let sink: Arc<dyn TelemetrySink> = Arc::new(CallbackTelemetrySink::new(move |span| {
+            let Ok(span) = to_js(&crate::telemetry::TelemetrySpanDto::from(span)) else {
+                return;
+            };
+            let _ = dispatch.0.call1(&JsValue::UNDEFINED, &span);
+        }));
+        options = options.with_telemetry(sink);
+    }
     let inner = open_lix(options).await.map_err(lix_error_to_js)?;
     Ok(WasmLix { inner, storage })
 }
+
+struct BrowserTelemetryDispatch(Function);
+
+#[expect(
+    clippy::non_send_fields_in_send_ty,
+    reason = "browser WASM is single-threaded but the shared telemetry trait requires Send"
+)]
+unsafe impl Send for BrowserTelemetryDispatch {}
+unsafe impl Sync for BrowserTelemetryDispatch {}
 
 #[wasm_bindgen(js_name = parseSqlScript)]
 pub fn parse_sql_script(sql: String, provided_param_count: usize) -> Result<JsValue, JsValue> {

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -18,7 +18,7 @@ use lix_sdk::{
     OpenLixOptions as RsOpenLixOptions, SqlScriptPlan,
     SwitchBranchOptions as RsSwitchBranchOptions, TelemetrySink, Value, WasmComponentInstance,
     WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState, WasmPluginFile, WasmRuntime,
-    open_lix, parse_sql_script as parse_rs_sql_script,
+    open_lix, open_lix_with_telemetry, parse_sql_script as parse_rs_sql_script,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_bytes::ByteBuf;
@@ -69,8 +69,8 @@ pub async fn open_memory_from_snapshot(
         }
         None => Memory::new(),
     };
-    let mut options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(runtime);
-    if let Some(dispatch) = telemetry_dispatch {
+    let options = RsOpenLixOptions::new(storage.clone()).with_wasm_runtime(runtime);
+    let telemetry = telemetry_dispatch.map(|dispatch| {
         let dispatch = BrowserTelemetryDispatch(dispatch);
         let sink: Arc<dyn TelemetrySink> = Arc::new(CallbackTelemetrySink::new(move |span| {
             let Ok(span) = to_js(&crate::telemetry::TelemetrySpanDto::from(span)) else {
@@ -78,9 +78,13 @@ pub async fn open_memory_from_snapshot(
             };
             let _ = dispatch.0.call1(&JsValue::UNDEFINED, &span);
         }));
-        options = options.with_telemetry(sink);
+        sink
+    });
+    let inner = match telemetry {
+        Some(telemetry) => open_lix_with_telemetry(options, telemetry).await,
+        None => open_lix(options).await,
     }
-    let inner = open_lix(options).await.map_err(lix_error_to_js)?;
+    .map_err(lix_error_to_js)?;
     Ok(WasmLix { inner, storage })
 }
 

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -67,11 +67,11 @@
 		"@lix-js/sdk-win32-x64": "0.8.4"
 	},
 	"devDependencies": {
-		"@vitest/browser-playwright": "4.0.18",
+		"@vitest/browser-playwright": "4.1.10",
 		"@types/node": "^24.10.2",
 		"playwright": "1.57.0",
 		"typescript": "^5.5.4",
-		"vitest": "^4.0.18"
+		"vitest": "4.1.10"
 	},
 	"dependencies": {
 		"@bytecodealliance/jco-transpile": "0.4.2",

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -8,6 +8,7 @@ import type {
 	MergeBranchReceipt,
 	SwitchBranchOptions,
 	SwitchBranchReceipt,
+	LixTelemetrySpan,
 } from "./types.js";
 import type { NativeLixValue } from "./value.js";
 
@@ -73,6 +74,7 @@ export type ObserveEventsBinding = {
 };
 
 export type PluginRuntimeDispatch = (request: unknown) => Promise<unknown>;
+export type TelemetryDispatch = (span: LixTelemetrySpan) => void;
 
 export type LixStorageConfig =
 	| { kind: "memory" }

--- a/packages/js-sdk/src/binding.browser.ts
+++ b/packages/js-sdk/src/binding.browser.ts
@@ -2,6 +2,7 @@ import type {
 	LixStorageConfig,
 	LixBinding,
 	PluginRuntimeDispatch,
+	TelemetryDispatch,
 } from "./binding-types.js";
 
 // Generated before TypeScript compilation and emitted beside this module.
@@ -17,6 +18,7 @@ function initializeWasm(): Promise<unknown> {
 export async function openLixBinding(
 	storage: LixStorageConfig,
 	dispatch: PluginRuntimeDispatch,
+	telemetry?: TelemetryDispatch,
 ): Promise<LixBinding> {
 	if (storage.kind !== "memory") {
 		throw new Error(
@@ -24,5 +26,5 @@ export async function openLixBinding(
 		);
 	}
 	await initializeWasm();
-	return openMemory(dispatch);
+	return openMemory(dispatch, telemetry);
 }

--- a/packages/js-sdk/src/binding.node.ts
+++ b/packages/js-sdk/src/binding.node.ts
@@ -5,20 +5,26 @@ import type {
 	LixStorageConfig,
 	LixBinding,
 	PluginRuntimeDispatch,
+	TelemetryDispatch,
 } from "./binding-types.js";
 
 type NativeAddon = {
 	Lix: {
-		openMemory(dispatch: PluginRuntimeDispatch): Promise<LixBinding>;
+		openMemory(
+			dispatch: PluginRuntimeDispatch,
+			telemetry?: (spanJson: string) => void,
+		): Promise<LixBinding>;
 		openSQLite(
 			path: string,
 			dispatch: PluginRuntimeDispatch,
+			telemetry?: (spanJson: string) => void,
 		): Promise<LixBinding>;
 		openLocalFilesystem(
 			path: string,
 			lixDir: string | undefined,
 			syncAllFiles: boolean,
 			dispatch: PluginRuntimeDispatch,
+			telemetry?: (spanJson: string) => void,
 		): Promise<LixBinding>;
 	};
 };
@@ -67,18 +73,23 @@ try {
 export function openLixBinding(
 	storage: LixStorageConfig,
 	dispatch: PluginRuntimeDispatch,
+	telemetry?: TelemetryDispatch,
 ): Promise<LixBinding> {
+	const nativeTelemetry = telemetry
+		? (spanJson: string) => telemetry(JSON.parse(spanJson))
+		: undefined;
 	switch (storage.kind) {
 		case "memory":
-			return addon.Lix.openMemory(dispatch);
+			return addon.Lix.openMemory(dispatch, nativeTelemetry);
 		case "sqlite":
-			return addon.Lix.openSQLite(storage.path, dispatch);
+			return addon.Lix.openSQLite(storage.path, dispatch, nativeTelemetry);
 		case "localFilesystem":
 			return addon.Lix.openLocalFilesystem(
 				storage.path,
 				storage.lixDir,
 				storage.syncAllFiles,
 				dispatch,
+				nativeTelemetry,
 			);
 	}
 }

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -31,6 +31,8 @@ export type {
 	MergeConflictSide,
 	ObserveEvent,
 	OpenLixOptions,
+	LixTelemetryOptions,
+	LixTelemetrySpan,
 	RemoteLixFetch,
 	RemoteLixServerOptions,
 	SqlParam,

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -7,6 +7,32 @@ registerMemoryStorageContract({
 	operationTimeoutMs: 30_000,
 });
 
+test("forwards opt-in SQL telemetry from browser WASM", async () => {
+	const { openLix } = await import("@lix-js/sdk");
+	let resolveSpan!: (span: { attributes: Record<string, unknown> }) => void;
+	const received = new Promise<{ attributes: Record<string, unknown> }>(
+		(resolve) => {
+			resolveSpan = resolve;
+		},
+	);
+	const lix = await openLix({
+		telemetry: {
+			onSpan(span) {
+				if (span.name === "lix.sql.query") resolveSpan(span);
+			},
+		},
+	});
+	try {
+		await lix.execute("SELECT 'private-value' AS value, 42 AS number");
+		const span = await received;
+		expect(span.attributes["db.query.text"]).toBe(
+			"SELECT ? AS value, ? AS number",
+		);
+	} finally {
+		await lix.close();
+	}
+});
+
 test("loads and executes the engine outside the browser main thread", async () => {
 	const wasm = WebAssembly as unknown as Record<
 		string,

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -21,12 +21,40 @@ import {
 	Value,
 	type ExecuteResult,
 	type Lix,
+	type LixTelemetrySpan,
 } from "./index.js";
 import { registerMemoryStorageContract } from "../tests/memory-storage-contract.js";
 
 registerMemoryStorageContract({
 	name: "Node native",
 	loadSdk: async () => await import("./index.js"),
+});
+
+test("openLix forwards opt-in SQL telemetry from the engine", async () => {
+	let resolveSpan!: (span: LixTelemetrySpan) => void;
+	const received = new Promise<LixTelemetrySpan>((resolve) => {
+		resolveSpan = resolve;
+	});
+	const lix = await openLix({
+		telemetry: {
+			onSpan(span) {
+				if (span.name === "lix.sql.query") resolveSpan(span);
+			},
+		},
+	});
+
+	await lix.execute("SELECT 'private-value' AS value, 42 AS number");
+	const span = await received;
+	expect(span).toMatchObject({
+		schemaVersion: 1,
+		name: "lix.sql.query",
+		status: "ok",
+	});
+	expect(span.durationMs).toBeGreaterThanOrEqual(0);
+	expect(span.attributes["db.query.text"]).toBe(
+		"SELECT ? AS value, ? AS number",
+	);
+	await lix.close();
 });
 
 test("openLix exposes the lix-sdk e2e flow", async () => {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -97,6 +97,15 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			"openLix() option 'backend' was removed; use 'storage' instead",
 		);
 	}
+	if (
+		options.telemetry !== undefined &&
+		(typeof options.telemetry !== "object" ||
+			typeof options.telemetry.onSpan !== "function")
+	) {
+		throw new TypeError(
+			"openLix() telemetry requires an onSpan callback",
+		);
+	}
 	if (options.server !== undefined) {
 		if (options.storage !== undefined) {
 			throw new TypeError(
@@ -108,14 +117,16 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 	}
 	const { openLixWorkerBinding } = await import("./worker/client.js");
 	if (options.storage === undefined) {
-		return new Lix(await openLixWorkerBinding({ kind: "memory" }));
+		return new Lix(
+			await openLixWorkerBinding({ kind: "memory" }, undefined, options.telemetry),
+		);
 	}
 	if (options.storage instanceof SQLite) {
 		return new Lix(
 			await openLixWorkerBinding({
 				kind: "sqlite",
 				path: options.storage.path,
-			}),
+			}, undefined, options.telemetry),
 		);
 	}
 	if (options.storage instanceof LocalFilesystem) {
@@ -133,6 +144,7 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 					syncAllFiles: storage.syncAllFiles,
 				},
 				() => openLocalFilesystems.delete(storage),
+				options.telemetry,
 			);
 			openLocalFilesystems.set(storage, binding);
 			return new Lix(binding);

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -20,16 +20,31 @@ export type RemoteLixServerOptions = {
 	fetch?: RemoteLixFetch;
 };
 
+export type LixTelemetrySpan = {
+	schemaVersion: 1;
+	name: string;
+	startedAtUnixMs: number;
+	durationMs: number;
+	status: "ok" | "error";
+	attributes: Record<string, string | number | boolean>;
+};
+
+export type LixTelemetryOptions = {
+	onSpan(span: LixTelemetrySpan): void;
+};
+
 export type OpenLixOptions =
 	| {
 			storage?:
 				| import("./open-lix.js").SQLite
 				| import("./open-lix.js").LocalFilesystem;
 			server?: never;
+			telemetry?: LixTelemetryOptions;
 	  }
 	| {
 			storage?: never;
 			server: RemoteLixServerOptions;
+			telemetry?: never;
 	  };
 
 export type LixValue =

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -5,6 +5,7 @@ import type {
 	LixTransactionBinding,
 	ObserveEventsBinding,
 } from "../binding-types.js";
+import type { LixTelemetryOptions } from "../types.js";
 import {
 	deserializeWorkerError,
 	type WorkerConnection,
@@ -21,10 +22,15 @@ type PendingRequest = {
 export async function openLixWorker(
 	storage: LixStorageConfig,
 	onDisposed?: () => void,
+	telemetry?: LixTelemetryOptions,
 ): Promise<LixWorkerClient> {
-	const client = new LixWorkerClient(onDisposed);
+	const client = new LixWorkerClient(onDisposed, undefined, telemetry);
 	try {
-		await client.request({ kind: "open", storage });
+		await client.request({
+			kind: "open",
+			storage,
+			telemetryEnabled: telemetry !== undefined,
+		});
 		return client;
 	} catch (error) {
 		await client.terminate();
@@ -36,8 +42,9 @@ export async function openLixWorker(
 export async function openLixWorkerBinding(
 	storage: LixStorageConfig,
 	onDisposed?: () => void,
+	telemetry?: LixTelemetryOptions,
 ): Promise<LixBinding> {
-	const client = await openLixWorker(storage, onDisposed);
+	const client = await openLixWorker(storage, onDisposed, telemetry);
 	return workerBinding(client);
 }
 
@@ -118,6 +125,7 @@ export class LixWorkerClient {
 	constructor(
 		private readonly onDisposed?: () => void,
 		private readonly connection: WorkerConnection = createWorkerConnection(),
+		private readonly telemetry?: LixTelemetryOptions,
 	) {
 		connection.onMessage((message) => this.handleMessage(message));
 		connection.onFatal((error) => this.handleFatal(error));
@@ -163,6 +171,14 @@ export class LixWorkerClient {
 	}
 
 	private handleMessage(message: WorkerResponse): void {
+		if ("kind" in message) {
+			try {
+				this.telemetry?.onSpan(message.span);
+			} catch {
+				// Telemetry callbacks are isolated from Lix operation results.
+			}
+			return;
+		}
 		const pending = this.pending.get(message.id);
 		if (!pending) return;
 		this.pending.delete(message.id);

--- a/packages/js-sdk/src/worker/host.ts
+++ b/packages/js-sdk/src/worker/host.ts
@@ -78,6 +78,9 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 				lix = await openLixBinding(
 					operation.storage,
 					createPluginRuntimeDispatch() as PluginRuntimeDispatch,
+					operation.telemetryEnabled
+						? (span) => endpoint.postMessage({ kind: "telemetry", span })
+						: undefined,
 				);
 				return undefined;
 			case "execute":

--- a/packages/js-sdk/src/worker/protocol.ts
+++ b/packages/js-sdk/src/worker/protocol.ts
@@ -9,6 +9,7 @@ import type {
 	LixBatchOptions,
 	MergeBranchOptions,
 	SwitchBranchOptions,
+	LixTelemetrySpan,
 } from "../types.js";
 
 export type WorkerRequest = {
@@ -17,7 +18,7 @@ export type WorkerRequest = {
 };
 
 export type WorkerOperation =
-	| { kind: "open"; storage: LixStorageConfig }
+	| { kind: "open"; storage: LixStorageConfig; telemetryEnabled: boolean }
 	| {
 			kind: "execute";
 			sql: string;
@@ -81,7 +82,8 @@ export type SerializedWorkerError = {
 
 export type WorkerResponse =
 	| { id: number; ok: true; value?: unknown }
-	| { id: number; ok: false; error: SerializedWorkerError };
+	| { id: number; ok: false; error: SerializedWorkerError }
+	| { kind: "telemetry"; span: LixTelemetrySpan };
 
 export function serializeWorkerError(error: unknown): SerializedWorkerError {
 	if (!(error instanceof Error)) {

--- a/packages/js-sdk/src/workerd.browser.test.ts
+++ b/packages/js-sdk/src/workerd.browser.test.ts
@@ -11,6 +11,7 @@ async function openMemoryLix(options: { snapshot?: Uint8Array } = {}) {
 		async () => {
 			throw new Error("plugins are unavailable in this test");
 		},
+		undefined,
 		options.snapshot,
 	);
 }

--- a/packages/js-sdk/src/workerd.ts
+++ b/packages/js-sdk/src/workerd.ts
@@ -65,6 +65,7 @@ export async function openMemoryLix(
 		async () => {
 			throw new Error("Lix plugin execution is unavailable in Workerd");
 		},
+		undefined,
 		options.snapshot,
 	);
 }

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -365,7 +365,8 @@ impl LocalFilesystem {
     ) -> Result<Self, LixError> {
         let layout = prepare_filesystem_layout(&options.root, options.lix_dir.as_deref())?;
         let storage = open_filesystem_rocksdb(&layout)?;
-        let engine = crate::lix::open_or_initialize_engine(storage.clone(), wasm_runtime).await?;
+        let engine =
+            crate::lix::open_or_initialize_engine(storage.clone(), wasm_runtime, None).await?;
         let inner =
             FilesystemSync::open_with_engine(storage, engine, layout, options.sync_all_files)
                 .await?;
@@ -2562,7 +2563,7 @@ mod tests {
         path_filter: FilesystemPathFilter,
     ) -> FilesystemState<RocksDBFilesystem> {
         let storage = open_filesystem_rocksdb(&layout).unwrap();
-        let engine = crate::lix::open_or_initialize_engine(storage.clone(), None)
+        let engine = crate::lix::open_or_initialize_engine(storage.clone(), None, None)
             .await
             .unwrap();
         FilesystemState {

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -14,7 +14,9 @@ mod sqlite;
 
 #[cfg(all(not(target_family = "wasm"), feature = "local_filesystem"))]
 pub use filesystem::{LocalFilesystem, LocalFilesystemOpenOptions};
-pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_storage};
+pub use lix::{
+    Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_storage, open_lix_with_telemetry,
+};
 pub use lix_engine::telemetry::{
     CallbackTelemetrySink, CompletedTelemetrySpan, TelemetryAttribute, TelemetrySink,
     TelemetrySpanEnd, TelemetrySpanHandle, TelemetrySpanKind, TelemetrySpanStart,

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -15,6 +15,11 @@ mod sqlite;
 #[cfg(all(not(target_family = "wasm"), feature = "local_filesystem"))]
 pub use filesystem::{LocalFilesystem, LocalFilesystemOpenOptions};
 pub use lix::{Lix, LixTransaction, OpenLixOptions, open_lix, open_lix_with_storage};
+pub use lix_engine::telemetry::{
+    CallbackTelemetrySink, CompletedTelemetrySpan, TelemetryAttribute, TelemetrySink,
+    TelemetrySpanEnd, TelemetrySpanHandle, TelemetrySpanKind, TelemetrySpanStart,
+    TelemetrySpanStatus, TelemetryValue, TracingTelemetrySink,
+};
 pub use lix_engine::wasm::{
     WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
     WasmPluginFile, WasmRuntime,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 pub struct OpenLixOptions<StorageImpl = Memory> {
     pub storage: StorageImpl,
     pub wasm_runtime: Option<Arc<dyn WasmRuntime>>,
-    pub telemetry: Option<Arc<dyn TelemetrySink>>,
 }
 
 impl Default for OpenLixOptions<Memory> {
@@ -21,7 +20,6 @@ impl Default for OpenLixOptions<Memory> {
         Self {
             storage: Memory::new(),
             wasm_runtime: None,
-            telemetry: None,
         }
     }
 }
@@ -31,17 +29,11 @@ impl<StorageImpl> OpenLixOptions<StorageImpl> {
         Self {
             storage,
             wasm_runtime: None,
-            telemetry: None,
         }
     }
 
     pub fn with_wasm_runtime(mut self, wasm_runtime: Arc<dyn WasmRuntime>) -> Self {
         self.wasm_runtime = Some(wasm_runtime);
-        self
-    }
-
-    pub fn with_telemetry(mut self, telemetry: Arc<dyn TelemetrySink>) -> Self {
-        self.telemetry = Some(telemetry);
         self
     }
 }
@@ -67,8 +59,32 @@ pub async fn open_lix<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    open_lix_with_optional_telemetry(options, None).await
+}
+
+/// Opens a Lix workspace session with an explicit per-engine telemetry sink.
+///
+/// Telemetry is intentionally a separate entry point so adding the opt-in does
+/// not break callers that construct [`OpenLixOptions`] with a struct literal.
+pub async fn open_lix_with_telemetry<StorageImpl>(
+    options: OpenLixOptions<StorageImpl>,
+    telemetry: Arc<dyn TelemetrySink>,
+) -> Result<Lix<StorageImpl>, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    open_lix_with_optional_telemetry(options, Some(telemetry)).await
+}
+
+async fn open_lix_with_optional_telemetry<StorageImpl>(
+    options: OpenLixOptions<StorageImpl>,
+    telemetry: Option<Arc<dyn TelemetrySink>>,
+) -> Result<Lix<StorageImpl>, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
     let engine =
-        open_or_initialize_engine(options.storage, options.wasm_runtime, options.telemetry).await?;
+        open_or_initialize_engine(options.storage, options.wasm_runtime, telemetry).await?;
     let session = engine.open_workspace_session().await?;
     Ok(Lix {
         _engine: engine,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -1,7 +1,8 @@
+use lix_engine::telemetry::TelemetrySink;
 use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
-    CreateBranchOptions, CreateBranchReceipt, Engine, ExecuteBatchStatement, ExecuteOptions,
-    ExecuteResult, LixError, Memory, MergeBranchOptions, MergeBranchPreview,
+    CreateBranchOptions, CreateBranchReceipt, Engine, EngineOptions, ExecuteBatchStatement,
+    ExecuteOptions, ExecuteResult, LixError, Memory, MergeBranchOptions, MergeBranchPreview,
     MergeBranchPreviewOptions, MergeBranchReceipt, ObserveEvents, SessionContext, Storage,
     SwitchBranchOptions, SwitchBranchReceipt, Value,
 };
@@ -12,6 +13,7 @@ use std::sync::Arc;
 pub struct OpenLixOptions<StorageImpl = Memory> {
     pub storage: StorageImpl,
     pub wasm_runtime: Option<Arc<dyn WasmRuntime>>,
+    pub telemetry: Option<Arc<dyn TelemetrySink>>,
 }
 
 impl Default for OpenLixOptions<Memory> {
@@ -19,6 +21,7 @@ impl Default for OpenLixOptions<Memory> {
         Self {
             storage: Memory::new(),
             wasm_runtime: None,
+            telemetry: None,
         }
     }
 }
@@ -28,11 +31,17 @@ impl<StorageImpl> OpenLixOptions<StorageImpl> {
         Self {
             storage,
             wasm_runtime: None,
+            telemetry: None,
         }
     }
 
     pub fn with_wasm_runtime(mut self, wasm_runtime: Arc<dyn WasmRuntime>) -> Self {
         self.wasm_runtime = Some(wasm_runtime);
+        self
+    }
+
+    pub fn with_telemetry(mut self, telemetry: Arc<dyn TelemetrySink>) -> Self {
+        self.telemetry = Some(telemetry);
         self
     }
 }
@@ -58,7 +67,8 @@ pub async fn open_lix<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    let engine = open_or_initialize_engine(options.storage, options.wasm_runtime).await?;
+    let engine =
+        open_or_initialize_engine(options.storage, options.wasm_runtime, options.telemetry).await?;
     let session = engine.open_workspace_session().await?;
     Ok(Lix {
         _engine: engine,
@@ -218,15 +228,16 @@ where
 pub(crate) async fn open_or_initialize_engine<StorageImpl>(
     storage: StorageImpl,
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,
+    telemetry: Option<Arc<dyn TelemetrySink>>,
 ) -> Result<Engine<StorageImpl>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    match new_engine(storage.clone(), wasm_runtime.clone()).await {
+    match new_engine(storage.clone(), wasm_runtime.clone(), telemetry.clone()).await {
         Ok(engine) => Ok(engine),
         Err(error) if error.code == "LIX_ERROR_NOT_INITIALIZED" => {
             Engine::initialize(storage.clone()).await?;
-            new_engine(storage, wasm_runtime).await
+            new_engine(storage, wasm_runtime, telemetry).await
         }
         Err(error) => Err(error),
     }
@@ -235,32 +246,31 @@ where
 async fn new_engine<StorageImpl>(
     storage: StorageImpl,
     wasm_runtime: Option<Arc<dyn WasmRuntime>>,
+    telemetry: Option<Arc<dyn TelemetrySink>>,
 ) -> Result<Engine<StorageImpl>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    match wasm_runtime {
-        Some(wasm_runtime) => Engine::new_with_wasm_runtime(storage, wasm_runtime).await,
-        None => new_engine_with_default_runtime(storage).await,
+    let wasm_runtime = match wasm_runtime {
+        Some(wasm_runtime) => Some(wasm_runtime),
+        None => default_wasm_runtime()?,
+    };
+    let mut options = EngineOptions::new();
+    if let Some(wasm_runtime) = wasm_runtime {
+        options = options.with_wasm_runtime(wasm_runtime);
     }
+    if let Some(telemetry) = telemetry {
+        options = options.with_telemetry(telemetry);
+    }
+    Engine::new_with_options(storage, options).await
 }
 
 #[cfg(feature = "default_wasm_runtime")]
-async fn new_engine_with_default_runtime<StorageImpl>(
-    storage: StorageImpl,
-) -> Result<Engine<StorageImpl>, LixError>
-where
-    StorageImpl: Storage + Clone + Send + Sync + 'static,
-{
-    Engine::new_with_wasm_runtime(storage, crate::default_wasm_runtime::runtime()?).await
+fn default_wasm_runtime() -> Result<Option<Arc<dyn WasmRuntime>>, LixError> {
+    Ok(Some(crate::default_wasm_runtime::runtime()?))
 }
 
 #[cfg(not(feature = "default_wasm_runtime"))]
-async fn new_engine_with_default_runtime<StorageImpl>(
-    storage: StorageImpl,
-) -> Result<Engine<StorageImpl>, LixError>
-where
-    StorageImpl: Storage + Clone + Send + Sync + 'static,
-{
-    Engine::new(storage).await
+fn default_wasm_runtime() -> Result<Option<Arc<dyn WasmRuntime>>, LixError> {
+    Ok(None)
 }

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,7 +1,7 @@
 use lix_sdk::{
     CallbackTelemetrySink, CompletedTelemetrySpan, CreateBranchOptions, ExecuteBatchStatement, Lix,
     LixError, Memory, MergeBranchOptions, MergeBranchOutcome, OpenLixOptions, Storage,
-    SwitchBranchOptions, TelemetryValue, Value, open_lix,
+    SwitchBranchOptions, TelemetryValue, Value, open_lix, open_lix_with_telemetry,
 };
 #[cfg(feature = "local_filesystem")]
 use lix_sdk::{LocalFilesystem, LocalFilesystemOpenOptions, open_lix_with_storage};
@@ -18,7 +18,7 @@ async fn rs_sdk_telemetry_is_explicit_and_redacts_sql_literals() {
     let telemetry = Arc::new(CallbackTelemetrySink::new(move |span| {
         captured.lock().unwrap().push(span);
     }));
-    let lix = open_lix(OpenLixOptions::default().with_telemetry(telemetry))
+    let lix = open_lix_with_telemetry(OpenLixOptions::default(), telemetry)
         .await
         .unwrap();
 

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,13 +1,48 @@
 use lix_sdk::{
-    CreateBranchOptions, ExecuteBatchStatement, Lix, LixError, Memory, MergeBranchOptions,
-    MergeBranchOutcome, OpenLixOptions, Storage, SwitchBranchOptions, Value, open_lix,
+    CallbackTelemetrySink, CompletedTelemetrySpan, CreateBranchOptions, ExecuteBatchStatement, Lix,
+    LixError, Memory, MergeBranchOptions, MergeBranchOutcome, OpenLixOptions, Storage,
+    SwitchBranchOptions, TelemetryValue, Value, open_lix,
 };
 #[cfg(feature = "local_filesystem")]
 use lix_sdk::{LocalFilesystem, LocalFilesystemOpenOptions, open_lix_with_storage};
 #[cfg(feature = "local_filesystem")]
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 #[cfg(feature = "local_filesystem")]
 use std::time::{Duration, Instant};
+
+#[tokio::test]
+async fn rs_sdk_telemetry_is_explicit_and_redacts_sql_literals() {
+    let spans = Arc::new(Mutex::new(Vec::<CompletedTelemetrySpan>::new()));
+    let captured = Arc::clone(&spans);
+    let telemetry = Arc::new(CallbackTelemetrySink::new(move |span| {
+        captured.lock().unwrap().push(span);
+    }));
+    let lix = open_lix(OpenLixOptions::default().with_telemetry(telemetry))
+        .await
+        .unwrap();
+
+    lix.execute("SELECT 'private-value' AS value, 42 AS number", &[])
+        .await
+        .unwrap();
+
+    let spans = spans.lock().unwrap();
+    let span = spans
+        .iter()
+        .find(|span| span.start.name == "lix.sql.query")
+        .expect("query telemetry should be emitted when configured");
+    let query_text = span
+        .start
+        .attributes
+        .iter()
+        .find_map(|attribute| match (&attribute.key, &attribute.value) {
+            (&"db.query.text", TelemetryValue::String(value)) => Some(value.as_str()),
+            _ => None,
+        })
+        .expect("query telemetry includes sanitized SQL");
+    assert_eq!(query_text, "SELECT ? AS value, ? AS number");
+    assert!(span.end.duration_ns > 0);
+}
 
 #[tokio::test]
 async fn rs_sdk_open_register_write_query_branch_and_merge_flow() {

--- a/packages/rs-sdk/tests/sqlite.rs
+++ b/packages/rs-sdk/tests/sqlite.rs
@@ -111,7 +111,6 @@ async fn sqlite_open_lix_options_supplies_plugin_wasm_runtime() {
     let lix = open_lix(OpenLixOptions {
         storage: SQLite::open(&path).expect("sqlite storage opens"),
         wasm_runtime: Some(wasm_runtime),
-        telemetry: None,
     })
     .await
     .expect("lix opens on sqlite storage with wasm runtime");

--- a/packages/rs-sdk/tests/sqlite.rs
+++ b/packages/rs-sdk/tests/sqlite.rs
@@ -111,6 +111,7 @@ async fn sqlite_open_lix_options_supplies_plugin_wasm_runtime() {
     let lix = open_lix(OpenLixOptions {
         storage: SQLite::open(&path).expect("sqlite storage opens"),
         wasm_runtime: Some(wasm_runtime),
+        telemetry: None,
     })
     .await
     .expect("lix opens on sqlite storage with wasm runtime");


### PR DESCRIPTION
## What

- add a vendor-neutral, opt-in telemetry sink at the Lix engine boundary
- emit centrally timed and redacted SQL query/batch spans from every engine execution path
- expose the same telemetry callback through rs-sdk, Node/N-API, and browser/WASM workers
- align Vitest browser packages and use a browser-safe clock for WASM

## Why

Consumers need one authoritative stream of measured SQL execution spans without duplicating instrumentation in every SDK or application. When no sink is supplied, the engine does not construct or emit telemetry spans.

## Impact

This adds an optional API only. Existing callers keep telemetry disabled by default. SQL literals and comments are removed before data leaves the engine; spans include sanitized query shape, fingerprint, operation, timing, row count, and status.

## Checks

- `cargo check -p lix_engine -p lix_sdk -p lix_js_sdk`
- `cargo test -p lix_engine sql_telemetry`
- `cargo test -p lix_sdk --test e2e rs_sdk_telemetry_is_explicit_and_redacts_sql_literals`
- Node Vitest telemetry test
- Chromium/WASM Vitest telemetry test
- `cargo fmt --all -- --check`
- `git diff --check`
