### PR TITLE
perf(sql): point-read scoped lix_change lookups

### DIFF
--- a/observations.md
+++ b/observations.md
@@ -60,3 +60,21 @@ than silently removed.
   directory-list projection and matched storage snapshots.
 - **Status:** observing; deferred while the bounded prefix strategy is safe
   and materially faster for indexed lists.
+
+## Active: runtime dynamic join-filter integration
+
+- **Evidence:** A one-row `lix_file` → `lix_change` join cannot pass the file
+  row's runtime `lixcol_change_id` into `ChangeSpec`; the provider must scan
+  the global direct/derived change surface. The bounded Markdown fix instead
+  issues a point `id + file_id` change lookup after reading the file.
+- **Potential:** General runtime dynamic-filter support could make correlated
+  joins use point reads without an application-level split query.
+- **Why it is not a small PR:** It requires filter-aware `PlannedScan` /
+  `SpecScanExec` plumbing plus per-provider dynamic-filter semantics and
+  validation of direct versus derived change rows, touching core SQL execution
+  across more than five files.
+- **Next measurement:** Prototype runtime filter binding for the exact
+  file-to-change join and compare observer re-execution at 2.5k, 10k, and
+  50k changes.
+- **Status:** observing; deferred while explicit 90%-path point lookups remain
+  sufficient.

--- a/packages/engine/src/sql2/providers/change.rs
+++ b/packages/engine/src/sql2/providers/change.rs
@@ -1,15 +1,16 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::context::ExecutionProps;
-use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
 
 use crate::LixError;
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangeScanRequest, ChangelogContext, ChangelogReader, CommitLoadEntry,
-    CommitProjection, CommitScanRequest,
+    ChangeId, ChangeLoadRequest, ChangeRecord, ChangeScanRequest, ChangelogContext,
+    ChangelogReader, CommitLoadEntry, CommitProjection, CommitScanRequest,
 };
 use crate::serialize_row_metadata;
 
@@ -24,6 +25,7 @@ use crate::sql2::result_metadata::json_field;
 use crate::storage_adapter::StorageAdapterRead;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
+use super::file::{FileIdConstraint, exact_string_column_constraint_from_filters};
 use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
 
 pub(super) async fn register_lix_change_read_provider<S>(
@@ -66,6 +68,19 @@ where
         lix_change_schema()
     }
 
+    fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
+        if change_filter_has_exact_string_conjunct(filter, "id")
+            || change_filter_has_exact_string_conjunct(filter, "file_id")
+        {
+            // Keep the residual filter: either constraint alone still needs the
+            // complete direct-plus-derived semantics. Together they unlock the
+            // direct point read in `plan_scan`.
+            TableProviderFilterPushDown::Inexact
+        } else {
+            TableProviderFilterPushDown::Unsupported
+        }
+    }
+
     async fn plan_scan(
         &self,
         projection: Option<&Vec<usize>>,
@@ -76,17 +91,21 @@ where
         let pushed_limit = if filters.is_empty() { limit } else { None };
         let schema = projected_schema(&lix_change_schema(), projection);
         let payload_projection = change_payload_projection(schema.as_ref(), filters);
+        let point_lookup = change_point_lookup_from_filters(filters)?;
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
             load: row_source(
-                (self.query_source.clone(), schema),
-                move |(query_source, schema)| async move {
+                (self.query_source.clone(), schema, point_lookup),
+                move |(query_source, schema, point_lookup)| async move {
                     let mut json_reader = query_source.json_reader;
-                    let canonical_changes =
-                        scan_changelog_changes(query_source.store, pushed_limit)
-                            .await
-                            .map_err(lix_error_to_datafusion_error)?;
+                    let canonical_changes = scan_changelog_changes(
+                        query_source.store,
+                        pushed_limit,
+                        point_lookup.as_ref(),
+                    )
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
                     let mut changes = Vec::with_capacity(canonical_changes.len());
                     for change in canonical_changes {
                         match change {
@@ -119,6 +138,68 @@ where
     }
 }
 
+/// An exact direct-change lookup is safe only when an exact `file_id` predicate
+/// excludes the derived `lix_commit` rows that share the `lix_change` surface.
+/// Other filter shapes retain the complete direct-plus-derived scan below.
+#[derive(Clone)]
+struct ChangePointLookup {
+    change_ids: Vec<ChangeId>,
+    file_ids: BTreeSet<String>,
+}
+
+fn change_point_lookup_from_filters(filters: &[Expr]) -> Result<Option<ChangePointLookup>> {
+    let conjuncts = change_filter_conjuncts(filters);
+    let FileIdConstraint::Ids(change_ids) =
+        exact_string_column_constraint_from_filters(&conjuncts, "id")?
+    else {
+        return Ok(None);
+    };
+    let FileIdConstraint::Ids(file_ids) =
+        exact_string_column_constraint_from_filters(&conjuncts, "file_id")?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(ChangePointLookup {
+        // Invalid SQL text cannot name a persisted UUID key, so it contributes
+        // no direct record while preserving the empty result of the full scan.
+        change_ids: change_ids
+            .iter()
+            .filter_map(|change_id| ChangeId::parse(change_id).ok())
+            .collect(),
+        file_ids,
+    }))
+}
+
+fn change_filter_has_exact_string_conjunct(filter: &Expr, column_name: &'static str) -> bool {
+    let mut conjuncts = Vec::new();
+    collect_and_conjuncts(filter, &mut conjuncts);
+    conjuncts.into_iter().any(|conjunct| {
+        matches!(
+            exact_string_column_constraint_from_filters(&[conjunct], column_name),
+            Ok(FileIdConstraint::Ids(_))
+        )
+    })
+}
+
+fn change_filter_conjuncts(filters: &[Expr]) -> Vec<Expr> {
+    let mut conjuncts = Vec::new();
+    for filter in filters {
+        collect_and_conjuncts(filter, &mut conjuncts);
+    }
+    conjuncts
+}
+
+fn collect_and_conjuncts(filter: &Expr, conjuncts: &mut Vec<Expr>) {
+    if let Expr::BinaryExpr(binary_expr) = filter
+        && binary_expr.op == Operator::And
+    {
+        collect_and_conjuncts(&binary_expr.left, conjuncts);
+        collect_and_conjuncts(&binary_expr.right, conjuncts);
+    } else {
+        conjuncts.push(filter.clone());
+    }
+}
+
 fn change_payload_projection(schema: &Schema, filters: &[Expr]) -> ChangePayloadProjection {
     let needs = |column_name: &str| {
         schema.field_with_name(column_name).is_ok()
@@ -138,11 +219,33 @@ fn change_payload_projection(schema: &Schema, filters: &[Expr]) -> ChangePayload
 async fn scan_changelog_changes<S>(
     store: S,
     limit: Option<usize>,
+    point_lookup: Option<&ChangePointLookup>,
 ) -> Result<Vec<LixChangeRow>, LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     let mut reader = ChangelogContext::new().reader(store);
+    if let Some(point_lookup) = point_lookup {
+        let loaded = reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &point_lookup.change_ids,
+            })
+            .await?;
+        let mut changes = loaded
+            .entries
+            .into_iter()
+            .flatten()
+            .filter(|change| {
+                change
+                    .file_id
+                    .as_deref()
+                    .is_some_and(|file_id| point_lookup.file_ids.contains(file_id))
+            })
+            .map(LixChangeRow::Direct)
+            .collect::<Vec<_>>();
+        changes.sort_by_key(LixChangeRow::change_id);
+        return Ok(changes);
+    }
     let mut changes = Vec::<LixChangeRow>::new();
     let mut start_after = None::<String>;
     loop {
@@ -274,10 +377,29 @@ fn change_batch_error(error: ColumnTableError) -> DataFusionError {
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::datatypes::Schema;
-    use datafusion::logical_expr::{Expr, col};
+    use std::collections::BTreeSet;
 
-    use super::{change_payload_projection, lix_change_schema};
+    use datafusion::arrow::datatypes::Schema;
+    use datafusion::common::{Column, ScalarValue};
+    use datafusion::logical_expr::{BinaryExpr, Expr, Operator, col};
+
+    use crate::changelog::ChangeId;
+
+    use super::{
+        change_filter_has_exact_string_conjunct, change_payload_projection,
+        change_point_lookup_from_filters, lix_change_schema,
+    };
+
+    fn equals(column_name: &str, value: &str) -> Expr {
+        Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(Expr::Column(Column::from_name(column_name))),
+            Operator::Eq,
+            Box::new(Expr::Literal(
+                ScalarValue::Utf8(Some(value.to_string())),
+                None,
+            )),
+        ))
+    }
 
     #[test]
     fn identity_projection_skips_json_payloads() {
@@ -306,5 +428,46 @@ mod tests {
 
         assert!(!projection.snapshot_content);
         assert!(projection.metadata);
+    }
+
+    #[test]
+    fn exact_change_and_file_id_filters_use_direct_lookup() {
+        let change_id = "019f7d6c-fb53-7423-9a32-a80ec52b128b";
+        let filter = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(equals("id", change_id)),
+            Operator::And,
+            Box::new(equals("file_id", "active-markdown")),
+        ));
+        let lookup = change_point_lookup_from_filters(&[filter.clone()])
+            .unwrap()
+            .expect("the exact direct change shape should route");
+
+        assert_eq!(lookup.change_ids, vec![ChangeId::parse(change_id).unwrap()]);
+        assert_eq!(
+            lookup.file_ids,
+            BTreeSet::from(["active-markdown".to_string()])
+        );
+        assert!(change_filter_has_exact_string_conjunct(&filter, "id"));
+        assert!(change_filter_has_exact_string_conjunct(&filter, "file_id"));
+    }
+
+    #[test]
+    fn change_lookup_requires_exact_file_id_and_skips_invalid_change_ids() {
+        assert!(
+            change_point_lookup_from_filters(&[equals(
+                "id",
+                "019f7d6c-fb53-7423-9a32-a80ec52b128b"
+            )])
+            .unwrap()
+            .is_none()
+        );
+
+        let invalid = change_point_lookup_from_filters(&[
+            equals("id", "not-a-change-id"),
+            equals("file_id", "active-markdown"),
+        ])
+        .unwrap()
+        .expect("the invalid id still has the safe direct-only shape");
+        assert!(invalid.change_ids.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Make exact `lix_change` predicates on both `id` and `file_id` use the existing changelog point loader instead of scanning every direct change and derived commit row.

The fast path deliberately requires both keys. An exact `file_id` predicate excludes derived commit rows (which have no file id); every other filter shape retains the complete direct-plus-derived scan and residual filtering.

Also adds one bounded architectural observation: runtime dynamic join-filter support could remove the application-level split query, but would cross core SQL planning/execution layers and is out of scope for this PR.

## Measured real path

Fresh remote LixRay fixture: 2,500 files, 5,077 `lix_change` rows, 50-row seed transactions, three warmups and 16 measured samples.

| Query path | p50 | p95 |
| --- | ---: | ---: |
| Fresh base split lookup | 16.741 ms | 18.100 ms |
| Point-read candidate | 7.344 ms | 8.283 ms |
| Change | **-56.1%** | **-54.2%** |

The direct scoped lookup alone improved from 12.825/21.425 ms to 5.374/7.389 ms (-58.1%/-65.5%). The legacy joined query measured 14.996/20.704 ms, so the complete new two-step user path was also -51.0%/-60.0%.

The harness checks `data`, `path`, `changeId`, and `originKey` equivalence in each fresh fixture. No p95 regression was observed.

## Validation

- `cargo fmt --all --check`
- `cargo test -p lix_engine sql2::providers::change --lib`
- `cargo test -p lix_engine --test sql lix_change`
- `cargo clippy -p lix_engine --lib -- -D warnings`

## Design precedent

This follows the bounded, key-directed access patterns documented by [Turso's batch API](https://docs.turso.tech/sdk/php/quickstart), [Dolt secondary indexes](https://www.dolthub.com/docs/concepts/dolt/sql/indexes/), [DuckDB indexing guidance](https://duckdb.org/docs/lts/guides/performance/indexing), and [Sapling IndexedLog](https://sapling-scm.com/docs/dev/internals/indexedlog/): use a precise key lookup where the semantics prove it safe, while retaining the generic path for all other queries.

## Stack

The consumer change will follow in Atelier: it splits the Markdown file observer from this exact scoped origin lookup.