### PR TITLE
perf(history): batch member change loads

### DIFF
--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -186,6 +186,26 @@ where
         request: &CommitGraphChangeHistoryRequest,
     ) -> Result<Vec<CommitGraphChangeHistoryEntry>, LixError> {
         let commits = self.reachable_commits(start_commit_id).await?;
+        let mut member_change_ids = Vec::new();
+        let mut seen_change_ids = BTreeSet::new();
+
+        for reachable in &commits {
+            if !depth_matches(reachable.depth, request) {
+                continue;
+            }
+
+            seen_change_ids.insert(reachable.commit.canonical_change.id);
+            for change_id in &reachable.commit.change_ids {
+                if seen_change_ids.insert(*change_id) {
+                    member_change_ids.push(*change_id);
+                }
+            }
+        }
+
+        let mut member_changes = self
+            .load_canonical_changes(&member_change_ids)
+            .await?
+            .into_iter();
         let mut entries = Vec::new();
         let mut seen_change_ids = BTreeSet::new();
 
@@ -211,7 +231,12 @@ where
                 if !seen_change_ids.insert(change_id) {
                     continue;
                 }
-                let change = self.load_member_canonical_change(&change_id).await?;
+                let change = member_changes.next().flatten().ok_or_else(|| {
+                    LixError::new(
+                        "LIX_ERROR_UNKNOWN",
+                        format!("commit_graph references missing change '{change_id}'"),
+                    )
+                })?;
                 if change_matches_history_request(&change, request) {
                     entries.push(CommitGraphChangeHistoryEntry {
                         change,
@@ -224,23 +249,6 @@ where
         }
 
         Ok(entries)
-    }
-
-    async fn load_member_canonical_change(
-        &mut self,
-        change_id: &ChangeId,
-    ) -> Result<CommitGraphChange, LixError> {
-        self.load_canonical_changes(std::slice::from_ref(change_id))
-            .await?
-            .into_iter()
-            .next()
-            .flatten()
-            .ok_or_else(|| {
-                LixError::new(
-                    "LIX_ERROR_UNKNOWN",
-                    format!("commit_graph references missing change '{change_id}'"),
-                )
-            })
     }
 
     async fn load_changelog_commit(
@@ -709,7 +717,10 @@ mod tests {
             .await
             .expect("first history should resolve");
         let calls_after_first = change_get_many_calls.load(Ordering::Relaxed);
-        assert!(calls_after_first > 0, "first history should load changes");
+        assert_eq!(
+            calls_after_first, 1,
+            "one history traversal should batch all uncached member changes"
+        );
 
         let second = reader
             .change_history_from_commit(&commit_head, &request)


### PR DESCRIPTION
## Why

History walks previously issued one storage get_many call per uncached member change. This showed up in real Atelier history queries after replaying 100 commits from the supplied lix-2 repository into LixRay.

## Change

Collect the member change IDs selected by the existing traversal, resolve them through the existing batched changelog loader once, then emit them in the original traversal order. The existing reader cache still handles repeated requests.

## Measured impact

Persisted LixRay workspace: 100 source commits, 119 Lix commits, 3,580 changes. 8 warm-ups and 40 measured endpoint calls per query.

- Atelier agent-turn history ordering: p50 177.79 ms to 43.14 ms (-75.7%); p95 234.15 ms to 45.14 ms (-80.7%).
- Atelier file-history-by-id: p50 215.55 ms to 74.44 ms (-65.5%); p95 324.23 ms to 78.11 ms (-75.9%).

## Correctness and trade-offs

The two-pass collection preserves the existing depth filter, first-seen rules, output order, and missing-change error point. The regression test now proves a traversal with two uncached members makes one change-space get_many call and that the cache eliminates further reads. This adds only a temporary vector/set of change IDs already represented by the reader cache and output; it adds no persistent index, storage writes, or write amplification.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- node scripts/validate-changes.mjs