### PR TITLE
perf(history): reuse directory history traversal

### DIFF
--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -201,31 +202,27 @@ where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     let event_route = route.traversal_only();
-    let event_entries = load_history_entries(
-        HistoryViewDescriptor {
-            view_name: "lix_directory_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
-        },
-        Arc::clone(&commit_graph),
-        query_source.json_reader.clone(),
-        &event_route,
-        vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
-        metadata_projection,
-    )
-    .await?;
     let context_route = route.starts_only();
-    let context_entries = load_history_entries(
-        HistoryViewDescriptor {
-            view_name: "lix_directory_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
-        },
-        commit_graph,
-        query_source.json_reader,
-        &context_route,
-        vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
-        metadata_projection,
-    )
-    .await?;
+    let (event_entries, context_entries) =
+        load_directory_history_entry_sets(&event_route, &context_route, move |route| {
+            let commit_graph = Arc::clone(&commit_graph);
+            let json_reader = query_source.json_reader.clone();
+            async move {
+                load_history_entries(
+                    HistoryViewDescriptor {
+                        view_name: "lix_directory_history",
+                        start_commit_column: HISTORY_COL_START_COMMIT_ID,
+                    },
+                    commit_graph,
+                    json_reader,
+                    &route,
+                    vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+                    metadata_projection,
+                )
+                .await
+            }
+        })
+        .await?;
     let event_descriptors = parse_directory_history_records(&event_entries)?;
     let descriptors = parse_directory_history_records(&context_entries)?;
     let mut output = Vec::new();
@@ -287,6 +284,24 @@ where
             .then(left.event.change.id.cmp(&right.event.change.id))
     });
     Ok(output)
+}
+
+async fn load_directory_history_entry_sets<Load, LoadFuture>(
+    event_route: &HistoryRoute,
+    context_route: &HistoryRoute,
+    load: Load,
+) -> Result<(Vec<HistoryEntry>, Vec<HistoryEntry>), LixError>
+where
+    Load: Fn(HistoryRoute) -> LoadFuture,
+    LoadFuture: Future<Output = Result<Vec<HistoryEntry>, LixError>>,
+{
+    let event_entries = load(event_route.clone()).await?;
+    let context_entries = if event_route == context_route {
+        event_entries.clone()
+    } else {
+        load(context_route.clone()).await?
+    };
+    Ok((event_entries, context_entries))
 }
 
 fn parse_directory_history_records(
@@ -446,4 +461,63 @@ pub(super) fn lix_directory_history_schema() -> SchemaRef {
         Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_DEPTH, DataType::Int64, false),
     ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::{HistoryRoute, load_directory_history_entry_sets};
+
+    #[tokio::test]
+    async fn identical_event_and_context_routes_load_history_once() {
+        let route = HistoryRoute {
+            start_commit_ids: vec!["cid-start".to_string()],
+            ..HistoryRoute::default()
+        };
+        let event_route = route.traversal_only();
+        let context_route = route.starts_only();
+        assert_eq!(event_route, context_route);
+
+        let loads = Arc::new(AtomicUsize::new(0));
+        let counted_loads = Arc::clone(&loads);
+        let (event_entries, context_entries) =
+            load_directory_history_entry_sets(&event_route, &context_route, move |_| {
+                counted_loads.fetch_add(1, Ordering::SeqCst);
+                async { Ok(Vec::new()) }
+            })
+            .await
+            .expect("identical routes should load");
+
+        assert!(event_entries.is_empty());
+        assert!(context_entries.is_empty());
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn differing_depth_routes_load_history_twice() {
+        let route = HistoryRoute {
+            start_commit_ids: vec!["cid-start".to_string()],
+            max_depth: Some(3),
+            ..HistoryRoute::default()
+        };
+        let event_route = route.traversal_only();
+        let context_route = route.starts_only();
+        assert_ne!(event_route, context_route);
+
+        let loads = Arc::new(AtomicUsize::new(0));
+        let counted_loads = Arc::clone(&loads);
+        let (event_entries, context_entries) =
+            load_directory_history_entry_sets(&event_route, &context_route, move |_| {
+                counted_loads.fetch_add(1, Ordering::SeqCst);
+                async { Ok(Vec::new()) }
+            })
+            .await
+            .expect("distinct routes should load");
+
+        assert!(event_entries.is_empty());
+        assert!(context_entries.is_empty());
+        assert_eq!(loads.load(Ordering::SeqCst), 2);
+    }
 }


### PR DESCRIPTION
## Stack

Depends on #635, which is already green.

## Why

The directory-history provider loaded the same full history twice when its event route and context route were equal. The normal MCP directory-history query has no depth filter, so both routes are identical.

## Change

Reuse the first traversal as context only when the routes are equal. Depth-filtered queries retain the existing two-traversal behavior because context requires the unbounded ancestor route.

## Measured impact

Real MCP directory-history listing against the persisted LixRay workspace replayed from 100 lix-2 commits. Release-server A/B/A, two runs per version, 8 warm-ups and 40 measured calls per run.

- p50: 59.77 ms to 44.09 ms (-26.2%).
- p95: 93.58 ms to 56.14 ms (-40.0%).
- mean: 65.11 ms to 45.84 ms (-29.6%).

## Correctness and trade-offs

Two unit tests cover the equal-route reuse and depth-route fallback. The reused entries are cloned rather than reloaded, so there is no persistent index, write-path change, or write amplification; the trade-off is a second in-memory vector of already-materialized entries, which the old implementation also materialized independently.

## Validation

- cargo fmt --check
- cargo test -p lix_engine --test sql lix_directory_history --locked
- cargo clippy -p lix_engine --all-targets --all-features --locked -- -D warnings