### PR TITLE
perf(engine): cache transaction path index overlays

### DIFF
--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -53,13 +53,22 @@ pub(crate) async fn commit_prepared_writes(
         }
     }
 
-    let mut state_rows = prepared_writes.state_rows;
-    let filesystem_view_changed = state_rows.iter().any(|row| {
+    let filesystem_view_changed = prepared_writes.state_rows.iter().any(|row| {
         matches!(
             row.schema_key.as_str(),
             "lix_file_descriptor" | "lix_directory_descriptor" | BRANCH_REF_SCHEMA_KEY
         )
-    });
+    }) || prepared_writes
+        .commit_change_refs_by_branch
+        .values()
+        .flat_map(|change_refs| change_refs.selected_change_refs.iter())
+        .any(|change_ref| {
+            matches!(
+                change_ref.schema_key.as_str(),
+                "lix_file_descriptor" | "lix_directory_descriptor"
+            )
+        });
+    let mut state_rows = prepared_writes.state_rows;
     let insert_identities = prepared_writes
         .insert_identities
         .into_keys()

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -9,13 +9,16 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(test)]
+use std::sync::Mutex;
+
 use async_trait::async_trait;
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use serde_json::Value as JsonValue;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobHash};
-use crate::branch::{BranchContext, BranchRefReader, branch_ref_stage_row};
+use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader, branch_ref_stage_row};
 use crate::catalog::CatalogContext;
 use crate::changelog::{ChangeId, CommitId};
 use crate::commit_graph::{CommitGraphContext, CommitGraphStoreReader};
@@ -23,8 +26,9 @@ use crate::common::LixTimestamp;
 use crate::domain::Domain;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
-    FilesystemIndex, FilesystemPathIndex, FilesystemPathIndexReader, FilesystemPathIndexRequest,
-    FilesystemRowContext, blob_ref_tombstone_row, build_path_index, filesystem_schema_keys,
+    FilesystemIndex, FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
+    FilesystemPathIndexRequest, FilesystemRowContext, blob_ref_tombstone_row,
+    filesystem_schema_keys, load_path_index_revision,
 };
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::live_state::{
@@ -73,6 +77,44 @@ pub(crate) struct TransactionCommitOutcome {
     pub(crate) storage_stats: StorageWriteSetStats,
 }
 
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct TransactionPathIndexBuildStats {
+    builds: usize,
+    descriptor_rows: usize,
+}
+
+#[cfg(test)]
+static TRANSACTION_PATH_INDEX_BUILD_STATS: Mutex<TransactionPathIndexBuildStats> =
+    Mutex::new(TransactionPathIndexBuildStats {
+        builds: 0,
+        descriptor_rows: 0,
+    });
+
+#[cfg(test)]
+fn reset_transaction_path_index_build_stats() {
+    *TRANSACTION_PATH_INDEX_BUILD_STATS
+        .lock()
+        .expect("transaction path index build stats lock") =
+        TransactionPathIndexBuildStats::default();
+}
+
+#[cfg(test)]
+fn transaction_path_index_build_stats() -> TransactionPathIndexBuildStats {
+    *TRANSACTION_PATH_INDEX_BUILD_STATS
+        .lock()
+        .expect("transaction path index build stats lock")
+}
+
+#[cfg(test)]
+fn record_transaction_path_index_build(descriptor_rows: usize) {
+    let mut stats = TRANSACTION_PATH_INDEX_BUILD_STATS
+        .lock()
+        .expect("transaction path index build stats lock");
+    stats.builds += 1;
+    stats.descriptor_rows += descriptor_rows;
+}
+
 /// One execution-scoped transaction capability for engine write paths.
 ///
 /// This is intentionally not a session-wide kitchen sink. It owns the storage
@@ -94,6 +136,8 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     catalog_context: Arc<CatalogContext>,
     schema_resolver: TransactionSchemaResolver,
     staged_writes: Arc<TransactionWriteBuffer>,
+    filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
+    filesystem_path_index_epoch: Arc<AtomicUsize>,
     storage: StorageAdapter<StorageImpl>,
     sql_schema_cache: SqlSchemaCache,
     functions: FunctionProviderHandle,
@@ -311,6 +355,8 @@ where
                 catalog_context,
                 schema_resolver,
                 staged_writes,
+                filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
+                filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
                 storage,
                 sql_schema_cache: SqlSchemaCache::default(),
                 functions,
@@ -412,6 +458,12 @@ where
         let write = self.reconcile_plugin_write(write).await?;
         require_valid_transaction_write_storage_scopes(&write)?;
         let write = self.prepare_transaction_write(write).await?;
+        if prepared_transaction_write_affects_filesystem_path_index(&write) {
+            // TransactionWriteBuffer may retain an earlier row from this batch even
+            // when a later row makes staging fail, so invalidate before staging.
+            self.filesystem_path_index_epoch
+                .fetch_add(1, Ordering::SeqCst);
+        }
         self.staged_writes.stage_write(write)
     }
 
@@ -894,6 +946,8 @@ where
         let functions = self.functions.clone();
         let staged = self.staged_writes.staging_overlay()?;
         let staged_writes = Arc::clone(&self.staged_writes);
+        let filesystem_path_index_cache = Arc::clone(&self.filesystem_path_index_cache);
+        let filesystem_path_index_epoch = Arc::clone(&self.filesystem_path_index_epoch);
         let plugin_host = self.plugin_host.clone();
 
         with_static_transaction_sql_read::<StorageImpl, _, _>(read, |read_store| async move {
@@ -907,6 +961,8 @@ where
                 functions,
                 staged,
                 staged_writes,
+                filesystem_path_index_cache,
+                filesystem_path_index_epoch,
                 plugin_host,
             };
             let result = crate::sql2::execute_transaction_read_statement_from_parsed(
@@ -1019,6 +1075,8 @@ pub(crate) struct TransactionSqlReadExecutionContext<R: crate::storage_adapter::
     functions: FunctionProviderHandle,
     staged: crate::transaction::staging::PreparedStateRowOverlay,
     staged_writes: Arc<TransactionWriteBuffer>,
+    filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
+    filesystem_path_index_epoch: Arc<AtomicUsize>,
     plugin_host: PluginRuntimeHost,
 }
 
@@ -1035,14 +1093,20 @@ where
     fn live_state(&self) -> Arc<dyn crate::live_state::LiveStateReader> {
         Arc::new(TransactionReadLiveStateReader {
             base: self.live_state.reader(self.read_store.clone()),
+            read_store: self.read_store.clone(),
             staged: self.staged.clone(),
+            filesystem_path_index_cache: Arc::clone(&self.filesystem_path_index_cache),
+            filesystem_path_index_epoch: Arc::clone(&self.filesystem_path_index_epoch),
         })
     }
 
     fn filesystem_path_index(&self) -> Arc<dyn FilesystemPathIndexReader> {
         Arc::new(TransactionReadLiveStateReader {
             base: self.live_state.reader(self.read_store.clone()),
+            read_store: self.read_store.clone(),
             staged: self.staged.clone(),
+            filesystem_path_index_cache: Arc::clone(&self.filesystem_path_index_cache),
+            filesystem_path_index_epoch: Arc::clone(&self.filesystem_path_index_epoch),
         })
     }
 
@@ -1138,7 +1202,10 @@ async fn load_transaction_blob_bytes(
 
 struct TransactionReadLiveStateReader<R: crate::storage_adapter::StorageRead> {
     base: crate::live_state::LiveStateStoreReader<SharedStorageAdapterRead<R>>,
+    read_store: SharedStorageAdapterRead<R>,
     staged: crate::transaction::staging::PreparedStateRowOverlay,
+    filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
+    filesystem_path_index_epoch: Arc<AtomicUsize>,
 }
 
 #[async_trait]
@@ -1191,7 +1258,35 @@ where
         &self,
         request: &FilesystemPathIndexRequest,
     ) -> Result<Arc<FilesystemPathIndex>, LixError> {
-        build_path_index(self, request).await
+        let descriptor_epoch = self.filesystem_path_index_epoch.load(Ordering::SeqCst);
+        if descriptor_epoch == 0 {
+            return self.base.path_index(request).await;
+        }
+        // The revision probe is only a cache-freshness optimization. Preserve the
+        // pre-cache overlay behavior if a storage fault affects that single key.
+        let cache_revision = load_path_index_revision(&self.read_store)
+            .await
+            .ok()
+            .map(|revision| transaction_path_index_cache_revision(revision, descriptor_epoch));
+        if let Some(cache_revision) = cache_revision.as_deref()
+            && let Some(index) = self
+                .filesystem_path_index_cache
+                .get(request, Some(cache_revision))
+        {
+            return Ok(index);
+        }
+        let rows =
+            overlay_scan_rows(&self.base, &self.staged, &request.live_state_request()).await?;
+        #[cfg(test)]
+        record_transaction_path_index_build(rows.len());
+        let index = Arc::new(FilesystemPathIndex::from_live_rows(rows)?);
+        Ok(match cache_revision {
+            Some(cache_revision) => {
+                self.filesystem_path_index_cache
+                    .insert(request, Some(&cache_revision), index)
+            }
+            None => index,
+        })
     }
 }
 
@@ -1385,18 +1480,41 @@ where
         &mut self,
         request: &FilesystemPathIndexRequest,
     ) -> Result<Arc<FilesystemPathIndex>, LixError> {
-        if !self.staged_writes.has_staged_filesystem_descriptors()? {
-            let read = SharedStorageAdapterRead::new(
-                self.storage
-                    .begin_read(StorageReadOptions::default())
-                    .await?,
-            );
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let descriptor_epoch = self.filesystem_path_index_epoch.load(Ordering::SeqCst);
+        if descriptor_epoch == 0 {
             return self.live_state.reader(read).path_index(request).await;
         }
-        let rows = self
-            .scan_visible_live_state(&request.live_state_request())
-            .await?;
-        Ok(Arc::new(FilesystemPathIndex::from_live_rows(rows)?))
+        // The revision probe is only a cache-freshness optimization. Preserve the
+        // pre-cache overlay behavior if a storage fault affects that single key.
+        let cache_revision = load_path_index_revision(&read)
+            .await
+            .ok()
+            .map(|revision| transaction_path_index_cache_revision(revision, descriptor_epoch));
+        if let Some(cache_revision) = cache_revision.as_deref()
+            && let Some(index) = self
+                .filesystem_path_index_cache
+                .get(request, Some(cache_revision))
+        {
+            return Ok(index);
+        }
+        let staged = self.staged_writes.staging_overlay()?;
+        let base = self.live_state.reader(read);
+        let rows = overlay_scan_rows(&base, &staged, &request.live_state_request()).await?;
+        #[cfg(test)]
+        record_transaction_path_index_build(rows.len());
+        let index = Arc::new(FilesystemPathIndex::from_live_rows(rows)?);
+        Ok(match cache_revision {
+            Some(cache_revision) => {
+                self.filesystem_path_index_cache
+                    .insert(request, Some(&cache_revision), index)
+            }
+            None => index,
+        })
     }
 
     async fn load_branch_head(&mut self, branch_id: &str) -> Result<Option<CommitId>, LixError> {
@@ -1418,6 +1536,38 @@ where
     ) -> Result<TransactionWriteOutcome, LixError> {
         Self::stage_write(self, write).await
     }
+}
+
+fn prepared_transaction_write_affects_filesystem_path_index(
+    write: &PreparedTransactionWrite,
+) -> bool {
+    let rows = match write {
+        PreparedTransactionWrite::Rows { rows, .. }
+        | PreparedTransactionWrite::RowsWithFileData { rows, .. } => rows,
+    };
+    rows.iter().any(|row| {
+        matches!(
+            row.schema_key.as_str(),
+            "lix_file_descriptor" | "lix_directory_descriptor" | BRANCH_REF_SCHEMA_KEY
+        )
+    })
+}
+
+fn transaction_path_index_cache_revision(
+    filesystem_revision: Option<Vec<u8>>,
+    descriptor_epoch: usize,
+) -> Vec<u8> {
+    let mut cache_revision = b"transaction-path-index-v1".to_vec();
+    cache_revision.extend_from_slice(&descriptor_epoch.to_be_bytes());
+    match filesystem_revision {
+        Some(revision) => {
+            cache_revision.push(1);
+            cache_revision.extend_from_slice(&revision.len().to_be_bytes());
+            cache_revision.extend_from_slice(&revision);
+        }
+        None => cache_revision.push(0),
+    }
+    cache_revision
 }
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
@@ -1714,10 +1864,12 @@ async fn load_workspace_branch_id(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Instant;
 
     use serde_json::json;
 
     use super::*;
+    use crate::Engine;
     use crate::GLOBAL_BRANCH_ID;
     use crate::NullableKeyFilter;
     use crate::branch::BranchContext;
@@ -1735,6 +1887,102 @@ mod tests {
     }
 
     const SCHEMA_FIXTURE_COMMIT_ID: &str = "01920000-0000-7000-8000-0000000000f1";
+
+    #[tokio::test]
+    #[ignore = "release-only transaction path-index benchmark probe"]
+    async fn transaction_path_index_benchmark_probe() {
+        let file_count = std::env::var("LIX_PATH_INDEX_BENCH_FILES")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(1_000);
+        let rounds = std::env::var("LIX_PATH_INDEX_BENCH_ROUNDS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(24);
+        let warmup_rounds = 4;
+
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("engine should open initialized storage");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+
+        let values = (0..file_count)
+            .map(|index| format!("('/seed-{index:05}.md', X'01')"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        session
+            .execute(
+                &format!("INSERT INTO lix_file (path, data) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("fixture files should commit");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (path, data) VALUES ('/transaction-anchor.md', X'01')",
+                &[],
+            )
+            .await
+            .expect("transaction anchor descriptor should stage");
+
+        reset_transaction_path_index_build_stats();
+        let sql = "UPDATE lix_file SET data = X'02' WHERE path = '/seed-00000.md'";
+        for _ in 0..warmup_rounds {
+            transaction
+                .execute(sql, &[])
+                .await
+                .expect("warm transaction path update should succeed");
+        }
+
+        let mut samples = Vec::with_capacity(rounds);
+        for _ in 0..rounds {
+            let started = Instant::now();
+            transaction
+                .execute(sql, &[])
+                .await
+                .expect("timed transaction path update should succeed");
+            samples.push(started.elapsed());
+        }
+        samples.sort_unstable();
+        let percentile = |numerator: usize, denominator: usize| {
+            samples[(samples.len() - 1) * numerator / denominator]
+        };
+        let stats = transaction_path_index_build_stats();
+        println!(
+            "transaction_path_index_probe files={file_count} rounds={rounds} \
+             builds={} descriptor_rows={} p50_us={} p95_us={}",
+            stats.builds,
+            stats.descriptor_rows,
+            percentile(50, 100).as_micros(),
+            percentile(95, 100).as_micros(),
+        );
+        assert_eq!(
+            stats.builds, 1,
+            "repeated data-only path updates should reuse one transaction-visible index"
+        );
+        assert_eq!(
+            stats.descriptor_rows,
+            file_count + 1,
+            "the one cached build should include the staged anchor and committed files"
+        );
+
+        transaction
+            .rollback()
+            .await
+            .expect("benchmark transaction should roll back");
+    }
 
     #[tokio::test]
     async fn stage_rows_routes_tracked_and_untracked_rows_without_sql() {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -395,21 +395,6 @@ impl TransactionWriteBuffer {
         })
     }
 
-    pub(crate) fn has_staged_filesystem_descriptors(&self) -> Result<bool, LixError> {
-        let rows = self.rows.lock().map_err(|_| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "failed to acquire transaction staged writes lock",
-            )
-        })?;
-        Ok(rows.iter().flatten().any(|row| {
-            matches!(
-                row.schema_key.as_str(),
-                "lix_file_descriptor" | "lix_directory_descriptor"
-            )
-        }))
-    }
-
     /// Returns transaction-local file bytes addressed by their eventual CAS hash.
     ///
     /// File data is flushed into the binary CAS only during commit, while SQL reads

--- a/packages/engine/tests/sql/lix_directory.rs
+++ b/packages/engine/tests/sql/lix_directory.rs
@@ -1627,3 +1627,107 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    lix_directory_transaction_path_index_rebuilds_for_subtree_move_and_delete,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('transaction-subtree-file', '/old/sub/readme.md', X'726561646D65')",
+                &[],
+            )
+            .await
+            .expect("subtree fixture should insert");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        let warm = transaction
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/old/sub/readme.md'",
+                &[],
+            )
+            .await
+            .expect("old subtree path should warm the transaction index");
+        assert_rows_eq(
+            warm,
+            vec![vec![Value::Text("transaction-subtree-file".to_string())]],
+        );
+
+        let moved = transaction
+            .execute(
+                "UPDATE lix_directory SET path = '/new/' WHERE path = '/old/'",
+                &[],
+            )
+            .await
+            .expect("transactional subtree root move should succeed");
+        assert_eq!(moved.rows_affected(), 1);
+
+        let old_path = transaction
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/old/sub/readme.md'",
+                &[],
+            )
+            .await
+            .expect("old subtree path lookup should succeed as a miss");
+        assert_eq!(old_path.len(), 0);
+        let moved_path = transaction
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/new/sub/readme.md'",
+                &[],
+            )
+            .await
+            .expect("moved descendant should use rebuilt transaction index");
+        assert_rows_eq(
+            moved_path,
+            vec![vec![
+                Value::Text("transaction-subtree-file".to_string()),
+                Value::Text("/new/sub/readme.md".to_string()),
+            ]],
+        );
+
+        let deleted = transaction
+            .execute("DELETE FROM lix_directory WHERE path = '/new/'", &[])
+            .await
+            .expect("transactional recursive subtree delete should succeed");
+        assert_eq!(deleted.rows_affected(), 3);
+        let after_delete = transaction
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/new/sub/readme.md'",
+                &[],
+            )
+            .await
+            .expect("deleted descendant path lookup should succeed as a miss");
+        assert_eq!(after_delete.len(), 0);
+
+        transaction
+            .rollback()
+            .await
+            .expect("transaction rollback should succeed");
+        let restored = session
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/old/sub/readme.md'",
+                &[],
+            )
+            .await
+            .expect("rollback should restore the original subtree path");
+        assert_rows_eq(
+            restored,
+            vec![vec![
+                Value::Text("transaction-subtree-file".to_string()),
+                Value::Text("/old/sub/readme.md".to_string()),
+            ]],
+        );
+    }
+);

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -1,6 +1,7 @@
 use lix_engine::ExecuteResult;
 use lix_engine::LixError;
 use lix_engine::Value;
+use lix_engine::{CreateBranchOptions, MergeBranchOptions, MergeBranchOutcome};
 
 use super::assert_rows_eq;
 
@@ -3121,5 +3122,418 @@ simulation_test!(
                 .contains("duplicate write target column 'path'"),
             "unexpected error: {error:?}"
         );
+    }
+);
+
+simulation_test!(
+    lix_file_transaction_path_index_cache_preserves_reads_after_failure_and_rollback,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('transaction-target', '/docs/target.md', X'6265666F7265')",
+                &[],
+            )
+            .await
+            .expect("transaction fixture file should insert");
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) \
+                 VALUES ('transaction-conflict-directory', '/conflict/')",
+                &[],
+            )
+            .await
+            .expect("transaction conflict directory should insert");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('transaction-anchor', '/transaction-anchor.md', X'01')",
+                &[],
+            )
+            .await
+            .expect("transaction descriptor anchor should stage");
+
+        let update = transaction
+            .execute(
+                "UPDATE lix_file SET data = X'6166746572' \
+                 WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("first path-filtered transaction update should succeed");
+        assert_eq!(update.rows_affected(), 1);
+
+        let first_read = transaction
+            .execute(
+                "SELECT id, data FROM lix_file WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("transaction read-your-writes lookup should succeed");
+        assert_rows_eq(
+            first_read,
+            vec![vec![
+                Value::Text("transaction-target".to_string()),
+                Value::Blob(b"after".to_vec()),
+            ]],
+        );
+
+        transaction
+            .execute(
+                "UPDATE lix_file SET data = X'616761696E' \
+                 WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("repeated path-filtered transaction update should succeed");
+        let repeated_read = transaction
+            .execute(
+                "SELECT data FROM lix_file WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("repeated transaction path lookup should succeed");
+        assert_rows_eq(repeated_read, vec![vec![Value::Blob(b"again".to_vec())]]);
+
+        let error = transaction
+            .execute(
+                "UPDATE lix_file SET path = '/conflict' WHERE id = 'transaction-target'",
+                &[],
+            )
+            .await
+            .expect_err("conflicting transaction path update should fail");
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+
+        let after_failure = transaction
+            .execute(
+                "SELECT id, path, data FROM lix_file WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("cached path lookup should remain usable after a failed write");
+        assert_rows_eq(
+            after_failure,
+            vec![vec![
+                Value::Text("transaction-target".to_string()),
+                Value::Text("/docs/target.md".to_string()),
+                Value::Blob(b"again".to_vec()),
+            ]],
+        );
+
+        transaction
+            .rollback()
+            .await
+            .expect("transaction rollback should succeed");
+
+        let rolled_back = session
+            .execute(
+                "SELECT id, data FROM lix_file WHERE path = '/docs/target.md'",
+                &[],
+            )
+            .await
+            .expect("rolled-back transaction path lookup should succeed");
+        assert_rows_eq(
+            rolled_back,
+            vec![vec![
+                Value::Text("transaction-target".to_string()),
+                Value::Blob(b"before".to_vec()),
+            ]],
+        );
+        let anchor = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/transaction-anchor.md'",
+                &[],
+            )
+            .await
+            .expect("rolled-back anchor lookup should succeed");
+        assert_eq!(anchor.len(), 0);
+    }
+);
+
+simulation_test!(
+    lix_file_transaction_path_index_cache_rebuilds_for_branch_local_tombstones,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let branch_id = sim.main_branch_id();
+
+        session
+            .execute(
+                "INSERT INTO lix_file_by_branch \
+                 (id, path, data, lixcol_global, lixcol_branch_id) \
+                 VALUES ('lane-file', '/global.md', X'01', true, 'global')",
+                &[],
+            )
+            .await
+            .expect("global lane file should insert");
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file_by_branch \
+                     (id, path, data, lixcol_branch_id) \
+                     VALUES ('lane-file', '/branch.md', X'02', '{branch_id}')"
+                ),
+                &[],
+            )
+            .await
+            .expect("branch-local lane file should insert");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('lane-anchor', '/lane-anchor.md', X'03')",
+                &[],
+            )
+            .await
+            .expect("transaction descriptor anchor should stage");
+
+        let local = transaction
+            .execute("SELECT id, path FROM lix_file WHERE id = 'lane-file'", &[])
+            .await
+            .expect("branch-local lane file should be visible");
+        assert_rows_eq(
+            local,
+            vec![vec![
+                Value::Text("lane-file".to_string()),
+                Value::Text("/branch.md".to_string()),
+            ]],
+        );
+
+        let deleted = transaction
+            .execute(
+                &format!(
+                    "DELETE FROM lix_file_by_branch \
+                     WHERE id = 'lane-file' AND lixcol_branch_id = '{branch_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("branch-local lane tombstone should stage");
+        assert_eq!(deleted.rows_affected(), 1);
+
+        let hidden_by_tombstone = transaction
+            .execute("SELECT id, path FROM lix_file WHERE id = 'lane-file'", &[])
+            .await
+            .expect("lane lookup should succeed after the local tombstone");
+        assert_eq!(
+            hidden_by_tombstone.len(),
+            0,
+            "the branch-local tombstone must suppress its lower-priority global lane"
+        );
+
+        transaction
+            .rollback()
+            .await
+            .expect("transaction rollback should succeed");
+        let restored = session
+            .execute("SELECT id, path FROM lix_file WHERE id = 'lane-file'", &[])
+            .await
+            .expect("branch-local lane should be restored after rollback");
+        assert_rows_eq(
+            restored,
+            vec![vec![
+                Value::Text("lane-file".to_string()),
+                Value::Text("/branch.md".to_string()),
+            ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_transaction_path_index_cache_observes_other_session_commits,
+    options = crate::support::simulation_test::engine::SimulationOptions {
+        deterministic: false,
+    },
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("transaction session should open"),
+            &engine,
+        );
+        let other_session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("other session should open"),
+            &engine,
+        );
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('revision-anchor', '/revision-anchor.md', X'01')",
+                &[],
+            )
+            .await
+            .expect("transaction descriptor anchor should stage");
+
+        let missing = transaction
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/other-session.md'",
+                &[],
+            )
+            .await
+            .expect("initial transaction lookup should succeed");
+        assert_eq!(missing.len(), 0);
+
+        other_session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('other-session-file', '/other-session.md', X'02')",
+                &[],
+            )
+            .await
+            .expect("other session file should commit");
+
+        let visible_after_commit = transaction
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/other-session.md'",
+                &[],
+            )
+            .await
+            .expect("transaction lookup should observe the newer committed path revision");
+        assert_rows_eq(
+            visible_after_commit,
+            vec![vec![
+                Value::Text("other-session-file".to_string()),
+                Value::Text("/other-session.md".to_string()),
+            ]],
+        );
+
+        transaction
+            .rollback()
+            .await
+            .expect("transaction rollback should succeed");
+    }
+);
+
+simulation_test!(
+    lix_file_transaction_path_index_cache_observes_merge_reachability_changes,
+    options = crate::support::simulation_test::engine::SimulationOptions {
+        deterministic: false,
+    },
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.create_branch(CreateBranchOptions {
+            id: Some("path-index-draft".to_string()),
+            name: "Path index draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft branch should create");
+        let draft = main.wrap_session(
+            engine
+                .open_session("path-index-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_file (id, path, data) \
+             VALUES ('merge-main-file', '/main.md', X'01')",
+            &[],
+        )
+        .await
+        .expect("main divergence file should insert");
+        draft
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('merge-draft-file', '/merged.md', X'02')",
+                &[],
+            )
+            .await
+            .expect("draft merge file should insert");
+
+        let transaction_session = main.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("transaction session should open"),
+            &engine,
+        );
+        let mut transaction = transaction_session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('merge-revision-anchor', '/merge-revision-anchor.md', X'03')",
+                &[],
+            )
+            .await
+            .expect("transaction descriptor anchor should stage");
+        let missing_before_merge = transaction
+            .execute("SELECT id FROM lix_file WHERE path = '/merged.md'", &[])
+            .await
+            .expect("initial merge path lookup should succeed");
+        assert_eq!(missing_before_merge.len(), 0);
+
+        let receipt = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "path-index-draft".to_string(),
+            })
+            .await
+            .expect("merge should succeed");
+        assert_eq!(receipt.outcome, MergeBranchOutcome::MergeCommitted);
+
+        let visible_after_merge = transaction
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/merged.md'",
+                &[],
+            )
+            .await
+            .expect("transaction lookup should observe merged reachable descriptors");
+        assert_rows_eq(
+            visible_after_merge,
+            vec![vec![
+                Value::Text("merge-draft-file".to_string()),
+                Value::Text("/merged.md".to_string()),
+            ]],
+        );
+
+        transaction
+            .rollback()
+            .await
+            .expect("transaction rollback should succeed");
     }
 );


### PR DESCRIPTION
## Summary

Caches the final transaction-visible filesystem path index after the first staged filesystem write. Cache entries are keyed by request, staged filesystem-view generation, and the committed path-index revision from the same read snapshot.

- Retains the existing full overlay scan on a miss, including directory move/delete handling and lane/tombstone resolution.
- Invalidates before descriptor or branch-ref staging, including failed batches that may have partially staged rows.
- Bumps the committed revision for merge-selected file and directory descriptor changes so reachability changes invalidate both committed and transaction-local indexes.
- Falls back to the uncached overlay when the optional revision probe fails, preserving prior staged-read failure behavior.

## Benchmark

Release probe: 4 warmups plus 24 timed normal SQL updates within an explicit transaction after one staged descriptor write.

| Files | Baseline p50 / p95 | Candidate p50 / p95 | Full builds | Descriptor rows scanned |
| --- | --- | --- | --- | --- |
| 1,000 | 14.905 ms / 17.156 ms | 7.412 ms / 8.383 ms | 56 -> 1 | 56,056 -> 1,001 |
| 10,000 | 176.674 ms / 211.348 ms | 87.930 ms / 100.777 ms | 56 -> 1 | 560,056 -> 10,001 |

This is about a 50% p50 improvement and a 51-52% p95 improvement at both sizes.

## Validation

- cargo test -p lix_engine --test sql (538 passed)
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all --check
- Release benchmark probe at 1,000 and 10,000 files

Focused regressions cover repeated read-your-writes path updates, failed write plus rollback, branch-local tombstones, directory subtree move/delete, other-session commits, and merge reachability.