### PR TITLE
test(engine): instrument plugin reconciliation hot paths

### DIFF
--- a/packages/engine/src/plugin/archive.rs
+++ b/packages/engine/src/plugin/archive.rs
@@ -149,6 +149,8 @@ pub(crate) fn load_installed_plugin_from_archive_bytes(
             hint: None,
             details: None,
         })?;
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_schema_parse();
         let schema_json: JsonValue = serde_json::from_slice(schema_bytes).map_err(|error| {
             LixError {
                 code: "LIX_ERROR_UNKNOWN".to_string(),
@@ -226,6 +228,8 @@ pub(crate) fn load_installed_plugin_metadata_from_archive_bytes(
             hint: None,
             details: None,
         })?;
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_schema_parse();
         let schema_json: JsonValue = serde_json::from_slice(schema_bytes).map_err(|error| {
             LixError {
                 code: "LIX_ERROR_UNKNOWN".to_string(),
@@ -300,6 +304,8 @@ fn read_archive_files_for_install(
             hint: None,
             details: None,
         })?;
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_archive_entry_inflated(bytes.len());
         if files.insert(entry_path.clone(), bytes).is_some() {
             return Err(LixError {
                 code: "LIX_ERROR_UNKNOWN".to_string(),
@@ -361,6 +367,8 @@ fn read_plugin_archive_files(
             hint: None,
             details: None,
         })?;
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_archive_entry_inflated(bytes.len());
         files.insert(entry_path, bytes);
     }
 

--- a/packages/engine/src/plugin/bench_stats.rs
+++ b/packages/engine/src/plugin/bench_stats.rs
@@ -1,0 +1,140 @@
+use std::cell::RefCell;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PluginBenchStats {
+    pub(crate) reconciliation_calls: usize,
+    pub(crate) candidate_file_writes: usize,
+    pub(crate) filesystem_scans: usize,
+    pub(crate) filesystem_rows_scanned: usize,
+    pub(crate) plugin_discovery_calls: usize,
+    pub(crate) discovery_file_entries_examined: usize,
+    pub(crate) file_id_entries_examined: usize,
+    pub(crate) plugin_archives_loaded: usize,
+    pub(crate) plugin_archive_bytes_loaded: usize,
+    pub(crate) archive_entries_inflated: usize,
+    pub(crate) archive_uncompressed_bytes: usize,
+    pub(crate) manifest_parses: usize,
+    pub(crate) schema_parses: usize,
+    pub(crate) glob_match_attempts: usize,
+    pub(crate) glob_compiles: usize,
+    pub(crate) plugin_state_reads: usize,
+    pub(crate) plugin_state_rows_loaded: usize,
+    pub(crate) wasm_component_initializations: usize,
+    pub(crate) wasm_detect_invocations: usize,
+    pub(crate) wasm_render_invocations: usize,
+}
+
+thread_local! {
+    // The probe runs on an explicit current-thread runtime so unrelated tests
+    // cannot contribute work to its measurements.
+    static PLUGIN_BENCH_STATS: RefCell<PluginBenchStats> = RefCell::default();
+}
+
+pub(crate) fn reset_plugin_bench_stats() {
+    PLUGIN_BENCH_STATS.with_borrow_mut(|stats| *stats = PluginBenchStats::default());
+}
+
+pub(crate) fn plugin_bench_stats() -> PluginBenchStats {
+    PLUGIN_BENCH_STATS.with_borrow(|stats| *stats)
+}
+
+fn update_plugin_bench_stats(update: impl FnOnce(&mut PluginBenchStats)) {
+    PLUGIN_BENCH_STATS.with_borrow_mut(update);
+}
+
+pub(crate) fn record_reconciliation(candidate_count: usize) {
+    update_plugin_bench_stats(|stats| {
+        stats.reconciliation_calls += 1;
+        stats.candidate_file_writes += candidate_count;
+    });
+}
+
+pub(crate) fn record_filesystem_scan(row_count: usize) {
+    update_plugin_bench_stats(|stats| {
+        stats.filesystem_scans += 1;
+        stats.filesystem_rows_scanned += row_count;
+    });
+}
+
+pub(crate) fn record_plugin_discovery(file_entry_count: usize) {
+    update_plugin_bench_stats(|stats| {
+        stats.plugin_discovery_calls += 1;
+        stats.discovery_file_entries_examined += file_entry_count;
+    });
+}
+
+pub(crate) fn record_file_id_entries_examined(entry_count: usize) {
+    update_plugin_bench_stats(|stats| stats.file_id_entries_examined += entry_count);
+}
+
+pub(crate) fn record_plugin_archive_load(byte_count: usize) {
+    update_plugin_bench_stats(|stats| {
+        stats.plugin_archives_loaded += 1;
+        stats.plugin_archive_bytes_loaded += byte_count;
+    });
+}
+
+pub(crate) fn record_archive_entry_inflated(byte_count: usize) {
+    update_plugin_bench_stats(|stats| {
+        stats.archive_entries_inflated += 1;
+        stats.archive_uncompressed_bytes += byte_count;
+    });
+}
+
+pub(crate) fn record_manifest_parse() {
+    update_plugin_bench_stats(|stats| stats.manifest_parses += 1);
+}
+
+pub(crate) fn record_schema_parse() {
+    update_plugin_bench_stats(|stats| stats.schema_parses += 1);
+}
+
+pub(crate) fn record_glob_match_attempt() {
+    update_plugin_bench_stats(|stats| stats.glob_match_attempts += 1);
+}
+
+pub(crate) fn record_glob_compile() {
+    update_plugin_bench_stats(|stats| stats.glob_compiles += 1);
+}
+
+pub(crate) fn record_plugin_state_read(row_count: usize) {
+    update_plugin_bench_stats(|stats| {
+        stats.plugin_state_reads += 1;
+        stats.plugin_state_rows_loaded += row_count;
+    });
+}
+
+pub(crate) fn record_wasm_component_initialization() {
+    update_plugin_bench_stats(|stats| stats.wasm_component_initializations += 1);
+}
+
+pub(crate) fn record_wasm_detect_invocation() {
+    update_plugin_bench_stats(|stats| stats.wasm_detect_invocations += 1);
+}
+
+pub(crate) fn record_wasm_render_invocation() {
+    update_plugin_bench_stats(|stats| stats.wasm_render_invocations += 1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_stats_are_isolated_by_thread() {
+        reset_plugin_bench_stats();
+        record_manifest_parse();
+
+        let other_thread_stats = std::thread::spawn(|| {
+            reset_plugin_bench_stats();
+            record_manifest_parse();
+            record_manifest_parse();
+            plugin_bench_stats()
+        })
+        .join()
+        .expect("counter test thread should join");
+
+        assert_eq!(other_thread_stats.manifest_parses, 2);
+        assert_eq!(plugin_bench_stats().manifest_parses, 1);
+    }
+}

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -64,6 +64,8 @@ pub(crate) async fn load_or_init_plugin_component(
         }
     }
 
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_wasm_component_initialization();
     let initialized = host
         .wasm_runtime()
         .init_component(plugin.wasm.clone(), WasmLimits::default())
@@ -95,6 +97,8 @@ pub(crate) async fn render_with_plugin(
     state: Vec<WasmPluginEntityState>,
 ) -> Result<Vec<u8>, LixError> {
     let instance = load_or_init_plugin_component(host, plugin).await?;
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_wasm_render_invocation();
     instance.render(state).await
 }
 
@@ -105,6 +109,8 @@ pub(crate) async fn detect_changes_with_plugin(
     file: WasmPluginFile,
 ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
     let instance = load_or_init_plugin_component(host, plugin).await?;
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_wasm_detect_invocation();
     instance.detect_changes(state, file).await
 }
 

--- a/packages/engine/src/plugin/manifest.rs
+++ b/packages/engine/src/plugin/manifest.rs
@@ -48,6 +48,8 @@ pub struct ValidatedPluginManifest {
 }
 
 pub fn parse_plugin_manifest_json(raw: &str) -> Result<ValidatedPluginManifest, LixError> {
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_manifest_parse();
     let manifest_json: JsonValue = serde_json::from_str(raw).map_err(|error| LixError {
         code: "LIX_ERROR_UNKNOWN".to_string(),
         message: format!("Plugin manifest must be valid JSON: {error}"),
@@ -118,6 +120,8 @@ pub fn select_best_glob_match<'a, T, C: Copy + PartialEq>(
 }
 
 pub fn glob_matches_path(glob: &str, path: &str) -> bool {
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_glob_match_attempt();
     if glob.is_empty() || path.is_empty() {
         return false;
     }
@@ -125,6 +129,8 @@ pub fn glob_matches_path(glob: &str, path: &str) -> bool {
         return true;
     }
 
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_glob_compile();
     GlobBuilder::new(glob)
         .literal_separator(false)
         .build()

--- a/packages/engine/src/plugin/materializer.rs
+++ b/packages/engine/src/plugin/materializer.rs
@@ -28,8 +28,14 @@ pub(crate) async fn load_installed_plugins_from_filesystem(
     filesystem: &FilesystemIndex,
     blob_reader: &dyn BlobDataReader,
 ) -> Result<Vec<InstalledPlugin>, LixError> {
+    #[cfg(test)]
+    let mut examined_file_entries = 0usize;
     let mut plugins = Vec::new();
     for (path, file) in filesystem.file_entries() {
+        #[cfg(test)]
+        {
+            examined_file_entries += 1;
+        }
         let Some(plugin_key) = plugin_key_from_archive_path(path) else {
             continue;
         };
@@ -47,12 +53,16 @@ pub(crate) async fn load_installed_plugins_from_filesystem(
                 format!("installed plugin archive '{path}' blob '{blob_hash}' is missing"),
             ));
         };
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_plugin_archive_load(archive_bytes.len());
         plugins.push(load_installed_plugin_from_archive_bytes(
             &plugin_key,
             path,
             &archive_bytes,
         )?);
     }
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_plugin_discovery(examined_file_entries);
     Ok(plugins)
 }
 

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -5,6 +5,8 @@
 //! buckets.
 
 mod archive;
+#[cfg(test)]
+pub(crate) mod bench_stats;
 pub(crate) mod component;
 mod install;
 mod manifest;

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -3355,6 +3355,8 @@ async fn render_plugin_file_for_sql(
             ..Default::default()
         })
         .await?;
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_plugin_state_read(rows.len());
     let active_state = retain_plugin_state_rows(plugin, rows);
     render_materialized_plugin_file(&plugin_render.host, plugin, &active_state).await
 }
@@ -3376,6 +3378,8 @@ async fn load_installed_plugins_for_lix_file_scan(
     plugin_request.limit = None;
 
     let rows = live_state.scan_rows(&plugin_request).await?;
+    #[cfg(test)]
+    crate::plugin::bench_stats::record_filesystem_scan(rows.len());
     let mut rows_by_branch = BTreeMap::<String, Vec<MaterializedLiveStateRow>>::new();
     for row in rows {
         rows_by_branch

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -538,6 +538,18 @@ where
         &mut self,
         file_data: &[TransactionFileData],
     ) -> Result<PluginFileDataReconciliation, LixError> {
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_reconciliation(
+            file_data
+                .iter()
+                .filter(|write| {
+                    write
+                        .path
+                        .as_deref()
+                        .is_some_and(is_plugin_reconciliation_candidate_path)
+                })
+                .count(),
+        );
         let mut reconciliation = PluginFileDataReconciliation::default();
         // A single staged write can contain many ordinary files for the same
         // branch. Reconciliation reads the pre-write filesystem each time, so
@@ -572,11 +584,19 @@ where
                 let context = contexts
                     .get(&write.branch_id)
                     .expect("plugin reconciliation context should be cached");
+                #[cfg(test)]
+                let mut examined_file_entries = 0usize;
                 let existing_file = context.filesystem.file_entries().find(|(_, file)| {
+                    #[cfg(test)]
+                    {
+                        examined_file_entries += 1;
+                    }
                     file.id == write.file_id
                         && file.scope.global == write.global
                         && file.scope.untracked == write.untracked
                 });
+                #[cfg(test)]
+                crate::plugin::bench_stats::record_file_id_entries_examined(examined_file_entries);
                 let existing_plugin = existing_file
                     .and_then(|(path, _)| select_plugin_for_path(&context.installed_plugins, path));
                 let selected_plugin =
@@ -723,6 +743,8 @@ where
                 ..Default::default()
             })
             .await?;
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_filesystem_scan(rows.len());
         FilesystemIndex::from_live_rows(rows)
     }
 
@@ -754,6 +776,8 @@ where
                 ..Default::default()
             })
             .await?;
+        #[cfg(test)]
+        crate::plugin::bench_stats::record_plugin_state_read(rows.len());
         Ok(retain_plugin_state_rows(plugin, rows))
     }
 

--- a/packages/engine/src/transaction/mod.rs
+++ b/packages/engine/src/transaction/mod.rs
@@ -3,6 +3,8 @@ mod bench_support;
 mod commit;
 mod context;
 mod normalization;
+#[cfg(test)]
+mod plugin_bench;
 mod schema_resolver;
 mod staging;
 pub(crate) mod types;

--- a/packages/engine/src/transaction/plugin_bench.rs
+++ b/packages/engine/src/transaction/plugin_bench.rs
@@ -1,0 +1,347 @@
+use std::io::{Cursor, Write};
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+
+use crate::plugin::bench_stats::{plugin_bench_stats, reset_plugin_bench_stats};
+use crate::storage_adapter::Memory;
+use crate::wasm::{
+    WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime,
+};
+use crate::{Engine, LixError, Value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeOperation {
+    Read,
+    Write,
+}
+
+impl ProbeOperation {
+    fn from_env() -> Self {
+        let value = match std::env::var("LIX_PLUGIN_BENCH_OPERATION") {
+            Ok(value) => value,
+            Err(std::env::VarError::NotPresent) => "write".to_string(),
+            Err(error) => panic!("LIX_PLUGIN_BENCH_OPERATION must be valid Unicode: {error}"),
+        };
+        match value.as_str() {
+            "read" => Self::Read,
+            "write" => Self::Write,
+            value => panic!("LIX_PLUGIN_BENCH_OPERATION must be read or write, got {value:?}"),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Write => "write",
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "release-only engine-overhead probe with a stub WASM runtime"]
+async fn plugin_reconciliation_benchmark_probe() {
+    let file_count = env_usize("LIX_PLUGIN_BENCH_FILES", 1_000);
+    let plugin_count = env_usize("LIX_PLUGIN_BENCH_PLUGINS", 0);
+    let file_offset = env_usize("LIX_PLUGIN_BENCH_OFFSET", 0);
+    let batch_size = env_usize("LIX_PLUGIN_BENCH_BATCH", 1);
+    let rounds = env_usize("LIX_PLUGIN_BENCH_ROUNDS", 20);
+    let warmup_rounds = env_usize("LIX_PLUGIN_BENCH_WARMUPS", 4);
+    let matching = env_bool("LIX_PLUGIN_BENCH_MATCHING", false);
+    let operation = ProbeOperation::from_env();
+
+    assert!(file_count > 0, "benchmark needs at least one file");
+    assert!(batch_size > 0, "benchmark batch must not be empty");
+    assert!(
+        file_offset
+            .checked_add(batch_size)
+            .is_some_and(|end| end <= file_count),
+        "offset plus batch cannot exceed file count"
+    );
+    assert!(rounds > 0, "benchmark needs at least one timed round");
+    assert!(
+        !matching || plugin_count > 0,
+        "matching mode needs at least one plugin"
+    );
+
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new_with_wasm_runtime(storage, Arc::new(ProbeWasmRuntime))
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let values = (0..file_count)
+        .map(|index| format!("('seed-{index:05}', '/seed-{index:05}.md', X'01')"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    session
+        .execute(
+            &format!("INSERT INTO lix_file (id, path, data) VALUES {values}"),
+            &[],
+        )
+        .await
+        .expect("benchmark files should insert");
+
+    for index in 0..plugin_count {
+        let key = format!("plugin_bench_{index:03}");
+        let archive = plugin_archive(index, matching && index == 0);
+        session
+            .execute(
+                "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                &[
+                    Value::Text(format!("/.lix/plugins/{key}.lixplugin")),
+                    Value::Blob(archive),
+                ],
+            )
+            .await
+            .expect("benchmark plugin should install");
+    }
+
+    let ids = (file_offset..file_offset + batch_size)
+        .map(|index| format!("'seed-{index:05}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let read_sql = format!("SELECT id, data FROM lix_file WHERE id IN ({ids}) ORDER BY id");
+    let write_sql = [
+        format!("UPDATE lix_file SET data = X'02' WHERE id IN ({ids})"),
+        format!("UPDATE lix_file SET data = X'03' WHERE id IN ({ids})"),
+    ];
+
+    if matching {
+        session
+            .execute(&write_sql[0], &[])
+            .await
+            .expect("matching benchmark files should materialize plugin state");
+    }
+
+    for round in 0..warmup_rounds {
+        execute_probe_round(
+            &session, operation, &read_sql, &write_sql, round, batch_size,
+        )
+        .await;
+    }
+
+    reset_plugin_bench_stats();
+    let mut samples = Vec::with_capacity(rounds);
+    for round in 0..rounds {
+        let started = Instant::now();
+        execute_probe_round(
+            &session,
+            operation,
+            &read_sql,
+            &write_sql,
+            warmup_rounds + round,
+            batch_size,
+        )
+        .await;
+        samples.push(started.elapsed());
+    }
+    samples.sort_unstable();
+    let stats = plugin_bench_stats();
+
+    println!(
+        "plugin_reconciliation_probe wasm_runtime=stub operation={} files={} plugins={} matching={} offset={} batch={} \
+         rounds={} p50_us={} p95_us={} stats={stats:?}",
+        operation.as_str(),
+        file_count,
+        plugin_count,
+        matching,
+        file_offset,
+        batch_size,
+        rounds,
+        percentile(&samples, 50, 100).as_micros(),
+        percentile(&samples, 95, 100).as_micros(),
+    );
+
+    session.close().await.expect("session should close");
+}
+
+fn percentile(
+    samples: &[std::time::Duration],
+    numerator: usize,
+    denominator: usize,
+) -> std::time::Duration {
+    assert!(!samples.is_empty(), "percentile needs at least one sample");
+    assert!(
+        denominator > 0 && (1..=denominator).contains(&numerator),
+        "percentile must be in (0, 1]"
+    );
+    let rank = samples
+        .len()
+        .checked_mul(numerator)
+        .expect("sample count should fit percentile arithmetic")
+        .div_ceil(denominator);
+    samples[rank - 1]
+}
+
+#[test]
+fn percentile_uses_nearest_rank() {
+    let samples = [
+        std::time::Duration::from_micros(10),
+        std::time::Duration::from_micros(20),
+    ];
+    assert_eq!(percentile(&samples, 50, 100), samples[0]);
+    assert_eq!(percentile(&samples, 95, 100), samples[1]);
+}
+
+async fn execute_probe_round(
+    session: &crate::session::SessionContext<Memory>,
+    operation: ProbeOperation,
+    read_sql: &str,
+    write_sql: &[String; 2],
+    round: usize,
+    batch_size: usize,
+) {
+    let result = match operation {
+        ProbeOperation::Read => session.execute(read_sql, &[]).await,
+        ProbeOperation::Write => {
+            session
+                .execute(&write_sql[round % write_sql.len()], &[])
+                .await
+        }
+    }
+    .expect("benchmark operation should succeed");
+    match operation {
+        ProbeOperation::Read => {
+            assert_eq!(result.len(), batch_size, "benchmark row count should match");
+        }
+        ProbeOperation::Write => assert_eq!(
+            result.rows_affected(),
+            batch_size as u64,
+            "benchmark affected-row count should match"
+        ),
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse()
+            .unwrap_or_else(|error| panic!("{name} must be an unsigned integer: {error}")),
+        Err(std::env::VarError::NotPresent) => default,
+        Err(error) => panic!("{name} must be valid Unicode: {error}"),
+    }
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(value) => match value.to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" => true,
+            "0" | "false" | "no" => false,
+            _ => panic!("{name} must be one of 1/true/yes or 0/false/no, got {value:?}"),
+        },
+        Err(std::env::VarError::NotPresent) => default,
+        Err(error) => panic!("{name} must be valid Unicode: {error}"),
+    }
+}
+
+#[derive(Debug, Default)]
+struct ProbeWasmRuntime;
+
+#[derive(Debug)]
+struct ProbeWasmComponent {
+    schema_key: String,
+}
+
+#[async_trait]
+impl WasmRuntime for ProbeWasmRuntime {
+    async fn init_component(
+        &self,
+        bytes: Vec<u8>,
+        _limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
+        let index_bytes: [u8; 4] = bytes
+            .get(8..12)
+            .and_then(|bytes| bytes.try_into().ok())
+            .ok_or_else(|| LixError::unknown("benchmark wasm is missing its schema index"))?;
+        let index = u32::from_le_bytes(index_bytes);
+        Ok(Arc::new(ProbeWasmComponent {
+            schema_key: format!("plugin_note_{index:03}"),
+        }))
+    }
+}
+
+#[async_trait]
+impl WasmComponentInstance for ProbeWasmComponent {
+    async fn detect_changes(
+        &self,
+        _state: Vec<WasmPluginEntityState>,
+        _file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+        Ok(vec![WasmPluginDetectedChange {
+            entity_pk: vec!["note".to_string()],
+            schema_key: self.schema_key.clone(),
+            snapshot_content: Some(r#"{"id":"note","value":"detected"}"#.to_string()),
+            metadata: None,
+        }])
+    }
+
+    async fn render(&self, _state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
+        Ok(b"plugin-rendered".to_vec())
+    }
+}
+
+fn plugin_archive(index: usize, matching: bool) -> Vec<u8> {
+    let plugin_key = format!("plugin_bench_{index:03}");
+    let schema_key = format!("plugin_note_{index:03}");
+    let schema_path = format!("schema/{schema_key}.json");
+    let path_glob = if matching {
+        "*.md".to_string()
+    } else {
+        format!("*.plugin-{index:03}")
+    };
+    let manifest = format!(
+        r#"{{
+            "key": "{plugin_key}",
+            "runtime": "wasm-component-v1",
+            "api_version": "0.1.0",
+            "match": {{ "path_glob": "{path_glob}" }},
+            "entry": "plugin.wasm",
+            "schemas": ["{schema_path}"]
+        }}"#
+    );
+    let schema = format!(
+        r#"{{
+            "x-lix-key": "{schema_key}",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {{
+                "id": {{ "type": "string" }},
+                "value": {{ "type": "string" }}
+            }},
+            "required": ["id", "value"],
+            "additionalProperties": false
+        }}"#
+    );
+    let mut wasm = b"\0asm\x01\0\0\0".to_vec();
+    let schema_index = u32::try_from(index).expect("benchmark plugin index should fit in u32");
+    wasm.extend_from_slice(&schema_index.to_le_bytes());
+
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        ("manifest.json", manifest.as_bytes()),
+        (schema_path.as_str(), schema.as_bytes()),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer
+            .start_file(path, options)
+            .expect("benchmark archive entry should start");
+        writer
+            .write_all(bytes)
+            .expect("benchmark archive entry should write");
+    }
+    writer
+        .finish()
+        .expect("benchmark archive should finish")
+        .into_inner()
+}


### PR DESCRIPTION
## Summary

- add test-only, thread-scoped counters at plugin reconciliation, filesystem scan, archive inflate/parse, glob matching, plugin-state read, and WASM invocation boundaries
- add an ignored optimized benchmark probe for ordinary writes, ordinary reads, and matching-plugin reads/writes
- make file count, plugin count, matching mode, file offset, batch size, warmups, rounds, and operation configurable
- keep the probe optimization-friendly: counters are measurements, not assertions of today's slow-path behavior
- add no production skip flag or behavior toggle

## Baseline evidence

Measured on this branch with the repository's release-derived test profile:

| Workload | Samples | p50 | p95 |
|---|---:|---:|---:|
| one-file write, 1k files, no plugin | 100 | 25.406 ms | 29.528 ms |
| one-file write, 10k files, no plugin | 40 | 258.323 ms | 276.001 ms |
| one-file read, 1k files, no plugin | 60 | 1.802 ms | 2.277 ms |
| one-file read, 10k files, no plugin | 30 | 2.125 ms | 2.306 ms |
| one-file write, 1k files, one matching plugin | 30 | 24.617 ms | 26.667 ms |
| rendered read, 1k files, one matching plugin | 30 | 14.335 ms | 15.333 ms |

The no-plugin write probe grows 10.17x at p50 from 1k to 10k files. Counters explain the scaling:

- 1k files: 2,000 live-state rows scanned and 1,000 file descriptors examined per write
- 10k files: 20,000 live-state rows scanned and 10,000 file descriptors examined per write
- ordinary stored-blob reads already perform zero plugin scans/discovery
- a matching plugin is reloaded, inflated, reparsed, and has its glob recompiled on every rendered read/write

The benchmark uses an explicitly labeled stub WASM runtime to isolate engine orchestration overhead. It does not measure real WASM compilation or guest execution.

## Run

```bash
LIX_PLUGIN_BENCH_FILES=10000 \
LIX_PLUGIN_BENCH_ROUNDS=40 \
LIX_PLUGIN_BENCH_WARMUPS=5 \
cargo test -p lix_engine --lib \
  transaction::plugin_bench::plugin_reconciliation_benchmark_probe \
  -- --ignored --exact --nocapture --test-threads=1
```

Set `LIX_PLUGIN_BENCH_OPERATION=read`, `LIX_PLUGIN_BENCH_PLUGINS`, `LIX_PLUGIN_BENCH_MATCHING`, `LIX_PLUGIN_BENCH_OFFSET`, and `LIX_PLUGIN_BENCH_BATCH` for the other cases.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p lix_engine --tests`
- `cargo clippy -p lix_engine --lib --tests -- -D warnings`
- `cargo test -p lix_engine --lib -- --test-threads=1` (1,014 passed, 2 intentionally ignored)
- `cargo test -p lix_engine --tests` (all integration tests and both simulation modes passed)
- concurrent ignored-benchmark review check confirmed thread-local counters do not contaminate one another