### PR TITLE
fix(engine): bound plugin archive parsing

### DIFF
--- a/.changenotes/bound-plugin-archives.md
+++ b/.changenotes/bound-plugin-archives.md
@@ -1,0 +1,13 @@
+---
+type: major
+---
+
+Plugin packages now have explicit validation and resource limits.
+
+Malformed ZIP packages and manifests, including invalid path globs, now fail with
+`LIX_ERROR_INVALID_PLUGIN`. Packages are limited to 32 MiB of archive bytes,
+128 ZIP entries, 64 MiB declared expansion, 32 MiB expanded per entry, 64 KiB
+manifests, 1 MiB per schema, 64 declared schemas, 512-byte paths, and
+1,024-character globs. ZIP parsing accepts stored or deflated entries, comments,
+data descriptors, and bounded per-entry ZIP64 sizes, but rejects ZIP64 central
+directories and archives with more than eight complete footer candidates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "lix_slatedb_storage",
  "lix_sqlite_storage",
  "lru",
+ "memchr",
  "musli",
  "object_store 0.14.0",
  "paste",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -84,6 +84,7 @@ jsonschema = { version = "0.17", default-features = false, features = ["draft202
 globset = "0.4"
 jiff = { version = "0.2.27", default-features = false, features = ["std"] }
 lru = "0.18"
+memchr = "2"
 uuid = { version = "1", features = ["v7", "std", "js", "fast-rng"] }
 unicode-normalization = "0.1"
 precis-profiles = "0.1.13"

--- a/packages/engine/src/common/error.rs
+++ b/packages/engine/src/common/error.rs
@@ -89,6 +89,11 @@ impl LixError {
     /// An internal engine invariant failed.
     pub const CODE_INTERNAL_ERROR: &'static str = "LIX_INTERNAL_ERROR";
 
+    /// A plugin ZIP package or manifest is malformed, unsafe, or exceeds the
+    /// static resource bounds accepted by the engine. Invalid embedded Lix
+    /// schema definitions retain [`Self::CODE_SCHEMA_DEFINITION`].
+    pub const CODE_INVALID_PLUGIN: &'static str = "LIX_ERROR_INVALID_PLUGIN";
+
     /// Write-time failure where user data did not conform to a registered
     /// schema (type mismatch, missing required field, pattern violation,
     /// additionalProperties, etc.). Raised from the JSON-Schema validator

--- a/packages/engine/src/plugin/archive.rs
+++ b/packages/engine/src/plugin/archive.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Cursor, Read};
 
 use serde_json::Value as JsonValue;
-use zip::read::ZipArchive;
+use zip::CompressionMethod;
+use zip::read::{ArchiveOffset, Config, ZipArchive};
 
 use crate::LixError;
 use crate::schema::{schema_key_from_definition, validate_lix_schema_definition};
@@ -15,76 +16,93 @@ pub(crate) struct ParsedPluginArchive {
     pub schemas: Vec<JsonValue>,
 }
 
+const KIB: u64 = 1024;
+const MIB: u64 = 1024 * KIB;
+
+#[derive(Debug, Clone, Copy)]
+struct PluginArchiveLimits {
+    archive_bytes: u64,
+    entries: u64,
+    entry_bytes: u64,
+    expanded_bytes: u64,
+    manifest_bytes: u64,
+    schema_bytes: u64,
+    path_bytes: u64,
+}
+
+impl PluginArchiveLimits {
+    const DEFAULT: Self = Self {
+        archive_bytes: 32 * MIB,
+        entries: 128,
+        entry_bytes: 32 * MIB,
+        expanded_bytes: 64 * MIB,
+        manifest_bytes: 64 * KIB,
+        schema_bytes: MIB,
+        path_bytes: 512,
+    };
+}
+
+#[derive(Debug)]
+struct LoadedPluginArchive {
+    manifest: PluginManifest,
+    normalized_manifest_json: String,
+    schemas: Vec<JsonValue>,
+    schema_keys: Vec<String>,
+    wasm: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PluginArchiveEntry {
+    index: usize,
+    declared_size: u64,
+}
+
+#[derive(Debug)]
+struct BoundedEntryRead {
+    bytes: Vec<u8>,
+    exceeded_limit: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PluginArchiveReadKind {
+    Manifest,
+    Schema,
+    Wasm,
+}
+
+impl PluginArchiveReadKind {
+    fn limit(self, limits: PluginArchiveLimits) -> u64 {
+        match self {
+            Self::Manifest => limits.manifest_bytes,
+            Self::Schema => limits.schema_bytes,
+            Self::Wasm => limits.entry_bytes,
+        }
+    }
+
+    fn resource_name(self) -> &'static str {
+        match self {
+            Self::Manifest => "manifest bytes",
+            Self::Schema => "schema bytes",
+            Self::Wasm => "entry bytes",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BoundedPluginArchive<'a> {
+    archive: ZipArchive<Cursor<&'a [u8]>>,
+    entries: BTreeMap<String, PluginArchiveEntry>,
+    expanded_bytes: u64,
+    limits: PluginArchiveLimits,
+}
+
 pub(crate) fn parse_plugin_archive_for_install(
     archive_bytes: &[u8],
 ) -> Result<ParsedPluginArchive, LixError> {
-    let files = read_archive_files_for_install(archive_bytes)?;
-
-    let manifest_bytes = files.get("manifest.json").ok_or_else(|| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: "Plugin archive must contain manifest.json".to_string(),
-        hint: None,
-        details: None,
-    })?;
-    let manifest_raw = std::str::from_utf8(manifest_bytes).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!("Plugin archive manifest.json must be UTF-8: {error}"),
-        hint: None,
-        details: None,
-    })?;
-    let validated_manifest = parse_plugin_manifest_json(manifest_raw)?;
-
-    let entry_path = parse_archive_path_for_install(&validated_manifest.manifest.entry)?;
-    let wasm_bytes = files
-        .get(&entry_path)
-        .ok_or_else(|| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!(
-                "Plugin archive is missing manifest entry file '{}'",
-                validated_manifest.manifest.entry
-            ),
-            hint: None,
-            details: None,
-        })?
-        .clone();
-    ensure_valid_plugin_wasm_for_install(&wasm_bytes)?;
-
-    let mut schemas = Vec::with_capacity(validated_manifest.manifest.schemas.len());
-    let mut seen_schema_keys = BTreeSet::<String>::new();
-    for schema_path in &validated_manifest.manifest.schemas {
-        let schema_entry_path = parse_archive_path_for_install(schema_path)?;
-        let schema_bytes = files.get(&schema_entry_path).ok_or_else(|| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!("Plugin archive is missing schema file '{schema_path}'"),
-            hint: None,
-            details: None,
-        })?;
-        let schema_json: JsonValue =
-            serde_json::from_slice(schema_bytes).map_err(|error| LixError {
-                code: "LIX_ERROR_UNKNOWN".to_string(),
-                message: format!("Plugin archive schema '{schema_path}' is invalid JSON: {error}"),
-                hint: None,
-                details: None,
-            })?;
-        validate_lix_schema_definition(&schema_json)?;
-        let schema_key = schema_key_from_definition(&schema_json)?;
-        if !seen_schema_keys.insert(schema_key.schema_key.clone()) {
-            return Err(LixError {
-                code: "LIX_ERROR_UNKNOWN".to_string(),
-                message: format!(
-                    "Plugin archive declares duplicate schema '{}'",
-                    schema_key.schema_key
-                ),
-                hint: None,
-                details: None,
-            });
-        }
-        schemas.push(schema_json);
-    }
-
+    let loaded = load_plugin_archive(archive_bytes, true, PluginArchiveLimits::DEFAULT)?;
     Ok(ParsedPluginArchive {
-        manifest: validated_manifest.manifest,
-        schemas,
+        manifest: loaded.manifest,
+        schemas: loaded.schemas,
     })
 }
 
@@ -93,87 +111,26 @@ pub(crate) fn load_installed_plugin_from_archive_bytes(
     archive_path: &str,
     archive_bytes: &[u8],
 ) -> Result<InstalledPlugin, LixError> {
-    let files = read_plugin_archive_files(archive_path, archive_bytes)?;
-    let manifest_bytes = files.get("manifest.json").ok_or_else(|| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!(
-            "plugin materialization: archive '{archive_path}' is missing manifest.json"
-        ),
-        hint: None,
-        details: None,
-    })?;
-    let manifest_raw = std::str::from_utf8(manifest_bytes).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!(
-            "plugin materialization: archive '{archive_path}' manifest.json must be UTF-8: {error}"
-        ),
-        hint: None,
-        details: None,
-    })?;
-    let validated_manifest = parse_plugin_manifest_json(manifest_raw)?;
-    if validated_manifest.manifest.key != plugin_key {
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!(
-                "plugin materialization: archive '{}' key mismatch: file id key '{}' vs manifest key '{}'",
-                archive_path, plugin_key, validated_manifest.manifest.key
-            ),
-            hint: None,
-            details: None,
-        });
-    }
-
-    let entry_path =
-        parse_plugin_archive_path_for_materialization(&validated_manifest.manifest.entry)?;
-    let wasm = files.get(&entry_path).ok_or_else(|| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!(
-            "plugin materialization: archive '{}' is missing entry file '{}'",
-            archive_path, validated_manifest.manifest.entry
-        ),
-        hint: None,
-        details: None,
-    })?;
-    ensure_valid_plugin_wasm_for_materialization(wasm)?;
-
-    let manifest = validated_manifest.manifest;
-    let content_type = manifest.file_match.content_type;
-    let mut schema_keys = Vec::with_capacity(manifest.schemas.len());
-    for schema_path in &manifest.schemas {
-        let schema_entry_path = parse_plugin_archive_path_for_materialization(schema_path)?;
-        let schema_bytes = files.get(&schema_entry_path).ok_or_else(|| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!(
-                "plugin materialization: archive '{archive_path}' is missing schema file '{schema_path}'"
-            ),
-            hint: None,
-            details: None,
-        })?;
-        let schema_json: JsonValue = serde_json::from_slice(schema_bytes).map_err(|error| {
-            LixError {
-                code: "LIX_ERROR_UNKNOWN".to_string(),
-                message: format!(
-                    "plugin materialization: archive '{archive_path}' schema '{schema_path}' is invalid JSON: {error}"
-                ),
-                hint: None,
-                details: None,
-            }
-        })?;
-        validate_lix_schema_definition(&schema_json)?;
-        let schema_key = schema_key_from_definition(&schema_json)?;
-        schema_keys.push(schema_key.schema_key);
+    let loaded = load_plugin_archive(archive_bytes, true, PluginArchiveLimits::DEFAULT)?;
+    if loaded.manifest.key != plugin_key {
+        return Err(invalid_plugin(format!(
+            "plugin materialization: archive '{archive_path}' key mismatch: file id key '{plugin_key}' vs manifest key '{}'",
+            loaded.manifest.key
+        )));
     }
 
     Ok(InstalledPlugin {
-        key: manifest.key,
-        runtime: manifest.runtime,
-        api_version: manifest.api_version,
-        path_glob: manifest.file_match.path_glob,
-        content_type,
-        entry: manifest.entry,
-        schema_keys,
-        manifest_json: validated_manifest.normalized_json,
-        wasm: wasm.clone(),
+        key: loaded.manifest.key,
+        runtime: loaded.manifest.runtime,
+        api_version: loaded.manifest.api_version,
+        path_glob: loaded.manifest.file_match.path_glob,
+        content_type: loaded.manifest.file_match.content_type,
+        entry: loaded.manifest.entry,
+        schema_keys: loaded.schema_keys,
+        manifest_json: loaded.normalized_manifest_json,
+        wasm: loaded
+            .wasm
+            .expect("full plugin archive load should include WASM bytes"),
     })
 }
 
@@ -183,266 +140,655 @@ pub(crate) fn load_installed_plugin_metadata_from_archive_bytes(
     archive_blob_hash: &str,
     archive_bytes: &[u8],
 ) -> Result<InstalledPluginMetadata, LixError> {
-    let files = read_plugin_archive_files(archive_path, archive_bytes)?;
-    let manifest_bytes = files.get("manifest.json").ok_or_else(|| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!(
-            "plugin metadata discovery: archive '{archive_path}' is missing manifest.json"
-        ),
-        hint: None,
-        details: None,
-    })?;
-    let manifest_raw = std::str::from_utf8(manifest_bytes).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!(
-            "plugin metadata discovery: archive '{archive_path}' manifest.json must be UTF-8: {error}"
-        ),
-        hint: None,
-        details: None,
-    })?;
-    let validated_manifest = parse_plugin_manifest_json(manifest_raw)?;
-    if validated_manifest.manifest.key != plugin_key {
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!(
-                "plugin metadata discovery: archive '{}' key mismatch: file id key '{}' vs manifest key '{}'",
-                archive_path, plugin_key, validated_manifest.manifest.key
-            ),
-            hint: None,
-            details: None,
-        });
-    }
-
-    let manifest = validated_manifest.manifest;
-    let content_type = manifest.file_match.content_type;
-    let mut schema_keys = Vec::with_capacity(manifest.schemas.len());
-    for schema_path in &manifest.schemas {
-        let schema_entry_path = parse_plugin_archive_path_for_materialization(schema_path)?;
-        let schema_bytes = files.get(&schema_entry_path).ok_or_else(|| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!(
-                "plugin metadata discovery: archive '{archive_path}' is missing schema file '{schema_path}'"
-            ),
-            hint: None,
-            details: None,
-        })?;
-        let schema_json: JsonValue = serde_json::from_slice(schema_bytes).map_err(|error| {
-            LixError {
-                code: "LIX_ERROR_UNKNOWN".to_string(),
-                message: format!(
-                    "plugin metadata discovery: archive '{archive_path}' schema '{schema_path}' is invalid JSON: {error}"
-                ),
-                hint: None,
-                details: None,
-            }
-        })?;
-        validate_lix_schema_definition(&schema_json)?;
-        let schema_key = schema_key_from_definition(&schema_json)?;
-        schema_keys.push(schema_key.schema_key);
+    let loaded = load_plugin_archive(archive_bytes, false, PluginArchiveLimits::DEFAULT)?;
+    if loaded.manifest.key != plugin_key {
+        return Err(invalid_plugin(format!(
+            "plugin metadata discovery: archive '{archive_path}' key mismatch: file id key '{plugin_key}' vs manifest key '{}'",
+            loaded.manifest.key
+        )));
     }
 
     Ok(InstalledPluginMetadata {
-        key: manifest.key,
+        key: loaded.manifest.key,
         archive_path: archive_path.to_string(),
         archive_blob_hash: archive_blob_hash.to_string(),
-        path_glob: manifest.file_match.path_glob,
-        content_type,
-        schema_keys,
+        path_glob: loaded.manifest.file_match.path_glob,
+        content_type: loaded.manifest.file_match.content_type,
+        schema_keys: loaded.schema_keys,
     })
 }
 
-fn read_archive_files_for_install(
+fn load_plugin_archive(
     archive_bytes: &[u8],
-) -> Result<BTreeMap<String, Vec<u8>>, LixError> {
-    if archive_bytes.is_empty() {
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: "Plugin archive bytes must not be empty".to_string(),
-            hint: None,
-            details: None,
-        });
+    include_wasm: bool,
+    limits: PluginArchiveLimits,
+) -> Result<LoadedPluginArchive, LixError> {
+    let mut archive = BoundedPluginArchive::open(archive_bytes, limits)?;
+    let manifest_bytes = archive.read_file("manifest.json", PluginArchiveReadKind::Manifest)?;
+    let manifest_raw = std::str::from_utf8(&manifest_bytes).map_err(|error| {
+        invalid_plugin(format!(
+            "Plugin archive manifest.json must be UTF-8: {error}"
+        ))
+    })?;
+    let validated_manifest = parse_plugin_manifest_json(manifest_raw)?;
+
+    let entry_path = parse_plugin_archive_path_with_limit(
+        &validated_manifest.manifest.entry,
+        "Plugin manifest entry",
+        limits.path_bytes,
+    )?;
+    archive.require_file(&entry_path, PluginArchiveReadKind::Wasm)?;
+    let wasm = if include_wasm {
+        let wasm = archive.read_file(&entry_path, PluginArchiveReadKind::Wasm)?;
+        ensure_valid_plugin_wasm(&wasm)?;
+        Some(wasm)
+    } else {
+        // Reserved plugin paths can only be written through the full install
+        // validator. Metadata discovery therefore checks package structure and
+        // referenced files without paying to inflate an already-validated WASM.
+        None
+    };
+
+    let mut schemas = Vec::with_capacity(validated_manifest.manifest.schemas.len());
+    let mut schema_keys = Vec::with_capacity(validated_manifest.manifest.schemas.len());
+    let mut seen_schema_keys = BTreeSet::<String>::new();
+    for schema_path in &validated_manifest.manifest.schemas {
+        let schema_entry_path = parse_plugin_archive_path_with_limit(
+            schema_path,
+            "Plugin manifest schema",
+            limits.path_bytes,
+        )?;
+        let schema_bytes = archive.read_file(&schema_entry_path, PluginArchiveReadKind::Schema)?;
+        let schema_json: JsonValue = serde_json::from_slice(&schema_bytes).map_err(|error| {
+            LixError::new(
+                LixError::CODE_SCHEMA_DEFINITION,
+                format!("Plugin archive schema '{schema_path}' is invalid JSON: {error}"),
+            )
+        })?;
+        validate_lix_schema_definition(&schema_json)?;
+        let schema_key = schema_key_from_definition(&schema_json)?.schema_key;
+        if !seen_schema_keys.insert(schema_key.clone()) {
+            return Err(invalid_plugin(format!(
+                "Plugin archive declares duplicate schema '{schema_key}'"
+            )));
+        }
+        schema_keys.push(schema_key);
+        schemas.push(schema_json);
     }
 
-    let mut archive = ZipArchive::new(Cursor::new(archive_bytes)).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!("Plugin archive is not a valid zip file: {error}"),
-        hint: None,
-        details: None,
-    })?;
-    let mut files = BTreeMap::<String, Vec<u8>>::new();
+    Ok(LoadedPluginArchive {
+        manifest: validated_manifest.manifest,
+        normalized_manifest_json: validated_manifest.normalized_json,
+        schemas,
+        schema_keys,
+        wasm,
+    })
+}
 
-    for index in 0..archive.len() {
-        let mut entry = archive.by_index(index).map_err(|error| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!("Failed to read plugin archive entry at index {index}: {error}"),
-            hint: None,
-            details: None,
-        })?;
-        let raw_name = entry.name().to_string();
-
-        if entry.is_dir() {
-            continue;
+impl<'a> BoundedPluginArchive<'a> {
+    fn open(archive_bytes: &'a [u8], limits: PluginArchiveLimits) -> Result<Self, LixError> {
+        let declared_entry_count = declared_zip_entry_count(archive_bytes, limits)?;
+        let config = Config {
+            archive_offset: ArchiveOffset::Known(0),
+        };
+        let mut archive =
+            ZipArchive::with_config(config, Cursor::new(archive_bytes)).map_err(|error| {
+                invalid_plugin(format!("Plugin archive is not a valid ZIP file: {error}"))
+            })?;
+        if usize_to_u64(archive.len()) != declared_entry_count {
+            return Err(invalid_plugin(format!(
+                "Plugin archive declares {declared_entry_count} entries but contains {} unique entries",
+                archive.len()
+            )));
         }
-        if is_symlink_mode(entry.unix_mode()) {
-            return Err(LixError {
-                code: "LIX_ERROR_UNKNOWN".to_string(),
-                message: format!("Plugin archive entry '{raw_name}' must not be a symlink"),
-                hint: None,
-                details: None,
+
+        let mut entries = BTreeMap::new();
+        let mut logical_paths = BTreeSet::new();
+        let mut expanded_bytes = 0u64;
+        for index in 0..archive.len() {
+            let (path, is_dir, declared_size) = {
+                let entry = archive.by_index_raw(index).map_err(|error| {
+                    invalid_plugin(format!(
+                        "Plugin archive entry at index {index} could not be opened: {error}"
+                    ))
+                })?;
+                let raw_path = std::str::from_utf8(entry.name_raw()).map_err(|error| {
+                    invalid_plugin(format!("Plugin archive entry path must be UTF-8: {error}"))
+                })?;
+                let path_bytes = usize_to_u64(entry.name_raw().len());
+                if path_bytes > limits.path_bytes {
+                    return Err(plugin_limit_error(
+                        "entry path bytes",
+                        path_bytes,
+                        limits.path_bytes,
+                        Some(raw_path),
+                    ));
+                }
+                let is_dir = entry.is_dir();
+                let logical_path = if is_dir {
+                    raw_path.strip_suffix('/').unwrap_or(raw_path)
+                } else {
+                    raw_path
+                };
+                let path = parse_plugin_archive_path_with_limit(
+                    logical_path,
+                    "Plugin archive entry",
+                    limits.path_bytes,
+                )?;
+                if entry.encrypted() {
+                    return Err(invalid_plugin(format!(
+                        "Plugin archive entry '{path}' must not be encrypted"
+                    )));
+                }
+                if entry.is_symlink() || is_symlink_mode(entry.unix_mode()) {
+                    return Err(invalid_plugin(format!(
+                        "Plugin archive entry '{path}' must not be a symlink"
+                    )));
+                }
+                if !matches!(
+                    entry.compression(),
+                    CompressionMethod::Stored | CompressionMethod::Deflated
+                ) {
+                    return Err(invalid_plugin(format!(
+                        "Plugin archive entry '{path}' uses unsupported compression {:?}",
+                        entry.compression()
+                    )));
+                }
+                (path, is_dir, entry.size())
+            };
+
+            if !logical_paths.insert(path.clone()) {
+                return Err(invalid_plugin(format!(
+                    "Plugin archive contains duplicate entry '{path}'"
+                )));
+            }
+            if declared_size > limits.entry_bytes {
+                return Err(plugin_limit_error(
+                    "entry bytes",
+                    declared_size,
+                    limits.entry_bytes,
+                    Some(&path),
+                ));
+            }
+            expanded_bytes = expanded_bytes
+                .checked_add(declared_size)
+                .ok_or_else(|| invalid_plugin("Plugin archive expanded byte count overflowed"))?;
+            if expanded_bytes > limits.expanded_bytes {
+                return Err(plugin_limit_error(
+                    "total expanded bytes",
+                    expanded_bytes,
+                    limits.expanded_bytes,
+                    Some(&path),
+                ));
+            }
+            if path == "manifest.json" && declared_size > limits.manifest_bytes {
+                return Err(plugin_limit_error(
+                    "manifest bytes",
+                    declared_size,
+                    limits.manifest_bytes,
+                    Some(&path),
+                ));
+            }
+
+            if !is_dir {
+                entries.insert(
+                    path,
+                    PluginArchiveEntry {
+                        index,
+                        declared_size,
+                    },
+                );
+            }
+        }
+
+        Ok(Self {
+            archive,
+            entries,
+            expanded_bytes: 0,
+            limits,
+        })
+    }
+
+    fn require_file(
+        &self,
+        path: &str,
+        kind: PluginArchiveReadKind,
+    ) -> Result<PluginArchiveEntry, LixError> {
+        let entry = self.entries.get(path).copied().ok_or_else(|| {
+            invalid_plugin(format!("Plugin archive is missing declared file '{path}'"))
+        })?;
+        let limit = kind.limit(self.limits);
+        if entry.declared_size > limit {
+            return Err(plugin_limit_error(
+                kind.resource_name(),
+                entry.declared_size,
+                limit,
+                Some(path),
+            ));
+        }
+        Ok(entry)
+    }
+
+    fn read_file(&mut self, path: &str, kind: PluginArchiveReadKind) -> Result<Vec<u8>, LixError> {
+        let metadata = self.require_file(path, kind)?;
+        let remaining_total = self
+            .limits
+            .expanded_bytes
+            .saturating_sub(self.expanded_bytes);
+        let role_limit = kind.limit(self.limits);
+        let (read_limit, resource_name, resource_limit) = if remaining_total < role_limit {
+            (
+                remaining_total,
+                "total expanded bytes",
+                self.limits.expanded_bytes,
+            )
+        } else {
+            (role_limit, kind.resource_name(), role_limit)
+        };
+
+        let mut entry = self.archive.by_index(metadata.index).map_err(|error| {
+            invalid_plugin(format!(
+                "Plugin archive entry '{path}' could not be decoded: {error}"
+            ))
+        })?;
+        let bounded_read = read_entry_with_limit(&mut entry, read_limit).map_err(|error| {
+            invalid_plugin(format!(
+                "Plugin archive entry '{path}' could not be read: {error}"
+            ))
+        })?;
+        if bounded_read.exceeded_limit {
+            let actual = read_limit.saturating_add(1);
+            let aggregate_actual = self.expanded_bytes.saturating_add(actual);
+            let reported_actual = if resource_name == "total expanded bytes" {
+                aggregate_actual
+            } else {
+                actual
+            };
+            return Err(plugin_limit_error(
+                resource_name,
+                reported_actual,
+                resource_limit,
+                Some(path),
+            ));
+        }
+        let bytes = bounded_read.bytes;
+        let actual = usize_to_u64(bytes.len());
+        if actual != metadata.declared_size {
+            return Err(invalid_plugin(format!(
+                "Plugin archive entry '{path}' expanded to {actual} bytes but declared {} bytes",
+                metadata.declared_size
+            )));
+        }
+        self.expanded_bytes = self
+            .expanded_bytes
+            .checked_add(actual)
+            .ok_or_else(|| invalid_plugin("Plugin archive expanded byte count overflowed"))?;
+        Ok(bytes)
+    }
+}
+
+fn read_entry_with_limit(
+    entry: &mut impl Read,
+    limit: u64,
+) -> Result<BoundedEntryRead, std::io::Error> {
+    let capacity = usize::try_from(limit.min(64 * KIB)).unwrap_or(64 * 1024);
+    let mut output = Vec::with_capacity(capacity);
+    let mut chunk = [0u8; 16 * 1024];
+    loop {
+        let output_len = usize_to_u64(output.len());
+        if output_len >= limit {
+            break;
+        }
+        let remaining = limit - output_len;
+        let read_len = usize::try_from(remaining.min(usize_to_u64(chunk.len())))
+            .expect("bounded plugin archive read length should fit usize");
+        let count = entry.read(&mut chunk[..read_len])?;
+        if count == 0 {
+            return Ok(BoundedEntryRead {
+                bytes: output,
+                exceeded_limit: false,
             });
         }
-
-        let entry_path = parse_archive_path_for_install(&raw_name)?;
-        let mut bytes = Vec::new();
-        entry.read_to_end(&mut bytes).map_err(|error| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!("Failed to read plugin archive entry '{raw_name}': {error}"),
-            hint: None,
-            details: None,
-        })?;
-        if files.insert(entry_path.clone(), bytes).is_some() {
-            return Err(LixError {
-                code: "LIX_ERROR_UNKNOWN".to_string(),
-                message: format!("Plugin archive contains duplicate entry '{entry_path}'"),
-                hint: None,
-                details: None,
-            });
-        }
+        output.extend_from_slice(&chunk[..count]);
     }
 
-    Ok(files)
+    let mut probe = [0u8; 1];
+    let exceeded_limit = entry.read(&mut probe)? != 0;
+    Ok(BoundedEntryRead {
+        bytes: output,
+        exceeded_limit,
+    })
 }
 
-fn read_plugin_archive_files(
-    archive_path: &str,
+fn declared_zip_entry_count(
     archive_bytes: &[u8],
-) -> Result<BTreeMap<String, Vec<u8>>, LixError> {
-    if archive_bytes.is_empty() {
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!("plugin materialization: archive '{archive_path}' is empty"),
-            hint: None,
-            details: None,
-        });
-    }
+    limits: PluginArchiveLimits,
+) -> Result<u64, LixError> {
+    const EOCD_LEN: usize = 22;
+    const MAX_EOCD_CANDIDATES: u64 = 8;
+    const EOCD_SIGNATURE: &[u8; 4] = b"PK\x05\x06";
+    const CENTRAL_SIGNATURE: &[u8; 4] = b"PK\x01\x02";
+    const ZIP64_LOCATOR_SIGNATURE: &[u8; 4] = b"PK\x06\x07";
 
-    let mut archive = ZipArchive::new(Cursor::new(archive_bytes)).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!(
-            "plugin materialization: archive '{archive_path}' is not a valid zip file: {error}"
-        ),
-        hint: None,
-        details: None,
-    })?;
-    let mut files = BTreeMap::<String, Vec<u8>>::new();
-
-    for index in 0..archive.len() {
-        let mut entry = archive.by_index(index).map_err(|error| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!(
-                "plugin materialization: failed to read archive '{archive_path}' entry index {index}: {error}"
-            ),
-            hint: None,
-            details: None,
-        })?;
-
-        let entry_name = entry.name().to_string();
-        if entry.is_dir() {
-            continue;
-        }
-        let entry_path = parse_plugin_archive_path_for_materialization(&entry_name)?;
-
-        let mut bytes = Vec::new();
-        entry.read_to_end(&mut bytes).map_err(|error| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!(
-                "plugin materialization: failed to read archive '{archive_path}' entry '{entry_name}': {error}"
-            ),
-            hint: None,
-            details: None,
-        })?;
-        files.insert(entry_path, bytes);
-    }
-
-    Ok(files)
-}
-
-fn parse_archive_path_for_install(path: &str) -> Result<String, LixError> {
-    parse_plugin_archive_path(path, "Plugin archive")
-}
-
-fn parse_plugin_archive_path_for_materialization(path: &str) -> Result<String, LixError> {
-    parse_plugin_archive_path(path, "plugin materialization: archive")
-}
-
-fn parse_plugin_archive_path(path: &str, context: &str) -> Result<String, LixError> {
-    if path.is_empty() {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            format!("{context} path must not be empty"),
+    let archive_len = usize_to_u64(archive_bytes.len());
+    if archive_len > limits.archive_bytes {
+        return Err(plugin_limit_error(
+            "archive bytes",
+            archive_len,
+            limits.archive_bytes,
+            None,
         ));
+    }
+    if archive_bytes.len() < EOCD_LEN {
+        return Err(invalid_plugin("Plugin archive is not a valid ZIP file"));
+    }
+
+    let first_offset = archive_bytes
+        .len()
+        .saturating_sub(EOCD_LEN + usize::from(u16::MAX));
+    let eocd_offset = memchr::memmem::rfind_iter(&archive_bytes[first_offset..], EOCD_SIGNATURE)
+        .map(|relative_offset| first_offset + relative_offset)
+        .find(|offset| {
+            let Some(fixed_footer) = archive_bytes.get(*offset..offset.saturating_add(EOCD_LEN))
+            else {
+                return false;
+            };
+            let comment_length =
+                usize::from(u16::from_le_bytes([fixed_footer[20], fixed_footer[21]]));
+            offset
+                .checked_add(EOCD_LEN + comment_length)
+                .is_some_and(|end| end == archive_bytes.len())
+        })
+        .ok_or_else(|| invalid_plugin("Plugin archive is not a valid ZIP file"))?;
+
+    // zip-rs allocates from footer counts before returning a ZipArchive and can
+    // fall back to an earlier footer. Cap both count fields for every candidate
+    // that can reach its central-directory reader, and reject an earlier such
+    // candidate. ArchiveOffset::Known(0) below makes the exact central-header
+    // check match zip-rs without interpreting incidental magic in payload or
+    // comment bytes as a directory record.
+    let mut eocd_candidates = 0u64;
+    for offset in memchr::memmem::find_iter(archive_bytes, EOCD_SIGNATURE) {
+        let Some(fixed_footer) = archive_bytes.get(offset..offset.saturating_add(EOCD_LEN)) else {
+            continue;
+        };
+        // zip-rs allocates and reads the declared comment before deciding
+        // whether this footer can identify a central directory. Bounding all
+        // complete candidates therefore bounds fallback work even for malformed
+        // comments and unusable directory offsets.
+        eocd_candidates = eocd_candidates.saturating_add(1);
+        if eocd_candidates > MAX_EOCD_CANDIDATES {
+            return Err(invalid_plugin(format!(
+                "Plugin archive contains more than {MAX_EOCD_CANDIDATES} ZIP footer candidates"
+            )));
+        }
+        let comment_length = usize::from(u16::from_le_bytes([fixed_footer[20], fixed_footer[21]]));
+        if offset
+            .checked_add(EOCD_LEN + comment_length)
+            .is_none_or(|end| end > archive_bytes.len())
+        {
+            continue;
+        }
+        let entries_on_disk = u64::from(u16::from_le_bytes([fixed_footer[8], fixed_footer[9]]));
+        let total_entries = u64::from(u16::from_le_bytes([fixed_footer[10], fixed_footer[11]]));
+        let central_size = u32::from_le_bytes([
+            fixed_footer[12],
+            fixed_footer[13],
+            fixed_footer[14],
+            fixed_footer[15],
+        ]);
+        let central_offset_raw = u32::from_le_bytes([
+            fixed_footer[16],
+            fixed_footer[17],
+            fixed_footer[18],
+            fixed_footer[19],
+        ]);
+        let has_zip64_locator = offset >= 20
+            && archive_bytes.get(offset - 20..offset - 16) == Some(ZIP64_LOCATOR_SIGNATURE);
+        let may_be_zip64 = total_entries == u64::from(u16::MAX)
+            || central_size == u32::MAX
+            || central_offset_raw == u32::MAX;
+
+        let central_offset = usize::try_from(central_offset_raw).unwrap_or(usize::MAX);
+        let points_to_central_directory = total_entries != 0
+            && central_offset < offset
+            && archive_bytes.get(central_offset..central_offset.saturating_add(4))
+                == Some(CENTRAL_SIGNATURE);
+        let can_reach_central_reader = offset == eocd_offset
+            || (may_be_zip64 && has_zip64_locator)
+            || (total_entries == 0 && entries_on_disk != 0)
+            || points_to_central_directory;
+        if !can_reach_central_reader {
+            continue;
+        }
+
+        if may_be_zip64 && has_zip64_locator {
+            return Err(invalid_plugin(
+                "Plugin archives with ZIP64 central directories are unsupported",
+            ));
+        }
+        if entries_on_disk > limits.entries {
+            return Err(plugin_limit_error(
+                "archive entries",
+                entries_on_disk,
+                limits.entries,
+                None,
+            ));
+        }
+        if total_entries > limits.entries {
+            return Err(plugin_limit_error(
+                "archive entries",
+                total_entries,
+                limits.entries,
+                None,
+            ));
+        }
+        if offset != eocd_offset {
+            return Err(invalid_plugin(
+                "Plugin archive contains multiple parseable ZIP footers",
+            ));
+        }
+    }
+
+    let field = |relative_offset: usize| {
+        u16::from_le_bytes([
+            archive_bytes[eocd_offset + relative_offset],
+            archive_bytes[eocd_offset + relative_offset + 1],
+        ])
+    };
+    let disk = field(4);
+    let directory_disk = field(6);
+    let entries_on_disk = field(8);
+    let entry_count = field(10);
+    if disk != 0 || directory_disk != 0 || entries_on_disk != entry_count {
+        return Err(invalid_plugin(
+            "Plugin archive must be a single-disk ZIP file",
+        ));
+    }
+
+    let entry_count = u64::from(entry_count);
+    if entry_count == 0 {
+        return Err(invalid_plugin(
+            "Plugin archive must contain at least one entry",
+        ));
+    }
+    if entry_count > limits.entries {
+        return Err(plugin_limit_error(
+            "archive entries",
+            entry_count,
+            limits.entries,
+            None,
+        ));
+    }
+    let central_offset = usize::try_from(u32::from_le_bytes([
+        archive_bytes[eocd_offset + 16],
+        archive_bytes[eocd_offset + 17],
+        archive_bytes[eocd_offset + 18],
+        archive_bytes[eocd_offset + 19],
+    ]))
+    .unwrap_or(usize::MAX);
+    if archive_bytes.get(central_offset..central_offset.saturating_add(4))
+        != Some(CENTRAL_SIGNATURE)
+    {
+        return Err(invalid_plugin(
+            "Plugin archive central directory offset is invalid",
+        ));
+    }
+    let central_size = usize::try_from(u32::from_le_bytes([
+        archive_bytes[eocd_offset + 12],
+        archive_bytes[eocd_offset + 13],
+        archive_bytes[eocd_offset + 14],
+        archive_bytes[eocd_offset + 15],
+    ]))
+    .map_err(|_| invalid_plugin("Plugin archive central directory size is invalid"))?;
+    let observed_entries = count_central_directory_entries(
+        archive_bytes,
+        central_offset,
+        central_size,
+        eocd_offset,
+        limits.entries,
+    )?;
+    if observed_entries != entry_count {
+        return Err(invalid_plugin(format!(
+            "Plugin archive footer declares {entry_count} entries but its central directory contains {observed_entries}"
+        )));
+    }
+    Ok(observed_entries)
+}
+
+fn count_central_directory_entries(
+    archive_bytes: &[u8],
+    central_offset: usize,
+    central_size: usize,
+    eocd_offset: usize,
+    entry_limit: u64,
+) -> Result<u64, LixError> {
+    const CENTRAL_HEADER_LEN: usize = 46;
+    const CENTRAL_SIGNATURE: &[u8; 4] = b"PK\x01\x02";
+
+    let central_end = central_offset
+        .checked_add(central_size)
+        .ok_or_else(|| invalid_plugin("Plugin archive central directory range overflowed"))?;
+    if central_end != eocd_offset {
+        return Err(invalid_plugin(
+            "Plugin archive central directory range is invalid",
+        ));
+    }
+
+    let mut cursor = central_offset;
+    let mut entry_count = 0u64;
+    while cursor < central_end {
+        let fixed_header = archive_bytes
+            .get(cursor..cursor.saturating_add(CENTRAL_HEADER_LEN))
+            .ok_or_else(|| invalid_plugin("Plugin archive central directory is truncated"))?;
+        if fixed_header.get(..4) != Some(CENTRAL_SIGNATURE) {
+            return Err(invalid_plugin(
+                "Plugin archive central directory contains an invalid entry header",
+            ));
+        }
+        entry_count = entry_count.saturating_add(1);
+        if entry_count > entry_limit {
+            return Err(plugin_limit_error(
+                "archive entries",
+                entry_count,
+                entry_limit,
+                None,
+            ));
+        }
+        let field = |offset: usize| {
+            usize::from(u16::from_le_bytes([
+                fixed_header[offset],
+                fixed_header[offset + 1],
+            ]))
+        };
+        let variable_size = field(28)
+            .checked_add(field(30))
+            .and_then(|size| size.checked_add(field(32)))
+            .ok_or_else(|| invalid_plugin("Plugin archive entry range overflowed"))?;
+        cursor = cursor
+            .checked_add(CENTRAL_HEADER_LEN)
+            .and_then(|value| value.checked_add(variable_size))
+            .ok_or_else(|| invalid_plugin("Plugin archive entry range overflowed"))?;
+        if cursor > central_end {
+            return Err(invalid_plugin(
+                "Plugin archive central directory entry is truncated",
+            ));
+        }
+    }
+    Ok(entry_count)
+}
+
+fn invalid_plugin(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INVALID_PLUGIN, message)
+}
+
+fn plugin_limit_error(resource: &str, actual: u64, limit: u64, path: Option<&str>) -> LixError {
+    let path = path.map_or_else(String::new, |path| format!(" for entry '{path}'"));
+    invalid_plugin(format!(
+        "Plugin archive {resource}{path} is {actual}, exceeding the maximum {limit}"
+    ))
+}
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn parse_plugin_archive_path_with_limit(
+    path: &str,
+    context: &str,
+    max_path_bytes: u64,
+) -> Result<String, LixError> {
+    let path_bytes = usize_to_u64(path.len());
+    if path_bytes > max_path_bytes {
+        return Err(plugin_limit_error(
+            "entry path bytes",
+            path_bytes,
+            max_path_bytes,
+            Some(path),
+        ));
+    }
+    if path.is_empty() {
+        return Err(invalid_plugin(format!("{context} path must not be empty")));
     }
     if path.starts_with('/') || path.starts_with('\\') {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            format!("{context} path '{path}' must be relative"),
-        ));
+        return Err(invalid_plugin(format!(
+            "{context} path '{path}' must be relative"
+        )));
     }
     if path.contains('\\') {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            format!("{context} path '{path}' must use forward slash separators"),
-        ));
+        return Err(invalid_plugin(format!(
+            "{context} path '{path}' must use forward slash separators"
+        )));
+    }
+    if path.contains('\0') {
+        return Err(invalid_plugin(format!(
+            "{context} path must not contain NUL bytes"
+        )));
     }
 
     for segment in path.split('/') {
         if segment.is_empty() {
-            return Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("{context} path '{path}' is invalid"),
-            ));
+            return Err(invalid_plugin(format!(
+                "{context} path '{path}' is invalid"
+            )));
         }
         if matches!(segment, "." | "..") {
-            return Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("{context} path '{path}' must not contain traversal or dot components"),
-            ));
+            return Err(invalid_plugin(format!(
+                "{context} path '{path}' must not contain traversal or dot components"
+            )));
         }
     }
 
     Ok(path.to_string())
 }
 
-fn ensure_valid_plugin_wasm_for_install(wasm_bytes: &[u8]) -> Result<(), LixError> {
-    if wasm_bytes.is_empty() {
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: "Plugin wasm bytes must not be empty".to_string(),
-            hint: None,
-            details: None,
-        });
-    }
-    if wasm_bytes.len() < 8 || !wasm_bytes.starts_with(&[0x00, 0x61, 0x73, 0x6d]) {
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: "Plugin wasm bytes must start with a valid wasm header".to_string(),
-            hint: None,
-            details: None,
-        });
-    }
-    Ok(())
-}
-
-fn ensure_valid_plugin_wasm_for_materialization(bytes: &[u8]) -> Result<(), LixError> {
+fn ensure_valid_plugin_wasm(bytes: &[u8]) -> Result<(), LixError> {
     const WASM_MAGIC: &[u8; 4] = b"\0asm";
-    if bytes.len() < WASM_MAGIC.len() || &bytes[..WASM_MAGIC.len()] != WASM_MAGIC {
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: "plugin materialization: entry file must be a valid WebAssembly module"
-                .to_string(),
-            hint: None,
-            details: None,
-        });
+    const WASM_HEADER_LEN: usize = 8;
+    if bytes.len() < WASM_HEADER_LEN || !bytes.starts_with(WASM_MAGIC) {
+        return Err(invalid_plugin(
+            "Plugin archive entry file must start with a valid WebAssembly header",
+        ));
     }
 
     Ok(())
@@ -456,63 +802,647 @@ fn is_symlink_mode(mode: Option<u32>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_archive_path_for_install, parse_plugin_archive_path_for_materialization};
+    use std::io::{Cursor, Write};
+
+    use zip::write::SimpleFileOptions;
+    use zip::{CompressionMethod, ZipWriter};
+
+    use crate::LixError;
+
+    use super::{
+        BoundedPluginArchive, PluginArchiveLimits, PluginArchiveReadKind, declared_zip_entry_count,
+        load_installed_plugin_from_archive_bytes,
+        load_installed_plugin_metadata_from_archive_bytes, load_plugin_archive,
+        parse_plugin_archive_for_install, parse_plugin_archive_path_with_limit,
+        read_entry_with_limit,
+    };
+
+    const MANIFEST: &[u8] = br#"{
+        "key":"plugin_test",
+        "runtime":"wasm-component-v1",
+        "api_version":"0.1.0",
+        "match":{"path_glob":"*.test"},
+        "entry":"plugin.wasm",
+        "schemas":["schema/plugin_test_note.json"]
+    }"#;
+    const SCHEMA: &[u8] = br#"{
+        "x-lix-key":"plugin_test_note",
+        "x-lix-primary-key":["/id"],
+        "type":"object",
+        "properties":{"id":{"type":"string"}},
+        "required":["id"],
+        "additionalProperties":false
+    }"#;
+    const WASM: &[u8] = b"\0asm\x01\0\0\0";
 
     #[test]
-    fn install_archive_path_parsing_is_slash_based() {
+    fn archive_path_parsing_is_slash_based() {
+        let parse = |path| parse_plugin_archive_path_with_limit(path, "Plugin archive", 512);
         assert_eq!(
-            parse_archive_path_for_install("schemas/table.json").as_deref(),
+            parse("schemas/table.json").as_deref(),
             Ok("schemas/table.json")
         );
         assert!(
-            parse_archive_path_for_install("schemas\\table.json")
+            parse("schemas\\table.json")
                 .expect_err("backslash must not be accepted as a portable archive separator")
                 .message
                 .contains("forward slash")
         );
         assert!(
-            parse_archive_path_for_install("schemas//table.json")
+            parse("schemas//table.json")
                 .expect_err("empty slash segments must be rejected")
                 .message
                 .contains("invalid")
         );
         assert!(
-            parse_archive_path_for_install("schemas/../table.json")
-                .expect_err("archive paths must not traverse")
-                .message
-                .contains("traversal")
-        );
-    }
-
-    #[test]
-    fn materialization_archive_path_parsing_is_slash_based() {
-        assert_eq!(
-            parse_plugin_archive_path_for_materialization("schemas/table.json").as_deref(),
-            Ok("schemas/table.json")
-        );
-        assert!(
-            parse_plugin_archive_path_for_materialization("schemas\\table.json")
-                .expect_err("backslash must not be accepted as a portable archive separator")
-                .message
-                .contains("forward slash")
-        );
-        assert!(
-            parse_plugin_archive_path_for_materialization("schemas//table.json")
-                .expect_err("empty slash segments must be rejected")
-                .message
-                .contains("invalid")
-        );
-        assert!(
-            parse_plugin_archive_path_for_materialization("schemas/../table.json")
+            parse("schemas/../table.json")
                 .expect_err("archive paths must not traverse")
                 .message
                 .contains("traversal")
         );
         assert!(
-            parse_plugin_archive_path_for_materialization("schemas/./table.json")
+            parse("schemas/./table.json")
                 .expect_err("archive paths must not contain dot segments")
                 .message
                 .contains("dot")
         );
+    }
+
+    #[test]
+    fn accepts_stored_and_deflated_plugin_archives() {
+        for method in [CompressionMethod::Stored, CompressionMethod::Deflated] {
+            let archive = plugin_archive(method);
+            let parsed = parse_plugin_archive_for_install(&archive)
+                .expect("canonical plugin archive should parse");
+            assert_eq!(parsed.manifest.key, "plugin_test");
+            assert_eq!(parsed.schemas.len(), 1);
+        }
+    }
+
+    #[test]
+    fn embedded_schema_errors_keep_the_schema_error_code() {
+        let archive = zip_entries(
+            &[
+                ("manifest.json", MANIFEST),
+                ("schema/plugin_test_note.json", b"{"),
+                ("plugin.wasm", WASM),
+            ],
+            CompressionMethod::Stored,
+        );
+        let error = parse_plugin_archive_for_install(&archive)
+            .expect_err("malformed embedded schema JSON must fail");
+        assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
+    }
+
+    #[test]
+    fn enforces_plugin_archive_limits_at_the_boundary() {
+        let archive = plugin_archive(CompressionMethod::Stored);
+        let payloads = [MANIFEST, SCHEMA, WASM];
+        let paths = [
+            "manifest.json",
+            "schema/plugin_test_note.json",
+            "plugin.wasm",
+        ];
+        let exact = PluginArchiveLimits {
+            archive_bytes: to_u64(archive.len()),
+            entries: to_u64(paths.len()),
+            entry_bytes: payloads
+                .iter()
+                .map(|payload| to_u64(payload.len()))
+                .max()
+                .expect("plugin archive has entries"),
+            expanded_bytes: payloads.iter().map(|payload| to_u64(payload.len())).sum(),
+            manifest_bytes: to_u64(MANIFEST.len()),
+            schema_bytes: to_u64(SCHEMA.len()),
+            path_bytes: paths
+                .iter()
+                .map(|path| to_u64(path.len()))
+                .max()
+                .expect("plugin archive has paths"),
+        };
+        load_plugin_archive(&archive, true, exact)
+            .expect("every exact plugin archive bound should be inclusive");
+
+        let cases = [
+            (
+                PluginArchiveLimits {
+                    archive_bytes: exact.archive_bytes - 1,
+                    ..exact
+                },
+                "archive bytes",
+            ),
+            (
+                PluginArchiveLimits {
+                    entries: exact.entries - 1,
+                    ..exact
+                },
+                "archive entries",
+            ),
+            (
+                PluginArchiveLimits {
+                    entry_bytes: exact.entry_bytes - 1,
+                    ..exact
+                },
+                "entry bytes",
+            ),
+            (
+                PluginArchiveLimits {
+                    expanded_bytes: exact.expanded_bytes - 1,
+                    ..exact
+                },
+                "total expanded bytes",
+            ),
+            (
+                PluginArchiveLimits {
+                    manifest_bytes: exact.manifest_bytes - 1,
+                    ..exact
+                },
+                "manifest bytes",
+            ),
+            (
+                PluginArchiveLimits {
+                    schema_bytes: exact.schema_bytes - 1,
+                    ..exact
+                },
+                "schema bytes",
+            ),
+            (
+                PluginArchiveLimits {
+                    path_bytes: exact.path_bytes - 1,
+                    ..exact
+                },
+                "entry path bytes",
+            ),
+        ];
+        for (limits, expected_resource) in cases {
+            assert_invalid_limit(&archive, limits, expected_resource);
+        }
+    }
+
+    #[test]
+    fn entry_count_guard_does_not_trust_a_forged_footer_count() {
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        for index in 0..129 {
+            writer
+                .start_file(format!("entry-{index}"), options)
+                .expect("entry-count fixture should start");
+        }
+        let mut archive = writer
+            .finish()
+            .expect("entry-count fixture should finish")
+            .into_inner();
+        let eocd_offset = archive.len() - 22;
+        archive[eocd_offset + 8..eocd_offset + 12].copy_from_slice(&[1, 0, 1, 0]);
+
+        let error = declared_zip_entry_count(&archive, PluginArchiveLimits::DEFAULT)
+            .expect_err("central headers must enforce the cap before zip-rs parses the footer");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(error.message.contains("archive entries"), "{error:?}");
+
+        let mut forged_disk_count = zip_entries(&[("entry", b"")], CompressionMethod::Stored);
+        let eocd_offset = forged_disk_count.len() - 22;
+        forged_disk_count[eocd_offset + 8..eocd_offset + 10].copy_from_slice(&129u16.to_le_bytes());
+        let error = declared_zip_entry_count(&forged_disk_count, PluginArchiveLimits::DEFAULT)
+            .expect_err("the on-disk footer count must be capped before zip-rs parses it");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(error.message.contains("archive entries"), "{error:?}");
+    }
+
+    #[test]
+    fn accepts_bounded_standard_zip_variants() {
+        let mut comment_writer = ZipWriter::new(Cursor::new(Vec::new()));
+        comment_writer
+            .set_comment("comment")
+            .expect("ZIP comment should be accepted by the fixture writer");
+        comment_writer
+            .start_file("entry", SimpleFileOptions::default())
+            .expect("comment fixture entry should start");
+        comment_writer
+            .write_all(b"data")
+            .expect("comment fixture entry should write");
+        let comment = comment_writer
+            .finish()
+            .expect("comment archive should finish")
+            .into_inner();
+
+        let mut zip64_writer = ZipWriter::new(Cursor::new(Vec::new()));
+        zip64_writer
+            .start_file("entry", SimpleFileOptions::default().large_file(true))
+            .expect("ZIP64 fixture entry should start");
+        zip64_writer
+            .write_all(b"data")
+            .expect("ZIP64 fixture entry should write");
+        let zip64 = zip64_writer
+            .finish()
+            .expect("ZIP64 archive should finish")
+            .into_inner();
+
+        let mut stream_writer = ZipWriter::new_stream(Vec::new());
+        stream_writer
+            .start_file("entry", SimpleFileOptions::default())
+            .expect("stream fixture entry should start");
+        stream_writer
+            .write_all(b"data")
+            .expect("stream fixture entry should write");
+        let descriptor = stream_writer
+            .finish()
+            .expect("stream archive should finish")
+            .into_inner();
+
+        for (label, archive) in [
+            ("comment", comment),
+            ("small ZIP64", zip64),
+            ("data descriptor", descriptor),
+        ] {
+            BoundedPluginArchive::open(&archive, PluginArchiveLimits::DEFAULT)
+                .unwrap_or_else(|error| panic!("{label} archive should be accepted: {error:?}"));
+        }
+    }
+
+    #[test]
+    fn ignores_incidental_eocd_magic_in_entry_data_and_comments() {
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+        writer
+            .set_comment("comment ending in PK\u{5}\u{6}")
+            .expect("ZIP comment should be accepted by the fixture writer");
+        writer
+            .start_file("entry", SimpleFileOptions::default())
+            .expect("incidental-magic fixture entry should start");
+        writer
+            .write_all(b"payload PK\x05\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
+            .expect("incidental-magic fixture entry should write");
+        let archive = writer
+            .finish()
+            .expect("incidental-magic archive should finish")
+            .into_inner();
+
+        BoundedPluginArchive::open(&archive, PluginArchiveLimits::DEFAULT)
+            .expect("incidental EOCD magic must not be treated as a ZIP footer");
+    }
+
+    #[test]
+    fn bounds_zip_footer_fallback_candidates() {
+        const FAKE_EOCD: &[u8] = b"PK\x05\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+        let accepted_payload = FAKE_EOCD.repeat(7);
+        let accepted = zip_entries(
+            &[("entry", accepted_payload.as_slice())],
+            CompressionMethod::Stored,
+        );
+        BoundedPluginArchive::open(&accepted, PluginArchiveLimits::DEFAULT)
+            .expect("seven incidental candidates plus the real footer should fit the bound");
+
+        let rejected_payload = FAKE_EOCD.repeat(8);
+        let rejected = zip_entries(
+            &[("entry", rejected_payload.as_slice())],
+            CompressionMethod::Stored,
+        );
+        let error = BoundedPluginArchive::open(&rejected, PluginArchiveLimits::DEFAULT)
+            .expect_err("eight incidental candidates plus the real footer must exceed the bound");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(error.message.contains("ZIP footer candidates"), "{error:?}");
+    }
+
+    #[test]
+    fn rejects_unsafe_archive_entries() {
+        let mut duplicate = zip_entries(
+            &[("entry-a", b"a"), ("entry-b", b"b")],
+            CompressionMethod::Stored,
+        );
+        assert_eq!(
+            replace_all(&mut duplicate, b"entry-b", b"entry-a"),
+            2,
+            "entry name should occur in its local and central headers"
+        );
+
+        let mut symlink_writer = ZipWriter::new(Cursor::new(Vec::new()));
+        symlink_writer
+            .add_symlink("link", "target", SimpleFileOptions::default())
+            .expect("symlink entry should write");
+        let symlink = symlink_writer
+            .finish()
+            .expect("symlink archive should finish")
+            .into_inner();
+
+        let traversal = zip_entries(&[("../entry", b"data")], CompressionMethod::Stored);
+        for (label, archive, expected_message) in [
+            ("duplicate", duplicate, "unique entries"),
+            ("symlink", symlink, "symlink"),
+            ("traversal", traversal, "traversal"),
+        ] {
+            let error = BoundedPluginArchive::open(&archive, PluginArchiveLimits::DEFAULT)
+                .expect_err("unsafe ZIP fixture must be rejected");
+            assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN, "{label}");
+            assert!(
+                error.message.contains(expected_message),
+                "{label}: {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn exact_limit_reads_still_validate_crc() {
+        let mut archive = zip_entries(&[("plugin.wasm", WASM)], CompressionMethod::Stored);
+        corrupt_first_entry_crc(&mut archive);
+        let limits = PluginArchiveLimits {
+            entry_bytes: to_u64(WASM.len()),
+            expanded_bytes: to_u64(WASM.len()),
+            ..PluginArchiveLimits::DEFAULT
+        };
+        let mut bounded = BoundedPluginArchive::open(&archive, limits)
+            .expect("header-consistent CRC fixture should pass preflight");
+        let error = bounded
+            .read_file("plugin.wasm", PluginArchiveReadKind::Wasm)
+            .expect_err("an exact-limit read must continue through CRC validation");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(
+            error.message.to_ascii_lowercase().contains("checksum"),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn bounded_reader_stops_after_the_limit_probe() {
+        let mut input = Cursor::new(vec![7u8; 64]);
+        let output = read_entry_with_limit(&mut input, 8).expect("bounded read should succeed");
+        assert_eq!(output.bytes.len(), 8);
+        assert!(output.exceeded_limit);
+        assert_eq!(input.position(), 9);
+    }
+
+    #[test]
+    fn metadata_loading_does_not_inflate_wasm() {
+        let mut archive = plugin_archive(CompressionMethod::Stored);
+        assert_eq!(
+            replace_all(&mut archive, WASM, b"\0asm\x02\0\0\0"),
+            1,
+            "WASM payload should occur exactly once"
+        );
+
+        let metadata = load_installed_plugin_metadata_from_archive_bytes(
+            "plugin_test",
+            "/.lix/plugins/plugin_test.lixplugin",
+            "test-blob",
+            &archive,
+        )
+        .expect("metadata loading should not decode the WASM entry");
+        assert_eq!(metadata.key, "plugin_test");
+
+        let error = load_installed_plugin_from_archive_bytes(
+            "plugin_test",
+            "/.lix/plugins/plugin_test.lixplugin",
+            &archive,
+        )
+        .expect_err("materialization must validate the WASM entry CRC");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(
+            error.message.to_ascii_lowercase().contains("checksum"),
+            "{error:?}"
+        );
+    }
+
+    fn plugin_archive(method: CompressionMethod) -> Vec<u8> {
+        zip_entries(
+            &[
+                ("manifest.json", MANIFEST),
+                ("schema/plugin_test_note.json", SCHEMA),
+                ("plugin.wasm", WASM),
+            ],
+            method,
+        )
+    }
+
+    fn zip_entries(entries: &[(&str, &[u8])], method: CompressionMethod) -> Vec<u8> {
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+        let options = SimpleFileOptions::default().compression_method(method);
+        for (path, bytes) in entries {
+            writer
+                .start_file(*path, options)
+                .expect("ZIP fixture entry should start");
+            writer
+                .write_all(bytes)
+                .expect("ZIP fixture entry should write");
+        }
+        writer
+            .finish()
+            .expect("ZIP fixture should finish")
+            .into_inner()
+    }
+
+    fn assert_invalid_limit(archive: &[u8], limits: PluginArchiveLimits, expected_resource: &str) {
+        let error = load_plugin_archive(archive, true, limits)
+            .expect_err("a bound lowered by one must reject the archive");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(
+            error.message.contains(expected_resource),
+            "expected {expected_resource:?} in {:?}",
+            error.message
+        );
+    }
+
+    fn replace_all(bytes: &mut [u8], from: &[u8], to: &[u8]) -> usize {
+        assert_eq!(from.len(), to.len());
+        let mut replacements = 0;
+        let mut cursor = 0;
+        while cursor + from.len() <= bytes.len() {
+            if &bytes[cursor..cursor + from.len()] == from {
+                bytes[cursor..cursor + to.len()].copy_from_slice(to);
+                replacements += 1;
+                cursor += from.len();
+            } else {
+                cursor += 1;
+            }
+        }
+        replacements
+    }
+
+    fn corrupt_first_entry_crc(archive: &mut [u8]) {
+        let central_offset = first_central_offset(archive);
+        let local_offset_bytes: [u8; 4] = archive[central_offset + 42..central_offset + 46]
+            .try_into()
+            .expect("central entry local offset should be four bytes");
+        let local_offset = usize::try_from(u32::from_le_bytes(local_offset_bytes))
+            .expect("fixture local offset should fit usize");
+        for offset in [local_offset + 14, central_offset + 16] {
+            archive[offset] ^= 1;
+        }
+    }
+
+    fn first_central_offset(archive: &[u8]) -> usize {
+        let eocd_offset = archive.len() - 22;
+        let offset: [u8; 4] = archive[eocd_offset + 16..eocd_offset + 20]
+            .try_into()
+            .expect("EOCD central offset should be four bytes");
+        usize::try_from(u32::from_le_bytes(offset))
+            .expect("fixture central offset should fit usize")
+    }
+
+    fn to_u64(value: usize) -> u64 {
+        u64::try_from(value).expect("fixture size should fit u64")
+    }
+}
+
+#[cfg(test)]
+mod benchmark_probe {
+    use std::hint::black_box;
+    use std::io::{Cursor, Write};
+    use std::time::{Duration, Instant};
+
+    use super::{
+        load_installed_plugin_from_archive_bytes,
+        load_installed_plugin_metadata_from_archive_bytes, parse_plugin_archive_for_install,
+    };
+
+    #[derive(Clone, Copy)]
+    enum Operation {
+        Install,
+        Metadata,
+        Materialize,
+    }
+
+    #[test]
+    #[ignore = "release-only plugin archive parser benchmark probe"]
+    fn plugin_archive_parse_benchmark_probe() {
+        let operation = match std::env::var("LIX_PLUGIN_ARCHIVE_BENCH_OPERATION")
+            .unwrap_or_else(|_| "install".to_string())
+            .as_str()
+        {
+            "install" => Operation::Install,
+            "metadata" => Operation::Metadata,
+            "materialize" => Operation::Materialize,
+            value => panic!(
+                "LIX_PLUGIN_ARCHIVE_BENCH_OPERATION must be install, metadata, or materialize, got {value:?}"
+            ),
+        };
+        let wasm_bytes = env_usize("LIX_PLUGIN_ARCHIVE_BENCH_WASM_BYTES", 2 * 1024 * 1024);
+        let rounds = env_usize("LIX_PLUGIN_ARCHIVE_BENCH_ROUNDS", 200);
+        let warmups = env_usize("LIX_PLUGIN_ARCHIVE_BENCH_WARMUPS", 20);
+        assert!(wasm_bytes >= 8, "benchmark WASM must include its header");
+        assert!(rounds > 0, "benchmark needs at least one measured round");
+
+        let archive = benchmark_archive(wasm_bytes);
+        for _ in 0..warmups {
+            run_operation(operation, &archive);
+        }
+
+        let mut samples = Vec::with_capacity(rounds);
+        for _ in 0..rounds {
+            let started = Instant::now();
+            run_operation(operation, &archive);
+            samples.push(started.elapsed());
+        }
+        samples.sort_unstable();
+        println!(
+            "plugin_archive_parse_probe operation={} archive_bytes={} wasm_bytes={} rounds={} p50_us={} p95_us={}",
+            operation_name(operation),
+            archive.len(),
+            wasm_bytes,
+            rounds,
+            percentile(&samples, 50, 100).as_micros(),
+            percentile(&samples, 95, 100).as_micros(),
+        );
+    }
+
+    fn run_operation(operation: Operation, archive: &[u8]) {
+        match operation {
+            Operation::Install => {
+                black_box(parse_plugin_archive_for_install(black_box(archive)))
+                    .expect("benchmark archive should parse");
+            }
+            Operation::Metadata => {
+                black_box(load_installed_plugin_metadata_from_archive_bytes(
+                    "plugin_bench",
+                    "/.lix/plugins/plugin_bench.lixplugin",
+                    "bench-blob",
+                    black_box(archive),
+                ))
+                .expect("benchmark archive metadata should load");
+            }
+            Operation::Materialize => {
+                black_box(load_installed_plugin_from_archive_bytes(
+                    "plugin_bench",
+                    "/.lix/plugins/plugin_bench.lixplugin",
+                    black_box(archive),
+                ))
+                .expect("benchmark archive should materialize");
+            }
+        }
+    }
+
+    fn operation_name(operation: Operation) -> &'static str {
+        match operation {
+            Operation::Install => "install",
+            Operation::Metadata => "metadata",
+            Operation::Materialize => "materialize",
+        }
+    }
+
+    fn env_usize(name: &str, default: usize) -> usize {
+        match std::env::var(name) {
+            Ok(value) => value
+                .parse()
+                .unwrap_or_else(|error| panic!("{name} must be an unsigned integer: {error}")),
+            Err(std::env::VarError::NotPresent) => default,
+            Err(error) => panic!("{name} must be valid Unicode: {error}"),
+        }
+    }
+
+    fn percentile(samples: &[Duration], numerator: usize, denominator: usize) -> Duration {
+        let rank = samples
+            .len()
+            .checked_mul(numerator)
+            .expect("sample count should fit percentile arithmetic")
+            .div_ceil(denominator);
+        samples[rank - 1]
+    }
+
+    fn benchmark_archive(wasm_bytes: usize) -> Vec<u8> {
+        let manifest = br#"{
+            "key":"plugin_bench",
+            "runtime":"wasm-component-v1",
+            "api_version":"0.1.0",
+            "match":{"path_glob":"*.bench"},
+            "entry":"plugin.wasm",
+            "schemas":["schema/plugin_bench_note.json"]
+        }"#;
+        let schema = br#"{
+            "x-lix-key":"plugin_bench_note",
+            "x-lix-primary-key":["/id"],
+            "type":"object",
+            "properties":{"id":{"type":"string"}},
+            "required":["id"],
+            "additionalProperties":false
+        }"#;
+        let mut wasm = vec![0u8; wasm_bytes];
+        wasm[..8].copy_from_slice(b"\0asm\x01\0\0\0");
+        let mut state = 0x9e37_79b9_u32;
+        for byte in &mut wasm[8..] {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            *byte = state.to_le_bytes()[0];
+        }
+
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        for (path, bytes) in [
+            ("manifest.json", manifest.as_slice()),
+            ("schema/plugin_bench_note.json", schema.as_slice()),
+            ("plugin.wasm", wasm.as_slice()),
+        ] {
+            writer
+                .start_file(path, options)
+                .expect("benchmark ZIP entry should start");
+            writer
+                .write_all(bytes)
+                .expect("benchmark ZIP entry should write");
+        }
+        writer
+            .finish()
+            .expect("benchmark ZIP should finish")
+            .into_inner()
     }
 }

--- a/packages/engine/src/plugin/manifest.rs
+++ b/packages/engine/src/plugin/manifest.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use globset::GlobBuilder;
+use globset::{GlobBuilder, GlobMatcher};
 use jsonschema::{Draft, JSONSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -48,27 +48,36 @@ pub struct ValidatedPluginManifest {
 }
 
 pub fn parse_plugin_manifest_json(raw: &str) -> Result<ValidatedPluginManifest, LixError> {
-    let manifest_json: JsonValue = serde_json::from_str(raw).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!("Plugin manifest must be valid JSON: {error}"),
-        hint: None,
-        details: None,
+    let manifest_json: JsonValue = serde_json::from_str(raw).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INVALID_PLUGIN,
+            format!("Plugin manifest must be valid JSON: {error}"),
+        )
     })?;
 
     validate_plugin_manifest_json(&manifest_json)?;
 
     let manifest: PluginManifest =
-        serde_json::from_value(manifest_json.clone()).map_err(|error| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!("Plugin manifest does not match expected shape: {error}"),
-            hint: None,
-            details: None,
+        serde_json::from_value(manifest_json.clone()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INVALID_PLUGIN,
+                format!("Plugin manifest does not match expected shape: {error}"),
+            )
         })?;
-    let normalized_json = serde_json::to_string(&manifest_json).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!("Failed to normalize plugin manifest JSON: {error}"),
-        hint: None,
-        details: None,
+    compile_path_glob(&manifest.file_match.path_glob).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INVALID_PLUGIN,
+            format!(
+                "Plugin manifest path_glob '{}' is invalid: {error}",
+                manifest.file_match.path_glob
+            ),
+        )
+    })?;
+    let normalized_json = serde_json::to_string(&manifest_json).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("Failed to normalize plugin manifest JSON: {error}"),
+        )
     })?;
 
     Ok(ValidatedPluginManifest {
@@ -125,23 +134,26 @@ pub fn glob_matches_path(glob: &str, path: &str) -> bool {
         return true;
     }
 
+    compile_path_glob(glob)
+        .map(|compiled| compiled.is_match(path))
+        .unwrap_or(false)
+}
+
+fn compile_path_glob(glob: &str) -> Result<GlobMatcher, globset::Error> {
     GlobBuilder::new(glob)
         .literal_separator(false)
         .build()
-        .map(|compiled| compiled.compile_matcher().is_match(path))
-        .unwrap_or(false)
+        .map(|compiled| compiled.compile_matcher())
 }
 
 fn validate_plugin_manifest_json(manifest: &JsonValue) -> Result<(), LixError> {
     let validator = plugin_manifest_validator()?;
     if let Err(errors) = validator.validate(manifest) {
         let details = format_validation_errors(errors);
-        return Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!("Invalid plugin manifest: {details}"),
-            hint: None,
-            details: None,
-        });
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PLUGIN,
+            format!("Invalid plugin manifest: {details}"),
+        ));
     }
     Ok(())
 }
@@ -181,24 +193,17 @@ fn plugin_manifest_validator() -> Result<&'static JSONSchema, LixError> {
             options.with_draft(Draft::Draft202012);
         }
 
-        options
-            .compile(plugin_manifest_schema())
-            .map_err(|error| LixError {
-                code: "LIX_ERROR_UNKNOWN".to_string(),
-                message: format!("Failed to compile plugin manifest schema: {error}"),
-                hint: None,
-                details: None,
-            })
+        options.compile(plugin_manifest_schema()).map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("Failed to compile plugin manifest schema: {error}"),
+            )
+        })
     });
 
     match result {
         Ok(schema) => Ok(schema),
-        Err(error) => Err(LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: error.message.clone(),
-            hint: None,
-            details: None,
-        }),
+        Err(error) => Err(error.clone()),
     }
 }
 
@@ -231,6 +236,8 @@ fn format_validation_errors<'a>(
 
 #[cfg(test)]
 mod tests {
+    use crate::LixError;
+
     use super::{PluginContentType, PluginRuntime, glob_matches_path, parse_plugin_manifest_json};
 
     #[test]
@@ -265,13 +272,14 @@ mod tests {
         )
         .expect_err("manifest should be invalid");
 
+        assert_eq!(err.code, LixError::CODE_INVALID_PLUGIN);
         assert!(err.message.contains("Invalid plugin manifest"));
         assert!(err.message.contains("key"));
     }
 
     #[test]
-    fn preserves_invalid_path_glob_text() {
-        let validated = parse_plugin_manifest_json(
+    fn rejects_invalid_path_glob() {
+        let error = parse_plugin_manifest_json(
             r#"{
                 "key":"plugin_markdown",
                 "runtime":"wasm-component-v1",
@@ -281,9 +289,40 @@ mod tests {
                 "schemas":["schema/default.json"]
             }"#,
         )
-        .expect("manifest should parse");
+        .expect_err("invalid path glob should be rejected");
 
-        assert_eq!(validated.manifest.file_match.path_glob, "*.{md,mdx");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(error.message.contains("path_glob"));
+    }
+
+    #[test]
+    fn enforces_manifest_work_bounds_at_the_boundary() {
+        let max_glob = "a".repeat(1024);
+        parse_plugin_manifest_json(&manifest_with(&max_glob, &["schema/default.json".into()]))
+            .expect("the maximum glob length should be inclusive");
+
+        let oversized_glob = "a".repeat(1025);
+        let error = parse_plugin_manifest_json(&manifest_with(
+            &oversized_glob,
+            &["schema/default.json".into()],
+        ))
+        .expect_err("a glob over the work bound must be rejected");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(error.message.contains("path_glob"), "{error:?}");
+
+        let max_schemas = (0..64)
+            .map(|index| format!("schema/{index}.json"))
+            .collect::<Vec<_>>();
+        parse_plugin_manifest_json(&manifest_with("*.json", &max_schemas))
+            .expect("the maximum schema count should be inclusive");
+
+        let oversized_schemas = (0..65)
+            .map(|index| format!("schema/{index}.json"))
+            .collect::<Vec<_>>();
+        let error = parse_plugin_manifest_json(&manifest_with("*.json", &oversized_schemas))
+            .expect_err("a schema list over the work bound must be rejected");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(error.message.contains("schemas"), "{error:?}");
     }
 
     #[test]
@@ -334,6 +373,19 @@ mod tests {
         )
         .expect_err("detect_changes state context config should be rejected");
 
+        assert_eq!(err.code, LixError::CODE_INVALID_PLUGIN);
         assert!(err.message.contains("detect_changes"));
+    }
+
+    fn manifest_with(path_glob: &str, schemas: &[String]) -> String {
+        serde_json::json!({
+            "key": "plugin_bounds",
+            "runtime": "wasm-component-v1",
+            "api_version": "0.1.0",
+            "match": { "path_glob": path_glob },
+            "entry": "plugin.wasm",
+            "schemas": schemas,
+        })
+        .to_string()
     }
 }

--- a/packages/engine/src/plugin/plugin_manifest.json
+++ b/packages/engine/src/plugin/plugin_manifest.json
@@ -34,7 +34,8 @@
       "properties": {
         "path_glob": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "maxLength": 1024
         },
         "content_type": {
           "type": "string",
@@ -44,14 +45,18 @@
     },
     "entry": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 512
     },
     "schemas": {
       "type": "array",
       "minItems": 1,
+      "maxItems": 64,
+      "uniqueItems": true,
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "maxLength": 512
       }
     }
   }

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -267,7 +267,55 @@ async fn sql_update_rejects_invalid_installed_plugin_storage_archive_data() {
         .await
         .expect_err("SQL update should reject invalid plugin archive data");
 
-    assert!(error.message.contains("valid zip file"));
+    assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+    assert!(error.message.contains("ZIP"));
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn sql_invalid_plugin_manifest_writes_are_atomic() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    let path = "/.lix/plugins/plugin_sentinel.lixplugin";
+    let invalid = invalid_glob_sentinel_plugin_archive();
+
+    let error = install_plugin(&session, "plugin_sentinel", &invalid)
+        .await
+        .expect_err("a fresh install with an invalid glob must fail");
+    assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+    assert!(error.message.contains("path_glob"));
+    assert_eq!(
+        read_file(&session, path)
+            .await
+            .expect("failed install archive lookup should succeed"),
+        None
+    );
+    assert_eq!(registered_plugin_note_schema_count(&session).await, 0);
+
+    let original = sentinel_plugin_archive();
+    install_plugin(&session, "plugin_sentinel", &original)
+        .await
+        .expect("valid plugin install should succeed");
+    let error = install_plugin(&session, "plugin_sentinel", &invalid)
+        .await
+        .expect_err("an update with an invalid glob must fail");
+    assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+    assert_eq!(
+        read_file(&session, path)
+            .await
+            .expect("installed archive lookup should succeed")
+            .as_deref(),
+        Some(original.as_slice())
+    );
+    assert_eq!(registered_plugin_note_schema_count(&session).await, 1);
 
     session.close().await.expect("session should close");
 }
@@ -771,6 +819,21 @@ where
     }
 }
 
+async fn registered_plugin_note_schema_count<S>(session: &S) -> usize
+where
+    S: TestSession + Sync + ?Sized,
+{
+    session
+        .execute_sql(
+            "SELECT value FROM lix_registered_schema \
+             WHERE lixcol_entity_pk = lix_json('[\"plugin_note\"]')",
+            &[],
+        )
+        .await
+        .expect("plugin schema lookup should succeed")
+        .len()
+}
+
 async fn mkdir<S>(session: &S, path: &str) -> Result<(), LixError>
 where
     S: TestSession + Sync + ?Sized,
@@ -1014,6 +1077,18 @@ fn sentinel_plugin_archive() -> Vec<u8> {
         "runtime": "wasm-component-v1",
         "api_version": "0.1.0",
         "match": { "path_glob": "*.sentinel" },
+        "entry": "plugin.wasm",
+        "schemas": ["schema/plugin_note.json"]
+    }"#;
+    plugin_archive(MANIFEST_JSON)
+}
+
+fn invalid_glob_sentinel_plugin_archive() -> Vec<u8> {
+    const MANIFEST_JSON: &[u8] = br#"{
+        "key": "plugin_sentinel",
+        "runtime": "wasm-component-v1",
+        "api_version": "0.1.0",
+        "match": { "path_glob": "*.{sentinel" },
         "entry": "plugin.wasm",
         "schemas": ["schema/plugin_note.json"]
     }"#;


### PR DESCRIPTION
## Summary

- preflight plugin ZIP archives with explicit raw, entry-count, expanded-size, path, manifest, schema, and footer-fallback bounds before `zip-rs` can allocate from untrusted metadata
- validate portable paths, duplicates, symlinks, referenced files, schema lists, and globs with the new public `LIX_ERROR_INVALID_PLUGIN` code
- retain standard Stored/Deflate archives, comments, data descriptors, and bounded per-entry ZIP64 sizes; true ZIP64 central directories are rejected
- make metadata discovery read only the manifest and schemas, while full install/materialization still verifies the referenced WASM payload and CRC
- add atomic install/update regressions and a major changenote for the new package/error contract

## Data

Identical optimized benchmark probe: deterministic 2 MiB deflated WASM payload, 10 warmups, 100 samples.

| Operation | Baseline p50/p95 | Final p50/p95 | Improvement |
| --- | ---: | ---: | ---: |
| install | 516 / 564 µs | 446 / 482 µs | 13.6% / 14.5% |
| metadata discovery | 399 / 424 µs | 94 / 121 µs | 76.4% / 71.5% |
| materialization | 480 / 515 µs | 444 / 472 µs | 7.5% / 8.3% |

A first scalar whole-archive signature scan regressed install to 1,456/1,547 µs and materialization to 1,467/1,566 µs. That implementation was rejected; the final preflight uses SIMD substring search and remains faster than baseline.

## Resource contract

- 32 MiB raw archive
- 128 ZIP entries
- 32 MiB per expanded entry and 64 MiB total declared/actual expansion
- 64 KiB manifest and 1 MiB per schema
- 64 schemas, 512-byte paths, and 1,024-character globs
- 8 complete EOCD candidates, bounding `zip-rs` fallback comment reads to 524,280 bytes

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (all tests and doctests)
- 12 focused archive boundary/adversarial tests
- 30 filesystem API integration tests
- independent static adversarial review: clear
