### PR TITLE
perf(rs-sdk): cache compiled WASM components across opens

### DIFF
--- a/.changenotes/cache-wasm-components.md
+++ b/.changenotes/cache-wasm-components.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+The native SDK now reuses compiled WASM components across Lix opens, bounds the
+compiled-component cache, and enforces `WasmLimits.max_memory_bytes` during
+component instantiation and growth.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,15 +3384,18 @@ name = "lix_sdk"
 version = "0.8.4"
 dependencies = [
  "async-trait",
+ "blake3",
  "bytes",
  "codspeed-criterion-compat",
  "lix_engine",
  "lix_local_filesystem",
  "lix_sqlite_storage",
+ "lru",
  "notify-debouncer-full",
  "rusqlite",
  "tempfile",
  "tokio",
+ "wasm-encoder 0.248.0",
  "wasmtime",
  "wasmtime-wasi",
  "zip",

--- a/packages/engine/src/wasm/mod.rs
+++ b/packages/engine/src/wasm/mod.rs
@@ -28,6 +28,9 @@ pub struct WasmPluginDetectedChange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WasmLimits {
+    /// Maximum bytes available to each guest linear memory. With Wasmtime's
+    /// standard 64 KiB pages, non-page-aligned values permit only the complete
+    /// pages that fit below this bound.
     pub max_memory_bytes: u64,
     pub max_fuel: Option<u64>,
     pub timeout_ms: Option<u64>,

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -22,7 +22,9 @@ lix_local_filesystem = { workspace = true, optional = true }
 lix_sqlite_storage = { workspace = true, optional = true }
 
 async-trait = "0.1"
+blake3 = { version = "1", optional = true }
 bytes = "1"
+lru = { version = "0.18", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 tempfile = { version = "3", optional = true }
 wasmtime = { version = "45", default-features = false, features = ["component-model", "cranelift", "runtime", "std"], optional = true }
@@ -36,11 +38,12 @@ tokio = { version = "1", features = ["rt", "sync"] }
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros"] }
+wasm-encoder = "0.248"
 zip = { version = "8", default-features = false }
 
 [features]
 default = ["default_wasm_runtime"]
-default_wasm_runtime = ["dep:wasmtime", "dep:wasmtime-wasi"]
+default_wasm_runtime = ["dep:blake3", "dep:lru", "dep:wasmtime", "dep:wasmtime-wasi"]
 local_filesystem = ["dep:lix_local_filesystem", "lix_local_filesystem/rocksdb"]
 sqlite = ["dep:lix_sqlite_storage", "dep:rusqlite", "dep:tempfile"]
 

--- a/packages/rs-sdk/src/default_wasm_runtime.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -10,8 +12,9 @@ use lix_engine::wasm::{
     WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
     WasmPluginFile, WasmRuntime,
 };
+use lru::LruCache;
 use wasmtime::component::{Component, Linker};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Config, Engine, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::{
     ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView, p2::add_to_linker_sync,
 };
@@ -22,6 +25,8 @@ mod plugin_bindings {
         world: "plugin",
     });
 }
+
+const COMPILED_COMPONENT_CACHE_CAPACITY: usize = 16;
 
 pub(crate) fn runtime() -> Result<Arc<dyn WasmRuntime>, LixError> {
     Ok(Arc::new(WasmtimePluginRuntime::new()?))
@@ -36,13 +41,34 @@ fn create_engine(consume_fuel: bool, epoch_interruption: bool) -> wasmtime::Resu
 }
 
 struct WasmtimePluginRuntime {
+    shared: Arc<WasmtimeSharedRuntime>,
+}
+
+struct WasmtimeSharedRuntime {
     engine: Engine,
     fuel_engine: Engine,
     timeout_engine: Engine,
     fuel_timeout_engine: Engine,
+    linker: OnceLock<Result<Linker<WasiHostState>, LixError>>,
+    fuel_linker: OnceLock<Result<Linker<WasiHostState>, LixError>>,
+    timeout_linker: OnceLock<Result<Linker<WasiHostState>, LixError>>,
+    fuel_timeout_linker: OnceLock<Result<Linker<WasiHostState>, LixError>>,
+    timeout_ticker: Arc<TimeoutTickerRegistry>,
+    fuel_timeout_ticker: Arc<TimeoutTickerRegistry>,
+    compiled_components: CompiledComponentCache,
 }
 
 impl WasmtimePluginRuntime {
+    fn new() -> Result<Self, LixError> {
+        static SHARED: OnceLock<Result<Arc<WasmtimeSharedRuntime>, LixError>> = OnceLock::new();
+        let shared = SHARED
+            .get_or_init(|| WasmtimeSharedRuntime::new().map(Arc::new))
+            .clone()?;
+        Ok(Self { shared })
+    }
+}
+
+impl WasmtimeSharedRuntime {
     fn new() -> Result<Self, LixError> {
         let engine = create_engine(false, false)
             .map_err(|error| wasm_runtime_error("failed to create Wasmtime engine", error))?;
@@ -54,11 +80,162 @@ impl WasmtimePluginRuntime {
         let fuel_timeout_engine = create_engine(true, true).map_err(|error| {
             wasm_runtime_error("failed to create Wasmtime fuel timeout engine", error)
         })?;
+        let timeout_ticker = Arc::new(TimeoutTickerRegistry::new(timeout_engine.clone()));
+        let fuel_timeout_ticker = Arc::new(TimeoutTickerRegistry::new(fuel_timeout_engine.clone()));
         Ok(Self {
             engine,
             fuel_engine,
             timeout_engine,
             fuel_timeout_engine,
+            linker: OnceLock::new(),
+            fuel_linker: OnceLock::new(),
+            timeout_linker: OnceLock::new(),
+            fuel_timeout_linker: OnceLock::new(),
+            timeout_ticker,
+            fuel_timeout_ticker,
+            compiled_components: CompiledComponentCache::new(COMPILED_COMPONENT_CACHE_CAPACITY),
+        })
+    }
+
+    fn engine(&self, profile: CompileProfile) -> &Engine {
+        match profile {
+            CompileProfile::Plain => &self.engine,
+            CompileProfile::Fuel => &self.fuel_engine,
+            CompileProfile::Timeout => &self.timeout_engine,
+            CompileProfile::FuelAndTimeout => &self.fuel_timeout_engine,
+        }
+    }
+
+    fn linker(&self, profile: CompileProfile) -> Result<&Linker<WasiHostState>, LixError> {
+        let linker = match profile {
+            CompileProfile::Plain => &self.linker,
+            CompileProfile::Fuel => &self.fuel_linker,
+            CompileProfile::Timeout => &self.timeout_linker,
+            CompileProfile::FuelAndTimeout => &self.fuel_timeout_linker,
+        };
+        linker
+            .get_or_init(|| create_linker(self.engine(profile)))
+            .as_ref()
+            .map_err(Clone::clone)
+    }
+
+    fn timeout_ticker(
+        &self,
+        profile: CompileProfile,
+    ) -> Result<Option<TimeoutTickerLease>, LixError> {
+        let registry = match profile {
+            CompileProfile::Plain | CompileProfile::Fuel => return Ok(None),
+            CompileProfile::Timeout => &self.timeout_ticker,
+            CompileProfile::FuelAndTimeout => &self.fuel_timeout_ticker,
+        };
+        registry.acquire().map(Some)
+    }
+}
+
+fn create_linker(engine: &Engine) -> Result<Linker<WasiHostState>, LixError> {
+    let mut linker = Linker::<WasiHostState>::new(engine);
+    add_to_linker_sync(&mut linker)
+        .map_err(|error| wasm_runtime_error("failed to configure WASI linker", error))?;
+    Ok(linker)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum CompileProfile {
+    Plain,
+    Fuel,
+    Timeout,
+    FuelAndTimeout,
+}
+
+impl CompileProfile {
+    fn from_limits(limits: WasmLimits) -> Self {
+        match (limits.max_fuel.is_some(), limits.timeout_ms.is_some()) {
+            (false, false) => Self::Plain,
+            (true, false) => Self::Fuel,
+            (false, true) => Self::Timeout,
+            (true, true) => Self::FuelAndTimeout,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct CompiledComponentKey {
+    wasm_hash: [u8; 32],
+    profile: CompileProfile,
+}
+
+impl CompiledComponentKey {
+    fn new(profile: CompileProfile, bytes: &[u8]) -> Self {
+        Self {
+            wasm_hash: *blake3::hash(bytes).as_bytes(),
+            profile,
+        }
+    }
+}
+
+type InFlightCompilation = Arc<tokio::sync::OnceCell<Result<Component, LixError>>>;
+
+struct CompiledComponentCacheState {
+    ready: LruCache<CompiledComponentKey, Component>,
+    in_flight: HashMap<CompiledComponentKey, InFlightCompilation>,
+}
+
+struct CompiledComponentCache {
+    state: Mutex<CompiledComponentCacheState>,
+}
+
+impl CompiledComponentCache {
+    fn new(capacity: usize) -> Self {
+        let capacity =
+            NonZeroUsize::new(capacity).expect("component cache capacity must be nonzero");
+        Self {
+            state: Mutex::new(CompiledComponentCacheState {
+                ready: LruCache::new(capacity),
+                in_flight: HashMap::new(),
+            }),
+        }
+    }
+
+    async fn get_or_compile(
+        &self,
+        key: CompiledComponentKey,
+        compile: impl FnOnce() -> Result<Component, LixError>,
+    ) -> Result<Component, LixError> {
+        let in_flight = {
+            let mut state = self.lock()?;
+            if let Some(component) = state.ready.get(&key) {
+                return Ok(component.clone());
+            }
+            state
+                .in_flight
+                .entry(key)
+                .or_insert_with(|| Arc::new(tokio::sync::OnceCell::new()))
+                .clone()
+        };
+
+        // Component::new is synchronous, but same-key waiters yield instead of
+        // occupying additional executor threads while the initializer runs.
+        let result = in_flight.get_or_init(|| async { compile() }).await.clone();
+        let mut state = self.lock()?;
+        let owns_entry = state
+            .in_flight
+            .get(&key)
+            .is_some_and(|current| Arc::ptr_eq(current, &in_flight));
+        if owns_entry {
+            state.in_flight.remove(&key);
+            if let Ok(component) = &result {
+                state.ready.put(key, component.clone());
+            }
+        }
+        result
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, CompiledComponentCacheState>, LixError> {
+        self.state.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "compiled WASM component cache lock poisoned",
+            )
         })
     }
 }
@@ -67,19 +244,21 @@ struct WasmtimePluginComponent {
     store: Mutex<Store<WasiHostState>>,
     bindings: plugin_bindings::Plugin,
     limits: WasmLimits,
-    _timeout_ticker: Option<TimeoutTicker>,
+    _timeout_ticker: Option<TimeoutTickerLease>,
 }
 
 struct WasiHostState {
     ctx: WasiCtx,
     table: ResourceTable,
+    limits: StoreLimits,
 }
 
 impl WasiHostState {
-    fn new() -> Self {
+    fn new(limits: StoreLimits) -> Self {
         Self {
             ctx: WasiCtxBuilder::new().build(),
             table: ResourceTable::new(),
+            limits,
         }
     }
 }
@@ -100,31 +279,25 @@ impl WasmRuntime for WasmtimePluginRuntime {
         bytes: Vec<u8>,
         limits: WasmLimits,
     ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
-        let engine = match (limits.max_fuel.is_some(), limits.timeout_ms.is_some()) {
-            (false, false) => &self.engine,
-            (true, false) => &self.fuel_engine,
-            (false, true) => &self.timeout_engine,
-            (true, true) => &self.fuel_timeout_engine,
-        };
-        let component = Component::new(engine, bytes)
-            .map_err(|error| wasm_runtime_error("failed to compile plugin component", error))?;
-        let mut linker = Linker::<WasiHostState>::new(engine);
-        add_to_linker_sync(&mut linker)
-            .map_err(|error| wasm_runtime_error("failed to configure WASI linker", error))?;
-        let mut store = Store::new(engine, WasiHostState::new());
-        if let Some(max_fuel) = limits.max_fuel {
-            store
-                .set_fuel(max_fuel)
-                .map_err(|error| wasm_runtime_error("failed to configure WASM fuel", error))?;
-        }
-        if let Some(timeout_ms) = limits.timeout_ms {
-            store.set_epoch_deadline(timeout_ms.max(1));
-            store.epoch_deadline_trap();
-        }
-        let timeout_ticker = limits
-            .timeout_ms
-            .map(|_| TimeoutTicker::start(engine.clone()));
-        let bindings = plugin_bindings::Plugin::instantiate(&mut store, &component, &linker)
+        let profile = CompileProfile::from_limits(limits);
+        let engine = self.shared.engine(profile);
+        let key = CompiledComponentKey::new(profile, &bytes);
+        let component = self
+            .shared
+            .compiled_components
+            .get_or_compile(key, || {
+                Component::new(engine, &bytes).map_err(|error| {
+                    wasm_runtime_error("failed to compile plugin component", error)
+                })
+            })
+            .await?;
+        let linker = self.shared.linker(profile)?;
+        let timeout_ticker = self.shared.timeout_ticker(profile)?;
+        // Set an epoch deadline only after hashing/compilation. Once another
+        // component has started the shared ticker, cold preparation must not
+        // consume this component's execution budget before instantiation.
+        let mut store = create_store(engine, limits)?;
+        let bindings = plugin_bindings::Plugin::instantiate(&mut store, &component, linker)
             .map_err(|error| wasm_runtime_error("failed to instantiate plugin component", error))?;
         Ok(Arc::new(WasmtimePluginComponent {
             store: Mutex::new(store),
@@ -133,6 +306,33 @@ impl WasmRuntime for WasmtimePluginRuntime {
             _timeout_ticker: timeout_ticker,
         }))
     }
+}
+
+fn create_store(engine: &Engine, limits: WasmLimits) -> Result<Store<WasiHostState>, LixError> {
+    let max_memory_bytes = usize::try_from(limits.max_memory_bytes).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!(
+                "WASM memory limit {} does not fit this host's address space",
+                limits.max_memory_bytes
+            ),
+        )
+    })?;
+    let store_limits = StoreLimitsBuilder::new()
+        .memory_size(max_memory_bytes)
+        .build();
+    let mut store = Store::new(engine, WasiHostState::new(store_limits));
+    store.limiter(|state| &mut state.limits);
+    if let Some(max_fuel) = limits.max_fuel {
+        store
+            .set_fuel(max_fuel)
+            .map_err(|error| wasm_runtime_error("failed to configure WASM fuel", error))?;
+    }
+    if let Some(timeout_ms) = limits.timeout_ms {
+        store.set_epoch_deadline(timeout_ms.max(1));
+        store.epoch_deadline_trap();
+    }
+    Ok(store)
 }
 
 #[async_trait]
@@ -199,6 +399,74 @@ impl WasmtimePluginComponent {
     }
 }
 
+struct TimeoutTickerRegistry {
+    engine: Engine,
+    state: Mutex<TimeoutTickerRegistryState>,
+}
+
+struct TimeoutTickerRegistryState {
+    ticker: Option<TimeoutTicker>,
+    leases: usize,
+}
+
+impl TimeoutTickerRegistry {
+    fn new(engine: Engine) -> Self {
+        Self {
+            engine,
+            state: Mutex::new(TimeoutTickerRegistryState {
+                ticker: None,
+                leases: 0,
+            }),
+        }
+    }
+
+    fn acquire(self: &Arc<Self>) -> Result<TimeoutTickerLease, LixError> {
+        let mut state = self.state.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "WASM timeout ticker registry lock poisoned",
+            )
+        })?;
+        let next_lease_count = state.leases.checked_add(1).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "WASM timeout ticker lease count overflowed",
+            )
+        })?;
+        if state.leases == 0 {
+            debug_assert!(state.ticker.is_none());
+            state.ticker = Some(TimeoutTicker::start(self.engine.clone()));
+        }
+        state.leases = next_lease_count;
+        Ok(TimeoutTickerLease {
+            registry: self.clone(),
+        })
+    }
+}
+
+struct TimeoutTickerLease {
+    registry: Arc<TimeoutTickerRegistry>,
+}
+
+impl Drop for TimeoutTickerLease {
+    fn drop(&mut self) {
+        let mut state = match self.registry.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        debug_assert!(state.leases > 0);
+        state.leases = state.leases.saturating_sub(1);
+        if state.leases == 0 {
+            // Keep the registry locked until the old thread has stopped. A new
+            // lease cannot start a replacement ticker against the same Engine
+            // while the old one is still advancing its epoch.
+            let ticker = state.ticker.take();
+            drop(ticker);
+        }
+        drop(state);
+    }
+}
+
 struct TimeoutTicker {
     stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
@@ -209,8 +477,11 @@ impl TimeoutTicker {
         let stop = Arc::new(AtomicBool::new(false));
         let thread_stop = stop.clone();
         let handle = std::thread::spawn(move || {
-            while !thread_stop.load(Ordering::Relaxed) {
+            loop {
                 std::thread::sleep(Duration::from_millis(1));
+                if thread_stop.load(Ordering::Relaxed) {
+                    break;
+                }
                 engine.increment_epoch();
             }
         });
@@ -284,4 +555,460 @@ fn wasm_runtime_error(context: impl Into<String>, error: impl fmt::Display) -> L
         LixError::CODE_INTERNAL_ERROR,
         format!("{}: {error}", context.into()),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+    use std::sync::atomic::AtomicUsize;
+
+    use wasm_encoder::{ComponentBuilder, MemorySection, MemoryType, Module, ModuleArg};
+
+    use super::*;
+
+    #[test]
+    fn default_runtime_reuses_process_wide_wasmtime_state() {
+        let first = WasmtimePluginRuntime::new().expect("first runtime should initialize");
+        let second = WasmtimePluginRuntime::new().expect("second runtime should initialize");
+        assert!(Arc::ptr_eq(&first.shared, &second.shared));
+    }
+
+    #[test]
+    fn compiled_component_cache_singleflights_same_key() {
+        let cache = Arc::new(CompiledComponentCache::new(2));
+        let component = empty_component();
+        let key = CompiledComponentKey::new(CompileProfile::Plain, b"same component");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(3));
+        let handles = (0..2)
+            .map(|_| {
+                let cache = cache.clone();
+                let component = component.clone();
+                let calls = calls.clone();
+                let start = start.clone();
+                std::thread::spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("test runtime should initialize");
+                    start.wait();
+                    runtime
+                        .block_on(cache.get_or_compile(key, || {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            std::thread::sleep(Duration::from_millis(50));
+                            Ok(component)
+                        }))
+                        .expect("component should compile")
+                })
+            })
+            .collect::<Vec<_>>();
+        start.wait();
+        for handle in handles {
+            handle.join().expect("cache worker should not panic");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn compiled_component_cache_singleflights_failure_wave_then_retries() {
+        let cache = Arc::new(CompiledComponentCache::new(2));
+        let key = CompiledComponentKey::new(CompileProfile::Plain, b"invalid component");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(AtomicBool::new(false));
+        let start = Arc::new(Barrier::new(3));
+        let handles = (0..2)
+            .map(|_| {
+                let cache = cache.clone();
+                let calls = calls.clone();
+                let release = release.clone();
+                let start = start.clone();
+                std::thread::spawn(move || {
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .build()
+                        .expect("test runtime should initialize");
+                    start.wait();
+                    runtime.block_on(cache.get_or_compile(key, || {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        while !release.load(Ordering::Acquire) {
+                            std::thread::yield_now();
+                        }
+                        Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "synthetic compile failure",
+                        ))
+                    }))
+                })
+            })
+            .collect::<Vec<_>>();
+        start.wait();
+
+        // Wait until both workers hold the same in-flight cell before letting
+        // the initializer fail. The map and both workers each own one Arc.
+        loop {
+            let waiter_joined = cache
+                .lock()
+                .expect("cache lock should be healthy")
+                .in_flight
+                .get(&key)
+                .is_some_and(|in_flight| Arc::strong_count(in_flight) >= 3);
+            if waiter_joined {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        release.store(true, Ordering::Release);
+        for handle in handles {
+            assert!(
+                handle
+                    .join()
+                    .expect("cache worker should not panic")
+                    .is_err(),
+                "compile failure must reach every waiter"
+            );
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should initialize");
+        let retry = runtime.block_on(cache.get_or_compile(key, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "synthetic retry failure",
+            ))
+        }));
+        assert!(retry.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn compiled_component_cache_retries_failures_and_evicts_lru() {
+        let cache = CompiledComponentCache::new(1);
+        let component = empty_component();
+        let failed_key = CompiledComponentKey::new(CompileProfile::Plain, b"invalid");
+        let failures = AtomicUsize::new(0);
+        for _ in 0..2 {
+            let result = cache
+                .get_or_compile(failed_key, || {
+                    failures.fetch_add(1, Ordering::SeqCst);
+                    Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "synthetic compile failure",
+                    ))
+                })
+                .await;
+            assert!(result.is_err(), "compile failure must be returned");
+        }
+        assert_eq!(failures.load(Ordering::SeqCst), 2);
+
+        let first_key = CompiledComponentKey::new(CompileProfile::Plain, b"first");
+        let second_key = CompiledComponentKey::new(CompileProfile::Plain, b"second");
+        let compiles = AtomicUsize::new(0);
+        for key in [first_key, second_key, first_key] {
+            cache
+                .get_or_compile(key, || {
+                    compiles.fetch_add(1, Ordering::SeqCst);
+                    Ok(component.clone())
+                })
+                .await
+                .expect("component should compile");
+        }
+        assert_eq!(compiles.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn compiled_component_key_separates_engine_profiles_not_numeric_limits() {
+        let bytes = b"component";
+        let plain = CompiledComponentKey::new(CompileProfile::Plain, bytes);
+        let fuel = CompiledComponentKey::new(CompileProfile::Fuel, bytes);
+        assert_ne!(plain, fuel);
+        assert_eq!(
+            CompileProfile::from_limits(WasmLimits {
+                max_fuel: Some(1),
+                ..WasmLimits::default()
+            }),
+            CompileProfile::from_limits(WasmLimits {
+                max_fuel: Some(1_000_000),
+                ..WasmLimits::default()
+            })
+        );
+    }
+
+    #[test]
+    fn timeout_ticker_is_single_and_stops_after_last_lease() {
+        let shared = WasmtimeSharedRuntime::new().expect("shared runtime should initialize");
+        let first = shared
+            .timeout_ticker(CompileProfile::Timeout)
+            .expect("ticker lock should be healthy")
+            .expect("timeout profile should have a ticker");
+        let second = shared
+            .timeout_ticker(CompileProfile::Timeout)
+            .expect("ticker lock should be healthy")
+            .expect("timeout profile should have a ticker");
+        assert!(Arc::ptr_eq(&first.registry, &second.registry));
+        {
+            let state = first
+                .registry
+                .state
+                .lock()
+                .expect("ticker registry lock should be healthy");
+            assert_eq!(state.leases, 2);
+            assert!(state.ticker.is_some());
+        }
+        drop(first);
+        {
+            let state = second
+                .registry
+                .state
+                .lock()
+                .expect("ticker registry lock should be healthy");
+            assert_eq!(state.leases, 1);
+            assert!(state.ticker.is_some());
+        }
+        let registry = second.registry.clone();
+        drop(second);
+        let state = registry
+            .state
+            .lock()
+            .expect("ticker registry lock should be healthy");
+        assert_eq!(state.leases, 0);
+        assert!(
+            state.ticker.is_none(),
+            "shared runtime must not keep the 1 kHz ticker alive"
+        );
+    }
+
+    #[test]
+    fn store_enforces_memory_limit_at_page_boundary() {
+        const PAGE_BYTES: u64 = 65_536;
+        let engine = create_engine(false, false).expect("test engine should initialize");
+        let bytes = component_with_initial_memory(2);
+        let component = Component::new(&engine, bytes).expect("test component should compile");
+        let linker = Linker::<WasiHostState>::new(&engine);
+
+        let instantiate = |max_memory_bytes| {
+            let limits = WasmLimits {
+                max_memory_bytes,
+                ..WasmLimits::default()
+            };
+            let mut store = create_store(&engine, limits).expect("test Store should initialize");
+            linker.instantiate(&mut store, &component)
+        };
+        instantiate(2 * PAGE_BYTES).expect("exactly two pages should fit");
+        instantiate(2 * PAGE_BYTES + 1).expect("one byte above two pages should still fit");
+        instantiate(2 * PAGE_BYTES - 1)
+            .expect_err("one byte below two pages must reject the initial memory");
+    }
+
+    fn empty_component() -> Component {
+        let engine = create_engine(false, false).expect("test engine should initialize");
+        Component::new(&engine, wasm_encoder::Component::new().finish())
+            .expect("empty component should compile")
+    }
+
+    fn component_with_initial_memory(pages: u64) -> Vec<u8> {
+        let mut memories = MemorySection::new();
+        memories.memory(MemoryType {
+            minimum: pages,
+            maximum: Some(pages),
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+        let mut module = Module::new();
+        module.section(&memories);
+
+        let mut component = ComponentBuilder::default();
+        let module = component.core_module(None, &module);
+        component.core_instantiate(
+            None,
+            module,
+            std::iter::empty::<(&'static str, ModuleArg)>(),
+        );
+        component.finish()
+    }
+}
+
+#[cfg(test)]
+mod benchmark_probe {
+    use std::hint::black_box;
+    use std::path::Path;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum Operation {
+        Runtime,
+        Hash,
+        Compile,
+        Linker,
+        Store,
+        Instantiate,
+        Init,
+        Call,
+    }
+
+    #[tokio::test]
+    #[ignore = "production Wasmtime lifecycle benchmark probe"]
+    async fn wasm_runtime_lifecycle_benchmark_probe() {
+        let operation = match std::env::var("LIX_WASM_BENCH_OPERATION")
+            .unwrap_or_else(|_| "init".to_string())
+            .as_str()
+        {
+            "runtime" => Operation::Runtime,
+            "hash" => Operation::Hash,
+            "compile" => Operation::Compile,
+            "linker" => Operation::Linker,
+            "store" => Operation::Store,
+            "instantiate" => Operation::Instantiate,
+            "init" => Operation::Init,
+            "call" => Operation::Call,
+            value => panic!(
+                "LIX_WASM_BENCH_OPERATION must be runtime, hash, compile, linker, store, instantiate, init, or call; got {value:?}"
+            ),
+        };
+        let rounds = env_usize("LIX_WASM_BENCH_ROUNDS", 50);
+        let warmups = env_usize("LIX_WASM_BENCH_WARMUPS", 5);
+        assert!(rounds > 0, "benchmark needs at least one measured round");
+
+        let wasm_path = std::env::var_os("LIX_WASM_BENCH_COMPONENT")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| {
+                panic!("LIX_WASM_BENCH_COMPONENT must point to a built plugin component")
+            });
+        let wasm_path = Path::new(&wasm_path);
+        let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+            panic!(
+                "failed to read bindep-built CSV plugin wasm at {}: {error}",
+                wasm_path.display()
+            )
+        });
+        let runtime = WasmtimePluginRuntime::new().expect("benchmark runtime should initialize");
+        let engine = runtime.shared.engine(CompileProfile::Plain);
+        let component = Component::new(engine, &wasm).expect("benchmark component should compile");
+        let mut linker = Linker::<WasiHostState>::new(engine);
+        add_to_linker_sync(&mut linker).expect("benchmark linker should initialize");
+        let instance = runtime
+            .init_component(wasm.clone(), WasmLimits::default())
+            .await
+            .expect("benchmark component should initialize");
+
+        for _ in 0..warmups {
+            run_operation(operation, &runtime, &wasm, &component, &linker, &instance).await;
+        }
+        let mut samples = Vec::with_capacity(rounds);
+        for _ in 0..rounds {
+            let started = Instant::now();
+            run_operation(operation, &runtime, &wasm, &component, &linker, &instance).await;
+            samples.push(started.elapsed());
+        }
+        samples.sort_unstable();
+        println!(
+            "wasm_runtime_lifecycle_probe operation={} wasm_bytes={} rounds={} p50_ns={} p95_ns={}",
+            operation_name(operation),
+            wasm.len(),
+            rounds,
+            percentile(&samples, 50, 100).as_nanos(),
+            percentile(&samples, 95, 100).as_nanos(),
+        );
+    }
+
+    async fn run_operation(
+        operation: Operation,
+        runtime: &WasmtimePluginRuntime,
+        wasm: &[u8],
+        component: &Component,
+        linker: &Linker<WasiHostState>,
+        instance: &Arc<dyn WasmComponentInstance>,
+    ) {
+        match operation {
+            Operation::Runtime => {
+                black_box(WasmtimePluginRuntime::new())
+                    .expect("benchmark runtime should initialize");
+            }
+            Operation::Hash => {
+                black_box(blake3::hash(black_box(wasm)));
+            }
+            Operation::Compile => {
+                black_box(Component::new(
+                    runtime.shared.engine(CompileProfile::Plain),
+                    black_box(wasm),
+                ))
+                .expect("benchmark component should compile");
+            }
+            Operation::Linker => {
+                let mut linker =
+                    Linker::<WasiHostState>::new(runtime.shared.engine(CompileProfile::Plain));
+                add_to_linker_sync(&mut linker).expect("benchmark linker should initialize");
+                black_box(linker);
+            }
+            Operation::Store => {
+                black_box(create_store(
+                    runtime.shared.engine(CompileProfile::Plain),
+                    WasmLimits::default(),
+                ))
+                .expect("benchmark Store should initialize");
+            }
+            Operation::Instantiate => {
+                let mut store = create_store(
+                    runtime.shared.engine(CompileProfile::Plain),
+                    WasmLimits::default(),
+                )
+                .expect("benchmark Store should initialize");
+                black_box(plugin_bindings::Plugin::instantiate(
+                    &mut store, component, linker,
+                ))
+                .expect("benchmark component should instantiate");
+            }
+            Operation::Init => {
+                black_box(
+                    runtime
+                        .init_component(black_box(wasm.to_vec()), WasmLimits::default())
+                        .await,
+                )
+                .expect("benchmark component should initialize");
+            }
+            Operation::Call => {
+                black_box(
+                    instance
+                        .detect_changes(
+                            Vec::new(),
+                            WasmPluginFile {
+                                filename: Some("probe.csv".to_string()),
+                                data: Vec::new(),
+                            },
+                        )
+                        .await,
+                )
+                .expect("benchmark guest call should succeed");
+            }
+        }
+    }
+
+    fn operation_name(operation: Operation) -> &'static str {
+        match operation {
+            Operation::Runtime => "runtime",
+            Operation::Hash => "hash",
+            Operation::Compile => "compile",
+            Operation::Linker => "linker",
+            Operation::Store => "store",
+            Operation::Instantiate => "instantiate",
+            Operation::Init => "init",
+            Operation::Call => "call",
+        }
+    }
+
+    fn env_usize(name: &str, default: usize) -> usize {
+        std::env::var(name).map_or(default, |value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{name} must be a positive integer"))
+        })
+    }
+
+    fn percentile(samples: &[Duration], numerator: usize, denominator: usize) -> Duration {
+        let index = samples.len().saturating_mul(numerator).saturating_sub(1) / denominator;
+        samples[index]
+    }
 }


### PR DESCRIPTION
## Summary

- share the default Wasmtime engines and WASI linkers process-wide
- cache compiled components in a bounded 16-entry LRU keyed by BLAKE3 digest and engine profile
- singleflight concurrent success and failure waves while retrying later failures
- enforce `WasmLimits.max_memory_bytes` per guest linear memory
- keep one epoch ticker per active timeout profile and stop it after the last component lease
- retain an ignored production lifecycle probe for reproducible stage measurements

## Performance evidence

Measured on pinned CPU 2 with the real 2,072,490-byte CSV plugin component.

The headline result is specifically a **repeated identical-component cache hit across Lix opens**, not cold first initialization.

| Operation | Baseline p50 / p95 | Final p50 / p95 | Result |
|---|---:|---:|---:|
| Repeated identical-component init | 1,338.215 / 1,345.867 ms | 0.641 / 0.670 ms | 99.95% lower |
| Direct cold compile, contemporaneous A/B | 1,331.901 / 1,335.347 ms | 1,326.536 / 1,342.893 ms | -0.40% / +0.57%; no material regression |
| Hot guest call, contemporaneous A/B | 31.439 / 40.757 µs | 31.448 / 40.436 µs | +0.03% / -0.79% |
| Store creation | 742 / 801 ns | 781 / 822 ns | +39 / +21 ns |

BLAKE3 hashing costs 497 / 529 µs p50/p95, about 78% of the remaining cache-hit initialization time.

A cold-compilation flamegraph collected 3,530 samples across five compiles. Leading costs were regalloc2 environment initialization (6.19%), regalloc2 execution (5.56%), Cranelift egraph elaboration (3.71%), and Pulley register allocation (2.85%). This confirms compiler backend work dominates uncached initialization.

## Correctness

- cache entries are engine-profile aware; numeric fuel, timeout, and memory values remain Store-local
- concurrent waiters yield and share both successful and failed compilation results
- failures leave no negative cache and are retried by later requests
- the timeout registry serializes last-user shutdown with replacement, so tickers cannot overlap
- the Store limiter is installed before instantiation and applies at memory creation and growth
- cache accounting is bounded by 16 compiled components

## Validation

- `node scripts/validate-changes.mjs`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (all tests and doctests passed)
- focused unit coverage for process-wide sharing, success/failure singleflight, retry and LRU eviction, engine-profile keys, ticker lifecycle, and memory page boundaries
- two independent static race/correctness reviews with no remaining P1/P2 findings
