### PR TITLE
perf(engine): index exact filesystem file IDs

### DIFF
--- a/.changenotes/index-files-by-id.md
+++ b/.changenotes/index-files-by-id.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Common exact-ID `lix_file` selections now binary-search a collision-safe
+secondary index when reusing the filesystem path cache, instead of scanning
+every visible path entry.

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -169,9 +169,16 @@ impl FilesystemPathSelection {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FilesystemPathIndex {
     entries: Vec<FilesystemPathEntry>,
+    file_indices_by_id: Vec<FilesystemFileIdIndexEntry>,
     file_count: usize,
     directory_count: usize,
     estimated_heap_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FilesystemFileIdIndexEntry {
+    hash: u64,
+    path_index: usize,
 }
 
 impl FilesystemPathIndex {
@@ -241,6 +248,7 @@ impl FilesystemPathIndex {
         let mut entries = Vec::<FilesystemPathEntry>::with_capacity(
             directory_rows.len().saturating_add(file_rows.len()),
         );
+        let file_count = file_rows.len();
 
         for (key, record) in &directory_rows {
             let path = directory_paths.get(key).ok_or_else(|| {
@@ -308,19 +316,30 @@ impl FilesystemPathIndex {
                 .then_with(|| left.key.cmp(&right.key))
                 .then_with(|| left.kind.cmp(&right.kind))
         });
-        let file_count = entries
-            .iter()
-            .filter(|entry| entry.kind == FilesystemPathKind::File)
-            .count();
+        let mut file_indices_by_id = Vec::with_capacity(file_count);
+        file_indices_by_id.extend(
+            entries
+                .iter()
+                .enumerate()
+                .filter(|(_, entry)| entry.kind == FilesystemPathKind::File)
+                .map(|(index, entry)| FilesystemFileIdIndexEntry {
+                    hash: xxhash_rust::xxh3::xxh3_64(entry.id().as_bytes()),
+                    path_index: index,
+                }),
+        );
+        radix_sort_file_indices_by_hash(&mut file_indices_by_id);
+        debug_assert_eq!(file_indices_by_id.len(), file_count);
         let directory_count = entries.len().saturating_sub(file_count);
         let estimated_heap_bytes = size_of::<Self>()
             + entries.capacity() * size_of::<FilesystemPathEntry>()
+            + file_indices_by_id.capacity() * size_of::<FilesystemFileIdIndexEntry>()
             + entries
                 .iter()
                 .map(FilesystemPathEntry::estimated_heap_bytes)
                 .sum::<usize>();
         Ok(Self {
             entries,
+            file_indices_by_id,
             file_count,
             directory_count,
             estimated_heap_bytes,
@@ -335,6 +354,25 @@ impl FilesystemPathIndex {
             .entries
             .partition_point(|entry| entry.path.as_str() <= path);
         start..end
+    }
+
+    /// Primary path-ordered indices for every file descriptor with this ID.
+    pub(crate) fn exact_file_id_indices<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> impl Iterator<Item = usize> + 'a {
+        let hash = xxhash_rust::xxh3::xxh3_64(id.as_bytes());
+        let start = self
+            .file_indices_by_id
+            .partition_point(|candidate| candidate.hash < hash);
+        let end = self
+            .file_indices_by_id
+            .partition_point(|candidate| candidate.hash <= hash);
+        self.file_indices_by_id[start..end]
+            .iter()
+            .filter_map(move |candidate| {
+                (self.entries[candidate.path_index].id() == id).then_some(candidate.path_index)
+            })
     }
 
     pub(crate) fn range_indices(
@@ -384,6 +422,43 @@ impl FilesystemPathIndex {
 
     pub(crate) fn estimated_heap_bytes(&self) -> usize {
         self.estimated_heap_bytes
+    }
+}
+
+/// Sort fingerprints in linear time. Entries start in primary path order, and
+/// the stable passes preserve that order inside each equal-hash bucket.
+fn radix_sort_file_indices_by_hash(entries: &mut Vec<FilesystemFileIdIndexEntry>) {
+    const RADIX_BITS: usize = 11;
+    const RADIX_BUCKETS: usize = 1 << RADIX_BITS;
+    const RADIX_MASK: u64 = RADIX_BUCKETS as u64 - 1;
+
+    if entries.len() < 2 {
+        return;
+    }
+    let mut scratch = vec![
+        FilesystemFileIdIndexEntry {
+            hash: 0,
+            path_index: 0,
+        };
+        entries.len()
+    ];
+    for shift in (0..u64::BITS as usize).step_by(RADIX_BITS) {
+        let mut offsets = [0_usize; RADIX_BUCKETS];
+        for entry in entries.iter() {
+            offsets[((entry.hash >> shift) & RADIX_MASK) as usize] += 1;
+        }
+        let mut next_offset = 0;
+        for offset in &mut offsets {
+            let count = *offset;
+            *offset = next_offset;
+            next_offset += count;
+        }
+        for entry in entries.iter() {
+            let bucket = ((entry.hash >> shift) & RADIX_MASK) as usize;
+            scratch[offsets[bucket]] = *entry;
+            offsets[bucket] += 1;
+        }
+        std::mem::swap(entries, &mut scratch);
     }
 }
 
@@ -686,6 +761,78 @@ mod tests {
             vec!["/docs/", "/docs/", "/docs/a.md", "/docs/a.md", "/docs/b.md"]
         );
         assert!(index.estimated_heap_bytes() > 0);
+    }
+
+    #[test]
+    fn exact_file_id_indices_keep_every_file_lane_and_exclude_directories() {
+        let index = FilesystemPathIndex::from_live_rows(vec![
+            directory_row("shared", None, "directory", "branch-a", false),
+            file_row("shared", None, "z-tracked.md", "branch-a", false),
+            file_row("shared", None, "a-global.md", "branch-a", true),
+            file_row("other", None, "other.md", "branch-a", false),
+        ])
+        .expect("path index should build");
+
+        let matches = index
+            .exact_file_id_indices("shared")
+            .map(|candidate| index.entry(candidate))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matches
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/a-global.md", "/z-tracked.md"]
+        );
+        assert!(
+            matches
+                .iter()
+                .all(|entry| entry.kind == FilesystemPathKind::File)
+        );
+        assert!(index.exact_file_id_indices("missing").next().is_none());
+
+        let expected_heap_bytes = size_of::<FilesystemPathIndex>()
+            + index.entries.capacity() * size_of::<FilesystemPathEntry>()
+            + index.file_indices_by_id.capacity() * size_of::<FilesystemFileIdIndexEntry>()
+            + index
+                .entries
+                .iter()
+                .map(FilesystemPathEntry::estimated_heap_bytes)
+                .sum::<usize>();
+        assert_eq!(index.estimated_heap_bytes(), expected_heap_bytes);
+        assert!(index.file_indices_by_id.capacity() >= 3);
+    }
+
+    #[test]
+    fn radix_sort_orders_hashes_and_preserves_primary_order_for_ties() {
+        let mut entries = vec![
+            FilesystemFileIdIndexEntry {
+                hash: u64::MAX,
+                path_index: 0,
+            },
+            FilesystemFileIdIndexEntry {
+                hash: 1,
+                path_index: 1,
+            },
+            FilesystemFileIdIndexEntry {
+                hash: u64::MAX,
+                path_index: 2,
+            },
+            FilesystemFileIdIndexEntry {
+                hash: 0,
+                path_index: 3,
+            },
+        ];
+
+        radix_sort_file_indices_by_hash(&mut entries);
+
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| (entry.hash, entry.path_index))
+                .collect::<Vec<_>>(),
+            vec![(0, 3), (1, 1), (u64::MAX, 0), (u64::MAX, 2)]
+        );
     }
 
     #[test]

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -3840,16 +3840,19 @@ fn indexed_file_id_matches(
     file_ids: &BTreeSet<String>,
     path_predicate: &FilePathPredicate,
 ) -> FilesystemPathSelection {
-    let indices = index
-        .entries()
-        .enumerate()
-        .filter(|(_, entry)| {
-            entry.kind == FilesystemPathKind::File
-                && file_ids.contains(entry.id())
-                && path_predicate.matches(&entry.path)
+    let mut indices = file_ids
+        .iter()
+        .flat_map(|file_id| index.exact_file_id_indices(file_id))
+        .filter(|candidate| {
+            let entry = index.entry(*candidate);
+            debug_assert_eq!(entry.kind, FilesystemPathKind::File);
+            path_predicate.matches(&entry.path)
         })
-        .map(|(index, _)| index)
-        .collect();
+        .collect::<Vec<_>>();
+    // Each equal-ID range is path-ordered, but multiple ranges arrive in ID
+    // order. Restore the primary index order promised to DataFusion before
+    // LIMIT is applied.
+    indices.sort_unstable();
     FilesystemPathSelection::new(index, indices)
 }
 
@@ -4503,9 +4506,11 @@ fn lix_error_to_datafusion_error(error: LixError) -> DataFusionError {
 #[expect(trivial_casts)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
+    use std::hint::black_box;
     use std::io::{Cursor, Write};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
 
     use async_trait::async_trait;
     use datafusion::arrow::array::{
@@ -4559,6 +4564,174 @@ mod tests {
 
     fn test_functions() -> FunctionProviderHandle {
         FunctionProviderHandle::system()
+    }
+
+    #[test]
+    #[ignore = "filesystem path index exact-ID lifecycle benchmark probe"]
+    fn filesystem_path_id_lookup_benchmark_probe() {
+        let file_count = benchmark_env_usize("LIX_PATH_INDEX_BENCH_FILES", 10_000);
+        let operation = std::env::var("LIX_PATH_INDEX_BENCH_OPERATION")
+            .unwrap_or_else(|_| "lookup".to_string());
+        let default_rounds = if operation == "build" { 20 } else { 2_000 };
+        let default_warmups = if operation == "build" { 3 } else { 100 };
+        let rounds = benchmark_env_usize("LIX_PATH_INDEX_BENCH_ROUNDS", default_rounds);
+        let warmups = benchmark_env_usize("LIX_PATH_INDEX_BENCH_WARMUPS", default_warmups);
+        assert!(file_count > 0, "benchmark needs at least one file");
+        assert!(rounds > 0, "benchmark needs at least one measured round");
+
+        let id_order = benchmark_shuffled_indices(file_count);
+        let target_id = format!("file-{:08}", id_order[file_count - 1]);
+        let rows = id_order
+            .into_iter()
+            .enumerate()
+            .map(|(path_index, id_index)| {
+                let id = format!("file-{id_index:08}");
+                let snapshot = serde_json::json!({
+                    "id": id,
+                    "directory_id": JsonValue::Null,
+                    "name": format!("path-{path_index:08}.txt"),
+                })
+                .to_string();
+                live_file_row(&id, "branch-b", &snapshot)
+            })
+            .collect::<Vec<_>>();
+
+        let mut samples = Vec::with_capacity(rounds);
+        let mut heap_bytes = 0;
+        match operation.as_str() {
+            "lookup" => {
+                let index = Arc::new(
+                    FilesystemPathIndex::from_live_rows(rows)
+                        .expect("benchmark path index should build"),
+                );
+                heap_bytes = index.estimated_heap_bytes();
+                let target_ids = BTreeSet::from([target_id]);
+                for iteration in 0..warmups.saturating_add(rounds) {
+                    let started = Instant::now();
+                    let selection = super::indexed_file_id_matches(
+                        Arc::clone(&index),
+                        &target_ids,
+                        &super::FilePathPredicate::All,
+                    );
+                    let elapsed = started.elapsed();
+                    assert_eq!(black_box(selection.len()), 1);
+                    if iteration >= warmups {
+                        samples.push(elapsed);
+                    }
+                }
+            }
+            "build" => {
+                for iteration in 0..warmups.saturating_add(rounds) {
+                    let input = rows.clone();
+                    let started = Instant::now();
+                    let index = FilesystemPathIndex::from_live_rows(input)
+                        .expect("benchmark path index should build");
+                    let elapsed = started.elapsed();
+                    heap_bytes = index.estimated_heap_bytes();
+                    assert_eq!(
+                        black_box(index.kind_count(super::FilesystemPathKind::File)),
+                        file_count
+                    );
+                    if iteration >= warmups {
+                        samples.push(elapsed);
+                    }
+                }
+            }
+            other => {
+                panic!("LIX_PATH_INDEX_BENCH_OPERATION must be lookup or build; got {other:?}")
+            }
+        }
+
+        samples.sort_unstable();
+        let p50 = benchmark_percentile(&samples, 50);
+        let p95 = benchmark_percentile(&samples, 95);
+        eprintln!(
+            "filesystem_path_id_probe operation={operation} files={file_count} rounds={rounds} p50_ns={} p95_ns={} heap_bytes={heap_bytes} heap_bytes_per_file={}",
+            p50.as_nanos(),
+            p95.as_nanos(),
+            heap_bytes / file_count,
+        );
+    }
+
+    fn benchmark_env_usize(name: &str, default: usize) -> usize {
+        std::env::var(name).map_or(default, |value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|error| panic!("{name} must be an integer: {error}"))
+        })
+    }
+
+    fn benchmark_percentile(samples: &[Duration], percentile: usize) -> Duration {
+        samples[(samples.len() - 1) * percentile / 100]
+    }
+
+    fn benchmark_shuffled_indices(len: usize) -> Vec<usize> {
+        let mut indices = (0..len).collect::<Vec<_>>();
+        let mut state = 0x9e37_79b9_7f4a_7c15_u64;
+        for upper in (1..len).rev() {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let modulus = u64::try_from(upper + 1).expect("benchmark size should fit u64");
+            let selected = usize::try_from(state % modulus)
+                .expect("shuffled benchmark index should fit usize");
+            indices.swap(upper, selected);
+        }
+        indices
+    }
+
+    #[test]
+    fn indexed_file_id_matches_restores_path_order_and_applies_path_predicate() {
+        let index = Arc::new(
+            FilesystemPathIndex::from_live_rows(vec![
+                live_file_row(
+                    "file-z",
+                    "branch-b",
+                    r#"{"id":"file-z","directory_id":null,"name":"a.txt"}"#,
+                ),
+                live_file_row(
+                    "file-a",
+                    "branch-b",
+                    r#"{"id":"file-a","directory_id":null,"name":"z.txt"}"#,
+                ),
+                live_file_row(
+                    "file-middle",
+                    "branch-b",
+                    r#"{"id":"file-middle","directory_id":null,"name":"middle.txt"}"#,
+                ),
+            ])
+            .expect("filesystem path index should build"),
+        );
+        let ids = BTreeSet::from(["file-a".to_string(), "file-z".to_string()]);
+
+        let matches = super::indexed_file_id_matches(
+            Arc::clone(&index),
+            &ids,
+            &super::FilePathPredicate::All,
+        );
+        assert_eq!(
+            matches
+                .entries()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/a.txt", "/z.txt"]
+        );
+
+        let filtered = super::indexed_file_id_matches(
+            index,
+            &ids,
+            &super::FilePathPredicate::Comparison {
+                operation: super::FilePathComparison::GreaterThan,
+                value: "/middle.txt".to_string(),
+            },
+        );
+        assert_eq!(
+            filtered
+                .entries()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/z.txt"]
+        );
     }
 
     fn string_literal(value: &str) -> Expr {


### PR DESCRIPTION
## Summary

- add a compact secondary exact-ID index to each cached `FilesystemPathIndex`
- use XXH3 fingerprints for the binary-search key and verify the full ID, so hash collisions cannot change results
- build the index with a stable six-pass radix sort to retain primary path order without comparison-sort construction cost
- preserve multi-ID path ordering before DataFusion applies `LIMIT`
- keep an ignored benchmark probe for lookup, construction, and retained-memory measurements

## Scope

The benchmark directly measures singleton `indexed_file_id_matches` selection after index construction. It excludes DataFusion planning, live-state loading, blob access, plugin reconciliation, and commit overhead.

## Performance

Pinned to CPU 2 using the repository's optimized test profile.

### Warm singleton exact-ID selection

| Files | Baseline p50 / p95 | Indexed p50 / p95 | Improvement |
|---:|---:|---:|---:|
| 1k | 9,467 / 17,995 ns | 250 / 251 ns | 97.4% / 98.6% |
| 10k | 148,710 / 168,266 ns | 140 / 151 ns | 99.9% / 99.9% |
| 50k | 770,879 / 851,300 ns | 150 / 151 ns | 99.98% / 99.98% |

The baseline grows 81.4x from 1k to 50k files. The indexed lookup remains effectively flat.

### Index construction

| Files | Baseline p50 / p95 | Indexed p50 / p95 | Cost |
|---:|---:|---:|---:|
| 1k | 0.324 / 0.375 ms | 0.346 / 0.408 ms | +7.1% / +8.9% |
| 10k | 3.226 / 3.359 ms | 3.541 / 3.640 ms | +9.8% / +8.4% |
| 50k | 17.059 / 17.522 ms | 18.781 / 19.054 ms | +10.1% / +8.7% |

Retained index memory increases from about 360 to 376 bytes per file: exactly 16 retained bytes per indexed file, or 4.4% in this fixture. Construction also uses one temporary entry-sized scratch buffer.

## Counterfactuals rejected

- sorting `Vec<usize>` by full ID improved lookup but increased 50k construction p50 by 81%
- sorting fingerprints with comparison sort still increased construction by 14–20%
- a 13-bit radix reduced the pass count but its larger counter table was slower than the retained 11-bit/six-pass form

## Profile evidence

A 50k-file baseline flamegraph captured 9,137 samples. `BTreeSet::search_tree::<str>` accounted for 31.18%, and scan/filter vector construction for 12.93%.

The final 50k-file profile captured 2,471 samples. Both the set-membership search and whole-index scan frames disappeared; samples are instead bounded lookup/selection work, timing overhead, and allocation.

## Correctness

Coverage verifies:

- duplicate tracked/global file lanes with one ID are retained
- a directory with the same ID is excluded
- missing IDs return no matches
- hash buckets are sorted stably across all 64 bits
- multi-ID results restore primary path order before `LIMIT`
- residual path predicates still apply
- retained heap accounting includes the secondary index

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine --all-features`
- `cargo test --workspace --all-features`
- `node scripts/validate-changes.mjs`