### PR TITLE
perf(engine): add durable plugin registry fast paths

### DIFF
--- a/.changenotes/durable-plugin-registry.md
+++ b/.changenotes/durable-plugin-registry.md
@@ -9,15 +9,19 @@ registry lookup, and warm plugin execution reuses compiled matchers and
 hash-matched WASM instances.
 
 The original `.lixplugin` ZIP remains the filesystem artifact; installation
-extracts and content-addresses its WASM component once. Existing workspaces
-created before the registry format require an explicit migration that
-reinstalls plugins and rematerializes owned files. Registered schema keys are
-immutable while a declaring plugin is active; uninstall the plugin before a
-schema migration, then install the updated package.
+extracts and content-addresses its WASM component once. Adding, replacing, or
+removing the archive remains the install, update, or uninstall operation; the
+registry is engine-owned derived state. Pre-registry installations are not
+discovered or decoded and must be removed and re-added. Registered schema keys
+are immutable while a declaring plugin is active; uninstall the plugin before
+a schema migration, then install the updated package.
 
 Registry v1 supports branch-local plugins only: `GLOBAL` and `UNTRACKED`
-archives, along with manifests that set `match.content_type`, are rejected. The
-internal `lix_plugin_registry_v1` and `lix_plugin_owner_v1` keys are reserved
-from public `lix_key_value` writes, each branch may install at most 128 plugins,
-and deleting one exact `.lixplugin` archive is the supported uninstall
-operation.
+archives are rejected. Registry entries require every v1 field; path-only
+matching is represented explicitly by a null content type rather than an
+omitted field. The internal `lix_plugin_registry_v1` and
+`lix_plugin_owner_v1` keys are
+reserved from public `lix_key_value` writes, and each branch may install at most
+128 plugins. Uninstall retains plugin-owned document state for reinstall; reads
+that require an absent plugin fail with `LIX_ERROR_PLUGIN_UNAVAILABLE` instead
+of silently returning empty bytes.

--- a/.changenotes/durable-plugin-registry.md
+++ b/.changenotes/durable-plugin-registry.md
@@ -1,0 +1,23 @@
+---
+type: major
+---
+
+Plugin execution now uses a durable branch-local registry and per-file owner
+records instead of discovering and reopening plugin archives on current-state
+reads and writes. Ordinary plugin-free file-data writes stop after the exact
+registry lookup, and warm plugin execution reuses compiled matchers and
+hash-matched WASM instances.
+
+The original `.lixplugin` ZIP remains the filesystem artifact; installation
+extracts and content-addresses its WASM component once. Existing workspaces
+created before the registry format require an explicit migration that
+reinstalls plugins and rematerializes owned files. Registered schema keys are
+immutable while a declaring plugin is active; uninstall the plugin before a
+schema migration, then install the updated package.
+
+Registry v1 supports branch-local plugins only: `GLOBAL` and `UNTRACKED`
+archives, along with manifests that set `match.content_type`, are rejected. The
+internal `lix_plugin_registry_v1` and `lix_plugin_owner_v1` keys are reserved
+from public `lix_key_value` writes, each branch may install at most 128 plugins,
+and deleting one exact `.lixplugin` archive is the supported uninstall
+operation.

--- a/packages/engine/src/common/error.rs
+++ b/packages/engine/src/common/error.rs
@@ -94,6 +94,10 @@ impl LixError {
     /// schema definitions retain [`Self::CODE_SCHEMA_DEFINITION`].
     pub const CODE_INVALID_PLUGIN: &'static str = "LIX_ERROR_INVALID_PLUGIN";
 
+    /// A file is materialized as durable plugin state, but the plugin needed
+    /// to render that state is not installed on the file's branch.
+    pub const CODE_PLUGIN_UNAVAILABLE: &'static str = "LIX_ERROR_PLUGIN_UNAVAILABLE";
+
     /// Write-time failure where user data did not conform to a registered
     /// schema (type mismatch, missing required field, pattern violation,
     /// additionalProperties, etc.). Raised from the JSON-Schema validator

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -32,6 +32,7 @@ pub(crate) trait LiveStateReader: Send + Sync {
         self.scan_rows(&request).await
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     async fn scan_file_rows(
         &self,
         request: &LiveStateFileScanRequest,

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -169,6 +169,7 @@ pub(crate) struct LiveStateScanRequest {
 /// `LiveStateScanRequest` so optimized implementations can preserve the exact
 /// generic scan semantics while specializing the storage path.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct LiveStateFileScanRequest {
     #[serde(default)]
     pub(crate) branch_ids: Vec<String>,
@@ -186,6 +187,7 @@ pub(crate) struct LiveStateFileScanRequest {
 }
 
 impl LiveStateFileScanRequest {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn to_scan_request(&self) -> LiveStateScanRequest {
         LiveStateScanRequest {
             filter: LiveStateFilter {

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -25,6 +25,7 @@ pub(crate) trait StagedLiveStateRows {
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
 
+    #[cfg_attr(not(test), allow(dead_code))]
     fn staged_file_rows(
         &self,
         request: &LiveStateFileScanRequest,
@@ -136,6 +137,7 @@ where
     ))
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) async fn overlay_scan_file_rows<S>(
     base: &dyn LiveStateReader,
     staged: &S,

--- a/packages/engine/src/plugin/archive.rs
+++ b/packages/engine/src/plugin/archive.rs
@@ -6,14 +6,24 @@ use zip::CompressionMethod;
 use zip::read::{ArchiveOffset, Config, ZipArchive};
 
 use crate::LixError;
+use crate::binary_cas::BlobHash;
 use crate::schema::{schema_key_from_definition, validate_lix_schema_definition};
 
 use super::{InstalledPlugin, InstalledPluginMetadata, PluginManifest, parse_plugin_manifest_json};
 
-#[derive(Debug, Clone)]
+/// Fully validated plugin package data needed by the install transaction.
+///
+/// The original ZIP remains the immutable filesystem artifact. This value is
+/// the parse-once install view: callers can write schema and registry rows and
+/// stage the extracted component in the binary CAS without reopening the ZIP.
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ParsedPluginArchive {
     pub manifest: PluginManifest,
+    pub normalized_manifest_json: String,
     pub schemas: Vec<JsonValue>,
+    pub schema_keys: Vec<String>,
+    pub wasm_bytes: Vec<u8>,
+    pub wasm_hash: BlobHash,
 }
 
 const KIB: u64 = 1024;
@@ -100,9 +110,17 @@ pub(crate) fn parse_plugin_archive_for_install(
     archive_bytes: &[u8],
 ) -> Result<ParsedPluginArchive, LixError> {
     let loaded = load_plugin_archive(archive_bytes, true, PluginArchiveLimits::DEFAULT)?;
+    let wasm_bytes = loaded
+        .wasm
+        .expect("full plugin archive load should include WASM bytes");
+    let wasm_hash = BlobHash::from_content(&wasm_bytes);
     Ok(ParsedPluginArchive {
         manifest: loaded.manifest,
+        normalized_manifest_json: loaded.normalized_manifest_json,
         schemas: loaded.schemas,
+        schema_keys: loaded.schema_keys,
+        wasm_bytes,
+        wasm_hash,
     })
 }
 
@@ -118,6 +136,10 @@ pub(crate) fn load_installed_plugin_from_archive_bytes(
             loaded.manifest.key
         )));
     }
+    let wasm = loaded
+        .wasm
+        .expect("full plugin archive load should include WASM bytes");
+    let wasm_hash = BlobHash::from_content(&wasm);
 
     Ok(InstalledPlugin {
         key: loaded.manifest.key,
@@ -128,9 +150,8 @@ pub(crate) fn load_installed_plugin_from_archive_bytes(
         entry: loaded.manifest.entry,
         schema_keys: loaded.schema_keys,
         manifest_json: loaded.normalized_manifest_json,
-        wasm: loaded
-            .wasm
-            .expect("full plugin archive load should include WASM bytes"),
+        wasm_hash,
+        wasm,
     })
 }
 
@@ -808,6 +829,7 @@ mod tests {
     use zip::{CompressionMethod, ZipWriter};
 
     use crate::LixError;
+    use crate::binary_cas::BlobHash;
 
     use super::{
         BoundedPluginArchive, PluginArchiveLimits, PluginArchiveReadKind, declared_zip_entry_count,
@@ -876,6 +898,21 @@ mod tests {
                 .expect("canonical plugin archive should parse");
             assert_eq!(parsed.manifest.key, "plugin_test");
             assert_eq!(parsed.schemas.len(), 1);
+            assert_eq!(parsed.schema_keys, ["plugin_test_note"]);
+            assert_eq!(parsed.wasm_bytes, WASM);
+            assert_eq!(parsed.wasm_hash, BlobHash::from_content(WASM));
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&parsed.normalized_manifest_json)
+                    .expect("normalized manifest should remain JSON")["key"],
+                "plugin_test"
+            );
+            let installed = load_installed_plugin_from_archive_bytes(
+                "plugin_test",
+                "/.lix/plugins/plugin_test.lixplugin",
+                &archive,
+            )
+            .expect("canonical plugin archive should materialize");
+            assert_eq!(installed.wasm_hash, BlobHash::from_content(WASM));
         }
     }
 

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -1,17 +1,18 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
+use crate::binary_cas::BlobHash;
 use crate::common::LixError;
 use crate::wasm::{
     WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
     WasmPluginFile, WasmRuntime,
 };
 
-use super::InstalledPlugin;
+use super::{CompiledPluginCatalog, InstalledPlugin, PluginCatalogCache, PluginRegistry};
 
 #[derive(Clone)]
 pub(crate) struct CachedPluginComponent {
-    pub(crate) wasm: Vec<u8>,
+    pub(crate) wasm_hash: BlobHash,
     pub(crate) instance: Arc<dyn WasmComponentInstance>,
 }
 
@@ -19,6 +20,7 @@ pub(crate) struct CachedPluginComponent {
 pub(crate) struct PluginRuntimeHost {
     wasm_runtime: Arc<dyn WasmRuntime>,
     plugin_component_cache: Arc<Mutex<BTreeMap<String, CachedPluginComponent>>>,
+    plugin_catalog_cache: Arc<Mutex<PluginCatalogCache>>,
 }
 
 impl PluginRuntimeHost {
@@ -26,7 +28,42 @@ impl PluginRuntimeHost {
         Self {
             wasm_runtime,
             plugin_component_cache: Arc::new(Mutex::new(BTreeMap::new())),
+            plugin_catalog_cache: Arc::new(Mutex::new(PluginCatalogCache::default())),
         }
+    }
+
+    /// Returns the compiled matcher for a durable registry generation.
+    ///
+    /// The host is shared across executions, so warm writes compile globs once
+    /// per generation rather than once per transaction or file.
+    pub(crate) fn compiled_plugin_catalog(
+        &self,
+        registry: &PluginRegistry,
+    ) -> Result<Arc<CompiledPluginCatalog>, LixError> {
+        self.plugin_catalog_cache
+            .lock()
+            .map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "plugin catalog cache lock poisoned",
+                )
+            })?
+            .get_or_compile(registry)
+    }
+
+    /// Returns a warm component without loading its content-addressed bytes.
+    ///
+    /// The lookup examines only the plugin key and fixed-size content hash, so
+    /// its work is independent of the component's byte length. Callers must
+    /// retain and execute the returned instance directly: discarding it and
+    /// performing a second key-only lookup would reopen a race with another
+    /// branch installing a different hash under the same plugin key.
+    pub(crate) fn cached_plugin_component(
+        &self,
+        plugin_key: &str,
+        wasm_hash: BlobHash,
+    ) -> Result<Option<Arc<dyn WasmComponentInstance>>, LixError> {
+        cached_plugin_component(&self.plugin_component_cache, plugin_key, wasm_hash)
     }
 }
 
@@ -46,43 +83,52 @@ pub(crate) trait PluginComponentHost {
     fn wasm_runtime(&self) -> &Arc<dyn WasmRuntime>;
 }
 
+fn cached_plugin_component(
+    cache: &Mutex<BTreeMap<String, CachedPluginComponent>>,
+    plugin_key: &str,
+    wasm_hash: BlobHash,
+) -> Result<Option<Arc<dyn WasmComponentInstance>>, LixError> {
+    let guard = cache.lock().map_err(|_| component_cache_lock_error())?;
+    Ok(guard
+        .get(plugin_key)
+        .filter(|cached| cached.wasm_hash == wasm_hash)
+        .map(|cached| Arc::clone(&cached.instance)))
+}
+
+fn component_cache_lock_error() -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        "plugin component cache lock poisoned",
+    )
+}
+
 pub(crate) async fn load_or_init_plugin_component(
     host: &impl PluginComponentHost,
     plugin: &InstalledPlugin,
 ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
+    if let Some(instance) =
+        cached_plugin_component(host.plugin_component_cache(), &plugin.key, plugin.wasm_hash)?
     {
-        let guard = host.plugin_component_cache().lock().map_err(|_| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: "plugin component cache lock poisoned".to_string(),
-            hint: None,
-            details: None,
-        })?;
-        if let Some(cached) = guard.get(&plugin.key) {
-            if cached.wasm == plugin.wasm {
-                return Ok(cached.instance.clone());
-            }
-        }
+        return Ok(instance);
     }
 
     let initialized = host
         .wasm_runtime()
         .init_component(plugin.wasm.clone(), WasmLimits::default())
         .await?;
-    let mut guard = host.plugin_component_cache().lock().map_err(|_| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: "plugin component cache lock poisoned".to_string(),
-        hint: None,
-        details: None,
-    })?;
+    let mut guard = host
+        .plugin_component_cache()
+        .lock()
+        .map_err(|_| component_cache_lock_error())?;
     if let Some(cached) = guard.get(&plugin.key) {
-        if cached.wasm == plugin.wasm {
-            return Ok(cached.instance.clone());
+        if cached.wasm_hash == plugin.wasm_hash {
+            return Ok(Arc::clone(&cached.instance));
         }
     }
     guard.insert(
         plugin.key.clone(),
         CachedPluginComponent {
-            wasm: plugin.wasm.clone(),
+            wasm_hash: plugin.wasm_hash,
             instance: initialized.clone(),
         },
     );
@@ -183,6 +229,7 @@ mod tests {
             entry: "plugin.wasm".to_string(),
             schema_keys: Vec::new(),
             manifest_json: "{}".to_string(),
+            wasm_hash: BlobHash::from_content(&[1]),
             wasm: vec![1],
         };
 
@@ -195,9 +242,44 @@ mod tests {
         assert_eq!(runtime.init_calls.load(Ordering::SeqCst), 1);
 
         plugin.wasm = vec![2];
+        plugin.wasm_hash = BlobHash::from_content(&plugin.wasm);
         load_or_init_plugin_component(&host, &plugin)
             .await
             .expect("changed wasm should reinitialize instance");
         assert_eq!(runtime.init_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn runtime_host_can_hit_component_cache_before_loading_wasm() {
+        let runtime = Arc::new(CountingRuntime::default());
+        let host = PluginRuntimeHost::new(runtime.clone());
+        let plugin = InstalledPlugin {
+            key: "k".to_string(),
+            runtime: PluginRuntime::WasmComponentV1,
+            api_version: "0.1.0".to_string(),
+            path_glob: "*.json".to_string(),
+            content_type: None,
+            entry: "plugin.wasm".to_string(),
+            schema_keys: Vec::new(),
+            manifest_json: "{}".to_string(),
+            wasm_hash: BlobHash::from_content(&[1]),
+            wasm: vec![1],
+        };
+
+        let initialized = load_or_init_plugin_component(&host, &plugin)
+            .await
+            .expect("first load should initialize the component");
+        let cached = host
+            .cached_plugin_component(&plugin.key, plugin.wasm_hash)
+            .expect("warm lookup should acquire the cache")
+            .expect("matching key and hash should hit the cache");
+        assert!(Arc::ptr_eq(&initialized, &cached));
+        assert_eq!(runtime.init_calls.load(Ordering::SeqCst), 1);
+
+        assert!(
+            host.cached_plugin_component(&plugin.key, BlobHash::from_content(&[2]))
+                .expect("hash-mismatch lookup should acquire the cache")
+                .is_none()
+        );
     }
 }

--- a/packages/engine/src/plugin/install.rs
+++ b/packages/engine/src/plugin/install.rs
@@ -59,14 +59,6 @@ pub(crate) fn plugin_install_plan_from_archive_path(
             ),
         ));
     }
-    if parsed.manifest.file_match.content_type.is_some() {
-        return Err(LixError::new(
-            LixError::CODE_INVALID_PLUGIN,
-            "Plugin installation does not support manifest match.content_type",
-        )
-        .with_hint("Remove match.content_type; registry matching currently uses path_glob only."));
-    }
-
     let schema_rows = plugin_schema_rows(&parsed, branch_id, global, untracked)?;
     Ok(PluginArchiveInstallPlan {
         archive_file_id: plugin_storage_archive_file_id(&plugin_key),
@@ -196,19 +188,45 @@ mod tests {
     }
 
     #[test]
-    fn install_plan_rejects_content_type_until_registry_matching_supports_it() {
+    fn install_plan_preserves_content_type_for_registry_matching() {
         let archive = plugin_archive(Some("text"));
-        let error = plugin_install_plan_from_archive_path(
+        let plan = plugin_install_plan_from_archive_path(
             "/.lix/plugins/plugin_test.lixplugin",
             &archive,
             "main",
             false,
             false,
         )
-        .expect_err("content_type must not be silently ignored by registry matching");
+        .expect("content_type is part of the durable matcher contract");
 
-        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
-        assert!(error.message.contains("content_type"), "{error:?}");
+        assert_eq!(
+            plan.parsed.manifest.file_match.content_type,
+            Some(crate::plugin::PluginContentType::Text)
+        );
+    }
+
+    #[test]
+    fn bundled_csv_and_markdown_content_type_manifests_install() {
+        let cases = [
+            ("plugin_csv", "*.{csv,tsv}"),
+            ("plugin_md_v2", "*.{md,markdown}"),
+        ];
+
+        for (plugin_key, path_glob) in cases {
+            let archive = plugin_archive_for(plugin_key, path_glob, Some("text"));
+            let path = format!("/.lix/plugins/{plugin_key}.lixplugin");
+            let plan = plugin_install_plan_from_archive_path(&path, &archive, "main", false, false)
+                .unwrap_or_else(|error| {
+                    panic!("bundled {plugin_key} manifest must install: {error:?}")
+                });
+
+            assert_eq!(plan.plugin_key, plugin_key);
+            assert_eq!(plan.parsed.manifest.file_match.path_glob, path_glob);
+            assert_eq!(
+                plan.parsed.manifest.file_match.content_type,
+                Some(crate::plugin::PluginContentType::Text)
+            );
+        }
     }
 
     #[test]
@@ -248,15 +266,23 @@ mod tests {
     }
 
     fn plugin_archive(content_type: Option<&str>) -> Vec<u8> {
+        plugin_archive_for("plugin_test", "*.test", content_type)
+    }
+
+    fn plugin_archive_for(
+        plugin_key: &str,
+        path_glob: &str,
+        content_type: Option<&str>,
+    ) -> Vec<u8> {
         let content_type = content_type
             .map(|value| format!(r#", "content_type":"{value}""#))
             .unwrap_or_default();
         let manifest = format!(
             r#"{{
-                "key":"plugin_test",
+                "key":"{plugin_key}",
                 "runtime":"wasm-component-v1",
                 "api_version":"0.1.0",
-                "match":{{"path_glob":"*.test"{content_type}}},
+                "match":{{"path_glob":"{path_glob}"{content_type}}},
                 "entry":"plugin.wasm",
                 "schemas":["schema/plugin_test_note.json"]
             }}"#

--- a/packages/engine/src/plugin/install.rs
+++ b/packages/engine/src/plugin/install.rs
@@ -9,21 +9,40 @@ use serde_json::{Value as JsonValue, json};
 use crate::LixError;
 use crate::plugin::{
     ParsedPluginArchive, parse_plugin_archive_for_install, plugin_key_from_archive_path,
+    plugin_storage_archive_file_id,
 };
-use crate::schema::{
-    registered_schema_entity_pk, schema_key_from_definition, validate_lix_schema_definition,
-};
+use crate::schema::registered_schema_entity_pk;
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
-pub(crate) fn plugin_schema_rows_from_archive_path(
+/// All derived state for one plugin archive write.
+///
+/// The transaction keeps the original archive bytes as the filesystem/CAS
+/// artifact. This plan owns the single validated extraction used to create the
+/// registry row, schema rows, and extracted component CAS entry.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PluginArchiveInstallPlan {
+    pub plugin_key: String,
+    pub archive_file_id: String,
+    pub parsed: ParsedPluginArchive,
+    pub schema_rows: Vec<TransactionWriteRow>,
+}
+
+pub(crate) fn plugin_install_plan_from_archive_path(
     archive_path: &str,
     archive_bytes: &[u8],
     branch_id: &str,
     global: bool,
     untracked: bool,
-) -> Result<Vec<TransactionWriteRow>, LixError> {
+) -> Result<PluginArchiveInstallPlan, LixError> {
+    if global || untracked {
+        return Err(LixError::new(
+            LixError::CODE_CONSTRAINT_VIOLATION,
+            "Plugin archives must be tracked and branch-local",
+        )
+        .with_hint("Install the plugin without GLOBAL or UNTRACKED scope."));
+    }
     let plugin_key = plugin_key_from_archive_path(archive_path).ok_or_else(|| {
         LixError::new(
             LixError::CODE_CONSTRAINT_VIOLATION,
@@ -40,7 +59,38 @@ pub(crate) fn plugin_schema_rows_from_archive_path(
             ),
         ));
     }
-    plugin_schema_rows(&parsed, branch_id, global, untracked)
+    if parsed.manifest.file_match.content_type.is_some() {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PLUGIN,
+            "Plugin installation does not support manifest match.content_type",
+        )
+        .with_hint("Remove match.content_type; registry matching currently uses path_glob only."));
+    }
+
+    let schema_rows = plugin_schema_rows(&parsed, branch_id, global, untracked)?;
+    Ok(PluginArchiveInstallPlan {
+        archive_file_id: plugin_storage_archive_file_id(&plugin_key),
+        plugin_key,
+        parsed,
+        schema_rows,
+    })
+}
+
+pub(crate) fn plugin_schema_rows_from_archive_path(
+    archive_path: &str,
+    archive_bytes: &[u8],
+    branch_id: &str,
+    global: bool,
+    untracked: bool,
+) -> Result<Vec<TransactionWriteRow>, LixError> {
+    Ok(plugin_install_plan_from_archive_path(
+        archive_path,
+        archive_bytes,
+        branch_id,
+        global,
+        untracked,
+    )?
+    .schema_rows)
 }
 
 fn plugin_schema_rows(
@@ -49,22 +99,30 @@ fn plugin_schema_rows(
     global: bool,
     untracked: bool,
 ) -> Result<Vec<TransactionWriteRow>, LixError> {
+    if parsed.schemas.len() != parsed.schema_keys.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "Parsed plugin schemas and schema keys must have the same length",
+        ));
+    }
     parsed
         .schemas
         .iter()
-        .map(|schema| registered_schema_row(schema, branch_id, global, untracked))
+        .zip(&parsed.schema_keys)
+        .map(|(schema, schema_key)| {
+            registered_schema_row(schema, schema_key, branch_id, global, untracked)
+        })
         .collect()
 }
 
 fn registered_schema_row(
     schema: &JsonValue,
+    schema_key: &str,
     branch_id: &str,
     global: bool,
     untracked: bool,
 ) -> Result<TransactionWriteRow, LixError> {
-    validate_lix_schema_definition(schema)?;
-    let schema_key = schema_key_from_definition(schema)?;
-    let entity_pk = registered_schema_entity_pk(&schema_key.schema_key)?;
+    let entity_pk = registered_schema_entity_pk(schema_key)?;
     Ok(TransactionWriteRow {
         entity_pk: Some(entity_pk),
         schema_key: REGISTERED_SCHEMA_KEY.to_string(),
@@ -83,4 +141,143 @@ fn registered_schema_row(
         untracked,
         branch_id: branch_id.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write};
+
+    use zip::ZipWriter;
+    use zip::write::SimpleFileOptions;
+
+    use crate::LixError;
+    use crate::binary_cas::BlobHash;
+
+    use super::plugin_install_plan_from_archive_path;
+
+    const SCHEMA: &[u8] = br#"{
+        "x-lix-key":"plugin_test_note",
+        "x-lix-primary-key":["/id"],
+        "type":"object",
+        "properties":{"id":{"type":"string"}},
+        "required":["id"],
+        "additionalProperties":false
+    }"#;
+    const WASM: &[u8] = b"\0asm\x01\0\0\0";
+
+    #[test]
+    fn install_plan_contains_all_parse_once_derived_state() {
+        let archive = plugin_archive(None);
+        let plan = plugin_install_plan_from_archive_path(
+            "/.lix/plugins/plugin_test.lixplugin",
+            &archive,
+            "draft",
+            false,
+            false,
+        )
+        .expect("canonical plugin should produce one install plan");
+
+        assert_eq!(plan.plugin_key, "plugin_test");
+        assert_eq!(plan.archive_file_id, "lix_plugin_archive::plugin_test");
+        assert_eq!(plan.parsed.manifest.key, "plugin_test");
+        assert_eq!(plan.parsed.schema_keys, ["plugin_test_note"]);
+        assert_eq!(plan.parsed.wasm_bytes, WASM);
+        assert_eq!(plan.parsed.wasm_hash, BlobHash::from_content(WASM));
+        assert_eq!(plan.schema_rows.len(), 1);
+        assert_eq!(plan.schema_rows[0].schema_key, "lix_registered_schema");
+        assert_eq!(plan.schema_rows[0].branch_id, "draft");
+        assert_eq!(
+            plan.schema_rows[0]
+                .snapshot
+                .as_ref()
+                .expect("schema install row needs a snapshot")["value"]["x-lix-key"],
+            "plugin_test_note"
+        );
+    }
+
+    #[test]
+    fn install_plan_rejects_content_type_until_registry_matching_supports_it() {
+        let archive = plugin_archive(Some("text"));
+        let error = plugin_install_plan_from_archive_path(
+            "/.lix/plugins/plugin_test.lixplugin",
+            &archive,
+            "main",
+            false,
+            false,
+        )
+        .expect_err("content_type must not be silently ignored by registry matching");
+
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(error.message.contains("content_type"), "{error:?}");
+    }
+
+    #[test]
+    fn install_plan_rejects_path_manifest_key_mismatch() {
+        let archive = plugin_archive(None);
+        let error = plugin_install_plan_from_archive_path(
+            "/.lix/plugins/plugin_other.lixplugin",
+            &archive,
+            "main",
+            false,
+            false,
+        )
+        .expect_err("archive path and manifest keys define one identity");
+
+        assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert!(error.message.contains("does not match"), "{error:?}");
+    }
+
+    #[test]
+    fn install_plan_rejects_global_and_untracked_lifecycles_before_parsing() {
+        for (global, untracked) in [(true, false), (false, true), (true, true)] {
+            let error = plugin_install_plan_from_archive_path(
+                "/.lix/plugins/plugin_test.lixplugin",
+                b"not parsed because the lifecycle scope is unsupported",
+                "main",
+                global,
+                untracked,
+            )
+            .expect_err("v1 registry entries are tracked and branch-local");
+
+            assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+            assert!(
+                error.message.contains("tracked and branch-local"),
+                "{error:?}"
+            );
+        }
+    }
+
+    fn plugin_archive(content_type: Option<&str>) -> Vec<u8> {
+        let content_type = content_type
+            .map(|value| format!(r#", "content_type":"{value}""#))
+            .unwrap_or_default();
+        let manifest = format!(
+            r#"{{
+                "key":"plugin_test",
+                "runtime":"wasm-component-v1",
+                "api_version":"0.1.0",
+                "match":{{"path_glob":"*.test"{content_type}}},
+                "entry":"plugin.wasm",
+                "schemas":["schema/plugin_test_note.json"]
+            }}"#
+        );
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+        let options = SimpleFileOptions::default();
+        for (path, bytes) in [
+            ("manifest.json", manifest.as_bytes()),
+            ("schema/plugin_test_note.json", SCHEMA),
+            ("plugin.wasm", WASM),
+        ] {
+            writer
+                .start_file(path, options)
+                .expect("plugin fixture entry should start");
+            writer
+                .write_all(bytes)
+                .expect("plugin fixture entry should write");
+        }
+        writer
+            .finish()
+            .expect("plugin fixture should finish")
+            .into_inner()
+    }
 }

--- a/packages/engine/src/plugin/manifest.rs
+++ b/packages/engine/src/plugin/manifest.rs
@@ -41,6 +41,19 @@ pub enum PluginContentType {
     Binary,
 }
 
+impl PluginContentType {
+    /// Classifies file bytes only when a caller already has the payload.
+    /// Empty bytes are valid UTF-8 and therefore text, matching the bundled
+    /// text plugins' treatment of a newly-created empty file.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+        if std::str::from_utf8(bytes).is_ok() {
+            Self::Text
+        } else {
+            Self::Binary
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedPluginManifest {
     pub manifest: PluginManifest,

--- a/packages/engine/src/plugin/materializer.rs
+++ b/packages/engine/src/plugin/materializer.rs
@@ -1,19 +1,15 @@
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use crate::LixError;
-use crate::binary_cas::{BlobDataReader, BlobHash};
 use crate::entity_pk::EntityPk;
-use crate::filesystem::FilesystemIndex;
 use crate::live_state::{LiveStateProjection, MaterializedLiveStateRow};
-use crate::wasm::{WasmPluginEntityState, WasmPluginFile};
+use crate::wasm::{WasmComponentInstance, WasmPluginEntityState, WasmPluginFile};
 
+use super::InstalledPlugin;
 use super::component::{
     PluginComponentHost, detect_changes_with_plugin as detect_changes_with_component,
     render_with_plugin as render_with_component,
-};
-use super::{
-    InstalledPlugin, load_installed_plugin_from_archive_bytes, plugin_key_from_archive_path,
-    select_best_glob_match,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,53 +18,6 @@ pub(crate) struct PluginDetectedChange {
     pub(crate) schema_key: String,
     pub(crate) snapshot_content: Option<String>,
     pub(crate) metadata: Option<String>,
-}
-
-pub(crate) async fn load_installed_plugins_from_filesystem(
-    filesystem: &FilesystemIndex,
-    blob_reader: &dyn BlobDataReader,
-) -> Result<Vec<InstalledPlugin>, LixError> {
-    let mut plugins = Vec::new();
-    for (path, file) in filesystem.file_entries() {
-        let Some(plugin_key) = plugin_key_from_archive_path(path) else {
-            continue;
-        };
-        let Some(blob_hash) = file.blob_hash.as_deref() else {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("installed plugin archive '{path}' is missing binary blob data"),
-            ));
-        };
-        let hash = BlobHash::from_hex(blob_hash)?;
-        let mut batch = blob_reader.load_bytes_many(&[hash]).await?.into_vec();
-        let Some(archive_bytes) = batch.pop().flatten() else {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("installed plugin archive '{path}' blob '{blob_hash}' is missing"),
-            ));
-        };
-        plugins.push(load_installed_plugin_from_archive_bytes(
-            &plugin_key,
-            path,
-            &archive_bytes,
-        )?);
-    }
-    Ok(plugins)
-}
-
-pub(crate) fn select_plugin_for_path<'a>(
-    plugins: &'a [InstalledPlugin],
-    path: &str,
-) -> Option<&'a InstalledPlugin> {
-    // Plugin ownership is path-based. File bytes, especially empty bytes, are
-    // not reliable for deciding which plugin is active for a path.
-    select_best_glob_match(
-        path,
-        None::<()>,
-        plugins,
-        |plugin| plugin.path_glob.as_str(),
-        |_plugin| None::<()>,
-    )
 }
 
 pub(crate) async fn detect_changes_with_plugin(
@@ -84,6 +33,26 @@ pub(crate) async fn detect_changes_with_plugin(
         file,
     )
     .await?;
+    normalize_detected_changes(changes)
+}
+
+/// Executes a component that was resolved from the warm hash cache before any
+/// CAS read. Keeping the exact `Arc` avoids a key-only cache race with another
+/// branch that has a different component version under the same plugin key.
+pub(crate) async fn detect_changes_with_component_instance(
+    instance: &Arc<dyn WasmComponentInstance>,
+    active_state: &[MaterializedLiveStateRow],
+    file: WasmPluginFile,
+) -> Result<Vec<PluginDetectedChange>, LixError> {
+    let changes = instance
+        .detect_changes(plugin_entity_state_from_live_rows(active_state)?, file)
+        .await?;
+    normalize_detected_changes(changes)
+}
+
+fn normalize_detected_changes(
+    changes: Vec<crate::wasm::WasmPluginDetectedChange>,
+) -> Result<Vec<PluginDetectedChange>, LixError> {
     changes
         .into_iter()
         .map(|change| {
@@ -112,6 +81,15 @@ pub(crate) async fn render_plugin_state(
     .await
 }
 
+pub(crate) async fn render_plugin_state_with_component_instance(
+    instance: &Arc<dyn WasmComponentInstance>,
+    active_state: &[MaterializedLiveStateRow],
+) -> Result<Vec<u8>, LixError> {
+    instance
+        .render(plugin_entity_state_from_live_rows(active_state)?)
+        .await
+}
+
 pub(crate) async fn render_materialized_plugin_file(
     host: &impl PluginComponentHost,
     plugin: &InstalledPlugin,
@@ -128,9 +106,16 @@ pub(crate) async fn render_materialized_plugin_file(
 
 pub(crate) fn retain_plugin_state_rows(
     plugin: &InstalledPlugin,
+    rows: Vec<MaterializedLiveStateRow>,
+) -> Vec<MaterializedLiveStateRow> {
+    retain_plugin_state_rows_for_schema_keys(&plugin.schema_keys, rows)
+}
+
+pub(crate) fn retain_plugin_state_rows_for_schema_keys(
+    schema_keys: &[String],
     mut rows: Vec<MaterializedLiveStateRow>,
 ) -> Vec<MaterializedLiveStateRow> {
-    let schema_keys = plugin.schema_keys.iter().collect::<BTreeSet<_>>();
+    let schema_keys = schema_keys.iter().collect::<BTreeSet<_>>();
     rows.retain(|row| schema_keys.contains(&row.schema_key) && row.snapshot_content.is_some());
     rows
 }

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -5,18 +5,24 @@
 //! buckets.
 
 mod archive;
-pub(crate) mod component;
+mod component;
 mod install;
 mod manifest;
 mod materializer;
+mod registry;
 mod storage;
 
 pub(crate) use archive::{
     ParsedPluginArchive, load_installed_plugin_from_archive_bytes,
     load_installed_plugin_metadata_from_archive_bytes, parse_plugin_archive_for_install,
 };
-pub(crate) use component::{CachedPluginComponent, PluginComponentHost, PluginRuntimeHost};
-pub(crate) use install::plugin_schema_rows_from_archive_path;
+pub(crate) use component::{
+    CachedPluginComponent, PluginComponentHost, PluginRuntimeHost, load_or_init_plugin_component,
+};
+pub(crate) use install::{
+    PluginArchiveInstallPlan, plugin_install_plan_from_archive_path,
+    plugin_schema_rows_from_archive_path,
+};
 #[allow(unused_imports)]
 pub(crate) use manifest::{
     PluginContentType, PluginManifest, PluginMatch, PluginRuntime, ValidatedPluginManifest,
@@ -24,15 +30,22 @@ pub(crate) use manifest::{
 };
 #[allow(unused_imports)]
 pub(crate) use materializer::{
-    PluginDetectedChange, detect_changes_with_plugin, load_installed_plugins_from_filesystem,
+    PluginDetectedChange, detect_changes_with_component_instance, detect_changes_with_plugin,
     plugin_state_live_state_projection, render_materialized_plugin_file, render_plugin_state,
-    retain_plugin_state_rows, select_plugin_for_path,
+    render_plugin_state_with_component_instance, retain_plugin_state_rows,
+    retain_plugin_state_rows_for_schema_keys,
+};
+#[allow(unused_imports)]
+pub(crate) use registry::{
+    CompiledPluginCatalog, MAX_PLUGIN_REGISTRY_ENTRIES, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY,
+    PluginCatalogCache, PluginFileOwner, PluginRegistry, PluginRegistryEntry,
+    PluginRegistryEntryInput,
 };
 #[allow(unused_imports)]
 pub(crate) use storage::{
     PLUGIN_ARCHIVE_FILE_EXTENSION, PLUGIN_STORAGE_ROOT_DIRECTORY_PATH, is_plugin_storage_path,
-    plugin_key_from_archive_path, plugin_storage_archive_file_id, plugin_storage_archive_path,
-    reject_normal_plugin_storage_mutation,
+    plugin_key_from_archive_file_id, plugin_key_from_archive_path, plugin_storage_archive_file_id,
+    plugin_storage_archive_path, reject_normal_plugin_storage_mutation,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,6 +58,10 @@ pub(crate) struct InstalledPlugin {
     pub entry: String,
     pub schema_keys: Vec<String>,
     pub manifest_json: String,
+    /// Content-addressed identity computed while the component bytes are
+    /// already in hand. Warm component-cache lookups must use this fixed-size
+    /// value instead of rehashing or comparing the full WASM payload.
+    pub wasm_hash: crate::binary_cas::BlobHash,
     pub wasm: Vec<u8>,
 }
 

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -54,8 +54,9 @@ pub(crate) struct PluginRegistryEntryInput {
 
 /// Metadata needed by current-state plugin matching and execution.
 ///
-/// `content_type` is omitted for path-only plugins so registry rows written
-/// before typed matching remain byte-for-byte generation compatible.
+/// Path-only matching is encoded explicitly as `content_type: null`. Registry
+/// rows are an internal engine format, so missing fields are rejected instead
+/// of carrying compatibility for unreleased representations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct PluginRegistryEntry {
@@ -63,7 +64,7 @@ pub(crate) struct PluginRegistryEntry {
     runtime: PluginRuntime,
     api_version: String,
     path_glob: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(deserialize_with = "deserialize_required_content_type")]
     content_type: Option<PluginContentType>,
     entry: String,
     schema_keys: Vec<String>,
@@ -72,6 +73,15 @@ pub(crate) struct PluginRegistryEntry {
     archive_path: String,
     archive_blob_hash: String,
     wasm_blob_hash: String,
+}
+
+fn deserialize_required_content_type<'de, D>(
+    deserializer: D,
+) -> Result<Option<PluginContentType>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<PluginContentType>::deserialize(deserializer)
 }
 
 impl PluginRegistryEntry {
@@ -1182,14 +1192,24 @@ mod tests {
     }
 
     #[test]
-    fn content_type_is_durable_and_path_only_rows_remain_compatible() {
-        let legacy = PluginRegistry::new(vec![entry("plugin_a", "*.json", 'a')]).unwrap();
-        let legacy_value = legacy.to_value().unwrap();
-        assert!(legacy_value["plugins"][0].get("content_type").is_none());
+    fn content_type_is_required_and_path_only_matching_is_explicit() {
+        let path_only = PluginRegistry::new(vec![entry("plugin_a", "*.json", 'a')]).unwrap();
+        let path_only_value = path_only.to_value().unwrap();
         assert_eq!(
-            PluginRegistry::from_optional_value(Some(&legacy_value)).unwrap(),
-            legacy
+            path_only_value["plugins"][0]["content_type"],
+            JsonValue::Null
         );
+        assert_eq!(
+            PluginRegistry::from_optional_value(Some(&path_only_value)).unwrap(),
+            path_only
+        );
+
+        let mut missing = path_only_value;
+        missing["plugins"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("content_type");
+        assert_invalid(missing, "missing field `content_type`");
 
         let typed = PluginRegistry::new(vec![entry_with_content_type(
             "plugin_a",
@@ -1204,7 +1224,7 @@ mod tests {
             PluginRegistry::from_optional_value(Some(&typed_value)).unwrap(),
             typed
         );
-        assert_ne!(legacy.generation(), typed.generation());
+        assert_ne!(path_only.generation(), typed.generation());
 
         let mut mismatched = typed_value;
         mismatched["plugins"][0]["content_type"] = json!("binary");

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -21,7 +21,9 @@ use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 use crate::{GLOBAL_BRANCH_ID, LixError};
 
 use super::InstalledPlugin;
-use super::manifest::{PluginManifest, PluginRuntime, parse_plugin_manifest_json};
+use super::manifest::{
+    PluginContentType, PluginManifest, PluginRuntime, parse_plugin_manifest_json,
+};
 use super::storage::{plugin_storage_archive_file_id, plugin_storage_archive_path};
 
 pub(crate) const PLUGIN_REGISTRY_KEY: &str = "lix_plugin_registry_v1";
@@ -40,6 +42,7 @@ pub(crate) struct PluginRegistryEntryInput {
     pub(crate) runtime: PluginRuntime,
     pub(crate) api_version: String,
     pub(crate) path_glob: String,
+    pub(crate) content_type: Option<PluginContentType>,
     pub(crate) entry: String,
     pub(crate) schema_keys: Vec<String>,
     pub(crate) manifest_json: String,
@@ -51,9 +54,8 @@ pub(crate) struct PluginRegistryEntryInput {
 
 /// Metadata needed by current-state plugin matching and execution.
 ///
-/// V1 intentionally has no `content_type`: path ownership is the complete
-/// matching contract. `deny_unknown_fields` also makes a hand-written
-/// `content_type` field fail closed when a durable row is decoded.
+/// `content_type` is omitted for path-only plugins so registry rows written
+/// before typed matching remain byte-for-byte generation compatible.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct PluginRegistryEntry {
@@ -61,6 +63,8 @@ pub(crate) struct PluginRegistryEntry {
     runtime: PluginRuntime,
     api_version: String,
     path_glob: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    content_type: Option<PluginContentType>,
     entry: String,
     schema_keys: Vec<String>,
     manifest_json: String,
@@ -77,6 +81,7 @@ impl PluginRegistryEntry {
             runtime: input.runtime,
             api_version: input.api_version,
             path_glob: input.path_glob,
+            content_type: input.content_type,
             entry: input.entry,
             schema_keys: input.schema_keys,
             manifest_json: canonicalize_json_text(
@@ -112,6 +117,10 @@ impl PluginRegistryEntry {
 
     pub(crate) fn path_glob(&self) -> &str {
         &self.path_glob
+    }
+
+    pub(crate) fn content_type(&self) -> Option<PluginContentType> {
+        self.content_type
     }
 
     pub(crate) fn entry(&self) -> &str {
@@ -156,7 +165,7 @@ impl PluginRegistryEntry {
             runtime: self.runtime,
             api_version: self.api_version.clone(),
             path_glob: self.path_glob.clone(),
-            content_type: None,
+            content_type: self.content_type,
             entry: self.entry.clone(),
             schema_keys: self.schema_keys.clone(),
             manifest_json: self.manifest_json.clone(),
@@ -637,7 +646,9 @@ impl CompiledPluginCatalog {
     /// fresh-file selection.
     ///
     /// That distinction lets a durable file owner keep rendering under
-    /// overlapping globs without recompiling an individual matcher.
+    /// overlapping globs without recompiling an individual matcher. Content
+    /// type is intentionally not rechecked: the owner records selection made
+    /// when file bytes were available.
     pub(crate) fn matches_plugin(&self, plugin_key: &str, path: &str) -> bool {
         if path.is_empty() {
             return false;
@@ -651,10 +662,39 @@ impl CompiledPluginCatalog {
         self.globs.matches(path).contains(&plugin_index)
     }
 
-    /// Select the most specific glob. Equal-specificity matches resolve by
-    /// lexicographically smallest plugin key because registry entries are
-    /// canonicalized by key and matching indices are ascending.
-    pub(crate) fn select(&self, path: &str) -> Option<&PluginRegistryEntry> {
+    /// Select the most specific compatible matcher. When callers already have
+    /// file bytes they pass the classified content type and both predicates
+    /// must match. `None` deliberately keeps the prior path-only behavior for
+    /// owner validation and other flows where bytes are not available.
+    /// Equal-specificity matches resolve by lexicographically smallest plugin
+    /// key because registry entries are canonicalized by key and matching
+    /// indices are ascending.
+    pub(crate) fn select(
+        &self,
+        path: &str,
+        file_content_type: Option<PluginContentType>,
+    ) -> Option<&PluginRegistryEntry> {
+        self.select_with_content_type(path, || file_content_type)
+    }
+
+    /// Selects for a known payload without scanning its bytes unless at least
+    /// one path-matching plugin actually declares a content-type constraint.
+    pub(crate) fn select_for_bytes(
+        &self,
+        path: &str,
+        bytes: &[u8],
+    ) -> Option<&PluginRegistryEntry> {
+        let mut classified = None;
+        self.select_with_content_type(path, || {
+            Some(*classified.get_or_insert_with(|| PluginContentType::from_bytes(bytes)))
+        })
+    }
+
+    fn select_with_content_type(
+        &self,
+        path: &str,
+        mut file_content_type: impl FnMut() -> Option<PluginContentType>,
+    ) -> Option<&PluginRegistryEntry> {
         if path.is_empty() {
             return None;
         }
@@ -663,10 +703,16 @@ impl CompiledPluginCatalog {
         let mut selected_rank = None;
         for index in matches {
             let rank = self.specificity[index];
-            if selected_rank.is_none_or(|current| rank > current) {
-                selected = Some(index);
-                selected_rank = Some(rank);
+            if selected_rank.is_some_and(|current| rank <= current) {
+                continue;
             }
+            if let Some(required) = self.plugins[index].content_type()
+                && file_content_type().is_some_and(|actual| actual != required)
+            {
+                continue;
+            }
+            selected = Some(index);
+            selected_rank = Some(rank);
         }
         selected.map(|index| &self.plugins[index])
     }
@@ -760,16 +806,11 @@ fn validate_entry(entry: &PluginRegistryEntry) -> Result<(), LixError> {
             entry.key
         ))
     })?;
-    if manifest.file_match.content_type.is_some() {
-        return Err(invalid_registry(format!(
-            "plugin '{}' uses content_type matching, which registry v1 does not support",
-            entry.key
-        )));
-    }
     if manifest.key != entry.key
         || manifest.runtime != entry.runtime
         || manifest.api_version != entry.api_version
         || manifest.file_match.path_glob != entry.path_glob
+        || manifest.file_match.content_type != entry.content_type
         || manifest.entry != entry.entry
     {
         return Err(invalid_registry(format!(
@@ -1005,6 +1046,7 @@ fn invalid_registry(message: impl Into<String>) -> LixError {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::sync::Arc;
 
     use serde_json::{Value as JsonValue, json};
@@ -1015,12 +1057,23 @@ mod tests {
         std::iter::repeat_n(byte, 64).collect()
     }
 
-    fn manifest(key: &str, path_glob: &str) -> String {
+    fn manifest_with_content_type(
+        key: &str,
+        path_glob: &str,
+        content_type: Option<PluginContentType>,
+    ) -> String {
+        let content_type = content_type
+            .map(|content_type| {
+                let value = serde_json::to_string(&content_type)
+                    .expect("plugin content type should serialize");
+                format!(r#","content_type":{value}"#)
+            })
+            .unwrap_or_default();
         format!(
             r#"{{
                 "schemas":["schema/default.json"],
                 "entry":"plugin.wasm",
-                "match":{{"path_glob":{path_glob:?}}},
+                "match":{{"path_glob":{path_glob:?}{content_type}}},
                 "api_version":"0.1.0",
                 "runtime":"wasm-component-v1",
                 "key":{key:?}
@@ -1029,14 +1082,24 @@ mod tests {
     }
 
     fn entry(key: &str, path_glob: &str, hash_byte: char) -> PluginRegistryEntry {
+        entry_with_content_type(key, path_glob, None, hash_byte)
+    }
+
+    fn entry_with_content_type(
+        key: &str,
+        path_glob: &str,
+        content_type: Option<PluginContentType>,
+        hash_byte: char,
+    ) -> PluginRegistryEntry {
         PluginRegistryEntry::new(PluginRegistryEntryInput {
             key: key.to_string(),
             runtime: PluginRuntime::WasmComponentV1,
             api_version: "0.1.0".to_string(),
             path_glob: path_glob.to_string(),
+            content_type,
             entry: "plugin.wasm".to_string(),
             schema_keys: vec![format!("{key}_schema")],
-            manifest_json: manifest(key, path_glob),
+            manifest_json: manifest_with_content_type(key, path_glob, content_type),
             archive_file_id: plugin_storage_archive_file_id(key),
             archive_path: plugin_storage_archive_path(key),
             archive_blob_hash: hash(hash_byte),
@@ -1119,31 +1182,33 @@ mod tests {
     }
 
     #[test]
-    fn rejects_content_type_in_manifest_or_registry_entry() {
-        let mut input = PluginRegistryEntryInput {
-            key: "plugin_a".to_string(),
-            runtime: PluginRuntime::WasmComponentV1,
-            api_version: "0.1.0".to_string(),
-            path_glob: "*.json".to_string(),
-            entry: "plugin.wasm".to_string(),
-            schema_keys: vec!["plugin_a_schema".to_string()],
-            manifest_json: manifest("plugin_a", "*.json"),
-            archive_file_id: plugin_storage_archive_file_id("plugin_a"),
-            archive_path: plugin_storage_archive_path("plugin_a"),
-            archive_blob_hash: hash('a'),
-            wasm_blob_hash: hash('b'),
-        };
-        input.manifest_json = input.manifest_json.replace(
-            r#""path_glob":"*.json""#,
-            r#""path_glob":"*.json","content_type":"text""#,
+    fn content_type_is_durable_and_path_only_rows_remain_compatible() {
+        let legacy = PluginRegistry::new(vec![entry("plugin_a", "*.json", 'a')]).unwrap();
+        let legacy_value = legacy.to_value().unwrap();
+        assert!(legacy_value["plugins"][0].get("content_type").is_none());
+        assert_eq!(
+            PluginRegistry::from_optional_value(Some(&legacy_value)).unwrap(),
+            legacy
         );
-        let error = PluginRegistryEntry::new(input).expect_err("content_type must be rejected");
-        assert!(error.message.contains("content_type"));
 
-        let registry = PluginRegistry::new(vec![entry("plugin_a", "*.json", 'a')]).unwrap();
-        let mut value = registry.to_value().unwrap();
-        value["plugins"][0]["content_type"] = json!("text");
-        assert_invalid(value, "content_type");
+        let typed = PluginRegistry::new(vec![entry_with_content_type(
+            "plugin_a",
+            "*.json",
+            Some(PluginContentType::Text),
+            'a',
+        )])
+        .unwrap();
+        let typed_value = typed.to_value().unwrap();
+        assert_eq!(typed_value["plugins"][0]["content_type"], json!("text"));
+        assert_eq!(
+            PluginRegistry::from_optional_value(Some(&typed_value)).unwrap(),
+            typed
+        );
+        assert_ne!(legacy.generation(), typed.generation());
+
+        let mut mismatched = typed_value;
+        mismatched["plugins"][0]["content_type"] = json!("binary");
+        assert_invalid(mismatched, "does not match manifest_json");
     }
 
     #[test]
@@ -1182,9 +1247,14 @@ mod tests {
             runtime: PluginRuntime::WasmComponentV1,
             api_version: "0.1.0".to_string(),
             path_glob: "*.json".to_string(),
+            content_type: Some(PluginContentType::Text),
             entry: "plugin.wasm".to_string(),
             schema_keys: vec!["plugin_a_schema".to_string()],
-            manifest_json: manifest("plugin_a", "*.json"),
+            manifest_json: manifest_with_content_type(
+                "plugin_a",
+                "*.json",
+                Some(PluginContentType::Text),
+            ),
             archive_file_id: plugin_storage_archive_file_id("plugin_a"),
             archive_path: plugin_storage_archive_path("plugin_a"),
             archive_blob_hash: hash('a'),
@@ -1195,6 +1265,7 @@ mod tests {
             .to_installed_plugin(wasm.clone())
             .expect("matching extracted WASM should materialize");
         assert_eq!(installed.key, "plugin_a");
+        assert_eq!(installed.content_type, Some(PluginContentType::Text));
         assert_eq!(installed.wasm_hash, BlobHash::from_content(&wasm));
         assert_eq!(installed.wasm, wasm);
 
@@ -1217,12 +1288,15 @@ mod tests {
         .unwrap();
         let catalog = CompiledPluginCatalog::compile(&registry).unwrap();
         assert_eq!(
-            catalog.select("src/data.json").unwrap().key(),
+            catalog.select("src/data.json", None).unwrap().key(),
             "plugin_specific"
         );
-        assert_eq!(catalog.select("data.json").unwrap().key(), "plugin_a");
-        assert_eq!(catalog.select("data.txt").unwrap().key(), "plugin_all");
-        assert!(catalog.select("").is_none());
+        assert_eq!(catalog.select("data.json", None).unwrap().key(), "plugin_a");
+        assert_eq!(
+            catalog.select("data.txt", None).unwrap().key(),
+            "plugin_all"
+        );
+        assert!(catalog.select("", None).is_none());
         assert!(catalog.matches_plugin("plugin_specific", "src/data.json"));
         assert!(catalog.matches_plugin("plugin_a", "src/data.json"));
         assert!(catalog.matches_plugin("plugin_z", "src/data.json"));
@@ -1245,6 +1319,88 @@ mod tests {
             cache.get_or_compile(&next).unwrap();
         }
         assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn compiled_catalog_applies_content_type_only_when_known() {
+        assert_eq!(PluginContentType::from_bytes(b""), PluginContentType::Text);
+        assert_eq!(
+            PluginContentType::from_bytes(b"hello"),
+            PluginContentType::Text
+        );
+        assert_eq!(
+            PluginContentType::from_bytes(&[0xff, 0xfe]),
+            PluginContentType::Binary
+        );
+
+        let text =
+            entry_with_content_type("plugin_text", "*.data", Some(PluginContentType::Text), 'a');
+        let binary = entry_with_content_type(
+            "plugin_binary",
+            "*.data",
+            Some(PluginContentType::Binary),
+            'b',
+        );
+        let text_only =
+            CompiledPluginCatalog::compile(&PluginRegistry::new(vec![text.clone()]).unwrap())
+                .unwrap();
+        let classification_calls = Cell::new(0);
+        assert!(
+            text_only
+                .select_with_content_type("document.other", || {
+                    classification_calls.set(classification_calls.get() + 1);
+                    Some(PluginContentType::Text)
+                })
+                .is_none()
+        );
+        assert_eq!(classification_calls.get(), 0);
+        assert_eq!(
+            text_only
+                .select("document.data", Some(PluginContentType::Text))
+                .map(PluginRegistryEntry::key),
+            Some("plugin_text")
+        );
+        assert!(
+            text_only
+                .select("document.data", Some(PluginContentType::Binary))
+                .is_none()
+        );
+
+        let catalog =
+            CompiledPluginCatalog::compile(&PluginRegistry::new(vec![text, binary]).unwrap())
+                .unwrap();
+        assert_eq!(
+            catalog
+                .select("document.data", Some(PluginContentType::Text))
+                .map(PluginRegistryEntry::key),
+            Some("plugin_text")
+        );
+        assert_eq!(
+            catalog
+                .select("document.data", Some(PluginContentType::Binary))
+                .map(PluginRegistryEntry::key),
+            Some("plugin_binary")
+        );
+        assert_eq!(
+            catalog
+                .select_for_bytes("document.data", b"hello")
+                .map(PluginRegistryEntry::key),
+            Some("plugin_text")
+        );
+        assert_eq!(
+            catalog
+                .select_for_bytes("document.data", &[0xff, 0xfe])
+                .map(PluginRegistryEntry::key),
+            Some("plugin_binary")
+        );
+        assert_eq!(
+            catalog
+                .select("document.data", None)
+                .map(PluginRegistryEntry::key),
+            Some("plugin_binary")
+        );
+        assert!(catalog.matches_plugin("plugin_text", "document.data"));
+        assert!(catalog.matches_plugin("plugin_binary", "document.data"));
     }
 
     #[test]

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -1,0 +1,1277 @@
+//! Durable, branch-local plugin registry state.
+//!
+//! The registry is one tracked `lix_key_value` entity per branch. File
+//! ownership uses the same reserved entity key for every file and relies on
+//! `file_id` for identity. That layout gives the transaction hot paths one
+//! exact registry read and one batched owner read instead of a filesystem
+//! scan.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+use lru::LruCache;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+
+use crate::binary_cas::BlobHash;
+use crate::entity_pk::EntityPk;
+use crate::live_state::MaterializedLiveStateRow;
+use crate::transaction::types::{TransactionJson, TransactionWriteRow};
+use crate::{GLOBAL_BRANCH_ID, LixError};
+
+use super::InstalledPlugin;
+use super::manifest::{PluginManifest, PluginRuntime, parse_plugin_manifest_json};
+use super::storage::{plugin_storage_archive_file_id, plugin_storage_archive_path};
+
+pub(crate) const PLUGIN_REGISTRY_KEY: &str = "lix_plugin_registry_v1";
+pub(crate) const PLUGIN_OWNER_KEY: &str = "lix_plugin_owner_v1";
+pub(crate) const MAX_PLUGIN_REGISTRY_ENTRIES: usize = 128;
+
+const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
+const REGISTRY_FORMAT_VERSION: u32 = 1;
+const MAX_CACHED_PLUGIN_CATALOGS: usize = 16;
+const DEFAULT_CACHED_PLUGIN_CATALOGS: usize = 8;
+
+/// Install-time data used to construct one canonical registry entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginRegistryEntryInput {
+    pub(crate) key: String,
+    pub(crate) runtime: PluginRuntime,
+    pub(crate) api_version: String,
+    pub(crate) path_glob: String,
+    pub(crate) entry: String,
+    pub(crate) schema_keys: Vec<String>,
+    pub(crate) manifest_json: String,
+    pub(crate) archive_file_id: String,
+    pub(crate) archive_path: String,
+    pub(crate) archive_blob_hash: String,
+    pub(crate) wasm_blob_hash: String,
+}
+
+/// Metadata needed by current-state plugin matching and execution.
+///
+/// V1 intentionally has no `content_type`: path ownership is the complete
+/// matching contract. `deny_unknown_fields` also makes a hand-written
+/// `content_type` field fail closed when a durable row is decoded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PluginRegistryEntry {
+    key: String,
+    runtime: PluginRuntime,
+    api_version: String,
+    path_glob: String,
+    entry: String,
+    schema_keys: Vec<String>,
+    manifest_json: String,
+    archive_file_id: String,
+    archive_path: String,
+    archive_blob_hash: String,
+    wasm_blob_hash: String,
+}
+
+impl PluginRegistryEntry {
+    pub(crate) fn new(input: PluginRegistryEntryInput) -> Result<Self, LixError> {
+        let mut entry = Self {
+            key: input.key,
+            runtime: input.runtime,
+            api_version: input.api_version,
+            path_glob: input.path_glob,
+            entry: input.entry,
+            schema_keys: input.schema_keys,
+            manifest_json: canonicalize_json_text(
+                &input.manifest_json,
+                "plugin registry manifest_json",
+            )?,
+            archive_file_id: input.archive_file_id,
+            archive_path: input.archive_path,
+            archive_blob_hash: input.archive_blob_hash,
+            wasm_blob_hash: input.wasm_blob_hash,
+        };
+        entry.schema_keys.sort();
+        // Install-time validation pays the complete JSON-Schema and glob
+        // checks once. Durable reads below use the already-validated compact
+        // fields and generation integrity, so warm transactions do not
+        // recompile one glob per plugin before consulting the catalog cache.
+        parse_plugin_manifest_json(&entry.manifest_json)?;
+        validate_entry(&entry)?;
+        Ok(entry)
+    }
+
+    pub(crate) fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub(crate) fn runtime(&self) -> PluginRuntime {
+        self.runtime
+    }
+
+    pub(crate) fn api_version(&self) -> &str {
+        &self.api_version
+    }
+
+    pub(crate) fn path_glob(&self) -> &str {
+        &self.path_glob
+    }
+
+    pub(crate) fn entry(&self) -> &str {
+        &self.entry
+    }
+
+    pub(crate) fn schema_keys(&self) -> &[String] {
+        &self.schema_keys
+    }
+
+    pub(crate) fn manifest_json(&self) -> &str {
+        &self.manifest_json
+    }
+
+    pub(crate) fn archive_file_id(&self) -> &str {
+        &self.archive_file_id
+    }
+
+    pub(crate) fn archive_path(&self) -> &str {
+        &self.archive_path
+    }
+
+    pub(crate) fn archive_blob_hash(&self) -> &str {
+        &self.archive_blob_hash
+    }
+
+    pub(crate) fn wasm_blob_hash(&self) -> &str {
+        &self.wasm_blob_hash
+    }
+
+    pub(crate) fn to_installed_plugin(&self, wasm: Vec<u8>) -> Result<InstalledPlugin, LixError> {
+        let wasm_hash = BlobHash::from_content(&wasm);
+        let actual_hash = wasm_hash.to_hex();
+        if actual_hash != self.wasm_blob_hash {
+            return Err(invalid_registry(format!(
+                "plugin '{}' WASM bytes hash '{}' does not match registry hash '{}'",
+                self.key, actual_hash, self.wasm_blob_hash
+            )));
+        }
+        Ok(InstalledPlugin {
+            key: self.key.clone(),
+            runtime: self.runtime,
+            api_version: self.api_version.clone(),
+            path_glob: self.path_glob.clone(),
+            content_type: None,
+            entry: self.entry.clone(),
+            schema_keys: self.schema_keys.clone(),
+            manifest_json: self.manifest_json.clone(),
+            wasm_hash,
+            wasm,
+        })
+    }
+}
+
+/// Canonical contents of `lix_key_value:lix_plugin_registry_v1`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginRegistry {
+    plugin_count: u32,
+    generation: String,
+    plugins: Vec<PluginRegistryEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PluginRegistryWire {
+    version: u32,
+    plugin_count: u32,
+    generation: String,
+    plugins: Vec<PluginRegistryEntry>,
+}
+
+#[derive(Serialize)]
+struct PluginRegistryGenerationPayload<'a> {
+    version: u32,
+    plugins: &'a [PluginRegistryEntry],
+}
+
+impl PluginRegistry {
+    pub(crate) fn empty() -> Self {
+        Self::new(Vec::new()).expect("the empty plugin registry is valid")
+    }
+
+    pub(crate) fn new(mut plugins: Vec<PluginRegistryEntry>) -> Result<Self, LixError> {
+        if plugins.len() > MAX_PLUGIN_REGISTRY_ENTRIES {
+            return Err(invalid_registry(format!(
+                "plugin_count {} exceeds the v1 limit of {MAX_PLUGIN_REGISTRY_ENTRIES}",
+                plugins.len()
+            )));
+        }
+        plugins.sort_by(|left, right| left.key.cmp(&right.key));
+        for entry in &plugins {
+            validate_entry(entry)?;
+        }
+        validate_strictly_increasing_plugin_keys(&plugins)?;
+
+        let plugin_count = u32::try_from(plugins.len()).map_err(|_| {
+            invalid_registry("plugin_count cannot be represented by the v1 registry format")
+        })?;
+        let generation = calculate_generation(&plugins)?;
+        Ok(Self {
+            plugin_count,
+            generation,
+            plugins,
+        })
+    }
+
+    pub(crate) fn plugin_count(&self) -> u32 {
+        self.plugin_count
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+
+    pub(crate) fn generation(&self) -> &str {
+        &self.generation
+    }
+
+    pub(crate) fn plugins(&self) -> &[PluginRegistryEntry] {
+        &self.plugins
+    }
+
+    pub(crate) fn plugin(&self, key: &str) -> Option<&PluginRegistryEntry> {
+        self.plugins
+            .binary_search_by(|entry| entry.key.as_str().cmp(key))
+            .ok()
+            .map(|index| &self.plugins[index])
+    }
+
+    pub(crate) fn get(&self, key: &str) -> Option<&PluginRegistryEntry> {
+        self.plugin(key)
+    }
+
+    pub(crate) fn upsert(
+        &mut self,
+        plugin: PluginRegistryEntry,
+    ) -> Result<Option<PluginRegistryEntry>, LixError> {
+        let mut next = self.clone();
+        let replaced = match next
+            .plugins
+            .binary_search_by(|entry| entry.key.cmp(&plugin.key))
+        {
+            Ok(index) => Some(std::mem::replace(&mut next.plugins[index], plugin)),
+            Err(index) => {
+                next.plugins.insert(index, plugin);
+                None
+            }
+        };
+        next.recompute_generation()?;
+        *self = next;
+        Ok(replaced)
+    }
+
+    pub(crate) fn remove(
+        &mut self,
+        plugin_key: &str,
+    ) -> Result<Option<PluginRegistryEntry>, LixError> {
+        let mut next = self.clone();
+        let removed = next
+            .plugins
+            .binary_search_by(|entry| entry.key.as_str().cmp(plugin_key))
+            .ok()
+            .map(|index| next.plugins.remove(index));
+        next.recompute_generation()?;
+        *self = next;
+        Ok(removed)
+    }
+
+    pub(crate) fn recompute_generation(&mut self) -> Result<(), LixError> {
+        if self.plugins.len() > MAX_PLUGIN_REGISTRY_ENTRIES {
+            return Err(invalid_registry(format!(
+                "plugin_count {} exceeds the v1 limit of {MAX_PLUGIN_REGISTRY_ENTRIES}",
+                self.plugins.len()
+            )));
+        }
+        validate_strictly_increasing_plugin_keys(&self.plugins)?;
+        for entry in &self.plugins {
+            validate_entry(entry)?;
+        }
+        self.plugin_count = u32::try_from(self.plugins.len()).map_err(|_| {
+            invalid_registry("plugin_count cannot be represented by the v1 registry format")
+        })?;
+        self.generation = calculate_generation(&self.plugins)?;
+        Ok(())
+    }
+
+    pub(crate) fn with_upserted(&self, plugin: PluginRegistryEntry) -> Result<Self, LixError> {
+        let mut plugins = self.plugins.clone();
+        match plugins.binary_search_by(|entry| entry.key.cmp(&plugin.key)) {
+            Ok(index) => plugins[index] = plugin,
+            Err(index) => plugins.insert(index, plugin),
+        }
+        Self::new(plugins)
+    }
+
+    pub(crate) fn without(&self, plugin_key: &str) -> Result<Self, LixError> {
+        let mut plugins = self.plugins.clone();
+        if let Ok(index) = plugins.binary_search_by(|entry| entry.key.as_str().cmp(plugin_key)) {
+            plugins.remove(index);
+        }
+        Self::new(plugins)
+    }
+
+    /// Decode the JSON held in the `value` field. A missing entity is the
+    /// canonical empty registry and requires no filesystem discovery.
+    pub(crate) fn from_optional_value(value: Option<&JsonValue>) -> Result<Self, LixError> {
+        let Some(value) = value else {
+            return Ok(Self::empty());
+        };
+        let wire: PluginRegistryWire = serde_json::from_value(value.clone()).map_err(|error| {
+            invalid_registry(format!("registry payload has an invalid shape: {error}"))
+        })?;
+        Self::from_wire(wire)
+    }
+
+    /// Decode and validate the complete `lix_key_value` snapshot wrapper.
+    pub(crate) fn from_optional_snapshot(snapshot: Option<&JsonValue>) -> Result<Self, LixError> {
+        let Some(snapshot) = snapshot else {
+            return Ok(Self::empty());
+        };
+        let value = decode_key_value_snapshot(snapshot, PLUGIN_REGISTRY_KEY)?;
+        Self::from_optional_value(Some(value))
+    }
+
+    pub(crate) fn from_optional_live_state_row(
+        row: Option<&MaterializedLiveStateRow>,
+        branch_id: &str,
+    ) -> Result<Self, LixError> {
+        let Some(row) = row else {
+            return Ok(Self::empty());
+        };
+        validate_live_state_identity(row, PLUGIN_REGISTRY_KEY, None, branch_id)?;
+        if row.deleted || row.snapshot_content.is_none() {
+            return Ok(Self::empty());
+        }
+        let snapshot = parse_snapshot_content(row, "plugin registry")?;
+        Self::from_optional_snapshot(Some(&snapshot))
+    }
+
+    pub(crate) fn to_value(&self) -> Result<JsonValue, LixError> {
+        self.validate()?;
+        serde_json::to_value(PluginRegistryWire {
+            version: REGISTRY_FORMAT_VERSION,
+            plugin_count: self.plugin_count,
+            generation: self.generation.clone(),
+            plugins: self.plugins.clone(),
+        })
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("failed to serialize plugin registry: {error}"),
+            )
+        })
+    }
+
+    pub(crate) fn to_snapshot(&self) -> Result<JsonValue, LixError> {
+        Ok(json!({
+            "key": PLUGIN_REGISTRY_KEY,
+            "value": self.to_value()?,
+        }))
+    }
+
+    pub(crate) fn to_canonical_json(&self) -> Result<String, LixError> {
+        Ok(canonical_json(&self.to_value()?))
+    }
+
+    pub(crate) fn write_row(&self, branch_id: &str) -> Result<TransactionWriteRow, LixError> {
+        tracked_key_value_write_row(
+            PLUGIN_REGISTRY_KEY,
+            None,
+            Some(self.to_snapshot()?),
+            branch_id,
+        )
+    }
+
+    pub(crate) fn delete_row(branch_id: &str) -> Result<TransactionWriteRow, LixError> {
+        tracked_key_value_write_row(PLUGIN_REGISTRY_KEY, None, None, branch_id)
+    }
+
+    fn from_wire(wire: PluginRegistryWire) -> Result<Self, LixError> {
+        if wire.version != REGISTRY_FORMAT_VERSION {
+            return Err(invalid_registry(format!(
+                "unsupported version {}; expected {REGISTRY_FORMAT_VERSION}",
+                wire.version
+            )));
+        }
+        if wire.plugins.len() > MAX_PLUGIN_REGISTRY_ENTRIES {
+            return Err(invalid_registry(format!(
+                "plugin_count {} exceeds the v1 limit of {MAX_PLUGIN_REGISTRY_ENTRIES}",
+                wire.plugins.len()
+            )));
+        }
+        let actual_count = u32::try_from(wire.plugins.len()).map_err(|_| {
+            invalid_registry("plugin_count cannot be represented by the v1 registry format")
+        })?;
+        if wire.plugin_count != actual_count {
+            return Err(invalid_registry(format!(
+                "plugin_count {} does not match {} plugin entries",
+                wire.plugin_count, actual_count
+            )));
+        }
+        validate_strictly_increasing_plugin_keys(&wire.plugins)?;
+        for entry in &wire.plugins {
+            validate_entry(entry)?;
+        }
+        let expected_generation = calculate_generation(&wire.plugins)?;
+        if wire.generation != expected_generation {
+            return Err(invalid_registry(format!(
+                "generation integrity check failed: stored '{}' but calculated '{expected_generation}'",
+                wire.generation
+            )));
+        }
+        Ok(Self {
+            plugin_count: wire.plugin_count,
+            generation: wire.generation,
+            plugins: wire.plugins,
+        })
+    }
+
+    fn validate(&self) -> Result<(), LixError> {
+        let wire = PluginRegistryWire {
+            version: REGISTRY_FORMAT_VERSION,
+            plugin_count: self.plugin_count,
+            generation: self.generation.clone(),
+            plugins: self.plugins.clone(),
+        };
+        Self::from_wire(wire).map(|_| ())
+    }
+}
+
+/// Durable per-file ownership. `file_id` is storage identity, not duplicated
+/// in the snapshot payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginFileOwner {
+    file_id: String,
+    plugin_key: String,
+    schema_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PluginFileOwnerValue {
+    version: u32,
+    plugin_key: String,
+    schema_keys: Vec<String>,
+}
+
+impl PluginFileOwner {
+    pub(crate) fn new(
+        file_id: impl Into<String>,
+        plugin_key: impl Into<String>,
+        mut schema_keys: Vec<String>,
+    ) -> Result<Self, LixError> {
+        schema_keys.sort();
+        let owner = Self {
+            file_id: file_id.into(),
+            plugin_key: plugin_key.into(),
+            schema_keys,
+        };
+        owner.validate()?;
+        Ok(owner)
+    }
+
+    pub(crate) fn file_id(&self) -> &str {
+        &self.file_id
+    }
+
+    pub(crate) fn plugin_key(&self) -> &str {
+        &self.plugin_key
+    }
+
+    pub(crate) fn schema_keys(&self) -> &[String] {
+        &self.schema_keys
+    }
+
+    pub(crate) fn from_registry_entry(
+        file_id: impl Into<String>,
+        plugin: &PluginRegistryEntry,
+    ) -> Result<Self, LixError> {
+        Self::new(file_id, plugin.key(), plugin.schema_keys().to_vec())
+    }
+
+    pub(crate) fn to_snapshot(&self) -> Result<JsonValue, LixError> {
+        self.validate()?;
+        Ok(json!({
+            "key": PLUGIN_OWNER_KEY,
+            "value": PluginFileOwnerValue {
+                version: REGISTRY_FORMAT_VERSION,
+                plugin_key: self.plugin_key.clone(),
+                schema_keys: self.schema_keys.clone(),
+            },
+        }))
+    }
+
+    pub(crate) fn from_live_state_row(
+        row: &MaterializedLiveStateRow,
+        branch_id: &str,
+    ) -> Result<Option<Self>, LixError> {
+        let file_id = row.file_id.as_deref().ok_or_else(|| {
+            invalid_registry("plugin owner row is missing its file_id storage identity")
+        })?;
+        validate_live_state_identity(row, PLUGIN_OWNER_KEY, Some(file_id), branch_id)?;
+        if row.deleted || row.snapshot_content.is_none() {
+            return Ok(None);
+        }
+        let snapshot = parse_snapshot_content(row, "plugin owner")?;
+        let value = decode_key_value_snapshot(&snapshot, PLUGIN_OWNER_KEY)?;
+        let owner_value: PluginFileOwnerValue =
+            serde_json::from_value(value.clone()).map_err(|error| {
+                invalid_registry(format!(
+                    "plugin owner payload has an invalid shape: {error}"
+                ))
+            })?;
+        if owner_value.version != REGISTRY_FORMAT_VERSION {
+            return Err(invalid_registry(format!(
+                "plugin owner version {} is unsupported; expected {REGISTRY_FORMAT_VERSION}",
+                owner_value.version
+            )));
+        }
+        Ok(Some(Self::new(
+            file_id,
+            owner_value.plugin_key,
+            owner_value.schema_keys,
+        )?))
+    }
+
+    pub(crate) fn write_row(&self, branch_id: &str) -> Result<TransactionWriteRow, LixError> {
+        tracked_key_value_write_row(
+            PLUGIN_OWNER_KEY,
+            Some(self.file_id.clone()),
+            Some(self.to_snapshot()?),
+            branch_id,
+        )
+    }
+
+    pub(crate) fn delete_row(
+        file_id: impl Into<String>,
+        branch_id: &str,
+    ) -> Result<TransactionWriteRow, LixError> {
+        let file_id = file_id.into();
+        if file_id.is_empty() {
+            return Err(invalid_registry("plugin owner file_id must not be empty"));
+        }
+        tracked_key_value_write_row(PLUGIN_OWNER_KEY, Some(file_id), None, branch_id)
+    }
+
+    fn validate(&self) -> Result<(), LixError> {
+        if self.file_id.is_empty() {
+            return Err(invalid_registry("plugin owner file_id must not be empty"));
+        }
+        if !valid_plugin_key(&self.plugin_key) {
+            return Err(invalid_registry(format!(
+                "plugin owner key '{}' is invalid",
+                self.plugin_key
+            )));
+        }
+        if self.schema_keys.is_empty() {
+            return Err(invalid_registry(format!(
+                "plugin owner for file '{}' must retain at least one schema key",
+                self.file_id
+            )));
+        }
+        if self.schema_keys.windows(2).any(|keys| keys[0] >= keys[1])
+            || self.schema_keys.iter().any(String::is_empty)
+        {
+            return Err(invalid_registry(format!(
+                "plugin owner for file '{}' schema_keys must be non-empty, unique, and lexicographically sorted",
+                self.file_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// One compiled multi-pattern matcher for a registry generation.
+#[derive(Debug)]
+pub(crate) struct CompiledPluginCatalog {
+    generation: String,
+    plugins: Arc<[PluginRegistryEntry]>,
+    globs: GlobSet,
+    specificity: Vec<(u8, i32)>,
+}
+
+impl CompiledPluginCatalog {
+    pub(crate) fn compile(registry: &PluginRegistry) -> Result<Self, LixError> {
+        registry.validate()?;
+        let mut builder = GlobSetBuilder::new();
+        let mut specificity = Vec::with_capacity(registry.plugins.len());
+        for plugin in &registry.plugins {
+            let glob = GlobBuilder::new(&plugin.path_glob)
+                .literal_separator(false)
+                .build()
+                .map_err(|error| {
+                    invalid_registry(format!(
+                        "plugin '{}' has invalid path_glob '{}': {error}",
+                        plugin.key, plugin.path_glob
+                    ))
+                })?;
+            builder.add(glob);
+            specificity.push(glob_specificity_rank(&plugin.path_glob));
+        }
+        let globs = builder.build().map_err(|error| {
+            invalid_registry(format!("failed to compile plugin matcher catalog: {error}"))
+        })?;
+        Ok(Self {
+            generation: registry.generation.clone(),
+            plugins: registry.plugins.clone().into(),
+            globs,
+            specificity,
+        })
+    }
+
+    pub(crate) fn generation(&self) -> &str {
+        &self.generation
+    }
+
+    pub(crate) fn plugin_count(&self) -> usize {
+        self.plugins.len()
+    }
+
+    /// Returns whether the named plugin's already-compiled glob matches the
+    /// path, independent of whether another, more-specific plugin would win
+    /// fresh-file selection.
+    ///
+    /// That distinction lets a durable file owner keep rendering under
+    /// overlapping globs without recompiling an individual matcher.
+    pub(crate) fn matches_plugin(&self, plugin_key: &str, path: &str) -> bool {
+        if path.is_empty() {
+            return false;
+        }
+        let Ok(plugin_index) = self
+            .plugins
+            .binary_search_by(|plugin| plugin.key.as_str().cmp(plugin_key))
+        else {
+            return false;
+        };
+        self.globs.matches(path).contains(&plugin_index)
+    }
+
+    /// Select the most specific glob. Equal-specificity matches resolve by
+    /// lexicographically smallest plugin key because registry entries are
+    /// canonicalized by key and matching indices are ascending.
+    pub(crate) fn select(&self, path: &str) -> Option<&PluginRegistryEntry> {
+        if path.is_empty() {
+            return None;
+        }
+        let matches = self.globs.matches(path);
+        let mut selected = None;
+        let mut selected_rank = None;
+        for index in matches {
+            let rank = self.specificity[index];
+            if selected_rank.is_none_or(|current| rank > current) {
+                selected = Some(index);
+                selected_rank = Some(rank);
+            }
+        }
+        selected.map(|index| &self.plugins[index])
+    }
+}
+
+/// Small generation-keyed LRU. It is deliberately owned by an engine
+/// context rather than process-global state, and its capacity is hard-bounded.
+#[derive(Debug)]
+pub(crate) struct PluginCatalogCache {
+    catalogs: LruCache<String, Arc<CompiledPluginCatalog>>,
+}
+
+impl Default for PluginCatalogCache {
+    fn default() -> Self {
+        Self::new(DEFAULT_CACHED_PLUGIN_CATALOGS)
+    }
+}
+
+impl PluginCatalogCache {
+    pub(crate) fn new(requested_capacity: usize) -> Self {
+        let capacity = requested_capacity.clamp(1, MAX_CACHED_PLUGIN_CATALOGS);
+        Self {
+            catalogs: LruCache::new(
+                NonZeroUsize::new(capacity).expect("clamped plugin catalog capacity is non-zero"),
+            ),
+        }
+    }
+
+    pub(crate) fn get_or_compile(
+        &mut self,
+        registry: &PluginRegistry,
+    ) -> Result<Arc<CompiledPluginCatalog>, LixError> {
+        if let Some(catalog) = self.catalogs.get(registry.generation()) {
+            return Ok(Arc::clone(catalog));
+        }
+        let catalog = Arc::new(CompiledPluginCatalog::compile(registry)?);
+        self.catalogs
+            .put(registry.generation().to_string(), Arc::clone(&catalog));
+        Ok(catalog)
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.catalogs.len()
+    }
+}
+
+fn validate_entry(entry: &PluginRegistryEntry) -> Result<(), LixError> {
+    if !valid_plugin_key(&entry.key) {
+        return Err(invalid_registry(format!(
+            "plugin key '{}' is invalid",
+            entry.key
+        )));
+    }
+    if entry.archive_file_id != plugin_storage_archive_file_id(&entry.key) {
+        return Err(invalid_registry(format!(
+            "plugin '{}' archive_file_id '{}' is not canonical",
+            entry.key, entry.archive_file_id
+        )));
+    }
+    if entry.archive_path != plugin_storage_archive_path(&entry.key) {
+        return Err(invalid_registry(format!(
+            "plugin '{}' archive_path '{}' is not canonical",
+            entry.key, entry.archive_path
+        )));
+    }
+    validate_blob_hash(&entry.archive_blob_hash, "archive_blob_hash", &entry.key)?;
+    validate_blob_hash(&entry.wasm_blob_hash, "wasm_blob_hash", &entry.key)?;
+    if entry.schema_keys.is_empty() {
+        return Err(invalid_registry(format!(
+            "plugin '{}' must own at least one schema",
+            entry.key
+        )));
+    }
+    if entry.schema_keys.windows(2).any(|keys| keys[0] >= keys[1]) {
+        return Err(invalid_registry(format!(
+            "plugin '{}' schema_keys must be unique and lexicographically sorted",
+            entry.key
+        )));
+    }
+    if entry.schema_keys.iter().any(String::is_empty) {
+        return Err(invalid_registry(format!(
+            "plugin '{}' has an empty schema key",
+            entry.key
+        )));
+    }
+
+    let manifest: PluginManifest = serde_json::from_str(&entry.manifest_json).map_err(|error| {
+        invalid_registry(format!(
+            "plugin '{}' manifest_json has an invalid shape: {error}",
+            entry.key
+        ))
+    })?;
+    if manifest.file_match.content_type.is_some() {
+        return Err(invalid_registry(format!(
+            "plugin '{}' uses content_type matching, which registry v1 does not support",
+            entry.key
+        )));
+    }
+    if manifest.key != entry.key
+        || manifest.runtime != entry.runtime
+        || manifest.api_version != entry.api_version
+        || manifest.file_match.path_glob != entry.path_glob
+        || manifest.entry != entry.entry
+    {
+        return Err(invalid_registry(format!(
+            "plugin '{}' registry metadata does not match manifest_json",
+            entry.key
+        )));
+    }
+    let canonical_manifest = canonicalize_json_text(
+        &entry.manifest_json,
+        &format!("plugin '{}' manifest_json", entry.key),
+    )?;
+    if canonical_manifest != entry.manifest_json {
+        return Err(invalid_registry(format!(
+            "plugin '{}' manifest_json is not canonical",
+            entry.key
+        )));
+    }
+    Ok(())
+}
+
+fn validate_strictly_increasing_plugin_keys(
+    plugins: &[PluginRegistryEntry],
+) -> Result<(), LixError> {
+    if plugins
+        .windows(2)
+        .any(|plugins| plugins[0].key >= plugins[1].key)
+    {
+        return Err(invalid_registry(
+            "plugin entries must have unique, lexicographically sorted keys",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_blob_hash(hash: &str, field: &str, plugin_key: &str) -> Result<(), LixError> {
+    if hash.len() != 64
+        || !hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(invalid_registry(format!(
+            "plugin '{plugin_key}' {field} must be a 64-character lowercase hex hash"
+        )));
+    }
+    Ok(())
+}
+
+fn valid_plugin_key(plugin_key: &str) -> bool {
+    if plugin_key.is_empty() || plugin_key.len() > 128 {
+        return false;
+    }
+    let mut bytes = plugin_key.bytes();
+    matches!(bytes.next(), Some(b'a'..=b'z'))
+        && bytes.all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'_' | b'-'))
+}
+
+fn calculate_generation(plugins: &[PluginRegistryEntry]) -> Result<String, LixError> {
+    let payload = serde_json::to_value(PluginRegistryGenerationPayload {
+        version: REGISTRY_FORMAT_VERSION,
+        plugins,
+    })
+    .map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to serialize plugin registry generation payload: {error}"),
+        )
+    })?;
+    Ok(blake3::hash(canonical_json(&payload).as_bytes())
+        .to_hex()
+        .to_string())
+}
+
+fn canonicalize_json_text(raw: &str, context: &str) -> Result<String, LixError> {
+    let value: JsonValue = serde_json::from_str(raw)
+        .map_err(|error| invalid_registry(format!("{context} must be valid JSON: {error}")))?;
+    Ok(canonical_json(&value))
+}
+
+fn canonical_json(value: &JsonValue) -> String {
+    match value {
+        JsonValue::Null => "null".to_string(),
+        JsonValue::Bool(value) => value.to_string(),
+        JsonValue::Number(value) => value.to_string(),
+        JsonValue::String(value) => {
+            serde_json::to_string(value).expect("serializing a JSON string cannot fail")
+        }
+        JsonValue::Array(values) => {
+            let mut out = String::from("[");
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                out.push_str(&canonical_json(value));
+            }
+            out.push(']');
+            out
+        }
+        JsonValue::Object(values) => {
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            let mut out = String::from("{");
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                out.push_str(
+                    &serde_json::to_string(key).expect("serializing a JSON key cannot fail"),
+                );
+                out.push(':');
+                out.push_str(&canonical_json(&values[key]));
+            }
+            out.push('}');
+            out
+        }
+    }
+}
+
+fn decode_key_value_snapshot<'a>(
+    snapshot: &'a JsonValue,
+    expected_key: &str,
+) -> Result<&'a JsonValue, LixError> {
+    let object = snapshot.as_object().ok_or_else(|| {
+        invalid_registry(format!(
+            "reserved lix_key_value '{expected_key}' snapshot must be an object"
+        ))
+    })?;
+    if object.len() != 2 {
+        return Err(invalid_registry(format!(
+            "reserved lix_key_value '{expected_key}' snapshot must contain only key and value"
+        )));
+    }
+    if object.get("key").and_then(JsonValue::as_str) != Some(expected_key) {
+        return Err(invalid_registry(format!(
+            "reserved lix_key_value snapshot key must be '{expected_key}'"
+        )));
+    }
+    object.get("value").ok_or_else(|| {
+        invalid_registry(format!(
+            "reserved lix_key_value '{expected_key}' snapshot is missing value"
+        ))
+    })
+}
+
+fn tracked_key_value_write_row(
+    key: &str,
+    file_id: Option<String>,
+    snapshot: Option<JsonValue>,
+    branch_id: &str,
+) -> Result<TransactionWriteRow, LixError> {
+    validate_branch_local_scope(branch_id)?;
+    let snapshot = snapshot
+        .map(|snapshot| TransactionJson::from_value(snapshot, "plugin registry key-value row"))
+        .transpose()?;
+    Ok(TransactionWriteRow {
+        entity_pk: Some(EntityPk::single(key)),
+        schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
+        file_id,
+        snapshot,
+        metadata: None,
+        origin: None,
+        created_at: None,
+        updated_at: None,
+        global: false,
+        change_id: None,
+        commit_id: None,
+        untracked: false,
+        branch_id: branch_id.to_string(),
+    })
+}
+
+fn validate_live_state_identity(
+    row: &MaterializedLiveStateRow,
+    key: &str,
+    expected_file_id: Option<&str>,
+    branch_id: &str,
+) -> Result<(), LixError> {
+    validate_branch_local_scope(branch_id)?;
+    if row.schema_key != KEY_VALUE_SCHEMA_KEY
+        || row.entity_pk.as_single_string().ok() != Some(key)
+        || row.file_id.as_deref() != expected_file_id
+        || row.global
+        || row.untracked
+        || row.branch_id != branch_id
+    {
+        return Err(invalid_registry(format!(
+            "reserved plugin row '{key}' has invalid tracked branch-local storage identity"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_branch_local_scope(branch_id: &str) -> Result<(), LixError> {
+    if branch_id.is_empty() || branch_id == GLOBAL_BRANCH_ID {
+        return Err(invalid_registry(
+            "plugin registry rows require a non-empty, non-global branch id",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_snapshot_content(
+    row: &MaterializedLiveStateRow,
+    kind: &str,
+) -> Result<JsonValue, LixError> {
+    let raw = row.snapshot_content.as_deref().ok_or_else(|| {
+        invalid_registry(format!("{kind} live-state row is missing snapshot_content"))
+    })?;
+    serde_json::from_str(raw)
+        .map_err(|error| invalid_registry(format!("{kind} snapshot is invalid JSON: {error}")))
+}
+
+fn glob_specificity_rank(glob: &str) -> (u8, i32) {
+    if matches!(glob, "*" | "**/*" | "**") {
+        return (0, i32::MIN);
+    }
+    let mut literal_chars = 0i32;
+    let mut wildcard_chars = 0i32;
+    for ch in glob.chars() {
+        match ch {
+            '*' | '?' | '[' | ']' | '{' | '}' => wildcard_chars += 1,
+            _ => literal_chars += 1,
+        }
+    }
+    (1, literal_chars - wildcard_chars)
+}
+
+fn invalid_registry(message: impl Into<String>) -> LixError {
+    LixError::new(
+        LixError::CODE_INVALID_PLUGIN,
+        format!("Invalid durable plugin registry: {}", message.into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::{Value as JsonValue, json};
+
+    use super::*;
+
+    fn hash(byte: char) -> String {
+        std::iter::repeat_n(byte, 64).collect()
+    }
+
+    fn manifest(key: &str, path_glob: &str) -> String {
+        format!(
+            r#"{{
+                "schemas":["schema/default.json"],
+                "entry":"plugin.wasm",
+                "match":{{"path_glob":{path_glob:?}}},
+                "api_version":"0.1.0",
+                "runtime":"wasm-component-v1",
+                "key":{key:?}
+            }}"#
+        )
+    }
+
+    fn entry(key: &str, path_glob: &str, hash_byte: char) -> PluginRegistryEntry {
+        PluginRegistryEntry::new(PluginRegistryEntryInput {
+            key: key.to_string(),
+            runtime: PluginRuntime::WasmComponentV1,
+            api_version: "0.1.0".to_string(),
+            path_glob: path_glob.to_string(),
+            entry: "plugin.wasm".to_string(),
+            schema_keys: vec![format!("{key}_schema")],
+            manifest_json: manifest(key, path_glob),
+            archive_file_id: plugin_storage_archive_file_id(key),
+            archive_path: plugin_storage_archive_path(key),
+            archive_blob_hash: hash(hash_byte),
+            wasm_blob_hash: hash(hash_byte),
+        })
+        .expect("test registry entry should be valid")
+    }
+
+    #[test]
+    fn missing_registry_is_empty_without_discovery() {
+        let registry = PluginRegistry::from_optional_value(None).expect("missing row is valid");
+        assert!(registry.is_empty());
+        assert_eq!(registry.plugin_count(), 0);
+        assert_eq!(registry.generation().len(), 64);
+    }
+
+    #[test]
+    fn canonical_encoding_and_generation_ignore_input_order() {
+        let first = PluginRegistry::new(vec![
+            entry("plugin_b", "*.b", 'b'),
+            entry("plugin_a", "*.a", 'a'),
+        ])
+        .expect("registry should be valid");
+        let second = PluginRegistry::new(vec![
+            entry("plugin_a", "*.a", 'a'),
+            entry("plugin_b", "*.b", 'b'),
+        ])
+        .expect("registry should be valid");
+
+        assert_eq!(first.generation(), second.generation());
+        assert_eq!(
+            first.to_canonical_json().unwrap(),
+            second.to_canonical_json().unwrap()
+        );
+        assert_eq!(first.plugins()[0].key(), "plugin_a");
+
+        let decoded = PluginRegistry::from_optional_snapshot(Some(&first.to_snapshot().unwrap()))
+            .expect("canonical snapshot should decode");
+        assert_eq!(decoded, first);
+    }
+
+    #[test]
+    fn upsert_and_remove_change_generation_deterministically() {
+        let empty = PluginRegistry::empty();
+        let installed = empty
+            .with_upserted(entry("plugin_a", "*.json", 'a'))
+            .expect("install should be valid");
+        assert_ne!(installed.generation(), empty.generation());
+        assert_eq!(installed.plugin("plugin_a").unwrap().path_glob(), "*.json");
+        let removed = installed
+            .without("plugin_a")
+            .expect("remove should be valid");
+        assert_eq!(removed, empty);
+    }
+
+    #[test]
+    fn rejects_count_generation_order_and_hash_integrity_failures() {
+        let registry = PluginRegistry::new(vec![entry("plugin_a", "*.a", 'a')]).unwrap();
+        let mut value = registry.to_value().unwrap();
+
+        value["plugin_count"] = json!(2);
+        assert_invalid(value.clone(), "plugin_count");
+        value["plugin_count"] = json!(1);
+
+        value["generation"] = json!(hash('f'));
+        assert_invalid(value.clone(), "generation integrity");
+        value["generation"] = json!(registry.generation());
+
+        value["plugins"][0]["archive_blob_hash"] = json!("ABC");
+        assert_invalid(value, "lowercase hex hash");
+
+        let two = PluginRegistry::new(vec![
+            entry("plugin_a", "*.a", 'a'),
+            entry("plugin_b", "*.b", 'b'),
+        ])
+        .unwrap();
+        let mut out_of_order = two.to_value().unwrap();
+        out_of_order["plugins"].as_array_mut().unwrap().swap(0, 1);
+        assert_invalid(out_of_order, "sorted keys");
+    }
+
+    #[test]
+    fn rejects_content_type_in_manifest_or_registry_entry() {
+        let mut input = PluginRegistryEntryInput {
+            key: "plugin_a".to_string(),
+            runtime: PluginRuntime::WasmComponentV1,
+            api_version: "0.1.0".to_string(),
+            path_glob: "*.json".to_string(),
+            entry: "plugin.wasm".to_string(),
+            schema_keys: vec!["plugin_a_schema".to_string()],
+            manifest_json: manifest("plugin_a", "*.json"),
+            archive_file_id: plugin_storage_archive_file_id("plugin_a"),
+            archive_path: plugin_storage_archive_path("plugin_a"),
+            archive_blob_hash: hash('a'),
+            wasm_blob_hash: hash('b'),
+        };
+        input.manifest_json = input.manifest_json.replace(
+            r#""path_glob":"*.json""#,
+            r#""path_glob":"*.json","content_type":"text""#,
+        );
+        let error = PluginRegistryEntry::new(input).expect_err("content_type must be rejected");
+        assert!(error.message.contains("content_type"));
+
+        let registry = PluginRegistry::new(vec![entry("plugin_a", "*.json", 'a')]).unwrap();
+        let mut value = registry.to_value().unwrap();
+        value["plugins"][0]["content_type"] = json!("text");
+        assert_invalid(value, "content_type");
+    }
+
+    #[test]
+    fn owner_rows_share_one_entity_key_and_use_file_id_identity() {
+        let owner = PluginFileOwner::new(
+            "file-a",
+            "plugin_a",
+            vec!["plugin_a_note".to_string(), "plugin_a_meta".to_string()],
+        )
+        .unwrap();
+        let row = owner.write_row("main").unwrap();
+        assert_eq!(
+            row.entity_pk.unwrap().as_single_string().unwrap(),
+            PLUGIN_OWNER_KEY
+        );
+        assert_eq!(row.file_id.as_deref(), Some("file-a"));
+        assert!(!row.global);
+        assert!(!row.untracked);
+        assert_eq!(row.branch_id, "main");
+        assert_eq!(row.snapshot.unwrap().value()["key"], PLUGIN_OWNER_KEY);
+        assert_eq!(owner.schema_keys(), ["plugin_a_meta", "plugin_a_note"]);
+
+        let registry_row = PluginRegistry::empty().write_row("main").unwrap();
+        assert_eq!(registry_row.file_id, None);
+        assert_eq!(
+            registry_row.entity_pk.unwrap().as_single_string().unwrap(),
+            PLUGIN_REGISTRY_KEY
+        );
+    }
+
+    #[test]
+    fn installed_plugin_materialization_verifies_extracted_wasm_hash() {
+        let wasm = b"compiled component".to_vec();
+        let mut input = PluginRegistryEntryInput {
+            key: "plugin_a".to_string(),
+            runtime: PluginRuntime::WasmComponentV1,
+            api_version: "0.1.0".to_string(),
+            path_glob: "*.json".to_string(),
+            entry: "plugin.wasm".to_string(),
+            schema_keys: vec!["plugin_a_schema".to_string()],
+            manifest_json: manifest("plugin_a", "*.json"),
+            archive_file_id: plugin_storage_archive_file_id("plugin_a"),
+            archive_path: plugin_storage_archive_path("plugin_a"),
+            archive_blob_hash: hash('a'),
+            wasm_blob_hash: BlobHash::from_content(&wasm).to_hex(),
+        };
+        let registry_entry = PluginRegistryEntry::new(input.clone()).unwrap();
+        let installed = registry_entry
+            .to_installed_plugin(wasm.clone())
+            .expect("matching extracted WASM should materialize");
+        assert_eq!(installed.key, "plugin_a");
+        assert_eq!(installed.wasm_hash, BlobHash::from_content(&wasm));
+        assert_eq!(installed.wasm, wasm);
+
+        input.wasm_blob_hash = hash('b');
+        let registry_entry = PluginRegistryEntry::new(input).unwrap();
+        let error = registry_entry
+            .to_installed_plugin(b"compiled component".to_vec())
+            .expect_err("mismatched extracted WASM must fail integrity validation");
+        assert!(error.message.contains("WASM bytes hash"));
+    }
+
+    #[test]
+    fn compiled_catalog_is_deterministic_and_lru_is_bounded() {
+        let registry = PluginRegistry::new(vec![
+            entry("plugin_z", "*.json", 'a'),
+            entry("plugin_a", "*.json", 'b'),
+            entry("plugin_specific", "src/*.json", 'c'),
+            entry("plugin_all", "**/*", 'd'),
+        ])
+        .unwrap();
+        let catalog = CompiledPluginCatalog::compile(&registry).unwrap();
+        assert_eq!(
+            catalog.select("src/data.json").unwrap().key(),
+            "plugin_specific"
+        );
+        assert_eq!(catalog.select("data.json").unwrap().key(), "plugin_a");
+        assert_eq!(catalog.select("data.txt").unwrap().key(), "plugin_all");
+        assert!(catalog.select("").is_none());
+        assert!(catalog.matches_plugin("plugin_specific", "src/data.json"));
+        assert!(catalog.matches_plugin("plugin_a", "src/data.json"));
+        assert!(catalog.matches_plugin("plugin_z", "src/data.json"));
+        assert!(catalog.matches_plugin("plugin_all", "src/data.json"));
+        assert!(!catalog.matches_plugin("plugin_specific", "data.json"));
+        assert!(!catalog.matches_plugin("missing", "src/data.json"));
+        assert!(!catalog.matches_plugin("plugin_all", ""));
+
+        let mut cache = PluginCatalogCache::new(2);
+        let first = cache.get_or_compile(&registry).unwrap();
+        let hit = cache.get_or_compile(&registry).unwrap();
+        assert!(Arc::ptr_eq(&first, &hit));
+        for index in 0..3 {
+            let next = PluginRegistry::new(vec![entry(
+                &format!("plugin_{index}"),
+                &format!("*.{index}"),
+                char::from_digit(index + 1, 16).unwrap(),
+            )])
+            .unwrap();
+            cache.get_or_compile(&next).unwrap();
+        }
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn complete_snapshot_wrapper_is_strict() {
+        let registry = PluginRegistry::empty();
+        let mut wrong_key = registry.to_snapshot().unwrap();
+        wrong_key["key"] = json!("not_the_registry");
+        let error = PluginRegistry::from_optional_snapshot(Some(&wrong_key)).unwrap_err();
+        assert!(error.message.contains("snapshot key"));
+
+        let extra = json!({
+            "key": PLUGIN_REGISTRY_KEY,
+            "value": registry.to_value().unwrap(),
+            "extra": true,
+        });
+        let error = PluginRegistry::from_optional_snapshot(Some(&extra)).unwrap_err();
+        assert!(error.message.contains("only key and value"));
+    }
+
+    fn assert_invalid(value: JsonValue, expected: &str) {
+        let error = PluginRegistry::from_optional_value(Some(&value))
+            .expect_err("registry value should be rejected");
+        assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
+        assert!(
+            error.message.contains(expected),
+            "expected {expected:?} in {}",
+            error.message
+        );
+    }
+}

--- a/packages/engine/src/plugin/storage.rs
+++ b/packages/engine/src/plugin/storage.rs
@@ -3,9 +3,10 @@ use crate::LixError;
 pub const PLUGIN_STORAGE_ROOT_DIRECTORY_PATH: &str = "/.lix/plugins/";
 const PLUGIN_STORAGE_ROOT_PATH: &str = "/.lix/plugins";
 pub const PLUGIN_ARCHIVE_FILE_EXTENSION: &str = ".lixplugin";
+const PLUGIN_ARCHIVE_FILE_ID_PREFIX: &str = "lix_plugin_archive::";
 
 pub fn plugin_storage_archive_file_id(plugin_key: &str) -> String {
-    format!("lix_plugin_archive::{plugin_key}")
+    format!("{PLUGIN_ARCHIVE_FILE_ID_PREFIX}{plugin_key}")
 }
 
 pub fn plugin_storage_archive_path(plugin_key: &str) -> String {
@@ -15,6 +16,19 @@ pub fn plugin_storage_archive_path(plugin_key: &str) -> String {
 pub fn plugin_key_from_archive_path(path: &str) -> Option<String> {
     let file_name = path.strip_prefix(PLUGIN_STORAGE_ROOT_DIRECTORY_PATH)?;
     let plugin_key = file_name.strip_suffix(PLUGIN_ARCHIVE_FILE_EXTENSION)?;
+    if !is_valid_plugin_key(plugin_key) {
+        return None;
+    }
+    Some(plugin_key.to_string())
+}
+
+/// Extracts the plugin key from its canonical deterministic archive file ID.
+///
+/// This is deliberately stricter than accepting an arbitrary descriptor ID:
+/// lifecycle code can use it to distinguish plugin install/update/delete
+/// operations without consulting the visible filesystem.
+pub fn plugin_key_from_archive_file_id(file_id: &str) -> Option<String> {
+    let plugin_key = file_id.strip_prefix(PLUGIN_ARCHIVE_FILE_ID_PREFIX)?;
     if !is_valid_plugin_key(plugin_key) {
         return None;
     }
@@ -53,7 +67,8 @@ mod tests {
     use crate::LixError;
 
     use super::{
-        plugin_key_from_archive_path, plugin_storage_archive_path,
+        plugin_key_from_archive_file_id, plugin_key_from_archive_path,
+        plugin_storage_archive_file_id, plugin_storage_archive_path,
         reject_normal_plugin_storage_mutation,
     };
 
@@ -78,6 +93,27 @@ mod tests {
             "/.lix/plugins/.lixplugin",
         ] {
             assert_eq!(plugin_key_from_archive_path(path), None);
+        }
+    }
+
+    #[test]
+    fn archive_file_id_round_trips_only_canonical_plugin_keys() {
+        for key in ["plugin_json", "a", "plugin-2"] {
+            let file_id = plugin_storage_archive_file_id(key);
+            assert_eq!(
+                plugin_key_from_archive_file_id(&file_id).as_deref(),
+                Some(key)
+            );
+        }
+
+        for file_id in [
+            "lix_plugin_archive::",
+            "lix_plugin_archive::PluginJson",
+            "lix_plugin_archive::plugin/nested",
+            "lix_plugin_archive::plugin_json::suffix",
+            "arbitrary-file-id",
+        ] {
+            assert_eq!(plugin_key_from_archive_file_id(file_id), None);
         }
     }
 

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -27,7 +27,7 @@ use datafusion::logical_expr::{BinaryExpr, Expr, Operator, TableProviderFilterPu
 use datafusion::physical_expr::{PhysicalExpr, create_physical_expr};
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
 use datafusion::prelude::SessionContext;
-use futures_util::FutureExt;
+use futures_util::{FutureExt, future::try_join_all};
 use serde::Deserialize;
 
 use crate::binary_cas::{BlobDataReader, BlobHash};
@@ -41,15 +41,15 @@ use crate::filesystem::{
 };
 use crate::functions::FunctionProviderHandle;
 use crate::live_state::{
-    LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection, LiveStateReader,
-    LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateScanRequest,
+    MaterializedLiveStateRow,
 };
 use crate::plugin::{
-    InstalledPlugin, PluginRuntimeHost, is_plugin_storage_path,
-    load_installed_plugins_from_filesystem, plugin_key_from_archive_path,
+    CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginFileOwner, PluginRegistry,
+    PluginRegistryEntry, PluginRuntimeHost, is_plugin_storage_path,
+    plugin_key_from_archive_file_id, plugin_key_from_archive_path,
     plugin_state_live_state_projection, plugin_storage_archive_file_id,
-    reject_normal_plugin_storage_mutation, render_materialized_plugin_file,
-    retain_plugin_state_rows, select_plugin_for_path,
+    render_plugin_state_with_component_instance,
 };
 use crate::sql2::branch_scope::{
     BranchBinding, explicit_branch_ids_from_dml_filters, resolve_provider_branch_ids,
@@ -64,6 +64,7 @@ use crate::sql2::write_normalization::{
     lix_file_data_type_error, lix_file_data_type_error_with_value, scalar_is_binary_or_null,
 };
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
+use crate::wasm::WasmComponentInstance;
 use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value, serialize_row_metadata};
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
@@ -330,6 +331,7 @@ impl LixFileSpec {
         target_file_ids: FileIdConstraint,
         indexed_matches: Option<FilesystemPathSelection>,
         needs_data: bool,
+        needs_plugin_ownership: bool,
         capture_path_resolver_rows: bool,
         captured: SharedLixFileDmlSourceState,
     ) -> RowSource {
@@ -343,6 +345,7 @@ impl LixFileSpec {
                 target_file_ids,
                 indexed_matches,
                 needs_data,
+                needs_plugin_ownership,
                 capture_path_resolver_rows,
                 captured,
             ),
@@ -355,6 +358,7 @@ impl LixFileSpec {
                 target_file_ids,
                 indexed_matches,
                 needs_data,
+                needs_plugin_ownership,
                 capture_path_resolver_rows,
                 captured,
             )| async move {
@@ -385,13 +389,15 @@ impl LixFileSpec {
                     )
                 };
                 let prepared = prepared.map_err(lix_error_to_datafusion_error)?;
-                let plugin_render = if prepared.needs_plugin_render(needs_data) {
+                let plugin_render = if prepared.needs_plugin_render(needs_data)
+                    || (needs_plugin_ownership && !prepared.file_rows.is_empty())
+                {
                     plugin_render_context_for_lix_file_scan(
                         live_state,
-                        &blob_reader,
                         &request,
                         plugin_host,
-                        needs_data,
+                        &prepared,
+                        needs_plugin_ownership,
                     )
                     .await
                     .map_err(|error| {
@@ -689,10 +695,10 @@ impl TableSpec for LixFileSpec {
                     let plugin_render = if prepared.needs_plugin_render(needs_data) {
                         plugin_render_context_for_lix_file_scan(
                             Arc::clone(&live_state),
-                            &blob_reader,
                             &request,
                             plugin_host,
-                            true,
+                            &prepared,
+                            false,
                         )
                         .await
                         .map_err(|error| {
@@ -773,6 +779,8 @@ impl TableSpec for LixFileSpec {
         filters: &[Expr],
         options: DmlPlanOptions,
     ) -> Result<PlannedDml> {
+        let plugin_archive_delete_target =
+            exact_plugin_archive_delete_target_from_filters(filters)?;
         let needs_data = filters.iter().any(|filter| contains_column(filter, "data"))
             || options.returning_columns.contains("data");
         let target_file_ids = file_id_constraint_from_filters(filters)?;
@@ -795,6 +803,7 @@ impl TableSpec for LixFileSpec {
             indexed_matches,
             needs_data,
             false,
+            false,
             Arc::clone(&captured),
         );
         let branch_binding = self.branch_binding.clone();
@@ -802,12 +811,14 @@ impl TableSpec for LixFileSpec {
             let write_ctx = write_ctx.clone();
             let branch_binding = branch_binding.clone();
             let captured = Arc::clone(&captured);
+            let plugin_archive_delete_target = plugin_archive_delete_target.clone();
             async move {
                 let source_state = lix_file_dml_source_state(&captured, "DELETE")?;
                 let staged = lix_file_delete_stage_from_batch(
                     &matched_batch,
                     branch_binding.active_branch_id(),
                     &source_state.blob_ref_keys,
+                    plugin_archive_delete_target.as_deref(),
                 )?;
                 let count = staged.count;
 
@@ -863,6 +874,7 @@ impl TableSpec for LixFileSpec {
             target_file_ids,
             indexed_matches,
             needs_data,
+            update_columns.updates_path() && !update_columns.data,
             capture_path_resolver_rows,
             Arc::clone(&captured),
         );
@@ -1107,10 +1119,10 @@ impl UpsertSupport for LixFileSpec {
         let plugin_render = if prepared.needs_plugin_render(true) {
             plugin_render_context_for_lix_file_scan(
                 live_state,
-                &self.blob_reader,
                 &request,
                 self.plugin_host.clone(),
-                true,
+                &prepared,
+                false,
             )
             .await
             .map_err(|error| {
@@ -1189,7 +1201,8 @@ impl UpsertSupport for LixFileSpec {
         .await
         .map_err(lix_error_to_datafusion_error)?;
 
-        let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
+        let live_state: Arc<dyn LiveStateReader> =
+            Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
         let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
             .await
             .map_err(lix_error_to_datafusion_error)?;
@@ -1197,19 +1210,31 @@ impl UpsertSupport for LixFileSpec {
             blob_ref_keys_from_live_rows(&rows).map_err(lix_error_to_datafusion_error)?;
 
         let plugin_rewrite_file_ids = if update_columns.updates_path() && !update_columns.data {
-            let plugin_render = plugin_render_context_for_lix_file_scan(
-                live_state.clone(),
-                &self.blob_reader,
-                &request,
-                self.plugin_host.clone(),
-                true,
-            )
-            .await
-            .map_err(|error| {
-                DataFusionError::Execution(format!(
-                    "sql2 lix_file plugin discovery failed: {error}"
-                ))
-            })?;
+            let plugin_host = self.plugin_host.clone();
+            let branches =
+                load_plugin_render_branches(Arc::clone(&live_state), &request, &plugin_host)
+                    .await
+                    .map_err(|error| {
+                        DataFusionError::Execution(format!(
+                            "sql2 lix_file plugin discovery failed: {error}"
+                        ))
+                    })?;
+            let plugin_render = if branches.is_empty() {
+                None
+            } else {
+                plugin_render_context_with_branches(
+                    live_state.clone(),
+                    plugin_host,
+                    branches,
+                    plugin_owner_candidates_from_batch(augmented, branch_binding)?,
+                )
+                .await
+                .map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "sql2 lix_file plugin discovery failed: {error}"
+                    ))
+                })?
+            };
             path_update_plugin_rewrite_file_ids(
                 plugin_render.as_ref(),
                 augmented,
@@ -1495,15 +1520,23 @@ impl FileDescriptorRecord {
 struct PluginRenderContext {
     live_state: Arc<dyn LiveStateReader>,
     host: PluginRuntimeHost,
-    installed_plugins_by_branch: BTreeMap<String, Vec<InstalledPlugin>>,
+    branches: BTreeMap<String, BranchPluginRenderContext>,
+    owners_by_file: BTreeMap<FilesystemDescriptorKey, PluginFileOwner>,
+}
+
+#[derive(Clone)]
+struct BranchPluginRenderContext {
+    registry: PluginRegistry,
+    catalog: Arc<CompiledPluginCatalog>,
 }
 
 impl PluginRenderContext {
-    fn installed_plugins_for_branch(&self, branch_id: &str) -> &[InstalledPlugin] {
-        self.installed_plugins_by_branch
-            .get(branch_id)
-            .map(Vec::as_slice)
-            .unwrap_or(&[])
+    fn branch(&self, branch_id: &str) -> Option<&BranchPluginRenderContext> {
+        self.branches.get(branch_id)
+    }
+
+    fn owner_for_file(&self, key: &FilesystemDescriptorKey) -> Option<&PluginFileOwner> {
+        self.owners_by_file.get(key)
     }
 }
 
@@ -1803,7 +1836,7 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
             &mut staged,
             existing.id,
             Some(path),
-            None,
+            Some(existing.name),
             data.clone(),
             context,
             has_blob_ref,
@@ -1891,13 +1924,13 @@ fn lix_file_delete_stage_from_batch(
     batch: &RecordBatch,
     branch_binding: Option<&str>,
     blob_ref_keys: &BTreeSet<FilesystemBlobRefKey>,
+    plugin_archive_delete_target: Option<&str>,
 ) -> Result<LixFileStagedBatch> {
     let mut staged = LixFileStagedBatch::default();
     for row_index in 0..batch.num_rows() {
-        if let Some(path) = optional_string_value(batch, row_index, "path")? {
-            parse_normal_write_file_path(&path, TransactionWriteOperation::Delete)?;
-        }
         let file_id = required_string_value(batch, row_index, "id")?;
+        let path = optional_string_value(batch, row_index, "path")?;
+        validate_lix_file_delete_target(path.as_deref(), &file_id, plugin_archive_delete_target)?;
         let context = file_row_context_from_batch(batch, row_index, branch_binding)?;
         staged
             .extend_filesystem_delete_plan(plan_file_delete(FileDeleteInput {
@@ -1909,6 +1942,52 @@ fn lix_file_delete_stage_from_batch(
             .map_err(lix_error_to_datafusion_error)?;
     }
     Ok(staged)
+}
+
+fn validate_lix_file_delete_target(
+    path: Option<&str>,
+    file_id: &str,
+    plugin_archive_delete_target: Option<&str>,
+) -> Result<()> {
+    let archive_id_plugin_key = plugin_key_from_archive_file_id(file_id);
+    let Some(path) = path else {
+        if archive_id_plugin_key.is_some() {
+            return Err(rejected_plugin_archive_delete_error(None, file_id));
+        }
+        return Ok(());
+    };
+    LixPath::try_from_file_path(path).map_err(lix_error_to_datafusion_error)?;
+    let archive_path_plugin_key = plugin_key_from_archive_path(path);
+    if !is_plugin_storage_path(path) && archive_id_plugin_key.is_none() {
+        return Ok(());
+    }
+
+    match (
+        archive_path_plugin_key.as_deref(),
+        archive_id_plugin_key.as_deref(),
+        plugin_archive_delete_target,
+    ) {
+        (Some(path_key), Some(id_key), Some(target_key))
+            if path_key == id_key && id_key == target_key =>
+        {
+            Ok(())
+        }
+        _ => Err(rejected_plugin_archive_delete_error(Some(path), file_id)),
+    }
+}
+
+fn rejected_plugin_archive_delete_error(path: Option<&str>, file_id: &str) -> DataFusionError {
+    lix_error_to_datafusion_error(
+        LixError::new(
+            LixError::CODE_CONSTRAINT_VIOLATION,
+            format!(
+                "DELETE FROM lix_file may only uninstall one exact canonical plugin archive; got path {path:?} and file id {file_id:?}"
+            ),
+        )
+        .with_hint(
+            "Delete one canonical /.lix/plugins/<key>.lixplugin path or its deterministic archive file ID.",
+        ),
+    )
 }
 
 fn blob_ref_keys_from_live_rows(
@@ -2034,6 +2113,13 @@ fn lix_file_existing_update_stage_from_batch(
 
         if include_data_writes {
             let data = update_required_binary_value(batch, assignment_values, row_index, "data")?;
+            let data_filename = match data_filename {
+                Some(filename) => Some(filename),
+                None if batch.schema().index_of("name").is_ok() => {
+                    optional_string_value(batch, row_index, "name")?
+                }
+                None => None,
+            };
             let path = if include_descriptor_writes {
                 match data_path {
                     Some(path) => Some(path),
@@ -2331,14 +2417,14 @@ fn path_update_plugin_rewrite_file_ids(
 
         let context =
             file_row_context_from_update(batch, assignment_values, row_index, branch_binding)?;
-        let plugins = plugin_render.installed_plugins_for_branch(&context.branch_id);
-        if plugins.is_empty() {
-            continue;
-        }
-        let existing_plugin = select_plugin_for_path(plugins, &existing_path);
-        let assigned_plugin = select_plugin_for_path(plugins, &assigned_path);
-        let existing_plugin_key = existing_plugin.map(|plugin| plugin.key.as_str());
-        let assigned_plugin_key = assigned_plugin.map(|plugin| plugin.key.as_str());
+        let file_key = FilesystemDescriptorKey::from_context(&context, &file_id);
+        let existing_plugin_key = plugin_render
+            .owner_for_file(&file_key)
+            .map(PluginFileOwner::plugin_key);
+        let assigned_plugin_key = plugin_render
+            .branch(&context.branch_id)
+            .and_then(|branch| branch.catalog.select(&assigned_path))
+            .map(PluginRegistryEntry::key);
         if existing_plugin_key != assigned_plugin_key {
             file_ids.insert(file_id);
         }
@@ -2589,7 +2675,8 @@ fn stage_lix_file_data_update_write(
         context.global,
         context.untracked,
         data,
-    );
+    )
+    .with_had_blob_ref(has_blob_ref);
     if file_payload.is_empty() {
         if has_blob_ref {
             let mut row = blob_ref_tombstone_row(file_id, context.clone());
@@ -2742,11 +2829,46 @@ struct PreparedLixFileRows {
 impl PreparedLixFileRows {
     fn needs_plugin_render(&self, needs_data: bool) -> bool {
         needs_data
-            && self
-                .file_rows
-                .values()
-                .any(|file| !self.blob_rows.contains_key(&file.blob_ref_key()))
+            && self.file_rows.values().any(|file| {
+                plugin_file_can_have_durable_owner(file)
+                    && !self.blob_rows.contains_key(&file.blob_ref_key())
+            })
     }
+
+    fn plugin_owner_candidates(&self, include_blob_backed: bool) -> Vec<FilesystemDescriptorKey> {
+        self.file_rows
+            .values()
+            .filter(|file| {
+                plugin_file_can_have_durable_owner(file)
+                    && (include_blob_backed || !self.blob_rows.contains_key(&file.blob_ref_key()))
+            })
+            .map(|file| file.key.clone())
+            .collect()
+    }
+}
+
+fn plugin_file_can_have_durable_owner(file: &FileDescriptorRecord) -> bool {
+    plugin_descriptor_key_can_have_durable_owner(&file.key)
+}
+
+fn plugin_descriptor_key_can_have_durable_owner(key: &FilesystemDescriptorKey) -> bool {
+    !key.global() && !key.is_untracked() && key.file_id().is_none()
+}
+
+fn plugin_owner_candidates_from_batch(
+    batch: &RecordBatch,
+    branch_binding: Option<&str>,
+) -> Result<Vec<FilesystemDescriptorKey>> {
+    let mut candidates = Vec::new();
+    for row_index in 0..batch.num_rows() {
+        let file_id = required_string_value(batch, row_index, "id")?;
+        let context = file_row_context_from_batch(batch, row_index, branch_binding)?;
+        let key = FilesystemDescriptorKey::from_context(&context, &file_id);
+        if plugin_descriptor_key_can_have_durable_owner(&key) {
+            candidates.push(key);
+        }
+    }
+    Ok(candidates)
 }
 
 fn prepare_lix_file_rows(
@@ -3215,6 +3337,20 @@ async fn lix_file_record_batch_from_prepared(
 
     let file_keys =
         path_ordered_file_keys.unwrap_or_else(|| file_rows.keys().cloned().collect::<Vec<_>>());
+    let mut rendered_plugin_bytes = match &plugin_render {
+        Some(plugin_render) if needs_data => {
+            render_plugin_files_for_sql(
+                plugin_render,
+                blob_reader,
+                &file_keys,
+                &file_rows,
+                &blob_rows,
+                &file_paths,
+            )
+            .await?
+        }
+        _ => BTreeMap::new(),
+    };
     for key in file_keys {
         let file = file_rows
             .remove(&key)
@@ -3226,15 +3362,7 @@ async fn lix_file_record_batch_from_prepared(
         let data = if needs_data {
             match blob_bytes.take(&blob_key) {
                 Some(data) => data,
-                None => {
-                    let rendered = match &plugin_render {
-                        Some(plugin_render) => {
-                            render_plugin_file_for_sql(plugin_render, &file, &path).await?
-                        }
-                        None => None,
-                    };
-                    Some(rendered.unwrap_or_default())
-                }
+                None => Some(rendered_plugin_bytes.remove(&key).unwrap_or_default()),
             }
         } else {
             Some(Vec::new())
@@ -3336,83 +3464,423 @@ async fn load_blob_bytes_for_files(
     })
 }
 
-async fn render_plugin_file_for_sql(
+async fn render_plugin_files_for_sql(
     plugin_render: &PluginRenderContext,
-    file: &FileDescriptorRecord,
-    path: &str,
-) -> Result<Option<Vec<u8>>, LixError> {
-    let installed_plugins = plugin_render.installed_plugins_for_branch(&file.live.branch_id);
-    let Some(plugin) = select_plugin_for_path(installed_plugins, path) else {
-        return Ok(None);
-    };
-    let rows = plugin_render
-        .live_state
-        .scan_file_rows(&LiveStateFileScanRequest {
-            branch_ids: vec![file.live.branch_id.clone()],
-            file_id: file.id.clone(),
-            schema_keys: plugin.schema_keys.clone(),
-            projection: plugin_state_live_state_projection(),
-            ..Default::default()
-        })
-        .await?;
-    let active_state = retain_plugin_state_rows(plugin, rows);
-    render_materialized_plugin_file(&plugin_render.host, plugin, &active_state).await
-}
-
-async fn load_installed_plugins_for_lix_file_scan(
-    live_state: Arc<dyn LiveStateReader>,
     blob_reader: &Arc<dyn BlobDataReader>,
-    request: &LiveStateScanRequest,
-) -> Result<BTreeMap<String, Vec<InstalledPlugin>>, LixError> {
-    let mut plugin_request = request.clone();
-    plugin_request.filter.schema_keys = vec![
-        FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
-        BLOB_REF_SCHEMA_KEY.to_string(),
-        DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string(),
-    ];
-    plugin_request.filter.entity_pks.clear();
-    plugin_request.filter.file_ids.clear();
-    plugin_request.projection = LiveStateProjection::default();
-    plugin_request.limit = None;
+    file_keys: &[FilesystemDescriptorKey],
+    file_rows: &BTreeMap<FilesystemDescriptorKey, FileDescriptorRecord>,
+    blob_rows: &BTreeMap<FilesystemBlobRefKey, BlobRefRecord>,
+    file_paths: &BTreeMap<FilesystemDescriptorKey, String>,
+) -> Result<BTreeMap<FilesystemDescriptorKey, Vec<u8>>, LixError> {
+    let owned_file_keys = file_keys
+        .iter()
+        .filter(|key| {
+            let file = file_rows
+                .get(*key)
+                .expect("prepared lix_file order should reference a descriptor");
+            let path = file_paths
+                .get(*key)
+                .expect("prepared lix_file descriptor should have a path");
+            let active_owner = plugin_render.owner_for_file(key).is_some_and(|owner| {
+                plugin_render
+                    .branch(key.branch_id())
+                    .is_some_and(|branch| branch.catalog.matches_plugin(owner.plugin_key(), path))
+            });
+            !blob_rows.contains_key(&file.blob_ref_key()) && active_owner
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if owned_file_keys.is_empty() {
+        return Ok(BTreeMap::new());
+    }
 
-    let rows = live_state.scan_rows(&plugin_request).await?;
-    let mut rows_by_branch = BTreeMap::<String, Vec<MaterializedLiveStateRow>>::new();
-    for row in rows {
-        rows_by_branch
-            .entry(row.branch_id.clone())
+    let mut execution_keys = BTreeSet::<(String, String)>::new();
+    for file_key in &owned_file_keys {
+        let owner = plugin_render
+            .owner_for_file(file_key)
+            .expect("owned file key was selected above");
+        execution_keys.insert((
+            file_key.branch_id().to_string(),
+            owner.plugin_key().to_string(),
+        ));
+    }
+
+    let mut component_instances =
+        BTreeMap::<(String, String), Arc<dyn WasmComponentInstance>>::new();
+    let mut cold_entries = BTreeMap::<(String, String), PluginRegistryEntry>::new();
+    for (branch_id, plugin_key) in &execution_keys {
+        let entry = plugin_render
+            .branch(branch_id)
+            .and_then(|branch| branch.registry.get(plugin_key))
+            .ok_or_else(|| invalid_plugin_read_state(format!(
+                "owner references plugin '{plugin_key}' absent from branch '{branch_id}' registry"
+            )))?;
+        let hash = BlobHash::from_hex(entry.wasm_blob_hash())?;
+        let key = (branch_id.clone(), plugin_key.clone());
+        if let Some(instance) = plugin_render
+            .host
+            .cached_plugin_component(entry.key(), hash)?
+        {
+            component_instances.insert(key, instance);
+        } else {
+            cold_entries.insert(key, entry.clone());
+        }
+    }
+
+    let wasm_hash_hexes = cold_entries
+        .values()
+        .map(|entry| entry.wasm_blob_hash().to_string())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let wasm_hashes = wasm_hash_hexes
+        .iter()
+        .map(|hash| BlobHash::from_hex(hash))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let wasm_values = if wasm_hashes.is_empty() {
+        Vec::new()
+    } else {
+        blob_reader.load_bytes_many(&wasm_hashes).await?.into_vec()
+    };
+    if wasm_values.len() != wasm_hashes.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "blob reader returned {} values for {} plugin WASM hashes",
+                wasm_values.len(),
+                wasm_hashes.len()
+            ),
+        ));
+    }
+    let mut wasm_by_hash = BTreeMap::<String, Vec<u8>>::new();
+    for (hash, bytes) in wasm_hash_hexes.into_iter().zip(wasm_values) {
+        let bytes = bytes.ok_or_else(|| {
+            invalid_plugin_read_state(format!(
+                "plugin registry references missing WASM blob '{hash}'"
+            ))
+        })?;
+        wasm_by_hash.insert(hash, bytes);
+    }
+
+    for (key, entry) in cold_entries {
+        let wasm = wasm_by_hash
+            .get(entry.wasm_blob_hash())
+            .expect("distinct plugin WASM hash was loaded")
+            .clone();
+        let plugin = entry.to_installed_plugin(wasm)?;
+        let instance =
+            crate::plugin::load_or_init_plugin_component(&plugin_render.host, &plugin).await?;
+        component_instances.insert(key, instance);
+    }
+
+    let mut file_ids_by_plugin = BTreeMap::<(String, String), BTreeSet<String>>::new();
+    let mut file_key_by_branch_and_id =
+        BTreeMap::<(String, String), FilesystemDescriptorKey>::new();
+    for file_key in &owned_file_keys {
+        let owner = plugin_render
+            .owner_for_file(file_key)
+            .expect("owned file key was selected above");
+        let branch_id = file_key.branch_id().to_string();
+        let file_id = file_key.descriptor_id().to_string();
+        file_ids_by_plugin
+            .entry((branch_id.clone(), owner.plugin_key().to_string()))
             .or_default()
-            .push(row);
+            .insert(file_id.clone());
+        if file_key_by_branch_and_id
+            .insert((branch_id.clone(), file_id.clone()), file_key.clone())
+            .is_some()
+        {
+            return Err(invalid_plugin_read_state(format!(
+                "branch '{branch_id}' has multiple plugin-render candidates for file id '{file_id}'"
+            )));
+        }
     }
 
-    let mut installed_plugins_by_branch = BTreeMap::new();
-    for (branch_id, rows) in rows_by_branch {
-        let filesystem = FilesystemIndex::from_live_rows(rows)?;
-        let installed_plugins =
-            load_installed_plugins_from_filesystem(&filesystem, blob_reader.as_ref()).await?;
-        installed_plugins_by_branch.insert(branch_id, installed_plugins);
+    let state_scans = file_ids_by_plugin
+        .into_iter()
+        .map(|(execution_key, file_ids)| {
+            let live_state = Arc::clone(&plugin_render.live_state);
+            let schema_keys = plugin_render
+                .branch(&execution_key.0)
+                .and_then(|branch| branch.registry.get(&execution_key.1))
+                .expect("registry entry exists for every state group")
+                .schema_keys()
+                .to_vec();
+            async move {
+                let branch_id = execution_key.0.clone();
+                let mut rows = live_state
+                    .scan_tracked_rows(&LiveStateScanRequest {
+                        filter: LiveStateFilter {
+                            schema_keys: schema_keys.clone(),
+                            branch_ids: vec![branch_id.clone()],
+                            file_ids: file_ids
+                                .iter()
+                                .cloned()
+                                .map(crate::NullableKeyFilter::Value)
+                                .collect(),
+                            untracked: Some(false),
+                            ..LiveStateFilter::default()
+                        },
+                        projection: plugin_state_live_state_projection(),
+                        limit: None,
+                    })
+                    .await?;
+                rows.retain(|row| {
+                    row.branch_id == branch_id
+                        && !row.global
+                        && !row.untracked
+                        && row
+                            .file_id
+                            .as_ref()
+                            .is_some_and(|file_id| file_ids.contains(file_id))
+                        && row.snapshot_content.is_some()
+                        && schema_keys.binary_search(&row.schema_key).is_ok()
+                });
+                Ok::<_, LixError>((execution_key, rows))
+            }
+        });
+    let state_groups = try_join_all(state_scans).await?;
+    let mut state_by_file = owned_file_keys
+        .iter()
+        .cloned()
+        .map(|key| (key, Vec::<MaterializedLiveStateRow>::new()))
+        .collect::<BTreeMap<_, _>>();
+    for ((branch_id, _plugin_key), rows) in state_groups {
+        for row in rows {
+            let Some(file_id) = row.file_id.as_deref() else {
+                continue;
+            };
+            let key = file_key_by_branch_and_id
+                .get(&(branch_id.clone(), file_id.to_string()))
+                .ok_or_else(|| {
+                    invalid_plugin_read_state(format!(
+                        "plugin state scan returned unexpected file id '{file_id}' in branch '{branch_id}'"
+                    ))
+                })?;
+            state_by_file
+                .get_mut(key)
+                .expect("owned file state bucket exists")
+                .push(row);
+        }
     }
-    Ok(installed_plugins_by_branch)
+    for rows in state_by_file.values_mut() {
+        rows.sort_by(|left, right| {
+            (&left.schema_key, &left.entity_pk).cmp(&(&right.schema_key, &right.entity_pk))
+        });
+    }
+
+    let mut rendered = BTreeMap::new();
+    for file_key in owned_file_keys {
+        let owner = plugin_render
+            .owner_for_file(&file_key)
+            .expect("owned file key was selected above");
+        let execution_key = (
+            file_key.branch_id().to_string(),
+            owner.plugin_key().to_string(),
+        );
+        let component = component_instances
+            .get(&execution_key)
+            .expect("resolved component exists for owned file");
+        let active_state = state_by_file.remove(&file_key).unwrap_or_default();
+        // The owner row, not the presence of plugin state rows, is the durable
+        // materialization signal. Plugins that intentionally emit zero state
+        // must still receive render([]).
+        let bytes = render_plugin_state_with_component_instance(component, &active_state).await?;
+        rendered.insert(file_key, bytes);
+    }
+    Ok(rendered)
 }
 
 async fn plugin_render_context_for_lix_file_scan(
     live_state: Arc<dyn LiveStateReader>,
-    blob_reader: &Arc<dyn BlobDataReader>,
     request: &LiveStateScanRequest,
     host: PluginRuntimeHost,
-    needs_data: bool,
+    prepared: &PreparedLixFileRows,
+    include_blob_backed_candidates: bool,
 ) -> Result<Option<PluginRenderContext>, LixError> {
-    if !needs_data {
+    let branches = load_plugin_render_branches(Arc::clone(&live_state), request, &host).await?;
+    if branches.is_empty() {
+        return Ok(None);
+    }
+    let mut candidates = prepared.plugin_owner_candidates(include_blob_backed_candidates);
+    if !include_blob_backed_candidates {
+        candidates.retain(|key| {
+            prepared.file_paths.get(key).is_some_and(|path| {
+                branches
+                    .get(key.branch_id())
+                    .and_then(|branch| branch.catalog.select(path))
+                    .is_some()
+            })
+        });
+    }
+    plugin_render_context_with_branches(live_state, host, branches, candidates).await
+}
+
+async fn load_plugin_render_branches(
+    live_state: Arc<dyn LiveStateReader>,
+    request: &LiveStateScanRequest,
+    host: &PluginRuntimeHost,
+) -> Result<BTreeMap<String, BranchPluginRenderContext>, LixError> {
+    let branch_ids = request
+        .filter
+        .branch_ids
+        .iter()
+        .filter(|branch_id| branch_id.as_str() != GLOBAL_BRANCH_ID)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let registry_reads = branch_ids.into_iter().map(|branch_id| {
+        let live_state = Arc::clone(&live_state);
+        async move {
+            let rows = live_state
+                .scan_tracked_rows(&LiveStateScanRequest {
+                    filter: LiveStateFilter {
+                        schema_keys: vec!["lix_key_value".to_string()],
+                        entity_pks: vec![EntityPk::single(PLUGIN_REGISTRY_KEY)],
+                        branch_ids: vec![branch_id.clone()],
+                        file_ids: vec![crate::NullableKeyFilter::Null],
+                        untracked: Some(false),
+                        ..LiveStateFilter::default()
+                    },
+                    projection: plugin_control_live_state_projection(),
+                    limit: Some(1),
+                })
+                .await?;
+            let row = rows.into_iter().find(|row| {
+                row.schema_key == "lix_key_value"
+                    && row.entity_pk.as_single_string().ok() == Some(PLUGIN_REGISTRY_KEY)
+                    && row.file_id.is_none()
+                    && row.branch_id == branch_id
+                    && !row.global
+                    && !row.untracked
+            });
+            let registry = PluginRegistry::from_optional_live_state_row(row.as_ref(), &branch_id)?;
+            Ok::<_, LixError>((branch_id, registry))
+        }
+    });
+
+    let mut branches = BTreeMap::<String, BranchPluginRenderContext>::new();
+    for (branch_id, registry) in try_join_all(registry_reads).await? {
+        if registry.is_empty() {
+            continue;
+        }
+        let catalog = host.compiled_plugin_catalog(&registry)?;
+        branches.insert(branch_id, BranchPluginRenderContext { registry, catalog });
+    }
+    // This is the O(1)-shape no-plugin path: exact registry lookups above are
+    // the only reads. No owner/state scan, CAS read, matcher compilation, or
+    // WASM work is reachable when every requested registry is absent/empty.
+    Ok(branches)
+}
+
+async fn plugin_render_context_with_branches(
+    live_state: Arc<dyn LiveStateReader>,
+    host: PluginRuntimeHost,
+    branches: BTreeMap<String, BranchPluginRenderContext>,
+    candidates: Vec<FilesystemDescriptorKey>,
+) -> Result<Option<PluginRenderContext>, LixError> {
+    if candidates.is_empty() {
         return Ok(None);
     }
 
-    let installed_plugins_by_branch =
-        load_installed_plugins_for_lix_file_scan(Arc::clone(&live_state), blob_reader, request)
-            .await?;
+    let mut candidate_keys_by_branch =
+        BTreeMap::<String, BTreeMap<String, FilesystemDescriptorKey>>::new();
+    for candidate in candidates {
+        if !branches.contains_key(candidate.branch_id()) {
+            continue;
+        }
+        let branch_id = candidate.branch_id().to_string();
+        let file_id = candidate.descriptor_id().to_string();
+        if candidate_keys_by_branch
+            .entry(branch_id.clone())
+            .or_default()
+            .insert(file_id.clone(), candidate)
+            .is_some()
+        {
+            return Err(invalid_plugin_read_state(format!(
+                "branch '{branch_id}' has multiple plugin-owner candidates for file id '{file_id}'"
+            )));
+        }
+    }
+
+    let owner_reads = candidate_keys_by_branch
+        .iter()
+        .map(|(branch_id, candidate_keys)| {
+            let live_state = Arc::clone(&live_state);
+            let branch_id = branch_id.clone();
+            let file_ids = candidate_keys.keys().cloned().collect::<BTreeSet<_>>();
+            async move {
+                let rows = live_state
+                    .scan_tracked_rows(&LiveStateScanRequest {
+                        filter: LiveStateFilter {
+                            schema_keys: vec!["lix_key_value".to_string()],
+                            entity_pks: vec![EntityPk::single(PLUGIN_OWNER_KEY)],
+                            branch_ids: vec![branch_id.clone()],
+                            file_ids: file_ids
+                                .iter()
+                                .cloned()
+                                .map(crate::NullableKeyFilter::Value)
+                                .collect(),
+                            untracked: Some(false),
+                            ..LiveStateFilter::default()
+                        },
+                        projection: plugin_control_live_state_projection(),
+                        limit: None,
+                    })
+                    .await?;
+                Ok::<_, LixError>((branch_id, file_ids, rows))
+            }
+        });
+    let mut owners_by_file = BTreeMap::new();
+    for (branch_id, file_ids, rows) in try_join_all(owner_reads).await? {
+        for row in rows {
+            let Some(file_id) = row.file_id.as_deref() else {
+                continue;
+            };
+            if row.schema_key != "lix_key_value"
+                || row.entity_pk.as_single_string().ok() != Some(PLUGIN_OWNER_KEY)
+                || row.branch_id != branch_id
+                || row.global
+                || row.untracked
+                || !file_ids.contains(file_id)
+            {
+                continue;
+            }
+            let Some(owner) = PluginFileOwner::from_live_state_row(&row, &branch_id)? else {
+                continue;
+            };
+            let candidate_key = candidate_keys_by_branch
+                .get(&branch_id)
+                .and_then(|candidate_keys| candidate_keys.get(file_id))
+                .expect("owner row was filtered to candidate file ids")
+                .clone();
+            // Keep a well-formed stale owner even when its plugin is currently
+            // absent. Rendering checks the current registry, while path moves
+            // still need the old key to force reconciliation; reinstall can
+            // then resume from the durable owner.
+            if owners_by_file.insert(candidate_key, owner).is_some() {
+                return Err(invalid_plugin_read_state(format!(
+                    "branch '{branch_id}' returned duplicate plugin owners for file id '{file_id}'"
+                )));
+            }
+        }
+    }
+
     Ok(Some(PluginRenderContext {
         live_state,
         host,
-        installed_plugins_by_branch,
+        branches,
+        owners_by_file,
     }))
+}
+
+fn invalid_plugin_read_state(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INTERNAL_ERROR, message)
+}
+
+fn plugin_control_live_state_projection() -> LiveStateProjection {
+    LiveStateProjection {
+        columns: vec!["snapshot_content".to_string()],
+    }
 }
 
 fn projected_schema(base_schema: &SchemaRef, projection: Option<&Vec<usize>>) -> Result<SchemaRef> {
@@ -3630,6 +4098,34 @@ impl FileIdConstraint {
 
 fn file_id_constraint_from_filters(filters: &[Expr]) -> Result<FileIdConstraint> {
     exact_string_column_constraint_from_filters(filters, "id")
+}
+
+fn exact_plugin_archive_delete_target_from_filters(filters: &[Expr]) -> Result<Option<String>> {
+    let path_plugin_key = single_exact_string_constraint(
+        exact_string_column_constraint_from_filters(filters, "path")?,
+    )
+    .as_deref()
+    .and_then(plugin_key_from_archive_path);
+    let id_plugin_key = single_exact_string_constraint(file_id_constraint_from_filters(filters)?)
+        .as_deref()
+        .and_then(plugin_key_from_archive_file_id);
+
+    match (path_plugin_key, id_plugin_key) {
+        (Some(path_key), Some(id_key)) if path_key != id_key => Ok(None),
+        (Some(path_key), _) => Ok(Some(path_key)),
+        (_, Some(id_key)) => Ok(Some(id_key)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn single_exact_string_constraint(constraint: FileIdConstraint) -> Option<String> {
+    let FileIdConstraint::Ids(values) = constraint else {
+        return None;
+    };
+    if values.len() != 1 {
+        return None;
+    }
+    values.into_iter().next()
 }
 
 pub(super) fn exact_string_column_constraint_from_filters(
@@ -4121,16 +4617,6 @@ fn physical_expr_contains_column(expr: &Arc<dyn PhysicalExpr>, column_name: &str
         .any(|child| physical_expr_contains_column(child, column_name))
 }
 
-fn parse_normal_write_file_path(
-    path: &str,
-    operation: TransactionWriteOperation,
-) -> Result<String> {
-    LixPath::try_from_file_path(path).map_err(lix_error_to_datafusion_error)?;
-    reject_normal_plugin_storage_mutation(path, lix_file_write_operation_label(operation))
-        .map_err(lix_error_to_datafusion_error)?;
-    Ok(path.to_string())
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedFileWritePath {
     path: String,
@@ -4541,13 +5027,20 @@ mod tests {
     use crate::functions::FunctionProviderHandle;
     use crate::live_state::{LiveStateFilter, MaterializedLiveStateRow};
     use crate::live_state::{LiveStateReader, LiveStateRowRequest, LiveStateScanRequest};
-    use crate::plugin::PluginRuntimeHost;
+    use crate::plugin::{
+        PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginFileOwner, PluginRegistry,
+        PluginRegistryEntry, PluginRegistryEntryInput, PluginRuntime, PluginRuntimeHost,
+        plugin_storage_archive_file_id, plugin_storage_archive_path,
+    };
     use crate::sql2::dml::InsertSink;
     use crate::sql2::{SqlWriteContext, SqlWriteExecutionContext, WriteContextBranchRefReader};
     use crate::transaction::types::{
         TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
     };
-    use crate::wasm::UnsupportedWasmRuntime;
+    use crate::wasm::{
+        UnsupportedWasmRuntime, WasmComponentInstance, WasmLimits, WasmPluginDetectedChange,
+        WasmPluginEntityState, WasmPluginFile, WasmRuntime,
+    };
     use crate::{LixError, NullableKeyFilter};
 
     use super::{
@@ -4846,6 +5339,52 @@ mod tests {
             vec![string_literal("file-a")],
             true,
         ))));
+    }
+
+    #[test]
+    fn plugin_archive_delete_target_requires_one_exact_canonical_path_or_id() {
+        let path = "/.lix/plugins/plugin_sentinel.lixplugin";
+        let file_id = "lix_plugin_archive::plugin_sentinel";
+
+        for filters in [
+            vec![eq_filter("path", path)],
+            vec![eq_filter("id", file_id)],
+        ] {
+            assert_eq!(
+                super::exact_plugin_archive_delete_target_from_filters(&filters).unwrap(),
+                Some("plugin_sentinel".to_string())
+            );
+        }
+
+        for filters in [
+            Vec::new(),
+            vec![lower_path_contains_filter("%/.lix/plugins/%")],
+            vec![Expr::InList(InList::new(
+                Box::new(column("path")),
+                vec![
+                    string_literal(path),
+                    string_literal("/.lix/plugins/plugin_other.lixplugin"),
+                ],
+                false,
+            ))],
+        ] {
+            assert_eq!(
+                super::exact_plugin_archive_delete_target_from_filters(&filters).unwrap(),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_archive_delete_target_rejects_conflicting_exact_identities() {
+        assert_eq!(
+            super::exact_plugin_archive_delete_target_from_filters(&[
+                eq_filter("path", "/.lix/plugins/plugin_sentinel.lixplugin"),
+                eq_filter("id", "lix_plugin_archive::plugin_other"),
+            ])
+            .unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -6025,6 +6564,21 @@ mod tests {
         bytes_by_hash: BTreeMap<BlobHash, Vec<u8>>,
     }
 
+    struct RecordingBlobReader {
+        bytes_by_hash: BTreeMap<BlobHash, Vec<u8>>,
+        requests: Arc<Mutex<Vec<Vec<BlobHash>>>>,
+    }
+
+    struct RecordingRenderRuntime {
+        rendered_states: Arc<Mutex<Vec<Vec<WasmPluginEntityState>>>>,
+        rendered_bytes: Vec<u8>,
+    }
+
+    struct RecordingRenderComponent {
+        rendered_states: Arc<Mutex<Vec<Vec<WasmPluginEntityState>>>>,
+        rendered_bytes: Vec<u8>,
+    }
+
     impl StaticBlobReader {
         fn from_blobs(blobs: impl IntoIterator<Item = Vec<u8>>) -> Self {
             Self {
@@ -6065,6 +6619,55 @@ mod tests {
                     .map(|hash| self.bytes_by_hash.get(hash).cloned())
                     .collect(),
             ))
+        }
+    }
+
+    #[async_trait]
+    impl BlobDataReader for RecordingBlobReader {
+        async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
+            self.requests
+                .lock()
+                .expect("blob request mutex should not be poisoned")
+                .push(hashes.to_vec());
+            Ok(BlobBytesBatch::new(
+                hashes
+                    .iter()
+                    .map(|hash| self.bytes_by_hash.get(hash).cloned())
+                    .collect(),
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl WasmRuntime for RecordingRenderRuntime {
+        async fn init_component(
+            &self,
+            _bytes: Vec<u8>,
+            _limits: WasmLimits,
+        ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
+            Ok(Arc::new(RecordingRenderComponent {
+                rendered_states: Arc::clone(&self.rendered_states),
+                rendered_bytes: self.rendered_bytes.clone(),
+            }))
+        }
+    }
+
+    #[async_trait]
+    impl WasmComponentInstance for RecordingRenderComponent {
+        async fn detect_changes(
+            &self,
+            _state: Vec<WasmPluginEntityState>,
+            _file: WasmPluginFile,
+        ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+            Ok(Vec::new())
+        }
+
+        async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
+            self.rendered_states
+                .lock()
+                .expect("rendered state mutex should not be poisoned")
+                .push(state);
+            Ok(self.rendered_bytes.clone())
         }
     }
 
@@ -6378,6 +6981,75 @@ mod tests {
         )
     }
 
+    fn test_plugin_registry_entry(
+        key: &str,
+        path_glob: &str,
+        schema_key: &str,
+        wasm: &[u8],
+    ) -> PluginRegistryEntry {
+        let manifest_json = serde_json::json!({
+            "api_version": "0.1.0",
+            "entry": "plugin.wasm",
+            "key": key,
+            "match": { "path_glob": path_glob },
+            "runtime": "wasm-component-v1",
+            "schemas": ["schema/plugin.json"],
+        })
+        .to_string();
+        PluginRegistryEntry::new(PluginRegistryEntryInput {
+            key: key.to_string(),
+            runtime: PluginRuntime::WasmComponentV1,
+            api_version: "0.1.0".to_string(),
+            path_glob: path_glob.to_string(),
+            entry: "plugin.wasm".to_string(),
+            schema_keys: vec![schema_key.to_string()],
+            manifest_json,
+            archive_file_id: plugin_storage_archive_file_id(key),
+            archive_path: plugin_storage_archive_path(key),
+            archive_blob_hash: BlobHash::from_content(format!("archive-{key}").as_bytes()).to_hex(),
+            wasm_blob_hash: BlobHash::from_content(wasm).to_hex(),
+        })
+        .expect("test plugin registry entry should be valid")
+    }
+
+    fn live_plugin_registry_row(
+        branch_id: &str,
+        entries: Vec<PluginRegistryEntry>,
+    ) -> MaterializedLiveStateRow {
+        let registry = PluginRegistry::new(entries).expect("test plugin registry should be valid");
+        let mut row = live_file_row(
+            PLUGIN_REGISTRY_KEY,
+            branch_id,
+            &registry
+                .to_snapshot()
+                .expect("registry snapshot should serialize")
+                .to_string(),
+        );
+        row.schema_key = "lix_key_value".to_string();
+        row
+    }
+
+    fn live_plugin_owner_row(
+        branch_id: &str,
+        file_id: &str,
+        plugin_key: &str,
+        schema_keys: Vec<String>,
+    ) -> MaterializedLiveStateRow {
+        let owner = PluginFileOwner::new(file_id, plugin_key, schema_keys)
+            .expect("test plugin owner should be valid");
+        let mut row = live_file_row(
+            PLUGIN_OWNER_KEY,
+            branch_id,
+            &owner
+                .to_snapshot()
+                .expect("owner snapshot should serialize")
+                .to_string(),
+        );
+        row.schema_key = "lix_key_value".to_string();
+        row.file_id = Some(file_id.to_string());
+        row
+    }
+
     fn plugin_archive(path_glob: &str, schema_key: &str) -> Vec<u8> {
         const WASM_HEADER: &[u8] = b"\0asm\x01\0\0\0";
         let manifest_json = format!(
@@ -6416,35 +7088,6 @@ mod tests {
             writer.write_all(bytes).unwrap();
         }
         writer.finish().unwrap().into_inner()
-    }
-
-    fn plugin_install_rows(branch_id: &str, archive_bytes: &[u8]) -> Vec<MaterializedLiveStateRow> {
-        let archive_file_id = "lix_plugin_archive::plugin_sentinel";
-        let blob_hash = BlobHash::from_content(archive_bytes).to_hex();
-        vec![
-            live_directory_row(
-                "dir-lix-system",
-                branch_id,
-                r#"{"id":"dir-lix-system","parent_id":null,"name":".lix"}"#,
-            ),
-            live_directory_row(
-                "dir-lix-system-plugins",
-                branch_id,
-                r#"{"id":"dir-lix-system-plugins","parent_id":"dir-lix-system","name":"plugins"}"#,
-            ),
-            live_file_row(
-                archive_file_id,
-                branch_id,
-                r#"{"id":"lix_plugin_archive::plugin_sentinel","directory_id":"dir-lix-system-plugins","name":"plugin_sentinel.lixplugin"}"#,
-            ),
-            live_blob_ref_row(
-                archive_file_id,
-                branch_id,
-                archive_file_id,
-                &blob_hash,
-                archive_bytes.len(),
-            ),
-        ]
     }
 
     fn string_column(values: Vec<Option<&str>>) -> ArrayRef {
@@ -6626,8 +7269,12 @@ mod tests {
     }
 
     fn file_delete_batch_with_path(path: Option<&str>) -> RecordBatch {
+        file_delete_batch_with_id_and_path("file-readme", path)
+    }
+
+    fn file_delete_batch_with_id_and_path(file_id: &str, path: Option<&str>) -> RecordBatch {
         let mut fields = vec![Field::new("id", DataType::Utf8, false)];
-        let mut columns = vec![string_column(vec![Some("file-readme")])];
+        let mut columns = vec![string_column(vec![Some(file_id)])];
         if let Some(path) = path {
             fields.push(Field::new("path", DataType::Utf8, false));
             columns.push(string_column(vec![Some(path)]));
@@ -6885,19 +7532,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn plugin_discovery_keeps_duplicate_archive_paths_branch_scoped() {
-        let archive_a = plugin_archive("*.branch-a", "plugin_note_a");
-        let archive_b = plugin_archive("*.branch-b", "plugin_note_b");
-        let mut rows = plugin_install_rows("branch-a", &archive_a);
-        rows.extend(plugin_install_rows("branch-b", &archive_b));
-        let blob_reader = Arc::new(StaticBlobReader::from_blobs(vec![
-            archive_a.clone(),
-            archive_b.clone(),
-        ])) as Arc<dyn BlobDataReader>;
-
-        let installed_plugins = super::load_installed_plugins_for_lix_file_scan(
+    async fn plugin_registry_catalogs_remain_branch_scoped() {
+        let wasm = b"test wasm";
+        let rows = vec![
+            live_plugin_registry_row(
+                "branch-a",
+                vec![test_plugin_registry_entry(
+                    "plugin_sentinel",
+                    "*.branch-a",
+                    "plugin_note_a",
+                    wasm,
+                )],
+            ),
+            live_plugin_registry_row(
+                "branch-b",
+                vec![test_plugin_registry_entry(
+                    "plugin_sentinel",
+                    "*.branch-b",
+                    "plugin_note_b",
+                    wasm,
+                )],
+            ),
+        ];
+        let prepared = super::prepare_lix_file_rows(
+            vec![
+                live_file_row(
+                    "file-a",
+                    "branch-a",
+                    r#"{"id":"file-a","directory_id":null,"name":"note.branch-a"}"#,
+                ),
+                live_file_row(
+                    "file-b",
+                    "branch-b",
+                    r#"{"id":"file-b","directory_id":null,"name":"note.branch-b"}"#,
+                ),
+            ],
+            &super::FilePathPredicate::All,
+        )
+        .expect("plugin candidates should prepare");
+        let context = super::plugin_render_context_for_lix_file_scan(
             Arc::new(RowsLiveStateReader { rows }) as Arc<dyn LiveStateReader>,
-            &blob_reader,
             &LiveStateScanRequest {
                 filter: LiveStateFilter {
                     branch_ids: vec!["branch-a".to_string(), "branch-b".to_string()],
@@ -6905,22 +7579,332 @@ mod tests {
                 },
                 ..Default::default()
             },
+            PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime)),
+            &prepared,
+            false,
         )
         .await
-        .expect("duplicate plugin paths in different branches should not collide");
+        .expect("branch registries should load")
+        .expect("non-empty registries should create a render context");
 
-        let branch_a_plugins = installed_plugins
-            .get("branch-a")
-            .expect("branch-a plugins should load");
-        let branch_b_plugins = installed_plugins
-            .get("branch-b")
-            .expect("branch-b plugins should load");
-        assert_eq!(branch_a_plugins.len(), 1);
-        assert_eq!(branch_b_plugins.len(), 1);
-        assert_eq!(branch_a_plugins[0].path_glob, "*.branch-a");
-        assert_eq!(branch_b_plugins[0].path_glob, "*.branch-b");
-        assert_eq!(branch_a_plugins[0].schema_keys, vec!["plugin_note_a"]);
-        assert_eq!(branch_b_plugins[0].schema_keys, vec!["plugin_note_b"]);
+        assert_eq!(
+            context
+                .branch("branch-a")
+                .and_then(|branch| branch.catalog.select("/note.branch-a"))
+                .map(PluginRegistryEntry::key),
+            Some("plugin_sentinel")
+        );
+        assert!(
+            context
+                .branch("branch-a")
+                .and_then(|branch| branch.catalog.select("/note.branch-b"))
+                .is_none()
+        );
+        assert_eq!(
+            context
+                .branch("branch-b")
+                .and_then(|branch| branch.catalog.select("/note.branch-b"))
+                .map(PluginRegistryEntry::key),
+            Some("plugin_sentinel")
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_plugin_registry_stops_after_one_exact_tracked_read() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let prepared = super::prepare_lix_file_rows(
+            vec![live_file_row(
+                "file-note",
+                "branch-b",
+                r#"{"id":"file-note","directory_id":null,"name":"note.sentinel"}"#,
+            )],
+            &super::FilePathPredicate::All,
+        )
+        .expect("blobless file should prepare");
+        let context = super::plugin_render_context_for_lix_file_scan(
+            Arc::new(RecordingLiveStateReader {
+                rows: Vec::new(),
+                scan_requests: Arc::clone(&requests),
+            }) as Arc<dyn LiveStateReader>,
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    branch_ids: vec!["branch-b".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime)),
+            &prepared,
+            false,
+        )
+        .await
+        .expect("missing registry is the empty registry");
+
+        assert!(context.is_none());
+        let requests = requests.lock().expect("scan request mutex");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].filter.schema_keys, vec!["lix_key_value"]);
+        assert_eq!(
+            requests[0].filter.entity_pks,
+            vec![crate::entity_pk::EntityPk::single(PLUGIN_REGISTRY_KEY)]
+        );
+        assert_eq!(requests[0].filter.branch_ids, vec!["branch-b"]);
+        assert_eq!(requests[0].filter.file_ids, vec![NullableKeyFilter::Null]);
+        assert_eq!(requests[0].filter.untracked, Some(false));
+        assert_eq!(requests[0].limit, Some(1));
+    }
+
+    #[tokio::test]
+    async fn installed_nonmatching_plugin_skips_owner_scan_for_blobless_files() {
+        let wasm = b"test wasm";
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let prepared = super::prepare_lix_file_rows(
+            vec![live_file_row(
+                "file-note",
+                "branch-b",
+                r#"{"id":"file-note","directory_id":null,"name":"note.txt"}"#,
+            )],
+            &super::FilePathPredicate::All,
+        )
+        .expect("blobless raw file should prepare");
+        let context = super::plugin_render_context_for_lix_file_scan(
+            Arc::new(RecordingLiveStateReader {
+                rows: vec![live_plugin_registry_row(
+                    "branch-b",
+                    vec![test_plugin_registry_entry(
+                        "plugin_sentinel",
+                        "*.sentinel",
+                        "plugin_note",
+                        wasm,
+                    )],
+                )],
+                scan_requests: Arc::clone(&requests),
+            }) as Arc<dyn LiveStateReader>,
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    branch_ids: vec!["branch-b".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime)),
+            &prepared,
+            false,
+        )
+        .await
+        .expect("nonmatching registry lookup should succeed");
+
+        assert!(context.is_none());
+        let requests = requests.lock().expect("scan request mutex");
+        assert_eq!(requests.len(), 1, "only the exact registry row is read");
+        assert_eq!(
+            requests[0].filter.entity_pks,
+            vec![crate::entity_pk::EntityPk::single(PLUGIN_REGISTRY_KEY)]
+        );
+    }
+
+    #[tokio::test]
+    async fn plugin_owner_renders_empty_state_with_one_wasm_batch() {
+        let wasm = b"test wasm".to_vec();
+        let entry =
+            test_plugin_registry_entry("plugin_sentinel", "*.sentinel", "plugin_note", &wasm);
+        let scan_requests = Arc::new(Mutex::new(Vec::new()));
+        let live_state = Arc::new(RecordingLiveStateReader {
+            rows: vec![
+                live_plugin_registry_row("branch-b", vec![entry]),
+                live_plugin_owner_row(
+                    "branch-b",
+                    "file-note",
+                    "plugin_sentinel",
+                    vec!["plugin_note".to_string()],
+                ),
+            ],
+            scan_requests: Arc::clone(&scan_requests),
+        }) as Arc<dyn LiveStateReader>;
+        let prepared = super::prepare_lix_file_rows(
+            vec![live_file_row(
+                "file-note",
+                "branch-b",
+                r#"{"id":"file-note","directory_id":null,"name":"note.sentinel"}"#,
+            )],
+            &super::FilePathPredicate::All,
+        )
+        .expect("owned blobless file should prepare");
+        let rendered_states = Arc::new(Mutex::new(Vec::new()));
+        let context = super::plugin_render_context_for_lix_file_scan(
+            Arc::clone(&live_state),
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    branch_ids: vec!["branch-b".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            PluginRuntimeHost::new(Arc::new(RecordingRenderRuntime {
+                rendered_states: Arc::clone(&rendered_states),
+                rendered_bytes: b"rendered empty state".to_vec(),
+            })),
+            &prepared,
+            false,
+        )
+        .await
+        .expect("plugin render context should load")
+        .expect("installed plugin should create a render context");
+        let blob_requests = Arc::new(Mutex::new(Vec::new()));
+        let blob_reader = Arc::new(RecordingBlobReader {
+            bytes_by_hash: BTreeMap::from([(BlobHash::from_content(&wasm), wasm)]),
+            requests: Arc::clone(&blob_requests),
+        }) as Arc<dyn BlobDataReader>;
+
+        let batch = super::lix_file_record_batch_from_prepared(
+            &super::lix_file_schema(),
+            &blob_reader,
+            Some(context.clone()),
+            true,
+            prepared,
+        )
+        .await
+        .expect("owned file should render");
+
+        let data = batch
+            .column(batch.schema().index_of("data").unwrap())
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .expect("data should be a large binary array");
+        assert_eq!(data.value(0), b"rendered empty state");
+        assert_eq!(
+            rendered_states
+                .lock()
+                .expect("rendered state mutex")
+                .as_slice(),
+            &[Vec::<WasmPluginEntityState>::new()]
+        );
+        assert_eq!(
+            blob_requests.lock().expect("blob request mutex").as_slice(),
+            &[vec![BlobHash::from_content(b"test wasm")]]
+        );
+
+        let warm_prepared = super::prepare_lix_file_rows(
+            vec![live_file_row(
+                "file-note",
+                "branch-b",
+                r#"{"id":"file-note","directory_id":null,"name":"note.sentinel"}"#,
+            )],
+            &super::FilePathPredicate::All,
+        )
+        .expect("warm owned file should prepare");
+        super::lix_file_record_batch_from_prepared(
+            &super::lix_file_schema(),
+            &blob_reader,
+            Some(context),
+            true,
+            warm_prepared,
+        )
+        .await
+        .expect("warm owned file should render without loading component bytes");
+        assert_eq!(
+            blob_requests.lock().expect("blob request mutex").as_slice(),
+            &[vec![BlobHash::from_content(b"test wasm")]],
+            "warm render must hit the hash cache before CAS"
+        );
+        assert_eq!(
+            rendered_states.lock().expect("rendered state mutex").len(),
+            2
+        );
+        let requests = scan_requests.lock().expect("scan request mutex");
+        assert_eq!(
+            requests.len(),
+            4,
+            "registry, owners, then one grouped state scan per render"
+        );
+        assert_eq!(
+            requests[1].filter.entity_pks,
+            vec![crate::entity_pk::EntityPk::single(PLUGIN_OWNER_KEY)]
+        );
+        assert_eq!(
+            requests[2].filter.file_ids,
+            vec![NullableKeyFilter::Value("file-note".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn path_update_uses_stale_owner_and_current_catalog() {
+        let wasm = b"test wasm";
+        let prepared = super::prepare_lix_file_rows(
+            vec![live_file_row(
+                "file-readme",
+                "branch-b",
+                r#"{"id":"file-readme","directory_id":null,"name":"note.removed"}"#,
+            )],
+            &super::FilePathPredicate::All,
+        )
+        .expect("blobless file should prepare");
+        let context = super::plugin_render_context_for_lix_file_scan(
+            Arc::new(RowsLiveStateReader {
+                rows: vec![
+                    live_plugin_registry_row(
+                        "branch-b",
+                        vec![test_plugin_registry_entry(
+                            "plugin_active",
+                            "*.active",
+                            "plugin_active_state",
+                            wasm,
+                        )],
+                    ),
+                    live_plugin_owner_row(
+                        "branch-b",
+                        "file-readme",
+                        "plugin_removed",
+                        vec!["plugin_removed_state".to_string()],
+                    ),
+                ],
+            }) as Arc<dyn LiveStateReader>,
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    branch_ids: vec!["branch-b".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime)),
+            &prepared,
+            true,
+        )
+        .await
+        .expect("plugin ownership should load")
+        .expect("the active registry should create a context");
+        let batch = path_update_batch_with_path("/note.removed");
+        let assignments = vec![literal_assignment(
+            "path",
+            ScalarValue::Utf8(Some("/note.active".to_string())),
+        )];
+        let assignment_values = super::UpdateAssignmentValues::evaluate(&batch, &assignments)
+            .expect("path assignment should evaluate");
+
+        let rewritten = super::path_update_plugin_rewrite_file_ids(
+            Some(&context),
+            &batch,
+            &assignment_values,
+            Some("branch-b"),
+        )
+        .expect("path ownership comparison should succeed");
+
+        assert_eq!(rewritten, BTreeSet::from(["file-readme".to_string()]));
+        assert_eq!(
+            context
+                .owners_by_file
+                .values()
+                .next()
+                .map(PluginFileOwner::plugin_key),
+            Some("plugin_removed")
+        );
+        assert_eq!(
+            context
+                .branch("branch-b")
+                .and_then(|branch| branch.catalog.select("/note.active"))
+                .map(PluginRegistryEntry::key),
+            Some("plugin_active")
+        );
     }
 
     #[test]
@@ -7084,18 +8068,73 @@ mod tests {
     }
 
     #[test]
-    fn file_delete_rejects_plugin_storage_path() {
+    fn file_delete_rejects_plugin_storage_path_without_exact_target() {
         let error = lix_file_delete_stage_from_batch(
-            &file_delete_batch_with_path(Some("/.lix/plugins/plugin_sentinel.lixplugin")),
+            &file_delete_batch_with_id_and_path(
+                "lix_plugin_archive::plugin_sentinel",
+                Some("/.lix/plugins/plugin_sentinel.lixplugin"),
+            ),
             None,
             &BTreeSet::new(),
+            None,
         )
-        .expect_err("normal file delete should reject installed archive path");
+        .expect_err("non-exact file delete should reject installed archive path");
 
         assert!(
-            error.to_string().contains("reserved plugin storage path"),
+            error
+                .to_string()
+                .contains("one exact canonical plugin archive"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn file_delete_allows_exact_canonical_plugin_archive_target() {
+        let staged = lix_file_delete_stage_from_batch(
+            &file_delete_batch_with_id_and_path(
+                "lix_plugin_archive::plugin_sentinel",
+                Some("/.lix/plugins/plugin_sentinel.lixplugin"),
+            ),
+            None,
+            &BTreeSet::new(),
+            Some("plugin_sentinel"),
+        )
+        .expect("exact canonical plugin archive delete should stage");
+
+        assert_eq!(staged.count, 1);
+        assert_eq!(staged.state_rows.len(), 1);
+        assert_eq!(staged.state_rows[0].schema_key, "lix_file_descriptor");
+        assert_eq!(staged.state_rows[0].snapshot, None);
+    }
+
+    #[test]
+    fn file_delete_rejects_noncanonical_plugin_archive_identity() {
+        for (file_id, path) in [
+            ("file-arbitrary", "/.lix/plugins/plugin_sentinel.lixplugin"),
+            (
+                "lix_plugin_archive::plugin_other",
+                "/.lix/plugins/plugin_sentinel.lixplugin",
+            ),
+            (
+                "lix_plugin_archive::plugin_sentinel",
+                "/.lix/plugins/nested/plugin_sentinel.lixplugin",
+            ),
+        ] {
+            let error = lix_file_delete_stage_from_batch(
+                &file_delete_batch_with_id_and_path(file_id, Some(path)),
+                None,
+                &BTreeSet::new(),
+                Some("plugin_sentinel"),
+            )
+            .expect_err("noncanonical plugin archive delete should fail");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("one exact canonical plugin archive"),
+                "unexpected error for {file_id} at {path}: {error}"
+            );
+        }
     }
 
     #[test]
@@ -7516,6 +8555,7 @@ mod tests {
             &batch,
             None,
             &BTreeSet::from([blob_ref_key("branch-b", false, false, "file-readme")]),
+            None,
         )
         .expect("decode file delete");
 
@@ -7549,7 +8589,7 @@ mod tests {
     #[test]
     fn file_delete_without_blob_ref_stages_only_descriptor_tombstone() {
         let batch = file_delete_batch();
-        let staged = lix_file_delete_stage_from_batch(&batch, None, &BTreeSet::new())
+        let staged = lix_file_delete_stage_from_batch(&batch, None, &BTreeSet::new(), None)
             .expect("decode file delete");
 
         assert_eq!(staged.count, 1);
@@ -7569,6 +8609,7 @@ mod tests {
             &batch,
             None,
             &BTreeSet::from([blob_ref_key("branch-a", false, false, "file-readme")]),
+            None,
         )
         .expect("decode file delete");
 
@@ -7783,6 +8824,7 @@ mod tests {
             panic!("data update should stage rows and file data");
         };
         assert!(file_data[0].data().is_empty());
+        assert!(file_data[0].had_blob_ref);
         assert!(
             rows.iter().any(|row| {
                 row.schema_key == super::BLOB_REF_SCHEMA_KEY && row.snapshot.is_none()
@@ -7881,6 +8923,7 @@ mod tests {
         assert_eq!(file_data.len(), 1);
         assert_eq!(file_data[0].path.as_deref(), Some("/docs/readme.md"));
         assert_eq!(file_data[0].data(), b"new");
+        assert!(file_data[0].had_blob_ref);
     }
 
     #[tokio::test]
@@ -7953,6 +8996,7 @@ mod tests {
                 assert_eq!(file_data[0].file_id, "file-readme");
                 assert_eq!(file_data[0].path.as_deref(), Some("/docs/readme.md"));
                 assert_eq!(file_data[0].data(), b"hello");
+                assert!(!file_data[0].had_blob_ref);
             }
             other => panic!("expected insert with file data staged write, got {other:?}"),
         }

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -702,9 +702,10 @@ impl TableSpec for LixFileSpec {
                         )
                         .await
                         .map_err(|error| {
-                            DataFusionError::Execution(format!(
-                                "sql2 lix_file plugin discovery failed: {error}"
-                            ))
+                            DataFusionError::Context(
+                                "sql2 lix_file plugin discovery failed".to_string(),
+                                Box::new(lix_error_to_datafusion_error(error)),
+                            )
                         })?
                     } else {
                         None
@@ -718,9 +719,10 @@ impl TableSpec for LixFileSpec {
                     )
                     .await
                     .map_err(|error| {
-                        DataFusionError::Execution(format!(
-                            "sql2 lix_file batch build failed: {error}"
-                        ))
+                        DataFusionError::Context(
+                            "sql2 lix_file batch build failed".to_string(),
+                            Box::new(lix_error_to_datafusion_error(error)),
+                        )
                     })?;
                     finish_scan_batch(batch, &filters, projection.as_deref(), limit, "lix_file")
                 },
@@ -1227,6 +1229,7 @@ impl UpsertSupport for LixFileSpec {
                     plugin_host,
                     branches,
                     plugin_owner_candidates_from_batch(augmented, branch_binding)?,
+                    true,
                 )
                 .await
                 .map_err(|error| {
@@ -3476,24 +3479,30 @@ async fn render_plugin_files_for_sql(
     blob_rows: &BTreeMap<FilesystemBlobRefKey, BlobRefRecord>,
     file_paths: &BTreeMap<FilesystemDescriptorKey, String>,
 ) -> Result<BTreeMap<FilesystemDescriptorKey, Vec<u8>>, LixError> {
-    let owned_file_keys = file_keys
-        .iter()
-        .filter(|key| {
-            let file = file_rows
-                .get(*key)
-                .expect("prepared lix_file order should reference a descriptor");
-            let path = file_paths
-                .get(*key)
-                .expect("prepared lix_file descriptor should have a path");
-            let active_owner = plugin_render.owner_for_file(key).is_some_and(|owner| {
-                plugin_render
-                    .branch(key.branch_id())
-                    .is_some_and(|branch| branch.catalog.matches_plugin(owner.plugin_key(), path))
-            });
-            !blob_rows.contains_key(&file.blob_ref_key()) && active_owner
-        })
-        .cloned()
-        .collect::<Vec<_>>();
+    let mut owned_file_keys = Vec::new();
+    for key in file_keys {
+        let file = file_rows
+            .get(key)
+            .expect("prepared lix_file order should reference a descriptor");
+        if blob_rows.contains_key(&file.blob_ref_key()) {
+            continue;
+        }
+        let Some(owner) = plugin_render.owner_for_file(key) else {
+            continue;
+        };
+        let path = file_paths
+            .get(key)
+            .expect("prepared lix_file descriptor should have a path");
+        let Some(branch) = plugin_render.branch(key.branch_id()) else {
+            return Err(plugin_unavailable_error(file, path, owner));
+        };
+        if branch.registry.get(owner.plugin_key()).is_none() {
+            return Err(plugin_unavailable_error(file, path, owner));
+        }
+        if branch.catalog.matches_plugin(owner.plugin_key(), path) {
+            owned_file_keys.push(key.clone());
+        }
+    }
     if owned_file_keys.is_empty() {
         return Ok(BTreeMap::new());
     }
@@ -3702,22 +3711,19 @@ async fn plugin_render_context_for_lix_file_scan(
     prepared: &PreparedLixFileRows,
     include_blob_backed_candidates: bool,
 ) -> Result<Option<PluginRenderContext>, LixError> {
-    let branches = load_plugin_render_branches(Arc::clone(&live_state), request, &host).await?;
-    if branches.is_empty() {
+    let candidates = prepared.plugin_owner_candidates(include_blob_backed_candidates);
+    if candidates.is_empty() {
         return Ok(None);
     }
-    let mut candidates = prepared.plugin_owner_candidates(include_blob_backed_candidates);
-    if !include_blob_backed_candidates {
-        candidates.retain(|key| {
-            prepared.file_paths.get(key).is_some_and(|path| {
-                branches
-                    .get(key.branch_id())
-                    .and_then(|branch| branch.catalog.select(path, None))
-                    .is_some()
-            })
-        });
-    }
-    plugin_render_context_with_branches(live_state, host, branches, candidates).await
+    let branches = load_plugin_render_branches(Arc::clone(&live_state), request, &host).await?;
+    plugin_render_context_with_branches(
+        live_state,
+        host,
+        branches,
+        candidates,
+        include_blob_backed_candidates,
+    )
+    .await
 }
 
 async fn load_plugin_render_branches(
@@ -3781,6 +3787,7 @@ async fn plugin_render_context_with_branches(
     host: PluginRuntimeHost,
     branches: BTreeMap<String, BranchPluginRenderContext>,
     candidates: Vec<FilesystemDescriptorKey>,
+    keep_catalog_without_owners: bool,
 ) -> Result<Option<PluginRenderContext>, LixError> {
     if candidates.is_empty() {
         return Ok(None);
@@ -3789,9 +3796,6 @@ async fn plugin_render_context_with_branches(
     let mut candidate_keys_by_branch =
         BTreeMap::<String, BTreeMap<String, FilesystemDescriptorKey>>::new();
     for candidate in candidates {
-        if !branches.contains_key(candidate.branch_id()) {
-            continue;
-        }
         let branch_id = candidate.branch_id().to_string();
         let file_id = candidate.descriptor_id().to_string();
         if candidate_keys_by_branch
@@ -3869,6 +3873,10 @@ async fn plugin_render_context_with_branches(
         }
     }
 
+    if owners_by_file.is_empty() && !keep_catalog_without_owners {
+        return Ok(None);
+    }
+
     Ok(Some(PluginRenderContext {
         live_state,
         host,
@@ -3879,6 +3887,30 @@ async fn plugin_render_context_with_branches(
 
 fn invalid_plugin_read_state(message: impl Into<String>) -> LixError {
     LixError::new(LixError::CODE_INTERNAL_ERROR, message)
+}
+
+fn plugin_unavailable_error(
+    file: &FileDescriptorRecord,
+    path: &str,
+    owner: &PluginFileOwner,
+) -> LixError {
+    LixError::new(
+        LixError::CODE_PLUGIN_UNAVAILABLE,
+        format!(
+            "file '{path}' requires unavailable plugin '{}'",
+            owner.plugin_key()
+        ),
+    )
+    .with_hint(format!(
+        "Add a valid .lixplugin archive for '{}' to /.lix/plugins/ to render the file again.",
+        owner.plugin_key()
+    ))
+    .with_details(serde_json::json!({
+        "branch_id": file.live.branch_id,
+        "file_id": file.id,
+        "path": path,
+        "plugin_key": owner.plugin_key(),
+    }))
 }
 
 fn plugin_control_live_state_projection() -> LiveStateProjection {
@@ -7567,6 +7599,12 @@ mod tests {
                     wasm,
                 )],
             ),
+            live_plugin_owner_row(
+                "branch-a",
+                "file-a",
+                "plugin_sentinel",
+                vec!["plugin_note_a".to_string()],
+            ),
             live_plugin_registry_row(
                 "branch-b",
                 vec![test_plugin_registry_entry(
@@ -7575,6 +7613,12 @@ mod tests {
                     "plugin_note_b",
                     wasm,
                 )],
+            ),
+            live_plugin_owner_row(
+                "branch-b",
+                "file-b",
+                "plugin_sentinel",
+                vec!["plugin_note_b".to_string()],
             ),
         ];
         let prepared = super::prepare_lix_file_rows(
@@ -7633,7 +7677,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_plugin_registry_stops_after_one_exact_tracked_read() {
+    async fn missing_plugin_registry_checks_blobless_file_ownership() {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let prepared = super::prepare_lix_file_rows(
             vec![live_file_row(
@@ -7665,7 +7709,7 @@ mod tests {
 
         assert!(context.is_none());
         let requests = requests.lock().expect("scan request mutex");
-        assert_eq!(requests.len(), 1);
+        assert_eq!(requests.len(), 2);
         assert_eq!(requests[0].filter.schema_keys, vec!["lix_key_value"]);
         assert_eq!(
             requests[0].filter.entity_pks,
@@ -7675,10 +7719,18 @@ mod tests {
         assert_eq!(requests[0].filter.file_ids, vec![NullableKeyFilter::Null]);
         assert_eq!(requests[0].filter.untracked, Some(false));
         assert_eq!(requests[0].limit, Some(1));
+        assert_eq!(
+            requests[1].filter.entity_pks,
+            vec![crate::entity_pk::EntityPk::single(PLUGIN_OWNER_KEY)]
+        );
+        assert_eq!(
+            requests[1].filter.file_ids,
+            vec![NullableKeyFilter::Value("file-note".to_string())]
+        );
     }
 
     #[tokio::test]
-    async fn installed_nonmatching_plugin_skips_owner_scan_for_blobless_files() {
+    async fn installed_nonmatching_plugin_checks_blobless_file_ownership() {
         let wasm = b"test wasm";
         let requests = Arc::new(Mutex::new(Vec::new()));
         let prepared = super::prepare_lix_file_rows(
@@ -7719,11 +7771,68 @@ mod tests {
 
         assert!(context.is_none());
         let requests = requests.lock().expect("scan request mutex");
-        assert_eq!(requests.len(), 1, "only the exact registry row is read");
+        assert_eq!(requests.len(), 2, "registry and exact owner rows are read");
         assert_eq!(
             requests[0].filter.entity_pks,
             vec![crate::entity_pk::EntityPk::single(PLUGIN_REGISTRY_KEY)]
         );
+        assert_eq!(
+            requests[1].filter.entity_pks,
+            vec![crate::entity_pk::EntityPk::single(PLUGIN_OWNER_KEY)]
+        );
+    }
+
+    #[tokio::test]
+    async fn blobless_owned_file_requires_its_installed_plugin() {
+        let prepared = super::prepare_lix_file_rows(
+            vec![live_file_row(
+                "file-note",
+                "branch-b",
+                r#"{"id":"file-note","directory_id":null,"name":"note.sentinel"}"#,
+            )],
+            &super::FilePathPredicate::All,
+        )
+        .expect("owned blobless file should prepare");
+        let context = super::plugin_render_context_for_lix_file_scan(
+            Arc::new(RowsLiveStateReader {
+                rows: vec![live_plugin_owner_row(
+                    "branch-b",
+                    "file-note",
+                    "plugin_sentinel",
+                    vec!["plugin_note".to_string()],
+                )],
+            }) as Arc<dyn LiveStateReader>,
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    branch_ids: vec!["branch-b".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime)),
+            &prepared,
+            false,
+        )
+        .await
+        .expect("durable owner lookup should succeed")
+        .expect("durable owner should create a render context");
+        let blob_reader = Arc::new(StaticBlobReader {
+            bytes_by_hash: BTreeMap::new(),
+        }) as Arc<dyn BlobDataReader>;
+
+        let error = super::lix_file_record_batch_from_prepared(
+            &super::lix_file_schema(),
+            &blob_reader,
+            Some(context),
+            true,
+            prepared,
+        )
+        .await
+        .expect_err("missing plugin must not silently render empty bytes");
+
+        assert_eq!(error.code, LixError::CODE_PLUGIN_UNAVAILABLE);
+        assert!(error.message.contains("plugin_sentinel"));
+        assert!(error.message.contains("/note.sentinel"));
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -2414,6 +2414,10 @@ fn path_update_plugin_rewrite_file_ids(
         if existing_path == assigned_path {
             continue;
         }
+        // Path-only UPDATE sources already materialize `data` so a plugin
+        // handoff can restage the file. Use those bytes for typed matching;
+        // this adds no storage or rendering work beyond the existing source.
+        let data = required_binary_value(batch, row_index, "data")?;
 
         let context =
             file_row_context_from_update(batch, assignment_values, row_index, branch_binding)?;
@@ -2423,7 +2427,7 @@ fn path_update_plugin_rewrite_file_ids(
             .map(PluginFileOwner::plugin_key);
         let assigned_plugin_key = plugin_render
             .branch(&context.branch_id)
-            .and_then(|branch| branch.catalog.select(&assigned_path))
+            .and_then(|branch| branch.catalog.select_for_bytes(&assigned_path, &data))
             .map(PluginRegistryEntry::key);
         if existing_plugin_key != assigned_plugin_key {
             file_ids.insert(file_id);
@@ -3708,7 +3712,7 @@ async fn plugin_render_context_for_lix_file_scan(
             prepared.file_paths.get(key).is_some_and(|path| {
                 branches
                     .get(key.branch_id())
-                    .and_then(|branch| branch.catalog.select(path))
+                    .and_then(|branch| branch.catalog.select(path, None))
                     .is_some()
             })
         });
@@ -5028,7 +5032,7 @@ mod tests {
     use crate::live_state::{LiveStateFilter, MaterializedLiveStateRow};
     use crate::live_state::{LiveStateReader, LiveStateRowRequest, LiveStateScanRequest};
     use crate::plugin::{
-        PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginFileOwner, PluginRegistry,
+        PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginContentType, PluginFileOwner, PluginRegistry,
         PluginRegistryEntry, PluginRegistryEntryInput, PluginRuntime, PluginRuntimeHost,
         plugin_storage_archive_file_id, plugin_storage_archive_path,
     };
@@ -6987,20 +6991,35 @@ mod tests {
         schema_key: &str,
         wasm: &[u8],
     ) -> PluginRegistryEntry {
-        let manifest_json = serde_json::json!({
+        test_plugin_registry_entry_with_content_type(key, path_glob, None, schema_key, wasm)
+    }
+
+    fn test_plugin_registry_entry_with_content_type(
+        key: &str,
+        path_glob: &str,
+        content_type: Option<PluginContentType>,
+        schema_key: &str,
+        wasm: &[u8],
+    ) -> PluginRegistryEntry {
+        let mut manifest = serde_json::json!({
             "api_version": "0.1.0",
             "entry": "plugin.wasm",
             "key": key,
             "match": { "path_glob": path_glob },
             "runtime": "wasm-component-v1",
             "schemas": ["schema/plugin.json"],
-        })
-        .to_string();
+        });
+        if let Some(content_type) = content_type {
+            manifest["match"]["content_type"] =
+                serde_json::to_value(content_type).expect("plugin content type should serialize");
+        }
+        let manifest_json = manifest.to_string();
         PluginRegistryEntry::new(PluginRegistryEntryInput {
             key: key.to_string(),
             runtime: PluginRuntime::WasmComponentV1,
             api_version: "0.1.0".to_string(),
             path_glob: path_glob.to_string(),
+            content_type,
             entry: "plugin.wasm".to_string(),
             schema_keys: vec![schema_key.to_string()],
             manifest_json,
@@ -7167,6 +7186,10 @@ mod tests {
     }
 
     fn path_update_batch_with_path(path: &str) -> RecordBatch {
+        path_update_batch_with_path_and_data(path, b"hello")
+    }
+
+    fn path_update_batch_with_path_and_data(path: &str, data: &[u8]) -> RecordBatch {
         RecordBatch::try_new(
             Arc::new(Schema::new(vec![
                 Field::new("id", DataType::Utf8, false),
@@ -7177,7 +7200,7 @@ mod tests {
             vec![
                 string_column(vec![Some("file-readme")]),
                 string_column(vec![Some(path)]),
-                Arc::new(BinaryArray::from_vec(vec![b"hello"])) as ArrayRef,
+                Arc::new(BinaryArray::from_vec(vec![data])) as ArrayRef,
                 string_column(vec![Some("branch-b")]),
             ],
         )
@@ -7590,20 +7613,20 @@ mod tests {
         assert_eq!(
             context
                 .branch("branch-a")
-                .and_then(|branch| branch.catalog.select("/note.branch-a"))
+                .and_then(|branch| branch.catalog.select("/note.branch-a", None))
                 .map(PluginRegistryEntry::key),
             Some("plugin_sentinel")
         );
         assert!(
             context
                 .branch("branch-a")
-                .and_then(|branch| branch.catalog.select("/note.branch-b"))
+                .and_then(|branch| branch.catalog.select("/note.branch-b", None))
                 .is_none()
         );
         assert_eq!(
             context
                 .branch("branch-b")
-                .and_then(|branch| branch.catalog.select("/note.branch-b"))
+                .and_then(|branch| branch.catalog.select("/note.branch-b", None))
                 .map(PluginRegistryEntry::key),
             Some("plugin_sentinel")
         );
@@ -7901,10 +7924,75 @@ mod tests {
         assert_eq!(
             context
                 .branch("branch-b")
-                .and_then(|branch| branch.catalog.select("/note.active"))
+                .and_then(|branch| branch.catalog.select("/note.active", None))
                 .map(PluginRegistryEntry::key),
             Some("plugin_active")
         );
+    }
+
+    #[tokio::test]
+    async fn path_update_uses_materialized_data_for_content_type_matching() {
+        let wasm = b"test wasm";
+        let prepared = super::prepare_lix_file_rows(
+            vec![live_file_row(
+                "file-readme",
+                "branch-b",
+                r#"{"id":"file-readme","directory_id":null,"name":"note.raw"}"#,
+            )],
+            &super::FilePathPredicate::All,
+        )
+        .expect("blobless file should prepare");
+        let context = super::plugin_render_context_for_lix_file_scan(
+            Arc::new(RowsLiveStateReader {
+                rows: vec![live_plugin_registry_row(
+                    "branch-b",
+                    vec![test_plugin_registry_entry_with_content_type(
+                        "plugin_text",
+                        "*.active",
+                        Some(PluginContentType::Text),
+                        "plugin_text_state",
+                        wasm,
+                    )],
+                )],
+            }) as Arc<dyn LiveStateReader>,
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    branch_ids: vec!["branch-b".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime)),
+            &prepared,
+            true,
+        )
+        .await
+        .expect("plugin registry should load")
+        .expect("the active registry should create a context");
+        let assignments = vec![literal_assignment(
+            "path",
+            ScalarValue::Utf8(Some("/note.active".to_string())),
+        )];
+
+        for (data, expected) in [
+            (
+                b"hello".as_slice(),
+                BTreeSet::from(["file-readme".to_string()]),
+            ),
+            ([0xff, 0xfe].as_slice(), BTreeSet::new()),
+        ] {
+            let batch = path_update_batch_with_path_and_data("/note.raw", data);
+            let assignment_values = super::UpdateAssignmentValues::evaluate(&batch, &assignments)
+                .expect("path assignment should evaluate");
+            let rewritten = super::path_update_plugin_rewrite_file_ids(
+                Some(&context),
+                &batch,
+                &assignment_values,
+                Some("branch-b"),
+            )
+            .expect("typed path ownership comparison should succeed");
+            assert_eq!(rewritten, expected);
+        }
     }
 
     #[test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -50,6 +50,9 @@ pub(crate) async fn commit_prepared_writes(
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
         for write in &prepared_writes.file_data_writes {
             blob_writer.stage_payload(write.payload()).await?;
+            for payload in write.auxiliary_payloads() {
+                blob_writer.stage_payload(payload).await?;
+            }
         }
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -26,21 +26,22 @@ use crate::common::LixTimestamp;
 use crate::domain::Domain;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
-    FilesystemIndex, FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
+    FilesystemPathIndex, FilesystemPathIndexCache, FilesystemPathIndexReader,
     FilesystemPathIndexRequest, FilesystemRowContext, blob_ref_tombstone_row,
-    filesystem_schema_keys, load_path_index_revision,
+    load_path_index_revision,
 };
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::live_state::{
-    LiveStateContext, LiveStateFileScanRequest, LiveStateFilter, LiveStateRowRequest,
-    LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateContext, LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection,
+    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
 };
 use crate::live_state::{overlay_scan_file_rows, overlay_scan_rows};
 use crate::plugin::{
-    InstalledPlugin, PluginDetectedChange, PluginRuntimeHost, detect_changes_with_plugin,
-    is_plugin_storage_path, load_installed_plugins_from_filesystem,
-    plugin_schema_rows_from_archive_path, plugin_state_live_state_projection,
-    retain_plugin_state_rows, select_plugin_for_path,
+    CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginArchiveInstallPlan,
+    PluginDetectedChange, PluginFileOwner, PluginRegistry, PluginRegistryEntry,
+    PluginRegistryEntryInput, PluginRuntimeHost, detect_changes_with_component_instance,
+    is_plugin_storage_path, plugin_install_plan_from_archive_path, plugin_key_from_archive_file_id,
+    plugin_state_live_state_projection, retain_plugin_state_rows_for_schema_keys,
 };
 use crate::session::{SessionMode, WORKSPACE_BRANCH_KEY};
 use crate::sql2::SqlWriteExecutionContext;
@@ -65,11 +66,11 @@ use crate::transaction::schema_resolver::TransactionSchemaResolver;
 use crate::transaction::staging::{PreparedWriteSet, TransactionWriteBuffer};
 use crate::transaction::types::{
     PreparedStateRow, PreparedTransactionWrite, StagedCommitChangeRef, TransactionFileData,
-    TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
-    TransactionWriteRow, stage_json_from_value,
+    TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOperation,
+    TransactionWriteOrigin, TransactionWriteOutcome, TransactionWriteRow, stage_json_from_value,
 };
 use crate::transaction::validation::{TransactionValidationInput, validate_prepared_writes};
-use crate::wasm::WasmPluginFile;
+use crate::wasm::{WasmComponentInstance, WasmPluginFile};
 use crate::{LixError, NullableKeyFilter, SqlQueryResult, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -481,43 +482,37 @@ where
         overlay_scan_rows(&base, &staged, request).await
     }
 
-    async fn scan_visible_live_state_file(
-        &mut self,
-        request: &LiveStateFileScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        let staged = self.staged_writes.staging_overlay()?;
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        let base = self.live_state.reader(read);
-        overlay_scan_file_rows(&base, &staged, request).await
-    }
-
     async fn reconcile_plugin_write(
         &mut self,
         write: TransactionWrite,
     ) -> Result<TransactionWrite, LixError> {
         match write {
             TransactionWrite::Rows { mode, mut rows } => {
-                rows.extend(self.plugin_delete_tombstone_rows(&rows).await?);
+                reject_external_plugin_registry_rows(&rows)?;
+                let mut reconciliation = self
+                    .plugin_write_reconciliation(&rows, &mut Vec::new())
+                    .await?;
+                mark_plugin_reconciliation_rows(&mut reconciliation.rows);
+                rows.extend(reconciliation.rows);
                 Ok(TransactionWrite::Rows { mode, rows })
             }
             TransactionWrite::RowsWithFileData {
                 mode,
                 rows,
-                file_data,
+                mut file_data,
                 count,
             } => {
                 let mut rows = rows;
-                let PluginFileDataReconciliation {
+                reject_external_plugin_registry_rows(&rows)?;
+                let PluginWriteReconciliation {
                     file_keys,
-                    rows: plugin_rows,
-                } = self.plugin_file_data_reconciliation(&file_data).await?;
+                    rows: mut plugin_rows,
+                } = self
+                    .plugin_write_reconciliation(&rows, &mut file_data)
+                    .await?;
+                mark_plugin_reconciliation_rows(&mut plugin_rows);
                 rows.retain(|row| !file_keys.iter().any(|key| key.matches_blob_ref_row(row)));
                 rows.extend(plugin_rows);
-                rows.extend(self.plugin_delete_tombstone_rows(&rows).await?);
                 let file_data = file_data
                     .into_iter()
                     .filter(|write| {
@@ -534,128 +529,103 @@ where
         }
     }
 
-    async fn plugin_file_data_reconciliation(
+    /// Reconciles plugin lifecycle, ownership, and state for one logical write
+    /// batch against one storage snapshot.
+    ///
+    /// The first and only mandatory current-state lookup is the small durable
+    /// registry row. An empty registry returns before owner, filesystem,
+    /// matcher, state, archive, CAS, or WASM work. Non-empty registries use
+    /// batched owner/state/CAS reads and execute plugin calls in input order.
+    async fn plugin_write_reconciliation(
         &mut self,
-        file_data: &[TransactionFileData],
-    ) -> Result<PluginFileDataReconciliation, LixError> {
-        let mut reconciliation = PluginFileDataReconciliation::default();
-        // A single staged write can contain many ordinary files for the same
-        // branch. Reconciliation reads the pre-write filesystem each time, so
-        // retain that immutable view for this invocation rather than rebuilding
-        // it once per file. Nothing from this write is staged until this method
-        // returns, which keeps the cached snapshot equivalent to the previous
-        // per-file reads.
-        let mut contexts = BTreeMap::<String, PluginReconciliationContext>::new();
-        for write in file_data {
-            if let Some(rows) = plugin_archive_schema_rows_for_write(write)? {
-                reconciliation.rows.extend(rows);
-                continue;
-            }
-            let Some(write_path) = write.path.as_deref() else {
-                continue;
-            };
-            if !is_plugin_reconciliation_candidate_path(write_path) {
-                continue;
-            }
-            if !contexts.contains_key(&write.branch_id) {
-                let filesystem = self.filesystem_index_for_branch(&write.branch_id).await?;
-                let installed_plugins = self.installed_plugins_for_filesystem(&filesystem).await?;
-                contexts.insert(
-                    write.branch_id.clone(),
-                    PluginReconciliationContext {
-                        filesystem,
-                        installed_plugins,
-                    },
-                );
-            }
-            let (existing_plugin, selected_plugin, filename, existing_file_has_blob) = {
-                let context = contexts
-                    .get(&write.branch_id)
-                    .expect("plugin reconciliation context should be cached");
-                let existing_file = context.filesystem.file_entries().find(|(_, file)| {
-                    file.id == write.file_id
-                        && file.scope.global == write.global
-                        && file.scope.untracked == write.untracked
-                });
-                let existing_plugin = existing_file
-                    .and_then(|(path, _)| select_plugin_for_path(&context.installed_plugins, path));
-                let selected_plugin =
-                    select_plugin_for_path(&context.installed_plugins, write_path);
-                let filename = write
-                    .filename
-                    .clone()
-                    .or_else(|| existing_file.map(|(_, file)| file.name.clone()));
-                let existing_file_has_blob =
-                    existing_file.is_some_and(|(_, file)| file.blob_hash.is_some());
-                (
-                    existing_plugin,
-                    selected_plugin,
-                    filename,
-                    existing_file_has_blob,
-                )
-            };
-            let context = FilesystemRowContext {
-                branch_id: write.branch_id.clone(),
-                global: write.global,
-                untracked: write.untracked,
-                file_id: None,
-                metadata: None,
-            };
-            if let Some(existing_plugin) = existing_plugin
-                && selected_plugin.is_none_or(|plugin| plugin.key != existing_plugin.key)
-            {
-                let existing_state = self
-                    .active_plugin_state_rows(&write.branch_id, &write.file_id, existing_plugin)
-                    .await?;
-                reconciliation.rows.extend(plugin_state_tombstone_rows(
-                    &existing_state,
-                    &write.file_id,
-                    &context,
-                ));
-            }
-            let Some(plugin) = selected_plugin else {
-                continue;
-            };
-            let active_state = self
-                .active_plugin_state_rows(&write.branch_id, &write.file_id, plugin)
-                .await?;
-            let changes = detect_changes_with_plugin(
-                &self.plugin_host,
-                plugin,
-                &active_state,
-                WasmPluginFile {
-                    filename,
-                    data: write.data().to_vec(),
-                },
-            )
-            .await?;
-            if existing_file_has_blob {
-                reconciliation.rows.push(blob_ref_tombstone_row(
-                    write.file_id.clone(),
-                    context.clone(),
-                ));
-            }
-            reconciliation.rows.extend(plugin_change_rows(
-                plugin,
-                changes,
-                &write.file_id,
-                &context,
-                "plugin detect-changes",
-            )?);
-            reconciliation
-                .file_keys
-                .insert(PluginFileWriteKey::from(write));
-        }
-        Ok(reconciliation)
-    }
+        input_rows: &[TransactionWriteRow],
+        file_data: &mut [TransactionFileData],
+    ) -> Result<PluginWriteReconciliation, LixError> {
+        let mut reconciliation = PluginWriteReconciliation::default();
+        let mut lifecycle = BTreeMap::<PluginLifecycleKey, Option<PluginRegistryEntry>>::new();
+        let mut lifecycle_schema_rows = Vec::<(PluginLifecycleKey, TransactionWriteRow)>::new();
+        let mut current_install_wasm = BTreeMap::<BlobHash, Vec<u8>>::new();
+        let mut branch_ids = BTreeSet::<String>::new();
 
-    async fn plugin_delete_tombstone_rows(
-        &mut self,
-        rows: &[TransactionWriteRow],
-    ) -> Result<Vec<TransactionWriteRow>, LixError> {
-        let mut tombstones = Vec::new();
-        let mut seen = BTreeSet::new();
-        for row in rows {
+        // Parse each archive exactly once. The original ZIP remains the file
+        // payload; the extracted component is staged as a second CAS payload.
+        for write in file_data.iter_mut() {
+            let Some(path) = write.path.as_deref() else {
+                continue;
+            };
+            if !is_plugin_storage_path(path) {
+                if !write.global && !write.untracked {
+                    branch_ids.insert(write.branch_id.clone());
+                }
+                continue;
+            }
+            let plan = plugin_install_plan_from_archive_path(
+                path,
+                write.data(),
+                &write.branch_id,
+                write.global,
+                write.untracked,
+            )?;
+            if write.file_id != plan.archive_file_id {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    format!(
+                        "plugin archive '{}' must use deterministic file id '{}'",
+                        plan.plugin_key, plan.archive_file_id
+                    ),
+                ));
+            }
+            let archive_blob_hash = write.blob_hash().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INVALID_PLUGIN,
+                    "plugin archive payload must not be empty",
+                )
+            })?;
+            let PluginArchiveInstallPlan {
+                plugin_key,
+                archive_file_id,
+                parsed,
+                schema_rows,
+            } = plan;
+            let entry = PluginRegistryEntry::new(PluginRegistryEntryInput {
+                key: plugin_key.clone(),
+                runtime: parsed.manifest.runtime,
+                api_version: parsed.manifest.api_version.clone(),
+                path_glob: parsed.manifest.file_match.path_glob.clone(),
+                entry: parsed.manifest.entry.clone(),
+                schema_keys: parsed.schema_keys.clone(),
+                manifest_json: parsed.normalized_manifest_json.clone(),
+                archive_file_id,
+                archive_path: path.to_string(),
+                archive_blob_hash: archive_blob_hash.to_hex(),
+                wasm_blob_hash: parsed.wasm_hash.to_hex(),
+            })?;
+            let lifecycle_key = PluginLifecycleKey {
+                branch_id: write.branch_id.clone(),
+                plugin_key,
+            };
+            if lifecycle
+                .insert(lifecycle_key.clone(), Some(entry))
+                .is_some()
+            {
+                return Err(duplicate_plugin_lifecycle_mutation());
+            }
+            current_install_wasm
+                .entry(parsed.wasm_hash)
+                .or_insert_with(|| parsed.wasm_bytes.clone());
+            write.add_auxiliary_payload(parsed.wasm_bytes);
+            lifecycle_schema_rows.extend(
+                schema_rows
+                    .into_iter()
+                    .map(|row| (lifecycle_key.clone(), row)),
+            );
+            branch_ids.insert(write.branch_id.clone());
+        }
+
+        // A canonical archive descriptor tombstone is the uninstall signal.
+        // Other descriptor tombstones are ownership cleanup candidates.
+        let mut deleted_file_keys = BTreeMap::<PluginFileWriteKey, Option<TransactionJson>>::new();
+        for row in input_rows {
             if row.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || row.snapshot.is_some() {
                 continue;
             }
@@ -666,95 +636,645 @@ where
             else {
                 continue;
             };
+            if let Some(plugin_key) = plugin_key_from_archive_file_id(file_id) {
+                if row.global || row.untracked || row.branch_id == GLOBAL_BRANCH_ID {
+                    return Err(LixError::new(
+                        LixError::CODE_CONSTRAINT_VIOLATION,
+                        "plugin uninstall requires a tracked branch-local archive",
+                    ));
+                }
+                let lifecycle_key = PluginLifecycleKey {
+                    branch_id: row.branch_id.clone(),
+                    plugin_key,
+                };
+                if lifecycle.insert(lifecycle_key, None).is_some() {
+                    return Err(duplicate_plugin_lifecycle_mutation());
+                }
+                branch_ids.insert(row.branch_id.clone());
+                continue;
+            }
+            if row.global || row.untracked {
+                continue;
+            }
             let key = PluginFileWriteKey {
                 branch_id: row.branch_id.clone(),
-                global: row.global,
-                untracked: row.untracked,
+                global: false,
+                untracked: false,
                 file_id: file_id.to_string(),
             };
-            if !seen.insert(key) {
-                continue;
-            }
-            let filesystem = self.filesystem_index_for_branch(&row.branch_id).await?;
-            let Some((path, _file)) = filesystem.file_entries().find(|(_, file)| {
-                file.id == file_id
-                    && file.scope.global == row.global
-                    && file.scope.untracked == row.untracked
-            }) else {
-                continue;
-            };
-            if !is_plugin_reconciliation_candidate_path(path) {
-                continue;
-            }
-            let installed_plugins = self.installed_plugins_for_filesystem(&filesystem).await?;
-            let Some(plugin) = select_plugin_for_path(&installed_plugins, path) else {
-                continue;
-            };
-            let active_state = self
-                .active_plugin_state_rows(&row.branch_id, file_id, plugin)
-                .await?;
-            let context = FilesystemRowContext {
-                branch_id: row.branch_id.clone(),
-                global: row.global,
-                untracked: row.untracked,
-                file_id: None,
-                metadata: row.metadata.clone(),
-            };
-            tombstones.extend(plugin_state_tombstone_rows(
-                &active_state,
-                file_id,
-                &context,
-            ));
+            deleted_file_keys
+                .entry(key)
+                .or_insert_with(|| row.metadata.clone());
+            branch_ids.insert(row.branch_id.clone());
         }
-        Ok(tombstones)
-    }
 
-    async fn filesystem_index_for_branch(
-        &mut self,
-        branch_id: &str,
-    ) -> Result<FilesystemIndex, LixError> {
-        let rows = self
-            .scan_visible_live_state(&LiveStateScanRequest {
-                filter: LiveStateFilter {
-                    schema_keys: filesystem_schema_keys(),
-                    branch_ids: vec![branch_id.to_string()],
-                    ..Default::default()
-                },
-                ..Default::default()
-            })
-            .await?;
-        FilesystemIndex::from_live_rows(rows)
-    }
+        // Registered-schema writes are rare lifecycle operations, but they
+        // must still consult the registry even when no file data is present.
+        // Otherwise a later public UPDATE/DELETE could invalidate an active
+        // plugin's durable state contract behind the registry's back.
+        for row in input_rows {
+            if row.schema_key == REGISTERED_SCHEMA_KEY && !row.global && !row.untracked {
+                branch_ids.insert(row.branch_id.clone());
+            }
+        }
 
-    async fn installed_plugins_for_filesystem(
-        &self,
-        filesystem: &FilesystemIndex,
-    ) -> Result<Vec<InstalledPlugin>, LixError> {
+        if branch_ids.is_empty() {
+            return Ok(reconciliation);
+        }
+
+        let staged = self.staged_writes.staging_overlay()?;
         let read = SharedStorageAdapterRead::new(
             self.storage
                 .begin_read(StorageReadOptions::default())
                 .await?,
         );
-        let blob_reader = self.binary_cas.reader(read);
-        load_installed_plugins_from_filesystem(filesystem, &blob_reader).await
-    }
+        let base = self.live_state.reader(read.clone());
 
-    async fn active_plugin_state_rows(
-        &mut self,
-        branch_id: &str,
-        file_id: &str,
-        plugin: &InstalledPlugin,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        let rows = self
-            .scan_visible_live_state_file(&LiveStateFileScanRequest {
-                branch_ids: vec![branch_id.to_string()],
-                file_id: file_id.to_string(),
-                schema_keys: plugin.schema_keys.clone(),
-                projection: plugin_state_live_state_projection(),
-                ..Default::default()
-            })
+        if !lifecycle_schema_rows.is_empty() {
+            let mut desired_schemas = BTreeMap::<(String, EntityPk), (String, JsonValue)>::new();
+            for (lifecycle_key, row) in &lifecycle_schema_rows {
+                let entity_pk = row.entity_pk.clone().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "plugin schema row is missing its entity identity",
+                    )
+                })?;
+                let snapshot = row.snapshot.as_ref().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "plugin schema row is missing its definition",
+                    )
+                })?;
+                let identity = (row.branch_id.clone(), entity_pk);
+                let definition = snapshot.value().clone();
+                if let Some((other_plugin, other_definition)) = desired_schemas.get(&identity)
+                    && other_definition != &definition
+                {
+                    return Err(plugin_schema_collision_error(
+                        &lifecycle_key.plugin_key,
+                        &identity.1,
+                        Some(other_plugin),
+                    ));
+                }
+                desired_schemas.insert(identity, (lifecycle_key.plugin_key.clone(), definition));
+            }
+
+            let schema_rows = overlay_scan_rows(
+                &base,
+                &staged,
+                &LiveStateScanRequest {
+                    filter: LiveStateFilter {
+                        schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
+                        entity_pks: desired_schemas
+                            .keys()
+                            .map(|(_, entity_pk)| entity_pk.clone())
+                            .collect::<BTreeSet<_>>()
+                            .into_iter()
+                            .collect(),
+                        branch_ids: desired_schemas
+                            .keys()
+                            .map(|(branch_id, _)| branch_id.clone())
+                            .collect::<BTreeSet<_>>()
+                            .into_iter()
+                            .collect(),
+                        file_ids: vec![NullableKeyFilter::Null],
+                        untracked: Some(false),
+                        ..Default::default()
+                    },
+                    projection: plugin_registry_live_state_projection(),
+                    ..Default::default()
+                },
+            )
             .await?;
-        Ok(retain_plugin_state_rows(plugin, rows))
+            let mut existing_schemas = BTreeMap::<(String, EntityPk), JsonValue>::new();
+            for row in schema_rows {
+                let Some(snapshot) = row.snapshot_content.as_deref() else {
+                    continue;
+                };
+                existing_schemas.insert(
+                    (row.branch_id, row.entity_pk),
+                    serde_json::from_str(snapshot).map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_SCHEMA_DEFINITION,
+                            format!("invalid existing registered schema snapshot: {error}"),
+                        )
+                    })?,
+                );
+            }
+            // Programmatic writes may pair a schema mutation with a plugin
+            // archive in one transaction batch. Model those rows after the
+            // visible snapshot before checking the derived plugin rows.
+            for row in input_rows {
+                if row.schema_key != REGISTERED_SCHEMA_KEY
+                    || row.global
+                    || row.untracked
+                    || row.file_id.is_some()
+                {
+                    continue;
+                }
+                let Some(entity_pk) = row.entity_pk.clone() else {
+                    continue;
+                };
+                let identity = (row.branch_id.clone(), entity_pk);
+                if !desired_schemas.contains_key(&identity) {
+                    continue;
+                }
+                match row.snapshot.as_ref() {
+                    Some(snapshot) => {
+                        existing_schemas.insert(identity, snapshot.value().clone());
+                    }
+                    None => {
+                        existing_schemas.remove(&identity);
+                    }
+                }
+            }
+            for (identity, (plugin_key, definition)) in &desired_schemas {
+                if let Some(existing) = existing_schemas.get(identity)
+                    && existing != definition
+                {
+                    return Err(plugin_schema_collision_error(plugin_key, &identity.1, None));
+                }
+            }
+            reconciliation
+                .rows
+                .extend(lifecycle_schema_rows.into_iter().map(|(_, row)| row));
+        }
+
+        let registry_rows = overlay_scan_rows(
+            &base,
+            &staged,
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
+                    entity_pks: vec![EntityPk::single(PLUGIN_REGISTRY_KEY)],
+                    branch_ids: branch_ids.iter().cloned().collect(),
+                    file_ids: vec![NullableKeyFilter::Null],
+                    untracked: Some(false),
+                    ..Default::default()
+                },
+                projection: plugin_registry_live_state_projection(),
+                ..Default::default()
+            },
+        )
+        .await?;
+        let mut registry_rows_by_branch = BTreeMap::<String, MaterializedLiveStateRow>::new();
+        for row in registry_rows {
+            if registry_rows_by_branch
+                .insert(row.branch_id.clone(), row)
+                .is_some()
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INVALID_PLUGIN,
+                    "durable plugin registry lookup returned duplicate branch rows",
+                ));
+            }
+        }
+
+        let mut registries = BTreeMap::<String, PluginRegistry>::new();
+        let mut changed_registry_branches = BTreeSet::<String>::new();
+        for branch_id in &branch_ids {
+            registries.insert(
+                branch_id.clone(),
+                PluginRegistry::from_optional_live_state_row(
+                    registry_rows_by_branch.get(branch_id),
+                    branch_id,
+                )?,
+            );
+        }
+        for (key, mutation) in lifecycle {
+            let registry = registries
+                .get_mut(&key.branch_id)
+                .expect("lifecycle branch should have a loaded registry");
+            match mutation {
+                Some(plugin) => {
+                    registry.upsert(plugin)?;
+                }
+                None => {
+                    registry.remove(&key.plugin_key)?;
+                }
+            }
+            changed_registry_branches.insert(key.branch_id);
+        }
+        for row in input_rows {
+            if row.schema_key != REGISTERED_SCHEMA_KEY || row.global || row.untracked {
+                continue;
+            }
+            let Some(schema_key) = row
+                .entity_pk
+                .as_ref()
+                .and_then(|entity_pk| entity_pk.as_single_string().ok())
+            else {
+                continue;
+            };
+            let Some(plugin) = registries.get(&row.branch_id).and_then(|registry| {
+                registry
+                    .plugins()
+                    .iter()
+                    .find(|plugin| plugin.schema_keys().iter().any(|key| key == schema_key))
+            }) else {
+                continue;
+            };
+            return Err(LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                format!(
+                    "registered schema '{schema_key}' is owned by active plugin '{}'; uninstall the plugin before migrating or deleting that schema",
+                    plugin.key()
+                ),
+            ));
+        }
+        for branch_id in changed_registry_branches {
+            reconciliation.rows.push(
+                registries
+                    .get(&branch_id)
+                    .expect("changed registry branch should remain loaded")
+                    .write_row(&branch_id)?,
+            );
+        }
+
+        // The dominant no-plugin path ends here. In particular, it does not
+        // inspect descriptors or owners left behind by an uninstall.
+        let active_branch_ids = branch_ids
+            .iter()
+            .filter(|branch_id| {
+                registries
+                    .get(*branch_id)
+                    .is_some_and(|registry| !registry.is_empty())
+            })
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if active_branch_ids.is_empty() && deleted_file_keys.is_empty() {
+            return Ok(reconciliation);
+        }
+
+        let owner_branch_ids = active_branch_ids
+            .iter()
+            .cloned()
+            .chain(deleted_file_keys.keys().map(|key| key.branch_id.clone()))
+            .collect::<BTreeSet<_>>();
+        let mut candidate_file_ids = BTreeSet::<String>::new();
+        for write in file_data.iter() {
+            if write.global
+                || write.untracked
+                || !active_branch_ids.contains(&write.branch_id)
+                || write.path.as_deref().is_none_or(is_plugin_storage_path)
+            {
+                continue;
+            }
+            candidate_file_ids.insert(write.file_id.clone());
+        }
+        for key in deleted_file_keys.keys() {
+            candidate_file_ids.insert(key.file_id.clone());
+        }
+        if candidate_file_ids.is_empty() {
+            return Ok(reconciliation);
+        }
+
+        let owner_rows = overlay_scan_rows(
+            &base,
+            &staged,
+            &LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
+                    entity_pks: vec![EntityPk::single(PLUGIN_OWNER_KEY)],
+                    branch_ids: owner_branch_ids.into_iter().collect(),
+                    file_ids: candidate_file_ids
+                        .iter()
+                        .cloned()
+                        .map(NullableKeyFilter::Value)
+                        .collect(),
+                    untracked: Some(false),
+                    ..Default::default()
+                },
+                projection: plugin_registry_live_state_projection(),
+                ..Default::default()
+            },
+        )
+        .await?;
+        let mut owners = BTreeMap::<PluginFileWriteKey, PluginFileOwner>::new();
+        for row in owner_rows {
+            let branch_id = row.branch_id.clone();
+            let Some(owner) = PluginFileOwner::from_live_state_row(&row, &branch_id)? else {
+                continue;
+            };
+            let key = PluginFileWriteKey {
+                branch_id,
+                global: false,
+                untracked: false,
+                file_id: owner.file_id().to_string(),
+            };
+            if owners.insert(key, owner).is_some() {
+                return Err(LixError::new(
+                    LixError::CODE_INVALID_PLUGIN,
+                    "durable plugin owner lookup returned duplicate file rows",
+                ));
+            }
+        }
+
+        let mut catalogs = BTreeMap::<String, Arc<CompiledPluginCatalog>>::new();
+        for branch_id in &active_branch_ids {
+            let registry = registries
+                .get(branch_id)
+                .expect("active branch should have a registry");
+            catalogs.insert(
+                branch_id.clone(),
+                self.plugin_host.compiled_plugin_catalog(registry)?,
+            );
+        }
+
+        let mut selected_plugins = BTreeMap::<PluginFileWriteKey, PluginRegistryEntry>::new();
+        for write in file_data.iter() {
+            let Some(path) = write.path.as_deref() else {
+                continue;
+            };
+            if write.global
+                || write.untracked
+                || is_plugin_storage_path(path)
+                || !active_branch_ids.contains(&write.branch_id)
+            {
+                continue;
+            }
+            let Some(plugin) = catalogs
+                .get(&write.branch_id)
+                .and_then(|catalog| catalog.select(path))
+            else {
+                continue;
+            };
+            selected_plugins.insert(PluginFileWriteKey::from(write), plugin.clone());
+        }
+
+        let mut state_groups = BTreeMap::<PluginStateGroupKey, PluginStateGroup>::new();
+        for (key, owner) in &owners {
+            let group_key = PluginStateGroupKey {
+                branch_id: key.branch_id.clone(),
+                plugin_key: owner.plugin_key().to_string(),
+            };
+            let group = state_groups.entry(group_key).or_default();
+            group.file_ids.insert(key.file_id.clone());
+            group
+                .schema_keys
+                .extend(owner.schema_keys().iter().cloned());
+            if let Some(selected) = selected_plugins.get(key)
+                && selected.key() == owner.plugin_key()
+            {
+                group
+                    .schema_keys
+                    .extend(selected.schema_keys().iter().cloned());
+            }
+        }
+        let mut state_by_file =
+            BTreeMap::<PluginStateFileKey, Vec<MaterializedLiveStateRow>>::new();
+        for (group_key, group) in state_groups {
+            let rows = overlay_scan_rows(
+                &base,
+                &staged,
+                &LiveStateScanRequest {
+                    filter: LiveStateFilter {
+                        schema_keys: group.schema_keys.into_iter().collect(),
+                        branch_ids: vec![group_key.branch_id.clone()],
+                        file_ids: group
+                            .file_ids
+                            .iter()
+                            .cloned()
+                            .map(NullableKeyFilter::Value)
+                            .collect(),
+                        untracked: Some(false),
+                        ..Default::default()
+                    },
+                    projection: plugin_state_live_state_projection(),
+                    ..Default::default()
+                },
+            )
+            .await?;
+            for row in rows {
+                let Some(file_id) = row.file_id.clone() else {
+                    continue;
+                };
+                state_by_file
+                    .entry(PluginStateFileKey {
+                        branch_id: group_key.branch_id.clone(),
+                        plugin_key: group_key.plugin_key.clone(),
+                        file_id,
+                    })
+                    .or_default()
+                    .push(row);
+            }
+        }
+
+        let mut selected_entries = BTreeMap::<PluginBranchEntryKey, PluginRegistryEntry>::new();
+        for (file_key, entry) in &selected_plugins {
+            selected_entries
+                .entry(PluginBranchEntryKey {
+                    branch_id: file_key.branch_id.clone(),
+                    plugin_key: entry.key().to_string(),
+                })
+                .or_insert_with(|| entry.clone());
+        }
+
+        // Resolve warm components by their fixed content hash before asking
+        // the CAS for bytes. Keep the returned Arc itself: another branch may
+        // concurrently replace the key-only cache with a different hash.
+        let mut component_instances =
+            BTreeMap::<PluginBranchEntryKey, Arc<dyn WasmComponentInstance>>::new();
+        let mut cold_entries = BTreeMap::<PluginBranchEntryKey, PluginRegistryEntry>::new();
+        for (key, entry) in selected_entries {
+            let hash = BlobHash::from_hex(entry.wasm_blob_hash())?;
+            if let Some(instance) = self
+                .plugin_host
+                .cached_plugin_component(entry.key(), hash)?
+            {
+                component_instances.insert(key, instance);
+            } else {
+                cold_entries.insert(key, entry);
+            }
+        }
+
+        let mut wasm_by_hash = current_install_wasm;
+        let mut missing_hashes = Vec::<BlobHash>::new();
+        for entry in cold_entries.values() {
+            let hash = BlobHash::from_hex(entry.wasm_blob_hash())?;
+            if !wasm_by_hash.contains_key(&hash) && !missing_hashes.contains(&hash) {
+                missing_hashes.push(hash);
+            }
+        }
+        if !missing_hashes.is_empty() {
+            let base_blob_reader = self.binary_cas.reader(read.clone());
+            let loaded = load_transaction_blob_bytes(
+                &base_blob_reader,
+                &self.staged_writes,
+                &missing_hashes,
+            )
+            .await?
+            .into_vec();
+            for (hash, bytes) in missing_hashes.into_iter().zip(loaded) {
+                let bytes = bytes.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PLUGIN,
+                        format!(
+                            "plugin registry references missing WASM blob '{}'",
+                            hash.to_hex()
+                        ),
+                    )
+                })?;
+                wasm_by_hash.insert(hash, bytes);
+            }
+        }
+        for (key, entry) in cold_entries {
+            let hash = BlobHash::from_hex(entry.wasm_blob_hash())?;
+            let wasm = wasm_by_hash.get(&hash).cloned().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INVALID_PLUGIN,
+                    format!(
+                        "plugin registry references unavailable WASM blob '{}'",
+                        hash.to_hex()
+                    ),
+                )
+            })?;
+            let plugin = entry.to_installed_plugin(wasm)?;
+            let instance =
+                crate::plugin::load_or_init_plugin_component(&self.plugin_host, &plugin).await?;
+            component_instances.insert(key, instance);
+        }
+
+        let mut reconciled_file_keys = BTreeSet::<PluginFileWriteKey>::new();
+        for write in file_data.iter() {
+            let Some(path) = write.path.as_deref() else {
+                continue;
+            };
+            if write.global
+                || write.untracked
+                || is_plugin_storage_path(path)
+                || !active_branch_ids.contains(&write.branch_id)
+            {
+                continue;
+            }
+            let file_key = PluginFileWriteKey::from(write);
+            let owner = owners.get(&file_key);
+            let selected = selected_plugins.get(&file_key);
+            let context = FilesystemRowContext {
+                branch_id: write.branch_id.clone(),
+                global: false,
+                untracked: false,
+                file_id: None,
+                metadata: None,
+            };
+            let old_state = owner
+                .and_then(|owner| {
+                    state_by_file.get(&PluginStateFileKey {
+                        branch_id: write.branch_id.clone(),
+                        plugin_key: owner.plugin_key().to_string(),
+                        file_id: write.file_id.clone(),
+                    })
+                })
+                .cloned()
+                .unwrap_or_default();
+
+            if owner.is_some_and(|owner| {
+                selected.is_none_or(|selected| selected.key() != owner.plugin_key())
+            }) {
+                reconciliation.rows.extend(plugin_state_tombstone_rows(
+                    &old_state,
+                    &write.file_id,
+                    &context,
+                ));
+            }
+
+            let Some(selected) = selected else {
+                if owner.is_some() {
+                    reconciliation.rows.push(PluginFileOwner::delete_row(
+                        write.file_id.clone(),
+                        &write.branch_id,
+                    )?);
+                }
+                reconciled_file_keys.insert(file_key);
+                continue;
+            };
+            let installed_key = PluginBranchEntryKey {
+                branch_id: write.branch_id.clone(),
+                plugin_key: selected.key().to_string(),
+            };
+            let component = component_instances
+                .get(&installed_key)
+                .expect("selected plugin should have a resolved component");
+            let active_state = if owner.is_some_and(|owner| owner.plugin_key() == selected.key()) {
+                let selected_schema_keys = selected.schema_keys().iter().collect::<BTreeSet<_>>();
+                let obsolete_state = old_state
+                    .iter()
+                    .filter(|row| !selected_schema_keys.contains(&row.schema_key))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                reconciliation.rows.extend(plugin_state_tombstone_rows(
+                    &obsolete_state,
+                    &write.file_id,
+                    &context,
+                ));
+                retain_plugin_state_rows_for_schema_keys(selected.schema_keys(), old_state)
+            } else {
+                Vec::new()
+            };
+            let changes = detect_changes_with_component_instance(
+                component,
+                &active_state,
+                WasmPluginFile {
+                    filename: write.filename.clone(),
+                    data: write.data().to_vec(),
+                },
+            )
+            .await?;
+            if write.had_blob_ref {
+                reconciliation.rows.push(blob_ref_tombstone_row(
+                    write.file_id.clone(),
+                    context.clone(),
+                ));
+            }
+            reconciliation.rows.extend(plugin_change_rows(
+                selected,
+                changes,
+                &write.file_id,
+                &context,
+                "plugin detect-changes",
+            )?);
+            reconciliation.rows.push(
+                PluginFileOwner::from_registry_entry(write.file_id.clone(), selected)?
+                    .write_row(&write.branch_id)?,
+            );
+            reconciliation.file_keys.insert(file_key.clone());
+            reconciled_file_keys.insert(file_key);
+        }
+
+        for (file_key, metadata) in deleted_file_keys {
+            if reconciled_file_keys.contains(&file_key) {
+                continue;
+            }
+            let Some(owner) = owners.get(&file_key) else {
+                continue;
+            };
+            let active_state = state_by_file
+                .get(&PluginStateFileKey {
+                    branch_id: file_key.branch_id.clone(),
+                    plugin_key: owner.plugin_key().to_string(),
+                    file_id: file_key.file_id.clone(),
+                })
+                .cloned()
+                .unwrap_or_default();
+            let context = FilesystemRowContext {
+                branch_id: file_key.branch_id.clone(),
+                global: false,
+                untracked: false,
+                file_id: None,
+                metadata,
+            };
+            reconciliation.rows.extend(plugin_state_tombstone_rows(
+                &active_state,
+                &file_key.file_id,
+                &context,
+            ));
+            reconciliation.rows.push(PluginFileOwner::delete_row(
+                file_key.file_id,
+                &file_key.branch_id,
+            )?);
+        }
+
+        Ok(reconciliation)
     }
 
     async fn prepare_transaction_write(
@@ -1572,6 +2092,35 @@ fn transaction_path_index_cache_revision(
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
+const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
+
+fn reject_external_plugin_registry_rows(rows: &[TransactionWriteRow]) -> Result<(), LixError> {
+    for row in rows {
+        if row.schema_key != KEY_VALUE_SCHEMA_KEY {
+            continue;
+        }
+        let entity_key = row
+            .entity_pk
+            .as_ref()
+            .and_then(|entity_pk| entity_pk.as_single_string().ok());
+        let snapshot_key = row
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.get("key"))
+            .and_then(JsonValue::as_str);
+        let reserved = [entity_key, snapshot_key]
+            .into_iter()
+            .flatten()
+            .find(|key| matches!(*key, PLUGIN_REGISTRY_KEY | PLUGIN_OWNER_KEY));
+        if let Some(key) = reserved {
+            return Err(LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                format!("'{key}' is reserved for engine-managed plugin state"),
+            ));
+        }
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct PluginFileWriteKey {
@@ -1603,48 +2152,93 @@ impl From<&TransactionFileData> for PluginFileWriteKey {
 }
 
 #[derive(Debug, Default)]
-struct PluginFileDataReconciliation {
+struct PluginWriteReconciliation {
     file_keys: BTreeSet<PluginFileWriteKey>,
     rows: Vec<TransactionWriteRow>,
 }
 
-/// The pre-write filesystem and plugin set for one branch during a single
-/// `RowsWithFileData` reconciliation pass.
-struct PluginReconciliationContext {
-    filesystem: FilesystemIndex,
-    installed_plugins: Vec<InstalledPlugin>,
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PluginLifecycleKey {
+    branch_id: String,
+    plugin_key: String,
 }
 
-fn plugin_archive_schema_rows_for_write(
-    write: &TransactionFileData,
-) -> Result<Option<Vec<TransactionWriteRow>>, LixError> {
-    let Some(path) = write.path.as_deref() else {
-        return Ok(None);
-    };
-    if !is_plugin_storage_path(path) {
-        return Ok(None);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PluginStateGroupKey {
+    branch_id: String,
+    plugin_key: String,
+}
+
+#[derive(Debug, Default)]
+struct PluginStateGroup {
+    file_ids: BTreeSet<String>,
+    schema_keys: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PluginStateFileKey {
+    branch_id: String,
+    plugin_key: String,
+    file_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PluginBranchEntryKey {
+    branch_id: String,
+    plugin_key: String,
+}
+
+fn duplicate_plugin_lifecycle_mutation() -> LixError {
+    LixError::new(
+        LixError::CODE_CONSTRAINT_VIOLATION,
+        "a write batch may mutate each plugin archive at most once",
+    )
+}
+
+fn plugin_schema_collision_error(
+    plugin_key: &str,
+    entity_pk: &EntityPk,
+    other_plugin: Option<&String>,
+) -> LixError {
+    let schema_key = entity_pk
+        .as_single_string()
+        .unwrap_or("<invalid schema identity>");
+    let owner = other_plugin.map_or_else(
+        || "an existing registered schema".to_string(),
+        |other| format!("plugin '{other}'"),
+    );
+    LixError::new(
+        LixError::CODE_CONSTRAINT_VIOLATION,
+        format!(
+            "plugin '{plugin_key}' schema '{schema_key}' conflicts with {owner}; shared schema keys must have identical definitions"
+        ),
+    )
+}
+
+fn mark_plugin_reconciliation_rows(rows: &mut [TransactionWriteRow]) {
+    for row in rows {
+        row.origin = Some(TransactionWriteOrigin {
+            surface: "plugin_reconciliation".to_string(),
+            operation: TransactionWriteOperation::Update,
+            primary_key: None,
+        });
     }
-    Ok(Some(plugin_schema_rows_from_archive_path(
-        path,
-        write.data(),
-        &write.branch_id,
-        write.global,
-        write.untracked,
-    )?))
 }
 
-fn is_plugin_reconciliation_candidate_path(path: &str) -> bool {
-    !is_plugin_storage_path(path)
+fn plugin_registry_live_state_projection() -> LiveStateProjection {
+    LiveStateProjection {
+        columns: vec!["snapshot_content".to_string()],
+    }
 }
 
 fn plugin_change_rows(
-    plugin: &InstalledPlugin,
+    plugin: &PluginRegistryEntry,
     changes: Vec<PluginDetectedChange>,
     file_id: &str,
     context: &FilesystemRowContext,
     json_context: &str,
 ) -> Result<Vec<TransactionWriteRow>, LixError> {
-    let schema_keys = plugin.schema_keys.iter().collect::<BTreeSet<_>>();
+    let schema_keys = plugin.schema_keys().iter().collect::<BTreeSet<_>>();
     changes
         .into_iter()
         .map(|change| {
@@ -1653,7 +2247,8 @@ fn plugin_change_rows(
                     LixError::CODE_SCHEMA_VALIDATION,
                     format!(
                         "plugin '{}' emitted schema key '{}' that is not declared in its manifest",
-                        plugin.key, change.schema_key
+                        plugin.key(),
+                        change.schema_key
                     ),
                 ));
             }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1234,10 +1234,13 @@ where
                 &context,
                 "plugin detect-changes",
             )?);
-            reconciliation.rows.push(
-                PluginFileOwner::from_registry_entry(write.file_id.clone(), selected)?
-                    .write_row(&write.branch_id)?,
-            );
+            let desired_owner =
+                PluginFileOwner::from_registry_entry(write.file_id.clone(), selected)?;
+            if plugin_owner_needs_write(owner, &desired_owner) {
+                reconciliation
+                    .rows
+                    .push(desired_owner.write_row(&write.branch_id)?);
+            }
             reconciliation.file_keys.insert(file_key.clone());
             reconciled_file_keys.insert(file_key);
         }
@@ -2189,6 +2192,10 @@ struct PluginBranchEntryKey {
     plugin_key: String,
 }
 
+fn plugin_owner_needs_write(current: Option<&PluginFileOwner>, desired: &PluginFileOwner) -> bool {
+    current != Some(desired)
+}
+
 fn duplicate_plugin_lifecycle_mutation() -> LixError {
     LixError::new(
         LixError::CODE_CONSTRAINT_VIOLATION,
@@ -2483,6 +2490,23 @@ mod tests {
     }
 
     const SCHEMA_FIXTURE_COMMIT_ID: &str = "01920000-0000-7000-8000-0000000000f1";
+
+    #[test]
+    fn plugin_owner_is_only_rewritten_when_its_durable_contract_changes() {
+        let current = PluginFileOwner::new("file-a", "plugin-a", vec!["schema-a".to_string()])
+            .expect("current owner should be valid");
+        assert!(!plugin_owner_needs_write(Some(&current), &current));
+        assert!(plugin_owner_needs_write(None, &current));
+
+        for desired in [
+            PluginFileOwner::new("file-a", "plugin-b", vec!["schema-a".to_string()])
+                .expect("changed plugin owner should be valid"),
+            PluginFileOwner::new("file-a", "plugin-a", vec!["schema-b".to_string()])
+                .expect("changed schema owner should be valid"),
+        ] {
+            assert!(plugin_owner_needs_write(Some(&current), &desired));
+        }
+    }
 
     #[tokio::test]
     #[ignore = "release-only transaction path-index benchmark probe"]

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -592,6 +592,7 @@ where
                 runtime: parsed.manifest.runtime,
                 api_version: parsed.manifest.api_version.clone(),
                 path_glob: parsed.manifest.file_match.path_glob.clone(),
+                content_type: parsed.manifest.file_match.content_type,
                 entry: parsed.manifest.entry.clone(),
                 schema_keys: parsed.schema_keys.clone(),
                 manifest_json: parsed.normalized_manifest_json.clone(),
@@ -995,7 +996,7 @@ where
             }
             let Some(plugin) = catalogs
                 .get(&write.branch_id)
-                .and_then(|catalog| catalog.select(path))
+                .and_then(|catalog| catalog.select_for_bytes(path, write.data()))
             else {
                 continue;
             };

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -414,19 +414,44 @@ impl TransactionWriteBuffer {
                 "failed to acquire transaction staged file data lock",
             )
         })?;
-        let mut bytes_by_hash = BTreeMap::<BlobHash, Vec<u8>>::new();
-        for write in file_data_guard.iter() {
+        let mut requested = hashes
+            .iter()
+            .copied()
+            .map(|hash| (hash, None))
+            .collect::<BTreeMap<BlobHash, Option<&[u8]>>>();
+        let mut remaining = requested.len();
+        'writes: for write in file_data_guard.iter() {
             let hash = write
                 .blob_hash()
                 .unwrap_or_else(|| BlobHash::from_content(write.data()));
-            bytes_by_hash
-                .entry(hash)
-                .or_insert_with(|| write.data().to_vec());
+            if let Some(bytes) = requested.get_mut(&hash)
+                && bytes.is_none()
+            {
+                *bytes = Some(write.data());
+                remaining -= 1;
+                if remaining == 0 {
+                    break 'writes;
+                }
+            }
+            for payload in write.auxiliary_payloads() {
+                let hash = payload
+                    .hash()
+                    .unwrap_or_else(|| BlobHash::from_content(payload.bytes()));
+                if let Some(bytes) = requested.get_mut(&hash)
+                    && bytes.is_none()
+                {
+                    *bytes = Some(payload.bytes());
+                    remaining -= 1;
+                    if remaining == 0 {
+                        break 'writes;
+                    }
+                }
+            }
         }
         Ok(BlobBytesBatch::new(
             hashes
                 .iter()
-                .map(|hash| bytes_by_hash.get(hash).cloned())
+                .map(|hash| requested.get(hash).copied().flatten().map(<[u8]>::to_vec))
                 .collect(),
         ))
     }
@@ -493,9 +518,8 @@ impl TransactionWriteBuffer {
         }
         for mut row in rows {
             let identity = PreparedStateRowIdentity::from(&row);
-            if mode == Some(TransactionWriteMode::Insert)
-                && by_identity_guard.contains_key(&identity)
-            {
+            let is_insert = row_is_insert(mode, &row);
+            if is_insert && by_identity_guard.contains_key(&identity) {
                 return Err(duplicate_insert_identity_error(&row));
             }
             let existing_slot = by_identity_guard.get(&identity).copied();
@@ -506,11 +530,6 @@ impl TransactionWriteBuffer {
             }
             add_row_to_commit_change_refs(&mut commit_change_refs_guard, &mut row, &functions);
             let identity = PreparedStateRowIdentity::from(&row);
-            let is_insert = mode == Some(TransactionWriteMode::Insert)
-                && !row
-                    .origin
-                    .as_ref()
-                    .is_some_and(|origin| origin.operation == TransactionWriteOperation::Update);
             if is_insert {
                 insert_identities_guard.insert(
                     identity.clone(),
@@ -566,6 +585,14 @@ impl TransactionWriteBuffer {
         }
         (state_rows, file_data_writes)
     }
+}
+
+fn row_is_insert(mode: Option<TransactionWriteMode>, row: &PreparedStateRow) -> bool {
+    mode == Some(TransactionWriteMode::Insert)
+        && !row
+            .origin
+            .as_ref()
+            .is_some_and(|origin| origin.operation == TransactionWriteOperation::Update)
 }
 
 /// Read overlay derived from staged transaction writes.
@@ -989,6 +1016,58 @@ mod tests {
     use crate::live_state::{LiveStateFilter, LiveStateRowRequest};
 
     #[tokio::test]
+    async fn update_origin_rows_replace_staged_identity_under_outer_insert_mode() {
+        let staged_writes = test_staged_writes();
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: vec![state_row("engine-owned-key", "first")],
+            })
+            .expect("initial internal identity should stage");
+
+        let mut replacement = state_row("engine-owned-key", "second");
+        replacement.origin = Some(TransactionWriteOrigin {
+            surface: "plugin_reconciliation".to_string(),
+            operation: TransactionWriteOperation::Update,
+            primary_key: None,
+        });
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Insert,
+                rows: vec![replacement],
+            })
+            .expect("derived update row should replace under outer insert mode");
+
+        let drained = staged_writes.drain().expect("drain should succeed");
+        assert!(drained.insert_identities.is_empty());
+        assert_eq!(drained.state_rows.len(), 1);
+        assert_eq!(
+            drained.state_rows[0]
+                .snapshot
+                .as_ref()
+                .expect("replacement snapshot")
+                .normalized
+                .as_ref(),
+            "{\"key\":\"engine-owned-key\",\"value\":\"second\"}"
+        );
+
+        let normal_insert = test_staged_writes();
+        normal_insert
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: vec![state_row("public-key", "first")],
+            })
+            .expect("initial public identity should stage");
+        let error = normal_insert
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Insert,
+                rows: vec![state_row("public-key", "second")],
+            })
+            .expect_err("ordinary insert must still reject a staged duplicate");
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+    }
+
+    #[tokio::test]
     async fn staging_overlay_uses_last_staged_row_for_exact_load() {
         let staged_writes = test_staged_writes();
 
@@ -1197,6 +1276,56 @@ mod tests {
         assert_eq!(drained.file_data_writes.len(), 1);
         assert_eq!(drained.file_data_writes[0].file_id, "file-readme");
         assert_eq!(drained.file_data_writes[0].data(), b"hello");
+    }
+
+    #[test]
+    fn staged_file_byte_lookup_filters_main_and_auxiliary_payloads_before_copying() {
+        let staged_writes = test_staged_writes();
+        let mut requested_write = TransactionFileData::new(
+            "requested-file".to_string(),
+            Some("/requested.bin".to_string()),
+            Some("requested.bin".to_string()),
+            "global".to_string(),
+            true,
+            true,
+            b"requested-main".to_vec(),
+        );
+        requested_write.add_auxiliary_payload(b"requested-auxiliary".to_vec());
+        let unrelated_write = TransactionFileData::new(
+            "unrelated-file".to_string(),
+            Some("/unrelated.bin".to_string()),
+            Some("unrelated.bin".to_string()),
+            "global".to_string(),
+            true,
+            true,
+            b"unrelated-main".to_vec(),
+        );
+        staged_writes
+            .stage_write(PreparedTransactionWrite::RowsWithFileData {
+                mode: TransactionWriteMode::Replace,
+                rows: Vec::new(),
+                file_data: vec![unrelated_write, requested_write],
+                count: 2,
+            })
+            .expect("file payloads should stage");
+
+        let auxiliary_hash = BlobHash::from_content(b"requested-auxiliary");
+        let missing_hash = BlobHash::from_content(b"missing");
+        let main_hash = BlobHash::from_content(b"requested-main");
+        let loaded = staged_writes
+            .load_staged_file_bytes_many(&[auxiliary_hash, missing_hash, main_hash, auxiliary_hash])
+            .expect("staged payload lookup should succeed")
+            .into_vec();
+
+        assert_eq!(
+            loaded,
+            vec![
+                Some(b"requested-auxiliary".to_vec()),
+                None,
+                Some(b"requested-main".to_vec()),
+                Some(b"requested-auxiliary".to_vec()),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -181,7 +181,18 @@ pub(crate) struct TransactionFileData {
     pub(crate) branch_id: String,
     pub(crate) global: bool,
     pub(crate) untracked: bool,
+    /// Whether the visible pre-write file had a binary blob reference.
+    ///
+    /// File providers already know this while lowering an UPDATE. Carrying the
+    /// fact through the transaction boundary avoids rediscovering it by
+    /// scanning the filesystem during plugin reconciliation. Inserts and
+    /// callers without a prior row leave this false.
+    pub(crate) had_blob_ref: bool,
     payload: BlobPayload,
+    /// Content-addressed payloads produced while validating this file write.
+    /// Plugin installation uses this for the extracted WASM component so
+    /// steady-state reads can load it directly without reopening the archive.
+    auxiliary_payloads: Vec<BlobPayload>,
 }
 
 impl TransactionFileData {
@@ -201,8 +212,19 @@ impl TransactionFileData {
             branch_id,
             global,
             untracked,
+            had_blob_ref: false,
             payload: BlobPayload::from_bytes(data),
+            auxiliary_payloads: Vec::new(),
         }
+    }
+
+    pub(crate) fn with_had_blob_ref(mut self, had_blob_ref: bool) -> Self {
+        self.had_blob_ref = had_blob_ref;
+        self
+    }
+
+    pub(crate) fn add_auxiliary_payload(&mut self, data: Vec<u8>) {
+        self.auxiliary_payloads.push(BlobPayload::from_bytes(data));
     }
 
     pub(crate) fn data(&self) -> &[u8] {
@@ -219,6 +241,10 @@ impl TransactionFileData {
 
     pub(crate) fn payload(&self) -> &BlobPayload {
         &self.payload
+    }
+
+    pub(crate) fn auxiliary_payloads(&self) -> &[BlobPayload] {
+        &self.auxiliary_payloads
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -1202,7 +1202,7 @@ impl PendingSchemaDomains {
             domains_by_key
                 .entry(SchemaCatalogKey::from_schema_key(key))
                 .or_default()
-                .insert(row.domain());
+                .insert(row.domain().schema_catalog_domain());
         }
         Ok(Self { domains_by_key })
     }
@@ -1214,8 +1214,11 @@ impl PendingSchemaDomains {
         let Some(domains) = self.domains_by_key.get(&key) else {
             return Ok(());
         };
-        let row_domain = row.domain();
-        if domains.contains(&row_domain) {
+        let visible_schema_domains = row.domain().schema_catalog_domains();
+        if domains
+            .iter()
+            .any(|domain| visible_schema_domains.contains(domain))
+        {
             return Ok(());
         }
         Err(LixError::new(
@@ -3410,6 +3413,28 @@ mod tests {
         validate_prepared_writes(validation_input(&staged_writes, &visible_schemas))
             .await
             .expect("pending registered schema should be visible to later staged rows");
+    }
+
+    #[test]
+    fn pending_schema_domain_covers_file_scoped_rows_in_the_same_catalog() {
+        let mut pending_schema = pending_registered_schema_row("pending_file_schema");
+        pending_schema.global = false;
+        pending_schema.branch_id = "branch-a".to_string();
+        let pending_rows = [PreparedValidationRow::State(&pending_schema)];
+        let domains = PendingSchemaDomains::from_staged_rows(&pending_rows)
+            .expect("pending schema domains should build");
+
+        let mut file_row = staged_row(
+            "pending_file_schema",
+            Some(json!({ "id": "entity-1" }).to_string()),
+        );
+        file_row.global = false;
+        file_row.branch_id = "branch-a".to_string();
+        file_row.file_id = Some("file-a".to_string());
+
+        domains
+            .validate_row_schema_domain(PreparedValidationRow::State(&file_row))
+            .expect("schema catalog scope should cover every file scope in its branch");
     }
 
     #[tokio::test]

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -620,12 +620,11 @@ async fn uninstall_keeps_owned_state_and_reinstall_resumes_rendering() {
         .expect("exact archive delete should uninstall");
     assert_eq!(plugin_owner_count(&session, &file_id).await, 1);
     assert_eq!(plugin_state_count(&session, &file_id).await, 1);
-    assert_eq!(
-        read_file(&session, "/resume.sentinel")
-            .await
-            .expect("uninstalled plugin file should remain visible"),
-        Some(Vec::new())
-    );
+    let unavailable = read_file(&session, "/resume.sentinel")
+        .await
+        .expect_err("uninstalled plugin state must not silently render as empty bytes");
+    assert_eq!(unavailable.code, LixError::CODE_PLUGIN_UNAVAILABLE);
+    assert!(unavailable.message.contains("plugin_sentinel"));
 
     install_plugin(&session, "plugin_sentinel", &archive)
         .await
@@ -645,6 +644,19 @@ async fn uninstall_keeps_owned_state_and_reinstall_resumes_rendering() {
         )
         .await
         .expect("second exact archive delete should uninstall");
+    let move_error = session
+        .execute(
+            "UPDATE lix_file SET path = '/resume.txt' \
+             WHERE path = '/resume.sentinel'",
+            &[],
+        )
+        .await
+        .expect_err("materialized plugin files cannot move while their plugin is unavailable");
+    assert_eq!(move_error.code, LixError::CODE_PLUGIN_UNAVAILABLE);
+
+    install_plugin(&session, "plugin_sentinel", &archive)
+        .await
+        .expect("second plugin reinstall should succeed");
     session
         .execute(
             "UPDATE lix_file SET path = '/resume.txt' \
@@ -652,15 +664,12 @@ async fn uninstall_keeps_owned_state_and_reinstall_resumes_rendering() {
             &[],
         )
         .await
-        .expect("path move while no plugins are installed should succeed");
-    install_plugin(&session, "plugin_sentinel", &archive)
-        .await
-        .expect("second plugin reinstall should succeed");
+        .expect("path move should succeed after the plugin is reinstalled");
     assert_eq!(
         read_file(&session, "/resume.txt")
             .await
-            .expect("moved stale-owner file should remain raw"),
-        Some(Vec::new())
+            .expect("moved file should preserve its rendered bytes"),
+        Some(b"plugin-rendered".to_vec())
     );
 
     session.close().await.expect("session should close");

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -152,6 +152,117 @@ async fn sql_plugin_archive_upsert_installs_and_updates_plugin() {
 }
 
 #[tokio::test]
+async fn installing_distinct_plugins_replaces_internal_singleton_rows_under_insert_mode() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(&session, "plugin_sentinel", &sentinel_plugin_archive())
+        .await
+        .expect("first plugin install should succeed");
+    install_plugin(&session, "plugin_second", &second_sentinel_plugin_archive())
+        .await
+        .expect("second plugin install should replace internal registry/schema rows");
+
+    let plugins = list_installed_plugins(&session)
+        .await
+        .expect("both installed plugins should list");
+    assert_eq!(
+        plugins
+            .iter()
+            .map(|plugin| plugin.key.as_str())
+            .collect::<Vec<_>>(),
+        vec!["plugin_second", "plugin_sentinel"]
+    );
+    assert_eq!(registered_plugin_note_schema_count(&session).await, 1);
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn plugin_install_rejects_conflicting_registered_schema_definition() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(&session, "plugin_sentinel", &sentinel_plugin_archive())
+        .await
+        .expect("first plugin install should succeed");
+    let error = install_plugin(
+        &session,
+        "plugin_conflicting",
+        &conflicting_schema_plugin_archive(),
+    )
+    .await
+    .expect_err("different definitions must not share one schema key");
+    assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+    assert!(error.message.contains("plugin_note"), "{error:?}");
+    assert_eq!(
+        list_installed_plugins(&session)
+            .await
+            .expect("failed install must leave the first plugin intact")
+            .len(),
+        1
+    );
+    assert_eq!(registered_plugin_note_schema_count(&session).await, 1);
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn active_plugin_prevents_public_mutation_of_its_registered_schema() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(&session, "plugin_sentinel", &sentinel_plugin_archive())
+        .await
+        .expect("plugin install should succeed");
+    let replacement = json!({
+        "x-lix-key": "plugin_note",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "value": { "type": "string" },
+            "extra": { "type": "string" }
+        },
+        "required": ["id", "value"],
+        "additionalProperties": false
+    });
+    let error = session
+        .execute(
+            "UPDATE lix_registered_schema SET value = $1 \
+             WHERE lixcol_entity_pk = lix_json('[\"plugin_note\"]')",
+            &[Value::Json(replacement)],
+        )
+        .await
+        .expect_err("active plugin schema mutation must be rejected");
+    assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+    assert!(error.message.contains("plugin_sentinel"), "{error:?}");
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
 async fn sql_plugin_archive_plain_insert_reuses_deterministic_file_id() {
     let storage = Memory::new();
     Engine::initialize(storage.clone())
@@ -205,6 +316,56 @@ async fn sql_plugin_archive_path_must_match_manifest_key() {
     assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
     assert!(error.message.contains("does not match manifest key"));
 
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn explicit_transaction_install_is_visible_to_later_plugin_write() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let runtime = Arc::new(SentinelPluginRuntime::default());
+    let engine = Engine::new_with_wasm_runtime(storage, runtime)
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    let mut tx = session
+        .begin_transaction()
+        .await
+        .expect("transaction should begin");
+
+    tx.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+        &[
+            Value::Text("/.lix/plugins/plugin_sentinel.lixplugin".to_string()),
+            Value::Blob(sentinel_plugin_archive()),
+        ],
+    )
+    .await
+    .expect("plugin install should stage");
+    tx.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+        &[
+            Value::Text("/same-transaction.sentinel".to_string()),
+            Value::Blob(b"hello".to_vec()),
+        ],
+    )
+    .await
+    .expect("later write should see staged registry and extracted WASM");
+    tx.commit()
+        .await
+        .expect("transaction should commit atomically");
+
+    assert_eq!(
+        read_file(&session, "/same-transaction.sentinel")
+            .await
+            .expect("committed plugin file should render"),
+        Some(b"plugin-rendered".to_vec())
+    );
     session.close().await.expect("session should close");
 }
 
@@ -321,7 +482,37 @@ async fn sql_invalid_plugin_manifest_writes_are_atomic() {
 }
 
 #[tokio::test]
-async fn sql_delete_rejects_installed_plugin_storage() {
+async fn sql_public_writes_cannot_forge_plugin_registry_or_owner_rows() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    for key in ["lix_plugin_registry_v1", "lix_plugin_owner_v1"] {
+        let error = session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+                &[
+                    Value::Text(key.to_string()),
+                    Value::Json(json!({"forged": true})),
+                ],
+            )
+            .await
+            .expect_err("engine-owned plugin keys must reject public writes");
+        assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert!(error.message.contains("reserved"), "{error:?}");
+    }
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn sql_exact_archive_delete_uninstalls_plugin_but_recursive_delete_is_rejected() {
     let storage = Memory::new();
     Engine::initialize(storage.clone())
         .await
@@ -336,20 +527,29 @@ async fn sql_delete_rejects_installed_plugin_storage() {
         .await
         .expect("plugin install should succeed");
 
-    let archive_error = session
+    let recursive_error = session
+        .execute(
+            "DELETE FROM lix_file \
+             WHERE path LIKE '/.lix/plugins/%.lixplugin'",
+            &[],
+        )
+        .await
+        .expect_err("recursive plugin archive delete should be rejected");
+    assert_eq!(recursive_error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+    assert!(
+        recursive_error
+            .message
+            .contains("one exact canonical plugin archive")
+    );
+
+    session
         .execute(
             "DELETE FROM lix_file \
              WHERE path = '/.lix/plugins/plugin_sentinel.lixplugin'",
             &[],
         )
         .await
-        .expect_err("SQL delete should reject installed plugin archive tombstones");
-    assert_eq!(archive_error.code, LixError::CODE_CONSTRAINT_VIOLATION);
-    assert!(
-        archive_error
-            .message
-            .contains("reserved plugin storage path")
-    );
+        .expect("one exact canonical archive delete should uninstall the plugin");
 
     let directory_error = session
         .execute(
@@ -368,10 +568,153 @@ async fn sql_delete_rejects_installed_plugin_storage() {
     assert_eq!(
         list_installed_plugins(&session)
             .await
-            .expect("plugin should still be installed")
+            .expect("uninstalled plugin list should load")
             .len(),
-        1
+        0
     );
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn uninstall_keeps_owned_state_and_reinstall_resumes_rendering() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let runtime = Arc::new(SentinelPluginRuntime::default());
+    let engine = Engine::new_with_wasm_runtime(storage, runtime)
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    let archive = sentinel_plugin_archive();
+
+    install_plugin(&session, "plugin_sentinel", &archive)
+        .await
+        .expect("plugin install should succeed");
+    write_file(&session, "/resume.sentinel", b"owned".to_vec())
+        .await
+        .expect("plugin file write should succeed");
+    let id_rows = session
+        .execute(
+            "SELECT id FROM lix_file WHERE path = '/resume.sentinel'",
+            &[],
+        )
+        .await
+        .expect("owned file id should load");
+    let [Value::Text(file_id)] = id_rows.rows()[0].values() else {
+        panic!("expected owned file id");
+    };
+    let file_id = file_id.clone();
+
+    session
+        .execute(
+            "DELETE FROM lix_file \
+             WHERE path = '/.lix/plugins/plugin_sentinel.lixplugin'",
+            &[],
+        )
+        .await
+        .expect("exact archive delete should uninstall");
+    assert_eq!(plugin_owner_count(&session, &file_id).await, 1);
+    assert_eq!(plugin_state_count(&session, &file_id).await, 1);
+    assert_eq!(
+        read_file(&session, "/resume.sentinel")
+            .await
+            .expect("uninstalled plugin file should remain visible"),
+        Some(Vec::new())
+    );
+
+    install_plugin(&session, "plugin_sentinel", &archive)
+        .await
+        .expect("plugin reinstall should succeed");
+    assert_eq!(
+        read_file(&session, "/resume.sentinel")
+            .await
+            .expect("reinstalled plugin file should render retained state"),
+        Some(b"plugin-rendered".to_vec())
+    );
+
+    session
+        .execute(
+            "DELETE FROM lix_file \
+             WHERE path = '/.lix/plugins/plugin_sentinel.lixplugin'",
+            &[],
+        )
+        .await
+        .expect("second exact archive delete should uninstall");
+    session
+        .execute(
+            "UPDATE lix_file SET path = '/resume.txt' \
+             WHERE path = '/resume.sentinel'",
+            &[],
+        )
+        .await
+        .expect("path move while no plugins are installed should succeed");
+    install_plugin(&session, "plugin_sentinel", &archive)
+        .await
+        .expect("second plugin reinstall should succeed");
+    assert_eq!(
+        read_file(&session, "/resume.txt")
+            .await
+            .expect("moved stale-owner file should remain raw"),
+        Some(Vec::new())
+    );
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn deleting_owned_file_after_uninstall_cleans_stale_owner_and_state() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let runtime = Arc::new(SentinelPluginRuntime::default());
+    let engine = Engine::new_with_wasm_runtime(storage, runtime)
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(&session, "plugin_sentinel", &sentinel_plugin_archive())
+        .await
+        .expect("plugin install should succeed");
+    write_file(&session, "/delete.sentinel", b"owned".to_vec())
+        .await
+        .expect("plugin-owned file write should succeed");
+    let id_rows = session
+        .execute(
+            "SELECT id FROM lix_file WHERE path = '/delete.sentinel'",
+            &[],
+        )
+        .await
+        .expect("owned file id should load");
+    let [Value::Text(file_id)] = id_rows.rows()[0].values() else {
+        panic!("expected owned file id");
+    };
+    let file_id = file_id.clone();
+
+    session
+        .execute(
+            "DELETE FROM lix_file \
+             WHERE path = '/.lix/plugins/plugin_sentinel.lixplugin'",
+            &[],
+        )
+        .await
+        .expect("exact archive delete should uninstall");
+    session
+        .execute("DELETE FROM lix_file WHERE path = '/delete.sentinel'", &[])
+        .await
+        .expect("deleting a stale-owned file should clean dependent plugin rows");
+
+    assert_eq!(read_file(&session, "/delete.sentinel").await.unwrap(), None);
+    assert_eq!(plugin_owner_count(&session, &file_id).await, 0);
+    assert_eq!(plugin_state_count(&session, &file_id).await, 0);
 
     session.close().await.expect("session should close");
 }
@@ -420,6 +763,56 @@ async fn empty_regular_file_does_not_render_through_later_installed_plugin() {
 }
 
 #[tokio::test]
+async fn durable_owner_keeps_rendering_when_new_plugin_is_more_specific() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let runtime = Arc::new(SentinelPluginRuntime::default());
+    let engine = Engine::new_with_wasm_runtime(storage, runtime.clone())
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(
+        &session,
+        "plugin_overlap_broad",
+        &broad_overlap_plugin_archive(),
+    )
+    .await
+    .expect("broad plugin install should succeed");
+    write_file(&session, "/special.overlap", b"owned-by-broad".to_vec())
+        .await
+        .expect("broad plugin should materialize the file");
+    assert_eq!(
+        read_file(&session, "/special.overlap").await.unwrap(),
+        Some(b"plugin-rendered".to_vec())
+    );
+
+    install_plugin(
+        &session,
+        "plugin_overlap_specific",
+        &specific_overlap_plugin_archive(),
+    )
+    .await
+    .expect("more-specific overlapping plugin install should succeed");
+
+    // Installation does not rewrite existing files. The durable broad owner
+    // remains valid because its own glob still matches, even though the new
+    // plugin would win selection for a fresh write at the same path.
+    assert_eq!(
+        read_file(&session, "/special.overlap").await.unwrap(),
+        Some(b"plugin-rendered".to_vec())
+    );
+    assert_eq!(runtime.render_calls.load(Ordering::SeqCst), 2);
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
 async fn plugin_detect_changes_receives_descriptor_filename() {
     let storage = Memory::new();
     Engine::initialize(storage.clone())
@@ -440,13 +833,99 @@ async fn plugin_detect_changes_receives_descriptor_filename() {
     write_file(&session, "/nested/raw.sentinel", b"hello".to_vec())
         .await
         .expect("plugin file write should succeed");
+    session
+        .execute(
+            "UPDATE lix_file SET data = X'776f726c64' \
+             WHERE path = '/nested/raw.sentinel'",
+            &[],
+        )
+        .await
+        .expect("plugin file data-only update should succeed");
 
     let filenames = runtime
         .detect_filenames
         .lock()
         .expect("detect filename lock should not be poisoned")
         .clone();
-    assert_eq!(filenames, vec![Some("raw.sentinel".to_string())]);
+    assert_eq!(
+        filenames,
+        vec![
+            Some("raw.sentinel".to_string()),
+            Some("raw.sentinel".to_string()),
+        ]
+    );
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn durable_owner_drives_raw_plugin_raw_path_transitions() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let runtime = Arc::new(SentinelPluginRuntime::default());
+    let engine = Engine::new_with_wasm_runtime(storage, runtime)
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(&session, "plugin_sentinel", &sentinel_plugin_archive())
+        .await
+        .expect("plugin install should succeed");
+    write_file(&session, "/transition.txt", b"raw".to_vec())
+        .await
+        .expect("raw file write should succeed");
+    let id_rows = session
+        .execute(
+            "SELECT id FROM lix_file WHERE path = '/transition.txt'",
+            &[],
+        )
+        .await
+        .expect("transition file id should load");
+    let [Value::Text(file_id)] = id_rows.rows()[0].values() else {
+        panic!("expected transition file id");
+    };
+    let file_id = file_id.clone();
+
+    session
+        .execute(
+            "UPDATE lix_file SET path = '/transition.sentinel' \
+             WHERE path = '/transition.txt'",
+            &[],
+        )
+        .await
+        .expect("raw-to-plugin path move should reconcile bytes");
+    assert_eq!(
+        read_file(&session, "/transition.sentinel")
+            .await
+            .expect("plugin-owned file should read"),
+        Some(b"plugin-rendered".to_vec())
+    );
+    assert_eq!(plugin_owner_count(&session, &file_id).await, 1);
+    assert_eq!(plugin_state_count(&session, &file_id).await, 1);
+    assert_eq!(blob_ref_count(&session, &file_id).await, 0);
+
+    session
+        .execute(
+            "UPDATE lix_file SET path = '/transition.txt' \
+             WHERE path = '/transition.sentinel'",
+            &[],
+        )
+        .await
+        .expect("plugin-to-raw path move should materialize rendered bytes");
+    assert_eq!(
+        read_file(&session, "/transition.txt")
+            .await
+            .expect("materialized raw file should read"),
+        Some(b"plugin-rendered".to_vec())
+    );
+    assert_eq!(plugin_owner_count(&session, &file_id).await, 0);
+    assert_eq!(plugin_state_count(&session, &file_id).await, 0);
+    assert_eq!(blob_ref_count(&session, &file_id).await, 1);
 
     session.close().await.expect("session should close");
 }
@@ -577,8 +1056,8 @@ async fn empty_write_to_binary_plugin_file_clears_plugin_state() {
     assert_eq!(
         read_file(&session, "/owned.binary-sentinel")
             .await
-            .expect("file read should succeed"),
-        Some(Vec::new())
+            .expect("zero-state owned file should still render through its durable owner"),
+        Some(b"plugin-rendered".to_vec())
     );
 
     let plugin_rows = session
@@ -834,6 +1313,60 @@ where
         .len()
 }
 
+async fn plugin_owner_count<S>(session: &S, file_id: &str) -> usize
+where
+    S: TestSession + Sync + ?Sized,
+{
+    session
+        .execute_sql(
+            &format!(
+                "SELECT entity_pk FROM lix_state \
+                 WHERE schema_key = 'lix_key_value' \
+                   AND entity_pk = lix_json('[\"lix_plugin_owner_v1\"]') \
+                   AND file_id = '{file_id}'"
+            ),
+            &[],
+        )
+        .await
+        .expect("plugin owner lookup should succeed")
+        .len()
+}
+
+async fn plugin_state_count<S>(session: &S, file_id: &str) -> usize
+where
+    S: TestSession + Sync + ?Sized,
+{
+    session
+        .execute_sql(
+            &format!(
+                "SELECT entity_pk FROM lix_state \
+                 WHERE schema_key = 'plugin_note' AND file_id = '{file_id}'"
+            ),
+            &[],
+        )
+        .await
+        .expect("plugin state lookup should succeed")
+        .len()
+}
+
+async fn blob_ref_count<S>(session: &S, file_id: &str) -> usize
+where
+    S: TestSession + Sync + ?Sized,
+{
+    session
+        .execute_sql(
+            &format!(
+                "SELECT entity_pk FROM lix_state \
+                 WHERE schema_key = 'lix_binary_blob_ref' \
+                   AND entity_pk = lix_json('[\"{file_id}\"]')"
+            ),
+            &[],
+        )
+        .await
+        .expect("blob ref lookup should succeed")
+        .len()
+}
+
 async fn mkdir<S>(session: &S, path: &str) -> Result<(), LixError>
 where
     S: TestSession + Sync + ?Sized,
@@ -1083,6 +1616,65 @@ fn sentinel_plugin_archive() -> Vec<u8> {
     plugin_archive(MANIFEST_JSON)
 }
 
+fn second_sentinel_plugin_archive() -> Vec<u8> {
+    const MANIFEST_JSON: &[u8] = br#"{
+        "key": "plugin_second",
+        "runtime": "wasm-component-v1",
+        "api_version": "0.1.0",
+        "match": { "path_glob": "*.second" },
+        "entry": "plugin.wasm",
+        "schemas": ["schema/plugin_note.json"]
+    }"#;
+    plugin_archive(MANIFEST_JSON)
+}
+
+fn conflicting_schema_plugin_archive() -> Vec<u8> {
+    const MANIFEST_JSON: &[u8] = br#"{
+        "key": "plugin_conflicting",
+        "runtime": "wasm-component-v1",
+        "api_version": "0.1.0",
+        "match": { "path_glob": "*.conflicting" },
+        "entry": "plugin.wasm",
+        "schemas": ["schema/plugin_note.json"]
+    }"#;
+    const CONFLICTING_SCHEMA_JSON: &[u8] = br#"{
+        "x-lix-key": "plugin_note",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "value": { "type": "integer" }
+        },
+        "required": ["id", "value"],
+        "additionalProperties": false
+    }"#;
+    plugin_archive_with_schema(MANIFEST_JSON, CONFLICTING_SCHEMA_JSON)
+}
+
+fn broad_overlap_plugin_archive() -> Vec<u8> {
+    const MANIFEST_JSON: &[u8] = br#"{
+        "key": "plugin_overlap_broad",
+        "runtime": "wasm-component-v1",
+        "api_version": "0.1.0",
+        "match": { "path_glob": "*.overlap" },
+        "entry": "plugin.wasm",
+        "schemas": ["schema/plugin_note.json"]
+    }"#;
+    plugin_archive(MANIFEST_JSON)
+}
+
+fn specific_overlap_plugin_archive() -> Vec<u8> {
+    const MANIFEST_JSON: &[u8] = br#"{
+        "key": "plugin_overlap_specific",
+        "runtime": "wasm-component-v1",
+        "api_version": "0.1.0",
+        "match": { "path_glob": "*/special.overlap" },
+        "entry": "plugin.wasm",
+        "schemas": ["schema/plugin_note.json"]
+    }"#;
+    plugin_archive(MANIFEST_JSON)
+}
+
 fn invalid_glob_sentinel_plugin_archive() -> Vec<u8> {
     const MANIFEST_JSON: &[u8] = br#"{
         "key": "plugin_sentinel",
@@ -1100,7 +1692,7 @@ fn binary_sentinel_plugin_archive() -> Vec<u8> {
         "key": "plugin_binary_sentinel",
         "runtime": "wasm-component-v1",
         "api_version": "0.1.0",
-        "match": { "path_glob": "*.binary-sentinel", "content_type": "binary" },
+        "match": { "path_glob": "*.binary-sentinel" },
         "entry": "plugin.wasm",
         "schemas": ["schema/plugin_note.json"]
     }"#;
@@ -1119,6 +1711,10 @@ fn plugin_archive(manifest_json: &[u8]) -> Vec<u8> {
         "required": ["id", "value"],
         "additionalProperties": false
     }"#;
+    plugin_archive_with_schema(manifest_json, SCHEMA_JSON)
+}
+
+fn plugin_archive_with_schema(manifest_json: &[u8], schema_json: &[u8]) -> Vec<u8> {
     const WASM_HEADER: &[u8] = b"\0asm\x01\0\0\0";
 
     let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
@@ -1126,7 +1722,7 @@ fn plugin_archive(manifest_json: &[u8]) -> Vec<u8> {
         zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
     for (path, bytes) in [
         ("manifest.json", manifest_json),
-        ("schema/plugin_note.json", SCHEMA_JSON),
+        ("schema/plugin_note.json", schema_json),
         ("plugin.wasm", WASM_HEADER),
     ] {
         writer.start_file(path, options).unwrap();

--- a/packages/engine/tests/plugin_registry_perf.rs
+++ b/packages/engine/tests/plugin_registry_perf.rs
@@ -1,0 +1,988 @@
+#![recursion_limit = "256"]
+
+//! Reproducible current-state plugin registry performance probe.
+//!
+//! This is intentionally ignored in normal test runs. Example:
+//!
+//! ```text
+//! LIX_PLUGIN_REGISTRY_PERF_MODE=all \
+//! LIX_PLUGIN_REGISTRY_PERF_FILES=10000 \
+//! LIX_PLUGIN_REGISTRY_PERF_BATCH_SIZE=100 \
+//! LIX_PLUGIN_REGISTRY_PERF_WASM_BYTES=1048576 \
+//! cargo test -p lix_engine --test plugin_registry_perf --release -- --ignored --nocapture
+//! ```
+//!
+//! Modes are `p0`, `p1_nonmatch`, `p1_zero_state_write`, `p1_state_write`, and
+//! `p1_read_render`. The legacy `p1_match` name aliases `p1_zero_state_write`.
+
+use std::fmt::Write as FmtWrite;
+use std::io::{Cursor, Write as IoWrite};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use lix_engine::storage::{
+    GetManyResult, GetOptions, Key, KeyRange, Memory, MemoryRead, MemoryWrite, ReadOptions,
+    ScanChunk, ScanOptions, SpaceId, Storage, StorageError, StorageRead, WriteOptions,
+};
+use lix_engine::wasm::{
+    WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
+    WasmPluginFile, WasmRuntime,
+};
+use lix_engine::{Engine, LixError, SessionContext, Value};
+use serde_json::json;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+const MODE_ENV: &str = "LIX_PLUGIN_REGISTRY_PERF_MODE";
+const FILE_COUNT_ENV: &str = "LIX_PLUGIN_REGISTRY_PERF_FILES";
+const BATCH_SIZE_ENV: &str = "LIX_PLUGIN_REGISTRY_PERF_BATCH_SIZE";
+const WARMUPS_ENV: &str = "LIX_PLUGIN_REGISTRY_PERF_WARMUPS";
+const SAMPLES_ENV: &str = "LIX_PLUGIN_REGISTRY_PERF_SAMPLES";
+const SETUP_CHUNK_ENV: &str = "LIX_PLUGIN_REGISTRY_PERF_SETUP_CHUNK_SIZE";
+const WASM_BYTES_ENV: &str = "LIX_PLUGIN_REGISTRY_PERF_WASM_BYTES";
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "manual plugin registry p50/p95 performance probe"]
+async fn plugin_registry_perf_probe() {
+    let config = ProbeConfig::from_env();
+    for mode in modes_from_env() {
+        run_mode(config, mode).await;
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProbeConfig {
+    file_count: usize,
+    batch_size: usize,
+    warmups: usize,
+    samples: usize,
+    setup_chunk_size: usize,
+    plugin_wasm_bytes: usize,
+}
+
+impl ProbeConfig {
+    fn from_env() -> Self {
+        let file_count = env_usize(FILE_COUNT_ENV, 1_000);
+        let config = Self {
+            file_count,
+            batch_size: env_usize(BATCH_SIZE_ENV, 1),
+            warmups: env_usize(WARMUPS_ENV, 20),
+            samples: env_usize(SAMPLES_ENV, 200),
+            setup_chunk_size: env_usize(SETUP_CHUNK_ENV, file_count),
+            plugin_wasm_bytes: env_usize(WASM_BYTES_ENV, 1024 * 1024),
+        };
+        assert!(config.file_count > 0, "{FILE_COUNT_ENV} must be positive");
+        assert!(config.batch_size > 0, "{BATCH_SIZE_ENV} must be positive");
+        assert!(
+            config.batch_size <= config.file_count,
+            "{BATCH_SIZE_ENV} must not exceed {FILE_COUNT_ENV}"
+        );
+        assert!(config.warmups > 0, "{WARMUPS_ENV} must be positive");
+        assert!(
+            config.samples >= 2,
+            "{SAMPLES_ENV} must contain at least two samples"
+        );
+        assert!(
+            config.setup_chunk_size > 0,
+            "{SETUP_CHUNK_ENV} must be positive"
+        );
+        assert!(
+            config.plugin_wasm_bytes >= 8,
+            "{WASM_BYTES_ENV} must be at least 8 bytes"
+        );
+        config
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeMode {
+    P0,
+    P1Nonmatch,
+    P1ZeroStateWrite,
+    P1StateWrite,
+    P1ReadRender,
+}
+
+impl ProbeMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::P0 => "p0",
+            Self::P1Nonmatch => "p1_nonmatch",
+            Self::P1ZeroStateWrite => "p1_zero_state_write",
+            Self::P1StateWrite => "p1_state_write",
+            Self::P1ReadRender => "p1_read_render",
+        }
+    }
+
+    fn plugin_glob(self) -> Option<&'static str> {
+        match self {
+            Self::P0 => None,
+            Self::P1Nonmatch => Some("*.owned"),
+            Self::P1ZeroStateWrite | Self::P1StateWrite | Self::P1ReadRender => Some("*.bench"),
+        }
+    }
+
+    fn workload(self) -> &'static str {
+        match self {
+            Self::P0 => "no_plugin_write_control",
+            Self::P1Nonmatch => "installed_nonmatching_plugin_write_control",
+            Self::P1ZeroStateWrite => "matched_zero_state_engine_overhead_write",
+            Self::P1StateWrite => "matched_stable_one_row_state_write",
+            Self::P1ReadRender => "matched_stable_one_row_state_read_render",
+        }
+    }
+
+    fn timed_operation(self) -> &'static str {
+        match self {
+            Self::P1ReadRender => "select_rendered_data_existing_files",
+            Self::P0 | Self::P1Nonmatch | Self::P1ZeroStateWrite | Self::P1StateWrite => {
+                "autocommit_update_existing_files"
+            }
+        }
+    }
+
+    fn timed_operation_appends_layer(self) -> bool {
+        self != Self::P1ReadRender
+    }
+
+    fn component_behavior(self) -> BenchComponentBehavior {
+        match self {
+            Self::P1StateWrite | Self::P1ReadRender => BenchComponentBehavior::StableState,
+            Self::P0 | Self::P1Nonmatch | Self::P1ZeroStateWrite => {
+                BenchComponentBehavior::ZeroState
+            }
+        }
+    }
+
+    fn timed_detects(self) -> bool {
+        matches!(self, Self::P1ZeroStateWrite | Self::P1StateWrite)
+    }
+
+    fn timed_renders(self) -> bool {
+        self == Self::P1ReadRender
+    }
+
+    fn primes_state(self) -> bool {
+        self == Self::P1ReadRender
+    }
+
+    fn initializes_component(self) -> bool {
+        matches!(
+            self,
+            Self::P1ZeroStateWrite | Self::P1StateWrite | Self::P1ReadRender
+        )
+    }
+
+    fn plugin_count(self) -> u8 {
+        match self {
+            Self::P0 => 0,
+            Self::P1Nonmatch | Self::P1ZeroStateWrite | Self::P1StateWrite | Self::P1ReadRender => {
+                1
+            }
+        }
+    }
+}
+
+fn modes_from_env() -> Vec<ProbeMode> {
+    let raw = std::env::var(MODE_ENV).unwrap_or_else(|_| "all".to_string());
+    if raw == "all" {
+        return vec![
+            ProbeMode::P0,
+            ProbeMode::P1Nonmatch,
+            ProbeMode::P1ZeroStateWrite,
+            ProbeMode::P1StateWrite,
+            ProbeMode::P1ReadRender,
+        ];
+    }
+    let modes = raw
+        .split(',')
+        .map(|value| match value.trim() {
+            "p0" => ProbeMode::P0,
+            "p1_nonmatch" => ProbeMode::P1Nonmatch,
+            "p1_match" | "p1_zero_state_write" => ProbeMode::P1ZeroStateWrite,
+            "p1_state_write" => ProbeMode::P1StateWrite,
+            "p1_read_render" => ProbeMode::P1ReadRender,
+            other => {
+                panic!(
+                    "{MODE_ENV} entries must be p0, p1_nonmatch, p1_zero_state_write, \
+                     p1_state_write, or p1_read_render; got {other:?}"
+                )
+            }
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        !modes.is_empty(),
+        "{MODE_ENV} must select at least one mode"
+    );
+    modes
+}
+
+async fn run_mode(config: ProbeConfig, mode: ProbeMode) {
+    let storage = CountingStorage::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("benchmark storage should initialize");
+    let runtime = Arc::new(BenchWasmRuntime::new(mode.component_behavior()));
+    let engine = Engine::new_with_wasm_runtime(storage.clone(), runtime.clone())
+        .await
+        .expect("benchmark engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("benchmark workspace session should open");
+
+    let files = seed_files(config);
+    let setup_commit_count = insert_seed_files(&session, &files, config.setup_chunk_size).await;
+    let plugin_install_commit_count = usize::from(mode.plugin_glob().is_some());
+    if let Some(path_glob) = mode.plugin_glob() {
+        install_benchmark_plugin(&session, path_glob, config.plugin_wasm_bytes).await;
+    }
+    let update_sql = update_sql(&files[..config.batch_size]);
+    let read_sql = read_sql(&files[..config.batch_size]);
+
+    let state_prime_commit_count = if mode.primes_state() {
+        execute_update(&session, &update_sql, update_payload(0), config.batch_size).await;
+        1
+    } else {
+        0
+    };
+
+    for sequence in 0..config.warmups {
+        if mode.timed_renders() {
+            execute_read_render(&session, &read_sql, config.batch_size).await;
+        } else {
+            execute_update(
+                &session,
+                &update_sql,
+                update_payload(sequence),
+                config.batch_size,
+            )
+            .await;
+        }
+    }
+    let expected_pre_timing_detects = usize::from(mode.primes_state())
+        .checked_add(if mode.timed_detects() {
+            config.warmups
+        } else {
+            0
+        })
+        .and_then(|calls| calls.checked_mul(config.batch_size))
+        .expect("pre-timing detect count should fit usize");
+    assert_eq!(
+        runtime.detect_calls.load(Ordering::Relaxed),
+        expected_pre_timing_detects,
+        "setup and warmup plugin matching did not execute the expected files"
+    );
+    let expected_warmup_renders = if mode.timed_renders() {
+        config
+            .warmups
+            .checked_mul(config.batch_size)
+            .expect("warmup render count should fit usize")
+    } else {
+        0
+    };
+    assert_eq!(
+        runtime.render_calls.load(Ordering::Relaxed),
+        expected_warmup_renders,
+        "warmup plugin rendering did not execute the expected files"
+    );
+    if mode.initializes_component() {
+        assert!(
+            runtime.init_calls.load(Ordering::Relaxed) > 0,
+            "matching mode must initialize the fake component"
+        );
+    } else {
+        assert_eq!(
+            runtime.init_calls.load(Ordering::Relaxed),
+            0,
+            "a missing or nonmatching plugin must not initialize a component"
+        );
+    }
+
+    runtime.detect_calls.store(0, Ordering::Relaxed);
+    runtime.render_calls.store(0, Ordering::Relaxed);
+    runtime.detect_input_state_rows.store(0, Ordering::Relaxed);
+    runtime.detect_output_state_rows.store(0, Ordering::Relaxed);
+    runtime.render_input_state_rows.store(0, Ordering::Relaxed);
+    storage.reset_read_counts();
+    let reads_before = storage.read_counts();
+    assert_eq!(
+        reads_before,
+        PhysicalReadCounts::default(),
+        "physical read counters must reset immediately before timed samples"
+    );
+    let split_index = config.samples / 2;
+    let mut durations = Vec::with_capacity(config.samples);
+    let mut reads_at_split = None;
+    for sample in 0..config.samples {
+        let sequence = config
+            .warmups
+            .checked_add(sample)
+            .expect("update sequence should fit usize");
+        durations.push(if mode.timed_renders() {
+            execute_read_render(&session, &read_sql, config.batch_size).await
+        } else {
+            execute_update(
+                &session,
+                &update_sql,
+                update_payload(sequence),
+                config.batch_size,
+            )
+            .await
+        });
+        if sample + 1 == split_index {
+            reads_at_split = Some(storage.read_counts());
+        }
+    }
+    let reads_after = storage.read_counts();
+    let timed_read_delta = reads_after.delta_since(reads_before);
+    let reads_at_split = reads_at_split.expect("sample split must be observed");
+    let first_half_read_delta = reads_at_split.delta_since(reads_before);
+    let second_half_read_delta = reads_after.delta_since(reads_at_split);
+
+    let expected_measured_detects = if mode.timed_detects() {
+        config
+            .samples
+            .checked_mul(config.batch_size)
+            .expect("measured detect count should fit usize")
+    } else {
+        0
+    };
+    let measured_detects = runtime.detect_calls.load(Ordering::Relaxed);
+    assert_eq!(
+        measured_detects, expected_measured_detects,
+        "measured plugin matching did not execute the expected files"
+    );
+    let expected_measured_renders = if mode.timed_renders() {
+        config
+            .samples
+            .checked_mul(config.batch_size)
+            .expect("measured render count should fit usize")
+    } else {
+        0
+    };
+    let measured_renders = runtime.render_calls.load(Ordering::Relaxed);
+    assert_eq!(
+        measured_renders, expected_measured_renders,
+        "measured plugin rendering did not execute the expected files"
+    );
+    let expected_detect_state_rows = if mode == ProbeMode::P1StateWrite {
+        expected_measured_detects
+    } else {
+        0
+    };
+    let measured_detect_input_state_rows = runtime.detect_input_state_rows.load(Ordering::Relaxed);
+    let measured_detect_output_state_rows =
+        runtime.detect_output_state_rows.load(Ordering::Relaxed);
+    assert_eq!(
+        measured_detect_input_state_rows, expected_detect_state_rows,
+        "stateful timed writes must read exactly one stable state row per file"
+    );
+    assert_eq!(
+        measured_detect_output_state_rows, expected_detect_state_rows,
+        "stateful timed writes must replace exactly one stable state row per file"
+    );
+    let measured_render_input_state_rows = runtime.render_input_state_rows.load(Ordering::Relaxed);
+    assert_eq!(
+        measured_render_input_state_rows, expected_measured_renders,
+        "timed renders must receive exactly one stable state row per file"
+    );
+
+    let mut first_half_durations = durations[..split_index].to_vec();
+    let mut second_half_durations = durations[split_index..].to_vec();
+    first_half_durations.sort_unstable();
+    second_half_durations.sort_unstable();
+    durations.sort_unstable();
+    let known_layer_appends_before_timing = setup_commit_count
+        + plugin_install_commit_count
+        + state_prime_commit_count
+        + if mode.timed_operation_appends_layer() {
+            config.warmups
+        } else {
+            0
+        };
+    let timed_layer_appends = if mode.timed_operation_appends_layer() {
+        config.samples
+    } else {
+        0
+    };
+    let first_half_layer_appends = if mode.timed_operation_appends_layer() {
+        split_index
+    } else {
+        0
+    };
+    let result = json!({
+        "probe": "lix_plugin_registry_perf",
+        "format_version": 1,
+        "mode": mode.label(),
+        "workload": mode.workload(),
+        "plugin_count": mode.plugin_count(),
+        "plugin_matches_timed_files": mode.initializes_component(),
+        "storage": "memory",
+        "tokio_runtime": "current_thread",
+        "build_profile": if cfg!(debug_assertions) { "debug" } else { "release" },
+        "timed_operation": mode.timed_operation(),
+        "timed_operation_appends_layer": mode.timed_operation_appends_layer(),
+        "selector": "id_in",
+        "ordinary_file_count": config.file_count,
+        "batch_size": config.batch_size,
+        "setup_chunk_size": config.setup_chunk_size,
+        "setup_commit_count": setup_commit_count,
+        "setup_commit_scope": "ordinary_files",
+        "plugin_install_commit_count": plugin_install_commit_count,
+        "state_prime_commit_count": state_prime_commit_count,
+        "plugin_wasm_payload_bytes": config.plugin_wasm_bytes,
+        "warmups": config.warmups,
+        "samples": config.samples,
+        "successful_timed_operations": config.samples,
+        "successful_timed_updates": if mode.timed_operation_appends_layer() { config.samples } else { 0 },
+        "successful_timed_reads": if mode.timed_renders() { config.samples } else { 0 },
+        "update_payload_bytes": if mode.timed_operation_appends_layer() { 8 } else { 0 },
+        "stable_state_rows_per_matched_file": i32::from(mode.component_behavior() == BenchComponentBehavior::StableState),
+        "component_init_calls_total": runtime.init_calls.load(Ordering::Relaxed),
+        "component_detect_calls_timed": measured_detects,
+        "component_render_calls_timed": measured_renders,
+        "component_detect_input_state_rows_timed": measured_detect_input_state_rows,
+        "component_detect_output_state_rows_timed": measured_detect_output_state_rows,
+        "component_render_input_state_rows_timed": measured_render_input_state_rows,
+        "layer_context": {
+            "backend": "layered_memory",
+            "engine_initialization_layer_depth": "not_observed",
+            "known_benchmark_layer_appends_before_timing": known_layer_appends_before_timing,
+            "known_benchmark_layer_appends_during_timing": timed_layer_appends,
+            "known_benchmark_layer_appends_after_timing": known_layer_appends_before_timing + timed_layer_appends,
+            "interpretation": if mode.timed_operation_appends_layer() {
+                "write samples deepen Memory; compare chronological sample halves"
+            } else {
+                "read samples do not append layers; setup depth remains fixed"
+            },
+        },
+        "physical_reads": {
+            "begin_read": {
+                "timed_delta": timed_read_delta.begin_read,
+                "first_half_delta": first_half_read_delta.begin_read,
+                "second_half_delta": second_half_read_delta.begin_read,
+                "total_after_reset": reads_after.begin_read,
+            },
+            "get_many": {
+                "timed_delta": timed_read_delta.get_many,
+                "first_half_delta": first_half_read_delta.get_many,
+                "second_half_delta": second_half_read_delta.get_many,
+                "total_after_reset": reads_after.get_many,
+            },
+            "scan": {
+                "timed_delta": timed_read_delta.scan,
+                "first_half_delta": first_half_read_delta.scan,
+                "second_half_delta": second_half_read_delta.scan,
+                "total_after_reset": reads_after.scan,
+            },
+        },
+        "first_half": {
+            "sample_start_inclusive": 0,
+            "sample_end_exclusive": split_index,
+            "sample_count": first_half_durations.len(),
+            "known_layer_appends_before_half": known_layer_appends_before_timing,
+            "known_layer_appends_after_half": known_layer_appends_before_timing + first_half_layer_appends,
+            "p50_ns": percentile_ns(&first_half_durations, 50),
+            "p95_ns": percentile_ns(&first_half_durations, 95),
+        },
+        "second_half": {
+            "sample_start_inclusive": split_index,
+            "sample_end_exclusive": config.samples,
+            "sample_count": second_half_durations.len(),
+            "known_layer_appends_before_half": known_layer_appends_before_timing + first_half_layer_appends,
+            "known_layer_appends_after_half": known_layer_appends_before_timing + timed_layer_appends,
+            "p50_ns": percentile_ns(&second_half_durations, 50),
+            "p95_ns": percentile_ns(&second_half_durations, 95),
+        },
+        "time_unit": "ns",
+        "min_ns": duration_ns(durations[0]),
+        "p50_ns": percentile_ns(&durations, 50),
+        "p95_ns": percentile_ns(&durations, 95),
+        "max_ns": duration_ns(*durations.last().expect("samples are nonempty")),
+    });
+
+    session
+        .close()
+        .await
+        .expect("benchmark workspace session should close");
+    let serialized = serde_json::to_string(&result).expect("benchmark result should serialize");
+    println!("{serialized}");
+}
+
+#[derive(Debug)]
+struct SeedFile {
+    id: String,
+    path: String,
+}
+
+fn seed_files(config: ProbeConfig) -> Vec<SeedFile> {
+    (0..config.file_count)
+        .map(|index| {
+            let path = if index < config.batch_size {
+                format!("/perf/target-{index:08}.bench")
+            } else {
+                format!("/perf/filler-{index:08}.txt")
+            };
+            SeedFile {
+                id: format!("perf-file-{index:08}"),
+                path,
+            }
+        })
+        .collect()
+}
+
+async fn insert_seed_files(
+    session: &SessionContext<CountingStorage>,
+    files: &[SeedFile],
+    chunk_size: usize,
+) -> usize {
+    let mut commit_count = 0;
+    for chunk in files.chunks(chunk_size) {
+        let mut sql = String::from("INSERT INTO lix_file (id, path, data) VALUES ");
+        for (index, file) in chunk.iter().enumerate() {
+            if index != 0 {
+                sql.push_str(", ");
+            }
+            write!(
+                &mut sql,
+                "('{id}', '{path}', X'00')",
+                id = file.id,
+                path = file.path
+            )
+            .expect("writing benchmark setup SQL should succeed");
+        }
+        let result = session.execute(&sql, &[]).await;
+        let result = result.expect("benchmark file setup chunk should commit");
+        assert_eq!(
+            result.rows_affected(),
+            u64::try_from(chunk.len()).expect("setup chunk length should fit u64"),
+            "benchmark setup must insert every requested file"
+        );
+        commit_count += 1;
+    }
+    commit_count
+}
+
+async fn install_benchmark_plugin(
+    session: &SessionContext<CountingStorage>,
+    path_glob: &str,
+    wasm_bytes: usize,
+) {
+    let result = session
+        .execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_perf.lixplugin".to_string()),
+                Value::Blob(benchmark_plugin_archive(path_glob, wasm_bytes)),
+            ],
+        )
+        .await;
+    let result = result.expect("benchmark plugin should install");
+    assert_eq!(result.rows_affected(), 1);
+}
+
+fn update_sql(files: &[SeedFile]) -> String {
+    let ids = files
+        .iter()
+        .map(|file| format!("'{id}'", id = file.id))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("UPDATE lix_file SET data = $1 WHERE id IN ({ids})")
+}
+
+fn read_sql(files: &[SeedFile]) -> String {
+    let ids = files
+        .iter()
+        .map(|file| format!("'{id}'", id = file.id))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("SELECT data FROM lix_file WHERE id IN ({ids})")
+}
+
+async fn execute_update(
+    session: &SessionContext<CountingStorage>,
+    sql: &str,
+    payload: Vec<u8>,
+    expected_rows: usize,
+) -> Duration {
+    let params = [Value::Blob(payload)];
+    let started = Instant::now();
+    let result = session.execute(sql, &params).await;
+    let elapsed = started.elapsed();
+    let result = result.expect("timed autocommit update should succeed");
+    assert_eq!(
+        result.rows_affected(),
+        u64::try_from(expected_rows).expect("batch size should fit u64"),
+        "timed update must affect the configured batch"
+    );
+    elapsed
+}
+
+async fn execute_read_render(
+    session: &SessionContext<CountingStorage>,
+    sql: &str,
+    expected_rows: usize,
+) -> Duration {
+    let started = Instant::now();
+    let result = session.execute(sql, &[]).await;
+    let elapsed = started.elapsed();
+    let result = result.expect("timed rendered read should succeed");
+    assert_eq!(
+        result.len(),
+        expected_rows,
+        "timed rendered read must return the configured batch"
+    );
+    for row in result.rows() {
+        assert_eq!(
+            row.values(),
+            &[Value::Blob(BENCH_RENDERED_BYTES.to_vec())],
+            "timed rendered read must return deterministic component bytes"
+        );
+    }
+    elapsed
+}
+
+fn update_payload(sequence: usize) -> Vec<u8> {
+    u64::try_from(sequence)
+        .expect("update sequence should fit u64")
+        .to_le_bytes()
+        .to_vec()
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse()
+            .unwrap_or_else(|error| panic!("{name} must be an unsigned integer: {error}")),
+        Err(std::env::VarError::NotPresent) => default,
+        Err(error) => panic!("{name} must be valid Unicode: {error}"),
+    }
+}
+
+fn percentile_ns(samples: &[Duration], percentile: usize) -> u64 {
+    assert!(!samples.is_empty());
+    assert!(percentile <= 100);
+    let index = (samples.len() - 1) * percentile / 100;
+    duration_ns(samples[index])
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).expect("benchmark duration nanoseconds should fit u64")
+}
+
+#[derive(Clone, Default)]
+struct CountingStorage {
+    inner: Memory,
+    counters: Arc<PhysicalReadCounters>,
+}
+
+impl CountingStorage {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn reset_read_counts(&self) {
+        self.counters.begin_read.store(0, Ordering::Relaxed);
+        self.counters.get_many.store(0, Ordering::Relaxed);
+        self.counters.scan.store(0, Ordering::Relaxed);
+    }
+
+    fn read_counts(&self) -> PhysicalReadCounts {
+        PhysicalReadCounts {
+            begin_read: self.counters.begin_read.load(Ordering::Relaxed),
+            get_many: self.counters.get_many.load(Ordering::Relaxed),
+            scan: self.counters.scan.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default)]
+struct PhysicalReadCounters {
+    begin_read: AtomicUsize,
+    get_many: AtomicUsize,
+    scan: AtomicUsize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct PhysicalReadCounts {
+    begin_read: usize,
+    get_many: usize,
+    scan: usize,
+}
+
+impl PhysicalReadCounts {
+    fn delta_since(self, before: Self) -> Self {
+        Self {
+            begin_read: self
+                .begin_read
+                .checked_sub(before.begin_read)
+                .expect("begin_read counter must be monotonic"),
+            get_many: self
+                .get_many
+                .checked_sub(before.get_many)
+                .expect("get_many counter must be monotonic"),
+            scan: self
+                .scan
+                .checked_sub(before.scan)
+                .expect("scan counter must be monotonic"),
+        }
+    }
+}
+
+impl Storage for CountingStorage {
+    type Read<'a>
+        = CountingRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        self.counters.begin_read.fetch_add(1, Ordering::Relaxed);
+        Ok(CountingRead {
+            inner: self.inner.begin_read(opts).await?,
+            counters: Arc::clone(&self.counters),
+        })
+    }
+
+    async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(opts).await
+    }
+}
+
+#[derive(Clone)]
+struct CountingRead {
+    inner: MemoryRead,
+    counters: Arc<PhysicalReadCounters>,
+}
+
+impl StorageRead for CountingRead {
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        self.counters.get_many.fetch_add(1, Ordering::Relaxed);
+        self.inner.get_many(space, keys, opts).await
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        self.counters.scan.fetch_add(1, Ordering::Relaxed);
+        self.inner.scan(space, range, opts).await
+    }
+}
+
+const BENCH_SCHEMA_KEY: &str = "plugin_perf_note";
+const BENCH_ENTITY_ID: &str = "document";
+const BENCH_STATE_BODY: &str =
+    "stable deterministic benchmark state payload used to exercise validation and storage";
+const BENCH_RENDERED_BYTES: &[u8] = b"deterministic-rendered-plugin-file";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BenchComponentBehavior {
+    ZeroState,
+    StableState,
+}
+
+struct BenchWasmRuntime {
+    behavior: BenchComponentBehavior,
+    init_calls: AtomicUsize,
+    detect_calls: Arc<AtomicUsize>,
+    render_calls: Arc<AtomicUsize>,
+    detect_input_state_rows: Arc<AtomicUsize>,
+    detect_output_state_rows: Arc<AtomicUsize>,
+    render_input_state_rows: Arc<AtomicUsize>,
+}
+
+impl BenchWasmRuntime {
+    fn new(behavior: BenchComponentBehavior) -> Self {
+        Self {
+            behavior,
+            init_calls: AtomicUsize::new(0),
+            detect_calls: Arc::new(AtomicUsize::new(0)),
+            render_calls: Arc::new(AtomicUsize::new(0)),
+            detect_input_state_rows: Arc::new(AtomicUsize::new(0)),
+            detect_output_state_rows: Arc::new(AtomicUsize::new(0)),
+            render_input_state_rows: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+struct BenchWasmComponent {
+    behavior: BenchComponentBehavior,
+    detect_calls: Arc<AtomicUsize>,
+    render_calls: Arc<AtomicUsize>,
+    detect_input_state_rows: Arc<AtomicUsize>,
+    detect_output_state_rows: Arc<AtomicUsize>,
+    render_input_state_rows: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl WasmRuntime for BenchWasmRuntime {
+    async fn init_component(
+        &self,
+        _bytes: Vec<u8>,
+        _limits: WasmLimits,
+    ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
+        self.init_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(Arc::new(BenchWasmComponent {
+            behavior: self.behavior,
+            detect_calls: Arc::clone(&self.detect_calls),
+            render_calls: Arc::clone(&self.render_calls),
+            detect_input_state_rows: Arc::clone(&self.detect_input_state_rows),
+            detect_output_state_rows: Arc::clone(&self.detect_output_state_rows),
+            render_input_state_rows: Arc::clone(&self.render_input_state_rows),
+        }))
+    }
+}
+
+#[async_trait]
+impl WasmComponentInstance for BenchWasmComponent {
+    async fn detect_changes(
+        &self,
+        state: Vec<WasmPluginEntityState>,
+        file: WasmPluginFile,
+    ) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
+        self.detect_calls.fetch_add(1, Ordering::Relaxed);
+        self.detect_input_state_rows
+            .fetch_add(state.len(), Ordering::Relaxed);
+        match self.behavior {
+            BenchComponentBehavior::ZeroState => {
+                assert!(state.is_empty(), "zero-state control must stay state-free");
+                Ok(Vec::new())
+            }
+            BenchComponentBehavior::StableState => {
+                assert!(
+                    state.len() <= 1,
+                    "stateful benchmark expects at most one row per file"
+                );
+                for entity in &state {
+                    assert_valid_benchmark_state(entity);
+                }
+                let revision_bytes: [u8; 8] = file
+                    .data
+                    .as_slice()
+                    .try_into()
+                    .expect("stateful benchmark writes must contain one u64 revision");
+                let filename = file
+                    .filename
+                    .expect("stateful benchmark detect must receive the descriptor filename");
+                let snapshot_content = json!({
+                    "id": BENCH_ENTITY_ID,
+                    "revision": u64::from_le_bytes(revision_bytes),
+                    "filename": filename,
+                    "body": BENCH_STATE_BODY,
+                })
+                .to_string();
+                self.detect_output_state_rows
+                    .fetch_add(1, Ordering::Relaxed);
+                Ok(vec![WasmPluginDetectedChange {
+                    entity_pk: vec![BENCH_ENTITY_ID.to_string()],
+                    schema_key: BENCH_SCHEMA_KEY.to_string(),
+                    snapshot_content: Some(snapshot_content),
+                    metadata: Some("{\"source\":\"plugin_registry_perf\"}".to_string()),
+                }])
+            }
+        }
+    }
+
+    async fn render(&self, state: Vec<WasmPluginEntityState>) -> Result<Vec<u8>, LixError> {
+        self.render_calls.fetch_add(1, Ordering::Relaxed);
+        self.render_input_state_rows
+            .fetch_add(state.len(), Ordering::Relaxed);
+        assert_eq!(
+            self.behavior,
+            BenchComponentBehavior::StableState,
+            "only the stateful benchmark component may render"
+        );
+        assert_eq!(
+            state.len(),
+            1,
+            "stateful render must receive one row per file"
+        );
+        assert_valid_benchmark_state(&state[0]);
+        Ok(BENCH_RENDERED_BYTES.to_vec())
+    }
+}
+
+fn assert_valid_benchmark_state(state: &WasmPluginEntityState) {
+    assert_eq!(state.entity_pk, [BENCH_ENTITY_ID.to_string()]);
+    assert_eq!(state.schema_key, BENCH_SCHEMA_KEY);
+    let snapshot: serde_json::Value = serde_json::from_str(&state.snapshot_content)
+        .expect("benchmark state snapshot must be valid JSON");
+    assert_eq!(snapshot.get("id"), Some(&json!(BENCH_ENTITY_ID)));
+    assert!(
+        snapshot
+            .get("revision")
+            .and_then(serde_json::Value::as_u64)
+            .is_some()
+    );
+    assert!(
+        snapshot
+            .get("filename")
+            .and_then(|value| value.as_str())
+            .is_some()
+    );
+    assert_eq!(snapshot.get("body"), Some(&json!(BENCH_STATE_BODY)));
+}
+
+fn benchmark_plugin_archive(path_glob: &str, wasm_bytes: usize) -> Vec<u8> {
+    const SCHEMA: &[u8] = br#"{
+        "x-lix-key":"plugin_perf_note",
+        "x-lix-primary-key":["/id"],
+        "type":"object",
+        "properties":{
+            "id":{"type":"string"},
+            "revision":{"type":"integer","minimum":0},
+            "filename":{"type":"string"},
+            "body":{"type":"string"}
+        },
+        "required":["id","revision","filename","body"],
+        "additionalProperties":false
+    }"#;
+    const WASM_HEADER: &[u8; 8] = b"\0asm\x01\0\0\0";
+    assert!(wasm_bytes >= WASM_HEADER.len());
+    let mut wasm = vec![0; wasm_bytes];
+    wasm[..WASM_HEADER.len()].copy_from_slice(WASM_HEADER);
+    let manifest = format!(
+        r#"{{
+            "key":"plugin_perf",
+            "runtime":"wasm-component-v1",
+            "api_version":"0.1.0",
+            "match":{{"path_glob":"{path_glob}"}},
+            "entry":"plugin.wasm",
+            "schemas":["schema/plugin_perf_note.json"]
+        }}"#
+    );
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    for (path, bytes) in [
+        ("manifest.json", manifest.as_bytes()),
+        ("schema/plugin_perf_note.json", SCHEMA),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer
+            .start_file(path, options)
+            .expect("benchmark plugin ZIP entry should start");
+        writer
+            .write_all(bytes)
+            .expect("benchmark plugin ZIP entry should write");
+    }
+    writer
+        .finish()
+        .expect("benchmark plugin ZIP should finish")
+        .into_inner()
+}

--- a/packages/engine/tests/plugin_registry_perf.rs
+++ b/packages/engine/tests/plugin_registry_perf.rs
@@ -13,7 +13,7 @@
 //! ```
 //!
 //! Modes are `p0`, `p1_nonmatch`, `p1_zero_state_write`, `p1_state_write`, and
-//! `p1_read_render`. The legacy `p1_match` name aliases `p1_zero_state_write`.
+//! `p1_read_render`.
 
 use std::fmt::Write as FmtWrite;
 use std::io::{Cursor, Write as IoWrite};
@@ -201,7 +201,7 @@ fn modes_from_env() -> Vec<ProbeMode> {
         .map(|value| match value.trim() {
             "p0" => ProbeMode::P0,
             "p1_nonmatch" => ProbeMode::P1Nonmatch,
-            "p1_match" | "p1_zero_state_write" => ProbeMode::P1ZeroStateWrite,
+            "p1_zero_state_write" => ProbeMode::P1ZeroStateWrite,
             "p1_state_write" => ProbeMode::P1StateWrite,
             "p1_read_render" => ProbeMode::P1ReadRender,
             other => {

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -1012,7 +1012,7 @@ test("SQL plugin archive upsert installs bundled plugin archive schemas", async 
 			"SELECT data FROM lix_file WHERE id = $1",
 			[`lix_plugin_archive::${plugin.key}`],
 		);
-		expect(get(stored, "data")).toEqual(plugin.archiveBytes);
+		expectBytesEqual(get(stored, "data"), plugin.archiveBytes);
 	}
 
 	const schemas = await lix.execute(
@@ -1046,7 +1046,7 @@ test("SQL plugin archive upsert stores the archive and installs schemas", async 
 		[`lix_plugin_archive::${csvPlugin.key}`],
 	);
 	expect(get(stored, "name")).toBe(`${csvPlugin.key}.lixplugin`);
-	expect(get(stored, "data")).toEqual(csvPlugin.archiveBytes);
+	expectBytesEqual(get(stored, "data"), csvPlugin.archiveBytes);
 
 	const schemas = await lix.execute(
 		"SELECT table_name \
@@ -1919,6 +1919,13 @@ async function activeHeadCommitId(lix: Lix): Promise<string> {
 
 function get(result: ExecuteResult, column: string, rowIndex = 0): unknown {
 	return result.rows[rowIndex]?.get(column);
+}
+
+function expectBytesEqual(actual: unknown, expected: Uint8Array): void {
+	expect(actual).toBeInstanceOf(Uint8Array);
+	const bytes = actual as Uint8Array;
+	expect(bytes.byteLength).toBe(expected.byteLength);
+	expect(bytes.every((byte, index) => byte === expected[index])).toBe(true);
 }
 
 async function withTimeout<T>(promise: Promise<T>, ms = 1_000): Promise<T> {


### PR DESCRIPTION
## Outcome

Ordinary file operations no longer discover installed plugins by scanning the visible filesystem and reopening `.lixplugin` ZIPs. Each branch instead maintains a durable, engine-owned registry and exact per-file ownership rows.

The public lifecycle stays filesystem-native:

- add `/.lix/plugins/<plugin-key>.lixplugin` to install;
- replace that archive to update;
- delete that exact archive to uninstall.

The ZIP remains the source artifact. Installation validates it once, records the matching/execution metadata, and stores the extracted WASM in content-addressed storage. This PR does not define or require a canonical packager-specific ZIP encoding.

## Hot-path changes

- One exact branch-registry lookup is the complete no-plugin path: no descriptor, owner, state, archive, CAS, matcher, or WASM scan.
- Installed plugins use a compiled matcher catalog cached by registry generation.
- Warm WASM components are cached by their fixed blob hash; a hit avoids CAS access and rehashing.
- Matching is done against durable registry metadata, including optional content type, without reopening archives.
- Durable file ownership prevents overlapping matchers from taking ownership nondeterministically.
- Owner/state work is restricted to affected file IDs and grouped by plugin; unchanged owner rows are not rewritten.
- Render reads use exact owner/state lookups instead of rediscovering plugins from the filesystem.

## Direct `main` A/B

Same release benchmark harness and public SQL operations on both revisions, pinned to CPU 4, in-memory storage, 1 MiB plugin WASM, batch size 1, 20 warmups, and 100 timed samples. Baseline is merged `main` at `a542bc9f`; measurements were collected on the pre-rebase candidate at `a1153dea`. The current head is a history-only rebase onto `45605bae` integrating #645’s file-ID index; benchmarks were not rerun.

| Files | Installed-plugin operation | `main` p50 / p95 | This PR p50 / p95 | Improvement p50 / p95 |
| ---: | --- | ---: | ---: | ---: |
| 1k | Nonmatching plugin write | 29.538 / 34.935 ms | 4.924 / 5.556 ms | 83.3% / 84.1% |
| 1k | Matching stable-state write | 30.401 / 36.295 ms | 4.969 / 5.654 ms | 83.7% / 84.4% |
| 1k | Matching rendered read | 15.641 / 16.539 ms | 1.900 / 2.002 ms | 87.9% / 87.9% |
| 10k | Nonmatching plugin write | 353.177 / 435.544 ms | 10.682 / 11.796 ms | 97.0% / 97.3% |
| 10k | Matching stable-state write | 367.411 / 457.072 ms | 10.334 / 11.670 ms | 97.2% / 97.4% |
| 10k | Matching rendered read | 203.410 / 209.039 ms | 3.201 / 3.635 ms | 98.4% / 98.3% |

The installed-plugin path is therefore fixed too; this is not only a no-plugin shortcut. At 10k files the current implementation pays filesystem-scale discovery costs on every operation, while the registry path remains tied to the affected file IDs and installed plugin set.

The broader candidate-only release matrix also measured the zero-plugin write at 5.018 / 6.318 ms for 1k files and 10.092 / 13.121 ms for 10k files (p50 / p95, 200 samples). At 10k files, batching 100 matching files reduced per-file stable-state writes to 0.578 ms and rendered reads to 0.135 ms.

## Breaking lifecycle contract

- Registry rows are an internal derived format, not a second installation API.
- There is no compatibility decoder for unreleased/pre-registry rows. Existing plugin archives must be removed and re-added to populate the registry and rematerialize ownership.
- Every registry-v1 field is required. Path-only matching uses explicit `"content_type": null`; an omitted field is invalid.
- Plugins are branch-local. `GLOBAL` and `UNTRACKED` plugin archives are rejected.
- Archive filename and manifest plugin key must agree.
- Internal registry and owner keys are reserved from public `lix_key_value` writes.
- Active plugin schema definitions are immutable; uninstall before replacing such a definition.
- A branch supports at most 128 installed plugins.
- Uninstall removes executable registry state but deliberately retains owned document state. Reads that need the absent plugin return `LIX_ERROR_PLUGIN_UNAVAILABLE`; reinstalling the same plugin resumes rendering. This avoids silently presenting plugin state as an empty file.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p lix_engine --lib -- -D warnings`
- `cargo test -p lix_engine --lib` — 1057 passed, 3 benchmark probes ignored
- `cargo test -p lix_engine --test fs_api` — 39 passed
- current-head release build and full 1k/10k installed-plugin A/B matrix

The focused filesystem suite covers archive install/update/delete, branch isolation, durable ownership, overlapping matchers, content-type matching, raw↔plugin path transitions, uninstall/reinstall recovery, reserved internal state, and structured unavailable-plugin errors.

## Deliberate 10% exclusions

- Reinstalling a plugin key with changed matching rules revalidates existing ownership lazily on the file's next write.
- Divergent branches using different WASM under the same plugin key can churn the one-version component cache.
- Cold component-cache misses are not single-flight.
- Concurrent divergent installs can conflict on the singleton branch-registry row.
- Plugin install/uninstall itself still validates and decodes the bounded registry payload; the optimized target is ordinary CRUD.