### PR TITLE
perf(engine): batch correlated live-state row reads

### DIFF
--- a/.changenotes/batch-correlated-live-state-reads.md
+++ b/.changenotes/batch-correlated-live-state-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Lix now batches exact correlated live-state row reads for ID-constrained `lix_file` queries and writes.
+
+This removes the previous Cartesian point-read expansion for batches of up to 32 files and the per-file prefix-scan fallback for larger batches. `SELECT`, `UPDATE`, `DELETE`, and ID-based upsert conflict probes use aligned exact identities while preserving branch/global visibility, tombstones, tracked and untracked rows, and staged transaction overlays.

--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -544,6 +544,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,

--- a/packages/engine/src/filesystem/visibility.rs
+++ b/packages/engine/src/filesystem/visibility.rs
@@ -361,6 +361,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RecordingLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -396,6 +403,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -14,8 +14,9 @@ use crate::live_state::index::{
     LiveStateIndexContext, LiveStateIndexFilter, LiveStateIndexScanRequest,
 };
 use crate::live_state::{
-    LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
-    VisibilityBranchScope, VisibilityRequest, expanded_branch_ids, resolve_visible_rows,
+    LiveStateExactBatchRequest, LiveStateReader, LiveStateRowIdentity, LiveStateRowRequest,
+    LiveStateScanRequest, MaterializedLiveStateRow, VisibilityBranchScope, VisibilityRequest,
+    expanded_branch_ids, resolve_visible_rows,
 };
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::{
@@ -159,6 +160,190 @@ where
         Ok(rows.into_iter().next())
     }
 
+    /// Loads exact visible identities without lowering correlated row keys to
+    /// independent scan dimensions.
+    pub(crate) async fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        if request.rows.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Commit-derived rows are synthesized rather than stored under the
+        // requested identity. Preserve their exact scan semantics without
+        // widening the optimized durable-state batch.
+        if request.rows.iter().any(|row| {
+            matches!(
+                row.schema_key.as_str(),
+                COMMIT_SCHEMA_KEY | COMMIT_EDGE_SCHEMA_KEY
+            )
+        }) {
+            let mut rows = Vec::with_capacity(request.rows.len());
+            for row in &request.rows {
+                rows.push(
+                    self.scan_rows(&request.row_scan_request(row))
+                        .await?
+                        .into_iter()
+                        .next(),
+                );
+            }
+            return Ok(rows);
+        }
+
+        let branch_ids = request
+            .rows
+            .iter()
+            .map(|row| row.branch_id.clone())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let scope_request = LiveStateScanRequest {
+            filter: crate::live_state::LiveStateFilter {
+                branch_ids,
+                untracked: request.untracked,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let reads_tracked = request.untracked != Some(true);
+        let scope =
+            scan_scope(&self.store, &self.live_index, &scope_request, reads_tracked).await?;
+        let visible_branch_ids = scope
+            .projection_branch_ids
+            .iter()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let mut storage_identities = std::collections::BTreeSet::new();
+        for row in &request.rows {
+            if !visible_branch_ids.contains(&row.branch_id) {
+                continue;
+            }
+            storage_identities.insert(LiveStateRowIdentity {
+                branch_id: row.branch_id.clone(),
+                schema_key: row.schema_key.clone(),
+                entity_pk: row.entity_pk.clone(),
+                file_id: row.file_id.clone(),
+            });
+            if row.branch_id != GLOBAL_BRANCH_ID {
+                storage_identities.insert(LiveStateRowIdentity {
+                    branch_id: GLOBAL_BRANCH_ID.to_string(),
+                    schema_key: row.schema_key.clone(),
+                    entity_pk: row.entity_pk.clone(),
+                    file_id: row.file_id.clone(),
+                });
+            }
+        }
+        let storage_identities = storage_identities.into_iter().collect::<Vec<_>>();
+        let mut candidates =
+            std::collections::BTreeMap::<LiveStateRowIdentity, MaterializedLiveStateRow>::new();
+
+        if request.untracked != Some(true) {
+            let mut identities_by_branch = std::collections::BTreeMap::<String, Vec<_>>::new();
+            for identity in &storage_identities {
+                if scope.branch_commit_ids.contains_key(&identity.branch_id) {
+                    identities_by_branch
+                        .entry(identity.branch_id.clone())
+                        .or_default()
+                        .push(identity.clone());
+                }
+            }
+            let projection =
+                crate::changelog::ChangeRecordProjection::from_columns(&request.projection.columns);
+            let tracked_batches = stream::iter(identities_by_branch)
+                .map(|(branch_id, identities)| {
+                    let commit_id = scope.branch_commit_ids[&branch_id].clone();
+                    let projection = projection.clone();
+                    async move {
+                        let keys = identities
+                            .iter()
+                            .map(|identity| crate::tracked_state::TrackedStateKey {
+                                schema_key: identity.schema_key.clone(),
+                                entity_pk: identity.entity_pk.clone(),
+                                file_id: identity.file_id.clone(),
+                            })
+                            .collect::<Vec<_>>();
+                        let rows = self
+                            .tracked_state
+                            .reader(&self.store)
+                            .load_projected_rows_at_commit(&commit_id, &keys, &projection)
+                            .await?;
+                        Ok::<_, LixError>((branch_id, identities, rows))
+                    }
+                })
+                .buffered(BRANCH_READ_CONCURRENCY)
+                .try_collect::<Vec<_>>()
+                .await?;
+            for (branch_id, identities, rows) in tracked_batches {
+                let source = tracked_source_from_branch_id(&branch_id);
+                for (identity, row) in identities.into_iter().zip(rows) {
+                    if let Some(row) = row {
+                        candidates.insert(identity, project_tracked_row(row, &branch_id, source));
+                    }
+                }
+            }
+        }
+
+        if request.untracked != Some(false) {
+            let index_requests = storage_identities
+                .iter()
+                .map(|identity| crate::live_state::LiveStateIndexRowRequest {
+                    branch_id: identity.branch_id.clone(),
+                    schema_key: identity.schema_key.clone(),
+                    entity_pk: identity.entity_pk.clone(),
+                    file_id: identity.file_id.clone(),
+                })
+                .collect::<Vec<_>>();
+            let rows = self
+                .live_index
+                .reader(&self.store)
+                .load_rows(&index_requests, &request.projection.columns)
+                .await?;
+            for (identity, row) in storage_identities.iter().cloned().zip(rows) {
+                if let Some(row) = row {
+                    // Mutable flat state is canonical over the tracked head for
+                    // the same storage identity.
+                    candidates.insert(identity, MaterializedLiveStateRow::from(row));
+                }
+            }
+        }
+
+        Ok(request
+            .rows
+            .iter()
+            .map(|requested| {
+                if !visible_branch_ids.contains(&requested.branch_id) {
+                    return None;
+                }
+                let branch_identity = LiveStateRowIdentity {
+                    branch_id: requested.branch_id.clone(),
+                    schema_key: requested.schema_key.clone(),
+                    entity_pk: requested.entity_pk.clone(),
+                    file_id: requested.file_id.clone(),
+                };
+                let global_identity = LiveStateRowIdentity {
+                    branch_id: GLOBAL_BRANCH_ID.to_string(),
+                    schema_key: requested.schema_key.clone(),
+                    entity_pk: requested.entity_pk.clone(),
+                    file_id: requested.file_id.clone(),
+                };
+                let mut row = candidates
+                    .get(&branch_identity)
+                    .or_else(|| candidates.get(&global_identity))?
+                    .clone();
+                if row.branch_id == GLOBAL_BRANCH_ID && requested.branch_id != GLOBAL_BRANCH_ID {
+                    row.branch_id.clone_from(&requested.branch_id);
+                    row.global = true;
+                }
+                if row.deleted && !request.include_tombstones {
+                    None
+                } else {
+                    Some(row)
+                }
+            })
+            .collect())
+    }
+
     pub(crate) async fn scan_tracked_rows(
         &self,
         request: &LiveStateScanRequest,
@@ -240,6 +425,13 @@ where
         request: &LiveStateRowRequest,
     ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
         Self::load_row(self, request).await
+    }
+
+    async fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        Self::load_exact_rows(self, request).await
     }
 
     async fn scan_tracked_rows(
@@ -638,8 +830,10 @@ mod tests {
     use crate::changelog::{ChangeId, ChangeRecord, ChangelogAppend, CommitId};
     use crate::entity_pk::EntityPk;
     use crate::json_store::{JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
-    use crate::live_state::LiveStateFilter;
     use crate::live_state::index::{LiveStateIndexContext, LiveStateIndexDeltaRef};
+    use crate::live_state::{
+        LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter, LiveStateProjection,
+    };
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
     use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
     use crate::tracked_state::{TrackedStateDeltaRef, TrackedStateScanRequest};
@@ -1041,7 +1235,24 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        write_empty_commits_to_store(&storage, &read, &["commit-tracked"]).await;
+        let mut writes = StorageWriteSet::new();
+        let mut json_writer = JsonStoreContext::new().writer();
+        stage_materialized_live_rows(
+            &read,
+            &mut writes,
+            &mut json_writer,
+            &[tracked_row_with_commit(
+                "tracked-value",
+                Some("change-tracked"),
+                "commit-tracked",
+            )],
+        )
+        .await
+        .expect("tracked row should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("tracked row should commit");
         write_untracked_rows_to_store(
             &storage,
             &read,
@@ -1085,6 +1296,86 @@ mod tests {
             loaded.snapshot_content.as_deref(),
             Some("{\"value\":\"untracked-value\"}")
         );
+    }
+
+    #[tokio::test]
+    async fn exact_batch_preserves_duplicate_and_missing_slots_for_flat_rows() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live_state = live_state_context();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut writes = StorageWriteSet::new();
+        let mut json_writer = JsonStoreContext::new().writer();
+        stage_materialized_live_rows(
+            &read,
+            &mut writes,
+            &mut json_writer,
+            &[tracked_row_with_commit(
+                "tracked-value",
+                Some("change-tracked"),
+                "commit-tracked",
+            )],
+        )
+        .await
+        .expect("tracked row should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("tracked row should commit");
+        write_untracked_rows_to_store(
+            &storage,
+            &read,
+            &[
+                branch_ref_row("global", "commit-tracked"),
+                untracked_row("untracked-value"),
+            ],
+        )
+        .await;
+
+        let selected = LiveStateExactRowRequest {
+            schema_key: "lix_key_value".to_string(),
+            branch_id: "global".to_string(),
+            entity_pk: identity("selected-tab"),
+            file_id: None,
+        };
+        let rows = live_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("read should reopen"),
+            )
+            .load_exact_rows(&LiveStateExactBatchRequest {
+                rows: vec![
+                    selected.clone(),
+                    selected,
+                    LiveStateExactRowRequest {
+                        schema_key: "lix_key_value".to_string(),
+                        branch_id: "global".to_string(),
+                        entity_pk: identity("missing"),
+                        file_id: None,
+                    },
+                ],
+                projection: LiveStateProjection {
+                    columns: vec!["snapshot_content".to_string()],
+                },
+                ..Default::default()
+            })
+            .await
+            .expect("exact batch should load");
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0], rows[1]);
+        assert_eq!(
+            rows[0]
+                .as_ref()
+                .and_then(|row| row.snapshot_content.as_deref()),
+            Some("{\"value\":\"untracked-value\"}")
+        );
+        assert!(rows[0].as_ref().is_some_and(|row| row.untracked));
+        assert_eq!(rows[2], None);
     }
 
     #[tokio::test]
@@ -1614,6 +1905,146 @@ mod tests {
         assert_eq!(tombstones[0].branch_id, "main");
         assert!(!tombstones[0].global);
         assert_eq!(tombstones[0].snapshot_content, None);
+    }
+
+    #[tokio::test]
+    async fn exact_batch_resolves_branch_global_tombstone_projection_and_correlated_keys() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live_state = live_state_context();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+
+        let mut global_fallback =
+            tracked_row_with_commit("global-fallback", Some("change-fallback"), "commit-global");
+        global_fallback.entity_pk = identity("fallback");
+        global_fallback.file_id = Some("fallback".to_string());
+        global_fallback.metadata = Some("{\"source\":\"global\"}".to_string());
+        let mut global_overridden =
+            tracked_row_with_commit("global-old", Some("change-global-old"), "commit-global");
+        global_overridden.entity_pk = identity("overridden");
+        global_overridden.file_id = Some("overridden".to_string());
+        let mut branch_override = tracked_row_at_with_commit(
+            "branch-a",
+            "branch-new",
+            Some("change-branch-new"),
+            "commit-branch",
+        );
+        branch_override.entity_pk = identity("overridden");
+        branch_override.file_id = Some("overridden".to_string());
+        let mut global_hidden =
+            tracked_row_with_commit("global-hidden", Some("change-hidden"), "commit-global");
+        global_hidden.entity_pk = identity("hidden");
+        global_hidden.file_id = Some("hidden".to_string());
+        let mut branch_tombstone = tombstone_tracked_row_at_with_commit(
+            "branch-a",
+            Some("change-tombstone"),
+            "commit-branch",
+        );
+        branch_tombstone.entity_pk = identity("hidden");
+        branch_tombstone.file_id = Some("hidden".to_string());
+        let mut malformed_cross_pair =
+            tracked_row_with_commit("cross-pair", Some("change-cross"), "commit-global");
+        malformed_cross_pair.entity_pk = identity("entity-a");
+        malformed_cross_pair.file_id = Some("file-b".to_string());
+
+        let rows = [
+            global_fallback,
+            global_overridden,
+            global_hidden,
+            malformed_cross_pair,
+            branch_override,
+            branch_tombstone,
+        ];
+        let mut writes = StorageWriteSet::new();
+        let mut json_writer = JsonStoreContext::new().writer();
+        stage_materialized_live_rows(&read, &mut writes, &mut json_writer, &rows)
+            .await
+            .expect("tracked rows should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("tracked rows should commit");
+        write_untracked_rows_to_store(
+            &storage,
+            &read,
+            &[
+                branch_ref_row("global", "commit-global"),
+                branch_ref_row("branch-a", "commit-branch"),
+            ],
+        )
+        .await;
+
+        let exact = |entity: &str, file_id: &str| LiveStateExactRowRequest {
+            schema_key: "lix_key_value".to_string(),
+            branch_id: "branch-a".to_string(),
+            entity_pk: identity(entity),
+            file_id: Some(file_id.to_string()),
+        };
+        let reader = live_state.reader(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read should reopen"),
+        );
+        let loaded = reader
+            .load_exact_rows(&LiveStateExactBatchRequest {
+                rows: vec![
+                    exact("fallback", "fallback"),
+                    exact("overridden", "overridden"),
+                    exact("hidden", "hidden"),
+                    exact("entity-a", "file-a"),
+                    exact("entity-b", "file-b"),
+                    exact("entity-a", "file-b"),
+                    exact("missing", "missing"),
+                ],
+                projection: LiveStateProjection {
+                    columns: vec!["snapshot_content".to_string()],
+                },
+                ..Default::default()
+            })
+            .await
+            .expect("exact tracked batch should load");
+
+        let fallback = loaded[0].as_ref().expect("global fallback should load");
+        assert!(fallback.global);
+        assert_eq!(fallback.branch_id, "branch-a");
+        assert_eq!(
+            fallback.snapshot_content.as_deref(),
+            Some("{\"value\":\"global-fallback\"}")
+        );
+        assert_eq!(fallback.metadata, None, "projection should omit metadata");
+        let overridden = loaded[1].as_ref().expect("branch override should load");
+        assert!(!overridden.global);
+        assert_eq!(
+            overridden.snapshot_content.as_deref(),
+            Some("{\"value\":\"branch-new\"}")
+        );
+        assert_eq!(loaded[2], None, "branch tombstone must hide global row");
+        assert_eq!(loaded[3], None, "entity A/file A must not cross-match");
+        assert_eq!(loaded[4], None, "entity B/file B must not cross-match");
+        assert_eq!(
+            loaded[5]
+                .as_ref()
+                .and_then(|row| row.snapshot_content.as_deref()),
+            Some("{\"value\":\"cross-pair\"}")
+        );
+        assert_eq!(loaded[6], None);
+
+        let tombstone = reader
+            .load_exact_rows(&LiveStateExactBatchRequest {
+                rows: vec![exact("hidden", "hidden")],
+                include_tombstones: true,
+                ..Default::default()
+            })
+            .await
+            .expect("exact tombstone read should load")
+            .pop()
+            .flatten()
+            .expect("tombstone should be returned when requested");
+        assert!(tombstone.deleted);
+        assert!(!tombstone.global);
     }
 
     #[tokio::test]

--- a/packages/engine/src/live_state/index/context.rs
+++ b/packages/engine/src/live_state/index/context.rs
@@ -4,9 +4,11 @@ use crate::LixError;
 use crate::changelog::{ChangeId, ChangeRecordProjection, materialize_change_payloads};
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 
+#[cfg(test)]
+use super::storage::load_value;
 use super::storage::{
-    FlatIdentity, FlatValue, LIVE_STATE_INDEX_ROW_SPACE, load_value, load_values, scan_values,
-    stage_delete, stage_put,
+    FlatIdentity, FlatValue, LIVE_STATE_INDEX_ROW_SPACE, load_values, scan_values, stage_delete,
+    stage_put,
 };
 use super::{
     LiveStateIndexDeltaRef, LiveStateIndexRow, LiveStateIndexRowRequest, LiveStateIndexScanRequest,
@@ -89,15 +91,54 @@ where
         &self,
         request: &LiveStateIndexRowRequest,
     ) -> Result<Option<MaterializedLiveStateIndexRow>, LixError> {
-        let identity = FlatIdentity::from_request(request);
-        let Some(value) = load_value(&self.store, &identity).await? else {
-            return Ok(None);
-        };
-        Ok(
-            materialize_entries(&self.store, vec![(identity, value)], &[])
-                .await?
-                .pop(),
-        )
+        Ok(self
+            .load_rows(std::slice::from_ref(request), &[])
+            .await?
+            .pop()
+            .flatten())
+    }
+
+    /// Loads correlated flat identities with one point-read plan and one
+    /// payload-materialization batch while preserving input alignment.
+    pub(crate) async fn load_rows(
+        &self,
+        requests: &[LiveStateIndexRowRequest],
+        projection: &[String],
+    ) -> Result<Vec<Option<MaterializedLiveStateIndexRow>>, LixError> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut output_indices = BTreeMap::<FlatIdentity, Vec<usize>>::new();
+        for (index, request) in requests.iter().enumerate() {
+            output_indices
+                .entry(FlatIdentity::from_request(request))
+                .or_default()
+                .push(index);
+        }
+        let identities = output_indices.keys().cloned().collect::<Vec<_>>();
+        let values = load_values(&self.store, &identities).await?;
+        let mut entries = Vec::new();
+        for (identity, value) in identities.into_iter().zip(values) {
+            if let Some(value) = value {
+                entries.push((identity, value));
+            }
+        }
+        let materialized = materialize_entries(&self.store, entries, projection).await?;
+        let mut rows = vec![None; requests.len()];
+        for row in materialized {
+            let identity = FlatIdentity {
+                branch_id: row.branch_id.clone(),
+                schema_key: row.schema_key.clone(),
+                entity_pk: row.entity_pk.clone(),
+                file_id: row.file_id.clone(),
+            };
+            if let Some(indices) = output_indices.get(&identity) {
+                for &index in indices {
+                    rows[index] = Some(row.clone());
+                }
+            }
+        }
+        Ok(rows)
     }
 
     pub(crate) async fn load_index_row(

--- a/packages/engine/src/live_state/index/storage.rs
+++ b/packages/engine/src/live_state/index/storage.rs
@@ -96,6 +96,7 @@ impl FlatIdentity {
     }
 }
 
+#[cfg(test)]
 pub(super) async fn load_value(
     store: &(impl StorageAdapterRead + ?Sized),
     identity: &FlatIdentity,

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -14,14 +14,18 @@ pub(crate) use index::{
 };
 #[allow(unused_imports)]
 pub(crate) use reader::LiveStateReader;
+#[cfg(test)]
+pub(crate) use reader::load_exact_rows_via_scan_for_test;
 #[allow(unused_imports)]
 pub(crate) use types::{
-    Bound, LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection, LiveStateRowFilter,
-    LiveStateRowIdentity, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
-    ScanConstraint, ScanField, ScanOperator,
+    Bound, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFileScanRequest,
+    LiveStateFilter, LiveStateProjection, LiveStateRowFilter, LiveStateRowIdentity,
+    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow, ScanConstraint, ScanField,
+    ScanOperator,
 };
 #[allow(unused_imports)]
 pub(crate) use visibility::{
     StagedLiveStateRows, VisibilityBranchScope, VisibilityRequest, expanded_branch_ids,
-    overlay_scan_file_rows, overlay_scan_rows, overlay_scan_tracked_rows, resolve_visible_rows,
+    overlay_load_exact_rows, overlay_scan_file_rows, overlay_scan_rows, overlay_scan_tracked_rows,
+    resolve_visible_rows,
 };

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 
 use crate::LixError;
 use crate::live_state::MaterializedLiveStateRow;
-use crate::live_state::{LiveStateFileScanRequest, LiveStateRowRequest, LiveStateScanRequest};
+use crate::live_state::{
+    LiveStateExactBatchRequest, LiveStateFileScanRequest, LiveStateRowRequest, LiveStateScanRequest,
+};
 
 /// Minimal engine read model for transaction planning and SQL providers.
 ///
@@ -44,4 +46,35 @@ pub(crate) trait LiveStateReader: Send + Sync {
         &self,
         request: &LiveStateRowRequest,
     ) -> Result<Option<MaterializedLiveStateRow>, LixError>;
+
+    /// Loads concrete visible identities while preserving request alignment.
+    ///
+    /// Implementations must provide a correlated batch path. There is no
+    /// scan-based default because silently lowering this operation to one scan
+    /// per row would reintroduce the amplification this API exists to prevent.
+    async fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError>;
+}
+
+#[cfg(test)]
+pub(crate) async fn load_exact_rows_via_scan_for_test<R>(
+    reader: &R,
+    request: &LiveStateExactBatchRequest,
+) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError>
+where
+    R: LiveStateReader + ?Sized,
+{
+    let mut rows = Vec::with_capacity(request.rows.len());
+    for row in &request.rows {
+        rows.push(
+            reader
+                .scan_rows(&request.row_scan_request(row))
+                .await?
+                .into_iter()
+                .next(),
+        );
+    }
+    Ok(rows)
 }

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -213,6 +213,56 @@ pub(crate) struct LiveStateRowRequest {
     pub(crate) file_id: NullableKeyFilter<String>,
 }
 
+/// One concrete visible-row identity in an exact batch read.
+///
+/// Unlike [`LiveStateFilter`], the identity fields in this request are
+/// correlated. Implementations must never expand multiple requests into the
+/// Cartesian product of their schema, entity, and file dimensions.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct LiveStateExactRowRequest {
+    pub(crate) schema_key: String,
+    pub(crate) branch_id: String,
+    pub(crate) entity_pk: EntityPk,
+    pub(crate) file_id: Option<String>,
+}
+
+/// Aligned point-read request for visible live-state rows.
+///
+/// Results preserve `rows` order and cardinality: duplicate identities produce
+/// duplicate result slots and missing or tombstoned identities produce `None`
+/// unless tombstones are explicitly requested.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct LiveStateExactBatchRequest {
+    pub(crate) rows: Vec<LiveStateExactRowRequest>,
+    pub(crate) projection: LiveStateProjection,
+    pub(crate) untracked: Option<bool>,
+    pub(crate) include_tombstones: bool,
+}
+
+impl LiveStateExactBatchRequest {
+    pub(crate) fn row_scan_request(&self, row: &LiveStateExactRowRequest) -> LiveStateScanRequest {
+        LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: vec![row.schema_key.clone()],
+                entity_pks: vec![row.entity_pk.clone()],
+                branch_ids: vec![row.branch_id.clone()],
+                file_ids: vec![
+                    row.file_id
+                        .as_ref()
+                        .map_or(NullableKeyFilter::Null, |file_id| {
+                            NullableKeyFilter::Value(file_id.clone())
+                        }),
+                ],
+                untracked: self.untracked,
+                include_tombstones: self.include_tombstones,
+                ..LiveStateFilter::default()
+            },
+            projection: self.projection.clone(),
+            limit: Some(1),
+        }
+    }
+}
+
 /// Stable visible-row identity used for overlay composition.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct LiveStateRowIdentity {

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::live_state::{
-    LiveStateFileScanRequest, LiveStateReader, LiveStateRowIdentity, LiveStateScanRequest,
-    MaterializedLiveStateRow,
+    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFileScanRequest,
+    LiveStateReader, LiveStateRowIdentity, LiveStateScanRequest, MaterializedLiveStateRow,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -31,6 +31,26 @@ pub(crate) trait StagedLiveStateRows {
         request: &LiveStateFileScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
         self.staged_rows(&request.to_scan_request())
+    }
+
+    /// Loads exact staged storage identities in request order.
+    ///
+    /// This does not apply global fallback: overlay composition needs the
+    /// branch and global candidates separately to preserve their precedence.
+    fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        request
+            .rows
+            .iter()
+            .map(|row| {
+                Ok(self
+                    .staged_rows(&request.row_scan_request(row))?
+                    .into_iter()
+                    .next())
+            })
+            .collect()
     }
 }
 
@@ -163,6 +183,120 @@ where
             limit: request.limit,
         },
     ))
+}
+
+/// Overlays staged exact identities without converting correlated row keys to
+/// independent scan filters.
+pub(crate) async fn overlay_load_exact_rows<S>(
+    base: &dyn LiveStateReader,
+    staged: &S,
+    request: &LiveStateExactBatchRequest,
+) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError>
+where
+    S: StagedLiveStateRows + ?Sized,
+{
+    if request.rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut base_request = request.clone();
+    base_request.include_tombstones = true;
+    let base_rows = base.load_exact_rows(&base_request).await?;
+    if base_rows.len() != request.rows.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "exact live-state base read expected {} result slots, got {}",
+                request.rows.len(),
+                base_rows.len()
+            ),
+        ));
+    }
+
+    let mut staged_requests = Vec::with_capacity(request.rows.len() * 2);
+    let mut staged_indices = Vec::with_capacity(request.rows.len());
+    for row in &request.rows {
+        let global_index = staged_requests.len();
+        staged_requests.push(LiveStateExactRowRequest {
+            branch_id: GLOBAL_BRANCH_ID.to_string(),
+            schema_key: row.schema_key.clone(),
+            entity_pk: row.entity_pk.clone(),
+            file_id: row.file_id.clone(),
+        });
+        let branch_index = if row.branch_id == GLOBAL_BRANCH_ID {
+            None
+        } else {
+            let index = staged_requests.len();
+            staged_requests.push(row.clone());
+            Some(index)
+        };
+        staged_indices.push((global_index, branch_index));
+    }
+    let staged_request = LiveStateExactBatchRequest {
+        rows: staged_requests,
+        projection: request.projection.clone(),
+        untracked: request.untracked,
+        include_tombstones: true,
+    };
+    let staged_rows = staged.load_exact_rows(&staged_request)?;
+    if staged_rows.len() != staged_request.rows.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "exact staged live-state read expected {} result slots, got {}",
+                staged_request.rows.len(),
+                staged_rows.len()
+            ),
+        ));
+    }
+
+    Ok(request
+        .rows
+        .iter()
+        .zip(base_rows)
+        .zip(staged_indices)
+        .map(|((requested, base), (global_index, branch_index))| {
+            let mut winner = base.map(|row| {
+                let tier = if row.global {
+                    OverlayTier::BaseGlobal
+                } else {
+                    OverlayTier::BaseBranch
+                };
+                (tier, row)
+            });
+            if let Some(mut row) = staged_rows[global_index].clone() {
+                if requested.branch_id != GLOBAL_BRANCH_ID {
+                    row.branch_id.clone_from(&requested.branch_id);
+                }
+                row.global = true;
+                insert_exact_overlay_candidate(&mut winner, OverlayTier::StagedGlobal, row);
+            }
+            if let Some(index) = branch_index
+                && let Some(row) = staged_rows[index].clone()
+            {
+                insert_exact_overlay_candidate(&mut winner, OverlayTier::StagedBranch, row);
+            }
+            let row = winner.map(|(_, row)| row)?;
+            if row.deleted && !request.include_tombstones {
+                None
+            } else {
+                Some(row)
+            }
+        })
+        .collect())
+}
+
+fn insert_exact_overlay_candidate(
+    winner: &mut Option<(OverlayTier, MaterializedLiveStateRow)>,
+    tier: OverlayTier,
+    row: MaterializedLiveStateRow,
+) {
+    if winner
+        .as_ref()
+        .is_none_or(|(existing_tier, _)| *existing_tier <= tier)
+    {
+        *winner = Some((tier, row));
+    }
 }
 
 /// Resolves raw tracked/untracked candidates into the rows visible for a scan.
@@ -760,6 +894,155 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn exact_overlay_preserves_branch_global_precedence_and_tombstones() {
+        let base = FilteringReader {
+            rows: vec![
+                row_at(
+                    "branch-a",
+                    "base-branch",
+                    "base-branch",
+                    false,
+                    Some("base-branch"),
+                ),
+                row_at(
+                    "branch-a",
+                    "base-global",
+                    "base-global",
+                    true,
+                    Some("base-global"),
+                ),
+                row_at(
+                    "branch-a",
+                    "stage-branch",
+                    "base-before-stage",
+                    false,
+                    Some("base-before-stage"),
+                ),
+                row_at(
+                    "branch-a",
+                    "stage-delete",
+                    "base-before-delete",
+                    true,
+                    Some("base-before-delete"),
+                ),
+                tombstone_at("branch-a", "base-tombstone", false, Some("base-tombstone")),
+                row_at(
+                    "branch-a",
+                    "global-delete",
+                    "global-before-delete",
+                    true,
+                    Some("global-before-delete"),
+                ),
+            ],
+        };
+        let staged = FilteringStagedRows {
+            rows: vec![
+                row_at(
+                    "global",
+                    "base-branch",
+                    "staged-global-loses",
+                    true,
+                    Some("staged-global-loses"),
+                ),
+                row_at(
+                    "global",
+                    "base-global",
+                    "staged-global-wins",
+                    true,
+                    Some("staged-global-wins"),
+                ),
+                row_at(
+                    "branch-a",
+                    "stage-branch",
+                    "staged-branch-wins",
+                    false,
+                    Some("staged-branch-wins"),
+                ),
+                tombstone_at(
+                    "branch-a",
+                    "stage-delete",
+                    false,
+                    Some("staged-branch-delete"),
+                ),
+                row_at(
+                    "global",
+                    "stage-global",
+                    "staged-global-only",
+                    true,
+                    Some("staged-global-only"),
+                ),
+                row_at(
+                    "global",
+                    "base-tombstone",
+                    "staged-global-hidden",
+                    true,
+                    Some("staged-global-hidden"),
+                ),
+                tombstone_at(
+                    "global",
+                    "global-delete",
+                    true,
+                    Some("staged-global-delete"),
+                ),
+            ],
+        };
+        let exact = |entity: &str| LiveStateExactRowRequest {
+            schema_key: "schema".to_string(),
+            branch_id: "branch-a".to_string(),
+            entity_pk: EntityPk::single(entity),
+            file_id: None,
+        };
+        let request = LiveStateExactBatchRequest {
+            rows: [
+                "base-branch",
+                "base-global",
+                "stage-branch",
+                "stage-delete",
+                "stage-global",
+                "base-tombstone",
+                "global-delete",
+            ]
+            .into_iter()
+            .map(exact)
+            .collect(),
+            ..Default::default()
+        };
+
+        let rows = overlay_load_exact_rows(&base, &staged, &request)
+            .await
+            .expect("exact overlay should resolve");
+        let value = |index: usize| {
+            rows[index]
+                .as_ref()
+                .and_then(|row| row.snapshot_content.as_deref())
+        };
+        assert_eq!(value(0), Some("{\"value\":\"base-branch\"}"));
+        assert_eq!(value(1), Some("{\"value\":\"staged-global-wins\"}"));
+        assert_eq!(value(2), Some("{\"value\":\"staged-branch-wins\"}"));
+        assert_eq!(rows[3], None, "staged branch tombstone should hide base");
+        assert_eq!(value(4), Some("{\"value\":\"staged-global-only\"}"));
+        assert_eq!(rows[5], None, "base branch tombstone beats staged global");
+        assert_eq!(rows[6], None, "staged global tombstone hides base global");
+
+        let tombstone = overlay_load_exact_rows(
+            &base,
+            &staged,
+            &LiveStateExactBatchRequest {
+                rows: vec![exact("stage-delete")],
+                include_tombstones: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("exact tombstone overlay should resolve")
+        .pop()
+        .flatten()
+        .expect("requested tombstone should be returned");
+        assert!(tombstone.deleted);
+        assert!(!tombstone.global);
+    }
+
     fn row_at(
         branch_id: &str,
         entity_pk: &str,
@@ -821,6 +1104,8 @@ mod tests {
             filter.branch_ids.is_empty() || filter.branch_ids.contains(&row.branch_id);
         let schema_matches =
             filter.schema_keys.is_empty() || filter.schema_keys.contains(&row.schema_key);
+        let entity_matches =
+            filter.entity_pks.is_empty() || filter.entity_pks.contains(&row.entity_pk);
         let file_matches = filter.file_ids.is_empty()
             || filter.file_ids.iter().any(|file_id| match file_id {
                 NullableKeyFilter::Any => true,
@@ -828,7 +1113,7 @@ mod tests {
                 NullableKeyFilter::Null => row.file_id.is_none(),
             });
         let tombstone_matches = filter.include_tombstones || !row.deleted;
-        branch_matches && schema_matches && file_matches && tombstone_matches
+        branch_matches && schema_matches && entity_matches && file_matches && tombstone_matches
     }
 
     struct EmptyStagedRows;
@@ -866,6 +1151,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for ExistingGlobalOnlyReader {
+        async fn load_exact_rows(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -896,6 +1188,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for FilteringReader {
+        async fn load_exact_rows(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -17,8 +17,8 @@ use crate::filesystem::{
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreReader;
 use crate::live_state::{
-    LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateRowRequest,
-    LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateExactBatchRequest, LiveStateFilter, LiveStateProjection, LiveStateReader,
+    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
 };
 use crate::plugin::PluginRuntimeHost;
 use crate::storage_adapter::StorageAdapterRead;
@@ -91,6 +91,22 @@ pub(crate) trait SqlWriteExecutionContext: Send {
         &mut self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
+
+    async fn load_exact_live_state_rows(
+        &mut self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        let mut rows = Vec::with_capacity(request.rows.len());
+        for row in &request.rows {
+            rows.push(
+                self.scan_live_state(&request.row_scan_request(row))
+                    .await?
+                    .into_iter()
+                    .next(),
+            );
+        }
+        Ok(rows)
+    }
 
     async fn filesystem_path_index(
         &mut self,
@@ -169,6 +185,22 @@ impl SqlWriteContext {
                 .as_mut()
                 .unwrap()
                 .scan_live_state(request)
+                .await
+        }
+    }
+
+    pub(crate) async fn load_exact_live_state_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        let _guard = self.gate.lock().await;
+        unsafe {
+            self.ptr
+                .0
+                .as_ptr()
+                .as_mut()
+                .unwrap()
+                .load_exact_live_state_rows(request)
                 .await
         }
     }
@@ -325,6 +357,13 @@ impl LiveStateReader for WriteContextLiveStateReader {
             })
             .await?;
         Ok(rows.pop())
+    }
+
+    async fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        self.ctx.load_exact_live_state_rows(request).await
     }
 }
 

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2010,6 +2010,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for DummyLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,
@@ -2068,6 +2075,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -2085,6 +2099,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for CapturingRowsLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -2106,6 +2127,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for CountingRowsLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -4121,22 +4149,28 @@ mod tests {
             })
             .count();
         assert_eq!(
-            directory_scans, 1,
-            "the conflict update needs one directory scan; an attribute-only update must not add a resolver scan"
+            directory_scans, 0,
+            "the augmented conflict batch already carries the selected path, so an attribute-only update needs no directory rescan"
         );
         let blob_requests = requests
             .iter()
             .filter(|request| request.filter.schema_keys == vec!["lix_binary_blob_ref".to_string()])
             .collect::<Vec<_>>();
-        assert_eq!(blob_requests.len(), 1);
         assert_eq!(
-            blob_requests[0].filter.entity_pks,
-            vec![crate::entity_pk::EntityPk::single("target")]
+            blob_requests.len(),
+            2,
+            "the conflict probe and conflict apply each point-load the targeted blob without rescanning topology"
         );
-        assert_eq!(
-            blob_requests[0].filter.file_ids,
-            vec![NullableKeyFilter::Value("target".to_string())]
-        );
+        for request in blob_requests {
+            assert_eq!(
+                request.filter.entity_pks,
+                vec![crate::entity_pk::EntityPk::single("target")]
+            );
+            assert_eq!(
+                request.filter.file_ids,
+                vec![NullableKeyFilter::Value("target".to_string())]
+            );
+        }
         drop(requests);
 
         let staged_writes = staged_writes.lock().expect("staged writes lock");

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -925,6 +925,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,
@@ -955,6 +962,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RoutingLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -1938,6 +1938,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RejectingLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1406,6 +1406,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -41,8 +41,8 @@ use crate::filesystem::{
 };
 use crate::functions::FunctionProviderHandle;
 use crate::live_state::{
-    LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateScanRequest,
-    MaterializedLiveStateRow,
+    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter, LiveStateProjection,
+    LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
 };
 use crate::plugin::{
     CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginFileOwner, PluginRegistry,
@@ -70,7 +70,6 @@ use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value, serialize_row_
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
-const INDEXED_BLOB_REF_EXACT_FILE_FILTER_MAX_IDS: usize = 32;
 
 use crate::filesystem::{
     BlobRefRowInput, DirectoryPathRecord, DirectoryPathResolver, FileDeleteInput,
@@ -212,14 +211,19 @@ struct LixFileDmlSourceState {
 type SharedLixFileDmlSourceState = Arc<Mutex<Option<LixFileDmlSourceState>>>;
 
 impl LixFileSpec {
-    async fn indexed_path_matches(
+    async fn indexed_dml_matches(
         &self,
         request: &LiveStateScanRequest,
         filters: &[Expr],
+        target_file_ids: &FileIdConstraint,
     ) -> Result<Option<FilesystemPathSelection>> {
         let predicate = file_path_predicate_from_filters(filters);
-        if predicate == FilePathPredicate::All {
-            return Ok(None);
+        match target_file_ids {
+            // Preserve the generic source's allocation-free contradiction
+            // short circuit instead of loading the path index for no rows.
+            FileIdConstraint::None => return Ok(None),
+            FileIdConstraint::All if predicate == FilePathPredicate::All => return Ok(None),
+            FileIdConstraint::All | FileIdConstraint::Ids(_) => {}
         }
         let index = self
             .filesystem_path_index
@@ -228,7 +232,11 @@ impl LixFileSpec {
             ))
             .await
             .map_err(lix_error_to_datafusion_error)?;
-        Ok(Some(indexed_file_matches(index, &predicate)))
+        Ok(Some(match target_file_ids {
+            FileIdConstraint::Ids(file_ids) => indexed_file_id_matches(index, file_ids, &predicate),
+            FileIdConstraint::All => indexed_file_matches(index, &predicate),
+            FileIdConstraint::None => unreachable!("handled before loading the path index"),
+        }))
     }
 
     fn active_branch(
@@ -367,10 +375,23 @@ impl LixFileSpec {
                 let (prepared, path_resolver_rows, path_index) = if let Some(indexed_matches) =
                     indexed_matches.as_ref()
                 {
-                    let rows =
-                        scan_indexed_file_rows(live_state.clone(), &request, indexed_matches, true)
+                    let rows = match &target_file_ids {
+                        // Exact DML must still validate a targeted blob ref
+                        // when its descriptor is missing from the path index.
+                        FileIdConstraint::Ids(file_ids) => {
+                            scan_exact_file_blob_rows(live_state.clone(), &request, file_ids).await
+                        }
+                        FileIdConstraint::All | FileIdConstraint::None => {
+                            scan_indexed_file_rows(
+                                live_state.clone(),
+                                &request,
+                                indexed_matches,
+                                true,
+                            )
                             .await
-                            .map_err(lix_error_to_datafusion_error)?;
+                        }
+                    }
+                    .map_err(lix_error_to_datafusion_error)?;
                     (
                         prepare_indexed_lix_file_rows(indexed_matches, rows),
                         None,
@@ -795,7 +816,9 @@ impl TableSpec for LixFileSpec {
         )
         .await
         .map_err(lix_error_to_datafusion_error)?;
-        let indexed_matches = self.indexed_path_matches(&request, filters).await?;
+        let indexed_matches = self
+            .indexed_dml_matches(&request, filters, &target_file_ids)
+            .await?;
 
         let captured: SharedLixFileDmlSourceState = Arc::new(Mutex::new(None));
         let source = self.dml_source(
@@ -861,7 +884,9 @@ impl TableSpec for LixFileSpec {
         )
         .await
         .map_err(lix_error_to_datafusion_error)?;
-        let indexed_matches = self.indexed_path_matches(&request, filters).await?;
+        let indexed_matches = self
+            .indexed_dml_matches(&request, filters, &target_file_ids)
+            .await?;
 
         let update_columns = LixFileUpdateColumns::from_assignments(&assignments);
         let capture_path_resolver_rows = update_columns.requires_path_resolver()
@@ -1093,12 +1118,7 @@ impl UpsertSupport for LixFileSpec {
         .await
         .map_err(lix_error_to_datafusion_error)?;
 
-        let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-        let prepared = if target.kind() == UpsertConflictKind::Path {
-            // Path conflicts only need the proposed paths. Use the filesystem
-            // index for descriptor matching, then fetch blob refs solely for
-            // matching files instead of materializing the complete file/blob
-            // candidate batch.
+        let indexed_matches = if target.kind() == UpsertConflictKind::Path {
             let index = self
                 .filesystem_path_index
                 .path_index(&FilesystemPathIndexRequest::new(
@@ -1106,11 +1126,28 @@ impl UpsertSupport for LixFileSpec {
                 ))
                 .await
                 .map_err(lix_error_to_datafusion_error)?;
-            let indexed_matches = indexed_file_matches(index, &path_predicate);
-            let rows = scan_indexed_file_rows(live_state.clone(), &request, &indexed_matches, true)
-                .await
-                .map_err(lix_error_to_datafusion_error)?;
-            prepare_indexed_lix_file_rows(&indexed_matches, rows)
+            Some(indexed_file_matches(index, &path_predicate))
+        } else {
+            self.indexed_dml_matches(&request, &[], &target_file_ids)
+                .await?
+        };
+
+        let live_state = Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
+        let prepared = if let Some(indexed_matches) = indexed_matches.as_ref() {
+            // Conflict probes only need the proposed exact IDs or paths. Use
+            // the visible filesystem index for descriptor matching, then fetch
+            // correlated blob refs solely for those files.
+            let rows = match &target_file_ids {
+                FileIdConstraint::Ids(file_ids) => {
+                    scan_exact_file_blob_rows(live_state.clone(), &request, file_ids).await
+                }
+                FileIdConstraint::All | FileIdConstraint::None => {
+                    scan_indexed_file_rows(live_state.clone(), &request, indexed_matches, true)
+                        .await
+                }
+            }
+            .map_err(lix_error_to_datafusion_error)?;
+            prepare_indexed_lix_file_rows(indexed_matches, rows)
         } else {
             let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
                 .await
@@ -1205,9 +1242,19 @@ impl UpsertSupport for LixFileSpec {
 
         let live_state: Arc<dyn LiveStateReader> =
             Arc::new(WriteContextLiveStateReader::new(write_ctx.clone()));
-        let rows = scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids)
-            .await
-            .map_err(lix_error_to_datafusion_error)?;
+        // The augmented conflict batch already carries the selected
+        // descriptors. Recover only their correlated blob refs; rebuilding
+        // the path index here would duplicate the conflict probe's topology
+        // read, especially for path-based upserts.
+        let rows = match &target_file_ids {
+            FileIdConstraint::Ids(file_ids) => {
+                scan_exact_file_blob_rows(live_state.clone(), &request, file_ids).await
+            }
+            FileIdConstraint::All | FileIdConstraint::None => {
+                scan_lix_file_live_rows(live_state.clone(), &request, &target_file_ids).await
+            }
+        }
+        .map_err(lix_error_to_datafusion_error)?;
         let blob_ref_keys =
             blob_ref_keys_from_live_rows(&rows).map_err(lix_error_to_datafusion_error)?;
 
@@ -4058,26 +4105,48 @@ async fn scan_indexed_file_rows(
     if file_ids.is_empty() {
         return Ok(Vec::new());
     }
-    let mut blob_request = request.clone();
-    blob_request.filter.schema_keys = vec![BLOB_REF_SCHEMA_KEY.to_string()];
-    blob_request.filter.entity_pks = file_ids
-        .iter()
-        .map(|file_id| EntityPk::single(file_id.clone()))
-        .collect();
-    // Small exact sets are cheaper as storage point reads. Valid blob refs use
-    // their file id as `entity_pk`, so for larger indexed lists omitting the
-    // independent file-id filter prevents a Cartesian product in storage. The
-    // final FilesystemBlobRefKey join still defends against malformed rows.
-    if file_ids.len() <= INDEXED_BLOB_REF_EXACT_FILE_FILTER_MAX_IDS {
-        blob_request.filter.file_ids = file_ids
-            .into_iter()
-            .map(crate::NullableKeyFilter::Value)
-            .collect();
-    } else {
-        blob_request.filter.file_ids.clear();
+    scan_exact_file_blob_rows(live_state, request, &file_ids).await
+}
+
+async fn scan_exact_file_blob_rows(
+    live_state: Arc<dyn LiveStateReader>,
+    request: &LiveStateScanRequest,
+    file_ids: &BTreeSet<String>,
+) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+    if file_ids.is_empty() {
+        return Ok(Vec::new());
     }
-    blob_request.limit = None;
-    live_state.scan_rows(&blob_request).await
+    if request.filter.branch_ids.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "exact lix_file blob reads require resolved branch IDs",
+        ));
+    }
+
+    let exact_rows = request
+        .filter
+        .branch_ids
+        .iter()
+        .flat_map(|branch_id| {
+            file_ids
+                .iter()
+                .map(move |file_id| LiveStateExactRowRequest {
+                    branch_id: branch_id.clone(),
+                    schema_key: BLOB_REF_SCHEMA_KEY.to_string(),
+                    entity_pk: EntityPk::single(file_id.clone()),
+                    file_id: Some(file_id.clone()),
+                })
+        })
+        .collect::<Vec<_>>();
+    let rows = live_state
+        .load_exact_rows(&LiveStateExactBatchRequest {
+            rows: exact_rows,
+            projection: request.projection.clone(),
+            untracked: request.filter.untracked,
+            include_tombstones: request.filter.include_tombstones,
+        })
+        .await?;
+    Ok(rows.into_iter().flatten().collect())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5061,14 +5130,17 @@ mod tests {
         FilesystemPathIndexReader, FilesystemPathIndexRequest, FilesystemRowContext,
     };
     use crate::functions::FunctionProviderHandle;
-    use crate::live_state::{LiveStateFilter, MaterializedLiveStateRow};
-    use crate::live_state::{LiveStateReader, LiveStateRowRequest, LiveStateScanRequest};
+    use crate::live_state::{
+        LiveStateExactBatchRequest, LiveStateFilter, LiveStateReader, LiveStateRowRequest,
+        LiveStateScanRequest, MaterializedLiveStateRow,
+    };
     use crate::plugin::{
         PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginContentType, PluginFileOwner, PluginRegistry,
         PluginRegistryEntry, PluginRegistryEntryInput, PluginRuntime, PluginRuntimeHost,
         plugin_storage_archive_file_id, plugin_storage_archive_path,
     };
     use crate::sql2::dml::InsertSink;
+    use crate::sql2::providers::upsert::UpsertConflictTarget;
     use crate::sql2::{SqlWriteContext, SqlWriteExecutionContext, WriteContextBranchRefReader};
     use crate::transaction::types::{
         TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOutcome,
@@ -6189,7 +6261,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn indexed_blob_entity_prefix_preserves_blob_storage_lanes() {
+    async fn exact_blob_batch_requires_resolved_branch_ids_without_scanning() {
+        let scan_count = Arc::new(AtomicUsize::new(0));
+        let live_state: Arc<dyn LiveStateReader> = Arc::new(RejectingLiveStateReader {
+            scan_count: Arc::clone(&scan_count),
+        });
+        let error = super::scan_exact_file_blob_rows(
+            live_state,
+            &LiveStateScanRequest::default(),
+            &BTreeSet::from(["file-a".to_string()]),
+        )
+        .await
+        .expect_err("branchless exact reads should be rejected");
+
+        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+        assert!(error.message.contains("require resolved branch IDs"));
+        assert_eq!(scan_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn indexed_blob_exact_batch_preserves_lanes_and_rejects_cross_pairs() {
         let tracked_data = b"tracked".to_vec();
         let global_data = b"global".to_vec();
         let untracked_data = b"untracked".to_vec();
@@ -6197,7 +6288,8 @@ mod tests {
 
         let mut global_file = live_file_row(
             "file-global",
-            crate::GLOBAL_BRANCH_ID,
+            // Path-index rows are already projected into the requested branch.
+            "branch-b",
             r#"{"id":"file-global","directory_id":null,"name":"global.md"}"#,
         );
         global_file.global = true;
@@ -6258,8 +6350,8 @@ mod tests {
         );
         untracked_blob.untracked = true;
         untracked_blob.change_id = Some(ChangeId::for_test_label("untracked-blob"));
-        // An unexpected file-id under a selected entity prefix must not attach
-        // to the descriptor: the final FilesystemBlobRefKey join includes it.
+        // A malformed `(entity=file-tracked, file=different-file-id)` row must
+        // never be fetched for the exact descriptor identity.
         let mut misplaced_blob = live_blob_ref_row(
             "file-tracked",
             "branch-b",
@@ -6341,7 +6433,7 @@ mod tests {
         assert_ne!(
             changes_by_path.get("/tracked.md"),
             Some(&ChangeId::for_test_label("misplaced-blob").to_string()),
-            "the full FilesystemBlobRefKey must reject a mismatched file-id"
+            "the exact live-state tuple must reject a mismatched file-id"
         );
         let requests = live_state_requests
             .lock()
@@ -6366,7 +6458,13 @@ mod tests {
                 .entity_pks
                 .contains(&crate::entity_pk::EntityPk::single("file-untracked"))
         );
-        assert!(requests[0].filter.file_ids.is_empty());
+        assert_eq!(requests[0].filter.file_ids.len(), 33);
+        assert!(
+            requests[0]
+                .filter
+                .file_ids
+                .contains(&NullableKeyFilter::Value("file-tracked".to_string()))
+        );
     }
 
     #[tokio::test]
@@ -6579,8 +6677,11 @@ mod tests {
     #[derive(Default)]
     struct CapturingWriteContext {
         rows: Vec<MaterializedLiveStateRow>,
+        blob_bytes_by_hash: BTreeMap<BlobHash, Vec<u8>>,
         writes: Vec<TransactionWrite>,
         scan_count: usize,
+        path_index_count: usize,
+        exact_load_requests: Vec<LiveStateExactBatchRequest>,
     }
 
     struct IndexedFileDataUpdateWriteContext {
@@ -6629,7 +6730,12 @@ mod tests {
     #[async_trait]
     impl BlobDataReader for CapturingWriteContext {
         async fn load_bytes_many(&self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
-            Ok(BlobBytesBatch::new(vec![None; hashes.len()]))
+            Ok(BlobBytesBatch::new(
+                hashes
+                    .iter()
+                    .map(|hash| self.blob_bytes_by_hash.get(hash).cloned())
+                    .collect(),
+            ))
         }
     }
 
@@ -6734,6 +6840,60 @@ mod tests {
         ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
             self.scan_count += 1;
             Ok(self.rows.clone())
+        }
+
+        async fn load_exact_live_state_rows(
+            &mut self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            self.exact_load_requests.push(request.clone());
+            Ok(request
+                .rows
+                .iter()
+                .map(|requested| {
+                    let matches = |row: &&MaterializedLiveStateRow| {
+                        row.schema_key == requested.schema_key
+                            && row.entity_pk == requested.entity_pk
+                            && row.file_id == requested.file_id
+                            && request
+                                .untracked
+                                .is_none_or(|untracked| row.untracked == untracked)
+                    };
+                    let mut row = self
+                        .rows
+                        .iter()
+                        .filter(matches)
+                        .find(|row| row.branch_id == requested.branch_id)
+                        .or_else(|| {
+                            self.rows
+                                .iter()
+                                .filter(matches)
+                                .find(|row| row.branch_id == crate::GLOBAL_BRANCH_ID)
+                        })?
+                        .clone();
+                    if row.branch_id == crate::GLOBAL_BRANCH_ID
+                        && requested.branch_id != crate::GLOBAL_BRANCH_ID
+                    {
+                        row.branch_id.clone_from(&requested.branch_id);
+                        row.global = true;
+                    }
+                    if row.deleted && !request.include_tombstones {
+                        None
+                    } else {
+                        Some(row)
+                    }
+                })
+                .collect())
+        }
+
+        async fn filesystem_path_index(
+            &mut self,
+            _request: &FilesystemPathIndexRequest,
+        ) -> Result<Arc<FilesystemPathIndex>, LixError> {
+            self.path_index_count += 1;
+            Ok(Arc::new(FilesystemPathIndex::from_live_rows(
+                self.rows.clone(),
+            )?))
         }
 
         async fn load_branch_head(
@@ -6853,10 +7013,108 @@ mod tests {
         ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
             Ok(None)
         }
+
+        async fn load_exact_rows(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            let mut recorded = LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    branch_ids: request
+                        .rows
+                        .iter()
+                        .map(|row| row.branch_id.clone())
+                        .collect(),
+                    schema_keys: request
+                        .rows
+                        .iter()
+                        .map(|row| row.schema_key.clone())
+                        .collect(),
+                    entity_pks: request
+                        .rows
+                        .iter()
+                        .map(|row| row.entity_pk.clone())
+                        .collect(),
+                    file_ids: request
+                        .rows
+                        .iter()
+                        .map(|row| match &row.file_id {
+                            Some(file_id) => NullableKeyFilter::Value(file_id.clone()),
+                            None => NullableKeyFilter::Null,
+                        })
+                        .collect(),
+                    untracked: request.untracked,
+                    include_tombstones: request.include_tombstones,
+                    ..LiveStateFilter::default()
+                },
+                projection: request.projection.clone(),
+                limit: None,
+            };
+            recorded.filter.branch_ids.sort();
+            recorded.filter.branch_ids.dedup();
+            recorded.filter.schema_keys.sort();
+            recorded.filter.schema_keys.dedup();
+            recorded.filter.entity_pks.sort();
+            recorded.filter.entity_pks.dedup();
+            recorded
+                .filter
+                .file_ids
+                .sort_by_key(|file_id| format!("{file_id:?}"));
+            recorded.filter.file_ids.dedup();
+            self.scan_requests
+                .lock()
+                .expect("live-state request mutex should not be poisoned")
+                .push(recorded);
+
+            Ok(request
+                .rows
+                .iter()
+                .map(|requested| {
+                    let exact_match = |row: &&MaterializedLiveStateRow| {
+                        row.schema_key == requested.schema_key
+                            && row.entity_pk == requested.entity_pk
+                            && row.file_id == requested.file_id
+                            && request
+                                .untracked
+                                .is_none_or(|untracked| row.untracked == untracked)
+                    };
+                    let mut row = self
+                        .rows
+                        .iter()
+                        .filter(exact_match)
+                        .find(|row| row.branch_id == requested.branch_id)
+                        .or_else(|| {
+                            self.rows
+                                .iter()
+                                .filter(exact_match)
+                                .find(|row| row.branch_id == crate::GLOBAL_BRANCH_ID)
+                        })?
+                        .clone();
+                    if row.branch_id == crate::GLOBAL_BRANCH_ID
+                        && requested.branch_id != crate::GLOBAL_BRANCH_ID
+                    {
+                        row.branch_id.clone_from(&requested.branch_id);
+                        row.global = true;
+                    }
+                    if row.deleted && !request.include_tombstones {
+                        None
+                    } else {
+                        Some(row)
+                    }
+                })
+                .collect())
+        }
     }
 
     #[async_trait]
     impl LiveStateReader for RejectingLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,
@@ -6911,6 +7169,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for RowsLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,
@@ -8953,6 +9218,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn file_delete_by_exact_id_uses_path_index_and_exact_blob_batch() {
+        let mut rows = file_dml_rows();
+        rows.extend([
+            live_file_row(
+                "file-other",
+                "branch-b",
+                r#"{"id":"file-other","directory_id":null,"name":"other.md"}"#,
+            ),
+            live_blob_ref_row("file-other", "branch-b", "file-other", &"1".repeat(64), 7),
+        ]);
+        let mut write_context = CapturingWriteContext {
+            rows,
+            ..CapturingWriteContext::default()
+        };
+        let write_ctx = SqlWriteContext::new(&mut write_context);
+        let spec = file_dml_spec(write_ctx.clone());
+        let planned = spec
+            .plan_delete(write_ctx, &[eq_filter("id", "file-readme")])
+            .await
+            .expect("plan exact-id file delete");
+
+        let source_batch = (planned.source)()
+            .await
+            .expect("load exact delete candidates");
+        assert_eq!(source_batch.num_rows(), 1);
+        assert_eq!(write_context.path_index_count, 1);
+        assert_eq!(write_context.scan_count, 0);
+        assert_eq!(write_context.exact_load_requests.len(), 1);
+        assert_eq!(write_context.exact_load_requests[0].rows.len(), 1);
+        assert_eq!(
+            write_context.exact_load_requests[0].rows[0].entity_pk,
+            crate::entity_pk::EntityPk::single("file-readme")
+        );
+        assert_eq!(
+            write_context.exact_load_requests[0].rows[0]
+                .file_id
+                .as_deref(),
+            Some("file-readme")
+        );
+    }
+
+    #[tokio::test]
     async fn file_update_reuses_source_rows_for_blob_and_path_state() {
         let mut write_context = CapturingWriteContext {
             rows: file_dml_rows(),
@@ -8985,6 +9292,48 @@ mod tests {
         };
         let snapshot = rows[0].snapshot.as_ref().expect("updated snapshot").value();
         assert_eq!(snapshot["name"], "README.md");
+    }
+
+    #[tokio::test]
+    async fn file_update_exact_id_intersects_path_before_exact_blob_batch() {
+        let mut rows = file_dml_rows();
+        rows.push(live_file_row(
+            "file-other",
+            "branch-b",
+            r#"{"id":"file-other","directory_id":null,"name":"other.md"}"#,
+        ));
+        let mut write_context = CapturingWriteContext {
+            rows,
+            ..CapturingWriteContext::default()
+        };
+        let write_ctx = SqlWriteContext::new(&mut write_context);
+        let spec = file_dml_spec(write_ctx.clone());
+        let planned = spec
+            .plan_update(
+                write_ctx,
+                vec![literal_assignment(
+                    "name",
+                    ScalarValue::Utf8(Some("README.md".to_string())),
+                )],
+                &[
+                    eq_filter("id", "file-readme"),
+                    eq_filter("path", "/other.md"),
+                ],
+            )
+            .await
+            .expect("plan exact-id/path file update");
+
+        let source_batch = (planned.source)()
+            .await
+            .expect("load exact update candidates");
+        assert_eq!(source_batch.num_rows(), 0);
+        assert_eq!(write_context.path_index_count, 1);
+        assert_eq!(write_context.scan_count, 0);
+        assert_eq!(
+            write_context.exact_load_requests.len(),
+            1,
+            "exact DML validates the requested blob identity even when the path predicate rejects its descriptor"
+        );
     }
 
     #[tokio::test]
@@ -9030,7 +9379,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_upsert_attribute_update_does_not_rescan_path_topology() {
+    async fn file_upsert_attribute_update_uses_exact_id_blob_lookup() {
         let mut write_context = CapturingWriteContext {
             rows: file_dml_rows(),
             ..CapturingWriteContext::default()
@@ -9050,12 +9399,53 @@ mod tests {
             .await
             .expect("attribute-only conflict update should stage");
 
-        assert_eq!(
-            write_context.scan_count, 2,
-            "the conflict update needs its matched file/blob and directory scans, but metadata must not add a resolver scan"
-        );
+        assert_eq!(write_context.path_index_count, 0);
+        assert_eq!(write_context.exact_load_requests.len(), 1);
+        assert_eq!(write_context.scan_count, 0);
         assert_eq!(staged.file_data.len(), 1);
         assert_eq!(staged.file_data[0].path.as_deref(), Some("/docs/readme.md"));
+    }
+
+    #[tokio::test]
+    async fn file_id_conflict_probe_uses_path_index_and_exact_blob_batch() {
+        let data = b"hello".to_vec();
+        let blob_hash = BlobHash::from_content(&data);
+        let rows = vec![
+            live_file_row(
+                "file-readme",
+                "branch-b",
+                r#"{"id":"file-readme","directory_id":null,"name":"readme.md"}"#,
+            ),
+            live_blob_ref_row(
+                "file-readme",
+                "branch-b",
+                "file-readme",
+                &blob_hash.to_hex(),
+                data.len(),
+            ),
+        ];
+        let mut write_context = CapturingWriteContext {
+            rows,
+            blob_bytes_by_hash: BTreeMap::from([(blob_hash, data)]),
+            ..CapturingWriteContext::default()
+        };
+        let write_ctx = SqlWriteContext::new(&mut write_context);
+        let spec = file_dml_spec(write_ctx.clone());
+
+        let candidates = spec
+            .scan_conflict_candidates(
+                &write_ctx,
+                &file_insert_batch(false, false),
+                &UpsertConflictTarget::id(super::LIX_FILE_IDENTITY),
+            )
+            .await
+            .expect("scan exact ID conflict candidates");
+
+        assert_eq!(candidates.num_rows(), 1);
+        assert_eq!(write_context.path_index_count, 1);
+        assert_eq!(write_context.exact_load_requests.len(), 1);
+        assert_eq!(write_context.exact_load_requests[0].rows.len(), 1);
+        assert_eq!(write_context.scan_count, 0);
     }
 
     #[tokio::test]
@@ -9155,8 +9545,7 @@ mod tests {
                 "branch-b",
                 "{\"id\":\"dir-docs\",\"parent_id\":null,\"name\":\"docs\"}",
             )],
-            writes: Vec::new(),
-            scan_count: 0,
+            ..CapturingWriteContext::default()
         };
         let write_ctx = SqlWriteContext::new(&mut write_context);
         let sink =
@@ -9215,8 +9604,7 @@ mod tests {
                     "{\"id\":\"dir-guides\",\"parent_id\":\"dir-docs\",\"name\":\"guides\"}",
                 ),
             ],
-            writes: Vec::new(),
-            scan_count: 0,
+            ..CapturingWriteContext::default()
         };
         let write_ctx = SqlWriteContext::new(&mut write_context);
         let sink =

--- a/packages/engine/src/sql2/providers/lix_state.rs
+++ b/packages/engine/src/sql2/providers/lix_state.rs
@@ -1273,6 +1273,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -581,6 +581,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -10,7 +10,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use crate::changelog::ChangeId;
+use crate::changelog::{ChangeId, ChangeRecordProjection};
 use crate::changelog::{
     ChangeLoadRequest, ChangeRecord, ChangelogContext, ChangelogReader, CommitId, CommitLoadEntry,
     CommitLoadRequest, CommitProjection, CommitRecord,
@@ -151,8 +151,7 @@ where
                 &tree_scan_request_from_tracked(request),
             )
             .await?;
-        let materialization =
-            crate::changelog::ChangeRecordProjection::from_columns(&request.read_columns.columns);
+        let materialization = ChangeRecordProjection::from_columns(&request.read_columns.columns);
         let mut rows =
             materialize_rows_from_index_entries(&self.store, rows, &materialization).await?;
         if !request.filter.include_tombstones {
@@ -164,35 +163,55 @@ where
         Ok(rows)
     }
 
+    pub(crate) async fn load_projected_rows_at_commit(
+        &mut self,
+        commit_id: &str,
+        keys: &[TrackedStateKey],
+        projection: &ChangeRecordProjection,
+    ) -> Result<Vec<Option<MaterializedTrackedStateRow>>, LixError> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut output_indices = BTreeMap::<TrackedStateKey, Vec<usize>>::new();
+        for (index, key) in keys.iter().cloned().enumerate() {
+            output_indices.entry(key).or_default().push(index);
+        }
+        let unique_keys = output_indices.keys().cloned().collect::<Vec<_>>();
+        let values = self
+            .commit_root_values_for_keys(commit_id, &unique_keys)
+            .await?;
+        let mut entries = Vec::new();
+        for (key, value) in unique_keys.into_iter().zip(values) {
+            if let Some(value) = value {
+                entries.push((key, value));
+            }
+        }
+        let materialized =
+            materialize_rows_from_index_entries(&self.store, entries, projection).await?;
+        let mut rows = vec![None; keys.len()];
+        for row in materialized {
+            let key = TrackedStateKey {
+                schema_key: row.schema_key.clone(),
+                entity_pk: row.entity_pk.clone(),
+                file_id: row.file_id.clone(),
+            };
+            if let Some(indices) = output_indices.get(&key) {
+                for &index in indices {
+                    rows[index] = Some(row.clone());
+                }
+            }
+        }
+        Ok(rows)
+    }
+
     #[cfg(any(test, feature = "storage-benches"))]
     pub(crate) async fn load_rows_at_commit(
         &mut self,
         commit_id: &str,
         keys: &[TrackedStateKey],
     ) -> Result<Vec<Option<MaterializedTrackedStateRow>>, LixError> {
-        if keys.is_empty() {
-            return Ok(Vec::new());
-        }
-        let values = self.commit_root_values_for_keys(commit_id, keys).await?;
-        let mut entry_indices = Vec::new();
-        let mut entries = Vec::new();
-        for (index, (key, value)) in keys.iter().cloned().zip(values).enumerate() {
-            if let Some(value) = value {
-                entry_indices.push(index);
-                entries.push((key, value));
-            }
-        }
-        let materialized = materialize_rows_from_index_entries(
-            &self.store,
-            entries,
-            &crate::changelog::ChangeRecordProjection::full(),
-        )
-        .await?;
-        let mut rows = vec![None; keys.len()];
-        for (index, row) in entry_indices.into_iter().zip(materialized) {
-            rows[index] = Some(row);
-        }
-        Ok(rows)
+        self.load_projected_rows_at_commit(commit_id, keys, &ChangeRecordProjection::full())
+            .await
     }
 
     pub(crate) async fn diff_commits(
@@ -831,7 +850,6 @@ where
             .ok_or_else(|| missing_commit_root_error(commit_id))
     }
 
-    #[cfg(any(test, feature = "storage-benches"))]
     async fn commit_root_values_for_keys(
         &mut self,
         commit_id: &str,

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -23,7 +23,6 @@ pub(crate) use row_materialization::materialize_rows_from_index_entries;
 pub(crate) use storage::load_root;
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE};
-#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use types::TrackedStateKey;
 pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateReadColumns,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -32,10 +32,10 @@ use crate::filesystem::{
 };
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::live_state::{
-    LiveStateContext, LiveStateFileScanRequest, LiveStateFilter, LiveStateProjection,
-    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateContext, LiveStateExactBatchRequest, LiveStateFileScanRequest, LiveStateFilter,
+    LiveStateProjection, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
 };
-use crate::live_state::{overlay_scan_file_rows, overlay_scan_rows};
+use crate::live_state::{overlay_load_exact_rows, overlay_scan_file_rows, overlay_scan_rows};
 use crate::plugin::{
     CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginArchiveInstallPlan,
     PluginDetectedChange, PluginFileOwner, PluginRegistry, PluginRegistryEntry,
@@ -480,6 +480,20 @@ where
         );
         let base = self.live_state.reader(read);
         overlay_scan_rows(&base, &staged, request).await
+    }
+
+    async fn load_visible_exact_live_state_rows(
+        &mut self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        let staged = self.staged_writes.staging_overlay()?;
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let base = self.live_state.reader(read);
+        overlay_load_exact_rows(&base, &staged, request).await
     }
 
     async fn reconcile_plugin_write(
@@ -1771,6 +1785,13 @@ where
             .into_iter()
             .next())
     }
+
+    async fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        overlay_load_exact_rows(&self.base, &self.staged, request).await
+    }
 }
 
 #[async_trait]
@@ -1998,6 +2019,13 @@ where
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
         self.scan_visible_live_state(request).await
+    }
+
+    async fn load_exact_live_state_rows(
+        &mut self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        self.load_visible_exact_live_state_rows(request).await
     }
 
     async fn filesystem_path_index(

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -7,8 +7,9 @@ use crate::LixError;
 use crate::catalog::{CatalogContext, CatalogSnapshot, TransactionCatalog};
 use crate::domain::Domain;
 use crate::live_state::{
-    LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
-    StagedLiveStateRows, overlay_scan_rows, overlay_scan_tracked_rows,
+    LiveStateExactBatchRequest, LiveStateReader, LiveStateRowRequest, LiveStateScanRequest,
+    MaterializedLiveStateRow, StagedLiveStateRows, overlay_load_exact_rows, overlay_scan_rows,
+    overlay_scan_tracked_rows,
 };
 use crate::transaction::staging::PreparedStateRowOverlay;
 
@@ -141,6 +142,13 @@ where
             .into_iter()
             .next())
     }
+
+    async fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        overlay_load_exact_rows(self.base, self.staged, request).await
+    }
 }
 
 #[cfg(test)]
@@ -156,6 +164,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for SplitCurrentAndTrackedReader {
+        async fn load_exact_rows(
+            &self,
+            request: &LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -22,7 +22,10 @@ use crate::functions::FunctionProvider;
 use crate::functions::FunctionProviderHandle;
 #[cfg(test)]
 use crate::live_state::LiveStateRowRequest;
-use crate::live_state::{LiveStateScanRequest, MaterializedLiveStateRow};
+use crate::live_state::{
+    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateScanRequest,
+    MaterializedLiveStateRow,
+};
 use crate::transaction::types::{
     LogicalPrimaryKey, PreparedTransactionWrite, StagedCommitChangeRef, TransactionFileData,
     TransactionWriteMode, TransactionWriteOperation, TransactionWriteOrigin,
@@ -673,7 +676,7 @@ impl PreparedStateRowOverlay {
     /// Returns a staged exact-row answer, if this transaction has one.
     #[cfg(test)]
     pub(crate) fn load_exact(&self, request: &LiveStateRowRequest) -> Option<StagedExactRow> {
-        let identity = PreparedStateRowIdentity::from_exact_request(request)?;
+        let identity = PreparedStateRowIdentity::from_row_request(request)?;
         if let Some(row) = self.load_state_slot(&identity) {
             return Some(if row.snapshot.is_none() {
                 StagedExactRow::Tombstone
@@ -701,6 +704,47 @@ impl crate::live_state::StagedLiveStateRows for PreparedStateRowOverlay {
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
         Ok(self.scan_parts(request)?.rows)
+    }
+
+    fn load_exact_rows(
+        &self,
+        request: &LiveStateExactBatchRequest,
+    ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+        let rows_guard = self.staged_writes.rows.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged writes lock",
+            )
+        })?;
+        let by_identity_guard = self.staged_writes.by_identity.lock().map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "failed to acquire transaction staged identity index lock",
+            )
+        })?;
+        Ok(request
+            .rows
+            .iter()
+            .map(|request_row| {
+                let identity = PreparedStateRowIdentity::from_exact_request(request_row);
+                let Some(RowSlot::State(index)) = by_identity_guard.get(&identity).copied() else {
+                    return None;
+                };
+                let row = rows_guard.get(index)?.as_ref()?;
+                if request
+                    .untracked
+                    .is_some_and(|untracked| row.untracked != untracked)
+                {
+                    return None;
+                }
+                let row = MaterializedLiveStateRow::from(row);
+                if row.deleted && !request.include_tombstones {
+                    None
+                } else {
+                    Some(row)
+                }
+            })
+            .collect())
     }
 }
 
@@ -734,8 +778,17 @@ impl PreparedStateRowIdentity {
         }
     }
 
+    fn from_exact_request(request: &LiveStateExactRowRequest) -> Self {
+        Self {
+            schema_key: request.schema_key.clone(),
+            entity_pk: request.entity_pk.clone(),
+            file_id: request.file_id.clone(),
+            branch_id: request.branch_id.clone(),
+        }
+    }
+
     #[cfg(test)]
-    fn from_exact_request(request: &LiveStateRowRequest) -> Option<Self> {
+    fn from_row_request(request: &LiveStateRowRequest) -> Option<Self> {
         let file_id = match &request.file_id {
             NullableKeyFilter::Null => None,
             NullableKeyFilter::Value(value) => Some(value.clone()),
@@ -1013,7 +1066,10 @@ fn nullable_key_matches_filter(value: &Option<String>, filter: &NullableKeyFilte
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::live_state::{LiveStateFilter, LiveStateRowRequest};
+    use crate::live_state::{
+        LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter, LiveStateRowRequest,
+        StagedLiveStateRows,
+    };
 
     #[tokio::test]
     async fn update_origin_rows_replace_staged_identity_under_outer_insert_mode() {
@@ -1103,6 +1159,66 @@ mod tests {
             row.snapshot_content.as_deref(),
             Some("{\"key\":\"sql2-duplicate-key\",\"value\":\"second\"}")
         );
+    }
+
+    #[test]
+    fn staging_overlay_exact_batch_is_correlated_aligned_and_tombstone_aware() {
+        let staged_writes = test_staged_writes();
+        staged_writes
+            .stage_write(PreparedTransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: vec![
+                    state_row("entity-a", "cross-pair").with_file_id("file-b"),
+                    tombstone_row("deleted").with_file_id("deleted"),
+                ],
+            })
+            .expect("rows should stage");
+        let overlay = staged_writes
+            .staging_overlay()
+            .expect("overlay should build");
+        let exact = |entity: &str, file_id: &str| LiveStateExactRowRequest {
+            schema_key: "lix_key_value".to_string(),
+            branch_id: "global".to_string(),
+            entity_pk: EntityPk::single(entity),
+            file_id: Some(file_id.to_string()),
+        };
+        let cross_pair = exact("entity-a", "file-b");
+        let rows = StagedLiveStateRows::load_exact_rows(
+            &overlay,
+            &LiveStateExactBatchRequest {
+                rows: vec![
+                    cross_pair.clone(),
+                    exact("entity-a", "file-a"),
+                    exact("entity-b", "file-b"),
+                    cross_pair,
+                    exact("missing", "missing"),
+                    exact("deleted", "deleted"),
+                ],
+                ..Default::default()
+            },
+        )
+        .expect("exact staged rows should load");
+
+        assert!(rows[0].is_some());
+        assert_eq!(rows[0], rows[3]);
+        assert_eq!(rows[1], None);
+        assert_eq!(rows[2], None);
+        assert_eq!(rows[4], None);
+        assert_eq!(rows[5], None, "tombstone should be hidden by default");
+
+        let tombstone = StagedLiveStateRows::load_exact_rows(
+            &overlay,
+            &LiveStateExactBatchRequest {
+                rows: vec![exact("deleted", "deleted")],
+                include_tombstones: true,
+                ..Default::default()
+            },
+        )
+        .expect("exact staged tombstone should load")
+        .pop()
+        .flatten()
+        .expect("tombstone should be returned");
+        assert!(tombstone.deleted);
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -2773,6 +2773,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for EmptyLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -2888,6 +2895,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for StaticLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -2925,6 +2939,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for OverlayingStaticLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -2993,6 +3014,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for StrictEmptyLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             _request: &LiveStateScanRequest,
@@ -3014,6 +3042,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for StrictStaticLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,
@@ -3045,6 +3080,13 @@ mod tests {
 
     #[async_trait]
     impl LiveStateReader for CountingStaticLiveStateReader {
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
         async fn scan_rows(
             &self,
             request: &LiveStateScanRequest,

--- a/packages/engine/tests/correlated_live_state_perf.rs
+++ b/packages/engine/tests/correlated_live_state_perf.rs
@@ -1,0 +1,888 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use lix_engine::storage::{
+    GetManyResult, GetOptions, Key, KeyRange, Memory, MemoryRead, MemoryWrite, ReadOptions,
+    ScanChunk, ScanOptions, SpaceId, Storage, StorageError, StorageRead, WriteOptions,
+};
+use lix_engine::{Engine, ExecuteResult, SessionContext, Value};
+use serde::Serialize;
+
+const FILES_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_FILES";
+const BATCH_SIZES_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_BATCH_SIZES";
+const OPERATIONS_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_OPERATIONS";
+const WARMUPS_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_WARMUPS";
+const SAMPLES_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_SAMPLES";
+const SETUP_CHUNK_SIZE_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_SETUP_CHUNK_SIZE";
+const SEED_INPUT_PATH_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_SEED_INPUT_PATH";
+const SEED_OUTPUT_PATH_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_SEED_OUTPUT_PATH";
+const PROFILE_READY_PATH_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_PROFILE_READY_PATH";
+const PROFILE_GO_PATH_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_PROFILE_GO_PATH";
+const PROFILE_ITERATIONS_ENV: &str = "LIX_CORRELATED_LIVE_STATE_PERF_PROFILE_ITERATIONS";
+
+// Seed input bypasses setup; seed output persists the exact bytes used by the run.
+// Setting any profile variable enables SELECT-only profile mode and requires all three.
+
+const DEFAULT_FILES: usize = 10_000;
+const DEFAULT_BATCH_SIZES: &str = "1,10,32,33,100";
+const DEFAULT_OPERATIONS: &str = "all";
+const DEFAULT_WARMUPS: usize = 10;
+const DEFAULT_SAMPLES: usize = 100;
+const DEFAULT_SETUP_CHUNK_SIZE: usize = 500;
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "manual release-mode performance harness"]
+async fn correlated_live_state_sql_perf() {
+    let config = Config::from_env();
+    let ids = file_ids(config.files);
+    let seed_snapshot = prepare_seed_snapshot(&config, &ids).await;
+    let mut measurements = Vec::with_capacity(config.batch_sizes.len() * config.operations.len());
+    let profile_measurement = if let Some(profile) = config.profile.as_ref() {
+        let batch_size = config.batch_sizes[0];
+        let selected_ids = &ids[..batch_size];
+        Some(
+            profile_select(
+                &seed_snapshot,
+                selected_ids,
+                &select_sql(selected_ids),
+                config.warmups,
+                profile,
+            )
+            .await,
+        )
+    } else {
+        for &batch_size in &config.batch_sizes {
+            let selected_ids = &ids[..batch_size];
+            let select_sql = select_sql(selected_ids);
+            let update_sql = update_sql(selected_ids);
+
+            if config.operations.contains(&Operation::Select) {
+                measurements.push(
+                    measure_select(
+                        &seed_snapshot,
+                        selected_ids,
+                        &select_sql,
+                        config.warmups,
+                        config.samples,
+                    )
+                    .await,
+                );
+            }
+            if config.operations.contains(&Operation::Update) {
+                measurements.push(
+                    measure_update(
+                        &seed_snapshot,
+                        selected_ids,
+                        &select_sql,
+                        &update_sql,
+                        config.warmups,
+                        config.samples,
+                    )
+                    .await,
+                );
+            }
+        }
+        None
+    };
+
+    let report = Report {
+        benchmark: "correlated_live_state_sql",
+        config,
+        measurements,
+        profile_measurement,
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("performance report should serialize")
+    );
+}
+
+#[derive(Debug, Serialize)]
+struct Config {
+    files: usize,
+    batch_sizes: Vec<usize>,
+    operations: Vec<Operation>,
+    warmups: usize,
+    samples: usize,
+    setup_chunk_size: usize,
+    seed_input_path: Option<PathBuf>,
+    seed_output_path: Option<PathBuf>,
+    profile: Option<ProfileConfig>,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        let files = parse_usize_env(FILES_ENV, DEFAULT_FILES);
+        let warmups = parse_usize_env(WARMUPS_ENV, DEFAULT_WARMUPS);
+        let samples = parse_usize_env(SAMPLES_ENV, DEFAULT_SAMPLES);
+        let setup_chunk_size = parse_usize_env(SETUP_CHUNK_SIZE_ENV, DEFAULT_SETUP_CHUNK_SIZE);
+        let seed_input_path = optional_path_env(SEED_INPUT_PATH_ENV);
+        let seed_output_path = optional_path_env(SEED_OUTPUT_PATH_ENV);
+        let profile = ProfileConfig::from_env();
+        let batch_sizes = parse_batch_sizes(
+            &env::var(BATCH_SIZES_ENV).unwrap_or_else(|_| DEFAULT_BATCH_SIZES.to_string()),
+        );
+        let operations = parse_operations(
+            &env::var(OPERATIONS_ENV).unwrap_or_else(|_| DEFAULT_OPERATIONS.to_string()),
+        );
+
+        assert!(files > 0, "{FILES_ENV} must be greater than zero");
+        assert!(samples > 0, "{SAMPLES_ENV} must be greater than zero");
+        assert!(
+            setup_chunk_size > 0,
+            "{SETUP_CHUNK_SIZE_ENV} must be greater than zero"
+        );
+        assert!(
+            batch_sizes.iter().all(|&size| size <= files),
+            "every {BATCH_SIZES_ENV} value must be at most {FILES_ENV} ({files})"
+        );
+        if profile.is_some() {
+            assert_eq!(
+                batch_sizes.len(),
+                1,
+                "profile mode requires exactly one {BATCH_SIZES_ENV} value"
+            );
+            assert_eq!(
+                operations.as_slice(),
+                &[Operation::Select],
+                "profile mode requires {OPERATIONS_ENV}=select"
+            );
+        }
+
+        Self {
+            files,
+            batch_sizes,
+            operations,
+            warmups,
+            samples,
+            setup_chunk_size,
+            seed_input_path,
+            seed_output_path,
+            profile,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileConfig {
+    ready_path: PathBuf,
+    go_path: PathBuf,
+    iterations: usize,
+}
+
+impl ProfileConfig {
+    fn from_env() -> Option<Self> {
+        let ready_path = optional_path_env(PROFILE_READY_PATH_ENV);
+        let go_path = optional_path_env(PROFILE_GO_PATH_ENV);
+        let iterations = env::var_os(PROFILE_ITERATIONS_ENV);
+
+        if ready_path.is_none() && go_path.is_none() && iterations.is_none() {
+            return None;
+        }
+
+        let ready_path = ready_path.unwrap_or_else(|| {
+            panic!("{PROFILE_READY_PATH_ENV} is required when profile mode is enabled")
+        });
+        let go_path = go_path.unwrap_or_else(|| {
+            panic!("{PROFILE_GO_PATH_ENV} is required when profile mode is enabled")
+        });
+        let iterations = parse_required_usize_env(PROFILE_ITERATIONS_ENV, iterations);
+
+        assert_ne!(
+            ready_path, go_path,
+            "{PROFILE_READY_PATH_ENV} and {PROFILE_GO_PATH_ENV} must differ"
+        );
+        assert!(
+            iterations > 0,
+            "{PROFILE_ITERATIONS_ENV} must be greater than zero"
+        );
+
+        Some(Self {
+            ready_path,
+            go_path,
+            iterations,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Operation {
+    Select,
+    Update,
+}
+
+fn parse_usize_env(name: &str, default: usize) -> usize {
+    env::var(name).map_or(default, |value| {
+        value
+            .parse::<usize>()
+            .unwrap_or_else(|error| panic!("{name} must be an unsigned integer: {error}"))
+    })
+}
+
+fn parse_required_usize_env(name: &str, value: Option<OsString>) -> usize {
+    let value = value
+        .unwrap_or_else(|| panic!("{name} is required when profile mode is enabled"))
+        .into_string()
+        .unwrap_or_else(|_| panic!("{name} must be valid Unicode"));
+    value
+        .parse::<usize>()
+        .unwrap_or_else(|error| panic!("{name} must be an unsigned integer: {error}"))
+}
+
+fn optional_path_env(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn parse_batch_sizes(value: &str) -> Vec<usize> {
+    let mut batch_sizes = value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.parse::<usize>().unwrap_or_else(|error| {
+                panic!("{BATCH_SIZES_ENV} contains invalid value {part:?}: {error}")
+            })
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        !batch_sizes.is_empty(),
+        "{BATCH_SIZES_ENV} must contain at least one batch size"
+    );
+    assert!(
+        batch_sizes.iter().all(|&size| size > 0),
+        "{BATCH_SIZES_ENV} values must be greater than zero"
+    );
+    batch_sizes.sort_unstable();
+    batch_sizes.dedup();
+    batch_sizes
+}
+
+fn parse_operations(value: &str) -> Vec<Operation> {
+    let mut select = false;
+    let mut update = false;
+    for operation in value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        match operation {
+            "all" => {
+                select = true;
+                update = true;
+            }
+            "select" => select = true,
+            "update" => update = true,
+            other => panic!(
+                "{OPERATIONS_ENV} contains invalid operation {other:?}; expected select, update, or all"
+            ),
+        }
+    }
+    assert!(select || update, "{OPERATIONS_ENV} must not be empty");
+
+    let mut operations = Vec::with_capacity(2);
+    if select {
+        operations.push(Operation::Select);
+    }
+    if update {
+        operations.push(Operation::Update);
+    }
+    operations
+}
+
+async fn prepare_seed_snapshot(config: &Config, ids: &[String]) -> Vec<u8> {
+    let snapshot = if let Some(input_path) = config.seed_input_path.as_ref() {
+        let snapshot = fs::read(input_path).unwrap_or_else(|error| {
+            panic!(
+                "failed to read {SEED_INPUT_PATH_ENV} {}: {error}",
+                input_path.display()
+            )
+        });
+        validate_seed_snapshot(&snapshot, config.files).await;
+        snapshot
+    } else {
+        seed_snapshot(config, ids).await
+    };
+
+    if let Some(output_path) = config.seed_output_path.as_ref() {
+        fs::write(output_path, &snapshot).unwrap_or_else(|error| {
+            panic!(
+                "failed to write {SEED_OUTPUT_PATH_ENV} {}: {error}",
+                output_path.display()
+            )
+        });
+    }
+
+    snapshot
+}
+
+async fn seed_snapshot(config: &Config, ids: &[String]) -> Vec<u8> {
+    let storage = CountingStorage::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("benchmark storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("benchmark engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("benchmark session should open");
+
+    for chunk in ids.chunks(config.setup_chunk_size) {
+        let values = chunk
+            .iter()
+            .map(|id| {
+                let suffix = id_index(id);
+                format!("('{id}', '/bench-{suffix:08}.bin', X'00')")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let result = session
+            .execute(
+                &format!("INSERT INTO lix_file (id, path, data) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("benchmark files should insert");
+        assert_eq!(
+            usize::try_from(result.rows_affected()).expect("affected row count should fit usize"),
+            chunk.len(),
+            "setup insert should affect every requested file"
+        );
+    }
+
+    let count = session
+        .execute("SELECT id FROM lix_file", &[])
+        .await
+        .expect("setup row count should be readable");
+    assert_eq!(count.len(), config.files, "setup should seed every file");
+    session.close().await.expect("setup session should close");
+    storage
+        .export_snapshot()
+        .expect("seeded Memory storage should export")
+}
+
+async fn validate_seed_snapshot(snapshot: &[u8], expected_files: usize) {
+    let (_, session) = open_case(snapshot).await;
+    let rows = session
+        .execute("SELECT id FROM lix_file", &[])
+        .await
+        .expect("input seed row count should be readable");
+    assert_eq!(
+        rows.len(),
+        expected_files,
+        "{SEED_INPUT_PATH_ENV} should contain exactly {expected_files} files"
+    );
+    session
+        .close()
+        .await
+        .expect("input seed validation session should close");
+}
+
+fn file_ids(count: usize) -> Vec<String> {
+    (0..count)
+        .map(|index| format!("bench-file-{index:08}"))
+        .collect()
+}
+
+fn id_index(id: &str) -> usize {
+    id.rsplit_once('-')
+        .expect("benchmark id should contain a numeric suffix")
+        .1
+        .parse()
+        .expect("benchmark id suffix should be numeric")
+}
+
+fn quoted_ids(ids: &[String]) -> String {
+    ids.iter()
+        .map(|id| format!("'{id}'"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn select_sql(ids: &[String]) -> String {
+    format!(
+        "SELECT id, data FROM lix_file WHERE id IN ({})",
+        quoted_ids(ids)
+    )
+}
+
+fn update_sql(ids: &[String]) -> String {
+    format!(
+        "UPDATE lix_file SET data = $1 WHERE id IN ({})",
+        quoted_ids(ids)
+    )
+}
+
+async fn open_case(seed_snapshot: &[u8]) -> (CountingStorage, SessionContext<CountingStorage>) {
+    let storage = CountingStorage::from_snapshot(seed_snapshot)
+        .expect("benchmark seed snapshot should reopen");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("benchmark engine should open from seed snapshot");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("benchmark session should open from seed snapshot");
+    (storage, session)
+}
+
+async fn profile_select(
+    seed_snapshot: &[u8],
+    ids: &[String],
+    sql: &str,
+    warmups: usize,
+    profile: &ProfileConfig,
+) -> ProfileMeasurement {
+    let (_, session) = open_case(seed_snapshot).await;
+
+    for _ in 0..warmups {
+        session
+            .execute(sql, &[])
+            .await
+            .expect("profile select warmup should succeed");
+    }
+    let validation = session
+        .execute(sql, &[])
+        .await
+        .expect("profile select validation should succeed");
+    validate_data(&validation, ids, &[0]);
+
+    assert!(
+        !profile.ready_path.exists(),
+        "remove stale {PROFILE_READY_PATH_ENV} marker {}",
+        profile.ready_path.display()
+    );
+    assert!(
+        !profile.go_path.exists(),
+        "remove stale {PROFILE_GO_PATH_ENV} marker {}",
+        profile.go_path.display()
+    );
+    fs::write(&profile.ready_path, format!("{}\n", std::process::id())).unwrap_or_else(|error| {
+        panic!(
+            "failed to write {PROFILE_READY_PATH_ENV} {}: {error}",
+            profile.ready_path.display()
+        )
+    });
+    while !profile.go_path.exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let mut final_result = None;
+    for _ in 0..profile.iterations {
+        final_result = Some(
+            session
+                .execute(sql, &[])
+                .await
+                .expect("profile select should succeed"),
+        );
+    }
+    validate_data(
+        final_result
+            .as_ref()
+            .expect("profile mode requires at least one iteration"),
+        ids,
+        &[0],
+    );
+
+    session
+        .close()
+        .await
+        .expect("profile select session should close");
+    ProfileMeasurement {
+        operation: "select_data_profile",
+        batch_size: ids.len(),
+        iterations: profile.iterations,
+    }
+}
+
+async fn measure_select(
+    seed_snapshot: &[u8],
+    ids: &[String],
+    sql: &str,
+    warmups: usize,
+    samples: usize,
+) -> Measurement {
+    let (storage, session) = open_case(seed_snapshot).await;
+    for _ in 0..warmups {
+        let result = session
+            .execute(sql, &[])
+            .await
+            .expect("select warmup should succeed");
+        validate_data(&result, ids, &[0]);
+    }
+
+    let mut observations = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let before = storage.stats();
+        let started = Instant::now();
+        let result = session
+            .execute(sql, &[])
+            .await
+            .expect("timed select should succeed");
+        let duration_ns = elapsed_ns(started);
+        let storage_delta = storage.stats().delta_since(before);
+        validate_data(&result, ids, &[0]);
+        observations.push(Observation {
+            duration_ns,
+            storage: storage_delta,
+        });
+    }
+
+    session.close().await.expect("select session should close");
+    Measurement::from_observations("select_data", ids.len(), observations)
+}
+
+async fn measure_update(
+    seed_snapshot: &[u8],
+    ids: &[String],
+    select_sql: &str,
+    update_sql: &str,
+    warmups: usize,
+    samples: usize,
+) -> Measurement {
+    let (storage, session) = open_case(seed_snapshot).await;
+    for iteration in 0..warmups {
+        let data = update_data(iteration);
+        let result = session
+            .execute(update_sql, &[Value::Blob(data.clone())])
+            .await
+            .expect("update warmup should succeed");
+        assert_eq!(
+            usize::try_from(result.rows_affected()).expect("affected row count should fit usize"),
+            ids.len()
+        );
+        validate_selected_data(&session, select_sql, ids, &data).await;
+    }
+
+    let mut observations = Vec::with_capacity(samples);
+    for sample in 0..samples {
+        let data = update_data(warmups + sample);
+        let before = storage.stats();
+        let started = Instant::now();
+        let result = session
+            .execute(update_sql, &[Value::Blob(data.clone())])
+            .await
+            .expect("timed update should succeed");
+        let duration_ns = elapsed_ns(started);
+        let storage_delta = storage.stats().delta_since(before);
+        assert_eq!(
+            usize::try_from(result.rows_affected()).expect("affected row count should fit usize"),
+            ids.len(),
+            "timed update should affect every requested file"
+        );
+        validate_selected_data(&session, select_sql, ids, &data).await;
+        observations.push(Observation {
+            duration_ns,
+            storage: storage_delta,
+        });
+    }
+
+    session.close().await.expect("update session should close");
+    Measurement::from_observations("update_data_end_to_end", ids.len(), observations)
+}
+
+fn update_data(iteration: usize) -> Vec<u8> {
+    vec![u8::try_from(iteration % 2 + 1).expect("update byte should fit")]
+}
+
+async fn validate_selected_data(
+    session: &SessionContext<CountingStorage>,
+    select_sql: &str,
+    ids: &[String],
+    expected_data: &[u8],
+) {
+    let result = session
+        .execute(select_sql, &[])
+        .await
+        .expect("updated data should be readable");
+    validate_data(&result, ids, expected_data);
+}
+
+fn validate_data(result: &ExecuteResult, ids: &[String], expected_data: &[u8]) {
+    assert_eq!(
+        result.len(),
+        ids.len(),
+        "select should return every requested file"
+    );
+    let expected = ids.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let mut seen = BTreeSet::new();
+
+    for row in result.rows() {
+        let [Value::Text(id), Value::Blob(data)] = row.values() else {
+            panic!("expected [text id, blob data], got {:?}", row.values());
+        };
+        assert!(expected.contains(id.as_str()), "unexpected file id {id}");
+        assert_eq!(data, expected_data, "unexpected data for {id}");
+        assert!(seen.insert(id.as_str()), "duplicate file id {id}");
+    }
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).expect("sample duration should fit in u64")
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct Observation {
+    duration_ns: u64,
+    storage: StorageStats,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    benchmark: &'static str,
+    config: Config,
+    measurements: Vec<Measurement>,
+    profile_measurement: Option<ProfileMeasurement>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileMeasurement {
+    operation: &'static str,
+    batch_size: usize,
+    iterations: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct Measurement {
+    operation: &'static str,
+    batch_size: usize,
+    duration_ns: Percentiles,
+    duration_ns_chronological_halves: Option<ChronologicalPercentiles>,
+    duration_ns_per_row: Percentiles,
+    storage_per_sample: StoragePercentiles,
+    raw_observations: Vec<Observation>,
+}
+
+impl Measurement {
+    fn from_observations(
+        operation: &'static str,
+        batch_size: usize,
+        observations: Vec<Observation>,
+    ) -> Self {
+        let duration_ns = observations
+            .iter()
+            .map(|observation| observation.duration_ns)
+            .collect::<Vec<_>>();
+        let divisor = u64::try_from(batch_size).expect("batch size should fit in u64");
+        let duration_ns_per_row = duration_ns
+            .iter()
+            .map(|duration| duration / divisor)
+            .collect::<Vec<_>>();
+        let duration_ns_chronological_halves = chronological_halves(&duration_ns);
+
+        Self {
+            operation,
+            batch_size,
+            duration_ns: percentiles(duration_ns),
+            duration_ns_chronological_halves,
+            duration_ns_per_row: percentiles(duration_ns_per_row),
+            storage_per_sample: StoragePercentiles {
+                begin_read_calls: percentiles(
+                    observations
+                        .iter()
+                        .map(|observation| observation.storage.begin_read_calls)
+                        .collect(),
+                ),
+                get_many_calls: percentiles(
+                    observations
+                        .iter()
+                        .map(|observation| observation.storage.get_many_calls)
+                        .collect(),
+                ),
+                get_many_requested_keys: percentiles(
+                    observations
+                        .iter()
+                        .map(|observation| observation.storage.get_many_requested_keys)
+                        .collect(),
+                ),
+                scan_calls: percentiles(
+                    observations
+                        .iter()
+                        .map(|observation| observation.storage.scan_calls)
+                        .collect(),
+                ),
+            },
+            raw_observations: observations,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct StoragePercentiles {
+    begin_read_calls: Percentiles,
+    get_many_calls: Percentiles,
+    get_many_requested_keys: Percentiles,
+    scan_calls: Percentiles,
+}
+
+#[derive(Debug, Serialize)]
+struct Percentiles {
+    p50: u64,
+    p95: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ChronologicalPercentiles {
+    first: Percentiles,
+    second: Percentiles,
+}
+
+fn chronological_halves(values: &[u64]) -> Option<ChronologicalPercentiles> {
+    if values.len() < 2 {
+        return None;
+    }
+    let midpoint = values.len().div_ceil(2);
+    Some(ChronologicalPercentiles {
+        first: percentiles(values[..midpoint].to_vec()),
+        second: percentiles(values[midpoint..].to_vec()),
+    })
+}
+
+fn percentiles(mut values: Vec<u64>) -> Percentiles {
+    assert!(
+        !values.is_empty(),
+        "percentiles require at least one sample"
+    );
+    values.sort_unstable();
+    Percentiles {
+        p50: nearest_rank(&values, 50),
+        p95: nearest_rank(&values, 95),
+    }
+}
+
+fn nearest_rank(sorted: &[u64], percentile: usize) -> u64 {
+    let rank = (sorted.len() * percentile).div_ceil(100);
+    sorted[rank.saturating_sub(1)]
+}
+
+#[derive(Clone, Default)]
+struct CountingStorage {
+    inner: Memory,
+    counters: Arc<StorageCounters>,
+}
+
+impl CountingStorage {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn from_snapshot(snapshot: &[u8]) -> Result<Self, StorageError> {
+        Ok(Self {
+            inner: Memory::from_snapshot(snapshot)?,
+            counters: Arc::new(StorageCounters::default()),
+        })
+    }
+
+    fn export_snapshot(&self) -> Result<Vec<u8>, StorageError> {
+        self.inner.export_snapshot()
+    }
+
+    fn stats(&self) -> StorageStats {
+        self.counters.snapshot()
+    }
+}
+
+struct CountingRead {
+    inner: MemoryRead,
+    counters: Arc<StorageCounters>,
+}
+
+impl Storage for CountingStorage {
+    type Read<'a>
+        = CountingRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        self.counters
+            .begin_read_calls
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(CountingRead {
+            inner: self.inner.begin_read(opts).await?,
+            counters: Arc::clone(&self.counters),
+        })
+    }
+
+    async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(opts).await
+    }
+}
+
+impl StorageRead for CountingRead {
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        self.counters.get_many_calls.fetch_add(1, Ordering::Relaxed);
+        self.counters.get_many_requested_keys.fetch_add(
+            u64::try_from(keys.len()).expect("requested key count should fit in u64"),
+            Ordering::Relaxed,
+        );
+        self.inner.get_many(space, keys, opts).await
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        self.counters.scan_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.scan(space, range, opts).await
+    }
+}
+
+#[derive(Default)]
+struct StorageCounters {
+    begin_read_calls: AtomicU64,
+    get_many_calls: AtomicU64,
+    get_many_requested_keys: AtomicU64,
+    scan_calls: AtomicU64,
+}
+
+impl StorageCounters {
+    fn snapshot(&self) -> StorageStats {
+        StorageStats {
+            begin_read_calls: self.begin_read_calls.load(Ordering::Relaxed),
+            get_many_calls: self.get_many_calls.load(Ordering::Relaxed),
+            get_many_requested_keys: self.get_many_requested_keys.load(Ordering::Relaxed),
+            scan_calls: self.scan_calls.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+struct StorageStats {
+    begin_read_calls: u64,
+    get_many_calls: u64,
+    get_many_requested_keys: u64,
+    scan_calls: u64,
+}
+
+impl StorageStats {
+    fn delta_since(self, before: Self) -> Self {
+        Self {
+            begin_read_calls: self.begin_read_calls - before.begin_read_calls,
+            get_many_calls: self.get_many_calls - before.get_many_calls,
+            get_many_requested_keys: self.get_many_requested_keys - before.get_many_requested_keys,
+            scan_calls: self.scan_calls - before.scan_calls,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replace uncorrelated live-state filter expansion with aligned exact-row batches for indexed `lix_file` reads and DML.

The old path represented `schema_keys`, `entity_pks`, and `file_ids` as independent dimensions. When the same `N` file IDs populated both identity dimensions:

- `N <= 32` expanded into an `N × N` point-key set;
- `N > 32` cleared the file-ID filter and fell back to one entity-prefix scan per blob lane.

This PR removes that heuristic. Exact `(branch_id, schema_key, entity_pk, file_id)` tuples remain correlated from the provider through tracked/flat storage and transaction overlays. Storage I/O is linear in the requested identities, with no 32/33 discontinuity.

No public SQL or SDK contract changes.

## Implementation

- Add `LiveStateExactRowRequest` / `LiveStateExactBatchRequest`.
- Preserve caller order and cardinality while deduplicating storage identities internally.
- Batch tracked-tree point loads by branch/commit and flat-index point loads with the requested projection.
- Preserve branch overrides, global fallback, tombstones, tracked/untracked selection, and staged-over-committed precedence.
- Route indexed `lix_file` SELECT, UPDATE, DELETE, and upsert/conflict probes through path-index descriptor selection followed by exact blob-reference batches.
- Remove `INDEXED_BLOB_REF_EXACT_FILE_FILTER_MAX_IDS` and its two-path heuristic.
- Require every `LiveStateReader` implementation to provide `load_exact_rows`; production readers cannot inherit a scan fallback.
- Reject branchless exact blob batches before storage I/O; callers must resolve branch scope.

Tests cover duplicate/missing result slots, projection, tracked and flat rows, globals/branch overrides/tombstones, malformed cross-pairs, staged overlays, exact-ID UPDATE/DELETE intersected with path predicates, orphan validation, and upsert conflict/application behavior.

## Performance evidence

### Protocol

- Base: `78398a8bd884696eec36df47468390122c596090` (`origin/main`)
- Measured head: `1878eeb8d6fd53f9d88b4b48261d8f0d169847a6` (pre-rebase candidate). Current PR head: `7949b7d9885dfbfd76391d84574a8f8dccfb5994`, rebased onto `main` at `25185d9044836666eae87fbc992c0c17ef8fe560`; benchmarks were not rerun because the rebase and fallback removal do not change the measured correlated storage algorithm.
- 10,000-file canonical in-memory snapshot; identical seed bytes in every process (`sha256 460c4e4f985d51623781acae001c664e64048ea249f977b2af92b5e153174a07`)
- Fresh isolated release binaries (`sha256 98c7e195ea1f0ea37996a34c894853ac4a4bcee530ea04f1f47126d8b1df153f` baseline, `584e0a7251737f6630928790608c66f1fee0c0d6381a5a053e8f05317d644a4c` candidate)
- Pinned to CPU 4; competing processes audited before every pair
- Three balanced pairs per point: baseline→candidate, candidate→baseline, baseline→candidate
- SELECT: 20 warmups, 200 chronological samples/run
- UPDATE: 10 warmups, 30 chronological samples/run
- Every cell is the median of three independent run percentiles; brackets are the complete run-level range
- All 54 JSON reports and 54 complete logs were validated for configuration, seed, sample count, balanced order, raw observations, and successful exit

### SELECT latency

All durations are milliseconds.

| Batch | Base p50 | Head p50 | Speedup | Base p95 | Head p95 | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1.824 [1.816–1.852] | 1.817 [1.808–1.830] | 1.004× | 1.947 [1.927–2.633] | 1.960 [1.902–2.696] | 0.993× |
| 10 | 2.703 [2.667–2.724] | 2.451 [2.450–2.461] | 1.103× | 2.864 [2.811–4.027] | 2.695 [2.586–2.721] | 1.063× |
| 32 | 5.585 [5.584–5.639] | 2.949 [2.932–2.955] | 1.894× | 5.894 [5.771–6.053] | 3.082 [3.038–3.088] | 1.912× |
| 33 | 6.195 [6.172–6.217] | 3.022 [3.011–3.048] | 2.050× | 6.462 [6.382–6.603] | 3.137 [3.118–3.170] | 2.060× |
| 100 | 10.473 [10.448–10.496] | 4.693 [4.664–4.707] | 2.232× | 10.962 [10.804–11.097] | 4.863 [4.850–4.866] | 2.254× |

The singleton control is unchanged. The gain begins where correlated work grows and is largest across the removed scan fallback.

### Deterministic storage shape

Tuples are `(get_many calls, requested keys, scans)` per sample.

| Operation | Batch | Base | Head |
|---|---:|---:|---:|
| SELECT | 32 | (32, 2,167, 2) | (31, 183, 2) |
| SELECT | 33 | (30, 120, 68) | (31, 186, 2) |
| SELECT | 100 | (30, 187, 202) | (31, 387, 2) |
| UPDATE | 32 | (262, 20,625, 141) | (261, 20,653, 11) |
| UPDATE | 33 | (267, 20,636, 145) | (266, 20,665, 11) |
| UPDATE | 100 | (603, 21,374, 413) | (602, 21,470, 11) |

UPDATE p50 is only 2.2–4.5% lower in this unstacked comparison and noisy enough to treat as latency parity at batches 33/100. The exact path removes 92–97% of scans, but the legacy plugin-reconciliation path still requests about 20,000 keys per sample. #647 addressed that independent cost and is now included in this PR’s base.

### Matched profile

A separate SELECT-B100 profile used the same binaries/seed, 20 warmups before an explicit ready/go barrier, then exactly 1,000 queries under `perf record -F 997 -e cycles:u -g --call-graph dwarf --inherit`.

| | Base | Head | Change |
|---|---:|---:|---:|
| Profile duration | 10.806 s | 5.085 s | 2.125× |
| Approx. sampled cycles/query | 32.009 M | 14.779 M | −53.8% |
| Samples / lost | 10,786 / 0 | 5,087 / 0 | 0 lost |

Largest complete flat-leaf reductions, cycles/query:

- `key_matches_scan_filters`: 2.251 M → 0
- `TrackedStateTree::scan_node`: 0.714 M → 0.006 M
- entity-PK decode: 0.522 M → 0.003 M
- tracked-state-key decode: 0.433 M → 0
- node decode: 0.347 M → 0.012 M

The candidate adds about 0.27 M cycles/query across exact-row identity/index/load/materialization symbols. Main-binary leaf symbol resolution was 99.77%/99.48%; release binaries lack line DWARF, so flame callchain coverage is 59.5%/50.7% and flat leaf attribution is the primary ranking evidence.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine --lib --quiet` — 1,065 passed, 3 ignored benchmark probes
- `cargo test -p lix_engine --test fs_api` — 39 passed
- focused branch-resolution invariant — branchless exact reads fail before reader I/O

## Deliberate fallback path

Synthesized commit and commit-edge rows retain their semantic per-request fallback because those rows are derived rather than stored under the requested identity. Production indexed-file reads have no branchless scan fallback, and `LiveStateReader` has no default exact-read implementation. Test fixtures opt into a test-only semantic adapter explicitly.

## Relationship to adjacent work

- #645 makes file-ID lookup inside an already-built filesystem path index effectively constant-time; this PR preserves its `exact_file_id_indices()` path and fixes the correlated live-state/blob fetch after descriptor selection.
- #647 is included in the base and removes plugin discovery/reconciliation amplification from ordinary writes. Together, #647 and this PR remove the two independent sources of UPDATE amplification.

The rebase conflicts in `file.rs` and transaction context were resolved deliberately: #645’s ID index, #647’s durable plugin registry, and this PR’s exact correlated row batches all remain active.