### PR TITLE
perf(engine): bypass DataFusion for exact primary-key reads

### DIFF
--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1232,4 +1232,107 @@ mod tests {
             serde_json::json!("value")
         );
     }
+
+    #[tokio::test]
+    async fn exact_primary_key_reads_match_datafusion_fallback_results() {
+        let session = open_session().await;
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES \
+                 ('native-file-a', '/native-a.bin', X'6100'), \
+                 ('native-file-b', '/native-b.bin', X'6200')",
+                &[],
+            )
+            .await
+            .expect("file fixtures should insert");
+
+        let file_params = [
+            Value::Text("native-file-b".to_string()),
+            Value::Text("native-file-a".to_string()),
+        ];
+        let native_files = session
+            .execute(
+                "SELECT id AS file_id, path, data AS bytes \
+                 FROM lix_file WHERE id IN ($1, $2)",
+                &file_params,
+            )
+            .await
+            .expect("native file read should succeed");
+        // The tautology is deliberately outside the native binder's exact-key
+        // language, forcing the same projection through DataFusion.
+        let datafusion_files = session
+            .execute(
+                "SELECT id AS file_id, path, data AS bytes \
+                 FROM lix_file WHERE id IN ($1, $2) AND id = id",
+                &file_params,
+            )
+            .await
+            .expect("DataFusion file read should succeed");
+        assert_eq!(native_files, datafusion_files);
+
+        let schema = serde_json::json!({
+            "x-lix-key": "native_pk_message",
+            "x-lix-primary-key": ["/workspace_id", "/id"],
+            "type": "object",
+            "properties": {
+                "workspace_id": { "type": "string" },
+                "id": { "type": "string" },
+                "payload": { "type": "object" }
+            },
+            "required": ["workspace_id", "id", "payload"],
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_registered_schema \
+                     (value, lixcol_global, lixcol_untracked) \
+                     VALUES (lix_json('{}'), false, false)",
+                    schema
+                ),
+                &[],
+            )
+            .await
+            .expect("entity schema should register");
+        session
+            .execute(
+                "INSERT INTO native_pk_message (workspace_id, id, payload) VALUES \
+                 ('workspace', 'alpha', lix_json('{\"kind\":\"first\"}')), \
+                 ('workspace', 'beta', lix_json('{\"kind\":\"second\"}'))",
+                &[],
+            )
+            .await
+            .expect("entity fixtures should insert");
+
+        let entity_params = [
+            Value::Text("workspace".to_string()),
+            Value::Text("beta".to_string()),
+            Value::Text("alpha".to_string()),
+        ];
+        let native_entities = session
+            .execute(
+                "SELECT id AS message_id, payload AS document \
+                 FROM native_pk_message \
+                 WHERE workspace_id = $1 AND id IN ($2, $3)",
+                &entity_params,
+            )
+            .await
+            .expect("native entity read should succeed");
+        let datafusion_entities = session
+            .execute(
+                "SELECT id AS message_id, payload AS document \
+                 FROM native_pk_message \
+                 WHERE workspace_id = $1 AND id IN ($2, $3) \
+                 AND workspace_id = workspace_id",
+                &entity_params,
+            )
+            .await
+            .expect("DataFusion entity read should succeed");
+        assert_eq!(native_entities, datafusion_entities);
+        assert!(
+            native_entities.rows()[0]
+                .value("document")
+                .is_ok_and(|value| matches!(value, Value::Json(_)))
+        );
+    }
 }

--- a/packages/engine/src/sql2/bind/mod.rs
+++ b/packages/engine/src/sql2/bind/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod classify;
 pub(crate) mod error;
 pub(crate) mod expr;
+pub(crate) mod primary_key_read;
 mod public_udf;
 pub(crate) mod read;
 pub(crate) mod statement;

--- a/packages/engine/src/sql2/bind/primary_key_read.rs
+++ b/packages/engine/src/sql2/bind/primary_key_read.rs
@@ -1,0 +1,684 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use datafusion::sql::parser::Statement as DataFusionStatement;
+use datafusion::sql::sqlparser::ast::{
+    BinaryOperator, Expr, GroupByExpr, Ident, Query, Select, SelectFlavor, SelectItem, SetExpr,
+    Statement as SqlStatement, TableFactor, Value as SqlValue,
+};
+
+use crate::Value;
+use crate::sql2::catalog::{PublicCatalog, PublicSurfaceContract, PublicSurfaceKind};
+
+const MAX_COMPOSITE_PRIMARY_KEYS: usize = 4096;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PrimaryKeyReadBinding {
+    Declined,
+    Ready(BoundPrimaryKeyRead),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BoundPrimaryKeyRead {
+    pub(crate) target: BoundPrimaryKeyReadTarget,
+    pub(crate) projection: Vec<BoundPrimaryKeyProjection>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum BoundPrimaryKeyReadTarget {
+    File {
+        ids: Vec<String>,
+    },
+    Entity {
+        schema_key: String,
+        primary_key_columns: Vec<String>,
+        /// Exact keys in schema primary-key order.
+        keys: Vec<Vec<String>>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BoundPrimaryKeyProjection {
+    /// Index in the public surface/provider schema.
+    pub(crate) source_index: usize,
+    pub(crate) source_name: String,
+    pub(crate) output_name: String,
+}
+
+/// Attempts to bind the deliberately small exact-primary-key SELECT language.
+///
+/// Declining is behavior preserving: the caller must run the existing DataFusion
+/// path. This function therefore never turns syntax, name-resolution, parameter,
+/// or type errors into native-path errors, and it performs no I/O.
+pub(crate) fn bind_primary_key_read(
+    statement: &DataFusionStatement,
+    catalog: &PublicCatalog,
+    params: &[Value],
+) -> PrimaryKeyReadBinding {
+    bind_primary_key_read_inner(statement, catalog, params)
+        .map(PrimaryKeyReadBinding::Ready)
+        .unwrap_or(PrimaryKeyReadBinding::Declined)
+}
+
+fn bind_primary_key_read_inner(
+    statement: &DataFusionStatement,
+    catalog: &PublicCatalog,
+    params: &[Value],
+) -> Option<BoundPrimaryKeyRead> {
+    let DataFusionStatement::Statement(statement) = statement else {
+        return None;
+    };
+    let SqlStatement::Query(query) = statement.as_ref() else {
+        return None;
+    };
+    let select = plain_select(query)?;
+    let (surface, qualifier) = bind_single_table(select, catalog)?;
+
+    let projection = bind_projection(select, surface, &qualifier)?;
+    let selection = select.selection.as_ref()?;
+    let mut parameter_indexes = BTreeSet::new();
+    let mut constraints = BTreeMap::<String, BTreeSet<String>>::new();
+    bind_constraints(
+        selection,
+        surface,
+        &qualifier,
+        params,
+        &mut parameter_indexes,
+        &mut constraints,
+    )?;
+
+    // Match DataFusion's positional count rule (the highest $N) and decline on
+    // every mismatch so its established error remains authoritative.
+    let expected_parameter_count = parameter_indexes.last().copied().unwrap_or(0);
+    if params.len() != expected_parameter_count {
+        return None;
+    }
+
+    let target = match &surface.kind {
+        PublicSurfaceKind::File => {
+            if constraints.len() != 1 {
+                return None;
+            }
+            let ids = constraints.remove("id")?.into_iter().collect::<Vec<_>>();
+            if ids.is_empty() {
+                return None;
+            }
+            BoundPrimaryKeyReadTarget::File { ids }
+        }
+        PublicSurfaceKind::EntityBase { schema_key } => {
+            let spec = catalog.entity_spec(schema_key)?;
+            let primary_key_columns = spec
+                .flat_string_primary_key_columns()?
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+            if constraints.len() != primary_key_columns.len()
+                || primary_key_columns
+                    .iter()
+                    .any(|column| !constraints.contains_key(column))
+            {
+                return None;
+            }
+            let value_sets = primary_key_columns
+                .iter()
+                .map(|column| constraints.get(column).cloned())
+                .collect::<Option<Vec<_>>>()?;
+            let keys = cartesian_primary_keys(&value_sets)?;
+            if keys.is_empty() {
+                return None;
+            }
+            BoundPrimaryKeyReadTarget::Entity {
+                schema_key: schema_key.clone(),
+                primary_key_columns,
+                keys,
+            }
+        }
+        _ => return None,
+    };
+
+    Some(BoundPrimaryKeyRead { target, projection })
+}
+
+fn plain_select(query: &Query) -> Option<&Select> {
+    if query.with.is_some()
+        || query.order_by.is_some()
+        || query.limit_clause.is_some()
+        || query.fetch.is_some()
+        || !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return None;
+    }
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return None;
+    };
+    if select.flavor != SelectFlavor::Standard
+        || select.optimizer_hint.is_some()
+        || select.distinct.is_some()
+        || select.select_modifiers.is_some()
+        || select.top.is_some()
+        || select.top_before_distinct
+        || select.exclude.is_some()
+        || select.into.is_some()
+        || !select.lateral_views.is_empty()
+        || select.prewhere.is_some()
+        || !select.connect_by.is_empty()
+        || !plain_group_by(&select.group_by)
+        || !select.cluster_by.is_empty()
+        || !select.distribute_by.is_empty()
+        || !select.sort_by.is_empty()
+        || select.having.is_some()
+        || !select.named_window.is_empty()
+        || select.qualify.is_some()
+        || select.value_table_mode.is_some()
+        || select.window_before_qualify
+        || select.from.len() != 1
+        || select.projection.is_empty()
+    {
+        return None;
+    }
+    Some(select)
+}
+
+fn plain_group_by(group_by: &GroupByExpr) -> bool {
+    matches!(group_by, GroupByExpr::Expressions(expressions, modifiers) if expressions.is_empty() && modifiers.is_empty())
+}
+
+fn bind_single_table<'a>(
+    select: &Select,
+    catalog: &'a PublicCatalog,
+) -> Option<(&'a PublicSurfaceContract, String)> {
+    let from = select.from.first()?;
+    if !from.joins.is_empty() {
+        return None;
+    }
+    let TableFactor::Table {
+        name,
+        alias,
+        args,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+    } = &from.relation
+    else {
+        return None;
+    };
+    if args.is_some()
+        || !with_hints.is_empty()
+        || version.is_some()
+        || *with_ordinality
+        || !partitions.is_empty()
+        || json_path.is_some()
+        || sample.is_some()
+        || !index_hints.is_empty()
+    {
+        return None;
+    }
+    if alias
+        .as_ref()
+        .is_some_and(|alias| !alias.columns.is_empty())
+    {
+        return None;
+    }
+    if name.0.len() != 1 {
+        return None;
+    }
+    let table_name = normalize_identifier(name.0.first()?.as_ident()?);
+    let surface = catalog.surface(&table_name)?;
+    if !matches!(
+        surface.kind,
+        PublicSurfaceKind::File | PublicSurfaceKind::EntityBase { .. }
+    ) {
+        return None;
+    }
+    let qualifier = alias
+        .as_ref()
+        .map(|alias| normalize_identifier(&alias.name))
+        .unwrap_or(table_name);
+    Some((surface, qualifier))
+}
+
+fn bind_projection(
+    select: &Select,
+    surface: &PublicSurfaceContract,
+    qualifier: &str,
+) -> Option<Vec<BoundPrimaryKeyProjection>> {
+    select
+        .projection
+        .iter()
+        .map(|item| {
+            let (expression, alias) = match item {
+                SelectItem::UnnamedExpr(expression) => (expression, None),
+                SelectItem::ExprWithAlias { expr, alias } => (expr, Some(alias)),
+                SelectItem::QualifiedWildcard(_, _) | SelectItem::Wildcard(_) => return None,
+            };
+            let column_name = bind_column_reference(expression, qualifier)?;
+            let column = surface.public_column(&column_name)?;
+            Some(BoundPrimaryKeyProjection {
+                source_index: column.id,
+                source_name: column.name.clone(),
+                output_name: alias
+                    .map(normalize_identifier)
+                    .unwrap_or_else(|| column.name.clone()),
+            })
+        })
+        .collect()
+}
+
+fn bind_constraints(
+    expression: &Expr,
+    surface: &PublicSurfaceContract,
+    qualifier: &str,
+    params: &[Value],
+    parameter_indexes: &mut BTreeSet<usize>,
+    constraints: &mut BTreeMap<String, BTreeSet<String>>,
+) -> Option<()> {
+    match expression {
+        Expr::Nested(expression) => bind_constraints(
+            expression,
+            surface,
+            qualifier,
+            params,
+            parameter_indexes,
+            constraints,
+        ),
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::And,
+            right,
+        } => {
+            bind_constraints(
+                left,
+                surface,
+                qualifier,
+                params,
+                parameter_indexes,
+                constraints,
+            )?;
+            bind_constraints(
+                right,
+                surface,
+                qualifier,
+                params,
+                parameter_indexes,
+                constraints,
+            )
+        }
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            let (column_expression, value_expression) = if is_column_reference(left, qualifier)
+                && !is_column_reference(right, qualifier)
+            {
+                (left.as_ref(), right.as_ref())
+            } else if is_column_reference(right, qualifier) && !is_column_reference(left, qualifier)
+            {
+                (right.as_ref(), left.as_ref())
+            } else {
+                return None;
+            };
+            let column_name = bind_column_reference(column_expression, qualifier)?;
+            surface.public_column(&column_name)?;
+            let value = bind_text_value(value_expression, params, parameter_indexes)?;
+            intersect_constraint(constraints, column_name, BTreeSet::from([value]))
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated: false,
+        } => {
+            let column_name = bind_column_reference(expr, qualifier)?;
+            surface.public_column(&column_name)?;
+            if list.is_empty() {
+                return None;
+            }
+            let values = list
+                .iter()
+                .map(|value| bind_text_value(value, params, parameter_indexes))
+                .collect::<Option<BTreeSet<_>>>()?;
+            intersect_constraint(constraints, column_name, values)
+        }
+        _ => None,
+    }
+}
+
+fn intersect_constraint(
+    constraints: &mut BTreeMap<String, BTreeSet<String>>,
+    column_name: String,
+    values: BTreeSet<String>,
+) -> Option<()> {
+    if values.is_empty() {
+        return None;
+    }
+    match constraints.entry(column_name) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(values);
+        }
+        std::collections::btree_map::Entry::Occupied(mut entry) => {
+            entry.get_mut().retain(|value| values.contains(value));
+            if entry.get().is_empty() {
+                return None;
+            }
+        }
+    }
+    Some(())
+}
+
+fn is_column_reference(expression: &Expr, qualifier: &str) -> bool {
+    bind_column_reference(expression, qualifier).is_some()
+}
+
+fn bind_column_reference(expression: &Expr, qualifier: &str) -> Option<String> {
+    match expression {
+        Expr::Identifier(identifier) => Some(normalize_identifier(identifier)),
+        Expr::CompoundIdentifier(parts) if parts.len() == 2 => {
+            let reference_qualifier = normalize_identifier(parts.first()?);
+            if reference_qualifier != qualifier {
+                return None;
+            }
+            Some(normalize_identifier(parts.get(1)?))
+        }
+        _ => None,
+    }
+}
+
+fn bind_text_value(
+    expression: &Expr,
+    params: &[Value],
+    parameter_indexes: &mut BTreeSet<usize>,
+) -> Option<String> {
+    let Expr::Value(value) = expression else {
+        return None;
+    };
+    match &value.value {
+        SqlValue::SingleQuotedString(value) => Some(value.clone()),
+        SqlValue::Placeholder(name) => {
+            let index = name
+                .strip_prefix('$')
+                .and_then(|raw| raw.parse::<usize>().ok())
+                .filter(|index| *index > 0)?;
+            parameter_indexes.insert(index);
+            match params.get(index - 1)? {
+                Value::Text(value) => Some(value.clone()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn cartesian_primary_keys(value_sets: &[BTreeSet<String>]) -> Option<Vec<Vec<String>>> {
+    let key_count = value_sets.iter().try_fold(1usize, |count, values| {
+        if values.is_empty() {
+            return None;
+        }
+        count.checked_mul(values.len())
+    })?;
+    if key_count == 0 || key_count > MAX_COMPOSITE_PRIMARY_KEYS {
+        return None;
+    }
+
+    let mut keys = vec![Vec::with_capacity(value_sets.len())];
+    for values in value_sets {
+        let mut next = Vec::with_capacity(keys.len() * values.len());
+        for key in &keys {
+            for value in values {
+                let mut expanded = key.clone();
+                expanded.push(value.clone());
+                next.push(expanded);
+            }
+        }
+        keys = next;
+    }
+    Some(keys)
+}
+
+fn normalize_identifier(identifier: &Ident) -> String {
+    if identifier.quote_style.is_some() {
+        identifier.value.clone()
+    } else {
+        identifier.value.to_ascii_lowercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::sql::parser::Statement as DataFusionStatement;
+    use serde_json::json;
+
+    use super::*;
+
+    fn catalog() -> PublicCatalog {
+        PublicCatalog::from_visible_schemas(&[
+            json!({
+                "x-lix-key": "message",
+                "x-lix-primary-key": ["/workspace_id", "/id"],
+                "properties": {
+                    "workspace_id": { "type": "string" },
+                    "id": { "type": "string" },
+                    "payload": { "type": "object" }
+                }
+            }),
+            json!({
+                "x-lix-key": "nested_key",
+                "x-lix-primary-key": ["/identity/id"],
+                "properties": {
+                    "identity": { "type": "object" }
+                }
+            }),
+            json!({
+                "x-lix-key": "integer_key",
+                "x-lix-primary-key": ["/id"],
+                "properties": {
+                    "id": { "type": "integer" }
+                }
+            }),
+        ])
+        .expect("catalog builds")
+    }
+
+    fn parse(sql: &str) -> DataFusionStatement {
+        crate::sql2::parse_statement(sql).expect("SQL parses")
+    }
+
+    fn bind(sql: &str, params: &[Value]) -> PrimaryKeyReadBinding {
+        bind_primary_key_read(&parse(sql), &catalog(), params)
+    }
+
+    fn ready(sql: &str, params: &[Value]) -> BoundPrimaryKeyRead {
+        let PrimaryKeyReadBinding::Ready(read) = bind(sql, params) else {
+            panic!("expected native binding for {sql}");
+        };
+        read
+    }
+
+    #[test]
+    fn binds_file_ids_with_intersection_deduplication_reversed_equality_and_aliases() {
+        assert!(matches!(
+            bind(
+                "SELECT f.data FROM lix_file AS f WHERE 'b' = f.id OR f.id = 'ignored'",
+                &[]
+            ),
+            PrimaryKeyReadBinding::Declined
+        ));
+
+        let read = ready(
+            "SELECT f.data AS payload, f.id, f.id AS duplicate_id \
+             FROM lix_file AS f \
+             WHERE 'b' = f.id AND f.id IN ('a', 'b', 'b')",
+            &[],
+        );
+        assert_eq!(
+            read.target,
+            BoundPrimaryKeyReadTarget::File {
+                ids: vec!["b".to_string()]
+            }
+        );
+        assert_eq!(
+            read.projection,
+            vec![
+                BoundPrimaryKeyProjection {
+                    source_index: 4,
+                    source_name: "data".to_string(),
+                    output_name: "payload".to_string(),
+                },
+                BoundPrimaryKeyProjection {
+                    source_index: 0,
+                    source_name: "id".to_string(),
+                    output_name: "id".to_string(),
+                },
+                BoundPrimaryKeyProjection {
+                    source_index: 0,
+                    source_name: "id".to_string(),
+                    output_name: "duplicate_id".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn binds_parameters_only_when_count_and_referenced_types_match_datafusion() {
+        let read = ready(
+            "SELECT id FROM lix_file WHERE id IN ($2, $2)",
+            &[Value::Integer(7), Value::Text("file-a".to_string())],
+        );
+        assert_eq!(
+            read.target,
+            BoundPrimaryKeyReadTarget::File {
+                ids: vec!["file-a".to_string()]
+            }
+        );
+
+        for (sql, params) in [
+            (
+                "SELECT id FROM lix_file WHERE id = $1",
+                vec![Value::Integer(1)],
+            ),
+            (
+                "SELECT id FROM lix_file WHERE id = $1",
+                vec![
+                    Value::Text("a".to_string()),
+                    Value::Text("extra".to_string()),
+                ],
+            ),
+            (
+                "SELECT id FROM lix_file WHERE id = $2",
+                vec![Value::Text("only-one".to_string())],
+            ),
+        ] {
+            assert!(matches!(
+                bind(sql, &params),
+                PrimaryKeyReadBinding::Declined
+            ));
+        }
+    }
+
+    #[test]
+    fn binds_complete_flat_string_composite_entity_keys_with_bounded_product() {
+        let read = ready(
+            "SELECT payload AS body, id, payload AS body_again FROM message \
+             WHERE workspace_id IN ('w2', 'w1') AND id IN ('b', 'a', 'a')",
+            &[],
+        );
+        assert_eq!(
+            read.target,
+            BoundPrimaryKeyReadTarget::Entity {
+                schema_key: "message".to_string(),
+                primary_key_columns: vec!["workspace_id".to_string(), "id".to_string()],
+                keys: vec![
+                    vec!["w1".to_string(), "a".to_string()],
+                    vec!["w1".to_string(), "b".to_string()],
+                    vec!["w2".to_string(), "a".to_string()],
+                    vec!["w2".to_string(), "b".to_string()],
+                ],
+            }
+        );
+        assert_eq!(read.projection[0].source_name, "payload");
+        assert_eq!(read.projection[0].output_name, "body");
+        assert_eq!(read.projection[0].source_index, 1);
+        assert_eq!(read.projection[2].source_index, 1);
+    }
+
+    #[test]
+    fn declines_partial_nonflat_nonstring_contradictory_and_excessive_entity_keys() {
+        for sql in [
+            "SELECT id FROM message WHERE id = 'a'",
+            "SELECT identity FROM nested_key WHERE identity = 'a'",
+            "SELECT id FROM integer_key WHERE id = '1'",
+            "SELECT id FROM message WHERE workspace_id = 'w' AND id = 'a' AND id = 'b'",
+        ] {
+            assert!(
+                matches!(bind(sql, &[]), PrimaryKeyReadBinding::Declined),
+                "{sql}"
+            );
+        }
+
+        let workspaces = (0..65)
+            .map(|index| format!("'w{index}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let ids = (0..64)
+            .map(|index| format!("'i{index}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let at_limit =
+            format!("SELECT id FROM message WHERE workspace_id IN ({ids}) AND id IN ({ids})");
+        assert!(matches!(
+            bind(&at_limit, &[]),
+            PrimaryKeyReadBinding::Ready(_)
+        ));
+        let above_limit = format!(
+            "SELECT id FROM message WHERE workspace_id IN ({workspaces}) AND id IN ({ids})"
+        );
+        assert!(matches!(
+            bind(&above_limit, &[]),
+            PrimaryKeyReadBinding::Declined
+        ));
+    }
+
+    #[test]
+    fn declines_every_complex_or_error_sensitive_select_shape() {
+        for sql in [
+            "SELECT * FROM lix_file WHERE id = 'a'",
+            "SELECT upper(id) FROM lix_file WHERE id = 'a'",
+            "SELECT missing FROM lix_file WHERE id = 'a'",
+            "SELECT id FROM lix_file WHERE missing = 'a'",
+            "SELECT id FROM lix_file WHERE id = 'a' OR id = 'b'",
+            "SELECT id FROM lix_file WHERE id NOT IN ('a')",
+            "SELECT id FROM lix_file WHERE id = 'a' ORDER BY id",
+            "SELECT id FROM lix_file WHERE id = 'a' LIMIT 1",
+            "SELECT DISTINCT id FROM lix_file WHERE id = 'a'",
+            "SELECT id FROM lix_file JOIN lix_file AS other ON true WHERE lix_file.id = 'a'",
+            "WITH files AS (SELECT * FROM lix_file) SELECT id FROM files WHERE id = 'a'",
+            "SELECT id FROM lix_file_by_branch WHERE id = 'a'",
+            "SELECT id FROM lix_file_history WHERE id = 'a'",
+            "SELECT id FROM lix_file AS f WHERE lix_file.id = 'a'",
+            "SELECT f.id FROM lix_file AS f (renamed) WHERE f.id = 'a'",
+            "SELECT id FROM lix_file WHERE id = 1",
+        ] {
+            assert!(
+                matches!(bind(sql, &[]), PrimaryKeyReadBinding::Declined),
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_projection_alias_preserves_exact_spelling() {
+        let read = ready(
+            "SELECT payload AS \"JSON Payload\" FROM message \
+             WHERE workspace_id = 'w' AND id = 'i'",
+            &[],
+        );
+        assert_eq!(read.projection[0].source_name, "payload");
+        assert_eq!(read.projection[0].output_name, "JSON Payload");
+    }
+}

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -53,6 +53,36 @@ impl EntitySurfaceSpec {
             .iter()
             .find(|column| column.name == column_name)
     }
+
+    /// Return the public columns that can losslessly form exact live-state
+    /// entity-primary-key filters.
+    ///
+    /// The native point-read route deliberately accepts only the common
+    /// schema shape: a non-empty primary key made entirely from top-level
+    /// string properties. Nested JSON pointers and non-string components
+    /// keep using the regular DataFusion route.
+    pub(crate) fn flat_string_primary_key_columns(&self) -> Option<Vec<&str>> {
+        if self.primary_key_paths.is_empty() {
+            return None;
+        }
+
+        let mut seen = BTreeSet::new();
+        self.primary_key_paths
+            .iter()
+            .map(|path| {
+                let [column_name] = path.as_slice() else {
+                    return None;
+                };
+                let column = self.visible_column(column_name)?;
+                if column.column_type != EntityColumnType::String
+                    || !seen.insert(column.name.as_str())
+                {
+                    return None;
+                }
+                Some(column.name.as_str())
+            })
+            .collect()
+    }
 }
 
 pub(crate) fn derive_entity_surface_spec_from_schema(
@@ -294,5 +324,64 @@ fn collect_entity_type_kinds<'a>(schema: &'a JsonValue, out: &mut BTreeSet<&'a s
                 collect_entity_type_kinds(branch, out);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EntityColumnType, EntitySurfaceColumn, EntitySurfaceSpec,
+        derive_entity_surface_spec_from_schema,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn flat_string_primary_key_columns_accepts_only_flat_string_components() {
+        let flat = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "project_item",
+            "x-lix-primary-key": ["/workspace", "/id"],
+            "type": "object",
+            "properties": {
+                "workspace": { "type": "string" },
+                "id": { "type": "string" },
+                "revision": { "type": "integer" }
+            }
+        }))
+        .expect("flat entity schema should derive");
+        assert_eq!(
+            flat.flat_string_primary_key_columns(),
+            Some(vec!["workspace", "id"])
+        );
+
+        let no_primary_key = EntitySurfaceSpec {
+            schema_key: "no_primary_key".to_string(),
+            primary_key_paths: Vec::new(),
+            columns: flat.columns.clone(),
+        };
+        assert_eq!(no_primary_key.flat_string_primary_key_columns(), None);
+
+        let nested = EntitySurfaceSpec {
+            schema_key: "nested".to_string(),
+            primary_key_paths: vec![vec!["scope".to_string(), "id".to_string()]],
+            columns: flat.columns.clone(),
+        };
+        assert_eq!(nested.flat_string_primary_key_columns(), None);
+
+        let non_string = EntitySurfaceSpec {
+            schema_key: "non_string".to_string(),
+            primary_key_paths: vec![vec!["revision".to_string()]],
+            columns: vec![EntitySurfaceColumn {
+                name: "revision".to_string(),
+                column_type: EntityColumnType::Integer,
+            }],
+        };
+        assert_eq!(non_string.flat_string_primary_key_columns(), None);
+
+        let duplicate = EntitySurfaceSpec {
+            schema_key: "duplicate".to_string(),
+            primary_key_paths: vec![vec!["id".to_string()], vec!["id".to_string()]],
+            columns: flat.columns,
+        };
+        assert_eq!(duplicate.flat_string_primary_key_columns(), None);
     }
 }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -23,6 +23,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use crate::functions::FunctionContext;
 use crate::sql2::bind::expr::{BoundCastType, BoundExpr, BoundLiteral};
+use crate::sql2::bind::primary_key_read::{PrimaryKeyReadBinding, bind_primary_key_read};
 use crate::sql2::bind::write::{BoundInsertValues, BoundReturning, FileWriteSurface};
 use crate::sql2::bind::write::{
     BoundWriteInput, BoundWriteOp, BoundWriteTarget, DirectoryWriteSurface,
@@ -39,12 +40,13 @@ use crate::sql2::result_metadata::{
     LIX_VALUE_TYPE_JSON, LIX_VALUE_TYPE_METADATA_KEY, field_is_json,
 };
 use crate::sql2::session::{
-    SqlWriteSessionOptions, build_read_session, build_transaction_read_session,
-    build_write_session_with_options,
+    PreparedReadSession, SqlWriteSessionOptions, build_read_session_from_prepared,
+    build_transaction_read_session, build_write_session_with_options, prepare_read_session,
 };
 use crate::sql2::write_normalization::lix_file_data_type_lix_error;
 use crate::sql2::{SqlExecutionContext, SqlWriteExecutionContext};
 
+use super::primary_key_read::execute_primary_key_read;
 use super::{SqlDataFusionLogicalPlan, SqlLogicalPlan, SqlWriteResult};
 
 pub(crate) const LIX_INSERT_COLUMN_OMITTED_METADATA_KEY: &str = "lix_insert_column_omitted";
@@ -82,20 +84,26 @@ where
     // Keep read-backed DataFusion providers scoped to this call. The returned
     // value is fully materialized, so callers cannot retain a plan/provider
     // that may carry an execution read handle.
-    let plan = create_logical_plan_from_parsed(ctx, sql, statement).await?;
+    crate::sql2::bind_read_statement(sql, &statement)?;
+    let prepared = prepare_read_session(ctx).await?;
+    if let PrimaryKeyReadBinding::Ready(read) =
+        bind_primary_key_read(&statement, prepared.catalog.as_ref(), params)
+    {
+        return execute_primary_key_read(ctx, &prepared, &read).await;
+    }
+    let plan = create_logical_plan_from_parsed(ctx, statement, &prepared).await?;
     execute_logical_plan(plan, params).await
 }
 
 async fn create_logical_plan_from_parsed<C>(
     ctx: &C,
-    sql: &str,
     statement: DataFusionStatement,
+    prepared: &PreparedReadSession,
 ) -> Result<SqlLogicalPlan, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    crate::sql2::bind_read_statement(sql, &statement)?;
-    let session = build_read_session(ctx).await?;
+    let session = build_read_session_from_prepared(ctx, prepared).await?;
     let plan = create_logical_plan_from_statement(&session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
@@ -1431,7 +1439,7 @@ fn datafusion_error_to_lix_error(error: datafusion::error::DataFusionError) -> L
     crate::sql2::error::datafusion_error_to_lix_error(error)
 }
 
-fn query_result_from_batches(
+pub(super) fn query_result_from_batches(
     result_fields: &[Field],
     batches: &[RecordBatch],
 ) -> Result<SqlQueryResult, LixError> {

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod bound_public_write;
 pub(crate) mod datafusion;
 pub(crate) mod fast_write;
+pub(crate) mod primary_key_read;
 pub(crate) mod write;
 
 use crate::SqlQueryResult;

--- a/packages/engine/src/sql2/exec/primary_key_read.rs
+++ b/packages/engine/src/sql2/exec/primary_key_read.rs
@@ -1,0 +1,189 @@
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::Field;
+use datafusion::arrow::record_batch::RecordBatch;
+
+use crate::entity_pk::EntityPk;
+use crate::sql2::SqlExecutionContext;
+use crate::sql2::bind::primary_key_read::{
+    BoundPrimaryKeyProjection, BoundPrimaryKeyRead, BoundPrimaryKeyReadTarget,
+};
+use crate::sql2::session::PreparedReadSession;
+use crate::{LixError, SqlQueryResult};
+
+use super::datafusion::query_result_from_batches;
+
+/// Execute a primary-key read after binding has committed to the native path.
+///
+/// This function has no unsupported/fallback result: once a provider loader is
+/// entered, every error is returned to the caller. Transaction-overlay reads
+/// cannot call this API because it accepts only the committed read context.
+pub(crate) async fn execute_primary_key_read<C>(
+    ctx: &C,
+    prepared: &PreparedReadSession,
+    read: &BoundPrimaryKeyRead,
+) -> Result<SqlQueryResult, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    let provider_projection = read
+        .projection
+        .iter()
+        .map(|projection| projection.source_index)
+        .collect::<Vec<_>>();
+
+    let batch = match &read.target {
+        BoundPrimaryKeyReadTarget::File { ids } => {
+            crate::sql2::providers::load_active_lix_file_ids(
+                ctx,
+                Arc::clone(&prepared.branch_ref),
+                &provider_projection,
+                ids,
+            )
+            .await?
+        }
+        BoundPrimaryKeyReadTarget::Entity {
+            schema_key, keys, ..
+        } => {
+            let spec = prepared
+                .catalog
+                .entity_spec(schema_key)
+                .cloned()
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "native primary-key read lost entity schema '{schema_key}' after binding"
+                        ),
+                    )
+                })?;
+            let entity_pks = keys
+                .iter()
+                .cloned()
+                .map(EntityPk::from_parts)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "native primary-key binder produced an invalid entity key for '{schema_key}': {error}"
+                        ),
+                    )
+                })?;
+
+            crate::sql2::providers::load_active_entity_pks(
+                ctx,
+                Arc::clone(&prepared.branch_ref),
+                Arc::new(spec),
+                &provider_projection,
+                &entity_pks,
+            )
+            .await?
+        }
+    };
+
+    let result_fields = aliased_result_fields(&batch, &read.projection)?;
+    query_result_from_batches(&result_fields, std::slice::from_ref(&batch))
+}
+
+/// Rename the provider's projected fields without rebuilding their types or
+/// metadata. The metadata is semantically significant: JSON-backed Utf8
+/// columns must still become `Value::Json` after a SQL alias is applied.
+fn aliased_result_fields(
+    batch: &RecordBatch,
+    projection: &[BoundPrimaryKeyProjection],
+) -> Result<Vec<Field>, LixError> {
+    if batch.num_columns() != projection.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "native primary-key provider returned {} columns for a {}-column projection",
+                batch.num_columns(),
+                projection.len()
+            ),
+        ));
+    }
+
+    batch
+        .schema()
+        .fields()
+        .iter()
+        .zip(projection)
+        .map(|(field, projection)| {
+            if field.name() != &projection.source_name {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "native primary-key provider returned column '{}' where '{}' was bound",
+                        field.name(),
+                        projection.source_name
+                    ),
+                ));
+            }
+            Ok(field
+                .as_ref()
+                .clone()
+                .with_name(projection.output_name.clone()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{ArrayRef, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use serde_json::json;
+
+    use crate::Value;
+    use crate::sql2::result_metadata::mark_json_field;
+
+    use super::*;
+
+    #[test]
+    fn aliases_preserve_json_field_metadata_during_result_conversion() {
+        let source_field = mark_json_field(Field::new("payload", DataType::Utf8, true));
+        let source_metadata = source_field.metadata().clone();
+        let values: ArrayRef = Arc::new(StringArray::from(vec![Some(r#"{"ok":true}"#)]));
+        let batch = RecordBatch::try_new(Arc::new(Schema::new(vec![source_field])), vec![values])
+            .expect("test batch");
+        let projection = vec![BoundPrimaryKeyProjection {
+            source_index: 0,
+            source_name: "payload".to_string(),
+            output_name: "document".to_string(),
+        }];
+
+        let fields = aliased_result_fields(&batch, &projection).expect("alias fields");
+
+        assert_eq!(fields[0].name(), "document");
+        assert_eq!(fields[0].data_type(), &DataType::Utf8);
+        assert!(fields[0].is_nullable());
+        assert_eq!(fields[0].metadata(), &source_metadata);
+
+        let result = query_result_from_batches(&fields, &[batch]).expect("convert result");
+        assert_eq!(result.columns, vec!["document"]);
+        assert_eq!(result.rows, vec![vec![Value::Json(json!({ "ok": true }))]]);
+    }
+
+    #[test]
+    fn aliased_fields_reject_provider_projection_drift() {
+        let batch = RecordBatch::new_empty(Arc::new(Schema::new(vec![Field::new(
+            "actual",
+            DataType::Utf8,
+            false,
+        )])));
+        let projection = vec![BoundPrimaryKeyProjection {
+            source_index: 0,
+            source_name: "expected".to_string(),
+            output_name: "alias".to_string(),
+        }];
+
+        let error = aliased_result_fields(&batch, &projection).expect_err("schema must match");
+
+        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+        assert!(error.message.contains("actual"));
+        assert!(error.message.contains("expected"));
+    }
+}

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -31,7 +31,8 @@ use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value};
 
 use crate::sql2::{
-    SqlHistoryQuerySource, SqlWriteContext, WriteAccess, WriteContextLiveStateReader,
+    SqlExecutionContext, SqlHistoryQuerySource, SqlWriteContext, WriteAccess,
+    WriteContextLiveStateReader,
 };
 use crate::transaction::types::{
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteRow,
@@ -47,8 +48,77 @@ use super::spec::{
 };
 use super::values::{
     optional_bool_value, optional_string_value, required_string_value, string_expr_literal,
+    string_in_filter,
 };
 use crate::storage_adapter::StorageAdapterRead;
+
+/// Load active entity rows by exact logical primary key while reusing the
+/// entity provider's branch validation, live-state projection, and Arrow
+/// materialization semantics.
+pub(crate) async fn load_active_entity_pks<C>(
+    ctx: &C,
+    branch_ref: Arc<dyn BranchRefReader>,
+    spec: Arc<EntitySurfaceSpec>,
+    projection: &[usize],
+    entity_pks: &[EntityPk],
+) -> std::result::Result<RecordBatch, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    let primary_key_columns = spec.flat_string_primary_key_columns().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            format!(
+                "native exact-key reads require entity surface '{}' to have a non-empty flat string primary key",
+                spec.schema_key
+            ),
+        )
+    })?;
+    if entity_pks
+        .iter()
+        .any(|entity_pk| entity_pk.parts.len() != primary_key_columns.len())
+    {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            format!(
+                "native exact-key read received an invalid primary-key tuple for entity surface '{}'",
+                spec.schema_key
+            ),
+        ));
+    }
+
+    let schema = entity_surface_schema(&spec, EntitySurfaceShape::Active);
+    let projection = projection.to_vec();
+    if entity_pks.is_empty() {
+        return Ok(RecordBatch::new_empty(projected_schema(
+            &schema,
+            Some(&projection),
+        )));
+    }
+
+    let encoded_pks = entity_pks
+        .iter()
+        .map(EntityPk::as_json_array_text)
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let provider = EntitySpec::active(
+        spec,
+        ctx.live_state(),
+        branch_ref,
+        ctx.active_branch_id().to_string(),
+    );
+    let planned = provider
+        .plan_scan(
+            Some(&projection),
+            &[string_in_filter("lixcol_entity_pk", &encoded_pks)],
+            None,
+            &ExecutionProps::new(),
+        )
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+    (planned.load)()
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
+}
 
 pub(crate) async fn register_entity_providers<S>(
     ctx: &SessionContext,
@@ -673,7 +743,7 @@ fn branch_id_from_column_literal_filter(column_expr: &Expr, literal_expr: &Expr)
 impl<'a> EntityPrimaryKeyFilterAnalyzer<'a> {
     fn new(spec: &'a EntitySurfaceSpec) -> Self {
         Self {
-            primary_key_columns: string_primary_key_columns(spec),
+            primary_key_columns: spec.flat_string_primary_key_columns().unwrap_or_default(),
         }
     }
 
@@ -991,20 +1061,6 @@ fn entity_filter_values_equal(
         ) => *actual as f64 == *expected,
         _ => actual == expected,
     }
-}
-
-fn string_primary_key_columns(spec: &EntitySurfaceSpec) -> Vec<&str> {
-    spec.primary_key_paths
-        .iter()
-        .map(|path| {
-            let [column_name] = path.as_slice() else {
-                return None;
-            };
-            let column = spec.visible_column(column_name)?;
-            (column.column_type == EntityColumnType::String).then_some(column.name.as_str())
-        })
-        .collect::<Option<Vec<_>>>()
-        .unwrap_or_default()
 }
 
 fn entity_pk_constraint_from_binary_filter(

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -84,7 +84,8 @@ use crate::filesystem::{
 use crate::sql2::result_metadata::json_field;
 use crate::sql2::session::SqlWriteSessionOptions;
 use crate::sql2::{
-    SqlWriteContext, SqlWriteExecutionContext, WriteAccess, WriteContextLiveStateReader,
+    SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,
+    WriteContextLiveStateReader,
 };
 use crate::transaction::types::{
     LogicalPrimaryKey, TransactionFileData, TransactionWrite, TransactionWriteMode,
@@ -98,6 +99,49 @@ use super::spec::{
 use super::upsert::{
     StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport, validate_target_columns,
 };
+use super::values::string_in_filter;
+
+/// Load active `lix_file` rows by exact file id while reusing the provider's
+/// path-index, blob, and plugin-rendering lanes.
+pub(crate) async fn load_active_lix_file_ids<C>(
+    ctx: &C,
+    branch_ref: Arc<dyn BranchRefReader>,
+    projection: &[usize],
+    file_ids: &[String],
+) -> std::result::Result<RecordBatch, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    let schema = lix_file_schema();
+    let projection = projection.to_vec();
+    let projected_schema = projected_schema(&schema, Some(&projection))
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+    if file_ids.is_empty() {
+        return Ok(RecordBatch::new_empty(projected_schema));
+    }
+
+    let provider = LixFileSpec::active_branch(
+        ctx.active_branch_id(),
+        ctx.live_state(),
+        ctx.filesystem_path_index(),
+        branch_ref,
+        ctx.blob_reader(),
+        ctx.plugin_host(),
+        ctx.functions(),
+    );
+    let planned = provider
+        .plan_scan(
+            Some(&projection),
+            &[string_in_filter("id", file_ids)],
+            None,
+            &ExecutionProps::new(),
+        )
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+    (planned.load)()
+        .await
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
+}
 
 pub(super) async fn register_lix_file_active_provider(
     session: &SessionContext,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -30,9 +30,10 @@ use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
 use datafusion::catalog::TableProvider;
 
+pub(crate) use entity::load_active_entity_pks;
 pub(crate) use file::{
     FastLixFilePathWriteConflict, execute_fast_lix_file_data_update_by_id,
-    execute_fast_lix_file_path_writes,
+    execute_fast_lix_file_path_writes, load_active_lix_file_ids,
 };
 pub(crate) use spec::DmlReturning;
 pub(crate) use upsert::{UpsertAction, excluded_field_name};
@@ -115,9 +116,27 @@ pub(crate) async fn register_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
+    let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
+    register_read_with_catalog(session, ctx, branch_ref, &catalog).await
+}
+
+/// Register read providers from a catalog the caller has already built.
+///
+/// Exact-primary-key reads inspect the same catalog before deciding whether to
+/// use their narrow provider path. Reusing it on fallback avoids deriving every
+/// public surface twice for candidate-shaped statements that DataFusion must
+/// ultimately execute.
+pub(crate) async fn register_read_with_catalog<C>(
+    session: &SessionContext,
+    ctx: &C,
+    branch_ref: Arc<dyn BranchRefReader>,
+    catalog: &PublicCatalog,
+) -> Result<(), LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
     let history_query_source = ctx.history_query_source();
     let changelog_query_source = ctx.changelog_query_source();
-    let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
     for surface in catalog.surfaces() {
         match &surface.kind {
             PublicSurfaceKind::LixState => {
@@ -247,7 +266,7 @@ where
         Arc::clone(&branch_ref),
         Arc::new(tokio::sync::Mutex::new(ctx.commit_graph())),
         history_query_source,
-        &catalog,
+        catalog,
     )
     .await?;
 

--- a/packages/engine/src/sql2/providers/values.rs
+++ b/packages/engine/src/sql2/providers/values.rs
@@ -4,7 +4,9 @@
 //! are only formatted on the error path.
 
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::common::{Column, DataFusionError, Result, ScalarValue};
+use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::expr::InList;
 
 pub(super) fn required_string_value(
     batch: &RecordBatch,
@@ -88,8 +90,8 @@ pub(super) fn optional_scalar_value(
 
 /// Extract a string literal from a logical expression, shared by the specs
 /// that parse pushed-down filters.
-pub(super) fn string_expr_literal(expr: &datafusion::logical_expr::Expr) -> Option<String> {
-    let datafusion::logical_expr::Expr::Literal(literal, _) = expr else {
+pub(super) fn string_expr_literal(expr: &Expr) -> Option<String> {
+    let Expr::Literal(literal, _) = expr else {
         return None;
     };
     match literal {
@@ -98,4 +100,18 @@ pub(super) fn string_expr_literal(expr: &datafusion::logical_expr::Expr) -> Opti
         | ScalarValue::LargeUtf8(Some(value)) => Some(value.clone()),
         _ => None,
     }
+}
+
+/// Build the exact string `IN` predicate understood by the file and entity
+/// provider filter analyzers.
+pub(super) fn string_in_filter(column_name: &str, values: &[String]) -> Expr {
+    Expr::InList(InList::new(
+        Box::new(Expr::Column(Column::from_name(column_name))),
+        values
+            .iter()
+            .cloned()
+            .map(|value| Expr::Literal(ScalarValue::Utf8(Some(value)), None))
+            .collect(),
+        false,
+    ))
 }

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -6,23 +6,57 @@ use crate::LixError;
 use crate::branch::BranchRefReader;
 
 use super::branch_ref::CachingBranchRefReader;
+use super::catalog::PublicCatalog;
 use super::providers;
 use super::udfs::register_sql2_functions;
 use super::{SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext};
 
-pub(crate) async fn build_read_session<C>(ctx: &C) -> Result<SessionContext, LixError>
+pub(crate) struct PreparedReadSession {
+    pub(crate) branch_ref: Arc<dyn BranchRefReader>,
+    pub(crate) active_branch_commit_id: Option<String>,
+    pub(crate) catalog: Arc<PublicCatalog>,
+}
+
+pub(crate) async fn prepare_read_session<C>(ctx: &C) -> Result<PreparedReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let session = new_sql_session_context();
     let branch_ref: Arc<dyn BranchRefReader> =
         Arc::new(CachingBranchRefReader::new(ctx.branch_ref()));
     let active_branch_commit_id = branch_ref
         .load_head(ctx.active_branch_id())
         .await?
         .map(|head| head.commit_id.to_string());
-    register_sql2_functions(&session, ctx.functions(), active_branch_commit_id);
-    providers::register_read(&session, ctx, branch_ref).await?;
+    let catalog = Arc::new(PublicCatalog::from_visible_schemas(
+        &ctx.list_visible_schemas()?,
+    )?);
+    Ok(PreparedReadSession {
+        branch_ref,
+        active_branch_commit_id,
+        catalog,
+    })
+}
+
+pub(crate) async fn build_read_session_from_prepared<C>(
+    ctx: &C,
+    prepared: &PreparedReadSession,
+) -> Result<SessionContext, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    let session = new_sql_session_context();
+    register_sql2_functions(
+        &session,
+        ctx.functions(),
+        prepared.active_branch_commit_id.clone(),
+    );
+    providers::register_read_with_catalog(
+        &session,
+        ctx,
+        Arc::clone(&prepared.branch_ref),
+        prepared.catalog.as_ref(),
+    )
+    .await?;
 
     Ok(session)
 }

--- a/packages/engine/tests/code_structure.rs
+++ b/packages/engine/tests/code_structure.rs
@@ -2743,11 +2743,15 @@ fn sql2_read_session_does_not_register_write_surfaces() {
     let read_session = source_between(
         relative,
         &source,
-        "pub(crate) async fn build_read_session",
+        "pub(crate) async fn build_read_session_from_prepared",
         "pub(crate) async fn build_transaction_read_session",
     );
 
-    assert_source_contains_all(relative, read_session, &["providers::register_read"]);
+    assert_source_contains_all(
+        relative,
+        read_session,
+        &["providers::register_read_with_catalog"],
+    );
     assert_source_contains_none(
         relative,
         read_session,

--- a/packages/engine/tests/native_pk_select_perf.rs
+++ b/packages/engine/tests/native_pk_select_perf.rs
@@ -1,0 +1,827 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use lix_engine::storage::{
+    GetManyResult, GetOptions, Key, KeyRange, Memory, MemoryRead, MemoryWrite, ReadOptions,
+    ScanChunk, ScanOptions, SpaceId, Storage, StorageError, StorageRead, WriteOptions,
+};
+use lix_engine::{Engine, ExecuteResult, SessionContext, Value};
+use serde::Serialize;
+
+const PREFIX: &str = "LIX_NATIVE_PK_SELECT_PERF_";
+const CANONICAL_SEED_ID: &str = "native-primary-key-select-v1";
+const DEFAULT_ROWS: usize = 10_000;
+const DEFAULT_WARMUPS: usize = 10;
+const DEFAULT_SAMPLES: usize = 100;
+const DEFAULT_CHUNK_SIZE: usize = 500;
+const FILE_DATA: &[u8] = b"native-primary-key-file-payload";
+
+const CASES: [Case; 9] = [
+    Case::new("entity_equality", Surface::Entity, 1),
+    Case::new("entity_in_10", Surface::Entity, 10),
+    Case::new("entity_in_100", Surface::Entity, 100),
+    Case::new("file_descriptor_equality", Surface::FileDescriptor, 1),
+    Case::new("file_descriptor_in_10", Surface::FileDescriptor, 10),
+    Case::new("file_descriptor_in_100", Surface::FileDescriptor, 100),
+    Case::new("file_data_equality", Surface::FileData, 1),
+    Case::new("file_data_in_10", Surface::FileData, 10),
+    Case::new("file_data_in_100", Surface::FileData, 100),
+];
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "manual release-mode performance harness"]
+async fn native_primary_key_select_perf() {
+    let config = Config::from_env();
+    let cases = selected_cases(&config.case_filter);
+    assert!(
+        cases.iter().all(|case| case.rows <= config.rows),
+        "selected cases must request at most {} rows",
+        config.rows
+    );
+    if config.profile.is_some() {
+        assert_eq!(cases.len(), 1, "profile mode requires exactly one case");
+    }
+
+    let fixtures = Fixtures::new(config.rows);
+    let snapshot = prepare_snapshot(&config, &fixtures).await;
+    let seed = SeedMetadata {
+        canonical_seed_id: CANONICAL_SEED_ID,
+        rows_per_surface: config.rows,
+        snapshot_bytes: snapshot.len(),
+        snapshot_blake3: blake3::hash(&snapshot).to_hex().to_string(),
+    };
+
+    let (measurements, profile) = match config.profile.as_ref() {
+        Some(profile) => (
+            Vec::new(),
+            Some(
+                profile_case(
+                    &snapshot,
+                    &fixtures,
+                    config.route,
+                    cases[0],
+                    config.warmups,
+                    profile,
+                )
+                .await,
+            ),
+        ),
+        None => {
+            let mut measurements = Vec::with_capacity(cases.len());
+            for case in cases {
+                measurements.push(
+                    measure_case(
+                        &snapshot,
+                        &fixtures,
+                        config.route,
+                        case,
+                        config.warmups,
+                        config.samples,
+                    )
+                    .await,
+                );
+            }
+            (measurements, None)
+        }
+    };
+
+    let report_output_path = config.report_output_path.clone();
+    let report = serde_json::to_string_pretty(&Report {
+        benchmark: "native_primary_key_select",
+        report_version: 1,
+        build: BuildMetadata {
+            debug_assertions: cfg!(debug_assertions),
+            build_id: env_value("BUILD_ID"),
+        },
+        seed,
+        config,
+        measurements,
+        profile,
+    })
+    .expect("report should serialize");
+    if let Some(path) = report_output_path {
+        fs::write(path, &report).expect("performance report should be writable");
+    }
+    println!("{report}");
+}
+
+#[derive(Debug, Serialize)]
+struct Config {
+    rows: usize,
+    case_filter: String,
+    route: Route,
+    warmups: usize,
+    samples: usize,
+    setup_chunk_size: usize,
+    seed_input_path: Option<PathBuf>,
+    seed_output_path: Option<PathBuf>,
+    report_output_path: Option<PathBuf>,
+    profile: Option<ProfileConfig>,
+    allow_debug: bool,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        let allow_debug = env_value("ALLOW_DEBUG").as_deref() == Some("1");
+        assert!(
+            !cfg!(debug_assertions) || allow_debug,
+            "performance measurements require --release; set {PREFIX}ALLOW_DEBUG=1 only for smoke validation"
+        );
+        let config = Self {
+            rows: usize_env("ROWS", DEFAULT_ROWS),
+            case_filter: env_value("CASES").unwrap_or_else(|| "all".to_string()),
+            route: Route::from_env(),
+            warmups: usize_env("WARMUPS", DEFAULT_WARMUPS),
+            samples: usize_env("SAMPLES", DEFAULT_SAMPLES),
+            setup_chunk_size: usize_env("SETUP_CHUNK_SIZE", DEFAULT_CHUNK_SIZE),
+            seed_input_path: path_env("SEED_INPUT_PATH"),
+            seed_output_path: path_env("SEED_OUTPUT_PATH"),
+            report_output_path: path_env("REPORT_OUTPUT_PATH"),
+            profile: ProfileConfig::from_env(),
+            allow_debug,
+        };
+        assert!(config.rows > 0, "{PREFIX}ROWS must be positive");
+        assert!(config.samples > 0, "{PREFIX}SAMPLES must be positive");
+        assert!(
+            config.setup_chunk_size > 0,
+            "{PREFIX}SETUP_CHUNK_SIZE must be positive"
+        );
+        config
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+enum Route {
+    #[serde(rename = "auto")]
+    Auto,
+}
+
+impl Route {
+    fn from_env() -> Self {
+        match env_value("ROUTE").as_deref().unwrap_or("auto") {
+            "auto" => Self::Auto,
+            route => panic!("unsupported {PREFIX}ROUTE {route:?}; supported route: auto"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileConfig {
+    ready_path: PathBuf,
+    go_path: PathBuf,
+    done_path: PathBuf,
+    acknowledged_path: PathBuf,
+    iterations: usize,
+}
+
+impl ProfileConfig {
+    fn from_env() -> Option<Self> {
+        let ready_path = path_env("PROFILE_READY_PATH");
+        let go_path = path_env("PROFILE_GO_PATH");
+        let done_path = path_env("PROFILE_DONE_PATH");
+        let acknowledged_path = path_env("PROFILE_ACKNOWLEDGED_PATH");
+        let iterations = env_value("PROFILE_ITERATIONS");
+        if ready_path.is_none()
+            && go_path.is_none()
+            && done_path.is_none()
+            && acknowledged_path.is_none()
+            && iterations.is_none()
+        {
+            return None;
+        }
+        let config = Self {
+            ready_path: ready_path.expect("profile mode requires PROFILE_READY_PATH"),
+            go_path: go_path.expect("profile mode requires PROFILE_GO_PATH"),
+            done_path: done_path.expect("profile mode requires PROFILE_DONE_PATH"),
+            acknowledged_path: acknowledged_path
+                .expect("profile mode requires PROFILE_ACKNOWLEDGED_PATH"),
+            iterations: iterations
+                .expect("profile mode requires PROFILE_ITERATIONS")
+                .parse()
+                .expect("PROFILE_ITERATIONS must be an unsigned integer"),
+        };
+        assert!(config.iterations > 0, "PROFILE_ITERATIONS must be positive");
+        let paths = [
+            &config.ready_path,
+            &config.go_path,
+            &config.done_path,
+            &config.acknowledged_path,
+        ];
+        for (index, left) in paths.iter().enumerate() {
+            assert!(
+                paths[index + 1..].iter().all(|right| left != right),
+                "profile paths must all differ"
+            );
+        }
+        Some(config)
+    }
+}
+
+fn env_value(suffix: &str) -> Option<String> {
+    env::var(format!("{PREFIX}{suffix}"))
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+fn usize_env(suffix: &str, default: usize) -> usize {
+    env_value(suffix).map_or(default, |value| {
+        value
+            .parse()
+            .unwrap_or_else(|error| panic!("{PREFIX}{suffix} must be an unsigned integer: {error}"))
+    })
+}
+
+fn path_env(suffix: &str) -> Option<PathBuf> {
+    env_value(suffix).map(PathBuf::from)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Case {
+    name: &'static str,
+    surface: Surface,
+    rows: usize,
+}
+
+impl Case {
+    const fn new(name: &'static str, surface: Surface, rows: usize) -> Self {
+        Self {
+            name,
+            surface,
+            rows,
+        }
+    }
+
+    fn query(self, fixtures: &Fixtures) -> Query {
+        let all_ids = match self.surface {
+            Surface::Entity => &fixtures.entity_ids,
+            Surface::FileDescriptor | Surface::FileData => &fixtures.file_ids,
+        };
+        let ids = spread_ids(all_ids, self.rows);
+        let (table, projection) = match self.surface {
+            Surface::Entity => ("perf_item", "id, payload"),
+            Surface::FileDescriptor => ("lix_file", "id, path"),
+            Surface::FileData => ("lix_file", "id, data"),
+        };
+        let predicate = if self.rows == 1 {
+            "id = $1".to_string()
+        } else {
+            let placeholders = (1..=self.rows)
+                .map(|index| format!("${index}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("id IN ({placeholders})")
+        };
+        Query {
+            sql: format!("SELECT {projection} FROM {table} WHERE {predicate}"),
+            params: ids.iter().cloned().map(Value::Text).collect(),
+            expected_ids: ids,
+        }
+    }
+}
+
+fn spread_ids(ids: &[String], count: usize) -> Vec<String> {
+    assert!(count > 0 && count <= ids.len());
+    if count == 1 {
+        return vec![ids[ids.len() / 2].clone()];
+    }
+    (0..count)
+        .map(|index| ids[index * (ids.len() - 1) / (count - 1)].clone())
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Surface {
+    Entity,
+    FileDescriptor,
+    FileData,
+}
+
+fn selected_cases(filter: &str) -> Vec<Case> {
+    if filter == "all" {
+        return CASES.to_vec();
+    }
+    let names = filter
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .collect::<BTreeSet<_>>();
+    assert!(!names.is_empty(), "{PREFIX}CASES must not be empty");
+    let selected = CASES
+        .iter()
+        .copied()
+        .filter(|case| names.contains(case.name))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        selected.len(),
+        names.len(),
+        "{PREFIX}CASES contains an unknown case; valid cases: {}",
+        CASES
+            .iter()
+            .map(|case| case.name)
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    selected
+}
+
+struct Fixtures {
+    entity_ids: Vec<String>,
+    file_ids: Vec<String>,
+}
+
+impl Fixtures {
+    fn new(rows: usize) -> Self {
+        Self {
+            entity_ids: (0..rows)
+                .map(|index| format!("perf-entity-{index:08}"))
+                .collect(),
+            file_ids: (0..rows)
+                .map(|index| format!("perf-file-{index:08}"))
+                .collect(),
+        }
+    }
+}
+
+struct Query {
+    sql: String,
+    params: Vec<Value>,
+    expected_ids: Vec<String>,
+}
+
+async fn prepare_snapshot(config: &Config, fixtures: &Fixtures) -> Vec<u8> {
+    let snapshot = match config.seed_input_path.as_ref() {
+        Some(path) => fs::read(path).expect("seed snapshot should be readable"),
+        None => seed_snapshot(config, fixtures).await,
+    };
+    validate_snapshot(&snapshot, config.rows).await;
+    if let Some(path) = config.seed_output_path.as_ref() {
+        fs::write(path, &snapshot).expect("seed snapshot should be writable");
+    }
+    snapshot
+}
+
+async fn seed_snapshot(config: &Config, fixtures: &Fixtures) -> Vec<u8> {
+    let storage = CountingStorage::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("benchmark storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("session should open");
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (\
+             lix_json('{\"x-lix-key\":\"perf_item\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"payload\":{\"type\":\"string\"}},\"required\":[\"id\",\"payload\"],\"additionalProperties\":false}'),\
+             false, false)",
+            &[],
+        )
+        .await
+        .expect("perf_item schema should register");
+
+    for ids in fixtures.entity_ids.chunks(config.setup_chunk_size) {
+        let values = ids
+            .iter()
+            .map(|id| format!("('{id}', '{}')", entity_payload(id)))
+            .collect::<Vec<_>>()
+            .join(",");
+        insert_rows(&session, "perf_item", "id, payload", values, ids.len()).await;
+    }
+    let data_hex = FILE_DATA
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    for ids in fixtures.file_ids.chunks(config.setup_chunk_size) {
+        let values = ids
+            .iter()
+            .map(|id| format!("('{id}', '{}', X'{data_hex}')", file_path(id)))
+            .collect::<Vec<_>>()
+            .join(",");
+        insert_rows(&session, "lix_file", "id, path, data", values, ids.len()).await;
+    }
+    session.close().await.expect("setup session should close");
+    storage.export_snapshot().expect("seed should export")
+}
+
+async fn insert_rows(
+    session: &SessionContext<CountingStorage>,
+    table: &str,
+    columns: &str,
+    values: String,
+    expected: usize,
+) {
+    let result = session
+        .execute(
+            &format!("INSERT INTO {table} ({columns}) VALUES {values}"),
+            &[],
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{table} setup insert should succeed: {error}"));
+    assert_eq!(
+        usize::try_from(result.rows_affected()).expect("row count should fit usize"),
+        expected
+    );
+}
+
+async fn validate_snapshot(snapshot: &[u8], expected: usize) {
+    let (_, session) = open_case(snapshot).await;
+    for table in ["perf_item", "lix_file"] {
+        let rows = session
+            .execute(&format!("SELECT id FROM {table}"), &[])
+            .await
+            .unwrap_or_else(|error| panic!("{table} seed should be readable: {error}"));
+        assert_eq!(rows.len(), expected, "unexpected {table} seed row count");
+    }
+    session
+        .close()
+        .await
+        .expect("validation session should close");
+}
+
+fn entity_payload(id: &str) -> String {
+    format!("payload-{}", suffix(id))
+}
+
+fn file_path(id: &str) -> String {
+    format!("/bench/{}.bin", suffix(id))
+}
+
+fn suffix(id: &str) -> &str {
+    id.rsplit_once('-')
+        .expect("fixture id should have suffix")
+        .1
+}
+
+async fn open_case(snapshot: &[u8]) -> (CountingStorage, SessionContext<CountingStorage>) {
+    let storage = CountingStorage::from_snapshot(snapshot).expect("seed should reopen");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("session should open");
+    (storage, session)
+}
+
+async fn execute_query(
+    session: &SessionContext<CountingStorage>,
+    route: Route,
+    query: &Query,
+) -> ExecuteResult {
+    // Future native routes only need another arm here; cases and evidence stay identical.
+    match route {
+        Route::Auto => session
+            .execute(&query.sql, &query.params)
+            .await
+            .expect("primary-key SELECT should succeed"),
+    }
+}
+
+async fn measure_case(
+    snapshot: &[u8],
+    fixtures: &Fixtures,
+    route: Route,
+    case: Case,
+    warmups: usize,
+    samples: usize,
+) -> Measurement {
+    let query = case.query(fixtures);
+    let (storage, session) = open_case(snapshot).await;
+    for _ in 0..warmups {
+        validate(case, &query, &execute_query(&session, route, &query).await);
+    }
+    let mut observations = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let before = storage.stats();
+        let started = Instant::now();
+        let result = execute_query(&session, route, &query).await;
+        let row_count = std::hint::black_box(result.len());
+        drop(result);
+        let duration_ns = elapsed_ns(started);
+        let storage = storage.stats().delta_since(before);
+        assert_eq!(row_count, case.rows, "unexpected timed SELECT row count");
+        observations.push(Observation {
+            duration_ns,
+            storage,
+        });
+    }
+    validate(case, &query, &execute_query(&session, route, &query).await);
+    session.close().await.expect("case session should close");
+    Measurement::new(case, route, query.sql, observations)
+}
+
+async fn profile_case(
+    snapshot: &[u8],
+    fixtures: &Fixtures,
+    route: Route,
+    case: Case,
+    warmups: usize,
+    profile: &ProfileConfig,
+) -> ProfileMeasurement {
+    let query = case.query(fixtures);
+    let (storage, session) = open_case(snapshot).await;
+    for _ in 0..warmups {
+        validate(case, &query, &execute_query(&session, route, &query).await);
+    }
+    assert!(!profile.ready_path.exists(), "remove stale ready marker");
+    assert!(!profile.go_path.exists(), "remove stale go marker");
+    assert!(!profile.done_path.exists(), "remove stale done marker");
+    assert!(
+        !profile.acknowledged_path.exists(),
+        "remove stale acknowledged marker"
+    );
+    fs::write(&profile.ready_path, format!("{}\n", std::process::id()))
+        .expect("ready marker should be writable");
+    while !profile.go_path.exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let before = storage.stats();
+    let started = Instant::now();
+    let mut row_count = 0;
+    for _ in 0..profile.iterations {
+        let result = execute_query(&session, route, &query).await;
+        row_count = std::hint::black_box(result.len());
+        drop(result);
+    }
+    let duration_ns = elapsed_ns(started);
+    let storage = storage.stats().delta_since(before);
+    assert_eq!(row_count, case.rows, "unexpected profiled SELECT row count");
+    fs::write(&profile.done_path, format!("{}\n", std::process::id()))
+        .expect("done marker should be writable");
+    while !profile.acknowledged_path.exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    validate(case, &query, &execute_query(&session, route, &query).await);
+    session.close().await.expect("profile session should close");
+    ProfileMeasurement {
+        case: case.name,
+        route,
+        sql: query.sql,
+        row_count: case.rows,
+        iterations: profile.iterations,
+        duration_ns,
+        storage,
+    }
+}
+
+fn validate(case: Case, query: &Query, result: &ExecuteResult) {
+    assert_eq!(result.len(), case.rows, "unexpected SELECT row count");
+    let expected = query
+        .expected_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let mut seen = BTreeSet::new();
+    for row in result.rows() {
+        let [Value::Text(id), value] = row.values() else {
+            panic!(
+                "expected [text id, projected value], got {:?}",
+                row.values()
+            );
+        };
+        assert!(expected.contains(id.as_str()), "unexpected id {id}");
+        assert!(seen.insert(id.as_str()), "duplicate id {id}");
+        let expected_value = match case.surface {
+            Surface::Entity => Value::Text(entity_payload(id)),
+            Surface::FileDescriptor => Value::Text(file_path(id)),
+            Surface::FileData => Value::Blob(FILE_DATA.to_vec()),
+        };
+        assert_eq!(value, &expected_value, "unexpected value for {id}");
+    }
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).expect("duration should fit u64")
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    benchmark: &'static str,
+    report_version: u32,
+    build: BuildMetadata,
+    seed: SeedMetadata,
+    config: Config,
+    measurements: Vec<Measurement>,
+    profile: Option<ProfileMeasurement>,
+}
+
+#[derive(Debug, Serialize)]
+struct BuildMetadata {
+    debug_assertions: bool,
+    build_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SeedMetadata {
+    canonical_seed_id: &'static str,
+    rows_per_surface: usize,
+    snapshot_bytes: usize,
+    snapshot_blake3: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct Observation {
+    duration_ns: u64,
+    storage: StorageStats,
+}
+
+#[derive(Debug, Serialize)]
+struct Measurement {
+    case: &'static str,
+    route: Route,
+    sql: String,
+    row_count: usize,
+    duration_ns: Percentiles,
+    storage_per_sample: StoragePercentiles,
+    raw_observations: Vec<Observation>,
+}
+
+impl Measurement {
+    fn new(case: Case, route: Route, sql: String, observations: Vec<Observation>) -> Self {
+        Self {
+            case: case.name,
+            route,
+            sql,
+            row_count: case.rows,
+            duration_ns: percentiles(&observations, |item| item.duration_ns),
+            storage_per_sample: StoragePercentiles {
+                begin_read_calls: percentiles(&observations, |item| item.storage.begin_read_calls),
+                get_many_calls: percentiles(&observations, |item| item.storage.get_many_calls),
+                get_many_requested_keys: percentiles(&observations, |item| {
+                    item.storage.get_many_requested_keys
+                }),
+                scan_calls: percentiles(&observations, |item| item.storage.scan_calls),
+            },
+            raw_observations: observations,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileMeasurement {
+    case: &'static str,
+    route: Route,
+    sql: String,
+    row_count: usize,
+    iterations: usize,
+    duration_ns: u64,
+    storage: StorageStats,
+}
+
+#[derive(Debug, Serialize)]
+struct StoragePercentiles {
+    begin_read_calls: Percentiles,
+    get_many_calls: Percentiles,
+    get_many_requested_keys: Percentiles,
+    scan_calls: Percentiles,
+}
+
+#[derive(Debug, Serialize)]
+struct Percentiles {
+    p50: u64,
+    p95: u64,
+}
+
+fn percentiles(observations: &[Observation], value: fn(&Observation) -> u64) -> Percentiles {
+    let mut values = observations.iter().map(value).collect::<Vec<_>>();
+    values.sort_unstable();
+    let nearest = |percentile: usize| {
+        let rank = (values.len() * percentile).div_ceil(100);
+        values[rank.saturating_sub(1)]
+    };
+    Percentiles {
+        p50: nearest(50),
+        p95: nearest(95),
+    }
+}
+
+#[derive(Clone, Default)]
+struct CountingStorage {
+    inner: Memory,
+    counters: Arc<StorageCounters>,
+}
+
+impl CountingStorage {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn from_snapshot(snapshot: &[u8]) -> Result<Self, StorageError> {
+        Ok(Self {
+            inner: Memory::from_snapshot(snapshot)?,
+            counters: Arc::new(StorageCounters::default()),
+        })
+    }
+
+    fn export_snapshot(&self) -> Result<Vec<u8>, StorageError> {
+        self.inner.export_snapshot()
+    }
+
+    fn stats(&self) -> StorageStats {
+        self.counters.snapshot()
+    }
+}
+
+struct CountingRead {
+    inner: MemoryRead,
+    counters: Arc<StorageCounters>,
+}
+
+impl Storage for CountingStorage {
+    type Read<'a>
+        = CountingRead
+    where
+        Self: 'a;
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        self.counters
+            .begin_read_calls
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(CountingRead {
+            inner: self.inner.begin_read(opts).await?,
+            counters: Arc::clone(&self.counters),
+        })
+    }
+
+    async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(opts).await
+    }
+}
+
+impl StorageRead for CountingRead {
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        self.counters.get_many_calls.fetch_add(1, Ordering::Relaxed);
+        self.counters.get_many_requested_keys.fetch_add(
+            u64::try_from(keys.len()).expect("key count should fit u64"),
+            Ordering::Relaxed,
+        );
+        self.inner.get_many(space, keys, opts).await
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        self.counters.scan_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.scan(space, range, opts).await
+    }
+}
+
+#[derive(Default)]
+struct StorageCounters {
+    begin_read_calls: AtomicU64,
+    get_many_calls: AtomicU64,
+    get_many_requested_keys: AtomicU64,
+    scan_calls: AtomicU64,
+}
+
+impl StorageCounters {
+    fn snapshot(&self) -> StorageStats {
+        StorageStats {
+            begin_read_calls: self.begin_read_calls.load(Ordering::Relaxed),
+            get_many_calls: self.get_many_calls.load(Ordering::Relaxed),
+            get_many_requested_keys: self.get_many_requested_keys.load(Ordering::Relaxed),
+            scan_calls: self.scan_calls.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+struct StorageStats {
+    begin_read_calls: u64,
+    get_many_calls: u64,
+    get_many_requested_keys: u64,
+    scan_calls: u64,
+}
+
+impl StorageStats {
+    fn delta_since(self, before: Self) -> Self {
+        Self {
+            begin_read_calls: self.begin_read_calls - before.begin_read_calls,
+            get_many_calls: self.get_many_calls - before.get_many_calls,
+            get_many_requested_keys: self.get_many_requested_keys - before.get_many_requested_keys,
+            scan_calls: self.scan_calls - before.scan_calls,
+        }
+    }
+}


### PR DESCRIPTION
## Hypothesis

The common exact-primary-key `SELECT` path pays DataFusion's catalog registration, logical planning, optimization, and physical planning costs even though Lix providers already know how to load exact file IDs and entity PKs. A strict native binder should remove that fixed CPU cost without changing storage behavior.

This PR is independent and based directly on `origin/main` at `78398a8b`.

## What changed

- Add a pure `Declined | Ready` binder for one active `lix_file` or typed entity surface.
- Accept only explicit column projections and AND trees of `=` / non-negated `IN` over the complete primary key.
- Support reversed equality, text literals, `$N` text parameters, intersections, deduplication, aliases, and flat-string composite PKs up to 4,096 expanded keys.
- Reuse one prepared public catalog and cached branch reader for native execution or DataFusion fallback.
- Reuse the existing file/entity provider `plan_scan` and `load` implementations, preserving branch validation, global overlays, path-index selection, blob reads, plugin rendering, and Arrow metadata.
- Preserve JSON field metadata through aliases.
- Keep transaction-overlay reads on DataFusion.
- Make fallback possible only before provider I/O; loader errors never trigger a second execution.
- Include an ignored, release-only benchmark with deterministic 10k-row snapshot export/import, raw samples, p50/p95, storage counters, build provenance, and gated profiling markers.

Complex SQL, partial/non-string/nested PKs, non-text parameters, contradictions, wildcard/expression projections, OR/residual predicates, by-branch/history surfaces, joins, CTEs, ordering, limits, grouping, and oversized products deliberately remain on DataFusion.

## Release evidence

CPU 4, in-memory storage, exact 7,925,508-byte snapshot, BLAKE3 `56b43e134ba610d7c5e7cae9daa799d71f914b7f1c90c1b0d02ecb7be2a20308`, 10 warmups, 100 raw samples/case. Baseline `0040e220` contains only the benchmark; candidate is `df9fc9e4`.

| Case | Baseline p50 / p95 | Candidate p50 / p95 | Speedup p50 / p95 |
| --- | ---: | ---: | ---: |
| Entity `=` | 3.091 / 3.201 ms | 2.589 / 2.723 ms | 1.194x / 1.175x |
| Entity `IN 10` | 3.639 / 3.796 ms | 3.080 / 3.225 ms | 1.182x / 1.177x |
| Entity `IN 100` | 8.504 / 8.933 ms | 7.473 / 7.703 ms | 1.138x / 1.160x |
| File descriptor `=` | 1.810 / 1.901 ms | 1.054 / 1.131 ms | 1.718x / 1.681x |
| File descriptor `IN 10` | 2.156 / 2.253 ms | 1.335 / 1.434 ms | 1.616x / 1.572x |
| File descriptor `IN 100` | 3.095 / 3.213 ms | 1.864 / 1.962 ms | 1.660x / 1.637x |
| File data `=` | 1.939 / 2.056 ms | 1.171 / 1.251 ms | 1.656x / 1.644x |
| File data `IN 10` | 3.157 / 3.314 ms | 2.306 / 2.478 ms | 1.369x / 1.337x |
| File data `IN 100` | 10.814 / 11.321 ms | 9.832 / 10.252 ms | 1.100x / 1.104x |

All nine storage-counter distributions are identical before/after. For entity equality that is 2 `begin_read`, 27 `get_many` calls / 86 requested keys, and 4 scans per query. The narrowing gain at 100 blobs shows the intended fixed-cost behavior rather than hidden I/O reduction.

## Profile evidence

Matched `perf record -e cycles:u -F 997 -g --call-graph dwarf,16384`, 4,000 entity-equality queries, explicit ready/go/done/ack boundaries, zero lost samples:

- sampled cycles/query: 9.559M -> 7.914M (`-17.2%`)
- profiled loop: 13.253 s -> 11.071 s (`-16.5%`)
- storage totals remained exactly 8,000 reads, 108,000 `get_many` calls / 344,000 keys, and 16,000 scans

The candidate flame graph is correspondingly more concentrated in tracked-state decoding/traversal and allocation: the useful provider/storage work is now the floor.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lix_engine --lib -- -D warnings`
- 8/8 native binder/executor tests
- native-vs-forced-DataFusion differential test for file descriptors/blobs and composite entity PKs/aliased JSON
- public-path nine-case smoke
- `cargo test -p lix_engine`: full package green, including 1,022 unit tests, 546 SQL simulation/conformance tests, storage/transaction tests, and doctests
- matched release benchmark and cycle profiles above

## Deliberate 10% exclusions

- no direct storage loader in v1; the existing provider path remains the semantic authority
- no native transaction-overlay reads
- no alternate SQL string literal syntaxes beyond ordinary single-quoted text
- no attempt to cache catalogs or prepared SQL across calls in this PR
- no native empty-intersection result, preserving current active-branch/error ordering through fallback
