### PR TITLE
perf(js-sdk): cache plugin preparation across opens

### DIFF
--- a/.changenotes/cache-js-plugin-components.md
+++ b/.changenotes/cache-js-plugin-components.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Repeated JavaScript SDK opens now reuse prepared WebAssembly plugins.
+
+Lix keeps a bounded plugin preparation cache while preserving a fresh isolated plugin instance for every open.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -51,6 +51,7 @@
 		"build:wasm": "node ./scripts/build-wasm.js",
 		"build:wasm:dev": "LIX_WASM_PROFILE=dev node ./scripts/build-wasm.js",
 		"build:plugins": "node ./scripts/build-bundled-plugins.js",
+		"benchmark:plugin-reopen": "node ./scripts/benchmark-plugin-reopen.mjs",
 		"clean": "node ./scripts/clean.js",
 		"prepare:native-package": "node ./scripts/prepare-native-package.js",
 		"build:ts": "tsc -p tsconfig.json",

--- a/packages/js-sdk/scripts/benchmark-plugin-reopen.mjs
+++ b/packages/js-sdk/scripts/benchmark-plugin-reopen.mjs
@@ -1,0 +1,64 @@
+import { performance } from "node:perf_hooks";
+
+import { bundledPluginArchives, openLix } from "../dist/index.js";
+
+const warmupIterations = Number(process.env.WARMUP_ITERATIONS ?? 2);
+const measuredIterations = Number(process.env.MEASURED_ITERATIONS ?? 12);
+const archives = await bundledPluginArchives();
+const csvPlugin = archives.find((plugin) => plugin.key === "plugin_csv");
+if (!csvPlugin) throw new Error("expected bundled CSV plugin");
+
+for (let index = 0; index < warmupIterations; index += 1) {
+	await runCycle(index);
+}
+
+const durations = [];
+for (let index = 0; index < measuredIterations; index += 1) {
+	const start = performance.now();
+	await runCycle(index);
+	durations.push(performance.now() - start);
+}
+
+console.log(
+	JSON.stringify(
+		{
+			warmupIterations,
+			measuredIterations,
+			p50Ms: percentile(durations, 0.5),
+			p95Ms: percentile(durations, 0.95),
+			minMs: Math.min(...durations),
+			maxMs: Math.max(...durations),
+			durationsMs: durations,
+		},
+		null,
+		2,
+	),
+);
+
+async function runCycle(index) {
+	const lix = await openLix();
+	try {
+		await lix.execute(
+			"INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+			[`/.lix/plugins/${csvPlugin.key}.lixplugin`, csvPlugin.archiveBytes],
+		);
+		await lix.execute(
+			"INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+			[
+				`/benchmark-${index}.csv`,
+				new TextEncoder().encode("name,age\nAda,36\nGrace,37\n"),
+			],
+		);
+		const result = await lix.execute("SELECT count(*) AS count FROM csv_row");
+		if (result.rows[0]?.get("count") !== 3) {
+			throw new Error("CSV plugin benchmark returned unexpected rows");
+		}
+	} finally {
+		await lix.close();
+	}
+}
+
+function percentile(values, quantile) {
+	const sorted = [...values].sort((left, right) => left - right);
+	return sorted[Math.ceil(sorted.length * quantile) - 1];
+}

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -174,6 +174,18 @@ test("committed writes survive close and reopen", async () => {
 	await second.close();
 });
 
+test("a closed handle stays closed after its worker is reused", async () => {
+	const first = await openLix();
+	await first.close();
+
+	const second = await openLix();
+	await expect(first.execute("SELECT 1")).rejects.toMatchObject({
+		code: "LIX_ERROR_CLOSED",
+	});
+	expect(get(await second.execute("SELECT 1 AS ok"), "ok")).toBe(1);
+	await second.close();
+});
+
 test("observe close reliably resolves pending next calls", async () => {
 	const lix = await openLix();
 

--- a/packages/js-sdk/src/plugin-runtime.test.ts
+++ b/packages/js-sdk/src/plugin-runtime.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+const { transpileBytes } = vi.hoisted(() => ({
+	transpileBytes: vi.fn(),
+}));
+
+vi.mock("#jco-transpile", () => ({ transpileBytes }));
+
+import { createPluginRuntimeDispatch } from "./plugin-runtime.js";
+
+const generatedModule = new TextEncoder().encode(`
+	let instanceCount = 0;
+	export async function instantiate(getCoreModule) {
+		await getCoreModule("core.wasm");
+		const instance = ++instanceCount;
+		return {
+			api: {
+				detectChanges() { return []; },
+				render() { return new Uint8Array([instance]); },
+			},
+		};
+	}
+`);
+const emptyWasmModule = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+
+beforeEach(() => {
+	transpileBytes.mockReset();
+	transpileBytes.mockResolvedValue({
+		files: {
+			"lix_plugin.js": generatedModule,
+			"core.wasm": emptyWasmModule,
+		},
+	});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+test("shares singleflight preparation while keeping plugin instances fresh", async () => {
+	const compile = vi.spyOn(WebAssembly, "compile");
+	const componentBytes = new Uint8Array([1, 2, 3, 4]);
+	const firstRuntime = createPluginRuntimeDispatch();
+	const secondRuntime = createPluginRuntimeDispatch();
+
+	const [first, second] = await Promise.all([
+		firstRuntime({ operation: "initComponent", componentBytes }),
+		secondRuntime({ operation: "initComponent", componentBytes }),
+	]);
+
+	expect(first.errorMessage).toBeUndefined();
+	expect(second.errorMessage).toBeUndefined();
+	expect(transpileBytes).toHaveBeenCalledTimes(1);
+	expect(compile).toHaveBeenCalledTimes(1);
+	const renders = await Promise.all([
+		firstRuntime({ operation: "render", componentId: first.componentId }),
+		secondRuntime({ operation: "render", componentId: second.componentId }),
+	]);
+	expect(renders.map((render) => render.bytes?.[0]).sort()).toEqual([1, 2]);
+
+});
+
+test("retries failed preparation", async () => {
+	transpileBytes.mockRejectedValueOnce(new Error("transpile failed"));
+	const componentBytes = new Uint8Array([5, 6, 7, 8]);
+
+	const first = await createPluginRuntimeDispatch()({
+		operation: "initComponent",
+		componentBytes,
+	});
+	const second = await createPluginRuntimeDispatch()({
+		operation: "initComponent",
+		componentBytes,
+	});
+
+	expect(first.errorMessage).toContain("transpile failed");
+	expect(second.errorMessage).toBeUndefined();
+	expect(transpileBytes).toHaveBeenCalledTimes(2);
+});

--- a/packages/js-sdk/src/plugin-runtime.test.ts
+++ b/packages/js-sdk/src/plugin-runtime.test.ts
@@ -33,7 +33,10 @@ beforeEach(() => {
 	});
 });
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
 
 test("shares singleflight preparation while keeping plugin instances fresh", async () => {
 	const compile = vi.spyOn(WebAssembly, "compile");
@@ -55,7 +58,6 @@ test("shares singleflight preparation while keeping plugin instances fresh", asy
 		secondRuntime({ operation: "render", componentId: second.componentId }),
 	]);
 	expect(renders.map((render) => render.bytes?.[0]).sort()).toEqual([1, 2]);
-
 });
 
 test("retries failed preparation", async () => {
@@ -74,4 +76,24 @@ test("retries failed preparation", async () => {
 	expect(first.errorMessage).toContain("transpile failed");
 	expect(second.errorMessage).toBeUndefined();
 	expect(transpileBytes).toHaveBeenCalledTimes(2);
+});
+
+test("initializes without caching when SubtleCrypto is unavailable", async () => {
+	vi.stubGlobal("crypto", {});
+	const compile = vi.spyOn(WebAssembly, "compile");
+	const componentBytes = new Uint8Array([9, 10, 11, 12]);
+
+	const first = await createPluginRuntimeDispatch()({
+		operation: "initComponent",
+		componentBytes,
+	});
+	const second = await createPluginRuntimeDispatch()({
+		operation: "initComponent",
+		componentBytes,
+	});
+
+	expect(first.errorMessage).toBeUndefined();
+	expect(second.errorMessage).toBeUndefined();
+	expect(transpileBytes).toHaveBeenCalledTimes(2);
+	expect(compile).toHaveBeenCalledTimes(2);
 });

--- a/packages/js-sdk/src/plugin-runtime.ts
+++ b/packages/js-sdk/src/plugin-runtime.ts
@@ -67,6 +67,15 @@ type InstantiationModule = {
 	): Promise<{ api?: PluginApi }>;
 };
 
+type PreparedComponent = {
+	generatedModule: InstantiationModule;
+	getCoreModule(path: string): Promise<object>;
+};
+
+const PREPARED_COMPONENT_CACHE_SIZE = 8;
+const preparedComponents = new Map<string, PreparedComponent>();
+const componentPreparations = new Map<string, Promise<PreparedComponent>>();
+
 class WasmPluginRuntime {
 	private nextComponentId = 1;
 	private readonly components = new Map<number, PluginApi>();
@@ -100,19 +109,7 @@ class WasmPluginRuntime {
 		}
 		const componentId = this.nextComponentId;
 		this.nextComponentId += 1;
-		const name = "lix_plugin";
-		const transpiled = await transpileBytes(request.componentBytes, {
-			name,
-			emitTypescriptDeclarations: false,
-			instantiation: "async",
-			nodejsCompat: false,
-		});
-		const files = new Map(Object.entries(transpiled.files));
-		const moduleSource = requiredFile(files, `${name}.js`);
-		const moduleUrl = `data:text/javascript;base64,${bytesToBase64(moduleSource)}`;
-		const generatedModule = (await import(
-			/* @vite-ignore */ moduleUrl
-		)) as InstantiationModule;
+		const prepared = await prepareComponent(request.componentBytes);
 		const wasi = new WASIShim({
 			sandbox: {
 				preopens: {},
@@ -121,9 +118,8 @@ class WasmPluginRuntime {
 				enableNetwork: false,
 			},
 		});
-		const instance = await generatedModule.instantiate(
-			async (path) =>
-				await webAssembly.compile(copyArrayBuffer(requiredFile(files, path))),
+		const instance = await prepared.generatedModule.instantiate(
+			prepared.getCoreModule,
 			wasi.getImportObject() as Record<string, unknown>,
 		);
 		if (!instance.api) {
@@ -169,6 +165,83 @@ class WasmPluginRuntime {
 
 export function createPluginRuntimeDispatch(): WasmPluginRuntime["dispatch"] {
 	return new WasmPluginRuntime().dispatch;
+}
+
+async function prepareComponent(
+	componentBytes: Uint8Array,
+): Promise<PreparedComponent> {
+	const cacheKey = await contentHash(componentBytes);
+	const cached = preparedComponents.get(cacheKey);
+	if (cached) {
+		preparedComponents.delete(cacheKey);
+		preparedComponents.set(cacheKey, cached);
+		return cached;
+	}
+
+	let preparation = componentPreparations.get(cacheKey);
+	if (!preparation) {
+		preparation = transpileAndCompile(componentBytes).then((prepared) => {
+			preparedComponents.set(cacheKey, prepared);
+			while (preparedComponents.size > PREPARED_COMPONENT_CACHE_SIZE) {
+				const oldest = preparedComponents.keys().next().value;
+				if (oldest === undefined) break;
+				preparedComponents.delete(oldest);
+			}
+			return prepared;
+		});
+		componentPreparations.set(cacheKey, preparation);
+	}
+
+	try {
+		return await preparation;
+	} finally {
+		if (componentPreparations.get(cacheKey) === preparation) {
+			componentPreparations.delete(cacheKey);
+		}
+	}
+}
+
+async function transpileAndCompile(
+	componentBytes: Uint8Array,
+): Promise<PreparedComponent> {
+	const name = "lix_plugin";
+	const transpiled = await transpileBytes(componentBytes, {
+		name,
+		emitTypescriptDeclarations: false,
+		instantiation: "async",
+		nodejsCompat: false,
+	});
+	const files = new Map(Object.entries(transpiled.files));
+	const moduleSource = requiredFile(files, `${name}.js`);
+	const moduleUrl = `data:text/javascript;base64,${bytesToBase64(moduleSource)}`;
+	const generatedModule = (await import(
+		/* @vite-ignore */ moduleUrl
+	)) as InstantiationModule;
+	const compiledCoreModules = new Map<string, Promise<object>>();
+
+	return {
+		generatedModule,
+		async getCoreModule(path) {
+			let compilation = compiledCoreModules.get(path);
+			if (!compilation) {
+				compilation = webAssembly
+					.compile(copyArrayBuffer(requiredFile(files, path)))
+					.catch((cause) => {
+						compiledCoreModules.delete(path);
+						throw cause;
+					});
+				compiledCoreModules.set(path, compilation);
+			}
+			return await compilation;
+		},
+	};
+}
+
+async function contentHash(bytes: Uint8Array): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", copyArrayBuffer(bytes));
+	return Array.from(new Uint8Array(digest), (byte) =>
+		byte.toString(16).padStart(2, "0"),
+	).join("");
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/packages/js-sdk/src/plugin-runtime.ts
+++ b/packages/js-sdk/src/plugin-runtime.ts
@@ -171,6 +171,9 @@ async function prepareComponent(
 	componentBytes: Uint8Array,
 ): Promise<PreparedComponent> {
 	const cacheKey = await contentHash(componentBytes);
+	if (cacheKey === undefined) {
+		return await transpileAndCompile(componentBytes);
+	}
 	const cached = preparedComponents.get(cacheKey);
 	if (cached) {
 		preparedComponents.delete(cacheKey);
@@ -237,11 +240,19 @@ async function transpileAndCompile(
 	};
 }
 
-async function contentHash(bytes: Uint8Array): Promise<string> {
-	const digest = await crypto.subtle.digest("SHA-256", copyArrayBuffer(bytes));
-	return Array.from(new Uint8Array(digest), (byte) =>
-		byte.toString(16).padStart(2, "0"),
-	).join("");
+async function contentHash(bytes: Uint8Array): Promise<string | undefined> {
+	const subtle = globalThis.crypto?.subtle;
+	if (!subtle) return undefined;
+	try {
+		const digest = await subtle.digest("SHA-256", copyArrayBuffer(bytes));
+		return Array.from(new Uint8Array(digest), (byte) =>
+			byte.toString(16).padStart(2, "0"),
+		).join("");
+	} catch {
+		// Caching is optional. Preserve plugin initialization in runtimes where
+		// Web Crypto is unavailable or rejects digest operations.
+		return undefined;
+	}
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -19,12 +19,23 @@ type PendingRequest = {
 	reject(error: unknown): void;
 };
 
+type RequestWorker = <T>(operation: WorkerOperation) => Promise<T>;
+type NotifyWorker = (notification: WorkerNotification) => void;
+
+const MAX_IDLE_WORKERS = 1;
+// The common serial reopen path retains one worker so its prepared plugin cache
+// survives close(). Concurrent opens still receive isolated workers.
+const idleWorkers: LixWorkerClient[] = [];
+
 export async function openLixWorker(
 	storage: LixStorageConfig,
 	onDisposed?: () => void,
 	telemetry?: LixTelemetryOptions,
 ): Promise<LixWorkerClient> {
-	const client = new LixWorkerClient(onDisposed, undefined, telemetry);
+	let client = idleWorkers.pop();
+	while (client?.isDisposed) client = idleWorkers.pop();
+	client ??= new LixWorkerClient();
+	client.beginLease(onDisposed, telemetry);
 	try {
 		await client.request({
 			kind: "open",
@@ -49,90 +60,134 @@ export async function openLixWorkerBinding(
 }
 
 function workerBinding(client: LixWorkerClient): LixBinding {
+	let closed = false;
+	const request: RequestWorker = (operation) => {
+		if (closed) return Promise.reject(workerClosedError());
+		return client.request(operation);
+	};
+	const notify: NotifyWorker = (notification) => {
+		if (!closed) client.notify(notification);
+	};
+
 	return {
 		execute: (sql, params, options) =>
-			client.request({ kind: "execute", sql, params, options }),
+			request({ kind: "execute", sql, params, options }),
 		executeBatch: (statements, options) =>
-			client.request({ kind: "executeBatch", statements, options }),
+			request({ kind: "executeBatch", statements, options }),
 		observe: async (sql, params) => {
-			const observeId = await client.request<number>({
+			const observeId = await request<number>({
 				kind: "observe",
 				sql,
 				params,
 			});
-			return workerObserveBinding(client, observeId);
+			return workerObserveBinding(request, notify, observeId);
 		},
 		beginTransaction: async () => {
-			const transactionId = await client.request<number>({
+			const transactionId = await request<number>({
 				kind: "beginTransaction",
 			});
-			return workerTransactionBinding(client, transactionId);
+			return workerTransactionBinding(request, transactionId);
 		},
-		activeBranchId: () => client.request({ kind: "activeBranchId" }),
+		activeBranchId: () => request({ kind: "activeBranchId" }),
 		createBranch: (options) =>
-			client.request({ kind: "createBranch", options }),
+			request({ kind: "createBranch", options }),
 		switchBranch: (options) =>
-			client.request({ kind: "switchBranch", options }),
+			request({ kind: "switchBranch", options }),
 		importFilesystemPaths: (paths) =>
-			client.request({ kind: "importFilesystemPaths", paths }),
+			request({ kind: "importFilesystemPaths", paths }),
 		mergeBranchPreview: (options) =>
-			client.request({ kind: "mergeBranchPreview", options }),
-		mergeBranch: (options) =>
-			client.request({ kind: "mergeBranch", options }),
-		syncDiskToLix: () => client.request({ kind: "syncDiskToLix" }),
+			request({ kind: "mergeBranchPreview", options }),
+		mergeBranch: (options) => request({ kind: "mergeBranch", options }),
+		syncDiskToLix: () => request({ kind: "syncDiskToLix" }),
 		close: async () => {
-			await client.request({ kind: "close" });
-			await client.terminate();
+			if (closed) return;
+			await request({ kind: "close" });
+			closed = true;
+			await releaseWorker(client);
 		},
 	};
 }
 
 function workerTransactionBinding(
-	client: LixWorkerClient,
+	request: RequestWorker,
 	transactionId: number,
 ): LixTransactionBinding {
 	return {
 		execute: (sql, params, options) =>
-			client.request({
+			request({
 				kind: "transaction.execute",
 				transactionId,
 				sql,
 				params,
 				options,
 			}),
-		commit: () =>
-			client.request({ kind: "transaction.commit", transactionId }),
-		rollback: () =>
-			client.request({ kind: "transaction.rollback", transactionId }),
+		commit: () => request({ kind: "transaction.commit", transactionId }),
+		rollback: () => request({ kind: "transaction.rollback", transactionId }),
 	};
 }
 
 function workerObserveBinding(
-	client: LixWorkerClient,
+	request: RequestWorker,
+	notify: NotifyWorker,
 	observeId: number,
 ): ObserveEventsBinding {
 	return {
-		next: () => client.request({ kind: "observe.next", observeId }),
-		close: () => client.notify({ kind: "observe.close", observeId }),
+		next: () => request({ kind: "observe.next", observeId }),
+		close: () => notify({ kind: "observe.close", observeId }),
 	};
+}
+
+async function releaseWorker(client: LixWorkerClient): Promise<void> {
+	client.endLease();
+	if (!client.isDisposed && idleWorkers.length < MAX_IDLE_WORKERS) {
+		idleWorkers.push(client);
+		return;
+	}
+	await client.terminate();
 }
 
 export class LixWorkerClient {
 	private nextRequestId = 1;
 	private readonly pending = new Map<number, PendingRequest>();
 	private disposed = false;
+	private leased = false;
+	private onDisposed?: () => void;
+	private telemetry?: LixTelemetryOptions;
 
 	constructor(
-		private readonly onDisposed?: () => void,
 		private readonly connection: WorkerConnection = createWorkerConnection(),
-		private readonly telemetry?: LixTelemetryOptions,
 	) {
 		connection.onMessage((message) => this.handleMessage(message));
 		connection.onFatal((error) => this.handleFatal(error));
 	}
 
+	get isDisposed(): boolean {
+		return this.disposed;
+	}
+
+	beginLease(
+		onDisposed?: () => void,
+		telemetry?: LixTelemetryOptions,
+	): void {
+		if (this.disposed || this.leased) throw workerClosedError();
+		this.leased = true;
+		this.onDisposed = onDisposed;
+		this.telemetry = telemetry;
+	}
+
+	endLease(): void {
+		if (!this.leased) return;
+		this.leased = false;
+		const onDisposed = this.onDisposed;
+		this.onDisposed = undefined;
+		this.telemetry = undefined;
+		onDisposed?.();
+	}
+
 	request<T>(operation: WorkerOperation): Promise<T> {
-		if (this.disposed) return Promise.reject(workerClosedError());
+		if (this.disposed || !this.leased) {
+			return Promise.reject(workerClosedError());
+		}
 		const id = this.nextRequestId++;
 		if (this.pending.size === 0) this.connection.ref();
 		return new Promise<T>((resolve, reject) => {
@@ -151,7 +206,7 @@ export class LixWorkerClient {
 	}
 
 	notify(notification: WorkerNotification): void {
-		if (this.disposed) return;
+		if (this.disposed || !this.leased) return;
 		try {
 			this.connection.postMessage(notification);
 		} catch {
@@ -166,7 +221,7 @@ export class LixWorkerClient {
 		try {
 			await this.connection.terminate();
 		} finally {
-			this.onDisposed?.();
+			this.endLease();
 		}
 	}
 
@@ -194,7 +249,7 @@ export class LixWorkerClient {
 		fatal.name = "LixError";
 		fatal.code ??= "LIX_WORKER_TERMINATED";
 		this.rejectPending(fatal);
-		this.onDisposed?.();
+		this.endLease();
 	}
 
 	private rejectPending(error: Error): void {
@@ -202,7 +257,6 @@ export class LixWorkerClient {
 		this.pending.clear();
 		this.connection.unref();
 	}
-
 }
 
 function workerClosedError(): Error & { code: string } {


### PR DESCRIPTION
## Summary

- keep a bounded 8-entry LRU of prepared JS plugin components, keyed by SHA-256 component content when Web Crypto is available
- singleflight JCO transpilation and core-module compilation; failed preparation is retried instead of cached
- fall back to uncached preparation when Web Crypto is unavailable or rejects hashing, preserving plugin support on insecure browser origins
- instantiate a fresh `WASIShim` and plugin API for every `initComponent`
- retain at most one idle worker so the preparation cache survives the common serial `openLix()` → `close()` → reopen path
- preserve isolation for concurrent opens and keep closed handles closed after their worker is reused
- add a reproducible Node reopen benchmark and a patch changenote

The bottleneck was not `WebAssembly.compile` alone. Every open created a worker, every close terminated it, and every plugin initialization repeated JCO transpilation, dynamic module loading, compilation, and instantiation. A cache scoped only to the old runtime instance therefore could not help across opens.

## End-to-end benchmark

Measured on arm64 macOS 26.3.1 with Node v22.22.3 and Playwright/Chromium 1.57.0. Input was the release CSV component (2,073,171 bytes; 2,076,455-byte `.lixplugin` archive).

Each sample performs the full memory `openLix()` → install CSV plugin → write a small CSV → query `csv_row` → `close()` cycle. Results use 2 warmups and 12 measured samples. Node can be reproduced with `npm run benchmark:plugin-reopen` after building the package; Chromium used the same loop through the existing Vitest browser configuration.

| Runtime | Metric | origin/main | This PR | Reduction |
| --- | --- | ---: | ---: | ---: |
| Node | p50 | 1,570.5 ms | 67.2 ms | 95.7% |
| Node | p95 | 1,798.9 ms | 138.4 ms | 92.3% |
| Chromium | p50 | 663.3 ms | 55.7 ms | 91.6% |
| Chromium | p95 | 756.5 ms | 68.8 ms | 90.9% |

These are whole-cycle numbers, so the remaining time includes worker messaging, opening/closing the in-memory Lix, plugin installation, and the CSV operations—not only plugin initialization.

## Scope choices

This intentionally optimizes the 90% serial-reopen path:

- one idle worker is retained; concurrent opens still create independent workers
- the preparation LRU is entry-count bounded rather than adding a byte-budget policy
- live plugin instances are never cached
- no negative cache or complex worker fleet management is introduced

## Validation

- `npm run build:browser`
- `npm run build:native`
- `npm run build:ts`
- `npm run typecheck`
- `npx vitest run --testTimeout=15000`: 97/97 tests passed
- `npm run test:browser:built`: 15/15 tests passed
- focused cache/lifecycle tests cover singleflight, one core compile, fresh instances, retry after preparation failure, Web Crypto-unavailable fallback, and closed-handle behavior after worker reuse

One default-timeout local rerun hit the two existing cold plugin archive tests' 5-second limits after several release builds; both pass in the full 15-second-timeout run above.