### PR TITLE
perf(engine): optimize read-only execute batches

### DIFF
--- a/.changenotes/optimize-read-only-execute-batches.md
+++ b/.changenotes/optimize-read-only-execute-batches.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved `executeBatch()` performance for read-only workloads without adding a new API.
+
+Pure-read batches now reuse one storage snapshot and prepared SQL session, while batches containing writes or durable runtime functions retain their existing transactional semantics.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -335,6 +335,11 @@ pub struct ExecuteBatchStatement {
     pub params: Vec<Value>,
 }
 
+enum ExecuteBatchExecution {
+    ReadOnly(Vec<datafusion::sql::parser::Statement>),
+    Transaction(Vec<datafusion::sql::parser::Statement>),
+}
+
 impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -483,11 +488,12 @@ where
         Ok(ExecuteResult::from_sql_query_result(read_result.query))
     }
 
-    /// Executes SQL statements sequentially in one atomic transaction.
+    /// Executes SQL statements sequentially against one atomic snapshot.
     ///
-    /// Each statement receives its own parameter list. The transaction commits
-    /// only after every statement succeeds, so reads can observe earlier
-    /// staged writes while observers see only the final committed state.
+    /// Pure-read batches share one immutable read snapshot and prepared SQL
+    /// session. Batches containing writes or durable runtime functions use a
+    /// write transaction, so reads can observe earlier staged writes and the
+    /// transaction commits only after every statement succeeds.
     pub async fn execute_batch(
         &self,
         statements: &[ExecuteBatchStatement],
@@ -536,47 +542,124 @@ where
         }
 
         let statements = statements.to_vec();
-        let telemetry_sink = self.telemetry.clone();
-        self.with_write_transaction(move |transaction| {
-            Box::pin(async move {
-                let mut results = Vec::with_capacity(statements.len());
-                for (statement_index, statement) in statements.iter().enumerate() {
-                    let telemetry = SqlStatementTelemetry::start(
-                        telemetry_sink.as_ref(),
+        match classify_execute_batch(&statements)? {
+            ExecuteBatchExecution::ReadOnly(parsed) => {
+                self.execute_read_only_batch(&statements, parsed).await
+            }
+            ExecuteBatchExecution::Transaction(parsed) => {
+                let telemetry_sink = self.telemetry.clone();
+                self.with_write_transaction(move |transaction| {
+                    Box::pin(async move {
+                        let mut results = Vec::with_capacity(statements.len());
+                        for (statement_index, (statement, parsed)) in
+                            statements.iter().zip(parsed).enumerate()
+                        {
+                            let telemetry = SqlStatementTelemetry::start(
+                                telemetry_sink.as_ref(),
+                                &statement.sql,
+                                "batch",
+                                Some(statement_index),
+                            );
+                            let operation = async {
+                                execute_transaction_statement(
+                                    transaction,
+                                    &statement.sql,
+                                    parsed,
+                                    &statement.params,
+                                    options.clone(),
+                                )
+                                .await
+                                .map_err(|error| {
+                                    with_batch_statement_index(
+                                        normalize_sql_surface_error(error, &statement.sql),
+                                        statement_index,
+                                    )
+                                })
+                            };
+                            let result = match telemetry.as_ref() {
+                                Some(telemetry) => telemetry.instrument(operation).await,
+                                None => operation.await,
+                            };
+                            if let Some(telemetry) = telemetry {
+                                telemetry.finish(&result);
+                            }
+                            results.push(result?);
+                        }
+                        Ok(results)
+                    })
+                })
+                .await
+            }
+        }
+    }
+
+    async fn execute_read_only_batch(
+        &self,
+        statements: &[ExecuteBatchStatement],
+        parsed: Vec<datafusion::sql::parser::Statement>,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        let _operation_guard = self.begin_waitable_session_operation().await?;
+        let read_scope = self
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await?;
+        with_static_session_sql_read::<StorageImpl, _, _, _>(read_scope, |read_store| async move {
+            let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+            let live_state: Arc<dyn crate::live_state::LiveStateReader> =
+                Arc::new(self.live_state.reader(read_store.clone()));
+            let visible_schemas = self
+                .catalog_context
+                .schema_jsons_for_sql_read_planning(live_state.as_ref(), &active_branch_id)
+                .await?;
+            let ctx = SessionSqlExecutionContext {
+                active_branch_id: &active_branch_id,
+                read_store,
+                live_state: Arc::clone(&self.live_state),
+                binary_cas: Arc::clone(&self.binary_cas),
+                branch_ctx: Arc::clone(&self.branch_ctx),
+                visible_schemas,
+                functions: FunctionProviderHandle::system(),
+                plugin_host: self.plugin_host.clone(),
+            };
+            let read_session = sql2::prepare_read_session(&ctx).await?;
+            let mut results = Vec::with_capacity(statements.len());
+            for (statement_index, (statement, parsed)) in statements.iter().zip(parsed).enumerate()
+            {
+                let telemetry = SqlStatementTelemetry::start(
+                    self.telemetry.as_ref(),
+                    &statement.sql,
+                    "batch",
+                    Some(statement_index),
+                );
+                let operation = async {
+                    sql2::execute_read_statement_in_session_from_parsed(
+                        &read_session,
                         &statement.sql,
-                        "batch",
-                        Some(statement_index),
-                    );
-                    let operation = async {
-                        let parsed = sql2::parse_statement(&statement.sql)
-                            .map_err(|error| with_batch_statement_index(error, statement_index))?;
-                        execute_transaction_statement(
-                            transaction,
-                            &statement.sql,
-                            parsed,
-                            &statement.params,
-                            options.clone(),
+                        parsed,
+                        &statement.params,
+                    )
+                    .await
+                    .map(ExecuteResult::from_sql_query_result)
+                    .map_err(|error| {
+                        with_batch_statement_index(
+                            normalize_sql_surface_error(error, &statement.sql),
+                            statement_index,
                         )
-                        .await
-                        .map_err(|error| {
-                            with_batch_statement_index(
-                                normalize_sql_surface_error(error, &statement.sql),
-                                statement_index,
-                            )
-                        })
-                    };
-                    let result = match telemetry.as_ref() {
-                        Some(telemetry) => telemetry.instrument(operation).await,
-                        None => operation.await,
-                    };
-                    if let Some(telemetry) = telemetry {
-                        telemetry.finish(&result);
-                    }
-                    let result = result?;
-                    results.push(result);
+                    })
+                };
+                let result = match telemetry.as_ref() {
+                    Some(telemetry) => telemetry.instrument(operation).await,
+                    None => operation.await,
+                };
+                if let Some(telemetry) = telemetry {
+                    telemetry.finish(&result);
                 }
-                Ok(results)
-            })
+                results.push(result?);
+            }
+            drop(read_session);
+            drop(ctx);
+            drop(live_state);
+            Ok(results)
         })
         .await
     }
@@ -634,7 +717,7 @@ where
             .await?;
         with_static_session_sql_read::<StorageImpl, _, _, _>(read_scope, |read_store| async move {
             let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
-            let active_branch_commit_id = self
+            let active_branch_head = self
                 .branch_ctx
                 .ref_reader(read_store.clone())
                 .load_head(&active_branch_id)
@@ -645,9 +728,8 @@ where
                         "execute coherent read batch",
                         "active branch",
                     )
-                })?
-                .commit_id
-                .to_string();
+                })?;
+            let active_branch_commit_id = active_branch_head.commit_id.to_string();
             let storage_mutation_revision =
                 StorageAdapter::<StorageImpl>::load_mutation_revision_from_read(&read_store)
                     .await?
@@ -676,6 +758,7 @@ where
                 functions: FunctionProviderHandle::system(),
                 plugin_host: self.plugin_host.clone(),
             };
+            let read_session = sql2::prepare_read_session_at_head(&ctx, active_branch_head).await?;
             let mut results = Vec::with_capacity(statements.len());
             for (statement_index, ((sql, params), statement)) in
                 statements.iter().zip(parsed).enumerate()
@@ -687,10 +770,15 @@ where
                     Some(statement_index),
                 );
                 let operation = async {
-                    sql2::execute_read_statement_from_parsed(&ctx, sql, statement, params)
-                        .await
-                        .map(ExecuteResult::from_sql_query_result)
-                        .map_err(|error| normalize_sql_surface_error(error, sql))
+                    sql2::execute_read_statement_in_session_from_parsed(
+                        &read_session,
+                        sql,
+                        statement,
+                        params,
+                    )
+                    .await
+                    .map(ExecuteResult::from_sql_query_result)
+                    .map_err(|error| normalize_sql_surface_error(error, sql))
                 };
                 let result = match telemetry.as_ref() {
                     Some(telemetry) => telemetry.instrument(operation).await,
@@ -701,6 +789,7 @@ where
                 }
                 results.push(result?);
             }
+            drop(read_session);
             drop(ctx);
             drop(live_state);
             Ok(CoherentReadBatch {
@@ -1002,6 +1091,34 @@ where
     result
 }
 
+fn classify_execute_batch(
+    statements: &[ExecuteBatchStatement],
+) -> Result<ExecuteBatchExecution, LixError> {
+    // Classify the complete batch before choosing a snapshot or transaction;
+    // switching execution modes between statements would break atomicity, and
+    // any possible durable mutation keeps the whole batch transactional so
+    // later reads retain read-after-write visibility.
+    let mut parsed = Vec::with_capacity(statements.len());
+    let mut is_read_only = true;
+    for (statement_index, statement) in statements.iter().enumerate() {
+        let parsed_statement = sql2::parse_statement(&statement.sql)
+            .map_err(|error| with_batch_statement_index(error, statement_index))?;
+        let route = sql2::bind_statement_route(&parsed_statement)
+            .map_err(|error| with_batch_statement_index(error, statement_index))?;
+        if route == sql2::BoundStatementRoute::Write
+            || sql2::statement_has_durable_runtime_function(&parsed_statement)
+        {
+            is_read_only = false;
+        }
+        parsed.push(parsed_statement);
+    }
+    if is_read_only {
+        Ok(ExecuteBatchExecution::ReadOnly(parsed))
+    } else {
+        Ok(ExecuteBatchExecution::Transaction(parsed))
+    }
+}
+
 async fn execute_transaction_statement<StorageImpl>(
     transaction: &mut crate::transaction::Transaction<StorageImpl>,
     sql: &str,
@@ -1124,6 +1241,71 @@ mod tests {
             .open_workspace_session()
             .await
             .expect("workspace session should open")
+    }
+
+    fn batch_statement(sql: &str) -> ExecuteBatchStatement {
+        ExecuteBatchStatement {
+            sql: sql.to_string(),
+            params: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn execute_batch_classifies_only_pure_reads_for_the_fast_path() {
+        assert!(matches!(
+            classify_execute_batch(&[
+                batch_statement("SELECT 1"),
+                batch_statement("SELECT * FROM lix_file"),
+            ])
+            .unwrap(),
+            ExecuteBatchExecution::ReadOnly(_)
+        ));
+        assert!(matches!(
+            classify_execute_batch(&[
+                batch_statement("SELECT 1"),
+                batch_statement("DELETE FROM lix_file WHERE id = 'missing'"),
+            ])
+            .unwrap(),
+            ExecuteBatchExecution::Transaction(_)
+        ));
+        assert!(matches!(
+            classify_execute_batch(&[batch_statement("SELECT lix_uuid_v7()")]).unwrap(),
+            ExecuteBatchExecution::Transaction(_)
+        ));
+    }
+
+    #[test]
+    fn execute_batch_classification_preserves_the_invalid_statement_index() {
+        let result = classify_execute_batch(&[
+            batch_statement("SELECT 1"),
+            batch_statement("this is not SQL"),
+        ]);
+        let Err(error) = result else {
+            panic!("invalid SQL should fail classification");
+        };
+
+        assert_eq!(error.details.unwrap()["statementIndex"], 1);
+    }
+
+    #[tokio::test]
+    async fn execute_batch_pure_read_fast_path_preserves_order_and_parameters() {
+        let session = open_session().await;
+        let results = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    sql: "SELECT $1 AS value".to_string(),
+                    params: vec![Value::Integer(11)],
+                },
+                ExecuteBatchStatement {
+                    sql: "SELECT $1 AS value".to_string(),
+                    params: vec![Value::Integer(22)],
+                },
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(results[0].rows()[0].get::<i64>("value").unwrap(), 11);
+        assert_eq!(results[1].rows()[0].get::<i64>("value").unwrap(), 22);
     }
 
     #[test]

--- a/packages/engine/src/sql2/branch_ref.rs
+++ b/packages/engine/src/sql2/branch_ref.rs
@@ -21,6 +21,13 @@ impl CachingBranchRefReader {
             heads: Mutex::new(HashMap::new()),
         }
     }
+
+    pub(super) fn with_head(inner: Arc<dyn BranchRefReader>, head: BranchHead) -> Self {
+        Self {
+            inner,
+            heads: Mutex::new(HashMap::from([(head.branch_id.clone(), Some(head))])),
+        }
+    }
 }
 
 #[async_trait]

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -20,7 +20,9 @@ use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::marker::PhantomData;
 
+use crate::branch::BranchHead;
 use crate::functions::FunctionContext;
 use crate::sql2::bind::expr::{BoundCastType, BoundExpr, BoundLiteral};
 use crate::sql2::bind::write::{BoundInsertValues, BoundReturning, FileWriteSurface};
@@ -39,8 +41,8 @@ use crate::sql2::result_metadata::{
     LIX_VALUE_TYPE_JSON, LIX_VALUE_TYPE_METADATA_KEY, field_is_json,
 };
 use crate::sql2::session::{
-    SqlWriteSessionOptions, build_read_session, build_transaction_read_session,
-    build_write_session_with_options,
+    SqlWriteSessionOptions, build_read_session, build_read_session_at_head,
+    build_transaction_read_session, build_write_session_with_options,
 };
 use crate::sql2::write_normalization::lix_file_data_type_lix_error;
 use crate::sql2::{SqlExecutionContext, SqlWriteExecutionContext};
@@ -61,6 +63,12 @@ pub(crate) struct SessionReadSqlResult {
     pub(crate) query: SqlQueryResult,
 }
 
+/// DataFusion catalog and providers scoped to one immutable storage read.
+pub(crate) struct ReadSqlSession<'ctx> {
+    session: SessionContext,
+    _context: PhantomData<&'ctx ()>,
+}
+
 #[cfg(test)]
 async fn execute_sql<C>(ctx: &C, sql: &str, params: &[Value]) -> Result<SqlQueryResult, LixError>
 where
@@ -79,31 +87,59 @@ pub(crate) async fn execute_read_statement_from_parsed<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
-    // Keep read-backed DataFusion providers scoped to this call. The returned
-    // value is fully materialized, so callers cannot retain a plan/provider
-    // that may carry an execution read handle.
-    let plan = create_logical_plan_from_parsed(ctx, sql, statement).await?;
-    execute_logical_plan(plan, params).await
+    let session = prepare_read_session(ctx).await?;
+    execute_read_statement_in_session_from_parsed(&session, sql, statement, params).await
 }
 
-async fn create_logical_plan_from_parsed<C>(
-    ctx: &C,
-    sql: &str,
-    statement: DataFusionStatement,
-) -> Result<SqlLogicalPlan, LixError>
+pub(crate) async fn prepare_read_session<'ctx, C>(
+    ctx: &'ctx C,
+) -> Result<ReadSqlSession<'ctx>, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
+    Ok(ReadSqlSession {
+        session: build_read_session(ctx).await?,
+        _context: PhantomData,
+    })
+}
+
+pub(crate) async fn prepare_read_session_at_head<'ctx, C>(
+    ctx: &'ctx C,
+    active_head: BranchHead,
+) -> Result<ReadSqlSession<'ctx>, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    Ok(ReadSqlSession {
+        session: build_read_session_at_head(ctx, active_head).await?,
+        _context: PhantomData,
+    })
+}
+
+pub(crate) async fn execute_read_statement_in_session_from_parsed(
+    session: &ReadSqlSession<'_>,
+    sql: &str,
+    statement: DataFusionStatement,
+    params: &[Value],
+) -> Result<SqlQueryResult, LixError> {
+    let plan = create_logical_plan_in_session_from_parsed(session, sql, statement).await?;
+    execute_logical_plan(plan, params).await
+}
+
+async fn create_logical_plan_in_session_from_parsed(
+    session: &ReadSqlSession<'_>,
+    sql: &str,
+    statement: DataFusionStatement,
+) -> Result<SqlLogicalPlan, LixError> {
     crate::sql2::bind_read_statement(sql, &statement)?;
-    let session = build_read_session(ctx).await?;
-    let plan = create_logical_plan_from_statement(&session, statement).await?;
+    let plan = create_logical_plan_from_statement(&session.session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
     let notices = history_filter_notices(&plan);
 
     Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
-        session,
+        session: session.session.clone(),
         plan,
         notices,
         json_predicate_params,

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -32,7 +32,9 @@ impl SqlWriteResult {
 
 pub(crate) use datafusion::{
     DataFusionLogicalPlan as SqlDataFusionLogicalPlan, SessionReadSqlResult,
-    execute_read_statement_from_parsed, execute_transaction_read_statement_from_parsed,
+    execute_read_statement_from_parsed, execute_read_statement_in_session_from_parsed,
+    execute_transaction_read_statement_from_parsed, prepare_read_session,
+    prepare_read_session_at_head,
 };
 #[cfg(test)]
 pub(crate) use write::{

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -37,7 +37,8 @@ pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{
     SqlLogicalPlan, create_write_logical_plan_from_parsed, execute_read_statement_from_parsed,
-    execute_transaction_read_statement_from_parsed, execute_write_logical_plan_result,
+    execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
+    execute_write_logical_plan_result, prepare_read_session, prepare_read_session_at_head,
 };
 #[cfg(test)]
 pub(crate) use exec::{

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use crate::LixError;
-use crate::branch::BranchRefReader;
+use crate::branch::{BranchHead, BranchRefReader};
 
 use super::branch_ref::CachingBranchRefReader;
 use super::providers;
@@ -14,13 +14,49 @@ pub(crate) async fn build_read_session<C>(ctx: &C) -> Result<SessionContext, Lix
 where
     C: SqlExecutionContext + ?Sized,
 {
+    build_read_session_with_active_head(ctx, None).await
+}
+
+pub(crate) async fn build_read_session_at_head<C>(
+    ctx: &C,
+    active_head: BranchHead,
+) -> Result<SessionContext, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    build_read_session_with_active_head(ctx, Some(active_head)).await
+}
+
+async fn build_read_session_with_active_head<C>(
+    ctx: &C,
+    active_head: Option<BranchHead>,
+) -> Result<SessionContext, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
     let session = new_sql_session_context();
-    let branch_ref: Arc<dyn BranchRefReader> =
-        Arc::new(CachingBranchRefReader::new(ctx.branch_ref()));
-    let active_branch_commit_id = branch_ref
-        .load_head(ctx.active_branch_id())
-        .await?
-        .map(|head| head.commit_id.to_string());
+    let branch_ref: Arc<dyn BranchRefReader> = match active_head.as_ref() {
+        Some(head) => {
+            if head.branch_id != ctx.active_branch_id() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "prepared SQL read head does not match the active branch",
+                ));
+            }
+            Arc::new(CachingBranchRefReader::with_head(
+                ctx.branch_ref(),
+                head.clone(),
+            ))
+        }
+        None => Arc::new(CachingBranchRefReader::new(ctx.branch_ref())),
+    };
+    let active_branch_commit_id = match active_head {
+        Some(head) => Some(head.commit_id.to_string()),
+        None => branch_ref
+            .load_head(ctx.active_branch_id())
+            .await?
+            .map(|head| head.commit_id.to_string()),
+    };
     register_sql2_functions(&session, ctx.functions(), active_branch_commit_id);
     providers::register_read(&session, ctx, branch_ref).await?;
 

--- a/packages/engine/tests/execute_batch_benchmark.rs
+++ b/packages/engine/tests/execute_batch_benchmark.rs
@@ -1,0 +1,288 @@
+//! Manual probe for `execute_batch` read-only performance.
+//!
+//! Run with `cargo test -p lix_engine --test execute_batch_benchmark --
+//! --ignored --nocapture`. The probe reuses one warmed session and reports
+//! latency plus storage operations for 1/3/5-statement batches.
+
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use lix_engine::{
+    Engine, ExecuteBatchStatement, GetManyResult, GetOptions, Key, KeyRange, Memory, MemoryRead,
+    MemoryWrite, ReadOptions, ScanChunk, ScanOptions, SessionContext, SpaceId, Storage,
+    StorageError, StorageRead, Value, WriteOptions,
+};
+
+const FILE_COUNT_ENV: &str = "LIX_EXECUTE_BATCH_BENCH_FILES";
+const ROUNDS_ENV: &str = "LIX_EXECUTE_BATCH_BENCH_ROUNDS";
+const WARMUPS_ENV: &str = "LIX_EXECUTE_BATCH_BENCH_WARMUPS";
+
+#[derive(Clone)]
+struct CountingStorage {
+    inner: Memory,
+    counters: Arc<StorageCounters>,
+}
+
+struct CountingRead {
+    inner: MemoryRead,
+    counters: Arc<StorageCounters>,
+}
+
+#[derive(Default)]
+struct StorageCounters {
+    begin_reads: AtomicU64,
+    get_many_calls: AtomicU64,
+    scan_calls: AtomicU64,
+}
+
+#[derive(Clone, Copy, Default)]
+struct CounterSnapshot {
+    begin_reads: u64,
+    get_many_calls: u64,
+    scan_calls: u64,
+}
+
+struct BenchStatement {
+    sql: &'static str,
+    params: Vec<Value>,
+}
+
+impl CountingStorage {
+    fn new() -> Self {
+        Self {
+            inner: Memory::new(),
+            counters: Arc::new(StorageCounters::default()),
+        }
+    }
+
+    fn snapshot(&self) -> CounterSnapshot {
+        CounterSnapshot {
+            begin_reads: self.counters.begin_reads.load(Ordering::Relaxed),
+            get_many_calls: self.counters.get_many_calls.load(Ordering::Relaxed),
+            scan_calls: self.counters.scan_calls.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Storage for CountingStorage {
+    type Read<'a>
+        = CountingRead
+    where
+        Self: 'a;
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        self.counters.begin_reads.fetch_add(1, Ordering::Relaxed);
+        Ok(CountingRead {
+            inner: self.inner.begin_read(options).await?,
+            counters: Arc::clone(&self.counters),
+        })
+    }
+
+    async fn begin_write(&self, options: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(options).await
+    }
+}
+
+impl StorageRead for CountingRead {
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        options: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        self.counters.get_many_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.get_many(space, keys, options).await
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        options: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        self.counters.scan_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.scan(space, range, options).await
+    }
+}
+
+impl CounterSnapshot {
+    fn delta(self, before: Self) -> Self {
+        Self {
+            begin_reads: self.begin_reads - before.begin_reads,
+            get_many_calls: self.get_many_calls - before.get_many_calls,
+            scan_calls: self.scan_calls - before.scan_calls,
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "manual performance probe; run with --ignored --nocapture"]
+async fn execute_batch_benchmark_probe() {
+    let file_count = parse_usize_env(FILE_COUNT_ENV, 10_000);
+    let rounds = parse_usize_env(ROUNDS_ENV, 200);
+    let warmups = parse_usize_env(WARMUPS_ENV, 20);
+    assert!(file_count > 0);
+    assert!(rounds > 0);
+
+    let storage = CountingStorage::new();
+    Engine::initialize(storage.clone()).await.unwrap();
+    let engine = Engine::new(storage.clone()).await.unwrap();
+    let session = engine.open_workspace_session().await.unwrap();
+    seed_files(&session, file_count).await;
+
+    for (workload, statements) in [
+        ("setup_only", setup_statements()),
+        ("branch_file_reads", realistic_statements(file_count)),
+    ] {
+        for statement_count in [1, 3, 5] {
+            run_case(
+                &session,
+                &storage,
+                workload,
+                &statements[..statement_count],
+                warmups,
+                rounds,
+            )
+            .await;
+        }
+    }
+}
+
+async fn run_case(
+    session: &SessionContext<CountingStorage>,
+    storage: &CountingStorage,
+    workload: &str,
+    statements: &[BenchStatement],
+    warmups: usize,
+    rounds: usize,
+) {
+    let statements = statements
+        .iter()
+        .map(|statement| ExecuteBatchStatement {
+            sql: statement.sql.to_string(),
+            params: statement.params.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    for _ in 0..warmups {
+        black_box(session.execute_batch(&statements).await.unwrap());
+    }
+
+    let mut durations = Vec::with_capacity(rounds);
+    let mut counters = CounterSnapshot::default();
+    for _ in 0..rounds {
+        let before = storage.snapshot();
+        let started = Instant::now();
+        black_box(session.execute_batch(&statements).await.unwrap());
+        durations.push(started.elapsed());
+        let delta = storage.snapshot().delta(before);
+        counters.begin_reads += delta.begin_reads;
+        counters.get_many_calls += delta.get_many_calls;
+        counters.scan_calls += delta.scan_calls;
+    }
+    durations.sort_unstable();
+
+    println!(
+        "execute_batch_bench workload={workload} files={} statements={} rounds={rounds} warmups={warmups} p50_ns={} p95_ns={} begin_reads_per_op={} get_many_calls_per_op={} scan_calls_per_op={}",
+        parse_usize_env(FILE_COUNT_ENV, 10_000),
+        statements.len(),
+        percentile(&durations, 50).as_nanos(),
+        percentile(&durations, 95).as_nanos(),
+        format_per_operation(counters.begin_reads, rounds),
+        format_per_operation(counters.get_many_calls, rounds),
+        format_per_operation(counters.scan_calls, rounds),
+    );
+}
+
+fn setup_statements() -> Vec<BenchStatement> {
+    (0..5)
+        .map(|ordinal| BenchStatement {
+            sql: "SELECT $1 AS ordinal",
+            params: vec![Value::Integer(ordinal)],
+        })
+        .collect()
+}
+
+fn realistic_statements(file_count: usize) -> Vec<BenchStatement> {
+    let middle = file_count / 2;
+    let last = file_count - 1;
+    vec![
+        BenchStatement {
+            sql: "SELECT id, path FROM lix_file WHERE path = $1",
+            params: vec![Value::Text(file_path(middle))],
+        },
+        BenchStatement {
+            sql: "SELECT id, path FROM lix_file WHERE id = $1",
+            params: vec![Value::Text(file_id(last))],
+        },
+        BenchStatement {
+            sql: "SELECT id, commit_id FROM lix_branch WHERE id = $1",
+            params: vec![Value::Text("main".to_string())],
+        },
+        BenchStatement {
+            sql: "SELECT path FROM lix_directory ORDER BY path",
+            params: Vec::new(),
+        },
+        BenchStatement {
+            sql: "SELECT id, path FROM lix_file WHERE path >= $1 ORDER BY path LIMIT 16",
+            params: vec![Value::Text(file_path(middle))],
+        },
+    ]
+}
+
+async fn seed_files(session: &SessionContext<CountingStorage>, file_count: usize) {
+    let mut sql = String::from("INSERT INTO lix_file (id, path, data) VALUES ");
+    for index in 0..file_count {
+        if index > 0 {
+            sql.push(',');
+        }
+        sql.push_str("('");
+        sql.push_str(&file_id(index));
+        sql.push_str("','");
+        sql.push_str(&file_path(index));
+        sql.push_str("',X'62656E6368')");
+    }
+    let result = session.execute(&sql, &[]).await.unwrap();
+    assert_eq!(
+        result.rows_affected(),
+        u64::try_from(file_count).expect("file count should fit in u64")
+    );
+}
+
+fn file_id(index: usize) -> String {
+    format!("execute-batch-bench-{index:08}")
+}
+
+fn file_path(index: usize) -> String {
+    format!("/execute-batch-bench/{index:08}.txt")
+}
+
+fn parse_usize_env(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(raw) => raw
+            .parse()
+            .unwrap_or_else(|error| panic!("invalid {name}: {error}")),
+        Err(std::env::VarError::NotPresent) => default,
+        Err(error) => panic!("failed to read {name}: {error}"),
+    }
+}
+
+fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(percentile).div_ceil(100);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+fn format_per_operation(total: u64, rounds: usize) -> String {
+    let rounds = u64::try_from(rounds).expect("round count should fit in u64");
+    format!(
+        "{}.{:03}",
+        total / rounds,
+        (total % rounds) * 1_000 / rounds
+    )
+}

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -129,7 +129,9 @@ where
             .await
     }
 
-    /// Executes statements sequentially in one atomic transaction.
+    /// Executes statements sequentially against one atomic snapshot.
+    /// Pure reads share one read snapshot; batches containing writes retain
+    /// transactional read-after-write and rollback semantics.
     pub async fn execute_batch(
         &self,
         statements: &[ExecuteBatchStatement],


### PR DESCRIPTION
## Why

`executeBatch()` already provides the batching surface applications use. PR #646 demonstrated that a snapshot-scoped SQL session can avoid repeated storage, catalog, provider, and UDF setup, but introduced a separate public `executeReadBatch()` API.

This PR supersedes #646 by making that optimization automatic for the common read-only `executeBatch()` path. It keeps the 10% edge cases on the existing transaction path instead of expanding the SDK, worker, remote, and protocol APIs.

## What

- Parses and classifies the complete batch before choosing an execution path.
- Routes batches containing only pure reads through one immutable storage snapshot and one prepared DataFusion session/catalog.
- Keeps write batches, mixed read/write batches, and reads containing durable runtime functions such as `lix_uuid_v7()` on the existing atomic write-transaction path.
- Preserves statement order, per-statement parameters, indexed errors, read-after-write behavior, rollback behavior, and existing return types.
- Reuses the same snapshot-scoped SQL session primitive in the existing hidden coherent-read helper.
- Adds no new public API or wire-protocol surface.

## Performance

Identical optimized test-profile probes on clean worktrees at current `origin/main` (`546fbe6a`) and this branch, using one warmed session, a 10,000-file fixture, 2,000 samples, and 100 warmups:

| workload | statements | before p50 / p95 | after p50 / p95 | p50 / p95 improvement |
|---|---:|---:|---:|---:|
| setup-only | 1 | 0.793 / 1.191 ms | 0.453 / 0.574 ms | 42.9% / 51.8% |
| setup-only | 3 | 1.817 / 4.244 ms | 0.573 / 0.994 ms | 68.5% / 76.6% |
| setup-only | 5 | 2.636 / 4.360 ms | 0.686 / 0.950 ms | 74.0% / 78.2% |
| branch/file reads | 1 | 0.904 / 2.131 ms | 0.497 / 0.782 ms | 45.1% / 63.3% |
| branch/file reads | 3 | 2.035 / 4.930 ms | 0.728 / 1.380 ms | 64.2% / 72.0% |
| branch/file reads | 5 | 4.769 / 8.043 ms | 2.677 / 5.231 ms | 43.9% / 35.0% |

The storage counters confirm the source of the improvement:

| workload | statements | read scopes before → after | `get_many` calls before → after | scans before → after |
|---|---:|---:|---:|---:|
| setup-only | 1 / 3 / 5 | 5 / 7 / 9 → 1 | 35 / 39 / 43 → 18 | 4 → 2 |
| branch/file reads | 1 / 3 / 5 | 7 / 14 / 20 → 1 | 38 / 53 / 63 → 19 / 26 / 28 | 4 / 5 / 5 → 2 / 3 / 3 |

CPU utilization was inspected around the benchmark runs because other benchmarks and desktop workloads can add noise. After observing noisy initial tails, the final matrix was increased to 2,000 samples per case and rerun against the newly advanced main branch. The ignored probe is included at `packages/engine/tests/execute_batch_benchmark.rs`.

## Semantics and scope

Classification is batch-wide, never statement-by-statement, so execution cannot switch snapshots or transaction modes within one batch.

The optimized path targets the common pure-read case. Explicit branch selection, snapshot receipts, oversized-batch policy, and specialized read APIs remain out of scope. Any batch that may mutate durable state conservatively falls back to the existing transaction implementation.

## Validation

- `cargo fmt --all -- --check`
- `node scripts/validate-changes.mjs`
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo test -p lix_engine` (full engine suite, both base and tracked-state-rebuild simulations, SQLite storage conformance, and doctests)
- `cargo test -p lix_sdk execute_batch_is_atomic_and_returns_ordered_results -- --exact --nocapture`
- `LIX_EXECUTE_BATCH_BENCH_ROUNDS=2000 LIX_EXECUTE_BATCH_BENCH_WARMUPS=100 cargo test -p lix_engine --test execute_batch_benchmark -- --ignored --nocapture`

Supersedes #646.
