### PR TITLE
perf(engine): reduce singleton commit write amplification

### DIFF
--- a/.changenotes/remove-derived-commit-tree-rows.md
+++ b/.changenotes/remove-derived-commit-tree-rows.md
@@ -1,0 +1,12 @@
+---
+type: major
+---
+
+Tracked-state roots no longer store derived `lix_commit` rows.
+
+Commit rows are synthesized from `changelog.commit`, leaving immutable state
+trees to contain only authored changes. This makes ordinary one-row commits use
+the tree's singleton path-copy path and substantially reduces write
+amplification. Commit-root metadata now carries a backend-neutral format marker;
+repositories written with the previous layout are rejected and must be
+recreated instead of being silently inherited.

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -1,7 +1,8 @@
+use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 use std::ops::Range;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Barrier};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -12,6 +13,12 @@ use futures_util::stream::{self, BoxStream};
 use lix_engine::storage::{
     GetOptions as StorageGetOptions, Key, ProjectedValue, PutBatch, PutEntry, ReadOptions, SpaceId,
     StorageRead, StorageWrite, StoredValue, WriteOptions,
+};
+#[cfg(feature = "storage-benches")]
+use lix_engine::storage_adapter::StorageAdapter;
+#[cfg(feature = "storage-benches")]
+use lix_engine::transaction::bench::{
+    BenchTransactionFixture, BenchTransactionRow, BenchWriteAccounting,
 };
 use lix_engine::{Engine, SessionContext, Storage, Value};
 use lix_slatedb_storage::{SlateDB, SlateDBCacheOptions, SlateDBObjectStoreOptions};
@@ -37,6 +44,10 @@ const CONCURRENCY_DELAY_MS: u64 = 10;
 const CONCURRENCY_REQUESTS: usize = 4;
 const CONCURRENCY_VALUE_BYTES: usize = 16 * 1024;
 const CONCURRENCY_SPACE: SpaceId = SpaceId(0x00ff_0001);
+#[cfg(feature = "storage-benches")]
+const SINGLETON_ACCOUNTING_ROWS: usize = 1_000;
+#[cfg(feature = "storage-benches")]
+const SINGLETON_ACCOUNTING_SAMPLES: usize = 50;
 
 static NEXT_DB_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -45,6 +56,9 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
         .enable_all()
         .build()
         .expect("create tokio runtime for slatedb_file_api benchmarks");
+    maybe_print_write_accounting(&runtime);
+    #[cfg(feature = "storage-benches")]
+    maybe_print_singleton_write_accounting(&runtime);
     let mut group = c.benchmark_group("slatedb_file_api_warm_cache");
     group.sample_size(10);
 
@@ -99,6 +113,184 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
     cached_preloaded_request_benches(c, &runtime);
     fresh_engine_select_benches(c, &runtime);
     storage_concurrency_benches(c);
+}
+
+#[cfg(feature = "storage-benches")]
+fn maybe_print_singleton_write_accounting(runtime: &tokio::runtime::Runtime) {
+    if std::env::var_os("LIX_SLATEDB_SINGLETON_ACCOUNTING").is_none() {
+        return;
+    }
+    let samples = std::env::var("LIX_SLATEDB_SINGLETON_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(SINGLETON_ACCOUNTING_SAMPLES)
+        .max(1);
+
+    let mut fixture = runtime.block_on(SingletonWriteFixture::new());
+    fixture.object_store.reset_write_stats();
+    let bulk_started = Instant::now();
+    let bulk_accounting = runtime.block_on(fixture.transaction.insert_all_accounting());
+    let bulk_elapsed = bulk_started.elapsed();
+    print_singleton_sample(
+        "insert_1k",
+        Duration::ZERO,
+        bulk_elapsed,
+        bulk_accounting,
+        &fixture.object_store.write_stats(),
+    );
+
+    for delay in [Duration::ZERO, Duration::from_millis(25)] {
+        fixture.object_store.set_delay(delay);
+        let mut elapsed = Vec::with_capacity(samples);
+        let mut logical_value_bytes = 0u64;
+        let mut staged_puts = 0u64;
+        let mut object_put_calls = 0u64;
+        let mut object_put_bytes = 0u64;
+        let mut wal_put_calls = 0u64;
+        let mut wal_put_bytes = 0u64;
+        for _ in 0..samples {
+            fixture.object_store.reset_write_stats();
+            let started = Instant::now();
+            let accounting = runtime.block_on(fixture.transaction.update_one_by_pk_accounting());
+            elapsed.push(started.elapsed());
+            let stats = fixture.object_store.write_stats();
+            let wal = stats.wal_totals();
+            logical_value_bytes += accounting.written_bytes;
+            staged_puts += accounting.staged_puts;
+            object_put_calls += stats.put_calls;
+            object_put_bytes += stats.put_bytes;
+            wal_put_calls += wal.put_calls;
+            wal_put_bytes += wal.put_bytes;
+        }
+        elapsed.sort_unstable();
+        let p50 = percentile(&elapsed, 50);
+        let p95 = percentile(&elapsed, 95);
+        let sample_count = u64::try_from(samples).expect("sample count fits u64");
+        println!(
+            "slatedb-singleton-update delay_ms={} samples={samples} p50_ns={} p95_ns={} staged_puts_avg={} logical_value_bytes_avg={} object_put_calls_avg={} object_put_bytes_avg={} wal_put_calls_avg={} wal_put_bytes_avg={}",
+            delay.as_millis(),
+            p50.as_nanos(),
+            p95.as_nanos(),
+            staged_puts / sample_count,
+            logical_value_bytes / sample_count,
+            object_put_calls / sample_count,
+            object_put_bytes / sample_count,
+            wal_put_calls / sample_count,
+            wal_put_bytes / sample_count,
+        );
+    }
+
+    let mut delete_fixture = runtime.block_on(SingletonWriteFixture::new());
+    runtime.block_on(delete_fixture.transaction.seed());
+    delete_fixture.object_store.reset_write_stats();
+    let delete_started = Instant::now();
+    let delete_accounting =
+        runtime.block_on(delete_fixture.transaction.delete_one_by_pk_accounting());
+    let delete_elapsed = delete_started.elapsed();
+    print_singleton_sample(
+        "delete_one",
+        Duration::ZERO,
+        delete_elapsed,
+        delete_accounting,
+        &delete_fixture.object_store.write_stats(),
+    );
+}
+
+#[cfg(feature = "storage-benches")]
+fn print_singleton_sample(
+    operation: &str,
+    delay: Duration,
+    elapsed: Duration,
+    accounting: BenchWriteAccounting,
+    stats: &ObjectStoreWriteStats,
+) {
+    let wal = stats.wal_totals();
+    println!(
+        "slatedb-singleton-sample operation={operation} delay_ms={} elapsed_ns={} logical_rows={} staged_puts={} staged_deletes={} logical_value_bytes={} object_put_calls={} object_put_bytes={} wal_put_calls={} wal_put_bytes={}",
+        delay.as_millis(),
+        elapsed.as_nanos(),
+        accounting.logical_rows,
+        accounting.staged_puts,
+        accounting.staged_deletes,
+        accounting.written_bytes,
+        stats.put_calls,
+        stats.put_bytes,
+        wal.put_calls,
+        wal.put_bytes,
+    );
+}
+
+#[cfg(feature = "storage-benches")]
+fn percentile(samples: &[Duration], percentile: usize) -> Duration {
+    let index = (samples.len() - 1) * percentile / 100;
+    samples[index]
+}
+
+#[cfg(feature = "storage-benches")]
+struct SingletonWriteFixture {
+    transaction: BenchTransactionFixture<SlateDB>,
+    object_store: Arc<DelayedObjectStore>,
+}
+
+#[cfg(feature = "storage-benches")]
+impl SingletonWriteFixture {
+    async fn new() -> Self {
+        let db_id = NEXT_DB_ID.fetch_add(1, Ordering::Relaxed);
+        let db_path = format!("slatedb-singleton-bench-{}-{db_id}", std::process::id());
+        let object_store = Arc::new(DelayedObjectStore::new(
+            Arc::new(InMemory::new()),
+            Duration::ZERO,
+        ));
+        let storage = SlateDB::open_object_store(db_path, object_store_handle(&object_store))
+            .expect("open SlateDB singleton accounting storage");
+        let rows = (0..SINGLETON_ACCOUNTING_ROWS)
+            .map(|index| {
+                let path = format!("/singleton/{index:04}");
+                BenchTransactionRow {
+                    schema_key: "json_pointer".to_string(),
+                    file_id: None,
+                    entity_pk: path.clone(),
+                    value: json!({"path": path, "value": format!("seed-{index:04}")}),
+                    updated_value: json!({
+                        "path": format!("/singleton/{index:04}"),
+                        "value": format!("updated-{index:04}"),
+                    }),
+                }
+            })
+            .collect();
+        let transaction =
+            BenchTransactionFixture::new_deterministic(StorageAdapter::new(storage), rows).await;
+        object_store.reset_write_stats();
+        Self {
+            transaction,
+            object_store,
+        }
+    }
+}
+
+fn maybe_print_write_accounting(runtime: &tokio::runtime::Runtime) {
+    if std::env::var_os("LIX_SLATEDB_WRITE_ACCOUNTING").is_none() {
+        return;
+    }
+    let fixture = runtime.block_on(UploadBenchFixture::seeded(Duration::ZERO));
+    black_box(runtime.block_on(fixture.upload_overwrite_file()));
+    fixture.object_store.reset_write_stats();
+    let started = Instant::now();
+    let rows_affected = runtime.block_on(fixture.upload_overwrite_file());
+    let elapsed = started.elapsed();
+    let stats = fixture.object_store.write_stats();
+    println!(
+        "slatedb-write-accounting rows_affected={rows_affected} elapsed_ns={} put_calls={} put_bytes={}",
+        elapsed.as_nanos(),
+        stats.put_calls,
+        stats.put_bytes,
+    );
+    for (path, path_stats) in stats.by_path {
+        println!(
+            "slatedb-object-write path={path} put_calls={} put_bytes={}",
+            path_stats.put_calls, path_stats.put_bytes,
+        );
+    }
 }
 
 fn cached_cold_lifecycle_benches(c: &mut Criterion, runtime: &tokio::runtime::Runtime) {
@@ -326,6 +518,7 @@ impl SeededStore {
 struct UploadBenchFixture {
     session: SessionContext<SlateDB>,
     _cache_dir: TempDir,
+    object_store: Arc<DelayedObjectStore>,
     next_upload_version: AtomicU64,
     upload_path: String,
 }
@@ -352,6 +545,7 @@ impl UploadBenchFixture {
         Self {
             session,
             _cache_dir: cache_dir,
+            object_store: seeded.object_store,
             next_upload_version: AtomicU64::new(0),
             upload_path: seeded.upload_path,
         }
@@ -920,6 +1114,38 @@ fn cached_object_store_options(cache_dir: &TempDir) -> SlateDBObjectStoreOptions
 struct DelayedObjectStore {
     inner: Arc<dyn ObjectStore>,
     delay_nanos: Arc<AtomicU64>,
+    record_write_stats: Arc<AtomicBool>,
+    write_stats: Arc<Mutex<ObjectStoreWriteStats>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ObjectStoreWriteStats {
+    put_calls: u64,
+    put_bytes: u64,
+    by_path: BTreeMap<String, ObjectStorePathWriteStats>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ObjectStorePathWriteStats {
+    put_calls: u64,
+    put_bytes: u64,
+}
+
+impl ObjectStoreWriteStats {
+    #[cfg(feature = "storage-benches")]
+    fn wal_totals(&self) -> ObjectStorePathWriteStats {
+        self.by_path
+            .iter()
+            .filter(|(path, _)| path.split('/').any(|segment| segment == "wal"))
+            .fold(
+                ObjectStorePathWriteStats::default(),
+                |mut total, (_, stats)| {
+                    total.put_calls += stats.put_calls;
+                    total.put_bytes += stats.put_bytes;
+                    total
+                },
+            )
+    }
 }
 
 impl DelayedObjectStore {
@@ -927,6 +1153,8 @@ impl DelayedObjectStore {
         Self {
             inner,
             delay_nanos: Arc::new(AtomicU64::new(duration_nanos(delay))),
+            record_write_stats: Arc::new(AtomicBool::new(false)),
+            write_stats: Arc::new(Mutex::new(ObjectStoreWriteStats::default())),
         }
     }
 
@@ -937,6 +1165,19 @@ impl DelayedObjectStore {
 
     fn delay(&self) -> Duration {
         Duration::from_nanos(self.delay_nanos.load(Ordering::Relaxed))
+    }
+
+    fn reset_write_stats(&self) {
+        *self.write_stats.lock().expect("object write stats mutex") =
+            ObjectStoreWriteStats::default();
+        self.record_write_stats.store(true, Ordering::Relaxed);
+    }
+
+    fn write_stats(&self) -> ObjectStoreWriteStats {
+        self.write_stats
+            .lock()
+            .expect("object write stats mutex")
+            .clone()
     }
 }
 
@@ -959,6 +1200,16 @@ impl ObjectStore for DelayedObjectStore {
         payload: PutPayload,
         opts: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
+        if self.record_write_stats.load(Ordering::Relaxed) {
+            let bytes = u64::try_from(payload.content_length())
+                .expect("object-store benchmark payload length fits u64");
+            let mut stats = self.write_stats.lock().expect("object write stats mutex");
+            stats.put_calls += 1;
+            stats.put_bytes += bytes;
+            let path_stats = stats.by_path.entry(location.to_string()).or_default();
+            path_stats.put_calls += 1;
+            path_stats.put_bytes += bytes;
+        }
         delay_once(self.delay()).await;
         self.inner.put_opts(location, payload, opts).await
     }

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -1926,3 +1926,79 @@ scale, not an effect.
 Read-path cost added: diff/commit-root validation loads change records
 for a commit's ref list instead of reading identities from the chunk —
 batched point reads on a validation path, not on live reads.
+
+## 2026-07-21 — Derive commit rows outside tracked-state trees
+
+Hypothesis: the synthetic `lix_commit` row added to every tracked root turns a
+one-row user commit into two immutable-tree mutations. It therefore misses the
+existing singleton path-copy path, grows the tree once per commit, and rewrites
+chunks unrelated to user state. The row is redundant: `changelog.commit` is the
+canonical record and live-state already synthesizes `lix_commit` rows from the
+commit graph.
+
+An environment-gated counterfactual first omitted only that tree delta. After
+the hypothesis cleared the byte gate, the production layout removed physical
+commit rows from initialization, normal commits, and root rebuilds. Exact 1k
+transaction accounting was identical on SQLite and RocksDB because both consume
+the same engine write set:
+
+| Operation | Baseline value bytes | Canonical layout | Change | Baseline puts | Canonical layout |
+|---|---:|---:|---:|---:|---:|
+| update one | 11,506 | 4,831 | -58.0% | 11 | 9 |
+| delete one | 11,287 | 4,612 | -59.1% | 11 | 9 |
+| insert 1k | 424,263 | 424,045 | -0.05% | 1,075 | 1,075 |
+| update 1k | 527,076 | 526,780 | -0.06% | 1,410 | 1,410 |
+| delete 1k | 170,289 | 169,993 | -0.17% | 1,031 | 1,031 |
+
+The singleton reduction was entirely `tracked_state.tree_chunk`: five puts and
+10,834 value bytes became three puts and 4,179 bytes. `written_bytes` excludes
+keys, tombstone framing, and the storage adapter's constant mutation-revision
+put, so it is a logical layout metric rather than physical backend I/O.
+
+SlateDB is the primary physical-write target. Its probe measured the durable WAL
+SST at the object-store boundary. Each transaction remained one WAL PUT:
+
+| Operation | Baseline WAL bytes | Canonical layout | Change |
+|---|---:|---:|---:|
+| insert 1k | 161,559 | 161,423 | -0.08% |
+| update one, first 200 commits (average) | 7,215 | 4,546 | -37.0% |
+| update one, next 200 commits (average) | 7,915 | 4,546 | -42.6% |
+| delete one | 5,715 | 4,496 | -21.3% |
+
+The canonical update stayed at 4,546 bytes while the baseline grew as each
+synthetic commit row accumulated in the state tree. In the final 200-sample A/B,
+local p50/p95 moved from 2.882/4.577 ms to 2.517/2.704 ms; with 25 ms simulated
+object latency it moved from 30.650/31.031 ms to 30.238/30.753 ms. Earlier
+counterbalanced pairs moved in both directions. The layout therefore clears the
+30–40% singleton byte gate and improves the CPU-dominated local run, but does
+not claim a remote durable-latency win: one object-store flush/RTT still
+dominates p95.
+
+RocksDB's final WAL records independently confirm that this is not a SlateDB
+artifact:
+
+| Operation | Baseline WAL append | Canonical layout | Change |
+|---|---:|---:|---:|
+| update one | 11,948 | 5,193 | -56.5% |
+| delete one | 11,728 | 4,973 | -57.6% |
+| update 1k | 567,280 | 566,984 | -0.05% |
+
+Each singleton result was byte-identical across three repetitions. RocksDB's
+current adapter uses a single `WriteBatch` with `sync=false`, so these are
+physical WAL write-amplification results, not durable-latency results.
+
+The resulting format is canonical rather than SlateDB-specific. New tracked
+roots contain authored changes only; initialization, root rebuild, validation,
+diff, merge, and materialization no longer carry a physical-commit-row path.
+RocksDB receives the same smaller `WriteBatch`; its current `sync=false` bench
+remains a CPU/layout portability control rather than a durable-latency measure.
+
+The hard cut is explicit and backend-neutral: commit-root metadata now starts
+with the `LXTR2` format marker, and unversioned roots clearly require repository
+recreation. There is no legacy decoder. This prevents an old root's physical
+commit rows from being silently inherited on SQLite, RocksDB, or SlateDB.
+
+Removing the synthetic row exposed a zero-delta case for allowed empty merges.
+Without a fast path, the generic tree builder would scan and rewrite the entire
+parent tree. Empty child roots now reuse the parent's root id, row count, and
+height, stage no tree chunks, and write only their own commit-root metadata.

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -37,7 +37,6 @@ impl BenchAppend {
         self.append
             .changes
             .iter()
-            .filter(|change| change.schema_key != "lix_commit")
             .map(|change| change.change_id.to_string())
             .collect()
     }
@@ -47,7 +46,7 @@ impl BenchAppend {
     }
 
     pub fn change_count(&self) -> usize {
-        self.change_ids().len()
+        self.append.changes.len()
     }
 
     pub fn append_id(&self) -> String {
@@ -646,14 +645,7 @@ impl BenchCorpus {
             .collect::<Vec<_>>();
         let change_ids = append_batches
             .iter()
-            .flat_map(|append| {
-                append
-                    .append
-                    .changes
-                    .iter()
-                    .filter(|change| change.schema_key != "lix_commit")
-                    .map(|change| change.change_id)
-            })
+            .flat_map(|append| append.append.changes.iter().map(|change| change.change_id))
             .collect::<Vec<_>>();
         Self {
             append_batches,

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -513,10 +513,10 @@ pub(crate) struct GcPlan {
     pub(crate) repair: GcRepairSet,
 }
 
-/// Canonical `lix_commit` row snapshot. Byte-identity across every producer
-/// (staging, rebuild, graph materialization, row materialization) is
-/// load-bearing: content-addressed roots and deterministic inline slots
-/// both depend on it, so all paths must call this one function.
+/// Canonical derived `lix_commit` row snapshot.
+///
+/// Commit graph, live-state, and SQL change surfaces must produce the same
+/// representation from the canonical `changelog.commit` record.
 pub(crate) fn commit_row_snapshot_json(commit_id: &str) -> Result<String, LixError> {
     serde_json::to_string(&serde_json::json!({ "id": commit_id })).map_err(|error| {
         LixError::new(

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -223,8 +223,7 @@ where
     .await?;
 
     {
-        let commit_row_change = seed_commit_row_change_record(&plan.commit)?;
-        let mut deltas = authored_changes
+        let deltas = authored_changes
             .iter()
             .map(|change| TrackedStateDeltaRef {
                 schema_key: &change.schema_key,
@@ -237,16 +236,6 @@ where
                 updated_at: change.created_at,
             })
             .collect::<Vec<_>>();
-        deltas.push(TrackedStateDeltaRef {
-            schema_key: &commit_row_change.schema_key,
-            file_id: commit_row_change.file_id.as_deref(),
-            entity_pk: &commit_row_change.entity_pk,
-            change_id: commit_row_change.change_id,
-            commit_id: plan.commit.id,
-            deleted: commit_row_change.snapshot.is_none(),
-            created_at: commit_row_change.created_at,
-            updated_at: commit_row_change.created_at,
-        });
         tracked_state
             .writer(&read, &mut writes)
             .stage_commit_root(&receipt.initial_commit_id, None, deltas)
@@ -309,28 +298,13 @@ fn seed_untracked_change_to_change_record(row: &InitSeedLiveRow) -> ChangeRecord
     }
 }
 
-fn seed_commit_row_change_record(commit: &InitSeedCommit) -> Result<ChangeRecord, LixError> {
-    let snapshot_content = commit_row_snapshot_content(&commit.id.to_string())?;
-    Ok(ChangeRecord {
-        format_version: 1,
-        change_id: commit.change_id,
-        entity_pk: EntityPk::single(commit.id),
-        schema_key: "lix_commit".to_string(),
-        file_id: None,
-        snapshot: crate::json_store::JsonSlot::from_json(&snapshot_content),
-        metadata: crate::json_store::JsonSlot::None,
-        created_at: commit.created_at,
-        origin_key: None,
-    })
-}
-
 fn stage_init_json_payloads(
     writes: &mut StorageWriteSet,
     plan: &InitSeedPlan,
 ) -> Result<(), LixError> {
     // Only payloads above the inline threshold need store rows; inline
-    // payloads live in their change records, and the commit-row snapshot
-    // is derived from the key at read time.
+    // Payloads live in their change records. Commit rows are derived directly
+    // from changelog.commit and never enter the tracked-state tree.
     JsonStoreContext::new().writer().stage_batch(
         writes,
         JsonWritePlacementRef::OutOfBand,
@@ -374,10 +348,6 @@ async fn stage_init_changelog_commit(
             commit_change_refs: vec![commit_change_refs],
         })
         .await
-}
-
-fn commit_row_snapshot_content(commit_id: &str) -> Result<String, LixError> {
-    crate::changelog::commit_row_snapshot_json(commit_id)
 }
 
 fn untracked_row(
@@ -696,8 +666,8 @@ mod tests {
             .await
             .expect("tracked initial root should scan");
         assert!(
-            rows.iter().any(|row| row.change_id == commit_change_id),
-            "initial commit root should surface its lix_commit row"
+            rows.is_empty(),
+            "initial commit rows are derived from changelog.commit, not stored in tracked roots"
         );
     }
 

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -1005,22 +1005,9 @@ mod tests {
         drop(writer);
         for commit_id in commit_ids {
             let commit_id_text = CommitId::for_test_label(commit_id).to_string();
-
-            let change_id = format!("{commit_id_text}:commit");
-            let entity_pk = EntityPk::single(&commit_id_text);
-            let deltas = [TrackedStateDeltaRef {
-                schema_key: COMMIT_SCHEMA_KEY,
-                file_id: None,
-                entity_pk: &entity_pk,
-                change_id: ChangeId::for_test_label(&change_id),
-                commit_id: CommitId::for_test_label(&commit_id_text),
-                deleted: false,
-                created_at: ts("1970-01-01T00:00:00.000Z"),
-                updated_at: ts("1970-01-01T00:00:00.000Z"),
-            }];
             TrackedStateContext::new()
                 .writer(read, &mut writes)
-                .stage_commit_root(&commit_id_text, None, deltas)
+                .stage_commit_root(&commit_id_text, None, [])
                 .await
                 .expect("empty tracked roots should stage");
         }
@@ -1121,9 +1108,8 @@ mod tests {
                 crate::changelog::ChangelogContext::new().writer(&mut changelog_read, writes);
             crate::changelog::ChangelogWriter::stage_append(&mut writer, append).await?;
             drop(writer);
-            let commit_entity_pk = EntityPk::single(&commit_id);
             let typed_commit_id = CommitId::for_test_label(&commit_id);
-            let mut deltas = rows
+            let deltas = rows
                 .iter()
                 .map(|(change, created_at, updated_at)| TrackedStateDeltaRef {
                     schema_key: &change.schema_key,
@@ -1136,16 +1122,6 @@ mod tests {
                     updated_at: *updated_at,
                 })
                 .collect::<Vec<_>>();
-            deltas.push(TrackedStateDeltaRef {
-                schema_key: COMMIT_SCHEMA_KEY,
-                file_id: None,
-                entity_pk: &commit_entity_pk,
-                change_id: ChangeId::for_test_label(&commit_change_id),
-                commit_id: typed_commit_id,
-                deleted: false,
-                created_at: commit_created_at,
-                updated_at: commit_created_at,
-            });
             TrackedStateContext::new()
                 .writer(&*store, writes)
                 .stage_commit_root(&commit_id, parent_commit_id.as_deref(), deltas)
@@ -1535,12 +1511,10 @@ mod tests {
         );
 
         let main_root_rows = scan_tracked_root(&tracked_state, &storage, "commit-main").await;
-        assert_eq!(
-            main_root_rows.len(),
-            1,
-            "empty commit root should contain only its derived lix_commit row"
+        assert!(
+            main_root_rows.is_empty(),
+            "derived commit rows must not be stored in tracked roots"
         );
-        assert_eq!(main_root_rows[0].schema_key, "lix_commit");
     }
 
     #[tokio::test]
@@ -2179,7 +2153,7 @@ mod tests {
         }
 
         let global_root_rows = scan_tracked_root(&tracked_state, &storage, "commit-global").await;
-        assert_eq!(global_root_rows.len(), 2);
+        assert_eq!(global_root_rows.len(), 1);
         let Some(global_row) = global_root_rows
             .iter()
             .find(|row| row.schema_key == "lix_key_value")
@@ -2192,7 +2166,7 @@ mod tests {
         );
 
         let main_root_rows = scan_tracked_root(&tracked_state, &storage, "commit-main").await;
-        assert_eq!(main_root_rows.len(), 2);
+        assert_eq!(main_root_rows.len(), 1);
         let Some(main_row) = main_root_rows
             .iter()
             .find(|row| row.schema_key == "lix_key_value")

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -289,6 +289,28 @@ impl StorageWriteSet {
         } = self;
 
         for mut group in groups {
+            #[cfg(feature = "storage-benches")]
+            if std::env::var_os("LIX_WRITE_SET_SPACE_STATS").is_some() {
+                let key_bytes = group
+                    .puts
+                    .iter()
+                    .map(|put| put.key.0.len())
+                    .chain(group.deletes.iter().map(|key| key.0.len()))
+                    .sum::<usize>();
+                let value_bytes = group
+                    .puts
+                    .iter()
+                    .map(|put| put.value.bytes.len())
+                    .sum::<usize>();
+                eprintln!(
+                    "write-set-space space={} puts={} deletes={} key_bytes={} value_bytes={}",
+                    group.space.name,
+                    group.puts.len(),
+                    group.deletes.len(),
+                    key_bytes,
+                    value_bytes,
+                );
+            }
             // Lower each space batch in ascending key order. Hash-keyed
             // spaces such as json_store produce effectively random insertion
             // order; sorted batches let B-tree storage implementations write with cursor

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -207,9 +207,7 @@ pub(crate) async fn stage_tracked_root_from_materialized(
         &changes,
     )
     .await?;
-    let typed_commit_id = test_commit_id(&commit_id_text);
-    let commit_entity_pk = crate::entity_pk::EntityPk::single(&commit_id_text);
-    let mut deltas = staged
+    let deltas = staged
         .change_commit_ids
         .iter()
         .map(|(row_index, change_commit_id)| {
@@ -233,16 +231,6 @@ pub(crate) async fn stage_tracked_root_from_materialized(
             }
         })
         .collect::<Vec<_>>();
-    deltas.push(TrackedStateDeltaRef {
-        schema_key: "lix_commit",
-        file_id: None,
-        entity_pk: &commit_entity_pk,
-        change_id: staged.commit_change_id,
-        commit_id: typed_commit_id,
-        deleted: false,
-        created_at: staged.commit_created_at,
-        updated_at: staged.commit_created_at,
-    });
     tracked_state
         .writer(read, writes)
         .stage_commit_root(&commit_id_text, parent_commit_id_text.as_deref(), deltas)
@@ -282,9 +270,7 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
         &changes,
     )
     .await?;
-    let typed_commit_id = test_commit_id(&commit_id_text);
-    let commit_entity_pk = crate::entity_pk::EntityPk::single(&commit_id_text);
-    let mut deltas = staged
+    let deltas = staged
         .change_commit_ids
         .iter()
         .map(|(row_index, change_commit_id)| {
@@ -308,16 +294,6 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
             }
         })
         .collect::<Vec<_>>();
-    deltas.push(TrackedStateDeltaRef {
-        schema_key: "lix_commit",
-        file_id: None,
-        entity_pk: &commit_entity_pk,
-        change_id: staged.commit_change_id,
-        commit_id: typed_commit_id,
-        deleted: false,
-        created_at: staged.commit_created_at,
-        updated_at: staged.commit_created_at,
-    });
     tracked_state
         .writer(read, writes)
         .stage_commit_root(
@@ -442,17 +418,11 @@ async fn stage_test_changelog_commit(
     let mut writer = ChangelogContext::new().writer(&mut read, writes);
     writer.stage_append(append).await?;
     change_commit_ids.sort_by_key(|(row_index, _)| *row_index);
-    Ok(TestStagedChangelogCommit {
-        change_commit_ids,
-        commit_change_id: typed_commit_change_id,
-        commit_created_at: created_at,
-    })
+    Ok(TestStagedChangelogCommit { change_commit_ids })
 }
 
 struct TestStagedChangelogCommit {
     change_commit_ids: Vec<(usize, CommitId)>,
-    commit_change_id: ChangeId,
-    commit_created_at: crate::common::LixTimestamp,
 }
 
 async fn load_existing_changelog_change_ids(

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -233,7 +233,9 @@ where
             change_ids: &change_refs,
         })
         .await?;
-    let mut deltas = change_refs
+    // Rebuild authored state only. Commit rows are a changelog.commit
+    // projection and are deliberately not part of the tracked tree.
+    let deltas = change_refs
         .iter()
         .zip(changes.entries)
         .map(|(change_id, change)| {
@@ -248,7 +250,6 @@ where
             rebuild_delta_from_change_ref(commit_id, *change_id, change)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    deltas.push(rebuild_delta_from_commit_record(&commit)?);
 
     Ok(CommitRootRebuildPlan {
         commit_id: commit.commit_id,
@@ -287,27 +288,6 @@ where
 
 fn first_parent_commit_id(commit: &CommitRecord) -> Option<CommitId> {
     commit.parent_commit_ids.first().copied()
-}
-
-fn rebuild_delta_from_commit_record(
-    commit: &CommitRecord,
-) -> Result<CommitRootRebuildDelta, LixError> {
-    let snapshot_content = commit_row_snapshot_content(&commit.commit_id.to_string())?;
-    Ok(CommitRootRebuildDelta {
-        schema_key: "lix_commit".to_string(),
-        file_id: None,
-        entity_pk: EntityPk::single(commit.commit_id),
-        change_id: commit.change_id,
-        commit_id: commit.commit_id,
-        snapshot: crate::json_store::JsonSlot::from_json(&snapshot_content),
-        metadata: crate::json_store::JsonSlot::None,
-        created_at: commit.created_at,
-        updated_at: commit.created_at,
-    })
-}
-
-fn commit_row_snapshot_content(commit_id: &str) -> Result<String, LixError> {
-    crate::changelog::commit_row_snapshot_json(commit_id)
 }
 
 fn rebuild_delta_from_change_ref(

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use crate::changelog::{ChangeId, ChangeRecordProjection};
 use crate::changelog::{
     ChangeLoadRequest, ChangeRecord, ChangelogContext, ChangelogReader, CommitId, CommitLoadEntry,
-    CommitLoadRequest, CommitProjection, CommitRecord,
+    CommitLoadRequest, CommitProjection,
 };
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
@@ -252,7 +252,6 @@ where
 
         let mut change_ids = rows
             .iter()
-            .filter(|(row, _)| row.schema_key != "lix_commit")
             .map(|(row, _)| row.change_id)
             .collect::<Vec<_>>();
         change_ids.sort();
@@ -273,28 +272,6 @@ where
             };
             changes.insert(change_id, change);
         }
-        let commit_ids = rows
-            .iter()
-            .filter(|(row, _)| row.schema_key == "lix_commit")
-            .map(|(row, _)| row.commit_id)
-            .collect::<Vec<_>>();
-        if !commit_ids.is_empty() {
-            let batch = changelog_reader
-                .load_commits(CommitLoadRequest {
-                    commit_ids: &commit_ids,
-                    projection: CommitProjection::Record,
-                })
-                .await?;
-            for (commit_id, entry) in commit_ids.into_iter().zip(batch.entries) {
-                let Some(CommitLoadEntry::Record(commit)) = entry else {
-                    return Err(LixError::unknown(format!(
-                        "tracked-state diff row references missing changelog commit '{commit_id}'"
-                    )));
-                };
-                changes.insert(commit.change_id, change_record_from_commit_record(&commit)?);
-            }
-        }
-
         let mut validation_cache = DiffCommitRootValidationCache::new();
         for (row, expected_commit_id) in rows {
             validate_diff_row_against_changelog(row, &changes)?;
@@ -486,8 +463,8 @@ where
             )));
         };
         let CommitLoadEntry::Full {
-            record,
             change_ref_chunks: chunks,
+            ..
         } = entry
         else {
             return Err(LixError::unknown(format!(
@@ -495,14 +472,6 @@ where
             )));
         };
         let mut winners = HashMap::new();
-        winners.insert(
-            TrackedStateIdentity {
-                schema_key: "lix_commit".to_string(),
-                file_id: None,
-                entity_pk: EntityPk::single(record.commit_id),
-            },
-            record.change_id,
-        );
         // Ref chunks carry change ids only; row identities live in the
         // change records, batch point-read here.
         let change_ids = chunks
@@ -887,7 +856,7 @@ where
 /// Writer for changelog-backed tracked-state commit roots.
 pub(crate) struct TrackedStateWriter<'a, S: ?Sized> {
     chunk_overlay: storage::TrackedStateChunkOverlay,
-    staged_roots: BTreeMap<String, TrackedStateRootId>,
+    staged_roots: BTreeMap<String, TrackedStateCommitRoot>,
     tree: TrackedStateTree,
     store: &'a S,
     writes: &'a mut StorageWriteSet,
@@ -930,13 +899,13 @@ where
         let typed_parent_commit_id = parent_commit_id
             .map(|id| CommitId::parse_lix(id, "tracked-state parent commit_id"))
             .transpose()?;
-        let base_root = match parent_commit_id {
+        let parent_metadata = match parent_commit_id {
             Some(parent_commit_id) => {
-                let root = match self.staged_roots.get(parent_commit_id) {
-                    Some(root) => Some(root.clone()),
-                    None => self.tree.load_root(self.store, parent_commit_id).await?,
+                let metadata = match self.staged_roots.get(parent_commit_id) {
+                    Some(metadata) => Some(metadata.clone()),
+                    None => storage::load_commit_root(self.store, parent_commit_id).await?,
                 };
-                let Some(root) = root else {
+                let Some(metadata) = metadata else {
                     return Err(LixError::new(
                         "LIX_ERROR_UNKNOWN",
                         format!(
@@ -944,10 +913,39 @@ where
                         ),
                     ));
                 };
-                Some(root)
+                Some(metadata)
             }
             None => None,
         };
+        let base_root = parent_metadata
+            .as_ref()
+            .map(|metadata| metadata.root_id.clone());
+        if deltas.is_empty()
+            && let Some(parent_metadata) = parent_metadata.as_ref()
+        {
+            let root_id = parent_metadata.root_id.clone();
+            let metadata = TrackedStateCommitRoot {
+                commit_id: typed_commit_id,
+                root_id: root_id.clone(),
+                parent_roots: vec![TrackedStateCommitRootParent {
+                    commit_id: typed_parent_commit_id.expect("parent metadata requires parent id"),
+                    root_id: root_id.clone(),
+                }],
+                changed_key_count: 0,
+                row_count_estimate: parent_metadata.row_count_estimate,
+                tree_height: parent_metadata.tree_height,
+                primary_chunk_count: 0,
+                primary_chunk_bytes: 0,
+            };
+            storage::stage_commit_root(self.writes, &metadata)?;
+            self.staged_roots.insert(commit_id.to_string(), metadata);
+            return Ok(TrackedStateWriteReport {
+                commit_id: typed_commit_id,
+                root_id,
+                changed_rows: 0,
+                primary_chunk_puts: 0,
+            });
+        }
         let parent_values = if let Some(base_root) = base_root.as_ref() {
             let keys = deltas
                 .iter()
@@ -994,54 +992,51 @@ where
                 Some(commit_id),
             )
             .await?;
-        self.staged_roots
-            .insert(commit_id.to_string(), result.root_id.clone());
-        storage::stage_commit_root(
-            self.writes,
-            &TrackedStateCommitRoot {
-                commit_id: typed_commit_id,
-                root_id: result.root_id.clone(),
-                parent_roots: typed_parent_commit_id
-                    .zip(base_root.as_ref())
-                    .map(|(parent_commit_id, root_id)| {
-                        vec![TrackedStateCommitRootParent {
-                            commit_id: parent_commit_id,
-                            root_id: root_id.clone(),
-                        }]
-                    })
-                    .unwrap_or_default(),
-                changed_key_count: u64::try_from(deltas.len()).map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state commit_root changed key count exceeds u64",
-                    )
-                })?,
-                row_count_estimate: u64::try_from(result.row_count).map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state commit_root row count exceeds u64",
-                    )
-                })?,
-                tree_height: u32::try_from(result.tree_height).map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state commit_root tree height exceeds u32",
-                    )
-                })?,
-                primary_chunk_count: u64::try_from(result.chunk_count).map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state commit_root chunk count exceeds u64",
-                    )
-                })?,
-                primary_chunk_bytes: u64::try_from(result.chunk_bytes).map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state commit_root chunk bytes exceeds u64",
-                    )
-                })?,
-            },
-        )?;
+        let metadata = TrackedStateCommitRoot {
+            commit_id: typed_commit_id,
+            root_id: result.root_id.clone(),
+            parent_roots: typed_parent_commit_id
+                .zip(base_root.as_ref())
+                .map(|(parent_commit_id, root_id)| {
+                    vec![TrackedStateCommitRootParent {
+                        commit_id: parent_commit_id,
+                        root_id: root_id.clone(),
+                    }]
+                })
+                .unwrap_or_default(),
+            changed_key_count: u64::try_from(deltas.len()).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root changed key count exceeds u64",
+                )
+            })?,
+            row_count_estimate: u64::try_from(result.row_count).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root row count exceeds u64",
+                )
+            })?,
+            tree_height: u32::try_from(result.tree_height).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root tree height exceeds u32",
+                )
+            })?,
+            primary_chunk_count: u64::try_from(result.chunk_count).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root chunk count exceeds u64",
+                )
+            })?,
+            primary_chunk_bytes: u64::try_from(result.chunk_bytes).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root chunk bytes exceeds u64",
+                )
+            })?,
+        };
+        storage::stage_commit_root(self.writes, &metadata)?;
+        self.staged_roots.insert(commit_id.to_string(), metadata);
 
         Ok(TrackedStateWriteReport {
             commit_id: typed_commit_id,
@@ -1118,25 +1113,6 @@ fn validate_diff_row_against_changelog(
     Ok(())
 }
 
-fn change_record_from_commit_record(commit: &CommitRecord) -> Result<ChangeRecord, LixError> {
-    let snapshot_content = commit_row_snapshot_content(&commit.commit_id.to_string())?;
-    Ok(ChangeRecord {
-        format_version: 1,
-        change_id: commit.change_id,
-        schema_key: "lix_commit".to_string(),
-        entity_pk: EntityPk::single(commit.commit_id),
-        file_id: None,
-        snapshot: crate::json_store::JsonSlot::from_json(&snapshot_content),
-        metadata: crate::json_store::JsonSlot::None,
-        created_at: commit.created_at,
-        origin_key: None,
-    })
-}
-
-fn commit_row_snapshot_content(commit_id: &str) -> Result<String, LixError> {
-    crate::changelog::commit_row_snapshot_json(commit_id)
-}
-
 fn tracked_state_identity_from_diff_row(
     row: &TrackedStateDiffRow,
 ) -> Result<TrackedStateIdentity, LixError> {
@@ -1182,6 +1158,7 @@ fn nullable_key_filter_allows(filters: &[NullableKeyFilter<String>], value: Opti
 mod tests {
     use super::*;
     use crate::NullableKeyFilter;
+    use crate::changelog::CommitRecord;
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
 
@@ -1278,11 +1255,74 @@ mod tests {
         assert_eq!(metadata.parent_roots.len(), 1);
         assert_eq!(metadata.parent_roots[0].commit_id, "parent");
         assert_eq!(metadata.parent_roots[0].root_id, parent_root);
-        assert_eq!(metadata.changed_key_count, 3);
-        assert_eq!(metadata.row_count_estimate, 4);
+        assert_eq!(metadata.changed_key_count, 2);
+        assert_eq!(metadata.row_count_estimate, 2);
         assert!(metadata.tree_height >= 1);
         assert!(metadata.primary_chunk_count >= 1);
         assert!(metadata.primary_chunk_bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn stage_empty_commit_root_reuses_parent_without_tree_chunks() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[row("entity-a", "change-parent", "parent")],
+        )
+        .await
+        .expect("parent root should write");
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let parent_metadata = storage::load_commit_root(&read, "parent")
+            .await
+            .expect("parent metadata should load")
+            .expect("parent metadata should exist");
+        let mut writes = storage.new_write_set();
+        let report = tracked_state
+            .writer(&mut read, &mut writes)
+            .stage_commit_root("empty-child", Some("parent"), [])
+            .await
+            .expect("empty child root should stage");
+
+        assert_eq!(report.changed_rows, 0);
+        assert_eq!(report.primary_chunk_puts, 0);
+        assert_eq!(report.root_id, parent_metadata.root_id);
+
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("empty child root should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should reopen");
+        let child_metadata = storage::load_commit_root(&read, "empty-child")
+            .await
+            .expect("child metadata should load")
+            .expect("child metadata should exist");
+
+        assert_eq!(child_metadata.root_id, parent_metadata.root_id);
+        assert_eq!(child_metadata.changed_key_count, 0);
+        assert_eq!(
+            child_metadata.row_count_estimate,
+            parent_metadata.row_count_estimate
+        );
+        assert_eq!(child_metadata.tree_height, parent_metadata.tree_height);
+        assert_eq!(child_metadata.primary_chunk_count, 0);
+        assert_eq!(child_metadata.primary_chunk_bytes, 0);
+        assert_eq!(child_metadata.parent_roots.len(), 1);
+        assert_eq!(child_metadata.parent_roots[0].commit_id, "parent");
+        assert_eq!(
+            child_metadata.parent_roots[0].root_id,
+            parent_metadata.root_id
+        );
     }
 
     #[tokio::test]
@@ -1898,65 +1938,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_rebuild_repairs_stale_root_missing_commit_row() {
-        let storage = StorageAdapter::new(Memory::new());
-        let tracked_state = TrackedStateContext::new();
-        let row = row_with_value("entity-a", "change-a", "commit-1", "value");
-        write_root_for_test(
-            &storage,
-            &tracked_state,
-            "commit-1",
-            None,
-            std::slice::from_ref(&row),
-        )
-        .await
-        .expect("root should write");
-        overwrite_root_without_commit_row_for_test(
-            &storage,
-            "commit-1",
-            std::slice::from_ref(&row),
-        )
-        .await;
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let mut writes = storage.new_write_set();
-        tracked_state
-            .root_rebuilder(&read, &mut writes)
-            .rebuild_commit_root_at("commit-1")
-            .await
-            .expect("stale root should repair");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("repaired root should commit");
-
-        let rows = tracked_state
-            .reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("read should open"),
-            )
-            .scan_rows_at_commit(
-                "commit-1",
-                &TrackedStateScanRequest {
-                    filter: crate::tracked_state::TrackedStateFilter {
-                        schema_keys: vec!["lix_commit".to_string()],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("repaired root should scan");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].schema_key, "lix_commit");
-    }
-
-    #[tokio::test]
     async fn explicit_rebuild_repairs_stale_root_missing_inherited_row() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
@@ -1980,8 +1961,7 @@ mod tests {
         )
         .await
         .expect("child root should write");
-        overwrite_root_without_commit_row_for_test(&storage, "child", std::slice::from_ref(&child))
-            .await;
+        overwrite_root_with_rows_for_test(&storage, "child", std::slice::from_ref(&child)).await;
 
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -2559,59 +2539,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn commit_rows_materialize_key_derived_snapshots() {
-        let storage = StorageAdapter::new(Memory::new());
-        let tracked_state = TrackedStateContext::new();
-        let row = row("entity-a", "change-a", "commit-1");
-        write_root_for_test(
-            &storage,
-            &tracked_state,
-            "commit-1",
-            None,
-            std::slice::from_ref(&row),
-        )
-        .await
-        .expect("root should write");
-
-        let mut reader = tracked_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let request = TrackedStateScanRequest {
-            filter: crate::tracked_state::TrackedStateFilter {
-                schema_keys: vec!["lix_commit".to_string()],
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let rows = reader
-            .scan_rows_at_commit("commit-1", &request)
-            .await
-            .expect("commit rows should scan");
-        let commit_row = rows
-            .iter()
-            .find(|row| row.schema_key == "lix_commit")
-            .expect("commit row should exist");
-        // The snapshot is synthesized from the key and must be byte-equal
-        // to the canonical producer.
-        let expected = crate::changelog::commit_row_snapshot_json(
-            &commit_row
-                .entity_pk
-                .parts
-                .first()
-                .cloned()
-                .unwrap_or_default(),
-        )
-        .expect("snapshot should encode");
-        assert_eq!(
-            commit_row.snapshot_content.as_deref(),
-            Some(expected.as_str())
-        );
-    }
-
-    #[tokio::test]
     async fn inline_threshold_boundary_routes_payloads_deterministically() {
         // 256 bytes inlines into the change record; 257 takes the
         // json_store ref path. Both must read back identically.
@@ -2968,7 +2895,7 @@ mod tests {
             .expect("root chunk corruption should commit");
     }
 
-    async fn overwrite_root_without_commit_row_for_test(
+    async fn overwrite_root_with_rows_for_test(
         storage: &StorageAdapter,
         commit_id: &str,
         rows: &[MaterializedTrackedStateRow],

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -132,11 +132,6 @@ where
         if let (Some(left), Some(right)) =
             (is_live_row(before.as_ref()), is_live_row(after.as_ref()))
         {
-            // Commit rows have no change records and are skipped by
-            // classification; loading their ids would always miss.
-            if left.schema_key == "lix_commit" {
-                continue;
-            }
             if left.change_id != right.change_id {
                 fallback_ids.push(left.change_id);
                 fallback_ids.push(right.change_id);
@@ -151,9 +146,6 @@ where
             Some(row) => TrackedStateDiffIdentity::from(row),
             None => continue,
         };
-        if identity.schema_key == "lix_commit" {
-            continue;
-        }
         let Some(entry) = classify_diff(identity, before, after, &payloads) else {
             continue;
         };
@@ -309,11 +301,6 @@ mod tests {
 
     fn change_id(label: &str) -> String {
         ChangeId::for_test_label(label).to_string()
-    }
-
-    fn commit_row_change_id(commit_id: &str) -> String {
-        let commit_id = CommitId::for_test_label(commit_id);
-        ChangeId::for_test_label(&format!("{commit_id}:commit")).to_string()
     }
 
     #[tokio::test]
@@ -676,20 +663,10 @@ mod tests {
         let updated_at = value.updated_at().to_string();
         value.created_at = LixTimestamp::expect_parse("created_at", "2026-01-03T00:00:00Z");
         value.updated_at = LixTimestamp::expect_parse("updated_at", &updated_at);
-        let parent_commit_row = commit_root_row_entry(
-            "parent",
-            &commit_row_change_id("parent"),
-            "2026-01-01T00:00:00Z",
-        );
-        let commit_row = commit_root_row_entry(
-            "child",
-            &commit_row_change_id("child"),
-            "2026-01-02T00:00:00Z",
-        );
         stage_corrupt_commit_root(
             &storage,
             "child",
-            vec![(key, value), parent_commit_row, commit_row],
+            vec![(key, value)],
             vec![TrackedStateCommitRootParent {
                 commit_id: CommitId::for_test_label("parent"),
                 root_id: tracked_state_root_id(&storage, "parent").await,
@@ -2149,29 +2126,6 @@ mod tests {
                 .message
                 .contains("does not preserve inherited identity")
             || error.message.contains("but changelog winner is")
-    }
-
-    fn commit_root_row_entry(
-        commit_id: &str,
-        change_id: &str,
-        created_at: &str,
-    ) -> (TrackedStateKey, TrackedStateIndexValue) {
-        let commit_id = CommitId::for_test_label(commit_id);
-        let commit_id_text = commit_id.to_string();
-        (
-            TrackedStateKey {
-                schema_key: "lix_commit".to_string(),
-                file_id: None,
-                entity_pk: EntityPk::single(&commit_id_text),
-            },
-            TrackedStateIndexValue {
-                change_id: ChangeId::for_test_label(change_id),
-                commit_id,
-                deleted: false,
-                created_at: LixTimestamp::expect_parse("created_at", created_at),
-                updated_at: LixTimestamp::expect_parse("updated_at", created_at),
-            },
-        )
     }
 
     fn tombstone(

--- a/packages/engine/src/tracked_state/merge.rs
+++ b/packages/engine/src/tracked_state/merge.rs
@@ -133,9 +133,6 @@ fn diff_by_identity(
 ) -> Result<BTreeMap<TrackedStateDiffIdentity, &TrackedStateDiffEntry>, LixError> {
     let mut entries = BTreeMap::new();
     for entry in &diff.entries {
-        if entry.identity.schema_key == "lix_commit" {
-            continue;
-        }
         if entries.insert(entry.identity.clone(), entry).is_some() {
             return Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",

--- a/packages/engine/src/tracked_state/row_materialization.rs
+++ b/packages/engine/src/tracked_state/row_materialization.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use crate::changelog::{
     ChangeId, ChangeRecordProjection, MaterializedChangePayload, materialize_change_payloads,
 };
-use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::MaterializedTrackedStateRow;
 use crate::tracked_state::types::{TrackedStateIndexValue, TrackedStateKey};
@@ -33,17 +32,14 @@ where
     }
 
     let mut remaining_payload_uses = HashMap::<ChangeId, usize>::new();
-    for (_, value) in entries
-        .iter()
-        .filter(|(key, value)| !value.deleted && key.schema_key != COMMIT_SCHEMA_KEY)
-    {
+    for (_, value) in entries.iter().filter(|(_, value)| !value.deleted) {
         *remaining_payload_uses.entry(value.change_id).or_default() += 1;
     }
     let mut payloads = materialize_change_payloads(
         store,
         entries
             .iter()
-            .filter(|(key, value)| !value.deleted && key.schema_key != COMMIT_SCHEMA_KEY)
+            .filter(|(_, value)| !value.deleted)
             .map(|(_, value)| value.change_id),
         *materialization,
         "tracked-state row",
@@ -54,17 +50,6 @@ where
     for (key, value) in entries {
         let (snapshot_content, metadata) = if value.deleted {
             (None, None)
-        } else if key.schema_key == COMMIT_SCHEMA_KEY {
-            // Commit rows have no change record; their snapshot is fully
-            // derivable from the key (the entity pk is the commit id).
-            (
-                if materialization.snapshot_content {
-                    Some(commit_row_snapshot_json(&key.entity_pk)?)
-                } else {
-                    None
-                },
-                None,
-            )
         } else {
             let payload =
                 take_payload(&mut payloads, &mut remaining_payload_uses, value.change_id)?;
@@ -129,18 +114,6 @@ fn take_payload(
             ),
         )
     })
-}
-
-const COMMIT_SCHEMA_KEY: &str = "lix_commit";
-
-fn commit_row_snapshot_json(entity_pk: &EntityPk) -> Result<String, LixError> {
-    let Some(commit_id) = entity_pk.parts.first() else {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            "lix_commit row has an empty entity pk",
-        ));
-    };
-    crate::changelog::commit_row_snapshot_json(commit_id)
 }
 
 fn materialize_entry_without_json(

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -29,6 +29,11 @@ pub(crate) const TRACKED_STATE_COMMIT_ROOT_SPACE: StorageSpace = StorageSpace::n
     TRACKED_STATE_COMMIT_ROOT_NAMESPACE,
 );
 
+// Version the root metadata independently of storage backends. Version 2 is a
+// hard format cut: roots written before commit rows became derived state must
+// not be inherited by a new commit and silently carry those rows forever.
+const TRACKED_STATE_COMMIT_ROOT_MAGIC: &[u8] = b"LXTR2";
+
 async fn get_one(
     store: &(impl StorageAdapterRead + ?Sized),
     space: StorageSpace,
@@ -186,11 +191,21 @@ fn full_value(value: StorageProjectedValue) -> Option<Vec<u8>> {
 }
 
 fn encode_commit_root(metadata: &TrackedStateCommitRoot) -> Result<Vec<u8>, LixError> {
-    storage_codec::encode("tracked_state commit_root", metadata)
+    let payload = storage_codec::encode("tracked_state commit_root", metadata)?;
+    let mut encoded = Vec::with_capacity(TRACKED_STATE_COMMIT_ROOT_MAGIC.len() + payload.len());
+    encoded.extend_from_slice(TRACKED_STATE_COMMIT_ROOT_MAGIC);
+    encoded.extend_from_slice(&payload);
+    Ok(encoded)
 }
 
 fn decode_commit_root(bytes: &[u8]) -> Result<TrackedStateCommitRoot, LixError> {
-    storage_codec::decode("tracked_state commit_root", bytes)
+    let Some(payload) = bytes.strip_prefix(TRACKED_STATE_COMMIT_ROOT_MAGIC) else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_root has an unsupported format; recreate the repository",
+        ));
+    };
+    storage_codec::decode("tracked_state commit_root", payload)
 }
 
 #[cfg(test)]
@@ -199,6 +214,7 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
 
+    use crate::LixError;
     use crate::binary_cas::kv::{
         BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE, BINARY_CAS_MANIFEST_SPACE,
     };
@@ -210,8 +226,8 @@ mod tests {
     };
 
     use super::{
-        TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE, decode_commit_root,
-        encode_commit_root,
+        TRACKED_STATE_COMMIT_ROOT_MAGIC, TRACKED_STATE_COMMIT_ROOT_SPACE,
+        TRACKED_STATE_TREE_CHUNK_SPACE, decode_commit_root, encode_commit_root,
     };
 
     #[test]
@@ -258,6 +274,7 @@ mod tests {
         };
 
         let encoded = encode_commit_root(&metadata).expect("commit root should encode");
+        assert!(encoded.starts_with(TRACKED_STATE_COMMIT_ROOT_MAGIC));
         let decoded = decode_commit_root(&encoded).expect("commit root should decode");
 
         assert_eq!(decoded, metadata);
@@ -266,12 +283,38 @@ mod tests {
     #[test]
     fn commit_root_codec_rejects_malformed_storage_bytes() {
         let error = decode_commit_root(b"LXTR1not-musli")
-            .expect_err("old hand-rolled bytes should not decode as musli");
+            .expect_err("old commit-root versions must fail loudly");
 
         assert!(
             error
                 .to_string()
-                .contains("failed to decode tracked_state commit_root")
+                .contains("unsupported format; recreate the repository")
+        );
+    }
+
+    #[test]
+    fn commit_root_codec_rejects_unversioned_musli_roots() {
+        let metadata = TrackedStateCommitRoot {
+            commit_id: CommitId::for_test_label("legacy"),
+            root_id: TrackedStateRootId::new([7; 32]),
+            parent_roots: Vec::new(),
+            changed_key_count: 1,
+            row_count_estimate: 1,
+            tree_height: 1,
+            primary_chunk_count: 1,
+            primary_chunk_bytes: 128,
+        };
+        let old_bytes = crate::storage_codec::encode("tracked_state commit_root", &metadata)
+            .expect("legacy commit root should encode");
+
+        let error = decode_commit_root(&old_bytes)
+            .expect_err("unversioned commit roots must not enter the new layout");
+
+        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+        assert!(
+            error
+                .message
+                .contains("unsupported format; recreate the repository")
         );
     }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -232,8 +232,6 @@ fn index_prepared_rows(rows: &[PreparedStateRow]) -> Result<PreparedRowIndex, Li
 struct StagedChangelogCommit {
     change_ids: Vec<ChangeId>,
     selected_change_refs: Vec<StagedCommitChangeRef>,
-    commit_change_id: ChangeId,
-    commit_created_at: LixTimestamp,
 }
 
 async fn stage_changelog_commits(
@@ -299,8 +297,6 @@ async fn stage_changelog_commits(
             StagedChangelogCommit {
                 change_ids,
                 selected_change_refs: commit_row.selected_change_refs.clone(),
-                commit_change_id: commit_row.change_id,
-                commit_created_at: commit_row.created_at,
             },
         );
     }
@@ -712,24 +708,16 @@ async fn stage_tracked_roots(
                 ),
             ));
         }
-        let commit_entity_pk = EntityPk::single(root.commit_id.to_string());
-        let mut deltas = state_row_indices
+        let deltas = state_row_indices
             .iter()
             .map(|&row_index| tracked_delta_from_state_row(&state_rows[row_index]))
             .chain(staged.selected_change_refs.iter().map(|change_ref| {
                 tracked_delta_from_selected_change_ref(change_ref, root.commit_id)
             }))
             .collect::<Result<Vec<_>, _>>()?;
-        deltas.push(TrackedStateDeltaRef {
-            schema_key: "lix_commit",
-            file_id: None,
-            entity_pk: &commit_entity_pk,
-            change_id: staged.commit_change_id,
-            commit_id: root.commit_id,
-            deleted: false,
-            created_at: staged.commit_created_at,
-            updated_at: staged.commit_created_at,
-        });
+        // Commit facts are canonical in changelog.commit and live-state derives
+        // lix_commit rows from the commit graph. Keeping them out of this tree
+        // also preserves the one-mutation path for ordinary singleton writes.
         let commit_id_text = root.commit_id.to_string();
         let parent_commit_id_text = root.parent_commit_id.map(|id| id.to_string());
         tracked_writer
@@ -1110,10 +1098,31 @@ mod tests {
             .await
             .expect("commit root should scan");
         assert!(
-            commit_rows
+            commit_rows.is_empty(),
+            "commit rows are derived from changelog.commit, not stored in tracked roots"
+        );
+        let derived_commit_rows = live_state_context()
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("read should open"),
+            )
+            .scan_rows(&crate::live_state::LiveStateScanRequest {
+                filter: crate::live_state::LiveStateFilter {
+                    schema_keys: vec!["lix_commit".to_string()],
+                    branch_ids: vec![GLOBAL_BRANCH_ID.to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .expect("derived commit rows should scan");
+        assert!(
+            derived_commit_rows
                 .iter()
-                .any(|row| row.change_id == record.change_id && row.snapshot_content.is_some()),
-            "commit root should surface the derived lix_commit row"
+                .any(|row| row.change_id == Some(record.change_id)),
+            "live state should derive the commit row from changelog.commit"
         );
 
         let loaded_head = branch_ctx


### PR DESCRIPTION
## What changed

- stop storing derived `lix_commit` rows in immutable tracked-state trees
- keep commit identity canonical in `changelog.commit` and synthesize commit rows for live-state reads
- add a zero-delta fast path that reuses the parent root for empty commits and merges
- introduce the backend-neutral `LXTR2` commit-root format marker
- reject repositories using the previous tracked-root layout; there is intentionally no legacy decoder
- add backend-neutral write-set accounting plus SlateDB object-store WAL probes

## Why

A normal singleton mutation also inserted a synthetic commit row into the tracked-state tree. That turned one authored mutation into two tree mutations, bypassed the existing singleton path-copy path, and made write cost grow with accumulated commit history.

The redundant row is removed before storage-adapter lowering. SlateDB and RocksDB therefore receive the same smaller logical mutation set without backend-specific layout code.

## Data

| Physical write | Before | After | Change |
|---|---:|---:|---:|
| SlateDB update, first 200 commits | 7,215 B | 4,546 B | -37.0% |
| SlateDB update, later 200 commits | 7,915 B | 4,546 B | -42.6% |
| SlateDB delete | 5,715 B | 4,496 B | -21.3% |
| RocksDB update WAL | 11,948 B | 5,193 B | -56.5% |
| RocksDB delete WAL | 11,728 B | 4,973 B | -57.6% |
| SlateDB insert 1k | 161,559 B | 161,423 B | -0.08% |
| RocksDB update 1k WAL | 567,280 B | 566,984 B | -0.05% |

SlateDB local update p50/p95 improved from 2.882/4.577 ms to 2.517/2.704 ms. With 25 ms simulated object-store latency, p50/p95 changed from 30.650/31.031 ms to 30.238/30.753 ms: every commit remains one durable WAL object PUT, so RTT still dominates remote p95.

RocksDB measurements parse exact physical WAL records. Its adapter currently uses one `WriteBatch` with `sync=false`, so those results validate backend portability and physical write amplification, not durable RocksDB latency.

## Breaking change

Tracked-state commit-root metadata now starts with `LXTR2`. Repositories written with the previous layout fail clearly and must be recreated. Commit IDs remain stable UUIDv7 identifiers stored in the canonical changelog; this only changes tracked-state materialization.

## Validation

- 1,068 engine tests passed; 3 ignored
- empty-merge integration variants passed
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- final SlateDB and RocksDB benchmark binaries rebuilt from the final source
- benchmark methodology and complete results recorded in `optimization_log.md`
