### PR TITLE
perf(engine): add compact tracked-state codec v3

### DIFF
--- a/.changenotes/compact-tracked-state-tree.md
+++ b/.changenotes/compact-tracked-state-tree.md
@@ -1,0 +1,19 @@
+---
+type: major
+---
+
+Reduced tracked-state write amplification with the v3 tree codec.
+
+Tracked-state keys now use a prefix-friendly ordered encoding. Leaf nodes
+front-code keys, dictionary repeated commit and state metadata, and compact
+equal or small timestamps; internal nodes front-code child boundaries. This is
+a hard storage-format cut; repositories created by older engine versions must
+be recreated.
+
+Ordinary tracked-state diffs now retain hash-guided sparse traversal: they bind
+commit-root first-parent metadata and point-validate every changed row's change
+record. Winner reachability, inherited timestamps, and whole-root coverage
+are checked against staged chunks by the full audit in the explicit tracked-state
+rebuild path before publication, instead of scanning all unchanged rows on every
+merge. A hierarchical Merkle zipper also preserves subtree skipping when an
+insert shifts chunk boundaries or changes the root height.

--- a/.changenotes/compact-tracked-state-tree.md
+++ b/.changenotes/compact-tracked-state-tree.md
@@ -1,5 +1,5 @@
 ---
-type: major
+type: minor
 ---
 
 Reduced tracked-state write amplification with the v3 tree codec.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -2002,3 +2002,127 @@ Removing the synthetic row exposed a zero-delta case for allowed empty merges.
 Without a fast path, the generic tree builder would scan and rewrite the entire
 parent tree. Empty child roots now reuse the parent's root id, row count, and
 height, stage no tree chunks, and write only their own commit-root metadata.
+
+## 2026-07-21 — Tracked-State Tree Codec V3
+
+Hypothesis: tracked-state tree chunks were paying general-purpose row-codec
+overhead independently for every key, value, and internal-node boundary even
+though each leaf is already an ordered block. Applying the same block-local
+ideas used by columnar pages and LSM/SST blocks—order-preserving keys,
+front-coding, and dictionaries for repeated fields—should reduce both durable
+bytes and the amount of data read without adding a second storage layer.
+
+The v3 writer emits one deterministic format:
+
+- Keys use an escaped, order-preserving tuple grammar. Schema and schema/file
+  encodings are exact prefixes, full keys are prefix-free, and variable-length
+  text now shares physical prefixes.
+- Leaves front-code adjacent keys, keep change ids inline, and dictionary only
+  repeated commit ids and state tails. Unique values never pay dictionary
+  entries.
+- A state-tail tag carries deletion, timestamp widths, and the common
+  `created_at == updated_at` case. Minimal little-endian timestamp payloads
+  bound values to 33–49 bytes: epoch/equal is 33 B, 2026/equal is 40 B,
+  two 2026 timestamps are 47 B, and the worst valid pair is 49 B.
+- Internal nodes front-code each first boundary against the prior child's last
+  boundary and each last boundary against its first.
+- Unary roots are promoted and the canonical empty-leaf sentinel cannot remain
+  beside live leaves.
+
+The first counterfactual used two fixed 8-byte timestamp fields. It looked good
+on the normal 2026 workload, but was rejected before publication: stacked on
+#653 it increased SlateDB singleton update/delete WAL bytes by about 9% because
+that deterministic fixture uses compact epoch-like timestamps. The width-tag
+form used here is never larger than that fixed representation and is smaller for
+both epoch-like and ordinary current timestamps.
+
+Current-main 1k transaction accounting at `553a6b7a` (SQLite; RocksDB has the
+same put counts and differs by at most 30 bytes from nondeterministic
+timestamps):
+
+| Operation | v2 bytes | v3 bytes | Change | v2 puts | v3 puts |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| insert all | 424,045 | 385,102 | -9.2% | 1,075 | 1,073 |
+| update all | 526,780 | 487,984 | -7.4% | 1,410 | 1,408 |
+| update one | 4,831 | 3,782 | -21.7% | 9 | 9 |
+| delete all | 169,993 | 131,182 | -22.8% | 1,031 | 1,029 |
+| delete one | 4,612 | 3,563 | -22.7% | 9 | 9 |
+
+After `insert_all`, `tracked_state.tree_chunk` moves from 27 rows / 75,270
+key-plus-value bytes to 24 rows / 35,323 bytes (-53.1%). Commit IDs remain
+stable; content-addressed tree chunk hashes and root IDs intentionally change
+with the canonical bytes.
+
+Current-main SlateDB physical validation at `553a6b7a`, 200 singleton samples,
+one durable WAL object PUT per transaction:
+
+| Operation | main logical bytes | v3 | main WAL bytes | v3 | WAL change |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| insert 1k | 135,608 | 132,189 | 161,423 | 157,937 | -2.2% |
+| update one, average | 3,766 | 3,260 | 4,546 | 3,988 | -12.3% |
+| delete one | 3,716 | 3,210 | 4,496 | 3,938 | -12.4% |
+
+The byte win is durable; remote latency remains dominated by the unchanged
+single object-store RTT.
+
+An earlier RocksDB 1k Criterion control had no material regression across CRUD
+point estimates: insert 22.48 ms, read all 6.18 ms, read many 714 us, update all
+21.72 ms, update one 1.42 ms, delete all 18.12 ms, and delete one 1.47 ms.
+`read_one_by_pk` has process-level spread at this scale; three v3 repeats were
+194.6/188.7/166.6 us (mean 183.3 us) versus the clean-main repeats'
+190.8/192.5/191.6 us (mean 191.6 us). No read regression is claimed.
+
+Fast-diff validation used the same invariant as
+[Dolt's prolly trees](https://www.dolthub.com/docs/architecture/storage-engine/prolly-tree/):
+boundaries depend only on keys, immutable nodes are content-addressed, and equal
+child hashes skip the entire subtree. Two pre-existing paths had weakened that
+property independently of the codec. Ordinary commit diff first ran whole-root
+coverage validation, and a key insertion that shifted an internal boundary fell
+back to enumerating every leaf summary.
+
+A release probe counted logical node loads and cold storage reads. Value updates
+and tombstones remain one path per root (6 loads / 6 reads at both 10k and 100k),
+and identical roots remain 0 / 0. For a one-key append, the old boundary-mismatch
+fallback grew with tree size while the hierarchical Merkle zipper stayed flat:
+
+| Rows | Current-main fallback | V3 hierarchical zipper |
+| ---: | ---: | ---: |
+| 10,000 | 20 loads / 11 reads | 6 loads / 6 reads |
+| 100,000 | 100 loads / 51 reads | 6 loads / 6 reads |
+
+The paired 10k release timings improved with the same access shape:
+
+| One-row diff | Current-main p50 / p95 | V3 p50 / p95 | p50 change |
+| --- | ---: | ---: | ---: |
+| value update | 50.3 / 60.9 us | 22.4 / 32.1 us | -55.5% |
+| append | 139.9 / 160.8 us | 29.2 / 39.8 us | -79.1% |
+| tombstone | 50.6 / 60.7 us | 22.3 / 30.9 us | -55.9% |
+
+At 100k rows, v3 update/append/tombstone p50 stayed at 29.1/39.8/28.8 us.
+Current-main append grew to 1.110 ms and 51 cold reads; v3 append remained six
+reads. Ten times more rows therefore adds less than 1.4x latency to the sparse
+path instead of turning it into a scan.
+
+The 100k v3 tree contained 997 chunks, so the append read 0.6% of them. A 10k
+control that scanned both roots for coverage needed 104 cold chunk reads; that
+scan no longer precedes every normal diff. Normal diff binds each commit root's
+first-parent metadata and point-validates only emitted change records. Winner
+reachability, inherited creation timestamps, and proof that no row was omitted
+remain in the full O(total rows) audit run by explicit tracked-state rebuild.
+Deep-tree oracle tests cover shifted leaf boundaries, prepend/middle/append
+inserts, updates, tombstones, and a root-height transition.
+
+A separately sampled, unfiltered 100k-row scan initially exposed allocator
+churn in the new decoder. The counterfactual made one-part entity keys allocate
+exactly once, preallocated unfiltered result rows from the root subtree count,
+and removed a duplicate post-decode predicate pass. Final single-root scan
+median was about 29.1 ms versus 31.2 ms on current main (about 7% faster); this
+fix does not change the wire format or the Merkle diff path.
+
+This is deliberately a hard cut. Commit-root metadata starts with `LXTR3`, only
+v3 leaf/internal kind bytes decode, and unversioned or older roots fail before
+tree traversal with a repository-recreation error. There is no legacy decoder
+or slow fallback. Validation includes golden wire bytes, logical-vs-byte
+ordering, prefix-freedom, malformed codec, multi-level routing, canonical
+rebuild, sparse/deep/height-transition diff oracles, and backend accounting
+coverage.

--- a/packages/engine/src/common/timestamp.rs
+++ b/packages/engine/src/common/timestamp.rs
@@ -94,7 +94,7 @@ impl LixTimestamp {
     }
 
     #[expect(clippy::cast_possible_wrap)]
-    fn from_packed(packed: u64) -> Result<Self, String> {
+    pub(crate) fn from_packed(packed: u64) -> Result<Self, String> {
         let timestamp = Self(packed);
         if !valid_offset_minutes(timestamp.offset_minutes()) {
             return Err(format!(

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -214,7 +214,9 @@ where
     /// This is intentionally an engine-level operation: callers should not need
     /// to know which KV namespaces back changelog, commit graph, or tracked
     /// state. The current branch head is read from the live-state facade so
-    /// rebuild uses the same moving-ref visibility as normal execution.
+    /// rebuild uses the same moving-ref visibility as normal execution. The
+    /// rebuilt root receives the full changelog coverage audit against its
+    /// staged chunks before the replacement root is published.
     pub async fn rebuild_tracked_state_for_branch(&self, branch_id: &str) -> Result<(), LixError> {
         let head_commit_id = self
             .load_branch_head_commit_id(branch_id)
@@ -240,7 +242,7 @@ where
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .map(|_| ())
-            .map_err(Into::into)
+            .map_err(LixError::from)
     }
 }
 

--- a/packages/engine/src/session/merge/analysis.rs
+++ b/packages/engine/src/session/merge/analysis.rs
@@ -60,7 +60,7 @@ where
         TrackedStateDiff::default()
     } else {
         reader
-            .diff_commits_with_validation(&base_commit_id, &target_commit_id, &request, false, true)
+            .diff_commits(&base_commit_id, &target_commit_id, &request)
             .await?
     };
 

--- a/packages/engine/src/tracked_state/codec.rs
+++ b/packages/engine/src/tracked_state/codec.rs
@@ -1,29 +1,24 @@
-use musli::{Decode, Encode};
 use xxhash_rust::xxh3::xxh3_64_with_seed;
 
 use crate::LixError;
-use crate::storage_codec;
+use crate::changelog::{ChangeId, CommitId};
+use crate::common::LixTimestamp;
 use crate::tracked_state::types::{
-    TRACKED_STATE_HASH_BYTES, TrackedSchemaFilePrefixRef, TrackedSchemaKeyPrefixRef,
-    TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
+    TRACKED_STATE_HASH_BYTES, TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey,
+    TrackedStateKeyRef,
 };
 
 const WEIBULL_K: i32 = 4;
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EncodedLeafEntry {
-    #[musli(bytes)]
     pub(crate) key: Vec<u8>,
-    #[musli(bytes)]
     pub(crate) value: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Copy, Encode, Decode)]
-#[musli(packed)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct EncodedLeafEntryRef<'a> {
-    #[musli(bytes)]
     pub(crate) key: &'a [u8],
-    #[musli(bytes)]
     pub(crate) value: &'a [u8],
 }
 
@@ -36,29 +31,23 @@ impl EncodedLeafEntry {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PendingChunkWrite {
     pub(crate) hash: [u8; TRACKED_STATE_HASH_BYTES],
-    #[musli(bytes)]
     pub(crate) data: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ChildSummary {
-    #[musli(bytes)]
     pub(crate) first_key: Vec<u8>,
-    #[musli(bytes)]
     pub(crate) last_key: Vec<u8>,
     pub(crate) child_hash: [u8; TRACKED_STATE_HASH_BYTES],
     pub(crate) subtree_count: u64,
 }
 
-#[derive(Debug, Clone, Copy, Encode, Decode)]
-#[musli(packed)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct ChildSummaryRef<'a> {
-    #[musli(bytes)]
     pub(crate) first_key: &'a [u8],
-    #[musli(bytes)]
     pub(crate) last_key: &'a [u8],
     pub(crate) child_hash: [u8; TRACKED_STATE_HASH_BYTES],
     pub(crate) subtree_count: u64,
@@ -77,66 +66,58 @@ impl ChildSummary {
 
 #[derive(Debug, Clone)]
 pub(crate) enum DecodedNode {
-    Leaf(DecodedLeafNode),
+    Leaf(DecodedLeafNodeRef),
     Internal(DecodedInternalNode),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum DecodedNodeRef<'a> {
-    Leaf(DecodedLeafNodeRef<'a>),
+pub(crate) enum DecodedNodeRef {
+    Leaf(DecodedLeafNodeRef),
     Internal(DecodedInternalNode),
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct DecodedLeafNode {
-    entries: Vec<EncodedLeafEntry>,
-}
-
-impl DecodedLeafNode {
-    pub(crate) fn entries(&self) -> &[EncodedLeafEntry] {
-        &self.entries
-    }
 }
 
 /// Decoded view of a leaf node.
 ///
 /// Keys are stored front-coded on disk and reconstructed into one arena at
-/// decode time. Values with a dictionaried commit-id slice are reconstructed
-/// into the same arena; verbatim values stay borrowed from the chunk bytes.
+/// decode time. Compact value parts are reconstructed byte-for-byte into the
+/// same arena, keeping entry access to two borrowed slices without per-entry
+/// allocations.
 #[derive(Debug, Clone)]
-pub(crate) struct DecodedLeafNodeRef<'a> {
-    key_arena: Vec<u8>,
-    entries: Vec<LeafEntrySpan<'a>>,
+pub(crate) struct DecodedLeafNodeRef {
+    arena: Vec<u8>,
+    entries: Vec<LeafEntrySpan>,
 }
 
 #[derive(Debug, Clone, Copy)]
-struct LeafEntrySpan<'a> {
+struct LeafEntrySpan {
     key_start: usize,
     key_end: usize,
-    value: LeafValueSpan<'a>,
+    value_start: usize,
+    value_end: usize,
 }
 
-/// Values whose commit-id slice was dictionaried are reconstructed into the
-/// arena; verbatim values stay borrowed from the chunk bytes.
-#[derive(Debug, Clone, Copy)]
-enum LeafValueSpan<'a> {
-    Borrowed(&'a [u8]),
-    Arena { start: usize, end: usize },
-}
-
-impl DecodedLeafNodeRef<'_> {
+impl DecodedLeafNodeRef {
     pub(crate) fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    pub(crate) fn first_key(&self) -> Option<&[u8]> {
+        self.entries
+            .first()
+            .map(|span| &self.arena[span.key_start..span.key_end])
+    }
+
+    pub(crate) fn last_key(&self) -> Option<&[u8]> {
+        self.entries
+            .last()
+            .map(|span| &self.arena[span.key_start..span.key_end])
     }
 
     #[expect(clippy::unnecessary_wraps)]
     pub(crate) fn entry(&self, index: usize) -> Result<Option<EncodedLeafEntryRef<'_>>, LixError> {
         Ok(self.entries.get(index).map(|span| EncodedLeafEntryRef {
-            key: &self.key_arena[span.key_start..span.key_end],
-            value: match span.value {
-                LeafValueSpan::Borrowed(value) => value,
-                LeafValueSpan::Arena { start, end } => &self.key_arena[start..end],
-            },
+            key: &self.arena[span.key_start..span.key_end],
+            value: &self.arena[span.value_start..span.value_end],
         }))
     }
 
@@ -145,7 +126,20 @@ impl DecodedLeafNodeRef<'_> {
         Ok(self
             .entries
             .get(index)
-            .map(|span| &self.key_arena[span.key_start..span.key_end]))
+            .map(|span| &self.arena[span.key_start..span.key_end]))
+    }
+
+    /// Materializes per-entry buffers only for mutation paths that need to
+    /// retain leaf entries after this decoded node is consumed. Read and diff
+    /// paths keep using the arena-backed view above.
+    pub(crate) fn into_entries(self) -> Vec<EncodedLeafEntry> {
+        self.entries
+            .into_iter()
+            .map(|span| EncodedLeafEntry {
+                key: self.arena[span.key_start..span.key_end].to_vec(),
+                value: self.arena[span.value_start..span.value_end].to_vec(),
+            })
+            .collect()
     }
 }
 
@@ -158,51 +152,61 @@ impl DecodedInternalNode {
     pub(crate) fn children(&self) -> &[ChildSummary] {
         &self.children
     }
+
+    pub(crate) fn into_children(self) -> Vec<ChildSummary> {
+        self.children
+    }
 }
 
-const NODE_KIND_LEAF_V2: u8 = 1;
-const NODE_KIND_INTERNAL: u8 = 2;
-
-#[derive(Encode, Decode)]
-struct StorageInternalNode<'a> {
-    children: Vec<ChildSummaryRef<'a>>,
-}
+const NODE_KIND_LEAF_V3: u8 = 3;
+const NODE_KIND_INTERNAL_V3: u8 = 4;
 
 pub(crate) fn hash_bytes(bytes: &[u8]) -> [u8; TRACKED_STATE_HASH_BYTES] {
     *blake3::hash(bytes).as_bytes()
 }
 
 pub(crate) fn encode_key(key: &TrackedStateKey) -> Vec<u8> {
-    storage_codec::encode("tracked-state key", key)
-        .expect("tracked-state key storage encoding should not fail")
+    encode_key_parts(
+        &key.schema_key,
+        key.file_id.as_deref(),
+        &key.entity_pk.parts,
+    )
 }
 
 pub(crate) fn encode_key_ref(key: TrackedStateKeyRef<'_>) -> Vec<u8> {
-    storage_codec::encode("tracked-state key", &key)
-        .expect("tracked-state key storage encoding should not fail")
+    encode_key_parts(key.schema_key, key.file_id, &key.entity_pk.parts)
 }
 
 pub(crate) fn encode_schema_key_prefix(schema_key: &str) -> Vec<u8> {
-    storage_codec::encode(
-        "tracked-state schema key prefix",
-        &TrackedSchemaKeyPrefixRef { schema_key },
-    )
-    .expect("tracked-state schema key prefix storage encoding should not fail")
+    let mut out = Vec::with_capacity(schema_key.len() + 2);
+    write_key_string(&mut out, schema_key, KEY_PART_FINAL);
+    out
 }
 
 pub(crate) fn encode_schema_file_prefix(schema_key: &str, file_id: Option<&str>) -> Vec<u8> {
-    storage_codec::encode(
-        "tracked-state schema/file prefix",
-        &TrackedSchemaFilePrefixRef {
-            schema_key,
-            file_id,
-        },
-    )
-    .expect("tracked-state schema/file prefix storage encoding should not fail")
+    let mut out =
+        Vec::with_capacity(schema_key.len() + file_id.map_or(1, |file_id| file_id.len() + 3) + 2);
+    write_key_string(&mut out, schema_key, KEY_PART_FINAL);
+    write_file_id(&mut out, file_id);
+    out
 }
 
 pub(crate) fn decode_key(bytes: &[u8]) -> Result<TrackedStateKey, LixError> {
-    storage_codec::decode("tracked-state key", bytes)
+    let mut offset = 0usize;
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error("schema key has an invalid terminator"));
+    }
+    let file_id = read_file_id(bytes, &mut offset)?;
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("has trailing bytes"));
+    }
+    Ok(TrackedStateKey {
+        schema_key,
+        file_id,
+        entity_pk,
+    })
 }
 
 /// Decodes a key after the caller has already proven the schema/file prefix.
@@ -215,13 +219,16 @@ pub(crate) fn decode_key_with_trusted_prefix(
     file_id: Option<&str>,
     prefix_len: usize,
 ) -> Result<TrackedStateKey, LixError> {
-    let suffix = bytes.get(prefix_len..).ok_or_else(|| {
-        LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            "tracked-state tree trusted key prefix is longer than encoded key",
-        )
-    })?;
-    let entity_pk = storage_codec::decode("tracked-state key entity primary key", suffix)?;
+    if prefix_len > bytes.len() {
+        return Err(key_codec_error(
+            "trusted prefix is longer than the encoded key",
+        ));
+    }
+    let mut offset = prefix_len;
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("has trailing bytes"));
+    }
     Ok(TrackedStateKey {
         schema_key: schema_key.to_string(),
         file_id: file_id.map(str::to_string),
@@ -229,15 +236,187 @@ pub(crate) fn decode_key_with_trusted_prefix(
     })
 }
 
+const KEY_ESCAPE: u8 = 0xff;
+const KEY_PART_FINAL: u8 = 0x00;
+const KEY_PART_MORE: u8 = 0x01;
+const FILE_ID_NONE: u8 = 0x00;
+const FILE_ID_SOME: u8 = 0x01;
+
+/// Order-preserving tracked-state key encoding.
+///
+/// NUL bytes are escaped as `00 ff`. Strings end in `00 00`, except a
+/// non-final entity-pk part which ends in `00 01`. File ids have a one-byte
+/// None/Some tag. The distinct entity terminators make complete keys
+/// prefix-free while preserving the derived tuple ordering byte-for-byte.
+fn encode_key_parts(schema_key: &str, file_id: Option<&str>, entity_pk: &[String]) -> Vec<u8> {
+    let strings_len = schema_key.len()
+        + file_id.map_or(0, str::len)
+        + entity_pk.iter().map(String::len).sum::<usize>();
+    let mut out = Vec::with_capacity(strings_len + 5 + entity_pk.len() * 2);
+    write_key_string(&mut out, schema_key, KEY_PART_FINAL);
+    write_file_id(&mut out, file_id);
+    for (index, part) in entity_pk.iter().enumerate() {
+        let terminator = if index + 1 == entity_pk.len() {
+            KEY_PART_FINAL
+        } else {
+            KEY_PART_MORE
+        };
+        write_key_string(&mut out, part, terminator);
+    }
+    out
+}
+
+fn write_file_id(out: &mut Vec<u8>, file_id: Option<&str>) {
+    match file_id {
+        None => out.push(FILE_ID_NONE),
+        Some(file_id) => {
+            out.push(FILE_ID_SOME);
+            write_key_string(out, file_id, KEY_PART_FINAL);
+        }
+    }
+}
+
+fn write_key_string(out: &mut Vec<u8>, value: &str, terminator: u8) {
+    for &byte in value.as_bytes() {
+        if byte == 0 {
+            out.extend_from_slice(&[0, KEY_ESCAPE]);
+        } else {
+            out.push(byte);
+        }
+    }
+    out.extend_from_slice(&[0, terminator]);
+}
+
+fn read_file_id(bytes: &[u8], offset: &mut usize) -> Result<Option<String>, LixError> {
+    let tag = *bytes
+        .get(*offset)
+        .ok_or_else(|| key_codec_error("file id tag is truncated"))?;
+    *offset += 1;
+    match tag {
+        FILE_ID_NONE => Ok(None),
+        FILE_ID_SOME => {
+            let (file_id, terminator) = read_key_string(bytes, offset, "file id")?;
+            if terminator != KEY_PART_FINAL {
+                return Err(key_codec_error("file id has an invalid terminator"));
+            }
+            Ok(Some(file_id))
+        }
+        other => Err(key_codec_error(format!("file id has unknown tag {other}"))),
+    }
+}
+
+fn read_entity_pk(
+    bytes: &[u8],
+    offset: &mut usize,
+) -> Result<crate::entity_pk::EntityPk, LixError> {
+    if *offset >= bytes.len() {
+        return Err(key_codec_error("entity primary key is empty or truncated"));
+    }
+    let (first, terminator) = read_key_string(bytes, offset, "entity primary-key part")?;
+    if terminator == KEY_PART_FINAL {
+        return Ok(crate::entity_pk::EntityPk::single(first));
+    }
+
+    let mut parts = Vec::with_capacity(2);
+    parts.push(first);
+    loop {
+        if *offset >= bytes.len() {
+            return Err(key_codec_error("entity primary key is empty or truncated"));
+        }
+        let (part, terminator) = read_key_string(bytes, offset, "entity primary-key part")?;
+        parts.push(part);
+        match terminator {
+            KEY_PART_FINAL => break,
+            KEY_PART_MORE => {}
+            _ => unreachable!("read_key_string validates terminators"),
+        }
+    }
+    crate::entity_pk::EntityPk::from_parts(parts).map_err(|error| {
+        key_codec_error(format!(
+            "entity primary key decoded from storage is invalid: {error}"
+        ))
+    })
+}
+
+fn read_key_string(
+    bytes: &[u8],
+    offset: &mut usize,
+    field: &str,
+) -> Result<(String, u8), LixError> {
+    let start = *offset;
+    let mut segment_start = start;
+    let mut decoded: Option<Vec<u8>> = None;
+    loop {
+        let tail = bytes
+            .get(segment_start..)
+            .ok_or_else(|| key_codec_error(format!("{field} is truncated")))?;
+        let relative_zero = memchr::memchr(0, tail)
+            .ok_or_else(|| key_codec_error(format!("{field} is truncated")))?;
+        let zero = segment_start + relative_zero;
+        let escape = *bytes
+            .get(zero + 1)
+            .ok_or_else(|| key_codec_error(format!("{field} escape is truncated")))?;
+        *offset = zero + 2;
+        match escape {
+            KEY_ESCAPE => {
+                let out = decoded.get_or_insert_with(|| {
+                    Vec::with_capacity(zero.saturating_sub(start).saturating_add(16))
+                });
+                out.extend_from_slice(&bytes[segment_start..zero]);
+                out.push(0);
+                segment_start = *offset;
+            }
+            KEY_PART_FINAL | KEY_PART_MORE => {
+                let value = decoded.map_or_else(
+                    || bytes[start..zero].to_vec(),
+                    |mut out| {
+                        out.extend_from_slice(&bytes[segment_start..zero]);
+                        out
+                    },
+                );
+                let value = String::from_utf8(value)
+                    .map_err(|_| key_codec_error(format!("{field} is not UTF-8")))?;
+                return Ok((value, escape));
+            }
+            other => {
+                return Err(key_codec_error(format!(
+                    "{field} has unknown escape {other}"
+                )));
+            }
+        }
+    }
+}
+
+fn key_codec_error(message: impl Into<String>) -> LixError {
+    LixError::new(
+        "LIX_ERROR_UNKNOWN",
+        format!("tracked-state key {}", message.into()),
+    )
+}
+
 #[cfg(test)]
 pub(crate) fn encode_value(value: &TrackedStateIndexValue) -> Vec<u8> {
-    storage_codec::encode("tracked-state value", value)
-        .expect("tracked-state value storage encoding should not fail")
+    encode_value_ref(TrackedStateIndexValueRef {
+        change_id: value.change_id,
+        commit_id: value.commit_id,
+        deleted: value.deleted,
+        created_at: value.created_at,
+        updated_at: value.updated_at,
+    })
 }
 
 pub(crate) fn encode_value_ref(value: TrackedStateIndexValueRef) -> Vec<u8> {
-    storage_codec::encode("tracked-state value", &value)
-        .expect("tracked-state value storage encoding should not fail")
+    let mut out = Vec::with_capacity(VALUE_MAX_BYTES);
+    out.extend_from_slice(value.change_id.as_uuid().as_bytes());
+    out.extend_from_slice(value.commit_id.as_uuid().as_bytes());
+    write_value_tail(
+        &mut out,
+        value.deleted,
+        value.created_at.packed(),
+        value.updated_at.packed(),
+    );
+    debug_assert!((VALUE_MIN_BYTES..=VALUE_MAX_BYTES).contains(&out.len()));
+    out
 }
 
 #[cfg(test)]
@@ -261,7 +440,165 @@ pub(crate) fn decode_visible_value(
 }
 
 fn decode_value_view(bytes: &[u8]) -> Result<TrackedStateIndexValueRef, LixError> {
-    storage_codec::decode("tracked-state value", bytes)
+    if !(VALUE_MIN_BYTES..=VALUE_MAX_BYTES).contains(&bytes.len()) {
+        return Err(value_codec_error(format!(
+            "has {} bytes; expected {VALUE_MIN_BYTES}..={VALUE_MAX_BYTES}",
+            bytes.len(),
+        )));
+    }
+    let change_id = ChangeId::new(uuid::Uuid::from_bytes(
+        bytes[..VALUE_CHANGE_ID_END]
+            .try_into()
+            .expect("fixed change-id slice"),
+    ));
+    let commit_id = CommitId::new(uuid::Uuid::from_bytes(
+        bytes[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END]
+            .try_into()
+            .expect("fixed commit-id slice"),
+    ));
+    let mut offset = VALUE_STATE_TAIL_START;
+    let (deleted, created_at_packed, updated_at_packed) =
+        read_value_tail_fields(bytes, &mut offset, "tracked-state value")?;
+    if offset != bytes.len() {
+        return Err(value_codec_error("has trailing bytes"));
+    }
+    let created_at = decode_value_timestamp(created_at_packed, "created_at")?;
+    let updated_at = decode_value_timestamp(updated_at_packed, "updated_at")?;
+    Ok(TrackedStateIndexValueRef {
+        change_id,
+        commit_id,
+        deleted,
+        created_at,
+        updated_at,
+    })
+}
+
+fn decode_value_timestamp(packed: u64, field: &str) -> Result<LixTimestamp, LixError> {
+    LixTimestamp::from_packed(packed)
+        .map_err(|error| value_codec_error(format!("has invalid {field}: {error}")))
+}
+
+fn read_value_tail_fields(
+    bytes: &[u8],
+    offset: &mut usize,
+    context: &str,
+) -> Result<(bool, u64, u64), LixError> {
+    let tag = *bytes.get(*offset).ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("{context} state tail is truncated"),
+        )
+    })?;
+    *offset += 1;
+    let deleted = tag & VALUE_TAIL_DELETED != 0;
+    let code = tag & VALUE_TAIL_CODE_MASK;
+    let (created_width, updated_width, equal) = match code {
+        0..=VALUE_TIMESTAMP_MAX_WIDTH => (usize::from(code), 0, true),
+        VALUE_TAIL_DISTINCT_MIN..=VALUE_TAIL_DISTINCT_MAX => {
+            let widths = code - VALUE_TAIL_DISTINCT_MIN;
+            (
+                usize::from(widths / VALUE_TIMESTAMP_WIDTH_COUNT),
+                usize::from(widths % VALUE_TIMESTAMP_WIDTH_COUNT),
+                false,
+            )
+        }
+        _ => {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                format!("{context} has reserved state-tail tag {code}"),
+            ));
+        }
+    };
+    let created_at = read_minimal_le_timestamp(bytes, offset, created_width, context)?;
+    let updated_at = if equal {
+        created_at
+    } else {
+        read_minimal_le_timestamp(bytes, offset, updated_width, context)?
+    };
+    if !equal && created_at == updated_at {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("{context} uses the distinct timestamp form for equal values"),
+        ));
+    }
+    Ok((deleted, created_at, updated_at))
+}
+
+fn write_value_tail(out: &mut Vec<u8>, deleted: bool, created_at: u64, updated_at: u64) {
+    let created_width = minimal_timestamp_width(created_at);
+    let updated_width = minimal_timestamp_width(updated_at);
+    let created_width_code =
+        u8::try_from(created_width).expect("timestamp byte width always fits in u8");
+    let updated_width_code =
+        u8::try_from(updated_width).expect("timestamp byte width always fits in u8");
+    let code = if created_at == updated_at {
+        created_width_code
+    } else {
+        VALUE_TAIL_DISTINCT_MIN
+            + created_width_code * VALUE_TIMESTAMP_WIDTH_COUNT
+            + updated_width_code
+    };
+    out.push(code | (u8::from(deleted) * VALUE_TAIL_DELETED));
+    out.extend_from_slice(&created_at.to_le_bytes()[..created_width]);
+    if created_at != updated_at {
+        out.extend_from_slice(&updated_at.to_le_bytes()[..updated_width]);
+    }
+}
+
+fn minimal_timestamp_width(value: u64) -> usize {
+    if value == 0 {
+        0
+    } else {
+        usize::try_from((u64::BITS - value.leading_zeros()).div_ceil(8))
+            .expect("timestamp byte width always fits in usize")
+    }
+}
+
+fn read_minimal_le_timestamp(
+    bytes: &[u8],
+    offset: &mut usize,
+    width: usize,
+    context: &str,
+) -> Result<u64, LixError> {
+    let end = offset.checked_add(width).ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("{context} timestamp width overflows usize"),
+        )
+    })?;
+    let encoded = bytes.get(*offset..end).ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("{context} timestamp is truncated"),
+        )
+    })?;
+    if width > 0 && encoded[width - 1] == 0 {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("{context} timestamp is not minimally encoded"),
+        ));
+    }
+    let mut storage = [0u8; 8];
+    storage[..width].copy_from_slice(encoded);
+    *offset = end;
+    Ok(u64::from_le_bytes(storage))
+}
+
+fn read_value_tail<'a>(
+    bytes: &'a [u8],
+    offset: &mut usize,
+    context: &str,
+) -> Result<&'a [u8], LixError> {
+    let start = *offset;
+    read_value_tail_fields(bytes, offset, context)?;
+    Ok(&bytes[start..*offset])
+}
+
+fn value_codec_error(message: impl Into<String>) -> LixError {
+    LixError::new(
+        "LIX_ERROR_UNKNOWN",
+        format!("tracked-state value {}", message.into()),
+    )
 }
 
 fn tracked_value_from_storage(value: TrackedStateIndexValueRef) -> TrackedStateIndexValue {
@@ -289,87 +626,106 @@ pub(crate) fn encode_leaf_node(entries: &[EncodedLeafEntry]) -> Vec<u8> {
     encode_leaf_node_refs(&entries)
 }
 
-/// Offsets of the commit-id slice inside a standard encoded value; pinned by
-/// `encoded_value_layout_places_ids_at_fixed_offsets`.
+/// Fixed id offsets in the typed tracked-state value. The state tail starts
+/// with a tag that stores deletion, timestamp widths, and whether both
+/// timestamps are equal, followed by their minimal little-endian bytes.
+const VALUE_CHANGE_ID_END: usize = 16;
 const VALUE_COMMIT_ID_START: usize = 16;
 const VALUE_COMMIT_ID_END: usize = 32;
+const VALUE_STATE_TAIL_START: usize = 32;
+const VALUE_MIN_BYTES: usize = VALUE_STATE_TAIL_START + 1;
+const VALUE_MAX_BYTES: usize = VALUE_STATE_TAIL_START + 1 + 8 + 8;
+const VALUE_TAIL_DELETED: u8 = 0x80;
+const VALUE_TAIL_CODE_MASK: u8 = 0x7f;
+const VALUE_TIMESTAMP_MAX_WIDTH: u8 = 8;
+const VALUE_TIMESTAMP_WIDTH_COUNT: u8 = VALUE_TIMESTAMP_MAX_WIDTH + 1;
+const VALUE_TAIL_DISTINCT_MIN: u8 = VALUE_TIMESTAMP_WIDTH_COUNT;
+const VALUE_TAIL_DISTINCT_MAX: u8 =
+    VALUE_TAIL_DISTINCT_MIN + VALUE_TIMESTAMP_WIDTH_COUNT * VALUE_TIMESTAMP_WIDTH_COUNT - 1;
 
-/// Leaf node wire format (v2):
+/// Leaf node wire format (v3):
 ///
 /// ```text
-/// [NODE_KIND_LEAF_V2]
+/// [NODE_KIND_LEAF_V3]
 /// varint entry_count
 /// varint commit_dict_len ++ commit_dict_len x 16 commit-id bytes
+/// varint tail_dict_len ++ tail_dict_len x self-delimiting state tails
 /// per entry:
 ///   varint shared_key_len   bytes shared with the previous entry's key
 ///   varint key_suffix_len ++ key suffix bytes
-///   varint dict_ref         0 = value stored verbatim; n>0 = the value's
-///                           commit-id slice [16..32) is dict entry n-1 and
-///                           is omitted from the stored bytes
-///   varint stored_value_len ++ stored value bytes
+///   16 change-id bytes
+///   varint commit_ref       0 + 16 literal bytes, or dictionary slot n-1
+///   varint tail_ref         0 + literal state tail, or dictionary slot n-1
 /// ```
 ///
-/// Bulk commits repeat one commit id across every entry, so the chunk-local
-/// dictionary collapses the 16-byte slice to a 1-byte ref; the splice is
-/// reversible byte-for-byte regardless of value semantics, and values
-/// shorter than 32 bytes are stored verbatim. The dictionary uses
-/// first-occurrence order, keeping the encoding a deterministic function of
-/// the entries.
+/// Only values repeated within the leaf enter a dictionary, so a dictionary
+/// can never expand unique commit ids or timestamp/deletion tails. Both
+/// dictionaries use first-occurrence order, keeping the encoding a
+/// deterministic function of the entries. State tails need no length prefix:
+/// their tag declares the timestamp equality and byte widths.
 ///
 /// Entries within a node are sorted by key, so consecutive keys share the
 /// encoded schema-key/file-id prefix and most of the entity-pk; front-coding
-/// removes that redundancy. Values are untouched: byte equality and the
-/// value codec stay exactly as before. Sortedness is a caller invariant
-/// (the tree builder always produces sorted entries); it is asserted in
-/// debug builds but not enforced in release, where unsorted input would
-/// round-trip faithfully and only confuse downstream binary search.
+/// removes that redundancy. Decode reconstructs the original value bytes
+/// exactly. Sortedness is a caller invariant (the tree builder always
+/// produces sorted entries); it is asserted in debug builds but not
+/// revalidated on every release-mode read.
 pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<u8> {
     debug_assert!(
         entries.windows(2).all(|pair| pair[0].key < pair[1].key),
         "leaf entries must be strictly sorted by key"
     );
-    let mut commit_dictionary: Vec<&[u8]> = Vec::new();
-    let mut dict_refs = Vec::with_capacity(entries.len());
     for entry in entries {
-        if entry.value.len() >= VALUE_COMMIT_ID_END {
-            let commit_id = &entry.value[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END];
-            let index = commit_dictionary
-                .iter()
-                .position(|known| *known == commit_id)
-                .unwrap_or_else(|| {
-                    commit_dictionary.push(commit_id);
-                    commit_dictionary.len() - 1
-                });
-            dict_refs.push(index as u64 + 1);
-        } else {
-            dict_refs.push(0);
+        assert!(
+            (VALUE_MIN_BYTES..=VALUE_MAX_BYTES).contains(&entry.value.len()),
+            "tracked-state leaf values must use the v3 value layout"
+        );
+        #[cfg(debug_assertions)]
+        {
+            let mut tail_end = VALUE_STATE_TAIL_START;
+            read_value_tail(entry.value, &mut tail_end, "tracked-state leaf value")
+                .expect("tracked-state leaf value must contain a valid v3 state tail");
+            assert_eq!(
+                tail_end,
+                entry.value.len(),
+                "tracked-state leaf value must end after its v3 state tail"
+            );
         }
     }
+    let commit_dictionary = repeated_dictionary::<16>(entries, VALUE_COMMIT_ID_START);
+    let tail_dictionary = repeated_tail_dictionary(entries);
 
     let mut out = Vec::with_capacity(64 + entries.len() * 24);
-    out.push(NODE_KIND_LEAF_V2);
+    out.push(NODE_KIND_LEAF_V3);
     write_varint(&mut out, entries.len() as u64);
     write_varint(&mut out, commit_dictionary.len() as u64);
     for commit_id in &commit_dictionary {
         out.extend_from_slice(commit_id);
     }
+    write_varint(&mut out, tail_dictionary.len() as u64);
+    for tail in &tail_dictionary {
+        out.extend_from_slice(tail);
+    }
     let mut previous_key: &[u8] = &[];
-    for (entry, dict_ref) in entries.iter().zip(&dict_refs) {
+    for entry in entries {
         let shared = shared_prefix_len(previous_key, entry.key);
         write_varint(&mut out, shared as u64);
         write_varint(&mut out, (entry.key.len() - shared) as u64);
         out.extend_from_slice(&entry.key[shared..]);
-        write_varint(&mut out, *dict_ref);
-        if *dict_ref == 0 {
-            write_varint(&mut out, entry.value.len() as u64);
-            out.extend_from_slice(entry.value);
-        } else {
-            write_varint(
-                &mut out,
-                (entry.value.len() - (VALUE_COMMIT_ID_END - VALUE_COMMIT_ID_START)) as u64,
-            );
-            out.extend_from_slice(&entry.value[..VALUE_COMMIT_ID_START]);
-            out.extend_from_slice(&entry.value[VALUE_COMMIT_ID_END..]);
+        out.extend_from_slice(&entry.value[..VALUE_CHANGE_ID_END]);
+        let commit_ref = dictionary_ref(
+            &commit_dictionary,
+            &entry.value[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END],
+        );
+        write_varint(&mut out, commit_ref);
+        if commit_ref == 0 {
+            out.extend_from_slice(&entry.value[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END]);
+        }
+        let tail = &entry.value[VALUE_STATE_TAIL_START..];
+        let tail_ref = slice_dictionary_ref(&tail_dictionary, tail);
+        write_varint(&mut out, tail_ref);
+        if tail_ref == 0 {
+            out.extend_from_slice(tail);
         }
         previous_key = entry.key;
     }
@@ -398,7 +754,57 @@ fn verify_leaf_round_trip(encoded: &[u8], entries: &[EncodedLeafEntryRef<'_>]) {
     }
 }
 
-fn decode_leaf_v2(body: &[u8]) -> Result<DecodedLeafNodeRef<'_>, LixError> {
+fn repeated_dictionary<const N: usize>(
+    entries: &[EncodedLeafEntryRef<'_>],
+    start: usize,
+) -> Vec<[u8; N]> {
+    let mut counts = Vec::<([u8; N], usize)>::new();
+    for entry in entries {
+        let value = <[u8; N]>::try_from(&entry.value[start..start + N])
+            .expect("fixed tracked-state value slice should match dictionary width");
+        if let Some((_, count)) = counts.iter_mut().find(|(known, _)| known == &value) {
+            *count += 1;
+        } else {
+            counts.push((value, 1));
+        }
+    }
+    counts
+        .into_iter()
+        .filter_map(|(value, count)| (count > 1).then_some(value))
+        .collect()
+}
+
+fn dictionary_ref<const N: usize>(dictionary: &[[u8; N]], value: &[u8]) -> u64 {
+    dictionary
+        .iter()
+        .position(|known| known.as_slice() == value)
+        .map_or(0, |index| index as u64 + 1)
+}
+
+fn repeated_tail_dictionary<'a>(entries: &[EncodedLeafEntryRef<'a>]) -> Vec<&'a [u8]> {
+    let mut counts = Vec::<(&'a [u8], usize)>::new();
+    for entry in entries {
+        let tail = &entry.value[VALUE_STATE_TAIL_START..];
+        if let Some((_, count)) = counts.iter_mut().find(|(known, _)| *known == tail) {
+            *count += 1;
+        } else {
+            counts.push((tail, 1));
+        }
+    }
+    counts
+        .into_iter()
+        .filter_map(|(tail, count)| (count > 1).then_some(tail))
+        .collect()
+}
+
+fn slice_dictionary_ref(dictionary: &[&[u8]], value: &[u8]) -> u64 {
+    dictionary
+        .iter()
+        .position(|known| *known == value)
+        .map_or(0, |index| index as u64 + 1)
+}
+
+fn decode_leaf_v3(body: &[u8]) -> Result<DecodedLeafNodeRef, LixError> {
     fn usize_from(value: u64, what: &str) -> Result<usize, LixError> {
         usize::try_from(value).map_err(|_| {
             LixError::new(
@@ -422,29 +828,52 @@ fn decode_leaf_v2(body: &[u8]) -> Result<DecodedLeafNodeRef<'_>, LixError> {
     }
 
     let mut offset = 0usize;
-    let entry_count = usize_from(read_varint(body, &mut offset)?, "entry count")?;
-    let dict_len = usize_from(read_varint(body, &mut offset)?, "commit dictionary length")?;
-    let dict_bytes = dict_len.checked_mul(16).ok_or_else(|| {
+    let entry_count = usize_from(
+        read_varint(body, &mut offset, "tracked-state leaf node")?,
+        "entry count",
+    )?;
+    let commit_dict_len = usize_from(
+        read_varint(body, &mut offset, "tracked-state leaf node")?,
+        "commit dictionary length",
+    )?;
+    let commit_dict_bytes = commit_dict_len.checked_mul(16).ok_or_else(|| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",
             "tracked-state leaf node commit dictionary length overflow",
         )
     })?;
-    let commit_dictionary = slice(body, &mut offset, dict_bytes)?;
-    // Reconstructed keys (and dictionary-spliced values) total the stored
-    // bytes plus re-expanded prefixes and commit ids, so heavy sharing can
-    // exceed the body length; the body length is a cheap reservation that
-    // avoids re-allocation for typical chunks.
-    let mut key_arena = Vec::with_capacity(body.len());
+    let commit_dictionary = slice(body, &mut offset, commit_dict_bytes)?;
+    let tail_dict_len = usize_from(
+        read_varint(body, &mut offset, "tracked-state leaf node")?,
+        "tail dictionary length",
+    )?;
+    let mut tail_dictionary = Vec::with_capacity(tail_dict_len.min(body.len()));
+    for _ in 0..tail_dict_len {
+        tail_dictionary.push(read_value_tail(
+            body,
+            &mut offset,
+            "tracked-state leaf node",
+        )?);
+    }
+    // Reconstructed keys can exceed their front-coded bytes, and dictionary
+    // refs can omit up to 33 bytes from each value. Cap the count contribution
+    // by the body size so corrupt metadata cannot force an unbounded reserve.
+    let omitted_value_bytes = entry_count
+        .min(body.len())
+        .saturating_mul(VALUE_MAX_BYTES - VALUE_CHANGE_ID_END);
+    let mut arena = Vec::with_capacity(body.len().saturating_add(omitted_value_bytes));
     let mut entries = Vec::with_capacity(entry_count.min(body.len()));
     let mut previous_key_start = 0usize;
-    // Tracked separately from the arena length: dictionaried values are
-    // appended to the same arena after their key, so the arena tail is not
-    // necessarily the previous key.
     let mut previous_key_end = 0usize;
     for _ in 0..entry_count {
-        let shared = usize_from(read_varint(body, &mut offset)?, "shared key length")?;
-        let suffix_len = usize_from(read_varint(body, &mut offset)?, "key suffix length")?;
+        let shared = usize_from(
+            read_varint(body, &mut offset, "tracked-state leaf node")?,
+            "shared key length",
+        )?;
+        let suffix_len = usize_from(
+            read_varint(body, &mut offset, "tracked-state leaf node")?,
+            "key suffix length",
+        )?;
         let previous_key_len = previous_key_end - previous_key_start;
         if shared > previous_key_len {
             return Err(LixError::new(
@@ -452,45 +881,57 @@ fn decode_leaf_v2(body: &[u8]) -> Result<DecodedLeafNodeRef<'_>, LixError> {
                 "tracked-state leaf node shares more key bytes than the previous key holds",
             ));
         }
-        let key_start = key_arena.len();
-        key_arena.extend_from_within(previous_key_start..previous_key_start + shared);
+        let key_start = arena.len();
+        arena.extend_from_within(previous_key_start..previous_key_start + shared);
         let suffix = slice(body, &mut offset, suffix_len)?;
-        key_arena.extend_from_slice(suffix);
-        let key_end = key_arena.len();
-        let dict_ref = usize_from(read_varint(body, &mut offset)?, "commit dictionary ref")?;
-        let value_len = usize_from(read_varint(body, &mut offset)?, "value length")?;
-        let stored_value = slice(body, &mut offset, value_len)?;
-        let value = if dict_ref == 0 {
-            LeafValueSpan::Borrowed(stored_value)
+        arena.extend_from_slice(suffix);
+        let key_end = arena.len();
+
+        let change_id = slice(body, &mut offset, VALUE_CHANGE_ID_END)?;
+        let commit_ref = usize_from(
+            read_varint(body, &mut offset, "tracked-state leaf node")?,
+            "commit dictionary ref",
+        )?;
+        let commit_id = if commit_ref == 0 {
+            slice(
+                body,
+                &mut offset,
+                VALUE_COMMIT_ID_END - VALUE_COMMIT_ID_START,
+            )?
         } else {
-            // Validate before index arithmetic: a huge dict_ref would wrap
-            // the multiplication and alias a valid dictionary slot.
-            if dict_ref > dict_len {
+            if commit_ref > commit_dict_len {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     "tracked-state leaf node commit dictionary ref is out of bounds",
                 ));
             }
-            let commit_id = &commit_dictionary[(dict_ref - 1) * 16..dict_ref * 16];
-            if stored_value.len() < VALUE_COMMIT_ID_START {
+            &commit_dictionary[(commit_ref - 1) * 16..commit_ref * 16]
+        };
+        let tail_ref = usize_from(
+            read_varint(body, &mut offset, "tracked-state leaf node")?,
+            "tail dictionary ref",
+        )?;
+        let tail = if tail_ref == 0 {
+            read_value_tail(body, &mut offset, "tracked-state leaf node")?
+        } else {
+            if tail_ref > tail_dict_len {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
-                    "tracked-state leaf node dictionaried value is too short",
+                    "tracked-state leaf node tail dictionary ref is out of bounds",
                 ));
             }
-            let start = key_arena.len();
-            key_arena.extend_from_slice(&stored_value[..VALUE_COMMIT_ID_START]);
-            key_arena.extend_from_slice(commit_id);
-            key_arena.extend_from_slice(&stored_value[VALUE_COMMIT_ID_START..]);
-            LeafValueSpan::Arena {
-                start,
-                end: key_arena.len(),
-            }
+            tail_dictionary[tail_ref - 1]
         };
+        let value_start = arena.len();
+        arena.extend_from_slice(change_id);
+        arena.extend_from_slice(commit_id);
+        arena.extend_from_slice(tail);
+        let value_end = arena.len();
         entries.push(LeafEntrySpan {
             key_start,
             key_end,
-            value,
+            value_start,
+            value_end,
         });
         previous_key_start = key_start;
         previous_key_end = key_end;
@@ -501,7 +942,7 @@ fn decode_leaf_v2(body: &[u8]) -> Result<DecodedLeafNodeRef<'_>, LixError> {
             "tracked-state leaf node has trailing bytes",
         ));
     }
-    Ok(DecodedLeafNodeRef { key_arena, entries })
+    Ok(DecodedLeafNodeRef { arena, entries })
 }
 
 fn shared_prefix_len(left: &[u8], right: &[u8]) -> usize {
@@ -523,21 +964,21 @@ fn write_varint(out: &mut Vec<u8>, mut value: u64) {
     }
 }
 
-fn read_varint(bytes: &[u8], offset: &mut usize) -> Result<u64, LixError> {
+fn read_varint(bytes: &[u8], offset: &mut usize, context: &str) -> Result<u64, LixError> {
     let mut value = 0u64;
     let mut shift = 0u32;
     loop {
         let byte = *bytes.get(*offset).ok_or_else(|| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
-                "tracked-state leaf node varint is truncated",
+                format!("{context} varint is truncated"),
             )
         })?;
         *offset += 1;
         if shift >= 64 || (shift == 63 && byte > 1) {
             return Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",
-                "tracked-state leaf node varint overflows u64",
+                format!("{context} varint overflows u64"),
             ));
         }
         value |= u64::from(byte & 0x7f) << shift;
@@ -557,63 +998,150 @@ pub(crate) fn encode_internal_node(children: &[ChildSummary]) -> Vec<u8> {
 }
 
 pub(crate) fn encode_internal_node_refs(children: &[ChildSummaryRef<'_>]) -> Vec<u8> {
-    let mut out = vec![NODE_KIND_INTERNAL];
-    out.extend_from_slice(
-        &storage_codec::encode(
-            "tracked-state internal node",
-            &StorageInternalNode {
-                children: children.to_vec(),
-            },
-        )
-        .expect("tracked-state internal node storage encoding should not fail"),
+    assert!(
+        !children.is_empty(),
+        "tracked-state internal nodes must contain at least one child"
     );
+    debug_assert!(
+        children
+            .iter()
+            .all(|child| { child.first_key <= child.last_key && child.subtree_count > 0 })
+    );
+    debug_assert!(
+        children
+            .windows(2)
+            .all(|pair| { pair[0].last_key < pair[1].first_key })
+    );
+
+    let mut out = Vec::with_capacity(2 + children.len() * 40);
+    out.push(NODE_KIND_INTERNAL_V3);
+    write_varint(&mut out, children.len() as u64);
+    let mut previous_last: &[u8] = &[];
+    for child in children {
+        write_front_coded(&mut out, previous_last, child.first_key);
+        write_front_coded(&mut out, child.first_key, child.last_key);
+        out.extend_from_slice(&child.child_hash);
+        write_varint(&mut out, child.subtree_count);
+        previous_last = child.last_key;
+    }
     out
+}
+
+fn write_front_coded(out: &mut Vec<u8>, base: &[u8], value: &[u8]) {
+    let shared = shared_prefix_len(base, value);
+    write_varint(out, shared as u64);
+    write_varint(out, (value.len() - shared) as u64);
+    out.extend_from_slice(&value[shared..]);
+}
+
+fn decode_internal_v3(body: &[u8]) -> Result<DecodedInternalNode, LixError> {
+    fn usize_from(value: u64, what: &str) -> Result<usize, LixError> {
+        usize::try_from(value).map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                format!("tracked-state internal node {what} does not fit in usize"),
+            )
+        })
+    }
+    fn slice<'a>(body: &'a [u8], offset: &mut usize, len: usize) -> Result<&'a [u8], LixError> {
+        let end = offset.checked_add(len).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal node length overflow",
+            )
+        })?;
+        let bytes = body.get(*offset..end).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal node is truncated",
+            )
+        })?;
+        *offset = end;
+        Ok(bytes)
+    }
+    fn front_coded(body: &[u8], offset: &mut usize, base: &[u8]) -> Result<Vec<u8>, LixError> {
+        let shared = usize_from(
+            read_varint(body, offset, "tracked-state internal node")?,
+            "shared boundary length",
+        )?;
+        if shared > base.len() {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal node shares more boundary bytes than its base holds",
+            ));
+        }
+        let suffix_len = usize_from(
+            read_varint(body, offset, "tracked-state internal node")?,
+            "boundary suffix length",
+        )?;
+        let suffix = slice(body, offset, suffix_len)?;
+        let mut value = Vec::with_capacity(shared.saturating_add(suffix_len));
+        value.extend_from_slice(&base[..shared]);
+        value.extend_from_slice(suffix);
+        Ok(value)
+    }
+
+    let mut offset = 0usize;
+    let child_count = usize_from(
+        read_varint(body, &mut offset, "tracked-state internal node")?,
+        "child count",
+    )?;
+    if child_count == 0 {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state internal node has no children",
+        ));
+    }
+    let mut children = Vec::with_capacity(child_count.min(body.len()));
+    for _ in 0..child_count {
+        let previous_last = children
+            .last()
+            .map_or(&[][..], |child: &ChildSummary| child.last_key.as_slice());
+        let first_key = front_coded(body, &mut offset, previous_last)?;
+        let last_key = front_coded(body, &mut offset, &first_key)?;
+        let child_hash = <[u8; TRACKED_STATE_HASH_BYTES]>::try_from(slice(
+            body,
+            &mut offset,
+            TRACKED_STATE_HASH_BYTES,
+        )?)
+        .expect("fixed-size tracked-state child hash slice should convert");
+        let subtree_count = read_varint(body, &mut offset, "tracked-state internal node")?;
+        if subtree_count == 0 {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal node child has an empty subtree",
+            ));
+        }
+        children.push(ChildSummary {
+            first_key,
+            last_key,
+            child_hash,
+            subtree_count,
+        });
+    }
+    if offset != body.len() {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state internal node has trailing bytes",
+        ));
+    }
+    Ok(DecodedInternalNode { children })
 }
 
 pub(crate) fn decode_node(bytes: &[u8]) -> Result<DecodedNode, LixError> {
     match decode_node_ref(bytes)? {
-        DecodedNodeRef::Leaf(leaf) => {
-            let mut entries = Vec::with_capacity(leaf.len());
-            for index in 0..leaf.len() {
-                let entry = leaf.entry(index)?.ok_or_else(|| {
-                    LixError::new(
-                        "LIX_ERROR_UNKNOWN",
-                        "tracked-state leaf entry disappeared during owned decode",
-                    )
-                })?;
-                entries.push(EncodedLeafEntry {
-                    key: entry.key.to_vec(),
-                    value: entry.value.to_vec(),
-                });
-            }
-            Ok(DecodedNode::Leaf(DecodedLeafNode { entries }))
-        }
+        DecodedNodeRef::Leaf(leaf) => Ok(DecodedNode::Leaf(leaf)),
         DecodedNodeRef::Internal(internal) => Ok(DecodedNode::Internal(internal)),
     }
 }
 
-pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef<'_>, LixError> {
+pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> {
     let (&kind, body) = bytes
         .split_first()
         .ok_or_else(|| LixError::new("LIX_ERROR_UNKNOWN", "tracked-state tree node is empty"))?;
     match kind {
-        NODE_KIND_LEAF_V2 => Ok(DecodedNodeRef::Leaf(decode_leaf_v2(body)?)),
-        NODE_KIND_INTERNAL => {
-            let node: StorageInternalNode<'_> =
-                storage_codec::decode("tracked-state internal node", body)?;
-            Ok(DecodedNodeRef::Internal(DecodedInternalNode {
-                children: node
-                    .children
-                    .into_iter()
-                    .map(|child| ChildSummary {
-                        first_key: child.first_key.to_vec(),
-                        last_key: child.last_key.to_vec(),
-                        child_hash: child.child_hash,
-                        subtree_count: child.subtree_count,
-                    })
-                    .collect(),
-            }))
-        }
+        NODE_KIND_LEAF_V3 => Ok(DecodedNodeRef::Leaf(decode_leaf_v3(body)?)),
+        NODE_KIND_INTERNAL_V3 => Ok(DecodedNodeRef::Internal(decode_internal_v3(body)?)),
         other => Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!("tracked-state tree node has unknown kind byte {other}"),
@@ -688,6 +1216,19 @@ mod tests {
         encode_leaf_node_refs as encode_leaf_refs_for_tests,
     };
 
+    fn raw_value(change: u8, commit: u8, tail: u8) -> Vec<u8> {
+        let mut value = Vec::with_capacity(VALUE_MAX_BYTES);
+        value.extend_from_slice(&[change; 16]);
+        value.extend_from_slice(&[commit; 16]);
+        write_value_tail(
+            &mut value,
+            tail & 1 != 0,
+            u64::from(tail),
+            u64::from(tail.wrapping_add(1)),
+        );
+        value
+    }
+
     fn leaf_entries_round_trip(entries: &[(Vec<u8>, Vec<u8>)]) {
         let refs = entries
             .iter()
@@ -714,26 +1255,36 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v2_round_trips_representative_shapes() {
+    fn leaf_v3_round_trips_representative_shapes() {
         leaf_entries_round_trip(&[]);
-        leaf_entries_round_trip(&[(b"only".to_vec(), b"value".to_vec())]);
+        leaf_entries_round_trip(&[(b"only".to_vec(), raw_value(1, 2, 3))]);
         leaf_entries_round_trip(&[
-            (b"a".to_vec(), Vec::new()),
-            (b"ab".to_vec(), vec![0u8; 300]),
-            (b"abc/0001".to_vec(), b"x".to_vec()),
-            (b"abc/0002".to_vec(), b"y".to_vec()),
-            (b"zzz".to_vec(), vec![0xff; 7]),
+            (b"a".to_vec(), raw_value(1, 9, 7)),
+            (b"ab".to_vec(), raw_value(2, 9, 7)),
+            (b"abc/0001".to_vec(), raw_value(3, 9, 8)),
+            (b"abc/0002".to_vec(), raw_value(4, 6, 8)),
+            (b"zzz".to_vec(), raw_value(5, 6, 5)),
         ]);
         // No shared prefixes at all (front-coding worst case).
         leaf_entries_round_trip(&[
-            (vec![0x00], b"a".to_vec()),
-            (vec![0x80, 0x01], b"b".to_vec()),
-            (vec![0xff, 0xff, 0xff], b"c".to_vec()),
+            (vec![0x00], raw_value(1, 2, 3)),
+            (vec![0x80, 0x01], raw_value(4, 5, 6)),
+            (vec![0xff, 0xff, 0xff], raw_value(7, 8, 9)),
         ]);
     }
 
     #[test]
-    fn leaf_v2_round_trips_generated_sorted_keys() {
+    fn leaf_v3_round_trips_dictionaries_with_variable_tail_widths() {
+        leaf_entries_round_trip(&[
+            (b"a".to_vec(), raw_value(1, 9, 0)),
+            (b"b".to_vec(), raw_value(2, 9, 0)),
+            (b"c".to_vec(), raw_value(3, 9, 1)),
+            (b"d".to_vec(), raw_value(4, 9, 1)),
+        ]);
+    }
+
+    #[test]
+    fn leaf_v3_round_trips_generated_sorted_keys() {
         // Deterministic pseudo-random keys with heavy shared prefixes,
         // mimicking encoded (schema_key, file_id, entity_pk) keys.
         let mut entries = (0..512usize)
@@ -746,7 +1297,7 @@ mod tests {
                     state % 1000
                 )
                 .into_bytes();
-                let value = state.to_be_bytes().repeat(1 + (index % 5));
+                let value = raw_value(state.to_le_bytes()[0], (index % 3) as u8, (index % 5) as u8);
                 (key, value)
             })
             .collect::<Vec<_>>();
@@ -756,14 +1307,14 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v2_round_trips_multibyte_varint_fields() {
+    fn leaf_v3_round_trips_multibyte_key_varints() {
         // Keys long enough that shared and suffix lengths need two-byte
         // varints, with >127 entries so the count does too.
         let mut entries = Vec::new();
         let prefix = "p".repeat(160);
         for index in 0..200usize {
             let key = format!("{prefix}/{index:05}").into_bytes();
-            let value = vec![index.to_le_bytes()[0]; 130];
+            let value = raw_value(index.to_le_bytes()[0], 1, 2);
             entries.push((key, value));
         }
         entries.sort();
@@ -784,36 +1335,24 @@ mod tests {
             created_at: timestamp("created_at", "2026-01-01T00:00:00Z"),
             updated_at: timestamp("updated_at", "2026-01-01T00:00:00Z"),
         });
+        assert!((VALUE_MIN_BYTES..=VALUE_MAX_BYTES).contains(&encoded.len()));
         assert_eq!(&encoded[..16], change_id.as_uuid().as_bytes());
         assert_eq!(&encoded[16..32], commit_id.as_uuid().as_bytes());
     }
 
     #[test]
-    fn leaf_v2_round_trips_dictionaried_commit_ids() {
-        // Realistic shape: >=32-byte values where bytes [16..32) repeat
-        // across entries (one commit id per bulk commit, a few stragglers),
-        // including a boundary 32-byte value and a verbatim short value.
+    fn leaf_v3_round_trips_repeated_and_literal_value_parts() {
         let mut entries = Vec::new();
         for index in 0..300usize {
             let key = format!("rows/{index:05}").into_bytes();
-            let value_len = match index {
-                0 => 32,
-                1 => 8,
-                _ => 90,
-            };
-            let mut value = vec![0u8; value_len];
-            if value_len >= 32 {
-                value[..16].copy_from_slice(&(index as u128).to_be_bytes());
-                let commit = (index % 3).to_le_bytes()[0];
-                value[16..32].copy_from_slice(&[commit; 16]);
-            }
+            let value = raw_value(index.to_le_bytes()[0], (index % 3) as u8, (index % 5) as u8);
             entries.push((key, value));
         }
         entries.sort();
         leaf_entries_round_trip(&entries);
 
-        // The dictionary must actually compress: ~300 entries x 16 bytes of
-        // commit id collapse to 3 dictionary rows.
+        // Both dictionaries must actually compress the repeated commit ids
+        // and state tails.
         let refs = entries
             .iter()
             .map(|(key, value)| EncodedLeafEntryRef {
@@ -827,25 +1366,20 @@ mod tests {
             .map(|(key, value)| key.len() + value.len())
             .sum();
         assert!(
-            encoded.len() + 298 * 14 < verbatim_size,
-            "dictionary must remove ~15 bytes per entry: encoded={} verbatim={}",
+            encoded.len() + 300 * 10 < verbatim_size,
+            "dictionaries must remove repeated value bytes: encoded={} verbatim={}",
             encoded.len(),
             verbatim_size
         );
     }
 
-    /// Pins the dictionaried wire bytes. The dict-len-0 golden test covers
-    /// verbatim values; this one pins the dictionary section and the
-    /// spliced value layout, so a drift (e.g. sorted instead of
-    /// first-occurrence dictionary order) fails a unit test instead of
-    /// silently changing every chunk hash.
     #[test]
-    fn leaf_v2_dictionaried_wire_format_is_pinned() {
-        let mut value_a = vec![0xAAu8; 33];
-        value_a[16..32].copy_from_slice(&[0xCC; 16]); // commit id slice
-        let mut value_b = vec![0xBBu8; 32];
-        value_b[16..32].copy_from_slice(&[0xCC; 16]); // same commit id
-        let entries = [(b"k1".to_vec(), value_a), (b"k2".to_vec(), value_b)];
+    fn leaf_v3_wire_format_is_pinned() {
+        let entries = [
+            (b"k1".to_vec(), raw_value(0xAA, 0xCC, 0xDD)),
+            (b"k2".to_vec(), raw_value(0xBB, 0xCC, 0xDD)),
+            (b"k3".to_vec(), raw_value(0xEE, 0xFF, 0x11)),
+        ];
         let refs = entries
             .iter()
             .map(|(key, value)| EncodedLeafEntryRef {
@@ -855,96 +1389,41 @@ mod tests {
             .collect::<Vec<_>>();
         let encoded = encode_leaf_refs_for_tests(&refs);
         let mut expected = vec![
-            1, // NODE_KIND_LEAF_V2
-            2, // entry count
+            3, // NODE_KIND_LEAF_V3
+            3, // entry count
             1, // commit dictionary length
         ];
         expected.extend_from_slice(&[0xCC; 16]); // dictionary slot 0
-        // entry 0: shared=0, suffix "k1", dict_ref=1, stored 17 bytes
-        expected.extend_from_slice(&[0, 2, b'k', b'1', 1, 17]);
-        expected.extend_from_slice(&[0xAA; 16]); // value prefix
-        expected.push(0xAA); // value rest (byte 32)
-        // entry 1: shared=1, suffix "2", dict_ref=1, stored 16 bytes
-        expected.extend_from_slice(&[1, 1, b'2', 1, 16]);
+        expected.push(1); // tail dictionary length
+        expected.extend_from_slice(&[0x93, 0xDD, 0xDE]); // dictionary slot 0
+        // Entry 0: full key, inline change id, both dictionary refs.
+        expected.extend_from_slice(&[0, 2, b'k', b'1']);
+        expected.extend_from_slice(&[0xAA; 16]);
+        expected.extend_from_slice(&[1, 1]);
+        // Entry 1: one-byte key suffix and both dictionary refs.
+        expected.extend_from_slice(&[1, 1, b'2']);
         expected.extend_from_slice(&[0xBB; 16]);
-        assert_eq!(
-            encoded, expected,
-            "dictionaried wire bytes must stay stable"
-        );
+        expected.extend_from_slice(&[1, 1]);
+        // Entry 2: literal unique commit id and tail.
+        expected.extend_from_slice(&[1, 1, b'3']);
+        expected.extend_from_slice(&[0xEE; 16]);
+        expected.push(0);
+        expected.extend_from_slice(&[0xFF; 16]);
+        expected.push(0);
+        expected.extend_from_slice(&[0x93, 0x11, 0x12]);
+        assert_eq!(encoded, expected, "v3 wire bytes must stay stable");
     }
 
     #[test]
-    fn leaf_v2_rejects_adversarial_dictionary_lengths() {
-        // dict_len claims more 16-byte slots than the body holds.
-        assert!(decode_node_ref_for_leaf_tests(&[1u8, 1, 200, 0, 0]).is_err());
-        // dict_len * 16 overflows usize.
-        let mut huge = vec![1u8, 1];
-        huge.extend_from_slice(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]);
-        assert!(decode_node_ref_for_leaf_tests(&huge).is_err());
-        // dict_ref > 0 with a stored value shorter than the splice prefix.
-        let mut short = vec![1u8, 1, 1];
-        short.extend_from_slice(&[9u8; 16]); // dictionary slot
-        short.extend_from_slice(&[0, 1, b'k', 1, 8]); // stored value only 8 bytes
-        short.extend_from_slice(&[0u8; 8]);
-        assert!(
-            decode_node_ref_for_leaf_tests(&short).is_err(),
-            "dictionaried values shorter than the splice prefix must be rejected"
-        );
-    }
-
-    #[test]
-    fn leaf_v2_rejects_out_of_bounds_dictionary_ref() {
-        // kind, count=1, dict_len=0, shared=0, suffix_len=1, 'k',
-        // dict_ref=1 (out of bounds), stored value 16 bytes.
-        let mut bytes = vec![1u8, 1, 0, 0, 1, b'k', 1, 16];
-        bytes.extend_from_slice(&[0u8; 16]);
-        assert!(decode_node_ref_for_leaf_tests(&bytes).is_err());
-    }
-
-    #[test]
-    fn leaf_v2_rejects_wrapping_dictionary_ref() {
-        // dict_ref = 2^60 + 1 would wrap (dict_ref - 1) * 16 to zero and
-        // alias dictionary slot 0 if validated after the multiplication.
-        let mut bytes = vec![1u8, 1, 1];
-        bytes.extend_from_slice(&[7u8; 16]); // one dictionary slot
-        bytes.extend_from_slice(&[0, 1, b'k']); // shared=0, suffix 'k'
-        bytes.extend_from_slice(&[0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x10]);
-        bytes.push(16); // stored value length
-        bytes.extend_from_slice(&[0u8; 16]);
-        assert!(
-            decode_node_ref_for_leaf_tests(&bytes).is_err(),
-            "wrapping dictionary refs must be rejected"
-        );
-    }
-
-    #[test]
-    fn leaf_v2_rejects_shared_len_exceeding_previous_key_after_dictionaried_value() {
-        // Entry A: 1-byte key, dictionaried value (reconstructed value bytes
-        // land in the arena after the key). Entry B claims shared=3, which
-        // exceeds A's key length; a guard computed from the arena tail
-        // instead of the previous key end would accept it and splice value
-        // bytes into B's key.
-        let mut bytes = vec![1u8, 2, 1];
-        bytes.extend_from_slice(&[7u8; 16]); // dictionary slot 0
-        bytes.extend_from_slice(&[0, 1, b'k', 1, 16]); // A: shared=0, 'k', dict_ref=1
-        bytes.extend_from_slice(&[1u8; 16]);
-        bytes.extend_from_slice(&[3, 0, 0, 0]); // B: shared=3, suffix 0, dict_ref=0, value 0
-        assert!(
-            decode_node_ref_for_leaf_tests(&bytes).is_err(),
-            "shared length beyond the previous key must be rejected"
-        );
-    }
-
-    /// Pins the exact wire bytes. Tree chunks are content-addressed, so any
-    /// accidental format drift changes chunk hashes; this golden test makes
-    /// such drift fail a unit test instead of only surfacing in storage.
-    #[test]
-    fn leaf_v2_wire_format_is_pinned() {
-        let entries = [
-            (b"shared/aaaa".to_vec(), b"v1".to_vec()),
-            (b"shared/aabb".to_vec(), b"v2".to_vec()),
-            (b"shared/bbbb".to_vec(), b"v3".to_vec()),
-        ];
+    fn leaf_v3_tail_dictionary_saves_83_bytes_for_modeled_shape() {
+        let entries = (0..32usize)
+            .map(|index| {
+                (
+                    format!("rows/{index:05}").into_bytes(),
+                    raw_value(index as u8, 9, (index % 4 + 1) as u8),
+                )
+            })
+            .collect::<Vec<_>>();
         let refs = entries
             .iter()
             .map(|(key, value)| EncodedLeafEntryRef {
@@ -953,22 +1432,32 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let encoded = encode_leaf_refs_for_tests(&refs);
-        let expected: &[u8] = &[
-            1, // NODE_KIND_LEAF_V2
-            3, // entry count
-            0, // commit dictionary length (values too short to dictionary)
-            0, 11, b's', b'h', b'a', b'r', b'e', b'd', b'/', b'a', b'a', b'a', b'a', 0, 2, b'v',
-            b'1', // entry 0: shared=0, suffix "shared/aaaa", dict_ref=0, value "v1"
-            9, 2, b'b', b'b', 0, 2, b'v', b'2', // entry 1: shared=9, suffix "bb"
-            7, 4, b'b', b'b', b'b', b'b', 0, 2, b'v',
-            b'3', // entry 2: shared=7, suffix "bbbb"
-        ];
-        assert_eq!(encoded, expected, "leaf v2 wire bytes must stay stable");
+        let key_section = refs
+            .iter()
+            .scan(&[][..], |previous, entry| {
+                let shared = shared_prefix_len(previous, entry.key);
+                *previous = entry.key;
+                Some(2 + entry.key.len() - shared)
+            })
+            .sum::<usize>();
+        // The v2 leaf stores a one-byte commit ref, one-byte value length,
+        // and the value after its dictionary-compressed 16-byte commit id.
+        let v2_bytes = 1
+            + 1
+            + 1
+            + 16
+            + key_section
+            + entries
+                .iter()
+                .map(|(_, value)| 2 + value.len() - 16)
+                .sum::<usize>();
+
+        assert_eq!(v2_bytes - encoded.len(), 83);
     }
 
     #[test]
-    fn leaf_v2_rejects_malformed_bytes() {
-        let entries = [(b"key-a".to_vec(), b"value-a".to_vec())];
+    fn leaf_v3_rejects_malformed_and_legacy_bytes() {
+        let entries = [(b"key-a".to_vec(), raw_value(1, 2, 3))];
         let encoded = encode_leaf_refs_for_tests(
             &entries
                 .iter()
@@ -990,12 +1479,28 @@ mod tests {
         trailing.push(0);
         assert!(decode_node_ref_for_leaf_tests(&trailing).is_err());
 
-        // shared_len larger than the previous key reconstructs nothing valid.
-        let mut bogus_share = vec![NODE_KIND_LEAF_V2];
-        bogus_share.extend_from_slice(&[1, 9, 1, b'k', 1, b'v']);
-        assert!(decode_node_ref_for_leaf_tests(&bogus_share).is_err());
-
+        assert!(decode_node_ref_for_leaf_tests(&[1, 0, 0]).is_err());
         assert!(decode_node_ref_for_leaf_tests(&[]).is_err());
+
+        // A dictionary length that cannot fit in the body.
+        assert!(decode_node_ref_for_leaf_tests(&[3, 1, 2, 0]).is_err());
+
+        // A state-tail dictionary entry with a reserved width tag.
+        assert!(decode_node_ref_for_leaf_tests(&[3, 0, 0, 1, 90]).is_err());
+
+        // Commit ref is non-zero while the dictionary is empty.
+        let mut bad_commit_ref = vec![3, 1, 0, 0, 0, 1, b'k'];
+        bad_commit_ref.extend_from_slice(&[0; 16]);
+        bad_commit_ref.push(1);
+        assert!(decode_node_ref_for_leaf_tests(&bad_commit_ref).is_err());
+
+        // Tail ref is non-zero while the dictionary is empty.
+        let mut bad_tail_ref = vec![3, 1, 0, 0, 0, 1, b'k'];
+        bad_tail_ref.extend_from_slice(&[0; 16]);
+        bad_tail_ref.push(0);
+        bad_tail_ref.extend_from_slice(&[0; 16]);
+        bad_tail_ref.push(1);
+        assert!(decode_node_ref_for_leaf_tests(&bad_tail_ref).is_err());
     }
 
     use super::*;
@@ -1104,11 +1609,7 @@ mod tests {
         encoded.truncate(encoded.len() - 1);
 
         let error = decode_key(&encoded).expect_err("truncated key should reject");
-        assert!(
-            error
-                .to_string()
-                .contains("failed to decode tracked-state key")
-        );
+        assert!(error.to_string().contains("tracked-state key"));
     }
 
     #[test]
@@ -1121,11 +1622,7 @@ mod tests {
 
         let error = decode_key(&encoded).expect_err("empty entity pk should reject");
 
-        assert!(
-            error
-                .message
-                .contains("entity primary key decoded from storage is invalid")
-        );
+        assert!(error.message.contains("entity primary key is empty"));
     }
 
     #[test]
@@ -1146,6 +1643,168 @@ mod tests {
         });
 
         assert!(prefix < extended);
+        assert!(!extended.starts_with(&prefix));
+    }
+
+    #[test]
+    fn key_codec_wire_format_is_pinned() {
+        let key = TrackedStateKey {
+            schema_key: "s\0".to_string(),
+            file_id: Some(String::new()),
+            entity_pk: EntityPk {
+                parts: vec!["a\0".to_string(), String::new()],
+            },
+        };
+        let encoded = encode_key(&key);
+
+        assert_eq!(
+            encoded,
+            vec![
+                b's', 0, 0xff, 0, 0, // schema "s\\0"
+                1, 0, 0, // Some("")
+                b'a', 0, 0xff, 0, 1, // non-final PK part "a\\0"
+                0, 0, // final empty PK part
+            ]
+        );
+        assert_eq!(decode_key(&encoded).expect("key should decode"), key);
+        assert_eq!(
+            encode_key_ref(TrackedStateKeyRef {
+                schema_key: &key.schema_key,
+                file_id: key.file_id.as_deref(),
+                entity_pk: &key.entity_pk,
+            }),
+            encoded
+        );
+    }
+
+    #[test]
+    fn key_codec_byte_order_matches_logical_order_and_is_prefix_free() {
+        let strings = ["", "\0", "a", "a\0", "a\u{1}", "z", "é"];
+        let mut keys = Vec::new();
+        for schema in strings {
+            for file_id in [None, Some(""), Some("a"), Some("a\0")] {
+                for first in strings {
+                    keys.push(TrackedStateKey {
+                        schema_key: schema.to_string(),
+                        file_id: file_id.map(str::to_string),
+                        entity_pk: EntityPk::single(first),
+                    });
+                    keys.push(TrackedStateKey {
+                        schema_key: schema.to_string(),
+                        file_id: file_id.map(str::to_string),
+                        entity_pk: EntityPk {
+                            parts: vec![first.to_string(), "tail".to_string()],
+                        },
+                    });
+                }
+            }
+        }
+        keys.sort();
+        keys.dedup();
+        let mut by_encoded = keys
+            .iter()
+            .cloned()
+            .map(|key| (encode_key(&key), key))
+            .collect::<Vec<_>>();
+        by_encoded.sort_by(|left, right| left.0.cmp(&right.0));
+
+        assert_eq!(
+            by_encoded.iter().map(|(_, key)| key).collect::<Vec<_>>(),
+            keys.iter().collect::<Vec<_>>()
+        );
+        for (index, (encoded, _)) in by_encoded.iter().enumerate() {
+            for (other_index, (other, _)) in by_encoded.iter().enumerate() {
+                if index != other_index {
+                    assert!(
+                        !other.starts_with(encoded),
+                        "complete encoded key {index} prefixes key {other_index}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn key_codec_prefixes_select_exact_schema_and_file() {
+        let keys = [
+            TrackedStateKey {
+                schema_key: "a".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single("one"),
+            },
+            TrackedStateKey {
+                schema_key: "a".to_string(),
+                file_id: Some(String::new()),
+                entity_pk: EntityPk::single("two"),
+            },
+            TrackedStateKey {
+                schema_key: "a\0".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single("three"),
+            },
+        ];
+        let encoded = keys.iter().map(encode_key).collect::<Vec<_>>();
+        let schema = encode_schema_key_prefix("a");
+        let null_file = encode_schema_file_prefix("a", None);
+        let empty_file = encode_schema_file_prefix("a", Some(""));
+
+        assert_eq!(
+            encoded
+                .iter()
+                .map(|key| key.starts_with(&schema))
+                .collect::<Vec<_>>(),
+            vec![true, true, false]
+        );
+        assert_eq!(
+            encoded
+                .iter()
+                .map(|key| key.starts_with(&null_file))
+                .collect::<Vec<_>>(),
+            vec![true, false, false]
+        );
+        assert_eq!(
+            encoded
+                .iter()
+                .map(|key| key.starts_with(&empty_file))
+                .collect::<Vec<_>>(),
+            vec![false, true, false]
+        );
+    }
+
+    #[test]
+    fn leaf_front_coding_round_trips_across_a_nul_escape_boundary() {
+        let short = encode_key(&TrackedStateKey {
+            schema_key: "schema".to_string(),
+            file_id: None,
+            entity_pk: EntityPk::single("a"),
+        });
+        let with_nul = encode_key(&TrackedStateKey {
+            schema_key: "schema".to_string(),
+            file_id: None,
+            entity_pk: EntityPk::single("a\0"),
+        });
+        let shared = shared_prefix_len(&short, &with_nul);
+        assert_eq!(short[shared - 1], 0);
+        assert_eq!(with_nul[shared], KEY_ESCAPE);
+
+        leaf_entries_round_trip(&[(short, raw_value(1, 2, 3)), (with_nul, raw_value(4, 2, 3))]);
+    }
+
+    #[test]
+    fn key_codec_rejects_invalid_escapes_tags_utf8_and_tuple_endings() {
+        assert!(decode_key(&[b's', 0]).is_err());
+        assert!(decode_key(&[b's', 0, 2]).is_err());
+        assert!(decode_key(&[0xff, 0, 0, 0]).is_err());
+        assert!(decode_key(&[b's', 0, 0, 2]).is_err());
+        assert!(decode_key(&[b's', 0, 0, 0]).is_err());
+
+        let mut missing_final = encode_key(&TrackedStateKey {
+            schema_key: "s".to_string(),
+            file_id: None,
+            entity_pk: EntityPk::single("pk"),
+        });
+        *missing_final.last_mut().expect("key has terminator") = KEY_PART_MORE;
+        assert!(decode_key(&missing_final).is_err());
     }
 
     #[test]
@@ -1177,27 +1836,50 @@ mod tests {
     }
 
     #[test]
-    fn value_codec_stores_fixed_width_timestamps() {
-        let mut matching = test_value("commit", "change");
+    fn value_codec_uses_variable_width_timestamps() {
+        let mut value = test_value("commit", "change");
+        set_timestamps(&mut value, "1970-01-01T00:00:00Z", "1970-01-01T00:00:00Z");
+        let epoch_equal = encode_value(&value);
+        assert_eq!(epoch_equal.len(), 33);
+        assert_eq!(epoch_equal[VALUE_STATE_TAIL_START], 0x00);
+        assert_eq!(decode_value(&epoch_equal).expect("epoch value"), value);
+
         set_timestamps(
-            &mut matching,
-            "2026-01-01T00:00:00Z",
-            "2026-01-01T00:00:00Z",
+            &mut value,
+            "1970-01-01T00:00:00Z",
+            "1970-01-01T00:00:00.001Z",
         );
-        let matching_len = encode_value(&matching).len();
+        let epoch_distinct = encode_value(&value);
+        assert_eq!(epoch_distinct.len(), 35);
+        assert_eq!(epoch_distinct[VALUE_STATE_TAIL_START], 0x0b);
+        assert_eq!(decode_value(&epoch_distinct).expect("epoch value"), value);
+
+        set_timestamps(&mut value, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z");
+        let modern_equal = encode_value(&value);
+        assert_eq!(modern_equal.len(), 40);
+        assert_eq!(modern_equal[VALUE_STATE_TAIL_START], 0x07);
         assert_eq!(
-            decode_value(&encode_value(&matching)).expect("value"),
-            matching
+            &modern_equal[VALUE_STATE_TAIL_START + 1..],
+            &[0x00, 0x00, 0x80, 0xaa, 0x6d, 0xb7, 0x19]
+        );
+        assert_eq!(decode_value(&modern_equal).expect("modern value"), value);
+
+        set_timestamps(&mut value, "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z");
+        let modern_distinct = encode_value(&value);
+        assert_eq!(modern_distinct.len(), 47);
+        assert_eq!(modern_distinct[VALUE_STATE_TAIL_START], 0x4f);
+        assert_eq!(decode_value(&modern_distinct).expect("modern value"), value);
+
+        value.deleted = true;
+        assert_eq!(
+            encode_value(&value)[VALUE_STATE_TAIL_START],
+            0x4f | VALUE_TAIL_DELETED
         );
 
-        set_timestamps(
-            &mut matching,
-            "2026-01-01T00:00:00Z",
-            "2026-01-02T00:00:00Z",
-        );
-        let distinct_len = encode_value(&matching).len();
-
-        assert_eq!(matching_len, distinct_len);
+        set_timestamps(&mut value, "3000-01-01T00:00:00Z", "3000-01-02T00:00:00Z");
+        let far_future = encode_value(&value);
+        assert_eq!(far_future.len(), VALUE_MAX_BYTES);
+        assert_eq!(decode_value(&far_future).expect("far-future value"), value);
     }
 
     #[test]
@@ -1205,13 +1887,19 @@ mod tests {
         let mut compact = test_value("commit", "change");
         set_timestamps(&mut compact, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z");
 
-        let compact_owned = storage_codec::encode("tracked-state owned value", &compact)
-            .expect("owned value should encode");
-        assert_eq!(compact_owned, encode_value(&compact));
-        let compact_decoded: TrackedStateIndexValue =
-            storage_codec::decode("tracked-state owned value", &compact_owned)
-                .expect("owned value should decode");
-        assert_eq!(compact_decoded, compact);
+        let compact_owned = encode_value(&compact);
+        let compact_borrowed = encode_value_ref(TrackedStateIndexValueRef {
+            change_id: compact.change_id,
+            commit_id: compact.commit_id,
+            deleted: compact.deleted,
+            created_at: compact.created_at,
+            updated_at: compact.updated_at,
+        });
+        assert_eq!(compact_owned, compact_borrowed);
+        assert_eq!(
+            decode_value(&compact_owned).expect("compact value"),
+            compact
+        );
 
         let mut distinct = compact.clone();
         set_timestamps(
@@ -1220,13 +1908,45 @@ mod tests {
             "2026-01-02T00:00:00Z",
         );
 
-        let distinct_owned = storage_codec::encode("tracked-state owned value", &distinct)
-            .expect("owned value should encode");
-        assert_eq!(distinct_owned, encode_value(&distinct));
-        let distinct_decoded: TrackedStateIndexValue =
-            storage_codec::decode("tracked-state owned value", &distinct_owned)
-                .expect("owned value should decode");
-        assert_eq!(distinct_decoded, distinct);
+        let distinct_owned = encode_value(&distinct);
+        let distinct_borrowed = encode_value_ref(TrackedStateIndexValueRef {
+            change_id: distinct.change_id,
+            commit_id: distinct.commit_id,
+            deleted: distinct.deleted,
+            created_at: distinct.created_at,
+            updated_at: distinct.updated_at,
+        });
+        assert_eq!(distinct_owned, distinct_borrowed);
+        assert_eq!(
+            decode_value(&distinct_owned).expect("distinct value"),
+            distinct
+        );
+    }
+
+    #[test]
+    fn value_codec_rejects_malformed_storage_bytes() {
+        let value = encode_value(&test_value("commit", "change"));
+        assert!(decode_value(&value[..value.len() - 1]).is_err());
+
+        let mut reserved_tag = value.clone();
+        reserved_tag[VALUE_STATE_TAIL_START] = 90;
+        assert!(decode_value(&reserved_tag).is_err());
+
+        let mut non_minimal = value[..VALUE_STATE_TAIL_START].to_vec();
+        non_minimal.extend_from_slice(&[1, 0]);
+        assert!(decode_value(&non_minimal).is_err());
+
+        let mut distinct_but_equal = value[..VALUE_STATE_TAIL_START].to_vec();
+        distinct_but_equal.extend_from_slice(&[0x13, 1, 1]);
+        assert!(decode_value(&distinct_but_equal).is_err());
+
+        let mut invalid_timestamp = value[..VALUE_STATE_TAIL_START].to_vec();
+        invalid_timestamp.extend_from_slice(&[2, 0xdc, 0x05]);
+        assert!(decode_value(&invalid_timestamp).is_err());
+
+        let mut trailing = encode_value(&test_value("commit", "change"));
+        trailing.push(0);
+        assert!(decode_value(&trailing).is_err());
     }
 
     #[test]
@@ -1265,11 +1985,11 @@ mod tests {
         let entries = vec![
             EncodedLeafEntry {
                 key: b"alpha".to_vec(),
-                value: b"one".to_vec(),
+                value: raw_value(1, 2, 3),
             },
             EncodedLeafEntry {
                 key: b"bravo".to_vec(),
-                value: b"two-two".to_vec(),
+                value: raw_value(4, 5, 6),
             },
         ];
 
@@ -1284,12 +2004,12 @@ mod tests {
             .expect("second entry")
             .expect("second entry exists");
         assert_eq!(second.key, b"bravo");
-        assert_eq!(second.value, b"two-two");
+        assert_eq!(second.value, raw_value(4, 5, 6));
 
         let DecodedNode::Leaf(owned) = decode_node(&encoded).expect("owned leaf") else {
             panic!("expected owned leaf node");
         };
-        assert_eq!(owned.entries(), entries.as_slice());
+        assert_eq!(owned.into_entries(), entries);
     }
 
     #[test]
@@ -1308,11 +2028,11 @@ mod tests {
         let entries = vec![
             EncodedLeafEntry {
                 key: b"alpha".to_vec(),
-                value: b"one".to_vec(),
+                value: raw_value(1, 2, 3),
             },
             EncodedLeafEntry {
                 key: b"bravo".to_vec(),
-                value: b"two".to_vec(),
+                value: raw_value(4, 5, 6),
             },
         ];
         let mut encoded = encode_leaf_node(&entries);
@@ -1324,6 +2044,66 @@ mod tests {
             error.to_string().contains("tracked-state leaf node"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn internal_v3_round_trips_and_pins_front_coded_boundaries() {
+        let children = vec![
+            ChildSummary {
+                first_key: b"aa".to_vec(),
+                last_key: b"az".to_vec(),
+                child_hash: [1; TRACKED_STATE_HASH_BYTES],
+                subtree_count: 3,
+            },
+            ChildSummary {
+                first_key: b"ba".to_vec(),
+                last_key: b"bz".to_vec(),
+                child_hash: [2; TRACKED_STATE_HASH_BYTES],
+                subtree_count: 4,
+            },
+        ];
+        let encoded = encode_internal_node(&children);
+        let mut expected = vec![
+            4, 2, // kind, child count
+            0, 2, b'a', b'a', // first "aa" relative to empty
+            1, 1, b'z', // last "az" relative to "aa"
+        ];
+        expected.extend_from_slice(&[1; TRACKED_STATE_HASH_BYTES]);
+        expected.extend_from_slice(&[
+            3, // subtree count
+            0, 2, b'b', b'a', // first "ba" relative to previous last "az"
+            1, 1, b'z', // last "bz" relative to "ba"
+        ]);
+        expected.extend_from_slice(&[2; TRACKED_STATE_HASH_BYTES]);
+        expected.push(4);
+        assert_eq!(encoded, expected, "internal v3 wire bytes must stay stable");
+
+        let DecodedNode::Internal(decoded) = decode_node(&encoded).expect("internal node") else {
+            panic!("expected internal node");
+        };
+        assert_eq!(decoded.children(), children);
+    }
+
+    #[test]
+    fn internal_v3_rejects_empty_truncated_and_invalid_boundaries() {
+        assert!(decode_node(&[NODE_KIND_INTERNAL_V3, 0]).is_err());
+        assert!(decode_node(&[NODE_KIND_INTERNAL_V3, 1]).is_err());
+        assert!(decode_node(&[NODE_KIND_INTERNAL_V3, 1, 1, 0]).is_err());
+
+        let child = ChildSummary {
+            first_key: b"a".to_vec(),
+            last_key: b"z".to_vec(),
+            child_hash: [9; TRACKED_STATE_HASH_BYTES],
+            subtree_count: 1,
+        };
+        let encoded = encode_internal_node(&[child]);
+        let mut zero_subtree = encoded.clone();
+        *zero_subtree.last_mut().expect("subtree count") = 0;
+        assert!(decode_node(&zero_subtree).is_err());
+
+        let mut trailing = encoded;
+        trailing.push(0);
+        assert!(decode_node(&trailing).is_err());
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -49,14 +49,18 @@ where
     for plan in plans.iter().rev() {
         report = Some(stage_rebuild_plan_with_writer(&mut writer, plan).await?);
     }
-    report.ok_or_else(|| {
+    let report = report.ok_or_else(|| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
                 "tracked_state commit_root rebuild for commit '{commit_id}' did not stage a root"
             ),
         )
-    })
+    })?;
+    writer
+        .validate_staged_commit_root_against_changelog(commit_id)
+        .await?;
+    Ok(report)
 }
 
 async fn load_rebuild_plans_to_nearest_available_root<S>(

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -20,7 +20,6 @@ use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use crate::tracked_state::codec::{encode_key_ref, encode_value_ref};
 use crate::tracked_state::diff::{
     TrackedStateDiff, TrackedStateDiffRequest, TrackedStateDiffRow, diff_commits,
-    diff_commits_with_validation,
 };
 use crate::tracked_state::materialize_rows_from_index_entries;
 #[cfg(test)]
@@ -223,58 +222,14 @@ where
         diff_commits(self, left_commit_id, right_commit_id, request).await
     }
 
-    pub(crate) async fn diff_commits_with_validation(
-        &mut self,
-        left_commit_id: &str,
-        right_commit_id: &str,
-        request: &TrackedStateDiffRequest,
-        validate_left_root: bool,
-        validate_right_root: bool,
-    ) -> Result<TrackedStateDiff, LixError> {
-        diff_commits_with_validation(
-            self,
-            left_commit_id,
-            right_commit_id,
-            request,
-            validate_left_root,
-            validate_right_root,
-        )
-        .await
-    }
-
     pub(crate) async fn validate_diff_rows_for_commits_against_changelog(
         &mut self,
         rows: &[(&TrackedStateDiffRow, &str)],
     ) -> Result<(), LixError> {
-        if rows.is_empty() {
-            return Ok(());
-        }
-
-        let mut change_ids = rows
-            .iter()
-            .map(|(row, _)| row.change_id)
-            .collect::<Vec<_>>();
-        change_ids.sort();
-        change_ids.dedup();
-
-        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
-        let loaded_changes = changelog_reader
-            .load_changes(ChangeLoadRequest {
-                change_ids: &change_ids,
-            })
-            .await?;
-        let mut changes = HashMap::new();
-        for (change_id, loaded) in change_ids.into_iter().zip(loaded_changes.entries) {
-            let Some(change) = loaded else {
-                return Err(LixError::unknown(format!(
-                    "tracked-state diff row references missing changelog change '{change_id}'"
-                )));
-            };
-            changes.insert(change_id, change);
-        }
+        let row_refs = rows.iter().map(|(row, _)| *row).collect::<Vec<_>>();
+        let changes = self.load_and_validate_diff_row_changes(&row_refs).await?;
         let mut validation_cache = DiffCommitRootValidationCache::new();
         for (row, expected_commit_id) in rows {
-            validate_diff_row_against_changelog(row, &changes)?;
             let change_created_at = changes
                 .get(&row.change_id)
                 .map(|change| change.created_at)
@@ -293,6 +248,53 @@ where
             .await?;
         }
         Ok(())
+    }
+
+    pub(crate) async fn validate_diff_rows_and_load_payloads(
+        &mut self,
+        rows: &[&TrackedStateDiffRow],
+    ) -> Result<
+        HashMap<ChangeId, (crate::json_store::JsonSlot, crate::json_store::JsonSlot)>,
+        LixError,
+    > {
+        let changes = self.load_and_validate_diff_row_changes(rows).await?;
+        Ok(changes
+            .into_iter()
+            .map(|(change_id, change)| (change_id, (change.snapshot, change.metadata)))
+            .collect())
+    }
+
+    async fn load_and_validate_diff_row_changes(
+        &mut self,
+        rows: &[&TrackedStateDiffRow],
+    ) -> Result<HashMap<ChangeId, ChangeRecord>, LixError> {
+        if rows.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut change_ids = rows.iter().map(|row| row.change_id).collect::<Vec<_>>();
+        change_ids.sort();
+        change_ids.dedup();
+
+        let mut changelog_reader = ChangelogContext::new().reader(&mut self.store);
+        let loaded_changes = changelog_reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &change_ids,
+            })
+            .await?;
+        let mut changes = HashMap::new();
+        for (change_id, loaded) in change_ids.into_iter().zip(loaded_changes.entries) {
+            let Some(change) = loaded else {
+                return Err(LixError::unknown(format!(
+                    "tracked-state diff row references missing changelog change '{change_id}'"
+                )));
+            };
+            changes.insert(change_id, change);
+        }
+        for row in rows {
+            validate_diff_row_against_changelog(row, &changes)?;
+        }
+        Ok(changes)
     }
 
     async fn validate_diff_row_commit_root_membership(
@@ -323,11 +325,11 @@ where
                 )));
             }
 
-            let winners = self
-                .load_cached_commit_ref_winners(&current_commit_id, cache)
+            let winner_change_id = self
+                .load_cached_commit_ref_winner(&current_commit_id, &identity, cache)
                 .await?;
-            if let Some(winner_change_id) = winners.get(&identity) {
-                if winner_change_id != &row.change_id {
+            if let Some(winner_change_id) = winner_change_id {
+                if winner_change_id != row.change_id {
                     return Err(LixError::unknown(format!(
                         "tracked-state diff row references changelog change '{}' that is not the first-parent winner for commit '{}' and identity {:?}",
                         row.change_id, root_commit_id, identity
@@ -372,6 +374,11 @@ where
         metadata: &TrackedStateCommitRoot,
         cache: &mut DiffCommitRootValidationCache,
     ) -> Result<(), LixError> {
+        if metadata.parent_roots.len() > 1 {
+            return Err(LixError::unknown(format!(
+                "tracked-state commit-root metadata for commit '{commit_id}' has more than one first-parent root"
+            )));
+        }
         let changelog_first_parent = self
             .load_cached_changelog_first_parent(commit_id, cache)
             .await?;
@@ -443,8 +450,37 @@ where
         commit_id: &str,
         cache: &mut DiffCommitRootValidationCache,
     ) -> Result<HashMap<TrackedStateIdentity, ChangeId>, LixError> {
-        if let Some(winners) = cache.commit_ref_winners.get(commit_id) {
-            return Ok(winners.clone());
+        self.ensure_cached_commit_ref_winners(commit_id, cache)
+            .await?;
+        Ok(cache
+            .commit_ref_winners
+            .get(commit_id)
+            .cloned()
+            .expect("commit-ref winners should be cached after loading"))
+    }
+
+    async fn load_cached_commit_ref_winner(
+        &mut self,
+        commit_id: &str,
+        identity: &TrackedStateIdentity,
+        cache: &mut DiffCommitRootValidationCache,
+    ) -> Result<Option<ChangeId>, LixError> {
+        self.ensure_cached_commit_ref_winners(commit_id, cache)
+            .await?;
+        Ok(cache
+            .commit_ref_winners
+            .get(commit_id)
+            .and_then(|winners| winners.get(identity))
+            .copied())
+    }
+
+    async fn ensure_cached_commit_ref_winners(
+        &mut self,
+        commit_id: &str,
+        cache: &mut DiffCommitRootValidationCache,
+    ) -> Result<(), LixError> {
+        if cache.commit_ref_winners.contains_key(commit_id) {
+            return Ok(());
         }
         let commit_ids = [CommitId::parse_lix(
             commit_id,
@@ -500,8 +536,8 @@ where
         }
         cache
             .commit_ref_winners
-            .insert(commit_id.to_string(), winners.clone());
-        Ok(winners)
+            .insert(commit_id.to_string(), winners);
+        Ok(())
     }
 
     async fn load_cached_commit_root_metadata(
@@ -703,12 +739,38 @@ where
         Ok(parent_value.map(|value| value.created_at()))
     }
 
-    pub(crate) async fn validate_tree_rows_at_commit_against_changelog(
+    /// Runs the full O(total rows) tracked-root coverage audit.
+    ///
+    /// Normal diff validates root metadata and changed rows only. Maintenance
+    /// and repair tooling can call this when it deliberately needs fsck-level
+    /// assurance for every unchanged row too.
+    pub(crate) async fn validate_commit_root_against_changelog(
+        &mut self,
+        commit_id: &str,
+    ) -> Result<(), LixError> {
+        self.validate_tree_rows_at_commit_against_changelog(
+            commit_id,
+            &TrackedStateTreeScanRequest::default(),
+        )
+        .await
+    }
+
+    async fn validate_tree_rows_at_commit_against_changelog(
         &mut self,
         commit_id: &str,
         request: &TrackedStateTreeScanRequest,
     ) -> Result<(), LixError> {
-        let root = self.load_ensured_root(commit_id).await?;
+        let mut validation_cache = DiffCommitRootValidationCache::new();
+        let metadata = self
+            .load_cached_commit_root_metadata(commit_id, &mut validation_cache)
+            .await?;
+        self.validate_commit_root_parent_matches_changelog(
+            commit_id,
+            &metadata,
+            &mut validation_cache,
+        )
+        .await?;
+        let root = metadata.root_id;
         let rows = self.tree.scan(&self.store, &root, request).await?;
         self.validate_commit_root_coverage(commit_id, request, &rows)
             .await?;
@@ -805,11 +867,32 @@ where
         right_commit_id: &str,
         request: &TrackedStateTreeScanRequest,
     ) -> Result<Vec<crate::tracked_state::types::TrackedStateTreeDiffEntry>, LixError> {
-        let left_root = self.load_ensured_root(left_commit_id).await?;
-        let right_root = self.load_ensured_root(right_commit_id).await?;
+        let mut cache = DiffCommitRootValidationCache::new();
+        let left_root = self
+            .load_validated_diff_root(left_commit_id, &mut cache)
+            .await?;
+        let right_root = if left_commit_id == right_commit_id {
+            left_root.clone()
+        } else {
+            self.load_validated_diff_root(right_commit_id, &mut cache)
+                .await?
+        };
         self.tree
             .diff(&self.store, Some(&left_root), Some(&right_root), request)
             .await
+    }
+
+    async fn load_validated_diff_root(
+        &mut self,
+        commit_id: &str,
+        cache: &mut DiffCommitRootValidationCache,
+    ) -> Result<TrackedStateRootId, LixError> {
+        let metadata = self
+            .load_cached_commit_root_metadata(commit_id, cache)
+            .await?;
+        self.validate_commit_root_parent_matches_changelog(commit_id, &metadata, cache)
+            .await?;
+        Ok(metadata.root_id)
     }
 
     async fn load_ensured_root(&mut self, commit_id: &str) -> Result<TrackedStateRootId, LixError> {
@@ -884,6 +967,21 @@ impl<S> TrackedStateWriter<'_, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    pub(crate) async fn validate_staged_commit_root_against_changelog(
+        &self,
+        commit_id: &str,
+    ) -> Result<(), LixError> {
+        let read = storage::TrackedStateStagedRead::new(
+            self.store,
+            self.staged_roots.values(),
+            &self.chunk_overlay,
+        )?;
+        TrackedStateContext::new()
+            .reader(read)
+            .validate_commit_root_against_changelog(commit_id)
+            .await
+    }
+
     pub(crate) async fn stage_commit_root<'a, I>(
         &mut self,
         commit_id: &str,
@@ -1260,6 +1358,70 @@ mod tests {
         assert!(metadata.tree_height >= 1);
         assert!(metadata.primary_chunk_count >= 1);
         assert!(metadata.primary_chunk_bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn staged_root_audit_failure_does_not_publish_replacement() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "commit-a",
+            None,
+            &[row("entity-a", "change-a", "commit-a")],
+        )
+        .await
+        .expect("committed root should write");
+        let original_root = {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("original-root read should open");
+            storage::load_root(&read, "commit-a")
+                .await
+                .expect("original root should load")
+                .expect("original root should exist")
+        };
+
+        {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("staged-root read should open");
+            let mut writes = storage.new_write_set();
+            let mut writer = tracked_state.writer(&read, &mut writes);
+            let replacement = writer
+                .stage_commit_root(
+                    "commit-a",
+                    None,
+                    std::iter::empty::<TrackedStateDeltaRef<'_>>(),
+                )
+                .await
+                .expect("invalid replacement should stage before audit");
+            assert_ne!(replacement.root_id, original_root);
+
+            let error = writer
+                .validate_staged_commit_root_against_changelog("commit-a")
+                .await
+                .expect_err("audit must reject a root that omits the changelog winner");
+            assert!(
+                error.message.contains("omits current changelog change"),
+                "unexpected error: {error}"
+            );
+            // Dropping the failed staged write set is the publication fence.
+        }
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("verification read should open");
+        assert_eq!(
+            storage::load_root(&read, "commit-a")
+                .await
+                .expect("published root should load"),
+            Some(original_root)
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -73,8 +73,13 @@ pub(crate) enum TrackedStateDiffKind {
     Removed,
 }
 
-/// Diffs two tracked-state commit roots.
+/// Diffs two tracked-state commit roots with hash-guided subtree skipping.
 ///
+/// Commit-root first-parent metadata is bound to the changelog. Every emitted
+/// row point-loads its change record and validates identity, deletion, and
+/// update time. Winner reachability, inherited creation time, and absence of
+/// omitted unchanged rows belong to the explicit full-root integrity audit;
+/// proving those here would make sparse diff O(total rows).
 pub(crate) async fn diff_commits<S>(
     reader: &mut TrackedStateStoreReader<S>,
     left_commit_id: &str,
@@ -84,34 +89,10 @@ pub(crate) async fn diff_commits<S>(
 where
     S: crate::storage_adapter::StorageAdapterRead,
 {
-    diff_commits_with_validation(reader, left_commit_id, right_commit_id, request, true, true).await
-}
-
-pub(crate) async fn diff_commits_with_validation<S>(
-    reader: &mut TrackedStateStoreReader<S>,
-    left_commit_id: &str,
-    right_commit_id: &str,
-    request: &TrackedStateDiffRequest,
-    validate_left_root: bool,
-    validate_right_root: bool,
-) -> Result<TrackedStateDiff, LixError>
-where
-    S: crate::storage_adapter::StorageAdapterRead,
-{
     let scan_request = scan_request_for_diff(request);
     let tree_entries = reader
         .diff_tree_entries_at_commits(left_commit_id, right_commit_id, &scan_request)
         .await?;
-    if validate_left_root {
-        reader
-            .validate_tree_rows_at_commit_against_changelog(left_commit_id, &scan_request)
-            .await?;
-    }
-    if validate_right_root && left_commit_id != right_commit_id {
-        reader
-            .validate_tree_rows_at_commit_against_changelog(right_commit_id, &scan_request)
-            .await?;
-    }
     let mut raw_rows = Vec::with_capacity(tree_entries.len());
     for tree_entry in tree_entries {
         let before = tree_entry
@@ -123,22 +104,27 @@ where
         raw_rows.push((before, after));
     }
 
+    // Validate only rows exposed by the hash-guided tree diff. Whole-root
+    // coverage validation is an explicit integrity audit; doing it here would
+    // turn every sparse diff back into an O(total rows) scan.
+    let mut rows_to_validate = Vec::with_capacity(raw_rows.len().saturating_mul(2));
+    for (before, after) in &raw_rows {
+        if let Some(before) = before {
+            rows_to_validate.push(before);
+        }
+        if let Some(after) = after {
+            rows_to_validate.push(after);
+        }
+    }
+    let payloads = reader
+        .validate_diff_rows_and_load_payloads(&rows_to_validate)
+        .await?;
+
     // Rows are identity-only; payload equality needs the change records when
     // a live/live pair carries different change ids (cross-branch writes can
     // produce identical content under distinct changes, which must classify
-    // as no-diff). Same change id == same change == equal payload, no load.
-    let mut fallback_ids = Vec::new();
-    for (before, after) in &raw_rows {
-        if let (Some(left), Some(right)) =
-            (is_live_row(before.as_ref()), is_live_row(after.as_ref()))
-        {
-            if left.change_id != right.change_id {
-                fallback_ids.push(left.change_id);
-                fallback_ids.push(right.change_id);
-            }
-        }
-    }
-    let payloads = reader.load_change_payloads(&fallback_ids).await?;
+    // as no-diff). Reuse the records loaded for changed-row validation instead
+    // of issuing a second changelog read.
 
     let mut entries = Vec::with_capacity(raw_rows.len());
     for (before, after) in raw_rows {
@@ -606,7 +592,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_rejects_update_with_arbitrary_forged_created_at() {
+    async fn full_root_audit_rejects_update_with_arbitrary_forged_created_at() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
@@ -674,13 +660,7 @@ mod tests {
         )
         .await;
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+        let error = audit_root(&storage, &tracked_state, "child")
             .await
             .expect_err("arbitrary forged created_at must be rejected");
 
@@ -794,7 +774,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_rejects_stale_ancestor_row_that_is_not_root_winner() {
+    async fn full_root_audit_rejects_stale_ancestor_row_that_is_not_root_winner() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
@@ -845,13 +825,7 @@ mod tests {
         )
         .await;
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits("left", "child", &TrackedStateDiffRequest::default())
+        let error = audit_root(&storage, &tracked_state, "child")
             .await
             .expect_err("stale ancestor winner must be rejected");
 
@@ -862,7 +836,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_rejects_valid_change_from_unreachable_commit_root() {
+    async fn full_root_audit_rejects_valid_change_from_unreachable_commit_root() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
@@ -948,13 +922,7 @@ mod tests {
         };
         assert_eq!(result.row_count, 1);
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits("left", "right-corrupt", &TrackedStateDiffRequest::default())
+        let error = audit_root(&storage, &tracked_state, "right-corrupt")
             .await
             .expect_err("unreachable valid change must be rejected");
 
@@ -965,7 +933,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_rejects_second_parent_row_without_commit_root_proof() {
+    async fn full_root_audit_rejects_second_parent_row_without_commit_root_proof() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(&storage, &tracked_state, "left", None, &[])
@@ -1030,13 +998,7 @@ mod tests {
         )
         .await;
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits("left", "merge", &TrackedStateDiffRequest::default())
+        let error = audit_root(&storage, &tracked_state, "merge")
             .await
             .expect_err("second-parent row without commit-root proof must be rejected");
 
@@ -1471,7 +1433,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_rejects_omitted_inherited_row_even_when_diff_is_non_empty() {
+    async fn full_root_audit_rejects_omitted_inherited_row() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(
@@ -1525,13 +1487,7 @@ mod tests {
         )
         .await;
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits("parent", "child", &TrackedStateDiffRequest::default())
+        let error = audit_root(&storage, &tracked_state, "child")
             .await
             .expect_err("omitted inherited row must be rejected");
 
@@ -1542,7 +1498,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_rejects_omitted_updated_row_even_when_diff_is_non_empty() {
+    async fn full_root_audit_rejects_omitted_updated_row() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(
@@ -1599,13 +1555,7 @@ mod tests {
         )
         .await;
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits("parent", "child", &TrackedStateDiffRequest::default())
+        let error = audit_root(&storage, &tracked_state, "child")
             .await
             .expect_err("omitted updated row must be rejected");
 
@@ -1616,7 +1566,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_rejects_shared_omitted_row_even_when_diff_is_non_empty() {
+    async fn full_root_audit_rejects_shared_omitted_row() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(
@@ -1710,13 +1660,7 @@ mod tests {
         )
         .await;
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits("left", "right", &TrackedStateDiffRequest::default())
+        let error = audit_root(&storage, &tracked_state, "left")
             .await
             .expect_err("shared hidden omission must be rejected");
 
@@ -1727,7 +1671,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn diff_commits_validates_roots_even_when_tree_diff_is_empty() {
+    async fn full_root_audit_validates_even_when_tree_diff_is_empty() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         write_root_committed_for_test(
@@ -1781,22 +1725,71 @@ mod tests {
         )
         .await;
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = tracked_state
-            .reader(read)
-            .diff_commits(
-                "left-corrupt",
-                "right-corrupt",
-                &TrackedStateDiffRequest::default(),
-            )
+        let error = audit_root(&storage, &tracked_state, "left-corrupt")
             .await
             .expect_err("identical corrupt roots must still be validated");
 
         assert!(
             is_commit_root_validation_error(&error),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn full_root_audit_rejects_forged_parent_metadata_on_empty_root() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_committed_for_test(&storage, &tracked_state, "parent", None, &[])
+            .await
+            .expect("parent root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "unrelated", None, &[])
+            .await
+            .expect("unrelated root should write");
+        write_root_committed_for_test(&storage, &tracked_state, "child", Some("parent"), &[])
+            .await
+            .expect("child root should write");
+
+        stage_corrupt_commit_root(
+            &storage,
+            "child",
+            Vec::new(),
+            vec![TrackedStateCommitRootParent {
+                commit_id: CommitId::for_test_label("unrelated"),
+                root_id: tracked_state_root_id(&storage, "unrelated").await,
+            }],
+        )
+        .await;
+
+        let error = audit_root(&storage, &tracked_state, "child")
+            .await
+            .expect_err("forged empty-root parent metadata must be rejected");
+
+        assert!(
+            is_commit_root_validation_error(&error),
+            "unexpected error: {error}"
+        );
+
+        stage_corrupt_commit_root(
+            &storage,
+            "child",
+            Vec::new(),
+            vec![
+                TrackedStateCommitRootParent {
+                    commit_id: CommitId::for_test_label("parent"),
+                    root_id: tracked_state_root_id(&storage, "parent").await,
+                },
+                TrackedStateCommitRootParent {
+                    commit_id: CommitId::for_test_label("unrelated"),
+                    root_id: tracked_state_root_id(&storage, "unrelated").await,
+                },
+            ],
+        )
+        .await;
+        let error = audit_root(&storage, &tracked_state, "child")
+            .await
+            .expect_err("extra commit-root parents must be rejected");
+        assert!(
+            error.message.contains("more than one first-parent root"),
             "unexpected error: {error}"
         );
     }
@@ -1947,6 +1940,21 @@ mod tests {
             .diff_commits("left", "right", &TrackedStateDiffRequest::default())
             .await
             .expect("diff should load")
+    }
+
+    async fn audit_root(
+        storage: &StorageAdapter,
+        tracked_state: &TrackedStateContext,
+        commit_id: &str,
+    ) -> Result<(), LixError> {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        tracked_state
+            .reader(read)
+            .validate_commit_root_against_changelog(commit_id)
+            .await
     }
 
     async fn seed_roots(

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -7,6 +7,10 @@
 use std::collections::HashMap;
 
 use crate::changelog::CommitId;
+use crate::storage::{
+    CoreProjection, GetManyResult, GetOptions, Key, KeyRange, ProjectedValue, ScanChunk,
+    ScanOptions, SpaceId, StorageError,
+};
 use crate::storage_adapter::{PointReadPlan, StorageAdapterRead, StorageSpace, StorageWriteSet};
 use crate::storage_adapter::{
     StorageGetOptions, StorageKey, StorageProjectedValue, StorageSpaceId, StorageValue,
@@ -29,10 +33,11 @@ pub(crate) const TRACKED_STATE_COMMIT_ROOT_SPACE: StorageSpace = StorageSpace::n
     TRACKED_STATE_COMMIT_ROOT_NAMESPACE,
 );
 
-// Version the root metadata independently of storage backends. Version 2 is a
-// hard format cut: roots written before commit rows became derived state must
-// not be inherited by a new commit and silently carry those rows forever.
-const TRACKED_STATE_COMMIT_ROOT_MAGIC: &[u8] = b"LXTR2";
+// Version the root metadata independently of storage backends. Version 3 is a
+// hard cut for derived commit rows, prefix-friendly keys, and compact tree
+// nodes. Reject older roots before their differently ordered state can be
+// inherited or traversed.
+const TRACKED_STATE_COMMIT_ROOT_MAGIC: &[u8] = b"LXTR3";
 
 async fn get_one(
     store: &(impl StorageAdapterRead + ?Sized),
@@ -173,6 +178,107 @@ impl TrackedStateChunkOverlay {
     }
 }
 
+/// Point-read overlay used to audit rebuilt roots before their write set is
+/// published. Changelog reads fall through to the coherent base snapshot;
+/// commit-root and tree-chunk reads see bytes staged by the root writer first.
+#[derive(Debug)]
+pub(crate) struct TrackedStateStagedRead<'a, S: ?Sized> {
+    store: &'a S,
+    commit_roots: HashMap<[u8; 16], Bytes>,
+    chunks: &'a TrackedStateChunkOverlay,
+}
+
+impl<'a, S> TrackedStateStagedRead<'a, S>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    pub(crate) fn new<'root>(
+        store: &'a S,
+        commit_roots: impl IntoIterator<Item = &'root TrackedStateCommitRoot>,
+        chunks: &'a TrackedStateChunkOverlay,
+    ) -> Result<Self, LixError> {
+        let mut encoded_roots = HashMap::new();
+        for metadata in commit_roots {
+            let key = *metadata.commit_id.as_uuid().as_bytes();
+            let value = Bytes::from(encode_commit_root(metadata)?);
+            if let Some(existing) = encoded_roots.insert(key, value.clone())
+                && existing != value
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked-state staged audit contains conflicting commit roots",
+                ));
+            }
+        }
+        Ok(Self {
+            store,
+            commit_roots: encoded_roots,
+            chunks,
+        })
+    }
+
+    fn staged_bytes(&self, space: SpaceId, key: &Key) -> Option<&[u8]> {
+        if space == TRACKED_STATE_COMMIT_ROOT_SPACE.id {
+            let key = <&[u8; 16]>::try_from(key.0.as_ref()).ok()?;
+            return self.commit_roots.get(key).map(AsRef::as_ref);
+        }
+        if space == TRACKED_STATE_TREE_CHUNK_SPACE.id {
+            let key = <&[u8; TRACKED_STATE_HASH_BYTES]>::try_from(key.0.as_ref()).ok()?;
+            return self.chunks.staged_chunk(key);
+        }
+        None
+    }
+}
+
+impl<S> StorageAdapterRead for TrackedStateStagedRead<'_, S>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        let mut result = self.store.get_many(space, keys, opts).await?;
+        if result.values.len() != keys.len() {
+            return Err(StorageError::Corruption(format!(
+                "tracked-state staged audit requested {} point reads but storage returned {} slots",
+                keys.len(),
+                result.values.len()
+            )));
+        }
+        for (key, slot) in keys.iter().zip(&mut result.values) {
+            let Some(bytes) = self.staged_bytes(space, key) else {
+                continue;
+            };
+            *slot = Some(match opts.projection {
+                CoreProjection::KeyOnly => ProjectedValue::KeyOnly,
+                CoreProjection::FullValue => {
+                    ProjectedValue::FullValue(Bytes::copy_from_slice(bytes))
+                }
+            });
+        }
+        Ok(result)
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        if space == TRACKED_STATE_COMMIT_ROOT_SPACE.id || space == TRACKED_STATE_TREE_CHUNK_SPACE.id
+        {
+            return Err(StorageError::Io(
+                "tracked-state staged audit supports point reads only for overlay spaces"
+                    .to_string(),
+            ));
+        }
+        self.store.scan(space, range, opts).await
+    }
+}
+
 fn key(bytes: Vec<u8>) -> StorageKey {
     StorageKey(Bytes::from(bytes))
 }
@@ -293,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_root_codec_rejects_unversioned_musli_roots() {
+    fn commit_root_codec_rejects_pre_v3_roots() {
         let metadata = TrackedStateCommitRoot {
             commit_id: CommitId::for_test_label("legacy"),
             root_id: TrackedStateRootId::new([7; 32]),
@@ -304,18 +410,22 @@ mod tests {
             primary_chunk_count: 1,
             primary_chunk_bytes: 128,
         };
-        let old_bytes = crate::storage_codec::encode("tracked_state commit_root", &metadata)
-            .expect("legacy commit root should encode");
+        let unversioned = crate::storage_codec::encode("tracked_state commit_root", &metadata)
+            .expect("pre-v3 commit root should encode");
+        let mut v2 = b"LXTR2".to_vec();
+        v2.extend_from_slice(&unversioned);
 
-        let error = decode_commit_root(&old_bytes)
-            .expect_err("unversioned commit roots must not enter the new layout");
+        for old_bytes in [&unversioned, &v2] {
+            let error = decode_commit_root(old_bytes)
+                .expect_err("pre-v3 roots must not enter the v3 tree layout");
 
-        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
-        assert!(
-            error
-                .message
-                .contains("unsupported format; recreate the repository")
-        );
+            assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+            assert!(
+                error
+                    .message
+                    .contains("unsupported format; recreate the repository")
+            );
+        }
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -113,12 +113,11 @@ impl TrackedStateTree {
         loop {
             match self.load_node(store, &current).await? {
                 DecodedNode::Leaf(leaf) => {
-                    let entry = leaf
-                        .entries()
-                        .binary_search_by(|entry| entry.key.as_slice().cmp(&encoded_key))
-                        .ok()
-                        .map(|index| &leaf.entries()[index]);
-                    return entry.map(|entry| decode_value(&entry.value)).transpose();
+                    let entry = binary_search_leaf_key(&leaf, &encoded_key)?
+                        .map(|index| leaf.entry(index))
+                        .transpose()?
+                        .flatten();
+                    return entry.map(|entry| decode_value(entry.value)).transpose();
                 }
                 DecodedNode::Internal(internal) => {
                     let child = internal
@@ -173,7 +172,31 @@ impl TrackedStateTree {
 
         let ranges = scan_ranges(request);
         let key_decode_hint = scan_key_decode_hint(request, &ranges);
+        let row_capacity = if request.include_tombstones
+            && request.schema_keys.is_empty()
+            && request.entity_pks.is_empty()
+            && request.file_ids.is_empty()
+        {
+            let row_count = match self.load_node(store, root_id.as_bytes()).await? {
+                DecodedNode::Leaf(leaf) => Some(leaf.len() as u64),
+                DecodedNode::Internal(internal) => internal
+                    .children()
+                    .iter()
+                    .try_fold(0u64, |count, child| count.checked_add(child.subtree_count)),
+            };
+            row_count
+                .and_then(|count| usize::try_from(count).ok())
+                .unwrap_or(0)
+        } else {
+            0
+        };
         let mut rows = Vec::new();
+        let reserve = request
+            .limit
+            .map_or(row_capacity, |limit| limit.min(row_capacity));
+        // Subtree counts are storage data. A corrupt count must not turn a
+        // best-effort scan allocation hint into a capacity panic.
+        let _ = rows.try_reserve_exact(reserve);
         self.scan_node(
             store,
             *root_id.as_bytes(),
@@ -457,55 +480,7 @@ impl TrackedStateTree {
         }))
     }
 
-    fn diff_nodes<'a, S>(
-        &'a self,
-        store: &'a S,
-        left_hash: [u8; TRACKED_STATE_HASH_BYTES],
-        right_hash: [u8; TRACKED_STATE_HASH_BYTES],
-        request: &'a TrackedStateTreeScanRequest,
-        out: &'a mut Vec<TrackedStateTreeDiffEntry>,
-    ) -> Pin<Box<dyn Future<Output = Result<(), LixError>> + 'a>>
-    where
-        S: StorageAdapterRead + 'a,
-    {
-        Box::pin(async move {
-            if left_hash == right_hash {
-                return Ok(());
-            }
-
-            let left = self.load_node(store, &left_hash).await?;
-            let right = self.load_node(store, &right_hash).await?;
-            match (left, right) {
-                (DecodedNode::Leaf(left), DecodedNode::Leaf(right)) => {
-                    self.diff_leaf_entries(left.entries(), right.entries(), request, out)?;
-                }
-                (DecodedNode::Internal(left), DecodedNode::Internal(right))
-                    if internal_boundaries_match(left.children(), right.children()) =>
-                {
-                    for (left_child, right_child) in left.children().iter().zip(right.children()) {
-                        if left_child == right_child {
-                            continue;
-                        }
-                        self.diff_nodes(
-                            store,
-                            left_child.child_hash,
-                            right_child.child_hash,
-                            request,
-                            out,
-                        )
-                        .await?;
-                    }
-                }
-                _ => {
-                    self.diff_leaf_summary_cursors(store, left_hash, right_hash, request, out)
-                        .await?;
-                }
-            }
-            Ok(())
-        })
-    }
-
-    async fn diff_leaf_summary_cursors(
+    async fn diff_nodes(
         &self,
         store: &impl StorageAdapterRead,
         left_hash: [u8; TRACKED_STATE_HASH_BYTES],
@@ -513,74 +488,133 @@ impl TrackedStateTree {
         request: &TrackedStateTreeScanRequest,
         out: &mut Vec<TrackedStateTreeDiffEntry>,
     ) -> Result<(), LixError> {
-        let mut left = LeafSummaryCursor::new(self, store, left_hash).await?;
-        let mut right = LeafSummaryCursor::new(self, store, right_hash).await?;
+        if left_hash == right_hash {
+            return Ok(());
+        }
+
+        let left = self.load_node(store, &left_hash).await?;
+        let right = self.load_node(store, &right_hash).await?;
+        if let (DecodedNode::Leaf(left), DecodedNode::Leaf(right)) = (&left, &right) {
+            return self.diff_decoded_leaves(left, right, request, out);
+        }
+
+        let mut left = node_diff_frontier(left_hash, left)?;
+        let mut right = node_diff_frontier(right_hash, right)?;
         let mut left_window = Vec::new();
         let mut right_window = Vec::new();
+        let mut left_loaded = None;
+        let mut right_loaded = None;
 
         loop {
-            match (left.current(), right.current()) {
-                (Some(left_leaf), Some(right_leaf)) if left_leaf == right_leaf => {
-                    self.diff_leaf_summary_window(store, &left_window, &right_window, request, out)
-                        .await?;
+            match (left.front().cloned(), right.front().cloned()) {
+                (Some(left_node), Some(right_node))
+                    if left_node.child_hash == right_node.child_hash =>
+                {
+                    self.diff_leaf_entries(&left_window, &right_window, request, out)?;
                     left_window.clear();
                     right_window.clear();
-                    left.advance(self, store).await?;
-                    right.advance(self, store).await?;
+                    left.pop_front();
+                    right.pop_front();
+                    left_loaded = None;
+                    right_loaded = None;
                 }
-                (Some(left_leaf), Some(right_leaf)) => {
-                    match left_leaf.last_key.cmp(&right_leaf.last_key) {
-                        std::cmp::Ordering::Less => {
-                            left_window.push(left_leaf.clone());
-                            left.advance(self, store).await?;
+                (Some(left_summary), Some(right_summary)) => {
+                    let left_node = match left_loaded.take() {
+                        Some(node) => node,
+                        None => self.load_node(store, &left_summary.child_hash).await?,
+                    };
+                    let right_node = match right_loaded.take() {
+                        Some(node) => node,
+                        None => self.load_node(store, &right_summary.child_hash).await?,
+                    };
+                    match (left_node, right_node) {
+                        (DecodedNode::Internal(left_node), DecodedNode::Internal(right_node)) => {
+                            replace_front_with_children(&mut left, left_node.into_children())?;
+                            replace_front_with_children(&mut right, right_node.into_children())?;
                         }
-                        std::cmp::Ordering::Greater => {
-                            right_window.push(right_leaf.clone());
-                            right.advance(self, store).await?;
+                        (DecodedNode::Internal(left_node), right_node @ DecodedNode::Leaf(_)) => {
+                            replace_front_with_children(&mut left, left_node.into_children())?;
+                            right_loaded = Some(right_node);
                         }
-                        std::cmp::Ordering::Equal => {
-                            left_window.push(left_leaf.clone());
-                            right_window.push(right_leaf.clone());
-                            left.advance(self, store).await?;
-                            right.advance(self, store).await?;
+                        (left_node @ DecodedNode::Leaf(_), DecodedNode::Internal(right_node)) => {
+                            left_loaded = Some(left_node);
+                            replace_front_with_children(&mut right, right_node.into_children())?;
+                        }
+                        (DecodedNode::Leaf(left_node), DecodedNode::Leaf(right_node)) => {
+                            match left_summary.last_key.cmp(&right_summary.last_key) {
+                                std::cmp::Ordering::Less => {
+                                    left_window.extend(left_node.into_entries());
+                                    left.pop_front();
+                                    right_loaded = Some(DecodedNode::Leaf(right_node));
+                                }
+                                std::cmp::Ordering::Greater => {
+                                    left_loaded = Some(DecodedNode::Leaf(left_node));
+                                    right_window.extend(right_node.into_entries());
+                                    right.pop_front();
+                                }
+                                std::cmp::Ordering::Equal => {
+                                    left.pop_front();
+                                    right.pop_front();
+                                    if left_window.is_empty() && right_window.is_empty() {
+                                        self.diff_decoded_leaves(
+                                            &left_node,
+                                            &right_node,
+                                            request,
+                                            out,
+                                        )?;
+                                    } else {
+                                        left_window.extend(left_node.into_entries());
+                                        right_window.extend(right_node.into_entries());
+                                        self.diff_leaf_entries(
+                                            &left_window,
+                                            &right_window,
+                                            request,
+                                            out,
+                                        )?;
+                                        left_window.clear();
+                                        right_window.clear();
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-                (Some(left_leaf), None) => {
-                    left_window.push(left_leaf.clone());
-                    left.advance(self, store).await?;
+                (Some(left_summary), None) => {
+                    let left_node = match left_loaded.take() {
+                        Some(node) => node,
+                        None => self.load_node(store, &left_summary.child_hash).await?,
+                    };
+                    match left_node {
+                        DecodedNode::Internal(node) => {
+                            replace_front_with_children(&mut left, node.into_children())?;
+                        }
+                        DecodedNode::Leaf(node) => {
+                            left_window.extend(node.into_entries());
+                            left.pop_front();
+                        }
+                    }
                 }
-                (None, Some(right_leaf)) => {
-                    right_window.push(right_leaf.clone());
-                    right.advance(self, store).await?;
+                (None, Some(right_summary)) => {
+                    let right_node = match right_loaded.take() {
+                        Some(node) => node,
+                        None => self.load_node(store, &right_summary.child_hash).await?,
+                    };
+                    match right_node {
+                        DecodedNode::Internal(node) => {
+                            replace_front_with_children(&mut right, node.into_children())?;
+                        }
+                        DecodedNode::Leaf(node) => {
+                            right_window.extend(node.into_entries());
+                            right.pop_front();
+                        }
+                    }
                 }
                 (None, None) => {
-                    self.diff_leaf_summary_window(store, &left_window, &right_window, request, out)
-                        .await?;
+                    self.diff_leaf_entries(&left_window, &right_window, request, out)?;
                     return Ok(());
                 }
             }
         }
-    }
-
-    async fn diff_leaf_summary_window(
-        &self,
-        store: &impl StorageAdapterRead,
-        left_leaves: &[ChildSummary],
-        right_leaves: &[ChildSummary],
-        request: &TrackedStateTreeScanRequest,
-        out: &mut Vec<TrackedStateTreeDiffEntry>,
-    ) -> Result<(), LixError> {
-        if left_leaves.is_empty() && right_leaves.is_empty() {
-            return Ok(());
-        }
-        let left_entries = self
-            .collect_entries_from_leaf_summaries(store, left_leaves)
-            .await?;
-        let right_entries = self
-            .collect_entries_from_leaf_summaries(store, right_leaves)
-            .await?;
-        self.diff_leaf_entries(&left_entries, &right_entries, request, out)
     }
 
     fn diff_leaf_entries(
@@ -595,18 +629,18 @@ impl TrackedStateTree {
         while left_index < left.len() && right_index < right.len() {
             match left[left_index].key.cmp(&right[right_index].key) {
                 std::cmp::Ordering::Less => {
-                    self.push_removed_diff(&left[left_index], request, out)?;
+                    self.push_removed_diff(left[left_index].as_ref(), request, out)?;
                     left_index += 1;
                 }
                 std::cmp::Ordering::Greater => {
-                    self.push_added_diff(&right[right_index], request, out)?;
+                    self.push_added_diff(right[right_index].as_ref(), request, out)?;
                     right_index += 1;
                 }
                 std::cmp::Ordering::Equal => {
                     if left[left_index].value != right[right_index].value {
                         self.push_modified_diff(
-                            &left[left_index],
-                            &right[right_index],
+                            left[left_index].as_ref(),
+                            right[right_index].as_ref(),
                             request,
                             out,
                         )?;
@@ -617,10 +651,51 @@ impl TrackedStateTree {
             }
         }
         for entry in &left[left_index..] {
-            self.push_removed_diff(entry, request, out)?;
+            self.push_removed_diff(entry.as_ref(), request, out)?;
         }
         for entry in &right[right_index..] {
-            self.push_added_diff(entry, request, out)?;
+            self.push_added_diff(entry.as_ref(), request, out)?;
+        }
+        Ok(())
+    }
+
+    fn diff_decoded_leaves(
+        &self,
+        left: &DecodedLeafNodeRef,
+        right: &DecodedLeafNodeRef,
+        request: &TrackedStateTreeScanRequest,
+        out: &mut Vec<TrackedStateTreeDiffEntry>,
+    ) -> Result<(), LixError> {
+        let mut left_index = 0usize;
+        let mut right_index = 0usize;
+        while left_index < left.len() && right_index < right.len() {
+            let left_entry = decoded_leaf_entry(left, left_index)?;
+            let right_entry = decoded_leaf_entry(right, right_index)?;
+            match left_entry.key.cmp(right_entry.key) {
+                std::cmp::Ordering::Less => {
+                    self.push_removed_diff(left_entry, request, out)?;
+                    left_index += 1;
+                }
+                std::cmp::Ordering::Greater => {
+                    self.push_added_diff(right_entry, request, out)?;
+                    right_index += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    if left_entry.value != right_entry.value {
+                        self.push_modified_diff(left_entry, right_entry, request, out)?;
+                    }
+                    left_index += 1;
+                    right_index += 1;
+                }
+            }
+        }
+        while left_index < left.len() {
+            self.push_removed_diff(decoded_leaf_entry(left, left_index)?, request, out)?;
+            left_index += 1;
+        }
+        while right_index < right.len() {
+            self.push_added_diff(decoded_leaf_entry(right, right_index)?, request, out)?;
+            right_index += 1;
         }
         Ok(())
     }
@@ -628,7 +703,7 @@ impl TrackedStateTree {
     #[expect(clippy::unused_self)]
     fn push_removed_diff(
         &self,
-        entry: &EncodedLeafEntry,
+        entry: EncodedLeafEntryRef<'_>,
         request: &TrackedStateTreeScanRequest,
         out: &mut Vec<TrackedStateTreeDiffEntry>,
     ) -> Result<(), LixError> {
@@ -645,7 +720,7 @@ impl TrackedStateTree {
     #[expect(clippy::unused_self)]
     fn push_added_diff(
         &self,
-        entry: &EncodedLeafEntry,
+        entry: EncodedLeafEntryRef<'_>,
         request: &TrackedStateTreeScanRequest,
         out: &mut Vec<TrackedStateTreeDiffEntry>,
     ) -> Result<(), LixError> {
@@ -662,8 +737,8 @@ impl TrackedStateTree {
     #[expect(clippy::unused_self)]
     fn push_modified_diff(
         &self,
-        left: &EncodedLeafEntry,
-        right: &EncodedLeafEntry,
+        left: EncodedLeafEntryRef<'_>,
+        right: EncodedLeafEntryRef<'_>,
         request: &TrackedStateTreeScanRequest,
         out: &mut Vec<TrackedStateTreeDiffEntry>,
     ) -> Result<(), LixError> {
@@ -867,9 +942,9 @@ impl TrackedStateTree {
                 .load_node_with_overlay(store, overlay, &current)
                 .await?
             {
-                DecodedNode::Leaf(leaf) => break leaf.entries().to_vec(),
+                DecodedNode::Leaf(leaf) => break leaf.into_entries(),
                 DecodedNode::Internal(internal) => {
-                    let children = internal.children().to_vec();
+                    let children = internal.into_children();
                     let child_index = children
                         .iter()
                         .position(|child| child.last_key.as_slice() >= encoded_key.as_slice())
@@ -989,12 +1064,17 @@ impl TrackedStateTree {
                 child_index..child_index + old_child_count,
                 replacement_children,
             );
-            replacement_children = self.build_internal_level(children, parent_level, &mut chunks);
+            let promoted_root = path.is_empty() && children.len() == 1;
+            replacement_children = if promoted_root {
+                children
+            } else {
+                self.build_internal_level(children, parent_level, &mut chunks)
+            };
             old_child_count = 1;
 
             let Some(frame) = path.pop() else {
                 let mut summaries = replacement_children;
-                let mut tree_height = parent_level + 1;
+                let mut tree_height = parent_level + usize::from(!promoted_root);
                 while summaries.len() > 1 {
                     summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
                     tree_height += 1;
@@ -1075,9 +1155,23 @@ impl TrackedStateTree {
     #[expect(clippy::cast_possible_truncation)]
     fn build_tree_from_leaf_summaries(
         &self,
-        leaf_summaries: Vec<ChildSummary>,
+        mut leaf_summaries: Vec<ChildSummary>,
         mut chunks: BTreeMap<[u8; TRACKED_STATE_HASH_BYTES], PendingChunkWrite>,
     ) -> Result<BuiltTree, LixError> {
+        if leaf_summaries.len() > 1 {
+            // The one empty leaf is the canonical empty-tree root, not a
+            // child that can coexist with live rows. Append-only patching can
+            // retain that sentinel beside newly built leaves unless it is
+            // removed here.
+            if leaf_summaries
+                .iter()
+                .any(|summary| summary.subtree_count != 0)
+            {
+                leaf_summaries.retain(|summary| summary.subtree_count != 0);
+            } else {
+                leaf_summaries.truncate(1);
+            }
+        }
         let row_count = leaf_summaries
             .iter()
             .map(|summary| summary.subtree_count as usize)
@@ -1124,8 +1218,24 @@ impl TrackedStateTree {
         let mut child_start = leaf_start;
         let mut old_child_count = old_leaf_count;
         let mut replacement_children = replacement_leaves;
+        let mut tree_height = levels.len();
 
         for level in 0..levels.len() - 1 {
+            if level + 2 == levels.len() {
+                let mut root_children = levels[level].clone();
+                root_children.splice(
+                    child_start..child_start + old_child_count,
+                    replacement_children,
+                );
+                if root_children.len() == 1 {
+                    replacement_children = root_children;
+                    tree_height -= 1;
+                } else {
+                    replacement_children =
+                        self.build_internal_level(root_children, level + 1, &mut chunks);
+                }
+                break;
+            }
             let patch = self.patch_parent_level(
                 &levels[level],
                 &levels[level + 1],
@@ -1142,7 +1252,6 @@ impl TrackedStateTree {
         }
 
         let mut summaries = replacement_children;
-        let mut tree_height = levels.len();
         while summaries.len() > 1 {
             summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
             tree_height += 1;
@@ -1395,7 +1504,7 @@ impl TrackedStateTree {
             let mut next = Vec::new();
             for hash in current {
                 match self.load_node_with_overlay(store, overlay, &hash).await? {
-                    DecodedNode::Leaf(leaf) => out.extend(leaf.entries().iter().cloned()),
+                    DecodedNode::Leaf(leaf) => out.extend(leaf.into_entries()),
                     DecodedNode::Internal(internal) => {
                         next.extend(internal.children().iter().map(|child| child.child_hash));
                     }
@@ -1461,9 +1570,10 @@ impl TrackedStateTree {
                         else {
                             continue;
                         };
-                        if key_decode_hint.is_some() || request.matches(&key, &value) {
-                            rows.push((key, value));
-                        }
+                        // Encoded ranges or key_matches_scan_filters already
+                        // proved the key predicates, and decode_visible_value
+                        // already enforced tombstone visibility.
+                        rows.push((key, value));
                     }
                 }
                 DecodedNodeRef::Internal(internal) => {
@@ -1556,18 +1666,6 @@ impl TrackedStateTree {
         })
     }
 
-    async fn collect_entries_from_leaf_summaries(
-        &self,
-        store: &impl StorageAdapterRead,
-        leaves: &[ChildSummary],
-    ) -> Result<Vec<EncodedLeafEntry>, LixError> {
-        let mut entries = Vec::new();
-        for leaf in leaves {
-            entries.extend(self.load_leaf_entries(store, &leaf.child_hash).await?);
-        }
-        Ok(entries)
-    }
-
     async fn collect_summary_levels_with_overlay(
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
@@ -1598,7 +1696,7 @@ impl TrackedStateTree {
         Box::pin(async move {
             match self.load_node_with_overlay(store, overlay, &hash).await? {
                 DecodedNode::Leaf(leaf) => {
-                    let summary = leaf_summary(hash, leaf.entries());
+                    let summary = decoded_leaf_summary(hash, &leaf);
                     push_level_summary(levels, 0, summary.clone());
                     Ok((summary, 0))
                 }
@@ -1643,20 +1741,6 @@ impl TrackedStateTree {
         })
     }
 
-    async fn load_leaf_entries(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-        hash: &[u8; TRACKED_STATE_HASH_BYTES],
-    ) -> Result<Vec<EncodedLeafEntry>, LixError> {
-        match self.load_node(store, hash).await? {
-            DecodedNode::Leaf(leaf) => Ok(leaf.entries().to_vec()),
-            DecodedNode::Internal(_) => Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "tracked-state expected leaf chunk but found internal node",
-            )),
-        }
-    }
-
     async fn load_leaf_entries_with_overlay(
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
@@ -1664,7 +1748,7 @@ impl TrackedStateTree {
         hash: &[u8; TRACKED_STATE_HASH_BYTES],
     ) -> Result<Vec<EncodedLeafEntry>, LixError> {
         match self.load_node_with_overlay(store, overlay, hash).await? {
-            DecodedNode::Leaf(leaf) => Ok(leaf.entries().to_vec()),
+            DecodedNode::Leaf(leaf) => Ok(leaf.into_entries()),
             DecodedNode::Internal(_) => Err(LixError::new(
                 "LIX_ERROR_UNKNOWN",
                 "tracked-state expected leaf chunk but found internal node",
@@ -1762,7 +1846,7 @@ struct ScanKeyDecodeHint<'a> {
 }
 
 fn binary_search_leaf_key(
-    leaf: &DecodedLeafNodeRef<'_>,
+    leaf: &DecodedLeafNodeRef,
     encoded_key: &[u8],
 ) -> Result<Option<usize>, LixError> {
     let mut low = 0usize;
@@ -1782,113 +1866,6 @@ fn binary_search_leaf_key(
         }
     }
     Ok(None)
-}
-
-struct LeafSummaryCursor {
-    stack: Vec<LeafSummaryCursorFrame>,
-    current: Option<ChildSummary>,
-}
-
-struct LeafSummaryCursorFrame {
-    children: Vec<ChildSummary>,
-    next_index: usize,
-    children_are_leaves: bool,
-}
-
-impl LeafSummaryCursor {
-    async fn new(
-        tree: &TrackedStateTree,
-        store: &impl StorageAdapterRead,
-        root_hash: [u8; TRACKED_STATE_HASH_BYTES],
-    ) -> Result<Self, LixError> {
-        let mut cursor = Self {
-            stack: Vec::new(),
-            current: None,
-        };
-        match tree.load_node(store, &root_hash).await? {
-            DecodedNode::Leaf(leaf) => {
-                cursor.current = Some(leaf_summary(root_hash, leaf.entries()));
-            }
-            DecodedNode::Internal(internal) => {
-                let children = internal.children().to_vec();
-                let children_are_leaves =
-                    child_summaries_are_leaves(tree, store, &children).await?;
-                cursor.stack.push(LeafSummaryCursorFrame {
-                    children,
-                    next_index: 0,
-                    children_are_leaves,
-                });
-                cursor.advance(tree, store).await?;
-            }
-        }
-        Ok(cursor)
-    }
-
-    fn current(&self) -> Option<&ChildSummary> {
-        self.current.as_ref()
-    }
-
-    async fn advance(
-        &mut self,
-        tree: &TrackedStateTree,
-        store: &impl StorageAdapterRead,
-    ) -> Result<(), LixError> {
-        self.current = None;
-        while let Some(frame) = self.stack.last_mut() {
-            if frame.next_index >= frame.children.len() {
-                self.stack.pop();
-                continue;
-            }
-
-            let next = frame.children[frame.next_index].clone();
-            let next_is_leaf = frame.children_are_leaves;
-            frame.next_index += 1;
-            if next_is_leaf {
-                self.current = Some(next);
-                return Ok(());
-            }
-            self.descend_to_leaf(tree, store, next).await?;
-            return Ok(());
-        }
-        Ok(())
-    }
-
-    async fn descend_to_leaf(
-        &mut self,
-        tree: &TrackedStateTree,
-        store: &impl StorageAdapterRead,
-        mut summary: ChildSummary,
-    ) -> Result<(), LixError> {
-        loop {
-            match tree.load_node(store, &summary.child_hash).await? {
-                DecodedNode::Leaf(_) => {
-                    self.current = Some(summary);
-                    return Ok(());
-                }
-                DecodedNode::Internal(internal) => {
-                    let children = internal.children().to_vec();
-                    let children_are_leaves =
-                        child_summaries_are_leaves(tree, store, &children).await?;
-                    let Some(first_child) = children.first().cloned() else {
-                        return Err(LixError::new(
-                            "LIX_ERROR_UNKNOWN",
-                            "tracked-state internal node has no children",
-                        ));
-                    };
-                    self.stack.push(LeafSummaryCursorFrame {
-                        children,
-                        next_index: 1,
-                        children_are_leaves,
-                    });
-                    if children_are_leaves {
-                        self.current = Some(first_child);
-                        return Ok(());
-                    }
-                    summary = first_child;
-                }
-            }
-        }
-    }
 }
 
 #[derive(Debug, Default)]
@@ -2146,31 +2123,63 @@ fn first_resync_index(
     None
 }
 
-fn internal_boundaries_match(left: &[ChildSummary], right: &[ChildSummary]) -> bool {
-    left.len() == right.len()
-        && left.iter().zip(right).all(|(left, right)| {
-            left.first_key == right.first_key && left.last_key == right.last_key
-        })
+fn node_diff_frontier(
+    hash: [u8; TRACKED_STATE_HASH_BYTES],
+    node: DecodedNode,
+) -> Result<VecDeque<ChildSummary>, LixError> {
+    match node {
+        DecodedNode::Leaf(leaf) => Ok(VecDeque::from([decoded_leaf_summary(hash, &leaf)])),
+        DecodedNode::Internal(internal) => {
+            let children = internal.into_children();
+            if children.is_empty() {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state internal node has no children",
+                ));
+            }
+            Ok(children.into())
+        }
+    }
 }
 
-async fn child_summaries_are_leaves(
-    tree: &TrackedStateTree,
-    store: &impl StorageAdapterRead,
-    children: &[ChildSummary],
-) -> Result<bool, LixError> {
-    let Some(first_child) = children.first() else {
-        return Ok(false);
-    };
-    Ok(matches!(
-        tree.load_node(store, &first_child.child_hash).await?,
-        DecodedNode::Leaf(_)
-    ))
+fn replace_front_with_children(
+    frontier: &mut VecDeque<ChildSummary>,
+    children: Vec<ChildSummary>,
+) -> Result<(), LixError> {
+    if children.is_empty() {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state internal node has no children",
+        ));
+    }
+    frontier.pop_front().ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state diff frontier unexpectedly became empty",
+        )
+    })?;
+    for child in children.into_iter().rev() {
+        frontier.push_front(child);
+    }
+    Ok(())
+}
+
+fn decoded_leaf_entry(
+    leaf: &DecodedLeafNodeRef,
+    index: usize,
+) -> Result<EncodedLeafEntryRef<'_>, LixError> {
+    leaf.entry(index)?.ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state leaf entry disappeared during diff",
+        )
+    })
 }
 
 fn decode_entry(
-    entry: &EncodedLeafEntry,
+    entry: EncodedLeafEntryRef<'_>,
 ) -> Result<(TrackedStateKey, TrackedStateIndexValue), LixError> {
-    Ok((decode_key(&entry.key)?, decode_value(&entry.value)?))
+    Ok((decode_key(entry.key)?, decode_value(entry.value)?))
 }
 
 fn parent_index_for_child_index(
@@ -2218,21 +2227,15 @@ fn child_range_for_parent(
     Ok(start..end)
 }
 
-fn leaf_summary(
+fn decoded_leaf_summary(
     hash: [u8; TRACKED_STATE_HASH_BYTES],
-    entries: &[EncodedLeafEntry],
+    leaf: &DecodedLeafNodeRef,
 ) -> ChildSummary {
     ChildSummary {
-        first_key: entries
-            .first()
-            .map(|entry| entry.key.clone())
-            .unwrap_or_default(),
-        last_key: entries
-            .last()
-            .map(|entry| entry.key.clone())
-            .unwrap_or_default(),
+        first_key: leaf.first_key().map(<[u8]>::to_vec).unwrap_or_default(),
+        last_key: leaf.last_key().map(<[u8]>::to_vec).unwrap_or_default(),
         child_hash: hash,
-        subtree_count: entries.len() as u64,
+        subtree_count: leaf.len() as u64,
     }
 }
 
@@ -2422,6 +2425,7 @@ fn scan_limit_reached(request: &TrackedStateTreeScanRequest, row_count: usize) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use bytes::Bytes;
@@ -2430,7 +2434,7 @@ mod tests {
     use crate::entity_pk::EntityPk;
     use crate::storage::{
         GetManyResult, GetOptions, Key, KeyRange, ProjectedValue, ScanChunk, ScanOptions, SpaceId,
-        StorageError, StorageRead,
+        Storage, StorageError, StorageRead,
     };
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
     use crate::storage_adapter::{StorageAdapter, StorageAdapterReadScope};
@@ -2441,6 +2445,38 @@ mod tests {
         bytes: Vec<u8>,
         storage_reads: Arc<AtomicUsize>,
         corrupt_first_read: bool,
+    }
+
+    struct CountingStorageRead<R> {
+        read: R,
+        tree_chunk_reads: Arc<AtomicUsize>,
+    }
+
+    impl<R> StorageRead for CountingStorageRead<R>
+    where
+        R: StorageRead,
+    {
+        fn get_many(
+            &self,
+            space: SpaceId,
+            keys: &[Key],
+            opts: GetOptions,
+        ) -> impl Future<Output = Result<GetManyResult, StorageError>> + Send {
+            if space == storage::TRACKED_STATE_TREE_CHUNK_SPACE.id {
+                self.tree_chunk_reads
+                    .fetch_add(keys.len(), Ordering::Relaxed);
+            }
+            self.read.get_many(space, keys, opts)
+        }
+
+        fn scan(
+            &self,
+            space: SpaceId,
+            range: KeyRange,
+            opts: ScanOptions,
+        ) -> impl Future<Output = Result<ScanChunk, StorageError>> + Send {
+            self.read.scan(space, range, opts)
+        }
     }
 
     impl StorageRead for CountingChunkRead {
@@ -2567,6 +2603,292 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sparse_diff_reads_only_the_changed_path() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        let builder = TrackedStateTree::new();
+        let rows = (0..10_000)
+            .map(|index| {
+                mutation_owned(
+                    key("schema", None, &format!("entity-{index:05}")),
+                    value(&format!("change-{index}"), Some("{}")),
+                )
+            })
+            .collect::<Vec<_>>();
+        let base = apply_mutations_for_test(&builder, &storage, None, rows, None)
+            .await
+            .expect("base should build");
+        let updated = apply_mutations_for_test(
+            &builder,
+            &storage,
+            Some(&base.root_id),
+            vec![mutation_owned(
+                key("schema", None, "entity-05000"),
+                value("change-updated", Some("{}")),
+            )],
+            None,
+        )
+        .await
+        .expect("sparse update should build");
+        assert_eq!(base.tree_height, updated.tree_height);
+        assert!(base.tree_height > 1, "fixture must have internal nodes");
+        let inserted = apply_mutations_for_test(
+            &builder,
+            &storage,
+            Some(&base.root_id),
+            vec![mutation_owned(
+                key("schema", None, "entity-10000"),
+                value("change-inserted", Some("{}")),
+            )],
+            None,
+        )
+        .await
+        .expect("sparse append should build");
+
+        let tree_chunk_reads = Arc::new(AtomicUsize::new(0));
+        let read = memory
+            .begin_read(crate::storage::ReadOptions::default())
+            .await
+            .expect("read should open");
+        let store = StorageAdapterReadScope::new(CountingStorageRead {
+            read,
+            tree_chunk_reads: Arc::clone(&tree_chunk_reads),
+        });
+        let cold_tree = TrackedStateTree::new();
+        let request = TrackedStateTreeScanRequest::default();
+
+        let identical = cold_tree
+            .diff(&store, Some(&base.root_id), Some(&base.root_id), &request)
+            .await
+            .expect("identical-root diff should run");
+        assert!(identical.is_empty());
+        assert_eq!(tree_chunk_reads.load(Ordering::Relaxed), 0);
+
+        let sparse = cold_tree
+            .diff(
+                &store,
+                Some(&base.root_id),
+                Some(&updated.root_id),
+                &request,
+            )
+            .await
+            .expect("sparse diff should run");
+        assert_eq!(sparse.len(), 1);
+        assert_eq!(
+            tree_chunk_reads.load(Ordering::Relaxed),
+            base.tree_height * 2,
+            "one value update should read one node from each root per level"
+        );
+
+        tree_chunk_reads.store(0, Ordering::Relaxed);
+        let cold_insert_tree = TrackedStateTree::new();
+        let inserted_diff = cold_insert_tree
+            .diff(
+                &store,
+                Some(&base.root_id),
+                Some(&inserted.root_id),
+                &request,
+            )
+            .await
+            .expect("sparse append diff should run");
+        assert_eq!(inserted_diff.len(), 1);
+        let insert_reads = tree_chunk_reads.load(Ordering::Relaxed);
+        let max_height = base.tree_height.max(inserted.tree_height);
+        assert!(
+            insert_reads <= max_height * 2 + 4,
+            "one appended key read {insert_reads} chunks across height {max_height}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hierarchical_diff_matches_naive_diff_across_shifted_boundaries() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tree = TrackedStateTree::with_options(TrackedStateTreeOptions {
+            target_chunk_bytes: 256,
+            min_chunk_bytes: 128,
+            max_chunk_bytes: 512,
+        });
+        let base_rows = (0..512usize)
+            .map(|index| {
+                (
+                    key("schema", None, &format!("entity-{:05}", index * 2)),
+                    value(&format!("base-change-{index}"), Some("{}")),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let base = apply_mutations_for_test(
+            &tree,
+            &storage,
+            None,
+            base_rows
+                .iter()
+                .map(|(key, value)| mutation(key, value))
+                .collect(),
+            None,
+        )
+        .await
+        .expect("deep base should build");
+        assert!(
+            base.tree_height >= 4,
+            "fixture must exercise a deep hierarchy, got height {}",
+            base.tree_height
+        );
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let overlay = storage::TrackedStateChunkOverlay::new();
+        let levels = tree
+            .collect_summary_levels_with_overlay(&read, &overlay, &base.root_id)
+            .await
+            .expect("summary levels should load");
+        let leaf_summaries = levels.first().expect("base should have a leaf level");
+        assert!(leaf_summaries.len() > 2, "fixture needs several leaves");
+        let boundary_key = decode_key(&leaf_summaries[leaf_summaries.len() / 2].last_key)
+            .expect("leaf boundary key should decode");
+        let boundary_number = boundary_key
+            .entity_pk
+            .as_single_string()
+            .expect("fixture key should be scalar")
+            .strip_prefix("entity-")
+            .expect("fixture key should have its prefix")
+            .parse::<usize>()
+            .expect("fixture key suffix should be numeric");
+        let boundary_insert_number = boundary_number + 1;
+        let middle_insert_number = if boundary_insert_number == 501 {
+            503
+        } else {
+            501
+        };
+
+        let mut changed_rows = base_rows.clone();
+        assert!(
+            changed_rows.remove(&boundary_key).is_some(),
+            "selected boundary key must exist in the base"
+        );
+        changed_rows.insert(
+            key(
+                "schema",
+                None,
+                &format!("entity-{boundary_insert_number:05}"),
+            ),
+            value("boundary-insert", Some("{}")),
+        );
+        changed_rows.insert(
+            key("schema", None, "entity--prepend"),
+            value("prepend-insert", Some("{}")),
+        );
+        changed_rows.insert(
+            key("schema", None, &format!("entity-{middle_insert_number:05}")),
+            value("middle-insert", Some("{}")),
+        );
+        changed_rows.insert(
+            key("schema", None, "entity-99999"),
+            value("append-insert", Some("{}")),
+        );
+        changed_rows.insert(
+            key("schema", None, "entity-00020"),
+            value("updated-existing", Some("{}")),
+        );
+        changed_rows.insert(
+            key("schema", None, "entity-00040"),
+            value("tombstoned-existing", None),
+        );
+
+        let changed = apply_mutations_for_test(
+            &tree,
+            &storage,
+            None,
+            changed_rows
+                .iter()
+                .map(|(key, value)| mutation(key, value))
+                .collect(),
+            None,
+        )
+        .await
+        .expect("changed tree should build");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("diff read should open");
+        let actual = TrackedStateTree::with_options(tree.options.clone())
+            .diff(
+                &read,
+                Some(&base.root_id),
+                Some(&changed.root_id),
+                &TrackedStateTreeScanRequest::default(),
+            )
+            .await
+            .expect("hierarchical diff should run");
+        let expected = naive_tree_diff(&base_rows, &changed_rows);
+
+        assert_eq!(
+            actual, expected,
+            "frontier diff must match ordered map diff"
+        );
+    }
+
+    #[tokio::test]
+    async fn hierarchical_diff_handles_root_height_transition() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tree = TrackedStateTree::with_options(TrackedStateTreeOptions {
+            target_chunk_bytes: 256,
+            min_chunk_bytes: 128,
+            max_chunk_bytes: 512,
+        });
+        let mut previous: Option<TrackedStateApplyResult> = None;
+        let mut transition = None;
+
+        for index in 0..2_048usize {
+            let inserted_key = key("schema", None, &format!("entity-{index:05}"));
+            let inserted_value = value(&format!("change-{index}"), Some("{}"));
+            let next = apply_mutations_for_test(
+                &tree,
+                &storage,
+                previous.as_ref().map(|result| &result.root_id),
+                vec![mutation(&inserted_key, &inserted_value)],
+                None,
+            )
+            .await
+            .expect("incremental append should build");
+            if let Some(before) = previous.as_ref()
+                && before.tree_height >= 3
+                && next.tree_height > before.tree_height
+            {
+                transition = Some((before.clone(), next.clone(), inserted_key, inserted_value));
+                break;
+            }
+            previous = Some(next);
+        }
+
+        let (before, after, inserted_key, inserted_value) =
+            transition.expect("fixture should cross a root-height boundary");
+        assert_eq!(after.tree_height, before.tree_height + 1);
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("diff read should open");
+        let actual = TrackedStateTree::with_options(tree.options.clone())
+            .diff(
+                &read,
+                Some(&before.root_id),
+                Some(&after.root_id),
+                &TrackedStateTreeScanRequest::default(),
+            )
+            .await
+            .expect("height-mismatched diff should run");
+
+        assert_eq!(
+            actual,
+            vec![TrackedStateTreeDiffEntry {
+                before: None,
+                after: Some((inserted_key, inserted_value)),
+            }]
+        );
+    }
+
+    #[tokio::test]
     async fn exact_read_roundtrips_from_applied_root() {
         let storage = StorageAdapter::new(Memory::new());
         let tree = TrackedStateTree::new();
@@ -2587,6 +2909,91 @@ mod tests {
                 .expect("row should load"),
             Some(value)
         );
+    }
+
+    #[tokio::test]
+    async fn v3_keys_route_through_multilevel_gets_and_prefix_scans() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tree = TrackedStateTree::with_options(TrackedStateTreeOptions {
+            target_chunk_bytes: 256,
+            min_chunk_bytes: 128,
+            max_chunk_bytes: 512,
+        });
+        let rows = (0..96usize)
+            .map(|index| {
+                let schema_key = match index % 3 {
+                    0 => "schema",
+                    1 => "schema\0",
+                    _ => "schéma",
+                };
+                let file_id = match index % 4 {
+                    0 => None,
+                    1 => Some(""),
+                    2 => Some("file\0"),
+                    _ => Some("文件"),
+                };
+                let entity_pk = if index % 2 == 0 {
+                    EntityPk::single(format!("entity\0{index:03}"))
+                } else {
+                    EntityPk {
+                        parts: vec![format!("entity-{index:03}"), "尾\0".to_string()],
+                    }
+                };
+                let key = TrackedStateKey {
+                    schema_key: schema_key.to_string(),
+                    file_id: file_id.map(str::to_string),
+                    entity_pk,
+                };
+                let value = value(&format!("change-{index}"), Some("{}"));
+                (key, value)
+            })
+            .collect::<Vec<_>>();
+        let mutations = rows
+            .iter()
+            .map(|(key, value)| mutation(key, value))
+            .collect();
+        let result = apply_mutations_for_test(&tree, &storage, None, mutations, None)
+            .await
+            .expect("v3-key mutations should apply");
+        assert!(
+            result.tree_height > 1,
+            "fixture must exercise internal nodes"
+        );
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let keys = rows.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>();
+        assert_eq!(
+            tree.get_many(&store, &result.root_id, &keys)
+                .await
+                .expect("all exact keys should load"),
+            rows.iter()
+                .map(|(_, value)| Some(value.clone()))
+                .collect::<Vec<_>>()
+        );
+
+        let scanned = tree
+            .scan(
+                &store,
+                &result.root_id,
+                &TrackedStateTreeScanRequest {
+                    schema_keys: vec!["schema\0".to_string()],
+                    file_ids: vec![NullableKeyFilter::Value(String::new())],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("schema/file prefix scan should succeed");
+        let expected = rows
+            .iter()
+            .filter(|(key, _)| key.schema_key == "schema\0" && key.file_id.as_deref() == Some(""))
+            .count();
+        assert_eq!(scanned.len(), expected);
+        assert!(scanned.iter().all(|(key, _)| {
+            key.schema_key == "schema\0" && key.file_id.as_deref() == Some("")
+        }));
     }
 
     #[tokio::test]
@@ -2738,6 +3145,23 @@ mod tests {
             "entity-a"
         );
         assert_eq!(rows[0].0.file_id.as_deref(), Some("file-a"));
+
+        // With no schema predicate there is no encoded scan range or trusted
+        // prefix. This exercises the decoded-key filter path directly.
+        let entity_only_rows = tree
+            .scan(
+                &store,
+                &result.root_id,
+                &TrackedStateTreeScanRequest {
+                    entity_pks: vec![EntityPk::single("entity-b")],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("entity-only scan should succeed");
+        assert_eq!(entity_only_rows.len(), 1);
+        assert_eq!(entity_only_rows[0].0.schema_key, "schema-a");
+        assert_eq!(entity_only_rows[0].0.file_id.as_deref(), Some("file-a"));
     }
 
     #[tokio::test]
@@ -3030,9 +3454,16 @@ mod tests {
                 value: encoded_inserted_value,
             },
         );
+        let expected_entries = canonical_entries.clone();
         let canonical = tree
             .build_tree_from_entries(canonical_entries)
             .expect("canonical root should build");
+
+        let fast_entries = tree
+            .collect_leaf_entries(&read, &fast.root_id)
+            .await
+            .expect("fast entries should collect");
+        assert_eq!(fast_entries, expected_entries);
 
         assert_eq!(fast.root_id, canonical.root_id);
     }
@@ -3218,6 +3649,26 @@ mod tests {
 
     fn mutation_owned(key: TrackedStateKey, value: TrackedStateIndexValue) -> TrackedStateMutation {
         mutation(&key, &value)
+    }
+
+    fn naive_tree_diff(
+        before: &BTreeMap<TrackedStateKey, TrackedStateIndexValue>,
+        after: &BTreeMap<TrackedStateKey, TrackedStateIndexValue>,
+    ) -> Vec<TrackedStateTreeDiffEntry> {
+        before
+            .keys()
+            .chain(after.keys())
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .filter_map(|key| match (before.get(&key), after.get(&key)) {
+                (Some(left), Some(right)) if left == right => None,
+                (left, right) => Some(TrackedStateTreeDiffEntry {
+                    before: left.cloned().map(|value| (key.clone(), value)),
+                    after: right.cloned().map(|value| (key, value)),
+                }),
+            })
+            .collect()
     }
 
     fn encoded_entries_with_change_id(change_id: &str) -> Vec<EncodedLeafEntry> {

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -20,37 +20,19 @@ impl TrackedStateRootId {
 }
 
 /// Root-independent tracked entity primary key.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, musli::Encode, musli::Decode)]
-#[musli(packed)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TrackedStateKey {
     pub(crate) schema_key: String,
-    #[musli(with = crate::storage_codec::option)]
     pub(crate) file_id: Option<String>,
     pub(crate) entity_pk: EntityPk,
 }
 
 /// Zero-copy view of primary tracked-state key.
-#[derive(Debug, Clone, Copy, musli::Encode)]
-#[musli(packed)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct TrackedStateKeyRef<'a> {
     pub(crate) schema_key: &'a str,
-    #[musli(with = crate::storage_codec::option)]
     pub(crate) file_id: Option<&'a str>,
     pub(crate) entity_pk: &'a EntityPk,
-}
-
-#[derive(Debug, Clone, Copy, musli::Encode)]
-#[musli(packed)]
-pub(crate) struct TrackedSchemaKeyPrefixRef<'a> {
-    pub(crate) schema_key: &'a str,
-}
-
-#[derive(Debug, Clone, Copy, musli::Encode)]
-#[musli(packed)]
-pub(crate) struct TrackedSchemaFilePrefixRef<'a> {
-    pub(crate) schema_key: &'a str,
-    #[musli(with = crate::storage_codec::option)]
-    pub(crate) file_id: Option<&'a str>,
 }
 
 /// Zero-copy tracked-state commit-root delta prepared from changelog facts.
@@ -67,8 +49,7 @@ pub(crate) struct TrackedStateDeltaRef<'a> {
 }
 
 /// Value stored in tracked-state commit-root trees.
-#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
-#[musli(packed)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TrackedStateIndexValue {
     pub(crate) change_id: ChangeId,
     pub(crate) commit_id: CommitId,
@@ -88,8 +69,7 @@ impl TrackedStateIndexValue {
 }
 
 /// Zero-copy view of a tracked-state commit-root value.
-#[derive(Debug, Clone, Copy, musli::Encode, musli::Decode)]
-#[musli(packed)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct TrackedStateIndexValueRef {
     pub(crate) change_id: ChangeId,
     pub(crate) commit_id: CommitId,


### PR DESCRIPTION
## Summary

- introduce a hard-cut `LXTR3` tracked-state root/node format with ordered, prefix-safe keys, front-coded leaf/internal keys, inline change IDs, and compact dictionaries
- retain prolly-tree properties: key-only content-defined boundaries, content-addressed nodes, structural sharing, and hash-guided sparse diffs
- replace boundary-mismatch leaf enumeration with a hierarchical Merkle zipper that skips equal subtrees at every level
- move full O(n) changelog/root validation to the staged rebuild audit before publication; normal commit diff validates only emitted changes
- remove legacy codec and slow compatibility paths

The diff design follows the invariants described in [Dolt's prolly-tree architecture](https://www.dolthub.com/docs/architecture/storage-engine/prolly-tree/): stable key-derived chunk boundaries plus subtree hashes let sparse changes be found without scanning unchanged data.

## Data

### 1k-row write accounting

| operation | main logical bytes / puts | v3 logical bytes / puts | bytes |
|---|---:|---:|---:|
| insert | 424,045 / 1,075 | 385,102 / 1,073 | -9.2% |
| update all | 526,780 / 1,410 | 487,984 / 1,408 | -7.4% |
| update one | 4,831 / 9 | 3,782 / 9 | -21.7% |
| delete all | 169,993 / 1,031 | 131,182 / 1,029 | -22.8% |
| delete one | 4,612 / 9 | 3,563 / 9 | -22.7% |

The materialized tree falls from 27 rows / 75,270 bytes to 24 rows / 35,323 bytes (-53.1%). RocksDB accounting stays within 30 bytes of SQLite with identical put counts.

### SlateDB WAL bytes

| operation | main | v3 | change |
|---|---:|---:|---:|
| 1k insert | 161,423 | 157,937 | -2.2% |
| singleton update | 4,546 | 3,988 | -12.3% |
| singleton delete | 4,496 | 3,938 | -12.4% |

Remote object PUT count is unchanged.

### Sparse diff

At 10k rows:

| change | main node reads, p50/p95 | v3 node reads, p50/p95 |
|---|---:|---:|
| update | 6, 50.3/60.9 us | 6, 22.4/32.1 us |
| append | 20 logical (11 unique), 139.9/160.8 us | 6, 29.2/39.8 us |
| tombstone | 6, 50.6/60.7 us | 6, 22.3/30.9 us |
| identical roots | 0, 50 ns | 0, 50 ns |

At 100k rows, v3 update/append/delete still read 6 nodes each with p50 29.1/39.8/28.8 us. Main append reads 100 nodes (51 unique) at 1.11 ms. A 10x row-count increase therefore stays below 1.4x latency for sparse v3 diffs.

A 10k two-root scan improves from 75.25 ms to 52.90 ms p50; a clean single-root scan improves from about 31.2 ms to 29.1 ms.

## Compatibility

This is intentionally format-breaking. Commit IDs remain stable because commit identity does not include the derived tracked-state root. Tree chunk/root IDs change, and repositories containing pre-v3 tracked-state roots must be recreated.

## Validation

- `cargo test -p lix_engine --lib`: 1,084 passed, 0 failed, 4 ignored
- `cargo clippy -p lix_engine --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- randomized hierarchical-diff equivalence tests, shifted-boundary and root-height-transition coverage, sparse-read counters, malformed codec cases, and staged-audit publication failure coverage
