### PR TITLE
perf(js-sdk): use native typed-array Base64 for remote blobs

### DIFF
--- a/.changenotes/use-native-remote-base64.md
+++ b/.changenotes/use-native-remote-base64.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Remote Lix clients now use native typed-array Base64 conversion when the runtime supports it.
+
+Large blob uploads and observation results avoid the previous byte-by-byte JavaScript conversion cost while retaining the existing compatibility fallback.

--- a/packages/js-sdk/src/remote/protocol.test.ts
+++ b/packages/js-sdk/src/remote/protocol.test.ts
@@ -1,0 +1,128 @@
+import { expect, test, vi } from "vitest";
+import { decodeExecuteResult, encodeWireValue } from "./protocol.js";
+
+test("remote blobs use native typed-array base64 when available", () => {
+	const prototype = Uint8Array.prototype as Uint8Array & {
+		toBase64?: () => string;
+	};
+	const constructor = Uint8Array as Uint8ArrayConstructor & {
+		fromBase64?: (value: string) => Uint8Array;
+	};
+	const originalToBase64 = Object.getOwnPropertyDescriptor(
+		prototype,
+		"toBase64",
+	);
+	const originalFromBase64 = Object.getOwnPropertyDescriptor(
+		constructor,
+		"fromBase64",
+	);
+	const toBase64 = vi.fn(() => "native-encoded");
+	const fromBase64 = vi.fn(() => new Uint8Array([4, 5, 6]));
+
+	try {
+		Object.defineProperty(prototype, "toBase64", {
+			configurable: true,
+			value: toBase64,
+		});
+		Object.defineProperty(constructor, "fromBase64", {
+			configurable: true,
+			value: fromBase64,
+		});
+
+		const bytes = new Uint8Array([1, 2, 3]);
+		expect(encodeWireValue({ kind: "blob", value: null, blob: bytes })).toEqual({
+			kind: "blob",
+			base64: "native-encoded",
+		});
+		expect(toBase64).toHaveBeenCalledOnce();
+		expect(toBase64.mock.contexts[0]).toBe(bytes);
+
+		const decoded = decodeExecuteResult({
+			columns: ["data"],
+			rows: [[{ kind: "blob", base64: "native-input" }]],
+			rowsAffected: 0,
+			notices: [],
+		});
+		expect(decoded.rows[0]?.[0]).toEqual({
+			kind: "blob",
+			value: null,
+			blob: new Uint8Array([4, 5, 6]),
+		});
+		expect(fromBase64).toHaveBeenCalledWith("native-input");
+
+		fromBase64.mockImplementationOnce(() => {
+			throw new SyntaxError("invalid base64");
+		});
+		expect(() =>
+			decodeExecuteResult({
+				columns: ["data"],
+				rows: [[{ kind: "blob", base64: "%%%" }]],
+				rowsAffected: 0,
+				notices: [],
+			}),
+		).toThrow(
+			expect.objectContaining({
+				code: "LIX_REMOTE_PROTOCOL_ERROR",
+				message: "blob wire value contains invalid base64",
+			}),
+		);
+	} finally {
+		restoreProperty(prototype, "toBase64", originalToBase64);
+		restoreProperty(constructor, "fromBase64", originalFromBase64);
+	}
+});
+
+test("remote blob base64 falls back on runtimes without native support", () => {
+	const prototype = Uint8Array.prototype as Uint8Array & {
+		toBase64?: () => string;
+	};
+	const constructor = Uint8Array as Uint8ArrayConstructor & {
+		fromBase64?: (value: string) => Uint8Array;
+	};
+	const originalToBase64 = Object.getOwnPropertyDescriptor(
+		prototype,
+		"toBase64",
+	);
+	const originalFromBase64 = Object.getOwnPropertyDescriptor(
+		constructor,
+		"fromBase64",
+	);
+
+	try {
+		Reflect.deleteProperty(prototype, "toBase64");
+		Reflect.deleteProperty(constructor, "fromBase64");
+		expect(
+			encodeWireValue({
+				kind: "blob",
+				value: null,
+				blob: new Uint8Array([1, 2, 3]),
+			}),
+		).toEqual({ kind: "blob", base64: "AQID" });
+		const decoded = decodeExecuteResult({
+			columns: ["data"],
+			rows: [[{ kind: "blob", base64: "BAUG" }]],
+			rowsAffected: 0,
+			notices: [],
+		});
+		expect(decoded.rows[0]?.[0]).toEqual({
+			kind: "blob",
+			value: null,
+			blob: new Uint8Array([4, 5, 6]),
+		});
+	} finally {
+		restoreProperty(prototype, "toBase64", originalToBase64);
+		restoreProperty(constructor, "fromBase64", originalFromBase64);
+	}
+});
+
+function restoreProperty(
+	target: object,
+	key: PropertyKey,
+	descriptor: PropertyDescriptor | undefined,
+): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+	} else {
+		Reflect.deleteProperty(target, key);
+	}
+}

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -350,6 +350,13 @@ function assertJsonValue(
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
+	const nativeToBase64 = (
+		bytes as Uint8Array & { toBase64?: () => string }
+	).toBase64;
+	if (typeof nativeToBase64 === "function") {
+		return nativeToBase64.call(bytes);
+	}
+
 	let binary = "";
 	const chunkSize = 0x8000;
 	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
@@ -359,6 +366,19 @@ function bytesToBase64(bytes: Uint8Array): string {
 }
 
 function base64ToBytes(base64: string): Uint8Array {
+	const nativeFromBase64 = (
+		Uint8Array as Uint8ArrayConstructor & {
+			fromBase64?: (value: string) => Uint8Array;
+		}
+	).fromBase64;
+	if (typeof nativeFromBase64 === "function") {
+		try {
+			return nativeFromBase64(base64);
+		} catch {
+			throw protocolError("blob wire value contains invalid base64");
+		}
+	}
+
 	let binary: string;
 	try {
 		binary = atob(base64);


### PR DESCRIPTION
## Summary

- feature-detect the standardized typed-array Base64 APIs in the remote JS transport
- retain the existing `btoa`/`atob` fallback for older browsers and Node
- preserve protocol validation errors from native decode failures

## Data

Chrome for Testing 149.0.7827.55, 100 samples/case, full 1 MiB request/response JSON pipeline:

| Pipeline | Before p50 / p95 | After p50 / p95 | p50 change |
| --- | ---: | ---: | ---: |
| request encode + stringify | 22.7 / 25.3 ms | 1.0 / 2.3 ms | -95.6% |
| response parse + decode | 4.6 / 7.1 ms | 1.3 / 2.3 ms | -71.7% |

The wire format is unchanged. A 1,048,576-byte blob remains 1,398,104 Base64 bytes; reducing that network expansion is intentionally separate work.

At 100 KiB (500 samples), encode p50 fell from 2.1 ms to below the 0.1 ms timer resolution and decode p50 from 0.6 ms to 0.1 ms.

## Validation

- `npx vitest run src/remote/protocol.test.ts src/remote/client.test.ts` (19 tests)
- `npm run typecheck`
- 18-case native/fallback parity corpus from empty through 1 MiB, including malformed input

Node 22 and 24 currently take the compatibility fallback. The fast path is feature-detected, so this remains compatible with runtimes that do not expose the typed-array methods.
