### PR TITLE
perf(remote): compress large HTTP JSON payloads

### DIFF
--- a/.changenotes/compress-remote-http-json.md
+++ b/.changenotes/compress-remote-http-json.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Remote Lix clients now gzip large compressible JSON uploads, and protocol servers gzip large finite JSON responses when requested.
+
+A bounded sample avoids spending time compressing small or incompressible uploads. Servers enforce request limits after decompression and leave live SSE streams unbuffered.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1074,23 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -2310,6 +2339,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -3425,6 +3455,7 @@ version = "0.8.4"
 dependencies = [
  "async-stream",
  "axum",
+ "flate2",
  "futures-core",
  "getrandom 0.3.4",
  "http-body-util",
@@ -3433,6 +3464,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5374,6 +5406,26 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from "vitest";
+import { gunzipSync } from "fflate";
 import { openLix } from "../index.js";
 
 test("remote mode uses the workspace protocol without loading a local engine", async () => {
@@ -98,6 +99,72 @@ test("remote mode uses the workspace protocol without loading a local engine", a
 	);
 	expect(requests[3]?.method).toBe("DELETE");
 	expect(requests[3]?.headers.get("lix-session-id")).toBe("session-1");
+});
+
+test("remote mode compresses only large compressible JSON requests", async () => {
+	const executeRequests: Request[] = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId: "main-id",
+						sessionId: "session-1",
+					});
+				}
+				if (pathname.endsWith("/lix/v1/execute")) {
+					executeRequests.push(request.clone());
+					return Response.json({
+						columns: [],
+						rows: [],
+						rowsAffected: 1,
+						notices: [],
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				throw new Error(`Unexpected request: ${request.url}`);
+			},
+		},
+	});
+
+	const compressible = new Uint8Array(100 * 1024).fill(0x41);
+	await lix.execute("UPDATE lix_file SET data = $1 WHERE id = $2", [
+		compressible,
+		"file-1",
+	]);
+	expect(executeRequests[0]?.headers.get("content-encoding")).toBe("gzip");
+	const compressedBody = new Uint8Array(
+		await executeRequests[0]!.arrayBuffer(),
+	);
+	const decodedBody = JSON.parse(
+		new TextDecoder().decode(gunzipSync(compressedBody)),
+	);
+	expect(decodedBody.params[0].base64).toBe("QUFB".repeat(34_133) + "QQ==");
+
+	let random = 0x1234_5678;
+	const incompressible = Uint8Array.from({ length: 100 * 1024 }, () => {
+		random ^= random << 13;
+		random ^= random >>> 17;
+		random ^= random << 5;
+		return random & 0xff;
+	});
+	await lix.execute("UPDATE lix_file SET data = $1 WHERE id = $2", [
+		incompressible,
+		"file-1",
+	]);
+	expect(executeRequests[1]?.headers.has("content-encoding")).toBe(false);
+	expect(await executeRequests[1]?.json()).toMatchObject({
+		params: [{ kind: "blob" }, { kind: "text", value: "file-1" }],
+	});
+
+	await lix.close();
 });
 
 test("remote executeBatch uses the first-class atomic batch endpoint", async () => {

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -36,6 +36,10 @@ import { readSseEvents } from "./sse.js";
 const OBSERVE_RETRY_BASE_MS = 100;
 const OBSERVE_RETRY_MAX_MS = 5_000;
 const REMOTE_SESSION_HEADER = "Lix-Session-Id";
+const MIN_COMPRESSIBLE_JSON_BYTES = 32 * 1024;
+const COMPRESSION_SAMPLE_BYTES = 32 * 1024;
+const MAX_COMPRESSION_SAMPLE_RATIO = 0.7;
+const MAX_COMPRESSED_BODY_RATIO = 0.9;
 
 export async function openRemoteLixBinding(
 	options: RemoteLixServerOptions,
@@ -254,11 +258,23 @@ class RemoteLixBinding implements LixBinding {
 		if (this.#sessionId === undefined) headers.delete(REMOTE_SESSION_HEADER);
 		else headers.set(REMOTE_SESSION_HEADER, this.#sessionId);
 		headers.set("accept", "application/json");
-		if (init.body !== undefined) headers.set("content-type", "application/json");
+		headers.delete("content-encoding");
+		let requestInit = init;
+		if (init.body !== undefined) {
+			headers.set("content-type", "application/json");
+			if (
+				typeof init.body === "string" &&
+				init.body.length >= MIN_COMPRESSIBLE_JSON_BYTES
+			) {
+				const prepared = await prepareJsonRequestBody(init.body);
+				requestInit = { ...init, body: prepared.body };
+				if (prepared.compressed) headers.set("content-encoding", "gzip");
+			}
+		}
 		let response: Response;
 		try {
 			response = await this.#fetch(new URL(path, this.#baseUrl), {
-				...init,
+				...requestInit,
 				headers,
 			});
 		} catch (cause) {
@@ -300,11 +316,20 @@ class RemoteLixBinding implements LixBinding {
 		headers.set(REMOTE_SESSION_HEADER, this.#sessionId);
 		headers.set("accept", "text/event-stream");
 		headers.set("content-type", "application/json");
+		headers.delete("content-encoding");
+		const observeBody = JSON.stringify({ subscriptions });
+		const prepared =
+			observeBody.length < MIN_COMPRESSIBLE_JSON_BYTES
+				? { body: observeBody, compressed: false }
+				: await prepareJsonRequestBody(observeBody);
+		if (prepared.compressed) {
+			headers.set("content-encoding", "gzip");
+		}
 		try {
 			return await this.#fetch(new URL("observe/multiplex", this.#baseUrl), {
 				method: "POST",
 				headers,
-				body: JSON.stringify({ subscriptions }),
+				body: prepared.body,
 				signal,
 			});
 		} catch (cause) {
@@ -700,6 +725,53 @@ class RemoteObservation implements ObserveEventsBinding {
 		this.#terminalError = error;
 		for (const waiter of this.#waiters.splice(0)) waiter.reject(error);
 	}
+}
+
+async function prepareJsonRequestBody(
+	body: string,
+): Promise<{ body: BodyInit; compressed: boolean }> {
+	const bytes = new TextEncoder().encode(body);
+	if (bytes.byteLength < MIN_COMPRESSIBLE_JSON_BYTES) {
+		return { body, compressed: false };
+	}
+	const sample = bytes.subarray(
+		0,
+		Math.min(bytes.byteLength, COMPRESSION_SAMPLE_BYTES),
+	);
+	const compressedSample = await gzipBytes(sample);
+	if (
+		compressedSample.byteLength >
+		sample.byteLength * MAX_COMPRESSION_SAMPLE_RATIO
+	) {
+		return { body, compressed: false };
+	}
+	const compressed = await gzipBytes(bytes);
+	if (compressed.byteLength > bytes.byteLength * MAX_COMPRESSED_BODY_RATIO) {
+		return { body, compressed: false };
+	}
+	const transportBody = new ArrayBuffer(compressed.byteLength);
+	new Uint8Array(transportBody).set(compressed);
+	return { body: transportBody, compressed: true };
+}
+
+async function gzipBytes(bytes: Uint8Array): Promise<Uint8Array> {
+	const CompressionStreamConstructor = (
+		globalThis as typeof globalThis & {
+			CompressionStream?: new (
+				format: "gzip",
+			) => TransformStream<Uint8Array, Uint8Array>;
+		}
+	).CompressionStream;
+	if (typeof CompressionStreamConstructor === "function") {
+		const stream = new CompressionStreamConstructor("gzip");
+		const output = new Response(stream.readable).arrayBuffer();
+		const writer = stream.writable.getWriter();
+		await writer.write(bytes);
+		await writer.close();
+		return new Uint8Array(await output);
+	}
+	const { gzipSync } = await import("fflate");
+	return gzipSync(bytes, { level: 1 });
 }
 
 async function resolveHeaders(

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -25,9 +25,11 @@ lix_sdk = { path = "../rs-sdk", version = "0.8.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "rt"] }
+tower-http = { version = "0.6", features = ["compression-gzip", "decompression-gzip"] }
 tracing = "0.1"
 
 [dev-dependencies]
+flate2 = "1"
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -32,6 +32,13 @@ use tokio::{
     sync::{Mutex as AsyncMutex, mpsc},
     task::JoinHandle,
 };
+use tower_http::{
+    compression::{
+        CompressionLayer, CompressionLevel,
+        predicate::{DefaultPredicate, Predicate as _, SizeAbove},
+    },
+    decompression::RequestDecompressionLayer,
+};
 use tracing::{Instrument as _, instrument::WithSubscriber as _};
 
 /// Stable URL prefix owned by the Lix server protocol.
@@ -48,6 +55,7 @@ pub const DEFAULT_SESSION_IDLE_TIMEOUT: Duration = Duration::from_mins(30);
 /// so 64 MiB carries the engine's 32 MiB maximum plugin archive with room for
 /// the SQL envelope and also covers ordinary larger document blobs.
 pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
+const MIN_COMPRESSION_BODY_BYTES: u16 = 32 * 1024;
 /// Maximum number of queries multiplexed onto one observation stream.
 pub const MAX_MULTIPLEX_SUBSCRIPTIONS: usize = 32;
 
@@ -384,9 +392,20 @@ where
             .route("/lix/v1/", get(handshake::<S>))
             .route("/lix/v1/session", delete(delete_session::<S>))
             .merge(protected)
+            .layer(
+                CompressionLayer::new()
+                    .gzip(true)
+                    .quality(CompressionLevel::Precise(2))
+                    .compress_when(
+                        DefaultPredicate::new().and(SizeAbove::new(MIN_COMPRESSION_BODY_BYTES)),
+                    ),
+            )
             .layer(DefaultBodyLimit::max(
                 self.inner.options.max_request_body_bytes,
             ))
+            // This must be outside DefaultBodyLimit so the configured limit
+            // applies to expanded JSON rather than attacker-controlled gzip.
+            .layer(RequestDecompressionLayer::new().gzip(true))
             .with_state(state)
     }
 
@@ -1246,12 +1265,16 @@ impl Drop for ObserveTaskGuard {
 mod tests {
     use super::*;
     use axum::{body::Body, http::Request};
+    use flate2::{Compression, read::GzDecoder, write::GzEncoder};
     use http_body_util::BodyExt as _;
     use lix_sdk::{
         Memory, OpenLixOptions, TracingTelemetrySink, open_lix, open_lix_with_telemetry,
     };
     use serde_json::{Value as JsonValue, json};
-    use std::sync::{Arc, Mutex};
+    use std::{
+        io::{Read as _, Write as _},
+        sync::{Arc, Mutex},
+    };
     use tower::ServiceExt as _;
     use tracing::Subscriber;
     use tracing_subscriber::{
@@ -1378,6 +1401,29 @@ mod tests {
             .expect("body")
             .to_bytes();
         serde_json::from_slice(&bytes).expect("json")
+    }
+
+    fn gzip(bytes: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(bytes).expect("gzip input");
+        encoder.finish().expect("finish gzip")
+    }
+
+    async fn gzip_response_json(response: Response) -> JsonValue {
+        assert_eq!(
+            response.headers().get(axum::http::header::CONTENT_ENCODING),
+            Some(&axum::http::HeaderValue::from_static("gzip"))
+        );
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("compressed body")
+            .to_bytes();
+        let mut decoder = GzDecoder::new(bytes.as_ref());
+        let mut decoded = Vec::new();
+        decoder.read_to_end(&mut decoded).expect("decode gzip");
+        serde_json::from_slice(&decoded).expect("compressed json")
     }
 
     async fn error_code(response: Response) -> String {
@@ -1599,6 +1645,134 @@ mod tests {
         .await;
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn compressed_execute_requests_are_expanded_before_json_extraction() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let request_body = json!({
+            "sql": "SELECT $1",
+            "params": [{ "kind": "text", "value": "x".repeat(64 * 1024) }]
+        })
+        .to_string();
+        let response = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/execute")
+                    .header(SESSION_ID_HEADER, session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .header(axum::http::header::CONTENT_ENCODING, "gzip")
+                    .body(Body::from(gzip(request_body.as_bytes())))
+                    .expect("compressed request"),
+            )
+            .await
+            .expect("compressed response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(response).await["rows"][0][0]["value"],
+            "x".repeat(64 * 1024)
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_body_limit_applies_to_expanded_json() {
+        let app = app_with_options(ProtocolServerOptions {
+            max_request_body_bytes: 1_024,
+            ..ProtocolServerOptions::default()
+        })
+        .await;
+        let (session_id, _) = new_session(&app.router).await;
+        let request_body = json!({
+            "sql": "SELECT $1",
+            "params": [{ "kind": "text", "value": "x".repeat(2_048) }]
+        })
+        .to_string();
+        let response = app
+            .router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/execute")
+                    .header(SESSION_ID_HEADER, session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .header(axum::http::header::CONTENT_ENCODING, "gzip")
+                    .body(Body::from(gzip(request_body.as_bytes())))
+                    .expect("compressed request"),
+            )
+            .await
+            .expect("compressed response");
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn large_finite_json_responses_use_gzip_but_sse_does_not() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let request_body = json!({
+            "sql": "SELECT $1",
+            "params": [{ "kind": "text", "value": "x".repeat(64 * 1024) }]
+        });
+        let mut request_builder = Request::builder()
+            .method("POST")
+            .uri("/lix/v1/execute")
+            .header(SESSION_ID_HEADER, &session_id)
+            .header(axum::http::header::ACCEPT_ENCODING, "gzip")
+            .header(axum::http::header::CONTENT_TYPE, "application/json");
+        let response = app
+            .router
+            .clone()
+            .oneshot(
+                request_builder
+                    .body(Body::from(request_body.to_string()))
+                    .expect("gzip response request"),
+            )
+            .await
+            .expect("gzip response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            gzip_response_json(response).await["rows"][0][0]["value"],
+            "x".repeat(64 * 1024)
+        );
+
+        let observe_body = json!({
+            "subscriptions": [{
+                "id": "large",
+                "sql": "SELECT $1",
+                "params": [{ "kind": "text", "value": "x".repeat(64 * 1024) }]
+            }]
+        });
+        request_builder = Request::builder()
+            .method("POST")
+            .uri("/lix/v1/observe/multiplex")
+            .header(SESSION_ID_HEADER, session_id)
+            .header(axum::http::header::ACCEPT_ENCODING, "gzip")
+            .header(axum::http::header::CONTENT_TYPE, "application/json");
+        let response = app
+            .router
+            .oneshot(
+                request_builder
+                    .body(Body::from(observe_body.to_string()))
+                    .expect("SSE response request"),
+            )
+            .await
+            .expect("SSE response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(axum::http::header::CONTENT_TYPE),
+            Some(&axum::http::HeaderValue::from_static("text/event-stream"))
+        );
+        assert!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_ENCODING)
+                .is_none()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- gzip remote JSON request bodies at 32 KiB and above when a bounded sample predicts useful compression
- accept gzip requests in the canonical Rust protocol and enforce the configured body limit after expansion
- gzip finite JSON responses at level 2 when the caller advertises support
- deliberately leave SSE uncompressed to preserve immediate event flushing

## Data

Measured against realistic JSON + Base64 wire bodies:

| Workload | Identity wire | Gzip wire | Compression CPU | Modeled change |
| --- | ---: | ---: | ---: | ---: |
| 100 KiB Markdown upload | 136.7 KiB | 39.2 KiB | 4.6 ms browser p50 | >10% at 50 Mbps / 75 ms RTT |
| 1 MiB Markdown upload | 1.398 MiB | 0.411 MiB | 42.8 ms browser p50 | -18% at 100 Mbps / 75 ms; -38% at 50 Mbps / 75 ms |
| 1 MiB Markdown response | 1.398 MiB | ~0.640 MiB | 9.7 ms Rust level 2 | ~-37% at 100 Mbps before RTT |

A 32 KiB sample clearly separated the tested text formats (0.28–0.42 compressed ratio) from random Base64 (0.77). Small bodies bypass compression synchronously, preserving existing request ordering. Incompressible uploads remain identity instead of paying the measured ~46 ms full-body compression cost at 1 MiB.

This PR does **not** improve the large observation/SSE payload yet. Tower intentionally excludes `text/event-stream` because stream compression can buffer events. Per-event compression/deltas are separate follow-up work.

## Validation

- `cargo test -p lix_server_protocol` (19 tests)
- `npx vitest run src/remote` (33 tests)
- `npm run typecheck`
- expanded-body limit, compressed request, compressed response, and uncompressed-SSE regressions
