### PR TITLE
perf(engine): fast-path batched lix_file metadata upserts

### DIFF
--- a/.changenotes/fast-batched-file-metadata-upserts.md
+++ b/.changenotes/fast-batched-file-metadata-upserts.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved the speed of batched `lix_file` path, data, and metadata upserts.
+
+Common upload statements that replace both file bytes and row metadata now use the native bound-write path while preserving descriptor identity, blob replacement, and plugin reconciliation.

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -36,6 +36,7 @@ const DELAYS_MS: &[u64] = &[0, 10, 25, 50];
 const SEED_FILE_COUNT: usize = 100;
 const FILE_SIZE_BYTES: usize = 4096;
 const UPLOAD_BATCH_SIZE: usize = 10;
+const LIXRAY_UPLOAD_BATCH_FILES: usize = 10;
 const BENCH_DISK_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const BENCH_BLOCK_CACHE_BYTES: u64 = 16 * 1024 * 1024;
 const BENCH_METADATA_CACHE_BYTES: u64 = 4 * 1024 * 1024;
@@ -75,6 +76,20 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
                     black_box(runtime.block_on(fixture.upload_overwrite_file()));
                     measure_iterations(iterations, || {
                         runtime.block_on(fixture.upload_overwrite_file())
+                    })
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("upload_overwrite_10_files_after_preload", &delay_label),
+            &delay,
+            |b, &delay| {
+                b.iter_custom(|iterations| {
+                    let fixture = runtime.block_on(UploadBenchFixture::seeded(delay));
+                    black_box(runtime.block_on(fixture.upload_overwrite_file_batch()));
+                    measure_iterations(iterations, || {
+                        runtime.block_on(fixture.upload_overwrite_file_batch())
                     })
                 });
             },
@@ -521,6 +536,8 @@ struct UploadBenchFixture {
     object_store: Arc<DelayedObjectStore>,
     next_upload_version: AtomicU64,
     upload_path: String,
+    upload_batch_paths: Vec<String>,
+    upload_batch_sql: String,
 }
 
 impl UploadBenchFixture {
@@ -548,6 +565,8 @@ impl UploadBenchFixture {
             object_store: seeded.object_store,
             next_upload_version: AtomicU64::new(0),
             upload_path: seeded.upload_path,
+            upload_batch_paths: (0..LIXRAY_UPLOAD_BATCH_FILES).map(file_path).collect(),
+            upload_batch_sql: upload_batch_sql(LIXRAY_UPLOAD_BATCH_FILES),
         }
     }
 
@@ -569,6 +588,44 @@ impl UploadBenchFixture {
             .expect("overwrite benchmark file");
         result.rows_affected()
     }
+
+    async fn upload_overwrite_file_batch(&self) -> u64 {
+        let version = self.next_upload_version.fetch_add(1, Ordering::Relaxed);
+        let mut params = Vec::with_capacity(self.upload_batch_paths.len() * 3);
+        for (file_index, path) in self.upload_batch_paths.iter().enumerate() {
+            let file_version = version
+                .wrapping_mul(self.upload_batch_paths.len() as u64)
+                .wrapping_add(file_index as u64);
+            params.push(Value::Text(path.clone()));
+            params.push(Value::Blob(upload_file_bytes(file_version)));
+            params.push(upload_file_metadata(file_version));
+        }
+        let result = self
+            .session
+            .execute(&self.upload_batch_sql, &params)
+            .await
+            .expect("overwrite benchmark file batch");
+        result.rows_affected()
+    }
+}
+
+fn upload_batch_sql(row_count: usize) -> String {
+    let placeholders = (0..row_count)
+        .map(|row_index| {
+            format!(
+                "(${}, ${}, ${})",
+                row_index * 3 + 1,
+                row_index * 3 + 2,
+                row_index * 3 + 3
+            )
+        })
+        .collect::<Vec<_>>();
+    format!(
+        "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES {} \
+         ON CONFLICT (path) DO UPDATE SET data = excluded.data, \
+         lixcol_metadata = excluded.lixcol_metadata",
+        placeholders.join(", ")
+    )
 }
 
 struct ReadBenchFixture {

--- a/packages/engine/src/filesystem/read.rs
+++ b/packages/engine/src/filesystem/read.rs
@@ -120,6 +120,7 @@ impl FilesystemIndex {
             };
             let file = FilesystemFileEntry {
                 id: snapshot.id.clone(),
+                directory_id: snapshot.directory_id,
                 name: snapshot.name,
                 blob_hash: blob_hashes_by_key
                     .get(&FilesystemBlobRefKey::from_context(
@@ -173,6 +174,7 @@ enum FilesystemEntry {
 #[derive(Debug, Clone)]
 pub(crate) struct FilesystemFileEntry {
     pub(crate) id: String,
+    pub(crate) directory_id: Option<String>,
     pub(crate) name: String,
     pub(crate) blob_hash: Option<String>,
     pub(crate) scope: RowScope,
@@ -491,6 +493,7 @@ mod tests {
     fn file_entry(id: &str) -> FilesystemFileEntry {
         FilesystemFileEntry {
             id: id.to_string(),
+            directory_id: None,
             name: "foo".to_string(),
             blob_hash: None,
             scope: row_scope(),

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -55,10 +55,11 @@ pub(crate) async fn try_execute_bound_public_write(
         }
         BoundWriteTarget::File(surface) => {
             if let Some(shape) = fast_file_path_write_shape(plan, surface) {
-                execute_file_path_write(ctx, plan, params, shape)
-                    .await
-                    .map(SqlWriteResult::affected)
-                    .map(BoundPublicWriteExecution::Executed)
+                Ok(execute_file_path_write(ctx, plan, params, shape)
+                    .await?
+                    .map_or(BoundPublicWriteExecution::Unsupported, |count| {
+                        BoundPublicWriteExecution::Executed(SqlWriteResult::affected(count))
+                    }))
             } else if let Some(shape) = fast_file_data_update_shape(plan, surface) {
                 execute_file_data_update(ctx, params, &shape)
                     .await
@@ -225,6 +226,7 @@ async fn load_active_branch_commit_id(
 struct FastFilePathWriteShape {
     path_index: usize,
     data_index: usize,
+    metadata_index: Option<usize>,
     conflict: crate::sql2::providers::FastLixFilePathWriteConflict,
 }
 
@@ -233,7 +235,7 @@ async fn execute_file_path_write(
     plan: &LogicalWritePlan,
     params: &[Value],
     shape: FastFilePathWriteShape,
-) -> Result<u64, LixError> {
+) -> Result<Option<u64>, LixError> {
     let BoundWriteInput::Values(values) = &plan.bound.input else {
         return Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
@@ -245,6 +247,11 @@ async fn execute_file_path_write(
         writes.push((
             eval_fast_file_text(&row[shape.path_index], params, "path")?,
             eval_fast_file_blob(&row[shape.data_index], params, "data")?,
+            shape
+                .metadata_index
+                .map(|index| eval_fast_file_metadata(&row[index], params))
+                .transpose()?
+                .flatten(),
         ));
     }
     crate::sql2::providers::execute_fast_lix_file_path_writes(ctx, writes, shape.conflict).await
@@ -260,15 +267,20 @@ fn fast_file_path_write_shape(
     let BoundWriteInput::Values(values) = &plan.bound.input else {
         return None;
     };
-    if values.rows.is_empty() || values.columns.len() != 2 {
+    if values.rows.is_empty() || !matches!(values.columns.len(), 2 | 3) {
         return None;
     }
     let path_index = values.column_index("path")?;
     let data_index = values.column_index("data")?;
+    let metadata_index = values.column_index("lixcol_metadata");
+    if values.columns.len() == 3 && metadata_index.is_none() {
+        return None;
+    }
     if values.rows.iter().any(|row| {
         row.len() != values.columns.len()
-            || !fast_file_value_expr_supported(&row[path_index])
-            || !fast_file_value_expr_supported(&row[data_index])
+            || !fast_file_text_expr_supported(&row[path_index])
+            || !fast_file_blob_expr_supported(&row[data_index])
+            || metadata_index.is_some_and(|index| !fast_file_metadata_expr_supported(&row[index]))
     }) {
         return None;
     }
@@ -276,9 +288,28 @@ fn fast_file_path_write_shape(
         None => crate::sql2::providers::FastLixFilePathWriteConflict::None,
         Some(conflict) => fast_file_path_conflict_shape(conflict)?,
     };
+    if conflict == crate::sql2::providers::FastLixFilePathWriteConflict::UpdateDataAndMetadata
+        && metadata_index.is_none()
+    {
+        return None;
+    }
+    if conflict == crate::sql2::providers::FastLixFilePathWriteConflict::UpdateData
+        && metadata_index.is_some()
+    {
+        return None;
+    }
+    // DataFusion ignores insert values for rows skipped by DO NOTHING. Keep
+    // metadata-bearing variants there so invalid metadata on an existing row
+    // retains that behavior without complicating the hot upsert path.
+    if conflict == crate::sql2::providers::FastLixFilePathWriteConflict::DoNothing
+        && metadata_index.is_some()
+    {
+        return None;
+    }
     Some(FastFilePathWriteShape {
         path_index,
         data_index,
+        metadata_index,
         conflict,
     })
 }
@@ -294,28 +325,40 @@ fn fast_file_path_conflict_shape(
             Some(crate::sql2::providers::FastLixFilePathWriteConflict::DoNothing)
         }
         BoundConflictAction::DoUpdate { assignments } => {
-            if assignments.len() != 1 {
-                return None;
-            }
-            let assignment = &assignments[0];
-            if assignment.column.name != "data" {
-                return None;
-            }
-            let BoundExpr::ExcludedColumn(column) = &assignment.value else {
-                return None;
+            let assigns_excluded_column = |assignment: &BoundAssignment, name: &str| {
+                assignment.column.name == name
+                    && matches!(
+                        &assignment.value,
+                        BoundExpr::ExcludedColumn(column) if column.name == name
+                    )
             };
-            if column.name != "data" {
-                return None;
+            if assignments.len() == 1 && assigns_excluded_column(&assignments[0], "data") {
+                return Some(crate::sql2::providers::FastLixFilePathWriteConflict::UpdateData);
             }
-            Some(crate::sql2::providers::FastLixFilePathWriteConflict::UpdateData)
+            if assignments.len() == 2
+                && assignments
+                    .iter()
+                    .any(|assignment| assigns_excluded_column(assignment, "data"))
+                && assignments
+                    .iter()
+                    .any(|assignment| assigns_excluded_column(assignment, "lixcol_metadata"))
+            {
+                return Some(
+                    crate::sql2::providers::FastLixFilePathWriteConflict::UpdateDataAndMetadata,
+                );
+            }
+            None
         }
     }
 }
 
-fn fast_file_value_expr_supported(expr: &BoundExpr) -> bool {
+fn fast_file_metadata_expr_supported(expr: &BoundExpr) -> bool {
     matches!(
         expr,
-        BoundExpr::Param(_) | BoundExpr::Literal(BoundLiteral::Text(_) | BoundLiteral::Blob(_))
+        BoundExpr::Param(_)
+            | BoundExpr::Literal(
+                BoundLiteral::Null | BoundLiteral::Text(_) | BoundLiteral::Json(_)
+            )
     )
 }
 
@@ -380,6 +423,49 @@ fn eval_fast_file_blob(
             format!("lix_file fast write column '{column}' supports params and blob literals only"),
         )),
     }
+}
+
+fn eval_fast_file_metadata(
+    expr: &BoundExpr,
+    params: &[Value],
+) -> Result<Option<TransactionJson>, LixError> {
+    let value = match expr {
+        BoundExpr::Literal(BoundLiteral::Null) => return Ok(None),
+        BoundExpr::Literal(BoundLiteral::Text(value)) => {
+            parse_row_metadata_value(value, "lix_file")?
+        }
+        BoundExpr::Literal(BoundLiteral::Json(value)) => {
+            validate_row_metadata(value, "lix_file")?;
+            value.clone()
+        }
+        BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
+            Some(Value::Null) => return Ok(None),
+            Some(Value::Text(value)) => parse_row_metadata_value(value, "lix_file")?,
+            Some(Value::Json(value)) => {
+                validate_row_metadata(value, "lix_file")?;
+                value.clone()
+            }
+            Some(_) => {
+                return Err(LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    "lix_file fast write column 'lixcol_metadata' expects a JSON object",
+                ));
+            }
+            None => {
+                return Err(LixError::new(
+                    LixError::CODE_INVALID_PARAM,
+                    format!("missing SQL parameter ${}", param.index),
+                ));
+            }
+        },
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_UNSUPPORTED_SQL,
+                "lix_file fast write column 'lixcol_metadata' supports params and literals only",
+            ));
+        }
+    };
+    TransactionJson::from_value(value, "lix_file metadata").map(Some)
 }
 
 async fn entity_insert(

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2369,7 +2369,17 @@ mod tests {
         Arc<Mutex<CapturingStagedWrites>>,
         Arc<AtomicUsize>,
     ) {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
+        counting_write_context_with_blob_reader(rows, Arc::new(DummyBlobReader))
+    }
+
+    fn counting_write_context_with_blob_reader(
+        rows: Vec<MaterializedLiveStateRow>,
+        blob_reader: Arc<dyn BlobDataReader>,
+    ) -> (
+        DummySqlWriteExecutionContext<'static>,
+        Arc<Mutex<CapturingStagedWrites>>,
+        Arc<AtomicUsize>,
+    ) {
         let scans = Arc::new(AtomicUsize::new(0));
         let live_state: Arc<dyn LiveStateReader> = Arc::new(CountingRowsLiveStateReader {
             rows,
@@ -4648,6 +4658,176 @@ mod tests {
         assert_eq!(scans.load(Ordering::SeqCst), 1);
         let staged_writes = staged_writes.lock().expect("staged writes lock");
         assert_eq!(staged_writes.deltas.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_multi_row_lix_file_path_data_metadata_params_use_fast_stage() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data, lixcol_metadata) \
+             VALUES ($1, $2, $3), ($4, $5, $6)",
+            &[
+                Value::Text("/multi/param-a.md".to_string()),
+                Value::Blob(b"param-a".to_vec()),
+                Value::Json(json!({"source": "json-param"})),
+                Value::Text("/multi/param-b.md".to_string()),
+                Value::Blob(b"param-b".to_vec()),
+                Value::Text(r#"{"source":"text-param"}"#.to_string()),
+            ],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect("parameterized path/data/metadata insert should use the fast writer");
+
+        assert_eq!(path, WriteExecutorPath::Fast);
+        assert_eq!(result.rows, vec![vec![Value::Integer(2)]]);
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let mut descriptor_metadata = overlay
+            .visible_semantic_rows(false, "lix_file_descriptor")
+            .into_iter()
+            .filter_map(|row| row.metadata)
+            .collect::<Vec<_>>();
+        descriptor_metadata.sort();
+        assert_eq!(
+            descriptor_metadata,
+            vec![
+                r#"{"source":"json-param"}"#.to_string(),
+                r#"{"source":"text-param"}"#.to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_lix_file_metadata_upsert_fast_path_matches_datafusion() {
+        let mut existing =
+            live_file_row("file-existing", "branch-a", Some("dir-docs"), "existing.md");
+        existing.metadata = Some(r#"{"source":"old"}"#.to_string());
+        let rows = vec![
+            live_directory_row("dir-docs", "branch-a", None, "docs"),
+            existing,
+            live_blob_ref_row("file-existing", "branch-a", b"old"),
+        ];
+        let fast_blob_reader: Arc<dyn BlobDataReader> = Arc::new(StaticBlobReader {
+            bytes: b"old".to_vec(),
+        });
+        let datafusion_blob_reader: Arc<dyn BlobDataReader> = Arc::new(StaticBlobReader {
+            bytes: b"old".to_vec(),
+        });
+        let (mut fast_ctx, fast_staged, fast_scans) =
+            counting_write_context_with_blob_reader(rows.clone(), fast_blob_reader);
+        let (mut datafusion_ctx, datafusion_staged, datafusion_scans) =
+            counting_write_context_with_blob_reader(rows, datafusion_blob_reader);
+        let sql = "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ($1, $2, $3) \
+                   ON CONFLICT (path) DO UPDATE SET data = excluded.data, \
+                   lixcol_metadata = excluded.lixcol_metadata";
+        let params = [
+            Value::Text("/docs/existing.md".to_string()),
+            Value::Blob(b"updated".to_vec()),
+            Value::Json(json!({"source": "upload"})),
+        ];
+
+        let (fast_result, fast_path) =
+            execute_write_sql_trace(&mut fast_ctx, sql, &params, WriteExecutorMode::ForceFast)
+                .await
+                .expect("metadata upsert should use the bound fast path");
+        let (datafusion_result, datafusion_path) = execute_write_sql_trace(
+            &mut datafusion_ctx,
+            sql,
+            &params,
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect("reference metadata upsert should succeed");
+
+        assert_eq!(fast_path, WriteExecutorPath::Fast);
+        assert_eq!(datafusion_path, WriteExecutorPath::DataFusion);
+        assert_eq!(fast_result.rows, datafusion_result.rows);
+        assert_eq!(fast_scans.load(Ordering::SeqCst), 1);
+        assert_eq!(datafusion_scans.load(Ordering::SeqCst), 3);
+
+        let fast_rows = fast_staged.lock().expect("fast writes lock").deltas[0]
+            .pending_write_overlay()
+            .expect("fast staged delta should project")
+            .visible_all_semantic_rows();
+        let datafusion_rows = datafusion_staged
+            .lock()
+            .expect("DataFusion writes lock")
+            .deltas[0]
+            .pending_write_overlay()
+            .expect("DataFusion staged delta should project")
+            .visible_all_semantic_rows();
+        assert_eq!(fast_rows, datafusion_rows);
+        let descriptor = fast_rows
+            .iter()
+            .find(|row| row.schema_key == "lix_file_descriptor")
+            .expect("metadata upsert should rewrite the descriptor");
+        assert_eq!(
+            descriptor.metadata.as_deref(),
+            Some(r#"{"source":"upload"}"#)
+        );
+        assert_eq!(descriptor.file_id, None);
+        let snapshot: JsonValue = serde_json::from_str(
+            descriptor
+                .snapshot_content
+                .as_deref()
+                .expect("descriptor snapshot"),
+        )
+        .expect("descriptor snapshot JSON");
+        assert_eq!(snapshot["directory_id"], "dir-docs");
+        assert_eq!(snapshot["name"], "existing.md");
+    }
+
+    #[tokio::test]
+    async fn execute_sql_lix_file_metadata_fast_path_validates_before_staging() {
+        let (mut ctx, staged_writes, scans) = counting_write_context(vec![]);
+
+        let error = execute_write_sql_trace(
+            &mut ctx,
+            "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ($1, $2, $3)",
+            &[
+                Value::Text("/invalid.md".to_string()),
+                Value::Blob(b"data".to_vec()),
+                Value::Json(json!(["not", "an", "object"])),
+            ],
+            WriteExecutorMode::ForceFast,
+        )
+        .await
+        .expect_err("non-object metadata should fail before the fast writer scans or stages");
+
+        assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
+        assert_eq!(scans.load(Ordering::SeqCst), 0);
+        assert!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn bound_lix_file_metadata_do_nothing_stays_on_datafusion() {
+        let (mut ctx, _, _) = counting_write_context(Vec::new());
+        let sql = "INSERT INTO lix_file (path, data, lixcol_metadata) \
+                   VALUES ($1, $2, $3) ON CONFLICT (path) DO NOTHING";
+        let plan = create_write_logical_plan(&mut ctx, sql)
+            .await
+            .expect("metadata DO NOTHING should plan");
+        let crate::sql2::exec::SqlLogicalPlan::Write(plan) = plan else {
+            panic!("metadata DO NOTHING should produce a write plan");
+        };
+
+        assert!(
+            !crate::sql2::exec::bound_public_write::supports_bound_public_write(&plan.plan),
+            "metadata DO NOTHING must preserve DataFusion's skipped-row validation semantics"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1728,15 +1728,16 @@ pub(crate) enum FastLixFilePathWriteConflict {
     None,
     DoNothing,
     UpdateData,
+    UpdateDataAndMetadata,
 }
 
 pub(crate) async fn execute_fast_lix_file_path_writes(
     ctx: &mut dyn SqlWriteExecutionContext,
-    writes: Vec<(String, Vec<u8>)>,
+    writes: Vec<(String, Vec<u8>, Option<TransactionJson>)>,
     conflict: FastLixFilePathWriteConflict,
-) -> Result<u64, LixError> {
+) -> Result<Option<u64>, LixError> {
     if writes.is_empty() {
-        return Ok(0);
+        return Ok(Some(0));
     }
 
     let active_branch_id = ctx.active_branch_id().to_string();
@@ -1753,7 +1754,15 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
             ..LiveStateScanRequest::default()
         })
         .await?;
-    let filesystem = FilesystemIndex::from_live_rows(live_rows.clone())?;
+    let filesystem = match FilesystemIndex::from_live_rows(live_rows.clone()) {
+        Ok(filesystem) => filesystem,
+        // The legacy write index intentionally rejects visible path collisions
+        // across storage scopes, while the general provider can disambiguate
+        // them. No writes have been staged yet, so decline the fast route and
+        // let the caller execute the original DataFusion plan.
+        Err(error) if error.code == LixError::CODE_CONSTRAINT_VIOLATION => return Ok(None),
+        Err(error) => return Err(error),
+    };
     let mut path_resolvers = directory_path_resolvers_from_state_rows(live_rows)?;
     let resolver_key = filesystem_storage_scope_key(&active_branch_id, false, false, None);
     path_resolvers.entry(resolver_key).or_default();
@@ -1774,7 +1783,7 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
                         global: false,
                         untracked: false,
                         file_id: None,
-                        metadata: None,
+                        metadata: write.metadata,
                     };
                     let plan = plan_parsed_file_path_write_with_resolvers(
                         &mut path_resolvers,
@@ -1812,6 +1821,33 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
                     .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
                     staged.add_count(1)?;
                 }
+                FastLixFilePathWriteConflict::UpdateDataAndMetadata => {
+                    let mut context = existing.scope.context(None);
+                    if context.global {
+                        context.branch_id = GLOBAL_BRANCH_ID.to_string();
+                    }
+                    context.metadata = write.metadata;
+                    staged
+                        .state_rows
+                        .push(file_descriptor_row(FileDescriptorRowInput {
+                            id: existing.id.clone(),
+                            directory_id: existing.directory_id.clone(),
+                            name: existing.name.clone(),
+                            context: context.clone(),
+                        }));
+                    stage_lix_file_data_update_write(
+                        &mut staged,
+                        existing.id.clone(),
+                        Some(write.parsed.path),
+                        Some(existing.name.clone()),
+                        write.data,
+                        context,
+                        existing.blob_hash.is_some(),
+                        None,
+                    )
+                    .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+                    staged.add_count(1)?;
+                }
             }
         } else {
             let context = FilesystemRowContext {
@@ -1819,7 +1855,7 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
                 global: false,
                 untracked: false,
                 file_id: None,
-                metadata: None,
+                metadata: write.metadata,
             };
             let file_id = write
                 .parsed
@@ -1842,11 +1878,11 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
 
     let mode = match conflict {
         FastLixFilePathWriteConflict::None => TransactionWriteMode::Insert,
-        FastLixFilePathWriteConflict::DoNothing | FastLixFilePathWriteConflict::UpdateData => {
-            TransactionWriteMode::Replace
-        }
+        FastLixFilePathWriteConflict::DoNothing
+        | FastLixFilePathWriteConflict::UpdateData
+        | FastLixFilePathWriteConflict::UpdateDataAndMetadata => TransactionWriteMode::Replace,
     };
-    stage_lix_file_fast_batch(ctx, mode, staged).await
+    stage_lix_file_fast_batch(ctx, mode, staged).await.map(Some)
 }
 
 pub(crate) async fn execute_fast_lix_file_data_update_by_id(
@@ -1934,18 +1970,20 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
 struct FastLixFilePathWrite {
     parsed: ParsedFileWritePath,
     data: Vec<u8>,
+    metadata: Option<TransactionJson>,
 }
 
 fn parse_fast_lix_file_path_writes(
-    writes: Vec<(String, Vec<u8>)>,
+    writes: Vec<(String, Vec<u8>, Option<TransactionJson>)>,
 ) -> std::result::Result<Vec<FastLixFilePathWrite>, LixError> {
     writes
         .into_iter()
-        .map(|(path, data)| {
+        .map(|(path, data, metadata)| {
             Ok(FastLixFilePathWrite {
                 parsed: parse_file_upsert_path(&path, TransactionWriteOperation::Insert)
                     .map_err(crate::sql2::error::datafusion_error_to_lix_error)?,
                 data,
+                metadata,
             })
         })
         .collect()
@@ -9586,6 +9624,37 @@ mod tests {
         assert_eq!(file_data[0].path.as_deref(), Some("/docs/readme.md"));
         assert_eq!(file_data[0].data(), b"new");
         assert!(file_data[0].had_blob_ref);
+    }
+
+    #[tokio::test]
+    async fn fast_file_path_write_declines_ambiguous_cross_scope_paths() {
+        let tracked = live_file_row(
+            "file-tracked",
+            "branch-b",
+            r#"{"id":"file-tracked","directory_id":null,"name":"shared.md"}"#,
+        );
+        let mut untracked = live_file_row(
+            "file-untracked",
+            "branch-b",
+            r#"{"id":"file-untracked","directory_id":null,"name":"shared.md"}"#,
+        );
+        untracked.untracked = true;
+        let mut write_context = CapturingWriteContext {
+            rows: vec![tracked, untracked],
+            ..CapturingWriteContext::default()
+        };
+
+        let outcome = super::execute_fast_lix_file_path_writes(
+            &mut write_context,
+            vec![("/shared.md".to_string(), b"new".to_vec(), None)],
+            super::FastLixFilePathWriteConflict::UpdateDataAndMetadata,
+        )
+        .await
+        .expect("ambiguous legacy topology should decline the fast path");
+
+        assert_eq!(outcome, None);
+        assert_eq!(write_context.scan_count, 1);
+        assert!(write_context.writes.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Specialize the bound `lix_file` writer for LixRay's batched upload shape:

```sql
INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ...
ON CONFLICT (path) DO UPDATE SET
  data = excluded.data,
  lixcol_metadata = excluded.lixcol_metadata
```

This avoids DataFusion write execution and full Arrow materialization for the common upload path while retaining the existing transaction and plugin-reconciliation boundary. There are no public API changes.

## Results

Criterion `sample_size = 10`, warm session/cache, 100 seeded files, and one timed statement overwriting 10 existing files with 4 KiB payloads plus JSON metadata. The engine baseline was `1fe843c9`; current main's subsequent `#656` changes only server-protocol code.

| Backend | Main | This PR | Criterion change |
|---|---:|---:|---:|
| SlateDB, 0 ms object-store delay | `[30.780, 32.631, 34.612] ms` | `[19.822, 20.344, 21.075] ms` | **33.9-40.1% faster** |
| SlateDB, 25 ms object-store delay | `[60.529, 61.839, 63.033] ms` | `[48.151, 49.521, 50.782] ms` | **17.7-22.2% faster** |
| RocksDB | `[16.217, 16.309, 16.428] ms` | `[5.7273, 5.7558, 5.7808] ms` | **64.5-65.2% faster** |

All comparisons have `p < 0.01`. The permanent SlateDB case is `upload_overwrite_10_files_after_preload`; the RocksDB comparison used the identical production SQL in a temporary persistent-session fixture.

Focused instrumentation records one live-state scan on the native path versus three on the DataFusion reference path.

## Scope and correctness

The specialization is intentionally narrow:

- base `lix_file`, active branch, `INSERT ... VALUES`;
- exact `path`, `data`, and `lixcol_metadata` inputs;
- `ON CONFLICT (path)` with both assignments sourced from the matching `excluded.*` columns;
- parameter or supported literal values only.

Broader columns, targets, expressions, branch surfaces, and assignment shapes continue through DataFusion. Metadata-bearing `DO NOTHING` also stays on DataFusion to preserve skipped-row validation semantics. If the legacy topology view encounters a legal cross-scope path collision, the fast route declines before staging and DataFusion handles it.

Before staging, the fast path parses every path and validates metadata as a JSON object. On conflict it preserves descriptor ID, directory, name, and storage scope, rewrites only descriptor metadata, and uses the existing blob helper for replacement/tombstone behavior. `RowsWithFileData` still passes through normal transaction and plugin reconciliation.

The design follows the same principle as DuckDB's transaction-bound typed [Appender](https://duckdb.org/docs/current/data/appender): keep a narrow bulk path narrow instead of routing it through generic row materialization. Dolt's own [Prolly-tree profiling](https://www.dolthub.com/blog/2024-03-03-prolly-trees/#prolly-trees-in-practice) similarly calls out SQL analysis and extra transformations as material overhead, which is why this change targets measured execution overhead rather than another storage-format rewrite.

## Validation

- `cargo test -p lix_engine --all-features --lib`: 1,089 passed, 4 ignored
- `cargo test -p lix_engine --all-features --test sql`: 546 passed
- strict `cargo clippy -p lix_engine --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- ForceFast/DataFusion semantic-row parity, including descriptor `file_id`
- cross-scope fallback declines before staging
- invalid metadata fails before scanning or staging

LixRay's server `cargo check` currently fails identically on this branch and plain `origin/main`: merged `#656` changed `lix_server_protocol::handler` to require `LixProtocolServer`, while `lixray/src/routes.rs:136` still passes `Arc<Lix<_>>`. This PR introduces no additional server error.

Related: #652, #654.