### PR TITLE
perf(remote): delta point-file observations

### DIFF
--- a/.changenotes/delta-remote-blob-requests.md
+++ b/.changenotes/delta-remote-blob-requests.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reduced remote sync latency and bandwidth for localized edits to large files.
+
+Remote clients now transparently send compact byte splices after a successful full write, while automatically retrying with full bytes if the server no longer has the required base.

--- a/.changenotes/delta-remote-file-observations.md
+++ b/.changenotes/delta-remote-file-observations.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Remote point observations of `SELECT data FROM lix_file` now send localized blob changes as compact prefix/suffix splices.
+
+The first result and large replacements remain complete snapshots. Deltas are used only when they reduce the live event by more than 10%, and reconnects always restart from a complete result.

--- a/.changenotes/use-native-remote-base64.md
+++ b/.changenotes/use-native-remote-base64.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Remote Lix clients now use native typed-array Base64 conversion when the runtime supports it.
+
+Large blob uploads and observation results avoid the previous byte-by-byte JavaScript conversion cost while retaining the existing compatibility fallback.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "lix_sdk",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tower",
  "tracing",

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -161,6 +161,244 @@ test("remote executeBatch uses the first-class atomic batch endpoint", async () 
 	await lix.close();
 });
 
+test("remote execute sends successful large blob updates as exact splices", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[16 * 1024] = 98;
+	const prototype = Uint8Array.prototype as Uint8Array & {
+		toBase64?: () => string;
+	};
+	const originalToBase64 = Object.getOwnPropertyDescriptor(
+		prototype,
+		"toBase64",
+	);
+	const encodedLengths: number[] = [];
+	Object.defineProperty(prototype, "toBase64", {
+		configurable: true,
+		value: function (this: Uint8Array) {
+			encodedLengths.push(this.byteLength);
+			return btoa(String.fromCharCode(...this));
+		},
+	});
+	let deltaEncodedLengths: number[];
+	try {
+		await lix.execute("UPDATE lix_file SET data = $1", [first]);
+		encodedLengths.length = 0;
+		await lix.execute("UPDATE lix_file SET data = $1", [second]);
+		deltaEncodedLengths = [...encodedLengths];
+	} finally {
+		if (originalToBase64 === undefined) delete prototype.toBase64;
+		else Object.defineProperty(prototype, "toBase64", originalToBase64);
+	}
+	await lix.close();
+
+	expect(deltaEncodedLengths).toEqual([1]);
+	expect(bodies[0]).toMatchObject({
+		cacheBlobs: true,
+		params: [{ kind: "blob" }],
+	});
+	const delta = (bodies[1]?.params as Array<Record<string, unknown>>)[0];
+	expect(bodies[1]?.cacheBlobs).toBe(true);
+	expect(delta).toMatchObject({
+		kind: "blob-splice",
+		prefixBytes: 16 * 1024,
+		suffixBytes: 16 * 1024 - 1,
+		insertBase64: "Yg==",
+	});
+	expect(delta?.baseSha256).toMatch(/^[0-9a-f]{64}$/);
+	expect(delta?.resultSha256).toMatch(/^[0-9a-f]{64}$/);
+	expect(delta?.baseSha256).not.toBe(delta?.resultSha256);
+	expect(JSON.stringify(bodies[1]).length).toBeLessThan(
+		JSON.stringify(bodies[0]).length * 0.1,
+	);
+});
+
+test("remote execute retries a missing blob base once with full bytes", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	let rejectedDelta = false;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				const body = (await request.json()) as Record<string, unknown>;
+				bodies.push(body);
+				const param = (body.params as Array<Record<string, unknown>>)[0];
+				if (param?.kind === "blob-splice" && !rejectedDelta) {
+					rejectedDelta = true;
+					return Response.json(
+						{
+							error: {
+								code: "LIX_REMOTE_BLOB_BASE_MISSING",
+								message: "Blob base was evicted",
+							},
+						},
+						{ status: 409 },
+					);
+				}
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[0] = 98;
+
+	await lix.execute("UPDATE lix_file SET data = $1", [first]);
+	await lix.execute("UPDATE lix_file SET data = $1", [second]);
+	await lix.close();
+
+	expect(bodies).toHaveLength(3);
+	expect((bodies[1]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob-splice",
+	);
+	expect((bodies[2]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob",
+	);
+	expect(bodies[2]?.cacheBlobs).toBe(true);
+});
+
+test("remote execute keeps small and low-saving blob updates full", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const unrelated = new Uint8Array(32 * 1024).fill(98);
+
+	await lix.execute("UPDATE lix_file SET data = $1", [first]);
+	await lix.execute("UPDATE lix_file SET data = $1", [unrelated]);
+	await lix.execute("UPDATE lix_file SET data = $1", [new Uint8Array(1024)]);
+	await lix.close();
+
+	expect((bodies[1]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob",
+	);
+	expect(bodies[1]?.cacheBlobs).toBe(true);
+	expect((bodies[2]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob",
+	);
+	expect(bodies[2]).not.toHaveProperty("cacheBlobs");
+});
+
+test("remote execute keeps large writes full without the splice capability", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId: "main-id",
+						sessionId: "session-1",
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[0] = 98;
+
+	await lix.execute("UPDATE lix_file SET data = $1", [first]);
+	await lix.execute("UPDATE lix_file SET data = $1", [second]);
+	await lix.close();
+
+	expect(bodies).toHaveLength(2);
+	for (const body of bodies) {
+		expect((body.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+			"blob",
+		);
+		expect(body).not.toHaveProperty("cacheBlobs");
+	}
+});
+
+test("remote executeBatch uses blob splices for stable statement slots", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json([emptyExecuteResponse()]);
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[second.byteLength - 1] = 98;
+	const statement = (blob: Uint8Array) => [
+		{ sql: "UPDATE lix_file SET data = $1", params: [blob] },
+	];
+
+	await lix.executeBatch(statement(first));
+	await lix.executeBatch(statement(second));
+	await lix.close();
+
+	const statements = bodies[1]?.statements as Array<{
+		params: Array<Record<string, unknown>>;
+	}>;
+	expect(bodies[1]?.cacheBlobs).toBe(true);
+	expect(statements[0]?.params[0]).toMatchObject({
+		kind: "blob-splice",
+		prefixBytes: 32 * 1024 - 1,
+		suffixBytes: 0,
+		insertBase64: "Yg==",
+	});
+});
+
 test("remote branches preserve local Lix branch semantics", async () => {
 	const requests: Request[] = [];
 	let activeBranchId = "main-id";
@@ -586,6 +824,24 @@ test("close waits for queued operations before deleting the remote session", asy
 	await Promise.all([executing, closing]);
 	expect(order).toEqual(["execute-start", "execute-finish", "delete"]);
 });
+
+function handshakeResponse() {
+	return Response.json({
+		protocolVersion: 1,
+		activeBranchId: "main-id",
+		sessionId: "session-1",
+		capabilities: { requestBlobSplice: true },
+	});
+}
+
+function emptyExecuteResponse() {
+	return {
+		columns: [],
+		rows: [],
+		rowsAffected: 1,
+		notices: [],
+	};
+}
 
 function deferred<T>() {
 	let resolve!: (value: T | PromiseLike<T>) => void;

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -430,6 +430,7 @@ class RemoteObservationHub {
 	): Promise<void> {
 		let reconnect = false;
 		let streamOpened = false;
+		const transportBases = new Map<string, BindingObserveEvent>();
 		try {
 			const response = await this.#openStream(
 				[...this.#observations.values()].map((observation) =>
@@ -478,8 +479,19 @@ class RemoteObservationHub {
 							JSON.parse(frame.data),
 							"remote multiplex observe next event",
 						);
-						const observation = this.#observation(payload.subscriptionId);
-						observation.accept(decodeObserveEvent(payload));
+						const subscriptionId = payload.subscriptionId;
+						if (typeof subscriptionId !== "string") {
+							throw protocolError(
+								"remote observe event requires subscriptionId",
+							);
+						}
+						const observation = this.#observation(subscriptionId);
+						const event = decodeObserveEvent(
+							payload,
+							transportBases.get(subscriptionId),
+						);
+						transportBases.set(subscriptionId, event);
+						observation.accept(event);
 						this.#retryAttempt = 0;
 					} catch (error) {
 						this.#failStream(

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -30,12 +30,24 @@ import {
 	REMOTE_PROTOCOL_PATH,
 	remoteError,
 	type RemoteObserveSubscription,
+	type WireRequestBlobSplice,
+	type WireRequestValue,
+	type WireValue,
 } from "./protocol.js";
 import { readSseEvents } from "./sse.js";
 
 const OBSERVE_RETRY_BASE_MS = 100;
 const OBSERVE_RETRY_MAX_MS = 5_000;
 const REMOTE_SESSION_HEADER = "Lix-Session-Id";
+const REQUEST_BLOB_DELTA_MIN_BYTES = 32 * 1024;
+const REQUEST_BLOB_DELTA_MIN_WIRE_RATIO = 0.9;
+const REQUEST_BLOB_BASE_MAX_ENTRIES = 8;
+const REQUEST_BLOB_BASE_MAX_BYTES = 2 * 1024 * 1024;
+const REMOTE_BLOB_BASE_MISSING = "LIX_REMOTE_BLOB_BASE_MISSING";
+const WIRE_BLOB_JSON_ENVELOPE_BYTES = JSON.stringify({
+	kind: "blob",
+	base64: "",
+}).length;
 
 export async function openRemoteLixBinding(
 	options: RemoteLixServerOptions,
@@ -50,7 +62,10 @@ class RemoteLixBinding implements LixBinding {
 	readonly #fetch: NonNullable<RemoteLixServerOptions["fetch"]>;
 	readonly #headers: RemoteLixServerOptions["headers"];
 	readonly #observationHub: RemoteObservationHub;
+	readonly #requestBlobBases = new Map<string, RequestBlobBase>();
 	#sessionId: string | undefined;
+	#supportsRequestBlobSplice = false;
+	#requestBlobBaseBytes = 0;
 	#acceptingOperations = true;
 	#operationQueue: Promise<void> = Promise.resolve();
 	#closePromise: Promise<void> | undefined;
@@ -89,6 +104,7 @@ class RemoteLixBinding implements LixBinding {
 			await this.#requestJson("", { method: "GET" }),
 		);
 		this.#sessionId = handshake.sessionId;
+		this.#supportsRequestBlobSplice = handshake.requestBlobSplice;
 	}
 
 	async execute(
@@ -97,18 +113,30 @@ class RemoteLixBinding implements LixBinding {
 		options?: ExecuteOptions,
 	): Promise<BindingExecuteResult> {
 		this.#assertOpen();
-		return this.#enqueue(async () =>
-			decodeExecuteResult(
-				await this.#requestJson("execute", {
+		const snapshot = snapshotParams(params);
+		return this.#enqueue(async () => {
+			const prepared = await this.#prepareParams(
+				snapshot,
+				(index) => requestBlobSlot("execute", sql, index),
+			);
+			const request = (params: WireRequestValue[]) =>
+				this.#requestJson("execute", {
 					method: "POST",
 					body: JSON.stringify({
 						sql,
-						params: params.map(encodeWireValue),
+						params,
 						...(options === undefined ? {} : { options }),
+						...(prepared.cacheBlobs ? { cacheBlobs: true } : {}),
 					}),
-				}),
-			),
-		);
+				});
+			const value = await requestWithFullBlobFallback(
+				() => request(prepared.params),
+				prepared.hasDelta ? () => request(prepared.fullParams()) : undefined,
+			);
+			const result = decodeExecuteResult(value);
+			this.#commitRequestBlobBases(prepared.cacheUpdates);
+			return result;
+		});
 	}
 
 	async executeBatch(
@@ -116,21 +144,58 @@ class RemoteLixBinding implements LixBinding {
 		options?: LixBatchOptions,
 	): Promise<BindingExecuteResult[]> {
 		this.#assertOpen();
+		const snapshot = statements.map((statement) => ({
+			sql: statement.sql,
+			params: snapshotParams(statement.params),
+		}));
 		return this.#enqueue(async () => {
-			const value = await this.#requestJson("execute-batch", {
-				method: "POST",
-				body: JSON.stringify({
-					statements: statements.map((statement) => ({
-						sql: statement.sql,
-						params: statement.params.map(encodeWireValue),
-					})),
-					...(options === undefined ? {} : { options }),
-				}),
-			});
+			const preparedStatements = await Promise.all(
+				snapshot.map(async (statement, statementIndex) => ({
+					sql: statement.sql,
+					prepared: await this.#prepareParams(statement.params, (paramIndex) =>
+						requestBlobSlot(
+							"batch",
+							statement.sql,
+							paramIndex,
+							statementIndex,
+						),
+					),
+				})),
+			);
+			const cacheBlobs = preparedStatements.some(
+				(statement) => statement.prepared.cacheBlobs,
+			);
+			const hasDelta = preparedStatements.some(
+				(statement) => statement.prepared.hasDelta,
+			);
+			const request = (full: boolean) =>
+				this.#requestJson("execute-batch", {
+					method: "POST",
+					body: JSON.stringify({
+						statements: preparedStatements.map((statement) => ({
+							sql: statement.sql,
+							params: full
+								? statement.prepared.fullParams()
+								: statement.prepared.params,
+						})),
+						...(options === undefined ? {} : { options }),
+						...(cacheBlobs ? { cacheBlobs: true } : {}),
+					}),
+				});
+			const value = await requestWithFullBlobFallback(
+				() => request(false),
+				hasDelta ? () => request(true) : undefined,
+			);
 			if (!Array.isArray(value)) {
 				throw protocolError("execute batch response must be an array");
 			}
-			return value.map(decodeExecuteResult);
+			const results = value.map(decodeExecuteResult);
+			this.#commitRequestBlobBases(
+				preparedStatements.flatMap(
+					(statement) => statement.prepared.cacheUpdates,
+				),
+			);
+			return results;
 		});
 	}
 
@@ -317,6 +382,81 @@ class RemoteLixBinding implements LixBinding {
 		}
 	}
 
+	async #prepareParams(
+		params: NativeLixValue[],
+		slot: (index: number) => string,
+	): Promise<PreparedRequestParams> {
+		const prepared = await Promise.all(
+			params.map(async (param, index): Promise<PreparedRequestParam> => {
+				if (
+					!this.#supportsRequestBlobSplice ||
+					param.kind !== "blob" ||
+					param.blob.byteLength < REQUEST_BLOB_DELTA_MIN_BYTES ||
+					param.blob.byteLength > REQUEST_BLOB_BASE_MAX_BYTES
+				) {
+					return fullRequestParam(param);
+				}
+				const resultSha256 = await sha256Hex(param.blob);
+				if (resultSha256 === undefined) return fullRequestParam(param);
+				const cacheSlot = slot(index);
+				const cacheUpdate = {
+					slot: cacheSlot,
+					base: {
+						sha256: resultSha256,
+						bytes: param.blob,
+					},
+				};
+				const base = this.#requestBlobBases.get(cacheSlot);
+				if (base === undefined) {
+					return { ...fullRequestParam(param), cacheUpdate };
+				}
+				const delta = planBlobSplice(base, param.blob, resultSha256);
+				if (!blobSpliceIsAtLeastTenPercentSmaller(delta, param.blob)) {
+					return { ...fullRequestParam(param), cacheUpdate };
+				}
+				return {
+					value: encodeBlobSplice(delta),
+					full: () => encodeWireValue(param),
+					cacheUpdate,
+				};
+			}),
+		);
+		return {
+			params: prepared.map((param) => param.value),
+			fullParams: () => prepared.map((param) => param.full()),
+			cacheUpdates: prepared.flatMap((param) =>
+				param.cacheUpdate === undefined ? [] : [param.cacheUpdate],
+			),
+			cacheBlobs: prepared.some((param) => param.cacheUpdate !== undefined),
+			hasDelta: prepared.some((param) => param.value.kind === "blob-splice"),
+		};
+	}
+
+	#commitRequestBlobBases(updates: RequestBlobCacheUpdate[]): void {
+		for (const update of updates) {
+			const previous = this.#requestBlobBases.get(update.slot);
+			if (previous !== undefined) {
+				this.#requestBlobBaseBytes -= previous.bytes.byteLength;
+				this.#requestBlobBases.delete(update.slot);
+			}
+			if (update.base.bytes.byteLength > REQUEST_BLOB_BASE_MAX_BYTES) continue;
+			while (
+				this.#requestBlobBases.size >= REQUEST_BLOB_BASE_MAX_ENTRIES ||
+				this.#requestBlobBaseBytes + update.base.bytes.byteLength >
+					REQUEST_BLOB_BASE_MAX_BYTES
+			) {
+				const oldest = this.#requestBlobBases.entries().next().value as
+					| [string, RequestBlobBase]
+					| undefined;
+				if (oldest === undefined) break;
+				this.#requestBlobBases.delete(oldest[0]);
+				this.#requestBlobBaseBytes -= oldest[1].bytes.byteLength;
+			}
+			this.#requestBlobBases.set(update.slot, update.base);
+			this.#requestBlobBaseBytes += update.base.bytes.byteLength;
+		}
+	}
+
 	#assertOpen(): void {
 		if (!this.#acceptingOperations) {
 			throw remoteError("LIX_ERROR_CLOSED", "Lix is closed");
@@ -331,6 +471,189 @@ class RemoteLixBinding implements LixBinding {
 		);
 		return result;
 	}
+}
+
+type RequestBlobBase = {
+	sha256: string;
+	bytes: Uint8Array;
+};
+
+type RequestBlobCacheUpdate = {
+	slot: string;
+	base: RequestBlobBase;
+};
+
+type PreparedRequestParam = {
+	value: WireRequestValue;
+	full: () => WireValue;
+	cacheUpdate?: RequestBlobCacheUpdate;
+};
+
+type PreparedRequestParams = {
+	params: WireRequestValue[];
+	fullParams: () => WireValue[];
+	cacheUpdates: RequestBlobCacheUpdate[];
+	cacheBlobs: boolean;
+	hasDelta: boolean;
+};
+
+type BlobSplicePlan = {
+	baseSha256: string;
+	resultSha256: string;
+	prefixBytes: number;
+	suffixBytes: number;
+	insert: Uint8Array;
+};
+
+function fullRequestParam(param: NativeLixValue): PreparedRequestParam {
+	const full = encodeWireValue(param);
+	return { value: full, full: () => full };
+}
+
+function snapshotParams(params: NativeLixValue[]): NativeLixValue[] {
+	return params.map((param) =>
+		param.kind === "blob"
+			? { kind: "blob", value: null, blob: new Uint8Array(param.blob) }
+			: param,
+	);
+}
+
+function requestBlobSlot(
+	kind: "execute" | "batch",
+	sql: string,
+	paramIndex: number,
+	statementIndex?: number,
+): string {
+	return JSON.stringify([kind, statementIndex, sql, paramIndex]);
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string | undefined> {
+	const subtle = globalThis.crypto?.subtle;
+	if (subtle === undefined) return undefined;
+	try {
+		const input =
+			bytes.buffer instanceof ArrayBuffer &&
+			bytes.byteOffset === 0 &&
+			bytes.byteLength === bytes.buffer.byteLength
+				? bytes.buffer
+				: copyArrayBuffer(bytes);
+		const digest = await subtle.digest("SHA-256", input);
+		return Array.from(new Uint8Array(digest), (byte) =>
+			byte.toString(16).padStart(2, "0"),
+		).join("");
+	} catch {
+		return undefined;
+	}
+}
+
+function planBlobSplice(
+	base: RequestBlobBase,
+	result: Uint8Array,
+	resultSha256: string,
+): BlobSplicePlan {
+	let prefixBytes = 0;
+	const prefixLimit = Math.min(base.bytes.byteLength, result.byteLength);
+	while (
+		prefixBytes < prefixLimit &&
+		base.bytes[prefixBytes] === result[prefixBytes]
+	) {
+		prefixBytes += 1;
+	}
+
+	let suffixBytes = 0;
+	const suffixLimit = Math.min(
+		base.bytes.byteLength - prefixBytes,
+		result.byteLength - prefixBytes,
+	);
+	while (
+		suffixBytes < suffixLimit &&
+		base.bytes[base.bytes.byteLength - suffixBytes - 1] ===
+			result[result.byteLength - suffixBytes - 1]
+	) {
+		suffixBytes += 1;
+	}
+
+	const insert = result.subarray(
+		prefixBytes,
+		result.byteLength - suffixBytes,
+	);
+	return {
+		baseSha256: base.sha256,
+		resultSha256,
+		prefixBytes,
+		suffixBytes,
+		insert,
+	};
+}
+
+function encodeBlobSplice(plan: BlobSplicePlan): WireRequestBlobSplice {
+	const encodedInsert = encodeWireValue({
+		kind: "blob",
+		value: null,
+		blob: plan.insert,
+	});
+	if (encodedInsert.kind !== "blob") {
+		throw protocolError("request blob splice insert could not be encoded");
+	}
+	return {
+		kind: "blob-splice",
+		baseSha256: plan.baseSha256,
+		resultSha256: plan.resultSha256,
+		prefixBytes: plan.prefixBytes,
+		suffixBytes: plan.suffixBytes,
+		insertBase64: encodedInsert.base64,
+	};
+}
+
+function blobSpliceIsAtLeastTenPercentSmaller(
+	delta: BlobSplicePlan,
+	full: Uint8Array,
+): boolean {
+	const deltaEnvelopeBytes = JSON.stringify({
+		kind: "blob-splice",
+		baseSha256: delta.baseSha256,
+		resultSha256: delta.resultSha256,
+		prefixBytes: delta.prefixBytes,
+		suffixBytes: delta.suffixBytes,
+		insertBase64: "",
+	}).length;
+	const deltaBytes =
+		deltaEnvelopeBytes + base64EncodedLength(delta.insert.byteLength);
+	const fullBytes =
+		WIRE_BLOB_JSON_ENVELOPE_BYTES + base64EncodedLength(full.byteLength);
+	return (
+		deltaBytes < fullBytes * REQUEST_BLOB_DELTA_MIN_WIRE_RATIO
+	);
+}
+
+function base64EncodedLength(byteLength: number): number {
+	return 4 * Math.ceil(byteLength / 3);
+}
+
+async function requestWithFullBlobFallback<T>(
+	request: () => Promise<T>,
+	fullFallback: (() => Promise<T>) | undefined,
+): Promise<T> {
+	try {
+		return await request();
+	} catch (error) {
+		if (fullFallback !== undefined && errorCode(error) === REMOTE_BLOB_BASE_MISSING) {
+			return await fullFallback();
+		}
+		throw error;
+	}
+}
+
+function errorCode(error: unknown): string | undefined {
+	return error instanceof Error && "code" in error
+		? (error as { code?: string }).code
+		: undefined;
+}
+
+function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	return copy.buffer;
 }
 
 type ObserveWaiter = {

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -48,6 +48,73 @@ test("remote observe streams native Lix results", async () => {
 	await lix.close();
 });
 
+test("remote observe applies every blob delta before coalescing delivery", async () => {
+	const body = [
+		sseFrame("next", {
+			subscriptionId: "observe-1",
+			sequence: 0,
+			mutationSequence: 10,
+			result: {
+				columns: ["data"],
+				rows: [[{ kind: "blob", base64: "YWJjZGVm" }]],
+				rowsAffected: 0,
+				notices: [],
+			},
+		}),
+		sseFrame("next", {
+			subscriptionId: "observe-1",
+			sequence: 1,
+			mutationSequence: 11,
+			delta: {
+				kind: "single-blob-splice",
+				baseSequence: 0,
+				prefixBytes: 2,
+				suffixBytes: 2,
+				insertBase64: "WFla",
+			},
+		}),
+		sseFrame("next", {
+			subscriptionId: "observe-1",
+			sequence: 2,
+			mutationSequence: 12,
+			delta: {
+				kind: "single-blob-splice",
+				baseSequence: 1,
+				prefixBytes: 3,
+				suffixBytes: 2,
+				insertBase64: "IQ==",
+			},
+		}),
+	].join("");
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				if (request.method === "DELETE") return closedSession();
+				return new URL(request.url).pathname.endsWith("/lix/v1/")
+					? handshake()
+					: sseResponse(body);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT data FROM lix_file WHERE id = $1", [
+		"file-1",
+	]);
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	const latest = await events.next();
+	expect(latest?.sequence).toBe(2);
+	expect(latest?.mutationSequence).toBe(12);
+	expect(
+		new TextDecoder().decode(latest?.result.rows[0]?.value("data").asBytes()),
+	).toBe("abX!ef");
+
+	events.close();
+	await lix.close();
+});
+
 test("remote observe multiplexes more than six subscriptions without blocking execute", async () => {
 	const observeRequests: Request[] = [];
 	let liveObserveRequests = 0;

--- a/packages/js-sdk/src/remote/protocol.test.ts
+++ b/packages/js-sdk/src/remote/protocol.test.ts
@@ -1,5 +1,9 @@
 import { expect, test, vi } from "vitest";
-import { decodeExecuteResult, encodeWireValue } from "./protocol.js";
+import {
+	decodeExecuteResult,
+	decodeObserveEvent,
+	encodeWireValue,
+} from "./protocol.js";
 
 test("remote blobs use native typed-array base64 when available", () => {
 	const prototype = Uint8Array.prototype as Uint8Array & {
@@ -126,3 +130,48 @@ function restoreProperty(
 		Reflect.deleteProperty(target, key);
 	}
 }
+
+test("observe blob deltas fail closed without an exact non-overlapping base", () => {
+	const full = {
+		sequence: 0,
+		mutationSequence: 0,
+		result: {
+			columns: ["data"],
+			rows: [[{ kind: "blob", base64: "YWJjZGVm" }]],
+			rowsAffected: 0,
+			notices: [],
+		},
+	};
+	const base = decodeObserveEvent(full);
+	const delta = {
+		sequence: 1,
+		mutationSequence: 1,
+		delta: {
+			kind: "single-blob-splice",
+			baseSequence: 0,
+			prefixBytes: 2,
+			suffixBytes: 2,
+			insertBase64: "WA==",
+		},
+	};
+	expect(decodeObserveEvent(delta, base).rows.rows[0]?.[0]).toEqual({
+		kind: "blob",
+		value: null,
+		blob: new TextEncoder().encode("abXef"),
+	});
+	expect(() => decodeObserveEvent(delta)).toThrow(
+		"observe blob delta does not match its transport base",
+	);
+	expect(() =>
+		decodeObserveEvent(
+			{
+				...delta,
+				delta: { ...delta.delta, prefixBytes: 5, suffixBytes: 2 },
+			},
+			base,
+		),
+	).toThrow("observe blob delta prefix and suffix overlap");
+	expect(() => decodeObserveEvent({ ...delta, result: full.result }, base)).toThrow(
+		"observe event requires exactly one of result or delta",
+	);
+});

--- a/packages/js-sdk/src/remote/protocol.test.ts
+++ b/packages/js-sdk/src/remote/protocol.test.ts
@@ -1,9 +1,30 @@
 import { expect, test, vi } from "vitest";
 import {
 	decodeExecuteResult,
+	decodeHandshake,
 	decodeObserveEvent,
 	encodeWireValue,
 } from "./protocol.js";
+
+test.each([
+	[undefined, false],
+	[{}, false],
+	[{ requestBlobSplice: false }, false],
+	[{ requestBlobSplice: "true" }, false],
+	[{ requestBlobSplice: true }, true],
+])(
+	"remote handshake negotiates only the exact blob splice capability: %j",
+	(capabilities, expected) => {
+		expect(
+			decodeHandshake({
+				protocolVersion: 1,
+				activeBranchId: "main-id",
+				sessionId: "session-1",
+				...(capabilities === undefined ? {} : { capabilities }),
+			}).requestBlobSplice,
+		).toBe(expected);
+	},
+);
 
 test("remote blobs use native typed-array base64 when available", () => {
 	const prototype = Uint8Array.prototype as Uint8Array & {

--- a/packages/js-sdk/src/remote/protocol.test.ts
+++ b/packages/js-sdk/src/remote/protocol.test.ts
@@ -1,0 +1,128 @@
+import { expect, test, vi } from "vitest";
+import { decodeExecuteResult, encodeWireValue } from "./protocol.js";
+
+test("remote blobs use native typed-array base64 when available", () => {
+	const prototype = Uint8Array.prototype as Uint8Array & {
+		toBase64?: () => string;
+	};
+	const constructor = Uint8Array as Uint8ArrayConstructor & {
+		fromBase64?: (value: string) => Uint8Array;
+	};
+	const originalToBase64 = Object.getOwnPropertyDescriptor(
+		prototype,
+		"toBase64",
+	);
+	const originalFromBase64 = Object.getOwnPropertyDescriptor(
+		constructor,
+		"fromBase64",
+	);
+	const toBase64 = vi.fn(() => "native-encoded");
+	const fromBase64 = vi.fn(() => new Uint8Array([4, 5, 6]));
+
+	try {
+		Object.defineProperty(prototype, "toBase64", {
+			configurable: true,
+			value: toBase64,
+		});
+		Object.defineProperty(constructor, "fromBase64", {
+			configurable: true,
+			value: fromBase64,
+		});
+
+		const bytes = new Uint8Array([1, 2, 3]);
+		expect(encodeWireValue({ kind: "blob", value: null, blob: bytes })).toEqual({
+			kind: "blob",
+			base64: "native-encoded",
+		});
+		expect(toBase64).toHaveBeenCalledOnce();
+		expect(toBase64.mock.contexts[0]).toBe(bytes);
+
+		const decoded = decodeExecuteResult({
+			columns: ["data"],
+			rows: [[{ kind: "blob", base64: "native-input" }]],
+			rowsAffected: 0,
+			notices: [],
+		});
+		expect(decoded.rows[0]?.[0]).toEqual({
+			kind: "blob",
+			value: null,
+			blob: new Uint8Array([4, 5, 6]),
+		});
+		expect(fromBase64).toHaveBeenCalledWith("native-input");
+
+		fromBase64.mockImplementationOnce(() => {
+			throw new SyntaxError("invalid base64");
+		});
+		expect(() =>
+			decodeExecuteResult({
+				columns: ["data"],
+				rows: [[{ kind: "blob", base64: "%%%" }]],
+				rowsAffected: 0,
+				notices: [],
+			}),
+		).toThrow(
+			expect.objectContaining({
+				code: "LIX_REMOTE_PROTOCOL_ERROR",
+				message: "blob wire value contains invalid base64",
+			}),
+		);
+	} finally {
+		restoreProperty(prototype, "toBase64", originalToBase64);
+		restoreProperty(constructor, "fromBase64", originalFromBase64);
+	}
+});
+
+test("remote blob base64 falls back on runtimes without native support", () => {
+	const prototype = Uint8Array.prototype as Uint8Array & {
+		toBase64?: () => string;
+	};
+	const constructor = Uint8Array as Uint8ArrayConstructor & {
+		fromBase64?: (value: string) => Uint8Array;
+	};
+	const originalToBase64 = Object.getOwnPropertyDescriptor(
+		prototype,
+		"toBase64",
+	);
+	const originalFromBase64 = Object.getOwnPropertyDescriptor(
+		constructor,
+		"fromBase64",
+	);
+
+	try {
+		Reflect.deleteProperty(prototype, "toBase64");
+		Reflect.deleteProperty(constructor, "fromBase64");
+		expect(
+			encodeWireValue({
+				kind: "blob",
+				value: null,
+				blob: new Uint8Array([1, 2, 3]),
+			}),
+		).toEqual({ kind: "blob", base64: "AQID" });
+		const decoded = decodeExecuteResult({
+			columns: ["data"],
+			rows: [[{ kind: "blob", base64: "BAUG" }]],
+			rowsAffected: 0,
+			notices: [],
+		});
+		expect(decoded.rows[0]?.[0]).toEqual({
+			kind: "blob",
+			value: null,
+			blob: new Uint8Array([4, 5, 6]),
+		});
+	} finally {
+		restoreProperty(prototype, "toBase64", originalToBase64);
+		restoreProperty(constructor, "fromBase64", originalFromBase64);
+	}
+});
+
+function restoreProperty(
+	target: object,
+	key: PropertyKey,
+	descriptor: PropertyDescriptor | undefined,
+): void {
+	if (descriptor) {
+		Object.defineProperty(target, key, descriptor);
+	} else {
+		Reflect.deleteProperty(target, key);
+	}
+}

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -350,6 +350,13 @@ function assertJsonValue(
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
+	const nativeToBase64 = (
+		bytes as Uint8Array & { toBase64?: () => string }
+	).toBase64;
+	if (typeof nativeToBase64 === "function") {
+		return nativeToBase64.call(bytes);
+	}
+
 	let binary = "";
 	const chunkSize = 0x8000;
 	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
@@ -359,6 +366,19 @@ function bytesToBase64(bytes: Uint8Array): string {
 }
 
 function base64ToBytes(base64: string): Uint8Array {
+	const nativeFromBase64 = (
+		Uint8Array as Uint8ArrayConstructor & {
+			fromBase64?: (value: string) => Uint8Array;
+		}
+	).fromBase64;
+	if (typeof nativeFromBase64 === "function") {
+		try {
+			return nativeFromBase64(base64);
+		} catch {
+			throw protocolError("blob wire value contains invalid base64");
+		}
+	}
+
 	let binary: string;
 	try {
 		binary = atob(base64);

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -16,21 +16,35 @@ export type WireValue =
 	| { kind: "json"; value: unknown }
 	| { kind: "blob"; base64: string };
 
+export type WireRequestBlobSplice = {
+	kind: "blob-splice";
+	baseSha256: string;
+	resultSha256: string;
+	prefixBytes: number;
+	suffixBytes: number;
+	insertBase64: string;
+};
+
+export type WireRequestValue = WireValue | WireRequestBlobSplice;
+
 export type RemoteHandshake = {
 	protocolVersion: number;
 	activeBranchId: string;
 	sessionId: string;
+	requestBlobSplice: boolean;
 };
 
 export type RemoteExecuteRequest = {
 	sql: string;
-	params: WireValue[];
+	params: WireRequestValue[];
 	options?: { originKey?: string };
+	cacheBlobs?: true;
 };
 
 export type RemoteExecuteBatchRequest = {
-	statements: Array<{ sql: string; params: WireValue[] }>;
+	statements: Array<{ sql: string; params: WireRequestValue[] }>;
 	options?: { originKey?: string };
+	cacheBlobs?: true;
 };
 
 export type RemoteExecuteResponse = {
@@ -40,7 +54,10 @@ export type RemoteExecuteResponse = {
 	notices: Array<{ code: string; message: string; hint?: string }>;
 };
 
-export type RemoteObserveRequest = Omit<RemoteExecuteRequest, "options">;
+export type RemoteObserveRequest = {
+	sql: string;
+	params: WireValue[];
+};
 
 export type RemoteObserveSubscription = RemoteObserveRequest & {
 	id: string;
@@ -198,6 +215,9 @@ export function decodeHandshake(value: unknown): RemoteHandshake {
 		protocolVersion: REMOTE_PROTOCOL_VERSION,
 		activeBranchId: handshake.activeBranchId,
 		sessionId: handshake.sessionId,
+		requestBlobSplice:
+			isRecord(handshake.capabilities) &&
+			handshake.capabilities.requestBlobSplice === true,
 	};
 }
 
@@ -369,6 +389,10 @@ export function record(
 		throw protocolError(`${description} must be an object`);
 	}
 	return value as Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function decodeWireValue(value: unknown): NativeLixValue {

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -50,11 +50,24 @@ export type RemoteMultiplexObserveRequest = {
 	subscriptions: RemoteObserveSubscription[];
 };
 
-export type RemoteObserveEvent = {
+type RemoteObserveEventBase = {
 	sequence: number;
 	mutationSequence: number;
-	result: RemoteExecuteResponse;
 };
+
+export type RemoteObserveBlobDelta = {
+	kind: "single-blob-splice";
+	baseSequence: number;
+	prefixBytes: number;
+	suffixBytes: number;
+	insertBase64: string;
+};
+
+export type RemoteObserveEvent = RemoteObserveEventBase &
+	(
+		| { result: RemoteExecuteResponse; delta?: never }
+		| { result?: never; delta: RemoteObserveBlobDelta }
+	);
 
 export type RemoteMultiplexObserveEvent = RemoteObserveEvent & {
 	subscriptionId: string;
@@ -188,7 +201,10 @@ export function decodeHandshake(value: unknown): RemoteHandshake {
 	};
 }
 
-export function decodeObserveEvent(value: unknown): BindingObserveEvent {
+export function decodeObserveEvent(
+	value: unknown,
+	base?: BindingObserveEvent,
+): BindingObserveEvent {
 	const event = record(value, "observe event");
 	if (
 		typeof event.sequence !== "number" ||
@@ -208,10 +224,89 @@ export function decodeObserveEvent(value: unknown): BindingObserveEvent {
 			"observe event mutationSequence must be a non-negative safe integer",
 		);
 	}
+	const hasResult = event.result !== undefined;
+	const hasDelta = event.delta !== undefined;
+	if (hasResult === hasDelta) {
+		throw protocolError("observe event requires exactly one of result or delta");
+	}
+	const sequence = event.sequence;
 	return {
-		sequence: event.sequence,
+		sequence,
 		mutationSequence: event.mutationSequence,
-		rows: decodeExecuteResult(event.result),
+		rows: hasResult
+			? decodeExecuteResult(event.result)
+			: applyObserveBlobDelta(event.delta, sequence, base),
+	};
+}
+
+function applyObserveBlobDelta(
+	value: unknown,
+	sequence: number,
+	base: BindingObserveEvent | undefined,
+): BindingExecuteResult {
+	const delta = record(value, "observe event delta");
+	if (delta.kind !== "single-blob-splice") {
+		throw protocolError(`unknown observe delta kind: ${String(delta.kind)}`);
+	}
+	const baseSequence = nonNegativeSafeInteger(
+		delta.baseSequence,
+		"observe delta baseSequence",
+	);
+	const prefixBytes = nonNegativeSafeInteger(
+		delta.prefixBytes,
+		"observe delta prefixBytes",
+	);
+	const suffixBytes = nonNegativeSafeInteger(
+		delta.suffixBytes,
+		"observe delta suffixBytes",
+	);
+	if (typeof delta.insertBase64 !== "string") {
+		throw protocolError("observe delta insertBase64 must be a string");
+	}
+	if (
+		base === undefined ||
+		base.sequence !== baseSequence ||
+		sequence !== baseSequence + 1
+	) {
+		throw protocolError("observe blob delta does not match its transport base");
+	}
+	const baseValue = base.rows.rows[0]?.[0];
+	if (
+		base.rows.columns.length !== 1 ||
+		base.rows.columns[0] !== "data" ||
+		base.rows.rows.length !== 1 ||
+		base.rows.rows[0]?.length !== 1 ||
+		base.rows.rowsAffected !== 0 ||
+		base.rows.notices.length !== 0 ||
+		baseValue?.kind !== "blob"
+	) {
+		throw protocolError("observe blob delta base is not a point blob result");
+	}
+	if (prefixBytes + suffixBytes > baseValue.blob.byteLength) {
+		throw protocolError("observe blob delta prefix and suffix overlap");
+	}
+	const insert = base64ToBytes(delta.insertBase64);
+	const nextLength = prefixBytes + insert.byteLength + suffixBytes;
+	if (!Number.isSafeInteger(nextLength)) {
+		throw protocolError("observe blob delta result is too large");
+	}
+	let blob: Uint8Array;
+	try {
+		blob = new Uint8Array(nextLength);
+	} catch {
+		throw protocolError("observe blob delta result is too large");
+	}
+	blob.set(baseValue.blob.subarray(0, prefixBytes), 0);
+	blob.set(insert, prefixBytes);
+	blob.set(
+		baseValue.blob.subarray(baseValue.blob.byteLength - suffixBytes),
+		prefixBytes + insert.byteLength,
+	);
+	return {
+		columns: ["data"],
+		rows: [[{ kind: "blob", value: null, blob }]],
+		rowsAffected: 0,
+		notices: [],
 	};
 }
 
@@ -320,6 +415,17 @@ function stringArray(value: unknown, description: string): string[] {
 		throw protocolError(`${description} must be an array of strings`);
 	}
 	return [...value];
+}
+
+function nonNegativeSafeInteger(value: unknown, description: string): number {
+	if (
+		typeof value !== "number" ||
+		!Number.isSafeInteger(value) ||
+		value < 0
+	) {
+		throw protocolError(`${description} must be a non-negative safe integer`);
+	}
+	return value;
 }
 
 function assertJsonValue(

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -24,6 +24,7 @@ getrandom = "0.3"
 lix_sdk = { path = "../rs-sdk", version = "0.8.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tokio = { version = "1", features = ["sync", "rt"] }
 tracing = "0.1"
 

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -794,18 +794,28 @@ where
         let parent = tracing::Span::current();
         tasks.push(tokio::spawn(
             async move {
+                let mut blob_base = None;
                 loop {
                     let message = match events.next().await {
-                        Ok(Some(event)) => match ObserveEventResponse::try_from(event) {
-                            Ok(payload) => MultiplexObserveMessage::Next {
-                                subscription_id: subscription_id.clone(),
-                                payload,
-                            },
-                            Err(error) => MultiplexObserveMessage::Error {
-                                subscription_id: subscription_id.clone(),
-                                error: ErrorEnvelope::from_lix_error(&error),
-                            },
-                        },
+                        Ok(Some(event)) => {
+                            match multiplex_observe_payload(event, blob_base.as_ref()) {
+                                Ok((payload, next_blob_base)) => {
+                                    let message = MultiplexObserveMessage::Next {
+                                        subscription_id: subscription_id.clone(),
+                                        payload,
+                                    };
+                                    if sender.send(message).await.is_err() {
+                                        break;
+                                    }
+                                    blob_base = next_blob_base;
+                                    continue;
+                                }
+                                Err(error) => MultiplexObserveMessage::Error {
+                                    subscription_id: subscription_id.clone(),
+                                    error: ErrorEnvelope::from_lix_error(&error),
+                                },
+                            }
+                        }
                         Ok(None) => break,
                         Err(error) => MultiplexObserveMessage::Error {
                             subscription_id: subscription_id.clone(),
@@ -834,6 +844,7 @@ where
                         sequence: payload.sequence,
                         mutation_sequence: payload.mutation_sequence,
                         result: payload.result,
+                        delta: payload.delta,
                     }));
                 }
                 MultiplexObserveMessage::Error { subscription_id, error } => {
@@ -1207,12 +1218,38 @@ impl TryFrom<ObserveEvent> for ObserveEventResponse {
 enum MultiplexObserveMessage {
     Next {
         subscription_id: String,
-        payload: ObserveEventResponse,
+        payload: MultiplexObservePayload,
     },
     Error {
         subscription_id: String,
         error: ErrorEnvelope,
     },
+}
+
+struct BlobDeltaBase {
+    sequence: u64,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MultiplexObservePayload {
+    sequence: u64,
+    mutation_sequence: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<ExecuteResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delta: Option<SingleBlobSplice>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SingleBlobSplice {
+    kind: &'static str,
+    base_sequence: u64,
+    prefix_bytes: u64,
+    suffix_bytes: u64,
+    insert_base64: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -1221,7 +1258,133 @@ struct MultiplexObserveEventResponse {
     subscription_id: String,
     sequence: u64,
     mutation_sequence: u64,
-    result: ExecuteResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<ExecuteResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delta: Option<SingleBlobSplice>,
+}
+
+const MIN_BLOB_DELTA_BYTES: usize = 32 * 1024;
+// Compared with only the full blob's Base64 length, this deliberately
+// overestimates every delta-only JSON/SSE field. The shared event envelope is
+// omitted from both sides, so passing the 90% test guarantees >10% savings.
+const BLOB_DELTA_ENVELOPE_BUDGET_BYTES: usize = 512;
+
+fn multiplex_observe_payload(
+    event: ObserveEvent,
+    base: Option<&BlobDeltaBase>,
+) -> Result<(MultiplexObservePayload, Option<BlobDeltaBase>), LixError> {
+    let next_base = point_blob_bytes(&event.rows).map(|bytes| BlobDeltaBase {
+        sequence: event.sequence,
+        bytes: bytes.to_vec(),
+    });
+    let delta = match base.zip(next_base.as_ref()) {
+        Some((base, next)) if base.sequence.checked_add(1) == Some(event.sequence) => {
+            single_blob_splice(base, next)?
+        }
+        _ => None,
+    };
+
+    let payload = if let Some(delta) = delta {
+        MultiplexObservePayload {
+            sequence: event.sequence,
+            mutation_sequence: event.mutation_sequence,
+            result: None,
+            delta: Some(delta),
+        }
+    } else {
+        MultiplexObservePayload {
+            sequence: event.sequence,
+            mutation_sequence: event.mutation_sequence,
+            result: Some(ExecuteResponse::try_from(event.rows)?),
+            delta: None,
+        }
+    };
+    Ok((payload, next_base))
+}
+
+fn point_blob_bytes(result: &ExecuteResult) -> Option<&[u8]> {
+    if result.columns() != ["data"]
+        || result.rows().len() != 1
+        || result.rows_affected() != 0
+        || !result.notices().is_empty()
+    {
+        return None;
+    }
+    match result.rows()[0].values() {
+        [Value::Blob(bytes)] => Some(bytes),
+        _ => None,
+    }
+}
+
+fn single_blob_splice(
+    base: &BlobDeltaBase,
+    next: &BlobDeltaBase,
+) -> Result<Option<SingleBlobSplice>, LixError> {
+    if next.bytes.len() < MIN_BLOB_DELTA_BYTES {
+        return Ok(None);
+    }
+    let prefix_bytes = base
+        .bytes
+        .iter()
+        .zip(&next.bytes)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let max_suffix = base
+        .bytes
+        .len()
+        .saturating_sub(prefix_bytes)
+        .min(next.bytes.len().saturating_sub(prefix_bytes));
+    let suffix_bytes = base
+        .bytes
+        .iter()
+        .rev()
+        .zip(next.bytes.iter().rev())
+        .take(max_suffix)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let insert_end = next.bytes.len().saturating_sub(suffix_bytes);
+    let insert = &next.bytes[prefix_bytes..insert_end];
+    let Some(full_base64_bytes) = padded_base64_len(next.bytes.len()) else {
+        return Ok(None);
+    };
+    let Some(delta_base64_bytes) = padded_base64_len(insert.len()) else {
+        return Ok(None);
+    };
+    let Some(delta_estimate) = delta_base64_bytes.checked_add(BLOB_DELTA_ENVELOPE_BUDGET_BYTES)
+    else {
+        return Ok(None);
+    };
+    if delta_estimate.saturating_mul(10) >= full_base64_bytes.saturating_mul(9) {
+        return Ok(None);
+    }
+    let WireValue::Blob {
+        base64: insert_base64,
+    } = WireValue::try_from_engine(&Value::Blob(insert.to_vec()))?
+    else {
+        unreachable!("blob wire conversion must return a blob")
+    };
+    Ok(Some(SingleBlobSplice {
+        kind: "single-blob-splice",
+        base_sequence: base.sequence,
+        prefix_bytes: u64::try_from(prefix_bytes).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "blob delta prefix is too large",
+            )
+        })?,
+        suffix_bytes: u64::try_from(suffix_bytes).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "blob delta suffix is too large",
+            )
+        })?,
+        insert_base64,
+    }))
+}
+
+fn padded_base64_len(bytes: usize) -> Option<usize> {
+    bytes.checked_add(2)?.checked_div(3)?.checked_mul(4)
 }
 
 #[derive(Debug, Serialize)]
@@ -1618,6 +1781,123 @@ mod tests {
         .await;
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    fn point_blob_event(sequence: u64, bytes: Vec<u8>) -> ObserveEvent {
+        ObserveEvent {
+            sequence,
+            mutation_sequence: sequence,
+            rows: ExecuteResult::from_rows(
+                vec!["data".to_string()],
+                vec![vec![Value::Blob(bytes)]],
+            ),
+        }
+    }
+
+    fn apply_blob_splice(base: &[u8], delta: SingleBlobSplice) -> Vec<u8> {
+        let Value::Blob(insert) = WireValue::Blob {
+            base64: delta.insert_base64,
+        }
+        .try_into_engine()
+        .expect("delta insert should decode") else {
+            panic!("delta insert should be a blob")
+        };
+        let prefix = usize::try_from(delta.prefix_bytes).expect("prefix should fit");
+        let suffix = usize::try_from(delta.suffix_bytes).expect("suffix should fit");
+        let mut next = Vec::with_capacity(prefix + insert.len() + base.len() - suffix);
+        next.extend_from_slice(&base[..prefix]);
+        next.extend_from_slice(&insert);
+        next.extend_from_slice(&base[base.len() - suffix..]);
+        next
+    }
+
+    #[test]
+    fn multiplex_blob_delta_roundtrips_replace_insert_and_delete() {
+        let initial = vec![b'a'; 100 * 1024];
+        let (payload, mut base) =
+            multiplex_observe_payload(point_blob_event(0, initial.clone()), None)
+                .expect("initial payload");
+        assert!(payload.result.is_some());
+        assert!(payload.delta.is_none());
+
+        let mut replaced = initial.clone();
+        replaced[50_000..50_032].fill(b'b');
+        let (payload, next_base) =
+            multiplex_observe_payload(point_blob_event(1, replaced.clone()), base.as_ref())
+                .expect("replacement delta");
+        assert_eq!(
+            apply_blob_splice(&initial, payload.delta.expect("replacement splice")),
+            replaced
+        );
+        base = next_base;
+
+        let mut inserted = replaced.clone();
+        inserted.splice(40_000..40_000, [b'x'; 32]);
+        let (payload, next_base) =
+            multiplex_observe_payload(point_blob_event(2, inserted.clone()), base.as_ref())
+                .expect("insert delta");
+        assert_eq!(
+            apply_blob_splice(&replaced, payload.delta.expect("insert splice")),
+            inserted
+        );
+        base = next_base;
+
+        let mut deleted = inserted.clone();
+        deleted.drain(60_000..60_032);
+        let (payload, _) =
+            multiplex_observe_payload(point_blob_event(3, deleted.clone()), base.as_ref())
+                .expect("delete delta");
+        assert_eq!(
+            apply_blob_splice(&inserted, payload.delta.expect("delete splice")),
+            deleted
+        );
+    }
+
+    #[test]
+    fn multiplex_blob_delta_requires_more_than_ten_percent_wire_saving() {
+        let initial = vec![b'a'; 1024 * 1024];
+        let (_, base) = multiplex_observe_payload(point_blob_event(0, initial.clone()), None)
+            .expect("initial payload");
+
+        let replace_89_percent = initial.len() * 89 / 100;
+        let mut next = initial.clone();
+        let start = (initial.len() - replace_89_percent) / 2;
+        next[start..start + replace_89_percent].fill(b'b');
+        let (payload, _) = multiplex_observe_payload(point_blob_event(1, next), base.as_ref())
+            .expect("89 percent payload");
+        assert!(payload.delta.is_some());
+        assert!(payload.result.is_none());
+
+        let replace_90_percent = initial.len() * 90 / 100;
+        let mut next = initial.clone();
+        let start = (initial.len() - replace_90_percent) / 2;
+        next[start..start + replace_90_percent].fill(b'b');
+        let (payload, _) = multiplex_observe_payload(point_blob_event(1, next), base.as_ref())
+            .expect("90 percent payload");
+        assert!(payload.result.is_some());
+        assert!(payload.delta.is_none());
+    }
+
+    #[test]
+    fn multiplex_blob_full_fallback_becomes_the_next_delta_base() {
+        let initial = vec![b'a'; 100 * 1024];
+        let (_, base) =
+            multiplex_observe_payload(point_blob_event(0, initial), None).expect("initial payload");
+        let replacement = vec![b'b'; 100 * 1024];
+        let (payload, base) =
+            multiplex_observe_payload(point_blob_event(1, replacement.clone()), base.as_ref())
+                .expect("full fallback");
+        assert!(payload.result.is_some());
+
+        let mut localized = replacement.clone();
+        localized[50_000] = b'c';
+        let (payload, _) =
+            multiplex_observe_payload(point_blob_event(2, localized.clone()), base.as_ref())
+                .expect("localized delta");
+        assert_eq!(
+            apply_blob_splice(&replacement, payload.delta.expect("localized splice")),
+            localized
+        );
     }
 
     #[tokio::test]

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -17,8 +17,9 @@ use lix_sdk::{
     ObserveEvent, ObserveEvents, Storage, SwitchBranchOptions, Value, WireValue,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     convert::Infallible,
     future::Future,
     sync::{
@@ -50,6 +51,14 @@ pub const DEFAULT_SESSION_IDLE_TIMEOUT: Duration = Duration::from_mins(30);
 pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
 /// Maximum number of queries multiplexed onto one observation stream.
 pub const MAX_MULTIPLEX_SUBSCRIPTIONS: usize = 32;
+
+/// Maximum number of request blobs retained by one remote session.
+const MAX_REQUEST_BLOB_CACHE_ENTRIES: usize = 8;
+/// Blobs below this size are cheaper to send whole than to retain and hash.
+const MIN_REQUEST_BLOB_CACHE_BYTES: usize = 32 * 1024;
+/// Maximum aggregate bytes retained by one remote session's request blob cache.
+const MAX_REQUEST_BLOB_CACHE_BYTES: usize = 2 * 1024 * 1024;
+const BLOB_BASE_MISSING_CODE: &str = "LIX_REMOTE_BLOB_BASE_MISSING";
 
 const SESSION_TOKEN_BYTES: usize = 32;
 const SESSION_TOKEN_HEX_LEN: usize = SESSION_TOKEN_BYTES * 2;
@@ -128,6 +137,49 @@ where
     lix: Arc<Lix<S>>,
     last_used: Mutex<Instant>,
     leases: AtomicUsize,
+    request_blobs: Mutex<RequestBlobCache>,
+}
+
+#[derive(Default)]
+struct RequestBlobCache {
+    entries: HashMap<String, Arc<[u8]>>,
+    insertion_order: VecDeque<String>,
+    total_bytes: usize,
+}
+
+impl RequestBlobCache {
+    fn get(&self, sha256: &str) -> Option<Arc<[u8]>> {
+        self.entries.get(sha256).cloned()
+    }
+
+    fn insert(&mut self, candidate: CachedRequestBlob) {
+        if !is_request_blob_cacheable(candidate.bytes.len())
+            || self.entries.contains_key(&candidate.sha256)
+        {
+            return;
+        }
+        while self.entries.len() >= MAX_REQUEST_BLOB_CACHE_ENTRIES
+            || self
+                .total_bytes
+                .checked_add(candidate.bytes.len())
+                .is_none_or(|total| total > MAX_REQUEST_BLOB_CACHE_BYTES)
+        {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            if let Some(removed) = self.entries.remove(&oldest) {
+                self.total_bytes = self.total_bytes.saturating_sub(removed.len());
+            }
+        }
+        self.total_bytes += candidate.bytes.len();
+        self.insertion_order.push_back(candidate.sha256.clone());
+        self.entries.insert(candidate.sha256, candidate.bytes);
+    }
+}
+
+struct CachedRequestBlob {
+    sha256: String,
+    bytes: Arc<[u8]>,
 }
 
 impl<S> SessionRecord<S>
@@ -139,6 +191,7 @@ where
             lix: Arc::new(lix),
             last_used: Mutex::new(now),
             leases: AtomicUsize::new(0),
+            request_blobs: Mutex::new(RequestBlobCache::default()),
         }
     }
 
@@ -172,6 +225,23 @@ where
 
     fn is_idle_expired(&self, now: Instant, timeout: Duration) -> bool {
         self.lease_count() == 0 && now.saturating_duration_since(self.last_used()) >= timeout
+    }
+
+    fn request_blob(&self, sha256: &str) -> Option<Arc<[u8]>> {
+        self.request_blobs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(sha256)
+    }
+
+    fn cache_request_blobs(&self, candidates: Vec<CachedRequestBlob>) {
+        let mut cache = self
+            .request_blobs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for candidate in candidates {
+            cache.insert(candidate);
+        }
     }
 }
 
@@ -626,6 +696,9 @@ where
             protocol_version: PROTOCOL_VERSION,
             active_branch_id,
             session_id: lease.session_id.clone(),
+            capabilities: ProtocolCapabilities {
+                request_blob_splice: true,
+            },
         }),
     ))
 }
@@ -650,11 +723,24 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let sql = required_non_empty(request.sql, "sql")?;
-    let params = decode_params(request.params)?;
+    let mut reconstructed_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+    let mut cache_candidate_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+    let mut cache_candidates = Vec::new();
+    let decoded = decode_request_params(
+        request.params,
+        None,
+        request.cache_blobs,
+        &mut reconstructed_bytes_remaining,
+        &mut cache_candidate_bytes_remaining,
+        &mut cache_candidates,
+        |sha256| lease.record.request_blob(sha256),
+    )?;
     let options = request.options.into();
+    let params = decoded.values;
     let result = lease
         .run(move |lix| async move { lix.execute_with_options(&sql, &params, options).await })
         .await?;
+    lease.record.cache_request_blobs(cache_candidates);
     Ok(Json(ExecuteResponse::try_from(result)?))
 }
 
@@ -668,14 +754,26 @@ where
     if request.statements.is_empty() {
         return Err(ApiError::bad_request("statements must not be empty"));
     }
+    let mut cache_candidates = Vec::new();
+    let mut reconstructed_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+    let mut cache_candidate_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
     let statements = request
         .statements
         .into_iter()
         .enumerate()
         .map(|(index, statement)| {
+            let decoded = decode_request_params(
+                statement.params,
+                Some(index),
+                request.cache_blobs,
+                &mut reconstructed_bytes_remaining,
+                &mut cache_candidate_bytes_remaining,
+                &mut cache_candidates,
+                |sha256| lease.record.request_blob(sha256),
+            )?;
             Ok(ExecuteBatchStatement {
                 sql: required_non_empty(statement.sql, "statements[].sql")?,
-                params: decode_params_at(statement.params, Some(index))?,
+                params: decoded.values,
             })
         })
         .collect::<Result<Vec<_>, ApiError>>()?;
@@ -683,6 +781,7 @@ where
     let results = lease
         .run(move |lix| async move { lix.execute_batch_with_options(&statements, options).await })
         .await?;
+    lease.record.cache_request_blobs(cache_candidates);
     Ok(Json(
         results
             .into_iter()
@@ -914,6 +1013,228 @@ fn decode_params_at(
         .collect()
 }
 
+struct DecodedRequestParams {
+    values: Vec<Value>,
+}
+
+fn decode_request_params(
+    params: Vec<RequestWireValue>,
+    statement_index: Option<usize>,
+    cache_full_blobs: bool,
+    reconstructed_bytes_remaining: &mut usize,
+    cache_candidate_bytes_remaining: &mut usize,
+    cache_candidates: &mut Vec<CachedRequestBlob>,
+    lookup_blob: impl Fn(&str) -> Option<Arc<[u8]>>,
+) -> Result<DecodedRequestParams, ApiError> {
+    let mut values = Vec::with_capacity(params.len());
+    for (parameter_index, value) in params.into_iter().enumerate() {
+        match value {
+            RequestWireValue::Value(value) => {
+                let value = value.try_into_engine().map_err(|error| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        error.code,
+                        error.message,
+                    )
+                })?;
+                if cache_full_blobs
+                    && let Value::Blob(bytes) = &value
+                    && is_request_blob_cacheable(bytes.len())
+                    && bytes.len() <= *cache_candidate_bytes_remaining
+                {
+                    prepare_cache_candidate(
+                        sha256_hex(bytes),
+                        bytes,
+                        cache_candidate_bytes_remaining,
+                        cache_candidates,
+                    );
+                }
+                values.push(value);
+            }
+            RequestWireValue::BlobSplice(splice) => {
+                let base_sha256 = splice.base_sha256;
+                let result_sha256 = splice.result_sha256;
+                if !is_lowercase_sha256(&base_sha256) {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice baseSha256 must be a lowercase SHA-256 hex digest",
+                    ));
+                }
+                if !is_lowercase_sha256(&result_sha256) {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice resultSha256 must be a lowercase SHA-256 hex digest",
+                    ));
+                }
+                let Some(base) = lookup_blob(&base_sha256) else {
+                    return Err(ApiError::blob_base_missing(
+                        base_sha256,
+                        parameter_index,
+                        statement_index,
+                    ));
+                };
+                let prefix = usize::try_from(splice.prefix_bytes).map_err(|_| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice prefixBytes is too large",
+                    )
+                })?;
+                let suffix = usize::try_from(splice.suffix_bytes).map_err(|_| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice suffixBytes is too large",
+                    )
+                })?;
+                if prefix > base.len()
+                    || suffix > base.len()
+                    || prefix.saturating_add(suffix) > base.len()
+                {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice prefix and suffix must not overlap the cached base",
+                    ));
+                }
+                let insert = WireValue::Blob {
+                    base64: splice.insert_base64,
+                }
+                .try_into_engine()
+                .map_err(|error| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        error.code,
+                        format!("invalid blob splice insertBase64: {}", error.message),
+                    )
+                })?;
+                let Value::Blob(insert) = insert else {
+                    unreachable!("WireValue::Blob must decode to Value::Blob")
+                };
+                let reconstructed_len = prefix
+                    .checked_add(insert.len())
+                    .and_then(|length| length.checked_add(suffix))
+                    .ok_or_else(|| {
+                        invalid_parameter_error(
+                            parameter_index,
+                            statement_index,
+                            LixError::CODE_INVALID_PARAM,
+                            "reconstructed blob size overflows the server address space",
+                        )
+                    })?;
+                if reconstructed_len > *reconstructed_bytes_remaining {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        format!(
+                            "aggregate reconstructed blobs exceed the {MAX_REQUEST_BLOB_CACHE_BYTES}-byte request limit"
+                        ),
+                    ));
+                }
+                *reconstructed_bytes_remaining -= reconstructed_len;
+                let mut reconstructed = Vec::with_capacity(reconstructed_len);
+                reconstructed.extend_from_slice(&base[..prefix]);
+                reconstructed.extend_from_slice(&insert);
+                reconstructed.extend_from_slice(&base[base.len() - suffix..]);
+                let actual_sha256 = sha256_hex(&reconstructed);
+                if actual_sha256 != result_sha256 {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice resultSha256 does not match the reconstructed bytes",
+                    ));
+                }
+                prepare_cache_candidate(
+                    result_sha256,
+                    &reconstructed,
+                    cache_candidate_bytes_remaining,
+                    cache_candidates,
+                );
+                values.push(Value::Blob(reconstructed));
+            }
+        }
+    }
+    Ok(DecodedRequestParams { values })
+}
+
+fn prepare_cache_candidate(
+    sha256: String,
+    bytes: &[u8],
+    bytes_remaining: &mut usize,
+    candidates: &mut Vec<CachedRequestBlob>,
+) {
+    if !is_request_blob_cacheable(bytes.len())
+        || bytes.len() > *bytes_remaining
+        || candidates
+            .iter()
+            .any(|candidate| candidate.sha256 == sha256)
+    {
+        return;
+    }
+    *bytes_remaining -= bytes.len();
+    candidates.push(CachedRequestBlob {
+        sha256,
+        bytes: Arc::from(bytes.to_vec()),
+    });
+}
+
+fn invalid_parameter_error(
+    parameter_index: usize,
+    statement_index: Option<usize>,
+    source_code: impl Into<String>,
+    message: impl Into<String>,
+) -> ApiError {
+    let mut details = serde_json::json!({
+        "parameterIndex": parameter_index,
+        "sourceCode": source_code.into(),
+    });
+    if let Some(statement_index) = statement_index {
+        details["statementIndex"] = statement_index.into();
+    }
+    ApiError::from(
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!(
+                "invalid SQL parameter at index {parameter_index}: {}",
+                message.into()
+            ),
+        )
+        .with_details(details),
+    )
+}
+
+fn is_lowercase_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn is_request_blob_cacheable(length: usize) -> bool {
+    (MIN_REQUEST_BLOB_CACHE_BYTES..=MAX_REQUEST_BLOB_CACHE_BYTES).contains(&length)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
 fn required_non_empty(value: Option<String>, field: &'static str) -> Result<String, ApiError> {
     match value {
         Some(value) if !value.trim().is_empty() => Ok(value),
@@ -955,6 +1276,29 @@ impl ApiError {
                 message,
                 None,
                 None,
+            ),
+        }
+    }
+
+    fn blob_base_missing(
+        base_sha256: String,
+        parameter_index: usize,
+        statement_index: Option<usize>,
+    ) -> Self {
+        let mut details = serde_json::json!({
+            "baseSha256": base_sha256,
+            "parameterIndex": parameter_index,
+        });
+        if let Some(statement_index) = statement_index {
+            details["statementIndex"] = statement_index.into();
+        }
+        Self {
+            status: StatusCode::CONFLICT,
+            body: ErrorEnvelope::from_parts(
+                BLOB_BASE_MISSING_CODE,
+                "the blob splice base is not available in this remote session",
+                Some("retry the request with the complete blob".to_string()),
+                Some(details),
             ),
         }
     }
@@ -1071,6 +1415,13 @@ struct HandshakeResponse {
     protocol_version: u32,
     active_branch_id: String,
     session_id: String,
+    capabilities: ProtocolCapabilities,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProtocolCapabilities {
+    request_blob_splice: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1078,9 +1429,11 @@ struct HandshakeResponse {
 struct ExecuteRequest {
     sql: Option<String>,
     #[serde(default)]
-    params: Vec<WireValue>,
+    params: Vec<RequestWireValue>,
     #[serde(default)]
     options: ExecuteOptionsRequest,
+    #[serde(default)]
+    cache_blobs: bool,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1104,13 +1457,40 @@ struct ExecuteBatchRequest {
     statements: Vec<ExecuteBatchStatementRequest>,
     #[serde(default)]
     options: ExecuteOptionsRequest,
+    #[serde(default)]
+    cache_blobs: bool,
 }
 
 #[derive(Debug, Deserialize)]
 struct ExecuteBatchStatementRequest {
     sql: Option<String>,
     #[serde(default)]
-    params: Vec<WireValue>,
+    params: Vec<RequestWireValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RequestWireValue {
+    BlobSplice(RequestBlobSplice),
+    Value(WireValue),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RequestBlobSplice {
+    #[serde(rename = "kind")]
+    _kind: RequestBlobSpliceKind,
+    base_sha256: String,
+    result_sha256: String,
+    prefix_bytes: u64,
+    suffix_bytes: u64,
+    insert_base64: String,
+}
+
+#[derive(Debug, Deserialize)]
+enum RequestBlobSpliceKind {
+    #[serde(rename = "blob-splice")]
+    BlobSplice,
 }
 
 #[derive(Debug, Serialize)]
@@ -1543,6 +1923,33 @@ mod tests {
         serde_json::from_slice(&bytes).expect("json")
     }
 
+    fn wire_blob_json(bytes: &[u8]) -> JsonValue {
+        let value =
+            WireValue::try_from_engine(&Value::Blob(bytes.to_vec())).expect("blob should encode");
+        serde_json::to_value(value).expect("wire blob should serialize")
+    }
+
+    fn blob_splice_json(
+        base: &[u8],
+        result: &[u8],
+        prefix_bytes: usize,
+        suffix_bytes: usize,
+        insert: &[u8],
+    ) -> JsonValue {
+        let insert_base64 = wire_blob_json(insert)["base64"]
+            .as_str()
+            .expect("blob base64")
+            .to_string();
+        json!({
+            "kind": "blob-splice",
+            "baseSha256": sha256_hex(base),
+            "resultSha256": sha256_hex(result),
+            "prefixBytes": prefix_bytes,
+            "suffixBytes": suffix_bytes,
+            "insertBase64": insert_base64,
+        })
+    }
+
     async fn error_code(response: Response) -> String {
         response_json(response).await["error"]["code"]
             .as_str()
@@ -1555,6 +1962,7 @@ mod tests {
         let app = app().await;
         let (session_id, first) = new_session(&app.router).await;
         assert_eq!(first["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(first["capabilities"]["requestBlobSplice"], true);
         assert_eq!(session_id.len(), SESSION_TOKEN_HEX_LEN);
         assert!(
             session_id
@@ -1715,6 +2123,395 @@ mod tests {
         assert_eq!(body.as_array().map(Vec::len), Some(2));
         assert_eq!(body[0]["rows"][0][0], json!({ "kind": "int", "value": 1 }));
         assert_eq!(body[1]["rows"][0][0], json!({ "kind": "int", "value": 2 }));
+    }
+
+    #[tokio::test]
+    async fn execute_reconstructs_cached_blob_splices_and_caches_each_result() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1 AS data",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let first_insert = b"BETA";
+        let replace_at = base.len() / 2;
+        let mut first = base.clone();
+        first[replace_at..replace_at + first_insert.len()].copy_from_slice(first_insert);
+        let first_response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1 AS data",
+                "params": [blob_splice_json(
+                    &base,
+                    &first,
+                    replace_at,
+                    base.len() - replace_at - first_insert.len(),
+                    first_insert,
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(first_response.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(first_response).await["rows"][0][0],
+            wire_blob_json(&first)
+        );
+
+        let second_insert = b"!";
+        let mut second = first.clone();
+        second.extend_from_slice(second_insert);
+        let second_response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1 AS data",
+                "params": [blob_splice_json(
+                    &first,
+                    &second,
+                    first.len(),
+                    0,
+                    second_insert,
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(second_response.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(second_response).await["rows"][0][0],
+            wire_blob_json(&second)
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_batch_accepts_blob_splices() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let mut result = base.clone();
+        result[0] = b'b';
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute-batch",
+            Some(&session_id),
+            Some(json!({
+                "statements": [
+                    {
+                        "sql": "SELECT $1 AS data",
+                        "params": [blob_splice_json(
+                            &base,
+                            &result,
+                            0,
+                            base.len() - 1,
+                            b"b",
+                        )],
+                    },
+                    { "sql": "SELECT 2 AS value" },
+                ],
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body[0]["rows"][0][0], wire_blob_json(&result));
+        assert_eq!(body[1]["rows"][0][0], json!({ "kind": "int", "value": 2 }));
+    }
+
+    #[tokio::test]
+    async fn missing_blob_splice_base_fails_before_sql_mutation() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let absent_base = b"not cached";
+        let result = b"replacement";
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                "params": [
+                    { "kind": "text", "value": "/must-not-exist.bin" },
+                    blob_splice_json(absent_base, result, 0, 0, result),
+                ],
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(error_code(response).await, BLOB_BASE_MISSING_CODE);
+
+        let read = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/must-not-exist.bin" }],
+            })),
+        )
+        .await;
+        assert_eq!(read.status(), StatusCode::OK);
+        assert_eq!(response_json(read).await["rows"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn execute_batch_bounds_aggregate_blob_reconstruction_before_mutation() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MAX_REQUEST_BLOB_CACHE_BYTES / 2];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                "params": [
+                    { "kind": "text", "value": "/aggregate-base.bin" },
+                    wire_blob_json(&base),
+                ],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let mut result = base.clone();
+        result.push(b'b');
+        let splice = blob_splice_json(&base, &result, base.len(), 0, b"b");
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute-batch",
+            Some(&session_id),
+            Some(json!({
+                "statements": [
+                    {
+                        "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                        "params": [
+                            { "kind": "text", "value": "/must-not-execute.bin" },
+                            splice,
+                        ],
+                    },
+                    {
+                        "sql": "SELECT $1",
+                        "params": [blob_splice_json(
+                            &base,
+                            &result,
+                            base.len(),
+                            0,
+                            b"b",
+                        )],
+                    },
+                ],
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(response).await, LixError::CODE_INVALID_PARAM);
+
+        let read = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/must-not-execute.bin" }],
+            })),
+        )
+        .await;
+        assert_eq!(read.status(), StatusCode::OK);
+        assert_eq!(response_json(read).await["rows"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn failed_execute_does_not_publish_full_blob_cache_candidates() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let failed = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "NOT VALID SQL",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_ne!(failed.status(), StatusCode::OK);
+
+        let mut result = base.clone();
+        result[0] = b'b';
+        let missing = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [blob_splice_json(
+                    &base,
+                    &result,
+                    0,
+                    base.len() - 1,
+                    b"b",
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::CONFLICT);
+        assert_eq!(error_code(missing).await, BLOB_BASE_MISSING_CODE);
+    }
+
+    #[tokio::test]
+    async fn malformed_and_hash_mismatched_blob_splices_are_rejected() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let overlap = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [blob_splice_json(
+                    &base,
+                    &base,
+                    base.len(),
+                    1,
+                    b"",
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(overlap.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(overlap).await, LixError::CODE_INVALID_PARAM);
+
+        let mismatch = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [{
+                    "kind": "blob-splice",
+                    "baseSha256": sha256_hex(&base),
+                    "resultSha256": "0".repeat(64),
+                    "prefixBytes": base.len(),
+                    "suffixBytes": 0,
+                    "insertBase64": wire_blob_json(b"")["base64"],
+                }],
+            })),
+        )
+        .await;
+        assert_eq!(mismatch.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(mismatch).await, LixError::CODE_INVALID_PARAM);
+    }
+
+    #[test]
+    fn request_blob_cache_evicts_by_entry_and_byte_limits() {
+        let mut cache = RequestBlobCache::default();
+        for index in 0..=MAX_REQUEST_BLOB_CACHE_ENTRIES {
+            cache.insert(CachedRequestBlob {
+                sha256: format!("entry-{index}"),
+                bytes: Arc::from(vec![
+                    u8::try_from(index).expect("test index should fit");
+                    MIN_REQUEST_BLOB_CACHE_BYTES
+                ]),
+            });
+        }
+        assert_eq!(cache.entries.len(), MAX_REQUEST_BLOB_CACHE_ENTRIES);
+        assert!(cache.get("entry-0").is_none());
+        assert!(
+            cache
+                .get(&format!("entry-{MAX_REQUEST_BLOB_CACHE_ENTRIES}"))
+                .is_some()
+        );
+
+        cache.insert(CachedRequestBlob {
+            sha256: "too-large".to_string(),
+            bytes: Arc::from(vec![0_u8; MAX_REQUEST_BLOB_CACHE_BYTES + 1]),
+        });
+        assert!(cache.get("too-large").is_none());
+        assert!(cache.total_bytes <= MAX_REQUEST_BLOB_CACHE_BYTES);
+
+        cache.insert(CachedRequestBlob {
+            sha256: "too-small".to_string(),
+            bytes: Arc::from(vec![0_u8; MIN_REQUEST_BLOB_CACHE_BYTES - 1]),
+        });
+        assert!(cache.get("too-small").is_none());
+    }
+
+    #[test]
+    fn request_cache_candidates_share_one_bounded_clone_budget() {
+        let mut remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+        let mut candidates = Vec::new();
+        let first = vec![b'a'; MAX_REQUEST_BLOB_CACHE_BYTES / 2];
+        prepare_cache_candidate(sha256_hex(&first), &first, &mut remaining, &mut candidates);
+        let after_first = remaining;
+        prepare_cache_candidate(sha256_hex(&first), &first, &mut remaining, &mut candidates);
+        assert_eq!(remaining, after_first, "duplicate should reuse candidate");
+
+        let over_remaining = vec![b'b'; after_first + 1];
+        prepare_cache_candidate(
+            sha256_hex(&over_remaining),
+            &over_remaining,
+            &mut remaining,
+            &mut candidates,
+        );
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(remaining, after_first);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keep the initial remote point-file observation as a complete result
- send later localized `data` changes as one raw-byte prefix/suffix splice
- use the delta only when a conservative size bound guarantees more than 10% wire savings
- scope bases to one stream/subscription and restart with a full result after reconnect
- reconstruct every transport delta before the JS observation queue coalesces user-visible events

This is result-driven: it optimizes only an actual one-row, one-column `data` blob result. It does not recognize SQL syntax and does not change the plugin API. Missing files, other result shapes, non-consecutive sequences, small files, and large replacements use the existing full result.

## Data

Chrome for Testing 149, exact modeled Axum SSE frames, 20 warmups:

| File / localized edit | Full SSE | Delta SSE | Wire saving | Full codec p50 | Delta codec p50 | CPU change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 100 KiB / 32 B | 136,719 B | 241 B | 99.824% | 0.210 ms | 0.130 ms | -38.1% |
| 100 KiB / 1 KiB | 136,719 B | 1,565 B | 98.855% | 0.190 ms | 0.130 ms | -31.6% |
| 1 MiB / 32 B | 1,398,287 B | 243 B | 99.983% | 2.250 ms | 1.300 ms | -42.2% |
| 1 MiB / 1 KiB | 1,398,287 B | 1,567 B | 99.888% | 2.250 ms | 1.300 ms | -42.2% |

At 100 Mbps, the current 1 MiB frame alone needs about 112 ms on the wire; the two measured deltas need about 0.02 ms and 0.13 ms. An 89% middle replacement still saved 11.0% and used a delta; a 90% replacement saved under 10% and correctly fell back to a full result.

Origin/main lower bound for the canonical two-session path (concurrent writer POST and peer SSE polling, 20 warmups + 120 samples):

| Storage | Size | Writer→peer p50 / p95 |
| --- | ---: | ---: |
| Memory | 1 KiB | 3.56 / 4.59 ms |
| Memory | 100 KiB | 5.37 / 7.12 ms |
| Memory | 1 MiB | 10.55 / 12.35 ms |
| SlateDB / in-memory object store | 1 KiB | 5.84 / 7.19 ms |
| SlateDB / in-memory object store | 100 KiB | 6.44 / 7.72 ms |
| SlateDB / in-memory object store | 1 MiB | 14.79 / 17.69 ms |

The small-update server path is already in Electric's published ~6 ms class. This PR targets the file-size-dependent wire cost that appears once a real network is added.

## Validation

- `cargo test -p lix_server_protocol` (19 tests)
- `cargo clippy -p lix_server_protocol --all-targets --no-deps -- -D warnings`
- `npx vitest run src/remote` (36 tests)
- `npm run typecheck`

Coverage includes full initial state, replace/insert/delete reconstruction, strict >10% fallback, full-fallback rebasing, malformed/overlapping/missing bases, and multiple deltas applied correctly despite user-visible queue coalescing.

## Stack

Base: #657. The native typed-array Base64 fast path keeps full snapshots fast and avoids conflicts in the shared protocol decoder. Review only commit `f2b9b8c6` for this layer.

## End-to-end implementation rerun

Canonical multiplex endpoint, two strict sessions, exact `data` point observation, concurrent POST + SSE consumption, 20 warmups + 120 samples, 32 changed bytes:

| Storage | Size | Origin p50 / p95 | Delta p50 / p95 | Change |
| --- | ---: | ---: | ---: | ---: |
| Memory | 1 MiB | 10.77 / 12.83 ms | 8.41 / 9.87 ms | -21.9% / -23.1% |
| SlateDB / in-memory object store | 100 KiB | 9.12 / 11.06 ms | 7.41 / 10.46 ms | -18.8% / -5.4% |
| SlateDB / in-memory object store | 1 MiB | 15.43 / 19.31 ms | 12.10 / 14.90 ms | -21.6% / -22.8% |

In the zero-network Memory 100 KiB case, p50 regressed 11.6% because the prefix/suffix scan outweighed avoided transfer; the actual frame still fell from 136,726 to 250 bytes, so any nontrivial link reverses that tradeoff.

For 1 MiB Memory fanout, time until all peers observed the edit improved 17.4% at 1 peer, 42.9% at 4 peers, and 72.1% at 16 peers. At 16 peers aggregate SSE fell from 22.373 MB to 4,032 bytes, while writer acknowledgement changed by only 4–8%.