### PR TITLE
perf(remote): delta repeated blob requests

### DIFF
--- a/.changenotes/delta-remote-blob-requests.md
+++ b/.changenotes/delta-remote-blob-requests.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reduced remote sync latency and bandwidth for localized edits to large files.
+
+Remote clients now transparently send compact byte splices after a successful full write, while automatically retrying with full bytes if the server no longer has the required base.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "lix_sdk",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tower",
  "tracing",

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -161,6 +161,244 @@ test("remote executeBatch uses the first-class atomic batch endpoint", async () 
 	await lix.close();
 });
 
+test("remote execute sends successful large blob updates as exact splices", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[16 * 1024] = 98;
+	const prototype = Uint8Array.prototype as Uint8Array & {
+		toBase64?: () => string;
+	};
+	const originalToBase64 = Object.getOwnPropertyDescriptor(
+		prototype,
+		"toBase64",
+	);
+	const encodedLengths: number[] = [];
+	Object.defineProperty(prototype, "toBase64", {
+		configurable: true,
+		value: function (this: Uint8Array) {
+			encodedLengths.push(this.byteLength);
+			return btoa(String.fromCharCode(...this));
+		},
+	});
+	let deltaEncodedLengths: number[];
+	try {
+		await lix.execute("UPDATE lix_file SET data = $1", [first]);
+		encodedLengths.length = 0;
+		await lix.execute("UPDATE lix_file SET data = $1", [second]);
+		deltaEncodedLengths = [...encodedLengths];
+	} finally {
+		if (originalToBase64 === undefined) delete prototype.toBase64;
+		else Object.defineProperty(prototype, "toBase64", originalToBase64);
+	}
+	await lix.close();
+
+	expect(deltaEncodedLengths).toEqual([1]);
+	expect(bodies[0]).toMatchObject({
+		cacheBlobs: true,
+		params: [{ kind: "blob" }],
+	});
+	const delta = (bodies[1]?.params as Array<Record<string, unknown>>)[0];
+	expect(bodies[1]?.cacheBlobs).toBe(true);
+	expect(delta).toMatchObject({
+		kind: "blob-splice",
+		prefixBytes: 16 * 1024,
+		suffixBytes: 16 * 1024 - 1,
+		insertBase64: "Yg==",
+	});
+	expect(delta?.baseSha256).toMatch(/^[0-9a-f]{64}$/);
+	expect(delta?.resultSha256).toMatch(/^[0-9a-f]{64}$/);
+	expect(delta?.baseSha256).not.toBe(delta?.resultSha256);
+	expect(JSON.stringify(bodies[1]).length).toBeLessThan(
+		JSON.stringify(bodies[0]).length * 0.1,
+	);
+});
+
+test("remote execute retries a missing blob base once with full bytes", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	let rejectedDelta = false;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				const body = (await request.json()) as Record<string, unknown>;
+				bodies.push(body);
+				const param = (body.params as Array<Record<string, unknown>>)[0];
+				if (param?.kind === "blob-splice" && !rejectedDelta) {
+					rejectedDelta = true;
+					return Response.json(
+						{
+							error: {
+								code: "LIX_REMOTE_BLOB_BASE_MISSING",
+								message: "Blob base was evicted",
+							},
+						},
+						{ status: 409 },
+					);
+				}
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[0] = 98;
+
+	await lix.execute("UPDATE lix_file SET data = $1", [first]);
+	await lix.execute("UPDATE lix_file SET data = $1", [second]);
+	await lix.close();
+
+	expect(bodies).toHaveLength(3);
+	expect((bodies[1]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob-splice",
+	);
+	expect((bodies[2]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob",
+	);
+	expect(bodies[2]?.cacheBlobs).toBe(true);
+});
+
+test("remote execute keeps small and low-saving blob updates full", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const unrelated = new Uint8Array(32 * 1024).fill(98);
+
+	await lix.execute("UPDATE lix_file SET data = $1", [first]);
+	await lix.execute("UPDATE lix_file SET data = $1", [unrelated]);
+	await lix.execute("UPDATE lix_file SET data = $1", [new Uint8Array(1024)]);
+	await lix.close();
+
+	expect((bodies[1]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob",
+	);
+	expect(bodies[1]?.cacheBlobs).toBe(true);
+	expect((bodies[2]?.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+		"blob",
+	);
+	expect(bodies[2]).not.toHaveProperty("cacheBlobs");
+});
+
+test("remote execute keeps large writes full without the splice capability", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId: "main-id",
+						sessionId: "session-1",
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[0] = 98;
+
+	await lix.execute("UPDATE lix_file SET data = $1", [first]);
+	await lix.execute("UPDATE lix_file SET data = $1", [second]);
+	await lix.close();
+
+	expect(bodies).toHaveLength(2);
+	for (const body of bodies) {
+		expect((body.params as Array<Record<string, unknown>>)[0]?.kind).toBe(
+			"blob",
+		);
+		expect(body).not.toHaveProperty("cacheBlobs");
+	}
+});
+
+test("remote executeBatch uses blob splices for stable statement slots", async () => {
+	const bodies: Array<Record<string, unknown>> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/workspace",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshakeResponse();
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				bodies.push((await request.json()) as Record<string, unknown>);
+				return Response.json([emptyExecuteResponse()]);
+			},
+		},
+	});
+	const first = new Uint8Array(32 * 1024).fill(97);
+	const second = new Uint8Array(first);
+	second[second.byteLength - 1] = 98;
+	const statement = (blob: Uint8Array) => [
+		{ sql: "UPDATE lix_file SET data = $1", params: [blob] },
+	];
+
+	await lix.executeBatch(statement(first));
+	await lix.executeBatch(statement(second));
+	await lix.close();
+
+	const statements = bodies[1]?.statements as Array<{
+		params: Array<Record<string, unknown>>;
+	}>;
+	expect(bodies[1]?.cacheBlobs).toBe(true);
+	expect(statements[0]?.params[0]).toMatchObject({
+		kind: "blob-splice",
+		prefixBytes: 32 * 1024 - 1,
+		suffixBytes: 0,
+		insertBase64: "Yg==",
+	});
+});
+
 test("remote branches preserve local Lix branch semantics", async () => {
 	const requests: Request[] = [];
 	let activeBranchId = "main-id";
@@ -586,6 +824,24 @@ test("close waits for queued operations before deleting the remote session", asy
 	await Promise.all([executing, closing]);
 	expect(order).toEqual(["execute-start", "execute-finish", "delete"]);
 });
+
+function handshakeResponse() {
+	return Response.json({
+		protocolVersion: 1,
+		activeBranchId: "main-id",
+		sessionId: "session-1",
+		capabilities: { requestBlobSplice: true },
+	});
+}
+
+function emptyExecuteResponse() {
+	return {
+		columns: [],
+		rows: [],
+		rowsAffected: 1,
+		notices: [],
+	};
+}
 
 function deferred<T>() {
 	let resolve!: (value: T | PromiseLike<T>) => void;

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -30,12 +30,24 @@ import {
 	REMOTE_PROTOCOL_PATH,
 	remoteError,
 	type RemoteObserveSubscription,
+	type WireRequestBlobSplice,
+	type WireRequestValue,
+	type WireValue,
 } from "./protocol.js";
 import { readSseEvents } from "./sse.js";
 
 const OBSERVE_RETRY_BASE_MS = 100;
 const OBSERVE_RETRY_MAX_MS = 5_000;
 const REMOTE_SESSION_HEADER = "Lix-Session-Id";
+const REQUEST_BLOB_DELTA_MIN_BYTES = 32 * 1024;
+const REQUEST_BLOB_DELTA_MIN_WIRE_RATIO = 0.9;
+const REQUEST_BLOB_BASE_MAX_ENTRIES = 8;
+const REQUEST_BLOB_BASE_MAX_BYTES = 2 * 1024 * 1024;
+const REMOTE_BLOB_BASE_MISSING = "LIX_REMOTE_BLOB_BASE_MISSING";
+const WIRE_BLOB_JSON_ENVELOPE_BYTES = JSON.stringify({
+	kind: "blob",
+	base64: "",
+}).length;
 
 export async function openRemoteLixBinding(
 	options: RemoteLixServerOptions,
@@ -50,7 +62,10 @@ class RemoteLixBinding implements LixBinding {
 	readonly #fetch: NonNullable<RemoteLixServerOptions["fetch"]>;
 	readonly #headers: RemoteLixServerOptions["headers"];
 	readonly #observationHub: RemoteObservationHub;
+	readonly #requestBlobBases = new Map<string, RequestBlobBase>();
 	#sessionId: string | undefined;
+	#supportsRequestBlobSplice = false;
+	#requestBlobBaseBytes = 0;
 	#acceptingOperations = true;
 	#operationQueue: Promise<void> = Promise.resolve();
 	#closePromise: Promise<void> | undefined;
@@ -89,6 +104,7 @@ class RemoteLixBinding implements LixBinding {
 			await this.#requestJson("", { method: "GET" }),
 		);
 		this.#sessionId = handshake.sessionId;
+		this.#supportsRequestBlobSplice = handshake.requestBlobSplice;
 	}
 
 	async execute(
@@ -97,18 +113,30 @@ class RemoteLixBinding implements LixBinding {
 		options?: ExecuteOptions,
 	): Promise<BindingExecuteResult> {
 		this.#assertOpen();
-		return this.#enqueue(async () =>
-			decodeExecuteResult(
-				await this.#requestJson("execute", {
+		const snapshot = snapshotParams(params);
+		return this.#enqueue(async () => {
+			const prepared = await this.#prepareParams(
+				snapshot,
+				(index) => requestBlobSlot("execute", sql, index),
+			);
+			const request = (params: WireRequestValue[]) =>
+				this.#requestJson("execute", {
 					method: "POST",
 					body: JSON.stringify({
 						sql,
-						params: params.map(encodeWireValue),
+						params,
 						...(options === undefined ? {} : { options }),
+						...(prepared.cacheBlobs ? { cacheBlobs: true } : {}),
 					}),
-				}),
-			),
-		);
+				});
+			const value = await requestWithFullBlobFallback(
+				() => request(prepared.params),
+				prepared.hasDelta ? () => request(prepared.fullParams()) : undefined,
+			);
+			const result = decodeExecuteResult(value);
+			this.#commitRequestBlobBases(prepared.cacheUpdates);
+			return result;
+		});
 	}
 
 	async executeBatch(
@@ -116,21 +144,58 @@ class RemoteLixBinding implements LixBinding {
 		options?: LixBatchOptions,
 	): Promise<BindingExecuteResult[]> {
 		this.#assertOpen();
+		const snapshot = statements.map((statement) => ({
+			sql: statement.sql,
+			params: snapshotParams(statement.params),
+		}));
 		return this.#enqueue(async () => {
-			const value = await this.#requestJson("execute-batch", {
-				method: "POST",
-				body: JSON.stringify({
-					statements: statements.map((statement) => ({
-						sql: statement.sql,
-						params: statement.params.map(encodeWireValue),
-					})),
-					...(options === undefined ? {} : { options }),
-				}),
-			});
+			const preparedStatements = await Promise.all(
+				snapshot.map(async (statement, statementIndex) => ({
+					sql: statement.sql,
+					prepared: await this.#prepareParams(statement.params, (paramIndex) =>
+						requestBlobSlot(
+							"batch",
+							statement.sql,
+							paramIndex,
+							statementIndex,
+						),
+					),
+				})),
+			);
+			const cacheBlobs = preparedStatements.some(
+				(statement) => statement.prepared.cacheBlobs,
+			);
+			const hasDelta = preparedStatements.some(
+				(statement) => statement.prepared.hasDelta,
+			);
+			const request = (full: boolean) =>
+				this.#requestJson("execute-batch", {
+					method: "POST",
+					body: JSON.stringify({
+						statements: preparedStatements.map((statement) => ({
+							sql: statement.sql,
+							params: full
+								? statement.prepared.fullParams()
+								: statement.prepared.params,
+						})),
+						...(options === undefined ? {} : { options }),
+						...(cacheBlobs ? { cacheBlobs: true } : {}),
+					}),
+				});
+			const value = await requestWithFullBlobFallback(
+				() => request(false),
+				hasDelta ? () => request(true) : undefined,
+			);
 			if (!Array.isArray(value)) {
 				throw protocolError("execute batch response must be an array");
 			}
-			return value.map(decodeExecuteResult);
+			const results = value.map(decodeExecuteResult);
+			this.#commitRequestBlobBases(
+				preparedStatements.flatMap(
+					(statement) => statement.prepared.cacheUpdates,
+				),
+			);
+			return results;
 		});
 	}
 
@@ -317,6 +382,81 @@ class RemoteLixBinding implements LixBinding {
 		}
 	}
 
+	async #prepareParams(
+		params: NativeLixValue[],
+		slot: (index: number) => string,
+	): Promise<PreparedRequestParams> {
+		const prepared = await Promise.all(
+			params.map(async (param, index): Promise<PreparedRequestParam> => {
+				if (
+					!this.#supportsRequestBlobSplice ||
+					param.kind !== "blob" ||
+					param.blob.byteLength < REQUEST_BLOB_DELTA_MIN_BYTES ||
+					param.blob.byteLength > REQUEST_BLOB_BASE_MAX_BYTES
+				) {
+					return fullRequestParam(param);
+				}
+				const resultSha256 = await sha256Hex(param.blob);
+				if (resultSha256 === undefined) return fullRequestParam(param);
+				const cacheSlot = slot(index);
+				const cacheUpdate = {
+					slot: cacheSlot,
+					base: {
+						sha256: resultSha256,
+						bytes: param.blob,
+					},
+				};
+				const base = this.#requestBlobBases.get(cacheSlot);
+				if (base === undefined) {
+					return { ...fullRequestParam(param), cacheUpdate };
+				}
+				const delta = planBlobSplice(base, param.blob, resultSha256);
+				if (!blobSpliceIsAtLeastTenPercentSmaller(delta, param.blob)) {
+					return { ...fullRequestParam(param), cacheUpdate };
+				}
+				return {
+					value: encodeBlobSplice(delta),
+					full: () => encodeWireValue(param),
+					cacheUpdate,
+				};
+			}),
+		);
+		return {
+			params: prepared.map((param) => param.value),
+			fullParams: () => prepared.map((param) => param.full()),
+			cacheUpdates: prepared.flatMap((param) =>
+				param.cacheUpdate === undefined ? [] : [param.cacheUpdate],
+			),
+			cacheBlobs: prepared.some((param) => param.cacheUpdate !== undefined),
+			hasDelta: prepared.some((param) => param.value.kind === "blob-splice"),
+		};
+	}
+
+	#commitRequestBlobBases(updates: RequestBlobCacheUpdate[]): void {
+		for (const update of updates) {
+			const previous = this.#requestBlobBases.get(update.slot);
+			if (previous !== undefined) {
+				this.#requestBlobBaseBytes -= previous.bytes.byteLength;
+				this.#requestBlobBases.delete(update.slot);
+			}
+			if (update.base.bytes.byteLength > REQUEST_BLOB_BASE_MAX_BYTES) continue;
+			while (
+				this.#requestBlobBases.size >= REQUEST_BLOB_BASE_MAX_ENTRIES ||
+				this.#requestBlobBaseBytes + update.base.bytes.byteLength >
+					REQUEST_BLOB_BASE_MAX_BYTES
+			) {
+				const oldest = this.#requestBlobBases.entries().next().value as
+					| [string, RequestBlobBase]
+					| undefined;
+				if (oldest === undefined) break;
+				this.#requestBlobBases.delete(oldest[0]);
+				this.#requestBlobBaseBytes -= oldest[1].bytes.byteLength;
+			}
+			this.#requestBlobBases.set(update.slot, update.base);
+			this.#requestBlobBaseBytes += update.base.bytes.byteLength;
+		}
+	}
+
 	#assertOpen(): void {
 		if (!this.#acceptingOperations) {
 			throw remoteError("LIX_ERROR_CLOSED", "Lix is closed");
@@ -331,6 +471,189 @@ class RemoteLixBinding implements LixBinding {
 		);
 		return result;
 	}
+}
+
+type RequestBlobBase = {
+	sha256: string;
+	bytes: Uint8Array;
+};
+
+type RequestBlobCacheUpdate = {
+	slot: string;
+	base: RequestBlobBase;
+};
+
+type PreparedRequestParam = {
+	value: WireRequestValue;
+	full: () => WireValue;
+	cacheUpdate?: RequestBlobCacheUpdate;
+};
+
+type PreparedRequestParams = {
+	params: WireRequestValue[];
+	fullParams: () => WireValue[];
+	cacheUpdates: RequestBlobCacheUpdate[];
+	cacheBlobs: boolean;
+	hasDelta: boolean;
+};
+
+type BlobSplicePlan = {
+	baseSha256: string;
+	resultSha256: string;
+	prefixBytes: number;
+	suffixBytes: number;
+	insert: Uint8Array;
+};
+
+function fullRequestParam(param: NativeLixValue): PreparedRequestParam {
+	const full = encodeWireValue(param);
+	return { value: full, full: () => full };
+}
+
+function snapshotParams(params: NativeLixValue[]): NativeLixValue[] {
+	return params.map((param) =>
+		param.kind === "blob"
+			? { kind: "blob", value: null, blob: new Uint8Array(param.blob) }
+			: param,
+	);
+}
+
+function requestBlobSlot(
+	kind: "execute" | "batch",
+	sql: string,
+	paramIndex: number,
+	statementIndex?: number,
+): string {
+	return JSON.stringify([kind, statementIndex, sql, paramIndex]);
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string | undefined> {
+	const subtle = globalThis.crypto?.subtle;
+	if (subtle === undefined) return undefined;
+	try {
+		const input =
+			bytes.buffer instanceof ArrayBuffer &&
+			bytes.byteOffset === 0 &&
+			bytes.byteLength === bytes.buffer.byteLength
+				? bytes.buffer
+				: copyArrayBuffer(bytes);
+		const digest = await subtle.digest("SHA-256", input);
+		return Array.from(new Uint8Array(digest), (byte) =>
+			byte.toString(16).padStart(2, "0"),
+		).join("");
+	} catch {
+		return undefined;
+	}
+}
+
+function planBlobSplice(
+	base: RequestBlobBase,
+	result: Uint8Array,
+	resultSha256: string,
+): BlobSplicePlan {
+	let prefixBytes = 0;
+	const prefixLimit = Math.min(base.bytes.byteLength, result.byteLength);
+	while (
+		prefixBytes < prefixLimit &&
+		base.bytes[prefixBytes] === result[prefixBytes]
+	) {
+		prefixBytes += 1;
+	}
+
+	let suffixBytes = 0;
+	const suffixLimit = Math.min(
+		base.bytes.byteLength - prefixBytes,
+		result.byteLength - prefixBytes,
+	);
+	while (
+		suffixBytes < suffixLimit &&
+		base.bytes[base.bytes.byteLength - suffixBytes - 1] ===
+			result[result.byteLength - suffixBytes - 1]
+	) {
+		suffixBytes += 1;
+	}
+
+	const insert = result.subarray(
+		prefixBytes,
+		result.byteLength - suffixBytes,
+	);
+	return {
+		baseSha256: base.sha256,
+		resultSha256,
+		prefixBytes,
+		suffixBytes,
+		insert,
+	};
+}
+
+function encodeBlobSplice(plan: BlobSplicePlan): WireRequestBlobSplice {
+	const encodedInsert = encodeWireValue({
+		kind: "blob",
+		value: null,
+		blob: plan.insert,
+	});
+	if (encodedInsert.kind !== "blob") {
+		throw protocolError("request blob splice insert could not be encoded");
+	}
+	return {
+		kind: "blob-splice",
+		baseSha256: plan.baseSha256,
+		resultSha256: plan.resultSha256,
+		prefixBytes: plan.prefixBytes,
+		suffixBytes: plan.suffixBytes,
+		insertBase64: encodedInsert.base64,
+	};
+}
+
+function blobSpliceIsAtLeastTenPercentSmaller(
+	delta: BlobSplicePlan,
+	full: Uint8Array,
+): boolean {
+	const deltaEnvelopeBytes = JSON.stringify({
+		kind: "blob-splice",
+		baseSha256: delta.baseSha256,
+		resultSha256: delta.resultSha256,
+		prefixBytes: delta.prefixBytes,
+		suffixBytes: delta.suffixBytes,
+		insertBase64: "",
+	}).length;
+	const deltaBytes =
+		deltaEnvelopeBytes + base64EncodedLength(delta.insert.byteLength);
+	const fullBytes =
+		WIRE_BLOB_JSON_ENVELOPE_BYTES + base64EncodedLength(full.byteLength);
+	return (
+		deltaBytes < fullBytes * REQUEST_BLOB_DELTA_MIN_WIRE_RATIO
+	);
+}
+
+function base64EncodedLength(byteLength: number): number {
+	return 4 * Math.ceil(byteLength / 3);
+}
+
+async function requestWithFullBlobFallback<T>(
+	request: () => Promise<T>,
+	fullFallback: (() => Promise<T>) | undefined,
+): Promise<T> {
+	try {
+		return await request();
+	} catch (error) {
+		if (fullFallback !== undefined && errorCode(error) === REMOTE_BLOB_BASE_MISSING) {
+			return await fullFallback();
+		}
+		throw error;
+	}
+}
+
+function errorCode(error: unknown): string | undefined {
+	return error instanceof Error && "code" in error
+		? (error as { code?: string }).code
+		: undefined;
+}
+
+function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	return copy.buffer;
 }
 
 type ObserveWaiter = {

--- a/packages/js-sdk/src/remote/protocol.test.ts
+++ b/packages/js-sdk/src/remote/protocol.test.ts
@@ -1,9 +1,30 @@
 import { expect, test, vi } from "vitest";
 import {
 	decodeExecuteResult,
+	decodeHandshake,
 	decodeObserveEvent,
 	encodeWireValue,
 } from "./protocol.js";
+
+test.each([
+	[undefined, false],
+	[{}, false],
+	[{ requestBlobSplice: false }, false],
+	[{ requestBlobSplice: "true" }, false],
+	[{ requestBlobSplice: true }, true],
+])(
+	"remote handshake negotiates only the exact blob splice capability: %j",
+	(capabilities, expected) => {
+		expect(
+			decodeHandshake({
+				protocolVersion: 1,
+				activeBranchId: "main-id",
+				sessionId: "session-1",
+				...(capabilities === undefined ? {} : { capabilities }),
+			}).requestBlobSplice,
+		).toBe(expected);
+	},
+);
 
 test("remote blobs use native typed-array base64 when available", () => {
 	const prototype = Uint8Array.prototype as Uint8Array & {

--- a/packages/js-sdk/src/remote/protocol.ts
+++ b/packages/js-sdk/src/remote/protocol.ts
@@ -16,21 +16,35 @@ export type WireValue =
 	| { kind: "json"; value: unknown }
 	| { kind: "blob"; base64: string };
 
+export type WireRequestBlobSplice = {
+	kind: "blob-splice";
+	baseSha256: string;
+	resultSha256: string;
+	prefixBytes: number;
+	suffixBytes: number;
+	insertBase64: string;
+};
+
+export type WireRequestValue = WireValue | WireRequestBlobSplice;
+
 export type RemoteHandshake = {
 	protocolVersion: number;
 	activeBranchId: string;
 	sessionId: string;
+	requestBlobSplice: boolean;
 };
 
 export type RemoteExecuteRequest = {
 	sql: string;
-	params: WireValue[];
+	params: WireRequestValue[];
 	options?: { originKey?: string };
+	cacheBlobs?: true;
 };
 
 export type RemoteExecuteBatchRequest = {
-	statements: Array<{ sql: string; params: WireValue[] }>;
+	statements: Array<{ sql: string; params: WireRequestValue[] }>;
 	options?: { originKey?: string };
+	cacheBlobs?: true;
 };
 
 export type RemoteExecuteResponse = {
@@ -40,7 +54,10 @@ export type RemoteExecuteResponse = {
 	notices: Array<{ code: string; message: string; hint?: string }>;
 };
 
-export type RemoteObserveRequest = Omit<RemoteExecuteRequest, "options">;
+export type RemoteObserveRequest = {
+	sql: string;
+	params: WireValue[];
+};
 
 export type RemoteObserveSubscription = RemoteObserveRequest & {
 	id: string;
@@ -198,6 +215,9 @@ export function decodeHandshake(value: unknown): RemoteHandshake {
 		protocolVersion: REMOTE_PROTOCOL_VERSION,
 		activeBranchId: handshake.activeBranchId,
 		sessionId: handshake.sessionId,
+		requestBlobSplice:
+			isRecord(handshake.capabilities) &&
+			handshake.capabilities.requestBlobSplice === true,
 	};
 }
 
@@ -369,6 +389,10 @@ export function record(
 		throw protocolError(`${description} must be an object`);
 	}
 	return value as Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function decodeWireValue(value: unknown): NativeLixValue {

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -24,6 +24,7 @@ getrandom = "0.3"
 lix_sdk = { path = "../rs-sdk", version = "0.8.4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tokio = { version = "1", features = ["sync", "rt"] }
 tracing = "0.1"
 

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -17,8 +17,9 @@ use lix_sdk::{
     ObserveEvent, ObserveEvents, Storage, SwitchBranchOptions, Value, WireValue,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     convert::Infallible,
     future::Future,
     sync::{
@@ -50,6 +51,14 @@ pub const DEFAULT_SESSION_IDLE_TIMEOUT: Duration = Duration::from_mins(30);
 pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
 /// Maximum number of queries multiplexed onto one observation stream.
 pub const MAX_MULTIPLEX_SUBSCRIPTIONS: usize = 32;
+
+/// Maximum number of request blobs retained by one remote session.
+const MAX_REQUEST_BLOB_CACHE_ENTRIES: usize = 8;
+/// Blobs below this size are cheaper to send whole than to retain and hash.
+const MIN_REQUEST_BLOB_CACHE_BYTES: usize = 32 * 1024;
+/// Maximum aggregate bytes retained by one remote session's request blob cache.
+const MAX_REQUEST_BLOB_CACHE_BYTES: usize = 2 * 1024 * 1024;
+const BLOB_BASE_MISSING_CODE: &str = "LIX_REMOTE_BLOB_BASE_MISSING";
 
 const SESSION_TOKEN_BYTES: usize = 32;
 const SESSION_TOKEN_HEX_LEN: usize = SESSION_TOKEN_BYTES * 2;
@@ -128,6 +137,49 @@ where
     lix: Arc<Lix<S>>,
     last_used: Mutex<Instant>,
     leases: AtomicUsize,
+    request_blobs: Mutex<RequestBlobCache>,
+}
+
+#[derive(Default)]
+struct RequestBlobCache {
+    entries: HashMap<String, Arc<[u8]>>,
+    insertion_order: VecDeque<String>,
+    total_bytes: usize,
+}
+
+impl RequestBlobCache {
+    fn get(&self, sha256: &str) -> Option<Arc<[u8]>> {
+        self.entries.get(sha256).cloned()
+    }
+
+    fn insert(&mut self, candidate: CachedRequestBlob) {
+        if !is_request_blob_cacheable(candidate.bytes.len())
+            || self.entries.contains_key(&candidate.sha256)
+        {
+            return;
+        }
+        while self.entries.len() >= MAX_REQUEST_BLOB_CACHE_ENTRIES
+            || self
+                .total_bytes
+                .checked_add(candidate.bytes.len())
+                .is_none_or(|total| total > MAX_REQUEST_BLOB_CACHE_BYTES)
+        {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            if let Some(removed) = self.entries.remove(&oldest) {
+                self.total_bytes = self.total_bytes.saturating_sub(removed.len());
+            }
+        }
+        self.total_bytes += candidate.bytes.len();
+        self.insertion_order.push_back(candidate.sha256.clone());
+        self.entries.insert(candidate.sha256, candidate.bytes);
+    }
+}
+
+struct CachedRequestBlob {
+    sha256: String,
+    bytes: Arc<[u8]>,
 }
 
 impl<S> SessionRecord<S>
@@ -139,6 +191,7 @@ where
             lix: Arc::new(lix),
             last_used: Mutex::new(now),
             leases: AtomicUsize::new(0),
+            request_blobs: Mutex::new(RequestBlobCache::default()),
         }
     }
 
@@ -172,6 +225,23 @@ where
 
     fn is_idle_expired(&self, now: Instant, timeout: Duration) -> bool {
         self.lease_count() == 0 && now.saturating_duration_since(self.last_used()) >= timeout
+    }
+
+    fn request_blob(&self, sha256: &str) -> Option<Arc<[u8]>> {
+        self.request_blobs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(sha256)
+    }
+
+    fn cache_request_blobs(&self, candidates: Vec<CachedRequestBlob>) {
+        let mut cache = self
+            .request_blobs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for candidate in candidates {
+            cache.insert(candidate);
+        }
     }
 }
 
@@ -626,6 +696,9 @@ where
             protocol_version: PROTOCOL_VERSION,
             active_branch_id,
             session_id: lease.session_id.clone(),
+            capabilities: ProtocolCapabilities {
+                request_blob_splice: true,
+            },
         }),
     ))
 }
@@ -650,11 +723,24 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let sql = required_non_empty(request.sql, "sql")?;
-    let params = decode_params(request.params)?;
+    let mut reconstructed_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+    let mut cache_candidate_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+    let mut cache_candidates = Vec::new();
+    let decoded = decode_request_params(
+        request.params,
+        None,
+        request.cache_blobs,
+        &mut reconstructed_bytes_remaining,
+        &mut cache_candidate_bytes_remaining,
+        &mut cache_candidates,
+        |sha256| lease.record.request_blob(sha256),
+    )?;
     let options = request.options.into();
+    let params = decoded.values;
     let result = lease
         .run(move |lix| async move { lix.execute_with_options(&sql, &params, options).await })
         .await?;
+    lease.record.cache_request_blobs(cache_candidates);
     Ok(Json(ExecuteResponse::try_from(result)?))
 }
 
@@ -668,14 +754,26 @@ where
     if request.statements.is_empty() {
         return Err(ApiError::bad_request("statements must not be empty"));
     }
+    let mut cache_candidates = Vec::new();
+    let mut reconstructed_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+    let mut cache_candidate_bytes_remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
     let statements = request
         .statements
         .into_iter()
         .enumerate()
         .map(|(index, statement)| {
+            let decoded = decode_request_params(
+                statement.params,
+                Some(index),
+                request.cache_blobs,
+                &mut reconstructed_bytes_remaining,
+                &mut cache_candidate_bytes_remaining,
+                &mut cache_candidates,
+                |sha256| lease.record.request_blob(sha256),
+            )?;
             Ok(ExecuteBatchStatement {
                 sql: required_non_empty(statement.sql, "statements[].sql")?,
-                params: decode_params_at(statement.params, Some(index))?,
+                params: decoded.values,
             })
         })
         .collect::<Result<Vec<_>, ApiError>>()?;
@@ -683,6 +781,7 @@ where
     let results = lease
         .run(move |lix| async move { lix.execute_batch_with_options(&statements, options).await })
         .await?;
+    lease.record.cache_request_blobs(cache_candidates);
     Ok(Json(
         results
             .into_iter()
@@ -914,6 +1013,228 @@ fn decode_params_at(
         .collect()
 }
 
+struct DecodedRequestParams {
+    values: Vec<Value>,
+}
+
+fn decode_request_params(
+    params: Vec<RequestWireValue>,
+    statement_index: Option<usize>,
+    cache_full_blobs: bool,
+    reconstructed_bytes_remaining: &mut usize,
+    cache_candidate_bytes_remaining: &mut usize,
+    cache_candidates: &mut Vec<CachedRequestBlob>,
+    lookup_blob: impl Fn(&str) -> Option<Arc<[u8]>>,
+) -> Result<DecodedRequestParams, ApiError> {
+    let mut values = Vec::with_capacity(params.len());
+    for (parameter_index, value) in params.into_iter().enumerate() {
+        match value {
+            RequestWireValue::Value(value) => {
+                let value = value.try_into_engine().map_err(|error| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        error.code,
+                        error.message,
+                    )
+                })?;
+                if cache_full_blobs
+                    && let Value::Blob(bytes) = &value
+                    && is_request_blob_cacheable(bytes.len())
+                    && bytes.len() <= *cache_candidate_bytes_remaining
+                {
+                    prepare_cache_candidate(
+                        sha256_hex(bytes),
+                        bytes,
+                        cache_candidate_bytes_remaining,
+                        cache_candidates,
+                    );
+                }
+                values.push(value);
+            }
+            RequestWireValue::BlobSplice(splice) => {
+                let base_sha256 = splice.base_sha256;
+                let result_sha256 = splice.result_sha256;
+                if !is_lowercase_sha256(&base_sha256) {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice baseSha256 must be a lowercase SHA-256 hex digest",
+                    ));
+                }
+                if !is_lowercase_sha256(&result_sha256) {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice resultSha256 must be a lowercase SHA-256 hex digest",
+                    ));
+                }
+                let Some(base) = lookup_blob(&base_sha256) else {
+                    return Err(ApiError::blob_base_missing(
+                        base_sha256,
+                        parameter_index,
+                        statement_index,
+                    ));
+                };
+                let prefix = usize::try_from(splice.prefix_bytes).map_err(|_| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice prefixBytes is too large",
+                    )
+                })?;
+                let suffix = usize::try_from(splice.suffix_bytes).map_err(|_| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice suffixBytes is too large",
+                    )
+                })?;
+                if prefix > base.len()
+                    || suffix > base.len()
+                    || prefix.saturating_add(suffix) > base.len()
+                {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice prefix and suffix must not overlap the cached base",
+                    ));
+                }
+                let insert = WireValue::Blob {
+                    base64: splice.insert_base64,
+                }
+                .try_into_engine()
+                .map_err(|error| {
+                    invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        error.code,
+                        format!("invalid blob splice insertBase64: {}", error.message),
+                    )
+                })?;
+                let Value::Blob(insert) = insert else {
+                    unreachable!("WireValue::Blob must decode to Value::Blob")
+                };
+                let reconstructed_len = prefix
+                    .checked_add(insert.len())
+                    .and_then(|length| length.checked_add(suffix))
+                    .ok_or_else(|| {
+                        invalid_parameter_error(
+                            parameter_index,
+                            statement_index,
+                            LixError::CODE_INVALID_PARAM,
+                            "reconstructed blob size overflows the server address space",
+                        )
+                    })?;
+                if reconstructed_len > *reconstructed_bytes_remaining {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        format!(
+                            "aggregate reconstructed blobs exceed the {MAX_REQUEST_BLOB_CACHE_BYTES}-byte request limit"
+                        ),
+                    ));
+                }
+                *reconstructed_bytes_remaining -= reconstructed_len;
+                let mut reconstructed = Vec::with_capacity(reconstructed_len);
+                reconstructed.extend_from_slice(&base[..prefix]);
+                reconstructed.extend_from_slice(&insert);
+                reconstructed.extend_from_slice(&base[base.len() - suffix..]);
+                let actual_sha256 = sha256_hex(&reconstructed);
+                if actual_sha256 != result_sha256 {
+                    return Err(invalid_parameter_error(
+                        parameter_index,
+                        statement_index,
+                        LixError::CODE_INVALID_PARAM,
+                        "blob splice resultSha256 does not match the reconstructed bytes",
+                    ));
+                }
+                prepare_cache_candidate(
+                    result_sha256,
+                    &reconstructed,
+                    cache_candidate_bytes_remaining,
+                    cache_candidates,
+                );
+                values.push(Value::Blob(reconstructed));
+            }
+        }
+    }
+    Ok(DecodedRequestParams { values })
+}
+
+fn prepare_cache_candidate(
+    sha256: String,
+    bytes: &[u8],
+    bytes_remaining: &mut usize,
+    candidates: &mut Vec<CachedRequestBlob>,
+) {
+    if !is_request_blob_cacheable(bytes.len())
+        || bytes.len() > *bytes_remaining
+        || candidates
+            .iter()
+            .any(|candidate| candidate.sha256 == sha256)
+    {
+        return;
+    }
+    *bytes_remaining -= bytes.len();
+    candidates.push(CachedRequestBlob {
+        sha256,
+        bytes: Arc::from(bytes.to_vec()),
+    });
+}
+
+fn invalid_parameter_error(
+    parameter_index: usize,
+    statement_index: Option<usize>,
+    source_code: impl Into<String>,
+    message: impl Into<String>,
+) -> ApiError {
+    let mut details = serde_json::json!({
+        "parameterIndex": parameter_index,
+        "sourceCode": source_code.into(),
+    });
+    if let Some(statement_index) = statement_index {
+        details["statementIndex"] = statement_index.into();
+    }
+    ApiError::from(
+        LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            format!(
+                "invalid SQL parameter at index {parameter_index}: {}",
+                message.into()
+            ),
+        )
+        .with_details(details),
+    )
+}
+
+fn is_lowercase_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn is_request_blob_cacheable(length: usize) -> bool {
+    (MIN_REQUEST_BLOB_CACHE_BYTES..=MAX_REQUEST_BLOB_CACHE_BYTES).contains(&length)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
 fn required_non_empty(value: Option<String>, field: &'static str) -> Result<String, ApiError> {
     match value {
         Some(value) if !value.trim().is_empty() => Ok(value),
@@ -955,6 +1276,29 @@ impl ApiError {
                 message,
                 None,
                 None,
+            ),
+        }
+    }
+
+    fn blob_base_missing(
+        base_sha256: String,
+        parameter_index: usize,
+        statement_index: Option<usize>,
+    ) -> Self {
+        let mut details = serde_json::json!({
+            "baseSha256": base_sha256,
+            "parameterIndex": parameter_index,
+        });
+        if let Some(statement_index) = statement_index {
+            details["statementIndex"] = statement_index.into();
+        }
+        Self {
+            status: StatusCode::CONFLICT,
+            body: ErrorEnvelope::from_parts(
+                BLOB_BASE_MISSING_CODE,
+                "the blob splice base is not available in this remote session",
+                Some("retry the request with the complete blob".to_string()),
+                Some(details),
             ),
         }
     }
@@ -1071,6 +1415,13 @@ struct HandshakeResponse {
     protocol_version: u32,
     active_branch_id: String,
     session_id: String,
+    capabilities: ProtocolCapabilities,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProtocolCapabilities {
+    request_blob_splice: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1078,9 +1429,11 @@ struct HandshakeResponse {
 struct ExecuteRequest {
     sql: Option<String>,
     #[serde(default)]
-    params: Vec<WireValue>,
+    params: Vec<RequestWireValue>,
     #[serde(default)]
     options: ExecuteOptionsRequest,
+    #[serde(default)]
+    cache_blobs: bool,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1104,13 +1457,40 @@ struct ExecuteBatchRequest {
     statements: Vec<ExecuteBatchStatementRequest>,
     #[serde(default)]
     options: ExecuteOptionsRequest,
+    #[serde(default)]
+    cache_blobs: bool,
 }
 
 #[derive(Debug, Deserialize)]
 struct ExecuteBatchStatementRequest {
     sql: Option<String>,
     #[serde(default)]
-    params: Vec<WireValue>,
+    params: Vec<RequestWireValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RequestWireValue {
+    BlobSplice(RequestBlobSplice),
+    Value(WireValue),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RequestBlobSplice {
+    #[serde(rename = "kind")]
+    _kind: RequestBlobSpliceKind,
+    base_sha256: String,
+    result_sha256: String,
+    prefix_bytes: u64,
+    suffix_bytes: u64,
+    insert_base64: String,
+}
+
+#[derive(Debug, Deserialize)]
+enum RequestBlobSpliceKind {
+    #[serde(rename = "blob-splice")]
+    BlobSplice,
 }
 
 #[derive(Debug, Serialize)]
@@ -1543,6 +1923,33 @@ mod tests {
         serde_json::from_slice(&bytes).expect("json")
     }
 
+    fn wire_blob_json(bytes: &[u8]) -> JsonValue {
+        let value =
+            WireValue::try_from_engine(&Value::Blob(bytes.to_vec())).expect("blob should encode");
+        serde_json::to_value(value).expect("wire blob should serialize")
+    }
+
+    fn blob_splice_json(
+        base: &[u8],
+        result: &[u8],
+        prefix_bytes: usize,
+        suffix_bytes: usize,
+        insert: &[u8],
+    ) -> JsonValue {
+        let insert_base64 = wire_blob_json(insert)["base64"]
+            .as_str()
+            .expect("blob base64")
+            .to_string();
+        json!({
+            "kind": "blob-splice",
+            "baseSha256": sha256_hex(base),
+            "resultSha256": sha256_hex(result),
+            "prefixBytes": prefix_bytes,
+            "suffixBytes": suffix_bytes,
+            "insertBase64": insert_base64,
+        })
+    }
+
     async fn error_code(response: Response) -> String {
         response_json(response).await["error"]["code"]
             .as_str()
@@ -1555,6 +1962,7 @@ mod tests {
         let app = app().await;
         let (session_id, first) = new_session(&app.router).await;
         assert_eq!(first["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(first["capabilities"]["requestBlobSplice"], true);
         assert_eq!(session_id.len(), SESSION_TOKEN_HEX_LEN);
         assert!(
             session_id
@@ -1715,6 +2123,395 @@ mod tests {
         assert_eq!(body.as_array().map(Vec::len), Some(2));
         assert_eq!(body[0]["rows"][0][0], json!({ "kind": "int", "value": 1 }));
         assert_eq!(body[1]["rows"][0][0], json!({ "kind": "int", "value": 2 }));
+    }
+
+    #[tokio::test]
+    async fn execute_reconstructs_cached_blob_splices_and_caches_each_result() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1 AS data",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let first_insert = b"BETA";
+        let replace_at = base.len() / 2;
+        let mut first = base.clone();
+        first[replace_at..replace_at + first_insert.len()].copy_from_slice(first_insert);
+        let first_response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1 AS data",
+                "params": [blob_splice_json(
+                    &base,
+                    &first,
+                    replace_at,
+                    base.len() - replace_at - first_insert.len(),
+                    first_insert,
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(first_response.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(first_response).await["rows"][0][0],
+            wire_blob_json(&first)
+        );
+
+        let second_insert = b"!";
+        let mut second = first.clone();
+        second.extend_from_slice(second_insert);
+        let second_response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1 AS data",
+                "params": [blob_splice_json(
+                    &first,
+                    &second,
+                    first.len(),
+                    0,
+                    second_insert,
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(second_response.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(second_response).await["rows"][0][0],
+            wire_blob_json(&second)
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_batch_accepts_blob_splices() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let mut result = base.clone();
+        result[0] = b'b';
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute-batch",
+            Some(&session_id),
+            Some(json!({
+                "statements": [
+                    {
+                        "sql": "SELECT $1 AS data",
+                        "params": [blob_splice_json(
+                            &base,
+                            &result,
+                            0,
+                            base.len() - 1,
+                            b"b",
+                        )],
+                    },
+                    { "sql": "SELECT 2 AS value" },
+                ],
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body[0]["rows"][0][0], wire_blob_json(&result));
+        assert_eq!(body[1]["rows"][0][0], json!({ "kind": "int", "value": 2 }));
+    }
+
+    #[tokio::test]
+    async fn missing_blob_splice_base_fails_before_sql_mutation() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let absent_base = b"not cached";
+        let result = b"replacement";
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                "params": [
+                    { "kind": "text", "value": "/must-not-exist.bin" },
+                    blob_splice_json(absent_base, result, 0, 0, result),
+                ],
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(error_code(response).await, BLOB_BASE_MISSING_CODE);
+
+        let read = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/must-not-exist.bin" }],
+            })),
+        )
+        .await;
+        assert_eq!(read.status(), StatusCode::OK);
+        assert_eq!(response_json(read).await["rows"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn execute_batch_bounds_aggregate_blob_reconstruction_before_mutation() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MAX_REQUEST_BLOB_CACHE_BYTES / 2];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                "params": [
+                    { "kind": "text", "value": "/aggregate-base.bin" },
+                    wire_blob_json(&base),
+                ],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let mut result = base.clone();
+        result.push(b'b');
+        let splice = blob_splice_json(&base, &result, base.len(), 0, b"b");
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute-batch",
+            Some(&session_id),
+            Some(json!({
+                "statements": [
+                    {
+                        "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                        "params": [
+                            { "kind": "text", "value": "/must-not-execute.bin" },
+                            splice,
+                        ],
+                    },
+                    {
+                        "sql": "SELECT $1",
+                        "params": [blob_splice_json(
+                            &base,
+                            &result,
+                            base.len(),
+                            0,
+                            b"b",
+                        )],
+                    },
+                ],
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(response).await, LixError::CODE_INVALID_PARAM);
+
+        let read = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/must-not-execute.bin" }],
+            })),
+        )
+        .await;
+        assert_eq!(read.status(), StatusCode::OK);
+        assert_eq!(response_json(read).await["rows"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn failed_execute_does_not_publish_full_blob_cache_candidates() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let failed = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "NOT VALID SQL",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_ne!(failed.status(), StatusCode::OK);
+
+        let mut result = base.clone();
+        result[0] = b'b';
+        let missing = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [blob_splice_json(
+                    &base,
+                    &result,
+                    0,
+                    base.len() - 1,
+                    b"b",
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::CONFLICT);
+        assert_eq!(error_code(missing).await, BLOB_BASE_MISSING_CODE);
+    }
+
+    #[tokio::test]
+    async fn malformed_and_hash_mismatched_blob_splices_are_rejected() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let base = vec![b'a'; MIN_REQUEST_BLOB_CACHE_BYTES];
+        let cached = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [wire_blob_json(&base)],
+                "cacheBlobs": true,
+            })),
+        )
+        .await;
+        assert_eq!(cached.status(), StatusCode::OK);
+
+        let overlap = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [blob_splice_json(
+                    &base,
+                    &base,
+                    base.len(),
+                    1,
+                    b"",
+                )],
+            })),
+        )
+        .await;
+        assert_eq!(overlap.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(overlap).await, LixError::CODE_INVALID_PARAM);
+
+        let mismatch = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT $1",
+                "params": [{
+                    "kind": "blob-splice",
+                    "baseSha256": sha256_hex(&base),
+                    "resultSha256": "0".repeat(64),
+                    "prefixBytes": base.len(),
+                    "suffixBytes": 0,
+                    "insertBase64": wire_blob_json(b"")["base64"],
+                }],
+            })),
+        )
+        .await;
+        assert_eq!(mismatch.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(mismatch).await, LixError::CODE_INVALID_PARAM);
+    }
+
+    #[test]
+    fn request_blob_cache_evicts_by_entry_and_byte_limits() {
+        let mut cache = RequestBlobCache::default();
+        for index in 0..=MAX_REQUEST_BLOB_CACHE_ENTRIES {
+            cache.insert(CachedRequestBlob {
+                sha256: format!("entry-{index}"),
+                bytes: Arc::from(vec![
+                    u8::try_from(index).expect("test index should fit");
+                    MIN_REQUEST_BLOB_CACHE_BYTES
+                ]),
+            });
+        }
+        assert_eq!(cache.entries.len(), MAX_REQUEST_BLOB_CACHE_ENTRIES);
+        assert!(cache.get("entry-0").is_none());
+        assert!(
+            cache
+                .get(&format!("entry-{MAX_REQUEST_BLOB_CACHE_ENTRIES}"))
+                .is_some()
+        );
+
+        cache.insert(CachedRequestBlob {
+            sha256: "too-large".to_string(),
+            bytes: Arc::from(vec![0_u8; MAX_REQUEST_BLOB_CACHE_BYTES + 1]),
+        });
+        assert!(cache.get("too-large").is_none());
+        assert!(cache.total_bytes <= MAX_REQUEST_BLOB_CACHE_BYTES);
+
+        cache.insert(CachedRequestBlob {
+            sha256: "too-small".to_string(),
+            bytes: Arc::from(vec![0_u8; MIN_REQUEST_BLOB_CACHE_BYTES - 1]),
+        });
+        assert!(cache.get("too-small").is_none());
+    }
+
+    #[test]
+    fn request_cache_candidates_share_one_bounded_clone_budget() {
+        let mut remaining = MAX_REQUEST_BLOB_CACHE_BYTES;
+        let mut candidates = Vec::new();
+        let first = vec![b'a'; MAX_REQUEST_BLOB_CACHE_BYTES / 2];
+        prepare_cache_candidate(sha256_hex(&first), &first, &mut remaining, &mut candidates);
+        let after_first = remaining;
+        prepare_cache_candidate(sha256_hex(&first), &first, &mut remaining, &mut candidates);
+        assert_eq!(remaining, after_first, "duplicate should reuse candidate");
+
+        let over_remaining = vec![b'b'; after_first + 1];
+        prepare_cache_candidate(
+            sha256_hex(&over_remaining),
+            &over_remaining,
+            &mut remaining,
+            &mut candidates,
+        );
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(remaining, after_first);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- transparently encode repeated 32 KiB–2 MiB Blob request parameters as one prefix/suffix splice
- address immutable session-local bases by SHA-256 and validate reconstructed bytes before SQL executes
- retry exactly once with the complete Blob when a base was evicted or lost
- negotiate the capability in the existing handshake; older servers keep receiving full Blobs
- leave SQL, commits, plugins, and the public Lix API unchanged

The client still calls `execute()` / `executeBatch()` with complete ordinary Blob values. This is strictly a transport optimization.

## Data

Chrome 149, 20 warmups + 120 samples, complete request preparation:

| Localized 32-byte edit | Full request | Splice request | Wire saving | Full p50 / p95 | Splice p50 / p95 |
| --- | ---: | ---: | ---: | ---: | ---: |
| 100 KiB | 136,677 B | 400 B | 99.707% | 0.2 / 0.5 ms | 0.3 / 0.5 ms |
| 1 MiB | 1,398,245 B | 402 B | 99.971% | 1.6 / 2.9 ms | 3.4 / 4.9 ms |

The selected splice path Base64-encodes only inserted bytes; the full fallback is encoded lazily only after a missing-base response.

Canonical two-session server rerun on this full stack (concurrent POST + peer SSE, 20 warmups + 120 samples, median p50 across three runs):

| Storage | 100 KiB peer-visible | 1 MiB peer-visible |
| --- | ---: | ---: |
| Memory | 4.66 ms | 8.19 ms |
| SlateDB / in-memory object store | 7.50 ms | 13.77 ms |

Those are zero-network lower bounds. Using exact frame sizes, measured Chrome codec times, the measured server p50s, 100 Mbps, and one 75 ms RTT, the repeated 1 MiB SlateDB path models from about 202 ms with a full upload to 94 ms with request + observation splices (-54%). Memory models from 198 ms to 88 ms (-56%). The 100 KiB path improves about 11–12%. At 1 Gbps/75 ms the gain falls below 10%, but both paths are already around the 100 ms target.

## Bounds and fallback

- splice is used only when its exact JSON value is strictly more than 10% smaller
- first writes, broad replacements, unsupported runtimes, and files outside 32 KiB–2 MiB stay full
- cache: at most 8 entries / 2 MiB per session
- one shared 2 MiB reconstruction budget and one 2 MiB candidate-clone budget per request/batch
- content hashes, Base64, lengths, overlap, and aggregate size are validated before execution
- `LIX_REMOTE_BLOB_BASE_MISSING` is emitted before SQL execution, making the one full retry non-duplicating

## Validation

- `cargo test -p lix_server_protocol` (27 tests)
- `cargo clippy -p lix_server_protocol --all-targets --no-deps -- -D warnings`
- `npx vitest run src/remote` (46 tests)
- `npm run typecheck`
- Lixray `strict_remote_sessions_merge_disjoint_markdown_blob_edits` integration test

## Stack

Base: #660, which provides change-proportional peer observations. That PR is based on #657. Review only commit `55fbaca1` for this layer.

#658 remains the independent adaptive-gzip fallback for first writes and broad replacements.