### PR TITLE
perf(engine): share acknowledged plugin file views

### DIFF
--- a/packages/engine/src/sql2/file_view.rs
+++ b/packages/engine/src/sql2/file_view.rs
@@ -41,7 +41,9 @@ pub(crate) struct SessionPluginFileView {
     /// prevents an old view from becoming valid again after plugin -> raw ->
     /// the same plugin.
     pub(crate) owner_change_id: String,
-    pub(crate) rows: Vec<MaterializedLiveStateRow>,
+    /// Immutable acknowledged rows are shared between deferred delivery and
+    /// the session cache. Cloning a view must not deep-clone every entity.
+    pub(crate) rows: Arc<[MaterializedLiveStateRow]>,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -3793,7 +3793,11 @@ async fn render_plugin_files_for_sql(
                         .owner_change_id_for_file(&file_key)
                         .expect("rendered plugin owner should have a change id")
                         .to_string(),
-                    rows: active_state.clone(),
+                    // Rendering only borrows the materialized state and this
+                    // is its final consumer. Move the row graph into the
+                    // session acknowledgement instead of deep-cloning every
+                    // entity on each exact blob read.
+                    rows: active_state.into(),
                 },
             );
         }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -621,7 +621,7 @@ where
                         && view.plugin_generation == plugin.archive_blob_hash()
                         && view.owner_change_id == owner_change_id =>
                 {
-                    Some(view.rows.clone())
+                    Some(view.rows.to_vec())
                 }
                 SessionFileViewMutation::Set { .. } | SessionFileViewMutation::Remove { .. } => {
                     None
@@ -635,7 +635,7 @@ where
                 plugin.archive_blob_hash(),
                 owner_change_id,
             )
-            .map(|view| view.rows)
+            .map(|view| view.rows.to_vec())
     }
 
     /// Reconciles plugin lifecycle, ownership, and state for one logical write
@@ -1437,7 +1437,7 @@ where
                         plugin_key: selected.key().to_string(),
                         plugin_generation: selected.archive_blob_hash().to_string(),
                         owner_change_id,
-                        rows: submitted_state,
+                        rows: submitted_state.into(),
                     },
                 },
             );


### PR DESCRIPTION
## What

- Store immutable acknowledged plugin rows as `Arc<[MaterializedLiveStateRow]>`.
- Move the renderer's final row vector into the acknowledgement instead of deep-cloning it.
- Materialize an owned `Vec` only when `detectChanges` needs one.

## Why

An acknowledgeable SQL blob read copied the complete semantic row graph through provider, deferred-result, and session ownership. That made each exact read scale with entity count in both CPU and retained memory.

## Measured impact

Release-mode SQL engine path using the real CSV Wasm plugin, raw RocksDB, and a 10.68 MiB / 220k-row file on an Apple M5 Pro:

| Alternating A/B | Forced rich clones p50 / p95 | Shared `Arc` p50 / p95 | p50 improvement |
|---|---:|---:|---:|
| A | 1,560.9 / 1,627.0 ms | 1,376.6 / 1,433.9 ms | 11.8% |
| B | 1,652.7 / 1,735.5 ms | 1,416.8 / 1,493.1 ms | 14.3% |

The paired max-RSS diagnostic fell by 137.3 MiB. A separate upstream acknowledgement/no-ack control attributed a conservative 62.72 MiB to retaining one rich view.

This isolates one ownership cost and should not be added arithmetically to the separate visibility-fast-path result.

## Semantic guardrails

- No plugin API or Wasm execution changes.
- File incarnation, plugin generation, owner change, and acknowledgement matching are unchanged.
- Omission/deletion authority is unchanged.
- The guest receives the same owned rows when detection runs; only immutable host-side ownership changes.

## Checks

- `cargo test -p lix_engine --lib`: 1,084 passed; 4 benchmark probes ignored.
- `cargo test -p lix_engine --test fs_api`: 52/52 passed, including the SlateDB concurrent merge case.
- `cargo clippy -p lix_engine --lib --all-features -- -D warnings`.
- `cargo fmt --all -- --check` and `git diff --check`.