### PR TITLE
perf(csv): build ordered projections without cloning rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,7 +4199,6 @@ dependencies = [
  "csv-nose",
  "encoding_rs",
  "imara-diff",
- "itertools 0.14.0",
  "lix_order_key",
  "rand 0.9.2",
  "serde_json",

--- a/plugins/csv/Cargo.toml
+++ b/plugins/csv/Cargo.toml
@@ -26,7 +26,6 @@ csv = "1"
 csv-nose = { version = "1.0.1", default-features = false }
 encoding_rs = "0.8"
 imara-diff = "0.2"
-itertools = "0.14"
 lix_order_key.workspace = true
 serde_json = "1"
 uuid = { version = "1", features = ["v7", "std", "js", "fast-rng"] }

--- a/plugins/csv/src/csv.rs
+++ b/plugins/csv/src/csv.rs
@@ -357,7 +357,7 @@ pub(crate) fn render_projection(projection: &Projection) -> Result<Vec<u8>, Plug
     }
     let mut writer = writer_builder.from_writer(Vec::new());
 
-    for row in projection.to_rows() {
+    for row in &projection.rows {
         writer.write_record(&row.cells).map_err(|error| {
             PluginError::Internal(format!("failed to render CSV row '{}': {error}", row.id))
         })?;

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -16,11 +16,9 @@ use crate::csv::{
 use crate::diff::{DiffRun, imara_diff_runs};
 pub use crate::exports::lix::plugin::api::{DetectedChange, File, PluginError};
 use crate::exports::lix::plugin::api::{EntityState, Guest as Plugin};
-use itertools::Itertools;
 use lix_order_key::OrderKey;
 use serde_json::Value;
-use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::str;
 use uuid::Uuid;
@@ -38,7 +36,7 @@ export!(CsvPlugin);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Projection {
-    rows_by_id: BTreeMap<String, RowSnapshot>,
+    rows: Vec<Row>,
     dialect: CsvDialect,
     table_present: bool,
 }
@@ -83,9 +81,9 @@ fn detect_changes_for_rows(
     file_rows: &[Vec<String>],
     after_dialect: CsvDialect,
 ) -> Result<Vec<DetectedChange>, PluginError> {
-    let base = before.to_rows();
+    let base = before.rows.as_slice();
     let (old_for_new, new_for_old) = match_diff_rows(
-        &base,
+        base,
         file_rows,
         imara_diff_runs(base.iter().map(|row| &row.cells), file_rows.iter()),
     );
@@ -106,7 +104,7 @@ fn detect_changes_for_rows(
             metadata: None,
         });
     }
-    detect_row_upsert_changes(&base, file_rows, &old_for_new, &inserted_ids, &mut changes)?;
+    detect_row_upsert_changes(base, file_rows, &old_for_new, &inserted_ids, &mut changes)?;
 
     if before.dialect != after_dialect
         || (!before.table_present
@@ -364,7 +362,8 @@ fn single_entity_pk(mut entity_pk: Vec<String>) -> Result<String, PluginError> {
 
 impl Projection {
     fn from_entity_state(changes: impl Iterator<Item = EntityState>) -> Result<Self, PluginError> {
-        let mut rows_by_id = BTreeMap::new();
+        let mut rows = Vec::new();
+        let mut row_ids = HashSet::new();
         let mut dialect = None;
 
         for change in changes {
@@ -385,42 +384,29 @@ impl Projection {
                 }
                 ROW_SCHEMA_KEY => {
                     let entity_pk = single_entity_pk(change.entity_pk)?;
-                    match rows_by_id.entry(entity_pk) {
-                        Entry::Occupied(entry) => {
-                            return Err(PluginError::InvalidInput(format!(
-                                "duplicate entity_pk '{}' for schema_key '{ROW_SCHEMA_KEY}'",
-                                entry.key()
-                            )));
-                        }
-                        Entry::Vacant(entry) => {
-                            let row = parse_row_snapshot(&change.snapshot_content, entry.key())?;
-                            entry.insert(row);
-                        }
+                    if !row_ids.insert(entity_pk.clone()) {
+                        return Err(PluginError::InvalidInput(format!(
+                            "duplicate entity_pk '{entity_pk}' for schema_key '{ROW_SCHEMA_KEY}'"
+                        )));
                     }
+                    let snapshot = parse_row_snapshot(&change.snapshot_content, &entity_pk)?;
+                    rows.push(Row {
+                        id: entity_pk,
+                        order_key: snapshot.order_key,
+                        cells: snapshot.cells,
+                    });
                 }
                 _ => {}
             }
         }
 
+        rows.sort_by(|a, b| a.order_key.cmp(&b.order_key).then_with(|| a.id.cmp(&b.id)));
+
         Ok(Self {
-            rows_by_id,
+            rows,
             dialect: dialect.unwrap_or_default(),
             table_present: dialect.is_some(),
         })
-    }
-
-    fn to_rows(&self) -> Vec<Row> {
-        let mut rows = self
-            .rows_by_id
-            .iter()
-            .map(|(id, row)| Row {
-                id: id.clone(),
-                order_key: row.order_key.clone(),
-                cells: row.cells.clone(),
-            })
-            .collect_vec();
-        rows.sort_by(|a, b| a.order_key.cmp(&b.order_key).then_with(|| a.id.cmp(&b.id)));
-        rows
     }
 }
 
@@ -534,7 +520,30 @@ mod tests {
     use super::*;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
-    use std::collections::BTreeMap;
+
+    #[test]
+    fn projection_rejects_duplicate_row_ids() {
+        let row = EntityState {
+            entity_pk: vec!["row:duplicate".to_string()],
+            schema_key: ROW_SCHEMA_KEY.to_string(),
+            snapshot_content: serde_json::json!({
+                "id": "row:duplicate",
+                "order_key": "80",
+                "cells": ["value"],
+            })
+            .to_string(),
+            metadata: None,
+        };
+
+        let error = Projection::from_entity_state(vec![row.clone(), row].into_iter())
+            .expect_err("duplicate row ids must be rejected");
+
+        assert!(matches!(
+            error,
+            PluginError::InvalidInput(message)
+                if message == "duplicate entity_pk 'row:duplicate' for schema_key 'csv_row'"
+        ));
+    }
 
     #[test]
     fn fuzz_detect_changes_round_trips_rows() {
@@ -561,7 +570,7 @@ mod tests {
             }
 
             let applied_rows = applied
-                .to_rows()
+                .rows
                 .into_iter()
                 .map(|row| row.cells)
                 .collect::<Vec<_>>();
@@ -590,8 +599,9 @@ mod tests {
 
                 let entity_pk = single_entity_pk(change.entity_pk.clone()).unwrap();
                 let before_row = before
-                    .rows_by_id
-                    .get(&entity_pk)
+                    .rows
+                    .iter()
+                    .find(|row| row.id == entity_pk)
                     .expect("reordering rows should only update existing row ids");
                 let snapshot_content = change
                     .snapshot_content
@@ -615,7 +625,7 @@ mod tests {
             }
 
             let applied_rows = applied
-                .to_rows()
+                .rows
                 .into_iter()
                 .map(|row| row.cells)
                 .collect::<Vec<_>>();
@@ -651,14 +661,18 @@ mod tests {
             .map(|offset| format!("row:{offset}"))
             .collect::<Vec<_>>();
         let order_keys = OrderKey::evenly_between(None, None, ids.len()).unwrap();
-        let rows_by_id = rows
+        let rows = rows
             .into_iter()
             .zip(ids.into_iter().zip(order_keys))
-            .map(|(cells, (id, order_key))| (id, RowSnapshot { order_key, cells }))
-            .collect::<BTreeMap<_, _>>();
+            .map(|(cells, (id, order_key))| Row {
+                id,
+                order_key,
+                cells,
+            })
+            .collect();
 
         Projection {
-            rows_by_id,
+            rows,
             dialect: CsvDialect::default(),
             table_present: true,
         }
@@ -681,10 +695,24 @@ mod tests {
             ROW_SCHEMA_KEY => {
                 let entity_pk = single_entity_pk(change.entity_pk)?;
                 if let Some(raw) = change.snapshot_content {
-                    let row = parse_row_snapshot(&raw, &entity_pk)?;
-                    projection.rows_by_id.insert(entity_pk, row);
+                    let snapshot = parse_row_snapshot(&raw, &entity_pk)?;
+                    let row = Row {
+                        id: entity_pk.clone(),
+                        order_key: snapshot.order_key,
+                        cells: snapshot.cells,
+                    };
+                    if let Some(existing) =
+                        projection.rows.iter_mut().find(|row| row.id == entity_pk)
+                    {
+                        *existing = row;
+                    } else {
+                        projection.rows.push(row);
+                    }
+                    projection.rows.sort_by(|a, b| {
+                        a.order_key.cmp(&b.order_key).then_with(|| a.id.cmp(&b.id))
+                    });
                 } else {
-                    projection.rows_by_id.remove(&entity_pk);
+                    projection.rows.retain(|row| row.id != entity_pk);
                 }
             }
             _ => {}


### PR DESCRIPTION
## What

- Build the CSV projection directly as an owned `Vec<Row>`.
- Detect duplicate entity IDs with a `HashSet`.
- Sort once by `(order_key, id)`.
- Borrow that ordered projection during detection and rendering.
- Remove the now-unused direct `itertools` dependency.

## Why

The previous path first built a `BTreeMap`, then deep-cloned every row ID, order key, and cell vector into a second collection and sorted it again. That repeated O(entity count) allocation and copying on every render or update.

## Measured impact

This is a **guest-only native release benchmark** of the CSV algorithm. It deliberately excludes component-model transfer, Wasmtime, host materialization, RocksDB, and SlateDB, so these numbers are not end-to-end engine predictions.

| File / operation | Before p50 | After p50 | Improvement |
|---|---:|---:|---:|
| 1 MiB no-op | 21.536 ms | 18.913 ms | 12.2% |
| 1 MiB one-row edit | 25.518 ms | 22.984 ms | 9.9% |
| 5 MiB no-op | 87.926 ms | 72.016 ms | 18.1% |
| 5 MiB one-row edit | 86.319 ms | 75.529 ms | 12.5% |

The rotated 15-round tournament ran against codec-v3 commit `115350f9`; this production patch is independently rebased onto current main (`8e4931eb`). Initial ingestion has no populated projection to optimize and varied from -1.4% at 1 MiB to -5.2% at 5 MiB. This PR targets repeated render/update work.

## Semantic guardrails

- The plugin remains Wasm and builds for `wasm32-wasip2`.
- Canonical row ordering remains `(order_key, id)`.
- Duplicate entity IDs remain rejected, with explicit regression coverage.
- Snapshot encoding, diff behavior, dialect handling, and UUID generation are unchanged.
- Benchmark-only dialect sampling/caching, UTF-8, and UUID hypotheses are intentionally excluded.

## Checks

- `cargo test -p plugin_csv`: 23/23 passed, including 200k property-test iterations and the new duplicate-ID test.
- `cargo clippy -p plugin_csv --all-targets -- -D warnings`.
- `cargo build -p plugin_csv --release --target wasm32-wasip2`.
- `cargo fmt --all -- --check` and `git diff --check`.