### PR TITLE
Let SlateDB batch background WAL flushes

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -228,6 +228,14 @@ discards the staged mutations.
 contract does not promise reads through a write handle or read-your-writes
 behavior.
 
+SlateDB publishes commits from its in-memory WAL immediately and flushes that
+WAL to object storage in the background (every 100 ms by default). Nearby
+commits therefore share an object-store write. `SlateDB::flush()` remains an
+explicit durability barrier for callers that need one, and orderly shutdown
+attempts to flush outstanding writes. Final-handle drop cannot report a flush
+failure, so callers that require an observed durability guarantee must call
+`flush()` explicitly.
+
 ## Required guarantees
 
 1. **Space isolation.** Identical keys in different `SpaceId` values never
@@ -238,9 +246,10 @@ behavior.
    order and pagination respects the exclusive cursor.
 4. **Atomic commits.** A successful `commit` publishes all staged mutations;
    failed or rolled-back writes do not publish a partial result.
-5. **Durability.** Persistent implementations honor the requested durability
-   and retain successful commits across process restart. `Memory` is explicitly
-   ephemeral.
+5. **Persistence.** Persistent implementations define their own durability
+   boundary. A storage may acknowledge visible commits before a background
+   flush; only commits that cross the provider's durability boundary are
+   guaranteed across process loss. `Memory` is explicitly ephemeral.
 
 Read handles release snapshots and other resources through `Drop`; there is no
 read `close` or `rollback` method. The `Storage` trait also does not prescribe

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -68,7 +68,7 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
         let delay_label = format!("{delay_ms}ms");
 
         group.bench_with_input(
-            BenchmarkId::new("upload_overwrite_file_after_preload", &delay_label),
+            BenchmarkId::new("accept_overwrite_file_after_preload", &delay_label),
             &delay,
             |b, &delay| {
                 b.iter_custom(|iterations| {
@@ -146,10 +146,16 @@ fn maybe_print_singleton_write_accounting(runtime: &tokio::runtime::Runtime) {
     let bulk_started = Instant::now();
     let bulk_accounting = runtime.block_on(fixture.transaction.insert_all_accounting());
     let bulk_elapsed = bulk_started.elapsed();
+    let bulk_flush_started = Instant::now();
+    runtime
+        .block_on(fixture.storage.flush())
+        .expect("flush singleton bulk insert");
+    let bulk_flush_elapsed = bulk_flush_started.elapsed();
     print_singleton_sample(
         "insert_1k",
         Duration::ZERO,
         bulk_elapsed,
+        bulk_flush_elapsed,
         bulk_accounting,
         &fixture.object_store.write_stats(),
     );
@@ -159,53 +165,60 @@ fn maybe_print_singleton_write_accounting(runtime: &tokio::runtime::Runtime) {
         let mut elapsed = Vec::with_capacity(samples);
         let mut logical_value_bytes = 0u64;
         let mut staged_puts = 0u64;
-        let mut object_put_calls = 0u64;
-        let mut object_put_bytes = 0u64;
-        let mut wal_put_calls = 0u64;
-        let mut wal_put_bytes = 0u64;
+        fixture.object_store.reset_write_stats();
         for _ in 0..samples {
-            fixture.object_store.reset_write_stats();
             let started = Instant::now();
             let accounting = runtime.block_on(fixture.transaction.update_one_by_pk_accounting());
             elapsed.push(started.elapsed());
-            let stats = fixture.object_store.write_stats();
-            let wal = stats.wal_totals();
             logical_value_bytes += accounting.written_bytes;
             staged_puts += accounting.staged_puts;
-            object_put_calls += stats.put_calls;
-            object_put_bytes += stats.put_bytes;
-            wal_put_calls += wal.put_calls;
-            wal_put_bytes += wal.put_bytes;
         }
+        let flush_started = Instant::now();
+        runtime
+            .block_on(fixture.storage.flush())
+            .expect("flush singleton update burst");
+        let flush_elapsed = flush_started.elapsed();
+        let stats = fixture.object_store.write_stats();
+        let wal = stats.wal_totals();
         elapsed.sort_unstable();
         let p50 = percentile(&elapsed, 50);
         let p95 = percentile(&elapsed, 95);
         let sample_count = u64::try_from(samples).expect("sample count fits u64");
         println!(
-            "slatedb-singleton-update delay_ms={} samples={samples} p50_ns={} p95_ns={} staged_puts_avg={} logical_value_bytes_avg={} object_put_calls_avg={} object_put_bytes_avg={} wal_put_calls_avg={} wal_put_bytes_avg={}",
+            "slatedb-singleton-update delay_ms={} samples={samples} accepted_p50_ns={} accepted_p95_ns={} flush_ns={} staged_puts_avg={} logical_value_bytes_avg={} object_put_calls_total={} object_put_bytes_total={} wal_put_calls_total={} wal_put_bytes_total={}",
             delay.as_millis(),
             p50.as_nanos(),
             p95.as_nanos(),
+            flush_elapsed.as_nanos(),
             staged_puts / sample_count,
             logical_value_bytes / sample_count,
-            object_put_calls / sample_count,
-            object_put_bytes / sample_count,
-            wal_put_calls / sample_count,
-            wal_put_bytes / sample_count,
+            stats.put_calls,
+            stats.put_bytes,
+            wal.put_calls,
+            wal.put_bytes,
         );
     }
 
     let mut delete_fixture = runtime.block_on(SingletonWriteFixture::new());
     runtime.block_on(delete_fixture.transaction.seed());
+    runtime
+        .block_on(delete_fixture.storage.flush())
+        .expect("flush singleton delete seed");
     delete_fixture.object_store.reset_write_stats();
     let delete_started = Instant::now();
     let delete_accounting =
         runtime.block_on(delete_fixture.transaction.delete_one_by_pk_accounting());
     let delete_elapsed = delete_started.elapsed();
+    let delete_flush_started = Instant::now();
+    runtime
+        .block_on(delete_fixture.storage.flush())
+        .expect("flush singleton delete");
+    let delete_flush_elapsed = delete_flush_started.elapsed();
     print_singleton_sample(
         "delete_one",
         Duration::ZERO,
         delete_elapsed,
+        delete_flush_elapsed,
         delete_accounting,
         &delete_fixture.object_store.write_stats(),
     );
@@ -215,15 +228,17 @@ fn maybe_print_singleton_write_accounting(runtime: &tokio::runtime::Runtime) {
 fn print_singleton_sample(
     operation: &str,
     delay: Duration,
-    elapsed: Duration,
+    accepted: Duration,
+    flush: Duration,
     accounting: BenchWriteAccounting,
     stats: &ObjectStoreWriteStats,
 ) {
     let wal = stats.wal_totals();
     println!(
-        "slatedb-singleton-sample operation={operation} delay_ms={} elapsed_ns={} logical_rows={} staged_puts={} staged_deletes={} logical_value_bytes={} object_put_calls={} object_put_bytes={} wal_put_calls={} wal_put_bytes={}",
+        "slatedb-singleton-sample operation={operation} delay_ms={} accepted_ns={} flush_ns={} logical_rows={} staged_puts={} staged_deletes={} logical_value_bytes={} object_put_calls={} object_put_bytes={} wal_put_calls={} wal_put_bytes={}",
         delay.as_millis(),
-        elapsed.as_nanos(),
+        accepted.as_nanos(),
+        flush.as_nanos(),
         accounting.logical_rows,
         accounting.staged_puts,
         accounting.staged_deletes,
@@ -244,6 +259,7 @@ fn percentile(samples: &[Duration], percentile: usize) -> Duration {
 #[cfg(feature = "storage-benches")]
 struct SingletonWriteFixture {
     transaction: BenchTransactionFixture<SlateDB>,
+    storage: SlateDB,
     object_store: Arc<DelayedObjectStore>,
 }
 
@@ -274,10 +290,16 @@ impl SingletonWriteFixture {
             })
             .collect();
         let transaction =
-            BenchTransactionFixture::new_deterministic(StorageAdapter::new(storage), rows).await;
+            BenchTransactionFixture::new_deterministic(StorageAdapter::new(storage.clone()), rows)
+                .await;
+        storage
+            .flush()
+            .await
+            .expect("flush singleton accounting setup");
         object_store.reset_write_stats();
         Self {
             transaction,
+            storage,
             object_store,
         }
     }
@@ -289,14 +311,23 @@ fn maybe_print_write_accounting(runtime: &tokio::runtime::Runtime) {
     }
     let fixture = runtime.block_on(UploadBenchFixture::seeded(Duration::ZERO));
     black_box(runtime.block_on(fixture.upload_overwrite_file()));
+    runtime
+        .block_on(fixture.storage.flush())
+        .expect("flush upload accounting warmup");
     fixture.object_store.reset_write_stats();
     let started = Instant::now();
     let rows_affected = runtime.block_on(fixture.upload_overwrite_file());
-    let elapsed = started.elapsed();
+    let accepted = started.elapsed();
+    let flush_started = Instant::now();
+    runtime
+        .block_on(fixture.storage.flush())
+        .expect("flush upload accounting write");
+    let flush = flush_started.elapsed();
     let stats = fixture.object_store.write_stats();
     println!(
-        "slatedb-write-accounting rows_affected={rows_affected} elapsed_ns={} put_calls={} put_bytes={}",
-        elapsed.as_nanos(),
+        "slatedb-write-accounting rows_affected={rows_affected} accepted_ns={} flush_ns={} put_calls={} put_bytes={}",
+        accepted.as_nanos(),
+        flush.as_nanos(),
         stats.put_calls,
         stats.put_bytes,
     );
@@ -532,6 +563,7 @@ impl SeededStore {
 
 struct UploadBenchFixture {
     session: SessionContext<SlateDB>,
+    storage: SlateDB,
     _cache_dir: TempDir,
     object_store: Arc<DelayedObjectStore>,
     next_upload_version: AtomicU64,
@@ -550,7 +582,7 @@ impl UploadBenchFixture {
             cached_object_store_options(&cache_dir),
         )
         .expect("reopen delayed SlateDB storage for upload benchmark");
-        let engine = Engine::new(storage)
+        let engine = Engine::new(storage.clone())
             .await
             .expect("open SlateDB upload benchmark engine");
         let session = engine
@@ -561,6 +593,7 @@ impl UploadBenchFixture {
 
         Self {
             session,
+            storage,
             _cache_dir: cache_dir,
             object_store: seeded.object_store,
             next_upload_version: AtomicU64::new(0),

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -7,9 +7,9 @@
 //!   concurrent sessions beyond each storage read snapshot.
 //! - `SessionContext::close()` is a lifecycle boundary. It waits for in-flight
 //!   reads, rejects live explicit transactions, cancels queued or pre-boundary
-//!   writes, and waits once a commit has entered the durable point-of-no-return.
-//! - Crash durability is delegated to the storage. The MVP does not add an
-//!   engine WAL, fsync policy, or recovery protocol above storage commits.
+//!   writes, and waits once a commit has entered the storage point-of-no-return.
+//! - Crash durability is provider-defined. The MVP does not add an engine WAL,
+//!   fsync policy, or recovery protocol above storage commits.
 //! - `storage` and `storage_adapter` are low-level surfaces. Code that bypasses
 //!   `Engine`/`SessionContext` also bypasses session lifecycle accounting and
 //!   relies on storage-provided serialization.
@@ -86,11 +86,11 @@ pub use storage::conformance::{
     StorageFactory, StorageFixture, StorageTestConfig, run_storage_conformance,
 };
 pub use storage::{
-    CommitResult, CoreProjection, Durability, GetManyResult, GetOptions, Key, KeyRange,
-    MAX_SCAN_PAGE_ROWS, Memory, MemoryFactory, MemoryFixture, MemoryRead, MemoryWrite, Prefix,
-    ProjectedValue, PutBatch, PutEntry, ReadConsistency, ReadEntry, ReadOptions, ScanChunk,
-    ScanOptions, SnapshotRef, SpaceId, Storage, StorageError, StorageRead, StorageWrite,
-    StoredValue, WriteOptions, WriteStats,
+    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, MAX_SCAN_PAGE_ROWS,
+    Memory, MemoryFactory, MemoryFixture, MemoryRead, MemoryWrite, Prefix, ProjectedValue,
+    PutBatch, PutEntry, ReadConsistency, ReadEntry, ReadOptions, ScanChunk, ScanOptions,
+    SnapshotRef, SpaceId, Storage, StorageError, StorageRead, StorageWrite, StoredValue,
+    WriteOptions, WriteStats,
 };
 
 pub(crate) const GLOBAL_BRANCH_ID: &str = "global";

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -910,7 +910,7 @@ mod tests {
 
         gate.release();
         join_thread(committer, "blocked committer")
-            .expect("commit already at durable boundary should finish");
+            .expect("commit already at storage boundary should finish");
         assert_close_finishes(close.as_mut(), "close after commit exits").await;
         assert!(
             !session.commit_in_progress_for_test(),

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -7,8 +7,8 @@
 //! `Transaction` directly or using session-level read helpers inside writes.
 //!
 //! MVP boundary: session close can cancel queued or pre-boundary writes until
-//! the durable commit point-of-no-return. After that point, close waits for
-//! commit completion. Durability itself is the storage's responsibility.
+//! the storage commit point-of-no-return. After that point, close waits for
+//! commit completion. Crash persistence is provider-defined.
 
 mod context;
 mod create_branch;

--- a/packages/engine/src/storage/mod.rs
+++ b/packages/engine/src/storage/mod.rs
@@ -18,8 +18,7 @@ pub use predicate::{
 };
 pub use traits::{Storage, StorageRead, StorageWrite};
 pub use types::{
-    CommitResult, CoreProjection, Durability, GetManyResult, GetOptions, Key, KeyRange,
-    MAX_SCAN_PAGE_ROWS, Prefix, ProjectedValue, PutBatch, PutEntry, ReadConsistency, ReadEntry,
-    ReadOptions, ScanChunk, ScanOptions, SnapshotRef, SpaceId, StoredValue, WriteOptions,
-    WriteStats,
+    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, MAX_SCAN_PAGE_ROWS,
+    Prefix, ProjectedValue, PutBatch, PutEntry, ReadConsistency, ReadEntry, ReadOptions, ScanChunk,
+    ScanOptions, SnapshotRef, SpaceId, StoredValue, WriteOptions, WriteStats,
 };

--- a/packages/engine/src/storage/traits.rs
+++ b/packages/engine/src/storage/traits.rs
@@ -34,8 +34,9 @@ pub trait Storage: Send + Sync {
     /// Opens one storage-owned write transaction.
     ///
     /// The storage is the concurrency boundary. Implementations are responsible
-    /// for their own durability and write concurrency semantics. A storage that
-    /// cannot safely support overlapping write transactions must serialize,
+    /// for their own persistence and write concurrency semantics. A storage may
+    /// publish a commit before its background durability boundary. A storage
+    /// that cannot safely support overlapping write transactions must serialize,
     /// use native transactional locking, or reject the second writer with a
     /// deterministic error.
     ///

--- a/packages/engine/src/storage/types.rs
+++ b/packages/engine/src/storage/types.rs
@@ -101,18 +101,11 @@ pub enum ReadConsistency {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct WriteOptions {
     pub base_snapshot: Option<SnapshotRef>,
-    pub durability: Durability,
     pub idempotency_key: Option<Bytes>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SnapshotRef(pub Bytes);
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum Durability {
-    #[default]
-    Durable,
-}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct WriteStats {

--- a/packages/engine/tests/code_structure.rs
+++ b/packages/engine/tests/code_structure.rs
@@ -2343,8 +2343,7 @@ fn current_sql2_data_sink_exec_violations() -> Vec<SqlRuntimeOwnershipViolation>
     violations.into_iter().collect()
 }
 
-fn current_session_transaction_durable_commit_boundary_violations() -> Vec<RawSqlExecutionViolation>
-{
+fn current_session_transaction_commit_boundary_violations() -> Vec<RawSqlExecutionViolation> {
     let mut violations = BTreeSet::new();
 
     for (relative_path, source) in production_source_files() {
@@ -2918,8 +2917,8 @@ fn sql2_write_session_registers_writable_transaction_surfaces() {
 }
 
 #[test]
-fn session_transaction_durable_commits_go_through_commit_boundary() {
-    let violations = current_session_transaction_durable_commit_boundary_violations();
+fn session_transaction_commits_go_through_commit_boundary() {
+    let violations = current_session_transaction_commit_boundary_violations();
 
     assert!(
         violations.is_empty(),

--- a/packages/engine/tests/storage/slatedb.rs
+++ b/packages/engine/tests/storage/slatedb.rs
@@ -184,7 +184,7 @@ async fn cached_slatedb_rebuilds_after_local_cache_is_deleted() {
 }
 
 #[tokio::test]
-async fn cached_slatedb_does_not_acknowledge_failed_remote_writes() {
+async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
     let object_store = Arc::new(InMemory::new());
     let db_path = "cached-slatedb-write-failure";
     let cache_parent = tempfile::tempdir().expect("create SlateDB failure cache parent");
@@ -214,9 +214,14 @@ async fn cached_slatedb_does_not_acknowledge_failed_remote_writes() {
         .expect("open cached failure-test storage");
         fault_store.fail_writes.store(true, Ordering::Relaxed);
 
-        let error = write_one(&storage, space, rejected_key.clone(), b"not-persisted")
+        write_one(&storage, space, rejected_key.clone(), b"not-persisted")
             .await
-            .expect_err("remote write failure must fail the storage commit");
+            .expect("commit should accept the visible write");
+
+        let error = storage
+            .flush()
+            .await
+            .expect_err("remote write failure must fail the explicit flush");
         assert!(format!("{error}").contains("not supported"));
     }
 
@@ -242,11 +247,11 @@ async fn cached_slatedb_does_not_acknowledge_failed_remote_writes() {
 }
 
 #[tokio::test]
-async fn slatedb_commit_flushes_one_wal_write_immediately() {
+async fn slatedb_explicit_flush_makes_visible_commit_durable() {
     let object_store = Arc::new(InMemory::new());
     let counting_store = Arc::new(FaultStore::new(object_store));
-    let storage = SlateDB::open_object_store("slatedb-immediate-wal-flush", counting_store.clone())
-        .expect("open immediate WAL flush storage");
+    let storage = SlateDB::open_object_store("slatedb-explicit-wal-flush", counting_store.clone())
+        .expect("open explicit WAL flush storage");
     counting_store.reset_write_count();
 
     write_one(
@@ -256,18 +261,19 @@ async fn slatedb_commit_flushes_one_wal_write_immediately() {
         b"value",
     )
     .await
-    .expect("commit immediately durable value");
+    .expect("publish visible value");
 
-    assert_eq!(counting_store.write_count(), 1);
+    storage.flush().await.expect("flush visible value");
+    assert_eq!(
+        counting_store.write_count(),
+        1,
+        "the visible commit should require one WAL write"
+    );
     storage
         .flush()
         .await
         .expect("flush already durable storage");
-    assert_eq!(
-        counting_store.write_count(),
-        1,
-        "an explicit flush after commit should not issue another remote write"
-    );
+    assert_eq!(counting_store.write_count(), 1);
 }
 
 async fn write_one(

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::future::Future;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::JoinHandle;
 
@@ -191,14 +191,8 @@ impl SlateDB {
     }
 
     pub async fn flush(&self) -> Result<(), StorageError> {
-        let durability_failed = Arc::clone(&self.worker.inner.durability_failed);
         self.worker
-            .call_with_visibility_lock(move |db| async move {
-                db.flush().await.map_err(|error| {
-                    durability_failed.store(true, Ordering::Release);
-                    slatedb_error(error)
-                })
-            })
+            .call(|db| async move { db.flush().await.map_err(slatedb_error) })
             .await
     }
 }
@@ -221,9 +215,7 @@ impl Storage for SlateDB {
         async move {
             let snapshot = self
                 .worker
-                .call_with_visibility_lock(|db| async move {
-                    db.snapshot().await.map_err(slatedb_error)
-                })
+                .call(|db| async move { db.snapshot().await.map_err(slatedb_error) })
                 .await?;
             Ok(SlateDBRead {
                 worker: self.worker.clone(),
@@ -238,7 +230,6 @@ impl Storage for SlateDB {
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
             let writer_permit = self.write_gate.acquire().await;
-            self.worker.ensure_usable()?;
             let base = self
                 .worker
                 .call(|db| async move { db.snapshot().await.map_err(slatedb_error) })
@@ -452,16 +443,14 @@ impl StorageWrite for SlateDBWrite {
                 ..
             } = self;
             if overlay.is_empty() {
-                worker.ensure_usable()?;
                 return Ok(CommitResult {
                     commit_id: None,
                     stats,
                 });
             }
 
-            let durability_failed = Arc::clone(&worker.inner.durability_failed);
             worker
-                .call_with_visibility_lock(move |db| async move {
+                .call(move |db| async move {
                     let _writer_permit = writer_permit;
                     let mut batch = WriteBatch::new();
                     for (key, value) in overlay {
@@ -478,18 +467,10 @@ impl StorageWrite for SlateDBWrite {
                         },
                     )
                     .await
-                    .map_err(|error| {
-                        durability_failed.store(true, Ordering::Release);
-                        slatedb_error(error)
-                    })?;
-                    // Keep the write and explicit WAL flush in one spawned task.
-                    // If the caller drops its commit future, durability still runs
-                    // to completion before the visibility lock and writer permit
-                    // are released.
-                    db.flush().await.map_err(|error| {
-                        durability_failed.store(true, Ordering::Release);
-                        slatedb_error(error)
-                    })?;
+                    .map_err(slatedb_error)?;
+                    // SlateDB owns WAL durability. Returning here makes the
+                    // commit visible immediately while its background flusher
+                    // batches this write with nearby commits.
                     Ok(CommitResult {
                         commit_id: None,
                         stats,
@@ -514,16 +495,6 @@ struct SlateDBWorker {
 struct SlateDBWorkerInner {
     runtime: Handle,
     db: Arc<Db>,
-    // A commit becomes visible before its explicit WAL flush completes. New
-    // snapshots share this lock with that write-plus-flush window; operations
-    // on already-pinned snapshots remain fully concurrent.
-    visibility_lock: Arc<AsyncMutex<()>>,
-    // SlateDB applies writes to its visible memtable before WAL durability.
-    // Publish a terminal failure before releasing the visibility lock so a
-    // failed commit can never be captured by a later storage snapshot.
-    durability_failed: Arc<AtomicBool>,
-    #[cfg(test)]
-    next_visibility_wait: Mutex<Option<mpsc::Sender<()>>>,
     in_flight: InFlightTracker,
     shutdown: mpsc::Sender<()>,
     manager: Mutex<Option<JoinHandle<()>>>,
@@ -612,10 +583,6 @@ impl SlateDBWorker {
                 inner: Arc::new(SlateDBWorkerInner {
                     runtime,
                     db,
-                    visibility_lock: Arc::new(AsyncMutex::new(())),
-                    durability_failed: Arc::new(AtomicBool::new(false)),
-                    #[cfg(test)]
-                    next_visibility_wait: Mutex::new(None),
                     in_flight,
                     shutdown,
                     manager: Mutex::new(Some(thread)),
@@ -634,37 +601,6 @@ impl SlateDBWorker {
         F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
         Fut: Future<Output = Result<R, StorageError>> + Send + 'static,
     {
-        self.call_inner(None, operation).await
-    }
-
-    fn ensure_usable(&self) -> Result<(), StorageError> {
-        if self.inner.durability_failed.load(Ordering::Acquire) {
-            Err(StorageError::Durability)
-        } else {
-            Ok(())
-        }
-    }
-
-    async fn call_with_visibility_lock<R, F, Fut>(&self, operation: F) -> Result<R, StorageError>
-    where
-        R: Send + 'static,
-        F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<R, StorageError>> + Send + 'static,
-    {
-        self.call_inner(Some(Arc::clone(&self.inner.visibility_lock)), operation)
-            .await
-    }
-
-    async fn call_inner<R, F, Fut>(
-        &self,
-        visibility_lock: Option<Arc<AsyncMutex<()>>>,
-        operation: F,
-    ) -> Result<R, StorageError>
-    where
-        R: Send + 'static,
-        F: FnOnce(Arc<Db>) -> Fut + Send + 'static,
-        Fut: Future<Output = Result<R, StorageError>> + Send + 'static,
-    {
         let (reply_tx, reply_rx) = oneshot::channel();
         // Manager shutdown waits for this guard. The guard is deliberately
         // independent of `SlateDBWorkerInner`: keeping the inner Arc in a task
@@ -672,52 +608,14 @@ impl SlateDBWorker {
         // self-deadlock when the task released the final Arc.
         let in_flight = self.inner.in_flight.enter();
         let db = Arc::clone(&self.inner.db);
-        let durability_failed = visibility_lock
-            .as_ref()
-            .map(|_| Arc::clone(&self.inner.durability_failed));
-        #[cfg(test)]
-        let visibility_wait = if visibility_lock.is_some() {
-            self.inner
-                .next_visibility_wait
-                .lock()
-                .expect("lock visibility wait probe")
-                .take()
-        } else {
-            None
-        };
         self.inner.runtime.spawn(async move {
             let _in_flight = in_flight;
-            let _visibility_guard = match visibility_lock {
-                Some(visibility_lock) => {
-                    #[cfg(test)]
-                    if let Some(visibility_wait) = visibility_wait {
-                        let _ = visibility_wait.send(());
-                    }
-                    Some(visibility_lock.lock_owned().await)
-                }
-                None => None,
-            };
-            let result = if durability_failed.is_some_and(|failed| failed.load(Ordering::Acquire)) {
-                Err(StorageError::Durability)
-            } else {
-                operation(db).await
-            };
+            let result = operation(db).await;
             let _ = reply_tx.send(result);
         });
         reply_rx
             .await
             .map_err(|error| StorageError::Io(format!("receive slatedb worker reply: {error}")))?
-    }
-
-    #[cfg(test)]
-    fn observe_next_visibility_wait(&self) -> mpsc::Receiver<()> {
-        let (wait_tx, wait_rx) = mpsc::channel();
-        *self
-            .inner
-            .next_visibility_wait
-            .lock()
-            .expect("lock visibility wait probe") = Some(wait_tx);
-        wait_rx
     }
 }
 
@@ -1120,6 +1018,7 @@ mod tests {
         PutResult, RenameOptions, Result as ObjectStoreResult,
     };
     use std::ops::Range;
+    use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -1155,102 +1054,52 @@ mod tests {
     }
 
     #[test]
-    fn visibility_operations_wait_for_commit_wal_durability() {
+    fn commit_is_visible_while_background_wal_flush_is_blocked() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let storage = SlateDB::open_object_store("test-commit-visibility", store.clone())
             .expect("open commit visibility storage");
         let space = SpaceId(8);
-        let key = Key(Bytes::from_static(b"visible-after-durable"));
+        let key = Key(Bytes::from_static(b"visible-before-durable"));
 
         let blocked_write = store.block_next_write();
-        let commit_storage = storage.clone();
-        let commit_key = key.clone();
-        let commit = std::thread::spawn(move || {
-            let mut write = block_on(commit_storage.begin_write(WriteOptions::default()))
-                .expect("begin visibility write");
-            block_on(write.put_many(
-                space,
-                PutBatch {
-                    entries: vec![PutEntry {
-                        key: commit_key,
-                        value: StoredValue {
-                            bytes: Bytes::from_static(b"value"),
-                        },
-                    }],
-                },
-            ))
-            .expect("stage visibility write");
-            block_on(write.commit())
-        });
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin visibility write");
+        block_on(write.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: key.clone(),
+                    value: StoredValue {
+                        bytes: Bytes::from_static(b"value"),
+                    },
+                }],
+            },
+        ))
+        .expect("stage visibility write");
+        block_on(write.commit()).expect("publish visibility value");
+
+        // The request has returned, but SlateDB's first background WAL upload
+        // is still in flight.
         blocked_write.wait_for_entries(1, "SlateDB WAL write");
 
-        let visibility_wait = storage.worker.observe_next_visibility_wait();
-        let read_storage = storage.clone();
-        let read_key = key;
-        let (read_result_tx, read_result_rx) = mpsc::channel();
-        let reader = std::thread::spawn(move || {
-            let result = block_on(async move {
-                let read = read_storage.begin_read(ReadOptions::default()).await?;
-                read.get_many(space, &[read_key], GetOptions::default())
-                    .await
-                    .map(|result| result.values)
-            });
-            let _ = read_result_tx.send(result);
-        });
-
-        visibility_wait
-            .recv_timeout(Duration::from_secs(2))
-            .expect("reader should reach the visibility lock");
-        assert!(
-            matches!(
-                read_result_rx.recv_timeout(Duration::from_millis(50)),
-                Err(mpsc::RecvTimeoutError::Timeout)
-            ),
-            "begin_read must remain queued until the WAL write is durable"
-        );
-
-        let flush_wait = storage.worker.observe_next_visibility_wait();
-        let flush_storage = storage;
-        let (flush_result_tx, flush_result_rx) = mpsc::channel();
-        let flusher = std::thread::spawn(move || {
-            let _ = flush_result_tx.send(block_on(flush_storage.flush()));
-        });
-        flush_wait
-            .recv_timeout(Duration::from_secs(2))
-            .expect("flush should reach the visibility lock");
-        assert!(
-            matches!(
-                flush_result_rx.recv_timeout(Duration::from_millis(50)),
-                Err(mpsc::RecvTimeoutError::Timeout)
-            ),
-            "flush must remain queued until the commit WAL write finishes"
-        );
-
-        drop(blocked_write);
-        commit
-            .join()
-            .expect("join visibility commit")
-            .expect("commit visibility value");
-        let values = read_result_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("visibility read should finish after WAL durability")
-            .expect("read visibility value");
+        let read = block_on(storage.begin_read(ReadOptions::default()))
+            .expect("begin visible in-memory read");
+        let values = block_on(read.get_many(space, &[key], GetOptions::default()))
+            .expect("read visible in-memory value")
+            .values;
         assert_eq!(
             values,
             vec![Some(ProjectedValue::FullValue(Bytes::from_static(
                 b"value"
             )))]
         );
-        reader.join().expect("join visibility reader");
-        flush_result_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("flush should finish after commit WAL durability")
-            .expect("flush committed database");
-        flusher.join().expect("join queued flusher");
+
+        drop(blocked_write);
+        block_on(storage.flush()).expect("flush visible value");
     }
 
     #[test]
-    fn failed_commit_rejects_queued_readers_and_future_writers() {
+    fn explicit_flush_reports_background_durability_failure() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let storage = SlateDB::open_object_store("test-failed-commit", store.clone())
             .expect("open failed commit storage");
@@ -1258,101 +1107,43 @@ mod tests {
         let key = Key(Bytes::from_static(b"rejected"));
 
         let blocked_write = store.block_next_write();
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin buffered write");
+        block_on(write.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key,
+                    value: StoredValue {
+                        bytes: Bytes::from_static(b"not-durable"),
+                    },
+                }],
+            },
+        ))
+        .expect("stage buffered write");
+        block_on(write.commit()).expect("publish buffered write");
+
+        blocked_write.wait_for_entries(1, "failing background WAL write");
         store.fail_writes();
-        let commit_storage = storage.clone();
-        let commit = std::thread::spawn(move || {
-            let mut write = block_on(commit_storage.begin_write(WriteOptions::default()))
-                .expect("begin failing write");
-            block_on(write.put_many(
-                space,
-                PutBatch {
-                    entries: vec![PutEntry {
-                        key,
-                        value: StoredValue {
-                            bytes: Bytes::from_static(b"not-durable"),
-                        },
-                    }],
-                },
-            ))
-            .expect("stage failing write");
-            block_on(write.commit())
-        });
-        blocked_write.wait_for_entries(1, "failing SlateDB WAL write");
-
-        let visibility_wait = storage.worker.observe_next_visibility_wait();
-        let read_storage = storage.clone();
-        let reader = std::thread::spawn(move || {
-            block_on(async move {
-                read_storage
-                    .begin_read(ReadOptions::default())
-                    .await
-                    .map(|_| ())
-            })
-        });
-        visibility_wait
-            .recv_timeout(Duration::from_secs(2))
-            .expect("reader should queue on the visibility lock");
-
         drop(blocked_write);
-        let commit_error = commit
-            .join()
-            .expect("join failing commit")
-            .expect_err("WAL failure must fail commit");
+        let flush_error = block_on(storage.flush()).expect_err("WAL flush must fail");
         assert!(
-            matches!(commit_error, StorageError::Io(message) if message.contains("injected write failure")),
-            "commit should preserve the SlateDB write error"
-        );
-        assert_eq!(
-            reader
-                .join()
-                .expect("join queued reader")
-                .expect_err("queued reader must reject a failed commit"),
-            StorageError::Durability
-        );
-        assert_eq!(
-            block_on(async {
-                storage
-                    .begin_write(WriteOptions::default())
-                    .await
-                    .map(|_| ())
-            })
-            .expect_err("future writers must reject a failed commit"),
-            StorageError::Durability
+            matches!(flush_error, StorageError::Io(message) if message.contains("injected write failure")),
+            "flush should preserve the SlateDB write error"
         );
     }
 
     #[test]
-    fn empty_commit_observes_prior_durability_failure() {
-        let storage =
-            SlateDB::open_object_store("test-empty-failed-commit", Arc::new(InMemory::new()))
-                .expect("open empty failed commit storage");
-        let write = block_on(storage.begin_write(WriteOptions::default()))
-            .expect("begin empty write before failure");
-
-        storage
-            .worker
-            .inner
-            .durability_failed
-            .store(true, Ordering::Release);
-
-        assert_eq!(
-            block_on(write.commit())
-                .expect_err("empty commit must observe prior durability failure"),
-            StorageError::Durability
-        );
-    }
-
-    #[test]
-    fn cancelled_commit_outlives_last_storage_handle_until_durable() {
+    fn dropping_last_handle_waits_for_background_flush() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
-        let db_path = "test-cancelled-commit-durability";
+        let db_path = "test-close-background-durability";
         let space = SpaceId(8);
-        let key = Key(Bytes::from_static(b"cancelled-commit"));
+        let key = Key(Bytes::from_static(b"background-commit"));
         let value = Bytes::from_static(b"durable");
-        let storage = SlateDB::open_object_store(db_path, store.clone())
-            .expect("open cancellation-test storage");
-        let mut write = block_on(storage.begin_write(WriteOptions::default()))
-            .expect("begin cancellation-test write");
+        let storage =
+            SlateDB::open_object_store(db_path, store.clone()).expect("open close-test storage");
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin close-test write");
         block_on(write.put_many(
             space,
             PutBatch {
@@ -1364,32 +1155,36 @@ mod tests {
                 }],
             },
         ))
-        .expect("stage cancellation-test value");
+        .expect("stage close-test value");
 
         let blocked_write = store.block_next_write();
-        let runtime = Builder::new_current_thread()
-            .build()
-            .expect("build cancellation-test runtime");
-        let commit = runtime.spawn(write.commit());
-        runtime.block_on(tokio::task::yield_now());
-        blocked_write.wait_for_entries(1, "cancelled commit WAL write");
-        commit.abort();
-        runtime
-            .block_on(commit)
-            .expect_err("commit receiver task should be cancelled");
-        drop(runtime);
+        block_on(write.commit()).expect("publish close-test value");
+        blocked_write.wait_for_entries(1, "background commit WAL write");
+
+        let (closed_tx, closed_rx) = mpsc::channel();
+        let closer = std::thread::spawn(move || {
+            drop(storage);
+            let _ = closed_tx.send(());
+        });
+        assert!(
+            matches!(
+                closed_rx.recv_timeout(Duration::from_millis(50)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "close must wait for the background WAL flush"
+        );
         drop(blocked_write);
-        // Dropping the final public handle asks the manager to shut down. It
-        // must wait for the detached write-plus-flush operation before closing
-        // SlateDB and returning.
-        drop(storage);
+        closed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("close should finish after WAL durability");
+        closer.join().expect("join close-test closer");
 
         let reopened =
-            SlateDB::open_object_store(db_path, store).expect("reopen cancellation-test storage");
-        let read = block_on(reopened.begin_read(ReadOptions::default()))
-            .expect("begin cancellation-test read");
+            SlateDB::open_object_store(db_path, store).expect("reopen close-test storage");
+        let read =
+            block_on(reopened.begin_read(ReadOptions::default())).expect("begin close-test read");
         let result = block_on(read.get_many(space, &[key], GetOptions::default()))
-            .expect("read cancellation-test value");
+            .expect("read close-test value");
         assert_eq!(result.values, vec![Some(ProjectedValue::FullValue(value))]);
     }
 


### PR DESCRIPTION
## Summary

- stop forcing `db.flush()` after every non-empty SlateDB commit
- publish an atomic write as soon as SlateDB accepts it into the visible WAL/memtable, then let SlateDB's native 100 ms background flusher batch nearby commits
- keep `SlateDB::flush()` as an explicit, observable durability barrier; final-handle shutdown still attempts a best-effort flush
- remove the unused one-value `Durability::Durable` write option and the Lix-only visibility/failure lock machinery that existed solely for synchronous remote durability
- rename and update the SlateDB benchmark accounting so accepted/visible latency and later flush latency are reported separately

## Root cause

The adapter used:

```text
write_with_options(await_durable: false)
db.flush()
```

for every commit while holding the writer gate. That defeated SlateDB's built-in WAL batching and put one object-store PUT/RTT on every interactive write.

SlateDB already buffers writes and flushes the WAL on an interval or size threshold. This change uses that existing mechanism instead of adding another journal or group-commit layer.

## Benchmark

Rebased on `main` at `26a38c67`. Focused singleton update benchmark, 4 KiB logical overwrite, 120 sequential commits:

| injected object-store latency | `main` p50 / p95 | this PR accepted p50 / p95 | p50 change | WAL PUTs for 120 commits |
| --- | ---: | ---: | ---: | ---: |
| 0 ms | 1.79 / 2.38 ms | 1.80 / 2.57 ms | +0.6% (noise) | 120 -> 3 (-97.5%) |
| 25 ms | 28.88 / 29.83 ms | 2.68 / 3.00 ms | -90.7% | 120 -> 4 (-96.7%) |

Recent `main` optimizations already make the zero-latency in-memory object-store path fast, so this PR does not claim a local latency improvement. It removes remote durability latency and object-store PUT amplification. With 25 ms injected latency, the final explicit flush took 26.3 ms, outside the interactive request path.

The comparison intentionally measures caller-visible acknowledgement: on `main`, acknowledgement included remote durability; in this PR, acknowledgement means accepted and visible.

## Semantics

This is an explicit hard cut:

- same-process readers and observers can see the commit immediately
- SlateDB normally persists it within its default 100 ms flush interval plus upload time
- abrupt server/node loss can lose the unflushed window
- final-handle drop attempts to flush but cannot report failure; callers that require an observed barrier must call `SlateDB::flush()`
- no client or remote protocol durability/version field is added

SlateDB references: [write flow](https://slatedb.io/docs/design/writes/), [flush tuning](https://slatedb.io/docs/operations/tuning/).

## Validation

- `cargo test -p lix_engine --features slatedb` on the rebased branch
- `cargo test -p lix_slatedb_storage`
- SlateDB storage conformance for cached and uncached stores
- blocked-object-store tests proving commits remain immediately visible and orderly close waits for the background flush
- `cargo clippy -p lix_engine -p lix_slatedb_storage --features 'lix_engine/slatedb,lix_engine/storage-benches' --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
