### PR TITLE
perf(remote): coalesce observation registration

### DIFF
--- a/.changenotes/coalesce-remote-observation-registration.md
+++ b/.changenotes/coalesce-remote-observation-registration.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reduced remote observation startup work when an interface registers several queries together.
+
+Same-turn registrations now open one multiplex stream with the complete subscription set instead of repeatedly opening and aborting partial streams.

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -208,9 +208,7 @@ class RemoteLixBinding implements LixBinding {
 		params: NativeLixValue[],
 	): Promise<ObserveEventsBinding> {
 		this.#assertOpen();
-		return this.#enqueue(async () =>
-			this.#observationHub.observe(sql, params.map(encodeWireValue)),
-		);
+		return this.#observationHub.observe(sql, params.map(encodeWireValue));
 	}
 
 	async beginTransaction(): Promise<LixTransactionBinding> {
@@ -375,6 +373,7 @@ class RemoteLixBinding implements LixBinding {
 				{ details: { cause: errorMessage(cause) } },
 			);
 		}
+		signal.throwIfAborted();
 		if (this.#sessionId === undefined) {
 			throw protocolError("remote observation started without a session");
 		}
@@ -390,6 +389,7 @@ class RemoteLixBinding implements LixBinding {
 		if (prepared.compressed) {
 			headers.set("content-encoding", "gzip");
 		}
+		signal.throwIfAborted();
 		try {
 			return await this.#fetch(new URL("observe/multiplex", this.#baseUrl), {
 				method: "POST",
@@ -706,6 +706,7 @@ class RemoteObservationHub {
 	#retryAttempt = 0;
 	#serverRetryMs: number | undefined;
 	#generation = 0;
+	#startQueued = false;
 	#closed = false;
 
 	constructor(options: RemoteObservationHubOptions) {
@@ -744,7 +745,12 @@ class RemoteObservationHub {
 
 	#restartStream(): void {
 		this.#stopStream();
-		this.#startStream();
+		if (this.#startQueued) return;
+		this.#startQueued = true;
+		queueMicrotask(() => {
+			this.#startQueued = false;
+			this.#startStream();
+		});
 	}
 
 	#startStream(): void {

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -117,12 +117,17 @@ test("remote observe applies every blob delta before coalescing delivery", async
 
 test("remote observe multiplexes more than six subscriptions without blocking execute", async () => {
 	const observeRequests: Request[] = [];
+	let headerResolutions = 0;
 	let liveObserveRequests = 0;
 	let maximumLiveObserveRequests = 0;
 	const lix = await openLix({
 		server: {
 			mode: "remote",
 			url: "https://lixray.test/@acme/workspace",
+			headers: () => {
+				headerResolutions += 1;
+				return {};
+			},
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -177,6 +182,7 @@ test("remote observe multiplexes more than six subscriptions without blocking ex
 			},
 		},
 	});
+	headerResolutions = 0;
 
 	const observations = Array.from({ length: 8 }, (_, index) =>
 		lix.observe(`SELECT ${index} AS value`),
@@ -189,6 +195,14 @@ test("remote observe multiplexes more than six subscriptions without blocking ex
 	);
 	expect(liveObserveRequests).toBe(1);
 	expect(maximumLiveObserveRequests).toBe(1);
+	expect(observeRequests).toHaveLength(1);
+	expect(headerResolutions).toBe(1);
+	let submittedSubscriptions = 0;
+	for (const request of observeRequests) {
+		const body = (await request.clone().json()) as { subscriptions: unknown[] };
+		submittedSubscriptions += body.subscriptions.length;
+	}
+	expect(submittedSubscriptions).toBe(8);
 	expect(
 		observeRequests.every((request) =>
 			new URL(request.url).pathname.endsWith("/observe/multiplex"),


### PR DESCRIPTION
## Hypothesis

Lixray mounts several observed queries in the same JavaScript turn. The remote SDK serialized each local registration through the finite-operation queue, so every partial subscription set opened and aborted its own multiplex request. Registering observations locally and starting the stream once at the end of the turn should remove quadratic request setup without delaying the single-observation path by a timer.

## Data

Exact Node/Vitest remote transport path on main 66ad14da versus this commit:

| Same-turn observations | main | candidate | improvement |
| --- | ---: | ---: | ---: |
| HTTP stream attempts (8 queries) | 8 | 1 | -87.5% |
| cumulative submitted subscriptions | 36 | 8 | -77.8% |
| async auth/header resolutions | 8 | 1 | -87.5% |

A 32-query stress run used eight fresh-process samples on each revision. Median test time moved from 299.72 ms to 265.92 ms (-11.3%); mean moved from 309.83 ms to 272.19 ms (-12.1%). Process startup makes time noisy, so the deterministic request and registration counts are the primary evidence. At 32 queries the structural reduction is 32 requests to 1 and 528 cumulative registrations to 32.

This targets the common UI-mount path; it does not claim an improvement for adding one isolated observation.

## Change

- observation registration no longer waits behind the finite remote mutation queue; observations are state streams and still deliver whichever state wins the request race, followed by invalidated state
- same-turn add/remove operations synchronously abort the obsolete stream and queue one microtask to open the final subscription set
- abort checks prevent stale header/compression continuations from dispatching a request
- no protocol version, fallback path, compatibility layer, or storage change

## Validation

- npx vitest run src/remote/observe.test.ts: 10 passed
- npm run build:ts
- npm run typecheck
- change-fragment validation
- existing reconnect, close, branch-switch, semantic-error, blob-delta, and multiplex behavior tests remain green

The broader source-only Vitest invocation was not used as evidence because this isolated worktree did not contain the generated native binding and bundled plugin archives; the focused remote suite is artifact-independent and CI performs the canonical full build.