### PR TITLE
perf(rocksdb): reuse large read buffers

### DIFF
--- a/.changenotes/adopt-large-rocksdb-read-buffers.md
+++ b/.changenotes/adopt-large-rocksdb-read-buffers.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+RocksDB-backed Lix instances now reuse RocksDB's owned buffers for full values of at least 64 KiB instead of copying them into a second allocation.
+
+Smaller values keep the existing copy path, which remains faster at that size.

--- a/packages/engine/benches/storage_v2.rs
+++ b/packages/engine/benches/storage_v2.rs
@@ -1427,6 +1427,41 @@ where
         }
     }
 
+    for (case_name, rows, value_size) in [
+        ("direct_get_many_unique_u1_v4096", 1, 4_096),
+        ("direct_get_many_unique_u100_v4096", 100, 4_096),
+        ("direct_get_many_unique_u1_v65536", 1, 65_536),
+        ("direct_get_many_unique_u100_v65536", 100, 65_536),
+    ] {
+        if should_run(case_name) {
+            let point_storage = storage_family.seed_points(SpaceId(1), rows, value_size);
+            let point_keys = physical_point_request_keys(1, rows as usize, rows as usize);
+            group.throughput(Throughput::Bytes(
+                u64::from(rows)
+                    * u64::try_from(value_size).expect("point read value size fits u64"),
+            ));
+            group.bench_function(case_name, |b| {
+                b.iter(|| {
+                    let read = block_on(point_storage.begin_read(ReadOptions::default()))
+                        .expect("begin direct unique large-value point read");
+                    let result = block_on(read.get_many(
+                        SpaceId(1),
+                        black_box(&point_keys),
+                        GetOptions::default(),
+                    ))
+                    .expect("direct unique large-value get_many");
+                    assert_eq!(result.values.len(), rows as usize);
+                    assert_eq!(
+                        result.values.iter().filter(|value| value.is_some()).count(),
+                        rows as usize
+                    );
+                    drop(read);
+                    black_box(result);
+                });
+            });
+        }
+    }
+
     if should_run("direct_get_many_unique_u1000") {
         let point_storage = storage_family.seed_points(SpaceId(1), 1_000, 32);
         let point_keys = physical_point_request_keys(1, 1_000, 1_000);
@@ -1474,6 +1509,37 @@ where
                     ))
                     .expect("direct materialized scan");
                     assert_eq!(chunk.entries.len(), 1_000);
+                    assert!(!chunk.has_more);
+                    drop(read);
+                    black_box(chunk);
+                });
+            });
+        }
+    }
+
+    for (case_name, rows) in [
+        ("direct_scan_full_q1_v65536", 1),
+        ("direct_scan_full_q100_v65536", 100),
+    ] {
+        if should_run(case_name) {
+            let scan_storage = storage_family.seed_points(SpaceId(1), rows, 65_536);
+            let scan_range = physical_point_scan_range(1);
+            group.throughput(Throughput::Bytes(u64::from(rows) * 65_536));
+            group.bench_function(case_name, |b| {
+                b.iter(|| {
+                    let read = block_on(scan_storage.begin_read(ReadOptions::default()))
+                        .expect("begin direct full-value scan read");
+                    let chunk = block_on(materialize_storage_scan(
+                        &read,
+                        scan_range.clone(),
+                        ScanOptions {
+                            limit_rows: rows as usize + 1,
+                            projection: CoreProjection::FullValue,
+                            ..ScanOptions::default()
+                        },
+                    ))
+                    .expect("direct full-value scan");
+                    assert_eq!(chunk.entries.len(), rows as usize);
                     assert!(!chunk.has_more);
                     drop(read);
                     black_box(chunk);

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -20,6 +20,8 @@ use rocksdb::Snapshot;
 use rocksdb::{DB, Direction, IteratorMode, Options, WriteBatch};
 use tempfile::TempDir;
 
+const OWNED_VALUE_MIN_BYTES: usize = 64 * 1024;
+
 #[derive(Debug)]
 pub struct RocksDBFactory {
     temp_dir: TempDir,
@@ -195,11 +197,7 @@ impl StorageRead for RocksDBRead<'_> {
                 .multi_get(physical_keys.iter().map(|key| key.0.as_ref()))
             {
                 let value = value.map_err(rocksdb_error)?;
-                values.push(
-                    value
-                        .as_ref()
-                        .map(|value| project_value(value.as_ref(), opts.projection)),
-                );
+                values.push(value.map(|value| project_owned_value(value, opts.projection)));
             }
             Ok(GetManyResult::new(values))
         }
@@ -244,7 +242,7 @@ impl StorageRead for RocksDBRead<'_> {
                 }
                 entries.push(ReadEntry {
                     key: Key(Bytes::copy_from_slice(&encoded_key[4..])),
-                    value: project_value(value.as_ref(), opts.projection),
+                    value: project_owned_value(value, opts.projection),
                 });
             }
             Ok(ScanChunk {
@@ -473,10 +471,19 @@ fn stored_value_bytes(value: StoredValue) -> Bytes {
     value.bytes
 }
 
-fn project_value(value: &[u8], projection: CoreProjection) -> ProjectedValue {
+fn project_owned_value<T>(value: T, projection: CoreProjection) -> ProjectedValue
+where
+    T: AsRef<[u8]>,
+    Bytes: From<T>,
+{
     match projection {
         CoreProjection::KeyOnly => ProjectedValue::KeyOnly,
-        CoreProjection::FullValue => ProjectedValue::FullValue(Bytes::copy_from_slice(value)),
+        CoreProjection::FullValue if value.as_ref().len() >= OWNED_VALUE_MIN_BYTES => {
+            ProjectedValue::FullValue(Bytes::from(value))
+        }
+        CoreProjection::FullValue => {
+            ProjectedValue::FullValue(Bytes::copy_from_slice(value.as_ref()))
+        }
     }
 }
 


### PR DESCRIPTION
## Hypothesis

rust-rocksdb already returns owned value buffers. Copying large full values into Bytes adds an avoidable allocation and memory-bandwidth pass.

## Result

Direct storage-adapter A/B, warmed RocksDB:

- point read, 1 x 64 KiB: 10.350 us to 4.602 us (-55.5%)
- point read, 100 x 64 KiB: 769.23 us to 656.65 us (-14.6%; repeated paired runs remained above the 10% gate)
- full scan, 1 x 64 KiB: 3.886 us to 3.224 us (-17.0%)
- full scan, 100 x 64 KiB: 338.72 us to 236.99 us (-30.0%)

The 4 KiB singleton and 1,000-row key-only controls were neutral. Adoption at 32 KiB improved only 6.9%; 16 KiB and 8 KiB also missed the gate or regressed, so this deliberately starts at 64 KiB.

## Change

Adopt the owned RocksDB value into Bytes for full values >=64 KiB. Keep the existing copy path below the measured break-even. Key-only reads and scan keys are unchanged; adopting scan keys was tested and rejected after a 151% regression.

No storage format, protocol, migration, or compatibility path is added.

## Validation

- RocksDB adapter tests pass.
- Engine RocksDB conformance passes.
- Strict Clippy with warnings denied passes.
- Formatting and diff checks pass.
- The benchmark matrix is committed in storage_v2.rs.