### PR TITLE
perf(slatedb): lazily snapshot range deletes

### DIFF
--- a/.changenotes/lazy-slatedb-write-snapshots.md
+++ b/.changenotes/lazy-slatedb-write-snapshots.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+SlateDB-backed writes now create a read snapshot only when a transaction deletes a range.
+
+Ordinary puts and point deletes avoid the extra worker round trip while range deletes retain a stable base snapshot.

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -127,6 +127,7 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
     cached_cold_lifecycle_benches(c, &runtime);
     cached_preloaded_request_benches(c, &runtime);
     fresh_engine_select_benches(c, &runtime);
+    storage_direct_benches(c, &runtime);
     storage_concurrency_benches(c);
 }
 
@@ -469,6 +470,55 @@ fn storage_concurrency_benches(c: &mut Criterion) {
     });
 
     group.finish();
+}
+
+fn storage_direct_benches(c: &mut Criterion, runtime: &tokio::runtime::Runtime) {
+    let mut group = c.benchmark_group("slatedb_storage_direct");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    group.bench_function("accept_put_u1_v4096", |b| {
+        b.iter_custom(|iterations| {
+            let db_id = NEXT_DB_ID.fetch_add(1, Ordering::Relaxed);
+            let storage = SlateDB::open_object_store(
+                format!("slatedb-direct-bench-{}-{db_id}", std::process::id()),
+                Arc::new(InMemory::new()),
+            )
+            .expect("open direct SlateDB benchmark storage");
+            let key = Key(Bytes::from_static(b"direct-key"));
+            let value = Bytes::from(vec![0x5a; FILE_SIZE_BYTES]);
+            runtime.block_on(write_direct_storage_value(&storage, &key, &value));
+            measure_iterations(iterations, || {
+                runtime.block_on(write_direct_storage_value(&storage, &key, &value))
+            })
+        });
+    });
+
+    group.finish();
+}
+
+async fn write_direct_storage_value(storage: &SlateDB, key: &Key, value: &Bytes) -> u64 {
+    let mut write = storage
+        .begin_write(WriteOptions::default())
+        .await
+        .expect("begin direct SlateDB write");
+    write
+        .put_many(
+            CONCURRENCY_SPACE,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: key.clone(),
+                    value: StoredValue {
+                        bytes: value.clone(),
+                    },
+                }],
+            },
+        )
+        .await
+        .expect("stage direct SlateDB value");
+    let commit = write.commit().await.expect("commit direct SlateDB value");
+    commit.stats.put_entries
 }
 
 fn measure_iterations<T>(iterations: u64, mut operation: impl FnMut() -> T) -> Duration {

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -90,7 +90,7 @@ pub struct SlateDBRead {
 pub struct SlateDBWrite {
     worker: SlateDBWorker,
     _writer_permit: OwnedMutexGuard<()>,
-    base: Arc<DbSnapshot>,
+    base: Option<Arc<DbSnapshot>>,
     overlay: BTreeMap<Key, Option<Bytes>>,
     stats: WriteStats,
 }
@@ -230,14 +230,10 @@ impl Storage for SlateDB {
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
             let writer_permit = self.write_gate.acquire().await;
-            let base = self
-                .worker
-                .call(|db| async move { db.snapshot().await.map_err(slatedb_error) })
-                .await?;
             Ok(SlateDBWrite {
                 worker: self.worker.clone(),
                 _writer_permit: writer_permit,
-                base,
+                base: None,
                 overlay: BTreeMap::new(),
                 stats: WriteStats::default(),
             })
@@ -405,7 +401,18 @@ impl StorageWrite for SlateDBWrite {
                 return Ok(());
             }
 
-            let base = Arc::clone(&self.base);
+            if self.base.is_none() {
+                self.base = Some(
+                    self.worker
+                        .call(|db| async move { db.snapshot().await.map_err(slatedb_error) })
+                        .await?,
+                );
+            }
+            let base = Arc::clone(
+                self.base
+                    .as_ref()
+                    .expect("SlateDB write base snapshot is initialized"),
+            );
             let base_keys = self
                 .worker
                 .call(move |_db| collect_snapshot_keys(base, bounds))


### PR DESCRIPTION
## Hypothesis

SlateDB write transactions only read a base snapshot when deleting a range. Creating that snapshot during every begin_write adds a worker task and oneshot round trip to ordinary puts and point deletes.

## Result

Criterion direct-storage A/B for a warmed, repeated 4 KiB overwrite (begin_write + put_many + commit with SlateDB background durability):

- main: 46.891 us [42.705, 54.316]
- candidate: 28.733 us [24.199, 31.722]
- estimate: **-38.7%**
- Criterion change interval: [-52.708%, -37.379%], p < 0.05

This isolates adapter overhead on an in-memory object store. Cold open and WAL durability are intentionally outside the sample; SlateDB continues to own and batch background WAL flushes.

## Change

Create and retain a snapshot only on the first delete_range call. Ordinary puts and point deletes never allocate one. The existing single-writer gate makes the lazy snapshot equivalent for the only operation that consumes it.

A direct JoinHandle shortcut was measured and rejected (~0.9% regression). No alternate path, migration, or compatibility layer is added.

## Validation

- 6 SlateDB adapter tests pass.
- 8 engine SlateDB integration/conformance tests pass.
- Strict Clippy with warnings denied passes.
- Formatting and diff checks pass.
- The Criterion fixture is committed in slatedb_file_api.rs.