### PR TITLE
perf(observe): share immutable results across fanout

### DIFF
--- a/.changenotes/share-observation-result-storage.md
+++ b/.changenotes/share-observation-result-storage.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reduced CPU time and memory copying when remote observations fan out large blob results.
+
+Immutable query results now share their backing storage across observation subscribers and retained transport delta bases.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::future::Future;
 use std::ops::ControlFlow;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use crate::branch::BranchRefReader;
 use crate::functions::{FunctionContext, FunctionProviderHandle};
@@ -29,12 +29,18 @@ use super::transaction::SessionTransaction;
 ///
 /// Column names live once at the result-set level. Individual rows only own
 /// values, which keeps the public API row-oriented without copying schema
-/// metadata into every row.
+/// metadata into every row. Result storage is immutable and reference counted
+/// so observation fanout does not copy large blob values per subscriber.
 #[derive(Debug, Clone)]
 pub struct ExecuteResult {
-    columns: Vec<String>,
-    rows: Vec<Row>,
+    backing: Arc<ExecuteResultBacking>,
     rows_affected: u64,
+}
+
+#[derive(Debug)]
+struct ExecuteResultBacking {
+    columns: Arc<[String]>,
+    rows: Vec<Row>,
     notices: Vec<LixNotice>,
     // Observe evaluations can be shared across sessions. Carry the exact
     // rendered plugin state with the rows so each receiving session can
@@ -44,10 +50,11 @@ pub struct ExecuteResult {
 
 impl PartialEq for ExecuteResult {
     fn eq(&self, other: &Self) -> bool {
-        self.columns == other.columns
-            && self.rows == other.rows
-            && self.rows_affected == other.rows_affected
-            && self.notices == other.notices
+        self.rows_affected == other.rows_affected
+            && (Arc::ptr_eq(&self.backing, &other.backing)
+                || (self.backing.columns == other.backing.columns
+                    && self.backing.rows == other.backing.rows
+                    && self.backing.notices == other.backing.notices))
     }
 }
 
@@ -62,14 +69,7 @@ pub struct CoherentReadBatch {
 
 impl ExecuteResult {
     fn from_sql_query_result(result: SqlQueryResult) -> Self {
-        Self {
-            columns: result.columns,
-            rows: Vec::new(),
-            rows_affected: 0,
-            notices: result.notices,
-            file_view_mutations: Vec::new(),
-        }
-        .with_rows(result.rows)
+        Self::from_query_parts(result.columns, result.rows, 0, result.notices)
     }
 
     fn from_sql_write_result(result: sql2::SqlWriteResult) -> Self {
@@ -78,86 +78,86 @@ impl ExecuteResult {
             returning,
         } = result;
         match returning {
-            Some(result) => Self {
-                columns: result.columns,
-                rows: Vec::new(),
-                rows_affected,
-                notices: result.notices,
-                file_view_mutations: Vec::new(),
+            Some(result) => {
+                Self::from_query_parts(result.columns, result.rows, rows_affected, result.notices)
             }
-            .with_rows(result.rows),
             None => Self::from_rows_affected(rows_affected),
         }
     }
 
     pub fn from_rows_affected(rows_affected: u64) -> Self {
         Self {
-            columns: Vec::new(),
-            rows: Vec::new(),
+            backing: empty_execute_result_backing(),
             rows_affected,
-            notices: Vec::new(),
-            file_view_mutations: Vec::new(),
         }
     }
 
     pub fn from_rows(columns: Vec<String>, rows: Vec<Vec<Value>>) -> Self {
-        Self {
-            columns,
-            rows: Vec::new(),
-            rows_affected: 0,
-            notices: Vec::new(),
-            file_view_mutations: Vec::new(),
-        }
-        .with_rows(rows)
+        Self::from_query_parts(columns, rows, 0, Vec::new())
     }
 
-    fn with_rows(mut self, rows: Vec<Vec<Value>>) -> Self {
-        let columns = Arc::<[String]>::from(self.columns.clone().into_boxed_slice());
-        self.rows = rows
+    fn from_query_parts(
+        columns: Vec<String>,
+        rows: Vec<Vec<Value>>,
+        rows_affected: u64,
+        notices: Vec<LixNotice>,
+    ) -> Self {
+        let columns: Arc<[String]> = columns.into();
+        let rows = rows
             .into_iter()
             .map(|values| Row {
                 columns: Arc::clone(&columns),
                 values,
             })
             .collect();
-        self
+        Self {
+            backing: Arc::new(ExecuteResultBacking {
+                columns,
+                rows,
+                notices,
+                file_view_mutations: Vec::new(),
+            }),
+            rows_affected,
+        }
     }
 
     fn with_file_view_mutations(mut self, mutations: Vec<sql2::SessionFileViewMutation>) -> Self {
-        self.file_view_mutations = mutations;
+        Arc::get_mut(&mut self.backing)
+            .expect("fresh execute result backing must be uniquely owned")
+            .file_view_mutations = mutations;
         self
     }
 
     pub(crate) fn file_view_mutations(&self) -> &[sql2::SessionFileViewMutation] {
-        &self.file_view_mutations
+        &self.backing.file_view_mutations
     }
 
     /// Returns the result-set column names in row value order.
     pub fn columns(&self) -> &[String] {
-        &self.columns
+        self.backing.columns.as_ref()
     }
 
     /// Returns the owned rows. Use `iter()` for name-based access.
     pub fn rows(&self) -> &[Row] {
-        &self.rows
+        &self.backing.rows
     }
 
     /// Iterates rows with borrowed access to the shared column metadata.
     pub fn iter(&self) -> impl Iterator<Item = RowRef<'_>> {
-        self.rows.iter().map(|row| RowRef {
-            columns: self.columns.as_slice(),
+        self.backing.rows.iter().map(|row| RowRef {
+            columns: self.backing.columns.as_ref(),
             values: row.values.as_slice(),
         })
     }
 
     /// Returns the number of rows in this result set.
     pub fn len(&self) -> usize {
-        self.rows.len()
+        self.backing.rows.len()
     }
 
     /// Returns true when this result set has no rows.
     pub fn is_empty(&self) -> bool {
-        self.rows.is_empty()
+        self.backing.rows.is_empty()
     }
 
     /// Returns the number of rows affected by a mutation statement.
@@ -167,7 +167,7 @@ impl ExecuteResult {
 
     /// Returns non-fatal diagnostics produced while executing the statement.
     pub fn notices(&self) -> &[LixNotice] {
-        &self.notices
+        &self.backing.notices
     }
 
     /// Looks up the value for `column_name` on an owned row from this set.
@@ -178,8 +178,23 @@ impl ExecuteResult {
 
     /// Returns the index for a column name.
     pub fn column_index(&self, column_name: &str) -> Option<usize> {
-        self.columns.iter().position(|column| column == column_name)
+        self.backing
+            .columns
+            .iter()
+            .position(|column| column == column_name)
     }
+}
+
+fn empty_execute_result_backing() -> Arc<ExecuteResultBacking> {
+    static EMPTY: OnceLock<Arc<ExecuteResultBacking>> = OnceLock::new();
+    Arc::clone(EMPTY.get_or_init(|| {
+        Arc::new(ExecuteResultBacking {
+            columns: Vec::new().into(),
+            rows: Vec::new(),
+            notices: Vec::new(),
+            file_view_mutations: Vec::new(),
+        })
+    }))
 }
 
 /// One owned row returned by a query.
@@ -1699,6 +1714,18 @@ mod tests {
             row.value("title").unwrap(),
             &Value::Text("Hello".to_string())
         );
+    }
+
+    #[test]
+    fn execute_result_clone_shares_immutable_backing() {
+        let result = ExecuteResult::from_rows(
+            vec!["data".to_string()],
+            vec![vec![Value::Blob(vec![b'x'; 1024 * 1024])]],
+        );
+        let cloned = result.clone();
+
+        assert!(Arc::ptr_eq(&result.backing, &cloned.backing));
+        assert_eq!(result, cloned);
     }
 
     #[test]

--- a/packages/engine/tests/execute_result_allocations.rs
+++ b/packages/engine/tests/execute_result_allocations.rs
@@ -1,0 +1,125 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::mem::size_of;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use lix_engine::{ExecuteResult, Value};
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: Delegates the allocation unchanged to the system allocator.
+        let pointer = unsafe { System.alloc(layout) };
+        record_allocation(pointer, layout.size());
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: Delegates the allocation unchanged to the system allocator.
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        record_allocation(pointer, layout.size());
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: The pointer and layout came from this allocator, which
+        // delegates every allocation to the system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: Delegates the reallocation unchanged to the system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        record_allocation(pointer, new_size);
+        pointer
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AllocationStats {
+    count: usize,
+    bytes: usize,
+}
+
+fn record_allocation(pointer: *mut u8, bytes: usize) {
+    if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+        ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+    }
+}
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, AllocationStats) {
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    assert!(!TRACK_ALLOCATIONS.swap(true, Ordering::SeqCst));
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    let stats = AllocationStats {
+        count: ALLOCATION_COUNT.load(Ordering::Relaxed),
+        bytes: ALLOCATED_BYTES.load(Ordering::Relaxed),
+    };
+    (result, stats)
+}
+
+fn blob_pointer(result: &ExecuteResult) -> *const u8 {
+    let [Value::Blob(bytes)] = result.rows()[0].values() else {
+        panic!("diagnostic result must contain one blob")
+    };
+    bytes.as_ptr()
+}
+
+#[test]
+#[ignore = "manual deterministic ExecuteResult allocation diagnostic"]
+fn execute_result_construction_and_clone_allocations() {
+    black_box(ExecuteResult::from_rows_affected(0));
+    let (_, rows_affected) =
+        measure_allocations(|| black_box(ExecuteResult::from_rows_affected(1)));
+    eprintln!(
+        "execute_result_rows_affected allocations={} allocated_bytes={}",
+        rows_affected.count, rows_affected.bytes
+    );
+    assert_eq!(
+        rows_affected.count, 0,
+        "rows-affected-only results must remain allocation-free"
+    );
+
+    for size_mib in [1_usize, 10] {
+        let size_bytes = size_mib * 1024 * 1024;
+        let columns = vec!["data".to_string()];
+        let rows = vec![vec![Value::Blob(vec![b'x'; size_bytes])]];
+        let (result, construction) =
+            measure_allocations(|| ExecuteResult::from_rows(columns, rows));
+        let probe = result.clone();
+        eprintln!(
+            "execute_result_construct size_mib={size_mib} layout_bytes={} allocations={} allocated_bytes={} clone_shares_blob={}",
+            size_of::<ExecuteResult>(),
+            construction.count,
+            construction.bytes,
+            blob_pointer(&result) == blob_pointer(&probe),
+        );
+
+        for fanout in [1_usize, 4, 16] {
+            let ((), cloning) = measure_allocations(|| {
+                for _ in 0..fanout {
+                    let cloned = result.clone();
+                    black_box(blob_pointer(&cloned));
+                    black_box(cloned);
+                }
+            });
+            eprintln!(
+                "execute_result_clone size_mib={size_mib} subscribers={fanout} allocations={} allocated_bytes={}",
+                cloning.count, cloning.bytes
+            );
+            assert_eq!(cloning.count, 0, "cloning must remain allocation-free");
+            assert_eq!(cloning.bytes, 0, "cloning must not copy result storage");
+        }
+    }
+}

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -1627,7 +1627,15 @@ enum MultiplexObserveMessage {
 
 struct BlobDeltaBase {
     sequence: u64,
-    bytes: Vec<u8>,
+    // ExecuteResult has immutable shared backing, so retaining the transport
+    // base does not copy the point-read blob for every subscription.
+    rows: ExecuteResult,
+}
+
+impl BlobDeltaBase {
+    fn bytes(&self) -> &[u8] {
+        point_blob_bytes(&self.rows).expect("blob delta bases are point blob results")
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1673,9 +1681,9 @@ fn multiplex_observe_payload(
     event: ObserveEvent,
     base: Option<&BlobDeltaBase>,
 ) -> Result<(MultiplexObservePayload, Option<BlobDeltaBase>), LixError> {
-    let next_base = point_blob_bytes(&event.rows).map(|bytes| BlobDeltaBase {
+    let next_base = point_blob_bytes(&event.rows).map(|_| BlobDeltaBase {
         sequence: event.sequence,
-        bytes: bytes.to_vec(),
+        rows: event.rows.clone(),
     });
     let delta = match base.zip(next_base.as_ref()) {
         Some((base, next)) if base.sequence.checked_add(1) == Some(event.sequence) => {
@@ -1720,31 +1728,30 @@ fn single_blob_splice(
     base: &BlobDeltaBase,
     next: &BlobDeltaBase,
 ) -> Result<Option<SingleBlobSplice>, LixError> {
-    if next.bytes.len() < MIN_BLOB_DELTA_BYTES {
+    if next.bytes().len() < MIN_BLOB_DELTA_BYTES {
         return Ok(None);
     }
-    let prefix_bytes = base
-        .bytes
+    let base_bytes = base.bytes();
+    let next_bytes = next.bytes();
+    let prefix_bytes = base_bytes
         .iter()
-        .zip(&next.bytes)
+        .zip(next_bytes)
         .take_while(|(left, right)| left == right)
         .count();
-    let max_suffix = base
-        .bytes
+    let max_suffix = base_bytes
         .len()
         .saturating_sub(prefix_bytes)
-        .min(next.bytes.len().saturating_sub(prefix_bytes));
-    let suffix_bytes = base
-        .bytes
+        .min(next_bytes.len().saturating_sub(prefix_bytes));
+    let suffix_bytes = base_bytes
         .iter()
         .rev()
-        .zip(next.bytes.iter().rev())
+        .zip(next_bytes.iter().rev())
         .take(max_suffix)
         .take_while(|(left, right)| left == right)
         .count();
-    let insert_end = next.bytes.len().saturating_sub(suffix_bytes);
-    let insert = &next.bytes[prefix_bytes..insert_end];
-    let Some(full_base64_bytes) = padded_base64_len(next.bytes.len()) else {
+    let insert_end = next_bytes.len().saturating_sub(suffix_bytes);
+    let insert = &next_bytes[prefix_bytes..insert_end];
+    let Some(full_base64_bytes) = padded_base64_len(next_bytes.len()) else {
         return Ok(None);
     };
     let Some(delta_base64_bytes) = padded_base64_len(insert.len()) else {
@@ -2783,6 +2790,17 @@ mod tests {
     }
 
     #[test]
+    fn multiplex_blob_delta_base_reuses_event_storage() {
+        let event = point_blob_event(0, vec![b'a'; 1024 * 1024]);
+        let event_bytes = point_blob_bytes(&event.rows).expect("point blob event");
+        let event_ptr = event_bytes.as_ptr();
+        let (_, base) = multiplex_observe_payload(event, None).expect("initial payload");
+        let base = base.expect("blob base");
+
+        assert_eq!(base.bytes().as_ptr(), event_ptr);
+    }
+
+    #[test]
     fn multiplex_blob_delta_roundtrips_replace_insert_and_delete() {
         let initial = vec![b'a'; 100 * 1024];
         let (payload, mut base) =
@@ -2869,6 +2887,57 @@ mod tests {
             apply_blob_splice(&replacement, payload.delta.expect("localized splice")),
             localized
         );
+    }
+
+    #[test]
+    #[ignore = "manual observation fanout performance diagnostic"]
+    fn multiplex_blob_delta_fanout_perf() {
+        use std::hint::black_box;
+        use std::time::{Duration, Instant};
+
+        const SAMPLES: usize = 60;
+        for size_mib in [1_usize, 10] {
+            let initial = vec![b'a'; size_mib * 1024 * 1024];
+            let mut localized = initial.clone();
+            let middle = localized.len() / 2;
+            localized[middle] = b'b';
+            let event = point_blob_event(1, localized);
+            for fanout in [1_usize, 4, 16] {
+                let bases = (0..fanout)
+                    .map(|_| {
+                        multiplex_observe_payload(point_blob_event(0, initial.clone()), None)
+                            .expect("initial payload")
+                            .1
+                            .expect("blob base")
+                    })
+                    .collect::<Vec<_>>();
+                let mut samples = Vec::with_capacity(SAMPLES);
+                for _ in 0..SAMPLES {
+                    let started = Instant::now();
+                    for base in &bases {
+                        black_box(
+                            multiplex_observe_payload(event.clone(), Some(base))
+                                .expect("delta payload"),
+                        );
+                    }
+                    samples.push(started.elapsed());
+                }
+                samples.sort_unstable();
+                let p50 = samples[SAMPLES / 2];
+                let p95 = samples[SAMPLES * 95 / 100];
+                let total_bytes = u32::try_from(size_mib * 1024 * 1024 * fanout)
+                    .expect("diagnostic byte count should fit u32");
+                let throughput = |elapsed: Duration| {
+                    f64::from(total_bytes) / elapsed.as_secs_f64() / (1024.0 * 1024.0)
+                };
+                eprintln!(
+                    "observe_fanout size_mib={size_mib} subscribers={fanout} p50_us={} p95_us={} logical_mib_s_p50={:.1}",
+                    p50.as_micros(),
+                    p95.as_micros(),
+                    throughput(p50),
+                );
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Hypothesis

The observation coordinator evaluates identical queries once, but ExecuteResult cloning still deep-copies rows and blob values for every subscriber and cached transport base. Making the immutable result storage shared should turn fanout clones into constant-time handles.

This follows the same shared-copy fanout principle described by Electric Durable Streams: one payload should be retained once and served to many readers (https://electric.ax/blog/2026/06/26/durable-streams-at-kernel-speed).

## Result

Exact paired p50, main to candidate:

| Blob | Subscribers | Main | Candidate | Improvement |
| --- | ---: | ---: | ---: | ---: |
| 1 MiB | 1 | 0.410 ms | 0.359 ms | 12.4% |
| 1 MiB | 4 | 4.648 ms | 1.459 ms | 68.6% |
| 1 MiB | 16 | 12.803 ms | 5.956 ms | 53.5% |
| 10 MiB | 1 | 4.419 ms | 3.614 ms | 18.2% |
| 10 MiB | 4 | 36.212 ms | 15.572 ms | 57.0% |
| 10 MiB | 16 | 78.600 ms | 61.993 ms | 21.1% |

Deterministic allocation accounting:

- rows-affected result: 0 to 0 allocations
- point-result construction: 4 to 3 allocations
- ExecuteResult handle: 104 to 16 bytes
- clone fanout at 1/4/16 subscribers: 5/20/80 to 0 allocations
- copied blob bytes at 10 MiB: 10.5/41.9/167.8 MB to 0

## Change

ExecuteResult now owns one Arc-backed immutable result backing plus the scalar rows-affected count. Rows, notices, columns, and delivered file-view acknowledgement state share that lifetime. The remote blob-delta base retains the shallow result handle instead of copying the point-file blob.

A first four-Arc implementation was rejected after it added four allocations to rows-affected results. The final single backing uses one shared immutable empty backing, preserving the common small-write path.

No public method, wire format, migration, or compatibility layer changes.

## Validation

- observation tests: 45 passed
- server protocol tests: 31 passed
- focused coordinator and plugin acknowledgement tests pass
- strict all-feature Clippy for engine, SDK, and server protocol passes
- formatting and diff checks pass
- repeatable allocation and fanout diagnostics are included