### PR TITLE
perf(remote): compare request blob deltas by words

### DIFF
--- a/.changenotes/chunk-request-blob-delta-comparisons.md
+++ b/.changenotes/chunk-request-blob-delta-comparisons.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Remote file writes now locate unchanged regions in cached request blobs with word-sized comparisons, reducing client CPU time for localized edits.

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -255,9 +255,12 @@ test("remote execute sends successful large blob updates as exact splices", asyn
 			},
 		},
 	});
-	const first = new Uint8Array(32 * 1024).fill(97);
-	const second = new Uint8Array(first);
-	second[16 * 1024] = 98;
+	const firstBacking = new Uint8Array(32 * 1024 + 3).fill(97);
+	const first = firstBacking.subarray(3);
+	const secondBacking = new Uint8Array(first.byteLength + 5);
+	secondBacking.set(first, 5);
+	const second = secondBacking.subarray(5);
+	second[16 * 1024 + 3] = 98;
 	const prototype = Uint8Array.prototype as Uint8Array & {
 		toBase64?: () => string;
 	};
@@ -294,8 +297,8 @@ test("remote execute sends successful large blob updates as exact splices", asyn
 	expect(bodies[1]?.cacheBlobs).toBe(true);
 	expect(delta).toMatchObject({
 		kind: "blob-splice",
-		prefixBytes: 16 * 1024,
-		suffixBytes: 16 * 1024 - 1,
+		prefixBytes: 16 * 1024 + 3,
+		suffixBytes: 16 * 1024 - 4,
 		insertBase64: "Yg==",
 	});
 	expect(delta?.baseSha256).toMatch(/^[0-9a-f]{64}$/);

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -41,6 +41,7 @@ const OBSERVE_RETRY_MAX_MS = 5_000;
 const REMOTE_SESSION_HEADER = "Lix-Session-Id";
 const REQUEST_BLOB_DELTA_MIN_BYTES = 32 * 1024;
 const REQUEST_BLOB_DELTA_MIN_WIRE_RATIO = 0.9;
+const REQUEST_BLOB_COMPARE_WORD_BYTES = 8;
 const REQUEST_BLOB_BASE_MAX_ENTRIES = 8;
 const REQUEST_BLOB_BASE_MAX_BYTES = 2 * 1024 * 1024;
 const REMOTE_BLOB_BASE_MISSING = "LIX_REMOTE_BLOB_BASE_MISSING";
@@ -576,8 +577,26 @@ function planBlobSplice(
 	result: Uint8Array,
 	resultSha256: string,
 ): BlobSplicePlan {
+	const baseView = new DataView(
+		base.bytes.buffer,
+		base.bytes.byteOffset,
+		base.bytes.byteLength,
+	);
+	const resultView = new DataView(
+		result.buffer,
+		result.byteOffset,
+		result.byteLength,
+	);
 	let prefixBytes = 0;
 	const prefixLimit = Math.min(base.bytes.byteLength, result.byteLength);
+	while (
+		prefixLimit - prefixBytes >= REQUEST_BLOB_COMPARE_WORD_BYTES &&
+		baseView.getUint32(prefixBytes) === resultView.getUint32(prefixBytes) &&
+		baseView.getUint32(prefixBytes + 4) ===
+			resultView.getUint32(prefixBytes + 4)
+	) {
+		prefixBytes += REQUEST_BLOB_COMPARE_WORD_BYTES;
+	}
 	while (
 		prefixBytes < prefixLimit &&
 		base.bytes[prefixBytes] === result[prefixBytes]
@@ -590,6 +609,20 @@ function planBlobSplice(
 		base.bytes.byteLength - prefixBytes,
 		result.byteLength - prefixBytes,
 	);
+	while (suffixLimit - suffixBytes >= REQUEST_BLOB_COMPARE_WORD_BYTES) {
+		const baseOffset =
+			base.bytes.byteLength - suffixBytes - REQUEST_BLOB_COMPARE_WORD_BYTES;
+		const resultOffset =
+			result.byteLength - suffixBytes - REQUEST_BLOB_COMPARE_WORD_BYTES;
+		if (
+			baseView.getUint32(baseOffset) !== resultView.getUint32(resultOffset) ||
+			baseView.getUint32(baseOffset + 4) !==
+				resultView.getUint32(resultOffset + 4)
+		) {
+			break;
+		}
+		suffixBytes += REQUEST_BLOB_COMPARE_WORD_BYTES;
+	}
 	while (
 		suffixBytes < suffixLimit &&
 		base.bytes[base.bytes.byteLength - suffixBytes - 1] ===


### PR DESCRIPTION
## Hypothesis

Localized remote file writes spend avoidable client CPU time finding unchanged request-blob regions one byte at a time. Comparing word-sized chunks should reduce end-to-end request preparation without changing the protocol.

## Result

Independent public-path A/B, median of seven fresh-process p50s:

| Scenario | `main` | Candidate | Change |
|---|---:|---:|---:|
| 32 KiB localized edit | 0.317 ms | 0.221 ms | -30.4% |
| 1 MiB localized edit | 2.433 ms | 1.474 ms | -39.4% |
| 2 MiB localized edit | 5.089 ms | 3.039 ms | -40.3% |

The measured path includes parameter snapshots, SHA-256, splice planning/encoding, JSON/compression preparation, `Request` construction, and response decoding.

Full-replacement controls remain neutral:

- 32 KiB: 2.563 → 2.484 ms (-3.1%)
- 1 MiB: 50.085 → 51.049 ms (+1.9%)
- 2 MiB: 96.608 → 96.354 ms (-0.3%)

## Implementation

`planBlobSplice` compares two 32-bit words per iteration through bounded `DataView`s, then retains the byte tail for exact boundaries. Prefix/suffix bounds and the existing wire-ratio check remain unchanged. There is no protocol or compatibility path.

## Validation

- 100,000 randomized different-length comparisons plus exact reconstruction checks
- exhaustive lengths 0–40, offsets 0–11, and 8-byte boundary edits
- direct `SharedArrayBuffer` validation and caller-mutation/cache-alias regression
- actual headless Chromium localized and length-changing splice test
- focused remote client tests: 23/23
- TypeScript build and typecheck
- changenote validation and `git diff --check`