### PR TITLE
perf(engine): avoid duplicate DataFusion write session

### DIFF
--- a/.changenotes/avoid-duplicate-datafusion-write-session.md
+++ b/.changenotes/avoid-duplicate-datafusion-write-session.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Improved DataFusion-backed SQL write performance by validating regular fallback writes in their authoritative execution session instead of preparing the same providers twice.

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -122,6 +122,37 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
         );
     }
 
+    for &delay_ms in FRESH_ENGINE_DELAYS_MS {
+        let delay = Duration::from_millis(delay_ms);
+        let delay_label = format!("{delay_ms}ms");
+
+        group.bench_with_input(
+            BenchmarkId::new("guarded_update_file_after_preload", &delay_label),
+            &delay,
+            |b, &delay| {
+                b.iter_custom(|iterations| {
+                    let fixture = runtime.block_on(UploadBenchFixture::seeded(delay));
+                    black_box(runtime.block_on(fixture.guarded_update_file()));
+                    measure_iterations(iterations, || {
+                        runtime.block_on(fixture.guarded_update_file())
+                    })
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("fast_update_file_after_preload", delay_label),
+            &delay,
+            |b, &delay| {
+                b.iter_custom(|iterations| {
+                    let fixture = runtime.block_on(UploadBenchFixture::seeded(delay));
+                    black_box(runtime.block_on(fixture.fast_update_file()));
+                    measure_iterations(iterations, || runtime.block_on(fixture.fast_update_file()))
+                });
+            },
+        );
+    }
+
     group.finish();
 
     cached_cold_lifecycle_benches(c, &runtime);
@@ -567,6 +598,8 @@ struct UploadBenchFixture {
     _cache_dir: TempDir,
     object_store: Arc<DelayedObjectStore>,
     next_upload_version: AtomicU64,
+    next_update_version: AtomicU64,
+    file_id: String,
     upload_path: String,
     upload_batch_paths: Vec<String>,
     upload_batch_sql: String,
@@ -597,6 +630,8 @@ impl UploadBenchFixture {
             _cache_dir: cache_dir,
             object_store: seeded.object_store,
             next_upload_version: AtomicU64::new(0),
+            next_update_version: AtomicU64::new(0),
+            file_id: seeded.file_id,
             upload_path: seeded.upload_path,
             upload_batch_paths: (0..LIXRAY_UPLOAD_BATCH_FILES).map(file_path).collect(),
             upload_batch_sql: upload_batch_sql(LIXRAY_UPLOAD_BATCH_FILES),
@@ -620,6 +655,51 @@ impl UploadBenchFixture {
             .await
             .expect("overwrite benchmark file");
         result.rows_affected()
+    }
+
+    async fn guarded_update_file(&self) -> u64 {
+        let version = self.next_update_version.fetch_add(1, Ordering::Relaxed);
+        let expected = if version == 0 {
+            file_bytes(0)
+        } else {
+            upload_file_bytes(version - 1)
+        };
+        let result = self
+            .session
+            .execute(
+                "UPDATE lix_file SET data = $1 WHERE id = $2 AND data = $3",
+                &[
+                    Value::Blob(upload_file_bytes(version)),
+                    Value::Text(self.file_id.clone()),
+                    Value::Blob(expected),
+                ],
+            )
+            .await
+            .expect("guarded-update benchmark file");
+        let rows_affected = result.rows_affected();
+        assert_eq!(
+            rows_affected, 1,
+            "guarded-update benchmark must keep its expected bytes in sync"
+        );
+        rows_affected
+    }
+
+    async fn fast_update_file(&self) -> u64 {
+        let version = self.next_update_version.fetch_add(1, Ordering::Relaxed);
+        let result = self
+            .session
+            .execute(
+                "UPDATE lix_file SET data = $1 WHERE id = $2",
+                &[
+                    Value::Blob(upload_file_bytes(version)),
+                    Value::Text(self.file_id.clone()),
+                ],
+            )
+            .await
+            .expect("fast-update benchmark file");
+        let rows_affected = result.rows_affected();
+        assert_eq!(rows_affected, 1);
+        rows_affected
     }
 
     async fn upload_overwrite_file_batch(&self) -> u64 {

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1899,6 +1899,11 @@ mod tests {
         schema_definitions: Vec<JsonValue>,
     }
 
+    struct CountingWriteSessionContext<'a> {
+        inner: DummySqlWriteExecutionContext<'a>,
+        branch_head_loads: Arc<AtomicUsize>,
+    }
+
     #[async_trait]
     impl SqlWriteExecutionContext for DummySqlWriteExecutionContext<'_> {
         fn active_branch_id(&self) -> &str {
@@ -1957,6 +1962,50 @@ mod tests {
                 .deltas
                 .push(CapturedStageWrite { rows });
             Ok(TransactionWriteOutcome { count })
+        }
+    }
+
+    #[async_trait]
+    impl SqlWriteExecutionContext for CountingWriteSessionContext<'_> {
+        fn active_branch_id(&self) -> &str {
+            self.inner.active_branch_id()
+        }
+
+        fn functions(&self) -> FunctionProviderHandle {
+            self.inner.functions()
+        }
+
+        fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
+            self.inner.list_visible_schemas()
+        }
+
+        async fn load_bytes_many(
+            &mut self,
+            hashes: &[crate::binary_cas::BlobHash],
+        ) -> Result<crate::binary_cas::BlobBytesBatch, LixError> {
+            self.inner.load_bytes_many(hashes).await
+        }
+
+        async fn scan_live_state(
+            &mut self,
+            request: &LiveStateScanRequest,
+        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            self.inner.scan_live_state(request).await
+        }
+
+        async fn load_branch_head(
+            &mut self,
+            branch_id: &str,
+        ) -> Result<Option<CommitId>, LixError> {
+            self.branch_head_loads.fetch_add(1, Ordering::SeqCst);
+            self.inner.load_branch_head(branch_id).await
+        }
+
+        async fn stage_write(
+            &mut self,
+            write: TransactionWrite,
+        ) -> Result<TransactionWriteOutcome, LixError> {
+            self.inner.stage_write(write).await
         }
     }
 
@@ -5189,6 +5238,73 @@ mod tests {
             .expect("DataFusion staged delta should project")
             .visible_all_semantic_rows();
         assert_eq!(fast_rows, datafusion_rows);
+    }
+
+    #[tokio::test]
+    async fn execute_sql_guarded_file_data_fallback_builds_one_write_session() {
+        let rows = vec![
+            live_directory_row("dir-docs", "branch-a", None, "docs"),
+            live_file_row("file-readme", "branch-a", Some("dir-docs"), "readme.md"),
+            live_blob_ref_row("file-readme", "branch-a", b"old"),
+        ];
+        let (inner, staged_writes, scans) = counting_write_context_with_blob_reader(
+            rows,
+            Arc::new(StaticBlobReader {
+                bytes: b"old".to_vec(),
+            }),
+        );
+        let branch_head_loads = Arc::new(AtomicUsize::new(0));
+        let mut ctx = CountingWriteSessionContext {
+            inner,
+            branch_head_loads: Arc::clone(&branch_head_loads),
+        };
+
+        let (result, path) = execute_write_sql_trace(
+            &mut ctx,
+            "UPDATE lix_file SET data = $1 WHERE id = $2 AND data = $3",
+            &[
+                Value::Blob(b"new".to_vec()),
+                Value::Text("file-readme".to_string()),
+                Value::Blob(b"old".to_vec()),
+            ],
+            WriteExecutorMode::Auto,
+        )
+        .await
+        .expect("guarded file update should use the DataFusion fallback");
+
+        assert_eq!(path, WriteExecutorPath::DataFusion);
+        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+        assert_eq!(
+            branch_head_loads.load(Ordering::SeqCst),
+            1,
+            "the fallback should build and initialize one DataFusion write session"
+        );
+        assert_eq!(
+            scans.load(Ordering::SeqCst),
+            2,
+            "the descriptor and blob-ref reads should run once, during execution"
+        );
+
+        let staged_writes = staged_writes.lock().expect("staged writes lock");
+        assert_eq!(staged_writes.deltas.len(), 1);
+        let overlay = staged_writes.deltas[0]
+            .pending_write_overlay()
+            .expect("staged delta should expose pending overlay");
+        let blob_refs = overlay.visible_semantic_rows(false, "lix_binary_blob_ref");
+        assert_eq!(blob_refs.len(), 1);
+        let snapshot: JsonValue = serde_json::from_str(
+            blob_refs[0]
+                .snapshot_content
+                .as_deref()
+                .expect("blob ref snapshot"),
+        )
+        .expect("blob ref snapshot JSON");
+        assert_eq!(snapshot["id"], "file-readme");
+        assert_eq!(snapshot["size_bytes"], 3);
+        assert_eq!(
+            snapshot["blob_hash"],
+            crate::binary_cas::BlobHash::from_content(b"new").to_hex()
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -163,10 +163,12 @@ async fn execute_write_logical_plan_with_mode_inner(
     }
 
     if mode != WriteExecutorModeInner::ForceDataFusion {
-        super::datafusion::validate_datafusion_write_logical_plan(ctx, &write_plan, params).await?;
-        if let Some(fast_plan) =
-            crate::sql2::optimize::simple_write::try_make_fast_write_plan(&write_plan)?
-        {
+        let fast_plan = crate::sql2::optimize::simple_write::try_make_fast_write_plan(&write_plan)?;
+        if requires_standalone_datafusion_validation(&write_plan, fast_plan.is_some(), mode) {
+            super::datafusion::validate_datafusion_write_logical_plan(ctx, &write_plan, params)
+                .await?;
+        }
+        if let Some(fast_plan) = fast_plan {
             let rows_affected =
                 crate::sql2::exec::fast_write::try_execute_simple_write(ctx, fast_plan, params)
                     .await?;
@@ -186,6 +188,24 @@ async fn execute_write_logical_plan_with_mode_inner(
     let result =
         super::datafusion::execute_datafusion_write_logical_plan(ctx, &write_plan, params).await?;
     Ok((result, WriteExecutorPath::DataFusion))
+}
+
+/// Fast executors rely on the DataFusion writer to preserve validation
+/// behavior that is outside their deliberately narrow implementations.
+///
+/// A regular DataFusion fallback does not need this separate pass: its
+/// executor performs the same input, session, provider, expression, and
+/// filter validation immediately before execution. Empty scopes and upserts
+/// retain the standalone pass because their execution paths can return early.
+fn requires_standalone_datafusion_validation(
+    plan: &LogicalWritePlan,
+    has_fast_plan: bool,
+    mode: WriteExecutorModeInner,
+) -> bool {
+    has_fast_plan
+        || mode == WriteExecutorModeInner::ForceFast
+        || plan.bound.branch_scope == BranchScope::Empty
+        || plan.bound.conflict.is_some()
 }
 
 fn resolve_parameterized_branch_scope(
@@ -699,4 +719,74 @@ fn validate_write_parameter_count(
             .map(|index| format!("${index}"))
             .collect::<Vec<_>>(),
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regular_datafusion_fallback_uses_execution_validation() {
+        let plan = plan_sql("UPDATE lix_file SET data = $1 WHERE id = $2 AND data = $3");
+        let has_fast_plan = crate::sql2::optimize::simple_write::try_make_fast_write_plan(&plan)
+            .expect("fast-plan eligibility should be computable")
+            .is_some();
+        assert!(!has_fast_plan);
+
+        assert!(!requires_standalone_datafusion_validation(
+            &plan,
+            has_fast_plan,
+            WriteExecutorModeInner::Auto,
+        ));
+    }
+
+    #[test]
+    fn early_or_fast_paths_keep_standalone_datafusion_validation() {
+        let fallback = plan_sql("UPDATE lix_file SET data = $1 WHERE id = $2 AND data = $3");
+        assert!(requires_standalone_datafusion_validation(
+            &fallback,
+            false,
+            WriteExecutorModeInner::ForceFast,
+        ));
+
+        let empty_scope = plan_sql(
+            "UPDATE lix_state_by_branch SET metadata = '{}' \
+             WHERE branch_id = 'branch-a' AND branch_id = 'branch-b'",
+        );
+        assert_eq!(empty_scope.bound.branch_scope, BranchScope::Empty);
+        assert!(requires_standalone_datafusion_validation(
+            &empty_scope,
+            false,
+            WriteExecutorModeInner::Auto,
+        ));
+
+        let conflict = plan_sql(
+            "INSERT INTO lix_file (path, data) VALUES ('/readme.md', X'41') \
+             ON CONFLICT (path) DO NOTHING",
+        );
+        assert!(conflict.bound.conflict.is_some());
+        assert!(requires_standalone_datafusion_validation(
+            &conflict,
+            false,
+            WriteExecutorModeInner::Auto,
+        ));
+
+        let fast = plan_sql("DELETE FROM lix_state WHERE false");
+        let has_fast_plan = crate::sql2::optimize::simple_write::try_make_fast_write_plan(&fast)
+            .expect("fast-plan eligibility should be computable")
+            .is_some();
+        assert!(has_fast_plan);
+        assert!(requires_standalone_datafusion_validation(
+            &fast,
+            has_fast_plan,
+            WriteExecutorModeInner::Auto,
+        ));
+    }
+
+    fn plan_sql(sql: &str) -> LogicalWritePlan {
+        let statement = crate::sql2::parse_statement(sql).expect("SQL should parse");
+        let bound =
+            crate::sql2::bind_statement(&statement, &[], "branch-a").expect("SQL should bind");
+        crate::sql2::plan_write(bound).expect("SQL write should plan")
+    }
 }


### PR DESCRIPTION
## Why

Atelier's guarded markdown autosave uses:

```sql
UPDATE lix_file SET data = $1 WHERE id = $2 AND data = $3
```

That query correctly falls back to the DataFusion writer. The `Auto` write path nevertheless built one complete DataFusion session/provider set to validate it, discarded that session, and immediately built the same setup again to execute it. On each autosave this duplicated the active-branch lookup and part of provider/live-state preparation.

DataFusion treats `SessionContext` as the query interface that owns shared resources for planning and execution ([SessionContext lifecycle](https://docs.rs/datafusion/53.0.0/datafusion/execution/context/struct.SessionContext.html#relationship-between-sessioncontext-sessionstate-and-taskcontext)). This change makes the authoritative execution session perform the validation it already contains instead of constructing a throwaway duplicate.

## What

- Compute fast-write eligibility once before choosing the executor.
- For regular `Auto` fallbacks, validate expressions, parameters, providers, and DML while building/executing the authoritative DataFusion session.
- Preserve the standalone validation pass for fast writes, `ForceFast`, empty branch scopes, and conflict/upsert paths whose execution can return early.
- Add a regression test proving the guarded update uses one write session, performs one descriptor/blob-ref read set, and stages the same blob reference.
- Add permanent SlateDB guarded-update and unaffected ID-only control benchmarks at 0 ms and 25 ms object-store delay.

No public API changes, complete DataFusion plans, or snapshot-bound providers are cached.

## Performance

Release build; median of 3 independent runs; each run used one warmed engine/session, 20 warmups, and 100 measured alternating 4 KiB updates. Both variants ran the exact same harness against fresh local RocksDB and SlateDB stores.

| Backend | Guarded autosave | `main` | This PR | Change |
| --- | --- | ---: | ---: | ---: |
| RocksDB | p50 | 3.399 ms | 2.755 ms | **-19.0%** |
| RocksDB | p95 | 3.532 ms | 2.870 ms | **-18.7%** |
| SlateDB | p50 | 8.045 ms | 7.006 ms | **-12.9%** |
| SlateDB | p95 | 9.148 ms | 7.739 ms | **-15.4%** |

The guarded write's physical read work changed as expected:

| Per operation | `main` | This PR |
| --- | ---: | ---: |
| `begin_read` | 14 | 12 |
| `get_many` calls | 78 | 75 |
| `get_many` keys | 254 | 251 |
| scans | 5 | 5 |
| scan rows | 71.5 | 71.5 |

The ID-only fast update is outside this optimization and served as the no-regression control:

| Backend | Control | `main` | This PR | Change |
| --- | --- | ---: | ---: | ---: |
| RocksDB | p50 | 2.110 ms | 2.099 ms | -0.5% |
| RocksDB | p95 | 2.207 ms | 2.174 ms | -1.5% |
| SlateDB | p50 | 6.665 ms | 6.221 ms | -6.7% |
| SlateDB | p95 | 7.156 ms | 6.832 ms | -4.5% |

Its storage-operation counts were identical before and after.

## Validation

- `cargo test -p lix_engine`
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo bench -p lix_engine --bench slatedb_file_api --features slatedb --no-run`
- Focused one-session/staged-output and validation-routing tests
- `cargo fmt --package lix_engine -- --check`
- `node scripts/validate-changes.mjs`
- `git diff --check`
