### PR TITLE
perf(engine): index existing lix_file path upserts

### DIFF
--- a/.changenotes/index-existing-file-path-upserts.md
+++ b/.changenotes/index-existing-file-path-upserts.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+Improved existing `lix_file` path upserts by reusing the revisioned filesystem
+path index instead of scanning and rebuilding the workspace filesystem state.

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -33,7 +33,7 @@ use serde_json::json;
 use tempfile::TempDir;
 
 const DELAYS_MS: &[u64] = &[0, 10, 25, 50];
-const SEED_FILE_COUNT: usize = 100;
+const DEFAULT_SEED_FILE_COUNT: usize = 100;
 const FILE_SIZE_BYTES: usize = 4096;
 const UPLOAD_BATCH_SIZE: usize = 10;
 const LIXRAY_UPLOAD_BATCH_FILES: usize = 10;
@@ -309,15 +309,33 @@ fn maybe_print_write_accounting(runtime: &tokio::runtime::Runtime) {
     if std::env::var_os("LIX_SLATEDB_WRITE_ACCOUNTING").is_none() {
         return;
     }
+    let samples = std::env::var("LIX_SLATEDB_WRITE_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1)
+        .max(1);
+    let operation =
+        std::env::var("LIX_SLATEDB_WRITE_OPERATION").unwrap_or_else(|_| "overwrite".to_string());
     let fixture = runtime.block_on(UploadBenchFixture::seeded(Duration::ZERO));
     black_box(runtime.block_on(fixture.upload_overwrite_file()));
     runtime
         .block_on(fixture.storage.flush())
         .expect("flush upload accounting warmup");
     fixture.object_store.reset_write_stats();
-    let started = Instant::now();
-    let rows_affected = runtime.block_on(fixture.upload_overwrite_file());
-    let accepted = started.elapsed();
+    let mut accepted = Vec::with_capacity(samples);
+    let mut rows_affected = 0;
+    for _ in 0..samples {
+        let started = Instant::now();
+        rows_affected += match operation.as_str() {
+            "overwrite" => runtime.block_on(fixture.upload_overwrite_file()),
+            "insert" => runtime.block_on(fixture.upload_new_file()),
+            other => panic!("unsupported LIX_SLATEDB_WRITE_OPERATION {other:?}"),
+        };
+        accepted.push(started.elapsed());
+    }
+    accepted.sort_unstable();
+    let p50 = accepted[(accepted.len() - 1) * 50 / 100];
+    let p95 = accepted[(accepted.len() - 1) * 95 / 100];
     let flush_started = Instant::now();
     runtime
         .block_on(fixture.storage.flush())
@@ -325,8 +343,10 @@ fn maybe_print_write_accounting(runtime: &tokio::runtime::Runtime) {
     let flush = flush_started.elapsed();
     let stats = fixture.object_store.write_stats();
     println!(
-        "slatedb-write-accounting rows_affected={rows_affected} accepted_ns={} flush_ns={} put_calls={} put_bytes={}",
-        accepted.as_nanos(),
+        "slatedb-write-accounting operation={operation} seed_files={} samples={samples} rows_affected={rows_affected} accepted_p50_ns={} accepted_p95_ns={} flush_ns={} put_calls={} put_bytes={}",
+        seed_file_count(),
+        p50.as_nanos(),
+        p95.as_nanos(),
         flush.as_nanos(),
         stats.put_calls,
         stats.put_bytes,
@@ -638,6 +658,26 @@ impl UploadBenchFixture {
             .execute(&self.upload_batch_sql, &params)
             .await
             .expect("overwrite benchmark file batch");
+        result.rows_affected()
+    }
+
+    async fn upload_new_file(&self) -> u64 {
+        let version = self.next_upload_version.fetch_add(1, Ordering::Relaxed);
+        let path = format!("/bench-new-{version:020}.bin");
+        let result = self
+            .session
+            .execute(
+                "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ($1, $2, $3) \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data, \
+                 lixcol_metadata = excluded.lixcol_metadata",
+                &[
+                    Value::Text(path),
+                    Value::Blob(upload_file_bytes(version)),
+                    upload_file_metadata(version),
+                ],
+            )
+            .await
+            .expect("insert benchmark file");
         result.rows_affected()
     }
 }
@@ -1110,8 +1150,10 @@ async fn read_storage_key(storage: &SlateDB, key: &Key) -> usize {
 }
 
 async fn seed_files(session: &SessionContext<SlateDB>) {
-    for chunk_start in (0..SEED_FILE_COUNT).step_by(UPLOAD_BATCH_SIZE) {
-        let chunk_end = (chunk_start + UPLOAD_BATCH_SIZE).min(SEED_FILE_COUNT);
+    let seed_file_count = seed_file_count();
+    let upload_batch_size = seed_upload_batch_size();
+    for chunk_start in (0..seed_file_count).step_by(upload_batch_size) {
+        let chunk_end = (chunk_start + upload_batch_size).min(seed_file_count);
         let mut placeholders = Vec::with_capacity(chunk_end - chunk_start);
         let mut params = Vec::with_capacity((chunk_end - chunk_start) * 3);
 
@@ -1172,10 +1214,26 @@ fn file_metadata() -> Value {
 }
 
 fn upload_file_bytes(version: u64) -> Vec<u8> {
-    let seed_file_count = u64::try_from(SEED_FILE_COUNT).expect("seed file count fits in u64");
+    let seed_file_count = u64::try_from(seed_file_count()).expect("seed file count fits in u64");
     let byte = u8::try_from((version % 251 + seed_file_count % 251) % 251)
         .expect("upload byte pattern fits in u8");
     vec![byte; FILE_SIZE_BYTES]
+}
+
+fn seed_file_count() -> usize {
+    std::env::var("LIX_SLATEDB_SEED_FILE_COUNT")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_SEED_FILE_COUNT)
+        .max(1)
+}
+
+fn seed_upload_batch_size() -> usize {
+    std::env::var("LIX_SLATEDB_SEED_BATCH_SIZE")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(UPLOAD_BATCH_SIZE)
+        .max(1)
 }
 
 fn upload_file_metadata(version: u64) -> Value {

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -4801,7 +4801,9 @@ mod tests {
         assert_eq!(fast_path, WriteExecutorPath::Fast);
         assert_eq!(datafusion_path, WriteExecutorPath::DataFusion);
         assert_eq!(fast_result.rows, datafusion_result.rows);
-        assert_eq!(fast_scans.load(Ordering::SeqCst), 1);
+        // The indexed existing-path route performs one path-index load and one
+        // exact blob-ref load. The counting test reader models both as scans.
+        assert_eq!(fast_scans.load(Ordering::SeqCst), 2);
         assert_eq!(datafusion_scans.load(Ordering::SeqCst), 3);
 
         let fast_rows = fast_staged.lock().expect("fast writes lock").deltas[0]
@@ -4935,7 +4937,9 @@ mod tests {
 
         assert_eq!(path, WriteExecutorPath::Fast);
         assert_eq!(result.rows, vec![vec![Value::Integer(2)]]);
-        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        // The indexed route probes the path index before declining to the
+        // generic mixed existing/new batch scan.
+        assert_eq!(scans.load(Ordering::SeqCst), 2);
 
         let staged_writes = staged_writes.lock().expect("staged writes lock");
         assert_eq!(staged_writes.deltas.len(), 1);
@@ -4972,7 +4976,10 @@ mod tests {
                 .expect_err("duplicate VALUES paths should fail");
 
             assert_eq!(error.code, LixError::CODE_UNIQUE, "{sql}");
-            assert_eq!(scans.load(Ordering::SeqCst), 1, "{sql}");
+            // Only DO UPDATE enters the indexed existing-path route before the
+            // generic scan rejects duplicate missing paths.
+            let expected_scans = if sql.contains("DO UPDATE") { 2 } else { 1 };
+            assert_eq!(scans.load(Ordering::SeqCst), expected_scans, "{sql}");
             assert!(
                 staged_writes
                     .lock()

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -36,7 +36,7 @@ use crate::common::{LixPath, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{FilesystemIndex, filesystem_schema_keys};
 use crate::filesystem::{
-    FilesystemPathIndexReader, FilesystemPathIndexRequest, FilesystemPathKind,
+    FilesystemPathEntry, FilesystemPathIndexReader, FilesystemPathIndexRequest, FilesystemPathKind,
     FilesystemPathSelection,
 };
 use crate::functions::FunctionProviderHandle;
@@ -1743,6 +1743,18 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
     let active_branch_id = ctx.active_branch_id().to_string();
     let parsed_writes = parse_fast_lix_file_path_writes(writes)?;
 
+    if matches!(
+        conflict,
+        FastLixFilePathWriteConflict::UpdateData
+            | FastLixFilePathWriteConflict::UpdateDataAndMetadata
+    ) && let Some(existing) =
+        exact_existing_file_entries(ctx, &active_branch_id, &parsed_writes).await?
+    {
+        return stage_exact_existing_file_path_writes(ctx, parsed_writes, existing, conflict)
+            .await
+            .map(Some);
+    }
+
     let live_rows = ctx
         .scan_live_state(&LiveStateScanRequest {
             filter: LiveStateFilter {
@@ -1883,6 +1895,136 @@ pub(crate) async fn execute_fast_lix_file_path_writes(
         | FastLixFilePathWriteConflict::UpdateDataAndMetadata => TransactionWriteMode::Replace,
     };
     stage_lix_file_fast_batch(ctx, mode, staged).await.map(Some)
+}
+
+async fn exact_existing_file_entries(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    active_branch_id: &str,
+    writes: &[FastLixFilePathWrite],
+) -> Result<Option<Vec<Arc<FilesystemPathEntry>>>, LixError> {
+    let index = ctx
+        .filesystem_path_index(&FilesystemPathIndexRequest::new(vec![
+            active_branch_id.to_string(),
+        ]))
+        .await?;
+    let mut existing = Vec::with_capacity(writes.len());
+    for write in writes {
+        let entries = index.exact_entries(&write.parsed.path);
+        let [entry] = entries.as_slice() else {
+            return Ok(None);
+        };
+        if entry.kind != FilesystemPathKind::File {
+            return Ok(None);
+        }
+        existing.push(Arc::clone(entry));
+    }
+    Ok(Some(existing))
+}
+
+async fn stage_exact_existing_file_path_writes(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    writes: Vec<FastLixFilePathWrite>,
+    existing: Vec<Arc<FilesystemPathEntry>>,
+    conflict: FastLixFilePathWriteConflict,
+) -> Result<u64, LixError> {
+    debug_assert_eq!(writes.len(), existing.len());
+    debug_assert!(matches!(
+        conflict,
+        FastLixFilePathWriteConflict::UpdateData
+            | FastLixFilePathWriteConflict::UpdateDataAndMetadata
+    ));
+    for (write, entry) in writes.iter().zip(&existing) {
+        validate_fast_lix_file_path_conflict_pair(entry.key.is_untracked(), &write.parsed.path)?;
+    }
+    let blob_backed = load_exact_existing_blob_keys(ctx, &existing).await?;
+    let mut staged = LixFileStagedBatch::default();
+
+    for (write, entry) in writes.into_iter().zip(existing) {
+        let has_blob_ref = blob_backed.contains(&entry.key);
+        let mut context = FilesystemRowContext {
+            branch_id: entry.key.branch_id().to_string(),
+            global: entry.key.global(),
+            untracked: entry.key.is_untracked(),
+            file_id: entry.key.file_id().map(str::to_string),
+            metadata: None,
+        };
+        if context.global {
+            context.branch_id = GLOBAL_BRANCH_ID.to_string();
+        }
+        match conflict {
+            FastLixFilePathWriteConflict::UpdateData => {
+                context.file_id = Some(entry.id().to_string());
+            }
+            FastLixFilePathWriteConflict::UpdateDataAndMetadata => {
+                context.metadata = write.metadata;
+                staged
+                    .state_rows
+                    .push(file_descriptor_row(FileDescriptorRowInput {
+                        id: entry.id().to_string(),
+                        directory_id: entry.parent_id.clone(),
+                        name: entry.name.clone(),
+                        context: context.clone(),
+                    }));
+            }
+            FastLixFilePathWriteConflict::None | FastLixFilePathWriteConflict::DoNothing => {
+                unreachable!("exact existing path route only handles conflict updates")
+            }
+        }
+        stage_lix_file_data_update_write(
+            &mut staged,
+            entry.id().to_string(),
+            Some(write.parsed.path),
+            Some(entry.name.clone()),
+            write.data,
+            context,
+            has_blob_ref,
+            None,
+        )
+        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+        staged.add_count(1)?;
+    }
+
+    stage_lix_file_fast_batch(ctx, TransactionWriteMode::Replace, staged).await
+}
+
+async fn load_exact_existing_blob_keys(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    entries: &[Arc<FilesystemPathEntry>],
+) -> Result<BTreeSet<FilesystemDescriptorKey>, LixError> {
+    if entries.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    let unique = entries
+        .iter()
+        .map(|entry| (entry.key.clone(), Arc::clone(entry)))
+        .collect::<BTreeMap<_, _>>();
+    let request = LiveStateExactBatchRequest {
+        rows: unique
+            .values()
+            .map(|entry| LiveStateExactRowRequest {
+                branch_id: entry.key.branch_id().to_string(),
+                schema_key: BLOB_REF_SCHEMA_KEY.to_string(),
+                entity_pk: EntityPk::single(entry.id()),
+                file_id: Some(entry.id().to_string()),
+            })
+            .collect(),
+        projection: LiveStateProjection::default(),
+        untracked: Some(false),
+        include_tombstones: false,
+    };
+    let rows = ctx.load_exact_live_state_rows(&request).await?;
+    Ok(unique
+        .into_keys()
+        .zip(rows)
+        .filter_map(|(key, row)| {
+            row.filter(|row| {
+                row.branch_id == key.branch_id()
+                    && row.global == key.global()
+                    && row.untracked == key.is_untracked()
+            })
+            .map(|_| key)
+        })
+        .collect())
 }
 
 pub(crate) async fn execute_fast_lix_file_data_update_by_id(
@@ -4482,10 +4624,7 @@ pub(super) fn indexed_path_matches(
         index: &crate::filesystem::FilesystemPathIndex,
         predicate: &FilePathPredicate,
         kind: FilesystemPathKind,
-    ) -> BTreeMap<
-        (FilesystemPathKind, FilesystemDescriptorKey),
-        Arc<crate::filesystem::FilesystemPathEntry>,
-    > {
+    ) -> BTreeMap<(FilesystemPathKind, FilesystemDescriptorKey), Arc<FilesystemPathEntry>> {
         let candidates = match predicate {
             FilePathPredicate::All => index.entries(),
             FilePathPredicate::Comparison { operation, value } => match operation {
@@ -9631,6 +9770,185 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fast_file_path_upsert_uses_exact_index_without_scanning_blob_state() {
+        let old_data = b"old";
+        let rows = vec![
+            live_file_row(
+                "file-readme",
+                "branch-b",
+                r#"{"id":"file-readme","directory_id":null,"name":"readme.md"}"#,
+            ),
+            live_blob_ref_row(
+                "file-readme",
+                "branch-b",
+                "file-readme",
+                &BlobHash::from_content(old_data).to_hex(),
+                old_data.len(),
+            ),
+        ];
+        let mut write_context = CapturingWriteContext {
+            rows,
+            ..CapturingWriteContext::default()
+        };
+
+        let outcome = super::execute_fast_lix_file_path_writes(
+            &mut write_context,
+            vec![(
+                "/readme.md".to_string(),
+                b"new".to_vec(),
+                Some(TransactionJson::from_value_for_test(
+                    serde_json::json!({"source": "upload"}),
+                )),
+            )],
+            super::FastLixFilePathWriteConflict::UpdateDataAndMetadata,
+        )
+        .await
+        .expect("existing path upsert should stage");
+
+        assert!(outcome.is_some());
+        assert_eq!(write_context.path_index_count, 1);
+        assert_eq!(write_context.exact_load_requests.len(), 1);
+        assert_eq!(write_context.exact_load_requests[0].rows.len(), 1);
+        assert_eq!(write_context.scan_count, 0);
+        let TransactionWrite::RowsWithFileData {
+            rows, file_data, ..
+        } = &write_context.writes[0]
+        else {
+            panic!("path upsert should stage descriptor, blob, and file data");
+        };
+        assert_eq!(file_data.len(), 1);
+        assert_eq!(file_data[0].path.as_deref(), Some("/readme.md"));
+        assert_eq!(file_data[0].data(), b"new");
+        assert!(file_data[0].had_blob_ref);
+        let descriptor = rows
+            .iter()
+            .find(|row| row.schema_key == super::FILE_DESCRIPTOR_SCHEMA_KEY)
+            .expect("metadata upsert should rewrite the descriptor");
+        assert_eq!(
+            descriptor.metadata.as_ref(),
+            Some(&TransactionJson::from_value_for_test(
+                serde_json::json!({"source": "upload"})
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn fast_file_path_upsert_does_not_cross_blob_ref_scope_lanes() {
+        let local_descriptor = live_file_row(
+            "file-local",
+            "branch-b",
+            r#"{"id":"file-local","directory_id":null,"name":"local.md"}"#,
+        );
+        let mut global_fallback = live_blob_ref_row(
+            "file-local",
+            crate::GLOBAL_BRANCH_ID,
+            "file-local",
+            &BlobHash::from_content(b"global").to_hex(),
+            6,
+        );
+        global_fallback.global = true;
+
+        let mut global_descriptor = live_file_row(
+            "file-global",
+            "branch-b",
+            r#"{"id":"file-global","directory_id":null,"name":"global.md"}"#,
+        );
+        global_descriptor.global = true;
+        let branch_override = live_blob_ref_row(
+            "file-global",
+            "branch-b",
+            "file-global",
+            &BlobHash::from_content(b"branch").to_hex(),
+            6,
+        );
+        let mut write_context = CapturingWriteContext {
+            rows: vec![
+                local_descriptor,
+                global_fallback,
+                global_descriptor,
+                branch_override,
+            ],
+            ..CapturingWriteContext::default()
+        };
+
+        let outcome = super::execute_fast_lix_file_path_writes(
+            &mut write_context,
+            vec![
+                ("/local.md".to_string(), b"new-local".to_vec(), None),
+                ("/global.md".to_string(), b"new-global".to_vec(), None),
+            ],
+            super::FastLixFilePathWriteConflict::UpdateData,
+        )
+        .await
+        .expect("scope-isolated path upsert should stage");
+
+        assert!(outcome.is_some());
+        assert_eq!(write_context.path_index_count, 1);
+        assert_eq!(write_context.exact_load_requests.len(), 1);
+        assert_eq!(write_context.exact_load_requests[0].rows.len(), 2);
+        assert_eq!(write_context.scan_count, 0);
+        let TransactionWrite::RowsWithFileData {
+            rows, file_data, ..
+        } = &write_context.writes[0]
+        else {
+            panic!("scope-isolated path upsert should stage file data");
+        };
+        assert_eq!(file_data.len(), 2);
+        assert!(file_data.iter().all(|write| !write.had_blob_ref));
+        assert!(rows.iter().all(|row| row.snapshot.is_some()));
+    }
+
+    #[tokio::test]
+    async fn fast_empty_file_path_upsert_loads_exact_prior_blob() {
+        let old_data = b"old";
+        let rows = vec![
+            live_file_row(
+                "file-readme",
+                "branch-b",
+                r#"{"id":"file-readme","directory_id":null,"name":"readme.md"}"#,
+            ),
+            live_blob_ref_row(
+                "file-readme",
+                "branch-b",
+                "file-readme",
+                &BlobHash::from_content(old_data).to_hex(),
+                old_data.len(),
+            ),
+        ];
+        let mut write_context = CapturingWriteContext {
+            rows,
+            ..CapturingWriteContext::default()
+        };
+
+        let outcome = super::execute_fast_lix_file_path_writes(
+            &mut write_context,
+            vec![("/readme.md".to_string(), Vec::new(), None)],
+            super::FastLixFilePathWriteConflict::UpdateData,
+        )
+        .await
+        .expect("empty existing path upsert should stage");
+
+        assert!(outcome.is_some());
+        assert_eq!(write_context.path_index_count, 1);
+        assert_eq!(write_context.exact_load_requests.len(), 1);
+        assert_eq!(write_context.exact_load_requests[0].rows.len(), 1);
+        assert_eq!(write_context.scan_count, 0);
+        let TransactionWrite::RowsWithFileData {
+            rows, file_data, ..
+        } = &write_context.writes[0]
+        else {
+            panic!("empty path upsert should stage a blob tombstone and file data");
+        };
+        assert!(file_data[0].data().is_empty());
+        assert!(file_data[0].had_blob_ref);
+        assert!(
+            rows.iter().any(|row| {
+                row.schema_key == super::BLOB_REF_SCHEMA_KEY && row.snapshot.is_none()
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn fast_file_path_write_declines_ambiguous_cross_scope_paths() {
         let tracked = live_file_row(
             "file-tracked",
@@ -9657,6 +9975,7 @@ mod tests {
         .expect("ambiguous legacy topology should decline the fast path");
 
         assert_eq!(outcome, None);
+        assert_eq!(write_context.path_index_count, 1);
         assert_eq!(write_context.scan_count, 1);
         assert!(write_context.writes.is_empty());
     }

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -869,6 +869,65 @@ async fn plugin_detect_changes_receives_descriptor_filename() {
 }
 
 #[tokio::test]
+async fn non_empty_plugin_overwrite_does_not_stage_blob_ref_tombstone() {
+    let storage = Memory::new();
+    let receipt = Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let runtime = Arc::new(SentinelPluginRuntime::default());
+    let engine = Engine::new_with_wasm_runtime(storage, runtime)
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_session(receipt.main_branch_id.clone())
+        .await
+        .expect("workspace session should open");
+
+    install_plugin(&session, "plugin_sentinel", &sentinel_plugin_archive())
+        .await
+        .expect("plugin install should succeed");
+    write_file(&session, "/owned.sentinel", b"first".to_vec())
+        .await
+        .expect("plugin file write should succeed");
+    let file = session
+        .execute(
+            "SELECT id FROM lix_file WHERE path = '/owned.sentinel'",
+            &[],
+        )
+        .await
+        .expect("plugin file id should load");
+    let [Value::Text(file_id)] = file.rows()[0].values() else {
+        panic!("expected plugin file id");
+    };
+    assert_eq!(blob_ref_count(&session, file_id).await, 0);
+
+    write_file(&session, "/owned.sentinel", b"second".to_vec())
+        .await
+        .expect("plugin file overwrite should succeed");
+    let commit_id = engine
+        .load_branch_head_commit_id(&receipt.main_branch_id)
+        .await
+        .expect("branch head should load")
+        .expect("branch head should exist");
+    let blob_ref_history = session
+        .execute(
+            &format!(
+                "SELECT entity_pk FROM lix_state_history \
+                 WHERE start_commit_id = '{commit_id}' \
+                   AND schema_key = 'lix_binary_blob_ref' \
+                   AND entity_pk = lix_json('[\"{file_id}\"]')"
+            ),
+            &[],
+        )
+        .await
+        .expect("blob ref history should load");
+
+    assert_eq!(blob_ref_history.len(), 0);
+    assert_eq!(blob_ref_count(&session, file_id).await, 0);
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
 async fn plugin_stale_writes_preserve_disjoint_entity_edits() {
     let (_engine, session_a, session_b) = keyed_collaboration_sessions().await;
     write_file(&session_a, "/shared.keyed", b"a=0\nb=0\n".to_vec())


### PR DESCRIPTION
## Hypothesis

The normal overwrite path already maintains a revisioned filesystem path index, but existing `lix_file` path upserts still scan and rebuild the entire live filesystem. Looking up exact existing descriptors and blob references through the maintained indexes should make overwrite latency independent of workspace size.

## Result

Frozen `main` versus the corrected candidate, identical seven-sample SlateDB command:

| Existing files | `main` | Candidate | Change |
|---:|---:|---:|---:|
| 100 | 13.631 ms | 8.684 ms | -36.3% |
| 1,000 | 79.371 ms | 43.399 ms | -45.3% |
| 10,000 | 670.572 ms | 277.273 ms | -58.7% |

An independent rebuild/run confirmed the gate at -40.3%, -61.4%, and -58.9% respectively.

## Implementation

- Resolve exact existing paths from the revisioned filesystem path index.
- Exact-read only the corresponding blob-reference rows.
- Match branch/global/untracked scope before treating a file as blob-backed.
- Fall back to the existing general path for missing, duplicate, directory, or ambiguous paths.
- Keep plugin semantic files semantic-only; no phantom blob tombstones or compatibility path.

The warm existing-file overwrite is the target 90% path. A first missing-path upsert after reopening a large workspace may build the index before using the old scan fallback; avoiding that cold edge would add disproportionate complexity.

## Validation

- full filesystem/plugin integration suite: 53/53
- path-upsert SQL integration: 10/10
- explicit branch/global/untracked lane regressions
- plugin-only overwrite history regression
- blob-backed and empty-write tombstone behavior
- multi-file, concurrent, and stale plugin writes
- strict all-feature library Clippy
- formatting and diff checks