### PR TITLE
perf(engine): skip unchanged file descriptor metadata

### DIFF
--- a/.changenotes/skip-unchanged-file-metadata.md
+++ b/.changenotes/skip-unchanged-file-metadata.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Existing `lix_file` path upserts no longer rewrite file descriptors when the
+incoming metadata is unchanged, avoiding workspace-wide namespace validation
+for byte-only overwrites.

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -328,6 +328,9 @@ fn maybe_print_write_accounting(runtime: &tokio::runtime::Runtime) {
         let started = Instant::now();
         rows_affected += match operation.as_str() {
             "overwrite" => runtime.block_on(fixture.upload_overwrite_file()),
+            "overwrite-static-metadata" => {
+                runtime.block_on(fixture.upload_overwrite_file_static_metadata())
+            }
             "insert" => runtime.block_on(fixture.upload_new_file()),
             other => panic!("unsupported LIX_SLATEDB_WRITE_OPERATION {other:?}"),
         };
@@ -639,6 +642,25 @@ impl UploadBenchFixture {
             )
             .await
             .expect("overwrite benchmark file");
+        result.rows_affected()
+    }
+
+    async fn upload_overwrite_file_static_metadata(&self) -> u64 {
+        let version = self.next_upload_version.fetch_add(1, Ordering::Relaxed);
+        let result = self
+            .session
+            .execute(
+                "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ($1, $2, $3) \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data, \
+                 lixcol_metadata = excluded.lixcol_metadata",
+                &[
+                    Value::Text(self.upload_path.clone()),
+                    Value::Blob(upload_file_bytes(version)),
+                    file_metadata(),
+                ],
+            )
+            .await
+            .expect("overwrite benchmark file with unchanged metadata");
         result.rows_affected()
     }
 

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1956,15 +1956,19 @@ async fn stage_exact_existing_file_path_writes(
                 context.file_id = Some(entry.id().to_string());
             }
             FastLixFilePathWriteConflict::UpdateDataAndMetadata => {
+                let metadata_changed =
+                    entry.metadata() != write.metadata.as_ref().map(TransactionJson::normalized);
                 context.metadata = write.metadata;
-                staged
-                    .state_rows
-                    .push(file_descriptor_row(FileDescriptorRowInput {
-                        id: entry.id().to_string(),
-                        directory_id: entry.parent_id.clone(),
-                        name: entry.name.clone(),
-                        context: context.clone(),
-                    }));
+                if metadata_changed {
+                    staged
+                        .state_rows
+                        .push(file_descriptor_row(FileDescriptorRowInput {
+                            id: entry.id().to_string(),
+                            directory_id: entry.parent_id.clone(),
+                            name: entry.name.clone(),
+                            context: context.clone(),
+                        }));
+                }
             }
             FastLixFilePathWriteConflict::None | FastLixFilePathWriteConflict::DoNothing => {
                 unreachable!("exact existing path route only handles conflict updates")

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -2,6 +2,7 @@ use lix_engine::ExecuteResult;
 use lix_engine::LixError;
 use lix_engine::Value;
 use lix_engine::{CreateBranchOptions, MergeBranchOptions, MergeBranchOutcome};
+use serde_json::json;
 
 use super::assert_rows_eq;
 
@@ -2362,6 +2363,218 @@ simulation_test!(lix_file_update_accepts_empty_blob_data, |sim| async move {
         .expect("blob ref state read should succeed");
     assert_eq!(blob_ref_result.len(), 0);
 });
+
+simulation_test!(
+    lix_file_equal_normalized_metadata_skips_descriptor_history,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let upsert = "INSERT INTO lix_file (path, data, lixcol_metadata) \
+                      VALUES ($1, $2, $3) \
+                      ON CONFLICT (path) DO UPDATE SET \
+                        data = excluded.data, \
+                        lixcol_metadata = excluded.lixcol_metadata";
+        let metadata = json!({"a": 1, "z": 2});
+        session
+            .execute(
+                upsert,
+                &[
+                    Value::Text("/equal-metadata.bin".to_string()),
+                    Value::Blob(b"before".to_vec()),
+                    Value::Json(metadata.clone()),
+                ],
+            )
+            .await
+            .expect("initial file upsert should succeed");
+        let file = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/equal-metadata.bin'",
+                &[],
+            )
+            .await
+            .expect("file id should load");
+        let [Value::Text(file_id)] = file.rows()[0].values() else {
+            panic!("expected file id");
+        };
+
+        session
+            .execute(
+                upsert,
+                &[
+                    Value::Text("/equal-metadata.bin".to_string()),
+                    Value::Blob(b"after".to_vec()),
+                    Value::Json(metadata.clone()),
+                ],
+            )
+            .await
+            .expect("equal-metadata overwrite should succeed");
+        let commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("branch head should load")
+            .expect("branch head should exist");
+
+        let current = session
+            .execute(
+                "SELECT data, lixcol_metadata \
+                 FROM lix_file WHERE path = '/equal-metadata.bin'",
+                &[],
+            )
+            .await
+            .expect("updated file should load");
+        assert_eq!(
+            current.rows()[0].values(),
+            &[Value::Blob(b"after".to_vec()), Value::Json(metadata),]
+        );
+        assert_eq!(
+            file_descriptor_event_count(&session, &commit_id, file_id).await,
+            0
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_changed_and_null_metadata_keep_descriptor_history_exact,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let upsert = "INSERT INTO lix_file (path, data, lixcol_metadata) \
+                      VALUES ($1, $2, $3) \
+                      ON CONFLICT (path) DO UPDATE SET \
+                        data = excluded.data, \
+                        lixcol_metadata = excluded.lixcol_metadata";
+        session
+            .execute(
+                upsert,
+                &[
+                    Value::Text("/changed-metadata.bin".to_string()),
+                    Value::Blob(b"one".to_vec()),
+                    Value::Json(json!({"version": 1})),
+                ],
+            )
+            .await
+            .expect("initial file upsert should succeed");
+        let file = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/changed-metadata.bin'",
+                &[],
+            )
+            .await
+            .expect("file id should load");
+        let [Value::Text(file_id)] = file.rows()[0].values() else {
+            panic!("expected file id");
+        };
+
+        session
+            .execute(
+                upsert,
+                &[
+                    Value::Text("/changed-metadata.bin".to_string()),
+                    Value::Blob(b"two".to_vec()),
+                    Value::Json(json!({"version": 2})),
+                ],
+            )
+            .await
+            .expect("changed-metadata overwrite should succeed");
+        let changed_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("branch head should load")
+            .expect("branch head should exist");
+        assert_eq!(
+            file_descriptor_event_count(&session, &changed_commit_id, file_id).await,
+            1
+        );
+
+        session
+            .execute(
+                upsert,
+                &[
+                    Value::Text("/changed-metadata.bin".to_string()),
+                    Value::Blob(b"three".to_vec()),
+                    Value::Null,
+                ],
+            )
+            .await
+            .expect("metadata removal should succeed");
+        let removed_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("branch head should load")
+            .expect("branch head should exist");
+        assert_eq!(
+            file_descriptor_event_count(&session, &removed_commit_id, file_id).await,
+            1
+        );
+
+        session
+            .execute(
+                upsert,
+                &[
+                    Value::Text("/changed-metadata.bin".to_string()),
+                    Value::Blob(b"four".to_vec()),
+                    Value::Null,
+                ],
+            )
+            .await
+            .expect("equal null metadata overwrite should succeed");
+        let equal_null_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("branch head should load")
+            .expect("branch head should exist");
+        assert_eq!(
+            file_descriptor_event_count(&session, &equal_null_commit_id, file_id).await,
+            0
+        );
+        let current = session
+            .execute(
+                "SELECT data, lixcol_metadata \
+                 FROM lix_file WHERE path = '/changed-metadata.bin'",
+                &[],
+            )
+            .await
+            .expect("null-metadata file should load");
+        assert_eq!(
+            current.rows()[0].values(),
+            &[Value::Blob(b"four".to_vec()), Value::Null]
+        );
+    }
+);
+
+async fn file_descriptor_event_count(
+    session: &crate::support::simulation_test::engine::SimSession,
+    commit_id: &str,
+    file_id: &str,
+) -> usize {
+    session
+        .execute(
+            &format!(
+                "SELECT entity_pk FROM lix_state_history \
+                 WHERE start_commit_id = '{commit_id}' \
+                   AND depth = 0 \
+                   AND schema_key = 'lix_file_descriptor' \
+                   AND entity_pk = lix_json('[\"{file_id}\"]')"
+            ),
+            &[],
+        )
+        .await
+        .expect("descriptor history should load")
+        .len()
+}
 
 simulation_test!(
     lix_file_update_empty_data_on_empty_file_does_not_stage_blob_ref_tombstone,


### PR DESCRIPTION
## Summary

- compare incoming normalized metadata with the indexed existing descriptor
- skip staging a descriptor change when metadata is identical, while still applying the file bytes
- preserve descriptor history for changed metadata and metadata removal
- add exact history regressions for equal, changed, removed, and null metadata

This is stacked on #673 because the exact existing-path index supplies the current descriptor metadata without a workspace scan. There is no compatibility path or format/protocol change.

## Benchmark

SlateDB existing-file `INSERT ... ON CONFLICT(path) DO UPDATE SET data, lixcol_metadata`, equal metadata, seven samples per size; frozen #673 head versus this commit:

| Existing files | Base p50 | Candidate p50 | Improvement |
| ---: | ---: | ---: | ---: |
| 100 | 15.20 ms | 6.32 ms | 58.4% |
| 1,000 | 37.39 ms | 4.63 ms | 87.6% |
| 10,000 | 281.69 ms | 8.14 ms | 97.1% |

The equal-metadata path avoids a descriptor event and therefore avoids workspace-wide filesystem namespace validation. Interleaved changed-metadata controls showed no reproducible regression; the 100-file median was 4.1% faster.

## Correctness

- equal normalized `Some` metadata: bytes update, no descriptor event
- changed `Some` metadata: bytes update, one descriptor event
- `Some -> None`: bytes update, one descriptor event
- `None -> None`: bytes update, no descriptor event

## Validation

- 159 `lix_file` tests
- 53 `fs_api` tests
- strict clippy with all features
- `cargo fmt --check`
- `git diff --check`