### PR TITLE
perf(engine): accelerate exact file reads

### DIFF
--- a/.changenotes/accelerate-exact-lix-file-reads.md
+++ b/.changenotes/accelerate-exact-lix-file-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Exact `lix_file` data and change-ID reads are now substantially faster.
+
+Canonical ID and path point reads avoid general SQL planning while preserving branch visibility, plugin rendering, and collaboration acknowledgement semantics.

--- a/packages/engine/src/functions/context.rs
+++ b/packages/engine/src/functions/context.rs
@@ -21,6 +21,17 @@ pub(crate) struct FunctionContext {
 }
 
 impl FunctionContext {
+    /// Creates the runtime bookkeeping context for a read that cannot invoke
+    /// SQL functions. Such a read never advances deterministic state, so it
+    /// does not need to load the persisted deterministic-mode rows first.
+    pub(crate) fn system_for_function_free_read() -> Self {
+        let mut bookkeeping_functions = SystemFunctionProvider;
+        Self {
+            functions: FunctionProviderHandle::system(),
+            bookkeeping_timestamp: bookkeeping_functions.timestamp(),
+        }
+    }
+
     /// Prepares the runtime function provider for one execution.
     ///
     /// If deterministic mode is absent or disabled, the context uses system
@@ -29,11 +40,7 @@ impl FunctionContext {
     pub(crate) async fn prepare(live_state: &dyn LiveStateReader) -> Result<Self, LixError> {
         let mode = state::load_mode(live_state).await?;
         if !mode.enabled {
-            let mut bookkeeping_functions = SystemFunctionProvider;
-            return Ok(Self {
-                functions: FunctionProviderHandle::system(),
-                bookkeeping_timestamp: bookkeeping_functions.timestamp(),
-            });
+            return Ok(Self::system_for_function_free_read());
         }
 
         let sequence = state::load_sequence(live_state).await?;

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -17,7 +17,7 @@ use crate::transaction::{begin_commit_boundary, commit_at_boundary};
 use crate::{LixError, LixNotice, SqlQueryResult, Value};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use datafusion::sql::sqlparser::ast::{
-    BinaryOperator, Expr, GroupByExpr, LimitClause, SelectFlavor, SelectItem, SetExpr,
+    BinaryOperator, Expr, GroupByExpr, LimitClause, Select, SelectFlavor, SelectItem, SetExpr,
     Statement as SqlStatement, TableFactor, Value as SqlValue, Visit, Visitor,
 };
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -473,6 +473,7 @@ where
         }
 
         let acknowledge_file_views = is_acknowledgeable_file_data_read(&statement, params);
+        let exact_lix_file_read = exact_lix_file_read(&statement, params);
         let has_durable_runtime_function = sql2::statement_has_durable_runtime_function(&statement);
         let runtime_write_access = if has_durable_runtime_function {
             let write_access = self.begin_session_write_access().await?;
@@ -507,6 +508,7 @@ where
                     statement,
                     params,
                     acknowledge_file_views,
+                    exact_lix_file_read,
                 )
                 .await
             },
@@ -973,6 +975,7 @@ where
         statement: datafusion::sql::parser::Statement,
         params: &[Value],
         acknowledge_file_views: bool,
+        exact_lix_file_read: Option<(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn)>,
     ) -> Result<
         (
             sql2::SessionReadSqlResult,
@@ -981,11 +984,43 @@ where
         LixError,
     > {
         let file_view_collector = acknowledge_file_views.then(sql2::SessionFileViews::default);
+        let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+        if let Some((selector, column)) = exact_lix_file_read {
+            let live_state: Arc<dyn crate::live_state::LiveStateReader> =
+                Arc::new(self.live_state.reader(read_store.clone()));
+            let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
+                Arc::new(self.live_state.reader(read_store.clone()));
+            let branch_ref: Arc<dyn BranchRefReader> =
+                Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
+            let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
+                Arc::new(self.binary_cas.reader(read_store));
+            let query = sql2::execute_exact_lix_file_read(
+                &active_branch_id,
+                live_state,
+                filesystem_path_index,
+                branch_ref,
+                blob_reader,
+                self.plugin_host.clone(),
+                file_view_collector.clone(),
+                &selector,
+                column,
+            )
+            .await?;
+            let file_view_mutations = file_view_collector
+                .map(|collector| collector.plugin_file_mutations())
+                .unwrap_or_default();
+            return Ok((
+                sql2::SessionReadSqlResult {
+                    runtime_functions: FunctionContext::system_for_function_free_read(),
+                    query,
+                },
+                file_view_mutations,
+            ));
+        }
         let live_state: Arc<dyn crate::live_state::LiveStateReader> =
             Arc::new(self.live_state.reader(read_store.clone()));
         let runtime_functions = FunctionContext::prepare(live_state.as_ref()).await?;
         let functions = runtime_functions.provider();
-        let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
         let visible_schemas = self
             .catalog_context
             .schema_jsons_for_sql_read_planning(live_state.as_ref(), &active_branch_id)
@@ -1199,11 +1234,72 @@ where
 /// This intentionally recognizes a narrow, predictable MVP surface. False
 /// negatives merely preserve an omitted entity; false positives can lose one.
 fn is_acknowledgeable_file_data_read(statement: &DataFusionStatement, params: &[Value]) -> bool {
-    let DataFusionStatement::Statement(statement) = statement else {
+    let Some(point_read) = simple_point_read(statement) else {
         return false;
     };
-    let SqlStatement::Query(query) = statement.as_ref() else {
+
+    if !point_read.select.projection.iter().any(|item| {
+        matches!(
+            item,
+            SelectItem::UnnamedExpr(expression)
+                | SelectItem::ExprWithAlias {
+                    expr: expression,
+                    ..
+                } if direct_column_name(expression).as_deref() == Some("data")
+        )
+    }) {
         return false;
+    }
+
+    let selection = point_read
+        .select
+        .selection
+        .as_ref()
+        .expect("simple point read requires a predicate");
+    let mut equality_columns = BTreeSet::new();
+    // Anonymous placeholders are bound in textual order. Atelier's point read
+    // projects the active branch as `? AS active_branch_id` before filtering
+    // by `file.id = ?`, so start the WHERE binder after projection params.
+    let mut anonymous_placeholder_index = point_read
+        .select
+        .projection
+        .iter()
+        .map(anonymous_placeholders_in_select_item)
+        .sum();
+    if !collect_literal_equalities(
+        selection,
+        &mut equality_columns,
+        params,
+        &mut anonymous_placeholder_index,
+    ) {
+        return false;
+    }
+    match point_read.table_name.as_str() {
+        "lix_file" => {
+            equality_columns.len() == 1
+                && (equality_columns.contains("id") || equality_columns.contains("path"))
+        }
+        "lix_file_by_branch" => {
+            equality_columns.len() == 2
+                && equality_columns.contains("lixcol_branch_id")
+                && (equality_columns.contains("id") || equality_columns.contains("path"))
+        }
+        _ => false,
+    }
+}
+
+struct SimplePointRead<'a> {
+    select: &'a Select,
+    table_name: String,
+    exact_table_shape: bool,
+}
+
+fn simple_point_read(statement: &DataFusionStatement) -> Option<SimplePointRead<'_>> {
+    let DataFusionStatement::Statement(statement) = statement else {
+        return None;
+    };
+    let SqlStatement::Query(query) = statement.as_ref() else {
+        return None;
     };
     if query.with.is_some()
         || query.order_by.is_some()
@@ -1215,10 +1311,10 @@ fn is_acknowledgeable_file_data_read(statement: &DataFusionStatement, params: &[
         || query.format_clause.is_some()
         || !query.pipe_operators.is_empty()
     {
-        return false;
+        return None;
     }
     let SetExpr::Select(select) = query.body.as_ref() else {
-        return false;
+        return None;
     };
     if select.flavor != SelectFlavor::Standard
         || select.optimizer_hint.is_some()
@@ -1239,30 +1335,18 @@ fn is_acknowledgeable_file_data_read(statement: &DataFusionStatement, params: &[
         || select.qualify.is_some()
         || select.value_table_mode.is_some()
     {
-        return false;
-    }
-
-    if !select.projection.iter().any(|item| {
-        matches!(
-            item,
-            SelectItem::UnnamedExpr(expression)
-                | SelectItem::ExprWithAlias {
-                    expr: expression,
-                    ..
-                } if direct_column_name(expression).as_deref() == Some("data")
-        )
-    }) {
-        return false;
+        return None;
     }
 
     let [from] = select.from.as_slice() else {
-        return false;
+        return None;
     };
     if !from.joins.is_empty() {
-        return false;
+        return None;
     }
     let TableFactor::Table {
         name,
+        alias,
         args,
         with_hints,
         version,
@@ -1274,7 +1358,7 @@ fn is_acknowledgeable_file_data_read(statement: &DataFusionStatement, params: &[
         ..
     } = &from.relation
     else {
-        return false;
+        return None;
     };
     if args.is_some()
         || !with_hints.is_empty()
@@ -1285,44 +1369,95 @@ fn is_acknowledgeable_file_data_read(statement: &DataFusionStatement, params: &[
         || sample.is_some()
         || !index_hints.is_empty()
     {
-        return false;
+        return None;
     }
-    let Some(table_name) = name.0.last().and_then(|part| part.as_ident()) else {
-        return false;
-    };
+    let table_name = name.0.last().and_then(|part| part.as_ident())?;
+    let unquoted_table = table_name.quote_style.is_none();
     let table_name = table_name.value.to_ascii_lowercase();
 
-    let Some(selection) = select.selection.as_ref() else {
-        return false;
-    };
-    let mut equality_columns = BTreeSet::new();
-    // Anonymous placeholders are bound in textual order. Atelier's point read
-    // projects the active branch as `? AS active_branch_id` before filtering
-    // by `file.id = ?`, so start the WHERE binder after projection params.
-    let mut anonymous_placeholder_index = select
-        .projection
-        .iter()
-        .map(anonymous_placeholders_in_select_item)
-        .sum();
-    if !collect_literal_equalities(
-        selection,
-        &mut equality_columns,
-        params,
-        &mut anonymous_placeholder_index,
-    ) {
-        return false;
+    select.selection.as_ref()?;
+    Some(SimplePointRead {
+        select,
+        table_name,
+        exact_table_shape: name.0.len() == 1
+            && unquoted_table
+            && alias.is_none()
+            && query.limit_clause.is_none(),
+    })
+}
+
+fn exact_lix_file_read(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn)> {
+    let point_read = simple_point_read(statement)?;
+    if point_read.table_name != "lix_file" || !point_read.exact_table_shape {
+        return None;
     }
-    match table_name.as_str() {
-        "lix_file" => {
-            equality_columns.len() == 1
-                && (equality_columns.contains("id") || equality_columns.contains("path"))
+    let [SelectItem::UnnamedExpr(projection)] = point_read.select.projection.as_slice() else {
+        return None;
+    };
+    let Expr::Identifier(projection) = projection else {
+        return None;
+    };
+    if projection.quote_style.is_some() {
+        return None;
+    }
+    let column = match projection.value.to_ascii_lowercase().as_str() {
+        "data" => sql2::ExactLixFileReadColumn::Data,
+        "lixcol_change_id" => sql2::ExactLixFileReadColumn::ChangeId,
+        _ => return None,
+    };
+    let selection = point_read.select.selection.as_ref()?;
+    let (identity_column, identity_value) = exact_point_identity(selection, params)?;
+    let selector = match identity_column.as_str() {
+        "id" => sql2::ExactLixFileReadSelector::Id(identity_value),
+        "path" => sql2::ExactLixFileReadSelector::Path(identity_value),
+        _ => return None,
+    };
+    Some((selector, column))
+}
+
+fn exact_point_identity(expression: &Expr, params: &[Value]) -> Option<(String, String)> {
+    let Expr::BinaryOp {
+        left,
+        op: BinaryOperator::Eq,
+        right,
+    } = expression
+    else {
+        return None;
+    };
+    match (exact_point_column(left), exact_point_column(right)) {
+        (Some(column), None) => Some((column, exact_point_text_param(right, params)?)),
+        (None, Some(column)) => Some((column, exact_point_text_param(left, params)?)),
+        _ => None,
+    }
+}
+
+fn exact_point_column(expression: &Expr) -> Option<String> {
+    let Expr::Identifier(identifier) = expression else {
+        return None;
+    };
+    if identifier.quote_style.is_some() {
+        return None;
+    }
+    Some(identifier.value.to_ascii_lowercase())
+}
+
+fn exact_point_text_param(expression: &Expr, params: &[Value]) -> Option<String> {
+    let Expr::Value(value) = expression else {
+        return None;
+    };
+    match &value.value {
+        SqlValue::Placeholder(placeholder)
+            if params.len() == 1 && (placeholder == "?" || placeholder == "$1") =>
+        {
+            let Value::Text(value) = &params[0] else {
+                return None;
+            };
+            Some(value.clone())
         }
-        "lix_file_by_branch" => {
-            equality_columns.len() == 2
-                && equality_columns.contains("lixcol_branch_id")
-                && (equality_columns.contains("id") || equality_columns.contains("path"))
-        }
-        _ => false,
+        _ => None,
     }
 }
 
@@ -1624,6 +1759,75 @@ mod tests {
         ExecuteBatchStatement {
             sql: sql.to_string(),
             params: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn exact_lix_file_read_recognizes_only_the_narrow_point_shapes() {
+        let data_by_id = sql2::parse_statement("SELECT data FROM lix_file WHERE id = $1").unwrap();
+        assert_eq!(
+            exact_lix_file_read(&data_by_id, &[Value::Text("file-a".to_string())]),
+            Some((
+                sql2::ExactLixFileReadSelector::Id("file-a".to_string()),
+                sql2::ExactLixFileReadColumn::Data,
+            ))
+        );
+
+        let change_by_path =
+            sql2::parse_statement("SELECT lixcol_change_id FROM lix_file WHERE path = ?").unwrap();
+        assert_eq!(
+            exact_lix_file_read(&change_by_path, &[Value::Text("/a.txt".to_string())]),
+            Some((
+                sql2::ExactLixFileReadSelector::Path("/a.txt".to_string()),
+                sql2::ExactLixFileReadColumn::ChangeId,
+            ))
+        );
+
+        for (sql, params) in [
+            (
+                "SELECT id FROM lix_file WHERE id = $1",
+                vec![Value::Text("file-a".to_string())],
+            ),
+            (
+                "SELECT data AS bytes FROM lix_file WHERE id = $1",
+                vec![Value::Text("file-a".to_string())],
+            ),
+            (
+                "SELECT data FROM lix_file AS file WHERE id = $1",
+                vec![Value::Text("file-a".to_string())],
+            ),
+            ("SELECT data FROM lix_file WHERE id = 'file-a'", vec![]),
+            (
+                "SELECT data FROM lix_file WHERE id = $1 LIMIT 1",
+                vec![Value::Text("file-a".to_string())],
+            ),
+            (
+                "SELECT \"DATA\" FROM lix_file WHERE id = $1",
+                vec![Value::Text("file-a".to_string())],
+            ),
+            (
+                "SELECT data FROM \"LIX_FILE\" WHERE id = $1",
+                vec![Value::Text("file-a".to_string())],
+            ),
+            (
+                "SELECT data FROM lix_file WHERE id = $1 AND true",
+                vec![Value::Text("file-a".to_string())],
+            ),
+            ("SELECT data FROM lix_file WHERE id = $1", vec![Value::Null]),
+            (
+                "SELECT data FROM lix_file WHERE id = $1",
+                vec![
+                    Value::Text("file-a".to_string()),
+                    Value::Text("extra".to_string()),
+                ],
+            ),
+        ] {
+            let statement = sql2::parse_statement(sql).unwrap();
+            assert_eq!(
+                exact_lix_file_read(&statement, &params),
+                None,
+                "unexpected fast-path match for {sql}"
+            );
         }
     }
 

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1467,7 +1467,7 @@ fn datafusion_error_to_lix_error(error: datafusion::error::DataFusionError) -> L
     crate::sql2::error::datafusion_error_to_lix_error(error)
 }
 
-fn query_result_from_batches(
+pub(crate) fn query_result_from_batches(
     result_fields: &[Field],
     batches: &[RecordBatch],
 ) -> Result<SqlQueryResult, LixError> {

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -53,4 +53,7 @@ pub(crate) use file_view::{
 };
 pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
+pub(crate) use providers::{
+    ExactLixFileReadColumn, ExactLixFileReadSelector, execute_exact_lix_file_read,
+};
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -66,7 +66,9 @@ use crate::sql2::write_normalization::{
 use crate::sql2::{SessionFileViewKey, SessionFileViews, SessionPluginFileView};
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 use crate::wasm::WasmComponentInstance;
-use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value, serialize_row_metadata};
+use crate::{
+    GLOBAL_BRANCH_ID, LixError, SqlQueryResult, parse_row_metadata_value, serialize_row_metadata,
+};
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
@@ -216,6 +218,27 @@ struct LixFileDmlSourceState {
     plugin_render: Option<PluginRenderContext>,
     path_resolver_rows: Option<Vec<MaterializedLiveStateRow>>,
     path_index: Option<FilesystemPathSelection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExactLixFileReadColumn {
+    Data,
+    ChangeId,
+}
+
+impl ExactLixFileReadColumn {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Data => "data",
+            Self::ChangeId => "lixcol_change_id",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExactLixFileReadSelector {
+    Id(String),
+    Path(String),
 }
 
 type SharedLixFileDmlSourceState = Arc<Mutex<Option<LixFileDmlSourceState>>>;
@@ -469,6 +492,87 @@ impl LixFileSpec {
             },
         )
     }
+}
+
+/// Executes the narrow active-branch point-read shape without constructing a
+/// DataFusion catalog and plan. Row selection, branch visibility, blob
+/// loading, plugin rendering, and session acknowledgement all stay on the
+/// regular `lix_file` provider helpers below.
+pub(crate) async fn execute_exact_lix_file_read(
+    active_branch_id: &str,
+    live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
+    branch_ref: Arc<dyn BranchRefReader>,
+    blob_reader: Arc<dyn BlobDataReader>,
+    plugin_host: PluginRuntimeHost,
+    session_file_views: Option<SessionFileViews>,
+    selector: &ExactLixFileReadSelector,
+    column: ExactLixFileReadColumn,
+) -> Result<SqlQueryResult, LixError> {
+    let base_schema = lix_file_schema();
+    let column_index = base_schema.index_of(column.name()).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("exact lix_file projection is missing: {error}"),
+        )
+    })?;
+    let schema = Arc::new(Schema::new(vec![
+        base_schema.field(column_index).as_ref().clone(),
+    ]));
+    let mut request = lix_file_scan_request(Some(active_branch_id), Some(schema.as_ref()), None);
+    let branch_binding = BranchBinding::active(active_branch_id);
+    request.filter.branch_ids = resolve_provider_branch_ids(
+        branch_ref.as_ref(),
+        &branch_binding,
+        request.filter.branch_ids,
+    )
+    .await?;
+
+    let index = filesystem_path_index
+        .path_index(&FilesystemPathIndexRequest::new(
+            request.filter.branch_ids.clone(),
+        ))
+        .await?;
+    let matches = match selector {
+        ExactLixFileReadSelector::Id(file_id) => indexed_file_id_matches(
+            index,
+            &BTreeSet::from([file_id.clone()]),
+            &FilePathPredicate::All,
+        ),
+        ExactLixFileReadSelector::Path(path) => indexed_file_matches(
+            index,
+            &FilePathPredicate::Comparison {
+                operation: FilePathComparison::Equal,
+                value: path.clone(),
+            },
+        ),
+    };
+    let rows = scan_indexed_file_rows(Arc::clone(&live_state), &request, &matches, true).await?;
+    let prepared = prepare_indexed_lix_file_rows(&matches, rows)?;
+    let load_data = column == ExactLixFileReadColumn::Data;
+    let plugin_render = if prepared.needs_plugin_render(load_data) {
+        plugin_render_context_for_lix_file_scan(live_state, &request, plugin_host, &prepared, false)
+            .await?
+            .map(|context| context.with_session_file_views(session_file_views))
+    } else {
+        None
+    };
+    let batch = lix_file_record_batch_from_prepared(
+        &schema,
+        &blob_reader,
+        plugin_render,
+        load_data,
+        prepared,
+    )
+    .await?;
+    crate::sql2::exec::datafusion::query_result_from_batches(
+        &schema
+            .fields()
+            .iter()
+            .map(|field| field.as_ref().clone())
+            .collect::<Vec<_>>(),
+        &[batch],
+    )
 }
 
 fn lix_file_dml_source_state(

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -31,7 +31,8 @@ use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 use datafusion::catalog::TableProvider;
 
 pub(crate) use file::{
-    FastLixFilePathWriteConflict, execute_fast_lix_file_data_update_by_id,
+    ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
+    execute_exact_lix_file_read, execute_fast_lix_file_data_update_by_id,
     execute_fast_lix_file_path_writes,
 };
 pub(crate) use spec::DmlReturning;

--- a/packages/engine/tests/exact_file_read_benchmark.rs
+++ b/packages/engine/tests/exact_file_read_benchmark.rs
@@ -1,0 +1,139 @@
+//! Manual benchmark for warmed exact `lix_file` reads through the public session API.
+//!
+//! Run with:
+//! `cargo test -p lix_engine --release --test exact_file_read_benchmark -- --ignored --nocapture`
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use lix_engine::{Engine, Memory, Storage, Value};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+use tempfile::TempDir;
+
+const WARMUPS: usize = 30;
+const ROUNDS: usize = 300;
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "manual performance probe; run with --ignored --nocapture"]
+async fn exact_file_read_benchmark_probe() {
+    run_backend("memory", Memory::new()).await;
+
+    let rocks_dir = TempDir::new().expect("create RocksDB benchmark directory");
+    run_backend(
+        "rocksdb",
+        RocksDB::open(rocks_dir.path().join("rocksdb")).expect("open RocksDB benchmark storage"),
+    )
+    .await;
+
+    let slate_dir = TempDir::new().expect("create SlateDB benchmark directory");
+    run_backend(
+        "slatedb",
+        SlateDB::open(slate_dir.path().join("slatedb")).expect("open SlateDB benchmark storage"),
+    )
+    .await;
+}
+
+async fn run_backend<S>(backend: &str, storage: S)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize benchmark storage");
+    let engine = Engine::new(storage).await.expect("open benchmark engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open benchmark session");
+
+    for (file_id, path, bytes) in [
+        ("exact-read-4k", "/exact-read-4k.bin", vec![0x41; 4 * 1024]),
+        (
+            "exact-read-1m",
+            "/exact-read-1m.bin",
+            vec![0x42; 1024 * 1024],
+        ),
+    ] {
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+                &[
+                    Value::Text(file_id.to_string()),
+                    Value::Text(path.to_string()),
+                    Value::Blob(bytes),
+                ],
+            )
+            .await
+            .expect("seed benchmark file");
+    }
+
+    // Warm the filesystem path index and backend caches before every timed shape.
+    for (shape, sql, parameter) in [
+        ("scalar_text", "SELECT $1 AS value", "control"),
+        (
+            "id_by_id_4k",
+            "SELECT id FROM lix_file WHERE id = $1",
+            "exact-read-4k",
+        ),
+        (
+            "data_by_id_4k",
+            "SELECT data FROM lix_file WHERE id = $1",
+            "exact-read-4k",
+        ),
+        (
+            "data_by_path_4k",
+            "SELECT data FROM lix_file WHERE path = $1",
+            "/exact-read-4k.bin",
+        ),
+        (
+            "change_id_by_id_4k",
+            "SELECT lixcol_change_id FROM lix_file WHERE id = $1",
+            "exact-read-4k",
+        ),
+        (
+            "data_by_id_1m",
+            "SELECT data FROM lix_file WHERE id = $1",
+            "exact-read-1m",
+        ),
+        (
+            "data_by_path_1m",
+            "SELECT data FROM lix_file WHERE path = $1",
+            "/exact-read-1m.bin",
+        ),
+    ] {
+        let params = [Value::Text(parameter.to_string())];
+        for _ in 0..WARMUPS {
+            black_box(
+                session
+                    .execute(sql, &params)
+                    .await
+                    .expect("warm exact read"),
+            );
+        }
+
+        let mut samples = Vec::with_capacity(ROUNDS);
+        for _ in 0..ROUNDS {
+            let started = Instant::now();
+            let result = session
+                .execute(sql, &params)
+                .await
+                .expect("execute exact read");
+            black_box(&result);
+            samples.push(started.elapsed());
+        }
+        samples.sort_unstable();
+        let mean_ns = samples.iter().map(Duration::as_nanos).sum::<u128>()
+            / u128::try_from(samples.len()).expect("sample count fits u128");
+        println!(
+            "exact_file_read backend={backend} shape={shape} rounds={ROUNDS} p50_ns={} p95_ns={} mean_ns={mean_ns}",
+            percentile(&samples, 50).as_nanos(),
+            percentile(&samples, 95).as_nanos(),
+        );
+    }
+}
+
+fn percentile(sorted: &[Duration], percentile: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(percentile).div_ceil(100);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -105,6 +105,64 @@ simulation_test!(
     }
 );
 
+simulation_test!(
+    exact_lix_file_point_reads_match_generic_sql_across_visible_lanes,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data, lixcol_global) VALUES \
+                 ('shared-point-file', '/shared-point.bin', X'61', false), \
+                 ('shared-point-file', '/shared-point.bin', X'62', true)",
+                &[],
+            )
+            .await
+            .expect("branch and global point-read fixtures should insert");
+
+        for (fast_sql, generic_sql, parameter) in [
+            (
+                "SELECT data FROM lix_file WHERE id = $1",
+                "SELECT data FROM lix_file WHERE id = $1 AND true",
+                "shared-point-file",
+            ),
+            (
+                "SELECT data FROM lix_file WHERE path = $1",
+                "SELECT data FROM lix_file WHERE path = $1 AND true",
+                "/shared-point.bin",
+            ),
+            (
+                "SELECT lixcol_change_id FROM lix_file WHERE id = $1",
+                "SELECT lixcol_change_id FROM lix_file WHERE id = $1 AND true",
+                "shared-point-file",
+            ),
+            (
+                "SELECT data FROM lix_file WHERE id = $1",
+                "SELECT data FROM lix_file WHERE id = $1 AND true",
+                "missing-point-file",
+            ),
+        ] {
+            let params = [Value::Text(parameter.to_string())];
+            let fast = session
+                .execute(fast_sql, &params)
+                .await
+                .expect("exact point read should execute");
+            let generic = session
+                .execute(generic_sql, &params)
+                .await
+                .expect("generic comparison read should execute");
+            assert_eq!(fast, generic, "point read differed for {fast_sql}");
+        }
+    }
+);
+
 #[tokio::test]
 async fn sql_plugin_archive_upsert_installs_and_updates_plugin() {
     let storage = Memory::new();


### PR DESCRIPTION
## Hypothesis

Exact `lix_file` reads already push down to the path index and exact storage lookups, but still construct a DataFusion catalog and plan for every evaluation. The fixed SQL-engine floor dominates the canonical one-file reads used by Lixray and Atelier.

A scalar control confirmed the floor: `SELECT $1` alone costs 1.11 ms on Memory, 1.18 ms on RocksDB, and 1.93 ms on SlateDB.

## Result

Warmed SessionContext p50, frozen `main` versus this branch:

| Query | Memory | RocksDB | SlateDB |
|---|---:|---:|---:|
| 4 KiB data by ID | 1.368 → 0.054 ms (-96.1%) | 1.348 → 0.071 ms (-94.7%) | 2.051 → 0.519 ms (-74.7%) |
| 4 KiB data by path | 1.380 → 0.054 ms (-96.1%) | 1.364 → 0.070 ms (-94.9%) | 2.581 → 0.549 ms (-78.7%) |
| Change ID by ID | 1.289 → 0.050 ms (-96.1%) | 1.371 → 0.064 ms (-95.3%) | 2.085 → 0.465 ms (-77.7%) |
| 1 MiB data by ID | 1.408 → 0.160 ms (-88.7%) | 1.591 → 0.350 ms (-78.0%) | 2.272 → 0.632 ms (-72.2%) |
| 1 MiB data by path | 1.416 → 0.177 ms (-87.5%) | 1.620 → 0.330 ms (-79.6%) | 2.222 → 0.620 ms (-72.1%) |

Unmatched scalar and descriptor-only controls ranged from -3.2% to +3.6%.

## Implementation

The fast path accepts only the current canonical consumer grammar:

- one direct `data` or `lixcol_change_id` projection
- unqualified, unaliased `lix_file`
- direct `id = $1/?` or `path = $1/?`
- exactly one text parameter

Both placeholders are intentional current usage: Lixray emits `$1`; Atelier's Excalidraw, CSV, and text views emit `?`. Aliases, literals, quoted identifiers, `LIMIT`, joins, transforms, compound predicates, nulls, and extra parameters use the regular SQL engine. There is no compatibility grammar or protocol change.

The executor reuses the existing path index, exact live-state/blob loads, branch visibility, blob CAS, plugin renderer, and `SessionFileViews` acknowledgement machinery. It bypasses only DataFusion catalog/plan construction for the canonical shape.

## Validation

- 54/54 full file API tests
- branch/global duplicate-lane differential coverage
- plugin rendering and raw/plugin transition coverage
- two-session merge and SlateDB collaboration coverage
- observation delivery/deferred acknowledgement coverage
- aggregate/NULL non-acknowledgement controls
- strict recognizer unit and unmatched-query controls
- strict Clippy, formatting, diff check, and changenote validation
