### PR TITLE
perf(engine): cache transaction SQL planning templates

### DIFF
--- a/.changenotes/cache-sql-write-templates.md
+++ b/.changenotes/cache-sql-write-templates.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+Repeated SQL writes now reuse parsed and bound templates plus stable catalog
+metadata. Transactions derive SQL-visible schemas from their compiled opening
+catalog instead of rereading durable schema state, while every execution still
+builds fresh snapshot-specific DataFusion providers and plans.

--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -390,6 +390,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn compiled_catalog_projects_the_same_sql_visible_schemas() {
+        let context = CatalogContext::new();
+        let mut tracked = registered_schema_row("zeta_tracked_schema");
+        tracked.untracked = false;
+        let reader = RowsLiveStateReader::new(vec![
+            registered_schema_row("alpha_untracked_schema"),
+            tracked,
+        ]);
+        let domain = Domain::schema_catalog("global", true);
+
+        let durable_projection = context
+            .schema_jsons_for_sql_read_planning(&reader, "global")
+            .await
+            .expect("SQL schema visibility should load");
+        let compiled_projection = context
+            .compiled_catalog_for_domain(&reader, &domain)
+            .await
+            .expect("catalog should compile")
+            .schema_jsons();
+
+        assert_eq!(compiled_projection, durable_projection);
+    }
+
+    #[tokio::test]
     async fn visible_schemas_include_registered_schema_rows() {
         let context = CatalogContext::new();
 

--- a/packages/engine/src/catalog/mod.rs
+++ b/packages/engine/src/catalog/mod.rs
@@ -7,4 +7,6 @@ pub(crate) use schema::{
     ForeignKeyPlan, SchemaCatalogFact, SchemaCatalogKey, SchemaPlan, SchemaPlanId,
     StateForeignKeyPlan,
 };
-pub(crate) use snapshot::{CatalogSnapshot, StateDeleteReferencePlan, TransactionCatalog};
+pub(crate) use snapshot::{
+    CatalogFingerprint, CatalogSnapshot, StateDeleteReferencePlan, TransactionCatalog,
+};

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -80,7 +80,6 @@ impl CatalogSnapshot {
         Self::from_entries(self.entries.clone())
     }
 
-    #[cfg(test)]
     pub(crate) fn fingerprint(&self) -> &CatalogFingerprint {
         &self.fingerprint
     }
@@ -240,6 +239,18 @@ impl CatalogSnapshot {
 
     pub(crate) fn plans(&self) -> impl Iterator<Item = &SchemaPlan> {
         self.plans.iter()
+    }
+
+    /// Returns the schema definitions represented by this compiled snapshot.
+    ///
+    /// SQL surface binding needs the authoritative catalog snapshot captured
+    /// when a transaction opens. Project it from that snapshot instead of
+    /// rescanning durable schema rows through live state.
+    pub(crate) fn schema_jsons(&self) -> Vec<JsonValue> {
+        self.by_key
+            .values()
+            .map(|plan_id| self.plans[plan_id.index()].schema.as_ref().clone())
+            .collect()
     }
 
     pub(crate) fn plan(&self, plan_id: SchemaPlanId) -> Option<&SchemaPlan> {
@@ -1141,6 +1152,27 @@ mod tests {
             .expect("child-first facts should bind as the same domain snapshot");
 
         assert_eq!(parent_first.fingerprint(), child_first.fingerprint());
+    }
+
+    #[test]
+    fn schema_jsons_project_compiled_catalog_in_schema_key_order() {
+        let zeta = schema_json("zeta_schema");
+        let alpha = schema_json("alpha_schema");
+        let catalog = CatalogSnapshot::from_schema_facts(&[
+            SchemaCatalogFact::new(
+                Domain::schema_catalog("main", false),
+                SchemaKey::new("zeta_schema"),
+                zeta.clone(),
+            ),
+            SchemaCatalogFact::new(
+                Domain::schema_catalog("main", false),
+                SchemaKey::new("alpha_schema"),
+                alpha.clone(),
+            ),
+        ])
+        .expect("catalog should bind");
+
+        assert_eq!(catalog.schema_jsons(), vec![alpha, zeta]);
     }
 
     #[test]

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::BinaryCasContext;
 use crate::branch::{BranchContext, BranchRefReader};
-use crate::catalog::CatalogContext;
+use crate::catalog::{CatalogContext, CatalogFingerprint};
 use crate::commit_graph::CommitGraphContext;
 use crate::entity_pk::EntityPk;
 use crate::init::InitReceipt;
@@ -14,6 +14,7 @@ use crate::observe_coordinator::ObserveCoordinator;
 use crate::observe_invalidation::ObserveInvalidation;
 use crate::plugin::PluginRuntimeHost;
 use crate::session::SessionContext;
+use crate::sql2::SqlPlanningCache;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{SharedStorageAdapterRead, StorageReadOptions, StorageWriteOptions};
 use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
@@ -31,6 +32,7 @@ pub struct Engine<StorageImpl: Storage = crate::storage_adapter::Memory> {
     branch_ctx: Arc<BranchContext>,
     binary_cas: Arc<BinaryCasContext>,
     catalog_context: Arc<CatalogContext>,
+    sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
     collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
     observe_coordinator: Arc<ObserveCoordinator>,
@@ -137,6 +139,7 @@ where
             live_state,
             branch_ctx,
             catalog_context: Arc::new(CatalogContext::new()),
+            sql_planning_cache: Arc::new(SqlPlanningCache::default()),
             deterministic_runtime_gate: Arc::new(tokio::sync::Mutex::new(())),
             collaboration_write_gate: Arc::new(tokio::sync::Mutex::new(())),
             observe_coordinator: Arc::new(ObserveCoordinator::new()),
@@ -185,6 +188,7 @@ where
             Arc::clone(&self.binary_cas),
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
+            Arc::clone(&self.sql_planning_cache),
             Arc::clone(&self.deterministic_runtime_gate),
             Arc::clone(&self.collaboration_write_gate),
             Arc::clone(&self.observe_coordinator),
@@ -203,6 +207,7 @@ where
             Arc::clone(&self.binary_cas),
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
+            Arc::clone(&self.sql_planning_cache),
             Arc::clone(&self.deterministic_runtime_gate),
             Arc::clone(&self.collaboration_write_gate),
             Arc::clone(&self.observe_coordinator),

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -11,7 +11,7 @@ use crate::binary_cas::{BinaryCasContext, BlobDataReader};
 use crate::branch::{
     BranchContext, BranchLifecycle, BranchOperation, BranchRefReader, BranchReferenceRole,
 };
-use crate::catalog::CatalogContext;
+use crate::catalog::{CatalogContext, CatalogFingerprint};
 use crate::commit_graph::{CommitGraphContext, CommitGraphReader};
 use crate::entity_pk::EntityPk;
 use crate::filesystem::FilesystemPathIndexReader;
@@ -23,7 +23,7 @@ use crate::observe_invalidation::ObserveInvalidation;
 use crate::plugin::{PluginComponentHost, PluginRuntimeHost};
 use crate::sql2::{
     ChangelogQuerySource, HistoryQuerySource, SessionFileViews, SqlChangelogQuerySource,
-    SqlExecutionContext, SqlHistoryQuerySource,
+    SqlExecutionContext, SqlHistoryQuerySource, SqlPlanningCache,
 };
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{Memory, StorageReadOptions};
@@ -60,6 +60,7 @@ pub struct SessionContext<StorageImpl: Storage = Memory> {
     pub(super) binary_cas: Arc<BinaryCasContext>,
     pub(super) branch_ctx: Arc<BranchContext>,
     pub(super) catalog_context: Arc<CatalogContext>,
+    pub(super) sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     pub(super) deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
     pub(super) collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
     pub(super) file_views: SessionFileViews,
@@ -81,6 +82,7 @@ where
         binary_cas: Arc<BinaryCasContext>,
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
+        sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
         observe_coordinator: Arc<ObserveCoordinator>,
@@ -96,6 +98,7 @@ where
             binary_cas,
             branch_ctx,
             catalog_context,
+            sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
             observe_coordinator,
@@ -115,6 +118,7 @@ where
         binary_cas: Arc<BinaryCasContext>,
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
+        sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
         observe_coordinator: Arc<ObserveCoordinator>,
@@ -132,6 +136,7 @@ where
             binary_cas,
             branch_ctx,
             catalog_context,
+            sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
             observe_coordinator,
@@ -149,6 +154,7 @@ where
         binary_cas: Arc<BinaryCasContext>,
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
+        sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
         observe_coordinator: Arc<ObserveCoordinator>,
@@ -164,6 +170,7 @@ where
             binary_cas,
             branch_ctx,
             catalog_context,
+            sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
             observe_coordinator,
@@ -183,6 +190,7 @@ where
         binary_cas: Arc<BinaryCasContext>,
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
+        sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
         observe_coordinator: Arc<ObserveCoordinator>,
@@ -200,6 +208,7 @@ where
             binary_cas,
             branch_ctx,
             catalog_context,
+            sql_planning_cache,
             deterministic_runtime_gate,
             collaboration_write_gate,
             file_views,
@@ -464,6 +473,7 @@ where
             self.plugin_host.clone(),
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
+            Arc::clone(&self.sql_planning_cache),
             self.file_views.clone(),
         )
         .await?;

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -452,24 +452,20 @@ where
         defer_file_view_acknowledgement: bool,
     ) -> Result<ExecuteResult, LixError> {
         self.ensure_open()?;
-        let statement = sql2::parse_statement(sql)?;
+        let statement = self.sql_planning_cache.parse_statement(sql)?;
         if sql2::bind_statement_route(&statement)? == sql2::BoundStatementRoute::Write {
             let write_access = self.begin_session_write_access().await?;
             let sql_for_error = sql.to_string();
+            let sql_for_planning = sql_for_error.clone();
             let params = params.to_vec();
             return self
                 .with_write_transaction_reserved(write_access, |transaction| {
                     Box::pin(async move {
                         let previous_origin_key =
                             transaction.replace_origin_key(options.origin_key);
-                        // Re-plan against the transaction-backed write
-                        // session so provider hooks read and stage through the
-                        // transaction-owned SQL write context.
                         let result = async {
-                            transaction.prepare_sql_visible_schemas().await?;
-                            let tx_plan =
-                                sql2::create_write_logical_plan_from_parsed(transaction, statement)
-                                    .await?;
+                            let tx_plan = transaction
+                                .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
                             let result = sql2::execute_write_logical_plan_result(
                                 transaction,
                                 tx_plan,
@@ -605,7 +601,7 @@ where
         }
 
         let statements = statements.to_vec();
-        match classify_execute_batch(&statements)? {
+        match classify_execute_batch(&statements, &self.sql_planning_cache)? {
             ExecuteBatchExecution::ReadOnly(parsed) => {
                 self.execute_read_only_batch(&statements, parsed).await
             }
@@ -771,7 +767,7 @@ where
         let parsed = statements
             .iter()
             .map(|(sql, _)| {
-                let statement = sql2::parse_statement(sql)?;
+                let statement = self.sql_planning_cache.parse_statement(sql)?;
                 if sql2::statement_has_durable_runtime_function(&statement) {
                     return Err(LixError::new(
                         LixError::CODE_INVALID_PARAM,
@@ -910,18 +906,17 @@ where
         mode: sql2::WriteExecutorMode,
     ) -> Result<ExecuteResult, LixError> {
         self.ensure_open()?;
-        let statement = sql2::parse_statement(sql)?;
+        let statement = self.sql_planning_cache.parse_statement(sql)?;
         if sql2::bind_statement_route(&statement)? == sql2::BoundStatementRoute::Write {
             let write_access = self.begin_session_write_access().await?;
             let sql_for_error = sql.to_string();
+            let sql_for_planning = sql_for_error.clone();
             let params = params.to_vec();
             return self
                 .with_write_transaction_reserved(write_access, |transaction| {
                     Box::pin(async move {
-                        transaction.prepare_sql_visible_schemas().await?;
-                        let tx_plan =
-                            sql2::create_write_logical_plan_from_parsed(transaction, statement)
-                                .await?;
+                        let tx_plan = transaction
+                            .prepare_sql_write_logical_plan(&sql_for_planning, &statement)?;
                         let result = sql2::execute_write_logical_plan_with_mode_result(
                             transaction,
                             tx_plan,
@@ -1112,7 +1107,7 @@ where
             SqlStatementTelemetry::start(self.telemetry.as_ref(), sql, "transaction", None);
         let operation = async {
             let _operation_guard = self.begin_session_operation()?;
-            let statement = sql2::parse_statement(sql)?;
+            let statement = self.sql_planning_cache.parse_statement(sql)?;
             let transaction = self.transaction_mut()?;
             execute_transaction_statement(transaction, sql, statement, params, options)
                 .await
@@ -1136,11 +1131,11 @@ where
         mode: sql2::WriteExecutorMode,
     ) -> Result<ExecuteResult, LixError> {
         let _operation_guard = self.begin_session_operation()?;
-        let statement = sql2::parse_statement(sql)?;
+        let statement = self.sql_planning_cache.parse_statement(sql)?;
         let transaction = self.transaction_mut()?;
         match sql2::bind_statement_route(&statement)? {
             sql2::BoundStatementRoute::Write => {
-                execute_transaction_write_with_mode(transaction, statement, params, mode)
+                execute_transaction_write_with_mode(transaction, sql, statement, params, mode)
                     .await
                     .map_err(|error| normalize_sql_surface_error(error, sql))
             }
@@ -1156,14 +1151,18 @@ where
         mode: sql2::WriteExecutorMode,
     ) -> Result<(ExecuteResult, Option<sql2::WriteExecutorPath>), LixError> {
         let _operation_guard = self.begin_session_operation()?;
-        let statement = sql2::parse_statement(sql)?;
+        let statement = self.sql_planning_cache.parse_statement(sql)?;
         let transaction = self.transaction_mut()?;
         match sql2::bind_statement_route(&statement)? {
-            sql2::BoundStatementRoute::Write => {
-                execute_transaction_write_with_mode_and_trace(transaction, statement, params, mode)
-                    .await
-                    .map_err(|error| normalize_sql_surface_error(error, sql))
-            }
+            sql2::BoundStatementRoute::Write => execute_transaction_write_with_mode_and_trace(
+                transaction,
+                sql,
+                statement,
+                params,
+                mode,
+            )
+            .await
+            .map_err(|error| normalize_sql_surface_error(error, sql)),
             sql2::BoundStatementRoute::Read => {
                 self.execute(sql, params).await.map(|result| (result, None))
             }
@@ -1187,6 +1186,7 @@ where
 
 async fn execute_transaction_write_auto<StorageImpl>(
     transaction: &mut crate::transaction::Transaction<StorageImpl>,
+    sql: &str,
     statement: datafusion::sql::parser::Statement,
     params: &[Value],
     options: ExecuteOptions,
@@ -1196,8 +1196,7 @@ where
 {
     let previous_origin_key = transaction.replace_origin_key(options.origin_key);
     let result = async {
-        transaction.prepare_sql_visible_schemas().await?;
-        let tx_plan = sql2::create_write_logical_plan_from_parsed(transaction, statement).await?;
+        let tx_plan = transaction.prepare_sql_write_logical_plan(sql, &statement)?;
         let result = sql2::execute_write_logical_plan_result(transaction, tx_plan, params).await?;
         Ok(ExecuteResult::from_sql_write_result(result))
     }
@@ -1485,6 +1484,7 @@ fn point_identity_value_is_text(
 
 fn classify_execute_batch(
     statements: &[ExecuteBatchStatement],
+    planning_cache: &sql2::SqlPlanningCache<crate::catalog::CatalogFingerprint>,
 ) -> Result<ExecuteBatchExecution, LixError> {
     // Classify the complete batch before choosing a snapshot or transaction;
     // switching execution modes between statements would break atomicity, and
@@ -1493,7 +1493,8 @@ fn classify_execute_batch(
     let mut parsed = Vec::with_capacity(statements.len());
     let mut is_read_only = true;
     for (statement_index, statement) in statements.iter().enumerate() {
-        let parsed_statement = sql2::parse_statement(&statement.sql)
+        let parsed_statement = planning_cache
+            .parse_statement(&statement.sql)
             .map_err(|error| with_batch_statement_index(error, statement_index))?;
         let route = sql2::bind_statement_route(&parsed_statement)
             .map_err(|error| with_batch_statement_index(error, statement_index))?;
@@ -1523,7 +1524,7 @@ where
 {
     match sql2::bind_statement_route(&statement)? {
         sql2::BoundStatementRoute::Write => {
-            execute_transaction_write_auto(transaction, statement, params, options).await
+            execute_transaction_write_auto(transaction, sql, statement, params, options).await
         }
         sql2::BoundStatementRoute::Read => transaction
             .execute_read_sql_statement(sql, statement, params)
@@ -1553,6 +1554,7 @@ fn with_batch_statement_index(mut error: LixError, statement_index: usize) -> Li
 #[cfg(test)]
 async fn execute_transaction_write_with_mode<StorageImpl>(
     transaction: &mut crate::transaction::Transaction<StorageImpl>,
+    sql: &str,
     statement: datafusion::sql::parser::Statement,
     params: &[Value],
     mode: sql2::WriteExecutorMode,
@@ -1560,8 +1562,7 @@ async fn execute_transaction_write_with_mode<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    transaction.prepare_sql_visible_schemas().await?;
-    let tx_plan = sql2::create_write_logical_plan_from_parsed(transaction, statement).await?;
+    let tx_plan = transaction.prepare_sql_write_logical_plan(sql, &statement)?;
     let result =
         sql2::execute_write_logical_plan_with_mode_result(transaction, tx_plan, params, mode)
             .await?;
@@ -1571,6 +1572,7 @@ where
 #[cfg(test)]
 async fn execute_transaction_write_with_mode_and_trace<StorageImpl>(
     transaction: &mut crate::transaction::Transaction<StorageImpl>,
+    sql: &str,
     statement: datafusion::sql::parser::Statement,
     params: &[Value],
     mode: sql2::WriteExecutorMode,
@@ -1578,8 +1580,7 @@ async fn execute_transaction_write_with_mode_and_trace<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    transaction.prepare_sql_visible_schemas().await?;
-    let tx_plan = sql2::create_write_logical_plan_from_parsed(transaction, statement).await?;
+    let tx_plan = transaction.prepare_sql_write_logical_plan(sql, &statement)?;
     let (result, path) = sql2::execute_write_logical_plan_with_mode_and_trace_result(
         transaction,
         tx_plan,
@@ -1644,34 +1645,45 @@ mod tests {
 
     #[test]
     fn execute_batch_classifies_only_pure_reads_for_the_fast_path() {
+        let cache = sql2::SqlPlanningCache::default();
         assert!(matches!(
-            classify_execute_batch(&[
-                batch_statement("SELECT 1"),
-                batch_statement("SELECT * FROM lix_file"),
-            ])
+            classify_execute_batch(
+                &[
+                    batch_statement("SELECT 1"),
+                    batch_statement("SELECT * FROM lix_file"),
+                ],
+                &cache
+            )
             .unwrap(),
             ExecuteBatchExecution::ReadOnly(_)
         ));
         assert!(matches!(
-            classify_execute_batch(&[
-                batch_statement("SELECT 1"),
-                batch_statement("DELETE FROM lix_file WHERE id = 'missing'"),
-            ])
+            classify_execute_batch(
+                &[
+                    batch_statement("SELECT 1"),
+                    batch_statement("DELETE FROM lix_file WHERE id = 'missing'"),
+                ],
+                &cache
+            )
             .unwrap(),
             ExecuteBatchExecution::Transaction(_)
         ));
         assert!(matches!(
-            classify_execute_batch(&[batch_statement("SELECT lix_uuid_v7()")]).unwrap(),
+            classify_execute_batch(&[batch_statement("SELECT lix_uuid_v7()")], &cache).unwrap(),
             ExecuteBatchExecution::Transaction(_)
         ));
     }
 
     #[test]
     fn execute_batch_classification_preserves_the_invalid_statement_index() {
-        let result = classify_execute_batch(&[
-            batch_statement("SELECT 1"),
-            batch_statement("this is not SQL"),
-        ]);
+        let cache = sql2::SqlPlanningCache::default();
+        let result = classify_execute_batch(
+            &[
+                batch_statement("SELECT 1"),
+                batch_statement("this is not SQL"),
+            ],
+            &cache,
+        );
         let Err(error) = result else {
             panic!("invalid SQL should fail classification");
         };

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -202,7 +202,7 @@ where
                 "observe requires a non-empty SQL string",
             ));
         }
-        let statement = sql2::parse_statement(sql)?;
+        let statement = self.sql_planning_cache.parse_statement(sql)?;
         if sql2::bind_statement_route(&statement)? == sql2::BoundStatementRoute::Write {
             return Err(LixError::new(
                 LixError::CODE_INVALID_PARAM,

--- a/packages/engine/src/session/switch_branch.rs
+++ b/packages/engine/src/session/switch_branch.rs
@@ -77,6 +77,7 @@ where
             Arc::clone(&self.binary_cas),
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
+            Arc::clone(&self.sql_planning_cache),
             Arc::clone(&self.deterministic_runtime_gate),
             Arc::clone(&self.collaboration_write_gate),
             Arc::clone(&self.observe_coordinator),

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
+use crate::catalog::CatalogFingerprint;
 use crate::functions::{DeterministicRuntimeGuard, FunctionContext};
 use crate::observe_invalidation::ObserveInvalidation;
+use crate::sql2::SqlPlanningCache;
 use crate::storage_adapter::Memory;
 use crate::storage_adapter::Storage;
 use crate::telemetry::TelemetrySink;
@@ -23,6 +25,7 @@ pub struct SessionTransaction<StorageImpl: Storage = Memory> {
     pub(super) runtime_functions: FunctionContext,
     transaction_manager: SessionTransactionManager,
     observe_invalidation: Arc<ObserveInvalidation>,
+    pub(super) sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     _deterministic_runtime_guard: Option<DeterministicRuntimeGuard>,
     write_access: Option<SessionWriteAccess>,
     pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
@@ -49,6 +52,7 @@ where
             self.plugin_host.clone(),
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
+            Arc::clone(&self.sql_planning_cache),
             self.file_views.clone(),
         )
         .await
@@ -69,6 +73,7 @@ where
             runtime_functions: opened.runtime_functions,
             transaction_manager: self.transaction_manager(),
             observe_invalidation: Arc::clone(&self.observe_invalidation),
+            sql_planning_cache: Arc::clone(&self.sql_planning_cache),
             _deterministic_runtime_guard: deterministic_runtime_guard,
             write_access: Some(write_access),
             telemetry: self.telemetry.clone(),

--- a/packages/engine/src/sql2/bind/mod.rs
+++ b/packages/engine/src/sql2/bind/mod.rs
@@ -9,4 +9,6 @@ pub(crate) mod write;
 
 pub(crate) use public_udf::statement_has_durable_runtime_function;
 pub(crate) use read::{BoundStatementRoute, bind_read_statement, bind_statement_route};
+#[cfg(test)]
 pub(crate) use statement::bind_statement;
+pub(crate) use statement::bind_statement_with_catalog;

--- a/packages/engine/src/sql2/bind/statement.rs
+++ b/packages/engine/src/sql2/bind/statement.rs
@@ -28,15 +28,24 @@ use super::write::{
     BoundWriteTarget, DirectoryWriteSurface, EntityWriteSurface, FileWriteSurface,
 };
 
+#[cfg(test)]
 pub(crate) fn bind_statement(
     statement: &DataFusionStatement,
     visible_schemas: &[JsonValue],
     active_branch_id: &str,
 ) -> Result<BoundWrite, LixError> {
     let catalog = PublicCatalog::from_visible_schemas(visible_schemas)?;
+    bind_statement_with_catalog(statement, &catalog, active_branch_id)
+}
+
+pub(crate) fn bind_statement_with_catalog(
+    statement: &DataFusionStatement,
+    catalog: &PublicCatalog,
+    active_branch_id: &str,
+) -> Result<BoundWrite, LixError> {
     match statement {
         DataFusionStatement::Statement(statement) => {
-            bind_sql_statement(statement, &catalog, active_branch_id)
+            bind_sql_statement(statement, catalog, active_branch_id)
         }
         DataFusionStatement::Explain(_) => Err(super::error::unsupported(
             "EXPLAIN statements are not supported by SQL write binding",

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -25,7 +25,7 @@ use crate::storage_adapter::StorageAdapterRead;
 use crate::transaction::types::{TransactionWrite, TransactionWriteOutcome};
 use crate::wasm::UnsupportedWasmRuntime;
 
-use super::SessionFileViews;
+use super::{PublicCatalog, SessionFileViews};
 
 pub(crate) type SqlChangelogQuerySource<S> = ChangelogQuerySource<S>;
 pub(crate) type SqlHistoryQuerySource<S> = HistoryQuerySource<S>;
@@ -87,6 +87,11 @@ pub(crate) trait SqlWriteExecutionContext: Send {
     fn active_branch_id(&self) -> &str;
     fn functions(&self) -> FunctionProviderHandle;
     fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError>;
+    fn public_catalog(&self) -> Result<Arc<PublicCatalog>, LixError> {
+        Ok(Arc::new(PublicCatalog::from_visible_schemas(
+            &self.list_visible_schemas()?,
+        )?))
+    }
     fn plugin_host(&self) -> PluginRuntimeHost {
         PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime))
     }
@@ -167,8 +172,8 @@ impl SqlWriteContext {
         Arc::new(WriteContextBlobDataReader::new(self.clone()))
     }
 
-    pub(crate) fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
-        unsafe { self.ptr.0.as_ref().list_visible_schemas() }
+    pub(crate) fn public_catalog(&self) -> Result<Arc<PublicCatalog>, LixError> {
+        unsafe { self.ptr.0.as_ref().public_catalog() }
     }
 
     pub(crate) fn active_branch_id(&self) -> String {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -11,9 +11,7 @@ use crate::sql2::bind::write::{
     BoundWriteOp, BoundWriteTarget, EntityWriteSurface, FileWriteSurface,
 };
 use crate::sql2::catalog::entity_surface::EntitySurfaceColumn;
-use crate::sql2::catalog::{
-    EntityColumnType, EntitySurfaceSpec, derive_entity_surface_spec_from_schema,
-};
+use crate::sql2::catalog::{EntityColumnType, EntitySurfaceSpec};
 use crate::sql2::plan::LogicalWritePlan;
 use crate::sql2::plan::branch_scope::BranchScope;
 use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
@@ -1310,10 +1308,9 @@ fn entity_spec(
     ctx: &dyn SqlWriteExecutionContext,
     schema_key: &str,
 ) -> Result<EntitySurfaceSpec, LixError> {
-    ctx.list_visible_schemas()?
-        .into_iter()
-        .filter_map(|schema| derive_entity_surface_spec_from_schema(&schema).ok())
-        .find(|spec| spec.schema_key == schema_key)
+    ctx.public_catalog()?
+        .entity_spec(schema_key)
+        .cloned()
         .ok_or_else(|| {
             LixError::new(
                 LixError::CODE_SCHEMA_DEFINITION,

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -44,8 +44,8 @@ pub(crate) use write::{
     execute_write_logical_plan_with_mode_result,
 };
 pub(crate) use write::{
-    WriteLogicalPlan as SqlWriteLogicalPlan, create_write_logical_plan_from_parsed,
-    execute_write_logical_plan_result,
+    WriteLogicalPlan as SqlWriteLogicalPlan, create_write_logical_plan_from_template,
+    create_write_plan_template_from_parsed, execute_write_logical_plan_result,
 };
 
 pub(crate) enum SqlLogicalPlan {

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -43,7 +43,8 @@ pub(crate) async fn create_write_logical_plan(
 }
 
 #[expect(clippy::needless_pass_by_ref_mut)]
-pub(crate) async fn create_write_logical_plan_from_parsed(
+#[cfg(test)]
+async fn create_write_logical_plan_from_parsed(
     ctx: &mut dyn SqlWriteExecutionContext,
     statement: DataFusionStatement,
 ) -> Result<SqlLogicalPlan, LixError> {
@@ -51,9 +52,25 @@ pub(crate) async fn create_write_logical_plan_from_parsed(
     let bound_write =
         crate::sql2::bind_statement(&statement, &visible_schemas, ctx.active_branch_id())?;
     let logical_write = crate::sql2::plan_write(bound_write)?;
-    Ok(SqlLogicalPlan::Write(WriteLogicalPlan {
+    Ok(create_write_logical_plan_from_template(logical_write))
+}
+
+pub(crate) fn create_write_plan_template_from_parsed(
+    statement: &DataFusionStatement,
+    catalog: &crate::sql2::PublicCatalog,
+    active_branch_id: &str,
+) -> Result<LogicalWritePlan, LixError> {
+    let bound_write =
+        crate::sql2::bind_statement_with_catalog(statement, catalog, active_branch_id)?;
+    crate::sql2::plan_write(bound_write)
+}
+
+pub(crate) fn create_write_logical_plan_from_template(
+    logical_write: LogicalWritePlan,
+) -> SqlLogicalPlan {
+    SqlLogicalPlan::Write(WriteLogicalPlan {
         plan: logical_write,
-    }))
+    })
 }
 
 #[cfg(test)]

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -13,6 +13,7 @@ mod history_route;
 mod optimize;
 mod parse;
 mod plan;
+mod planning_cache;
 mod predicate_typecheck;
 mod providers;
 mod read_only;
@@ -25,10 +26,13 @@ mod test_support;
 mod udfs;
 mod write_normalization;
 
+#[cfg(test)]
+pub(crate) use bind::bind_statement;
 pub(crate) use bind::{
-    BoundStatementRoute, bind_read_statement, bind_statement, bind_statement_route,
+    BoundStatementRoute, bind_read_statement, bind_statement_route, bind_statement_with_catalog,
     statement_has_durable_runtime_function,
 };
+pub(crate) use catalog::PublicCatalog;
 pub(crate) use context::{
     ChangelogQuerySource, HistoryQuerySource, SqlChangelogQuerySource, SqlExecutionContext,
     SqlHistoryQuerySource, SqlJsonReader, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,
@@ -37,7 +41,8 @@ pub(crate) use context::{
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{
-    SqlLogicalPlan, create_write_logical_plan_from_parsed, execute_read_statement_from_parsed,
+    SqlLogicalPlan, create_write_logical_plan_from_template,
+    create_write_plan_template_from_parsed, execute_read_statement_from_parsed,
     execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
     execute_write_logical_plan_result, prepare_read_session, prepare_read_session_at_head,
 };
@@ -51,6 +56,8 @@ pub(crate) use exec::{
 pub(crate) use file_view::{
     SessionFileViewKey, SessionFileViewMutation, SessionFileViews, SessionPluginFileView,
 };
+#[cfg(test)]
 pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
+pub(crate) use planning_cache::SqlPlanningCache;
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/engine/src/sql2/planning_cache.rs
+++ b/packages/engine/src/sql2/planning_cache.rs
@@ -1,0 +1,313 @@
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use crate::LixError;
+use crate::sql2::catalog::PublicCatalog;
+use crate::sql2::plan::LogicalWritePlan;
+use datafusion::sql::parser::Statement as DataFusionStatement;
+use lru::LruCache;
+
+const PARSED_STATEMENT_CAPACITY: usize = 256;
+const PUBLIC_CATALOG_CAPACITY: usize = 16;
+const WRITE_PLAN_CAPACITY: usize = 256;
+
+/// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
+///
+/// Parsed statements depend only on the exact SQL text. Bound write plans also
+/// depend on the visible catalog and active branch because binding resolves
+/// public surfaces and injects branch scope. DataFusion plans deliberately do
+/// not belong here: they capture providers tied to one storage snapshot.
+pub(crate) struct SqlPlanningCache<CatalogKey> {
+    parsed_statements: Mutex<LruCache<Arc<str>, Arc<DataFusionStatement>>>,
+    public_catalogs: Mutex<LruCache<CatalogKey, Arc<PublicCatalog>>>,
+    write_plans: Mutex<LruCache<WritePlanCacheKey<CatalogKey>, Arc<LogicalWritePlan>>>,
+}
+
+impl<CatalogKey> std::fmt::Debug for SqlPlanningCache<CatalogKey> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SqlPlanningCache")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct WritePlanCacheKey<CatalogKey> {
+    sql: Arc<str>,
+    catalog: CatalogKey,
+    active_branch_id: Arc<str>,
+}
+
+impl<CatalogKey> Default for SqlPlanningCache<CatalogKey>
+where
+    CatalogKey: Clone + Eq + Hash,
+{
+    fn default() -> Self {
+        Self::with_capacities(
+            PARSED_STATEMENT_CAPACITY,
+            PUBLIC_CATALOG_CAPACITY,
+            WRITE_PLAN_CAPACITY,
+        )
+    }
+}
+
+impl<CatalogKey> SqlPlanningCache<CatalogKey>
+where
+    CatalogKey: Clone + Eq + Hash,
+{
+    /// Parses exact SQL once and returns an owned clone of the cached AST.
+    ///
+    /// Parse failures are intentionally not cached. Two concurrent cold calls
+    /// may do duplicate parsing, but parsing happens outside the mutex and the
+    /// second insertion reuses the first successful template.
+    pub(crate) fn parse_statement(&self, sql: &str) -> Result<DataFusionStatement, LixError> {
+        let cached = lock_or_recover(&self.parsed_statements).get(sql).cloned();
+        if let Some(statement) = cached {
+            return Ok(statement.as_ref().clone());
+        }
+
+        let parsed = crate::sql2::parse::parse_statement(sql)?;
+        let mut statements = lock_or_recover(&self.parsed_statements);
+        if let Some(statement) = statements.get(sql).cloned() {
+            drop(statements);
+            return Ok(statement.as_ref().clone());
+        }
+        statements.put(Arc::from(sql), Arc::new(parsed.clone()));
+        Ok(parsed)
+    }
+
+    /// Returns stable public-surface metadata for one catalog generation.
+    ///
+    /// Callers are responsible for using a key that changes whenever any
+    /// visible schema changes. Invalid catalogs are not cached.
+    pub(crate) fn public_catalog<F>(
+        &self,
+        catalog_key: &CatalogKey,
+        visible_schemas: F,
+    ) -> Result<Arc<PublicCatalog>, LixError>
+    where
+        F: FnOnce() -> Result<Vec<serde_json::Value>, LixError>,
+    {
+        if let Some(catalog) = lock_or_recover(&self.public_catalogs).get(catalog_key) {
+            return Ok(Arc::clone(catalog));
+        }
+
+        let visible_schemas = visible_schemas()?;
+        let built = Arc::new(PublicCatalog::from_visible_schemas(&visible_schemas)?);
+        let mut catalogs = lock_or_recover(&self.public_catalogs);
+        if let Some(catalog) = catalogs.get(catalog_key) {
+            return Ok(Arc::clone(catalog));
+        }
+        catalogs.put(catalog_key.clone(), Arc::clone(&built));
+        Ok(built)
+    }
+
+    /// Returns a cloned write template for this exact planning environment.
+    ///
+    /// Execution may resolve parameterized branch scopes by mutating its owned
+    /// plan, so cache hits must never expose the stored template by reference.
+    pub(crate) fn write_plan(
+        &self,
+        sql: &str,
+        catalog_key: &CatalogKey,
+        active_branch_id: &str,
+    ) -> Option<LogicalWritePlan> {
+        let key = WritePlanCacheKey::new(sql, catalog_key.clone(), active_branch_id);
+        let cached = lock_or_recover(&self.write_plans).get(&key).cloned();
+        cached.map(|plan| plan.as_ref().clone())
+    }
+
+    pub(crate) fn remember_write_plan(
+        &self,
+        sql: &str,
+        catalog_key: CatalogKey,
+        active_branch_id: &str,
+        plan: &LogicalWritePlan,
+    ) {
+        let key = WritePlanCacheKey::new(sql, catalog_key, active_branch_id);
+        lock_or_recover(&self.write_plans).put(key, Arc::new(plan.clone()));
+    }
+
+    fn with_capacities(
+        parsed_statement_capacity: usize,
+        public_catalog_capacity: usize,
+        write_plan_capacity: usize,
+    ) -> Self {
+        Self {
+            parsed_statements: Mutex::new(LruCache::new(non_zero(parsed_statement_capacity))),
+            public_catalogs: Mutex::new(LruCache::new(non_zero(public_catalog_capacity))),
+            write_plans: Mutex::new(LruCache::new(non_zero(write_plan_capacity))),
+        }
+    }
+}
+
+impl<CatalogKey> WritePlanCacheKey<CatalogKey> {
+    fn new(sql: &str, catalog: CatalogKey, active_branch_id: &str) -> Self {
+        Self {
+            sql: Arc::from(sql),
+            catalog,
+            active_branch_id: Arc::from(active_branch_id),
+        }
+    }
+}
+
+fn non_zero(capacity: usize) -> NonZeroUsize {
+    NonZeroUsize::new(capacity.max(1)).expect("SQL planning cache capacity is non-zero")
+}
+
+fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql2::bind_statement;
+    use crate::sql2::plan::branch_scope::BranchScope;
+    use serde_json::json;
+
+    fn test_cache(capacity: usize) -> SqlPlanningCache<String> {
+        SqlPlanningCache::with_capacities(capacity, capacity, capacity)
+    }
+
+    fn write_plan(sql: &str, active_branch_id: &str) -> LogicalWritePlan {
+        let statement = crate::sql2::parse_statement(sql).expect("SQL parses");
+        let bound = bind_statement(&statement, &[], active_branch_id).expect("SQL binds");
+        crate::sql2::plan_write(bound).expect("SQL plans")
+    }
+
+    #[test]
+    fn parsed_statements_are_keyed_by_exact_sql_and_bounded() {
+        let cache = test_cache(2);
+        let sql = "SELECT $1";
+
+        let first = cache.parse_statement(sql).expect("first parse");
+        let second = cache.parse_statement(sql).expect("cached parse");
+        assert_eq!(first, second);
+        assert_eq!(lock_or_recover(&cache.parsed_statements).len(), 1);
+
+        cache
+            .parse_statement("SELECT  $1")
+            .expect("whitespace variant parses");
+        assert_eq!(lock_or_recover(&cache.parsed_statements).len(), 2);
+
+        cache.parse_statement("SELECT 2").expect("third SQL parses");
+        let statements = lock_or_recover(&cache.parsed_statements);
+        assert_eq!(statements.len(), 2);
+        assert!(!statements.contains(sql));
+    }
+
+    #[test]
+    fn parse_failures_are_not_cached() {
+        let cache = test_cache(2);
+
+        assert!(cache.parse_statement("SELECT (").is_err());
+        assert!(lock_or_recover(&cache.parsed_statements).is_empty());
+    }
+
+    #[test]
+    fn public_catalogs_reuse_stable_metadata_by_catalog_key() {
+        let cache = test_cache(2);
+        let catalog_a = "catalog-a".to_string();
+        let catalog_b = "catalog-b".to_string();
+        let schema = json!({
+            "x-lix-key": "app_note",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "text": { "type": "string" }
+            },
+            "required": ["id", "text"]
+        });
+
+        let first = cache
+            .public_catalog(&catalog_a, || Ok(vec![schema.clone()]))
+            .expect("first catalog builds");
+        let second = cache
+            .public_catalog(&catalog_a, || Ok(vec![schema]))
+            .expect("catalog cache hit");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(first.surface("app_note").is_some());
+
+        let system_only = cache
+            .public_catalog(&catalog_b, || Ok(Vec::new()))
+            .expect("second catalog builds");
+        assert!(system_only.surface("app_note").is_none());
+    }
+
+    #[test]
+    fn write_plans_are_keyed_by_sql_catalog_and_active_branch() {
+        let cache = test_cache(8);
+        let catalog_a = "catalog-a".to_string();
+        let catalog_b = "catalog-b".to_string();
+        let sql = "DELETE FROM lix_file WHERE id = $1";
+        let plan = write_plan(sql, "branch-a");
+        cache.remember_write_plan(sql, catalog_a.clone(), "branch-a", &plan);
+
+        assert_eq!(cache.write_plan(sql, &catalog_a, "branch-a"), Some(plan));
+        assert!(
+            cache
+                .write_plan(
+                    "DELETE  FROM lix_file WHERE id = $1",
+                    &catalog_a,
+                    "branch-a"
+                )
+                .is_none()
+        );
+        assert!(cache.write_plan(sql, &catalog_b, "branch-a").is_none());
+        assert!(cache.write_plan(sql, &catalog_a, "branch-b").is_none());
+    }
+
+    #[test]
+    fn write_plan_hits_clone_the_immutable_template() {
+        let cache = test_cache(2);
+        let catalog = "catalog-a".to_string();
+        let sql = "DELETE FROM lix_file WHERE id = $1";
+        let plan = write_plan(sql, "branch-a");
+        cache.remember_write_plan(sql, catalog.clone(), "branch-a", &plan);
+
+        let mut first = cache
+            .write_plan(sql, &catalog, "branch-a")
+            .expect("first cache hit");
+        first.bound.branch_scope = BranchScope::Empty;
+
+        let second = cache
+            .write_plan(sql, &catalog, "branch-a")
+            .expect("second cache hit");
+        assert_eq!(second, plan);
+    }
+
+    #[test]
+    fn write_plan_cache_evicts_least_recently_used_template() {
+        let cache = test_cache(2);
+        let catalog = "catalog-a".to_string();
+        let first_sql = "DELETE FROM lix_file WHERE id = 'first'";
+        let second_sql = "DELETE FROM lix_file WHERE id = 'second'";
+        let third_sql = "DELETE FROM lix_file WHERE id = 'third'";
+        for sql in [first_sql, second_sql] {
+            cache.remember_write_plan(
+                sql,
+                catalog.clone(),
+                "branch-a",
+                &write_plan(sql, "branch-a"),
+            );
+        }
+        cache
+            .write_plan(first_sql, &catalog, "branch-a")
+            .expect("first entry is promoted");
+        cache.remember_write_plan(
+            third_sql,
+            catalog.clone(),
+            "branch-a",
+            &write_plan(third_sql, "branch-a"),
+        );
+
+        assert!(cache.write_plan(first_sql, &catalog, "branch-a").is_some());
+        assert!(cache.write_plan(second_sql, &catalog, "branch-a").is_none());
+        assert!(cache.write_plan(third_sql, &catalog, "branch-a").is_some());
+    }
+}

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -415,7 +415,7 @@ pub(crate) async fn register_write(
     branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
 ) -> Result<(), LixError> {
-    let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
+    let catalog = write_ctx.public_catalog()?;
     register_write_from_catalog(
         session,
         write_ctx,
@@ -440,9 +440,9 @@ where
     C: SqlExecutionContext + ?Sized,
 {
     // Both capabilities project the same transaction-scoped schema snapshot.
-    // Build that immutable metadata once, then install read-only providers from
-    // the committed read capability and writable providers from the overlay.
-    let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
+    // Reuse that immutable metadata, then install read-only providers from the
+    // committed read capability and writable providers from the overlay.
+    let catalog = write_ctx.public_catalog()?;
     register_read_from_catalog(
         session,
         read_ctx,

--- a/packages/engine/src/sql2/test_support/differential.rs
+++ b/packages/engine/src/sql2/test_support/differential.rs
@@ -175,8 +175,12 @@ mod tests {
             .as_ref()
             .ok()
             .and_then(|(_result, path)| *path);
-        let staged_rows =
-            probe_transaction_state(&mut transaction, case.probes, &active_branch_id).await;
+        let staged_rows = Box::pin(probe_transaction_state(
+            &mut transaction,
+            case.probes,
+            &active_branch_id,
+        ))
+        .await;
 
         match execution_result {
             Ok(_) => transaction
@@ -247,8 +251,12 @@ mod tests {
             });
         }
 
-        let staged_rows =
-            probe_transaction_state(&mut transaction, case.probes, &active_branch_id).await;
+        let staged_rows = Box::pin(probe_transaction_state(
+            &mut transaction,
+            case.probes,
+            &active_branch_id,
+        ))
+        .await;
         transaction
             .commit()
             .await

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -288,6 +288,7 @@ where
             crate::plugin::PluginRuntimeHost::new(Arc::new(crate::wasm::UnsupportedWasmRuntime)),
             Arc::clone(&self.branch_ctx),
             Arc::clone(&self.catalog_context),
+            Arc::new(crate::sql2::SqlPlanningCache::default()),
             crate::sql2::SessionFileViews::default(),
         )
         .await

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -19,7 +19,7 @@ use serde_json::Value as JsonValue;
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobHash};
 use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader, branch_ref_stage_row};
-use crate::catalog::CatalogContext;
+use crate::catalog::{CatalogContext, CatalogFingerprint, CatalogSnapshot};
 use crate::changelog::{ChangeId, CommitId};
 use crate::commit_graph::{CommitGraphContext, CommitGraphStoreReader};
 use crate::common::LixTimestamp;
@@ -44,12 +44,12 @@ use crate::plugin::{
     plugin_state_live_state_projection, retain_plugin_state_rows_for_schema_keys,
 };
 use crate::session::{SessionMode, WORKSPACE_BRANCH_KEY};
-use crate::sql2::SqlWriteExecutionContext;
 use crate::sql2::{
     ChangelogQuerySource, HistoryQuerySource, SessionFileViewKey, SessionFileViewMutation,
     SessionFileViews, SessionPluginFileView, SqlChangelogQuerySource, SqlExecutionContext,
     SqlHistoryQuerySource,
 };
+use crate::sql2::{SqlPlanningCache, SqlWriteExecutionContext};
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     Memory, StorageReadOptions, StorageWriteOptions, StorageWriteSetStats,
@@ -135,42 +135,21 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     binary_cas: Arc<BinaryCasContext>,
     plugin_host: PluginRuntimeHost,
     branch_ctx: Arc<BranchContext>,
-    catalog_context: Arc<CatalogContext>,
     schema_resolver: TransactionSchemaResolver,
+    /// SQL binding is snapshot-isolated at transaction open. Schema writes
+    /// staged later in this transaction affect validation but become visible
+    /// to SQL planning only after commit opens a new transaction snapshot.
+    sql_schema_snapshot: Arc<CatalogSnapshot>,
+    sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
     filesystem_path_index_epoch: Arc<AtomicUsize>,
     storage: StorageAdapter<StorageImpl>,
-    sql_schema_cache: SqlSchemaCache,
     functions: FunctionProviderHandle,
     commit_boundary: Option<TransactionCommitBoundary>,
     origin_key: Option<String>,
     session_file_views: SessionFileViews,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
-}
-
-#[derive(Default)]
-struct SqlSchemaCache {
-    visible_schemas: Option<Vec<JsonValue>>,
-}
-
-impl SqlSchemaCache {
-    fn is_prepared(&self) -> bool {
-        self.visible_schemas.is_some()
-    }
-
-    fn prepare(&mut self, visible_schemas: Vec<JsonValue>) {
-        self.visible_schemas = Some(visible_schemas);
-    }
-
-    fn visible_schemas(&self) -> Result<&[JsonValue], LixError> {
-        self.visible_schemas.as_deref().ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "SQL visible schemas were requested before SQL transaction context preparation",
-            )
-        })
-    }
 }
 
 #[derive(Clone)]
@@ -306,6 +285,7 @@ where
         plugin_host: PluginRuntimeHost,
         branch_ctx: Arc<BranchContext>,
         catalog_context: Arc<CatalogContext>,
+        sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         session_file_views: SessionFileViews,
     ) -> Result<OpenTransaction<StorageImpl>, LixError> {
         let read =
@@ -346,7 +326,7 @@ where
         let mut schema_resolver = TransactionSchemaResolver::new(Arc::clone(&catalog_context));
         schema_resolver.remember_compiled_catalog(
             &Domain::schema_catalog(active_branch_id.clone(), true),
-            schema_catalog,
+            Arc::clone(&schema_catalog),
         );
         let staged_writes = Arc::new(TransactionWriteBuffer::new(functions.clone()));
         Ok(OpenTransaction {
@@ -357,13 +337,13 @@ where
                 binary_cas,
                 plugin_host,
                 branch_ctx,
-                catalog_context,
                 schema_resolver,
+                sql_schema_snapshot: schema_catalog,
+                sql_planning_cache,
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
                 filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
                 storage,
-                sql_schema_cache: SqlSchemaCache::default(),
                 functions,
                 commit_boundary: None,
                 origin_key: None,
@@ -1652,6 +1632,47 @@ where
         &self.active_branch_id
     }
 
+    /// Returns the content identity of the SQL schema catalog captured when
+    /// this transaction opened.
+    pub(crate) fn sql_catalog_fingerprint(&self) -> &CatalogFingerprint {
+        self.sql_schema_snapshot.fingerprint()
+    }
+
+    pub(crate) fn sql_public_catalog(&self) -> Result<Arc<crate::sql2::PublicCatalog>, LixError> {
+        self.sql_planning_cache
+            .public_catalog(self.sql_catalog_fingerprint(), || {
+                Ok(self.sql_schema_snapshot.schema_jsons())
+            })
+    }
+
+    pub(crate) fn prepare_sql_write_logical_plan(
+        &self,
+        sql: &str,
+        statement: &DataFusionStatement,
+    ) -> Result<crate::sql2::SqlLogicalPlan, LixError> {
+        let fingerprint = self.sql_catalog_fingerprint();
+        if let Some(plan) =
+            self.sql_planning_cache
+                .write_plan(sql, fingerprint, &self.active_branch_id)
+        {
+            return Ok(crate::sql2::create_write_logical_plan_from_template(plan));
+        }
+
+        let catalog = self.sql_public_catalog()?;
+        let plan = crate::sql2::create_write_plan_template_from_parsed(
+            statement,
+            catalog.as_ref(),
+            &self.active_branch_id,
+        )?;
+        self.sql_planning_cache.remember_write_plan(
+            sql,
+            fingerprint.clone(),
+            &self.active_branch_id,
+            &plan,
+        );
+        Ok(crate::sql2::create_write_logical_plan_from_template(plan))
+    }
+
     /// Returns this transaction's prepared runtime functions.
     pub(crate) fn functions(&self) -> FunctionProviderHandle {
         self.functions.clone()
@@ -1667,14 +1688,13 @@ where
         statement: DataFusionStatement,
         params: &[Value],
     ) -> Result<SqlQueryResult, LixError> {
-        self.prepare_sql_visible_schemas().await?;
         let storage = self.storage.clone();
         let read = storage.begin_read(StorageReadOptions::default()).await?;
         let active_branch_id = self.active_branch_id.clone();
         let live_state = Arc::clone(&self.live_state);
         let binary_cas = Arc::clone(&self.binary_cas);
         let branch_ctx = Arc::clone(&self.branch_ctx);
-        let visible_schemas = self.cached_visible_schemas()?.to_vec();
+        let visible_schemas = self.sql_visible_schemas();
         let functions = self.functions.clone();
         let staged = self.staged_writes.staging_overlay()?;
         let staged_writes = Arc::clone(&self.staged_writes);
@@ -1707,26 +1727,8 @@ where
         .await
     }
 
-    pub(crate) async fn prepare_sql_visible_schemas(&mut self) -> Result<(), LixError> {
-        if self.sql_schema_cache.is_prepared() {
-            return Ok(());
-        }
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        let live_state = self.live_state.reader(&read);
-        let visible_schemas = self
-            .catalog_context
-            .schema_jsons_for_sql_read_planning(&live_state, &self.active_branch_id)
-            .await?;
-        self.sql_schema_cache.prepare(visible_schemas);
-        Ok(())
-    }
-
-    fn cached_visible_schemas(&self) -> Result<&[JsonValue], LixError> {
-        self.sql_schema_cache.visible_schemas()
+    fn sql_visible_schemas(&self) -> Vec<JsonValue> {
+        self.sql_schema_snapshot.schema_jsons()
     }
 
     /// Advances a branch ref without staging tracked rows.
@@ -2168,6 +2170,7 @@ pub(crate) async fn open_transaction<StorageImpl>(
     plugin_host: PluginRuntimeHost,
     branch_ctx: Arc<BranchContext>,
     catalog_context: Arc<CatalogContext>,
+    sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     session_file_views: SessionFileViews,
 ) -> Result<OpenTransaction<StorageImpl>, LixError>
 where
@@ -2182,6 +2185,7 @@ where
         plugin_host,
         branch_ctx,
         catalog_context,
+        sql_planning_cache,
         session_file_views,
     )
     .await
@@ -2201,7 +2205,11 @@ where
     }
 
     fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
-        Ok(self.cached_visible_schemas()?.to_vec())
+        Ok(self.sql_visible_schemas())
+    }
+
+    fn public_catalog(&self) -> Result<Arc<crate::sql2::PublicCatalog>, LixError> {
+        self.sql_public_catalog()
     }
 
     fn plugin_host(&self) -> PluginRuntimeHost {
@@ -2997,6 +3005,7 @@ mod tests {
             PluginRuntimeHost::new(Arc::new(crate::wasm::UnsupportedWasmRuntime)),
             Arc::clone(&branch_ctx),
             Arc::clone(&catalog_context),
+            Arc::new(SqlPlanningCache::default()),
             SessionFileViews::default(),
         )
         .await
@@ -3219,6 +3228,7 @@ mod tests {
             PluginRuntimeHost::new(Arc::new(crate::wasm::UnsupportedWasmRuntime)),
             Arc::clone(&branch_ctx),
             Arc::clone(&catalog_context),
+            Arc::new(SqlPlanningCache::default()),
             SessionFileViews::default(),
         )
         .await
@@ -3502,6 +3512,7 @@ mod tests {
             PluginRuntimeHost::new(Arc::new(crate::wasm::UnsupportedWasmRuntime)),
             Arc::clone(&branch_ctx),
             catalog_context,
+            Arc::new(SqlPlanningCache::default()),
             SessionFileViews::default(),
         )
         .await

--- a/packages/engine/tests/branching.rs
+++ b/packages/engine/tests/branching.rs
@@ -371,6 +371,48 @@ simulation_test!(
 );
 
 simulation_test!(
+    cached_write_templates_are_isolated_across_branch_switches,
+    |sim| async move {
+        let (engine, main, _draft) = create_draft_from_main(&sim).await;
+        let insert_sql = "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)";
+
+        main.execute(
+            insert_sql,
+            &[
+                Value::Text("template-main-only".to_string()),
+                Value::Text("main".to_string()),
+            ],
+        )
+        .await
+        .expect("main write should warm the exact SQL template");
+
+        let (switched, _) = main
+            .switch_branch(SwitchBranchOptions {
+                branch_id: "draft-branch".to_string(),
+            })
+            .await
+            .expect("switch should succeed");
+        switched
+            .execute(
+                insert_sql,
+                &[
+                    Value::Text("template-draft-only".to_string()),
+                    Value::Text("draft".to_string()),
+                ],
+            )
+            .await
+            .expect("the same SQL should bind to the switched branch");
+
+        assert_key_value(&switched, "template-draft-only", Some("\"draft\"")).await;
+        assert_key_value(&main, "template-draft-only", None).await;
+        assert_key_value(&main, "template-main-only", Some("\"main\"")).await;
+        assert_key_value(&switched, "template-main-only", None).await;
+
+        drop(engine);
+    }
+);
+
+simulation_test!(
     pinned_switch_branch_is_ephemeral_and_does_not_advance_refs,
     |sim| async move {
         let (engine, main, _draft) = create_draft_from_main(&sim).await;

--- a/packages/engine/tests/code_structure.rs
+++ b/packages/engine/tests/code_structure.rs
@@ -2869,7 +2869,7 @@ fn sql2_write_session_registers_writable_transaction_surfaces() {
         relative,
         write_registration,
         &[
-            "PublicCatalog::from_visible_schemas",
+            "write_ctx.public_catalog()",
             "catalog.surfaces()",
             "PublicSurfaceKind::LixState",
             "PublicSurfaceKind::LixStateByBranch",
@@ -2894,6 +2894,7 @@ fn sql2_write_session_registers_writable_transaction_surfaces() {
         &[
             "ctx.live_state()",
             "ctx.branch_ref()",
+            "PublicCatalog::from_visible_schemas",
             "register_lix_state_providers",
             "register_lix_branch_provider",
             "register_lix_change_provider",

--- a/packages/engine/tests/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/sql/lix_registered_schema.rs
@@ -98,6 +98,78 @@ simulation_test!(
 );
 
 simulation_test!(
+    sql_catalog_templates_follow_committed_transaction_snapshots,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+
+        transaction
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"sql_template_snapshot_note\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"text\":{\"type\":\"string\"}},\"required\":[\"id\",\"text\"],\"additionalProperties\":false}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("schema registration should stage");
+
+        let insert_sql = "INSERT INTO sql_template_snapshot_note (id, text) VALUES ($1, $2)";
+        transaction
+            .execute(
+                insert_sql,
+                &[
+                    Value::Text("note-1".to_string()),
+                    Value::Text("after commit".to_string()),
+                ],
+            )
+            .await
+            .expect_err("SQL binding should keep the transaction-opening catalog snapshot");
+
+        transaction
+            .commit()
+            .await
+            .expect("schema transaction should commit");
+
+        let inserted = session
+            .execute(
+                insert_sql,
+                &[
+                    Value::Text("note-1".to_string()),
+                    Value::Text("after commit".to_string()),
+                ],
+            )
+            .await
+            .expect("the next transaction should bind against the committed catalog");
+        assert_eq!(inserted.rows_affected(), 1);
+
+        let selected = session
+            .execute(
+                "SELECT text FROM sql_template_snapshot_note WHERE id = $1",
+                &[Value::Text("note-1".to_string())],
+            )
+            .await
+            .expect("new entity surface should be readable after commit");
+        assert_rows_eq(
+            selected,
+            vec![vec![Value::Text("after commit".to_string())]],
+        );
+    }
+);
+
+simulation_test!(
     untracked_registered_schema_does_not_authorize_tracked_state_write,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/engine/tests/sql/read_only.rs
+++ b/packages/engine/tests/sql/read_only.rs
@@ -348,6 +348,53 @@ simulation_test!(read_only_typed_history_views_reject_dml, |sim| async move {
     );
 });
 
+simulation_test!(
+    cached_read_syntax_uses_a_fresh_storage_snapshot,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let reader = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("reader session should open"),
+            &engine,
+        );
+        let writer = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("writer session should open"),
+            &engine,
+        );
+        let select_sql = "SELECT data FROM lix_file WHERE id = $1";
+        let params = [Value::Text("fresh-snapshot-file".to_string())];
+
+        let before = reader
+            .execute(select_sql, &params)
+            .await
+            .expect("initial cached-syntax read should succeed");
+        assert_eq!(before.len(), 0);
+
+        writer
+            .execute(
+                "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+                &[
+                    Value::Text("fresh-snapshot-file".to_string()),
+                    Value::Text("/fresh-snapshot.txt".to_string()),
+                    Value::Blob(b"fresh".to_vec()),
+                ],
+            )
+            .await
+            .expect("intervening write should commit");
+
+        let after = reader
+            .execute(select_sql, &params)
+            .await
+            .expect("repeated syntax should use a fresh provider snapshot");
+        assert_eq!(after.rows()[0].values(), &[Value::Blob(b"fresh".to_vec())]);
+    }
+);
+
 fn assert_read_only_error(error: LixError, schema_key: &str, hint_fragment: &str) {
     assert_eq!(error.code, LixError::CODE_READ_ONLY);
     assert!(


### PR DESCRIPTION
## Summary

- keep one bounded, engine-owned cache for exact parsed SQL, stable `PublicCatalog` metadata, and cloned Lix write templates
- key bound templates by exact SQL + transaction catalog fingerprint + active branch
- derive SQL-visible schemas from the transaction-opening compiled catalog instead of opening a second durable schema read
- continue creating fresh DataFusion sessions, providers, logical plans, and physical plans for every storage snapshot

The caches are deliberately small (256 parsed statements, 16 catalogs, 256 write templates). Parse/bind/catalog failures are not cached. Cached AST and write-plan values are held behind `Arc`s so engine-global locks are released before an owned deep clone is made for execution.

## Benchmark

Median of three independent release runs, each with 20 warmups and 100 measured alternating 4 KiB updates. The guarded query matches the Atelier autosave shape:

```sql
UPDATE lix_file SET data=$1 WHERE id=$2 AND data=$3
```

The fast control removes the previous-value guard. The unique-SQL control gives every execution a distinct SQL comment, forcing parsed/write-template cache misses and covering cold-cache overhead.

| Backend / query | main p50 | PR p50 | p50 | main p95 | PR p95 | p95 |
|---|---:|---:|---:|---:|---:|---:|
| RocksDB guarded | 3.353 ms | 2.125 ms | **-36.6%** | 3.487 ms | 2.281 ms | **-34.6%** |
| RocksDB fast control | 2.112 ms | 1.275 ms | **-39.6%** | 2.197 ms | 1.404 ms | **-36.1%** |
| RocksDB unique-SQL miss | 2.175 ms | 1.401 ms | **-35.6%** | 2.256 ms | 1.545 ms | **-31.5%** |
| local SlateDB guarded | 7.978 ms | 6.223 ms | **-22.0%** | 8.712 ms | 6.889 ms | **-20.9%** |
| local SlateDB fast control | 6.475 ms | 5.001 ms | **-22.8%** | 7.590 ms | 5.906 ms | **-22.2%** |
| local SlateDB unique-SQL miss | 6.754 ms | 5.182 ms | **-23.3%** | 7.750 ms | 5.860 ms | **-24.4%** |

The storage counters explain the backend-independent gain. Per guarded write, `begin_read` falls 14 -> 13, `get_many` 78 -> 69, keys 254 -> 189, and scans 5 -> 3. The fast and unique-SQL controls fall 11 -> 10 reads, 72 -> 63 `get_many`, 247 -> 182 keys, and 7 -> 5 scans.

## Correctness and invalidation

- catalog fingerprints change on committed schema changes
- active branch is part of every bound-template key
- each cache hit clones the immutable write template before parameterized branch-scope resolution
- SQL binding remains snapshot-isolated to the transaction-opening catalog; a committed schema becomes visible in the next transaction
- repeated reads retain only parsed syntax and still build fresh providers, proven with an intervening commit regression test
- no public API changes

## Validation

- `cargo test -p lix_engine`
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `node scripts/validate-changes.mjs`
- `cargo fmt --package lix_engine`
- `git diff --check`

## Design references

- DataFusion documents that `SessionContext` owns session state while execution uses per-query task state: https://docs.rs/datafusion/53.0.0/datafusion/execution/context/struct.SessionContext.html#relationship-between-sessioncontext-sessionstate-and-taskcontext
- DataFusion logical plans retain `TableSource` / `TableProvider` objects, which is why this PR does not cache complete DataFusion plans: https://datafusion.apache.org/library-user-guide/building-logical-plans.html#table-sources
- DuckDB invalidates prepared statements using catalog identity/version: https://github.com/duckdb/duckdb/blob/3305afbcb08c39a056ad9c098754df57d07bcbe0/src/main/prepared_statement_data.cpp#L96-L135
- Turso reparses/reprepares when schema state changes: https://github.com/tursodatabase/turso/blob/9e265213a076cec4e33b361925221d965d89e59e/core/statement.rs#L515-L578
- SlateDB read snapshots are immutable views, matching the rule that provider instances stay snapshot-local: https://slatedb.io/docs/design/reads/
