### PR TITLE
perf(observe): compare shared results once per generation

### DIFF
--- a/.changenotes/compare-shared-observation-results-once.md
+++ b/.changenotes/compare-shared-observation-results-once.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reduced CPU time when identical observations fan out large results.
+
+Lix now compares each new shared query result with its predecessor once and lets subscribers reuse that equivalence decision, while retaining each generation's fresh result metadata.

--- a/.changenotes/share-observation-result-storage.md
+++ b/.changenotes/share-observation-result-storage.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reduced CPU time and memory copying when remote observations fan out large blob results.
+
+Immutable query results now share their backing storage across observation subscribers and retained transport delta bases.

--- a/packages/engine/src/observe_coordinator.rs
+++ b/packages/engine/src/observe_coordinator.rs
@@ -122,12 +122,49 @@ pub(crate) struct ObserveQueryState {
     changes: watch::Sender<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ObserveSharedContent {
+    pub(crate) generation: u64,
+    pub(crate) compared_generation: Option<u64>,
+    pub(crate) matches_compared_generation: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ObserveQueryEvaluation {
+    pub(crate) rows: ExecuteResult,
+    pub(crate) shared_content: Option<ObserveSharedContent>,
+}
+
+impl ObserveQueryEvaluation {
+    pub(crate) fn unshared(rows: ExecuteResult) -> Self {
+        Self {
+            rows,
+            shared_content: None,
+        }
+    }
+
+    pub(crate) fn rows_changed_since(
+        &self,
+        last_rows: Option<&ExecuteResult>,
+        last_shared_content: Option<ObserveSharedContent>,
+    ) -> bool {
+        if let (Some(previous), Some(current)) = (last_shared_content, self.shared_content)
+            && current.compared_generation == Some(previous.generation)
+        {
+            return !current.matches_compared_generation;
+        }
+
+        last_rows.is_none_or(|last_rows| *last_rows != self.rows)
+    }
+}
+
 impl ObserveQueryState {
     pub(crate) async fn evaluate<F, Fut>(
         &self,
         generation: u64,
+        compare_results: bool,
         evaluate: F,
-    ) -> Result<ExecuteResult, LixError>
+    ) -> Result<ObserveQueryEvaluation, LixError>
     where
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<ExecuteResult, LixError>>,
@@ -137,8 +174,8 @@ impl ObserveQueryState {
         loop {
             {
                 let mut inner = self.lock();
-                if let Some(rows) = inner.cached.get(&generation) {
-                    return Ok(rows.clone());
+                if let Some(cached) = inner.cached.get(&generation) {
+                    return Ok(cached.evaluation(generation));
                 }
 
                 if inner.in_flight.insert(generation) {
@@ -149,16 +186,13 @@ impl ObserveQueryState {
             }
 
             if changes.changed().await.is_err() {
-                return evaluate().await;
+                return evaluate().await.map(ObserveQueryEvaluation::unshared);
             }
         }
 
-        let guard = InFlightGuard::new(self, generation);
+        let guard = InFlightGuard::new(self, generation, compare_results);
         match evaluate().await {
-            Ok(rows) => {
-                guard.finish_success(rows.clone());
-                Ok(rows)
-            }
+            Ok(rows) => Ok(guard.finish_success(rows)),
             Err(error) => {
                 guard.finish_without_cache();
                 Err(error)
@@ -191,43 +225,82 @@ impl ObserveQueryState {
 
 #[derive(Debug, Default)]
 struct ObserveQueryStateInner {
-    cached: BTreeMap<u64, ExecuteResult>,
+    cached: BTreeMap<u64, CachedObserveResult>,
     in_flight: BTreeSet<u64>,
     change_sequence: u64,
+}
+
+#[derive(Clone, Debug)]
+struct CachedObserveResult {
+    rows: ExecuteResult,
+    compared_generation: Option<u64>,
+    matches_compared_generation: bool,
+}
+
+impl CachedObserveResult {
+    fn evaluation(&self, generation: u64) -> ObserveQueryEvaluation {
+        ObserveQueryEvaluation {
+            rows: self.rows.clone(),
+            shared_content: Some(ObserveSharedContent {
+                generation,
+                compared_generation: self.compared_generation,
+                matches_compared_generation: self.matches_compared_generation,
+            }),
+        }
+    }
 }
 
 struct InFlightGuard<'a> {
     state: &'a ObserveQueryState,
     generation: u64,
+    compare_results: bool,
     active: bool,
 }
 
 impl<'a> InFlightGuard<'a> {
-    fn new(state: &'a ObserveQueryState, generation: u64) -> Self {
+    fn new(state: &'a ObserveQueryState, generation: u64, compare_results: bool) -> Self {
         Self {
             state,
             generation,
+            compare_results,
             active: true,
         }
     }
 
-    fn finish_success(mut self, rows: ExecuteResult) {
-        self.finish(Some(rows));
+    fn finish_success(mut self, rows: ExecuteResult) -> ObserveQueryEvaluation {
+        self.finish(Some(rows))
+            .expect("successful observe evaluation must produce a cached result")
     }
 
     fn finish_without_cache(mut self) {
-        self.finish(None);
+        let _ = self.finish(None);
     }
 
-    fn finish(&mut self, rows: Option<ExecuteResult>) {
+    fn finish(&mut self, rows: Option<ExecuteResult>) -> Option<ObserveQueryEvaluation> {
         if !self.active {
-            return;
+            return None;
         }
         self.active = false;
         let mut inner = self.state.lock();
         inner.in_flight.remove(&self.generation);
-        if let Some(rows) = rows {
-            inner.cached.insert(self.generation, rows);
+        let evaluation = rows.map(|rows| {
+            let (compared_generation, matches_compared_generation) = if self.compare_results {
+                inner
+                    .cached
+                    .range(..self.generation)
+                    .next_back()
+                    .map(|(generation, cached)| (Some(*generation), cached.rows == rows))
+                    .unwrap_or((None, false))
+            } else {
+                (None, false)
+            };
+            let cached = CachedObserveResult {
+                rows,
+                compared_generation,
+                matches_compared_generation,
+            };
+            let evaluation = cached.evaluation(self.generation);
+            inner.cached.insert(self.generation, cached);
             while inner.cached.len() > MAX_CACHED_GENERATIONS_PER_QUERY {
                 let Some(oldest_generation) = inner.cached.first_key_value().map(|(key, _)| *key)
                 else {
@@ -235,15 +308,17 @@ impl<'a> InFlightGuard<'a> {
                 };
                 inner.cached.remove(&oldest_generation);
             }
-        }
+            evaluation
+        });
         inner.change_sequence = inner.change_sequence.saturating_add(1);
         self.state.send_change(inner.change_sequence);
+        evaluation
     }
 }
 
 impl Drop for InFlightGuard<'_> {
     fn drop(&mut self) {
-        self.finish(None);
+        let _ = self.finish(None);
     }
 }
 
@@ -256,8 +331,22 @@ mod tests {
 
     use tokio::sync::oneshot;
 
-    use super::ObserveQueryState;
-    use crate::ExecuteResult;
+    use super::{ObserveQueryEvaluation, ObserveQueryState, ObserveSharedContent};
+    use crate::{ExecuteResult, Value};
+
+    fn blob_result(byte: u8) -> ExecuteResult {
+        ExecuteResult::from_rows(
+            vec!["data".to_string()],
+            vec![vec![Value::Blob(vec![byte; 1024])]],
+        )
+    }
+
+    fn blob_pointer(result: &ExecuteResult) -> *const u8 {
+        match result.rows()[0].get_index(0) {
+            Some(Value::Blob(bytes)) => bytes.as_ptr(),
+            value => panic!("expected blob result, got {value:?}"),
+        }
+    }
 
     #[tokio::test]
     async fn evaluate_cleans_up_in_flight_generation_when_leader_is_cancelled() {
@@ -266,7 +355,7 @@ mod tests {
         let leader_state = Arc::clone(&state);
         let leader = tokio::spawn(async move {
             leader_state
-                .evaluate(1, || async move {
+                .evaluate(1, false, || async move {
                     let _ = started_tx.send(());
                     std::future::pending().await
                 })
@@ -281,13 +370,15 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(1),
-            state.evaluate(1, || async { Ok(ExecuteResult::from_rows_affected(0)) }),
+            state.evaluate(1, false, || async {
+                Ok(ExecuteResult::from_rows_affected(0))
+            }),
         )
         .await
         .expect("cancelled in-flight generation should not strand followers")
         .expect("replacement evaluation should succeed");
 
-        assert_eq!(result, ExecuteResult::from_rows_affected(0));
+        assert_eq!(result.rows, ExecuteResult::from_rows_affected(0));
     }
 
     #[tokio::test]
@@ -297,7 +388,7 @@ mod tests {
 
         let first_attempts = Arc::clone(&attempts);
         let first = state
-            .evaluate(1, || async move {
+            .evaluate(1, false, || async move {
                 first_attempts.fetch_add(1, Ordering::SeqCst);
                 Err(crate::LixError::new(crate::LixError::CODE_UNKNOWN, "boom"))
             })
@@ -306,18 +397,129 @@ mod tests {
 
         let second_attempts = Arc::clone(&attempts);
         let second = state
-            .evaluate(1, || async move {
+            .evaluate(1, false, || async move {
                 second_attempts.fetch_add(1, Ordering::SeqCst);
                 Ok(ExecuteResult::from_rows_affected(0))
             })
             .await
             .expect("second evaluation should not reuse the first error");
 
-        assert_eq!(second, ExecuteResult::from_rows_affected(0));
+        assert_eq!(second.rows, ExecuteResult::from_rows_affected(0));
         assert_eq!(
             attempts.load(Ordering::SeqCst),
             2,
             "failed evaluations must not be cached for followers"
         );
     }
+
+    #[tokio::test]
+    async fn identical_generations_share_one_comparison_without_reusing_results() {
+        let state = ObserveQueryState::new();
+        let first = state
+            .evaluate(1, true, || async { Ok(blob_result(b'a')) })
+            .await
+            .expect("first evaluation should succeed");
+        let second = state
+            .evaluate(2, true, || async { Ok(blob_result(b'a')) })
+            .await
+            .expect("second evaluation should succeed");
+
+        let first_content = first
+            .shared_content
+            .expect("coordinated result should carry comparison metadata");
+        let second_content = second
+            .shared_content
+            .expect("coordinated result should carry comparison metadata");
+        assert_eq!(first_content.compared_generation, None);
+        assert_eq!(second_content.compared_generation, Some(1));
+        assert!(second_content.matches_compared_generation);
+        assert_ne!(
+            blob_pointer(&first.rows),
+            blob_pointer(&second.rows),
+            "each generation must retain its freshly evaluated result"
+        );
+    }
+
+    #[tokio::test]
+    async fn comparison_starts_without_losing_single_observer_generation_identity() {
+        let state = ObserveQueryState::new();
+        let first = state
+            .evaluate(1, false, || async { Ok(blob_result(b'a')) })
+            .await
+            .expect("first evaluation should succeed");
+        let second = state
+            .evaluate(2, false, || async { Ok(blob_result(b'a')) })
+            .await
+            .expect("second evaluation should succeed");
+        let third = state
+            .evaluate(3, true, || async { Ok(blob_result(b'a')) })
+            .await
+            .expect("fanout evaluation should succeed");
+
+        let first_content = first
+            .shared_content
+            .expect("first generation should carry its identity");
+        let second_content = second
+            .shared_content
+            .expect("second generation should carry its identity");
+        let third_content = third
+            .shared_content
+            .expect("fanout generation should carry its comparison");
+        assert_eq!(first_content.generation, 1);
+        assert_eq!(first_content.compared_generation, None);
+        assert_eq!(second_content.generation, 2);
+        assert_eq!(second_content.compared_generation, None);
+        assert_eq!(third_content.compared_generation, Some(2));
+        assert!(third_content.matches_compared_generation);
+    }
+
+    #[tokio::test]
+    async fn changed_and_out_of_order_generations_keep_direct_comparisons() {
+        let state = ObserveQueryState::new();
+        let first = state
+            .evaluate(1, true, || async { Ok(blob_result(b'a')) })
+            .await
+            .expect("first evaluation should succeed");
+        let third = state
+            .evaluate(3, true, || async { Ok(blob_result(b'a')) })
+            .await
+            .expect("third evaluation should succeed");
+        let second = state
+            .evaluate(2, true, || async { Ok(blob_result(b'b')) })
+            .await
+            .expect("late second evaluation should succeed");
+
+        let first_content = first.shared_content.expect("first comparison metadata");
+        let third_content = third.shared_content.expect("third comparison metadata");
+        let second_content = second.shared_content.expect("second comparison metadata");
+        assert_eq!(first_content.compared_generation, None);
+        assert_eq!(third_content.compared_generation, Some(1));
+        assert!(third_content.matches_compared_generation);
+        assert_eq!(second_content.compared_generation, Some(1));
+        assert!(!second_content.matches_compared_generation);
+
+        let skipped_equal = ObserveQueryEvaluation {
+            rows: blob_result(b'a'),
+            shared_content: Some(ObserveSharedContent {
+                generation: 4,
+                compared_generation: Some(3),
+                matches_compared_generation: false,
+            }),
+        };
+        assert!(
+            !skipped_equal.rows_changed_since(Some(&first.rows), Some(first_content)),
+            "a skipped comparison must fall back to exact row equality"
+        );
+
+        let cached_third = state
+            .evaluate(3, true, || async {
+                panic!("cached generation must not re-evaluate")
+            })
+            .await
+            .expect("cached third evaluation should succeed");
+        assert_eq!(cached_third.shared_content, Some(third_content));
+    }
 }
+
+#[cfg(test)]
+mod performance_tests;

--- a/packages/engine/src/observe_coordinator/performance_tests.rs
+++ b/packages/engine/src/observe_coordinator/performance_tests.rs
@@ -1,0 +1,150 @@
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use super::{ObserveQueryEvaluation, ObserveQueryState, ObserveSharedContent};
+use crate::{ExecuteResult, Value};
+
+fn sized_blob_result(size: usize, changed: bool) -> ExecuteResult {
+    let mut bytes = vec![0; size];
+    if changed {
+        bytes[size / 2] = 1;
+    }
+    ExecuteResult::from_rows(vec!["data".to_string()], vec![vec![Value::Blob(bytes)]])
+}
+
+#[test]
+#[ignore = "manual performance probe"]
+fn observe_result_equivalence_baseline_performance_probe() {
+    run_observe_result_equivalence_performance_probe(false);
+}
+
+#[test]
+#[ignore = "manual performance probe"]
+fn observe_result_equivalence_shared_performance_probe() {
+    run_observe_result_equivalence_performance_probe(true);
+}
+
+fn run_observe_result_equivalence_performance_probe(share_comparison: bool) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build performance probe runtime");
+    let mode = if share_comparison {
+        "candidate"
+    } else {
+        "baseline"
+    };
+    println!("size_mib\tobservers\tworkload\tmode\tmedian_ms\tp10_ms\tp90_ms\titerations");
+    for size_mib in [1_usize, 10] {
+        for observers in [1_usize, 2, 4, 16] {
+            for changed in [false, true] {
+                let state = ObserveQueryState::new();
+                let initial = runtime
+                    .block_on(
+                        state.evaluate(1, share_comparison && observers > 1, || async {
+                            Ok(sized_blob_result(size_mib * 1024 * 1024, false))
+                        }),
+                    )
+                    .expect("seed performance probe result");
+                let mut last_rows = vec![initial.rows; observers];
+                let mut last_content = vec![initial.shared_content; observers];
+                let mut generation = 1_u64;
+
+                for _ in 0..3 {
+                    run_probe_iteration(
+                        &runtime,
+                        &state,
+                        &mut generation,
+                        size_mib * 1024 * 1024,
+                        changed,
+                        share_comparison,
+                        &mut last_rows,
+                        &mut last_content,
+                    );
+                }
+                let calibration_start = Instant::now();
+                for _ in 0..3 {
+                    run_probe_iteration(
+                        &runtime,
+                        &state,
+                        &mut generation,
+                        size_mib * 1024 * 1024,
+                        changed,
+                        share_comparison,
+                        &mut last_rows,
+                        &mut last_content,
+                    );
+                }
+                let per_iteration = calibration_start.elapsed() / 3;
+                let iterations = u32::try_from(
+                    (Duration::from_millis(30).as_nanos() / per_iteration.as_nanos().max(1))
+                        .clamp(2, 100),
+                )
+                .expect("bounded performance probe iteration count should fit u32");
+
+                let mut samples = Vec::with_capacity(21);
+                for _ in 0..21 {
+                    let start = Instant::now();
+                    for _ in 0..iterations {
+                        run_probe_iteration(
+                            &runtime,
+                            &state,
+                            &mut generation,
+                            size_mib * 1024 * 1024,
+                            changed,
+                            share_comparison,
+                            &mut last_rows,
+                            &mut last_content,
+                        );
+                    }
+                    samples.push(start.elapsed().as_secs_f64() * 1000.0 / f64::from(iterations));
+                }
+                samples.sort_by(f64::total_cmp);
+                println!(
+                    "{size_mib}\t{observers}\t{}\t{mode}\t{:.3}\t{:.3}\t{:.3}\t{iterations}",
+                    if changed { "changed" } else { "unchanged" },
+                    samples[10],
+                    samples[2],
+                    samples[18]
+                );
+            }
+        }
+    }
+}
+
+fn run_probe_iteration(
+    runtime: &tokio::runtime::Runtime,
+    state: &ObserveQueryState,
+    generation: &mut u64,
+    size: usize,
+    changed: bool,
+    share_comparison: bool,
+    last_rows: &mut [ExecuteResult],
+    last_content: &mut [Option<ObserveSharedContent>],
+) {
+    *generation += 1;
+    let variant = changed && (*generation).is_multiple_of(2);
+    let evaluation = runtime
+        .block_on(state.evaluate(
+            *generation,
+            share_comparison && last_rows.len() > 1,
+            || async move { Ok(sized_blob_result(size, variant)) },
+        ))
+        .expect("performance probe evaluation");
+    for (previous_rows, previous_content) in last_rows.iter_mut().zip(last_content.iter_mut()) {
+        let rows_changed = observed_rows_changed(previous_rows, *previous_content, &evaluation);
+        *previous_content = evaluation.shared_content;
+        if rows_changed {
+            *previous_rows = evaluation.rows.clone();
+        }
+        black_box(rows_changed);
+    }
+}
+
+fn observed_rows_changed(
+    previous_rows: &ExecuteResult,
+    previous_content: Option<ObserveSharedContent>,
+    evaluation: &ObserveQueryEvaluation,
+) -> bool {
+    evaluation.rows_changed_since(Some(previous_rows), previous_content)
+}

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::future::Future;
 use std::ops::ControlFlow;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use crate::branch::BranchRefReader;
 use crate::functions::{FunctionContext, FunctionProviderHandle};
@@ -29,12 +29,18 @@ use super::transaction::SessionTransaction;
 ///
 /// Column names live once at the result-set level. Individual rows only own
 /// values, which keeps the public API row-oriented without copying schema
-/// metadata into every row.
+/// metadata into every row. Result storage is immutable and reference counted
+/// so observation fanout does not copy large blob values per subscriber.
 #[derive(Debug, Clone)]
 pub struct ExecuteResult {
-    columns: Vec<String>,
-    rows: Vec<Row>,
+    backing: Arc<ExecuteResultBacking>,
     rows_affected: u64,
+}
+
+#[derive(Debug)]
+struct ExecuteResultBacking {
+    columns: Arc<[String]>,
+    rows: Vec<Row>,
     notices: Vec<LixNotice>,
     // Observe evaluations can be shared across sessions. Carry the exact
     // rendered plugin state with the rows so each receiving session can
@@ -44,10 +50,11 @@ pub struct ExecuteResult {
 
 impl PartialEq for ExecuteResult {
     fn eq(&self, other: &Self) -> bool {
-        self.columns == other.columns
-            && self.rows == other.rows
-            && self.rows_affected == other.rows_affected
-            && self.notices == other.notices
+        self.rows_affected == other.rows_affected
+            && (Arc::ptr_eq(&self.backing, &other.backing)
+                || (self.backing.columns == other.backing.columns
+                    && self.backing.rows == other.backing.rows
+                    && self.backing.notices == other.backing.notices))
     }
 }
 
@@ -62,14 +69,7 @@ pub struct CoherentReadBatch {
 
 impl ExecuteResult {
     fn from_sql_query_result(result: SqlQueryResult) -> Self {
-        Self {
-            columns: result.columns,
-            rows: Vec::new(),
-            rows_affected: 0,
-            notices: result.notices,
-            file_view_mutations: Vec::new(),
-        }
-        .with_rows(result.rows)
+        Self::from_query_parts(result.columns, result.rows, 0, result.notices)
     }
 
     fn from_sql_write_result(result: sql2::SqlWriteResult) -> Self {
@@ -78,86 +78,86 @@ impl ExecuteResult {
             returning,
         } = result;
         match returning {
-            Some(result) => Self {
-                columns: result.columns,
-                rows: Vec::new(),
-                rows_affected,
-                notices: result.notices,
-                file_view_mutations: Vec::new(),
+            Some(result) => {
+                Self::from_query_parts(result.columns, result.rows, rows_affected, result.notices)
             }
-            .with_rows(result.rows),
             None => Self::from_rows_affected(rows_affected),
         }
     }
 
     pub fn from_rows_affected(rows_affected: u64) -> Self {
         Self {
-            columns: Vec::new(),
-            rows: Vec::new(),
+            backing: empty_execute_result_backing(),
             rows_affected,
-            notices: Vec::new(),
-            file_view_mutations: Vec::new(),
         }
     }
 
     pub fn from_rows(columns: Vec<String>, rows: Vec<Vec<Value>>) -> Self {
-        Self {
-            columns,
-            rows: Vec::new(),
-            rows_affected: 0,
-            notices: Vec::new(),
-            file_view_mutations: Vec::new(),
-        }
-        .with_rows(rows)
+        Self::from_query_parts(columns, rows, 0, Vec::new())
     }
 
-    fn with_rows(mut self, rows: Vec<Vec<Value>>) -> Self {
-        let columns = Arc::<[String]>::from(self.columns.clone().into_boxed_slice());
-        self.rows = rows
+    fn from_query_parts(
+        columns: Vec<String>,
+        rows: Vec<Vec<Value>>,
+        rows_affected: u64,
+        notices: Vec<LixNotice>,
+    ) -> Self {
+        let columns: Arc<[String]> = columns.into();
+        let rows = rows
             .into_iter()
             .map(|values| Row {
                 columns: Arc::clone(&columns),
                 values,
             })
             .collect();
-        self
+        Self {
+            backing: Arc::new(ExecuteResultBacking {
+                columns,
+                rows,
+                notices,
+                file_view_mutations: Vec::new(),
+            }),
+            rows_affected,
+        }
     }
 
     fn with_file_view_mutations(mut self, mutations: Vec<sql2::SessionFileViewMutation>) -> Self {
-        self.file_view_mutations = mutations;
+        Arc::get_mut(&mut self.backing)
+            .expect("fresh execute result backing must be uniquely owned")
+            .file_view_mutations = mutations;
         self
     }
 
     pub(crate) fn file_view_mutations(&self) -> &[sql2::SessionFileViewMutation] {
-        &self.file_view_mutations
+        &self.backing.file_view_mutations
     }
 
     /// Returns the result-set column names in row value order.
     pub fn columns(&self) -> &[String] {
-        &self.columns
+        self.backing.columns.as_ref()
     }
 
     /// Returns the owned rows. Use `iter()` for name-based access.
     pub fn rows(&self) -> &[Row] {
-        &self.rows
+        &self.backing.rows
     }
 
     /// Iterates rows with borrowed access to the shared column metadata.
     pub fn iter(&self) -> impl Iterator<Item = RowRef<'_>> {
-        self.rows.iter().map(|row| RowRef {
-            columns: self.columns.as_slice(),
+        self.backing.rows.iter().map(|row| RowRef {
+            columns: self.backing.columns.as_ref(),
             values: row.values.as_slice(),
         })
     }
 
     /// Returns the number of rows in this result set.
     pub fn len(&self) -> usize {
-        self.rows.len()
+        self.backing.rows.len()
     }
 
     /// Returns true when this result set has no rows.
     pub fn is_empty(&self) -> bool {
-        self.rows.is_empty()
+        self.backing.rows.is_empty()
     }
 
     /// Returns the number of rows affected by a mutation statement.
@@ -167,7 +167,7 @@ impl ExecuteResult {
 
     /// Returns non-fatal diagnostics produced while executing the statement.
     pub fn notices(&self) -> &[LixNotice] {
-        &self.notices
+        &self.backing.notices
     }
 
     /// Looks up the value for `column_name` on an owned row from this set.
@@ -178,8 +178,23 @@ impl ExecuteResult {
 
     /// Returns the index for a column name.
     pub fn column_index(&self, column_name: &str) -> Option<usize> {
-        self.columns.iter().position(|column| column == column_name)
+        self.backing
+            .columns
+            .iter()
+            .position(|column| column == column_name)
     }
+}
+
+fn empty_execute_result_backing() -> Arc<ExecuteResultBacking> {
+    static EMPTY: OnceLock<Arc<ExecuteResultBacking>> = OnceLock::new();
+    Arc::clone(EMPTY.get_or_init(|| {
+        Arc::new(ExecuteResultBacking {
+            columns: Vec::new().into(),
+            rows: Vec::new(),
+            notices: Vec::new(),
+            file_view_mutations: Vec::new(),
+        })
+    }))
 }
 
 /// One owned row returned by a query.
@@ -1699,6 +1714,18 @@ mod tests {
             row.value("title").unwrap(),
             &Value::Text("Hello".to_string())
         );
+    }
+
+    #[test]
+    fn execute_result_clone_shares_immutable_backing() {
+        let result = ExecuteResult::from_rows(
+            vec!["data".to_string()],
+            vec![vec![Value::Blob(vec![b'x'; 1024 * 1024])]],
+        );
+        let cloned = result.clone();
+
+        assert!(Arc::ptr_eq(&result.backing, &cloned.backing));
+        assert_eq!(result, cloned);
     }
 
     #[test]

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 
-use crate::observe_coordinator::{ObserveQueryKey, ObserveQueryState, ObserveSessionScope};
+use crate::observe_coordinator::{
+    ObserveQueryEvaluation, ObserveQueryKey, ObserveQueryState, ObserveSessionScope,
+    ObserveSharedContent,
+};
 use crate::storage_adapter::Memory;
 use crate::storage_adapter::Storage;
 use crate::{ExecuteResult, LixError, Value, sql2};
@@ -47,6 +50,7 @@ where
     receiver: watch::Receiver<u64>,
     sequence: u64,
     last_rows: Option<ExecuteResult>,
+    last_shared_content: Option<ObserveSharedContent>,
     closed: bool,
 }
 
@@ -60,11 +64,14 @@ where
             return Ok(None);
         }
         if self.last_rows.is_none() {
-            let Some((mutation_sequence, rows)) = self.evaluate_stable_snapshot().await? else {
+            let Some((mutation_sequence, evaluation)) = self.evaluate_stable_snapshot().await?
+            else {
                 return Ok(None);
             };
+            let rows = evaluation.rows;
             self.acknowledge_delivered_file_views(&rows);
             self.last_rows = Some(rows.clone());
+            self.last_shared_content = evaluation.shared_content;
             return Ok(Some(ObserveEvent {
                 sequence: self.sequence,
                 mutation_sequence,
@@ -88,14 +95,15 @@ where
                 return Ok(None);
             }
 
-            let Some((mutation_sequence, rows)) = self.evaluate_stable_snapshot().await? else {
+            let Some((mutation_sequence, evaluation)) = self.evaluate_stable_snapshot().await?
+            else {
                 return Ok(None);
             };
-            if self
-                .last_rows
-                .as_ref()
-                .is_none_or(|last_rows| *last_rows != rows)
-            {
+            let changed =
+                evaluation.rows_changed_since(self.last_rows.as_ref(), self.last_shared_content);
+            self.last_shared_content = evaluation.shared_content;
+            if changed {
+                let rows = evaluation.rows;
                 self.acknowledge_delivered_file_views(&rows);
                 self.sequence += 1;
                 self.last_rows = Some(rows.clone());
@@ -122,7 +130,9 @@ where
         Ok(self.receiver.changed().await.is_ok())
     }
 
-    async fn evaluate_stable_snapshot(&mut self) -> Result<Option<(u64, ExecuteResult)>, LixError> {
+    async fn evaluate_stable_snapshot(
+        &mut self,
+    ) -> Result<Option<(u64, ObserveQueryEvaluation)>, LixError> {
         loop {
             let operation_guard = self.session.begin_waitable_session_operation().await?;
             #[cfg(not(target_family = "wasm"))]
@@ -148,16 +158,17 @@ where
         }
     }
 
-    async fn execute_or_share(&self, generation: u64) -> Result<ExecuteResult, LixError> {
+    async fn execute_or_share(&self, generation: u64) -> Result<ObserveQueryEvaluation, LixError> {
         let Some(shared_state) = &self.query.shared_state else {
             return self
                 .session
                 .execute_for_observe(&self.query.sql, &self.query.params)
-                .await;
+                .await
+                .map(ObserveQueryEvaluation::unshared);
         };
 
         shared_state
-            .evaluate(generation, || async {
+            .evaluate(generation, Arc::strong_count(shared_state) > 1, || async {
                 self.session
                     .execute_for_observe(&self.query.sql, &self.query.params)
                     .await
@@ -213,6 +224,7 @@ where
             receiver: self.observe_invalidation.subscribe(),
             sequence: 0,
             last_rows: None,
+            last_shared_content: None,
             closed: false,
         })
     }

--- a/packages/engine/tests/execute_result_allocations.rs
+++ b/packages/engine/tests/execute_result_allocations.rs
@@ -1,0 +1,125 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::mem::size_of;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use lix_engine::{ExecuteResult, Value};
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: Delegates the allocation unchanged to the system allocator.
+        let pointer = unsafe { System.alloc(layout) };
+        record_allocation(pointer, layout.size());
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: Delegates the allocation unchanged to the system allocator.
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        record_allocation(pointer, layout.size());
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: The pointer and layout came from this allocator, which
+        // delegates every allocation to the system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: Delegates the reallocation unchanged to the system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        record_allocation(pointer, new_size);
+        pointer
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AllocationStats {
+    count: usize,
+    bytes: usize,
+}
+
+fn record_allocation(pointer: *mut u8, bytes: usize) {
+    if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+        ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+    }
+}
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, AllocationStats) {
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    assert!(!TRACK_ALLOCATIONS.swap(true, Ordering::SeqCst));
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    let stats = AllocationStats {
+        count: ALLOCATION_COUNT.load(Ordering::Relaxed),
+        bytes: ALLOCATED_BYTES.load(Ordering::Relaxed),
+    };
+    (result, stats)
+}
+
+fn blob_pointer(result: &ExecuteResult) -> *const u8 {
+    let [Value::Blob(bytes)] = result.rows()[0].values() else {
+        panic!("diagnostic result must contain one blob")
+    };
+    bytes.as_ptr()
+}
+
+#[test]
+#[ignore = "manual deterministic ExecuteResult allocation diagnostic"]
+fn execute_result_construction_and_clone_allocations() {
+    black_box(ExecuteResult::from_rows_affected(0));
+    let (_, rows_affected) =
+        measure_allocations(|| black_box(ExecuteResult::from_rows_affected(1)));
+    eprintln!(
+        "execute_result_rows_affected allocations={} allocated_bytes={}",
+        rows_affected.count, rows_affected.bytes
+    );
+    assert_eq!(
+        rows_affected.count, 0,
+        "rows-affected-only results must remain allocation-free"
+    );
+
+    for size_mib in [1_usize, 10] {
+        let size_bytes = size_mib * 1024 * 1024;
+        let columns = vec!["data".to_string()];
+        let rows = vec![vec![Value::Blob(vec![b'x'; size_bytes])]];
+        let (result, construction) =
+            measure_allocations(|| ExecuteResult::from_rows(columns, rows));
+        let probe = result.clone();
+        eprintln!(
+            "execute_result_construct size_mib={size_mib} layout_bytes={} allocations={} allocated_bytes={} clone_shares_blob={}",
+            size_of::<ExecuteResult>(),
+            construction.count,
+            construction.bytes,
+            blob_pointer(&result) == blob_pointer(&probe),
+        );
+
+        for fanout in [1_usize, 4, 16] {
+            let ((), cloning) = measure_allocations(|| {
+                for _ in 0..fanout {
+                    let cloned = result.clone();
+                    black_box(blob_pointer(&cloned));
+                    black_box(cloned);
+                }
+            });
+            eprintln!(
+                "execute_result_clone size_mib={size_mib} subscribers={fanout} allocations={} allocated_bytes={}",
+                cloning.count, cloning.bytes
+            );
+            assert_eq!(cloning.count, 0, "cloning must remain allocation-free");
+            assert_eq!(cloning.bytes, 0, "cloning must not copy result storage");
+        }
+    }
+}

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use std::io::{Cursor, Read, Write};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use lix_engine::wasm::{
@@ -1238,6 +1239,90 @@ async fn observe_point_read_acknowledges_delivered_plugin_state_per_session() {
     assert_eq!(
         read_file(&session_a, "/shared.keyed").await.unwrap(),
         Some(b"a=A\nb=B\n".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn observe_late_subscriber_acknowledges_fresh_plugin_incarnation_after_unchanged_bytes() {
+    let (engine, session_a, session_b) = keyed_collaboration_sessions().await;
+    let session_c = engine
+        .open_session(
+            session_a
+                .active_branch_id()
+                .await
+                .expect("active branch should load"),
+        )
+        .await
+        .expect("late subscriber session should open");
+    write_file(&session_a, "/shared.keyed", b"a=0\n".to_vec())
+        .await
+        .expect("seed file should write");
+
+    let query = "SELECT data FROM lix_file WHERE path = $1";
+    let params = [Value::Text("/shared.keyed".to_string())];
+    let mut first = session_a
+        .observe(query, &params)
+        .expect("first observation should open");
+    let mut peer = session_b
+        .observe(query, &params)
+        .expect("peer observation should open");
+    first
+        .next()
+        .await
+        .expect("first observation should execute")
+        .expect("first snapshot should be delivered");
+    peer.next()
+        .await
+        .expect("peer observation should execute")
+        .expect("peer snapshot should be delivered");
+
+    // Recreate the plugin owner while preserving the rendered bytes. The next
+    // shared evaluation must keep the fresh owner incarnation even though its
+    // visible rows compare equal to the prior generation.
+    session_a
+        .execute(
+            "UPDATE lix_file SET path = '/shared.bin' WHERE path = '/shared.keyed'",
+            &[],
+        )
+        .await
+        .expect("plugin-to-raw transition should succeed");
+    session_a
+        .execute(
+            "UPDATE lix_file SET path = '/shared.keyed' WHERE path = '/shared.bin'",
+            &[],
+        )
+        .await
+        .expect("raw-to-plugin transition should succeed");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), first.next())
+            .await
+            .is_err(),
+        "unchanged bytes should not emit an observation"
+    );
+
+    let mut late = session_c
+        .observe(query, &params)
+        .expect("late observation should open");
+    let late_initial = late
+        .next()
+        .await
+        .expect("late observation should execute")
+        .expect("late initial snapshot should be delivered");
+    assert_eq!(
+        late_initial.rows.rows()[0].values(),
+        &[Value::Blob(b"a=0\n".to_vec())]
+    );
+
+    write_file(&session_a, "/shared.keyed", b"a=0\nb=remote\n".to_vec())
+        .await
+        .expect("remote entity should write");
+    write_file(&session_c, "/shared.keyed", Vec::new())
+        .await
+        .expect("late subscriber deletion should write");
+    assert_eq!(
+        keyed_entity_values(&session_a, "/shared.keyed").await,
+        BTreeMap::from([("b".to_string(), "remote".to_string())]),
+        "the late subscriber may delete acknowledged state but not unseen state"
     );
 }
 

--- a/packages/engine/tests/observe.rs
+++ b/packages/engine/tests/observe.rs
@@ -565,6 +565,55 @@ async fn observe_identical_queries_share_one_evaluation_per_generation() {
 }
 
 simulation_test!(
+    observe_new_subscriber_receives_current_rows_after_unchanged_generation,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-current', 'v0')",
+                &[],
+            )
+            .await
+            .expect("target insert should commit");
+
+        let mut first = observe_key(&raw_session, "observe-current");
+        let first_initial = next_event(&mut first, "first current snapshot").await;
+        assert_key_value_row(&first_initial, "observe-current", "v0");
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('observe-unrelated', 'v0')",
+                &[],
+            )
+            .await
+            .expect("unrelated insert should commit");
+
+        let mut newcomer = observe_key(&raw_session, "observe-current");
+        let newcomer_initial = next_event(&mut newcomer, "new subscriber snapshot").await;
+        assert_eq!(newcomer_initial.sequence, 0);
+        assert!(
+            newcomer_initial.mutation_sequence > first_initial.mutation_sequence,
+            "new subscriber should evaluate the current generation"
+        );
+        assert_key_value_row(&newcomer_initial, "observe-current", "v0");
+        expect_no_event(&mut first, "unchanged result for first subscriber").await;
+
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'v1' WHERE key = 'observe-current'",
+                &[],
+            )
+            .await
+            .expect("target update should commit");
+        let first_update = next_event(&mut first, "first changed result").await;
+        let newcomer_update = next_event(&mut newcomer, "newcomer changed result").await;
+        assert_key_value_row(&first_update, "observe-current", "v1");
+        assert_key_value_row(&newcomer_update, "observe-current", "v1");
+    }
+);
+
+simulation_test!(
     observe_rejects_durable_runtime_functions,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -1627,7 +1627,15 @@ enum MultiplexObserveMessage {
 
 struct BlobDeltaBase {
     sequence: u64,
-    bytes: Vec<u8>,
+    // ExecuteResult has immutable shared backing, so retaining the transport
+    // base does not copy the point-read blob for every subscription.
+    rows: ExecuteResult,
+}
+
+impl BlobDeltaBase {
+    fn bytes(&self) -> &[u8] {
+        point_blob_bytes(&self.rows).expect("blob delta bases are point blob results")
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1673,9 +1681,9 @@ fn multiplex_observe_payload(
     event: ObserveEvent,
     base: Option<&BlobDeltaBase>,
 ) -> Result<(MultiplexObservePayload, Option<BlobDeltaBase>), LixError> {
-    let next_base = point_blob_bytes(&event.rows).map(|bytes| BlobDeltaBase {
+    let next_base = point_blob_bytes(&event.rows).map(|_| BlobDeltaBase {
         sequence: event.sequence,
-        bytes: bytes.to_vec(),
+        rows: event.rows.clone(),
     });
     let delta = match base.zip(next_base.as_ref()) {
         Some((base, next)) if base.sequence.checked_add(1) == Some(event.sequence) => {
@@ -1720,31 +1728,30 @@ fn single_blob_splice(
     base: &BlobDeltaBase,
     next: &BlobDeltaBase,
 ) -> Result<Option<SingleBlobSplice>, LixError> {
-    if next.bytes.len() < MIN_BLOB_DELTA_BYTES {
+    if next.bytes().len() < MIN_BLOB_DELTA_BYTES {
         return Ok(None);
     }
-    let prefix_bytes = base
-        .bytes
+    let base_bytes = base.bytes();
+    let next_bytes = next.bytes();
+    let prefix_bytes = base_bytes
         .iter()
-        .zip(&next.bytes)
+        .zip(next_bytes)
         .take_while(|(left, right)| left == right)
         .count();
-    let max_suffix = base
-        .bytes
+    let max_suffix = base_bytes
         .len()
         .saturating_sub(prefix_bytes)
-        .min(next.bytes.len().saturating_sub(prefix_bytes));
-    let suffix_bytes = base
-        .bytes
+        .min(next_bytes.len().saturating_sub(prefix_bytes));
+    let suffix_bytes = base_bytes
         .iter()
         .rev()
-        .zip(next.bytes.iter().rev())
+        .zip(next_bytes.iter().rev())
         .take(max_suffix)
         .take_while(|(left, right)| left == right)
         .count();
-    let insert_end = next.bytes.len().saturating_sub(suffix_bytes);
-    let insert = &next.bytes[prefix_bytes..insert_end];
-    let Some(full_base64_bytes) = padded_base64_len(next.bytes.len()) else {
+    let insert_end = next_bytes.len().saturating_sub(suffix_bytes);
+    let insert = &next_bytes[prefix_bytes..insert_end];
+    let Some(full_base64_bytes) = padded_base64_len(next_bytes.len()) else {
         return Ok(None);
     };
     let Some(delta_base64_bytes) = padded_base64_len(insert.len()) else {
@@ -2783,6 +2790,17 @@ mod tests {
     }
 
     #[test]
+    fn multiplex_blob_delta_base_reuses_event_storage() {
+        let event = point_blob_event(0, vec![b'a'; 1024 * 1024]);
+        let event_bytes = point_blob_bytes(&event.rows).expect("point blob event");
+        let event_ptr = event_bytes.as_ptr();
+        let (_, base) = multiplex_observe_payload(event, None).expect("initial payload");
+        let base = base.expect("blob base");
+
+        assert_eq!(base.bytes().as_ptr(), event_ptr);
+    }
+
+    #[test]
     fn multiplex_blob_delta_roundtrips_replace_insert_and_delete() {
         let initial = vec![b'a'; 100 * 1024];
         let (payload, mut base) =
@@ -2869,6 +2887,57 @@ mod tests {
             apply_blob_splice(&replacement, payload.delta.expect("localized splice")),
             localized
         );
+    }
+
+    #[test]
+    #[ignore = "manual observation fanout performance diagnostic"]
+    fn multiplex_blob_delta_fanout_perf() {
+        use std::hint::black_box;
+        use std::time::{Duration, Instant};
+
+        const SAMPLES: usize = 60;
+        for size_mib in [1_usize, 10] {
+            let initial = vec![b'a'; size_mib * 1024 * 1024];
+            let mut localized = initial.clone();
+            let middle = localized.len() / 2;
+            localized[middle] = b'b';
+            let event = point_blob_event(1, localized);
+            for fanout in [1_usize, 4, 16] {
+                let bases = (0..fanout)
+                    .map(|_| {
+                        multiplex_observe_payload(point_blob_event(0, initial.clone()), None)
+                            .expect("initial payload")
+                            .1
+                            .expect("blob base")
+                    })
+                    .collect::<Vec<_>>();
+                let mut samples = Vec::with_capacity(SAMPLES);
+                for _ in 0..SAMPLES {
+                    let started = Instant::now();
+                    for base in &bases {
+                        black_box(
+                            multiplex_observe_payload(event.clone(), Some(base))
+                                .expect("delta payload"),
+                        );
+                    }
+                    samples.push(started.elapsed());
+                }
+                samples.sort_unstable();
+                let p50 = samples[SAMPLES / 2];
+                let p95 = samples[SAMPLES * 95 / 100];
+                let total_bytes = u32::try_from(size_mib * 1024 * 1024 * fanout)
+                    .expect("diagnostic byte count should fit u32");
+                let throughput = |elapsed: Duration| {
+                    f64::from(total_bytes) / elapsed.as_secs_f64() / (1024.0 * 1024.0)
+                };
+                eprintln!(
+                    "observe_fanout size_mib={size_mib} subscribers={fanout} p50_us={} p95_us={} logical_mib_s_p50={:.1}",
+                    p50.as_micros(),
+                    p95.as_micros(),
+                    throughput(p50),
+                );
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- compare each shared observation generation with its immediately preceding cached generation once
- let subscribers reuse that decision only when it directly spans their own previous generation
- retain exact row equality for late, skipped, out-of-order, evicted, unshared, and single-subscriber paths

The implementation is 80 net production LOC. It removes the earlier sequence/overflow design and keeps the existing four-generation cache and immutable result-sharing memory shape from #669.

## Data

Fresh-process paired p50, #669 baseline versus this PR:

| Payload | Subscribers | Result | Before | After | Change |
| ---: | ---: | --- | ---: | ---: | ---: |
| 1 MiB | 2 | unchanged | 0.060 ms | 0.039 ms | -35.0% |
| 1 MiB | 2 | changed | 0.036 ms | 0.026 ms | -27.8% |
| 10 MiB | 2 | unchanged | 1.930 ms | 1.646 ms | -14.7% |
| 10 MiB | 2 | changed | 0.524 ms | 0.436 ms | -16.8% |
| 1 MiB | 4 | unchanged / changed | 0.106 / 0.056 ms | 0.039 / 0.025 ms | -63.2% / -55.4% |
| 10 MiB | 4 | unchanged / changed | 2.620 / 0.899 ms | 1.965 / 0.436 ms | -25.0% / -51.5% |
| 10 MiB | 16 | unchanged / changed | 6.326 / 2.779 ms | 1.950 / 0.666 ms | -69.2% / -76.0% |

One-subscriber unchanged controls were neutral: 1 MiB 0.033→0.033 ms and 10 MiB 0.624→0.626 ms (+0.3%).

## Correctness

- a shared comparison is trusted only when `compared_generation` exactly equals the subscriber's prior generation
- skipped/out-of-order generations and cache eviction use exact row equality
- cancellation and errors never cache a comparison and still wake followers
- first and late deliveries acknowledge the freshly evaluated result
- subscriber-count races can only cause conservative equality work or one unnecessary shared comparison

## Validation

- all 1,103 library tests (1,097 passed, 6 existing ignored)
- all 53 filesystem tests
- all 47 observation simulations
- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
