### PR TITLE
perf(engine): construct transaction SQL providers once

### DIFF
--- a/.changenotes/coalesce-transaction-sql-providers.md
+++ b/.changenotes/coalesce-transaction-sql-providers.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Transaction SQL reads now construct each DataFusion table provider once by
+installing snapshot-backed history providers alongside transaction-overlay
+writable providers, instead of constructing and then replacing duplicates.

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -58,13 +58,14 @@ pub(crate) async fn register_entity_providers<S>(
     commit_graph: Arc<tokio::sync::Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
     catalog: &PublicCatalog,
+    include_write_surfaces: bool,
 ) -> Result<(), LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     for surface in catalog.surfaces() {
         match &surface.kind {
-            PublicSurfaceKind::EntityBase { schema_key } => {
+            PublicSurfaceKind::EntityBase { schema_key } if include_write_surfaces => {
                 let spec = catalog_entity_spec(catalog, schema_key)?;
                 register_spec_table(
                     ctx,
@@ -78,7 +79,7 @@ where
                     WriteAccess::read_only(),
                 )?;
             }
-            PublicSurfaceKind::EntityByBranch { schema_key } => {
+            PublicSurfaceKind::EntityByBranch { schema_key } if include_write_surfaces => {
                 let spec = catalog_entity_spec(catalog, schema_key)?;
                 register_spec_table(
                     ctx,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -24,7 +24,7 @@ mod spec;
 mod upsert;
 mod values;
 
-use crate::sql2::catalog::{PublicCatalog, PublicSurfaceKind};
+use crate::sql2::catalog::{PublicCatalog, PublicSurfaceContract, PublicSurfaceKind};
 use crate::sql2::session::SqlWriteSessionOptions;
 use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
@@ -115,10 +115,42 @@ pub(crate) async fn register_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
+    let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
+    register_read_from_catalog(session, ctx, branch_ref, &catalog, ReadProviderScope::All).await
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReadProviderScope {
+    All,
+    ReadOnly,
+}
+
+impl ReadProviderScope {
+    fn includes(self, surface: &PublicSurfaceContract) -> bool {
+        self == Self::All || !is_write_surface(surface)
+    }
+}
+
+fn is_write_surface(surface: &PublicSurfaceContract) -> bool {
+    surface.capabilities.insert || surface.capabilities.update || surface.capabilities.delete
+}
+
+async fn register_read_from_catalog<C>(
+    session: &SessionContext,
+    ctx: &C,
+    branch_ref: Arc<dyn BranchRefReader>,
+    catalog: &PublicCatalog,
+    scope: ReadProviderScope,
+) -> Result<(), LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
     let history_query_source = ctx.history_query_source();
     let changelog_query_source = ctx.changelog_query_source();
-    let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
     for surface in catalog.surfaces() {
+        if !scope.includes(surface) {
+            continue;
+        }
         match &surface.kind {
             PublicSurfaceKind::LixState => {
                 lix_state::register_lix_state_active_provider(
@@ -249,7 +281,8 @@ where
         Arc::clone(&branch_ref),
         Arc::new(tokio::sync::Mutex::new(ctx.commit_graph())),
         history_query_source,
-        &catalog,
+        catalog,
+        scope == ReadProviderScope::All,
     )
     .await?;
 
@@ -263,10 +296,45 @@ pub(crate) async fn register_write(
     options: SqlWriteSessionOptions,
 ) -> Result<(), LixError> {
     let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
+    register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog).await
+}
+
+pub(crate) async fn register_transaction<C>(
+    session: &SessionContext,
+    read_ctx: &C,
+    read_branch_ref: Arc<dyn BranchRefReader>,
+    write_ctx: SqlWriteContext,
+    write_branch_ref: Arc<dyn BranchRefReader>,
+    options: SqlWriteSessionOptions,
+) -> Result<(), LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    // Both capabilities project the same transaction-scoped schema snapshot.
+    // Build that immutable metadata once, then install read-only providers from
+    // the committed read capability and writable providers from the overlay.
+    let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
+    register_read_from_catalog(
+        session,
+        read_ctx,
+        read_branch_ref,
+        &catalog,
+        ReadProviderScope::ReadOnly,
+    )
+    .await?;
+    register_write_from_catalog(session, write_ctx, write_branch_ref, options, &catalog).await
+}
+
+async fn register_write_from_catalog(
+    session: &SessionContext,
+    write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
+    options: SqlWriteSessionOptions,
+    catalog: &PublicCatalog,
+) -> Result<(), LixError> {
     for surface in catalog.surfaces() {
         match &surface.kind {
             PublicSurfaceKind::LixState => {
-                replace_registered_table(session, &surface.name)?;
                 lix_state::register_lix_state_active_write_provider(
                     session,
                     &surface.name,
@@ -276,7 +344,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::LixStateByBranch => {
-                replace_registered_table(session, &surface.name)?;
                 lix_state::register_lix_state_by_branch_write_provider(
                     session,
                     &surface.name,
@@ -286,7 +353,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::Branch => {
-                replace_registered_table(session, &surface.name)?;
                 branch::register_write_provider(
                     session,
                     &surface.name,
@@ -296,7 +362,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::File => {
-                replace_registered_table(session, &surface.name)?;
                 file::register_active_write_provider(
                     session,
                     &surface.name,
@@ -307,7 +372,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::FileByBranch => {
-                replace_registered_table(session, &surface.name)?;
                 file::register_by_branch_write_provider(
                     session,
                     &surface.name,
@@ -318,7 +382,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::Directory => {
-                replace_registered_table(session, &surface.name)?;
                 directory::register_active_write_provider(
                     session,
                     &surface.name,
@@ -328,7 +391,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::DirectoryByBranch => {
-                replace_registered_table(session, &surface.name)?;
                 directory::register_by_branch_write_provider(
                     session,
                     &surface.name,
@@ -346,28 +408,8 @@ pub(crate) async fn register_write(
             | PublicSurfaceKind::EntityHistory { .. } => {}
         }
     }
-    for surface in catalog.surfaces() {
-        if matches!(
-            surface.kind,
-            PublicSurfaceKind::EntityBase { .. } | PublicSurfaceKind::EntityByBranch { .. }
-        ) {
-            replace_registered_table(session, &surface.name)?;
-        }
-    }
-    entity::register_entity_write_providers(session, write_ctx.clone(), branch_ref, &catalog)
-        .await?;
+    entity::register_entity_write_providers(session, write_ctx, branch_ref, catalog).await?;
     Ok(())
-}
-
-fn replace_registered_table(session: &SessionContext, name: &str) -> Result<(), LixError> {
-    match session.deregister_table(name) {
-        Ok(_) => Ok(()),
-        Err(error) if error.to_string().contains("not found") => Ok(()),
-        Err(error) => Err(LixError::new(
-            LixError::CODE_UNKNOWN,
-            format!("sql2 DataFusion error: {error}"),
-        )),
-    }
 }
 
 #[cfg(test)]
@@ -398,9 +440,67 @@ mod tests {
     };
 
     use super::{
-        branch, change, directory, directory_history, entity, file, file_history, history,
-        lix_state,
+        ReadProviderScope, branch, change, directory, directory_history, entity, file,
+        file_history, history, is_write_surface, lix_state,
     };
+
+    #[test]
+    fn transaction_registration_partitions_provider_construction_once() {
+        let schema = json!({
+            "x-lix-key": "phase8_entity",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": { "id": { "type": "string" } }
+        });
+        let catalog = PublicCatalog::from_visible_schemas(&[schema]).expect("catalog should build");
+
+        let read_only = catalog
+            .surfaces()
+            .filter(|surface| ReadProviderScope::ReadOnly.includes(surface))
+            .map(|surface| surface.name.as_str())
+            .collect::<Vec<_>>();
+        let writable = catalog
+            .surfaces()
+            .filter(|surface| is_write_surface(surface))
+            .map(|surface| surface.name.as_str())
+            .collect::<Vec<_>>();
+        let all_read = catalog
+            .surfaces()
+            .filter(|surface| ReadProviderScope::All.includes(surface))
+            .count();
+
+        assert_eq!(
+            read_only,
+            vec![
+                "lix_change",
+                "lix_directory_history",
+                "lix_file_history",
+                "lix_state_history",
+                "phase8_entity_history",
+            ]
+        );
+        assert_eq!(
+            writable,
+            vec![
+                "lix_branch",
+                "lix_directory",
+                "lix_directory_by_branch",
+                "lix_file",
+                "lix_file_by_branch",
+                "lix_state",
+                "lix_state_by_branch",
+                "phase8_entity",
+                "phase8_entity_by_branch",
+            ]
+        );
+        assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
+        assert_eq!(all_read + writable.len(), 23, "previous construction count");
+        assert_eq!(
+            read_only.len() + writable.len(),
+            14,
+            "new construction count"
+        );
+    }
 
     #[test]
     fn provider_history_schemas_match_catalog_contract_order() {
@@ -507,6 +607,7 @@ mod tests {
             Arc::new(tokio::sync::Mutex::new(Box::new(EmptyCommitGraphReader))),
             empty_history_query_source().await,
             &catalog,
+            true,
         )
         .await
         .expect("entity providers should register");

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -78,13 +78,14 @@ where
         .await?
         .map(|head| head.commit_id.to_string());
     register_sql2_functions(&session, read_ctx.functions(), active_branch_commit_id);
-    providers::register_read(&session, read_ctx, read_branch_ref).await?;
     let write_ctx = SqlWriteContext::new(write_ctx);
     let write_branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(
         Arc::new(super::WriteContextBranchRefReader::new(write_ctx.clone())),
     ));
-    providers::register_write(
+    providers::register_transaction(
         &session,
+        read_ctx,
+        read_branch_ref,
         write_ctx,
         write_branch_ref,
         SqlWriteSessionOptions::default(),


### PR DESCRIPTION
## Summary

- construct each transaction-scoped DataFusion table provider exactly once
- install immutable/history providers from the transaction read snapshot and writable providers from the transaction overlay
- build one `PublicCatalog` for the combined provider set instead of rebuilding it for read and write registration
- leave standalone read and write sessions unchanged

Before this change, an explicit-transaction read session registered every read provider and then deregistered/replaced every writable surface. With the system catalog plus one custom entity, that was 23 provider construction attempts (14 read + 9 write, including 9 replacements) and two catalog builds. This change installs the same 14 surfaces once—five immutable/history plus nine writable/overlay—and builds the catalog once.

## Benchmark

Median of three independent alternating main/PR release runs per variant, with 50 warmups and 1,000 measured operations in each process. The benchmark covers an explicit-transaction point SELECT, an explicit-transaction point UPDATE, and a normal session SELECT control on both RocksDB and local SlateDB.

| Backend / query | main p50 | PR p50 | p50 | main p95 | PR p95 | p95 |
|---|---:|---:|---:|---:|---:|---:|
| RocksDB transaction SELECT | 1.454 ms | 1.077 ms | **-25.9%** | 1.577 ms | 1.155 ms | **-26.7%** |
| SlateDB transaction SELECT | 2.238 ms | 1.781 ms | **-20.4%** | 2.611 ms | 1.909 ms | **-26.9%** |
| RocksDB normal SELECT control | 1.638 ms | 1.642 ms | +0.3% | 1.764 ms | 1.754 ms | -0.6% |
| SlateDB normal SELECT control | 3.437 ms | 3.237 ms | -5.8% | 3.947 ms | 3.579 ms | -9.3% |
| RocksDB transaction UPDATE control | 0.416 ms | 0.417 ms | +0.2% | 0.499 ms | 0.448 ms | -10.2% |
| SlateDB transaction UPDATE control | 1.176 ms | 1.182 ms | +0.6% | 1.455 ms | 1.332 ms | -8.4% |

Storage work is exactly identical before and after, isolating provider construction as the cause:

- normal SELECT: 2 `begin_read`, 27 `get_many` calls / 85 keys, 4 scans
- transaction SELECT: 3 `begin_read`, 9 `get_many` calls / 11 keys, 2 scans
- transaction UPDATE: 4 `begin_read`, 11 `get_many` calls / 14 keys, 2 scans / 1 row

## Correctness

- writable surfaces continue to use transaction-overlay providers, preserving read-your-writes
- history/change surfaces continue to use the immutable transaction read snapshot
- custom entity base and by-branch surfaces are writable; custom entity history remains snapshot-backed
- standalone sessions keep their existing registration paths
- no provider, DataFusion plan, or session is cached across snapshots
- no public API changes

## Validation

- `cargo test -p lix_engine`
- `cargo test -p lix_engine --test transaction`
- `cargo clippy -p lix_engine --lib --test sql_transaction_provider_perf -- -D warnings`
- `node scripts/validate-changes.mjs`
- `cargo fmt --package lix_engine -- --check`
- `git diff --check`

## Design references

- DataFusion describes `SessionContext` as the owner of session state while query execution gets per-query task state: https://docs.rs/datafusion/53.0.0/datafusion/execution/context/struct.SessionContext.html#relationship-between-sessioncontext-sessionstate-and-taskcontext
- DataFusion logical-plan table sources retain their `TableProvider`, which is why this change only coalesces providers within one transaction session and does not cache them: https://datafusion.apache.org/library-user-guide/building-logical-plans.html#table-sources
- SlateDB read snapshots are immutable views, matching the split between snapshot-backed history providers and transaction-overlay writable providers: https://slatedb.io/docs/design/reads/
