### PR TITLE
perf(engine): register only referenced SQL providers

### DIFF
--- a/.changenotes/coalesce-transaction-sql-providers.md
+++ b/.changenotes/coalesce-transaction-sql-providers.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Transaction SQL reads now construct each DataFusion table provider once by
+installing snapshot-backed history providers alongside transaction-overlay
+writable providers, instead of constructing and then replacing duplicates.

--- a/.changenotes/register-referenced-sql-providers.md
+++ b/.changenotes/register-referenced-sql-providers.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Read queries now construct only the snapshot-local DataFusion table providers
+referenced by their parsed SQL, while catalog-wide introspection retains the
+complete provider set.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -677,7 +677,7 @@ where
                     plugin_host: self.plugin_host.clone(),
                     file_views: file_view_collector.clone(),
                 };
-                let read_session = sql2::prepare_read_session(&ctx).await?;
+                let read_session = sql2::prepare_read_session(&ctx, &parsed).await?;
                 let mut results = Vec::with_capacity(statements.len());
                 for (statement_index, (statement, parsed)) in
                     statements.iter().zip(parsed).enumerate()
@@ -834,7 +834,7 @@ where
                     file_views: file_view_collector.clone(),
                 };
                 let read_session =
-                    sql2::prepare_read_session_at_head(&ctx, active_branch_head).await?;
+                    sql2::prepare_read_session_at_head(&ctx, active_branch_head, &parsed).await?;
                 let mut results = Vec::with_capacity(statements.len());
                 for (statement_index, ((sql, params), statement)) in
                     statements.iter().zip(parsed).enumerate()
@@ -1790,5 +1790,93 @@ mod tests {
             row.get::<serde_json::Value>("value").unwrap(),
             serde_json::json!("value")
         );
+    }
+
+    #[tokio::test]
+    async fn coherent_read_batch_registers_union_of_referenced_providers() {
+        let session = open_session().await;
+        let statements: [(&str, &[Value]); 3] = [
+            ("SELECT 1 AS one", &[]),
+            ("SELECT COUNT(*) AS files FROM lix_file", &[]),
+            ("SELECT COUNT(*) AS states FROM lix_state", &[]),
+        ];
+
+        let batch = session
+            .execute_coherent_read_batch(&statements)
+            .await
+            .expect("coherent batch should register every referenced provider");
+
+        assert_eq!(batch.results.len(), 3);
+        assert_eq!(batch.results[0].rows()[0].get::<i64>("one").unwrap(), 1);
+        assert_eq!(batch.results[1].rows()[0].get::<i64>("files").unwrap(), 0);
+        assert!(batch.results[2].rows()[0].get::<i64>("states").unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn referenced_provider_reads_preserve_complex_and_catalog_wide_queries() {
+        let session = open_session().await;
+        let complex = session
+            .execute(
+                "WITH files AS (SELECT id FROM lix_file) \
+                 SELECT COUNT(*) AS row_count \
+                 FROM files AS file_a \
+                 JOIN files AS file_b ON file_a.id = file_b.id \
+                 LEFT JOIN (\
+                     SELECT entity_pk FROM lix_state \
+                     UNION ALL \
+                     SELECT entity_pk FROM lix_state\
+                 ) AS states ON false",
+                &[],
+            )
+            .await
+            .expect("nested CTE, self-join, and UNION should resolve providers");
+        assert_eq!(complex.rows()[0].get::<i64>("row_count").unwrap(), 0);
+
+        let catalog = session
+            .execute(
+                "SELECT COUNT(*) AS surfaces \
+                 FROM information_schema.tables \
+                 WHERE table_schema = 'public'",
+                &[],
+            )
+            .await
+            .expect("information_schema should retain catalog-wide visibility");
+        assert!(catalog.rows()[0].get::<i64>("surfaces").unwrap() > 1);
+    }
+
+    #[tokio::test]
+    async fn transaction_referenced_provider_reads_see_staged_writes() {
+        let session = open_session().await;
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (id, path) VALUES ('selected-provider-file', '/selected.txt')",
+                &[],
+            )
+            .await
+            .expect("file should stage");
+
+        let result = transaction
+            .execute(
+                "WITH selected AS (\
+                     SELECT id FROM lix_file WHERE id = 'selected-provider-file'\
+                 ) \
+                 SELECT id FROM selected",
+                &[],
+            )
+            .await
+            .expect("selected overlay provider should expose staged writes");
+        assert_eq!(
+            result.rows()[0].get::<String>("id").unwrap(),
+            "selected-provider-file"
+        );
+
+        transaction
+            .rollback()
+            .await
+            .expect("transaction should roll back");
     }
 }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -87,18 +87,19 @@ pub(crate) async fn execute_read_statement_from_parsed<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let session = prepare_read_session(ctx).await?;
+    let session = prepare_read_session(ctx, std::slice::from_ref(&statement)).await?;
     execute_read_statement_in_session_from_parsed(&session, sql, statement, params).await
 }
 
 pub(crate) async fn prepare_read_session<'ctx, C>(
     ctx: &'ctx C,
+    statements: &[DataFusionStatement],
 ) -> Result<ReadSqlSession<'ctx>, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
     Ok(ReadSqlSession {
-        session: build_read_session(ctx).await?,
+        session: build_read_session(ctx, statements).await?,
         _context: PhantomData,
     })
 }
@@ -106,12 +107,13 @@ where
 pub(crate) async fn prepare_read_session_at_head<'ctx, C>(
     ctx: &'ctx C,
     active_head: BranchHead,
+    statements: &[DataFusionStatement],
 ) -> Result<ReadSqlSession<'ctx>, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
     Ok(ReadSqlSession {
-        session: build_read_session_at_head(ctx, active_head).await?,
+        session: build_read_session_at_head(ctx, active_head, statements).await?,
         _context: PhantomData,
     })
 }
@@ -168,7 +170,7 @@ async fn create_transaction_read_logical_plan_from_parsed(
     statement: DataFusionStatement,
 ) -> Result<SqlLogicalPlan, LixError> {
     crate::sql2::bind_read_statement(sql, &statement)?;
-    let session = build_transaction_read_session(read_ctx, write_ctx).await?;
+    let session = build_transaction_read_session(read_ctx, write_ctx, &statement).await?;
     let plan = create_logical_plan_from_statement(&session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -58,13 +58,14 @@ pub(crate) async fn register_entity_providers<S>(
     commit_graph: Arc<tokio::sync::Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
     catalog: &PublicCatalog,
+    include_write_surfaces: bool,
 ) -> Result<(), LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     for surface in catalog.surfaces() {
         match &surface.kind {
-            PublicSurfaceKind::EntityBase { schema_key } => {
+            PublicSurfaceKind::EntityBase { schema_key } if include_write_surfaces => {
                 let spec = catalog_entity_spec(catalog, schema_key)?;
                 register_spec_table(
                     ctx,
@@ -78,7 +79,7 @@ where
                     WriteAccess::read_only(),
                 )?;
             }
-            PublicSurfaceKind::EntityByBranch { schema_key } => {
+            PublicSurfaceKind::EntityByBranch { schema_key } if include_write_surfaces => {
                 let spec = catalog_entity_spec(catalog, schema_key)?;
                 register_spec_table(
                     ctx,

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -37,6 +37,7 @@ use crate::transaction::types::{
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteRow,
 };
 
+use super::ReadProviderSelection;
 use super::entity_history::register_entity_history_surface;
 use datafusion::physical_plan::ExecutionPlan;
 
@@ -55,15 +56,19 @@ pub(crate) async fn register_entity_providers<S>(
     active_branch_id: &str,
     live_state: Arc<dyn LiveStateReader>,
     branch_ref: Arc<dyn BranchRefReader>,
-    commit_graph: Arc<tokio::sync::Mutex<Box<dyn CommitGraphReader>>>,
-    query_source: SqlHistoryQuerySource<S>,
+    commit_graph: Option<Arc<tokio::sync::Mutex<Box<dyn CommitGraphReader>>>>,
+    query_source: Option<SqlHistoryQuerySource<S>>,
     catalog: &PublicCatalog,
     include_write_surfaces: bool,
+    selection: &ReadProviderSelection,
 ) -> Result<(), LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     for surface in catalog.surfaces() {
+        if !selection.includes(surface) {
+            continue;
+        }
         match &surface.kind {
             PublicSurfaceKind::EntityBase { schema_key } if include_write_surfaces => {
                 let spec = catalog_entity_spec(catalog, schema_key)?;
@@ -93,12 +98,20 @@ where
                 )?;
             }
             PublicSurfaceKind::EntityHistory { schema_key } => {
+                let (Some(commit_graph), Some(query_source)) =
+                    (commit_graph.as_ref(), query_source.as_ref())
+                else {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "selected entity history provider is missing its history context",
+                    ));
+                };
                 let spec = catalog_entity_spec(catalog, schema_key)?;
                 register_entity_history_surface(
                     ctx,
                     &surface.name,
                     spec,
-                    Arc::clone(&commit_graph),
+                    Arc::clone(commit_graph),
                     query_source.clone(),
                 )?;
             }
@@ -114,8 +127,12 @@ pub(crate) async fn register_entity_write_providers(
     write_ctx: SqlWriteContext,
     branch_ref: Arc<dyn BranchRefReader>,
     catalog: &PublicCatalog,
+    selection: &ReadProviderSelection,
 ) -> Result<(), LixError> {
     for surface in catalog.surfaces() {
+        if !selection.includes(surface) {
+            continue;
+        }
         match &surface.kind {
             PublicSurfaceKind::EntityBase { schema_key } => {
                 let spec = catalog_entity_spec(catalog, schema_key)?;

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::cloned_ref_to_slice_refs, clippy::match_same_arms)]
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use datafusion::physical_plan::ExecutionPlan;
@@ -111,12 +112,102 @@ pub(crate) async fn register_read<C>(
     session: &SessionContext,
     ctx: &C,
     branch_ref: Arc<dyn BranchRefReader>,
+    selection: &ReadProviderSelection,
 ) -> Result<(), LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
     let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
-    register_read_from_catalog(session, ctx, branch_ref, &catalog, ReadProviderScope::All).await
+    register_read_from_catalog(
+        session,
+        ctx,
+        branch_ref,
+        &catalog,
+        ReadProviderScope::All,
+        selection,
+    )
+    .await
+}
+
+/// Snapshot-local providers needed to plan a set of already-parsed reads.
+///
+/// DataFusion's resolver is deliberately used here instead of maintaining a
+/// second SQL AST walker. It is the same resolver called by
+/// `SessionState::statement_to_plan`, including its CTE scoping and identifier
+/// normalization rules. The selection retains names only; providers and plans
+/// remain scoped to the current storage snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ReadProviderSelection {
+    /// Register every surface when catalog-wide visibility is part of the SQL
+    /// semantics (notably `information_schema` and rewritten `SHOW` queries),
+    /// or when reference resolution cannot prove a narrower set is sufficient.
+    All,
+    /// Register the union of concrete table names referenced by the statements.
+    Only(BTreeSet<String>),
+}
+
+impl ReadProviderSelection {
+    fn includes(&self, surface: &PublicSurfaceContract) -> bool {
+        match self {
+            Self::All => true,
+            Self::Only(names) => names.contains(&surface.name),
+        }
+    }
+}
+
+pub(crate) fn read_provider_selection(
+    session: &SessionContext,
+    statements: &[datafusion::sql::parser::Statement],
+) -> ReadProviderSelection {
+    let mut names = BTreeSet::new();
+    let state = session.state();
+    for statement in statements {
+        if statement_requires_all_providers(statement) {
+            return ReadProviderSelection::All;
+        }
+        let Ok(references) = state.resolve_table_references(statement) else {
+            return ReadProviderSelection::All;
+        };
+        for reference in references {
+            if reference.schema() == Some("information_schema") {
+                return ReadProviderSelection::All;
+            }
+            names.insert(reference.table().to_string());
+        }
+    }
+    ReadProviderSelection::Only(names)
+}
+
+fn statement_requires_all_providers(statement: &datafusion::sql::parser::Statement) -> bool {
+    use datafusion::sql::parser::Statement as DataFusionStatement;
+    use datafusion::sql::sqlparser::ast::Statement as SqlStatement;
+
+    fn sql_statement_requires_all_providers(statement: &SqlStatement) -> bool {
+        match statement {
+            SqlStatement::ShowFunctions { .. }
+            | SqlStatement::ShowVariable { .. }
+            | SqlStatement::ShowStatus { .. }
+            | SqlStatement::ShowVariables { .. }
+            | SqlStatement::ShowCreate { .. }
+            | SqlStatement::ShowColumns { .. }
+            | SqlStatement::ShowTables { .. }
+            | SqlStatement::ShowCollation { .. } => true,
+            SqlStatement::Explain { statement, .. } => {
+                sql_statement_requires_all_providers(statement)
+            }
+            _ => false,
+        }
+    }
+
+    match statement {
+        DataFusionStatement::Statement(statement) => {
+            sql_statement_requires_all_providers(statement)
+        }
+        DataFusionStatement::Explain(explain) => {
+            statement_requires_all_providers(explain.statement.as_ref())
+        }
+        _ => false,
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,14 +232,33 @@ async fn register_read_from_catalog<C>(
     branch_ref: Arc<dyn BranchRefReader>,
     catalog: &PublicCatalog,
     scope: ReadProviderScope,
+    selection: &ReadProviderSelection,
 ) -> Result<(), LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let history_query_source = ctx.history_query_source();
-    let changelog_query_source = ctx.changelog_query_source();
+    let needs_history_query_source = catalog.surfaces().any(|surface| {
+        scope.includes(surface)
+            && selection.includes(surface)
+            && matches!(
+                &surface.kind,
+                PublicSurfaceKind::History
+                    | PublicSurfaceKind::FileHistory
+                    | PublicSurfaceKind::DirectoryHistory
+                    | PublicSurfaceKind::EntityHistory { .. }
+            )
+    });
+    let history_query_source = needs_history_query_source.then(|| ctx.history_query_source());
+    let history_query_source_for_provider = || {
+        history_query_source.clone().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "selected history provider is missing its query source",
+            )
+        })
+    };
     for surface in catalog.surfaces() {
-        if !scope.includes(surface) {
+        if !scope.includes(surface) || !selection.includes(surface) {
             continue;
         }
         match &surface.kind {
@@ -184,7 +294,7 @@ where
                 change::register_lix_change_read_provider(
                     session,
                     &surface.name,
-                    changelog_query_source.clone(),
+                    ctx.changelog_query_source(),
                 )
                 .await?;
             }
@@ -193,7 +303,7 @@ where
                     session,
                     &surface.name,
                     ctx.commit_graph(),
-                    history_query_source.clone(),
+                    history_query_source_for_provider()?,
                 )
                 .await?;
             }
@@ -231,7 +341,7 @@ where
                     session,
                     &surface.name,
                     ctx.commit_graph(),
-                    history_query_source.clone(),
+                    history_query_source_for_provider()?,
                     ctx.blob_reader(),
                     ctx.plugin_host(),
                 )
@@ -265,7 +375,7 @@ where
                     session,
                     &surface.name,
                     ctx.commit_graph(),
-                    history_query_source.clone(),
+                    history_query_source_for_provider()?,
                 )
                 .await?;
             }
@@ -274,15 +384,25 @@ where
             | PublicSurfaceKind::EntityHistory { .. } => {}
         }
     }
+    let needs_entity_history = catalog.surfaces().any(|surface| {
+        scope.includes(surface)
+            && selection.includes(surface)
+            && matches!(&surface.kind, PublicSurfaceKind::EntityHistory { .. })
+    });
     entity::register_entity_providers(
         session,
         ctx.active_branch_id(),
         ctx.live_state(),
         Arc::clone(&branch_ref),
-        Arc::new(tokio::sync::Mutex::new(ctx.commit_graph())),
-        history_query_source,
+        needs_entity_history.then(|| Arc::new(tokio::sync::Mutex::new(ctx.commit_graph()))),
+        if needs_entity_history {
+            Some(history_query_source_for_provider()?)
+        } else {
+            None
+        },
         catalog,
         scope == ReadProviderScope::All,
+        selection,
     )
     .await?;
 
@@ -296,7 +416,15 @@ pub(crate) async fn register_write(
     options: SqlWriteSessionOptions,
 ) -> Result<(), LixError> {
     let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
-    register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog).await
+    register_write_from_catalog(
+        session,
+        write_ctx,
+        branch_ref,
+        options,
+        &catalog,
+        &ReadProviderSelection::All,
+    )
+    .await
 }
 
 pub(crate) async fn register_transaction<C>(
@@ -306,6 +434,7 @@ pub(crate) async fn register_transaction<C>(
     write_ctx: SqlWriteContext,
     write_branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
+    selection: &ReadProviderSelection,
 ) -> Result<(), LixError>
 where
     C: SqlExecutionContext + ?Sized,
@@ -320,9 +449,18 @@ where
         read_branch_ref,
         &catalog,
         ReadProviderScope::ReadOnly,
+        selection,
     )
     .await?;
-    register_write_from_catalog(session, write_ctx, write_branch_ref, options, &catalog).await
+    register_write_from_catalog(
+        session,
+        write_ctx,
+        write_branch_ref,
+        options,
+        &catalog,
+        selection,
+    )
+    .await
 }
 
 async fn register_write_from_catalog(
@@ -331,8 +469,12 @@ async fn register_write_from_catalog(
     branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
     catalog: &PublicCatalog,
+    selection: &ReadProviderSelection,
 ) -> Result<(), LixError> {
     for surface in catalog.surfaces() {
+        if !selection.includes(surface) {
+            continue;
+        }
         match &surface.kind {
             PublicSurfaceKind::LixState => {
                 lix_state::register_lix_state_active_write_provider(
@@ -408,12 +550,14 @@ async fn register_write_from_catalog(
             | PublicSurfaceKind::EntityHistory { .. } => {}
         }
     }
-    entity::register_entity_write_providers(session, write_ctx, branch_ref, catalog).await?;
+    entity::register_entity_write_providers(session, write_ctx, branch_ref, catalog, selection)
+        .await?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use async_trait::async_trait;
@@ -440,9 +584,116 @@ mod tests {
     };
 
     use super::{
-        ReadProviderScope, branch, change, directory, directory_history, entity, file,
-        file_history, history, is_write_surface, lix_state,
+        ReadProviderScope, ReadProviderSelection, branch, change, directory, directory_history,
+        entity, file, file_history, history, is_write_surface, lix_state, read_provider_selection,
     };
+
+    fn selection_for_sql(sql: &[&str]) -> ReadProviderSelection {
+        let statements = sql
+            .iter()
+            .map(|sql| crate::sql2::parse_statement(sql).expect("SQL should parse"))
+            .collect::<Vec<_>>();
+        read_provider_selection(&SessionContext::new(), &statements)
+    }
+
+    fn selected_names(names: &[&str]) -> ReadProviderSelection {
+        ReadProviderSelection::Only(names.iter().map(|name| (*name).to_string()).collect())
+    }
+
+    #[test]
+    fn referenced_provider_selection_uses_datafusion_cte_and_set_operation_resolution() {
+        let selection = selection_for_sql(&["WITH shadowed AS (\
+                 SELECT entity_pk FROM lix_state \
+                 WHERE EXISTS (SELECT 1 FROM lix_file)\
+             ) \
+             SELECT left_side.entity_pk \
+             FROM shadowed AS left_side \
+             JOIN (\
+                 SELECT entity_pk FROM lix_change \
+                 UNION ALL \
+                 SELECT entity_pk FROM lix_change\
+             ) AS right_side \
+               ON left_side.entity_pk = right_side.entity_pk \
+             JOIN public.\"lix_directory\" AS directory_a ON true \
+             JOIN public.\"lix_directory\" AS directory_b ON true"]);
+
+        assert_eq!(
+            selection,
+            selected_names(&["lix_change", "lix_directory", "lix_file", "lix_state"])
+        );
+    }
+
+    #[test]
+    fn referenced_provider_selection_excludes_shadowed_and_recursive_cte_names() {
+        assert_eq!(
+            selection_for_sql(&["WITH lix_file AS (SELECT entity_pk FROM lix_state) \
+                 SELECT * FROM lix_file",]),
+            selected_names(&["lix_state"])
+        );
+        assert_eq!(
+            selection_for_sql(&["WITH RECURSIVE walk(id) AS (\
+                     SELECT id FROM lix_branch \
+                     UNION ALL \
+                     SELECT branch.id FROM lix_branch AS branch \
+                     JOIN walk ON branch.id = walk.id\
+                 ) \
+                 SELECT * FROM walk",]),
+            selected_names(&["lix_branch"])
+        );
+    }
+
+    #[test]
+    fn referenced_provider_selection_unions_batches_and_preserves_unknown_names() {
+        assert_eq!(
+            selection_for_sql(&[
+                "SELECT * FROM lix_file",
+                "SELECT * FROM public.lix_state JOIN \"UnknownTable\" ON true",
+            ]),
+            selected_names(&["UnknownTable", "lix_file", "lix_state"])
+        );
+    }
+
+    #[test]
+    fn referenced_provider_selection_registers_none_for_table_free_queries() {
+        assert_eq!(
+            selection_for_sql(&["SELECT 1, lix_uuid_v7()"]),
+            ReadProviderSelection::Only(BTreeSet::new())
+        );
+    }
+
+    #[test]
+    fn referenced_provider_selection_keeps_catalog_wide_information_schema_semantics() {
+        assert_eq!(
+            selection_for_sql(&["SELECT * FROM information_schema.tables"]),
+            ReadProviderSelection::All
+        );
+        assert_eq!(
+            selection_for_sql(&["SHOW TABLES"]),
+            ReadProviderSelection::All
+        );
+    }
+
+    #[test]
+    fn referenced_provider_selection_filters_transaction_capabilities_symmetrically() {
+        let catalog = PublicCatalog::from_visible_schemas(&[]).expect("catalog should build");
+        let selection = selected_names(&["lix_file", "lix_state_history"]);
+
+        let committed_read_names = catalog
+            .surfaces()
+            .filter(|surface| {
+                ReadProviderScope::ReadOnly.includes(surface) && selection.includes(surface)
+            })
+            .map(|surface| surface.name.as_str())
+            .collect::<Vec<_>>();
+        let overlay_write_names = catalog
+            .surfaces()
+            .filter(|surface| is_write_surface(surface) && selection.includes(surface))
+            .map(|surface| surface.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(committed_read_names, vec!["lix_state_history"]);
+        assert_eq!(overlay_write_names, vec!["lix_file"]);
+    }
 
     #[test]
     fn transaction_registration_partitions_provider_construction_once() {
@@ -604,10 +855,13 @@ mod tests {
             "branch-a",
             Arc::new(EmptyLiveStateReader),
             Arc::new(EmptyBranchRefReader),
-            Arc::new(tokio::sync::Mutex::new(Box::new(EmptyCommitGraphReader))),
-            empty_history_query_source().await,
+            Some(Arc::new(tokio::sync::Mutex::new(Box::new(
+                EmptyCommitGraphReader,
+            )))),
+            Some(empty_history_query_source().await),
             &catalog,
             true,
+            &ReadProviderSelection::All,
         )
         .await
         .expect("entity providers should register");

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -24,7 +24,7 @@ mod spec;
 mod upsert;
 mod values;
 
-use crate::sql2::catalog::{PublicCatalog, PublicSurfaceKind};
+use crate::sql2::catalog::{PublicCatalog, PublicSurfaceContract, PublicSurfaceKind};
 use crate::sql2::session::SqlWriteSessionOptions;
 use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
@@ -115,10 +115,42 @@ pub(crate) async fn register_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
+    let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
+    register_read_from_catalog(session, ctx, branch_ref, &catalog, ReadProviderScope::All).await
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReadProviderScope {
+    All,
+    ReadOnly,
+}
+
+impl ReadProviderScope {
+    fn includes(self, surface: &PublicSurfaceContract) -> bool {
+        self == Self::All || !is_write_surface(surface)
+    }
+}
+
+fn is_write_surface(surface: &PublicSurfaceContract) -> bool {
+    surface.capabilities.insert || surface.capabilities.update || surface.capabilities.delete
+}
+
+async fn register_read_from_catalog<C>(
+    session: &SessionContext,
+    ctx: &C,
+    branch_ref: Arc<dyn BranchRefReader>,
+    catalog: &PublicCatalog,
+    scope: ReadProviderScope,
+) -> Result<(), LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
     let history_query_source = ctx.history_query_source();
     let changelog_query_source = ctx.changelog_query_source();
-    let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
     for surface in catalog.surfaces() {
+        if !scope.includes(surface) {
+            continue;
+        }
         match &surface.kind {
             PublicSurfaceKind::LixState => {
                 lix_state::register_lix_state_active_provider(
@@ -249,7 +281,8 @@ where
         Arc::clone(&branch_ref),
         Arc::new(tokio::sync::Mutex::new(ctx.commit_graph())),
         history_query_source,
-        &catalog,
+        catalog,
+        scope == ReadProviderScope::All,
     )
     .await?;
 
@@ -263,10 +296,45 @@ pub(crate) async fn register_write(
     options: SqlWriteSessionOptions,
 ) -> Result<(), LixError> {
     let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
+    register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog).await
+}
+
+pub(crate) async fn register_transaction<C>(
+    session: &SessionContext,
+    read_ctx: &C,
+    read_branch_ref: Arc<dyn BranchRefReader>,
+    write_ctx: SqlWriteContext,
+    write_branch_ref: Arc<dyn BranchRefReader>,
+    options: SqlWriteSessionOptions,
+) -> Result<(), LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    // Both capabilities project the same transaction-scoped schema snapshot.
+    // Build that immutable metadata once, then install read-only providers from
+    // the committed read capability and writable providers from the overlay.
+    let catalog = PublicCatalog::from_visible_schemas(&write_ctx.list_visible_schemas()?)?;
+    register_read_from_catalog(
+        session,
+        read_ctx,
+        read_branch_ref,
+        &catalog,
+        ReadProviderScope::ReadOnly,
+    )
+    .await?;
+    register_write_from_catalog(session, write_ctx, write_branch_ref, options, &catalog).await
+}
+
+async fn register_write_from_catalog(
+    session: &SessionContext,
+    write_ctx: SqlWriteContext,
+    branch_ref: Arc<dyn BranchRefReader>,
+    options: SqlWriteSessionOptions,
+    catalog: &PublicCatalog,
+) -> Result<(), LixError> {
     for surface in catalog.surfaces() {
         match &surface.kind {
             PublicSurfaceKind::LixState => {
-                replace_registered_table(session, &surface.name)?;
                 lix_state::register_lix_state_active_write_provider(
                     session,
                     &surface.name,
@@ -276,7 +344,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::LixStateByBranch => {
-                replace_registered_table(session, &surface.name)?;
                 lix_state::register_lix_state_by_branch_write_provider(
                     session,
                     &surface.name,
@@ -286,7 +353,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::Branch => {
-                replace_registered_table(session, &surface.name)?;
                 branch::register_write_provider(
                     session,
                     &surface.name,
@@ -296,7 +362,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::File => {
-                replace_registered_table(session, &surface.name)?;
                 file::register_active_write_provider(
                     session,
                     &surface.name,
@@ -307,7 +372,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::FileByBranch => {
-                replace_registered_table(session, &surface.name)?;
                 file::register_by_branch_write_provider(
                     session,
                     &surface.name,
@@ -318,7 +382,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::Directory => {
-                replace_registered_table(session, &surface.name)?;
                 directory::register_active_write_provider(
                     session,
                     &surface.name,
@@ -328,7 +391,6 @@ pub(crate) async fn register_write(
                 .await?;
             }
             PublicSurfaceKind::DirectoryByBranch => {
-                replace_registered_table(session, &surface.name)?;
                 directory::register_by_branch_write_provider(
                     session,
                     &surface.name,
@@ -346,28 +408,8 @@ pub(crate) async fn register_write(
             | PublicSurfaceKind::EntityHistory { .. } => {}
         }
     }
-    for surface in catalog.surfaces() {
-        if matches!(
-            surface.kind,
-            PublicSurfaceKind::EntityBase { .. } | PublicSurfaceKind::EntityByBranch { .. }
-        ) {
-            replace_registered_table(session, &surface.name)?;
-        }
-    }
-    entity::register_entity_write_providers(session, write_ctx.clone(), branch_ref, &catalog)
-        .await?;
+    entity::register_entity_write_providers(session, write_ctx, branch_ref, catalog).await?;
     Ok(())
-}
-
-fn replace_registered_table(session: &SessionContext, name: &str) -> Result<(), LixError> {
-    match session.deregister_table(name) {
-        Ok(_) => Ok(()),
-        Err(error) if error.to_string().contains("not found") => Ok(()),
-        Err(error) => Err(LixError::new(
-            LixError::CODE_UNKNOWN,
-            format!("sql2 DataFusion error: {error}"),
-        )),
-    }
 }
 
 #[cfg(test)]
@@ -398,9 +440,67 @@ mod tests {
     };
 
     use super::{
-        branch, change, directory, directory_history, entity, file, file_history, history,
-        lix_state,
+        ReadProviderScope, branch, change, directory, directory_history, entity, file,
+        file_history, history, is_write_surface, lix_state,
     };
+
+    #[test]
+    fn transaction_registration_partitions_provider_construction_once() {
+        let schema = json!({
+            "x-lix-key": "phase8_entity",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": { "id": { "type": "string" } }
+        });
+        let catalog = PublicCatalog::from_visible_schemas(&[schema]).expect("catalog should build");
+
+        let read_only = catalog
+            .surfaces()
+            .filter(|surface| ReadProviderScope::ReadOnly.includes(surface))
+            .map(|surface| surface.name.as_str())
+            .collect::<Vec<_>>();
+        let writable = catalog
+            .surfaces()
+            .filter(|surface| is_write_surface(surface))
+            .map(|surface| surface.name.as_str())
+            .collect::<Vec<_>>();
+        let all_read = catalog
+            .surfaces()
+            .filter(|surface| ReadProviderScope::All.includes(surface))
+            .count();
+
+        assert_eq!(
+            read_only,
+            vec![
+                "lix_change",
+                "lix_directory_history",
+                "lix_file_history",
+                "lix_state_history",
+                "phase8_entity_history",
+            ]
+        );
+        assert_eq!(
+            writable,
+            vec![
+                "lix_branch",
+                "lix_directory",
+                "lix_directory_by_branch",
+                "lix_file",
+                "lix_file_by_branch",
+                "lix_state",
+                "lix_state_by_branch",
+                "phase8_entity",
+                "phase8_entity_by_branch",
+            ]
+        );
+        assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
+        assert_eq!(all_read + writable.len(), 23, "previous construction count");
+        assert_eq!(
+            read_only.len() + writable.len(),
+            14,
+            "new construction count"
+        );
+    }
 
     #[test]
     fn provider_history_schemas_match_catalog_contract_order() {
@@ -507,6 +607,7 @@ mod tests {
             Arc::new(tokio::sync::Mutex::new(Box::new(EmptyCommitGraphReader))),
             empty_history_query_source().await,
             &catalog,
+            true,
         )
         .await
         .expect("entity providers should register");

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -1,4 +1,5 @@
 use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion::sql::parser::Statement as DataFusionStatement;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -10,26 +11,31 @@ use super::providers;
 use super::udfs::register_sql2_functions;
 use super::{SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext};
 
-pub(crate) async fn build_read_session<C>(ctx: &C) -> Result<SessionContext, LixError>
+pub(crate) async fn build_read_session<C>(
+    ctx: &C,
+    statements: &[DataFusionStatement],
+) -> Result<SessionContext, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    build_read_session_with_active_head(ctx, None).await
+    build_read_session_with_active_head(ctx, None, statements).await
 }
 
 pub(crate) async fn build_read_session_at_head<C>(
     ctx: &C,
     active_head: BranchHead,
+    statements: &[DataFusionStatement],
 ) -> Result<SessionContext, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    build_read_session_with_active_head(ctx, Some(active_head)).await
+    build_read_session_with_active_head(ctx, Some(active_head), statements).await
 }
 
 async fn build_read_session_with_active_head<C>(
     ctx: &C,
     active_head: Option<BranchHead>,
+    statements: &[DataFusionStatement],
 ) -> Result<SessionContext, LixError>
 where
     C: SqlExecutionContext + ?Sized,
@@ -58,7 +64,8 @@ where
             .map(|head| head.commit_id.to_string()),
     };
     register_sql2_functions(&session, ctx.functions(), active_branch_commit_id);
-    providers::register_read(&session, ctx, branch_ref).await?;
+    let provider_selection = providers::read_provider_selection(&session, statements);
+    providers::register_read(&session, ctx, branch_ref, &provider_selection).await?;
 
     Ok(session)
 }
@@ -66,6 +73,7 @@ where
 pub(crate) async fn build_transaction_read_session<C>(
     read_ctx: &C,
     write_ctx: &mut dyn SqlWriteExecutionContext,
+    statement: &DataFusionStatement,
 ) -> Result<SessionContext, LixError>
 where
     C: SqlExecutionContext + ?Sized,
@@ -82,6 +90,8 @@ where
     let write_branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(
         Arc::new(super::WriteContextBranchRefReader::new(write_ctx.clone())),
     ));
+    let provider_selection =
+        providers::read_provider_selection(&session, std::slice::from_ref(statement));
     providers::register_transaction(
         &session,
         read_ctx,
@@ -89,6 +99,7 @@ where
         write_ctx,
         write_branch_ref,
         SqlWriteSessionOptions::default(),
+        &provider_selection,
     )
     .await?;
     Ok(session)

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -78,13 +78,14 @@ where
         .await?
         .map(|head| head.commit_id.to_string());
     register_sql2_functions(&session, read_ctx.functions(), active_branch_commit_id);
-    providers::register_read(&session, read_ctx, read_branch_ref).await?;
     let write_ctx = SqlWriteContext::new(write_ctx);
     let write_branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(
         Arc::new(super::WriteContextBranchRefReader::new(write_ctx.clone())),
     ));
-    providers::register_write(
+    providers::register_transaction(
         &session,
+        read_ctx,
+        read_branch_ref,
         write_ctx,
         write_branch_ref,
         SqlWriteSessionOptions::default(),


### PR DESCRIPTION
## Stack

Depends on #679 (`perf(engine): construct transaction SQL providers once`). This PR is benchmarked incrementally against that parent and targets `codex/coalesce-transaction-sql-providers`.

## Summary

- use DataFusion's own `SessionState::resolve_table_references` on already-parsed read statements
- register only the referenced snapshot-local providers for single reads and the union for shared read batches
- apply the same selection to immutable/history and transaction-overlay provider halves, preserving read-your-writes
- construct history/changelog state lazily only when a selected surface needs it
- conservatively register every provider for `information_schema`, `SHOW`, or resolver uncertainty

No DataFusion plan, provider, session, or storage snapshot is cached. Write sessions retain the complete provider set.

## Benchmark

Median of five alternating parent/PR release processes. Each process ran 50 warmups and 1,000 measured operations per case on RocksDB and local SlateDB. The probes were byte-identical and storage operation counts were exactly identical before and after.

| Backend / query | parent p50 | PR p50 | p50 | parent p95 | PR p95 | p95 |
|---|---:|---:|---:|---:|---:|---:|
| RocksDB transaction SELECT | 1.070 ms | 0.863 ms | **-19.4%** | 1.150 ms | 0.946 ms | **-17.8%** |
| SlateDB transaction SELECT | 1.799 ms | 1.608 ms | **-10.6%** | 2.011 ms | 1.709 ms | **-15.0%** |
| RocksDB normal SELECT | 1.631 ms | 1.423 ms | **-12.8%** | 1.747 ms | 1.550 ms | **-11.3%** |
| SlateDB normal SELECT | 3.261 ms | 3.064 ms | -6.1% | 3.701 ms | 3.484 ms | -5.9% |
| RocksDB `SELECT 1` | 1.482 ms | 1.247 ms | **-15.9%** | 1.573 ms | 1.343 ms | **-14.6%** |
| SlateDB `SELECT 1` | 2.793 ms | 2.573 ms | -7.9% | 3.155 ms | 3.024 ms | -4.2% |
| RocksDB two-table join | 2.135 ms | 1.921 ms | **-10.0%** | 2.300 ms | 2.010 ms | **-12.6%** |
| SlateDB two-table join | 4.278 ms | 3.990 ms | -6.7% | 4.905 ms | 4.645 ms | -5.3% |
| RocksDB information-schema control | 1.626 ms | 1.653 ms | +1.7% | 1.719 ms | 1.733 ms | +0.8% |
| SlateDB information-schema control | 2.950 ms | 2.941 ms | -0.3% | 3.242 ms | 3.193 ms | -1.5% |
| RocksDB transaction UPDATE control | 0.409 ms | 0.408 ms | -0.4% | 0.464 ms | 0.453 ms | -2.3% |
| SlateDB transaction UPDATE control | 1.204 ms | 1.224 ms | +1.7% | 1.400 ms | 1.373 ms | -2.0% |

The selected provider count follows query shape: zero for a table-free query, one for a point read, and two for the join. Catalog-wide introspection deliberately keeps the complete set, explaining its neutral control result.

## Correctness

- DataFusion's resolver supplies identifier normalization, nested-query traversal, CTE shadowing/recursion, and set-operation handling
- coherent/read-only batches union references before constructing their shared session
- transaction live surfaces use overlay providers; history surfaces remain bound to the immutable transaction snapshot
- unknown and quoted names retain normal DataFusion resolution errors
- `information_schema`, all `SHOW` variants, and resolver errors fall back to all providers
- no public API changes

## Validation

- `cargo test -p lix_engine --lib` (1,107 tests)
- `cargo test -p lix_engine --test sql --test transaction`
- `cargo clippy -p lix_engine --lib --all-features -- -D warnings`
- five parent/PR release benchmark pairs on both storage backends
- `node scripts/validate-changes.mjs`
- `cargo fmt --package lix_engine -- --check`
- `git diff --check`
- independent read-only diff review: no actionable findings

## Design references

- DataFusion exposes `resolve_table_references` as the same reference-resolution step used by `statement_to_plan`: https://docs.rs/datafusion/53.1.0/datafusion/execution/session_state/struct.SessionState.html#method.resolve_table_references
- DataFusion catalogs map names to table providers, so reducing the registered snapshot-local set is sufficient without retaining providers across queries: https://datafusion.apache.org/library-user-guide/catalogs.html
- SlateDB reads use immutable snapshots, which is why each query still receives fresh snapshot-scoped providers: https://slatedb.io/docs/design/reads/
