### PR TITLE
perf(engine): skip neutral namespace validation

### DIFF
--- a/.changenotes/skip-neutral-filesystem-namespace-validation.md
+++ b/.changenotes/skip-neutral-filesystem-namespace-validation.md
@@ -1,0 +1,9 @@
+---
+type: patch
+---
+
+Improved metadata-only file updates by checking the affected descriptor directly
+instead of scanning the entire workspace namespace when its path is unchanged.
+
+Process-median SlateDB p50 improved from 36.639 ms to 23.209 ms with 1,000
+files (36.7%) and from 317.733 ms to 156.995 ms with 10,000 files (50.6%).

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -136,6 +136,12 @@ impl<'a> PreparedValidationRow<'a> {
         }
     }
 
+    pub(crate) fn origin(&self) -> Option<&TransactionWriteOrigin> {
+        match self {
+            Self::State(row) => row.origin.as_ref(),
+        }
+    }
+
     pub(crate) fn is_tombstone(&self) -> bool {
         match self {
             Self::State(row) => row.snapshot.is_none(),
@@ -270,6 +276,17 @@ impl PreparedWriteSet {
             rows,
             insert_identities,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remember_insert_identity_for_tests(&mut self, row: &PreparedStateRow) {
+        self.insert_identities.insert(
+            PreparedStateRowIdentity::from(row),
+            PreparedInsertIdentity {
+                untracked: row.untracked,
+                origin: row.origin.clone(),
+            },
+        );
     }
 }
 

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -44,7 +44,7 @@ use crate::transaction::staging::duplicate_insert_identity_message;
 use crate::transaction::staging::{PreparedValidationRow, PreparedWriteValidationSet};
 #[cfg(test)]
 use crate::transaction::types::PreparedStateRow;
-use crate::transaction::types::TransactionWriteOrigin;
+use crate::transaction::types::{TransactionWriteOperation, TransactionWriteOrigin};
 
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
@@ -550,12 +550,69 @@ async fn validate_filesystem_namespace(
     // projected globals do not participate in branch-local constraint checks.
     let domains = staged_filesystem_namespace_domains(staged_rows);
     for domain in domains {
+        if !filesystem_namespace_domain_changed(input, staged_rows, &domain).await? {
+            continue;
+        }
         let mut occupants =
             committed_filesystem_namespace_occupants(input.live_state, &domain).await?;
         apply_staged_filesystem_namespace_rows(staged_rows, &domain, &mut occupants)?;
         validate_filesystem_namespace_occupants(&domain, occupants)?;
     }
     Ok(())
+}
+
+async fn filesystem_namespace_domain_changed(
+    input: &TransactionValidationInput<'_>,
+    staged_rows: &[PreparedValidationRow<'_>],
+    domain: &Domain,
+) -> Result<bool, LixError> {
+    // Existing occupants that keep the same kind, identity, parent, and name
+    // cannot introduce a namespace collision. Every uncertain case falls back
+    // to validating the complete domain below.
+    let mut descriptor_rows = staged_rows.iter().copied().filter(|row| {
+        row.domain() == *domain
+            && (row.schema_key() == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                || row.schema_key() == FILE_DESCRIPTOR_SCHEMA_KEY)
+    });
+    let Some(row) = descriptor_rows.next() else {
+        return Ok(false);
+    };
+    if descriptor_rows.next().is_some() {
+        return Ok(true);
+    }
+    if row
+        .origin()
+        .is_some_and(|origin| origin.operation == TransactionWriteOperation::Insert)
+        || input
+            .staged_writes
+            .insert_identities()
+            .any(|(identity, untracked, _)| {
+                identity.domain(untracked) == row.domain()
+                    && identity.schema_key() == row.schema_key()
+                    && identity.entity_pk() == row.entity_pk()
+            })
+    {
+        return Ok(true);
+    }
+    let Some(snapshot) = row.snapshot_json() else {
+        return Ok(true);
+    };
+    let Some(committed) = load_committed_constraint_row(
+        input.live_state,
+        domain,
+        row.schema_key(),
+        row.entity_pk().clone(),
+        false,
+    )
+    .await?
+    else {
+        return Ok(true);
+    };
+    let Some((_, committed_occupant)) = filesystem_namespace_occupant_from_live_row(&committed)?
+    else {
+        return Ok(true);
+    };
+    Ok(committed_occupant != filesystem_namespace_occupant_from_staged_row(row, snapshot)?)
 }
 
 fn staged_filesystem_namespace_domains(
@@ -2812,6 +2869,61 @@ mod tests {
         TransactionValidationInput::new(validation_set, catalog, &EmptyLiveStateReader)
     }
 
+    async fn filesystem_namespace_domain_changed_for_test(
+        staged_rows: Vec<PreparedStateRow>,
+        committed_rows: Vec<MaterializedLiveStateRow>,
+    ) -> Result<bool, LixError> {
+        let staged_writes = PreparedWriteSet {
+            state_rows: staged_rows,
+            ..empty_staged_write_set()
+        };
+        let validation_set = staged_writes.validation_set_for_tests();
+        let staged_rows = validation_set.rows().collect::<Vec<_>>();
+        let domain = staged_rows
+            .first()
+            .expect("namespace test requires a staged descriptor")
+            .domain();
+        let catalog = CatalogSnapshot::from_visible_schemas(&[
+            file_descriptor_schema(),
+            directory_descriptor_schema(),
+        ])?;
+        let live_state = StrictStaticLiveStateReader {
+            rows: committed_rows,
+        };
+        let input = TransactionValidationInput::new(&validation_set, &catalog, &live_state);
+        filesystem_namespace_domain_changed(&input, &staged_rows, &domain).await
+    }
+
+    async fn assert_filesystem_namespace_domain_changed(
+        staged_rows: Vec<PreparedStateRow>,
+        committed_rows: Vec<MaterializedLiveStateRow>,
+        expected: bool,
+        scenario: &str,
+    ) {
+        let actual = filesystem_namespace_domain_changed_for_test(staged_rows, committed_rows)
+            .await
+            .unwrap_or_else(|error| panic!("{scenario}: {error}"));
+        assert_eq!(actual, expected, "{scenario}");
+    }
+
+    async fn filesystem_namespace_validation_scan_count_for_test(
+        staged_writes: PreparedWriteSet,
+    ) -> Result<usize, LixError> {
+        let validation_set = staged_writes.validation_set_for_tests();
+        let staged_rows = validation_set.rows().collect::<Vec<_>>();
+        let catalog = CatalogSnapshot::from_visible_schemas(&[
+            file_descriptor_schema(),
+            directory_descriptor_schema(),
+        ])?;
+        let live_state = CountingStaticLiveStateReader {
+            rows: Vec::new(),
+            scan_count: AtomicUsize::new(0),
+        };
+        let input = TransactionValidationInput::new(&validation_set, &catalog, &live_state);
+        validate_filesystem_namespace(&input, &staged_rows).await?;
+        Ok(live_state.scan_count.load(Ordering::Relaxed))
+    }
+
     fn catalog_from_transaction_input<'a>(
         input: &'a TransactionValidationInput<'a>,
     ) -> Result<&'a CatalogSnapshot, LixError> {
@@ -3149,6 +3261,141 @@ mod tests {
         assert_eq!(catalog.len(), 3);
         assert!(catalog.contains("visible_schema"));
         assert!(catalog.contains("pending_schema"));
+    }
+
+    #[tokio::test]
+    async fn filesystem_namespace_change_detection_skips_unchanged_exact_occupants() {
+        let mut tracked = staged_file_descriptor_row("file-a", "branch-a");
+        tracked.metadata = Some(test_stage_json(r#"{"revision":2}"#));
+        let mut untracked = staged_file_descriptor_row("file-u", "branch-a");
+        mark_prepared_row_untracked(&mut untracked);
+        let mut committed_untracked = committed_file_descriptor_row("file-u", "branch-a");
+        mark_live_row_untracked(&mut committed_untracked);
+        let directory = directory_descriptor_row("dir-a", None, "dir", "branch-a");
+
+        let cases = vec![
+            (
+                vec![tracked],
+                vec![committed_file_descriptor_row("file-a", "branch-a")],
+                "tracked descriptor",
+            ),
+            (
+                vec![untracked],
+                vec![committed_untracked],
+                "untracked descriptor",
+            ),
+            (
+                vec![staged_file_descriptor_row(
+                    "global-file",
+                    crate::GLOBAL_BRANCH_ID,
+                )],
+                vec![committed_file_descriptor_row(
+                    "global-file",
+                    crate::GLOBAL_BRANCH_ID,
+                )],
+                "global descriptor",
+            ),
+            (
+                vec![directory.clone()],
+                vec![MaterializedLiveStateRow::from(directory)],
+                "directory descriptor",
+            ),
+        ];
+        for (staged, committed, scenario) in cases {
+            assert_filesystem_namespace_domain_changed(staged, committed, false, scenario).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn filesystem_namespace_change_detection_falls_back_for_namespace_mutations() {
+        let committed_file = committed_file_descriptor_row("file-a", "branch-a");
+
+        let mut renamed = staged_file_descriptor_row("file-a", "branch-a");
+        renamed.snapshot = Some(test_stage_json(
+            r#"{"id":"file-a","directory_id":null,"name":"renamed"}"#,
+        ));
+        let mut moved = staged_file_descriptor_row("file-a", "branch-a");
+        moved.snapshot = Some(test_stage_json(
+            r#"{"id":"file-a","directory_id":"dir-a","name":"file-a"}"#,
+        ));
+        let mut deleted = staged_file_descriptor_row("file-a", "branch-a");
+        deleted.snapshot = None;
+        let mut untracked = staged_file_descriptor_row("file-a", "branch-a");
+        mark_prepared_row_untracked(&mut untracked);
+        let mut renamed_directory = directory_descriptor_row("dir-a", None, "before", "branch-a");
+        let committed_directory = MaterializedLiveStateRow::from(renamed_directory.clone());
+        renamed_directory.snapshot = Some(test_stage_json(
+            r#"{"id":"dir-a","parent_id":null,"name":"after"}"#,
+        ));
+
+        let cases = vec![
+            (vec![renamed], vec![committed_file.clone()], "rename"),
+            (vec![moved], vec![committed_file.clone()], "move"),
+            (vec![deleted], vec![committed_file.clone()], "delete"),
+            (
+                vec![
+                    staged_file_descriptor_row("file-a", "branch-a"),
+                    staged_file_descriptor_row("file-new", "branch-a"),
+                ],
+                vec![committed_file.clone()],
+                "mixed existing/new descriptors",
+            ),
+            (
+                vec![
+                    staged_file_descriptor_row("file-a", "branch-a"),
+                    staged_file_descriptor_row("file-b", "branch-a"),
+                ],
+                vec![
+                    committed_file.clone(),
+                    committed_file_descriptor_row("file-b", "branch-a"),
+                ],
+                "multiple unchanged descriptors",
+            ),
+            (vec![untracked], vec![committed_file], "durability mismatch"),
+            (
+                vec![renamed_directory],
+                vec![committed_directory],
+                "directory rename",
+            ),
+        ];
+        for (staged, committed, scenario) in cases {
+            assert_filesystem_namespace_domain_changed(staged, committed, true, scenario).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn filesystem_namespace_inserts_do_not_add_a_point_read_before_full_validation() {
+        let mut logical_insert = staged_file_descriptor_row("logical-insert", "branch-a");
+        logical_insert.origin = Some(TransactionWriteOrigin {
+            surface: "lix_file".to_string(),
+            operation: TransactionWriteOperation::Insert,
+            primary_key: None,
+        });
+        let logical_write = PreparedWriteSet {
+            state_rows: vec![logical_insert],
+            ..empty_staged_write_set()
+        };
+        assert_eq!(
+            filesystem_namespace_validation_scan_count_for_test(logical_write)
+                .await
+                .expect("logical insert validation should succeed"),
+            1,
+            "logical inserts should perform only the complete namespace scan"
+        );
+
+        let explicit_insert = staged_file_descriptor_row("explicit-insert", "branch-a");
+        let mut explicit_write = PreparedWriteSet {
+            state_rows: vec![explicit_insert.clone()],
+            ..empty_staged_write_set()
+        };
+        explicit_write.remember_insert_identity_for_tests(&explicit_insert);
+        assert_eq!(
+            filesystem_namespace_validation_scan_count_for_test(explicit_write)
+                .await
+                .expect("explicit insert validation should succeed"),
+            1,
+            "explicit inserts should perform only the complete namespace scan"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- point-check one existing staged file/directory descriptor before rebuilding the complete filesystem namespace
- skip the namespace scan only when kind, identity, parent, and name are unchanged in the exact branch/file/durability domain
- keep the original full validator for inserts, deletes, moves, renames, mixed/multi-row writes, and uncertain reads

Logical `INSERT ... ON CONFLICT` origins and explicit insert identities are guarded before the point read, so new files retain the old one-scan path.

## Data

Process-median SlateDB p50 versus exact #674:

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| new-file insert, 100 files | 10.386 ms | 10.451 ms | +0.6% (neutral) |
| new-file insert, 1,000 files | 69.657 ms | 68.086 ms | -2.3% (neutral) |
| changed-metadata overwrite, 1,000 files | 34.211 ms | 19.180 ms | -43.9% |
| changed-metadata overwrite, 10,000 files | 332.590 ms | 176.932 ms | -46.8% |

The insert controls use five independent runs of 11 samples. The serialized 10k confirmation is consistent with an earlier replicated 317.733→156.995 ms result (-50.6%). Equal-metadata overwrites are already handled by #674; this PR targets writes whose metadata changes while their path does not.

## Correctness

The shortcut requires exactly one existing descriptor in one exact domain with identical namespace identity. Every create/delete/move/rename, multiple descriptor write, durability mismatch, missing/tombstoned row, or malformed/uncertain result runs the original complete validator.

## Validation

- strict all-feature/all-target Clippy
- all integration targets, including 550 SQL simulations
- library suite: 1,096 pass, 4 existing ignored; only the inherited #673 scan-accounting expectations fail and are unchanged
- formatting, changenote validation, and `git diff --check`
