### PR TITLE
perf(rocksdb): filter missing point reads

### DIFF
--- a/.changenotes/filter-missing-rocksdb-reads.md
+++ b/.changenotes/filter-missing-rocksdb-reads.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+RocksDB-backed Lix instances now use whole-key Bloom filters to avoid unnecessary SST reads when a requested key is absent.

--- a/packages/engine/benches/storage_v2.rs
+++ b/packages/engine/benches/storage_v2.rs
@@ -1462,6 +1462,35 @@ where
         }
     }
 
+    for rows in [100_u32, 1_000, 10_000] {
+        for requested_keys in [1_usize, 32] {
+            let case_name = format!("direct_get_many_missing_m{requested_keys}_s{rows}");
+            if should_run(&case_name) {
+                let point_storage = storage_family.seed_points(SpaceId(1), rows, 32);
+                let point_keys = missing_point_request_keys(requested_keys);
+                group.throughput(Throughput::Elements(
+                    u64::try_from(requested_keys).expect("requested key count fits u64"),
+                ));
+                group.bench_function(case_name, |b| {
+                    b.iter(|| {
+                        let read = block_on(point_storage.begin_read(ReadOptions::default()))
+                            .expect("begin direct missing-key point read");
+                        let result = block_on(read.get_many(
+                            SpaceId(1),
+                            black_box(&point_keys),
+                            GetOptions::default(),
+                        ))
+                        .expect("direct missing-key get_many");
+                        assert_eq!(result.values.len(), requested_keys);
+                        assert!(result.values.iter().all(Option::is_none));
+                        drop(read);
+                        black_box(result);
+                    });
+                });
+            }
+        }
+    }
+
     if should_run("direct_get_many_unique_u1000") {
         let point_storage = storage_family.seed_points(SpaceId(1), 1_000, 32);
         let point_keys = physical_point_request_keys(1, 1_000, 1_000);
@@ -2083,6 +2112,12 @@ fn physical_point_request_keys(
     // Keys are logical under the space-aware interface; the space travels
     // as a parameter on the storage calls.
     point_request_keys(requested_keys, unique_keys)
+}
+
+fn missing_point_request_keys(requested_keys: usize) -> Vec<Key> {
+    (0..requested_keys)
+        .map(|index| key(format!("missing-point-{index:04}")))
+        .collect()
 }
 
 fn physical_point_scan_range(_space_id: u32) -> KeyRange {

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -17,7 +17,7 @@ use lix_engine::storage::{
 };
 use lix_engine::{StorageFactory, StorageFixture, StorageTestConfig};
 use rocksdb::Snapshot;
-use rocksdb::{DB, Direction, IteratorMode, Options, WriteBatch};
+use rocksdb::{BlockBasedOptions, DB, Direction, IteratorMode, Options, WriteBatch};
 use tempfile::TempDir;
 
 const OWNED_VALUE_MIN_BYTES: usize = 64 * 1024;
@@ -464,6 +464,11 @@ fn open_rocksdb(path: &Path) -> Result<DB, StorageError> {
     options.create_if_missing(true);
     options.set_use_fsync(false);
     options.set_write_buffer_size(64 * 1024 * 1024);
+    let mut table_options = BlockBasedOptions::default();
+    // Full whole-key filters let missing point reads skip unrelated SST data.
+    table_options.set_bloom_filter(8.0, false);
+    table_options.set_optimize_filters_for_memory(true);
+    options.set_block_based_table_factory(&table_options);
     DB::open(&options, path).map_err(rocksdb_error)
 }
 


### PR DESCRIPTION
## Summary

- enable an 8-bit whole-key Bloom filter for RocksDB SSTs
- let absent point reads skip unrelated data blocks
- add permanent 1-key and 32-key missing-read benchmarks at 100, 1,000, and 10,000 rows

This is stacked on #667 so its measurements isolate Bloom filtering from the already-proposed large-value read-buffer reuse.

## Performance

Counterbalanced release A/B against #667:

| Seed rows | Warm miss ×1 | Warm miss ×32 |
| ---: | ---: | ---: |
| 100 | -22.7% | -46.1% |
| 1,000 | -23.2% | -48.4% |
| 10,000 | -28.4% | -40.2% |

Cold single-layout misses improved 14.4–19.6%; cold mixed-SST misses improved 80.3–85.9%. One fixed mixed 10k/32-key case hit a deterministic false positive and improved 3.7%, which is expected Bloom-filter behavior.

Existing-key and scan controls remained below the 10% rejection threshold (worst observed +9.1%). Commit p50 changed between +0.05% and -1.2%, flush p50 between +7.0% and -3.2%, and SST size increased only 0.37–0.73%.

## Validation

- RocksDB storage conformance: 3/3
- all `lix_rocksdb_storage` targets pass
- strict Clippy passes for the storage package and `storage_v2` benchmark
- formatting, all six permanent benchmark cases, and diff checks pass

The rejected prefix-extractor and lower-density filter experiments are not included.
