### PR TITLE
perf(engine): index binary CAS chunk presence

### DIFF
--- a/.changenotes/avoid-reading-cas-payloads-for-dedupe.md
+++ b/.changenotes/avoid-reading-cas-payloads-for-dedupe.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved large binary file write performance on native storage.
+
+Lix now checks compact content-presence markers when deduplicating binary chunks, avoiding reads of unchanged chunk payloads during common localized file updates.

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -64,6 +64,12 @@ path = "benches/slatedb_file_api.rs"
 harness = false
 required-features = ["slatedb"]
 
+[[bench]]
+name = "large_blob_updates"
+path = "benches/large_blob_updates.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
 [dependencies]
 ahash = "0.8"
 async-trait = "0.1"

--- a/packages/engine/benches/large_blob_updates.rs
+++ b/packages/engine/benches/large_blob_updates.rs
@@ -1,0 +1,470 @@
+use std::fmt::{self, Display, Formatter};
+use std::fs;
+use std::ops::Bound;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use lix_engine::storage_bench::{binary_cas_write_accounting, reset_binary_cas_write_accounting};
+use lix_engine::{
+    CoreProjection, Engine, KeyRange, MAX_SCAN_PAGE_ROWS, ProjectedValue, ReadOptions, ScanOptions,
+    SessionContext, SpaceId, Storage, StorageRead, Value,
+};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+use tempfile::TempDir;
+
+const SIZES: &[usize] = &[1 << 20, 4 << 20, 10 << 20];
+const BACKENDS: &[Backend] = &[Backend::Rocks, Backend::Slate];
+const OPERATIONS: &[Operation] = &[
+    Operation::LocalizedUpdate,
+    Operation::FullRewrite,
+    Operation::InitialWrite,
+];
+const LOCAL_EDIT_BYTES: usize = 4 << 10;
+const MANIFEST_SPACE: SpaceId = SpaceId(0x0005_0001);
+const MANIFEST_CHUNK_SPACE: SpaceId = SpaceId(0x0005_0002);
+const PAYLOAD_SPACE: SpaceId = SpaceId(0x0005_0003);
+const PRESENCE_SPACE: SpaceId = SpaceId(0x0005_0004);
+const UPSERT_SQL: &str = "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
+                          ON CONFLICT (path) DO UPDATE SET data = excluded.data";
+
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    Rocks,
+    Slate,
+}
+
+impl Display for Backend {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Rocks => formatter.write_str("rocksdb"),
+            Self::Slate => formatter.write_str("slatedb"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Operation {
+    LocalizedUpdate,
+    FullRewrite,
+    InitialWrite,
+}
+
+impl Display for Operation {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LocalizedUpdate => formatter.write_str("localized_4k_update"),
+            Self::FullRewrite => formatter.write_str("full_rewrite"),
+            Self::InitialWrite => formatter.write_str("initial_write"),
+        }
+    }
+}
+
+fn large_blob_updates(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create large blob benchmark runtime");
+
+    if std::env::var_os("LIX_LARGE_BLOB_ACCOUNTING").is_some() {
+        runtime.block_on(print_accounting());
+        return;
+    }
+
+    let mut group = c.benchmark_group("large_blob_updates");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(4));
+
+    for &backend in BACKENDS {
+        for &size in SIZES {
+            group.throughput(Throughput::Bytes(size as u64));
+            for &operation in OPERATIONS {
+                let parameter = format!("{backend}/{operation}/{}mib", size >> 20);
+                group.bench_with_input(
+                    BenchmarkId::new("sql_blob_write", parameter),
+                    &(backend, size, operation),
+                    |b, &(backend, size, operation)| {
+                        b.iter_custom(|iterations| {
+                            let mut fixture =
+                                runtime.block_on(Fixture::new(backend, size, operation));
+                            let mut elapsed = Duration::ZERO;
+                            for _ in 0..iterations {
+                                let prepared = fixture.prepare();
+                                let started = Instant::now();
+                                let rows_affected = runtime.block_on(fixture.write(prepared));
+                                elapsed += started.elapsed();
+                                black_box(rows_affected);
+                            }
+                            elapsed
+                        });
+                    },
+                );
+            }
+        }
+    }
+
+    group.finish();
+}
+
+async fn print_accounting() {
+    let samples = std::env::var("LIX_LARGE_BLOB_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(12)
+        .max(1);
+
+    for &backend in BACKENDS {
+        if !selected("LIX_LARGE_BLOB_BACKENDS", &backend.to_string()) {
+            continue;
+        }
+        for &size in SIZES {
+            if !selected("LIX_LARGE_BLOB_SIZES_MIB", &(size >> 20).to_string()) {
+                continue;
+            }
+            for &operation in OPERATIONS {
+                if !selected("LIX_LARGE_BLOB_OPERATIONS", &operation.to_string()) {
+                    continue;
+                }
+                let mut fixture = Fixture::new(backend, size, operation).await;
+                fixture.flush().await;
+                let storage_bytes_before = directory_bytes(fixture.root());
+                reset_binary_cas_write_accounting();
+
+                let mut timings = Vec::with_capacity(samples);
+                for _ in 0..samples {
+                    let prepared = fixture.prepare();
+                    let started = Instant::now();
+                    black_box(fixture.write(prepared).await);
+                    timings.push(started.elapsed());
+                }
+                let metrics = binary_cas_write_accounting();
+
+                fixture.flush().await;
+                let storage_bytes_after = directory_bytes(fixture.root());
+                let manifest = fixture.space_accounting(MANIFEST_SPACE).await;
+                let manifest_chunk = fixture.space_accounting(MANIFEST_CHUNK_SPACE).await;
+                let payload = fixture.space_accounting(PAYLOAD_SPACE).await;
+                let presence = fixture.space_accounting(PRESENCE_SPACE).await;
+                timings.sort_unstable();
+
+                println!(
+                    "large_blob_accounting,backend={backend},operation={operation},\
+                     size_bytes={size},samples={samples},p50_ms={:.3},p95_ms={:.3},\
+                     total_ms={:.3},chunk_lookups={},chunk_lookup_batches={},\
+                     chunk_lookup_hits={},chunk_lookup_misses={},chunk_lookup_ms={:.3},\
+                     storage_bytes_before={storage_bytes_before},\
+                     storage_bytes_after={storage_bytes_after},storage_bytes_delta={},\
+                     manifest_rows={},manifest_value_bytes={},manifest_chunk_rows={},\
+                     manifest_chunk_value_bytes={},payload_rows={},payload_value_bytes={},\
+                     presence_rows={},presence_value_bytes={}",
+                    percentile(&timings, 50, 100).as_secs_f64() * 1_000.0,
+                    percentile(&timings, 95, 100).as_secs_f64() * 1_000.0,
+                    timings.iter().sum::<Duration>().as_secs_f64() * 1_000.0,
+                    metrics.chunk_lookup_count,
+                    metrics.chunk_lookup_batch_count,
+                    metrics.chunk_lookup_hit_count,
+                    metrics.chunk_lookup_miss_count,
+                    Duration::from_nanos(metrics.chunk_lookup_elapsed_ns).as_secs_f64() * 1_000.0,
+                    i128::from(storage_bytes_after) - i128::from(storage_bytes_before),
+                    manifest.rows,
+                    manifest.value_bytes,
+                    manifest_chunk.rows,
+                    manifest_chunk.value_bytes,
+                    payload.rows,
+                    payload.value_bytes,
+                    presence.rows,
+                    presence.value_bytes,
+                );
+            }
+        }
+    }
+}
+
+fn selected(variable: &str, candidate: &str) -> bool {
+    std::env::var(variable).map_or(true, |selection| {
+        selection
+            .split(',')
+            .map(str::trim)
+            .any(|value| value == candidate)
+    })
+}
+
+fn percentile(sorted: &[Duration], numerator: usize, denominator: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(numerator).div_ceil(denominator);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+struct PreparedWrite {
+    path: String,
+    data: Vec<u8>,
+}
+
+struct WorkloadState {
+    size: usize,
+    operation: Operation,
+    base: Vec<u8>,
+    version: u64,
+}
+
+impl WorkloadState {
+    fn new(size: usize, operation: Operation) -> Self {
+        Self {
+            size,
+            operation,
+            base: deterministic_bytes(size, 0),
+            version: 1,
+        }
+    }
+
+    fn seed(&self) -> Option<PreparedWrite> {
+        match self.operation {
+            Operation::InitialWrite => None,
+            Operation::LocalizedUpdate | Operation::FullRewrite => Some(PreparedWrite {
+                path: "/large.bin".to_owned(),
+                data: self.base.clone(),
+            }),
+        }
+    }
+
+    fn prepare(&mut self) -> PreparedWrite {
+        let version = self.version;
+        self.version += 1;
+        match self.operation {
+            Operation::LocalizedUpdate => {
+                let mut data = self.base.clone();
+                let edit_len = LOCAL_EDIT_BYTES.min(data.len());
+                let edit_start = (data.len() - edit_len) / 2;
+                fill_deterministic(
+                    &mut data[edit_start..edit_start + edit_len],
+                    version ^ 0x5a17_5a17_5a17_5a17,
+                );
+                PreparedWrite {
+                    path: "/large.bin".to_owned(),
+                    data,
+                }
+            }
+            Operation::FullRewrite => PreparedWrite {
+                path: "/large.bin".to_owned(),
+                data: deterministic_bytes(self.size, version),
+            },
+            Operation::InitialWrite => PreparedWrite {
+                path: format!("/large-{version}.bin"),
+                data: deterministic_bytes(self.size, version),
+            },
+        }
+    }
+}
+
+struct BackendFixture<S: Storage> {
+    session: SessionContext<S>,
+    storage: S,
+    _temp_dir: TempDir,
+    root: PathBuf,
+    workload: WorkloadState,
+}
+
+impl<S> BackendFixture<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    async fn create(storage: S, temp_dir: TempDir, size: usize, operation: Operation) -> Self {
+        let root = temp_dir.path().to_owned();
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("initialize large blob benchmark engine");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("open large blob benchmark engine");
+        let session = engine
+            .open_session(receipt.main_branch_id)
+            .await
+            .expect("open large blob benchmark session");
+        let workload = WorkloadState::new(size, operation);
+        let fixture = Self {
+            session,
+            storage,
+            _temp_dir: temp_dir,
+            root,
+            workload,
+        };
+        if let Some(seed) = fixture.workload.seed() {
+            fixture.write(seed).await;
+        }
+        fixture
+    }
+
+    fn prepare(&mut self) -> PreparedWrite {
+        self.workload.prepare()
+    }
+
+    async fn write(&self, prepared: PreparedWrite) -> u64 {
+        let result = self
+            .session
+            .execute(
+                UPSERT_SQL,
+                &[Value::Text(prepared.path), Value::Blob(prepared.data)],
+            )
+            .await
+            .expect("write large benchmark blob");
+        assert_eq!(result.rows_affected(), 1);
+        result.rows_affected()
+    }
+
+    async fn space_accounting(&self, space: SpaceId) -> SpaceAccounting {
+        space_accounting(&self.storage, space).await
+    }
+}
+
+enum Fixture {
+    Rocks(BackendFixture<RocksDB>),
+    Slate(BackendFixture<SlateDB>),
+}
+
+impl Fixture {
+    async fn new(backend: Backend, size: usize, operation: Operation) -> Self {
+        let temp_dir = tempfile::tempdir().expect("create large blob benchmark directory");
+        let database_path = temp_dir.path().join("database");
+        match backend {
+            Backend::Rocks => {
+                let storage = RocksDB::open(&database_path).expect("open benchmark RocksDB");
+                Self::Rocks(BackendFixture::create(storage, temp_dir, size, operation).await)
+            }
+            Backend::Slate => {
+                let storage = SlateDB::open(&database_path).expect("open benchmark SlateDB");
+                Self::Slate(BackendFixture::create(storage, temp_dir, size, operation).await)
+            }
+        }
+    }
+
+    fn prepare(&mut self) -> PreparedWrite {
+        match self {
+            Self::Rocks(fixture) => fixture.prepare(),
+            Self::Slate(fixture) => fixture.prepare(),
+        }
+    }
+
+    async fn write(&self, prepared: PreparedWrite) -> u64 {
+        match self {
+            Self::Rocks(fixture) => fixture.write(prepared).await,
+            Self::Slate(fixture) => fixture.write(prepared).await,
+        }
+    }
+
+    fn root(&self) -> &Path {
+        match self {
+            Self::Rocks(fixture) => &fixture.root,
+            Self::Slate(fixture) => &fixture.root,
+        }
+    }
+
+    async fn flush(&self) {
+        match self {
+            Self::Rocks(fixture) => fixture.storage.flush().expect("flush benchmark RocksDB"),
+            Self::Slate(fixture) => fixture
+                .storage
+                .flush()
+                .await
+                .expect("flush benchmark SlateDB"),
+        }
+    }
+
+    async fn space_accounting(&self, space: SpaceId) -> SpaceAccounting {
+        match self {
+            Self::Rocks(fixture) => fixture.space_accounting(space).await,
+            Self::Slate(fixture) => fixture.space_accounting(space).await,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SpaceAccounting {
+    rows: u64,
+    value_bytes: u64,
+}
+
+async fn space_accounting<S>(storage: &S, space: SpaceId) -> SpaceAccounting
+where
+    S: Storage,
+{
+    let read = storage
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open accounting read");
+    let mut accounting = SpaceAccounting::default();
+    let mut resume_after = None;
+    loop {
+        let page = read
+            .scan(
+                space,
+                KeyRange {
+                    lower: Bound::Unbounded,
+                    upper: Bound::Unbounded,
+                },
+                ScanOptions {
+                    projection: CoreProjection::FullValue,
+                    limit_rows: MAX_SCAN_PAGE_ROWS,
+                    resume_after,
+                },
+            )
+            .await
+            .expect("scan accounting space");
+        accounting.rows += page.entries.len() as u64;
+        accounting.value_bytes += page
+            .entries
+            .iter()
+            .map(|entry| match &entry.value {
+                ProjectedValue::KeyOnly => 0,
+                ProjectedValue::FullValue(value) => value.len() as u64,
+            })
+            .sum::<u64>();
+        if !page.has_more {
+            break;
+        }
+        resume_after = Some(
+            page.entries
+                .last()
+                .expect("non-final accounting page has a row")
+                .key
+                .clone(),
+        );
+    }
+    accounting
+}
+
+fn deterministic_bytes(len: usize, seed: u64) -> Vec<u8> {
+    let mut bytes = vec![0; len];
+    fill_deterministic(&mut bytes, seed);
+    bytes
+}
+
+fn fill_deterministic(bytes: &mut [u8], seed: u64) {
+    let mut state = seed ^ 0xd1b5_4a32_d192_ed03;
+    for chunk in bytes.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let generated = state.to_le_bytes();
+        chunk.copy_from_slice(&generated[..chunk.len()]);
+    }
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if metadata.is_file() {
+        return metadata.len();
+    }
+    if !metadata.is_dir() {
+        return 0;
+    }
+    fs::read_dir(path)
+        .expect("read benchmark storage directory")
+        .map(|entry| directory_bytes(&entry.expect("read benchmark directory entry").path()))
+        .sum()
+}
+
+criterion_group!(benches, large_blob_updates);
+criterion_main!(benches);

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -25,6 +25,7 @@ use web_time::Instant;
 pub(crate) const BINARY_CAS_MANIFEST_NAMESPACE: &str = "binary_cas.manifest";
 pub(crate) const BINARY_CAS_MANIFEST_CHUNK_NAMESPACE: &str = "binary_cas.manifest_chunk";
 pub(crate) const BINARY_CAS_CHUNK_NAMESPACE: &str = "binary_cas.chunk";
+pub(crate) const BINARY_CAS_CHUNK_PRESENCE_NAMESPACE: &str = "binary_cas.chunk_presence";
 pub(crate) const BINARY_CAS_MANIFEST_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0005_0001), BINARY_CAS_MANIFEST_NAMESPACE);
 pub(crate) const BINARY_CAS_MANIFEST_CHUNK_SPACE: StorageSpace = StorageSpace::new(
@@ -33,6 +34,10 @@ pub(crate) const BINARY_CAS_MANIFEST_CHUNK_SPACE: StorageSpace = StorageSpace::n
 );
 pub(crate) const BINARY_CAS_CHUNK_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0005_0003), BINARY_CAS_CHUNK_NAMESPACE);
+pub(crate) const BINARY_CAS_CHUNK_PRESENCE_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0005_0004),
+    BINARY_CAS_CHUNK_PRESENCE_NAMESPACE,
+);
 
 #[derive(Debug)]
 struct BlobWritePlan {
@@ -140,6 +145,16 @@ pub(crate) fn stage_chunk(
     uncompressed_len: u64,
     payload: &[u8],
 ) {
+    // The storage API's key-only projection still has to materialize a value
+    // on backends without an exact exists primitive. Keep an empty marker in
+    // a separate space so content-addressed dedupe never reads chunk payloads
+    // merely to prove that their hash is present. The marker and payload are
+    // staged in the same canonical write set and become visible atomically.
+    writes.put(
+        BINARY_CAS_CHUNK_PRESENCE_SPACE,
+        key(chunk_key(chunk_hash)),
+        value(Vec::new()),
+    );
     writes.put(
         BINARY_CAS_CHUNK_SPACE,
         key(chunk_key(chunk_hash)),
@@ -762,7 +777,7 @@ async fn chunk_keys_exist(
     keys: Vec<StorageKey>,
 ) -> Result<Vec<bool>, LixError> {
     let started = Instant::now();
-    let result = PointReadPlan::from_unique_keys(BINARY_CAS_CHUNK_SPACE, keys)
+    let result = PointReadPlan::from_unique_keys(BINARY_CAS_CHUNK_PRESENCE_SPACE, keys)
         .materialize(
             store,
             StorageGetOptions {
@@ -1052,7 +1067,7 @@ mod tests {
             writer
                 .stage_payload(&payload)
                 .expect("initial blob write should stage");
-            assert_eq!(writes.stats().staged_puts, 2);
+            assert_eq!(writes.stats().staged_puts, 3);
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -1063,6 +1078,16 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
+        assert_eq!(
+            get_one(
+                &store,
+                BINARY_CAS_CHUNK_PRESENCE_SPACE,
+                chunk_key(BlobHash::from_content(data)),
+            )
+            .await
+            .expect("chunk presence marker should load"),
+            Some(Vec::new())
+        );
         let mut writes = storage.new_write_set();
         let mut writer =
             BinaryCasContext::new().writer_skipping_existing_chunks(&store, &mut writes);
@@ -1071,7 +1096,11 @@ mod tests {
             .await
             .expect("repeat blob write should stage");
 
-        assert_eq!(writes.stats().staged_puts, 1);
+        assert_eq!(
+            writes.stats().staged_puts,
+            1,
+            "a persisted marker should make the repeat write stage only its manifest"
+        );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -1184,7 +1213,7 @@ mod tests {
         })
         .expect("duplicate chunk payload write should stage");
 
-        assert_eq!(writes.stats().staged_puts, 4);
+        assert_eq!(writes.stats().staged_puts, 5);
         writes
             .validate()
             .expect("duplicate chunk payload should be staged only once");

--- a/packages/engine/src/binary_cas/metrics.rs
+++ b/packages/engine/src/binary_cas/metrics.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct BinaryCasWriteMetrics {
     pub chunk_lookup_count: u64,
@@ -19,7 +19,7 @@ static CHUNK_LOOKUP_MISS_COUNT: AtomicU64 = AtomicU64::new(0);
 static CHUNK_LOOKUP_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_DUPLICATE_CHUNK_COUNT: AtomicU64 = AtomicU64::new(0);
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn reset_binary_cas_write_metrics() {
     CHUNK_LOOKUP_COUNT.store(0, Ordering::Relaxed);
     CHUNK_LOOKUP_BATCH_COUNT.store(0, Ordering::Relaxed);
@@ -29,7 +29,7 @@ pub(crate) fn reset_binary_cas_write_metrics() {
     TRANSACTION_DUPLICATE_CHUNK_COUNT.store(0, Ordering::Relaxed);
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn binary_cas_write_metrics_snapshot() -> BinaryCasWriteMetrics {
     BinaryCasWriteMetrics {
         chunk_lookup_count: CHUNK_LOOKUP_COUNT.load(Ordering::Relaxed),

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -2,7 +2,7 @@ mod chunking;
 mod codec;
 mod context;
 pub(crate) mod kv;
-mod metrics;
+pub(crate) mod metrics;
 #[cfg(test)]
 mod stats;
 mod types;

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -3,7 +3,8 @@ use std::ops::Bound;
 use crate::LixError;
 use crate::binary_cas::codec::{BinaryCasManifest, decode_binary_cas_manifest};
 use crate::binary_cas::kv::{
-    BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE, BINARY_CAS_MANIFEST_SPACE,
+    BINARY_CAS_CHUNK_PRESENCE_SPACE, BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE,
+    BINARY_CAS_MANIFEST_SPACE,
 };
 use crate::storage_adapter::{
     StorageAdapterRead, StorageCoreProjection, StorageError, StorageKeyRange,
@@ -17,6 +18,7 @@ pub(crate) struct BinaryCasStorageStats {
     pub single_chunk_blob_rows: u64,
     pub chunked_blob_rows: u64,
     pub manifest_chunk_rows: u64,
+    pub chunk_presence_rows: u64,
     pub chunk_rows: u64,
     pub total_chunk_refs: u64,
     pub logical_blob_bytes: u64,
@@ -59,6 +61,7 @@ where
     )
     .await?;
     stats.manifest_chunk_rows = count_space(read, BINARY_CAS_MANIFEST_CHUNK_SPACE.id).await?;
+    stats.chunk_presence_rows = count_space(read, BINARY_CAS_CHUNK_PRESENCE_SPACE.id).await?;
     stats.chunk_rows = count_space(read, BINARY_CAS_CHUNK_SPACE.id).await?;
     Ok(stats)
 }
@@ -206,6 +209,7 @@ mod tests {
                 single_chunk_blob_rows: 1,
                 chunked_blob_rows: 1,
                 manifest_chunk_rows: 2,
+                chunk_presence_rows: 3,
                 chunk_rows: 3,
                 total_chunk_refs: 3,
                 logical_blob_bytes: 14,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -15,6 +15,32 @@ static TRANSACTION_SCHEMA_CATALOG_LOADS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_SCHEMA_CATALOG_COMPILES: AtomicU64 = AtomicU64::new(0);
 static JSON_STORE_STAGE_BYTES: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BinaryCasWriteAccounting {
+    pub chunk_lookup_count: u64,
+    pub chunk_lookup_batch_count: u64,
+    pub chunk_lookup_hit_count: u64,
+    pub chunk_lookup_miss_count: u64,
+    pub chunk_lookup_elapsed_ns: u64,
+    pub transaction_duplicate_chunk_count: u64,
+}
+
+pub fn reset_binary_cas_write_accounting() {
+    crate::binary_cas::metrics::reset_binary_cas_write_metrics();
+}
+
+pub fn binary_cas_write_accounting() -> BinaryCasWriteAccounting {
+    let metrics = crate::binary_cas::metrics::binary_cas_write_metrics_snapshot();
+    BinaryCasWriteAccounting {
+        chunk_lookup_count: metrics.chunk_lookup_count,
+        chunk_lookup_batch_count: metrics.chunk_lookup_batch_count,
+        chunk_lookup_hit_count: metrics.chunk_lookup_hit_count,
+        chunk_lookup_miss_count: metrics.chunk_lookup_miss_count,
+        chunk_lookup_elapsed_ns: metrics.chunk_lookup_elapsed_ns,
+        transaction_duplicate_chunk_count: metrics.transaction_duplicate_chunk_count,
+    }
+}
+
 pub(crate) fn record_transaction_rows_staged(count: usize) {
     TRANSACTION_ROWS_STAGED.fetch_add(count as u64, Ordering::Relaxed);
 }
@@ -107,6 +133,7 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::tracked_state::TRACKED_STATE_COMMIT_ROOT_SPACE,
         crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE,
         crate::binary_cas::kv::BINARY_CAS_MANIFEST_CHUNK_SPACE,
+        crate::binary_cas::kv::BINARY_CAS_CHUNK_PRESENCE_SPACE,
         crate::binary_cas::kv::BINARY_CAS_CHUNK_SPACE,
         crate::changelog::COMMIT_SPACE,
         crate::changelog::CHANGE_SPACE,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -319,7 +319,8 @@ mod tests {
 
     use crate::LixError;
     use crate::binary_cas::kv::{
-        BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE, BINARY_CAS_MANIFEST_SPACE,
+        BINARY_CAS_CHUNK_PRESENCE_SPACE, BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE,
+        BINARY_CAS_MANIFEST_SPACE,
     };
     use crate::changelog::{CHANGE_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, CommitId};
     use crate::json_store::store::JSON_SPACE;
@@ -342,6 +343,7 @@ mod tests {
             TRACKED_STATE_COMMIT_ROOT_SPACE,
             BINARY_CAS_MANIFEST_SPACE,
             BINARY_CAS_MANIFEST_CHUNK_SPACE,
+            BINARY_CAS_CHUNK_PRESENCE_SPACE,
             BINARY_CAS_CHUNK_SPACE,
             COMMIT_SPACE,
             CHANGE_SPACE,


### PR DESCRIPTION
## Hypothesis

Localized rewrites of large files spend material time proving that unchanged content-addressed chunks already exist. `KeyOnly` storage reads still materialize the chunk value on native backends, so RocksDB reads megabyte payloads only to discard them.

Store an empty presence marker atomically beside every new CAS payload and probe that compact keyspace during deduplication. This is a storage-schema hard cut: there is no version, migration, compatibility branch, or fallback path. Existing payloads remain readable; a missing marker simply causes the normal content-addressed write to restage the marker and payload.

## Results

Counterbalanced baseline/candidate runs used the real `lix_file` SQL upsert path, deterministic 1/4/10 MiB files, 4 KiB localized edits, and 20 measured updates per case.

| Backend / workload | Baseline p50 | Candidate p50 | Change |
|---|---:|---:|---:|
| RocksDB, 4 MiB localized update | 10.259 ms | 9.115 ms | **-11.2%** |
| RocksDB, 10 MiB localized update | 17.230 ms | 13.346 ms | **-22.5%** |
| SlateDB, 4 MiB localized update | — | — | -6.9% (below threshold) |
| SlateDB, 10 MiB localized update | — | — | -1.6% (neutral) |

CAS existence-check time fell about 98–99%. The extra marker data was roughly 1 KiB across 20 revisions, or 0.004–0.007% of physical storage. Initial writes and full rewrites showed no repeatable regression over 10%.

## Scope

- Production change is a compact marker space plus an atomic marker write and marker lookup.
- Adds a reproducible RocksDB/SlateDB large-blob benchmark and feature-gated accounting.
- Does not change the plugin API, remote protocol, or merge semantics.

## Validation

- `cargo test -p lix_engine --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/validate-changes.mjs`
- `git diff --check`