### PR TITLE
perf(engine): skip fixed schema storage reads

### DIFF
--- a/.changenotes/skip-fixed-schema-read-loads.md
+++ b/.changenotes/skip-fixed-schema-read-loads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved SQL read performance for table-free queries and fixed Lix system surfaces.
+
+These reads now use immutable system metadata without scanning registered schemas. Runtime schema registrations are rejected only when their generated base, `_by_branch`, or `_history` table names would collide with a fixed system SQL surface.

--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde_json::Value as JsonValue;
@@ -22,13 +24,16 @@ const COMPILED_CATALOG_CACHE_LIMIT: usize = 64;
 
 /// Engine schema visibility boundary.
 ///
-/// SQL planning receives a schema snapshot from live state. System schemas are
-/// seeded as ordinary `lix_registered_schema` rows during initialization, so
-/// runtime schema visibility has one source of truth. The context also owns
+/// Dynamic SQL planning receives a schema snapshot from live state. System
+/// schemas are also seeded as ordinary `lix_registered_schema` rows for
+/// validation and introspection, while fixed-surface reads may use their
+/// compile-time definitions without loading those rows. The context also owns
 /// the engine-wide cache of compiled catalog snapshots, keyed by fact content.
 pub(crate) struct CatalogContext {
     compiled_catalogs: Mutex<HashMap<CatalogFingerprint, Arc<CatalogSnapshot>>>,
     compiled_catalogs_by_rows: Mutex<HashMap<CatalogRowsFingerprint, Arc<CatalogSnapshot>>>,
+    #[cfg(test)]
+    sql_read_schema_loads: AtomicUsize,
 }
 
 /// Fingerprint of the raw catalog rows visible to a domain, hashed before any
@@ -44,6 +49,8 @@ impl CatalogContext {
         Self {
             compiled_catalogs: Mutex::new(HashMap::new()),
             compiled_catalogs_by_rows: Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            sql_read_schema_loads: AtomicUsize::new(0),
         }
     }
 
@@ -148,6 +155,8 @@ impl CatalogContext {
     where
         R: LiveStateReader + ?Sized,
     {
+        #[cfg(test)]
+        self.sql_read_schema_loads.fetch_add(1, Ordering::Relaxed);
         let facts = self
             .schema_facts_for_domain(live_state, &Domain::schema_catalog(branch_id, true))
             .await?;
@@ -168,6 +177,11 @@ impl CatalogContext {
             }
         }
         Ok(schemas.into_values().collect())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sql_read_schema_load_count_for_test(&self) -> usize {
+        self.sql_read_schema_loads.load(Ordering::Relaxed)
     }
 
     /// Loads schema facts reachable from a row domain.

--- a/packages/engine/src/schema/definition.json
+++ b/packages/engine/src/schema/definition.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Lix Schema Definition",
-  "description": "A Lix schema is a JSON Schema draft 2020-12 document augmented with `x-lix-*` extensions that identify and constrain an entity type. Every schema must declare `x-lix-key` (snake_case identifier, preferably prefixed with a plugin or domain namespace such as `library_book` to avoid collisions) and `additionalProperties: false`; add `x-lix-primary-key` (array of JSON Pointers to required string properties) to make the schema writable. Lix will auto-materialize a public virtual table named after `x-lix-key` with an `INSERT/UPDATE/DELETE` surface. See the `examples` field for a minimal working schema.",
+  "description": "A Lix schema is a JSON Schema draft 2020-12 document augmented with `x-lix-*` extensions that identify and constrain an entity type. Every schema must declare `x-lix-key` (snake_case identifier, preferably prefixed with a plugin or domain namespace such as `library_book` to avoid collisions) and `additionalProperties: false`; runtime registrations must not collide with fixed system SQL surfaces. Add `x-lix-primary-key` (array of JSON Pointers to required string properties) to make the schema writable. Lix will auto-materialize a public virtual table named after `x-lix-key` with an `INSERT/UPDATE/DELETE` surface. See the `examples` field for a minimal working schema.",
   "examples": [
     {
       "x-lix-key": "library_book",
@@ -145,7 +145,7 @@
         "x-lix-key": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9_]*$",
-          "description": "The schema identifier. Must be snake_case (lowercase, underscores) to safely embed in SQL identifiers. Prefix keys with a plugin, app, or domain namespace such as `library_book` or `csv_plugin_cell` to avoid collisions with other schemas.",
+          "description": "The schema identifier. Must be snake_case (lowercase, underscores) to safely embed in SQL identifiers. Runtime registrations must not generate base, `_by_branch`, or `_history` table names that collide with fixed system SQL surfaces. Prefix application keys with a plugin, app, or domain namespace such as `library_book` or `csv_plugin_cell` to avoid collisions with other schemas.",
           "examples": [
             "library_book",
             "csv_plugin_cell"

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 
 use crate::GLOBAL_BRANCH_ID;
@@ -533,12 +534,13 @@ pub(super) struct SessionSqlExecutionContext<'a, R: crate::storage_adapter::Stor
     pub(super) live_state: Arc<LiveStateContext>,
     pub(super) binary_cas: Arc<BinaryCasContext>,
     pub(super) branch_ctx: Arc<BranchContext>,
-    pub(super) visible_schemas: Vec<JsonValue>,
+    pub(super) catalog_context: Arc<CatalogContext>,
     pub(super) functions: FunctionProviderHandle,
     pub(super) plugin_host: PluginRuntimeHost,
     pub(super) file_views: Option<SessionFileViews>,
 }
 
+#[async_trait]
 impl<R> SqlExecutionContext for SessionSqlExecutionContext<'_, R>
 where
     R: crate::storage_adapter::StorageRead + 'static,
@@ -590,8 +592,11 @@ where
         Arc::new(self.binary_cas.reader(self.read_store.clone())) as Arc<dyn BlobDataReader>
     }
 
-    fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
-        Ok(self.visible_schemas.clone())
+    async fn load_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
+        let live_state = self.live_state();
+        self.catalog_context
+            .schema_jsons_for_sql_read_planning(live_state.as_ref(), self.active_branch_id)
+            .await
     }
 
     fn plugin_host(&self) -> PluginRuntimeHost {

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -675,19 +675,13 @@ where
                 let file_view_collector =
                     acknowledge_file_views.then(sql2::SessionFileViews::default);
                 let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
-                let live_state: Arc<dyn crate::live_state::LiveStateReader> =
-                    Arc::new(self.live_state.reader(read_store.clone()));
-                let visible_schemas = self
-                    .catalog_context
-                    .schema_jsons_for_sql_read_planning(live_state.as_ref(), &active_branch_id)
-                    .await?;
                 let ctx = SessionSqlExecutionContext {
                     active_branch_id: &active_branch_id,
                     read_store,
                     live_state: Arc::clone(&self.live_state),
                     binary_cas: Arc::clone(&self.binary_cas),
                     branch_ctx: Arc::clone(&self.branch_ctx),
-                    visible_schemas,
+                    catalog_context: Arc::clone(&self.catalog_context),
                     functions: FunctionProviderHandle::system(),
                     plugin_host: self.plugin_host.clone(),
                     file_views: file_view_collector.clone(),
@@ -730,7 +724,6 @@ where
                 }
                 drop(read_session);
                 drop(ctx);
-                drop(live_state);
                 let file_view_mutations = file_view_collector
                     .map(|collector| collector.plugin_file_mutations())
                     .unwrap_or_default();
@@ -831,19 +824,13 @@ where
                         Vec::new(),
                     ));
                 }
-                let live_state: Arc<dyn crate::live_state::LiveStateReader> =
-                    Arc::new(self.live_state.reader(read_store.clone()));
-                let visible_schemas = self
-                    .catalog_context
-                    .schema_jsons_for_sql_read_planning(live_state.as_ref(), &active_branch_id)
-                    .await?;
                 let ctx = SessionSqlExecutionContext {
                     active_branch_id: &active_branch_id,
                     read_store,
                     live_state: Arc::clone(&self.live_state),
                     binary_cas: Arc::clone(&self.binary_cas),
                     branch_ctx: Arc::clone(&self.branch_ctx),
-                    visible_schemas,
+                    catalog_context: Arc::clone(&self.catalog_context),
                     functions: FunctionProviderHandle::system(),
                     plugin_host: self.plugin_host.clone(),
                     file_views: file_view_collector.clone(),
@@ -882,7 +869,6 @@ where
                 }
                 drop(read_session);
                 drop(ctx);
-                drop(live_state);
                 let file_view_mutations = file_view_collector
                     .map(|collector| collector.plugin_file_mutations())
                     .unwrap_or_default();
@@ -1001,17 +987,13 @@ where
         let runtime_functions = FunctionContext::prepare(live_state.as_ref()).await?;
         let functions = runtime_functions.provider();
         let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
-        let visible_schemas = self
-            .catalog_context
-            .schema_jsons_for_sql_read_planning(live_state.as_ref(), &active_branch_id)
-            .await?;
         let ctx = SessionSqlExecutionContext {
             active_branch_id: &active_branch_id,
             read_store,
             live_state: Arc::clone(&self.live_state),
             binary_cas: Arc::clone(&self.binary_cas),
             branch_ctx: Arc::clone(&self.branch_ctx),
-            visible_schemas,
+            catalog_context: Arc::clone(&self.catalog_context),
             functions: functions.clone(),
             plugin_host: self.plugin_host.clone(),
             file_views: file_view_collector.clone(),
@@ -1591,7 +1573,10 @@ where
 }
 
 fn normalize_sql_surface_error(error: LixError, sql: &str) -> LixError {
-    if error.code.starts_with("LIX_ERROR_PATH_") && sql_uses_public_filesystem_path_surface(sql) {
+    if (error.code.starts_with("LIX_ERROR_PATH_") && sql_uses_public_filesystem_path_surface(sql))
+        || (error.code == LixError::CODE_SCHEMA_DEFINITION
+            && error.message.to_ascii_lowercase().contains("system schema"))
+    {
         return LixError {
             code: LixError::CODE_INVALID_PARAM.to_string(),
             ..error
@@ -1869,6 +1854,117 @@ mod tests {
             .await
             .expect("information_schema should retain catalog-wide visibility");
         assert!(catalog.rows()[0].get::<i64>("surfaces").unwrap() > 1);
+    }
+
+    #[tokio::test]
+    async fn read_provider_selection_loads_storage_catalog_only_for_dynamic_visibility() {
+        let session = open_session().await;
+        let schema_loads = || {
+            session
+                .catalog_context
+                .sql_read_schema_load_count_for_test()
+        };
+
+        let before = schema_loads();
+        session
+            .execute("SELECT 1 AS one", &[])
+            .await
+            .expect("table-free read should execute");
+        assert_eq!(schema_loads(), before, "SELECT 1 needs no SQL catalog");
+
+        session
+            .execute("SELECT COUNT(*) AS rows FROM lix_key_value", &[])
+            .await
+            .expect("fixed entity surface should execute");
+        assert_eq!(
+            schema_loads(),
+            before,
+            "fixed entity metadata comes from compile-time schemas"
+        );
+
+        session
+            .execute(
+                "SELECT COUNT(*) AS rows FROM lix_key_value_history \
+                 WHERE lixcol_start_commit_id = lix_active_branch_commit_id()",
+                &[],
+            )
+            .await
+            .expect("fixed history surface should execute");
+        assert_eq!(
+            schema_loads(),
+            before,
+            "fixed history metadata comes from compile-time schemas"
+        );
+
+        session
+            .execute(
+                "SELECT COUNT(*) AS rows FROM lix_key_value AS kv \
+                 JOIN lix_state AS state ON false",
+                &[],
+            )
+            .await
+            .expect("join of fixed surfaces should execute");
+        assert_eq!(
+            schema_loads(),
+            before,
+            "a join remains storage-free when every table is fixed"
+        );
+
+        session
+            .execute(
+                "SELECT COUNT(*) AS surfaces FROM information_schema.tables",
+                &[],
+            )
+            .await
+            .expect("information schema should execute");
+        assert_eq!(
+            schema_loads(),
+            before + 1,
+            "catalog-wide visibility must load dynamic schemas"
+        );
+
+        let custom_schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "x-lix-key": "custom_catalog_probe",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": { "id": { "type": "string" } },
+            "required": ["id"],
+            "additionalProperties": false,
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(custom_schema.to_string())],
+            )
+            .await
+            .expect("custom schema should register");
+        let before_custom_read = schema_loads();
+
+        session
+            .execute("SELECT COUNT(*) AS rows FROM custom_catalog_probe", &[])
+            .await
+            .expect("custom entity should execute");
+        assert_eq!(
+            schema_loads(),
+            before_custom_read + 1,
+            "custom entity metadata must load the visible catalog"
+        );
+
+        let before_mixed_join = schema_loads();
+        session
+            .execute(
+                "SELECT COUNT(*) AS rows FROM lix_key_value AS kv \
+                 JOIN custom_catalog_probe AS custom ON false",
+                &[],
+            )
+            .await
+            .expect("mixed fixed/custom join should execute");
+        assert_eq!(
+            schema_loads(),
+            before_mixed_join + 1,
+            "one custom table makes the whole session use the visible catalog"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 #[cfg(test)]
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 #[cfg(test)]
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -41,6 +42,25 @@ impl PublicCatalog {
         Ok(catalog)
     }
 
+    /// Compile-time SQL surfaces whose shape cannot be changed at runtime.
+    ///
+    /// Alongside the hand-written state/filesystem surfaces, Lix seeds a fixed
+    /// set of system entity schemas. Runtime registration rejects schema keys
+    /// whose generated base, `_by_branch`, or `_history` surface would shadow
+    /// this metadata, so it does not need a storage-backed visible-schema
+    /// snapshot.
+    pub(crate) fn fixed_system() -> &'static Self {
+        static FIXED_SYSTEM_CATALOG: OnceLock<PublicCatalog> = OnceLock::new();
+        FIXED_SYSTEM_CATALOG.get_or_init(|| {
+            let schemas = crate::schema::seed_schema_definitions()
+                .into_iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            Self::from_visible_schemas(&schemas)
+                .expect("compile-time Lix schemas must form a valid SQL catalog")
+        })
+    }
+
     pub(crate) fn insert(&mut self, surface: PublicSurfaceContract) -> Result<(), LixError> {
         if self.surfaces.contains_key(&surface.name) {
             return Err(LixError::new(
@@ -54,6 +74,21 @@ impl PublicCatalog {
 
     pub(crate) fn surface(&self, table_name: &str) -> Option<&PublicSurfaceContract> {
         self.surfaces.get(table_name)
+    }
+
+    /// Returns the fixed schema or SQL surface shadowed by a runtime schema key.
+    pub(crate) fn fixed_system_collision_for_schema_key(schema_key: &str) -> Option<String> {
+        if crate::schema::is_seed_schema_key(schema_key) {
+            return Some(schema_key.to_string());
+        }
+
+        [
+            schema_key.to_string(),
+            format!("{schema_key}_by_branch"),
+            format!("{schema_key}_history"),
+        ]
+        .into_iter()
+        .find(|surface_name| Self::fixed_system().surface(surface_name).is_some())
     }
 
     pub(crate) fn surfaces(&self) -> impl Iterator<Item = &PublicSurfaceContract> {

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -51,6 +51,7 @@ pub(crate) struct ChangelogQuerySource<S> {
 /// `SqlWriteExecutionContext` so transaction-scoped reads and staging stay in
 /// the transaction capability instead of flowing through committed read
 /// sources.
+#[async_trait]
 pub(crate) trait SqlExecutionContext {
     type ReadStore: StorageAdapterRead + Clone + Send + Sync + 'static;
 
@@ -65,7 +66,9 @@ pub(crate) trait SqlExecutionContext {
     fn commit_graph(&self) -> Box<dyn CommitGraphReader>;
     fn branch_ref(&self) -> Arc<dyn BranchRefReader>;
     fn blob_reader(&self) -> Arc<dyn BlobDataReader>;
-    fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError>;
+    /// Loads runtime-defined SQL entity metadata when provider selection could
+    /// not be satisfied entirely by compile-time system surfaces.
+    async fn load_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError>;
 
     fn plugin_host(&self) -> PluginRuntimeHost {
         PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime))

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1838,6 +1838,7 @@ mod tests {
         schema_definitions: Vec<JsonValue>,
     }
 
+    #[async_trait]
     impl<'a> SqlExecutionContext for DummySqlExecutionContext<'a> {
         type ReadStore = SharedStorageAdapterRead<MemoryRead>;
 
@@ -1888,7 +1889,7 @@ mod tests {
             Arc::new(DummyBranchRefReader)
         }
 
-        fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
+        async fn load_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
             Ok(self.schema_definitions.clone())
         }
     }

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use bind::{
     BoundStatementRoute, bind_read_statement, bind_statement, bind_statement_route,
     statement_has_durable_runtime_function,
 };
+pub(crate) use catalog::PublicCatalog;
 pub(crate) use context::{
     ChangelogQuerySource, HistoryQuerySource, SqlChangelogQuerySource, SqlExecutionContext,
     SqlHistoryQuerySource, SqlJsonReader, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -117,12 +117,21 @@ pub(crate) async fn register_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let catalog = PublicCatalog::from_visible_schemas(&ctx.list_visible_schemas()?)?;
+    if selection.is_empty() {
+        return Ok(());
+    }
+    let dynamic_catalog;
+    let catalog = if selection.requires_visible_schemas() {
+        dynamic_catalog = PublicCatalog::from_visible_schemas(&ctx.load_visible_schemas().await?)?;
+        &dynamic_catalog
+    } else {
+        PublicCatalog::fixed_system()
+    };
     register_read_from_catalog(
         session,
         ctx,
         branch_ref,
-        &catalog,
+        catalog,
         ReadProviderScope::All,
         selection,
     )
@@ -147,10 +156,32 @@ pub(crate) enum ReadProviderSelection {
 }
 
 impl ReadProviderSelection {
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Only(names) if names.is_empty())
+    }
+
     fn includes(&self, surface: &PublicSurfaceContract) -> bool {
         match self {
             Self::All => true,
             Self::Only(names) => names.contains(&surface.name),
+        }
+    }
+
+    /// Whether resolving this selection requires the storage-backed catalog.
+    ///
+    /// Table-free reads and references satisfied by the immutable system catalog
+    /// can install providers without scanning `lix_registered_schema` rows.
+    /// Runtime registration rejects schema keys whose generated table names
+    /// would shadow these fixed providers.
+    /// `All` and every unknown name remain conservative: they load the full
+    /// visible catalog so information-schema, custom entities, and normal
+    /// unknown-table errors keep their current semantics.
+    fn requires_visible_schemas(&self) -> bool {
+        match self {
+            Self::All => true,
+            Self::Only(names) => names
+                .iter()
+                .any(|name| PublicCatalog::fixed_system().surface(name).is_none()),
         }
     }
 }
@@ -670,6 +701,28 @@ mod tests {
         assert_eq!(
             selection_for_sql(&["SHOW TABLES"]),
             ReadProviderSelection::All
+        );
+    }
+
+    #[test]
+    fn visible_schema_loading_boundary_is_conservative() {
+        assert!(!selection_for_sql(&["SELECT 1"]).requires_visible_schemas());
+        assert!(!selection_for_sql(&["SELECT * FROM lix_key_value"]).requires_visible_schemas());
+        assert!(
+            !selection_for_sql(&["SELECT * FROM lix_key_value_history"]).requires_visible_schemas()
+        );
+        assert!(
+            !selection_for_sql(&["SELECT * FROM lix_key_value JOIN lix_state ON false"])
+                .requires_visible_schemas()
+        );
+        assert!(selection_for_sql(&["SELECT * FROM custom_entity"]).requires_visible_schemas());
+        assert!(
+            selection_for_sql(&["SELECT * FROM lix_key_value JOIN custom_entity ON false",])
+                .requires_visible_schemas()
+        );
+        assert!(
+            selection_for_sql(&["SELECT * FROM information_schema.tables"])
+                .requires_visible_schemas()
         );
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1820,6 +1820,7 @@ pub(crate) struct TransactionSqlReadExecutionContext<R: crate::storage_adapter::
     plugin_host: PluginRuntimeHost,
 }
 
+#[async_trait]
 impl<R> SqlExecutionContext for TransactionSqlReadExecutionContext<R>
 where
     R: crate::storage_adapter::StorageRead + 'static,
@@ -1882,7 +1883,7 @@ where
         })
     }
 
-    fn list_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
+    async fn load_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
         Ok(self.visible_schemas.clone())
     }
 

--- a/packages/engine/src/transaction/normalization.rs
+++ b/packages/engine/src/transaction/normalization.rs
@@ -11,9 +11,9 @@ use crate::domain::Domain;
 use crate::entity_pk::{EntityPk, EntityPkError};
 use crate::functions::FunctionProviderHandle;
 use crate::schema::{
-    is_seed_schema_key, schema_from_registered_snapshot, validate_lix_schema,
-    validate_lix_schema_definition,
+    SchemaKey, schema_from_registered_snapshot, validate_lix_schema, validate_lix_schema_definition,
 };
+use crate::sql2::PublicCatalog;
 use crate::transaction::types::{PreparedRowFacts, TransactionJson, TransactionWriteRow};
 
 pub(crate) const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
@@ -244,18 +244,27 @@ pub(crate) fn remember_pending_registered_schema(
         validate_lix_schema(registered_schema_definition, snapshot)?;
     }
     let (key, schema) = schema_from_registered_snapshot(snapshot)?;
-    if is_seed_schema_key(&key.schema_key) {
-        return Err(LixError::new(
-            LixError::CODE_SCHEMA_DEFINITION,
-            format!(
-                "schema '{}' is a system schema and cannot be registered at runtime",
-                key.schema_key
-            ),
-        ));
-    }
+    reject_fixed_system_schema_collision(&key)?;
     validate_lix_schema_definition(&schema)?;
     schema_catalog.insert_schema_for_domain(domain, key, schema)?;
     Ok(())
+}
+
+pub(crate) fn reject_fixed_system_schema_collision(key: &SchemaKey) -> Result<(), LixError> {
+    let Some(surface_name) = PublicCatalog::fixed_system_collision_for_schema_key(&key.schema_key)
+    else {
+        return Ok(());
+    };
+    Err(LixError::new(
+        LixError::CODE_SCHEMA_DEFINITION,
+        format!(
+            "schema '{}' conflicts with fixed system schema or public SQL surface '{}' and cannot be registered at runtime",
+            key.schema_key, surface_name
+        ),
+    )
+    .with_hint(
+        "Choose a schema key whose base, `_by_branch`, and `_history` table names do not overlap a fixed Lix surface.",
+    ))
 }
 
 #[cfg(test)]
@@ -512,6 +521,61 @@ mod tests {
             dynamic.row.entity_pk.as_ref(),
             Some(&EntityPk::single("dynamic-1"))
         );
+    }
+
+    #[test]
+    fn normalization_rejects_fixed_and_generated_system_surface_schema_keys() {
+        let mut catalog = catalog_with(vec![
+            seed_schema_definition(REGISTERED_SCHEMA_KEY)
+                .expect("registered schema builtin")
+                .clone(),
+        ]);
+
+        for (schema_key, collision_kind) in [
+            ("lix_file", "fixed base surface"),
+            ("lix_key_value_history", "generated system history surface"),
+        ] {
+            let mut schema = dynamic_schema_definition();
+            schema["x-lix-key"] = json!(schema_key);
+            let registered = TransactionWriteRow {
+                entity_pk: None,
+                schema_key: REGISTERED_SCHEMA_KEY.to_string(),
+                snapshot: Some(transaction_json(json!({ "value": schema }))),
+                ..base_stage_row()
+            };
+
+            let error = normalize_transaction_write_row(registered, &mut catalog, functions())
+                .expect_err(collision_kind);
+
+            assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
+            assert!(error.message.contains("fixed system schema"), "{error:?}");
+            assert!(error.message.contains(schema_key), "{error:?}");
+            assert!(
+                !catalog.snapshot().contains(schema_key),
+                "rejected schema must not enter the transaction catalog"
+            );
+        }
+    }
+
+    #[test]
+    fn normalization_allows_noncolliding_lix_prefixed_schema_key() {
+        let mut catalog = catalog_with(vec![
+            seed_schema_definition(REGISTERED_SCHEMA_KEY)
+                .expect("registered schema builtin")
+                .clone(),
+        ]);
+        let mut schema = dynamic_schema_definition();
+        schema["x-lix-key"] = json!("lix_plugin_note");
+        let registered = TransactionWriteRow {
+            entity_pk: None,
+            schema_key: REGISTERED_SCHEMA_KEY.to_string(),
+            snapshot: Some(transaction_json(json!({ "value": schema }))),
+            ..base_stage_row()
+        };
+
+        normalize_transaction_write_row(registered, &mut catalog, functions())
+            .expect("a noncolliding lix-prefixed key remains valid");
+        assert!(catalog.snapshot().contains("lix_plugin_note"));
     }
 
     #[test]

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -32,12 +32,11 @@ use crate::live_state::{
     MaterializedLiveStateRow,
 };
 #[cfg(test)]
-use crate::schema::{
-    SchemaKey, is_seed_schema_key, validate_lix_schema, validate_lix_schema_definition,
-};
+use crate::schema::{SchemaKey, validate_lix_schema, validate_lix_schema_definition};
 use crate::schema::{
     format_lix_schema_validation_errors, schema_from_registered_snapshot, validate_schema_amendment,
 };
+use crate::transaction::normalization::reject_fixed_system_schema_collision;
 #[cfg(test)]
 use crate::transaction::staging::PreparedWriteSet;
 use crate::transaction::staging::duplicate_insert_identity_message;
@@ -304,6 +303,12 @@ async fn validate_registered_schema_identity_is_canonical(
     }
 
     for pending_row in pending_schema_rows {
+        let pending_snapshot = pending_row
+            .snapshot_json()
+            .expect("pending registered schema row has snapshot_content");
+        let (key, _) = schema_from_registered_snapshot(pending_snapshot)?;
+        reject_fixed_system_schema_collision(&key)?;
+
         let Some(row) = load_committed_constraint_row(
             input.live_state,
             &pending_row.domain().with_exact_file_scope(None),
@@ -319,9 +324,6 @@ async fn validate_registered_schema_identity_is_canonical(
             continue;
         };
         let snapshot = parse_registered_schema_snapshot(snapshot_content)?;
-        let pending_snapshot = pending_row
-            .snapshot_json()
-            .expect("pending registered schema row has snapshot_content");
         if &snapshot != pending_snapshot {
             let (key, pending_schema) = schema_from_registered_snapshot(pending_snapshot)?;
             let (_, committed_schema) = schema_from_registered_snapshot(&snapshot)?;
@@ -2697,24 +2699,10 @@ fn validate_pending_registered_schema(
     // `lix_registered_schema` schema, and the inner definition must be a valid
     // Lix schema before it can extend the transaction-visible catalog.
     let (key, schema) = schema_from_registered_snapshot(&snapshot)?;
-    reject_seed_schema_registration(&key)?;
+    reject_fixed_system_schema_collision(&key)?;
     validate_lix_schema_definition(&schema)?;
     validate_lix_schema(registered_schema_definition, &snapshot)?;
     Ok((key, schema))
-}
-
-#[cfg(test)]
-fn reject_seed_schema_registration(key: &SchemaKey) -> Result<(), LixError> {
-    if is_seed_schema_key(&key.schema_key) {
-        return Err(LixError::new(
-            LixError::CODE_SCHEMA_DEFINITION,
-            format!(
-                "schema '{}' is a system schema and cannot be registered at runtime",
-                key.schema_key
-            ),
-        ));
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/packages/engine/tests/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/sql/lix_registered_schema.rs
@@ -139,7 +139,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_registered_schema_insert_rejects_system_schema_key,
+    lix_registered_schema_insert_rejects_fixed_system_surface_collisions,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -150,24 +150,50 @@ simulation_test!(
             &engine,
         );
 
-        let error = session
+        for (schema_key, collision_kind) in [
+            ("lix_file", "fixed base surface"),
+            ("lix_key_value_history", "generated system history surface"),
+        ] {
+            let schema = json!({
+                "x-lix-key": schema_key,
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": { "id": { "type": "string" } },
+                "required": ["id"],
+                "additionalProperties": false,
+            });
+            let error = session
+                .execute(
+                    "INSERT INTO lix_registered_schema \
+                     (value, lixcol_global, lixcol_untracked) \
+                     VALUES ($1, false, false)",
+                    &[Value::Json(schema)],
+                )
+                .await
+                .expect_err(collision_kind);
+
+            assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+            assert!(error.message.contains("fixed system schema"), "{error:?}");
+            assert!(error.message.contains(schema_key), "{error:?}");
+        }
+
+        let noncolliding_schema = json!({
+            "x-lix-key": "lix_plugin_note",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": { "id": { "type": "string" } },
+            "required": ["id"],
+            "additionalProperties": false,
+        });
+        session
             .execute(
-                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-                 VALUES (\
-                 lix_json('{\"x-lix-key\":\"lix_change\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}},\"required\":[\"id\"],\"additionalProperties\":false}'),\
-                 false,\
-                 false\
-                 )",
-                &[],
+                "INSERT INTO lix_registered_schema \
+                 (value, lixcol_global, lixcol_untracked) \
+                 VALUES ($1, false, false)",
+                &[Value::Json(noncolliding_schema)],
             )
             .await
-            .expect_err("system schema keys should not be user-registerable");
-
-        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
-        assert!(
-            error.message.contains("system schema"),
-            "unexpected error: {error:?}"
-        );
+            .expect("a noncolliding lix-prefixed key remains registerable");
     }
 );
 


### PR DESCRIPTION
## Summary

- Resolve the SQL statement's table references before loading runtime schema rows.
- Use one immutable compile-time catalog when every referenced surface is fixed.
- Load custom/dynamic schema metadata lazily from the same storage snapshot for unknown names, mixed queries, `information_schema`, and `SHOW`.
- Reject only runtime schema keys whose generated base, `_by_branch`, or `_history` name would shadow a fixed system surface; non-colliding `lix_*` keys remain valid.
- Keep provider instances and complete DataFusion plans query/snapshot-local.

## Benchmark

Release build with `storage-benches`, 1,000 measured operations after 50 warmups. Five alternating parent/candidate runs; values below are the median run p50/p95. The parent is #680.

| Backend / query | Parent p50 / p95 | Candidate p50 / p95 | Delta p50 / p95 |
| --- | ---: | ---: | ---: |
| RocksDB fixed SELECT | 1.421 / 1.512 ms | 0.623 / 0.687 ms | **-56.2% / -54.6%** |
| RocksDB `SELECT 1` | 1.242 / 1.323 ms | 0.460 / 0.507 ms | **-62.9% / -61.7%** |
| RocksDB fixed two-table join | 1.918 / 2.033 ms | 1.120 / 1.212 ms | **-41.6% / -40.4%** |
| SlateDB fixed SELECT | 3.090 / 3.445 ms | 1.768 / 2.009 ms | **-42.8% / -41.7%** |
| SlateDB `SELECT 1` | 2.554 / 2.771 ms | 1.246 / 1.386 ms | **-51.2% / -50.0%** |
| SlateDB fixed two-table join | 4.083 / 4.432 ms | 2.699 / 3.084 ms | **-33.9% / -30.4%** |

For the representative RocksDB fixed SELECT, storage accounting changes from 27 to 18 `get_many` calls, 85 to 20 requested keys, and 4 to 2 scans per operation. `SELECT 1` drops from 22 to 13 `get_many` calls, 78 to 13 keys, and 2 to 0 scans.

Controls did not regress materially: dynamic `information_schema` stays on the storage-backed catalog path and improved 2.4-4.2%; transaction SELECT/UPDATE paths were unchanged within 2.1% noise. Storage operation counts and result counts were identical on every control.

## Correctness boundaries

- DataFusion reference resolution stays conservative: catalog-wide and unresolved queries load the full visible catalog.
- The lazy load uses the existing per-query storage read, preserving SlateDB/RocksDB snapshot visibility.
- Fixed metadata is generated from the same compile-time seed definitions used at initialization.
- Runtime collision checks are enforced during both early row normalization and authoritative commit validation, including DataFusion-produced writes.
- No public API changes and no cached logical/physical plan captures snapshot-specific providers.

## Design references

- DataFusion 53.1's [`SessionState::resolve_table_references`](https://docs.rs/datafusion/53.1.0/datafusion/execution/session_state/struct.SessionState.html#method.resolve_table_references) is the table-discovery boundary used here.
- DataFusion's [catalog model](https://datafusion.apache.org/library-user-guide/catalogs.html) explicitly supports in-memory metadata and asynchronous metadata backed by transactional storage; this change selects between those two paths.
- SlateDB [read snapshots](https://slatedb.io/docs/design/reads/) keep the lazy dynamic-schema load on the query's authoritative read view.
- DuckDB similarly [bounds broad schema searches for catalog diagnostics](https://duckdb.org/docs/stable/configuration/pragmas.html#metadata), while known references take the targeted path.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lix_engine --all-features --lib -- -D warnings`
- `cargo test -p lix_engine` (1,111 unit tests, 546 SQL simulations, transaction/storage integration tests, and doctests)
- Changenote parser validation

Stacked on #680.
