### PR TITLE
perf(engine): register only write target provider

### DIFF
--- a/.changenotes/register-write-target-provider.md
+++ b/.changenotes/register-write-target-provider.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved SQL write performance by constructing only the target table's
+DataFusion provider for UPDATE, DELETE, and VALUES-based INSERT statements.
+Query-backed INSERT statements retain catalog-wide provider registration.

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -37,6 +37,7 @@ use crate::{GLOBAL_BRANCH_ID, LixError, LixNotice, SqlQueryResult, Value};
 use crate::sql2::predicate_typecheck::{
     json_predicate_placeholder_indexes_with_dfschema, validate_json_predicate_expr_with_dfschema,
 };
+use crate::sql2::providers::ProviderSelection;
 use crate::sql2::result_metadata::{
     LIX_VALUE_TYPE_JSON, LIX_VALUE_TYPE_METADATA_KEY, field_is_json,
 };
@@ -302,8 +303,11 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
     params: &[Value],
 ) -> Result<SqlWriteResult, LixError> {
     validate_bound_write_input(plan, params)?;
-    let session = build_write_session_with_options(ctx, write_session_options(plan)).await?;
     let table_name = write_target_table_name(plan)?;
+    let provider_selection = write_provider_selection(plan, &table_name);
+    let session =
+        build_write_session_with_options(ctx, write_session_options(plan), &provider_selection)
+            .await?;
     let table = session
         .table_provider(&table_name)
         .await
@@ -434,8 +438,11 @@ pub(crate) async fn validate_datafusion_write_logical_plan(
     params: &[Value],
 ) -> Result<(), LixError> {
     validate_bound_write_input(plan, params)?;
-    let session = build_write_session_with_options(ctx, write_session_options(plan)).await?;
     let table_name = write_target_table_name(plan)?;
+    let provider_selection = write_provider_selection(plan, &table_name);
+    let session =
+        build_write_session_with_options(ctx, write_session_options(plan), &provider_selection)
+            .await?;
     let table = session
         .table_provider(&table_name)
         .await
@@ -765,6 +772,20 @@ fn write_session_options(plan: &LogicalWritePlan) -> SqlWriteSessionOptions {
     }
     SqlWriteSessionOptions {
         omitted_insert_columns,
+    }
+}
+
+fn write_provider_selection(plan: &LogicalWritePlan, target_table_name: &str) -> ProviderSelection {
+    // Bound VALUES, UPDATE, and DELETE expressions can reference only the
+    // target surface. Query-backed inserts may read any visible surface, so
+    // keep their existing catalog-wide registration until source selection is
+    // derived from the bound query itself.
+    match (&plan.bound.op, &plan.bound.input) {
+        (BoundWriteOp::Insert, BoundWriteInput::Values(_))
+        | (BoundWriteOp::Update | BoundWriteOp::Delete, BoundWriteInput::None) => {
+            ProviderSelection::Only(BTreeSet::from([target_table_name.to_string()]))
+        }
+        _ => ProviderSelection::All,
     }
 }
 
@@ -1683,6 +1704,7 @@ fn string_scalar_to_lix_value(value: &str, field: Option<&Field>) -> Result<Valu
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -1693,7 +1715,10 @@ mod tests {
     use serde_json::Value as JsonValue;
     use serde_json::json;
 
-    use super::{SqlExecutionContext, SqlWriteExecutionContext, execute_sql};
+    use super::{
+        SqlExecutionContext, SqlWriteExecutionContext, build_write_session_with_options,
+        execute_sql, write_provider_selection, write_session_options, write_target_table_name,
+    };
     use crate::binary_cas::BlobDataReader;
     use crate::branch::BranchRefReader;
     use crate::changelog::{ChangeId, CommitId};
@@ -2043,6 +2068,144 @@ mod tests {
             },
             path,
         ))
+    }
+
+    #[tokio::test]
+    async fn target_only_write_shapes_construct_only_the_target_provider() {
+        for sql in [
+            "UPDATE lix_file SET data = X'41' WHERE id = 'file-readme'",
+            "DELETE FROM lix_file WHERE id = 'file-readme' RETURNING id, path",
+            "INSERT INTO lix_file (path, data) VALUES ('/readme.md', X'41') \
+             ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+        ] {
+            let (mut ctx, _, _) = counting_write_context(Vec::new());
+            let plan = create_write_logical_plan(&mut ctx, sql)
+                .await
+                .unwrap_or_else(|error| panic!("target-only write should plan: {sql}: {error}"));
+            let crate::sql2::exec::SqlLogicalPlan::Write(plan) = plan else {
+                panic!("target-only SQL should produce a write plan: {sql}");
+            };
+            let table_name = write_target_table_name(&plan.plan).expect("target should resolve");
+            let selection = write_provider_selection(&plan.plan, &table_name);
+
+            assert_eq!(
+                selection,
+                crate::sql2::providers::ProviderSelection::Only(BTreeSet::from([
+                    "lix_file".to_string()
+                ])),
+                "{sql}"
+            );
+
+            let session = build_write_session_with_options(
+                &mut ctx,
+                write_session_options(&plan.plan),
+                &selection,
+            )
+            .await
+            .unwrap_or_else(|error| {
+                panic!("target-only write session should build: {sql}: {error}")
+            });
+            let public = session
+                .catalog("datafusion")
+                .expect("default catalog should exist")
+                .schema("public")
+                .expect("public schema should exist");
+            let mut table_names = public.table_names();
+            table_names.sort();
+
+            assert_eq!(table_names, vec!["lix_file"], "{sql}");
+        }
+    }
+
+    #[tokio::test]
+    async fn query_backed_insert_keeps_catalog_wide_provider_registration() {
+        let (mut ctx, _, _) = counting_write_context(Vec::new());
+        let insert_select = create_write_logical_plan(
+            &mut ctx,
+            "INSERT INTO lix_file (id, path) SELECT 'copied', '/copied.md'",
+        )
+        .await
+        .expect("query-backed insert should plan");
+        let crate::sql2::exec::SqlLogicalPlan::Write(insert_select) = insert_select else {
+            panic!("query-backed insert should produce a write plan");
+        };
+        let table_name =
+            write_target_table_name(&insert_select.plan).expect("target should resolve");
+        let selection = write_provider_selection(&insert_select.plan, &table_name);
+
+        assert_eq!(selection, crate::sql2::providers::ProviderSelection::All,);
+
+        let session = build_write_session_with_options(
+            &mut ctx,
+            write_session_options(&insert_select.plan),
+            &selection,
+        )
+        .await
+        .expect("query-backed insert session should build");
+        let public = session
+            .catalog("datafusion")
+            .expect("default catalog should exist")
+            .schema("public")
+            .expect("public schema should exist");
+        let mut table_names = public.table_names();
+        table_names.sort();
+
+        assert_eq!(
+            table_names,
+            vec![
+                "lix_branch",
+                "lix_directory",
+                "lix_directory_by_branch",
+                "lix_file",
+                "lix_file_by_branch",
+                "lix_state",
+                "lix_state_by_branch",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn target_only_delete_returning_executes_with_selected_provider() {
+        let (mut ctx, staged_writes, _) = counting_write_context(vec![live_file_row(
+            "file-readme",
+            "branch-a",
+            None,
+            "readme.md",
+        )]);
+        let plan = create_write_logical_plan(
+            &mut ctx,
+            "DELETE FROM lix_file WHERE id = 'file-readme' RETURNING id, path",
+        )
+        .await
+        .expect("DELETE RETURNING should plan");
+        let (result, path) = crate::sql2::execute_write_logical_plan_with_mode_and_trace_result(
+            &mut ctx,
+            plan,
+            &[],
+            WriteExecutorMode::ForceDataFusion,
+        )
+        .await
+        .expect("target-only DELETE RETURNING should execute");
+
+        assert_eq!(path, WriteExecutorPath::DataFusion);
+        assert_eq!(result.rows_affected, 1);
+        let returning = result.returning.expect("RETURNING rows should be present");
+        assert_eq!(returning.columns, vec!["id", "path"]);
+        assert_eq!(
+            returning.rows,
+            vec![vec![
+                Value::Text("file-readme".to_string()),
+                Value::Text("/readme.md".to_string()),
+            ]]
+        );
+        assert_eq!(
+            staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .len(),
+            1
+        );
     }
 
     #[async_trait]

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -37,7 +37,7 @@ use crate::transaction::types::{
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteRow,
 };
 
-use super::ReadProviderSelection;
+use super::ProviderSelection;
 use super::entity_history::register_entity_history_surface;
 use datafusion::physical_plan::ExecutionPlan;
 
@@ -60,7 +60,7 @@ pub(crate) async fn register_entity_providers<S>(
     query_source: Option<SqlHistoryQuerySource<S>>,
     catalog: &PublicCatalog,
     include_write_surfaces: bool,
-    selection: &ReadProviderSelection,
+    selection: &ProviderSelection,
 ) -> Result<(), LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
@@ -127,7 +127,7 @@ pub(crate) async fn register_entity_write_providers(
     write_ctx: SqlWriteContext,
     branch_ref: Arc<dyn BranchRefReader>,
     catalog: &PublicCatalog,
-    selection: &ReadProviderSelection,
+    selection: &ProviderSelection,
 ) -> Result<(), LixError> {
     for surface in catalog.surfaces() {
         if !selection.includes(surface) {

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -113,7 +113,7 @@ pub(crate) async fn register_read<C>(
     session: &SessionContext,
     ctx: &C,
     branch_ref: Arc<dyn BranchRefReader>,
-    selection: &ReadProviderSelection,
+    selection: &ProviderSelection,
 ) -> Result<(), LixError>
 where
     C: SqlExecutionContext + ?Sized,
@@ -139,15 +139,16 @@ where
     .await
 }
 
-/// Snapshot-local providers needed to plan a set of already-parsed reads.
+/// Snapshot-local providers needed to plan already-bound SQL.
 ///
-/// DataFusion's resolver is deliberately used here instead of maintaining a
-/// second SQL AST walker. It is the same resolver called by
+/// For reads, DataFusion's resolver is deliberately used instead of maintaining
+/// a second SQL AST walker. It is the same resolver called by
 /// `SessionState::statement_to_plan`, including its CTE scoping and identifier
-/// normalization rules. The selection retains names only; providers and plans
-/// remain scoped to the current storage snapshot.
+/// normalization rules. Bound target-only writes select their known target
+/// directly. The selection retains names only; providers and plans remain
+/// scoped to the current storage snapshot.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ReadProviderSelection {
+pub(crate) enum ProviderSelection {
     /// Register every surface when catalog-wide visibility is part of the SQL
     /// semantics (notably `information_schema` and rewritten `SHOW` queries),
     /// or when reference resolution cannot prove a narrower set is sufficient.
@@ -156,7 +157,7 @@ pub(crate) enum ReadProviderSelection {
     Only(BTreeSet<String>),
 }
 
-impl ReadProviderSelection {
+impl ProviderSelection {
     fn is_empty(&self) -> bool {
         matches!(self, Self::Only(names) if names.is_empty())
     }
@@ -190,24 +191,24 @@ impl ReadProviderSelection {
 pub(crate) fn read_provider_selection(
     session: &SessionContext,
     statements: &[datafusion::sql::parser::Statement],
-) -> ReadProviderSelection {
+) -> ProviderSelection {
     let mut names = BTreeSet::new();
     let state = session.state();
     for statement in statements {
         if statement_requires_all_providers(statement) {
-            return ReadProviderSelection::All;
+            return ProviderSelection::All;
         }
         let Ok(references) = state.resolve_table_references(statement) else {
-            return ReadProviderSelection::All;
+            return ProviderSelection::All;
         };
         for reference in references {
             if reference.schema() == Some("information_schema") {
-                return ReadProviderSelection::All;
+                return ProviderSelection::All;
             }
             names.insert(reference.table().to_string());
         }
     }
-    ReadProviderSelection::Only(names)
+    ProviderSelection::Only(names)
 }
 
 fn statement_requires_all_providers(statement: &datafusion::sql::parser::Statement) -> bool {
@@ -264,7 +265,7 @@ async fn register_read_from_catalog<C>(
     branch_ref: Arc<dyn BranchRefReader>,
     catalog: &PublicCatalog,
     scope: ReadProviderScope,
-    selection: &ReadProviderSelection,
+    selection: &ProviderSelection,
 ) -> Result<(), LixError>
 where
     C: SqlExecutionContext + ?Sized,
@@ -446,17 +447,10 @@ pub(crate) async fn register_write(
     write_ctx: SqlWriteContext,
     branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
+    selection: &ProviderSelection,
 ) -> Result<(), LixError> {
     let catalog = write_ctx.public_catalog()?;
-    register_write_from_catalog(
-        session,
-        write_ctx,
-        branch_ref,
-        options,
-        &catalog,
-        &ReadProviderSelection::All,
-    )
-    .await
+    register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog, selection).await
 }
 
 pub(crate) async fn register_transaction<C>(
@@ -466,7 +460,7 @@ pub(crate) async fn register_transaction<C>(
     write_ctx: SqlWriteContext,
     write_branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
-    selection: &ReadProviderSelection,
+    selection: &ProviderSelection,
 ) -> Result<(), LixError>
 where
     C: SqlExecutionContext + ?Sized,
@@ -501,7 +495,7 @@ async fn register_write_from_catalog(
     branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
     catalog: &PublicCatalog,
-    selection: &ReadProviderSelection,
+    selection: &ProviderSelection,
 ) -> Result<(), LixError> {
     for surface in catalog.surfaces() {
         if !selection.includes(surface) {
@@ -616,11 +610,11 @@ mod tests {
     };
 
     use super::{
-        ReadProviderScope, ReadProviderSelection, branch, change, directory, directory_history,
-        entity, file, file_history, history, is_write_surface, lix_state, read_provider_selection,
+        ProviderSelection, ReadProviderScope, branch, change, directory, directory_history, entity,
+        file, file_history, history, is_write_surface, lix_state, read_provider_selection,
     };
 
-    fn selection_for_sql(sql: &[&str]) -> ReadProviderSelection {
+    fn selection_for_sql(sql: &[&str]) -> ProviderSelection {
         let statements = sql
             .iter()
             .map(|sql| crate::sql2::parse_statement(sql).expect("SQL should parse"))
@@ -628,8 +622,8 @@ mod tests {
         read_provider_selection(&SessionContext::new(), &statements)
     }
 
-    fn selected_names(names: &[&str]) -> ReadProviderSelection {
-        ReadProviderSelection::Only(names.iter().map(|name| (*name).to_string()).collect())
+    fn selected_names(names: &[&str]) -> ProviderSelection {
+        ProviderSelection::Only(names.iter().map(|name| (*name).to_string()).collect())
     }
 
     #[test]
@@ -689,7 +683,7 @@ mod tests {
     fn referenced_provider_selection_registers_none_for_table_free_queries() {
         assert_eq!(
             selection_for_sql(&["SELECT 1, lix_uuid_v7()"]),
-            ReadProviderSelection::Only(BTreeSet::new())
+            ProviderSelection::Only(BTreeSet::new())
         );
     }
 
@@ -697,12 +691,9 @@ mod tests {
     fn referenced_provider_selection_keeps_catalog_wide_information_schema_semantics() {
         assert_eq!(
             selection_for_sql(&["SELECT * FROM information_schema.tables"]),
-            ReadProviderSelection::All
+            ProviderSelection::All
         );
-        assert_eq!(
-            selection_for_sql(&["SHOW TABLES"]),
-            ReadProviderSelection::All
-        );
+        assert_eq!(selection_for_sql(&["SHOW TABLES"]), ProviderSelection::All);
     }
 
     #[test]
@@ -805,6 +796,24 @@ mod tests {
             14,
             "new construction count"
         );
+    }
+
+    #[test]
+    fn target_write_selection_reduces_provider_construction_count_to_one() {
+        let catalog = PublicCatalog::from_visible_schemas(&[]).expect("catalog should build");
+        let all_writable = catalog
+            .surfaces()
+            .filter(|surface| is_write_surface(surface))
+            .count();
+        let selection = selected_names(&["lix_file"]);
+        let selected_writable = catalog
+            .surfaces()
+            .filter(|surface| is_write_surface(surface) && selection.includes(surface))
+            .map(|surface| surface.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(all_writable, 7, "previous standalone write count");
+        assert_eq!(selected_writable, vec!["lix_file"]);
     }
 
     #[test]
@@ -915,7 +924,7 @@ mod tests {
             Some(empty_history_query_source().await),
             &catalog,
             true,
-            &ReadProviderSelection::All,
+            &ProviderSelection::All,
         )
         .await
         .expect("entity providers should register");

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -113,6 +113,7 @@ pub(crate) struct SqlWriteSessionOptions {
 pub(crate) async fn build_write_session_with_options(
     ctx: &mut dyn SqlWriteExecutionContext,
     options: SqlWriteSessionOptions,
+    provider_selection: &providers::ProviderSelection,
 ) -> Result<SessionContext, LixError> {
     let session = new_sql_session_context();
     let write_ctx = SqlWriteContext::new(ctx);
@@ -136,7 +137,7 @@ pub(crate) async fn build_write_session_with_options(
         write_ctx.functions(),
         Some(active_branch_commit_id.commit_id.to_string()),
     );
-    providers::register_write(&session, write_ctx, branch_ref, options).await?;
+    providers::register_write(&session, write_ctx, branch_ref, options, provider_selection).await?;
 
     Ok(session)
 }


### PR DESCRIPTION
## Summary

- Resolve target-only `UPDATE`, `DELETE`, and literal/values `INSERT` statements before provider registration.
- Register only the writable target provider instead of constructing every visible provider.
- Keep query-backed `INSERT` conservative with catalog-wide registration.
- Reuse the transaction cached public catalog; no complete DataFusion plan or snapshot-bound provider is cached.
- Keep all changes crate-private; there is no public API change.

This follows DataFusion catalog guidance: table references are resolved first, and only referenced providers need to be registered in the per-execution context. See [DataFusion table-reference resolution](https://docs.rs/datafusion/53.1.0/datafusion/execution/session_state/struct.SessionState.html#method.resolve_table_references) and [DataFusion catalogs](https://datafusion.apache.org/library-user-guide/catalogs.html).

## Benchmark

Exact comparison: latest `main` (`8b557304`) versus this commit, release binaries, five alternating parent/candidate pairs, 50 warmups and 1,000 measured operations per run. Reported values are medians of the five run-level percentiles.

Primary workload: one-row transactional `lix_state` update, representative of Lixray server writes.

| Backend | parent p50 | candidate p50 | change | parent p95 | candidate p95 | change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RocksDB | 538.443 us | 371.138 us | **-31.1%** | 604.938 us | 392.018 us | **-35.2%** |
| SlateDB | 1.361 ms | 1.021 ms | **-25.0%** | 1.484 ms | 1.152 ms | **-22.3%** |

Storage operations were identical before and after: 4 `begin_read`, 11 `get_many` calls / 14 keys, 2 scans, and 1 returned row per operation. The gain is provider/catalog/planning CPU work, not changed storage semantics.

Regression controls covered transactional file reads, normal transaction reads and writes, non-transaction reads, joins, literal selects, and `information_schema` on both backends. No control regressed by 10%; observed changes were within run noise or improvements.

## Validation

- `cargo test -p lix_engine --lib`: 1,127 passed, 0 failed, 6 ignored
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- changenote parser validation
- independent correctness review of target classification, redirected global state, dynamic entities, transaction snapshot ownership, and query-backed inserts: no findings

The manual benchmark harness is intentionally excluded from the production diff.