### PR TITLE
perf(engine): skip unused durable function state

### DIFF
--- a/.changenotes/skip-unused-durable-function-state.md
+++ b/.changenotes/skip-unused-durable-function-state.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved ordinary SQL read performance by skipping deterministic runtime-function state work when a query does not call `lix_uuid_v7()` or `lix_timestamp()`.
+
+Queries that use durable runtime functions retain their existing deterministic sequencing and persistence behavior.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -520,6 +520,7 @@ where
                     params,
                     acknowledge_file_views,
                     exact_lix_file_read,
+                    has_durable_runtime_function,
                 )
                 .await
             },
@@ -530,12 +531,16 @@ where
                 return Err(normalize_sql_surface_error(error, sql));
             }
         };
-        let runtime_storage_stats = self
-            .persist_runtime_functions_if_needed(
-                &read_result.runtime_functions,
-                runtime_write_access.as_ref(),
-            )
-            .await?;
+        let runtime_storage_stats = match read_result.runtime_functions.as_ref() {
+            Some(runtime_functions) => {
+                self.persist_runtime_functions_if_needed(
+                    runtime_functions,
+                    runtime_write_access.as_ref(),
+                )
+                .await?
+            }
+            None => None,
+        };
         drop(runtime_write_access);
         if let Some(stats) = runtime_storage_stats {
             self.observe_invalidation.bump_if_storage_changed(&stats);
@@ -972,6 +977,7 @@ where
         params: &[Value],
         acknowledge_file_views: bool,
         exact_lix_file_read: Option<(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn)>,
+        has_durable_runtime_function: bool,
     ) -> Result<
         (
             sql2::SessionReadSqlResult,
@@ -1007,7 +1013,7 @@ where
                 .unwrap_or_default();
             return Ok((
                 sql2::SessionReadSqlResult {
-                    runtime_functions: FunctionContext::system_for_function_free_read(),
+                    runtime_functions: None,
                     query,
                 },
                 file_view_mutations,
@@ -1015,8 +1021,17 @@ where
         }
         let live_state: Arc<dyn crate::live_state::LiveStateReader> =
             Arc::new(self.live_state.reader(read_store.clone()));
-        let runtime_functions = FunctionContext::prepare(live_state.as_ref()).await?;
-        let functions = runtime_functions.provider();
+        let runtime_functions = if has_durable_runtime_function {
+            Some(FunctionContext::prepare(live_state.as_ref()).await?)
+        } else {
+            None
+        };
+        // Read providers do not consume durable function state themselves;
+        // only the registered timestamp/UUID SQL UDFs do. Keep their AST
+        // classifier conservative if new readable statement shapes appear.
+        let functions = runtime_functions
+            .as_ref()
+            .map_or_else(FunctionProviderHandle::system, FunctionContext::provider);
         let ctx = SessionSqlExecutionContext {
             active_branch_id: &active_branch_id,
             read_store,

--- a/packages/engine/src/sql2/bind/public_udf.rs
+++ b/packages/engine/src/sql2/bind/public_udf.rs
@@ -70,6 +70,12 @@ pub(crate) fn validate_public_udf_calls_in_datafusion_statement(
     visit_datafusion_statement(statement, &mut visitor)
 }
 
+/// Conservatively reports whether a read statement can invoke an engine UDF
+/// whose state must be loaded before execution and persisted afterward.
+///
+/// This classifier runs before provider/session construction, so every
+/// inspectable nested expression must be visited and unknown statement shapes
+/// must fail toward doing the durable setup.
 pub(crate) fn statement_has_durable_runtime_function(statement: &DataFusionStatement) -> bool {
     let mut visitor = DurableRuntimeFunctionVisitor { found: false };
     visit_datafusion_statement_for_durable_runtime_function(statement, &mut visitor);
@@ -130,7 +136,13 @@ fn visit_datafusion_statement_for_durable_runtime_function(
                 visitor,
             );
         }
-        _ => {}
+        // Extension statements are currently rejected by statement routing,
+        // but keep this detector conservative if one becomes readable later.
+        // Skipping durable setup on an AST shape we did not inspect would be
+        // a correctness bug; doing the setup unnecessarily is only slower.
+        DataFusionStatement::CreateExternalTable(_)
+        | DataFusionStatement::CopyTo(_)
+        | DataFusionStatement::Reset(_) => visitor.found = true,
     }
 }
 
@@ -202,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn marks_durable_runtime_functions() {
+    fn marks_direct_durable_runtime_functions() {
         assert!(statement_has_durable_runtime_function(&parse_statement(
             "SELECT lix_uuid_v7()"
         )));
@@ -212,5 +224,27 @@ mod tests {
         assert!(!statement_has_durable_runtime_function(&parse_statement(
             "SELECT lix_json('{\"x\":1}')"
         )));
+        assert!(!statement_has_durable_runtime_function(&parse_statement(
+            "SELECT 'lix_uuid_v7()' AS literal"
+        )));
+        assert!(!statement_has_durable_runtime_function(&parse_statement(
+            "SELECT 1 /* lix_timestamp() */"
+        )));
+    }
+
+    #[test]
+    fn marks_nested_aliased_and_explained_durable_runtime_functions() {
+        for sql in [
+            "WITH generated AS (SELECT lix_uuid_v7() AS value) SELECT value FROM generated",
+            "SELECT value FROM (SELECT lix_timestamp() AS value) AS generated",
+            "SELECT lix_uuid_v7() AS generated_id",
+            "SELECT CASE WHEN true THEN lix_timestamp() ELSE 'never' END AS value",
+            "EXPLAIN SELECT lix_uuid_v7()",
+        ] {
+            assert!(
+                statement_has_durable_runtime_function(&parse_statement(sql)),
+                "nested or aliased durable function should be detected in: {sql}"
+            );
+        }
     }
 }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -60,7 +60,7 @@ pub(crate) struct DataFusionLogicalPlan {
 }
 
 pub(crate) struct SessionReadSqlResult {
-    pub(crate) runtime_functions: FunctionContext,
+    pub(crate) runtime_functions: Option<FunctionContext>,
     pub(crate) query: SqlQueryResult,
 }
 

--- a/packages/engine/tests/durable_function_fast_path.rs
+++ b/packages/engine/tests/durable_function_fast_path.rs
@@ -1,0 +1,192 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use lix_engine::{
+    Engine, GetManyResult, GetOptions, Key, KeyRange, Memory, MemoryRead, MemoryWrite, ReadOptions,
+    ScanChunk, ScanOptions, SpaceId, Storage, StorageError, StorageRead, Value, WriteOptions,
+};
+
+#[derive(Clone, Default)]
+struct CountingStorage {
+    inner: Memory,
+    counters: Arc<StorageCounters>,
+}
+
+struct CountingRead {
+    inner: MemoryRead,
+    counters: Arc<StorageCounters>,
+}
+
+#[derive(Default)]
+struct StorageCounters {
+    begin_reads: AtomicU64,
+    get_many_calls: AtomicU64,
+    scan_calls: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct CounterSnapshot {
+    begin_reads: u64,
+    get_many_calls: u64,
+    scan_calls: u64,
+}
+
+impl CountingStorage {
+    fn snapshot(&self) -> CounterSnapshot {
+        CounterSnapshot {
+            begin_reads: self.counters.begin_reads.load(Ordering::Relaxed),
+            get_many_calls: self.counters.get_many_calls.load(Ordering::Relaxed),
+            scan_calls: self.counters.scan_calls.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Storage for CountingStorage {
+    type Read<'a>
+        = CountingRead
+    where
+        Self: 'a;
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        self.counters.begin_reads.fetch_add(1, Ordering::Relaxed);
+        Ok(CountingRead {
+            inner: self.inner.begin_read(options).await?,
+            counters: Arc::clone(&self.counters),
+        })
+    }
+
+    async fn begin_write(&self, options: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(options).await
+    }
+}
+
+impl StorageRead for CountingRead {
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        options: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        self.counters.get_many_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.get_many(space, keys, options).await
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        options: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        self.counters.scan_calls.fetch_add(1, Ordering::Relaxed);
+        self.inner.scan(space, range, options).await
+    }
+}
+
+impl CounterSnapshot {
+    fn delta_since(self, before: Self) -> Self {
+        Self {
+            begin_reads: self.begin_reads - before.begin_reads,
+            get_many_calls: self.get_many_calls - before.get_many_calls,
+            scan_calls: self.scan_calls - before.scan_calls,
+        }
+    }
+}
+
+async fn open_session() -> (CountingStorage, lix_engine::SessionContext<CountingStorage>) {
+    let storage = CountingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("initialized storage should create engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    (storage, session)
+}
+
+#[tokio::test]
+async fn pure_read_skips_durable_function_state_storage_work() {
+    let (storage, session) = open_session().await;
+
+    // Warm durable state first because persisting it invalidates session cache
+    // generations, then warm the pure-query catalog state used for comparison.
+    session.execute("SELECT lix_uuid_v7()", &[]).await.unwrap();
+    session.execute("SELECT 1 AS value", &[]).await.unwrap();
+
+    let before_pure = storage.snapshot();
+    let pure = session.execute("SELECT 1 AS value", &[]).await.unwrap();
+    let pure_reads = storage.snapshot().delta_since(before_pure);
+    assert_eq!(pure.rows()[0].get::<i64>("value").unwrap(), 1);
+
+    let before_durable = storage.snapshot();
+    session.execute("SELECT lix_uuid_v7()", &[]).await.unwrap();
+    let durable_reads = storage.snapshot().delta_since(before_durable);
+
+    assert_eq!(
+        durable_reads.begin_reads,
+        pure_reads.begin_reads + 1,
+        "durable setup should own exactly one additional read snapshot: \
+         pure={pure_reads:?}, durable={durable_reads:?}"
+    );
+    assert!(
+        durable_reads.get_many_calls > pure_reads.get_many_calls,
+        "only the durable-function statement should load durable mode state: \
+         pure={pure_reads:?}, durable={durable_reads:?}"
+    );
+    assert_eq!(durable_reads.scan_calls, pure_reads.scan_calls);
+}
+
+#[tokio::test]
+async fn pure_reads_do_not_advance_and_durable_reads_still_persist_deterministic_runtime_state() {
+    let (_storage, session) = open_session().await;
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_global, lixcol_untracked) \
+             VALUES ('lix_deterministic_mode', lix_json('{\"enabled\":true}'), true, true)",
+            &[],
+        )
+        .await
+        .expect("deterministic mode should enable");
+
+    for value in 0..10 {
+        let result = session
+            .execute("SELECT $1 AS value", &[Value::Integer(value)])
+            .await
+            .expect("pure read should execute in deterministic mode");
+        assert_eq!(result.rows()[0].get::<i64>("value").unwrap(), value);
+    }
+
+    let first_uuid = session
+        .execute("SELECT lix_uuid_v7() AS value", &[])
+        .await
+        .expect("durable function should execute")
+        .rows()[0]
+        .get::<String>("value")
+        .expect("uuid should be text");
+    assert_eq!(first_uuid, "01920000-0000-7000-8000-000000000000");
+
+    let first_timestamp = session
+        .execute("SELECT lix_timestamp() AS value", &[])
+        .await
+        .expect("second durable function should execute")
+        .rows()[0]
+        .get::<String>("value")
+        .expect("timestamp should be text");
+    assert_eq!(first_timestamp, "1970-01-01T00:00:00.001Z");
+
+    let next_uuid = session
+        .execute("SELECT lix_uuid_v7() AS value", &[])
+        .await
+        .expect("persisted durable sequence should continue")
+        .rows()[0]
+        .get::<String>("value")
+        .expect("uuid should be text");
+    assert_eq!(next_uuid, "01920000-0000-7000-8000-000000000002");
+}


### PR DESCRIPTION
## Summary

- Detect whether a read statement can call `lix_uuid_v7()` or `lix_timestamp()` before session/provider construction.
- Skip deterministic runtime-function state loading and persistence for ordinary reads.
- Traverse nested expressions, subqueries, CTEs, `CASE`, aliases, and `EXPLAIN`; unknown extension statements conservatively keep the existing setup.
- Keep writes, explicit transactions, batches, observers, and durable-function reads on their existing paths.
- Keep this internal: there is no public API change.

This was developed and measured on #687; that dependency merged with all checks green, so this branch is rebased directly onto current `main`.

## Benchmark

Exact incremental comparison: #687 head (`dbb7edaf`) versus this patch, release binaries with distinct checksums, five alternating parent/candidate pairs, 50 warmups and 1,000 measured operations per run. Values below are medians of the five run-level percentiles.

| SlateDB workload | parent p50 | candidate p50 | change | parent p95 | candidate p95 | change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| key/value point read | 1.698 ms | 1.388 ms | **-18.3%** | 2.452 ms | 1.602 ms | **-34.7%** |
| literal `SELECT 1` | 1.259 ms | 0.930 ms | **-26.1%** | 1.379 ms | 1.147 ms | **-16.8%** |
| `information_schema` read | 2.943 ms | 2.473 ms | **-16.0%** | 3.383 ms | 2.726 ms | **-19.4%** |
| exact file-by-id read | 1.922 ms | 1.613 ms | **-16.1%** | 2.195 ms | 1.890 ms | **-13.9%** |

RocksDB also improved without crossing the 10% publication threshold by itself: 1.7-7.7% p50 and 2.0-7.3% p95 across the ordinary-read matrix; the exact file read improved 3.5% p50 / 4.3% p95.

For an ordinary key lookup, storage work falls from 2 to 1 read snapshots and from 18 to 14 `get_many` calls (20 to 16 keys); scan work is unchanged. UUID/timestamp reads retain the original counts. Explicit transaction read/write counts are identical before and after, and their latency medians remain neutral or improve.

## Correctness

The new tests prove that pure reads skip durable storage work and do not advance deterministic sequences, while UUID/timestamp reads still persist and resume the exact sequence. A conservative AST visitor covers nested durable calls and avoids substring false positives in literals/comments.

One intentional semantic relaxation follows from avoiding unrelated state: a pure read no longer fails merely because unused deterministic-runtime state is malformed. Durable calls and writes still load and validate it.

## Validation

- `cargo test -p lix_engine --lib`: 1,128 passed, 0 failed, 6 ignored
- `cargo test -p lix_engine --test durable_function_fast_path`: 2 passed
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- changenote parser validation
- independent correctness review: no findings

Manual benchmark harnesses are intentionally excluded from the production diff.