### PR TITLE
perf(engine): bypass Arrow for exact file batches

### DIFF
--- a/.changenotes/accelerate-exact-file-batches.md
+++ b/.changenotes/accelerate-exact-file-batches.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Accelerated exact `lix_file` path batch reads by moving owned file bytes directly into SQL results instead of copying them through Arrow.
+
+Exact batch reads also acknowledge delivered plugin-backed file views so later file writes retain the correct session merge base.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -483,8 +483,12 @@ where
                 .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
         }
 
-        let acknowledge_file_views = is_acknowledgeable_file_data_read(&statement, params);
-        let exact_lix_file_read = exact_lix_file_read(&statement, params);
+        let exact_lix_file_read = exact_lix_file_read_route(&statement, params);
+        let acknowledge_file_views = is_acknowledgeable_file_data_read(&statement, params)
+            || matches!(
+                &exact_lix_file_read,
+                Some(ExactLixFileRead::PathDataBatch(_))
+            );
         let has_durable_runtime_function = sql2::statement_has_durable_runtime_function(&statement);
         let runtime_write_access = if has_durable_runtime_function {
             let write_access = self.begin_session_write_access().await?;
@@ -976,7 +980,7 @@ where
         statement: datafusion::sql::parser::Statement,
         params: &[Value],
         acknowledge_file_views: bool,
-        exact_lix_file_read: Option<(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn)>,
+        exact_lix_file_read: Option<ExactLixFileRead>,
         has_durable_runtime_function: bool,
     ) -> Result<
         (
@@ -987,7 +991,7 @@ where
     > {
         let file_view_collector = acknowledge_file_views.then(sql2::SessionFileViews::default);
         let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
-        if let Some((selector, column)) = exact_lix_file_read {
+        if let Some(exact_lix_file_read) = exact_lix_file_read {
             let live_state: Arc<dyn crate::live_state::LiveStateReader> =
                 Arc::new(self.live_state.reader(read_store.clone()));
             let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
@@ -996,18 +1000,35 @@ where
                 Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
             let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
                 Arc::new(self.binary_cas.reader(read_store));
-            let query = sql2::execute_exact_lix_file_read(
-                &active_branch_id,
-                live_state,
-                filesystem_path_index,
-                branch_ref,
-                blob_reader,
-                self.plugin_host.clone(),
-                file_view_collector.clone(),
-                &selector,
-                column,
-            )
-            .await?;
+            let query = match exact_lix_file_read {
+                ExactLixFileRead::Point(selector, column) => {
+                    sql2::execute_exact_lix_file_read(
+                        &active_branch_id,
+                        live_state,
+                        filesystem_path_index,
+                        branch_ref,
+                        blob_reader,
+                        self.plugin_host.clone(),
+                        file_view_collector.clone(),
+                        &selector,
+                        column,
+                    )
+                    .await?
+                }
+                ExactLixFileRead::PathDataBatch(paths) => {
+                    sql2::execute_exact_lix_file_batch_read(
+                        &active_branch_id,
+                        live_state,
+                        filesystem_path_index,
+                        branch_ref,
+                        blob_reader,
+                        self.plugin_host.clone(),
+                        file_view_collector.clone(),
+                        &paths,
+                    )
+                    .await?
+                }
+            };
             let file_view_mutations = file_view_collector
                 .map(|collector| collector.plugin_file_mutations())
                 .unwrap_or_default();
@@ -1397,7 +1418,28 @@ fn simple_point_read(statement: &DataFusionStatement) -> Option<SimplePointRead<
     })
 }
 
-fn exact_lix_file_read(
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExactLixFileRead {
+    Point(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn),
+    PathDataBatch(BTreeSet<String>),
+}
+
+fn exact_lix_file_read_route(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<ExactLixFileRead> {
+    if let Some((selector, column)) = exact_lix_file_point_read(statement, params) {
+        return Some(ExactLixFileRead::Point(selector, column));
+    }
+
+    let point_read = simple_point_read(statement)?;
+    if point_read.table_name != "lix_file" || !point_read.exact_table_shape {
+        return None;
+    }
+    exact_path_data_batch(point_read.select, params).map(ExactLixFileRead::PathDataBatch)
+}
+
+fn exact_lix_file_point_read(
     statement: &DataFusionStatement,
     params: &[Value],
 ) -> Option<(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn)> {
@@ -1427,6 +1469,56 @@ fn exact_lix_file_read(
         _ => return None,
     };
     Some((selector, column))
+}
+
+/// Recognizes the exact batch download shape used by Lixray. Keeping the
+/// projection and numbered placeholders strict makes the direct result path
+/// equivalent to the DataFusion query without reimplementing general SQL.
+fn exact_path_data_batch(select: &Select, params: &[Value]) -> Option<BTreeSet<String>> {
+    let [
+        SelectItem::UnnamedExpr(path_projection),
+        SelectItem::UnnamedExpr(data_projection),
+    ] = select.projection.as_slice()
+    else {
+        return None;
+    };
+    if exact_point_column(path_projection).as_deref() != Some("path")
+        || exact_point_column(data_projection).as_deref() != Some("data")
+    {
+        return None;
+    }
+    let Expr::InList {
+        expr,
+        list,
+        negated: false,
+    } = select.selection.as_ref()?
+    else {
+        return None;
+    };
+    if exact_point_column(expr).as_deref() != Some("path")
+        || list.is_empty()
+        || list.len() != params.len()
+    {
+        return None;
+    }
+
+    let mut paths = BTreeSet::new();
+    for (index, (expression, param)) in list.iter().zip(params).enumerate() {
+        let Expr::Value(value) = expression else {
+            return None;
+        };
+        let SqlValue::Placeholder(placeholder) = &value.value else {
+            return None;
+        };
+        if placeholder != &format!("${}", index + 1) {
+            return None;
+        }
+        let Value::Text(path) = param else {
+            return None;
+        };
+        paths.insert(path.clone());
+    }
+    Some(paths)
 }
 
 fn exact_point_identity(expression: &Expr, params: &[Value]) -> Option<(String, String)> {
@@ -1779,11 +1871,11 @@ mod tests {
     }
 
     #[test]
-    fn exact_lix_file_read_recognizes_only_the_narrow_point_shapes() {
+    fn exact_lix_file_read_recognizes_only_the_narrow_shapes() {
         let data_by_id = sql2::parse_statement("SELECT data FROM lix_file WHERE id = $1").unwrap();
         assert_eq!(
-            exact_lix_file_read(&data_by_id, &[Value::Text("file-a".to_string())]),
-            Some((
+            exact_lix_file_read_route(&data_by_id, &[Value::Text("file-a".to_string())]),
+            Some(ExactLixFileRead::Point(
                 sql2::ExactLixFileReadSelector::Id("file-a".to_string()),
                 sql2::ExactLixFileReadColumn::Data,
             ))
@@ -1792,12 +1884,72 @@ mod tests {
         let change_by_path =
             sql2::parse_statement("SELECT lixcol_change_id FROM lix_file WHERE path = ?").unwrap();
         assert_eq!(
-            exact_lix_file_read(&change_by_path, &[Value::Text("/a.txt".to_string())]),
-            Some((
+            exact_lix_file_read_route(&change_by_path, &[Value::Text("/a.txt".to_string())]),
+            Some(ExactLixFileRead::Point(
                 sql2::ExactLixFileReadSelector::Path("/a.txt".to_string()),
                 sql2::ExactLixFileReadColumn::ChangeId,
             ))
         );
+
+        let data_by_paths =
+            sql2::parse_statement("SELECT path, data FROM lix_file WHERE path IN ($1, $2, $3)")
+                .unwrap();
+        assert_eq!(
+            exact_lix_file_read_route(
+                &data_by_paths,
+                &[
+                    Value::Text("/b.txt".to_string()),
+                    Value::Text("/a.txt".to_string()),
+                    Value::Text("/b.txt".to_string()),
+                ],
+            ),
+            Some(ExactLixFileRead::PathDataBatch(BTreeSet::from([
+                "/a.txt".to_string(),
+                "/b.txt".to_string(),
+            ])))
+        );
+
+        for (sql, params) in [
+            (
+                "SELECT data, path FROM lix_file WHERE path IN ($1, $2)",
+                vec![
+                    Value::Text("/a.txt".to_string()),
+                    Value::Text("/b.txt".to_string()),
+                ],
+            ),
+            (
+                "SELECT path, data FROM lix_file WHERE path IN ($2, $1)",
+                vec![
+                    Value::Text("/a.txt".to_string()),
+                    Value::Text("/b.txt".to_string()),
+                ],
+            ),
+            (
+                "SELECT path, data FROM lix_file WHERE path IN ($1, $2) ORDER BY path",
+                vec![
+                    Value::Text("/a.txt".to_string()),
+                    Value::Text("/b.txt".to_string()),
+                ],
+            ),
+            (
+                "SELECT path, data FROM lix_file WHERE path IN ($1, $2) LIMIT 1",
+                vec![
+                    Value::Text("/a.txt".to_string()),
+                    Value::Text("/b.txt".to_string()),
+                ],
+            ),
+            (
+                "SELECT path, data FROM lix_file WHERE path IN ($1, $2)",
+                vec![Value::Text("/a.txt".to_string()), Value::Null],
+            ),
+        ] {
+            let statement = sql2::parse_statement(sql).unwrap();
+            assert_eq!(
+                exact_lix_file_read_route(&statement, &params),
+                None,
+                "unexpected batch fast-path match for {sql}"
+            );
+        }
 
         for (sql, params) in [
             (
@@ -1840,7 +1992,7 @@ mod tests {
         ] {
             let statement = sql2::parse_statement(sql).unwrap();
             assert_eq!(
-                exact_lix_file_read(&statement, &params),
+                exact_lix_file_read_route(&statement, &params),
                 None,
                 "unexpected fast-path match for {sql}"
             );
@@ -1914,6 +2066,48 @@ mod tests {
 
         assert_eq!(results[0].rows()[0].get::<i64>("value").unwrap(), 11);
         assert_eq!(results[1].rows()[0].get::<i64>("value").unwrap(), 22);
+    }
+
+    #[tokio::test]
+    async fn exact_batch_file_read_returns_each_matching_file_once() {
+        let session = open_session().await;
+        session
+            .execute(
+                "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4)",
+                &[
+                    Value::Text("/b.txt".to_string()),
+                    Value::Blob(b"bravo".to_vec()),
+                    Value::Text("/a.txt".to_string()),
+                    Value::Blob(b"alpha".to_vec()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let result = session
+            .execute(
+                "SELECT path, data FROM lix_file WHERE path IN ($1, $2, $3)",
+                &[
+                    Value::Text("/b.txt".to_string()),
+                    Value::Text("/a.txt".to_string()),
+                    Value::Text("/b.txt".to_string()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.columns(), &["path", "data"]);
+        assert_eq!(result.rows().len(), 2);
+        assert_eq!(result.rows()[0].get::<String>("path").unwrap(), "/a.txt");
+        assert_eq!(
+            result.rows()[0].value("data").unwrap(),
+            &Value::Blob(b"alpha".to_vec())
+        );
+        assert_eq!(result.rows()[1].get::<String>("path").unwrap(), "/b.txt");
+        assert_eq!(
+            result.rows()[1].value("data").unwrap(),
+            &Value::Blob(b"bravo".to_vec())
+        );
     }
 
     #[test]

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -61,6 +61,7 @@ pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::SqlPlanningCache;
 pub(crate) use providers::{
-    ExactLixFileReadColumn, ExactLixFileReadSelector, execute_exact_lix_file_read,
+    ExactLixFileReadColumn, ExactLixFileReadSelector, execute_exact_lix_file_batch_read,
+    execute_exact_lix_file_read,
 };
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -67,7 +67,8 @@ use crate::sql2::{SessionFileViewKey, SessionFileViews, SessionPluginFileView};
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 use crate::wasm::WasmComponentInstance;
 use crate::{
-    GLOBAL_BRANCH_ID, LixError, SqlQueryResult, parse_row_metadata_value, serialize_row_metadata,
+    GLOBAL_BRANCH_ID, LixError, SqlQueryResult, Value, parse_row_metadata_value,
+    serialize_row_metadata,
 };
 
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
@@ -573,6 +574,67 @@ pub(crate) async fn execute_exact_lix_file_read(
             .collect::<Vec<_>>(),
         &[batch],
     )
+}
+
+/// Executes Lixray's exact active-branch file batch without constructing a
+/// DataFusion catalog, plan, or Arrow result batch. Keep this separate from
+/// the established point-read path so unrelated file queries remain
+/// byte-for-byte on their existing implementation.
+pub(crate) async fn execute_exact_lix_file_batch_read(
+    active_branch_id: &str,
+    live_state: Arc<dyn LiveStateReader>,
+    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
+    branch_ref: Arc<dyn BranchRefReader>,
+    blob_reader: Arc<dyn BlobDataReader>,
+    plugin_host: PluginRuntimeHost,
+    session_file_views: Option<SessionFileViews>,
+    paths: &BTreeSet<String>,
+) -> Result<SqlQueryResult, LixError> {
+    let base_schema = lix_file_schema();
+    let schema = Arc::new(Schema::new(vec![
+        base_schema
+            .field_with_name("path")
+            .expect("lix_file schema should have path")
+            .clone(),
+        base_schema
+            .field_with_name("data")
+            .expect("lix_file schema should have data")
+            .clone(),
+    ]));
+    let mut request = lix_file_scan_request(Some(active_branch_id), Some(schema.as_ref()), None);
+    let branch_binding = BranchBinding::active(active_branch_id);
+    request.filter.branch_ids = resolve_provider_branch_ids(
+        branch_ref.as_ref(),
+        &branch_binding,
+        request.filter.branch_ids,
+    )
+    .await?;
+
+    let index = filesystem_path_index
+        .path_index(&FilesystemPathIndexRequest::new(
+            request.filter.branch_ids.clone(),
+        ))
+        .await?;
+    let matches = indexed_file_matches(index, &FilePathPredicate::In(paths.clone()));
+    let rows = scan_indexed_file_rows(Arc::clone(&live_state), &request, &matches, true).await?;
+    let prepared = prepare_indexed_lix_file_rows(&matches, rows)?;
+    let plugin_render = if prepared.needs_plugin_render(true) {
+        plugin_render_context_for_lix_file_scan(live_state, &request, plugin_host, &prepared, false)
+            .await?
+            .map(|context| context.with_session_file_views(session_file_views))
+    } else {
+        None
+    };
+
+    // No relational operators remain after exact path selection. Move owned
+    // blobs into the result instead of packing them into Arrow only for
+    // DataFusion to copy them back into row values.
+    let rows = exact_path_data_rows_from_prepared(&blob_reader, plugin_render, prepared).await?;
+    Ok(SqlQueryResult {
+        columns: vec!["path".to_string(), "data".to_string()],
+        rows,
+        notices: Vec::new(),
+    })
 }
 
 fn lix_file_dml_source_state(
@@ -3855,6 +3917,56 @@ async fn lix_file_record_batch_from_prepared(
     }
 
     columns.into_record_batch(schema)
+}
+
+async fn exact_path_data_rows_from_prepared(
+    blob_reader: &Arc<dyn BlobDataReader>,
+    plugin_render: Option<PluginRenderContext>,
+    prepared: PreparedLixFileRows,
+) -> Result<Vec<Vec<Value>>, LixError> {
+    let PreparedLixFileRows {
+        mut file_rows,
+        blob_rows,
+        mut file_paths,
+        path_ordered_file_keys,
+    } = prepared;
+    let mut blob_bytes = load_blob_bytes_for_files(blob_reader, &file_rows, &blob_rows).await?;
+    let file_keys =
+        path_ordered_file_keys.unwrap_or_else(|| file_rows.keys().cloned().collect::<Vec<_>>());
+    let mut rows = Vec::with_capacity(file_keys.len());
+    let mut rendered_plugin_bytes = match &plugin_render {
+        Some(plugin_render) => {
+            render_plugin_files_for_sql(
+                plugin_render,
+                blob_reader,
+                &file_keys,
+                &file_rows,
+                &blob_rows,
+                &file_paths,
+            )
+            .await?
+        }
+        None => BTreeMap::new(),
+    };
+    for key in file_keys {
+        let file = file_rows
+            .remove(&key)
+            .expect("prepared lix_file order should reference a descriptor");
+        let path = file_paths
+            .remove(&key)
+            .expect("prepared lix_file descriptor should have a path");
+        let blob_key = file.blob_ref_key();
+        let data = match blob_bytes.take(&blob_key) {
+            Some(data) => data,
+            None => Some(rendered_plugin_bytes.remove(&key).unwrap_or_default()),
+        };
+        rows.push(vec![
+            Value::Text(path),
+            data.map_or(Value::Null, Value::Blob),
+        ]);
+    }
+
+    Ok(rows)
 }
 
 #[derive(Default)]

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -33,8 +33,8 @@ use datafusion::catalog::TableProvider;
 
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
-    execute_exact_lix_file_read, execute_fast_lix_file_data_update_by_id,
-    execute_fast_lix_file_path_writes,
+    execute_exact_lix_file_batch_read, execute_exact_lix_file_read,
+    execute_fast_lix_file_data_update_by_id, execute_fast_lix_file_path_writes,
 };
 pub(crate) use spec::DmlReturning;
 pub(crate) use upsert::{UpsertAction, excluded_field_name};

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -1317,6 +1317,56 @@ async fn atelier_markdown_point_read_acknowledges_only_delivered_plugin_state() 
 }
 
 #[tokio::test]
+async fn lixray_batch_read_acknowledges_only_delivered_plugin_state() {
+    let (_engine, session_a, session_b) = keyed_collaboration_sessions().await;
+    write_file(&session_a, "/shared.keyed", b"root=0\nseen=S\n".to_vec())
+        .await
+        .expect("seed file should write");
+
+    let delivered = session_b
+        .execute(
+            "SELECT path, data FROM lix_file WHERE path IN ($1, $2)",
+            &[
+                Value::Text("/missing.keyed".to_string()),
+                Value::Text("/shared.keyed".to_string()),
+            ],
+        )
+        .await
+        .expect("Lixray-shaped batch read should execute");
+    assert_eq!(delivered.len(), 1);
+    assert_eq!(
+        delivered.rows()[0].values(),
+        &[
+            Value::Text("/shared.keyed".to_string()),
+            Value::Blob(b"root=0\nseen=S\n".to_vec()),
+        ]
+    );
+
+    write_file(
+        &session_a,
+        "/shared.keyed",
+        b"remote=R\nroot=0\nseen=S\n".to_vec(),
+    )
+    .await
+    .expect("remote entity should write");
+    write_file(&session_b, "/shared.keyed", b"root=B\n".to_vec())
+        .await
+        .expect("stale Lixray edit should write");
+
+    assert_eq!(
+        read_file(&session_a, "/shared.keyed").await.unwrap(),
+        Some(b"remote=R\nroot=B\n".to_vec())
+    );
+    assert_eq!(
+        keyed_entity_values(&session_a, "/shared.keyed").await,
+        BTreeMap::from([
+            ("remote".to_string(), "R".to_string()),
+            ("root".to_string(), "B".to_string()),
+        ])
+    );
+}
+
+#[tokio::test]
 async fn observe_point_read_acknowledges_delivered_plugin_state_per_session() {
     let (_engine, session_a, session_b) = keyed_collaboration_sessions().await;
     write_file(&session_a, "/shared.keyed", b"a=0\nb=0\n".to_vec())


### PR DESCRIPTION
## What changed

- Recognize only the exact Lixray batch shape `SELECT path, data FROM lix_file WHERE path IN ($1, ...)`.
- Reuse the existing active-branch path index, visibility rules, plugin renderer, and CAS loader, then move owned paths/blobs directly into `SqlQueryResult`.
- Avoid the DataFusion plan plus Arrow pack/unpack round trip for this shape.
- Acknowledge the exact plugin-backed bytes delivered by the batch so later whole-file writes retain the correct per-session merge base.
- Keep the established point-read implementation source-identical; every other SQL shape falls through to the general engine.

## Why

Lixray batches up to 50 file downloads with this exact query. Profiling showed that materializing already-selected owned blobs into Arrow and immediately copying them back into row values was a large, avoidable share of read latency. The strict recognizer keeps the optimization local instead of reimplementing general SQL semantics.

## Benchmarks

Release binaries were built from the exact `e1a57ec3` parent in the same disposable worktree and Cargo target, then copied before/after the candidate. Results are midpoint p50s from a B/C/C/B run with 30 samples per batch fixture.

| Backend | File size × 8 | Main p50 | Candidate p50 | Change |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 1 MiB × 8 | 26.72 ms | 11.01 ms | **-58.8%** |
| RocksDB | 4 MiB × 8 | 143.36 ms | 108.05 ms | **-24.6%** |
| RocksDB | 10 MiB × 8 | 341.24 ms | 229.33 ms | **-32.8%** |
| SlateDB | 1 MiB × 8 | 3.17 ms | 1.28 ms | **-59.5%** |
| SlateDB | 4 MiB × 8 | 28.96 ms | 3.43 ms | **-88.2%** |
| SlateDB | 10 MiB × 8 | 72.15 ms | 16.30 ms | **-77.4%** |

The existing single-file point-read control used 100 samples per fixture in B/C/C/B order. Its six midpoint changes ranged from -14% to +5.2%; no control regressed by 10%. A 50-sample localized-write control also had no regression over 10%.

## Validation

- `cargo test -p lix_engine --lib` (1,141 passed, 6 ignored)
- `cargo test -p lix_engine --test fs_api` (57 passed)
- `cargo clippy -p lix_engine --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- Added strict recognizer/fallback coverage, duplicate/missing path result coverage, and a two-session plugin merge-base integration test using the real Lixray batch query.
