### PR TITLE
Remove dead code and compatibility layers

### DIFF
--- a/.changenotes/remove-unreleased-compatibility-layers.md
+++ b/.changenotes/remove-unreleased-compatibility-layers.md
@@ -1,0 +1,9 @@
+---
+type: minor
+---
+
+Removed unreleased storage compatibility APIs and format fallbacks.
+
+SlateDB callers must use `SlateDB::open()` or
+`SlateDB::open_object_store_with_options()`. Legacy namespaced CLI snapshots,
+and change records without origin keys are no longer accepted.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -603,7 +603,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -972,7 +972,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1942,7 +1942,7 @@ checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2457,7 +2457,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2975,19 +2975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iref"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c686ecc4b688a6beb639434f8c10900ebb00ae73b9e981db430eb8416cc17ca"
-dependencies = [
- "pct-str",
- "smallvec",
- "static-automata",
- "str-newtype",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,7 +3063,7 @@ checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3307,13 +3294,11 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 name = "lix_cli"
 version = "0.8.4"
 dependencies = [
- "async-trait",
  "base64 0.22.1",
  "bytes",
  "clap",
  "comfy-table",
  "lix_sdk",
- "pollster",
  "serde",
  "serde_json",
  "sha2",
@@ -3336,7 +3321,6 @@ dependencies = [
  "fastcdc",
  "futures-util",
  "globset",
- "iref",
  "jiff",
  "jsonschema",
  "lix_rocksdb_storage",
@@ -3347,7 +3331,6 @@ dependencies = [
  "musli",
  "object_store 0.14.0",
  "paste",
- "precis-profiles",
  "rusqlite",
  "rustc-hash",
  "ruzstd",
@@ -3356,7 +3339,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "unicode-normalization",
  "uuid",
  "web-time",
  "xxhash-rust",
@@ -3554,7 +3536,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3700,7 +3682,7 @@ checksum = "ff6dea70dccfc68fd441c128bdaf31c454542676f750f095465640367fd94118"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3737,7 +3719,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3750,7 +3732,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4067,7 +4049,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4106,15 +4088,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pct-str"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756dc82399e1ef9b37bd698266e4b7fed5f3d3cccb09fbc6b602086c9077e4ad"
-dependencies = [
- "utf8-decode",
-]
-
-[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,7 +4107,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4262,12 +4235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4319,71 +4286,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "precis-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2e7b31f132e0c6f8682cfb7bf4a5340dbe925b7986618d0826a56dfe0c8e56"
-dependencies = [
- "precis-tools",
- "ucd-parse",
- "unicode-normalization",
-]
-
-[[package]]
-name = "precis-profiles"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e2768890a47af73a032af9f0cedbddce3c9d06cf8de201d5b8f2436ded7674"
-dependencies = [
- "lazy_static",
- "precis-core",
- "precis-tools",
- "unicode-normalization",
-]
-
-[[package]]
-name = "precis-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc1eb2d5887ac7bfd2c0b745764db89edb84b856e4214e204ef48ef96d10c4a"
-dependencies = [
- "lazy_static",
- "regex",
- "ucd-parse",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "syn",
 ]
 
 [[package]]
@@ -4403,7 +4312,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -4428,7 +4337,7 @@ checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4572,12 +4481,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -4760,7 +4663,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4996,7 +4899,7 @@ checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5004,28 +4907,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static-automata"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24aafe52c9851a4ac4a9746224300d2e0c2a26d2da510ce36bd4fbe5aed56579"
-dependencies = [
- "static-automata-macros",
-]
-
-[[package]]
-name = "static-automata-macros"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36fcb2913af3b8d092099595dbb13c750474f486acc83c9cf058971ceae3c74"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "static_assertions"
@@ -5044,42 +4925,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "str-newtype"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae04885ca2475d7ab569df6dfd14238c2ec736464866ec45da54009a8cd7ec8"
-dependencies = [
- "str-newtype-derive",
-]
-
-[[package]]
-name = "str-newtype-derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0d70ab7f0bc2dcd347d558a4305d979d407d1941e536e986e05d55c661e751"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -5106,7 +4955,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5197,7 +5046,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5208,7 +5057,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5280,21 +5129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5318,7 +5152,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5457,7 +5291,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5524,15 +5358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "ucd-parse"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06ff81122fcbf4df4c1660b15f7e3336058e7aec14437c9f85c6b31a0f279b9"
-dependencies = [
- "regex-lite",
-]
-
-[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5563,15 +5388,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -5608,12 +5424,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf8-decode"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7932c10aa1600e9ddee027024aa9c0d397a103478253bf3fd6cea6dd03161b8a"
 
 [[package]]
 name = "utf8_iter"
@@ -5734,7 +5544,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5931,7 +5741,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
  "wit-parser 0.248.0",
@@ -6039,7 +5849,7 @@ checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6251,7 +6061,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6262,7 +6072,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6567,7 +6377,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata 0.244.0",
  "wit-bindgen-core 0.51.0",
  "wit-component 0.244.0",
@@ -6583,7 +6393,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata 0.247.0",
  "wit-bindgen-core 0.57.1",
  "wit-component 0.247.0",
@@ -6599,7 +6409,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core 0.51.0",
  "wit-bindgen-rust 0.51.0",
 ]
@@ -6615,7 +6425,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core 0.57.1",
  "wit-bindgen-rust 0.57.1",
 ]
@@ -6751,7 +6561,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6772,7 +6582,7 @@ checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6792,7 +6602,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6826,7 +6636,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -23,11 +23,9 @@ path = "src/main.rs"
 [dependencies]
 lix_sdk = { workspace = true }
 
-async-trait = "0.1"
 clap = { version = "4.5.31", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-pollster = "0.4"
 comfy-table = "7.1"
 base64 = "0.22"
 bytes = "1"

--- a/packages/cli/src/db/mod.rs
+++ b/packages/cli/src/db/mod.rs
@@ -475,13 +475,14 @@ impl Drop for FileStorageWrite {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FileSnapshot {
     entries: Vec<FileEntry>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FileEntry {
-    namespace: String,
     key: String,
     value: String,
 }
@@ -498,13 +499,6 @@ fn read_kv_file(path: &Path) -> Result<KvMap, CliError> {
         .map_err(|error| CliError::msg(format!("failed to decode lix file: {error}")))?;
     let mut kv = KvMap::new();
     for entry in snapshot.entries {
-        if !entry.namespace.is_empty() {
-            return Err(CliError::msg(format!(
-                "unsupported legacy lix namespace '{}' in {}",
-                entry.namespace,
-                path.display()
-            )));
-        }
         kv.insert(decode_bytes(&entry.key)?, decode_bytes(&entry.value)?);
     }
     Ok(kv)
@@ -515,7 +509,6 @@ fn write_kv_file(path: &Path, kv: &KvMap) -> Result<(), LixError> {
         entries: kv
             .iter()
             .map(|(key, value)| FileEntry {
-                namespace: String::new(),
                 key: encode_bytes(key),
                 value: encode_bytes(value),
             })
@@ -586,7 +579,7 @@ fn lix_to_storage_error(error: LixError) -> StorageError {
 
 #[cfg(test)]
 mod tests {
-    use super::{init_lix_at, prepare_lix_output_path, resolve_db_path};
+    use super::{init_lix_at, prepare_lix_output_path, read_kv_file, resolve_db_path};
     use crate::app::AppContext;
     use std::fs;
     use std::path::PathBuf;
@@ -644,6 +637,23 @@ mod tests {
             !temp_dir.exists(),
             "validator should reject before creating parent directories"
         );
+    }
+
+    #[test]
+    fn file_storage_rejects_removed_namespace_field() {
+        let temp_dir = unique_temp_dir();
+        fs::create_dir_all(&temp_dir).expect("temp dir should be created");
+        let path = temp_dir.join("legacy.lix");
+        fs::write(
+            &path,
+            r#"{"entries":[{"namespace":"legacy","key":"a2V5","value":"dmFsdWU="}]}"#,
+        )
+        .expect("legacy snapshot should be written");
+
+        let error = read_kv_file(&path).expect_err("removed namespace field should be rejected");
+        assert!(error.to_string().contains("unknown field `namespace`"));
+
+        fs::remove_dir_all(&temp_dir).expect("temp dir should be removable");
     }
 
     fn unique_temp_dir() -> PathBuf {

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -92,8 +92,6 @@ jiff = { version = "0.2.27", default-features = false, features = ["std"] }
 lru = "0.18"
 memchr = "2"
 uuid = { version = "1", features = ["v7", "std", "js", "fast-rng"] }
-unicode-normalization = "0.1"
-precis-profiles = "0.1.13"
 web-time = "1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 tokio = { version = "1", features = ["rt"] }
@@ -107,7 +105,6 @@ zip = { version = "8", default-features = false, features = ["deflate-flate2-zli
 
 [dev-dependencies]
 criterion = { package = "codspeed-criterion-compat", version = "*" }
-iref = "4.0.0"
 lix_rocksdb_storage = { workspace = true }
 lix_slatedb_storage = { workspace = true }
 lix_sqlite_storage = { workspace = true }

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -304,8 +304,12 @@ impl SingletonWriteFixture {
             Arc::new(InMemory::new()),
             Duration::ZERO,
         ));
-        let storage = SlateDB::open_object_store(db_path, object_store_handle(&object_store))
-            .expect("open SlateDB singleton accounting storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            object_store_handle(&object_store),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open SlateDB singleton accounting storage");
         let rows = (0..SINGLETON_ACCOUNTING_ROWS)
             .map(|index| {
                 let path = format!("/singleton/{index:04}");
@@ -535,9 +539,10 @@ fn storage_direct_benches(c: &mut Criterion, runtime: &tokio::runtime::Runtime) 
     group.bench_function("accept_put_u1_v4096", |b| {
         b.iter_custom(|iterations| {
             let db_id = NEXT_DB_ID.fetch_add(1, Ordering::Relaxed);
-            let storage = SlateDB::open_object_store(
+            let storage = SlateDB::open_object_store_with_options(
                 format!("slatedb-direct-bench-{}-{db_id}", std::process::id()),
                 Arc::new(InMemory::new()),
+                SlateDBObjectStoreOptions::default(),
             )
             .expect("open direct SlateDB benchmark storage");
             let key = Key(Bytes::from_static(b"direct-key"));
@@ -615,8 +620,12 @@ impl SeededStore {
         let db_id = NEXT_DB_ID.fetch_add(1, Ordering::Relaxed);
         let db_path = format!("slatedb-file-api-bench-{}-{db_id}", std::process::id());
         let seed_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let storage = SlateDB::open_object_store(db_path.clone(), Arc::clone(&seed_object_store))
-            .expect("open SlateDB seed storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path.clone(),
+            Arc::clone(&seed_object_store),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open SlateDB seed storage");
         let init_receipt = Engine::initialize(storage.clone())
             .await
             .expect("initialize SlateDB file benchmark engine");
@@ -1065,9 +1074,10 @@ impl CachedRequestBenchFixture {
 impl FreshEngineSelectBenchFixture {
     async fn seeded(delay: Duration) -> Self {
         let seeded = SeededStore::create().await;
-        let storage = SlateDB::open_object_store(
+        let storage = SlateDB::open_object_store_with_options(
             seeded.db_path.clone(),
             object_store_handle(&seeded.object_store),
+            SlateDBObjectStoreOptions::default(),
         )
         .expect("reopen uncached SlateDB file benchmark storage");
         seeded.object_store.set_delay(delay);
@@ -1151,9 +1161,12 @@ impl StorageConcurrencyFixture {
             .collect::<Vec<_>>();
 
         {
-            let storage =
-                SlateDB::open_object_store(db_path.clone(), Arc::clone(&seed_object_store))
-                    .expect("open SlateDB concurrency seed storage");
+            let storage = SlateDB::open_object_store_with_options(
+                db_path.clone(),
+                Arc::clone(&seed_object_store),
+                SlateDBObjectStoreOptions::default(),
+            )
+            .expect("open SlateDB concurrency seed storage");
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -1189,8 +1202,12 @@ impl StorageConcurrencyFixture {
         }
 
         let object_store = Arc::new(DelayedObjectStore::new(seed_object_store, Duration::ZERO));
-        let storage = SlateDB::open_object_store(db_path, object_store_handle(&object_store))
-            .expect("reopen SlateDB concurrency benchmark storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            object_store_handle(&object_store),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("reopen SlateDB concurrency benchmark storage");
         let readers = StorageReadWorkers::new(&storage, &keys);
         object_store.set_delay(delay);
 

--- a/packages/engine/src/binary_cas/context.rs
+++ b/packages/engine/src/binary_cas/context.rs
@@ -14,8 +14,8 @@ pub(crate) trait BlobDataReader: Send + Sync {
 /// Long-lived Binary CAS context factory.
 ///
 /// The context does not own storage. Callers explicitly provide a KV store via
-/// `reader(...)` or `writer(...)`, keeping storage and transaction ownership at
-/// the execution layer.
+/// `reader(...)` or `writer_skipping_existing_chunks(...)`, keeping storage and
+/// transaction ownership at the execution layer.
 pub(crate) struct BinaryCasContext {
     chunking: BinaryCasChunking,
 }
@@ -37,11 +37,6 @@ impl BinaryCasContext {
         S: StorageAdapterRead,
     {
         BinaryCasStoreReader { store }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn writer<'a>(&self, writes: &'a mut StorageWriteSet) -> BinaryCasWriter<'a> {
-        BinaryCasWriter::new(writes, self.chunking)
     }
 
     pub(crate) fn writer_skipping_existing_chunks<'a, S>(
@@ -87,18 +82,6 @@ where
     }
 }
 
-/// Transaction-scoped Binary CAS writer.
-///
-/// This type does not begin, commit, or roll back transactions. It only writes
-/// CAS data into the transaction supplied by the caller.
-#[allow(dead_code)]
-pub(crate) struct BinaryCasWriter<'a> {
-    writes: &'a mut StorageWriteSet,
-    chunking: BinaryCasChunking,
-    blob_hashes: HashSet<[u8; 32]>,
-    chunk_keys: HashSet<Vec<u8>>,
-}
-
 /// Binary CAS writer that avoids re-putting chunk payload rows already present
 /// in the backing store.
 pub(crate) struct ExistingChunkAwareBinaryCasWriter<'a, S>
@@ -110,44 +93,6 @@ where
     chunking: BinaryCasChunking,
     blob_hashes: HashSet<[u8; 32]>,
     chunk_keys: HashSet<Vec<u8>>,
-}
-
-#[allow(dead_code)]
-impl<'a> BinaryCasWriter<'a> {
-    fn new(writes: &'a mut StorageWriteSet, chunking: BinaryCasChunking) -> Self {
-        Self {
-            writes,
-            chunking,
-            blob_hashes: HashSet::new(),
-            chunk_keys: HashSet::new(),
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn stage_bytes(&mut self, bytes: &[u8]) -> Result<BlobWriteReceipt, LixError> {
-        crate::binary_cas::kv::stage_blob_write(
-            self.chunking,
-            self.writes,
-            &mut self.blob_hashes,
-            &mut self.chunk_keys,
-            bytes,
-            None,
-        )
-    }
-
-    pub(crate) fn stage_payload(
-        &mut self,
-        payload: &BlobPayload,
-    ) -> Result<BlobWriteReceipt, LixError> {
-        crate::binary_cas::kv::stage_blob_write(
-            self.chunking,
-            self.writes,
-            &mut self.blob_hashes,
-            &mut self.chunk_keys,
-            payload.bytes(),
-            payload.hash(),
-        )
-    }
 }
 
 impl<'a, S> ExistingChunkAwareBinaryCasWriter<'a, S>

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -541,25 +541,6 @@ fn decode_and_verify_chunk(
     Ok(chunk_payload)
 }
 
-#[allow(dead_code)]
-pub(in crate::binary_cas) fn stage_blob_write(
-    chunking: BinaryCasChunking,
-    writes: &mut StorageWriteSet,
-    blob_hashes: &mut HashSet<[u8; 32]>,
-    chunk_keys: &mut HashSet<Vec<u8>>,
-    bytes: &[u8],
-    precomputed_hash: Option<BlobHash>,
-) -> Result<BlobWriteReceipt, LixError> {
-    stage_blob_write_with_chunk_filter(
-        chunking,
-        writes,
-        blob_hashes,
-        bytes,
-        precomputed_hash,
-        |chunk_hash| Ok(chunk_keys.insert(chunk_key(chunk_hash))),
-    )
-}
-
 pub(in crate::binary_cas) async fn stage_blob_write_skipping_existing_chunks<S>(
     chunking: BinaryCasChunking,
     store: &S,
@@ -581,26 +562,6 @@ where
     let mut chunk_hashes_to_stage = missing_chunk_hashes(store, chunk_keys, bytes, &plan).await?;
     stage_prepared_blob_write(writes, bytes, &plan, |chunk_hash| {
         Ok(chunk_hashes_to_stage.remove(&chunk_hash))
-    })?;
-    Ok(receipt)
-}
-
-fn stage_blob_write_with_chunk_filter(
-    chunking: BinaryCasChunking,
-    writes: &mut StorageWriteSet,
-    blob_hashes: &mut HashSet<[u8; 32]>,
-    bytes: &[u8],
-    precomputed_hash: Option<BlobHash>,
-    mut should_stage_chunk: impl FnMut(BlobHash) -> Result<bool, LixError>,
-) -> Result<BlobWriteReceipt, LixError> {
-    let plan = prepare_blob_write(chunking, bytes, precomputed_hash)?;
-    let receipt = plan.receipt.clone();
-    if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
-        return Ok(receipt);
-    }
-
-    stage_prepared_blob_write(writes, bytes, &plan, |chunk_hash| {
-        should_stage_chunk(chunk_hash)
     })?;
     Ok(receipt)
 }
@@ -876,6 +837,30 @@ mod tests {
         Memory, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
     };
 
+    async fn stage_test_payload(
+        storage: &StorageAdapter<Memory>,
+        writes: &mut StorageWriteSet,
+        payload: &BlobPayload,
+    ) -> BlobWriteReceipt {
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("test blob read should open");
+        BinaryCasContext::new()
+            .writer_skipping_existing_chunks(&store, writes)
+            .stage_payload(payload)
+            .await
+            .expect("test blob write should stage")
+    }
+
+    async fn stage_test_bytes(
+        storage: &StorageAdapter<Memory>,
+        writes: &mut StorageWriteSet,
+        bytes: &[u8],
+    ) -> BlobWriteReceipt {
+        stage_test_payload(storage, writes, &BlobPayload::from_bytes(bytes.to_vec())).await
+    }
+
     #[tokio::test]
     async fn stores_manifest_chunks_in_scan_order() {
         let storage = StorageAdapter::new(Memory::new());
@@ -1012,8 +997,7 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            let mut writer = BinaryCasContext::new().writer(&mut writes);
-            writer.stage_bytes(data).expect("blob write should stage");
+            stage_test_bytes(&storage, &mut writes, data).await;
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -1065,10 +1049,7 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            let mut writer = BinaryCasContext::new().writer(&mut writes);
-            writer
-                .stage_payload(&payload)
-                .expect("initial blob write should stage");
+            stage_test_payload(&storage, &mut writes, &payload).await;
             assert_eq!(writes.stats().staged_puts, 3);
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
@@ -1136,10 +1117,7 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            let mut writer = BinaryCasContext::new().writer(&mut writes);
-            writer
-                .stage_payload(&payload)
-                .expect("initial blob write should stage");
+            stage_test_payload(&storage, &mut writes, &payload).await;
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -1232,10 +1210,7 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            let mut writer = BinaryCasContext::new().writer(&mut writes);
-            writer
-                .stage_payload(&payload)
-                .expect("blob write should stage with payload hash");
+            stage_test_payload(&storage, &mut writes, &payload).await;
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -1273,8 +1248,7 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            let mut writer = BinaryCasContext::new().writer(&mut writes);
-            writer.stage_bytes(data).expect("blob write should stage");
+            stage_test_bytes(&storage, &mut writes, data).await;
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -1375,8 +1349,7 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            let mut writer = BinaryCasContext::new().writer(&mut writes);
-            writer.stage_bytes(data).expect("blob write should stage");
+            stage_test_bytes(&storage, &mut writes, data).await;
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -1414,8 +1387,7 @@ mod tests {
 
         {
             let mut writes = storage.new_write_set();
-            let mut writer = BinaryCasContext::new().writer(&mut writes);
-            writer.stage_bytes(&data).expect("blob write should stage");
+            stage_test_bytes(&storage, &mut writes, &data).await;
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -1,7 +1,6 @@
 use super::types::{
-    ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, ChangeRecordViewV1,
-    CommitChangeRefChunk, CommitChangeRefChunkWire, CommitChangeRefChunkWireRef, CommitId,
-    CommitRecord,
+    ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRefChunk,
+    CommitChangeRefChunkWire, CommitChangeRefChunkWireRef, CommitId, CommitRecord,
 };
 use crate::common::LixError;
 use crate::entity_pk::EntityPk;
@@ -32,24 +31,7 @@ pub(crate) fn decode_change_record(
     bytes: &[u8],
     change_id: ChangeId,
 ) -> Result<ChangeRecord, LixError> {
-    let view: ChangeRecordView<'_> = match storage_codec::decode("change record", bytes) {
-        Ok(view) => view,
-        Err(new_format_error) => {
-            let legacy: ChangeRecordViewV1<'_> =
-                storage_codec::decode("change record", bytes).map_err(|_| new_format_error)?;
-            return Ok(ChangeRecord {
-                format_version: legacy.format_version,
-                change_id,
-                schema_key: legacy.schema_key.to_string(),
-                entity_pk: entity_pk_from_parts(legacy.entity_pk)?,
-                file_id: legacy.file_id,
-                snapshot: legacy.snapshot,
-                metadata: legacy.metadata,
-                created_at: legacy.created_at,
-                origin_key: None,
-            });
-        }
-    };
+    let view: ChangeRecordView<'_> = storage_codec::decode("change record", bytes)?;
     Ok(ChangeRecord {
         format_version: view.format_version,
         change_id,

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -430,22 +430,6 @@ pub(crate) struct ChangeRecordView<'a> {
     pub(crate) origin_key: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, musli::Decode)]
-#[musli(packed)]
-pub(crate) struct ChangeRecordViewV1<'a> {
-    pub(crate) format_version: u32,
-    pub(crate) schema_key: &'a str,
-    #[musli(with = crate::storage_codec::id_string_seq)]
-    pub(crate) entity_pk: Vec<String>,
-    #[musli(with = crate::storage_codec::option_id_string)]
-    pub(crate) file_id: Option<String>,
-    #[musli(with = crate::json_store::json_slot_storage)]
-    pub(crate) snapshot: JsonSlot,
-    #[musli(with = crate::json_store::json_slot_storage)]
-    pub(crate) metadata: JsonSlot,
-    pub(crate) created_at: LixTimestamp,
-}
-
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ChangeLoadRequest<'a> {
     pub(crate) change_ids: &'a [ChangeId],

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -32,7 +32,6 @@ pub(crate) mod json_store;
 pub(crate) mod live_state;
 pub(crate) mod observe_coordinator;
 pub(crate) mod observe_invalidation;
-#[allow(dead_code, unused_imports)]
 pub(crate) mod plugin;
 mod schema;
 pub mod session;

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -18,14 +18,12 @@ pub(crate) use reader::LiveStateReader;
 pub(crate) use reader::load_exact_rows_via_scan_for_test;
 #[allow(unused_imports)]
 pub(crate) use types::{
-    Bound, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFileScanRequest,
-    LiveStateFilter, LiveStateProjection, LiveStateRowFilter, LiveStateRowIdentity,
-    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow, ScanConstraint, ScanField,
-    ScanOperator,
+    Bound, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter,
+    LiveStateProjection, LiveStateRowFilter, LiveStateRowIdentity, LiveStateRowRequest,
+    LiveStateScanRequest, MaterializedLiveStateRow, ScanConstraint, ScanField, ScanOperator,
 };
 #[allow(unused_imports)]
 pub(crate) use visibility::{
     StagedLiveStateRows, VisibilityBranchScope, VisibilityRequest, expanded_branch_ids,
-    overlay_load_exact_rows, overlay_scan_file_rows, overlay_scan_rows, overlay_scan_tracked_rows,
-    resolve_visible_rows,
+    overlay_load_exact_rows, overlay_scan_rows, overlay_scan_tracked_rows, resolve_visible_rows,
 };

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -2,9 +2,7 @@ use async_trait::async_trait;
 
 use crate::LixError;
 use crate::live_state::MaterializedLiveStateRow;
-use crate::live_state::{
-    LiveStateExactBatchRequest, LiveStateFileScanRequest, LiveStateRowRequest, LiveStateScanRequest,
-};
+use crate::live_state::{LiveStateExactBatchRequest, LiveStateRowRequest, LiveStateScanRequest};
 
 /// Minimal engine read model for transaction planning and SQL providers.
 ///
@@ -32,14 +30,6 @@ pub(crate) trait LiveStateReader: Send + Sync {
         let mut request = request.clone();
         request.filter.untracked = Some(false);
         self.scan_rows(&request).await
-    }
-
-    #[cfg_attr(not(test), allow(dead_code))]
-    async fn scan_file_rows(
-        &self,
-        request: &LiveStateFileScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        self.scan_rows(&request.to_scan_request()).await
     }
 
     async fn load_row(

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -162,48 +162,6 @@ pub(crate) struct LiveStateScanRequest {
     pub(crate) limit: Option<usize>,
 }
 
-/// File-scoped scan request for visible live-state rows.
-///
-/// This is the named form of the common query shape "rows for this branch,
-/// concrete file id, and schema set". It deliberately lowers to
-/// `LiveStateScanRequest` so optimized implementations can preserve the exact
-/// generic scan semantics while specializing the storage path.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) struct LiveStateFileScanRequest {
-    #[serde(default)]
-    pub(crate) branch_ids: Vec<String>,
-    pub(crate) file_id: String,
-    #[serde(default)]
-    pub(crate) schema_keys: Vec<String>,
-    #[serde(default)]
-    pub(crate) untracked: Option<bool>,
-    #[serde(default)]
-    pub(crate) include_tombstones: bool,
-    #[serde(default)]
-    pub(crate) projection: LiveStateProjection,
-    #[serde(default)]
-    pub(crate) limit: Option<usize>,
-}
-
-impl LiveStateFileScanRequest {
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn to_scan_request(&self) -> LiveStateScanRequest {
-        LiveStateScanRequest {
-            filter: LiveStateFilter {
-                schema_keys: self.schema_keys.clone(),
-                branch_ids: self.branch_ids.clone(),
-                file_ids: vec![NullableKeyFilter::Value(self.file_id.clone())],
-                untracked: self.untracked,
-                include_tombstones: self.include_tombstones,
-                ..LiveStateFilter::default()
-            },
-            projection: self.projection.clone(),
-            limit: self.limit,
-        }
-    }
-}
-
 /// Point lookup request for one visible live-state row.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct LiveStateRowRequest {

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::live_state::{
-    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFileScanRequest,
-    LiveStateReader, LiveStateRowIdentity, LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateReader, LiveStateRowIdentity,
+    LiveStateScanRequest, MaterializedLiveStateRow,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -25,14 +25,6 @@ pub(crate) trait StagedLiveStateRows {
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
-
-    #[cfg_attr(not(test), allow(dead_code))]
-    fn staged_file_rows(
-        &self,
-        request: &LiveStateFileScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        self.staged_rows(&request.to_scan_request())
-    }
 
     /// Loads exact staged storage identities in request order.
     ///
@@ -153,34 +145,6 @@ where
                 branch_ids: request.filter.branch_ids.clone(),
             },
             include_tombstones: request.filter.include_tombstones,
-            limit: request.limit,
-        },
-    ))
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) async fn overlay_scan_file_rows<S>(
-    base: &dyn LiveStateReader,
-    staged: &S,
-    request: &LiveStateFileScanRequest,
-) -> Result<Vec<MaterializedLiveStateRow>, LixError>
-where
-    S: StagedLiveStateRows + ?Sized,
-{
-    let mut candidate_request = request.clone();
-    candidate_request.limit = None;
-    candidate_request.include_tombstones = true;
-    candidate_request.branch_ids = expanded_branch_ids(&request.branch_ids);
-    let staged_rows = staged.staged_file_rows(&candidate_request)?;
-    let rows = base.scan_file_rows(&candidate_request).await?;
-    Ok(resolve_visible_rows(
-        rows,
-        staged_rows,
-        &VisibilityRequest {
-            branch_scope: VisibilityBranchScope::BranchIds {
-                branch_ids: request.branch_ids.clone(),
-            },
-            include_tombstones: request.include_tombstones,
             limit: request.limit,
         },
     ))
@@ -501,7 +465,7 @@ mod tests {
     use crate::NullableKeyFilter;
     use crate::changelog::{ChangeId, CommitId};
     use crate::entity_pk::EntityPk;
-    use crate::live_state::{LiveStateFileScanRequest, LiveStateProjection, LiveStateRowRequest};
+    use crate::live_state::LiveStateRowRequest;
     use async_trait::async_trait;
 
     #[test]
@@ -925,40 +889,6 @@ mod tests {
         assert_eq!(rows.len(), 1);
     }
 
-    #[test]
-    fn file_scan_request_lowers_to_equivalent_generic_scan_request() {
-        let request = LiveStateFileScanRequest {
-            branch_ids: vec!["branch-a".to_string()],
-            file_id: "file-a".to_string(),
-            schema_keys: vec!["schema-a".to_string(), "schema-b".to_string()],
-            untracked: Some(false),
-            include_tombstones: true,
-            projection: LiveStateProjection {
-                columns: vec!["snapshot_content".to_string(), "metadata".to_string()],
-            },
-            limit: Some(3),
-        };
-
-        let scan = request.to_scan_request();
-
-        assert_eq!(scan.filter.branch_ids, vec!["branch-a"]);
-        assert_eq!(
-            scan.filter.file_ids,
-            vec![NullableKeyFilter::Value("file-a".to_string())]
-        );
-        assert_eq!(
-            scan.filter.schema_keys,
-            vec!["schema-a".to_string(), "schema-b".to_string()]
-        );
-        assert_eq!(scan.filter.untracked, Some(false));
-        assert!(scan.filter.include_tombstones);
-        assert_eq!(
-            scan.projection.columns,
-            vec!["snapshot_content".to_string(), "metadata".to_string()]
-        );
-        assert_eq!(scan.limit, Some(3));
-    }
-
     #[tokio::test]
     async fn overlay_scan_fetches_base_global_candidates_for_staged_only_branch_scope() {
         let base = ExistingGlobalOnlyReader {
@@ -992,68 +922,6 @@ mod tests {
         assert_eq!(
             rows[0].snapshot_content.as_deref(),
             Some("{\"value\":\"global-value\"}")
-        );
-    }
-
-    #[tokio::test]
-    async fn overlay_scan_file_rows_matches_equivalent_generic_overlay_scan() {
-        let base = FilteringReader {
-            rows: vec![
-                file_row_at("global", "shared", "global", true, "schema-a", "file-a"),
-                file_row_at(
-                    "branch-a",
-                    "shared",
-                    "branch-base",
-                    false,
-                    "schema-a",
-                    "file-a",
-                ),
-                file_row_at(
-                    "branch-a",
-                    "other-file",
-                    "ignored",
-                    false,
-                    "schema-a",
-                    "file-b",
-                ),
-                file_row_at(
-                    "branch-a",
-                    "other-schema",
-                    "ignored",
-                    false,
-                    "schema-b",
-                    "file-a",
-                ),
-            ],
-        };
-        let staged = FilteringStagedRows {
-            rows: vec![file_row_at(
-                "branch-a", "shared", "staged", false, "schema-a", "file-a",
-            )],
-        };
-        let file_request = LiveStateFileScanRequest {
-            branch_ids: vec!["branch-a".to_string()],
-            file_id: "file-a".to_string(),
-            schema_keys: vec!["schema-a".to_string()],
-            projection: LiveStateProjection {
-                columns: vec!["snapshot_content".to_string()],
-            },
-            ..Default::default()
-        };
-        let generic_request = file_request.to_scan_request();
-
-        let file_rows = overlay_scan_file_rows(&base, &staged, &file_request)
-            .await
-            .expect("file overlay scan should succeed");
-        let generic_rows = overlay_scan_rows(&base, &staged, &generic_request)
-            .await
-            .expect("generic overlay scan should succeed");
-
-        assert_eq!(file_rows, generic_rows);
-        assert_eq!(file_rows.len(), 1);
-        assert_eq!(
-            file_rows[0].snapshot_content.as_deref(),
-            Some("{\"value\":\"staged\"}")
         );
     }
 

--- a/packages/engine/src/plugin/component.rs
+++ b/packages/engine/src/plugin/component.rs
@@ -3,10 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::binary_cas::BlobHash;
 use crate::common::LixError;
-use crate::wasm::{
-    WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
-    WasmPluginFile, WasmRuntime,
-};
+use crate::wasm::{WasmComponentInstance, WasmLimits, WasmPluginEntityState, WasmRuntime};
 
 use super::{CompiledPluginCatalog, InstalledPlugin, PluginCatalogCache, PluginRegistry};
 
@@ -156,21 +153,11 @@ pub(crate) async fn render_with_plugin(
     instance.render(state).await
 }
 
-pub(crate) async fn detect_changes_with_plugin(
-    host: &impl PluginComponentHost,
-    plugin: &InstalledPlugin,
-    state: Vec<WasmPluginEntityState>,
-    file: WasmPluginFile,
-) -> Result<Vec<WasmPluginDetectedChange>, LixError> {
-    let instance = load_or_init_plugin_component(host, plugin).await?;
-    instance.detect_changes(state, file).await
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::plugin::{InstalledPlugin, PluginRuntime};
-    use crate::wasm::WasmRuntime;
+    use crate::wasm::{WasmPluginDetectedChange, WasmPluginFile, WasmRuntime};
     use async_trait::async_trait;
     use std::collections::BTreeMap;
     use std::sync::Mutex;

--- a/packages/engine/src/plugin/install.rs
+++ b/packages/engine/src/plugin/install.rs
@@ -68,23 +68,6 @@ pub(crate) fn plugin_install_plan_from_archive_path(
     })
 }
 
-pub(crate) fn plugin_schema_rows_from_archive_path(
-    archive_path: &str,
-    archive_bytes: &[u8],
-    branch_id: &str,
-    global: bool,
-    untracked: bool,
-) -> Result<Vec<TransactionWriteRow>, LixError> {
-    Ok(plugin_install_plan_from_archive_path(
-        archive_path,
-        archive_bytes,
-        branch_id,
-        global,
-        untracked,
-    )?
-    .schema_rows)
-}
-
 fn plugin_schema_rows(
     parsed: &ParsedPluginArchive,
     branch_id: &str,

--- a/packages/engine/src/plugin/materializer.rs
+++ b/packages/engine/src/plugin/materializer.rs
@@ -7,10 +7,7 @@ use crate::live_state::{LiveStateProjection, MaterializedLiveStateRow};
 use crate::wasm::{WasmComponentInstance, WasmPluginEntityState, WasmPluginFile};
 
 use super::InstalledPlugin;
-use super::component::{
-    PluginComponentHost, detect_changes_with_plugin as detect_changes_with_component,
-    render_with_plugin as render_with_component,
-};
+use super::component::{PluginComponentHost, render_with_plugin as render_with_component};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PluginDetectedChange {
@@ -18,22 +15,6 @@ pub(crate) struct PluginDetectedChange {
     pub(crate) schema_key: String,
     pub(crate) snapshot_content: Option<String>,
     pub(crate) metadata: Option<String>,
-}
-
-pub(crate) async fn detect_changes_with_plugin(
-    host: &impl PluginComponentHost,
-    plugin: &InstalledPlugin,
-    active_state: &[MaterializedLiveStateRow],
-    file: WasmPluginFile,
-) -> Result<Vec<PluginDetectedChange>, LixError> {
-    let changes = detect_changes_with_component(
-        host,
-        plugin,
-        plugin_entity_state_from_live_rows(active_state)?,
-        file,
-    )
-    .await?;
-    normalize_detected_changes(changes)
 }
 
 /// Executes a component that was resolved from the warm hash cache before any

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -19,33 +19,26 @@ pub(crate) use archive::{
 pub(crate) use component::{
     CachedPluginComponent, PluginComponentHost, PluginRuntimeHost, load_or_init_plugin_component,
 };
-pub(crate) use install::{
-    PluginArchiveInstallPlan, plugin_install_plan_from_archive_path,
-    plugin_schema_rows_from_archive_path,
-};
-#[allow(unused_imports)]
+pub(crate) use install::{PluginArchiveInstallPlan, plugin_install_plan_from_archive_path};
 pub(crate) use manifest::{
-    PluginContentType, PluginManifest, PluginMatch, PluginRuntime, ValidatedPluginManifest,
-    glob_matches_path, parse_plugin_manifest_json, select_best_glob_match,
+    PluginContentType, PluginManifest, PluginRuntime, parse_plugin_manifest_json,
+    select_best_glob_match,
 };
-#[allow(unused_imports)]
 pub(crate) use materializer::{
-    PluginDetectedChange, detect_changes_with_component_instance, detect_changes_with_plugin,
-    plugin_state_live_state_projection, render_materialized_plugin_file, render_plugin_state,
+    PluginDetectedChange, detect_changes_with_component_instance,
+    plugin_state_live_state_projection, render_materialized_plugin_file,
     render_plugin_state_with_component_instance, retain_plugin_state_rows,
     retain_plugin_state_rows_for_schema_keys,
 };
-#[allow(unused_imports)]
 pub(crate) use registry::{
-    CompiledPluginCatalog, MAX_PLUGIN_REGISTRY_ENTRIES, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY,
-    PluginCatalogCache, PluginFileOwner, PluginRegistry, PluginRegistryEntry,
-    PluginRegistryEntryInput,
+    CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginCatalogCache,
+    PluginFileOwner, PluginRegistry, PluginRegistryEntry, PluginRegistryEntryInput,
 };
-#[allow(unused_imports)]
+#[cfg(test)]
+pub(crate) use storage::plugin_storage_archive_path;
 pub(crate) use storage::{
-    PLUGIN_ARCHIVE_FILE_EXTENSION, PLUGIN_STORAGE_ROOT_DIRECTORY_PATH, is_plugin_storage_path,
-    plugin_key_from_archive_file_id, plugin_key_from_archive_path, plugin_storage_archive_file_id,
-    plugin_storage_archive_path, reject_normal_plugin_storage_mutation,
+    is_plugin_storage_path, plugin_key_from_archive_file_id, plugin_key_from_archive_path,
+    plugin_storage_archive_file_id, reject_normal_plugin_storage_mutation,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -117,40 +117,12 @@ impl PluginRegistryEntry {
         &self.key
     }
 
-    pub(crate) fn runtime(&self) -> PluginRuntime {
-        self.runtime
-    }
-
-    pub(crate) fn api_version(&self) -> &str {
-        &self.api_version
-    }
-
-    pub(crate) fn path_glob(&self) -> &str {
-        &self.path_glob
-    }
-
     pub(crate) fn content_type(&self) -> Option<PluginContentType> {
         self.content_type
     }
 
-    pub(crate) fn entry(&self) -> &str {
-        &self.entry
-    }
-
     pub(crate) fn schema_keys(&self) -> &[String] {
         &self.schema_keys
-    }
-
-    pub(crate) fn manifest_json(&self) -> &str {
-        &self.manifest_json
-    }
-
-    pub(crate) fn archive_file_id(&self) -> &str {
-        &self.archive_file_id
-    }
-
-    pub(crate) fn archive_path(&self) -> &str {
-        &self.archive_path
     }
 
     pub(crate) fn archive_blob_hash(&self) -> &str {
@@ -237,10 +209,6 @@ impl PluginRegistry {
         })
     }
 
-    pub(crate) fn plugin_count(&self) -> u32 {
-        self.plugin_count
-    }
-
     pub(crate) fn is_empty(&self) -> bool {
         self.plugins.is_empty()
     }
@@ -317,23 +285,6 @@ impl PluginRegistry {
         Ok(())
     }
 
-    pub(crate) fn with_upserted(&self, plugin: PluginRegistryEntry) -> Result<Self, LixError> {
-        let mut plugins = self.plugins.clone();
-        match plugins.binary_search_by(|entry| entry.key.cmp(&plugin.key)) {
-            Ok(index) => plugins[index] = plugin,
-            Err(index) => plugins.insert(index, plugin),
-        }
-        Self::new(plugins)
-    }
-
-    pub(crate) fn without(&self, plugin_key: &str) -> Result<Self, LixError> {
-        let mut plugins = self.plugins.clone();
-        if let Ok(index) = plugins.binary_search_by(|entry| entry.key.as_str().cmp(plugin_key)) {
-            plugins.remove(index);
-        }
-        Self::new(plugins)
-    }
-
     /// Decode the JSON held in the `value` field. A missing entity is the
     /// canonical empty registry and requires no filesystem discovery.
     pub(crate) fn from_optional_value(value: Option<&JsonValue>) -> Result<Self, LixError> {
@@ -393,10 +344,6 @@ impl PluginRegistry {
         }))
     }
 
-    pub(crate) fn to_canonical_json(&self) -> Result<String, LixError> {
-        Ok(canonical_json(&self.to_value()?))
-    }
-
     pub(crate) fn write_row(&self, branch_id: &str) -> Result<TransactionWriteRow, LixError> {
         tracked_key_value_write_row(
             PLUGIN_REGISTRY_KEY,
@@ -404,10 +351,6 @@ impl PluginRegistry {
             Some(self.to_snapshot()?),
             branch_id,
         )
-    }
-
-    pub(crate) fn delete_row(branch_id: &str) -> Result<TransactionWriteRow, LixError> {
-        tracked_key_value_write_row(PLUGIN_REGISTRY_KEY, None, None, branch_id)
     }
 
     fn from_wire(wire: PluginRegistryWire) -> Result<Self, LixError> {
@@ -608,7 +551,6 @@ impl PluginFileOwner {
 /// One compiled multi-pattern matcher for a registry generation.
 #[derive(Debug)]
 pub(crate) struct CompiledPluginCatalog {
-    generation: String,
     plugins: Arc<[PluginRegistryEntry]>,
     globs: GlobSet,
     specificity: Vec<(u8, i32)>,
@@ -636,19 +578,10 @@ impl CompiledPluginCatalog {
             invalid_registry(format!("failed to compile plugin matcher catalog: {error}"))
         })?;
         Ok(Self {
-            generation: registry.generation.clone(),
             plugins: registry.plugins.clone().into(),
             globs,
             specificity,
         })
-    }
-
-    pub(crate) fn generation(&self) -> &str {
-        &self.generation
-    }
-
-    pub(crate) fn plugin_count(&self) -> usize {
-        self.plugins.len()
     }
 
     /// Returns whether the named plugin's already-compiled glob matches the
@@ -670,21 +603,6 @@ impl CompiledPluginCatalog {
             return false;
         };
         self.globs.matches(path).contains(&plugin_index)
-    }
-
-    /// Select the most specific compatible matcher. When callers already have
-    /// file bytes they pass the classified content type and both predicates
-    /// must match. `None` deliberately keeps the prior path-only behavior for
-    /// owner validation and other flows where bytes are not available.
-    /// Equal-specificity matches resolve by lexicographically smallest plugin
-    /// key because registry entries are canonicalized by key and matching
-    /// indices are ascending.
-    pub(crate) fn select(
-        &self,
-        path: &str,
-        file_content_type: Option<PluginContentType>,
-    ) -> Option<&PluginRegistryEntry> {
-        self.select_with_content_type(path, || file_content_type)
     }
 
     /// Selects for a known payload without scanning its bytes unless at least
@@ -1122,7 +1040,7 @@ mod tests {
     fn missing_registry_is_empty_without_discovery() {
         let registry = PluginRegistry::from_optional_value(None).expect("missing row is valid");
         assert!(registry.is_empty());
-        assert_eq!(registry.plugin_count(), 0);
+        assert!(registry.plugins().is_empty());
         assert_eq!(registry.generation().len(), 64);
     }
 
@@ -1141,8 +1059,8 @@ mod tests {
 
         assert_eq!(first.generation(), second.generation());
         assert_eq!(
-            first.to_canonical_json().unwrap(),
-            second.to_canonical_json().unwrap()
+            canonical_json(&first.to_value().unwrap()),
+            canonical_json(&second.to_value().unwrap())
         );
         assert_eq!(first.plugins()[0].key(), "plugin_a");
 
@@ -1154,15 +1072,16 @@ mod tests {
     #[test]
     fn upsert_and_remove_change_generation_deterministically() {
         let empty = PluginRegistry::empty();
-        let installed = empty
-            .with_upserted(entry("plugin_a", "*.json", 'a'))
+        let mut installed = empty.clone();
+        installed
+            .upsert(entry("plugin_a", "*.json", 'a'))
             .expect("install should be valid");
         assert_ne!(installed.generation(), empty.generation());
-        assert_eq!(installed.plugin("plugin_a").unwrap().path_glob(), "*.json");
-        let removed = installed
-            .without("plugin_a")
+        assert_eq!(installed.plugin("plugin_a").unwrap().path_glob, "*.json");
+        installed
+            .remove("plugin_a")
             .expect("remove should be valid");
-        assert_eq!(removed, empty);
+        assert_eq!(installed, empty);
     }
 
     #[test]
@@ -1308,15 +1227,21 @@ mod tests {
         .unwrap();
         let catalog = CompiledPluginCatalog::compile(&registry).unwrap();
         assert_eq!(
-            catalog.select("src/data.json", None).unwrap().key(),
+            catalog
+                .select_for_bytes("src/data.json", b"")
+                .unwrap()
+                .key(),
             "plugin_specific"
         );
-        assert_eq!(catalog.select("data.json", None).unwrap().key(), "plugin_a");
         assert_eq!(
-            catalog.select("data.txt", None).unwrap().key(),
+            catalog.select_for_bytes("data.json", b"").unwrap().key(),
+            "plugin_a"
+        );
+        assert_eq!(
+            catalog.select_for_bytes("data.txt", b"").unwrap().key(),
             "plugin_all"
         );
-        assert!(catalog.select("", None).is_none());
+        assert!(catalog.select_for_bytes("", b"").is_none());
         assert!(catalog.matches_plugin("plugin_specific", "src/data.json"));
         assert!(catalog.matches_plugin("plugin_a", "src/data.json"));
         assert!(catalog.matches_plugin("plugin_z", "src/data.json"));
@@ -1376,13 +1301,13 @@ mod tests {
         assert_eq!(classification_calls.get(), 0);
         assert_eq!(
             text_only
-                .select("document.data", Some(PluginContentType::Text))
+                .select_with_content_type("document.data", || Some(PluginContentType::Text))
                 .map(PluginRegistryEntry::key),
             Some("plugin_text")
         );
         assert!(
             text_only
-                .select("document.data", Some(PluginContentType::Binary))
+                .select_with_content_type("document.data", || Some(PluginContentType::Binary))
                 .is_none()
         );
 
@@ -1391,13 +1316,13 @@ mod tests {
                 .unwrap();
         assert_eq!(
             catalog
-                .select("document.data", Some(PluginContentType::Text))
+                .select_with_content_type("document.data", || Some(PluginContentType::Text))
                 .map(PluginRegistryEntry::key),
             Some("plugin_text")
         );
         assert_eq!(
             catalog
-                .select("document.data", Some(PluginContentType::Binary))
+                .select_with_content_type("document.data", || Some(PluginContentType::Binary))
                 .map(PluginRegistryEntry::key),
             Some("plugin_binary")
         );
@@ -1410,12 +1335,6 @@ mod tests {
         assert_eq!(
             catalog
                 .select_for_bytes("document.data", &[0xff, 0xfe])
-                .map(PluginRegistryEntry::key),
-            Some("plugin_binary")
-        );
-        assert_eq!(
-            catalog
-                .select("document.data", None)
                 .map(PluginRegistryEntry::key),
             Some("plugin_binary")
         );

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -8368,20 +8368,20 @@ mod tests {
         assert_eq!(
             context
                 .branch("branch-a")
-                .and_then(|branch| branch.catalog.select("/note.branch-a", None))
+                .and_then(|branch| branch.catalog.select_for_bytes("/note.branch-a", b""))
                 .map(PluginRegistryEntry::key),
             Some("plugin_sentinel")
         );
         assert!(
             context
                 .branch("branch-a")
-                .and_then(|branch| branch.catalog.select("/note.branch-b", None))
+                .and_then(|branch| branch.catalog.select_for_bytes("/note.branch-b", b""))
                 .is_none()
         );
         assert_eq!(
             context
                 .branch("branch-b")
-                .and_then(|branch| branch.catalog.select("/note.branch-b", None))
+                .and_then(|branch| branch.catalog.select_for_bytes("/note.branch-b", b""))
                 .map(PluginRegistryEntry::key),
             Some("plugin_sentinel")
         );
@@ -8744,7 +8744,7 @@ mod tests {
         assert_eq!(
             context
                 .branch("branch-b")
-                .and_then(|branch| branch.catalog.select("/note.active", None))
+                .and_then(|branch| branch.catalog.select_for_bytes("/note.active", b""))
                 .map(PluginRegistryEntry::key),
             Some("plugin_active")
         );

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -32,10 +32,10 @@ use crate::filesystem::{
 };
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::live_state::{
-    LiveStateContext, LiveStateExactBatchRequest, LiveStateFileScanRequest, LiveStateFilter,
-    LiveStateProjection, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
+    LiveStateContext, LiveStateExactBatchRequest, LiveStateFilter, LiveStateProjection,
+    LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
 };
-use crate::live_state::{overlay_load_exact_rows, overlay_scan_file_rows, overlay_scan_rows};
+use crate::live_state::{overlay_load_exact_rows, overlay_scan_rows};
 use crate::plugin::{
     CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginArchiveInstallPlan,
     PluginDetectedChange, PluginFileOwner, PluginRegistry, PluginRegistryEntry,
@@ -1961,13 +1961,6 @@ where
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
         overlay_scan_rows(&self.base, &self.staged, request).await
-    }
-
-    async fn scan_file_rows(
-        &self,
-        request: &LiveStateFileScanRequest,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-        overlay_scan_file_rows(&self.base, &self.staged, request).await
     }
 
     async fn load_row(

--- a/packages/engine/tests/storage/slatedb.rs
+++ b/packages/engine/tests/storage/slatedb.rs
@@ -151,8 +151,12 @@ async fn cached_slatedb_rebuilds_after_local_cache_is_deleted() {
     let space = SpaceId(11);
 
     {
-        let storage = SlateDB::open_object_store(db_path, object_store.clone())
-            .expect("open uncached seed storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            object_store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open uncached seed storage");
         let mut write = storage
             .begin_write(WriteOptions::default())
             .await
@@ -194,8 +198,12 @@ async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
     let rejected_key = Key(Bytes::from_static(b"rejected"));
 
     {
-        let storage = SlateDB::open_object_store(db_path, object_store.clone())
-            .expect("open failure-test seed storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            object_store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open failure-test seed storage");
         write_one(&storage, space, durable_key.clone(), b"persisted")
             .await
             .expect("persist seed value");
@@ -226,8 +234,12 @@ async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
     }
 
     std::fs::remove_dir_all(&cache_path).expect("delete failure-test cache");
-    let reopened = SlateDB::open_object_store(db_path, object_store)
-        .expect("reopen failure-test storage from durable store");
+    let reopened = SlateDB::open_object_store_with_options(
+        db_path,
+        object_store,
+        SlateDBObjectStoreOptions::default(),
+    )
+    .expect("reopen failure-test storage from durable store");
     let read = reopened
         .begin_read(ReadOptions::default())
         .await
@@ -250,8 +262,12 @@ async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
 async fn slatedb_explicit_flush_makes_visible_commit_durable() {
     let object_store = Arc::new(InMemory::new());
     let counting_store = Arc::new(FaultStore::new(object_store));
-    let storage = SlateDB::open_object_store("slatedb-explicit-wal-flush", counting_store.clone())
-        .expect("open explicit WAL flush storage");
+    let storage = SlateDB::open_object_store_with_options(
+        "slatedb-explicit-wal-flush",
+        counting_store.clone(),
+        SlateDBObjectStoreOptions::default(),
+    )
+    .expect("open explicit WAL flush storage");
     counting_store.reset_write_count();
 
     write_one(

--- a/packages/slatedb-storage/src/lib.rs
+++ b/packages/slatedb-storage/src/lib.rs
@@ -4,5 +4,5 @@ mod slatedb;
 
 pub use slatedb::{
     SlateDB, SlateDBCacheOptions, SlateDBFactory, SlateDBFixture, SlateDBObjectStoreOptions,
-    SlateDBOptions, SlateDBRead, SlateDBWrite,
+    SlateDBRead, SlateDBWrite,
 };

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -62,11 +62,6 @@ pub struct SlateDB {
     write_gate: WriteGate,
 }
 
-#[derive(Clone, Debug)]
-pub struct SlateDBOptions {
-    pub path: PathBuf,
-}
-
 #[derive(Clone, Debug, Default)]
 pub struct SlateDBObjectStoreOptions {
     pub cache: Option<SlateDBCacheOptions>,
@@ -141,10 +136,6 @@ impl StorageFixture for SlateDBFixture {
 }
 
 impl SlateDB {
-    pub fn new(options: SlateDBOptions) -> Result<Self, StorageError> {
-        Self::open(options.path)
-    }
-
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, StorageError> {
         let path = path.into();
         std::fs::create_dir_all(&path).map_err(|error| {
@@ -155,21 +146,15 @@ impl SlateDB {
         })?;
         let object_store: Arc<dyn ObjectStore> =
             Arc::new(LocalFileSystem::new_with_prefix(&path).map_err(object_store_error)?);
-        Self::open_object_store(DB_PATH, object_store).map(|mut storage| {
-            storage.path = path;
-            storage
-        })
-    }
-
-    pub fn open_object_store(
-        db_path: impl Into<String>,
-        object_store: Arc<dyn ObjectStore>,
-    ) -> Result<Self, StorageError> {
         Self::open_object_store_with_options(
-            db_path,
+            DB_PATH,
             object_store,
             SlateDBObjectStoreOptions::default(),
         )
+        .map(|mut storage| {
+            storage.path = path;
+            storage
+        })
     }
 
     pub fn open_object_store_with_options(
@@ -711,7 +696,7 @@ fn open_slatedb(
                 .with_db_cache(Arc::new(db_cache));
         } else {
             // The SlateDB dependency is compiled with Moka support so cached
-            // callers can choose bounded capacities. Keep the legacy constructor
+            // callers can choose bounded capacities. Keep default construction
             // cacheless instead of accepting SlateDB's much larger defaults.
             builder = builder.with_db_cache_disabled();
         }
@@ -1030,8 +1015,12 @@ mod tests {
 
     #[test]
     fn open_object_store_round_trips_with_memory_store() {
-        let storage = SlateDB::open_object_store("test-db", Arc::new(InMemory::new()))
-            .expect("open memory object-store slatedb storage");
+        let storage = SlateDB::open_object_store_with_options(
+            "test-db",
+            Arc::new(InMemory::new()),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open memory object-store slatedb storage");
 
         let space = SpaceId(7);
         let key = Key(Bytes::from_static(b"hello"));
@@ -1063,8 +1052,12 @@ mod tests {
     #[test]
     fn commit_is_visible_while_background_wal_flush_is_blocked() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
-        let storage = SlateDB::open_object_store("test-commit-visibility", store.clone())
-            .expect("open commit visibility storage");
+        let storage = SlateDB::open_object_store_with_options(
+            "test-commit-visibility",
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open commit visibility storage");
         let space = SpaceId(8);
         let key = Key(Bytes::from_static(b"visible-before-durable"));
 
@@ -1108,8 +1101,12 @@ mod tests {
     #[test]
     fn explicit_flush_reports_background_durability_failure() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
-        let storage = SlateDB::open_object_store("test-failed-commit", store.clone())
-            .expect("open failed commit storage");
+        let storage = SlateDB::open_object_store_with_options(
+            "test-failed-commit",
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open failed commit storage");
         let space = SpaceId(9);
         let key = Key(Bytes::from_static(b"rejected"));
 
@@ -1147,8 +1144,12 @@ mod tests {
         let space = SpaceId(8);
         let key = Key(Bytes::from_static(b"background-commit"));
         let value = Bytes::from_static(b"durable");
-        let storage =
-            SlateDB::open_object_store(db_path, store.clone()).expect("open close-test storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open close-test storage");
         let mut write =
             block_on(storage.begin_write(WriteOptions::default())).expect("begin close-test write");
         block_on(write.put_many(
@@ -1186,8 +1187,12 @@ mod tests {
             .expect("close should finish after WAL durability");
         closer.join().expect("join close-test closer");
 
-        let reopened =
-            SlateDB::open_object_store(db_path, store).expect("reopen close-test storage");
+        let reopened = SlateDB::open_object_store_with_options(
+            db_path,
+            store,
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("reopen close-test storage");
         let read =
             block_on(reopened.begin_read(ReadOptions::default())).expect("begin close-test read");
         let result = block_on(read.get_many(space, &[key], GetOptions::default()))
@@ -1205,8 +1210,12 @@ mod tests {
         let value = Bytes::from(vec![b'x'; 128 * 1024]);
 
         {
-            let storage = SlateDB::open_object_store(db_path, inner.clone())
-                .expect("open concurrent-read seed storage");
+            let storage = SlateDB::open_object_store_with_options(
+                db_path,
+                inner.clone(),
+                SlateDBObjectStoreOptions::default(),
+            )
+            .expect("open concurrent-read seed storage");
             let mut write = block_on(storage.begin_write(WriteOptions::default()))
                 .expect("begin concurrent-read seed write");
             block_on(write.put_many(
@@ -1233,8 +1242,12 @@ mod tests {
         }
 
         let store = Arc::new(BlockingStore::new(inner));
-        let storage = SlateDB::open_object_store(db_path, store.clone())
-            .expect("reopen concurrent-read storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("reopen concurrent-read storage");
         let read = Arc::new(
             block_on(storage.begin_read(ReadOptions::default()))
                 .expect("begin shared snapshot read"),
@@ -1279,8 +1292,12 @@ mod tests {
         let value = Bytes::from(vec![b'x'; 128 * 1024]);
 
         {
-            let storage = SlateDB::open_object_store(db_path, inner.clone())
-                .expect("open async-read seed storage");
+            let storage = SlateDB::open_object_store_with_options(
+                db_path,
+                inner.clone(),
+                SlateDBObjectStoreOptions::default(),
+            )
+            .expect("open async-read seed storage");
             let mut write = storage
                 .begin_write(WriteOptions::default())
                 .await
@@ -1303,8 +1320,12 @@ mod tests {
         }
 
         let store = Arc::new(BlockingStore::new(inner));
-        let storage =
-            SlateDB::open_object_store(db_path, store.clone()).expect("reopen async-read storage");
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("reopen async-read storage");
         let read = storage
             .begin_read(ReadOptions::default())
             .await


### PR DESCRIPTION
## Summary

Remove unreleased compatibility APIs, format fallbacks, and dead internal code.

- remove `SlateDBOptions`, `SlateDB::new`, and the no-options object-store constructor
- reject legacy namespaced CLI snapshots instead of silently accepting their old shape
- remove changelog V1 decoding
- remove unused live-state, Binary CAS, plugin, dependency, and test scaffolding
- add a minor changenote documenting the intentional breaking cuts

The local-filesystem crate, SDK surface, metadata migration behavior, docs, and tests are intentionally retained because Flashtype is an active consumer.

## Validation

- `cargo fmt --all -- --check`
- `cargo machete`
- `node scripts/validate-changes.mjs`
- `cargo check -p lix_local_filesystem`
- `cargo test -p lix_cli db::tests` — 4 passed
- `cargo test -p lix_engine --lib` — 1,139 passed, 6 ignored
- `git diff --check origin/main...HEAD`

This is intentionally not backward compatible for the removed APIs; SlateDB callers should use `SlateDB::open` or `SlateDB::open_object_store_with_options`.