### PR TITLE
perf(engine): fast path key-value point reads

### DIFF
--- a/.changenotes/fast-key-value-point-read.md
+++ b/.changenotes/fast-key-value-point-read.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved parameterized `lix_key_value` observer reads by resolving exact keys
+through the live-state point reader instead of constructing a DataFusion plan.
+Active-branch overrides and global fallback retain their existing behavior.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -485,6 +485,7 @@ where
 
         let acknowledge_file_views = is_acknowledgeable_file_data_read(&statement, params);
         let exact_lix_file_read = exact_lix_file_read(&statement, params);
+        let exact_lix_key_value_read = exact_lix_key_value_read(&statement, params);
         let has_durable_runtime_function = sql2::statement_has_durable_runtime_function(&statement);
         let runtime_write_access = if has_durable_runtime_function {
             let write_access = self.begin_session_write_access().await?;
@@ -520,6 +521,7 @@ where
                     params,
                     acknowledge_file_views,
                     exact_lix_file_read,
+                    exact_lix_key_value_read,
                     has_durable_runtime_function,
                 )
                 .await
@@ -977,6 +979,7 @@ where
         params: &[Value],
         acknowledge_file_views: bool,
         exact_lix_file_read: Option<(sql2::ExactLixFileReadSelector, sql2::ExactLixFileReadColumn)>,
+        exact_lix_key_value_read: Option<String>,
         has_durable_runtime_function: bool,
     ) -> Result<
         (
@@ -987,6 +990,26 @@ where
     > {
         let file_view_collector = acknowledge_file_views.then(sql2::SessionFileViews::default);
         let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+        if let Some(key) = exact_lix_key_value_read {
+            let live_state: Arc<dyn crate::live_state::LiveStateReader> =
+                Arc::new(self.live_state.reader(read_store.clone()));
+            let branch_ref: Arc<dyn BranchRefReader> =
+                Arc::new(self.branch_ctx.ref_reader(read_store));
+            let query = sql2::execute_exact_lix_key_value_read(
+                &active_branch_id,
+                live_state,
+                branch_ref,
+                &key,
+            )
+            .await?;
+            return Ok((
+                sql2::SessionReadSqlResult {
+                    runtime_functions: None,
+                    query,
+                },
+                Vec::new(),
+            ));
+        }
         if let Some((selector, column)) = exact_lix_file_read {
             let live_state: Arc<dyn crate::live_state::LiveStateReader> =
                 Arc::new(self.live_state.reader(read_store.clone()));
@@ -1429,6 +1452,24 @@ fn exact_lix_file_read(
     Some((selector, column))
 }
 
+fn exact_lix_key_value_read(statement: &DataFusionStatement, params: &[Value]) -> Option<String> {
+    let point_read = simple_point_read(statement)?;
+    if point_read.table_name != "lix_key_value" || !point_read.exact_table_shape {
+        return None;
+    }
+    let [SelectItem::UnnamedExpr(Expr::Identifier(projection))] =
+        point_read.select.projection.as_slice()
+    else {
+        return None;
+    };
+    if projection.quote_style.is_some() || !projection.value.eq_ignore_ascii_case("value") {
+        return None;
+    }
+    let selection = point_read.select.selection.as_ref()?;
+    let (identity_column, identity_value) = exact_point_identity(selection, params)?;
+    (identity_column == "key").then_some(identity_value)
+}
+
 fn exact_point_identity(expression: &Expr, params: &[Value]) -> Option<(String, String)> {
     let Expr::BinaryOp {
         left,
@@ -1843,6 +1884,71 @@ mod tests {
                 exact_lix_file_read(&statement, &params),
                 None,
                 "unexpected fast-path match for {sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_lix_key_value_read_recognizes_only_the_atelier_observer_shape() {
+        for sql in [
+            "SELECT value FROM lix_key_value WHERE key = $1",
+            "select VALUE from LIX_KEY_VALUE where KEY = ?",
+            "SELECT value FROM lix_key_value WHERE $1 = key",
+        ] {
+            let statement = sql2::parse_statement(sql).unwrap();
+            assert_eq!(
+                exact_lix_key_value_read(&statement, &[Value::Text("observer-key".to_string())]),
+                Some("observer-key".to_string()),
+                "expected exact key/value match for {sql}"
+            );
+        }
+
+        for (sql, params) in [
+            (
+                "SELECT key, value FROM lix_key_value WHERE key = $1",
+                vec![Value::Text("observer-key".to_string())],
+            ),
+            (
+                "SELECT value AS observed_value FROM lix_key_value WHERE key = $1",
+                vec![Value::Text("observer-key".to_string())],
+            ),
+            (
+                "SELECT value FROM lix_key_value AS kv WHERE key = $1",
+                vec![Value::Text("observer-key".to_string())],
+            ),
+            (
+                "SELECT value FROM lix_key_value WHERE key = 'observer-key'",
+                vec![],
+            ),
+            (
+                "SELECT value FROM lix_key_value WHERE key = $1 LIMIT 1",
+                vec![Value::Text("observer-key".to_string())],
+            ),
+            (
+                "SELECT value FROM lix_key_value WHERE key = $1 AND true",
+                vec![Value::Text("observer-key".to_string())],
+            ),
+            (
+                "SELECT value FROM lix_key_value_by_branch WHERE key = $1",
+                vec![Value::Text("observer-key".to_string())],
+            ),
+            (
+                "SELECT value FROM lix_key_value WHERE key = $1",
+                vec![Value::Null],
+            ),
+            (
+                "SELECT value FROM lix_key_value WHERE key = $1",
+                vec![
+                    Value::Text("observer-key".to_string()),
+                    Value::Text("extra".to_string()),
+                ],
+            ),
+        ] {
+            let statement = sql2::parse_statement(sql).unwrap();
+            assert_eq!(
+                exact_lix_key_value_read(&statement, &params),
+                None,
+                "unexpected exact key/value match for {sql}"
             );
         }
     }

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -62,5 +62,6 @@ pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::SqlPlanningCache;
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, execute_exact_lix_file_read,
+    execute_exact_lix_key_value_read,
 };
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -19,7 +19,8 @@ use crate::commit_graph::CommitGraphReader;
 use crate::entity_pk::EntityPk;
 use crate::live_state::MaterializedLiveStateRow;
 use crate::live_state::{
-    LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateRowFilter, LiveStateScanRequest,
+    LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter, LiveStateProjection,
+    LiveStateReader, LiveStateRowFilter, LiveStateScanRequest,
 };
 use crate::sql2::branch_scope::{BranchBinding, resolve_provider_branch_ids};
 use crate::sql2::catalog::{
@@ -28,7 +29,7 @@ use crate::sql2::catalog::{
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::read_only::reject_read_only_entity_surface;
-use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value};
+use crate::{GLOBAL_BRANCH_ID, LixError, SqlQueryResult, Value, parse_row_metadata_value};
 
 use crate::sql2::{
     SqlHistoryQuerySource, SqlWriteContext, WriteAccess, WriteContextLiveStateReader,
@@ -165,6 +166,72 @@ pub(crate) async fn register_entity_write_providers(
     }
 
     Ok(())
+}
+
+/// Executes Atelier's exact active-branch key/value observer read without
+/// constructing a DataFusion catalog and plan. The live-state exact reader
+/// retains the normal branch-over-global visibility rules while lowering the
+/// primary-key predicate to one correlated point read.
+pub(crate) async fn execute_exact_lix_key_value_read(
+    active_branch_id: &str,
+    live_state: Arc<dyn LiveStateReader>,
+    branch_ref: Arc<dyn BranchRefReader>,
+    key: &str,
+) -> Result<SqlQueryResult, LixError> {
+    let branch_ids = resolve_provider_branch_ids(
+        branch_ref.as_ref(),
+        &BranchBinding::active(active_branch_id),
+        Vec::new(),
+    )
+    .await?;
+    let branch_id = branch_ids.into_iter().next().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "exact lix_key_value read resolved an empty active branch scope",
+        )
+    })?;
+    let mut rows = live_state
+        .load_exact_rows(&LiveStateExactBatchRequest {
+            rows: vec![LiveStateExactRowRequest {
+                schema_key: "lix_key_value".to_string(),
+                branch_id,
+                entity_pk: EntityPk::single(key),
+                file_id: None,
+            }],
+            projection: LiveStateProjection {
+                columns: vec!["snapshot_content".to_string()],
+            },
+            untracked: None,
+            include_tombstones: false,
+        })
+        .await?;
+    if rows.len() != 1 {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "exact lix_key_value read expected one aligned result slot, got {}",
+                rows.len()
+            ),
+        ));
+    }
+
+    let rows = match rows.pop().flatten() {
+        None => Vec::new(),
+        Some(row) => {
+            let snapshot = parse_snapshot(row.snapshot_content.as_deref())
+                .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
+            let value = match snapshot.as_ref().and_then(|snapshot| snapshot.get("value")) {
+                None | Some(JsonValue::Null) => Value::Null,
+                Some(value) => Value::Json(value.clone()),
+            };
+            vec![vec![value]]
+        }
+    };
+    Ok(SqlQueryResult {
+        columns: vec!["value".to_string()],
+        rows,
+        notices: Vec::new(),
+    })
 }
 
 fn catalog_entity_spec(

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -31,6 +31,7 @@ use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
 use datafusion::catalog::TableProvider;
 
+pub(crate) use entity::execute_exact_lix_key_value_read;
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_file_read, execute_fast_lix_file_data_update_by_id,

--- a/packages/engine/tests/sql/lix_key_value.rs
+++ b/packages/engine/tests/sql/lix_key_value.rs
@@ -1,6 +1,121 @@
 use lix_engine::ExecuteResult;
 use lix_engine::LixError;
 use lix_engine::Value;
+use serde_json::json;
+
+simulation_test!(
+    lix_key_value_parameter_point_read_preserves_active_global_and_missing_rows,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let global_session = sim.wrap_session(
+            engine
+                .open_session("global")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+
+        global_session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_global) \
+                 VALUES ('kv-point-global', lix_json('{\"source\":\"global\"}'), true)",
+                &[],
+            )
+            .await
+            .expect("global point-read fixture should insert");
+
+        let global_fallback = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = $1",
+                &[Value::Text("kv-point-global".to_string())],
+            )
+            .await
+            .expect("active branch should read the global fallback");
+        assert_eq!(
+            global_fallback.rows()[0].values(),
+            &[Value::Json(json!({"source": "global"}))]
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) \
+                 VALUES ('kv-point-global', lix_json('{\"source\":\"active\"}')) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                &[],
+            )
+            .await
+            .expect("active override should insert");
+        let active_override = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = $1",
+                &[Value::Text("kv-point-global".to_string())],
+            )
+            .await
+            .expect("active branch should prefer its override");
+        assert_eq!(
+            active_override.rows()[0].values(),
+            &[Value::Json(json!({"source": "active"}))]
+        );
+
+        let aliased_fallback = session
+            .execute(
+                "SELECT value AS observed_value FROM lix_key_value WHERE key = $1",
+                &[Value::Text("kv-point-global".to_string())],
+            )
+            .await
+            .expect("non-matching alias shape should retain generic SQL behavior");
+        assert_eq!(aliased_fallback.columns(), &["observed_value"]);
+        assert_eq!(
+            aliased_fallback.rows()[0].values(),
+            &[Value::Json(json!({"source": "active"}))]
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) \
+                 VALUES ('kv-point-null', lix_json('null'))",
+                &[],
+            )
+            .await
+            .expect("JSON null fixture should insert");
+        let json_null = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = $1",
+                &[Value::Text("kv-point-null".to_string())],
+            )
+            .await
+            .expect("JSON null point read should succeed");
+        assert_eq!(json_null.rows()[0].values(), &[Value::Null]);
+
+        let missing = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = $1",
+                &[Value::Text("kv-point-missing".to_string())],
+            )
+            .await
+            .expect("missing point read should succeed");
+        assert!(missing.is_empty());
+
+        let global_still_global = global_session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = $1",
+                &[Value::Text("kv-point-global".to_string())],
+            )
+            .await
+            .expect("global session should retain the global value");
+        assert_eq!(
+            global_still_global.rows()[0].values(),
+            &[Value::Json(json!({"source": "global"}))]
+        );
+    }
+);
 
 simulation_test!(lix_key_value_roundtrips_arbitrary_json, |sim| async move {
     let engine = sim.boot_engine().await;


### PR DESCRIPTION
## Summary

- recognize Atelier's exact parameterized observer shape: `SELECT value FROM lix_key_value WHERE key = $1`
- lower that shape directly to the live-state exact reader instead of constructing a DataFusion catalog and plan
- preserve active-branch-over-global visibility, tombstones, JSON/null conversion, missing rows, and branch validation
- conservatively retain the generic SQL path for aliases, literals, extra projections/predicates, joins, limits, and every other shape

This is crate-private and does not change the public API.

## Results

Five alternating-order process pairs, pinned to CPU 7, with 50 warmups and 1,000 measured iterations per case. The table reports the median of run-level p50/p95 latency. Baseline and candidate were built from the same engine tree at `35f7e1c691fb4108a7d20c392fe2c18fb2d6c676`; current `main` only adds CI/JS-build changes in #692.

| Backend / case | p50 before → after | p50 | p95 before → after | p95 |
| --- | ---: | ---: | ---: | ---: |
| RocksDB active row | 573,949 → 93,556 ns | **-83.7%** | 615,397 → 119,736 ns | **-80.5%** |
| RocksDB global fallback | 575,952 → 96,091 ns | **-83.3%** | 614,405 → 125,946 ns | **-79.5%** |
| RocksDB branch override | 576,623 → 98,816 ns | **-82.9%** | 615,647 → 124,845 ns | **-79.7%** |
| RocksDB global session | 515,409 → 41,849 ns | **-91.9%** | 553,070 → 58,609 ns | **-89.4%** |
| RocksDB missing key | 564,702 → 88,356 ns | **-84.4%** | 611,361 → 113,745 ns | **-81.4%** |
| SlateDB active row | 987,147 → 425,711 ns | **-56.9%** | 1,055,475 → 477,649 ns | **-54.7%** |
| SlateDB global fallback | 986,506 → 432,994 ns | **-56.1%** | 1,056,017 → 501,092 ns | **-52.5%** |
| SlateDB branch override | 1,006,173 → 458,742 ns | **-54.4%** | 1,086,854 → 612,141 ns | **-43.7%** |
| SlateDB global session | 738,209 → 213,431 ns | **-71.1%** | 787,041 → 260,821 ns | **-66.9%** |
| SlateDB missing key | 959,385 → 403,908 ns | **-57.9%** | 1,034,415 → 461,909 ns | **-55.3%** |

The deliberately non-matching aliased-query control stayed within noise: RocksDB +1.3% p50/+0.2% p95; SlateDB +0.8%/+3.0%. Deterministic storage traces show that matching reads replace one or two scans with correlated exact batches; control traces are unchanged.

Artifacts:

- identical harness SHA-256: `18967354b354a3f234479cad6dd50fc28e959bf95483992f0738f54ced935375`
- baseline binary SHA-256: `664cf9005bb3ce3b414be0671e36dd1f11b82e6ddc1f1165a7f0ac8af60c57cb`
- candidate binary SHA-256: `6a4164c54c0ebecc73f5f404d2c7963bdd937709b519336b1918a4cf3452de90`

The manual benchmark harness is intentionally excluded from this PR.

## Why this shape

This follows the same principle as DataFusion's exact filter pushdown and DuckDB's primary-key point probes: use a selective equality predicate to avoid scanning and generic relational machinery. It also maps naturally to SlateDB's native key-oriented read path.

- https://datafusion.apache.org/library-user-guide/custom-table-providers.html#filter-pushdown-doing-less-work
- https://duckdb.org/docs/lts/guides/performance/indexing
- https://slatedb.io/docs/design/reads/

The recognizer is intentionally narrow. Unsupported syntax falls back before any semantic work, keeping the optimized 90% path bounded and maintainable.

## Validation

- `cargo test -p lix_engine --lib`: 1,142 passed, 0 failed, 6 ignored
- focused classifier: 1 passed
- focused storage-backed SQL simulation modes: 2 passed
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent static review: no actionable findings
