### PR TITLE
perf(engine): cache transaction-opening catalogs

### DIFF
--- a/.changenotes/cache-transaction-opening-catalogs.md
+++ b/.changenotes/cache-transaction-opening-catalogs.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved RocksDB and SlateDB CRUD performance by reusing compiled schema catalogs across ordinary implicit transactions.
+
+Schema registrations, merges, branch-head changes, and tracked-state repairs still invalidate the cached catalog atomically before the next transaction opens.

--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::Value as JsonValue;
 
+use crate::catalog::revision::CatalogRevision;
 use crate::catalog::snapshot::{
     CatalogFingerprint, fingerprint_schema_facts, hash_fingerprint_part,
 };
@@ -28,10 +29,13 @@ const COMPILED_CATALOG_CACHE_LIMIT: usize = 64;
 /// schemas are also seeded as ordinary `lix_registered_schema` rows for
 /// validation and introspection, while fixed-surface reads may use their
 /// compile-time definitions without loading those rows. The context also owns
-/// the engine-wide cache of compiled catalog snapshots, keyed by fact content.
+/// engine-wide caches of compiled snapshots, keyed by either fact content or
+/// the atomic storage revision captured when a transaction opens.
 pub(crate) struct CatalogContext {
     compiled_catalogs: Mutex<HashMap<CatalogFingerprint, Arc<CatalogSnapshot>>>,
     compiled_catalogs_by_rows: Mutex<HashMap<CatalogRowsFingerprint, Arc<CatalogSnapshot>>>,
+    transaction_opening_catalogs:
+        Mutex<HashMap<TransactionOpeningCatalogKey, Arc<CatalogSnapshot>>>,
     #[cfg(test)]
     sql_read_schema_loads: AtomicUsize,
 }
@@ -44,21 +48,74 @@ pub(crate) struct CatalogContext {
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct CatalogRowsFingerprint(String);
 
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct TransactionOpeningCatalogKey {
+    domain: Domain,
+    revision: CatalogRevision,
+}
+
 impl CatalogContext {
     pub(crate) fn new() -> Self {
         Self {
             compiled_catalogs: Mutex::new(HashMap::new()),
             compiled_catalogs_by_rows: Mutex::new(HashMap::new()),
+            transaction_opening_catalogs: Mutex::new(HashMap::new()),
             #[cfg(test)]
             sql_read_schema_loads: AtomicUsize::new(0),
         }
     }
 
+    /// Returns the catalog captured by a transaction-opening storage snapshot.
+    ///
+    /// The revision is loaded from the same pinned read as `live_state`. A
+    /// matching `(domain, revision)` therefore proves that registered-schema
+    /// visibility is identical without rescanning its tracked and untracked
+    /// rows. Missing revisions conservatively retain the scan path for stores
+    /// initialized by older engines.
+    pub(crate) async fn compiled_catalog_for_transaction_open<R>(
+        &self,
+        live_state: &R,
+        domain: &Domain,
+        revision: Option<&CatalogRevision>,
+    ) -> Result<Arc<CatalogSnapshot>, LixError>
+    where
+        R: LiveStateReader + ?Sized,
+    {
+        let Some(revision) = revision else {
+            return self.compiled_catalog_for_domain(live_state, domain).await;
+        };
+        let key = TransactionOpeningCatalogKey {
+            domain: domain.clone(),
+            revision: revision.clone(),
+        };
+        if let Some(snapshot) = self
+            .transaction_opening_catalogs
+            .lock()
+            .expect("transaction opening catalog cache lock should not be poisoned")
+            .get(&key)
+        {
+            return Ok(Arc::clone(snapshot));
+        }
+
+        let snapshot = self.compiled_catalog_for_domain(live_state, domain).await?;
+        let mut cache = self
+            .transaction_opening_catalogs
+            .lock()
+            .expect("transaction opening catalog cache lock should not be poisoned");
+        if cache.len() >= COMPILED_CATALOG_CACHE_LIMIT {
+            if let Some(evicted) = cache.keys().find(|entry| **entry != key).cloned() {
+                cache.remove(&evicted);
+            }
+        }
+        cache.insert(key, Arc::clone(&snapshot));
+        Ok(snapshot)
+    }
+
     /// Returns the compiled snapshot for the catalog rows visible to `domain`.
     ///
-    /// This is the transaction hot path. On a hit it costs one live-state scan
-    /// plus a hash of the raw row contents; schema rows are only JSON-decoded
-    /// and canonicalized when the raw fingerprint has not been seen before.
+    /// This is the transaction-opening cache-miss path and the authoritative
+    /// path for validation overlays. Identical raw rows avoid JSON decoding and
+    /// canonicalization, but still require the live-state scans.
     pub(crate) async fn compiled_catalog_for_domain<R>(
         &self,
         live_state: &R,
@@ -337,6 +394,65 @@ mod tests {
         assert!(!first.contains("gamma_schema"));
     }
 
+    #[tokio::test]
+    async fn transaction_opening_revision_skips_catalog_row_scans_until_it_changes() {
+        let context = CatalogContext::new();
+        let domain = Domain::schema_catalog("global", true);
+        let revision = CatalogRevision::for_test(b"revision-one");
+        let reader = RowsLiveStateReader::new(vec![registered_schema_row("alpha_schema")]);
+
+        let first = context
+            .compiled_catalog_for_transaction_open(&reader, &domain, Some(&revision))
+            .await
+            .expect("opening catalog should compile");
+        assert_eq!(
+            reader.scan_count(),
+            2,
+            "cold open scans both durability scopes"
+        );
+        let second = context
+            .compiled_catalog_for_transaction_open(&reader, &domain, Some(&revision))
+            .await
+            .expect("opening catalog should hit by revision");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            reader.scan_count(),
+            2,
+            "hot open must not rescan registered-schema rows"
+        );
+
+        let changed_reader = RowsLiveStateReader::new(vec![registered_schema_row("beta_schema")]);
+        let changed = context
+            .compiled_catalog_for_transaction_open(
+                &changed_reader,
+                &domain,
+                Some(&CatalogRevision::for_test(b"revision-two")),
+            )
+            .await
+            .expect("changed revision should reload the catalog");
+        assert_eq!(changed_reader.scan_count(), 2);
+        assert!(changed.contains("beta_schema"));
+        assert!(!changed.contains("alpha_schema"));
+    }
+
+    #[tokio::test]
+    async fn missing_transaction_opening_revision_conservatively_rescans() {
+        let context = CatalogContext::new();
+        let domain = Domain::schema_catalog("global", true);
+        let reader = RowsLiveStateReader::new(vec![registered_schema_row("alpha_schema")]);
+
+        context
+            .compiled_catalog_for_transaction_open(&reader, &domain, None)
+            .await
+            .expect("first opening catalog should compile");
+        context
+            .compiled_catalog_for_transaction_open(&reader, &domain, None)
+            .await
+            .expect("second opening catalog should compile");
+
+        assert_eq!(reader.scan_count(), 4);
+    }
+
     #[test]
     fn compiled_catalog_cache_shares_snapshots_for_equal_facts() {
         let context = CatalogContext::new();
@@ -572,11 +688,19 @@ mod tests {
 
     struct RowsLiveStateReader {
         rows: Vec<MaterializedLiveStateRow>,
+        scan_count: AtomicUsize,
     }
 
     impl RowsLiveStateReader {
         fn new(rows: Vec<MaterializedLiveStateRow>) -> Self {
-            Self { rows }
+            Self {
+                rows,
+                scan_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn scan_count(&self) -> usize {
+            self.scan_count.load(Ordering::Relaxed)
         }
     }
 
@@ -593,6 +717,7 @@ mod tests {
             &self,
             request: &LiveStateScanRequest,
         ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            self.scan_count.fetch_add(1, Ordering::Relaxed);
             Ok(self
                 .rows
                 .iter()

--- a/packages/engine/src/catalog/mod.rs
+++ b/packages/engine/src/catalog/mod.rs
@@ -1,8 +1,10 @@
 mod context;
+mod revision;
 mod schema;
 mod snapshot;
 
 pub(crate) use context::CatalogContext;
+pub(crate) use revision::{load_catalog_revision, stage_catalog_revision};
 pub(crate) use schema::{
     ForeignKeyPlan, SchemaCatalogFact, SchemaCatalogKey, SchemaPlan, SchemaPlanId,
     StateForeignKeyPlan,

--- a/packages/engine/src/catalog/revision.rs
+++ b/packages/engine/src/catalog/revision.rs
@@ -1,0 +1,484 @@
+use bytes::Bytes;
+
+use crate::LixError;
+use crate::storage_adapter::{
+    PointReadPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions, StorageKey,
+    StorageProjectedValue, StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+};
+
+const CATALOG_REVISION_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0007_0003), "catalog.schema_revision");
+const CATALOG_REVISION_KEY: &[u8] = b"global";
+
+/// Storage-snapshot identity for the visible registered-schema catalog.
+///
+/// The token is updated atomically with mutations that can change schema
+/// visibility. It is intentionally opaque: equality is the only operation a
+/// catalog cache needs.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct CatalogRevision(Bytes);
+
+#[cfg(test)]
+impl CatalogRevision {
+    pub(crate) fn for_test(value: &'static [u8]) -> Self {
+        Self(Bytes::from_static(value))
+    }
+}
+
+pub(crate) async fn load_catalog_revision(
+    store: &(impl StorageAdapterRead + ?Sized),
+) -> Result<Option<CatalogRevision>, LixError> {
+    let result = PointReadPlan::new(
+        CATALOG_REVISION_SPACE,
+        &[StorageKey(Bytes::from_static(CATALOG_REVISION_KEY))],
+    )
+    .materialize(
+        store,
+        StorageGetOptions {
+            projection: StorageCoreProjection::FullValue,
+        },
+    )
+    .await?;
+    Ok(result
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .and_then(|value| match value {
+            StorageProjectedValue::FullValue(bytes) => Some(CatalogRevision(bytes)),
+            StorageProjectedValue::KeyOnly => None,
+        }))
+}
+
+pub(crate) fn stage_catalog_revision(writes: &mut StorageWriteSet) {
+    writes.put(
+        CATALOG_REVISION_SPACE,
+        StorageKey(Bytes::from_static(CATALOG_REVISION_KEY)),
+        StorageValue {
+            bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value as JsonValue, json};
+
+    use crate::changelog::CommitId;
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+    use crate::{
+        CreateBranchOptions, Engine, MergeBranchOptions, MergeBranchOutcome, SessionContext, Value,
+    };
+
+    #[tokio::test]
+    async fn catalog_revision_round_trips_through_one_storage_snapshot() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("initial read should open");
+        assert_eq!(
+            load_catalog_revision(&read)
+                .await
+                .expect("missing revision should load"),
+            None
+        );
+
+        let mut writes = storage.new_write_set();
+        stage_catalog_revision(&mut writes);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("revision should commit");
+
+        assert_eq!(
+            load_catalog_revision(&read)
+                .await
+                .expect("pinned read should remain valid"),
+            None,
+            "an existing read must retain its pre-commit snapshot"
+        );
+        let next_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("next read should open");
+        assert!(
+            load_catalog_revision(&next_read)
+                .await
+                .expect("committed revision should load")
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_commit_advances_revision_while_ordinary_crud_does_not() {
+        let storage = Memory::new();
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let adapter = StorageAdapter::new(storage.clone());
+        let initial_revision = current_revision(&adapter).await;
+
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("engine should open");
+        let session = engine
+            .open_session(&receipt.main_branch_id)
+            .await
+            .expect("main session should open");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('revision-control', 'one')",
+                &[],
+            )
+            .await
+            .expect("ordinary CRUD should commit");
+        assert_eq!(
+            current_revision(&adapter).await,
+            initial_revision,
+            "ordinary state writes must keep the hot catalog generation"
+        );
+
+        let no_op = session
+            .execute(
+                "UPDATE lix_registered_schema SET value = value \
+                 WHERE lixcol_entity_pk = lix_json('[\"missing-schema\"]')",
+                &[],
+            )
+            .await
+            .expect("zero-row schema update should succeed");
+        assert_eq!(no_op.rows_affected(), 0);
+        assert_eq!(current_revision(&adapter).await, initial_revision);
+
+        let mut rolled_back = session
+            .begin_transaction()
+            .await
+            .expect("rollback transaction should begin");
+        rolled_back
+            .execute(
+                "INSERT INTO lix_registered_schema \
+                 (value, lixcol_global, lixcol_untracked) VALUES ($1, false, true)",
+                &[Value::Json(test_schema("rolled_back_schema", false))],
+            )
+            .await
+            .expect("rolled-back schema should stage");
+        rolled_back
+            .rollback()
+            .await
+            .expect("schema transaction should roll back");
+        assert_eq!(current_revision(&adapter).await, initial_revision);
+
+        register_schema(&session, "untracked_revision_probe", true).await;
+        let untracked_revision = current_revision(&adapter).await;
+        assert_ne!(untracked_revision, initial_revision);
+        let inserted = session
+            .execute(
+                "INSERT INTO untracked_revision_probe (id, lixcol_untracked) \
+                 VALUES ('untracked-row', true)",
+                &[],
+            )
+            .await
+            .expect("untracked schema should be visible after commit");
+        assert_eq!(inserted.rows_affected(), 1);
+        assert_eq!(
+            current_revision(&adapter).await,
+            untracked_revision,
+            "writes through a dynamic surface must not invalidate its catalog"
+        );
+
+        register_schema(&session, "tracked_revision_probe", false).await;
+        let tracked_revision = current_revision(&adapter).await;
+        assert_ne!(tracked_revision, untracked_revision);
+        let amended = session
+            .execute(
+                "UPDATE lix_registered_schema SET value = $1 \
+                 WHERE lixcol_entity_pk = lix_json('[\"tracked_revision_probe\"]')",
+                &[Value::Json(test_schema("tracked_revision_probe", true))],
+            )
+            .await
+            .expect("compatible tracked schema amendment should commit");
+        assert_eq!(amended.rows_affected(), 1);
+        let amended_revision = current_revision(&adapter).await;
+        assert_ne!(amended_revision, tracked_revision);
+
+        let delete_error = session
+            .execute(
+                "DELETE FROM lix_registered_schema \
+                 WHERE lixcol_entity_pk = lix_json('[\"tracked_revision_probe\"]')",
+                &[],
+            )
+            .await
+            .expect_err("public registered-schema deletion remains unsupported");
+        assert_eq!(delete_error.code, LixError::CODE_UNSUPPORTED_SQL);
+        assert_eq!(current_revision(&adapter).await, amended_revision);
+    }
+
+    #[tokio::test]
+    async fn concurrent_engine_commit_invalidates_next_open_but_not_open_transaction() {
+        let storage = Memory::new();
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let adapter = StorageAdapter::new(storage.clone());
+        let engine_a = Engine::new(storage.clone())
+            .await
+            .expect("first engine should open");
+        let engine_b = Engine::new(storage.clone())
+            .await
+            .expect("second engine should open");
+        let session_a = engine_a
+            .open_session(&receipt.main_branch_id)
+            .await
+            .expect("first session should open");
+        let session_b = engine_b
+            .open_session(&receipt.main_branch_id)
+            .await
+            .expect("second session should open");
+
+        session_a
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('warm-engine-a', 'one')",
+                &[],
+            )
+            .await
+            .expect("first engine should warm its transaction-opening cache");
+        let pinned_read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("pre-schema read should pin");
+        let pinned_revision = load_catalog_revision(&pinned_read)
+            .await
+            .expect("pinned revision should load")
+            .expect("pinned revision should exist");
+        let mut open_transaction = session_a
+            .begin_transaction()
+            .await
+            .expect("explicit transaction should capture the old catalog");
+
+        register_schema(&session_b, "concurrent_revision_probe", false).await;
+        let committed_revision = current_revision(&adapter).await;
+        assert_ne!(committed_revision, pinned_revision);
+        assert_eq!(
+            load_catalog_revision(&pinned_read)
+                .await
+                .expect("pinned revision should remain readable"),
+            Some(pinned_revision),
+            "the token and schema facts share one pinned storage snapshot"
+        );
+
+        open_transaction
+            .execute(
+                "INSERT INTO concurrent_revision_probe (id) VALUES ('too-new')",
+                &[],
+            )
+            .await
+            .expect_err("an already-open transaction must retain its old SQL catalog");
+        open_transaction
+            .rollback()
+            .await
+            .expect("old transaction should roll back");
+
+        let inserted = session_a
+            .execute(
+                "INSERT INTO concurrent_revision_probe (id) VALUES ('next-open')",
+                &[],
+            )
+            .await
+            .expect("the next transaction on the other engine must reload the catalog");
+        assert_eq!(inserted.rows_affected(), 1);
+        assert_eq!(current_revision(&adapter).await, committed_revision);
+    }
+
+    #[tokio::test]
+    async fn branch_ref_rewind_and_restore_use_fresh_revisions_without_false_hits() {
+        let storage = Memory::new();
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let adapter = StorageAdapter::new(storage.clone());
+        let initial_revision = current_revision(&adapter).await;
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("engine should open");
+        let session = engine
+            .open_session(&receipt.main_branch_id)
+            .await
+            .expect("main session should open");
+        let initial_head = engine
+            .load_branch_head_commit_id(&receipt.main_branch_id)
+            .await
+            .expect("initial head should load")
+            .expect("initial head should exist");
+
+        register_schema(&session, "branch_rewind_probe", false).await;
+        session
+            .execute(
+                "INSERT INTO branch_rewind_probe (id) VALUES ('before-rewind')",
+                &[],
+            )
+            .await
+            .expect("new surface should warm the registered catalog");
+        let schema_head = engine
+            .load_branch_head_commit_id(&receipt.main_branch_id)
+            .await
+            .expect("schema head should load")
+            .expect("schema head should exist");
+        let schema_revision = current_revision(&adapter).await;
+        assert_ne!(schema_revision, initial_revision);
+
+        move_branch_ref(&session, &receipt.main_branch_id, &initial_head).await;
+        let rewind_revision = current_revision(&adapter).await;
+        assert_ne!(rewind_revision, initial_revision);
+        assert_ne!(rewind_revision, schema_revision);
+        session
+            .execute(
+                "INSERT INTO branch_rewind_probe (id) VALUES ('must-not-bind')",
+                &[],
+            )
+            .await
+            .expect_err("rewinding the head must hide the newer schema");
+        assert_eq!(
+            current_revision(&adapter).await,
+            rewind_revision,
+            "failed SQL must not advance the token"
+        );
+
+        move_branch_ref(&session, &receipt.main_branch_id, &schema_head).await;
+        let restored_revision = current_revision(&adapter).await;
+        assert_ne!(restored_revision, rewind_revision);
+        assert_ne!(restored_revision, schema_revision);
+        let restored = session
+            .execute(
+                "INSERT INTO branch_rewind_probe (id) VALUES ('after-restore')",
+                &[],
+            )
+            .await
+            .expect("restoring the head must restore the newer schema");
+        assert_eq!(restored.rows_affected(), 1);
+    }
+
+    #[tokio::test]
+    async fn schema_merges_advance_revision_for_fast_forward_and_merge_commit_paths() {
+        run_schema_merge_case(false, MergeBranchOutcome::FastForward).await;
+        run_schema_merge_case(true, MergeBranchOutcome::MergeCommitted).await;
+    }
+
+    async fn run_schema_merge_case(diverge_target: bool, expected: MergeBranchOutcome) {
+        let storage = Memory::new();
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let adapter = StorageAdapter::new(storage.clone());
+        let engine = Engine::new(storage).await.expect("engine should open");
+        let main = engine
+            .open_session(&receipt.main_branch_id)
+            .await
+            .expect("main session should open");
+        let revision_before_branch = current_revision(&adapter).await;
+        main.create_branch(CreateBranchOptions {
+            id: Some("catalog-revision-draft".to_string()),
+            name: "Catalog revision draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft branch should be created");
+        assert_ne!(current_revision(&adapter).await, revision_before_branch);
+        let draft = engine
+            .open_session("catalog-revision-draft")
+            .await
+            .expect("draft session should open");
+        if diverge_target {
+            main.execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('merge-target-change', 'one')",
+                &[],
+            )
+            .await
+            .expect("target should diverge");
+        }
+
+        let schema_key = if diverge_target {
+            "merge_commit_revision_probe"
+        } else {
+            "fast_forward_revision_probe"
+        };
+        register_schema(&draft, schema_key, false).await;
+        let revision_before_merge = current_revision(&adapter).await;
+        let receipt = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "catalog-revision-draft".to_string(),
+            })
+            .await
+            .expect("schema branch should merge");
+        assert_eq!(receipt.outcome, expected);
+        let revision_after_merge = current_revision(&adapter).await;
+        assert_ne!(revision_after_merge, revision_before_merge);
+
+        let insert_sql = format!("INSERT INTO {schema_key} (id) VALUES ('merged-row')");
+        let inserted = main
+            .execute(&insert_sql, &[])
+            .await
+            .expect("merged schema surface should be visible");
+        assert_eq!(inserted.rows_affected(), 1);
+
+        let no_op_revision = current_revision(&adapter).await;
+        let no_op = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "catalog-revision-draft".to_string(),
+            })
+            .await
+            .expect("repeated merge should be a no-op");
+        assert_eq!(no_op.outcome, MergeBranchOutcome::AlreadyUpToDate);
+        assert_eq!(current_revision(&adapter).await, no_op_revision);
+    }
+
+    async fn current_revision(adapter: &StorageAdapter<Memory>) -> CatalogRevision {
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("revision read should open");
+        load_catalog_revision(&read)
+            .await
+            .expect("catalog revision should load")
+            .expect("initialized storage should have a catalog revision")
+    }
+
+    async fn register_schema(session: &SessionContext<Memory>, schema_key: &str, untracked: bool) {
+        let sql = format!(
+            "INSERT INTO lix_registered_schema \
+             (value, lixcol_global, lixcol_untracked) VALUES ($1, false, {untracked})"
+        );
+        session
+            .execute(&sql, &[Value::Json(test_schema(schema_key, false))])
+            .await
+            .expect("schema registration should commit");
+    }
+
+    fn test_schema(schema_key: &str, amended: bool) -> JsonValue {
+        let mut schema = json!({
+            "x-lix-key": schema_key,
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": { "id": { "type": "string" } },
+            "required": ["id"],
+            "additionalProperties": false
+        });
+        if amended {
+            schema["description"] = json!("compatible additive amendment");
+            schema["properties"]["title"] = json!({ "type": "string" });
+        }
+        schema
+    }
+
+    async fn move_branch_ref(session: &SessionContext<Memory>, branch_id: &str, commit_id: &str) {
+        let branch_id = branch_id.to_string();
+        let commit_id = CommitId::parse_lix(commit_id, "catalog revision test branch head")
+            .expect("test commit id should parse");
+        session
+            .with_write_transaction(move |transaction| {
+                Box::pin(async move { transaction.advance_branch_ref(&branch_id, commit_id).await })
+            })
+            .await
+            .expect("branch ref should move");
+    }
+}

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -247,6 +247,11 @@ where
             .rebuild_commit_root_at(&head_commit_id)
             .await;
         rebuild_result?;
+        // A healthy rebuild is content-equivalent, but this API also repairs a
+        // stale or damaged serving root. Conservatively invalidate transaction
+        // opening catalogs so repaired registered-schema facts are never hidden
+        // behind a pre-rebuild cache entry.
+        crate::catalog::stage_catalog_revision(&mut writes);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -260,6 +260,7 @@ where
             )
             .await?;
     }
+    crate::catalog::stage_catalog_revision(&mut writes);
 
     storage
         .commit_write_set(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -19,7 +19,10 @@ use serde_json::Value as JsonValue;
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobHash};
 use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader, branch_ref_stage_row};
-use crate::catalog::{CatalogContext, CatalogFingerprint, CatalogSnapshot};
+use crate::catalog::{
+    CatalogContext, CatalogFingerprint, CatalogSnapshot, load_catalog_revision,
+    stage_catalog_revision,
+};
 use crate::changelog::{ChangeId, CommitId};
 use crate::commit_graph::{CommitGraphContext, CommitGraphStoreReader};
 use crate::common::LixTimestamp;
@@ -300,11 +303,13 @@ where
             };
             let functions = runtime_functions.provider();
             let schema_catalog = {
+                let catalog_revision = load_catalog_revision(&read).await?;
                 let visible_live_state = live_state.reader(&read);
                 catalog_context
-                    .compiled_catalog_for_domain(
+                    .compiled_catalog_for_transaction_open(
                         &visible_live_state,
                         &Domain::schema_catalog(active_branch_id.clone(), true),
+                        catalog_revision.as_ref(),
                     )
                     .await?
             };
@@ -371,6 +376,7 @@ where
                 return Err(error);
             }
         };
+        let catalog_revision_changed = prepared_writes_change_catalog(&prepared_writes);
         let _commit_guard = begin_commit_boundary(commit_boundary.as_ref());
         check_commit_boundary(commit_boundary.as_ref())?;
         transaction
@@ -407,7 +413,7 @@ where
         } else {
             load_path_index_revision(&read).await.ok().flatten()
         };
-        let writes = match commit::commit_prepared_writes(
+        let mut writes = match commit::commit_prepared_writes(
             &transaction.binary_cas,
             transaction.branch_ctx.as_ref(),
             transaction.live_state.index(),
@@ -420,6 +426,9 @@ where
             Ok(writes) => writes,
             Err(error) => return Err(error),
         };
+        if catalog_revision_changed {
+            stage_catalog_revision(&mut writes);
+        }
         let prepared_commit = transaction
             .storage
             .prepare_write_set(writes, StorageWriteOptions::default())
@@ -2155,6 +2164,19 @@ fn parse_prepared_timestamp(column: &str, timestamp: &str) -> Result<LixTimestam
             "invalid {column} timestamp for prepared state row: {error}"
         ))
     })
+}
+
+fn prepared_writes_change_catalog(prepared_writes: &PreparedWriteSet) -> bool {
+    prepared_writes.state_rows.iter().any(|row| {
+        matches!(
+            row.schema_key.as_str(),
+            REGISTERED_SCHEMA_KEY | BRANCH_REF_SCHEMA_KEY
+        )
+    }) || prepared_writes
+        .commit_change_refs_by_branch
+        .values()
+        .flat_map(|change_refs| change_refs.selected_change_refs.iter())
+        .any(|change_ref| change_ref.schema_key == REGISTERED_SCHEMA_KEY)
 }
 
 pub(crate) struct OpenTransaction<StorageImpl: Storage = Memory> {


### PR DESCRIPTION
## Summary

- store one opaque catalog revision token in the same atomic write set as every mutation that can change visible `lix_registered_schema` facts
- load that token from the transaction's pinned storage snapshot and reuse the compiled catalog by `(domain, revision)`
- replace repeated registered-schema scans on ordinary implicit transactions with one point read
- conservatively retain the existing scan path when a revision marker is absent

Ordinary CRUD does not advance the revision. Direct tracked/untracked schema writes, selected schema merges, branch-ref moves, initialization, and tracked-root repair do. Open transactions retain the catalog from their pinned snapshot, while concurrent engines see a new revision on their next transaction.

This is crate-private, changes no public API, and does not add SQL parsing or planning logic.

## Results

Five alternating-order process pairs pinned to CPU 0, with 50 warmups and 1,000 measured iterations per case. Values are medians of the five run-level p50/p95 values.

| Backend / case | p50 before → after | p50 | p95 before → after | p95 |
| --- | ---: | ---: | ---: | ---: |
| RocksDB Atelier file UPSERT | 1,512,284 → 1,148,781 ns | **-24.04%** | 1,994,572 → 1,403,169 ns | **-29.65%** |
| RocksDB file UPDATE by id | 2,150,784 → 1,728,992 ns | **-19.61%** | 2,538,273 → 1,989,541 ns | **-21.62%** |
| RocksDB key/value UPDATE | 2,712,722 → 2,226,146 ns | **-17.94%** | 3,184,830 → 2,521,241 ns | **-20.84%** |
| SlateDB Atelier file UPSERT | 3,610,471 → 2,946,511 ns | **-18.39%** | 4,276,704 → 3,589,952 ns | **-16.06%** |
| SlateDB file UPDATE by id | 5,253,271 → 4,521,904 ns | **-13.92%** | 6,125,541 → 5,424,191 ns | **-11.45%** |
| SlateDB key/value UPDATE | 6,459,710 → 5,709,307 ns | **-11.62%** | 7,348,851 → 6,661,399 ns | -9.35% |

Controls:

| Backend / control | p50 | p95 |
| --- | ---: | ---: |
| RocksDB non-transaction read | -0.04% | +1.86% |
| RocksDB repeated UPDATE in one explicit transaction | +1.40% | +3.69% |
| SlateDB non-transaction read | -0.32% | +0.53% |
| SlateDB repeated UPDATE in one explicit transaction | +5.63% | +6.25% |

The control code paths and storage traces are unchanged; the small timing movements are below the 10% threshold and vary across runs.

Deterministic storage accounting was identical across all five runs and both backends:

- every implicit operation: **2 fewer scans**
- every implicit operation: **8 fewer `get_many` calls**
- every implicit operation: **64 fewer requested keys**
- `begin_read` and live-state row counts: unchanged
- both controls: byte-for-byte identical counts

The candidate's one revision point read is already included in those net counts.

## Method and artifacts

The benchmark parent and candidate used the same engine base `35f7e1c691fb4108a7d20c392fe2c18fb2d6c676`. Current `main` adds only the CI/JS-build changes from #692.

- baseline binary SHA-256: `c4ccfcb61b7f038121b35395cd5c229210c5a6fcfa1cb9c0e2e95f1e6ffed0af`
- candidate binary SHA-256: `50934228c364fc7bd47d7e9446a5d157024c6f46aa53b53c3a015ce032cae043`
- identical harness SHA-256: `52fb300342a6b7d27cd811e6e0ac9dd7e8e91a0ce2e86abe655cd3f4666f8a15`
- aggregate SHA-256: `48c3e3112d1f3853585d0e90fedb60e145671bc24f372c9f3dc62990ad68706f`

The manual benchmark harness is intentionally excluded from this PR.

## Design precedent

The revision acts as a snapshot-local catalog generation: reuse is allowed only when the generation matches, and schema-visible mutations invalidate atomically. This is the same broad pattern used by systems that cache prepared/bound state and rebind after catalog modification; for example, DuckDB checks catalog modification before executing cached prepared statements:

- https://github.com/duckdb/duckdb/blob/master/src/main/client_context.cpp
- https://duckdb.org/docs/lts/clients/c/prepared.html

Unlike a cached DataFusion plan, this cache contains only an immutable compiled catalog snapshot and never captures snapshot-specific providers or storage readers.

## Validation

- focused revision/invalidation tests: 5 passed
- focused cache scan-count tests: 2 passed
- `cargo test -p lix_engine --lib`: 1,148 passed, 0 failed, 6 ignored
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent static audit of mutation coverage, snapshot isolation, concurrent engines, namespace use, and public API: no actionable findings
