### PR TITLE
bench: guard pinned session read performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,6 +3435,7 @@ version = "0.8.4"
 dependencies = [
  "async-stream",
  "axum",
+ "codspeed-criterion-compat",
  "flate2",
  "futures-core",
  "getrandom 0.3.4",

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -79,3 +79,8 @@ name = "sqlite"
 path = "benches/sqlite.rs"
 harness = false
 required-features = ["sqlite"]
+
+[[bench]]
+name = "branch_session"
+path = "benches/branch_session.rs"
+harness = false

--- a/packages/rs-sdk/benches/branch_session.rs
+++ b/packages/rs-sdk/benches/branch_session.rs
@@ -1,0 +1,63 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use lix_sdk::{OpenLixOptions, Value, open_lix};
+
+fn bench_branch_session(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("build benchmark runtime");
+    let workspace = runtime
+        .block_on(open_lix(OpenLixOptions::default()))
+        .expect("open benchmark workspace");
+    let main_branch_id = runtime
+        .block_on(workspace.active_branch_id())
+        .expect("load main branch id");
+    runtime
+        .block_on(workspace.execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/branch-session-bench.bin".to_string()),
+                Value::Blob(vec![0x5a; 2_048]),
+            ],
+        ))
+        .expect("seed benchmark file");
+    let pinned = runtime
+        .block_on(workspace.open_session(main_branch_id))
+        .expect("open branch-pinned session");
+
+    let sql = "SELECT data FROM lix_file WHERE path = $1";
+    let params = [Value::Text("/branch-session-bench.bin".to_string())];
+    for session in [&workspace, &pinned] {
+        let result = runtime
+            .block_on(session.execute(sql, &params))
+            .expect("verify benchmark read");
+        assert_eq!(result.rows().len(), 1);
+        assert_eq!(result.rows()[0].values(), &[Value::Blob(vec![0x5a; 2_048])]);
+    }
+
+    let mut group = c.benchmark_group("exact_file_read_2k");
+    group.throughput(Throughput::Bytes(2_048));
+    group.bench_function("workspace_selector", |b| {
+        b.iter(|| {
+            black_box(
+                runtime
+                    .block_on(workspace.execute(sql, &params))
+                    .expect("read through workspace selector"),
+            );
+        });
+    });
+    group.bench_function("branch_pinned", |b| {
+        b.iter(|| {
+            black_box(
+                runtime
+                    .block_on(pinned.execute(sql, &params))
+                    .expect("read through pinned branch"),
+            );
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_branch_session);
+criterion_main!(benches);

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -30,8 +30,14 @@ tower-http = { version = "0.6", features = ["compression-gzip", "decompression-g
 tracing = "0.1"
 
 [dev-dependencies]
+criterion = { package = "codspeed-criterion-compat", version = "4" }
 flate2 = "1"
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3"
+
+[[bench]]
+name = "session_read"
+path = "benches/session_read.rs"
+harness = false

--- a/packages/server-protocol/benches/session_read.rs
+++ b/packages/server-protocol/benches/session_read.rs
@@ -1,0 +1,118 @@
+use std::{hint::black_box, sync::Arc};
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::CONTENT_TYPE},
+};
+use criterion::{Criterion, criterion_group, criterion_main};
+use lix_sdk::{OpenLixOptions, Value, open_lix};
+use lix_server_protocol::{LixProtocolServer, SESSION_ID_HEADER, handler};
+use serde_json::{Value as JsonValue, json};
+use tower::ServiceExt;
+
+const FILE_PATH: &str = "/protocol-session-bench.bin";
+const RESPONSE_LIMIT: usize = 16 * 1024;
+
+fn bench_session_read(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("build benchmark runtime");
+    let root = Arc::new(
+        runtime
+            .block_on(open_lix(OpenLixOptions::default()))
+            .expect("open benchmark workspace"),
+    );
+    runtime
+        .block_on(root.execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text(FILE_PATH.to_string()),
+                Value::Blob(vec![0x5a; 2_048]),
+            ],
+        ))
+        .expect("seed benchmark file");
+    let router = handler(LixProtocolServer::new(root));
+    let session_id = runtime.block_on(open_session(&router));
+    let request_body = serde_json::to_vec(&json!({
+        "sql": "SELECT data FROM lix_file WHERE path = $1",
+        "params": [{ "kind": "text", "value": FILE_PATH }],
+    }))
+    .expect("encode execute request");
+    runtime.block_on(verify_read(&router, &session_id, request_body.clone()));
+
+    let mut group = c.benchmark_group("in_process_protocol_exact_file_read_2k");
+    group.bench_function("default_remote_session", |b| {
+        b.iter(|| {
+            let response = runtime
+                .block_on(
+                    router
+                        .clone()
+                        .oneshot(execute_request(&session_id, request_body.clone())),
+                )
+                .expect("execute protocol request");
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = runtime
+                .block_on(to_bytes(response.into_body(), RESPONSE_LIMIT))
+                .expect("read execute response");
+            black_box(body);
+        });
+    });
+    group.finish();
+}
+
+fn execute_request(session_id: &str, body: Vec<u8>) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/lix/v1/execute")
+        .header(SESSION_ID_HEADER, session_id)
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .expect("build execute request")
+}
+
+async fn verify_read(router: &Router, session_id: &str, request_body: Vec<u8>) {
+    let response = router
+        .clone()
+        .oneshot(execute_request(session_id, request_body))
+        .await
+        .expect("verify execute request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), RESPONSE_LIMIT)
+        .await
+        .expect("read verified response");
+    let value: JsonValue = serde_json::from_slice(&body).expect("decode verified response");
+    assert_eq!(value["rows"][0][0]["kind"], "blob");
+    assert_eq!(
+        value["rows"][0][0]["base64"]
+            .as_str()
+            .expect("verified blob")
+            .len(),
+        2_732
+    );
+}
+
+async fn open_session(router: &Router) -> String {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/lix/v1")
+                .body(Body::empty())
+                .expect("build handshake request"),
+        )
+        .await
+        .expect("handshake");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), RESPONSE_LIMIT)
+        .await
+        .expect("read handshake response");
+    let value: JsonValue = serde_json::from_slice(&body).expect("decode handshake response");
+    value["sessionId"]
+        .as_str()
+        .expect("handshake session id")
+        .to_string()
+}
+
+criterion_group!(benches, bench_session_read);
+criterion_main!(benches);


### PR DESCRIPTION
## What

- add a paired engine benchmark for exact 2 KiB file reads through a workspace-selector session and a branch-pinned session
- add an in-process protocol benchmark that handshakes through the default remote path, retains the session ID, and repeatedly reads the same file through Axum
- verify the expected blob before timing so an empty or stale result cannot appear fast

## Why

#700 already contains the optimization explored in #699: a default remote handshake resolves the current branch once and opens a pinned engine session. Subsequent requests reuse that handle, while an explicit branch switch replaces it. This PR records the attributable performance difference and guards the optimized default protocol path without reintroducing the public immutable-branch API from #699.

## Results

Criterion point estimates on the same host, pinned to one CPU, with 5 s warm-up, 20 s measurement, and 100 samples:

| Benchmark | Workspace selector | Branch pinned | Change |
| --- | ---: | ---: | ---: |
| Core exact-file read | 48.359 µs | 35.588 µs | **-26.4%** |

The identical in-process protocol harness was also run in three alternating pairs on pre-#700 `defa42a9` and #700/main `9c0f9ce6`:

| Run | Pre-#700 | #700/main |
| --- | ---: | ---: |
| 1 | 84.714 µs | 59.557 µs |
| 2 | 85.278 µs | 62.458 µs |
| 3 | 84.776 µs | 58.698 µs |
| Median | 84.776 µs | 59.557 µs |

That is **29.7% lower** at the median of the run-level point estimates. Each pair improves by more than 10%.

Scope: the protocol benchmark uses memory storage and `Router::oneshot`. It includes handshake-derived session routing, JSON/Axum handling, leasing, and response-body consumption, but excludes sockets, TLS, the JS client, production storage, and concurrent server throughput. These are Criterion estimates, not p50/p95 latency claims.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `node scripts/validate-changes.mjs`
- `cargo clippy --profile test -p lix_sdk -p lix_server_protocol --all-targets --all-features -- -D warnings`
- `cargo test --profile test -p lix_sdk -p lix_server_protocol --all-features` (104 passed, 2 ignored)
- both benchmark targets compiled and executed successfully

No changenote: this is a repository benchmark-only change.