### PR TITLE
perf(remote): cache active branch state

### DIFF
--- a/.changenotes/cache-remote-active-branch.md
+++ b/.changenotes/cache-remote-active-branch.md
@@ -1,0 +1,10 @@
+---
+type: patch
+---
+
+Improved remote active branch reads by reusing the session state established
+during the initial handshake.
+
+`activeBranchId()` now avoids a redundant network request and remains
+synchronized after successful branch switches. Ambiguous switch failures
+invalidate the cached value so the next read reconciles it with the server.

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -111,17 +111,15 @@ test("remote mode uses the workspace protocol without loading a local engine", a
 		new Uint8Array([1, 2, 3]),
 	);
 	expect(result.rows[0]?.get("json")).toEqual({ ok: true });
-	expect(headerCalls).toBe(3);
+	expect(headerCalls).toBe(2);
 	expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
-		"/@acme/workspace/lix/v1/",
 		"/@acme/workspace/lix/v1/",
 		"/@acme/workspace/lix/v1/execute",
 	]);
-	expect(requests[2]?.headers.get("authorization")).toBe("Bearer token-3");
+	expect(requests[1]?.headers.get("authorization")).toBe("Bearer token-2");
 	expect(requests[0]?.headers.has("lix-session-id")).toBe(false);
 	expect(requests[1]?.headers.get("lix-session-id")).toBe("session-1");
-	expect(requests[2]?.headers.get("lix-session-id")).toBe("session-1");
-	expect(await requests[2]?.json()).toEqual({
+	expect(await requests[1]?.json()).toEqual({
 		sql: "SELECT $1, $2, $3, $4, $5, $6, $7",
 		params: [
 			{ kind: "null", value: null },
@@ -136,11 +134,11 @@ test("remote mode uses the workspace protocol without loading a local engine", a
 	});
 
 	await lix.close();
-	expect(new URL(requests[3]?.url ?? "").pathname).toBe(
+	expect(new URL(requests[2]?.url ?? "").pathname).toBe(
 		"/@acme/workspace/lix/v1/session",
 	);
-	expect(requests[3]?.method).toBe("DELETE");
-	expect(requests[3]?.headers.get("lix-session-id")).toBe("session-1");
+	expect(requests[2]?.method).toBe("DELETE");
+	expect(requests[2]?.headers.get("lix-session-id")).toBe("session-1");
 });
 
 test("remote mode compresses only large compressible JSON requests", async () => {
@@ -560,11 +558,13 @@ test("remote branches preserve local Lix branch semantics", async () => {
 	expect(
 		await Promise.all(posted.map((request) => request.clone().json())),
 	).toEqual([{ name: "Draft" }, { branchId: "draft-id" }]);
+	expect(requests.filter((request) => request.method === "GET")).toHaveLength(1);
 
 	await lix.close();
 });
 
 test("a failed remote branch switch leaves the active branch unchanged", async () => {
+	let handshakeCalls = 0;
 	const lix = await openLix({
 		server: {
 			mode: "remote",
@@ -575,23 +575,25 @@ test("a failed remote branch switch leaves the active branch unchanged", async (
 				if (request.method === "DELETE") {
 					return new Response(null, { status: 204 });
 				}
-				return pathname.endsWith("/lix/v1/")
-					? Response.json({
-							protocolVersion: 1,
-							activeBranchId: "main-id",
-							sessionId: "session-1",
-						})
-					: Response.json(
-							{
-								error: {
-									code: "LIX_BRANCH_NOT_FOUND",
-									message: "Branch not found",
-									hint: "Choose an existing branch",
-									details: { branchId: "missing" },
-								},
-							},
-							{ status: 404 },
-						);
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId: "main-id",
+						sessionId: "session-1",
+					});
+				}
+				return Response.json(
+					{
+						error: {
+							code: "LIX_BRANCH_NOT_FOUND",
+							message: "Branch not found",
+							hint: "Choose an existing branch",
+							details: { branchId: "missing" },
+						},
+					},
+					{ status: 404 },
+				);
 			}) as typeof fetch,
 		},
 	});
@@ -607,6 +609,91 @@ test("a failed remote branch switch leaves the active branch unchanged", async (
 		},
 	);
 	expect(await lix.activeBranchId()).toBe("main-id");
+	expect(handshakeCalls).toBe(1);
+
+	await lix.close();
+});
+
+test("an ambiguous remote branch switch is reconciled by the next branch read", async () => {
+	let activeBranchId = "main-id";
+	let handshakeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId,
+						sessionId: "session-1",
+					});
+				}
+				if (pathname.endsWith("/branch/switch")) {
+					const body = (await request.json()) as { branchId: string };
+					activeBranchId = body.branchId;
+					return Response.json({ branchId: "malformed-response" });
+				}
+				throw new Error(`Unexpected request: ${pathname}`);
+			}) as typeof fetch,
+		},
+	});
+
+	await expect(
+		lix.switchBranch({ branchId: "draft-id" }),
+	).rejects.toMatchObject({ code: "LIX_REMOTE_PROTOCOL_ERROR" });
+	expect(await lix.activeBranchId()).toBe("draft-id");
+	expect(handshakeCalls).toBe(2);
+
+	await lix.close();
+});
+
+test("branch reconciliation rejects and never caches a replacement session", async () => {
+	let handshakeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					return Response.json({
+						protocolVersion: 1,
+						activeBranchId: "draft-id",
+						sessionId: handshakeCalls === 1 ? "session-1" : "session-2",
+					});
+				}
+				if (pathname.endsWith("/branch/switch")) {
+					return Response.json({ branchId: "malformed-response" });
+				}
+				throw new Error(`Unexpected request: ${pathname}`);
+			}) as typeof fetch,
+		},
+	});
+
+	await expect(
+		lix.switchBranch({ branchId: "draft-id" }),
+	).rejects.toMatchObject({ code: "LIX_REMOTE_PROTOCOL_ERROR" });
+	await expect(lix.activeBranchId()).rejects.toMatchObject({
+		code: "LIX_REMOTE_PROTOCOL_ERROR",
+		message: "remote handshake changed sessionId",
+	});
+	await expect(lix.activeBranchId()).rejects.toMatchObject({
+		code: "LIX_REMOTE_PROTOCOL_ERROR",
+		message: "remote handshake changed sessionId",
+	});
+	expect(handshakeCalls).toBe(3);
 
 	await lix.close();
 });
@@ -704,12 +791,18 @@ test("remote operations preserve normal Lix call ordering", async () => {
 	});
 
 	const switching = lix.switchBranch({ branchId: "draft-id" });
+	const readingActiveBranch = lix.activeBranchId();
 	const executing = lix.execute("SELECT 1");
 	await Promise.resolve();
 	await Promise.resolve();
 	expect(requestOrder).toEqual(["switch"]);
 	finishSwitch?.();
-	await Promise.all([switching, executing]);
+	const [, activeBranchId] = await Promise.all([
+		switching,
+		readingActiveBranch,
+		executing,
+	]);
+	expect(activeBranchId).toBe("draft-id");
 	expect(requestOrder).toEqual(["switch", "execute"]);
 	expect(executeBody).toEqual({ sql: "SELECT 1", params: [] });
 
@@ -823,7 +916,7 @@ test.each([undefined, "", " contains-space", "contains\nnewline", 42])(
 	},
 );
 
-test("a later handshake cannot silently replace the remote session", async () => {
+test("active branch reads reuse the initial handshake without another GET", async () => {
 	let handshakeCalls = 0;
 	const lix = await openLix({
 		server: {
@@ -838,16 +931,15 @@ test("a later handshake cannot silently replace the remote session", async () =>
 				return Response.json({
 					protocolVersion: 1,
 					activeBranchId: "main-id",
-					sessionId: handshakeCalls === 1 ? "session-1" : "session-2",
+					sessionId: "session-1",
 				});
 			},
 		},
 	});
 
-	await expect(lix.activeBranchId()).rejects.toMatchObject({
-		code: "LIX_REMOTE_PROTOCOL_ERROR",
-		message: "remote handshake changed sessionId",
-	});
+	expect(await lix.activeBranchId()).toBe("main-id");
+	expect(await lix.activeBranchId()).toBe("main-id");
+	expect(handshakeCalls).toBe(1);
 	await lix.close();
 });
 

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -76,6 +76,7 @@ class RemoteLixBinding implements LixBinding {
 	readonly #observationHub: RemoteObservationHub;
 	readonly #requestBlobBases = new Map<string, RequestBlobBase>();
 	#sessionId: string | undefined;
+	#activeBranchId: string | undefined;
 	#supportsRequestBlobSplice = false;
 	#requestBlobBaseBytes = 0;
 	#acceptingOperations = true;
@@ -130,6 +131,7 @@ class RemoteLixBinding implements LixBinding {
 			await this.#requestJson(path, { method: "GET" }),
 		);
 		this.#sessionId = handshake.sessionId;
+		this.#activeBranchId = handshake.activeBranchId;
 		this.#supportsRequestBlobSplice = handshake.requestBlobSplice;
 	}
 
@@ -241,13 +243,17 @@ class RemoteLixBinding implements LixBinding {
 	async activeBranchId(): Promise<string> {
 		this.#assertOpen();
 		return this.#enqueue(async () => {
-			const handshake = decodeHandshake(
-				await this.#requestJson("", { method: "GET" }),
-			);
-			if (handshake.sessionId !== this.#sessionId) {
-				throw protocolError("remote handshake changed sessionId");
+			if (this.#activeBranchId === undefined) {
+				const handshake = decodeHandshake(
+					await this.#requestJson("", { method: "GET" }),
+				);
+				if (handshake.sessionId !== this.#sessionId) {
+					throw protocolError("remote handshake changed sessionId");
+				}
+				this.#activeBranchId = handshake.activeBranchId;
+				this.#supportsRequestBlobSplice = handshake.requestBlobSplice;
 			}
-			return handshake.activeBranchId;
+			return this.#activeBranchId;
 		});
 	}
 
@@ -285,18 +291,27 @@ class RemoteLixBinding implements LixBinding {
 	): Promise<SwitchBranchReceipt> {
 		this.#assertOpen();
 		return this.#enqueue(async () => {
-			const value = record(
-				await this.#requestJson("branch/switch", {
-					method: "POST",
-					body: JSON.stringify(options),
-				}),
-				"switch branch response",
-			);
-			if (value.branchId !== options.branchId) {
-				throw protocolError("switch branch response is invalid");
+			try {
+				const value = record(
+					await this.#requestJson("branch/switch", {
+						method: "POST",
+						body: JSON.stringify(options),
+					}),
+					"switch branch response",
+				);
+				if (value.branchId !== options.branchId) {
+					throw protocolError("switch branch response is invalid");
+				}
+				this.#activeBranchId = options.branchId;
+				this.#observationHub.restart();
+				return { branchId: options.branchId };
+			} catch (error) {
+				if (!isDefinitiveClientError(error)) {
+					this.#activeBranchId = undefined;
+					this.#observationHub.restart();
+				}
+				throw error;
 			}
-			this.#observationHub.restart();
-			return { branchId: options.branchId };
 		});
 	}
 
@@ -1196,6 +1211,18 @@ async function errorFromHttpResponse(response: Response): Promise<Error> {
 			},
 		);
 	}
+}
+
+function isDefinitiveClientError(error: unknown): boolean {
+	if (!(error instanceof Error) || !("status" in error)) return false;
+	const status = (error as { status?: unknown }).status;
+	return (
+		typeof status === "number" &&
+		status >= 400 &&
+		status < 500 &&
+		status !== 408 &&
+		status !== 429
+	);
 }
 
 function isRetryableObserveStatus(status: number): boolean {

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -291,12 +291,20 @@ class RemoteLixBinding implements LixBinding {
 	): Promise<SwitchBranchReceipt> {
 		this.#assertOpen();
 		return this.#enqueue(async () => {
+			let requestAttempted = false;
 			try {
 				const value = record(
-					await this.#requestJson("branch/switch", {
-						method: "POST",
-						body: JSON.stringify(options),
-					}),
+					await this.#requestJson(
+						"branch/switch",
+						{
+							method: "POST",
+							body: JSON.stringify(options),
+						},
+						"json",
+						() => {
+							requestAttempted = true;
+						},
+					),
 					"switch branch response",
 				);
 				if (value.branchId !== options.branchId) {
@@ -306,7 +314,7 @@ class RemoteLixBinding implements LixBinding {
 				this.#observationHub.restart();
 				return { branchId: options.branchId };
 			} catch (error) {
-				if (!isDefinitiveClientError(error)) {
+				if (requestAttempted && !isDefinitiveClientError(error)) {
 					this.#activeBranchId = undefined;
 					this.#observationHub.restart();
 				}
@@ -352,6 +360,7 @@ class RemoteLixBinding implements LixBinding {
 		path: string,
 		init: RequestInit,
 		responseKind: "json" | "empty" = "json",
+		onRequestAttempt?: () => void,
 	): Promise<unknown> {
 		const headers = new Headers(await resolveHeaders(this.#headers));
 		if (this.#sessionId === undefined) headers.delete(REMOTE_SESSION_HEADER);
@@ -371,11 +380,16 @@ class RemoteLixBinding implements LixBinding {
 			}
 		}
 		let response: Response;
+		const url = new URL(path, this.#baseUrl);
+		const fetchInit = {
+			...requestInit,
+			headers,
+		};
+		// A custom fetch may transmit before throwing, so failures become
+		// ambiguous only once control is handed to it.
+		onRequestAttempt?.();
 		try {
-			response = await this.#fetch(new URL(path, this.#baseUrl), {
-				...requestInit,
-				headers,
-			});
+			response = await this.#fetch(url, fetchInit);
 		} catch (cause) {
 			throw remoteError(
 				"LIX_REMOTE_UNAVAILABLE",

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -437,6 +437,57 @@ test("a successful branch switch restarts observations on the pinned session", a
 	await lix.close();
 });
 
+test("a local branch switch setup failure preserves a healthy observation", async () => {
+	let failHeaders = false;
+	let observeRequests = 0;
+	let branchSwitchRequests = 0;
+	let observeSignal: AbortSignal | undefined;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/workspace",
+			headers: () => {
+				if (failHeaders) throw new Error("headers unavailable");
+				return {};
+			},
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) return handshake();
+				if (request.method === "DELETE") return closedSession();
+				if (pathname.endsWith("/branch/switch")) {
+					branchSwitchRequests += 1;
+					return Response.json({ branchId: "draft-id" });
+				}
+				observeRequests += 1;
+				observeSignal = request.signal;
+				return heldSseResponse(
+					sseFrame(
+						"next",
+						multiplexObservePayload("observe-1", "main-id", 0, 0),
+					),
+					request.signal,
+				);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT active_branch");
+	expect((await events.next())?.result.rows[0]?.get("value")).toBe("main-id");
+	failHeaders = true;
+	await expect(
+		lix.switchBranch({ branchId: "draft-id" }),
+	).rejects.toThrow("headers unavailable");
+	expect(branchSwitchRequests).toBe(0);
+	expect(observeSignal?.aborted).toBe(false);
+	expect(observeRequests).toBe(1);
+	expect(await lix.activeBranchId()).toBe("main-id");
+
+	failHeaders = false;
+	events.close();
+	await lix.close();
+});
+
 test("remote observe reconnects retryable failures with fresh headers", async () => {
 	vi.useFakeTimers();
 	try {

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -419,15 +419,18 @@ test("a successful branch switch restarts observations on the pinned session", a
 
 	const events = lix.observe("SELECT active_branch");
 	expect((await events.next())?.result.rows[0]?.get("value")).toBe("main-id");
+	expect(await lix.activeBranchId()).toBe("main-id");
 	const afterSwitch = events.next();
 	await lix.switchBranch({ branchId: "draft-id" });
 	const switched = await afterSwitch;
 	expect(switched?.result.rows[0]?.get("value")).toBe("draft-id");
 	expect(switched?.sequence).toBe(1);
+	expect(await lix.activeBranchId()).toBe("draft-id");
 	expect(observeRequests).toBe(2);
 	await expect(
 		lix.switchBranch({ branchId: "missing-id" }),
 	).rejects.toMatchObject({ code: "LIX_BRANCH_NOT_FOUND" });
+	expect(await lix.activeBranchId()).toBe("draft-id");
 	expect(observeRequests).toBe(2);
 
 	events.close();


### PR DESCRIPTION
## Summary

- seed the remote client's active branch cache from the session handshake
- update it after successful branch switches
- invalidate and reconcile it after ambiguous switch outcomes
- keep active-branch reads in the existing per-client operation queue

## Why

The active branch is session-scoped state, but every `activeBranchId()` call repeated the protocol handshake. On the normal `activeBranchId()` + query path this doubled requests and latency even though the client already received the value when it opened the pinned session.

## Measured impact

Real Rust server + SlateDB, 1,000 alternating ABBA samples of the same query path:

| path | p50 | p95 | mean | requests |
| --- | ---: | ---: | ---: | ---: |
| cached / execute only | 1.522 ms | 4.529 ms | 2.117 ms | 1 |
| redundant branch GET + execute | 3.195 ms | 9.002 ms | 3.975 ms | 2 |

Removing the redundant handshake improves p50 by **52.4%**, p95 by **49.7%**, mean by **46.8%**, and halves requests on this happy path.

## Correctness

A definitive 4xx switch failure preserves the known branch. Network, timeout, retryable HTTP, or malformed-response outcomes invalidate the cache because the server may have committed the switch; the next read performs a session-checked handshake. A replacement session is rejected and never cached.

Client-local setup failures occur before the request-attempt boundary, so header/body preparation errors preserve both the known branch and any healthy observation stream. This boundary has a deterministic regression test and independent re-review found no remaining issue.

## Validation

- `npm run build`
- full Node Vitest suite: 130 passed
- built browser suite: 23 passed
- packed Vite consumer smoke test
- TypeScript typecheck
- changenote validation and `git diff --check`

This changes no physical storage layout and remains compatible with existing Lix files.