### PR TITLE
perf(storage)!: use a versioned LZ4 SlateDB layout

### DIFF
--- a/.changenotes/compress-slatedb-storage.md
+++ b/.changenotes/compress-slatedb-storage.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reduced SlateDB storage and network usage with LZ4 compression.
+
+New SlateDB writes use fast block compression while existing uncompressed databases remain readable without migration.

--- a/.changenotes/compress-slatedb-storage.md
+++ b/.changenotes/compress-slatedb-storage.md
@@ -1,7 +1,9 @@
 ---
-type: patch
+type: minor
 ---
 
-Reduced SlateDB storage and network usage with LZ4 compression.
+Changed SlateDB storage to a versioned LZ4 physical layout.
 
-New SlateDB writes use fast block compression while existing uncompressed databases remain readable without migration.
+Existing SlateDB-backed Lixes must be recreated. The new layout does not read
+the previous physical namespace and provides no migration or compatibility
+fallback.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex",
+ "lz4_flex 0.13.0",
 ]
 
 [[package]]
@@ -3513,6 +3513,15 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
@@ -4808,6 +4817,7 @@ dependencies = [
  "futures",
  "log",
  "lru",
+ "lz4_flex 0.11.6",
  "moka",
  "object_store 0.14.0",
  "ouroboros",

--- a/packages/slatedb-storage/Cargo.toml
+++ b/packages/slatedb-storage/Cargo.toml
@@ -22,7 +22,7 @@ lix_engine = { workspace = true }
 bytes = "1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 object_store = { version = "0.14", default-features = false, features = ["fs"] }
-slatedb = { version = "0.14.1", default-features = false, features = ["moka"] }
+slatedb = { version = "0.14.1", default-features = false, features = ["lz4", "moka"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -22,8 +22,8 @@ use lix_engine::{StorageFactory, StorageFixture, StorageTestConfig};
 use object_store::ObjectStore;
 use object_store::local::LocalFileSystem;
 use slatedb::config::{
-    ObjectStoreCacheOptions, PreloadLevel, ScanOptions as SlateDBScanOptions, Settings,
-    WriteOptions as SlateDBWriteOptions,
+    CompressionCodec, ObjectStoreCacheOptions, PreloadLevel, ScanOptions as SlateDBScanOptions,
+    Settings, WriteOptions as SlateDBWriteOptions,
 };
 use slatedb::db_cache::moka::{MokaCache, MokaCacheOptions};
 use slatedb::db_cache::{DbCache, SplitCache};
@@ -674,18 +674,16 @@ fn open_slatedb(
 ) -> Result<Db, StorageError> {
     runtime.block_on(async move {
         let mut builder = Db::builder(db_path, object_store);
+        let mut settings = slatedb_settings();
         if let Some(cache) = options.cache {
-            let settings = Settings {
-                object_store_cache_options: ObjectStoreCacheOptions {
-                    root_folder: Some(cache.root_folder),
-                    max_cache_size_bytes: Some(cache.max_disk_cache_bytes),
-                    part_size_bytes: OBJECT_STORE_CACHE_PART_SIZE_BYTES,
-                    cache_puts: true,
-                    preload_disk_cache_on_startup: Some(PreloadLevel::AllSst),
-                    scan_interval: None,
-                    ..ObjectStoreCacheOptions::default()
-                },
-                ..Settings::default()
+            settings.object_store_cache_options = ObjectStoreCacheOptions {
+                root_folder: Some(cache.root_folder),
+                max_cache_size_bytes: Some(cache.max_disk_cache_bytes),
+                part_size_bytes: OBJECT_STORE_CACHE_PART_SIZE_BYTES,
+                cache_puts: true,
+                preload_disk_cache_on_startup: Some(PreloadLevel::AllSst),
+                scan_interval: None,
+                ..ObjectStoreCacheOptions::default()
             };
             let db_cache = SplitCache::new()
                 .with_block_cache(moka_cache(cache.block_cache_bytes))
@@ -698,10 +696,17 @@ fn open_slatedb(
             // The SlateDB dependency is compiled with Moka support so cached
             // callers can choose bounded capacities. Keep default construction
             // cacheless instead of accepting SlateDB's much larger defaults.
-            builder = builder.with_db_cache_disabled();
+            builder = builder.with_settings(settings).with_db_cache_disabled();
         }
         builder.build().await.map_err(slatedb_error)
     })
+}
+
+fn slatedb_settings() -> Settings {
+    Settings {
+        compression_codec: Some(CompressionCodec::Lz4),
+        ..Settings::default()
+    }
 }
 
 fn validate_object_store_options(options: &SlateDBObjectStoreOptions) -> Result<(), StorageError> {
@@ -1009,9 +1014,136 @@ mod tests {
         ListResult, MultipartUpload, ObjectMeta, PutMultipartOptions, PutOptions, PutPayload,
         PutResult, RenameOptions, Result as ObjectStoreResult,
     };
+    use slatedb::config::{FlushOptions, FlushType};
     use std::ops::Range;
     use std::sync::atomic::AtomicBool;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn uses_lz4_compression_by_default() {
+        assert_eq!(
+            slatedb_settings().compression_codec,
+            Some(CompressionCodec::Lz4)
+        );
+    }
+
+    #[test]
+    fn lz4_storage_reopens_uncompressed_and_mixed_data() {
+        let store = Arc::new(InMemory::new());
+        let db_path = "test-lz4-backward-compatibility";
+        let space = SpaceId(7);
+        let old_key = Key(Bytes::from_static(b"uncompressed-key"));
+        let old_value = Bytes::from_static(b"uncompressed-value");
+
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build raw SlateDB test runtime")
+            .block_on(async {
+                let settings = Settings {
+                    compression_codec: None,
+                    ..Settings::default()
+                };
+                let db = Db::builder(db_path, store.clone())
+                    .with_settings(settings)
+                    .with_db_cache_disabled()
+                    .build()
+                    .await
+                    .expect("open uncompressed SlateDB");
+                let mut batch = WriteBatch::new();
+                batch.put_bytes(
+                    physical_key(space, &old_key)
+                        .expect("encode old physical key")
+                        .0,
+                    old_value.clone(),
+                );
+                db.write_with_options(
+                    batch,
+                    &SlateDBWriteOptions {
+                        await_durable: false,
+                        ..SlateDBWriteOptions::default()
+                    },
+                )
+                .await
+                .expect("write uncompressed row");
+                db.flush().await.expect("flush uncompressed row");
+                db.close().await.expect("close uncompressed SlateDB");
+            });
+
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            store.clone(),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("reopen uncompressed data with LZ4 enabled");
+        {
+            let read =
+                block_on(storage.begin_read(ReadOptions::default())).expect("begin old row read");
+            let result = block_on(read.get_many(
+                space,
+                std::slice::from_ref(&old_key),
+                GetOptions::default(),
+            ))
+            .expect("read uncompressed row");
+            assert_eq!(
+                result.values,
+                vec![Some(ProjectedValue::FullValue(old_value.clone()))]
+            );
+        }
+
+        let new_key = Key(Bytes::from_static(b"lz4-key"));
+        let new_value = Bytes::from_static(b"lz4-value");
+        let mut write =
+            block_on(storage.begin_write(WriteOptions::default())).expect("begin LZ4 write");
+        block_on(write.put_many(
+            space,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: new_key.clone(),
+                    value: StoredValue {
+                        bytes: new_value.clone(),
+                    },
+                }],
+            },
+        ))
+        .expect("stage LZ4 row");
+        block_on(write.commit()).expect("commit LZ4 row");
+        block_on(storage.flush()).expect("flush LZ4 row");
+        block_on(storage.worker.call(|db| async move {
+            db.flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .map_err(slatedb_error)?;
+            assert!(
+                db.manifest()
+                    .l0()
+                    .iter()
+                    .any(|view| { view.sst.info.compression_codec == Some(CompressionCodec::Lz4) }),
+                "new physical SST must record the LZ4 codec"
+            );
+            Ok(())
+        }))
+        .expect("flush and inspect LZ4 SST");
+        drop(storage);
+
+        let storage = SlateDB::open_object_store_with_options(
+            db_path,
+            store,
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("reopen mixed uncompressed and LZ4 data");
+        let read = block_on(storage.begin_read(ReadOptions::default())).expect("begin mixed read");
+        let result = block_on(read.get_many(space, &[old_key, new_key], GetOptions::default()))
+            .expect("read mixed rows");
+        assert_eq!(
+            result.values,
+            vec![
+                Some(ProjectedValue::FullValue(old_value)),
+                Some(ProjectedValue::FullValue(new_value)),
+            ]
+        );
+    }
 
     #[test]
     fn open_object_store_round_trips_with_memory_store() {

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -33,6 +33,7 @@ use tokio::runtime::{Builder, Handle, Runtime};
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard, oneshot};
 
 const DB_PATH: &str = "db";
+const LZ4_FORMAT_PATH: &str = "lix-lz4-v1";
 const SPACE_PREFIX_LEN: usize = 4;
 const MAX_SLATEDB_KEY_LEN: usize = u16::MAX as usize;
 const RUNTIME_WORKER_THREADS: usize = 2;
@@ -673,7 +674,8 @@ fn open_slatedb(
     options: SlateDBObjectStoreOptions,
 ) -> Result<Db, StorageError> {
     runtime.block_on(async move {
-        let mut builder = Db::builder(db_path, object_store);
+        let physical_db_path = join_db_path(&db_path, LZ4_FORMAT_PATH);
+        let mut builder = Db::builder(physical_db_path, object_store);
         let mut settings = slatedb_settings();
         if let Some(cache) = options.cache {
             settings.object_store_cache_options = ObjectStoreCacheOptions {
@@ -700,6 +702,15 @@ fn open_slatedb(
         }
         builder.build().await.map_err(slatedb_error)
     })
+}
+
+fn join_db_path(db_path: &str, child: &str) -> String {
+    let db_path = db_path.trim_end_matches('/');
+    if db_path.is_empty() {
+        child.to_string()
+    } else {
+        format!("{db_path}/{child}")
+    }
 }
 
 fn slatedb_settings() -> Settings {
@@ -1028,80 +1039,33 @@ mod tests {
     }
 
     #[test]
-    fn lz4_storage_reopens_uncompressed_and_mixed_data() {
+    fn opens_fresh_local_versioned_storage() {
+        let directory = tempfile::tempdir().expect("create fresh local storage directory");
+        let storage = SlateDB::open(directory.path()).expect("open fresh local LZ4 storage");
+        assert_eq!(storage.path(), directory.path());
+    }
+
+    #[test]
+    fn fresh_storage_uses_versioned_lz4_format() {
         let store = Arc::new(InMemory::new());
-        let db_path = "test-lz4-backward-compatibility";
+        let db_path = "test-lz4-physical-format";
         let space = SpaceId(7);
-        let old_key = Key(Bytes::from_static(b"uncompressed-key"));
-        let old_value = Bytes::from_static(b"uncompressed-value");
-
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("build raw SlateDB test runtime")
-            .block_on(async {
-                let settings = Settings {
-                    compression_codec: None,
-                    ..Settings::default()
-                };
-                let db = Db::builder(db_path, store.clone())
-                    .with_settings(settings)
-                    .with_db_cache_disabled()
-                    .build()
-                    .await
-                    .expect("open uncompressed SlateDB");
-                let mut batch = WriteBatch::new();
-                batch.put_bytes(
-                    physical_key(space, &old_key)
-                        .expect("encode old physical key")
-                        .0,
-                    old_value.clone(),
-                );
-                db.write_with_options(
-                    batch,
-                    &SlateDBWriteOptions {
-                        await_durable: false,
-                        ..SlateDBWriteOptions::default()
-                    },
-                )
-                .await
-                .expect("write uncompressed row");
-                db.flush().await.expect("flush uncompressed row");
-                db.close().await.expect("close uncompressed SlateDB");
-            });
-
         let storage = SlateDB::open_object_store_with_options(
             db_path,
             store.clone(),
             SlateDBObjectStoreOptions::default(),
         )
-        .expect("reopen uncompressed data with LZ4 enabled");
-        {
-            let read =
-                block_on(storage.begin_read(ReadOptions::default())).expect("begin old row read");
-            let result = block_on(read.get_many(
-                space,
-                std::slice::from_ref(&old_key),
-                GetOptions::default(),
-            ))
-            .expect("read uncompressed row");
-            assert_eq!(
-                result.values,
-                vec![Some(ProjectedValue::FullValue(old_value.clone()))]
-            );
-        }
+        .expect("open fresh LZ4 storage");
 
-        let new_key = Key(Bytes::from_static(b"lz4-key"));
-        let new_value = Bytes::from_static(b"lz4-value");
         let mut write =
             block_on(storage.begin_write(WriteOptions::default())).expect("begin LZ4 write");
         block_on(write.put_many(
             space,
             PutBatch {
                 entries: vec![PutEntry {
-                    key: new_key.clone(),
+                    key: Key(Bytes::from_static(b"lz4-key")),
                     value: StoredValue {
-                        bytes: new_value.clone(),
+                        bytes: Bytes::from_static(b"lz4-value"),
                     },
                 }],
             },
@@ -1127,21 +1091,26 @@ mod tests {
         .expect("flush and inspect LZ4 SST");
         drop(storage);
 
-        let storage = SlateDB::open_object_store_with_options(
-            db_path,
-            store,
-            SlateDBObjectStoreOptions::default(),
-        )
-        .expect("reopen mixed uncompressed and LZ4 data");
-        let read = block_on(storage.begin_read(ReadOptions::default())).expect("begin mixed read");
-        let result = block_on(read.get_many(space, &[old_key, new_key], GetOptions::default()))
-            .expect("read mixed rows");
-        assert_eq!(
-            result.values,
-            vec![
-                Some(ProjectedValue::FullValue(old_value)),
-                Some(ProjectedValue::FullValue(new_value)),
-            ]
+        let physical_prefix = format!("{db_path}/{LZ4_FORMAT_PATH}/");
+        let object_paths = block_on(async {
+            let mut objects = store.list(None);
+            let mut paths = Vec::new();
+            while let Some(object) = objects.next().await {
+                paths.push(
+                    object
+                        .expect("list fresh LZ4 storage object")
+                        .location
+                        .to_string(),
+                );
+            }
+            paths
+        });
+        assert!(!object_paths.is_empty(), "fresh storage must write objects");
+        assert!(
+            object_paths
+                .iter()
+                .all(|path| path.starts_with(&physical_prefix)),
+            "all objects must use the versioned LZ4 namespace: {object_paths:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- enable SlateDB's LZ4 feature and use LZ4 for cached and cacheless opens
- move every physical database to `<logical path>/lix-lz4-v1`
- make a clean format cut: no legacy reads, migration, fallback, mixed-codec handling, or old-format probe
- verify both the versioned object namespace and the LZ4 codec recorded in physical SST metadata

## Breaking behavior

Existing SlateDB-backed Lixes must be recreated. New code only reads and writes the versioned namespace; legacy `manifest`, `wal`, and `compacted` objects remain untouched and are not consulted. Pointing the new adapter at a prefix containing an old database initializes/uses only the new namespace.

The namespace cut is intentional. SlateDB records compression per SST, so enabling LZ4 alone would continue decoding old uncompressed data. This PR removes that implicit compatibility without adding a migration or an extra object-store request on open.

## Why LZ4

LZ4 targets the common LSM trade-off here: materially fewer stored/transferred bytes with low codec overhead. See [SlateDB's compression design](https://slatedb.io/docs/design/compression/) and [RocksDB's compression guidance](https://github.com/facebook/rocksdb/wiki/Compression).

## Measured impact

Real `lix_file` overwrite + flush workload, six alternating uncompressed/LZ4 pairs:

| metric | uncompressed | LZ4 | change |
| --- | ---: | ---: | ---: |
| aggregate physical bytes | 85,277 | 29,711 | **-65.2%** |
| median physical bytes | 15,139 | 4,634 | **-69.4%** |

Additional controls:

- 200-update workload: bytes/update **-52.7%**, runtime p50 +4.8%, p95 -18.0%
- 14.08 MB Lix-shaped dataset: physical bytes **-90.3%**
- incompressible-data control: bytes -0.17%, elapsed +5.2%

The optimization claim is reduced storage and object-store/network I/O. A workload-local SQL timing improvement was observed, but this PR does not rely on or promise a general SQL speedup. No measured runtime control regressed by 20%.

## Validation

- `cargo test -p lix_slatedb_storage --all-features` (9 passed)
- `cargo test -p lix_engine --test storage --features slatedb slatedb` (8 passed)
- `cargo clippy -p lix_slatedb_storage --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/validate-changes.mjs`
- `git diff --check`
- independent clean-cut re-review with no actionable findings