### PR TITLE
refactor!(sql): make information_schema an executable contract

### DIFF
--- a/.changenotes/executable-information-schema-contract.md
+++ b/.changenotes/executable-information-schema-contract.md
@@ -1,0 +1,30 @@
+---
+type: minor
+---
+
+Made `information_schema.columns` the executable Lix SQL contract.
+
+Public columns now use canonical SQL type names, including `BYTEA` for binary
+data across reads and writes. JSON-backed text is identified through
+`lix_value_kind`, while `lix_insert_policy` and `column_default` describe
+omission independently from read nullability. Defaulted ids may be omitted but
+explicit `NULL` is rejected.
+
+The advertised scalar type names now work as explicit casts across reads and
+runtime-entity writes. Bound writes use the canonical names and retire
+`BINARY` in favor of `BYTEA`; read expressions retain DataFusion's wider cast
+dialect.
+
+Typed `BIGINT` columns normalize mathematically integral JSON numbers such as
+`1.0` and reject non-integral or out-of-range stored values instead of
+projecting `NULL`. This contract also applies to typed history, pushed filters,
+bound numeric predicates, and `DELETE ... RETURNING`. SQL decimal literals are
+now kept distinct from values produced by `lix_json(...)`, so numeric
+comparisons no longer acquire JSON comparison rules accidentally. BIGINT
+writes and predicates parse integer, decimal, and exponent spellings exactly,
+preventing out-of-range literals from rounding onto an in-range boundary.
+
+Registered-entity defaults are materialized before `ON CONFLICT` routing and
+`excluded.*` evaluation. `INSERT ... RETURNING` and `UPDATE ... RETURNING` are
+now rejected explicitly until those result paths are implemented; they are no
+longer accepted while silently discarding the requested rows.

--- a/.changenotes/support-binary-casts-in-file-writes.md
+++ b/.changenotes/support-binary-casts-in-file-writes.md
@@ -4,4 +4,4 @@ type: minor
 
 Lix SQL file writes now support explicit casts to binary data.
 
-Use `CAST(value AS BINARY)` when inserting or updating UTF-8 text in `lix_file.data`.
+Use `CAST(value AS BYTEA)` when inserting or updating UTF-8 text in `lix_file.data`.

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -120,13 +120,23 @@ INSERT INTO event (id, occurred_at) VALUES (lix_uuid_v7(), lix_timestamp());
 
 ## Text & bytes
 
-Use standard SQL casts to convert between UTF-8 text and bytes:
+Lix accepts the canonical public cast names advertised by
+`information_schema.columns`: `TEXT`, `BYTEA`, `BIGINT`,
+`DOUBLE PRECISION`, and `BOOLEAN`. The same spellings work in `SELECT` and in
+bound `INSERT`/`UPDATE` expressions. Bound writes use those canonical names and
+retire the ambiguous binary spelling `BINARY` in favor of `BYTEA`.
+
+Read expressions retain DataFusion's wider SQL cast dialect, including types
+such as `DATE`, `INTEGER`, `DECIMAL`, and `TIMESTAMP`; the public column types
+above describe Lix surfaces rather than limiting query expressions.
+
+Use `TEXT` and `BYTEA` to convert between UTF-8 text and bytes:
 
 ```sql
 SELECT CAST(data AS TEXT) FROM lix_file WHERE path = '/notes/readme.md';
 
 INSERT INTO lix_file (path, data)
-VALUES ('/notes/hello.txt', CAST('hello world' AS BINARY));
+VALUES ('/notes/hello.txt', CAST('hello world' AS BYTEA));
 ```
 
 ## Notes

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -6,6 +6,48 @@ description: The SQL surfaces in Lix at a glance. State surfaces are JSON-shaped
 
 Lix exposes the same underlying state through several SQL surfaces so you can query it the way that fits the question you're asking.
 
+The SQL engine is backed by DataFusion. Query
+`information_schema.columns` for the executable public contract instead of
+inferring types from Arrow or JSON Schema names. Lix reports the canonical SQL
+types `TEXT`, `BYTEA`, `BIGINT`, `DOUBLE PRECISION`, and `BOOLEAN`.
+JSON-backed columns remain SQL `TEXT` and are marked with
+`lix_value_kind = 'JSON'`. `is_nullable` describes values returned by reads;
+`column_default` and `lix_insert_policy` separately describe whether a write
+may omit a column. In particular, a defaulted id is non-null when read, may be
+omitted on insert, and rejects an explicit `NULL`.
+
+The reported scalar type name is executable as an explicit `CAST` in
+`SELECT`, `INSERT`, and `UPDATE`. Bound Lix writes use those canonical names;
+read expressions retain DataFusion's wider cast dialect. `BINARY` is retired
+in favor of `BYTEA`.
+
+`lix_insert_policy` describes omission on `INSERT`:
+
+| Policy | Meaning |
+| --- | --- |
+| `READ_ONLY` | The column cannot be supplied on insert. |
+| `REQUIRED` | Every inserted row must supply the column. |
+| `OPTIONAL` | The column may be omitted without generating a value. |
+| `DEFAULT` | Omission evaluates the expression in `column_default`. |
+| `CONDITIONAL` | Whether the column is required depends on the row's other inputs. |
+
+`CONDITIONAL` covers deliberate alternative forms: filesystem rows can use
+`path` or descriptor fields, typed entities derive `lixcol_entity_pk` from
+their public primary-key columns (while schemas without `x-lix-primary-key`
+require `lixcol_entity_pk`), and raw `_by_branch` global rows can omit a branch
+id.
+These policies describe omission only; `is_nullable` still describes values
+returned by reads. Defaulted filesystem and typed-entity ids reject explicit
+`NULL`.
+
+```sql
+SELECT column_name, data_type, is_nullable, column_default,
+       lix_value_kind, lix_insert_policy
+FROM information_schema.columns
+WHERE table_name = 'lix_file'
+ORDER BY ordinal_position;
+```
+
 Two ergonomic axes:
 
 - **Grain.** Typed columns for one schema vs. raw JSON across all schemas vs. file bytes.

--- a/docs/what-is-lix.md
+++ b/docs/what-is-lix.md
@@ -18,7 +18,7 @@ import { openLix } from "@lix-js/sdk";
 const lix = await openLix();
 
 await lix.execute(
-  "INSERT INTO lix_file (path, data) VALUES (?, CAST(? AS BINARY))",
+  "INSERT INTO lix_file (path, data) VALUES (?, CAST(? AS BYTEA))",
   ["/hello.txt", "hello"],
 );
 

--- a/packages/cli/src/cli/sql.rs
+++ b/packages/cli/src/cli/sql.rs
@@ -11,7 +11,7 @@ pub enum SqlSubcommand {
     /// Execute SQL text. Use '-' to read SQL from stdin.
     #[command(after_long_help = "\
 Examples:
-  lix sql execute \"INSERT INTO lix_file (path, data) VALUES ('/hello.md', CAST('# Hello' AS BINARY))\"
+  lix sql execute \"INSERT INTO lix_file (path, data) VALUES ('/hello.md', CAST('# Hello' AS BYTEA))\"
   lix sql execute \"SELECT path, CAST(data AS TEXT) FROM lix_file\"
   lix sql execute \"SELECT path, lixcol_depth FROM lix_file_history\"")]
     Execute(SqlExecuteArgs),

--- a/packages/cli/src/hints.rs
+++ b/packages/cli/src/hints.rs
@@ -21,7 +21,7 @@ impl CommandOutput {
 pub fn hint_after_init() -> Vec<String> {
     vec![
         "Try inserting data with: lix sql execute \"INSERT INTO lix_key_value (key, value) VALUES ('hello', '\"world\"')\"".into(),
-        "Store files with: lix sql execute \"INSERT INTO lix_file (path, data) VALUES ('/readme.txt', CAST('hello' AS BINARY))\"".into(),
+        "Store files with: lix sql execute \"INSERT INTO lix_file (path, data) VALUES ('/readme.txt', CAST('hello' AS BYTEA))\"".into(),
     ]
 }
 

--- a/packages/engine/src/catalog/mod.rs
+++ b/packages/engine/src/catalog/mod.rs
@@ -10,5 +10,5 @@ pub(crate) use schema::{
     StateForeignKeyPlan,
 };
 pub(crate) use snapshot::{
-    CatalogFingerprint, CatalogSnapshot, StateDeleteReferencePlan, TransactionCatalog,
+    CatalogFingerprint, CatalogSnapshot, DefaultPlan, StateDeleteReferencePlan, TransactionCatalog,
 };

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -445,7 +445,7 @@ enum DefaultValuePlan {
 }
 
 impl DefaultPlan {
-    fn from_schema(schema: &JsonValue) -> Self {
+    pub(crate) fn from_schema(schema: &JsonValue) -> Self {
         let Some(properties) = schema.get("properties").and_then(JsonValue::as_object) else {
             return Self::default();
         };

--- a/packages/engine/src/sql2/bind/expr.rs
+++ b/packages/engine/src/sql2/bind/expr.rs
@@ -1,3 +1,7 @@
+use datafusion::sql::sqlparser::ast::{CastKind, DataType as SqlDataType, Expr};
+
+use crate::LixError;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum BoundExpr {
     Column(BoundColumnRef),
@@ -16,7 +20,23 @@ pub(crate) enum BoundExpr {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum BoundCastType {
+    Text,
     Binary,
+    BigInt,
+    Double,
+    Boolean,
+}
+
+impl BoundCastType {
+    pub(crate) fn canonical_sql_name(self) -> &'static str {
+        match self {
+            Self::Text => "TEXT",
+            Self::Binary => "BYTEA",
+            Self::BigInt => "BIGINT",
+            Self::Double => "DOUBLE PRECISION",
+            Self::Boolean => "BOOLEAN",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -24,6 +44,10 @@ pub(crate) enum BoundLiteral {
     Null,
     Bool(bool),
     Integer(i64),
+    Number {
+        raw: String,
+        value: serde_json::Number,
+    },
     Text(String),
     Json(serde_json::Value),
     Blob(Vec<u8>),
@@ -39,4 +63,37 @@ pub(crate) struct BoundColumnRef {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) struct BoundParamRef {
     pub(crate) index: usize,
+}
+
+pub(crate) fn bind_public_cast_type(
+    kind: &CastKind,
+    expr: &Expr,
+    data_type: &SqlDataType,
+    array: bool,
+    has_format: bool,
+) -> Result<BoundCastType, LixError> {
+    let cast_type = match data_type {
+        SqlDataType::Text => Some(BoundCastType::Text),
+        SqlDataType::Bytea => Some(BoundCastType::Binary),
+        SqlDataType::BigInt(None) => Some(BoundCastType::BigInt),
+        SqlDataType::DoublePrecision => Some(BoundCastType::Double),
+        SqlDataType::Boolean => Some(BoundCastType::Boolean),
+        _ => None,
+    };
+    if kind == &CastKind::Cast && !array && !has_format {
+        if let Some(cast_type) = cast_type {
+            return Ok(cast_type);
+        }
+    }
+    Err(unsupported_public_cast(expr, data_type))
+}
+
+fn unsupported_public_cast(expr: &Expr, data_type: &SqlDataType) -> LixError {
+    LixError::new(
+        LixError::CODE_UNSUPPORTED_SQL,
+        format!("unsupported SQL cast 'CAST({expr} AS {data_type})'"),
+    )
+    .with_hint(
+        "Use one of the canonical Lix SQL cast types: TEXT, BYTEA, BIGINT, DOUBLE PRECISION, or BOOLEAN.",
+    )
 }

--- a/packages/engine/src/sql2/bind/statement.rs
+++ b/packages/engine/src/sql2/bind/statement.rs
@@ -9,6 +9,7 @@ use datafusion::sql::sqlparser::ast::{
     Statement as SqlStatement, TableFactor, TableObject, TableWithJoins, UnaryOperator, Update,
     Value, Visit, Visitor, WildcardAdditionalOptions,
 };
+#[cfg(test)]
 use serde_json::Value as JsonValue;
 
 use crate::GLOBAL_BRANCH_ID;
@@ -17,7 +18,7 @@ use crate::sql2::catalog::{PublicCatalog, PublicSurfaceContract, PublicSurfaceKi
 use crate::sql2::plan::branch_scope::BranchScope;
 use crate::sql2::plan::predicate::BoundPredicate;
 
-use super::expr::{BoundCastType, BoundExpr, BoundLiteral, BoundParamRef};
+use super::expr::{BoundExpr, BoundLiteral, BoundParamRef, bind_public_cast_type};
 use super::read::BoundRead;
 use super::table::{
     BoundTable, bind_public_column_ref, bind_public_table, require_writable_column,
@@ -926,19 +927,9 @@ fn bind_cast_expr(
     params: &mut ParamBinder,
     bind_inner: impl FnOnce(&Expr, &mut ParamBinder) -> Result<BoundExpr, LixError>,
 ) -> Result<BoundExpr, LixError> {
-    if kind != &CastKind::Cast
-        || array
-        || has_format
-        || !matches!(data_type, SqlDataType::Binary(None))
-    {
-        return Err(super::error::unsupported(format!(
-            "unsupported SQL cast 'CAST({expr} AS {data_type})'"
-        )));
-    }
-
     Ok(BoundExpr::Cast {
         expr: Box::new(bind_inner(expr, params)?),
-        data_type: BoundCastType::Binary,
+        data_type: bind_public_cast_type(kind, expr, data_type, array, has_format)?,
     })
 }
 
@@ -962,17 +953,20 @@ fn bind_number_literal(value: &str) -> Result<BoundExpr, LixError> {
     if let Ok(value) = value.parse::<i64>() {
         return Ok(BoundExpr::Literal(BoundLiteral::Integer(value)));
     }
-    let value = value
-        .parse::<f64>()
-        .map_err(|_| super::error::unsupported(format!("unsupported numeric literal '{value}'")))?;
-    let Some(number) = serde_json::Number::from_f64(value) else {
-        return Err(super::error::unsupported(
-            "unsupported non-finite numeric literal",
-        ));
-    };
-    Ok(BoundExpr::Literal(BoundLiteral::Json(JsonValue::Number(
-        number,
-    ))))
+    let number = value.parse::<serde_json::Number>().or_else(|_| {
+        value
+            .parse::<f64>()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .ok_or(())
+    });
+    number
+        .map(|number| BoundLiteral::Number {
+            raw: value.to_string(),
+            value: number,
+        })
+        .map(BoundExpr::Literal)
+        .map_err(|()| super::error::unsupported(format!("unsupported numeric literal '{value}'")))
 }
 
 fn bind_negative_number_expr(expr: &Expr) -> Result<BoundExpr, LixError> {
@@ -1241,6 +1235,11 @@ fn require_write_capability(
                 | PublicSurfaceKind::History
         ) {
             error = error.with_hint("History views are query-only.");
+        } else if let PublicSurfaceKind::EntityBase { schema_key }
+        | PublicSurfaceKind::EntityByBranch { schema_key } = &surface.kind
+            && let Some(hint) = crate::sql2::read_only::read_only_entity_surface_hint(schema_key)
+        {
+            error = error.with_hint(hint);
         }
         Err(error)
     }
@@ -2131,7 +2130,7 @@ mod tests {
     #[test]
     fn bind_statement_binds_public_values_functions() {
         let statement = parse_statement(
-            "INSERT INTO lix_file (id, path, data) VALUES (lix_uuid_v7(), lix_timestamp(), CAST('hello' AS BINARY))",
+            "INSERT INTO lix_file (id, path, data) VALUES (lix_uuid_v7(), lix_timestamp(), CAST('hello' AS BYTEA))",
         );
         let bound = bind_statement(&statement, &[], "branch1").expect("insert should bind");
 
@@ -2446,6 +2445,17 @@ mod tests {
             write.assignments[0].value,
             BoundExpr::Literal(BoundLiteral::Integer(-1))
         ));
+    }
+
+    #[test]
+    fn bind_number_literal_keeps_sql_numbers_distinct_from_json() {
+        for raw in ["1.0", "01.0", "9223372036854775808"] {
+            let BoundExpr::Literal(BoundLiteral::Number { .. }) =
+                bind_number_literal(raw).expect("SQL numeric literal should bind")
+            else {
+                panic!("{raw} should bind as a SQL number");
+            };
+        }
     }
 
     #[test]

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -33,6 +33,9 @@ pub(crate) enum EntityColumnType {
 pub(crate) struct EntitySurfaceColumn {
     pub(crate) name: String,
     pub(crate) column_type: EntityColumnType,
+    pub(crate) read_nullable: bool,
+    pub(crate) insert_required: bool,
+    pub(crate) default_expression: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,6 +43,7 @@ pub(crate) struct EntitySurfaceSpec {
     pub(crate) schema_key: String,
     pub(crate) primary_key_paths: Vec<Vec<String>>,
     pub(crate) columns: Vec<EntitySurfaceColumn>,
+    pub(crate) defaults: crate::catalog::DefaultPlan,
 }
 
 impl EntitySurfaceSpec {
@@ -77,6 +81,18 @@ pub(crate) fn derive_entity_surface_spec_from_schema(
                 format!("schema '{schema_key}' must define object properties"),
             )
         })?;
+    let required = schema
+        .get("required")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(JsonValue::as_str)
+        .collect::<BTreeSet<_>>();
+    let primary_key_paths = parse_primary_key_paths(schema)?;
+    let primary_key_roots = primary_key_paths
+        .iter()
+        .filter_map(|path| path.first())
+        .collect::<BTreeSet<_>>();
 
     let mut columns = properties
         .iter()
@@ -94,17 +110,28 @@ pub(crate) fn derive_entity_surface_spec_from_schema(
             Ok(EntitySurfaceColumn {
                 name: key.clone(),
                 column_type,
+                read_nullable: !primary_key_roots.contains(key)
+                    && (!required.contains(key.as_str())
+                        || entity_schema_allows_null(property_schema)),
+                insert_required: required.contains(key.as_str()),
+                default_expression: property_schema
+                    .get("x-lix-default")
+                    .map(lix_default_expression)
+                    .or_else(|| {
+                        property_schema
+                            .get("default")
+                            .map(json_schema_default_expression)
+                    }),
             })
         })
         .collect::<Result<Vec<_>, LixError>>()?;
     columns.sort_by(|left, right| left.name.cmp(&right.name));
 
-    let primary_key_paths = parse_primary_key_paths(schema)?;
-
     Ok(EntitySurfaceSpec {
         schema_key: schema_key.to_string(),
         primary_key_paths,
         columns,
+        defaults: crate::catalog::DefaultPlan::from_schema(schema),
     })
 }
 
@@ -133,10 +160,15 @@ pub(crate) fn entity_surface_schema(
         .columns
         .iter()
         .map(|column| {
+            let read_nullable = if shape == EntitySurfaceShape::History {
+                !history_identity_roots.contains(&column.name)
+            } else {
+                column.read_nullable
+            };
             let field = Field::new(
                 &column.name,
                 arrow_data_type_for_entity_column_type(column.column_type),
-                !history_identity_roots.contains(&column.name),
+                read_nullable,
             );
             if column.column_type == EntityColumnType::Json {
                 mark_json_field(field)
@@ -277,6 +309,31 @@ fn entity_column_type_from_schema(schema: &JsonValue) -> Option<EntityColumnType
     Some(EntityColumnType::Json)
 }
 
+fn entity_schema_allows_null(schema: &JsonValue) -> bool {
+    let mut kinds = BTreeSet::new();
+    collect_entity_type_kinds(schema, &mut kinds);
+    kinds.contains("null")
+}
+
+fn lix_default_expression(default: &JsonValue) -> String {
+    match default {
+        JsonValue::String(value) => value.clone(),
+        value => value.to_string(),
+    }
+}
+
+fn json_schema_default_expression(default: &JsonValue) -> String {
+    match default {
+        JsonValue::Null => "NULL".to_string(),
+        JsonValue::Bool(value) => value.to_string().to_ascii_uppercase(),
+        JsonValue::Number(value) => value.to_string(),
+        JsonValue::String(value) => format!("'{}'", value.replace('\'', "''")),
+        JsonValue::Array(_) | JsonValue::Object(_) => {
+            format!("lix_json('{}')", default.to_string().replace('\'', "''"))
+        }
+    }
+}
+
 fn arrow_data_type_for_entity_column_type(column_type: EntityColumnType) -> DataType {
     match column_type {
         EntityColumnType::String | EntityColumnType::Json => DataType::Utf8,
@@ -360,11 +417,11 @@ mod tests {
 
         let active = entity_surface_schema(&spec, EntitySurfaceShape::Active);
         assert!(
-            active
+            !active
                 .field_with_name("identity")
                 .expect("active identity input")
                 .is_nullable(),
-            "write surfaces keep omission/default input semantics"
+            "read nullability is independent from omission/default input semantics"
         );
     }
 }

--- a/packages/engine/src/sql2/catalog/mod.rs
+++ b/packages/engine/src/sql2/catalog/mod.rs
@@ -7,9 +7,9 @@ pub(crate) mod surface;
 pub(crate) use capability::SurfaceCapabilities;
 pub(crate) use entity_surface::{
     EntityColumnType, EntitySurfaceShape, EntitySurfaceSpec,
-    derive_entity_surface_spec_from_schema, entity_surface_schema, entity_system_fields,
+    derive_entity_surface_spec_from_schema, entity_surface_schema,
     schema_exposed_as_entity_history_surface, schema_exposed_as_entity_surface,
 };
 pub(crate) use registry::PublicCatalog;
-pub(crate) use schema::PublicColumn;
+pub(crate) use schema::{PublicColumn, PublicColumnInsertPolicy};
 pub(crate) use surface::{PublicSurfaceContract, PublicSurfaceKind};

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -14,8 +14,7 @@ use super::{PublicColumn, PublicSurfaceContract, PublicSurfaceKind, SurfaceCapab
 use crate::sql2::catalog::entity_surface_schema;
 use crate::sql2::catalog::{
     EntitySurfaceShape, EntitySurfaceSpec, derive_entity_surface_spec_from_schema,
-    entity_system_fields, schema_exposed_as_entity_history_surface,
-    schema_exposed_as_entity_surface,
+    schema_exposed_as_entity_history_surface, schema_exposed_as_entity_surface,
 };
 use crate::sql2::history_route::{
     HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT, HISTORY_COL_CHANGE_ID,
@@ -208,10 +207,11 @@ impl PublicCatalog {
             "lix_branch",
             PublicSurfaceKind::Branch,
             vec![
-                PublicColumn::public_insert_only("id"),
-                PublicColumn::public("name"),
-                PublicColumn::public("hidden"),
-                PublicColumn::public("commit_id"),
+                PublicColumn::public_insert_only("id", false),
+                PublicColumn::public("name", false),
+                PublicColumn::public("hidden", false).with_default("FALSE"),
+                PublicColumn::public("commit_id", false)
+                    .with_default("lix_active_branch_commit_id()"),
             ],
             SurfaceCapabilities::read_write(),
         ))?;
@@ -219,14 +219,14 @@ impl PublicCatalog {
             "lix_change",
             PublicSurfaceKind::Change,
             public_columns([
-                "id",
-                "entity_pk",
-                "schema_key",
-                "file_id",
-                "metadata",
-                "created_at",
-                "origin_key",
-                "snapshot_content",
+                ("id", false),
+                ("entity_pk", false),
+                ("schema_key", false),
+                ("file_id", true),
+                ("metadata", true),
+                ("created_at", false),
+                ("origin_key", true),
+                ("snapshot_content", true),
             ]),
             SurfaceCapabilities::read_only(),
         ))?;
@@ -261,7 +261,13 @@ impl PublicCatalog {
         }
 
         let mut columns = entity_columns(&spec);
-        columns.extend(entity_hidden_columns(false));
+        columns.extend(entity_hidden_columns(&spec, false));
+        let capabilities = if crate::sql2::read_only::is_read_only_entity_surface(&spec.schema_key)
+        {
+            SurfaceCapabilities::read_only()
+        } else {
+            SurfaceCapabilities::read_write()
+        };
 
         self.insert(surface(
             &spec.schema_key,
@@ -269,11 +275,11 @@ impl PublicCatalog {
                 schema_key: spec.schema_key.clone(),
             },
             columns,
-            SurfaceCapabilities::read_write(),
+            capabilities.clone(),
         ))?;
 
         let mut by_branch_columns = entity_columns(&spec);
-        by_branch_columns.extend(entity_hidden_columns(true));
+        by_branch_columns.extend(entity_hidden_columns(&spec, true));
 
         self.insert(surface(
             format!("{}_by_branch", spec.schema_key),
@@ -281,16 +287,22 @@ impl PublicCatalog {
                 schema_key: spec.schema_key.clone(),
             },
             by_branch_columns,
-            SurfaceCapabilities::read_write(),
+            capabilities,
         ))?;
 
         if schema_exposed_as_entity_history_surface(&spec.schema_key) {
+            let history_identity_roots = primary_key_roots(&spec);
             let mut history_columns = spec
                 .columns
                 .iter()
-                .map(|column| PublicColumn::public(column.name.as_str()))
+                .map(|column| {
+                    PublicColumn::public(
+                        column.name.as_str(),
+                        !history_identity_roots.contains(&column.name),
+                    )
+                })
                 .collect::<Vec<_>>();
-            history_columns.extend(entity_system_columns(EntitySurfaceShape::History));
+            history_columns.extend(entity_history_system_columns());
 
             self.insert(surface(
                 format!("{}_history", spec.schema_key),
@@ -413,57 +425,76 @@ fn surface(
     }
 }
 
-fn public_columns<const N: usize>(names: [&str; N]) -> Vec<PublicColumn> {
-    names.into_iter().map(PublicColumn::public).collect()
+fn public_columns<const N: usize>(columns: [(&str, bool); N]) -> Vec<PublicColumn> {
+    columns
+        .into_iter()
+        .map(|(name, read_nullable)| PublicColumn::public(name, read_nullable))
+        .collect()
+}
+
+fn primary_key_roots(spec: &EntitySurfaceSpec) -> std::collections::BTreeSet<&String> {
+    spec.primary_key_paths
+        .iter()
+        .filter_map(|path| path.first())
+        .collect()
 }
 
 fn entity_columns(spec: &EntitySurfaceSpec) -> Vec<PublicColumn> {
-    let primary_key_roots = spec
-        .primary_key_paths
-        .iter()
-        .filter_map(|path| path.first())
-        .collect::<std::collections::BTreeSet<_>>();
+    let primary_key_roots = primary_key_roots(spec);
     spec.columns
         .iter()
         .map(|column| {
-            if spec.schema_key == "lix_registered_schema" && column.name == "value" {
-                PublicColumn::public(column.name.as_str())
-            } else if primary_key_roots.contains(&column.name) {
-                PublicColumn::public_insert_only(column.name.as_str())
+            let public_column =
+                if spec.schema_key == "lix_registered_schema" && column.name == "value" {
+                    PublicColumn::public(column.name.as_str(), column.read_nullable)
+                } else if primary_key_roots.contains(&column.name) {
+                    PublicColumn::public_insert_only(column.name.as_str(), column.read_nullable)
+                } else {
+                    PublicColumn::public(column.name.as_str(), column.read_nullable)
+                };
+            if let Some(default) = column.default_expression.as_deref() {
+                public_column.with_default(default)
+            } else if !column.insert_required {
+                public_column.optional_on_insert()
             } else {
-                PublicColumn::public(column.name.as_str())
+                public_column
             }
         })
         .collect()
 }
 
 fn lix_state_columns(by_branch: bool) -> Vec<PublicColumn> {
+    let global = if by_branch {
+        PublicColumn::public("global", false).conditional_on_insert()
+    } else {
+        PublicColumn::public("global", false).with_default("FALSE")
+    };
     let mut columns = vec![
-        PublicColumn::public_insert_only("entity_pk"),
-        PublicColumn::public_insert_only("schema_key"),
-        PublicColumn::public_insert_only("file_id"),
-        PublicColumn::public("snapshot_content"),
-        PublicColumn::public("metadata"),
-        PublicColumn::public_insert_only("created_at"),
-        PublicColumn::public_insert_only("updated_at"),
-        PublicColumn::public_insert_only("global"),
-        PublicColumn::public_insert_only("change_id"),
-        PublicColumn::public_insert_only("commit_id"),
-        PublicColumn::public_insert_only("untracked"),
+        PublicColumn::public_insert_only("entity_pk", false),
+        PublicColumn::public_insert_only("schema_key", false),
+        PublicColumn::public_insert_only("file_id", true).optional_on_insert(),
+        PublicColumn::public("snapshot_content", true).optional_on_insert(),
+        PublicColumn::public("metadata", true).optional_on_insert(),
+        PublicColumn::public_read_only("created_at", false),
+        PublicColumn::public_read_only("updated_at", false),
+        global,
+        PublicColumn::public_read_only("change_id", true),
+        PublicColumn::public_read_only("commit_id", true),
+        PublicColumn::public("untracked", false).with_default("FALSE"),
     ];
     if by_branch {
-        columns.push(PublicColumn::public_insert_only("branch_id"));
+        columns.push(PublicColumn::public_insert_only("branch_id", false).conditional_on_insert());
     }
     columns
 }
 
 fn filesystem_columns(by_branch: bool) -> Vec<PublicColumn> {
     let mut columns = vec![
-        PublicColumn::public_insert_only("id"),
-        PublicColumn::public("path"),
-        PublicColumn::public("directory_id"),
-        PublicColumn::public("name"),
-        PublicColumn::public("data"),
+        PublicColumn::public_insert_only("id", false).with_default("lix_uuid_v7()"),
+        PublicColumn::public("path", false).conditional_on_insert(),
+        PublicColumn::public("directory_id", true).conditional_on_insert(),
+        PublicColumn::public("name", false).conditional_on_insert(),
+        PublicColumn::public("data", false).with_default("X''"),
     ];
     columns.extend(filesystem_hidden_columns(by_branch));
     columns
@@ -471,112 +502,140 @@ fn filesystem_columns(by_branch: bool) -> Vec<PublicColumn> {
 
 fn directory_columns(by_branch: bool) -> Vec<PublicColumn> {
     let mut columns = vec![
-        PublicColumn::public_insert_only("id"),
-        PublicColumn::public("path"),
-        PublicColumn::public("parent_id"),
-        PublicColumn::public("name"),
+        PublicColumn::public_insert_only("id", false).with_default("lix_uuid_v7()"),
+        PublicColumn::public("path", true).conditional_on_insert(),
+        PublicColumn::public("parent_id", true).conditional_on_insert(),
+        PublicColumn::public("name", false).conditional_on_insert(),
     ];
     columns.extend(filesystem_hidden_columns(by_branch));
     columns
 }
 
-fn entity_hidden_columns(by_branch: bool) -> Vec<PublicColumn> {
-    entity_system_columns(if by_branch {
-        EntitySurfaceShape::ByBranch
-    } else {
-        EntitySurfaceShape::Active
-    })
+fn entity_hidden_columns(spec: &EntitySurfaceSpec, by_branch: bool) -> Vec<PublicColumn> {
+    entity_system_columns(
+        spec,
+        if by_branch {
+            EntitySurfaceShape::ByBranch
+        } else {
+            EntitySurfaceShape::Active
+        },
+    )
 }
 
 fn filesystem_hidden_columns(by_branch: bool) -> Vec<PublicColumn> {
     let mut columns = vec![
-        PublicColumn::hidden("lixcol_entity_pk"),
-        PublicColumn::hidden("lixcol_schema_key"),
-        PublicColumn::hidden("lixcol_file_id"),
-        PublicColumn::public_insert_only("lixcol_global"),
-        PublicColumn::public_read_only("lixcol_change_id"),
-        PublicColumn::hidden("lixcol_created_at"),
-        PublicColumn::hidden("lixcol_updated_at"),
-        PublicColumn::hidden("lixcol_commit_id"),
-        PublicColumn::public_insert_only("lixcol_untracked"),
-        PublicColumn::public("lixcol_metadata"),
+        PublicColumn::hidden("lixcol_entity_pk", false),
+        PublicColumn::hidden("lixcol_schema_key", false),
+        PublicColumn::hidden("lixcol_file_id", true),
+        PublicColumn::public_insert_only("lixcol_global", false).with_default("FALSE"),
+        PublicColumn::public_read_only("lixcol_change_id", true),
+        PublicColumn::hidden("lixcol_created_at", false),
+        PublicColumn::hidden("lixcol_updated_at", false),
+        PublicColumn::hidden("lixcol_commit_id", true),
+        PublicColumn::public_insert_only("lixcol_untracked", false).with_default("FALSE"),
+        PublicColumn::public("lixcol_metadata", true).optional_on_insert(),
     ];
     if by_branch {
-        columns.push(PublicColumn::public_insert_only("lixcol_branch_id"));
+        columns.push(PublicColumn::public_insert_only("lixcol_branch_id", false));
     }
     columns
 }
 
-fn entity_system_columns(variant: EntitySurfaceShape) -> Vec<PublicColumn> {
-    if variant == EntitySurfaceShape::History {
-        return entity_system_fields(variant)
-            .into_iter()
-            .map(|field| PublicColumn::public(field.name().as_str()))
-            .collect();
+fn entity_system_columns(
+    spec: &EntitySurfaceSpec,
+    variant: EntitySurfaceShape,
+) -> Vec<PublicColumn> {
+    debug_assert_ne!(variant, EntitySurfaceShape::History);
+    let entity_pk = PublicColumn::public_insert_only("lixcol_entity_pk", false);
+    let entity_pk = if spec.primary_key_paths.is_empty() {
+        entity_pk
+    } else {
+        entity_pk.conditional_on_insert()
+    };
+    let mut columns = vec![
+        entity_pk,
+        PublicColumn::public_read_only("lixcol_schema_key", false),
+        PublicColumn::public_insert_only("lixcol_file_id", true).optional_on_insert(),
+        PublicColumn::hidden("lixcol_snapshot_content", true),
+        PublicColumn::public("lixcol_metadata", true).optional_on_insert(),
+        PublicColumn::public_read_only("lixcol_created_at", false),
+        PublicColumn::public_read_only("lixcol_updated_at", false),
+        PublicColumn::public_insert_only("lixcol_global", false).with_default("FALSE"),
+        PublicColumn::public_read_only("lixcol_change_id", true),
+        PublicColumn::public_read_only("lixcol_commit_id", true),
+        PublicColumn::public_insert_only("lixcol_untracked", false).with_default("FALSE"),
+    ];
+    if variant == EntitySurfaceShape::ByBranch {
+        columns.push(PublicColumn::public_insert_only("lixcol_branch_id", false));
     }
+    columns
+}
 
-    entity_system_fields(variant)
-        .into_iter()
-        .map(|field| match field.name().as_str() {
-            "lixcol_schema_key" | "lixcol_change_id" | "lixcol_created_at"
-            | "lixcol_updated_at" | "lixcol_commit_id" => {
-                PublicColumn::public_read_only(field.name().as_str())
-            }
-            "lixcol_entity_pk" | "lixcol_file_id" | "lixcol_global" | "lixcol_untracked"
-            | "lixcol_branch_id" => PublicColumn::public_insert_only(field.name().as_str()),
-            "lixcol_metadata" => PublicColumn::public(field.name().as_str()),
-            _ => PublicColumn::hidden(field.name().as_str()),
-        })
-        .collect()
+fn entity_history_system_columns() -> Vec<PublicColumn> {
+    public_columns([
+        (HISTORY_COL_ENTITY_PK, false),
+        (HISTORY_COL_SCHEMA_KEY, false),
+        (HISTORY_COL_FILE_ID, true),
+        (HISTORY_COL_SNAPSHOT_CONTENT, true),
+        (HISTORY_COL_METADATA, true),
+        (HISTORY_COL_CHANGE_ID, false),
+        (HISTORY_COL_CHANGE_CREATED_AT, false),
+        (HISTORY_COL_ORIGIN_KEY, true),
+        (HISTORY_COL_OBSERVED_COMMIT_ID, false),
+        (HISTORY_COL_COMMIT_CREATED_AT, false),
+        (HISTORY_COL_AS_OF_COMMIT_ID, false),
+        (HISTORY_COL_DEPTH, false),
+        (HISTORY_COL_IS_DELETED, false),
+    ])
 }
 
 fn state_history_columns() -> Vec<PublicColumn> {
     public_columns([
-        HISTORY_COL_ENTITY_PK,
-        HISTORY_COL_SCHEMA_KEY,
-        HISTORY_COL_FILE_ID,
-        HISTORY_COL_SNAPSHOT_CONTENT,
-        HISTORY_COL_METADATA,
-        HISTORY_COL_CHANGE_ID,
-        HISTORY_COL_CHANGE_CREATED_AT,
-        HISTORY_COL_ORIGIN_KEY,
-        HISTORY_COL_OBSERVED_COMMIT_ID,
-        HISTORY_COL_COMMIT_CREATED_AT,
-        HISTORY_COL_AS_OF_COMMIT_ID,
-        HISTORY_COL_DEPTH,
-        HISTORY_COL_IS_DELETED,
+        (HISTORY_COL_ENTITY_PK, false),
+        (HISTORY_COL_SCHEMA_KEY, false),
+        (HISTORY_COL_FILE_ID, true),
+        (HISTORY_COL_SNAPSHOT_CONTENT, true),
+        (HISTORY_COL_METADATA, true),
+        (HISTORY_COL_CHANGE_ID, false),
+        (HISTORY_COL_CHANGE_CREATED_AT, false),
+        (HISTORY_COL_ORIGIN_KEY, true),
+        (HISTORY_COL_OBSERVED_COMMIT_ID, false),
+        (HISTORY_COL_COMMIT_CREATED_AT, false),
+        (HISTORY_COL_AS_OF_COMMIT_ID, false),
+        (HISTORY_COL_DEPTH, false),
+        (HISTORY_COL_IS_DELETED, false),
     ])
 }
 
 fn file_history_columns() -> Vec<PublicColumn> {
     public_columns([
-        "id",
-        "path",
-        "directory_id",
-        "name",
-        "data",
-        HISTORY_COL_ENTITY_PK,
-        HISTORY_COL_SOURCE_CHANGES,
-        HISTORY_COL_OBSERVED_COMMIT_ID,
-        HISTORY_COL_COMMIT_CREATED_AT,
-        HISTORY_COL_AS_OF_COMMIT_ID,
-        HISTORY_COL_DEPTH,
-        HISTORY_COL_IS_DELETED,
+        ("id", false),
+        ("path", true),
+        ("directory_id", true),
+        ("name", true),
+        ("data", true),
+        (HISTORY_COL_ENTITY_PK, false),
+        (HISTORY_COL_SOURCE_CHANGES, false),
+        (HISTORY_COL_OBSERVED_COMMIT_ID, false),
+        (HISTORY_COL_COMMIT_CREATED_AT, false),
+        (HISTORY_COL_AS_OF_COMMIT_ID, false),
+        (HISTORY_COL_DEPTH, false),
+        (HISTORY_COL_IS_DELETED, false),
     ])
 }
 
 fn directory_history_columns() -> Vec<PublicColumn> {
     public_columns([
-        "id",
-        "path",
-        "parent_id",
-        "name",
-        HISTORY_COL_ENTITY_PK,
-        HISTORY_COL_SOURCE_CHANGES,
-        HISTORY_COL_OBSERVED_COMMIT_ID,
-        HISTORY_COL_COMMIT_CREATED_AT,
-        HISTORY_COL_AS_OF_COMMIT_ID,
-        HISTORY_COL_DEPTH,
-        HISTORY_COL_IS_DELETED,
+        ("id", false),
+        ("path", true),
+        ("parent_id", true),
+        ("name", true),
+        (HISTORY_COL_ENTITY_PK, false),
+        (HISTORY_COL_SOURCE_CHANGES, false),
+        (HISTORY_COL_OBSERVED_COMMIT_ID, false),
+        (HISTORY_COL_COMMIT_CREATED_AT, false),
+        (HISTORY_COL_AS_OF_COMMIT_ID, false),
+        (HISTORY_COL_DEPTH, false),
+        (HISTORY_COL_IS_DELETED, false),
     ])
 }

--- a/packages/engine/src/sql2/catalog/schema.rs
+++ b/packages/engine/src/sql2/catalog/schema.rs
@@ -2,48 +2,84 @@
 pub(crate) struct PublicColumn {
     pub(crate) id: usize,
     pub(crate) name: String,
+    /// Whether a row returned by the public SQL surface may contain SQL NULL.
+    ///
+    /// This is a SQL surface contract, not a copy of the provider's Arrow
+    /// field. Provider schemas also serve planning and write normalization and
+    /// can therefore be more permissive than the values a public read emits.
+    pub(crate) read_nullable: bool,
     pub(crate) role: PublicColumnRole,
     pub(crate) write: PublicColumnWrite,
+    pub(crate) insert_policy: PublicColumnInsertPolicy,
+    pub(crate) column_default: Option<String>,
 }
 
 impl PublicColumn {
-    pub(crate) fn public(name: impl Into<String>) -> Self {
+    pub(crate) fn public(name: impl Into<String>, read_nullable: bool) -> Self {
         Self {
             id: 0,
             name: name.into(),
+            read_nullable,
             role: PublicColumnRole::Public,
             write: PublicColumnWrite::READ_WRITE,
+            insert_policy: PublicColumnInsertPolicy::Required,
+            column_default: None,
         }
     }
 
-    pub(crate) fn public_insert_only(name: impl Into<String>) -> Self {
+    pub(crate) fn public_insert_only(name: impl Into<String>, read_nullable: bool) -> Self {
         Self {
             id: 0,
             name: name.into(),
+            read_nullable,
             role: PublicColumnRole::Public,
             write: PublicColumnWrite {
                 insert: true,
                 update: false,
             },
+            insert_policy: PublicColumnInsertPolicy::Required,
+            column_default: None,
         }
     }
 
-    pub(crate) fn public_read_only(name: impl Into<String>) -> Self {
+    pub(crate) fn public_read_only(name: impl Into<String>, read_nullable: bool) -> Self {
         Self {
             id: 0,
             name: name.into(),
+            read_nullable,
             role: PublicColumnRole::Public,
             write: PublicColumnWrite::READ_ONLY,
+            insert_policy: PublicColumnInsertPolicy::ReadOnly,
+            column_default: None,
         }
     }
 
-    pub(crate) fn hidden(name: impl Into<String>) -> Self {
+    pub(crate) fn hidden(name: impl Into<String>, read_nullable: bool) -> Self {
         Self {
             id: 0,
             name: name.into(),
+            read_nullable,
             role: PublicColumnRole::Hidden,
             write: PublicColumnWrite::READ_ONLY,
+            insert_policy: PublicColumnInsertPolicy::ReadOnly,
+            column_default: None,
         }
+    }
+
+    pub(crate) fn optional_on_insert(mut self) -> Self {
+        self.insert_policy = PublicColumnInsertPolicy::Optional;
+        self
+    }
+
+    pub(crate) fn conditional_on_insert(mut self) -> Self {
+        self.insert_policy = PublicColumnInsertPolicy::Conditional;
+        self
+    }
+
+    pub(crate) fn with_default(mut self, default: impl Into<String>) -> Self {
+        self.insert_policy = PublicColumnInsertPolicy::Default;
+        self.column_default = Some(default.into());
+        self
     }
 
     pub(crate) fn is_public(&self) -> bool {
@@ -61,6 +97,27 @@ impl PublicColumn {
 
     pub(crate) fn is_updatable(&self) -> bool {
         self.write.update
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PublicColumnInsertPolicy {
+    ReadOnly,
+    Required,
+    Optional,
+    Conditional,
+    Default,
+}
+
+impl PublicColumnInsertPolicy {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "READ_ONLY",
+            Self::Required => "REQUIRED",
+            Self::Optional => "OPTIONAL",
+            Self::Conditional => "CONDITIONAL",
+            Self::Default => "DEFAULT",
+        }
     }
 }
 

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
@@ -151,6 +152,7 @@ pub(crate) trait SqlWriteExecutionContext: Send {
 pub(crate) struct SqlWriteContext {
     ptr: Arc<SqlWriteContextPtr>,
     gate: Arc<Mutex<()>>,
+    explicit_insert_columns: Option<Arc<BTreeSet<String>>>,
 }
 
 struct SqlWriteContextPtr(NonNull<dyn SqlWriteExecutionContext>);
@@ -173,7 +175,20 @@ impl SqlWriteContext {
         Self {
             ptr: Arc::new(SqlWriteContextPtr(ptr)),
             gate: Arc::new(Mutex::new(())),
+            explicit_insert_columns: None,
         }
+    }
+
+    pub(crate) fn with_explicit_insert_columns(
+        mut self,
+        columns: Option<BTreeSet<String>>,
+    ) -> Self {
+        self.explicit_insert_columns = columns.map(Arc::new);
+        self
+    }
+
+    pub(crate) fn explicit_insert_columns(&self) -> Option<&BTreeSet<String>> {
+        self.explicit_insert_columns.as_deref()
     }
 
     pub(crate) fn functions(&self) -> FunctionProviderHandle {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -1,3 +1,5 @@
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::ScalarValue;
 use serde_json::Value as JsonValue;
 
 use crate::changelog::CommitId;
@@ -5,7 +7,7 @@ use crate::common::validate_row_metadata;
 use crate::entity_pk::EntityPk;
 use crate::live_state::{LiveStateFilter, LiveStateScanRequest};
 use crate::sql2::SqlWriteExecutionContext;
-use crate::sql2::bind::expr::{BoundExpr, BoundLiteral};
+use crate::sql2::bind::expr::{BoundCastType, BoundExpr, BoundLiteral};
 use crate::sql2::bind::write::{
     BoundAssignment, BoundConflictAction, BoundInsertConflict, BoundInsertValues, BoundWriteInput,
     BoundWriteOp, BoundWriteTarget, EntityWriteSurface, FileWriteSurface,
@@ -16,6 +18,7 @@ use crate::sql2::plan::LogicalWritePlan;
 use crate::sql2::plan::branch_scope::BranchScope;
 use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
 use crate::sql2::read_only::reject_read_only_entity_surface;
+use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::transaction::types::{
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteRow,
 };
@@ -541,6 +544,7 @@ fn entity_insert_rows(
         write_rows.push(entity_insert_row(
             ctx,
             plan,
+            spec,
             &layout,
             row,
             params,
@@ -589,7 +593,13 @@ async fn entity_update(
                 )?;
                 visible_assignments.push((
                     column.name.clone(),
-                    entity_json_value(value, column.column_type)?,
+                    entity_json_value(
+                        &assignment.value,
+                        value,
+                        column.column_type,
+                        &spec.schema_key,
+                        &column.name,
+                    )?,
                 ));
             } else if assignment.column.name == "lixcol_metadata" {
                 // handled below from the assignment list
@@ -760,9 +770,27 @@ fn entity_returning_value(
     if bound_expr_is_json(expr, spec) {
         return Ok(match value {
             EntityEvalValue::SqlNull => Value::Null,
+            EntityEvalValue::Json(JsonValue::Null)
+                if visible_entity_column(expr, spec)
+                    .is_some_and(|column| column.column_type == EntityColumnType::Json) =>
+            {
+                Value::Null
+            }
             EntityEvalValue::SqlText(value) => Value::Text(value),
             EntityEvalValue::Json(value) => Value::Json(value),
         });
+    }
+    if let Some(column) = visible_entity_column(expr, spec) {
+        if column.column_type == EntityColumnType::Integer {
+            let value = value.into_json();
+            return json_bigint_value(Some(&value), &spec.schema_key, &column.name)
+                .map(|value| value.map_or(Value::Null, Value::Integer));
+        }
+        if column.column_type == EntityColumnType::Number {
+            let value = value.into_json();
+            return json_double_value(Some(&value), &spec.schema_key, &column.name)
+                .map(|value| value.map_or(Value::Null, Value::Real));
+        }
     }
     Ok(match value {
         EntityEvalValue::SqlNull | EntityEvalValue::Json(JsonValue::Null) => Value::Null,
@@ -779,6 +807,16 @@ fn entity_returning_value(
             Value::Json(value)
         }
     })
+}
+
+fn visible_entity_column<'a>(
+    expr: &BoundExpr,
+    spec: &'a EntitySurfaceSpec,
+) -> Option<&'a EntitySurfaceColumn> {
+    let (BoundExpr::Column(column) | BoundExpr::ExcludedColumn(column)) = expr else {
+        return None;
+    };
+    spec.visible_column(&column.name)
 }
 
 fn entity_conflict_update_row(
@@ -817,7 +855,13 @@ fn entity_conflict_update_row(
             )?;
             visible_assignments.push((
                 column.name.clone(),
-                entity_json_value(value, column.column_type)?,
+                entity_json_value(
+                    &assignment.value,
+                    value,
+                    column.column_type,
+                    &spec.schema_key,
+                    &column.name,
+                )?,
             ));
         } else if assignment.column.name == "lixcol_metadata" {
             // handled by entity_replace_row_from_live from the assignment list
@@ -1030,6 +1074,7 @@ enum InsertColumnTarget {
     Visible {
         name: String,
         column_type: EntityColumnType,
+        read_nullable: bool,
     },
     EntityPk,
     FileId,
@@ -1058,6 +1103,7 @@ impl InsertRowLayout {
                     return Ok(InsertColumnTarget::Visible {
                         name: surface_column.name.clone(),
                         column_type: surface_column.column_type,
+                        read_nullable: surface_column.read_nullable,
                     });
                 }
                 Ok(match column.name.as_str() {
@@ -1092,6 +1138,7 @@ impl InsertRowLayout {
 fn entity_insert_row(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
+    spec: &EntitySurfaceSpec,
     layout: &InsertRowLayout,
     row: &[BoundExpr],
     params: &[Value],
@@ -1118,6 +1165,24 @@ fn entity_insert_row(
             reject_direct_blob_json_value(expr, *column_type, params)?;
         }
         let eval_value = eval_expr_value(expr, &context, ctx, params, active_branch_commit_id)?;
+        if matches!(
+            target,
+            InsertColumnTarget::Global | InsertColumnTarget::Untracked
+        ) && entity_eval_value_is_null(&eval_value)
+        {
+            let column_name = match target {
+                InsertColumnTarget::Global => "lixcol_global",
+                InsertColumnTarget::Untracked => "lixcol_untracked",
+                _ => unreachable!("matched defaulted boolean system column"),
+            };
+            return Err(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!(
+                    "INSERT into {} column '{column_name}' may be omitted to use its default, but explicit NULL is not allowed",
+                    layout.schema_key
+                ),
+            ));
+        }
         if matches!(target, InsertColumnTarget::Metadata) {
             metadata = optional_metadata_from_eval_value(
                 eval_value,
@@ -1126,8 +1191,25 @@ fn entity_insert_row(
             )?;
             continue;
         }
-        if let InsertColumnTarget::Visible { name, column_type } = target {
-            snapshot.insert(name.clone(), entity_json_value(eval_value, *column_type)?);
+        if let InsertColumnTarget::Visible {
+            name,
+            column_type,
+            read_nullable,
+        } = target
+        {
+            if !read_nullable && entity_eval_value_is_null(&eval_value) {
+                return Err(LixError::new(
+                    LixError::CODE_SCHEMA_VALIDATION,
+                    format!(
+                        "INSERT into {} column '{name}' does not allow explicit NULL",
+                        layout.schema_key
+                    ),
+                ));
+            }
+            snapshot.insert(
+                name.clone(),
+                entity_json_value(expr, eval_value, *column_type, &layout.schema_key, name)?,
+            );
             continue;
         }
         let value = eval_value.into_json();
@@ -1154,7 +1236,36 @@ fn entity_insert_row(
         }
     }
 
+    spec.defaults
+        .apply(&mut snapshot, ctx.functions(), &layout.schema_key)?;
     let snapshot = JsonValue::Object(snapshot);
+    if !spec.primary_key_paths.is_empty() {
+        let derived_entity_pk =
+            EntityPk::from_primary_key_paths(&snapshot, &spec.primary_key_paths).map_err(
+                |error| {
+                    LixError::new(
+                        LixError::CODE_SCHEMA_VALIDATION,
+                        format!(
+                            "INSERT failed to derive entity primary key for schema '{}': {error}",
+                            layout.schema_key
+                        ),
+                    )
+                },
+            )?;
+        if entity_pk
+            .as_ref()
+            .is_some_and(|explicit_entity_pk| explicit_entity_pk != &derived_entity_pk)
+        {
+            return Err(LixError::new(
+                LixError::CODE_SCHEMA_VALIDATION,
+                format!(
+                    "INSERT into {} has lixcol_entity_pk that does not match its public primary-key columns",
+                    layout.schema_key
+                ),
+            ));
+        }
+        entity_pk = Some(derived_entity_pk);
+    }
     let global = global.unwrap_or(false);
     let branch_id = entity_row_branch_id(plan, explicit_branch_id, global)?;
     Ok(TransactionWriteRow {
@@ -1338,6 +1449,100 @@ impl EntityEvalValue {
     }
 }
 
+fn entity_eval_value_is_null(value: &EntityEvalValue) -> bool {
+    matches!(
+        value,
+        EntityEvalValue::SqlNull | EntityEvalValue::Json(JsonValue::Null)
+    )
+}
+
+fn cast_entity_eval_value(
+    value: EntityEvalValue,
+    cast_type: BoundCastType,
+) -> Result<EntityEvalValue, LixError> {
+    if cast_type == BoundCastType::Binary {
+        return Err(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            "BYTEA casts require a binary SQL column",
+        )
+        .with_hint(
+            "Use BYTEA for lix_file.data; registered entity schemas expose no binary column type.",
+        ));
+    }
+
+    let target_type = match cast_type {
+        BoundCastType::Text => DataType::Utf8,
+        BoundCastType::BigInt => DataType::Int64,
+        BoundCastType::Double => DataType::Float64,
+        BoundCastType::Boolean => DataType::Boolean,
+        BoundCastType::Binary => unreachable!("binary entity casts rejected above"),
+    };
+    let scalar = scalar_from_entity_eval_value(value);
+    let casted = scalar.cast_to(&target_type).map_err(|error| {
+        LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            format!("CAST AS {} failed: {error}", cast_type.canonical_sql_name()),
+        )
+    })?;
+    entity_eval_value_from_cast_scalar(casted, cast_type)
+}
+
+fn scalar_from_entity_eval_value(value: EntityEvalValue) -> ScalarValue {
+    match value {
+        EntityEvalValue::SqlNull | EntityEvalValue::Json(JsonValue::Null) => ScalarValue::Null,
+        EntityEvalValue::SqlText(value) | EntityEvalValue::Json(JsonValue::String(value)) => {
+            ScalarValue::Utf8(Some(value))
+        }
+        EntityEvalValue::Json(JsonValue::Bool(value)) => ScalarValue::Boolean(Some(value)),
+        EntityEvalValue::Json(JsonValue::Number(value)) => value.as_i64().map_or_else(
+            || {
+                value.as_u64().map_or_else(
+                    || ScalarValue::Float64(value.as_f64()),
+                    |value| ScalarValue::UInt64(Some(value)),
+                )
+            },
+            |value| ScalarValue::Int64(Some(value)),
+        ),
+        EntityEvalValue::Json(value @ (JsonValue::Array(_) | JsonValue::Object(_))) => {
+            ScalarValue::Utf8(Some(value.to_string()))
+        }
+    }
+}
+
+fn entity_eval_value_from_cast_scalar(
+    value: ScalarValue,
+    cast_type: BoundCastType,
+) -> Result<EntityEvalValue, LixError> {
+    if value.is_null() {
+        return Ok(EntityEvalValue::SqlNull);
+    }
+    match value {
+        ScalarValue::Utf8(Some(value))
+        | ScalarValue::Utf8View(Some(value))
+        | ScalarValue::LargeUtf8(Some(value)) => Ok(EntityEvalValue::SqlText(value)),
+        ScalarValue::Int64(Some(value)) => {
+            Ok(EntityEvalValue::Json(JsonValue::Number(value.into())))
+        }
+        ScalarValue::Float64(Some(value)) => serde_json::Number::from_f64(value)
+            .map(JsonValue::Number)
+            .map(EntityEvalValue::Json)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    "DOUBLE PRECISION cast produced a non-finite number",
+                )
+            }),
+        ScalarValue::Boolean(Some(value)) => Ok(EntityEvalValue::Json(JsonValue::Bool(value))),
+        other => Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "CAST AS {} produced unexpected scalar {other:?}",
+                cast_type.canonical_sql_name()
+            ),
+        )),
+    }
+}
+
 fn eval_expr(
     expr: &BoundExpr,
     context: &EntityEvalContext<'_>,
@@ -1373,10 +1578,10 @@ fn eval_expr_value(
             }),
         BoundExpr::Column(column) => column_eval_value(context, &column.name),
         BoundExpr::ExcludedColumn(column) => excluded_column_eval_value(context, &column.name),
-        BoundExpr::Cast { .. } => Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            "bound entity writes do not support CAST expressions yet",
-        )),
+        BoundExpr::Cast { expr, data_type } => {
+            let value = eval_expr_value(expr, context, ctx, params, active_branch_commit_id)?;
+            cast_entity_eval_value(value, *data_type)
+        }
         BoundExpr::Function { name, args } if name == "lix_json" && args.len() == 1 => {
             let raw = eval_expr_value(&args[0], context, ctx, params, active_branch_commit_id)?;
             let raw = match raw {
@@ -1502,16 +1707,9 @@ fn predicate_matches(
             Ok(false)
         }
         BoundPredicate::Eq(left, right) => {
-            let (left, right) = eval_comparison_operands(
-                left,
-                right,
-                context,
-                spec,
-                ctx,
-                params,
-                active_branch_commit_id,
-            )?;
-            Ok(!left.is_null() && !right.is_null() && left == right)
+            let left_value = eval_expr(left, context, ctx, params, active_branch_commit_id)?;
+            let right_value = eval_expr(right, context, ctx, params, active_branch_commit_id)?;
+            comparison_values_equal(left, left_value, right, right_value, spec)
         }
         BoundPredicate::Like { .. } => Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
@@ -1532,14 +1730,7 @@ fn predicate_matches(
             }
             for value_expr in values {
                 let value = eval_expr(value_expr, context, ctx, params, active_branch_commit_id)?;
-                let (candidate, value) = normalize_comparison_operands(
-                    expr,
-                    candidate.clone(),
-                    value_expr,
-                    value,
-                    spec,
-                )?;
-                if !value.is_null() && candidate == value {
+                if comparison_values_equal(expr, candidate.clone(), value_expr, value, spec)? {
                     return Ok(true);
                 }
             }
@@ -1548,18 +1739,116 @@ fn predicate_matches(
     }
 }
 
-fn eval_comparison_operands(
-    left: &BoundExpr,
-    right: &BoundExpr,
-    context: &EntityEvalContext<'_>,
+#[derive(Clone, Copy, Debug)]
+enum NumericComparisonValue {
+    Signed(i64),
+    Unsigned(u64),
+    Double(f64),
+}
+
+fn comparison_values_equal(
+    left_expr: &BoundExpr,
+    mut left_value: JsonValue,
+    right_expr: &BoundExpr,
+    mut right_value: JsonValue,
     spec: &EntitySurfaceSpec,
-    ctx: &mut dyn SqlWriteExecutionContext,
-    params: &[Value],
-    active_branch_commit_id: Option<&CommitId>,
-) -> Result<(JsonValue, JsonValue), LixError> {
-    let left_value = eval_expr(left, context, ctx, params, active_branch_commit_id)?;
-    let right_value = eval_expr(right, context, ctx, params, active_branch_commit_id)?;
-    normalize_comparison_operands(left, left_value, right, right_value, spec)
+) -> Result<bool, LixError> {
+    normalize_bigint_comparison_literal(left_expr, right_expr, &mut right_value, spec)?;
+    normalize_bigint_comparison_literal(right_expr, left_expr, &mut left_value, spec)?;
+    let (left_value, right_value) =
+        normalize_comparison_operands(left_expr, left_value, right_expr, right_value, spec)?;
+    if left_value.is_null() || right_value.is_null() {
+        return Ok(false);
+    }
+
+    let left_numeric = numeric_comparison_value(left_expr, &left_value, spec)?;
+    let right_numeric = numeric_comparison_value(right_expr, &right_value, spec)?;
+    match (left_numeric, right_numeric) {
+        (Some(left), Some(right)) => Ok(numeric_values_equal(left, right)),
+        _ => Ok(left_value == right_value),
+    }
+}
+
+fn normalize_bigint_comparison_literal(
+    column_expr: &BoundExpr,
+    value_expr: &BoundExpr,
+    value: &mut JsonValue,
+    spec: &EntitySurfaceSpec,
+) -> Result<(), LixError> {
+    let Some(column) = visible_entity_column(column_expr, spec) else {
+        return Ok(());
+    };
+    if column.column_type != EntityColumnType::Integer {
+        return Ok(());
+    }
+    if let Some(exact) = bigint_number_literal(value_expr, &spec.schema_key, &column.name)? {
+        *value = JsonValue::from(exact);
+    }
+    Ok(())
+}
+
+fn numeric_comparison_value(
+    expr: &BoundExpr,
+    value: &JsonValue,
+    spec: &EntitySurfaceSpec,
+) -> Result<Option<NumericComparisonValue>, LixError> {
+    if let Some(column) = visible_entity_column(expr, spec) {
+        return match column.column_type {
+            EntityColumnType::Integer => {
+                json_bigint_value(Some(value), &spec.schema_key, &column.name)
+                    .map(|value| value.map(NumericComparisonValue::Signed))
+            }
+            EntityColumnType::Number => {
+                json_double_value(Some(value), &spec.schema_key, &column.name)
+                    .map(|value| value.map(NumericComparisonValue::Double))
+            }
+            EntityColumnType::String | EntityColumnType::Json | EntityColumnType::Boolean => {
+                Ok(None)
+            }
+        };
+    }
+
+    let JsonValue::Number(number) = value else {
+        return Ok(None);
+    };
+    if let Some(value) = number.as_i64() {
+        return Ok(Some(NumericComparisonValue::Signed(value)));
+    }
+    if let Some(value) = number.as_u64() {
+        return Ok(Some(NumericComparisonValue::Unsigned(value)));
+    }
+    Ok(number.as_f64().map(NumericComparisonValue::Double))
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    clippy::float_cmp,
+    reason = "SQL numeric equality coerces mixed BIGINT/DOUBLE operands to DOUBLE PRECISION"
+)]
+fn numeric_values_equal(left: NumericComparisonValue, right: NumericComparisonValue) -> bool {
+    match (left, right) {
+        (NumericComparisonValue::Signed(left), NumericComparisonValue::Signed(right)) => {
+            left == right
+        }
+        (NumericComparisonValue::Unsigned(left), NumericComparisonValue::Unsigned(right)) => {
+            left == right
+        }
+        (NumericComparisonValue::Signed(left), NumericComparisonValue::Unsigned(right))
+        | (NumericComparisonValue::Unsigned(right), NumericComparisonValue::Signed(left)) => {
+            u64::try_from(left).is_ok_and(|left| left == right)
+        }
+        (NumericComparisonValue::Double(left), NumericComparisonValue::Double(right)) => {
+            left == right
+        }
+        (NumericComparisonValue::Double(left), NumericComparisonValue::Signed(right))
+        | (NumericComparisonValue::Signed(right), NumericComparisonValue::Double(left)) => {
+            left == right as f64
+        }
+        (NumericComparisonValue::Double(left), NumericComparisonValue::Unsigned(right))
+        | (NumericComparisonValue::Unsigned(right), NumericComparisonValue::Double(left)) => {
+            left == right as f64
+        }
+    }
 }
 
 fn normalize_comparison_operands(
@@ -1641,6 +1930,20 @@ fn validate_bound_write_supported(
         for item in &returning.items {
             validate_expr_supported(&item.expr)?;
         }
+    }
+    if plan.bound.returning.is_some() && plan.bound.op != BoundWriteOp::Delete {
+        let action = match plan.bound.op {
+            BoundWriteOp::Insert => "INSERT",
+            BoundWriteOp::Update => "UPDATE",
+            BoundWriteOp::Delete => unreachable!("DELETE RETURNING is supported"),
+        };
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            format!("{action} RETURNING is not supported for registered entity surfaces"),
+        )
+        .with_hint(format!(
+            "Run the {action} without RETURNING, then SELECT the row explicitly."
+        )));
     }
     Ok(())
 }
@@ -1827,10 +2130,7 @@ fn validate_expr_supported(expr: &BoundExpr) -> Result<(), LixError> {
         | BoundExpr::ExcludedColumn(_)
         | BoundExpr::Param(_)
         | BoundExpr::Literal(_) => Ok(()),
-        BoundExpr::Cast { .. } => Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            "bound entity writes do not support CAST expressions yet",
-        )),
+        BoundExpr::Cast { expr, .. } => validate_expr_supported(expr),
         BoundExpr::Function { name, args } => {
             match name.as_str() {
                 "lix_json" if args.len() == 1 => {}
@@ -1871,29 +2171,189 @@ fn candidate_snapshot(
         .transpose()
 }
 
-#[expect(clippy::unnecessary_wraps)]
 fn entity_json_value(
+    expr: &BoundExpr,
     value: EntityEvalValue,
     column_type: EntityColumnType,
+    schema_key: &str,
+    column_name: &str,
 ) -> Result<JsonValue, LixError> {
-    Ok(match (value, column_type) {
-        (EntityEvalValue::SqlNull, _) => JsonValue::Null,
-        (EntityEvalValue::SqlText(value), EntityColumnType::Json) => {
-            serde_json::from_str(&value).unwrap_or(JsonValue::String(value))
+    let exact_bigint_literal = if column_type == EntityColumnType::Integer {
+        bigint_number_literal(expr, schema_key, column_name)?
+    } else {
+        None
+    };
+    let value = exact_bigint_literal.map_or_else(
+        || match (value, column_type) {
+            (EntityEvalValue::SqlNull, _) => JsonValue::Null,
+            (EntityEvalValue::SqlText(value), EntityColumnType::Json) => {
+                serde_json::from_str(&value).unwrap_or(JsonValue::String(value))
+            }
+            (EntityEvalValue::SqlText(value), _) => JsonValue::String(value),
+            (EntityEvalValue::Json(JsonValue::String(value)), EntityColumnType::String) => {
+                JsonValue::String(value)
+            }
+            (
+                EntityEvalValue::Json(JsonValue::Number(value)),
+                EntityColumnType::Number | EntityColumnType::Integer,
+            ) => JsonValue::Number(value),
+            (EntityEvalValue::Json(JsonValue::Bool(value)), EntityColumnType::Boolean) => {
+                JsonValue::Bool(value)
+            }
+            (EntityEvalValue::Json(value), _) => value,
+        },
+        JsonValue::from,
+    );
+    match column_type {
+        EntityColumnType::Integer => {
+            json_bigint_value(Some(&value), schema_key, column_name)?;
         }
-        (EntityEvalValue::SqlText(value), _) => JsonValue::String(value),
-        (EntityEvalValue::Json(JsonValue::String(value)), EntityColumnType::String) => {
-            JsonValue::String(value)
+        EntityColumnType::Number => {
+            json_double_value(Some(&value), schema_key, column_name)?;
         }
-        (
-            EntityEvalValue::Json(JsonValue::Number(value)),
-            EntityColumnType::Number | EntityColumnType::Integer,
-        ) => JsonValue::Number(value),
-        (EntityEvalValue::Json(JsonValue::Bool(value)), EntityColumnType::Boolean) => {
-            JsonValue::Bool(value)
+        EntityColumnType::String | EntityColumnType::Json | EntityColumnType::Boolean => {}
+    }
+    Ok(value)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BigintNumberLiteral {
+    Exact(i64),
+    NonIntegral,
+}
+
+fn bigint_number_literal(
+    expr: &BoundExpr,
+    schema_key: &str,
+    column_name: &str,
+) -> Result<Option<i64>, LixError> {
+    let raw = match expr {
+        BoundExpr::Literal(BoundLiteral::Number { raw, .. }) => raw,
+        BoundExpr::Cast {
+            expr,
+            data_type: BoundCastType::BigInt,
+        } => return bigint_number_literal(expr, schema_key, column_name),
+        _ => return Ok(None),
+    };
+    let Some(BigintNumberLiteral::Exact(value)) = classify_bigint_literal(raw) else {
+        return Err(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            format!(
+                "typed SQL surface '{schema_key}' column '{column_name}' cannot represent SQL numeric literal {raw} as BIGINT"
+            ),
+        )
+        .with_hint(
+            "Use an exact integer between -9223372036854775808 and 9223372036854775807.",
+        ));
+    };
+    Ok(Some(value))
+}
+
+fn classify_bigint_literal(raw: &str) -> Option<BigintNumberLiteral> {
+    let (negative, unsigned) = raw.strip_prefix('-').map_or_else(
+        || (false, raw.strip_prefix('+').unwrap_or(raw)),
+        |unsigned| (true, unsigned),
+    );
+    let (mantissa, exponent) = if let Some((mantissa, exponent)) = unsigned.split_once(['e', 'E']) {
+        if exponent.contains(['e', 'E']) {
+            return None;
         }
-        (EntityEvalValue::Json(value), _) => value,
-    })
+        (mantissa, exponent.parse::<i64>().ok()?)
+    } else {
+        (unsigned, 0)
+    };
+    let (integer_digits, fractional_digits) =
+        if let Some((integer_digits, fractional_digits)) = mantissa.split_once('.') {
+            if fractional_digits.contains('.') {
+                return None;
+            }
+            (integer_digits, fractional_digits)
+        } else {
+            (mantissa, "")
+        };
+    if integer_digits.is_empty() && fractional_digits.is_empty() {
+        return None;
+    }
+    if !integer_digits.bytes().all(|byte| byte.is_ascii_digit())
+        || !fractional_digits.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let mut digits = String::with_capacity(integer_digits.len() + fractional_digits.len());
+    digits.push_str(integer_digits);
+    digits.push_str(fractional_digits);
+    if digits.bytes().all(|byte| byte == b'0') {
+        return Some(BigintNumberLiteral::Exact(0));
+    }
+
+    let fractional_len = i64::try_from(fractional_digits.len()).ok()?;
+    let decimal_shift = exponent.checked_sub(fractional_len)?;
+    if decimal_shift >= 0 {
+        let significant = digits.trim_start_matches('0');
+        let trailing_zeros = usize::try_from(decimal_shift).ok()?;
+        if significant.len().checked_add(trailing_zeros)? > 19 {
+            return None;
+        }
+        let mut magnitude = String::with_capacity(significant.len() + trailing_zeros);
+        magnitude.push_str(significant);
+        magnitude.extend(std::iter::repeat_n('0', trailing_zeros));
+        return signed_bigint_magnitude(&magnitude, negative).map(BigintNumberLiteral::Exact);
+    }
+
+    let removed_digits = usize::try_from(decimal_shift.unsigned_abs()).ok()?;
+    if removed_digits > digits.len() {
+        return Some(BigintNumberLiteral::NonIntegral);
+    }
+    let split = digits.len() - removed_digits;
+    let integer_magnitude = digits[..split].trim_start_matches('0');
+    let fractional_is_zero = digits[split..].bytes().all(|byte| byte == b'0');
+    if fractional_is_zero {
+        let integer_magnitude = if integer_magnitude.is_empty() {
+            "0"
+        } else {
+            integer_magnitude
+        };
+        return signed_bigint_magnitude(integer_magnitude, negative)
+            .map(BigintNumberLiteral::Exact);
+    }
+    if non_integral_magnitude_is_in_bigint_range(integer_magnitude, negative) {
+        Some(BigintNumberLiteral::NonIntegral)
+    } else {
+        None
+    }
+}
+
+fn signed_bigint_magnitude(magnitude: &str, negative: bool) -> Option<i64> {
+    let maximum = if negative {
+        "9223372036854775808"
+    } else {
+        "9223372036854775807"
+    };
+    if magnitude.len() > maximum.len() || (magnitude.len() == maximum.len() && magnitude > maximum)
+    {
+        return None;
+    }
+    let magnitude = magnitude.parse::<u64>().ok()?;
+    if negative {
+        if magnitude == 9_223_372_036_854_775_808_u64 {
+            Some(i64::MIN)
+        } else {
+            i64::try_from(magnitude).ok().map(|value| -value)
+        }
+    } else {
+        i64::try_from(magnitude).ok()
+    }
+}
+
+fn non_integral_magnitude_is_in_bigint_range(magnitude: &str, negative: bool) -> bool {
+    let maximum_integer_part = if negative {
+        "9223372036854775807"
+    } else {
+        "9223372036854775806"
+    };
+    magnitude.len() < maximum_integer_part.len()
+        || (magnitude.len() == maximum_integer_part.len() && magnitude <= maximum_integer_part)
 }
 
 fn reject_direct_blob_json_value(
@@ -1925,6 +2385,7 @@ fn literal_json(literal: &BoundLiteral) -> JsonValue {
         BoundLiteral::Null => JsonValue::Null,
         BoundLiteral::Bool(value) => JsonValue::Bool(*value),
         BoundLiteral::Integer(value) => JsonValue::from(*value),
+        BoundLiteral::Number { value, .. } => JsonValue::Number(value.clone()),
         BoundLiteral::Text(value) => JsonValue::String(value.clone()),
         BoundLiteral::Json(value) => value.clone(),
         BoundLiteral::Blob(value) => {

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1159,21 +1159,41 @@ async fn insert_values_input_plan(
             "sql2 DataFusion reference writer cannot execute empty INSERT",
         ));
     }
-    let nullable_schema = std::sync::Arc::new(Schema::new(
-        schema
-            .fields()
-            .iter()
-            .map(|field| Field::new(field.name(), field.data_type().clone(), true))
-            .collect::<Vec<_>>(),
-    ));
-    let df_schema = std::sync::Arc::new(
-        DFSchema::try_from(nullable_schema).map_err(datafusion_error_to_lix_error)?,
-    );
     let field_source_indexes = schema
         .fields()
         .iter()
         .map(|field| values.column_index(field.name()))
         .collect::<Vec<_>>();
+    // Keep omission intent on the VALUES input fields as well as the output
+    // aliases below. DataFusion can eliminate the identity projection while
+    // optimizing an INSERT, but it preserves the VALUES schema at the table
+    // provider boundary.
+    let nullable_schema = std::sync::Arc::new(Schema::new(
+        schema
+            .fields()
+            .iter()
+            .zip(field_source_indexes.iter())
+            .map(|(field, source_index)| {
+                let field = Field::new(field.name(), field.data_type().clone(), true);
+                if source_index.is_none() && !insert_field_is_derived_from_scope(plan, field.name())
+                {
+                    field.with_metadata(
+                        [(
+                            LIX_INSERT_COLUMN_OMITTED_METADATA_KEY.to_string(),
+                            "true".to_string(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    )
+                } else {
+                    field
+                }
+            })
+            .collect::<Vec<_>>(),
+    ));
+    let df_schema = std::sync::Arc::new(
+        DFSchema::try_from(nullable_schema).map_err(datafusion_error_to_lix_error)?,
+    );
     let rows = values
         .rows
         .iter()
@@ -1202,7 +1222,9 @@ async fn insert_values_input_plan(
         .zip(field_source_indexes.iter())
         .enumerate()
         .map(|(index, (field, source_index))| {
-            let metadata = if source_index.is_none() {
+            let metadata = if source_index.is_none()
+                && !insert_field_is_derived_from_scope(plan, field.name())
+            {
                 Some(FieldMetadata::new(BTreeMap::from([(
                     LIX_INSERT_COLUMN_OMITTED_METADATA_KEY.to_string(),
                     "true".to_string(),
@@ -1310,6 +1332,31 @@ fn insert_column_is_omitted(values: &BoundInsertValues, field_name: &str) -> boo
 }
 
 fn validate_bound_write_input(plan: &LogicalWritePlan, params: &[Value]) -> Result<(), LixError> {
+    if plan.bound.op == BoundWriteOp::Insert
+        && matches!(
+            plan.bound.target,
+            BoundWriteTarget::File(_) | BoundWriteTarget::Directory(_)
+        )
+        && let BoundWriteInput::Values(values) = &plan.bound.input
+        && let Some(id_index) = values.column_index("id")
+    {
+        for row in &values.rows {
+            let explicit_null = match &row[id_index] {
+                BoundExpr::Literal(BoundLiteral::Null) => true,
+                BoundExpr::Param(param) => params
+                    .get(param.index.saturating_sub(1))
+                    .is_some_and(|value| matches!(value, Value::Null)),
+                _ => false,
+            };
+            if explicit_null {
+                return Err(LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    "defaulted filesystem id may be omitted, but explicit NULL is not allowed",
+                ));
+            }
+        }
+    }
+
     if !matches!(
         plan.bound.target,
         BoundWriteTarget::File(FileWriteSurface::Base | FileWriteSurface::ByBranch)
@@ -1379,8 +1426,28 @@ fn write_session_options(plan: &LogicalWritePlan) -> SqlWriteSessionOptions {
             omitted_insert_columns.insert("data".to_string());
         }
     }
+    let explicit_insert_columns = match &plan.bound.input {
+        BoundWriteInput::Values(values) => {
+            let mut columns = values
+                .columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect::<BTreeSet<_>>();
+            for field_name in ["branch_id", "global"] {
+                if insert_field_is_derived_from_scope(plan, field_name) {
+                    columns.insert(field_name.to_string());
+                }
+            }
+            Some(columns)
+        }
+        BoundWriteInput::Query { columns, .. } => {
+            Some(columns.iter().map(|column| column.name.clone()).collect())
+        }
+        BoundWriteInput::None => None,
+    };
     SqlWriteSessionOptions {
         omitted_insert_columns,
+        explicit_insert_columns,
     }
 }
 
@@ -1474,6 +1541,12 @@ fn sql_write_empty_returning_result(
     ))
 }
 
+fn insert_field_is_derived_from_scope(plan: &LogicalWritePlan, field_name: &str) -> bool {
+    matches!(plan.bound.target, BoundWriteTarget::LixStateByBranch)
+        && plan.bound.branch_scope == BranchScope::Global
+        && matches!(field_name, "branch_id" | "global")
+}
+
 fn insert_field_expr(
     session: &SessionContext,
     row: &[BoundExpr],
@@ -1483,11 +1556,15 @@ fn insert_field_expr(
     plan: &LogicalWritePlan,
     params: &[Value],
 ) -> Result<Expr, LixError> {
-    if plan.bound.branch_scope == BranchScope::Global && field_name == "global" {
-        let has_explicit_global = source_index.is_some();
-        if !has_explicit_global {
-            return Ok(Expr::Literal(ScalarValue::Boolean(Some(true)), None));
-        }
+    if source_index.is_none() && insert_field_is_derived_from_scope(plan, field_name) {
+        return Ok(Expr::Literal(
+            match field_name {
+                "branch_id" => ScalarValue::Utf8(Some(GLOBAL_BRANCH_ID.to_string())),
+                "global" => ScalarValue::Boolean(Some(true)),
+                _ => unreachable!("scope-derived fields are branch_id or global"),
+            },
+            None,
+        ));
     }
 
     source_index
@@ -1811,7 +1888,11 @@ fn datafusion_expr_from_bound_expr(
         }
         BoundExpr::Cast { expr, data_type } => {
             let data_type = match data_type {
+                BoundCastType::Text => DataType::Utf8,
                 BoundCastType::Binary => DataType::Binary,
+                BoundCastType::BigInt => DataType::Int64,
+                BoundCastType::Double => DataType::Float64,
+                BoundCastType::Boolean => DataType::Boolean,
             };
             Ok(Expr::Cast(Cast::new(
                 Box::new(datafusion_expr_from_bound_expr(session, expr, params)?),
@@ -1834,6 +1915,10 @@ fn scalar_from_bound_literal(literal: &BoundLiteral) -> Result<ScalarValue, LixE
         BoundLiteral::Null => ScalarValue::Null,
         BoundLiteral::Bool(value) => ScalarValue::Boolean(Some(*value)),
         BoundLiteral::Integer(value) => ScalarValue::Int64(Some(*value)),
+        BoundLiteral::Number { value, .. } => value.as_u64().map_or_else(
+            || ScalarValue::Float64(value.as_f64()),
+            |value| ScalarValue::UInt64(Some(value)),
+        ),
         BoundLiteral::Text(value) => ScalarValue::Utf8(Some(value.clone())),
         BoundLiteral::Json(value) => ScalarValue::Utf8(Some(value.to_string())),
         BoundLiteral::Blob(value) => ScalarValue::LargeBinary(Some(value.clone())),

--- a/packages/engine/src/sql2/exec/write.rs
+++ b/packages/engine/src/sql2/exec/write.rs
@@ -234,7 +234,12 @@ fn resolve_parameterized_branch_scope(
             mut branch_ids,
             param_indexes,
         } => {
-            insert_branch_param_values(&mut branch_ids, &param_indexes, params)?;
+            insert_branch_param_values(
+                &mut branch_ids,
+                &param_indexes,
+                params,
+                BranchParamNullPolicy::Reject,
+            )?;
             if branch_ids.is_empty() {
                 BranchScope::Empty
             } else {
@@ -258,7 +263,12 @@ fn resolve_parameterized_branch_scope(
                         BranchScope::ExplicitRequired { branch_ids }
                     }
                     ResolvedBranchSelector::Missing => {
-                        insert_branch_param_values(&mut branch_ids, &param_indexes, params)?;
+                        insert_branch_param_values(
+                            &mut branch_ids,
+                            &param_indexes,
+                            params,
+                            BranchParamNullPolicy::Ignore,
+                        )?;
                         if branch_ids.is_empty() {
                             BranchScope::Empty
                         } else {
@@ -268,7 +278,12 @@ fn resolve_parameterized_branch_scope(
                 }
             }
             None => {
-                insert_branch_param_values(&mut branch_ids, &param_indexes, params)?;
+                insert_branch_param_values(
+                    &mut branch_ids,
+                    &param_indexes,
+                    params,
+                    BranchParamNullPolicy::Ignore,
+                )?;
                 if branch_ids.is_empty() {
                     BranchScope::Empty
                 } else {
@@ -673,13 +688,20 @@ fn insert_branch_param_values(
     branch_ids: &mut BTreeSet<String>,
     param_indexes: &BTreeSet<usize>,
     params: &[Value],
+    null_policy: BranchParamNullPolicy,
 ) -> Result<(), LixError> {
     for index in param_indexes {
         match params.get(index.saturating_sub(1)) {
             Some(Value::Text(branch_id)) => {
                 branch_ids.insert(branch_id.clone());
             }
-            Some(Value::Null) => {}
+            Some(Value::Null) if null_policy == BranchParamNullPolicy::Ignore => {}
+            Some(Value::Null) => {
+                return Err(LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    "INSERT into a by-branch SQL surface requires non-null text branch-id parameters",
+                ));
+            }
             Some(_) => {
                 return Err(LixError::new(
                     LixError::CODE_TYPE_MISMATCH,
@@ -695,6 +717,12 @@ fn insert_branch_param_values(
         }
     }
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BranchParamNullPolicy {
+    Reject,
+    Ignore,
 }
 
 fn normalize_bound_public_write_error(error: LixError) -> LixError {

--- a/packages/engine/src/sql2/information_schema.rs
+++ b/packages/engine/src/sql2/information_schema.rs
@@ -1,0 +1,369 @@
+use std::any::Any;
+use std::sync::{Arc, Weak};
+
+use async_trait::async_trait;
+use datafusion::arrow::array::{ArrayRef, StringArray, UInt64Array};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::information_schema::{
+    INFORMATION_SCHEMA, INFORMATION_SCHEMA_TABLES, InformationSchemaProvider,
+};
+use datafusion::catalog::{CatalogProviderList, SchemaProvider, TableProvider};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::MemTable;
+use datafusion::prelude::SessionContext;
+
+use crate::LixError;
+
+use super::catalog::{PublicCatalog, PublicColumnInsertPolicy};
+use super::result_metadata::field_is_json;
+
+const LIX_VALUE_KIND_JSON: &str = "JSON";
+
+/// Installs Lix's SQL-level column contract while retaining DataFusion's other
+/// standard information-schema views.
+///
+/// Arrow schemas remain the execution representation. The public catalog must
+/// instead advertise spellings that Lix SQL accepts, plus the distinction
+/// between read nullability and insert-time omission/default behavior.
+pub(crate) fn register(
+    session: &SessionContext,
+    public_catalog: &PublicCatalog,
+) -> Result<(), LixError> {
+    let state = session.state();
+    let catalog_name = state.config_options().catalog.default_catalog.clone();
+    let schema_name = state.config_options().catalog.default_schema.clone();
+    let catalog_list = Arc::clone(state.catalog_list());
+    let catalog = catalog_list.catalog(&catalog_name).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("SQL default catalog '{catalog_name}' is missing"),
+        )
+    })?;
+    let provider: Arc<dyn SchemaProvider> = Arc::new(LixInformationSchemaProvider::new(
+        catalog_list,
+        public_catalog.clone(),
+        catalog_name.clone(),
+        schema_name,
+    ));
+    catalog
+        .register_schema(INFORMATION_SCHEMA, provider)
+        .map_err(super::error::datafusion_error_to_lix_error)?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct LixInformationSchemaProvider {
+    // This provider is itself registered inside the catalog list. A strong
+    // reference here would create a cycle that retains every session table
+    // provider and its storage read handles.
+    catalog_list: Weak<dyn CatalogProviderList>,
+    public_catalog: PublicCatalog,
+    public_catalog_name: String,
+    public_schema_name: String,
+}
+
+impl LixInformationSchemaProvider {
+    fn new(
+        catalog_list: Arc<dyn CatalogProviderList>,
+        public_catalog: PublicCatalog,
+        public_catalog_name: String,
+        public_schema_name: String,
+    ) -> Self {
+        Self {
+            catalog_list: Arc::downgrade(&catalog_list),
+            public_catalog,
+            public_catalog_name,
+            public_schema_name,
+        }
+    }
+
+    async fn columns_table(&self) -> Result<Arc<dyn TableProvider>> {
+        let schema = columns_schema();
+        let mut rows = ColumnsRows::default();
+        let catalog_list = self.catalog_list.upgrade().ok_or_else(|| {
+            DataFusionError::Execution("SQL catalog closed while reading information_schema".into())
+        })?;
+        let delegate = InformationSchemaProvider::new(Arc::clone(&catalog_list));
+        let mut catalog_names = catalog_list.catalog_names();
+        catalog_names.sort();
+        for catalog_name in catalog_names {
+            let Some(catalog) = catalog_list.catalog(&catalog_name) else {
+                continue;
+            };
+            let mut schema_names = catalog.schema_names();
+            schema_names.sort();
+            for schema_name in schema_names {
+                if schema_name == INFORMATION_SCHEMA {
+                    continue;
+                }
+                let Some(schema_provider) = catalog.schema(&schema_name) else {
+                    continue;
+                };
+                let mut table_names = schema_provider.table_names();
+                table_names.sort();
+                for table_name in table_names {
+                    let Some(table) = schema_provider.table(&table_name).await? else {
+                        continue;
+                    };
+                    rows.add_table(
+                        &catalog_name,
+                        &schema_name,
+                        &table_name,
+                        table.schema().as_ref(),
+                        (catalog_name == self.public_catalog_name
+                            && schema_name == self.public_schema_name)
+                            .then_some(&self.public_catalog),
+                    );
+                }
+            }
+
+            for table_name in INFORMATION_SCHEMA_TABLES {
+                let table_schema = if *table_name == "columns" {
+                    Arc::clone(&schema)
+                } else {
+                    delegate
+                        .table(table_name)
+                        .await?
+                        .map(|table| table.schema())
+                        .ok_or_else(|| {
+                            DataFusionError::Execution(format!(
+                                "information_schema.{table_name} is missing"
+                            ))
+                        })?
+                };
+                rows.add_table(
+                    &catalog_name,
+                    INFORMATION_SCHEMA,
+                    table_name,
+                    table_schema.as_ref(),
+                    None,
+                );
+            }
+        }
+
+        let batch = rows.finish(Arc::clone(&schema))?;
+        Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for LixInformationSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        INFORMATION_SCHEMA_TABLES
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect()
+    }
+
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+        if name.eq_ignore_ascii_case("columns") {
+            return self.columns_table().await.map(Some);
+        }
+        let catalog_list = self.catalog_list.upgrade().ok_or_else(|| {
+            DataFusionError::Execution("SQL catalog closed while reading information_schema".into())
+        })?;
+        InformationSchemaProvider::new(catalog_list)
+            .table(name)
+            .await
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        INFORMATION_SCHEMA_TABLES
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(name))
+    }
+}
+
+fn columns_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("table_catalog", DataType::Utf8, false),
+        Field::new("table_schema", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("column_name", DataType::Utf8, false),
+        Field::new("ordinal_position", DataType::UInt64, false),
+        Field::new("column_default", DataType::Utf8, true),
+        Field::new("is_nullable", DataType::Utf8, false),
+        Field::new("data_type", DataType::Utf8, false),
+        Field::new("character_maximum_length", DataType::UInt64, true),
+        Field::new("character_octet_length", DataType::UInt64, true),
+        Field::new("numeric_precision", DataType::UInt64, true),
+        Field::new("numeric_precision_radix", DataType::UInt64, true),
+        Field::new("numeric_scale", DataType::UInt64, true),
+        Field::new("datetime_precision", DataType::UInt64, true),
+        Field::new("interval_type", DataType::Utf8, true),
+        Field::new("lix_value_kind", DataType::Utf8, true),
+        Field::new("lix_insert_policy", DataType::Utf8, false),
+    ]))
+}
+
+#[derive(Default)]
+struct ColumnsRows {
+    table_catalog: Vec<String>,
+    table_schema: Vec<String>,
+    table_name: Vec<String>,
+    column_name: Vec<String>,
+    ordinal_position: Vec<u64>,
+    column_default: Vec<Option<String>>,
+    is_nullable: Vec<String>,
+    data_type: Vec<String>,
+    character_maximum_length: Vec<Option<u64>>,
+    character_octet_length: Vec<Option<u64>>,
+    numeric_precision: Vec<Option<u64>>,
+    numeric_precision_radix: Vec<Option<u64>>,
+    numeric_scale: Vec<Option<u64>>,
+    datetime_precision: Vec<Option<u64>>,
+    interval_type: Vec<Option<String>>,
+    lix_value_kind: Vec<Option<String>>,
+    lix_insert_policy: Vec<String>,
+}
+
+impl ColumnsRows {
+    fn add_table(
+        &mut self,
+        catalog_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        schema: &Schema,
+        public_catalog: Option<&PublicCatalog>,
+    ) {
+        for (index, field) in schema.fields().iter().enumerate() {
+            let column_contract = public_catalog
+                .and_then(|catalog| catalog.surface(table_name))
+                .and_then(|surface| {
+                    surface
+                        .columns
+                        .iter()
+                        .find(|column| column.name == field.name().as_str())
+                        .map(|column| (surface, column))
+                });
+            let column_default = column_contract.as_ref().and_then(|(surface, column)| {
+                surface
+                    .capabilities
+                    .insert
+                    .then(|| column.column_default.clone())
+                    .flatten()
+            });
+            let insert_policy =
+                column_contract.map_or(PublicColumnInsertPolicy::ReadOnly, |(surface, column)| {
+                    if surface.capabilities.insert && column.is_insertable() {
+                        column.insert_policy
+                    } else {
+                        PublicColumnInsertPolicy::ReadOnly
+                    }
+                });
+            let (character_maximum_length, character_octet_length) =
+                character_lengths(field.data_type());
+            let (numeric_precision, numeric_precision_radix, numeric_scale) =
+                numeric_metadata(field.data_type());
+
+            self.table_catalog.push(catalog_name.to_string());
+            self.table_schema.push(schema_name.to_string());
+            self.table_name.push(table_name.to_string());
+            self.column_name.push(field.name().clone());
+            self.ordinal_position.push((index + 1) as u64);
+            self.column_default.push(column_default);
+            let read_nullable = column_contract
+                .as_ref()
+                .map_or_else(|| field.is_nullable(), |(_, column)| column.read_nullable);
+            self.is_nullable
+                .push(if read_nullable { "YES" } else { "NO" }.to_string());
+            self.data_type.push(public_sql_type(field.data_type()));
+            self.character_maximum_length.push(character_maximum_length);
+            self.character_octet_length.push(character_octet_length);
+            self.numeric_precision.push(numeric_precision);
+            self.numeric_precision_radix.push(numeric_precision_radix);
+            self.numeric_scale.push(numeric_scale);
+            self.datetime_precision.push(None);
+            self.interval_type.push(None);
+            self.lix_value_kind
+                .push(field_is_json(field).then(|| LIX_VALUE_KIND_JSON.to_string()));
+            self.lix_insert_policy
+                .push(insert_policy.as_str().to_string());
+        }
+    }
+
+    fn finish(self, schema: SchemaRef) -> Result<RecordBatch> {
+        let arrays: Vec<ArrayRef> = vec![
+            Arc::new(StringArray::from(self.table_catalog)),
+            Arc::new(StringArray::from(self.table_schema)),
+            Arc::new(StringArray::from(self.table_name)),
+            Arc::new(StringArray::from(self.column_name)),
+            Arc::new(UInt64Array::from(self.ordinal_position)),
+            Arc::new(StringArray::from(self.column_default)),
+            Arc::new(StringArray::from(self.is_nullable)),
+            Arc::new(StringArray::from(self.data_type)),
+            Arc::new(UInt64Array::from(self.character_maximum_length)),
+            Arc::new(UInt64Array::from(self.character_octet_length)),
+            Arc::new(UInt64Array::from(self.numeric_precision)),
+            Arc::new(UInt64Array::from(self.numeric_precision_radix)),
+            Arc::new(UInt64Array::from(self.numeric_scale)),
+            Arc::new(UInt64Array::from(self.datetime_precision)),
+            Arc::new(StringArray::from(self.interval_type)),
+            Arc::new(StringArray::from(self.lix_value_kind)),
+            Arc::new(StringArray::from(self.lix_insert_policy)),
+        ];
+        Ok(RecordBatch::try_new(schema, arrays)?)
+    }
+}
+
+fn public_sql_type(data_type: &DataType) -> String {
+    match data_type {
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => "TEXT".to_string(),
+        DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::FixedSizeBinary(_) => "BYTEA".to_string(),
+        DataType::Boolean => "BOOLEAN".to_string(),
+        DataType::Int8 | DataType::UInt8 | DataType::Int16 | DataType::UInt16 => {
+            "SMALLINT".to_string()
+        }
+        DataType::Int32 | DataType::UInt32 => "INTEGER".to_string(),
+        DataType::Int64 | DataType::UInt64 => "BIGINT".to_string(),
+        DataType::Float16 | DataType::Float32 => "REAL".to_string(),
+        DataType::Float64 => "DOUBLE PRECISION".to_string(),
+        DataType::Decimal32(precision, scale)
+        | DataType::Decimal64(precision, scale)
+        | DataType::Decimal128(precision, scale)
+        | DataType::Decimal256(precision, scale) => {
+            format!("DECIMAL({precision},{scale})")
+        }
+        DataType::Date32 | DataType::Date64 => "DATE".to_string(),
+        DataType::Timestamp(_, _) => "TIMESTAMP".to_string(),
+        DataType::Null => "NULL".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn character_lengths(data_type: &DataType) -> (Option<u64>, Option<u64>) {
+    match data_type {
+        DataType::Utf8 | DataType::Binary => (None, Some(i32::MAX as u64)),
+        DataType::LargeUtf8 | DataType::LargeBinary => (None, Some(i64::MAX as u64)),
+        _ => (None, None),
+    }
+}
+
+fn numeric_metadata(data_type: &DataType) -> (Option<u64>, Option<u64>, Option<u64>) {
+    match data_type {
+        DataType::Int8 | DataType::UInt8 => (Some(8), Some(2), None),
+        DataType::Int16 | DataType::UInt16 => (Some(16), Some(2), None),
+        DataType::Int32 | DataType::UInt32 => (Some(32), Some(2), None),
+        DataType::Int64 | DataType::UInt64 => (Some(64), Some(2), None),
+        DataType::Float16 => (Some(11), Some(2), None),
+        DataType::Float32 => (Some(24), Some(2), None),
+        DataType::Float64 => (Some(53), Some(2), None),
+        DataType::Decimal32(precision, scale)
+        | DataType::Decimal64(precision, scale)
+        | DataType::Decimal128(precision, scale)
+        | DataType::Decimal256(precision, scale) => (
+            Some((*precision).into()),
+            Some(10),
+            u64::try_from(*scale).ok(),
+        ),
+        _ => (None, None, None),
+    }
+}

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -10,6 +10,7 @@ mod exec;
 mod file_view;
 mod history_projection;
 mod history_route;
+mod information_schema;
 mod optimize;
 mod parse;
 mod plan;
@@ -24,6 +25,7 @@ mod session;
 #[cfg(test)]
 mod test_support;
 mod udfs;
+mod value_contract;
 mod write_normalization;
 
 #[cfg(test)]

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datafusion::arrow::array::{BooleanArray, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result, ScalarValue};
@@ -25,7 +26,10 @@ use crate::live_state::{
     MaterializedLiveStateRow,
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
-use crate::sql2::write_normalization::{InsertCell, SqlCell, UpdateAssignmentValues};
+use crate::sql2::write_normalization::{
+    InsertCell, SqlCell, UpdateAssignmentValues, defaultable_bool_insert_value,
+    defaultable_text_insert_value, insert_column_is_omitted,
+};
 use crate::sql2::{SqlWriteContext, WriteAccess, WriteContextLiveStateReader};
 use crate::transaction::types::{
     LogicalPrimaryKey, TransactionWrite, TransactionWriteMode, TransactionWriteOperation,
@@ -36,10 +40,8 @@ use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::spec::{
     PlannedDml, PlannedScan, TableSpec, projected_schema, register_spec_table, row_source,
 };
-use super::upsert::{StagedUpsert, UpsertSupport};
-use super::values::{
-    optional_bool_value, optional_string_value, required_bool_value, required_string_value,
-};
+use super::upsert::{StagedUpsert, UpsertSupport, materialize_omitted_column};
+use super::values::{required_bool_value, required_string_value};
 
 pub(super) async fn register_lix_branch_read_provider(
     session: &datafusion::prelude::SessionContext,
@@ -321,6 +323,44 @@ impl UpsertSupport for BranchSpec {
             .flat_map(branch_insert_stage_rows)
             .collect::<Vec<_>>();
         Ok(StagedUpsert::rows(rows))
+    }
+
+    fn validate_proposed_batch(&self, batch: &RecordBatch) -> Result<()> {
+        for row_index in 0..batch.num_rows() {
+            defaultable_bool_insert_value(batch, row_index, "hidden", "INSERT into lix_branch")?;
+            defaultable_text_insert_value(batch, row_index, "commit_id", "INSERT into lix_branch")?;
+        }
+        Ok(())
+    }
+
+    async fn materialize_excluded_defaults(
+        &self,
+        write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        let materialized = materialize_omitted_column(
+            proposed,
+            "hidden",
+            Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
+        )?;
+        if !insert_column_is_omitted(&materialized, "commit_id") {
+            return Ok(materialized);
+        }
+        let default_commit_id = self
+            .branch_ref
+            .load_head(&write_ctx.active_branch_id())
+            .await
+            .map_err(lix_error_to_datafusion_error)?
+            .map(|head| head.commit_id)
+            .ok_or_else(|| {
+                DataFusionError::Execution(
+                    "INSERT into lix_branch could not resolve active branch head".to_string(),
+                )
+            })?;
+        let values = (0..materialized.num_rows())
+            .map(|_| Some(default_commit_id.to_string()))
+            .collect::<StringArray>();
+        materialize_omitted_column(&materialized, "commit_id", Arc::new(values))
     }
 
     async fn scan_conflict_candidates(
@@ -663,15 +703,24 @@ fn branch_insert_rows_from_batch(
         .map(|row_index| {
             let id = required_string_value(batch, row_index, "id", "INSERT lix_branch")?;
             let name = required_string_value(batch, row_index, "name", "INSERT lix_branch")?;
-            let hidden = optional_bool_value(batch, row_index, "hidden", "INSERT lix_branch")?
-                .unwrap_or(false);
-            let commit_id =
-                optional_string_value(batch, row_index, "commit_id", "INSERT lix_branch")?
-                    .map(|commit_id| {
-                        parse_branch_row_commit_id(commit_id, TransactionWriteOperation::Insert)
-                    })
-                    .transpose()?
-                    .unwrap_or(*default_commit_id);
+            let hidden = defaultable_bool_insert_value(
+                batch,
+                row_index,
+                "hidden",
+                "INSERT into lix_branch",
+            )?
+            .unwrap_or(false);
+            let commit_id = defaultable_text_insert_value(
+                batch,
+                row_index,
+                "commit_id",
+                "INSERT into lix_branch",
+            )?
+            .map(|commit_id| {
+                parse_branch_row_commit_id(commit_id, TransactionWriteOperation::Insert)
+            })
+            .transpose()?
+            .unwrap_or(*default_commit_id);
             Ok(BranchRow {
                 id,
                 name,

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -39,7 +39,10 @@ use crate::sql2::branch_scope::{
 use crate::sql2::predicate_typecheck::{
     canonicalize_json_identity_text_filters, validate_json_predicate_filters,
 };
-use crate::sql2::write_normalization::{InsertCell, SqlCell, UpdateAssignmentValues};
+use crate::sql2::write_normalization::{
+    InsertCell, SqlCell, UpdateAssignmentValues, defaultable_bool_insert_value,
+    defaultable_text_insert_value, insert_column_is_omitted,
+};
 use crate::transaction::types::{
     LogicalPrimaryKey, TransactionJson, TransactionWriteOperation, TransactionWriteOrigin,
     TransactionWriteRow,
@@ -67,7 +70,8 @@ use super::spec::{
     register_spec_table, row_source,
 };
 use super::upsert::{
-    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport, validate_target_columns,
+    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport,
+    materialize_omitted_column, validate_target_columns,
 };
 use crate::entity_pk::EntityPk;
 
@@ -736,6 +740,50 @@ impl UpsertSupport for LixDirectorySpec {
         Ok(StagedUpsert::rows(rows))
     }
 
+    fn validate_proposed_batch(&self, batch: &RecordBatch) -> Result<()> {
+        for row_index in 0..batch.num_rows() {
+            defaultable_text_insert_value(batch, row_index, "id", "INSERT into lix_directory")?;
+            defaultable_bool_insert_value(
+                batch,
+                row_index,
+                "lixcol_global",
+                "INSERT into lix_directory",
+            )?;
+            defaultable_bool_insert_value(
+                batch,
+                row_index,
+                "lixcol_untracked",
+                "INSERT into lix_directory",
+            )?;
+        }
+        Ok(())
+    }
+
+    async fn materialize_excluded_defaults(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        let materialized = if insert_column_is_omitted(proposed, "id") {
+            let ids = (0..proposed.num_rows())
+                .map(|_| Some(self.functions.call_uuid_v7().to_string()))
+                .collect::<StringArray>();
+            materialize_omitted_column(proposed, "id", Arc::new(ids))?
+        } else {
+            proposed.clone()
+        };
+        let materialized = materialize_omitted_column(
+            &materialized,
+            "lixcol_global",
+            Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
+        )?;
+        materialize_omitted_column(
+            &materialized,
+            "lixcol_untracked",
+            Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
+        )
+    }
+
     /// Scan the existing directories that could conflict with `proposed`,
     /// scoped to the active/explicit branch and narrowed to the proposed
     /// directory ids or exact paths, returned as a batch in this table's
@@ -1226,7 +1274,8 @@ fn lix_directory_write_rows_from_batch_with_options_and_path_resolvers(
         }
 
         let path = optional_string_value(batch, row_index, "path")?;
-        let id = optional_string_value(batch, row_index, "id")?;
+        let id =
+            defaultable_text_insert_value(batch, row_index, "id", "INSERT into lix_directory")?;
         let context = directory_row_context_from_batch(batch, row_index, branch_binding)?;
 
         if let Some(path) = path.filter(|_| reject_read_only_fields) {
@@ -1354,7 +1403,12 @@ fn directory_row_context_from_batch(
     branch_binding: Option<&str>,
 ) -> Result<FilesystemRowContext> {
     let scope = resolve_write_branch_scope(
-        optional_bool_value(batch, row_index, "lixcol_global")?,
+        defaultable_bool_insert_value(
+            batch,
+            row_index,
+            "lixcol_global",
+            "INSERT into lix_directory",
+        )?,
         optional_string_value(batch, row_index, "lixcol_branch_id")?,
         branch_binding,
         "INSERT into lix_directory_by_branch",
@@ -1364,7 +1418,13 @@ fn directory_row_context_from_batch(
     Ok(FilesystemRowContext {
         branch_id: scope.branch_id,
         global: scope.global,
-        untracked: optional_bool_value(batch, row_index, "lixcol_untracked")?.unwrap_or(false),
+        untracked: defaultable_bool_insert_value(
+            batch,
+            row_index,
+            "lixcol_untracked",
+            "INSERT into lix_directory",
+        )?
+        .unwrap_or(false),
         file_id: optional_string_value(batch, row_index, "lixcol_file_id")?,
         metadata: optional_metadata_value(batch, row_index, "lixcol_metadata", "lix_directory")?,
     })

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -28,6 +28,7 @@ use crate::sql2::catalog::{
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::read_only::reject_read_only_entity_surface;
+use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value};
 
 use crate::sql2::{
@@ -875,21 +876,22 @@ impl<'a> EntityRowFilterAnalyzer<'a> {
             return None;
         };
         let column_name = self.filterable_column_name(&column.name)?;
+        let column_type = self
+            .spec
+            .visible_column(column_name)
+            .expect("filterable column should exist")
+            .column_type;
         let values = in_list
             .list
             .iter()
-            .map(entity_filter_value_literal)
+            .map(|expr| entity_filter_value_literal(expr, column_type))
             .collect::<Option<Vec<_>>>()?;
         if values.is_empty() {
             return None;
         }
         Some(EntityRowFilter::ColumnIn {
             column: column_name.to_string(),
-            column_type: self
-                .spec
-                .visible_column(column_name)
-                .expect("filterable column should exist")
-                .column_type,
+            column_type,
             values,
         })
     }
@@ -903,14 +905,15 @@ impl<'a> EntityRowFilterAnalyzer<'a> {
             return None;
         };
         let column_name = self.filterable_column_name(&column.name)?;
+        let column_type = self
+            .spec
+            .visible_column(column_name)
+            .expect("filterable column should exist")
+            .column_type;
         Some(EntityRowFilter::ColumnEq {
             column: column_name.to_string(),
-            column_type: self
-                .spec
-                .visible_column(column_name)
-                .expect("filterable column should exist")
-                .column_type,
-            value: entity_filter_value_literal(literal_expr)?,
+            column_type,
+            value: entity_filter_value_literal(literal_expr, column_type)?,
         })
     }
 
@@ -951,38 +954,45 @@ enum EntityRowFilter {
 }
 
 impl EntityRowFilter {
-    fn matches_snapshot(&self, snapshot: Option<&JsonValue>) -> bool {
+    fn matches_snapshot(&self, snapshot: Option<&JsonValue>, schema_key: &str) -> Result<bool> {
         match self {
             Self::ColumnEq {
                 column,
                 column_type,
                 value,
-            } => entity_snapshot_value(snapshot, column, *column_type)
-                .is_some_and(|actual| entity_filter_values_equal(&actual, value, *column_type)),
+            } => Ok(
+                entity_snapshot_value(snapshot, schema_key, column, *column_type)?
+                    .is_some_and(|actual| entity_filter_values_equal(&actual, value, *column_type)),
+            ),
             Self::ColumnIn {
                 column,
                 column_type,
                 values,
-            } => entity_snapshot_value(snapshot, column, *column_type).is_some_and(|actual| {
-                values
-                    .iter()
-                    .any(|expected| entity_filter_values_equal(&actual, expected, *column_type))
-            }),
-            Self::And(left, right) => {
-                left.matches_snapshot(snapshot) && right.matches_snapshot(snapshot)
-            }
-            Self::Or(left, right) => {
-                left.matches_snapshot(snapshot) || right.matches_snapshot(snapshot)
-            }
+            } => Ok(
+                entity_snapshot_value(snapshot, schema_key, column, *column_type)?.is_some_and(
+                    |actual| {
+                        values.iter().any(|expected| {
+                            entity_filter_values_equal(&actual, expected, *column_type)
+                        })
+                    },
+                ),
+            ),
+            Self::And(left, right) => Ok(left.matches_snapshot(snapshot, schema_key)?
+                && right.matches_snapshot(snapshot, schema_key)?),
+            Self::Or(left, right) => Ok(left.matches_snapshot(snapshot, schema_key)?
+                || right.matches_snapshot(snapshot, schema_key)?),
         }
     }
 }
 
-fn entity_filter_value_literal(expr: &Expr) -> Option<EntityFilterValue> {
+fn entity_filter_value_literal(
+    expr: &Expr,
+    column_type: EntityColumnType,
+) -> Option<EntityFilterValue> {
     let Expr::Literal(literal, _) = expr else {
         return None;
     };
-    match literal {
+    let value = match literal {
         ScalarValue::Boolean(Some(value)) => Some(EntityFilterValue::Boolean(*value)),
         ScalarValue::Int8(Some(value)) => Some(EntityFilterValue::Integer(i64::from(*value))),
         ScalarValue::Int16(Some(value)) => Some(EntityFilterValue::Integer(i64::from(*value))),
@@ -1000,25 +1010,42 @@ fn entity_filter_value_literal(expr: &Expr) -> Option<EntityFilterValue> {
         | ScalarValue::Utf8View(Some(value))
         | ScalarValue::LargeUtf8(Some(value)) => Some(EntityFilterValue::String(value.clone())),
         _ => None,
+    }?;
+    match (&value, column_type) {
+        (EntityFilterValue::Boolean(_), EntityColumnType::Boolean)
+        | (EntityFilterValue::Integer(_), EntityColumnType::Integer)
+        | (
+            EntityFilterValue::Integer(_) | EntityFilterValue::Number(_),
+            EntityColumnType::Number,
+        )
+        | (EntityFilterValue::String(_), EntityColumnType::String) => Some(value),
+        _ => None,
     }
 }
 
 fn entity_snapshot_value(
     snapshot: Option<&JsonValue>,
+    schema_key: &str,
     column: &str,
     column_type: EntityColumnType,
-) -> Option<EntityFilterValue> {
-    let value = snapshot?.get(column)?;
-    match column_type {
+) -> Result<Option<EntityFilterValue>> {
+    let Some(value) = snapshot.and_then(|snapshot| snapshot.get(column)) else {
+        return Ok(None);
+    };
+    Ok(match column_type {
         EntityColumnType::String => match value {
             JsonValue::String(value) => Some(EntityFilterValue::String(value.clone())),
             _ => None,
         },
-        EntityColumnType::Integer => entity_i64_value(Some(value)).map(EntityFilterValue::Integer),
-        EntityColumnType::Number => entity_f64_value(Some(value)).map(EntityFilterValue::Number),
+        EntityColumnType::Integer => {
+            entity_i64_value(Some(value), schema_key, column)?.map(EntityFilterValue::Integer)
+        }
+        EntityColumnType::Number => {
+            entity_f64_value(Some(value), schema_key, column)?.map(EntityFilterValue::Number)
+        }
         EntityColumnType::Boolean => value.as_bool().map(EntityFilterValue::Boolean),
         EntityColumnType::Json => None,
-    }
+    })
 }
 
 #[expect(clippy::cast_precision_loss, clippy::float_cmp)]
@@ -1207,10 +1234,14 @@ fn apply_entity_row_filters(
                 ),
             )))
         })?;
-        if filters
-            .iter()
-            .all(|filter| filter.matches_snapshot(Some(&snapshot)))
-        {
+        let mut matches = true;
+        for filter in filters {
+            if !filter.matches_snapshot(Some(&snapshot), &row.schema_key)? {
+                matches = false;
+                break;
+            }
+        }
+        if matches {
             filtered_rows.push(row);
         }
     }
@@ -1327,14 +1358,14 @@ fn entity_column_array(
         EntityColumnType::Integer => Arc::new(Int64Array::from(
             values
                 .iter()
-                .map(|value| entity_i64_value(*value))
-                .collect::<Vec<_>>(),
+                .map(|value| entity_i64_value(*value, &spec.schema_key, column_name))
+                .collect::<Result<Vec<_>>>()?,
         )) as ArrayRef,
         EntityColumnType::Number => Arc::new(Float64Array::from(
             values
                 .iter()
-                .map(|value| entity_f64_value(*value))
-                .collect::<Vec<_>>(),
+                .map(|value| entity_f64_value(*value, &spec.schema_key, column_name))
+                .collect::<Result<Vec<_>>>()?,
         )) as ArrayRef,
         EntityColumnType::Boolean => Arc::new(BooleanArray::from(
             values
@@ -1404,20 +1435,20 @@ pub(super) fn entity_json_text_value(
     })
 }
 
-pub(super) fn entity_i64_value(value: Option<&JsonValue>) -> Option<i64> {
-    match value {
-        Some(JsonValue::Number(number)) => number.as_i64(),
-        Some(JsonValue::String(value)) => value.parse::<i64>().ok(),
-        _ => None,
-    }
+pub(super) fn entity_i64_value(
+    value: Option<&JsonValue>,
+    schema_key: &str,
+    column_name: &str,
+) -> Result<Option<i64>> {
+    json_bigint_value(value, schema_key, column_name).map_err(lix_error_to_datafusion_error)
 }
 
-pub(super) fn entity_f64_value(value: Option<&JsonValue>) -> Option<f64> {
-    match value {
-        Some(JsonValue::Number(number)) => number.as_f64(),
-        Some(JsonValue::String(value)) => value.parse::<f64>().ok(),
-        _ => None,
-    }
+pub(super) fn entity_f64_value(
+    value: Option<&JsonValue>,
+    schema_key: &str,
+    column_name: &str,
+) -> Result<Option<f64>> {
+    json_double_value(value, schema_key, column_name).map_err(lix_error_to_datafusion_error)
 }
 
 fn json_to_string(value: &JsonValue) -> Result<String> {
@@ -1639,9 +1670,10 @@ mod tests {
                     "id": { "type": "string" },
                     "kind": { "type": "string" },
                     "score": { "type": "number" },
+                    "count": { "type": "integer" },
                     "meta": { "type": "object" }
                 },
-                "required": ["id", "kind", "score"]
+                "required": ["id", "kind", "score", "count"]
             }))
             .expect("schema should derive entity surface spec"),
         )
@@ -1761,7 +1793,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_schema_allows_defaulted_identity_columns_to_be_omitted() {
+    fn read_schema_keeps_defaulted_required_identity_non_null() {
         let spec = derive_entity_surface_spec_from_schema(&json!({
             "x-lix-key": "project_message",
             "x-lix-primary-key": ["/id"],
@@ -1775,11 +1807,11 @@ mod tests {
 
         let schema = entity_surface_schema(&spec, EntitySurfaceShape::Active);
         assert!(
-            schema
+            !schema
                 .field_with_name("id")
                 .expect("id field")
                 .is_nullable(),
-            "defaulted primary-key property should be nullable at SQL input"
+            "read nullability must not encode that INSERT may omit a defaulted id"
         );
         assert!(
             schema
@@ -1863,6 +1895,63 @@ mod tests {
                 .value(0),
             "branch-a"
         );
+    }
+
+    #[test]
+    fn bigint_projection_normalizes_integral_reals_and_rejects_invalid_values() {
+        for (raw, expected) in [
+            ("1.0", 1_i64),
+            ("-0.0", 0_i64),
+            ("9223372036854775807", i64::MAX),
+            ("-9223372036854775808", i64::MIN),
+        ] {
+            let value =
+                serde_json::from_str::<serde_json::Value>(raw).expect("test value should parse");
+            assert_eq!(
+                super::entity_i64_value(Some(&value), "integer_contract", "count")
+                    .expect("in-range integral JSON number should project"),
+                Some(expected),
+                "{raw}"
+            );
+        }
+
+        for raw in ["1.5", "9223372036854775808", "\"1\""] {
+            let value =
+                serde_json::from_str::<serde_json::Value>(raw).expect("test value should parse");
+            let error = super::entity_i64_value(Some(&value), "integer_contract", "count")
+                .expect_err("invalid BIGINT value should not project as NULL");
+            let error = crate::sql2::error::datafusion_error_to_lix_error(error);
+            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH, "{raw}");
+            assert!(error.message.contains("integer_contract"), "{error:?}");
+            assert!(error.message.contains("count"), "{error:?}");
+            assert!(error.message.contains("BIGINT"), "{error:?}");
+        }
+    }
+
+    #[test]
+    fn double_projection_accepts_numbers_and_rejects_other_json_kinds() {
+        for (raw, expected) in [("1", 1.0), ("1.5", 1.5)] {
+            let value =
+                serde_json::from_str::<serde_json::Value>(raw).expect("test value should parse");
+            assert_eq!(
+                super::entity_f64_value(Some(&value), "number_contract", "ratio")
+                    .expect("JSON number should project"),
+                Some(expected),
+                "{raw}"
+            );
+        }
+
+        for raw in ["\"1\"", "true"] {
+            let value =
+                serde_json::from_str::<serde_json::Value>(raw).expect("test value should parse");
+            let error = super::entity_f64_value(Some(&value), "number_contract", "ratio")
+                .expect_err("non-number JSON values should not project as DOUBLE PRECISION");
+            let error = crate::sql2::error::datafusion_error_to_lix_error(error);
+            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH, "{raw}");
+            assert!(error.message.contains("number_contract"), "{error:?}");
+            assert!(error.message.contains("ratio"), "{error:?}");
+            assert!(error.message.contains("DOUBLE PRECISION"), "{error:?}");
+        }
     }
 
     #[tokio::test]
@@ -2077,6 +2166,42 @@ mod tests {
         assert!(row_filters.is_empty());
     }
 
+    #[tokio::test]
+    async fn integer_filter_does_not_claim_exact_pushdown_for_real_literal() {
+        let spec = filter_pushdown_spec();
+        let provider = super::EntitySpec::by_branch(
+            Arc::clone(&spec),
+            Arc::new(EmptyLiveStateReader) as Arc<dyn LiveStateReader>,
+            empty_branch_ref(),
+        );
+        let entity_pk_index = provider
+            .schema
+            .index_of("lixcol_entity_pk")
+            .expect("system entity-pk column should exist");
+        let projection = vec![entity_pk_index];
+        let filter = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(column("count")),
+            Operator::Eq,
+            Box::new(Expr::Literal(ScalarValue::Float64(Some(1.0)), None)),
+        ));
+
+        let (_schema, request, row_filters) = provider
+            .plan_scan_parts(Some(&projection), &[filter], Some(5))
+            .await
+            .expect("scan should plan");
+
+        assert_eq!(request.limit, Some(5));
+        assert!(
+            !request
+                .projection
+                .columns
+                .iter()
+                .any(|column| column == "snapshot_content"),
+            "coercive integer comparisons must remain with DataFusion"
+        );
+        assert!(row_filters.is_empty());
+    }
+
     #[test]
     fn payload_row_filter_invalid_snapshot_errors() {
         let mut rows = vec![MaterializedLiveStateRow {
@@ -2098,5 +2223,26 @@ mod tests {
                 .contains("could not parse snapshot_content"),
             "error should explain invalid snapshot_content: {error}"
         );
+    }
+
+    #[test]
+    fn payload_integer_filter_rejects_out_of_bigint_snapshot() {
+        let mut rows = vec![MaterializedLiveStateRow {
+            snapshot_content: Some(r#"{"body":"hello","count":9223372036854775808}"#.to_string()),
+            ..live_row()
+        }];
+        let filters = vec![super::EntityRowFilter::ColumnEq {
+            column: "count".to_string(),
+            column_type: EntityColumnType::Integer,
+            value: super::EntityFilterValue::Integer(1),
+        }];
+
+        let error = super::apply_entity_row_filters(&mut rows, &filters)
+            .expect_err("out-of-BIGINT values must not be silently filtered out");
+        let error = crate::sql2::error::datafusion_error_to_lix_error(error);
+
+        assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
+        assert!(error.message.contains("count"), "{error:?}");
+        assert!(error.message.contains("BIGINT"), "{error:?}");
     }
 }

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -357,14 +357,14 @@ fn entity_history_column_array(
         EntityColumnType::Integer => Arc::new(Int64Array::from(
             projected_values
                 .iter()
-                .map(|snapshot| entity_i64_value(snapshot.as_ref()))
-                .collect::<Vec<_>>(),
+                .map(|snapshot| entity_i64_value(snapshot.as_ref(), &spec.schema_key, column_name))
+                .collect::<Result<Vec<_>>>()?,
         )) as ArrayRef,
         EntityColumnType::Number => Arc::new(Float64Array::from(
             projected_values
                 .iter()
-                .map(|snapshot| entity_f64_value(snapshot.as_ref()))
-                .collect::<Vec<_>>(),
+                .map(|snapshot| entity_f64_value(snapshot.as_ref(), &spec.schema_key, column_name))
+                .collect::<Result<Vec<_>>>()?,
         )) as ArrayRef,
         EntityColumnType::Boolean => Arc::new(BooleanArray::from(
             projected_values

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -61,6 +61,7 @@ use crate::sql2::predicate_typecheck::{
 };
 use crate::sql2::write_normalization::{
     InsertCell, InsertColumnIntents, SqlCell, UpdateAssignmentValues, UpdateCell,
+    defaultable_bool_insert_value, defaultable_text_insert_value, insert_column_is_omitted,
     lix_file_data_type_error, lix_file_data_type_error_with_value, scalar_is_binary_or_null,
 };
 use crate::sql2::{SessionFileViewKey, SessionFileViews, SessionPluginFileView};
@@ -100,7 +101,8 @@ use super::spec::{
     finish_scan_batch, register_spec_table, row_source,
 };
 use super::upsert::{
-    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport, validate_target_columns,
+    StagedUpsert, UpsertConflictKind, UpsertConflictTarget, UpsertSupport,
+    materialize_omitted_column, validate_target_columns,
 };
 
 pub(super) async fn register_lix_file_active_provider(
@@ -945,9 +947,14 @@ impl TableSpec for LixFileSpec {
         input: &Arc<dyn ExecutionPlan>,
     ) -> Result<Option<InsertApply>> {
         let insert_intents = InsertColumnIntents::from_input(input);
-        let include_data_writes = self.schema.field_with_name("data").is_ok()
-            && insert_intents.includes_column("data")
-            && !self.options.omitted_insert_columns.contains("data");
+        let data_is_explicit = write_ctx.explicit_insert_columns().map_or_else(
+            || {
+                insert_intents.includes_column("data")
+                    && !self.options.omitted_insert_columns.contains("data")
+            },
+            |columns| columns.contains("data"),
+        );
+        let include_data_writes = self.schema.field_with_name("data").is_ok() && data_is_explicit;
         let sink = Arc::new(LixFileInsertSink::new(
             write_ctx,
             self.functions.clone(),
@@ -1269,6 +1276,61 @@ impl UpsertSupport for LixFileSpec {
             staged.state_rows,
             staged.file_data_writes,
         ))
+    }
+
+    fn validate_proposed_batch(&self, batch: &RecordBatch) -> Result<()> {
+        for row_index in 0..batch.num_rows() {
+            defaultable_text_insert_value(batch, row_index, "id", "INSERT into lix_file")?;
+            defaultable_bool_insert_value(
+                batch,
+                row_index,
+                "lixcol_global",
+                "INSERT into lix_file",
+            )?;
+            defaultable_bool_insert_value(
+                batch,
+                row_index,
+                "lixcol_untracked",
+                "INSERT into lix_file",
+            )?;
+            if !insert_column_is_omitted(batch, "data") {
+                insert_optional_binary_value(batch, row_index, "data")?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn materialize_excluded_defaults(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        let materialized = if insert_column_is_omitted(proposed, "id") {
+            let ids = (0..proposed.num_rows())
+                .map(|_| Some(self.functions.call_uuid_v7().to_string()))
+                .collect::<StringArray>();
+            materialize_omitted_column(proposed, "id", Arc::new(ids))?
+        } else {
+            proposed.clone()
+        };
+        let materialized = materialize_omitted_column(
+            &materialized,
+            "data",
+            Arc::new(LargeBinaryArray::from(vec![
+                Some(&[][..]);
+                proposed.num_rows()
+            ])),
+        )?;
+        let materialized = materialize_omitted_column(
+            &materialized,
+            "lixcol_global",
+            Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
+        )?;
+        materialize_omitted_column(
+            &materialized,
+            "lixcol_untracked",
+            Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
+        )
     }
 
     async fn scan_conflict_candidates(
@@ -2995,7 +3057,7 @@ fn lix_file_stage_from_batch_with_options_and_path_resolvers(
         }
 
         let path = optional_string_value(batch, row_index, "path")?;
-        let id = optional_string_value(batch, row_index, "id")?;
+        let id = defaultable_text_insert_value(batch, row_index, "id", "INSERT into lix_file")?;
         let context = file_row_context_from_batch(batch, row_index, branch_binding)?;
         let data = if include_data_writes {
             insert_optional_binary_value(batch, row_index, "data")?
@@ -3265,7 +3327,7 @@ fn file_row_context_from_batch(
 ) -> Result<FilesystemRowContext> {
     let explicit_branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?;
     let scope = resolve_write_branch_scope(
-        optional_bool_value(batch, row_index, "lixcol_global")?,
+        defaultable_bool_insert_value(batch, row_index, "lixcol_global", "INSERT into lix_file")?,
         explicit_branch_id,
         branch_binding,
         "INSERT into lix_file_by_branch",
@@ -3275,7 +3337,13 @@ fn file_row_context_from_batch(
     Ok(FilesystemRowContext {
         branch_id: scope.branch_id,
         global: scope.global,
-        untracked: optional_bool_value(batch, row_index, "lixcol_untracked")?.unwrap_or(false),
+        untracked: defaultable_bool_insert_value(
+            batch,
+            row_index,
+            "lixcol_untracked",
+            "INSERT into lix_file",
+        )?
+        .unwrap_or(false),
         file_id: optional_string_value(batch, row_index, "lixcol_file_id")?,
         metadata: optional_metadata_value(batch, row_index, "lixcol_metadata", "lix_file")?,
     })

--- a/packages/engine/src/sql2/providers/lix_state.rs
+++ b/packages/engine/src/sql2/providers/lix_state.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datafusion::arrow::array::BooleanArray;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
@@ -29,7 +30,9 @@ use crate::live_state::{
 use crate::sql2::branch_scope::{BranchBinding, resolve_provider_branch_ids};
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::read_only::reject_read_only_stage_rows;
-use crate::sql2::write_normalization::{InsertCell, SqlCell, UpdateAssignmentValues};
+use crate::sql2::write_normalization::{
+    InsertCell, SqlCell, UpdateAssignmentValues, defaultable_bool_insert_value,
+};
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 use crate::{LixError, NullableKeyFilter, parse_row_metadata_value};
 
@@ -46,7 +49,7 @@ use super::spec::{
     PlannedDml, PlannedScan, RowSource, TableSpec, projected_schema, register_spec_table,
     row_source,
 };
-use super::upsert::{StagedUpsert, UpsertSupport};
+use super::upsert::{StagedUpsert, UpsertSupport, materialize_omitted_column};
 use super::values::string_expr_literal;
 
 pub(super) async fn register_lix_state_active_provider(
@@ -201,6 +204,31 @@ impl UpsertSupport for LixStateSpec {
         let rows = lix_state_write_rows_from_batch(batch, branch_binding, "INSERT into lix_state")?;
         reject_read_only_stage_rows(&rows, "INSERT into lix_state")?;
         Ok(StagedUpsert::rows(rows))
+    }
+
+    fn validate_proposed_batch(&self, batch: &RecordBatch) -> Result<()> {
+        for row_index in 0..batch.num_rows() {
+            defaultable_bool_insert_value(batch, row_index, "global", "INSERT into lix_state")?;
+            defaultable_bool_insert_value(batch, row_index, "untracked", "INSERT into lix_state")?;
+        }
+        Ok(())
+    }
+
+    async fn materialize_excluded_defaults(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        let materialized = materialize_omitted_column(
+            proposed,
+            "global",
+            Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
+        )?;
+        materialize_omitted_column(
+            &materialized,
+            "untracked",
+            Arc::new(BooleanArray::from(vec![false; proposed.num_rows()])),
+        )
     }
 
     async fn scan_conflict_candidates(
@@ -495,7 +523,8 @@ fn lix_state_update_write_rows_from_batch(
     let assignment_values = UpdateAssignmentValues::evaluate(batch, assignments)?;
     (0..batch.num_rows())
         .map(|row_index| {
-            let global = optional_bool_value(batch, row_index, "global")?.unwrap_or(false);
+            let global =
+                update_required_bool_value(batch, &assignment_values, row_index, "global")?;
             let branch_id =
                 optional_string_value(batch, row_index, "branch_id")?.unwrap_or_else(|| {
                     if global {
@@ -544,11 +573,45 @@ fn lix_state_update_write_rows_from_batch(
                 global,
                 change_id: None,
                 commit_id: None,
-                untracked: optional_bool_value(batch, row_index, "untracked")?.unwrap_or(false),
+                untracked: update_required_bool_value(
+                    batch,
+                    &assignment_values,
+                    row_index,
+                    "untracked",
+                )?,
                 branch_id,
             })
         })
         .collect()
+}
+
+fn update_required_bool_value(
+    batch: &RecordBatch,
+    assignment_values: &UpdateAssignmentValues,
+    row_index: usize,
+    column_name: &str,
+) -> Result<bool> {
+    match assignment_values.assigned_or_existing_cell(batch, row_index, column_name)? {
+        InsertCell::Provided(SqlCell::Value(ScalarValue::Boolean(Some(value)))) => Ok(value),
+        InsertCell::Omitted => {
+            optional_bool_value(batch, row_index, column_name)?.ok_or_else(|| {
+                lix_error_to_datafusion_error(LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    format!("UPDATE lix_state requires non-null boolean column '{column_name}'"),
+                ))
+            })
+        }
+        InsertCell::Provided(SqlCell::Null) => Err(lix_error_to_datafusion_error(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            format!("UPDATE lix_state requires non-null boolean column '{column_name}'"),
+        ))),
+        InsertCell::Provided(SqlCell::Value(other)) => {
+            Err(lix_error_to_datafusion_error(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!("UPDATE lix_state expected boolean column '{column_name}', got {other:?}"),
+            )))
+        }
+    }
 }
 
 fn lix_state_deletable_write_rows_from_batch(
@@ -617,7 +680,9 @@ fn lix_state_write_rows_from_batch(
 ) -> Result<Vec<TransactionWriteRow>> {
     (0..batch.num_rows())
         .map(|row_index| {
-            let global = optional_bool_value(batch, row_index, "global")?.unwrap_or(false);
+            let global =
+                defaultable_bool_insert_value(batch, row_index, "global", "INSERT into lix_state")?
+                    .unwrap_or(false);
             let branch_id =
                 optional_string_value(batch, row_index, "branch_id")?.unwrap_or_else(|| {
                     if global {
@@ -655,7 +720,13 @@ fn lix_state_write_rows_from_batch(
                 global,
                 change_id: optional_string_value(batch, row_index, "change_id")?,
                 commit_id: optional_string_value(batch, row_index, "commit_id")?,
-                untracked: optional_bool_value(batch, row_index, "untracked")?.unwrap_or(false),
+                untracked: defaultable_bool_insert_value(
+                    batch,
+                    row_index,
+                    "untracked",
+                    "INSERT into lix_state",
+                )?
+                .unwrap_or(false),
                 branch_id,
             })
         })

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -149,7 +149,8 @@ where
         ReadProviderScope::All,
         selection,
     )
-    .await
+    .await?;
+    crate::sql2::information_schema::register(session, catalog)
 }
 
 /// Snapshot-local providers needed to plan already-bound SQL.
@@ -475,7 +476,9 @@ pub(crate) async fn register_write(
     selection: &ProviderSelection,
 ) -> Result<(), LixError> {
     let catalog = write_ctx.public_catalog()?;
-    register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog, selection).await
+    register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog, selection)
+        .await?;
+    crate::sql2::information_schema::register(session, &catalog)
 }
 
 pub(crate) async fn register_transaction<C>(
@@ -513,7 +516,8 @@ where
         &catalog,
         selection,
     )
-    .await
+    .await?;
+    crate::sql2::information_schema::register(session, &catalog)
 }
 
 async fn register_write_from_catalog(

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -40,6 +40,7 @@ use futures_util::{TryStreamExt, stream};
 
 use crate::LixError;
 use crate::sql2::dml::{InsertExec, InsertSink};
+use crate::sql2::write_normalization::{InsertColumnIntents, mark_omitted_insert_columns};
 use crate::sql2::{SqlWriteContext, WriteAccess};
 
 use super::upsert;
@@ -500,15 +501,28 @@ impl TableProvider for SpecTableProvider {
             .require_write(&format!("INSERT into {table}"))?;
         self.schema
             .logically_equivalent_names_and_types(&input.schema())?;
+        let omitted_insert_columns = write_ctx.explicit_insert_columns().map_or_else(
+            || InsertColumnIntents::from_input(&input).omitted_columns(self.schema.as_ref()),
+            |explicit_columns| {
+                self.schema
+                    .fields()
+                    .iter()
+                    .filter(|field| !explicit_columns.contains(field.name().as_str()))
+                    .map(|field| field.name().clone())
+                    .collect()
+            },
+        );
         let sink: Arc<dyn InsertSink> =
             match self.spec.plan_insert(write_ctx.clone(), &input).await? {
                 Some(apply) => Arc::new(PlannedInsertSink {
                     table: table.into(),
                     apply,
+                    omitted_insert_columns,
                 }),
                 None => Arc::new(SpecInsertSink {
                     spec: Arc::clone(&self.spec),
                     write_ctx,
+                    omitted_insert_columns,
                 }),
             };
         Ok(Arc::new(InsertExec::new(input, sink)))
@@ -577,6 +591,7 @@ fn physical_filters(
 struct SpecInsertSink {
     spec: Arc<dyn TableSpec>,
     write_ctx: SqlWriteContext,
+    omitted_insert_columns: BTreeSet<String>,
 }
 
 impl std::fmt::Debug for SpecInsertSink {
@@ -600,6 +615,10 @@ impl InsertSink for SpecInsertSink {
         batches: Vec<RecordBatch>,
         _context: &Arc<TaskContext>,
     ) -> Result<u64> {
+        let batches = batches
+            .into_iter()
+            .map(|batch| mark_omitted_insert_columns(batch, &self.omitted_insert_columns))
+            .collect::<Result<Vec<_>>>()?;
         self.spec.stage_insert(&self.write_ctx, batches).await
     }
 }
@@ -608,6 +627,7 @@ impl InsertSink for SpecInsertSink {
 struct PlannedInsertSink {
     table: Arc<str>,
     apply: InsertApply,
+    omitted_insert_columns: BTreeSet<String>,
 }
 
 impl std::fmt::Debug for PlannedInsertSink {
@@ -631,6 +651,10 @@ impl InsertSink for PlannedInsertSink {
         batches: Vec<RecordBatch>,
         _context: &Arc<TaskContext>,
     ) -> Result<u64> {
+        let batches = batches
+            .into_iter()
+            .map(|batch| mark_omitted_insert_columns(batch, &self.omitted_insert_columns))
+            .collect::<Result<Vec<_>>>()?;
         (self.apply)(batches).await
     }
 }

--- a/packages/engine/src/sql2/providers/upsert.rs
+++ b/packages/engine/src/sql2/providers/upsert.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, UInt64Array};
+use datafusion::arrow::array::{Array, ArrayRef, UInt64Array};
 use datafusion::arrow::compute::take;
 use datafusion::arrow::datatypes::{Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
@@ -26,6 +26,7 @@ use datafusion::physical_expr::PhysicalExpr;
 
 use crate::sql2::SqlWriteContext;
 use crate::sql2::error::lix_error_to_datafusion_error;
+use crate::sql2::write_normalization::{insert_column_is_omitted, mark_omitted_insert_columns};
 use crate::transaction::types::{
     TransactionFileData, TransactionWrite, TransactionWriteMode, TransactionWriteRow,
 };
@@ -143,6 +144,29 @@ pub(super) trait UpsertSupport: Send + Sync {
         batch: &RecordBatch,
     ) -> Result<StagedUpsert>;
 
+    /// Validate every proposed row before conflict routing. INSERT-only
+    /// constraints must still run when the conflict action bypasses the
+    /// plain-insert builder.
+    fn validate_proposed_batch(&self, _batch: &RecordBatch) -> Result<()> {
+        Ok(())
+    }
+
+    /// Materialize provider defaults that a `DO UPDATE` expression can read
+    /// through `excluded.*`.
+    ///
+    /// DataFusion represents omitted INSERT columns as typed NULLs plus intent
+    /// metadata at the provider boundary. That is sufficient for plain INSERT
+    /// staging, but `excluded.*` denotes the proposed row after defaults have
+    /// been applied. Providers with defaults that can be referenced by a
+    /// conflict assignment replace those placeholders here.
+    async fn materialize_excluded_defaults(
+        &self,
+        _write_ctx: &SqlWriteContext,
+        proposed: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        Ok(proposed.clone())
+    }
+
     /// Scan existing rows whose identity matches a proposed row, returned as a
     /// batch in this table's column schema.
     async fn scan_conflict_candidates(
@@ -189,8 +213,25 @@ pub(super) async fn execute_upsert<S: UpsertSupport + ?Sized>(
     let conflict_columns = target.columns();
     let mut staged = StagedUpsert::default();
     let mut affected: u64 = 0;
+    let proposed_batches = proposed_batches
+        .into_iter()
+        .map(|batch| {
+            let Some(explicit_columns) = write_ctx.explicit_insert_columns() else {
+                return Ok(batch);
+            };
+            let omitted_columns = batch
+                .schema()
+                .fields()
+                .iter()
+                .filter(|field| !explicit_columns.contains(field.name().as_str()))
+                .map(|field| field.name().clone())
+                .collect::<BTreeSet<_>>();
+            mark_omitted_insert_columns(batch, &omitted_columns)
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     for batch in &proposed_batches {
+        spec.validate_proposed_batch(batch)?;
         let existing = spec
             .scan_conflict_candidates(write_ctx, batch, target)
             .await?;
@@ -225,6 +266,9 @@ pub(super) async fn execute_upsert<S: UpsertSupport + ?Sized>(
             if let UpsertAction::DoUpdate { assignments } = action {
                 let existing_matched = take_rows(&existing, &matched_existing)?;
                 let proposed_matched = take_rows(batch, &matched_proposed)?;
+                let proposed_matched = spec
+                    .materialize_excluded_defaults(write_ctx, &proposed_matched)
+                    .await?;
                 let augmented = augment_with_excluded(&existing_matched, &proposed_matched)?;
                 staged.extend(
                     spec.apply_conflict_update(write_ctx, &augmented, assignments)
@@ -255,6 +299,28 @@ pub(super) async fn execute_upsert<S: UpsertSupport + ?Sized>(
             .map_err(lix_error_to_datafusion_error)?;
     }
     Ok(affected)
+}
+
+/// Replace one omitted INSERT placeholder with its provider-evaluated default.
+///
+/// Keep the omission metadata on the field: it records how the SQL row was
+/// authored, while the replacement array is the semantic value visible
+/// through `excluded.*`.
+pub(super) fn materialize_omitted_column<A>(
+    proposed: &RecordBatch,
+    column_name: &str,
+    values: Arc<A>,
+) -> Result<RecordBatch>
+where
+    A: Array + 'static,
+{
+    if !insert_column_is_omitted(proposed, column_name) {
+        return Ok(proposed.clone());
+    }
+    let column_index = proposed.schema().index_of(column_name)?;
+    let mut columns = proposed.columns().to_vec();
+    columns[column_index] = values;
+    RecordBatch::try_new(proposed.schema(), columns).map_err(DataFusionError::from)
 }
 
 pub(super) fn validate_target_columns(

--- a/packages/engine/src/sql2/read_only.rs
+++ b/packages/engine/src/sql2/read_only.rs
@@ -7,17 +7,23 @@ pub(crate) fn reject_read_only_entity_surface(
     schema_key: &str,
     action: &str,
 ) -> Result<(), DataFusionError> {
-    if schema_key == "lix_directory_descriptor" {
-        return Err(read_only_error(
-            action,
-            schema_key,
-            "Use the writable lix_directory surface to create, update, or delete directories.",
-        ));
-    }
-    if let Some(message) = read_only_schema_message(schema_key) {
+    if let Some(message) = read_only_entity_surface_hint(schema_key) {
         return Err(read_only_error(action, schema_key, message));
     }
     Ok(())
+}
+
+pub(crate) fn is_read_only_entity_surface(schema_key: &str) -> bool {
+    read_only_entity_surface_hint(schema_key).is_some()
+}
+
+pub(crate) fn read_only_entity_surface_hint(schema_key: &str) -> Option<&'static str> {
+    if schema_key == "lix_directory_descriptor" {
+        return Some(
+            "Use the writable lix_directory surface to create, update, or delete directories.",
+        );
+    }
+    read_only_schema_message(schema_key)
 }
 
 pub(crate) fn reject_read_only_stage_rows(

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -126,6 +126,7 @@ where
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SqlWriteSessionOptions {
     pub(crate) omitted_insert_columns: BTreeSet<String>,
+    pub(crate) explicit_insert_columns: Option<BTreeSet<String>>,
 }
 
 pub(crate) async fn build_write_session_with_options(
@@ -134,7 +135,8 @@ pub(crate) async fn build_write_session_with_options(
     provider_selection: &providers::ProviderSelection,
 ) -> Result<SessionContext, LixError> {
     let session = new_sql_session_context();
-    let write_ctx = SqlWriteContext::new(ctx);
+    let write_ctx = SqlWriteContext::new(ctx)
+        .with_explicit_insert_columns(options.explicit_insert_columns.clone());
     let active_branch_id = write_ctx.active_branch_id();
     let branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(Arc::new(
         super::WriteContextBranchRefReader::new(write_ctx.clone()),
@@ -164,7 +166,7 @@ pub(crate) async fn build_write_session_with_options(
 pub(crate) fn new_sql_session_context() -> SessionContext {
     SessionContext::new_with_config(
         SessionConfig::new()
-            .with_information_schema(true)
+            .with_information_schema(false)
             .with_target_partitions(1)
             .set_bool("datafusion.optimizer.repartition_aggregations", false)
             .set_bool("datafusion.optimizer.repartition_joins", false)

--- a/packages/engine/src/sql2/value_contract.rs
+++ b/packages/engine/src/sql2/value_contract.rs
@@ -1,0 +1,98 @@
+use serde_json::Value as JsonValue;
+
+use crate::LixError;
+
+const I64_LOWER_INCLUSIVE_AS_F64: f64 = -9_223_372_036_854_775_808.0;
+const I64_UPPER_EXCLUSIVE_AS_F64: f64 = 9_223_372_036_854_775_808.0;
+
+/// Project a JSON-Schema integer through the public SQL `BIGINT` contract.
+///
+/// JSON has one numeric kind, so mathematically integral real spellings such
+/// as `1.0` are valid JSON-Schema integers. SQL still needs an exact, bounded
+/// `i64`: normalize integral real values and reject every value that cannot be
+/// represented instead of silently projecting SQL `NULL`.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "the explicit integral and BIGINT range checks make the f64-to-i64 cast exact"
+)]
+pub(crate) fn json_bigint_value(
+    value: Option<&JsonValue>,
+    surface_name: &str,
+    column_name: &str,
+) -> Result<Option<i64>, LixError> {
+    match value {
+        None | Some(JsonValue::Null) => Ok(None),
+        Some(number_value @ JsonValue::Number(number)) => {
+            if let Some(value) = number.as_i64() {
+                return Ok(Some(value));
+            }
+            if number.as_u64().is_some() {
+                return Err(bigint_projection_error(
+                    surface_name,
+                    column_name,
+                    number_value,
+                ));
+            }
+            let Some(value) = number.as_f64() else {
+                return Err(bigint_projection_error(
+                    surface_name,
+                    column_name,
+                    number_value,
+                ));
+            };
+            if value.fract() != 0.0
+                || !(I64_LOWER_INCLUSIVE_AS_F64..I64_UPPER_EXCLUSIVE_AS_F64).contains(&value)
+            {
+                return Err(bigint_projection_error(
+                    surface_name,
+                    column_name,
+                    number_value,
+                ));
+            }
+            Ok(Some(value as i64))
+        }
+        Some(other) => Err(bigint_projection_error(surface_name, column_name, other)),
+    }
+}
+
+/// Project a JSON-Schema number through the public SQL `DOUBLE PRECISION`
+/// contract.
+pub(crate) fn json_double_value(
+    value: Option<&JsonValue>,
+    surface_name: &str,
+    column_name: &str,
+) -> Result<Option<f64>, LixError> {
+    match value {
+        None | Some(JsonValue::Null) => Ok(None),
+        Some(JsonValue::Number(value)) => value
+            .as_f64()
+            .map(Some)
+            .ok_or_else(|| double_projection_error(surface_name, column_name, value.to_string())),
+        Some(other) => Err(double_projection_error(
+            surface_name,
+            column_name,
+            other.to_string(),
+        )),
+    }
+}
+
+fn bigint_projection_error(surface_name: &str, column_name: &str, value: &JsonValue) -> LixError {
+    LixError::new(
+        LixError::CODE_TYPE_MISMATCH,
+        format!(
+            "typed SQL surface '{surface_name}' column '{column_name}' cannot represent JSON value {value} as BIGINT"
+        ),
+    )
+    .with_hint(
+        "Store an integral JSON number between -9223372036854775808 and 9223372036854775807.",
+    )
+}
+
+fn double_projection_error(surface_name: &str, column_name: &str, value: String) -> LixError {
+    LixError::new(
+        LixError::CODE_TYPE_MISMATCH,
+        format!(
+            "typed SQL surface '{surface_name}' column '{column_name}' cannot represent JSON value {value} as DOUBLE PRECISION"
+        ),
+    )
+}

--- a/packages/engine/src/sql2/write_normalization.rs
+++ b/packages/engine/src/sql2/write_normalization.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use datafusion::arrow::array::ArrayRef;
+use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result, ScalarValue};
 use datafusion::physical_expr::PhysicalExpr;
@@ -107,6 +108,18 @@ impl InsertColumnIntents {
             .as_ref()
             .is_none_or(|columns| columns.contains(column_name))
     }
+
+    pub(crate) fn omitted_columns(&self, schema: &Schema) -> BTreeSet<String> {
+        let Some(explicit_columns) = self.explicit_columns.as_ref() else {
+            return BTreeSet::new();
+        };
+        schema
+            .fields()
+            .iter()
+            .filter(|field| !explicit_columns.contains(field.name().as_str()))
+            .map(|field| field.name().clone())
+            .collect()
+    }
 }
 
 fn field_is_omitted_insert_default(field: &datafusion::arrow::datatypes::Field) -> bool {
@@ -114,6 +127,117 @@ fn field_is_omitted_insert_default(field: &datafusion::arrow::datatypes::Field) 
         .metadata()
         .get(LIX_INSERT_COLUMN_OMITTED_METADATA_KEY)
         .is_some_and(|value| value == "true")
+}
+
+pub(crate) fn insert_column_is_omitted(batch: &RecordBatch, column_name: &str) -> bool {
+    batch
+        .schema()
+        .field_with_name(column_name)
+        .is_ok_and(field_is_omitted_insert_default)
+}
+
+/// Reads a defaultable text input without collapsing an omitted column into an
+/// explicitly provided SQL `NULL`.
+pub(crate) fn defaultable_text_insert_value(
+    batch: &RecordBatch,
+    row_index: usize,
+    column_name: &str,
+    context: &str,
+) -> Result<Option<String>> {
+    let schema = batch.schema();
+    let Ok(column_index) = schema.index_of(column_name) else {
+        return Ok(None);
+    };
+    let field = schema.field(column_index);
+    if field_is_omitted_insert_default(field) {
+        return Ok(None);
+    }
+    match ScalarValue::try_from_array(batch.column(column_index).as_ref(), row_index)? {
+        ScalarValue::Utf8(Some(value))
+        | ScalarValue::Utf8View(Some(value))
+        | ScalarValue::LargeUtf8(Some(value)) => Ok(Some(value)),
+        value if value.is_null() => {
+            Err(super::error::lix_error_to_datafusion_error(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!(
+                    "{context} column '{column_name}' may be omitted to use its default, but explicit NULL is not allowed"
+                ),
+            )))
+        }
+        other => Err(super::error::lix_error_to_datafusion_error(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            format!("{context} expected text-compatible column '{column_name}', got {other:?}"),
+        ))),
+    }
+}
+
+/// Reads a defaultable boolean input without collapsing an omitted column into
+/// an explicitly provided SQL `NULL`.
+pub(crate) fn defaultable_bool_insert_value(
+    batch: &RecordBatch,
+    row_index: usize,
+    column_name: &str,
+    context: &str,
+) -> Result<Option<bool>> {
+    let schema = batch.schema();
+    let Ok(column_index) = schema.index_of(column_name) else {
+        return Ok(None);
+    };
+    let field = schema.field(column_index);
+    if field_is_omitted_insert_default(field) {
+        return Ok(None);
+    }
+    match ScalarValue::try_from_array(batch.column(column_index).as_ref(), row_index)? {
+        ScalarValue::Boolean(Some(value)) => Ok(Some(value)),
+        value if value.is_null() => {
+            Err(super::error::lix_error_to_datafusion_error(LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!(
+                    "{context} column '{column_name}' may be omitted to use its default, but explicit NULL is not allowed"
+                ),
+            )))
+        }
+        other => Err(super::error::lix_error_to_datafusion_error(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            format!("{context} expected boolean column '{column_name}', got {other:?}"),
+        ))),
+    }
+}
+
+/// Restores insert-column intent metadata at the provider boundary.
+///
+/// DataFusion can discard alias metadata while executing a physical
+/// projection, so detecting omission only from the resulting batch would
+/// collapse omitted defaults into explicit `NULL`. The provider computes the
+/// intent from the physical input plan and reapplies it here.
+pub(crate) fn mark_omitted_insert_columns(
+    batch: RecordBatch,
+    omitted_columns: &BTreeSet<String>,
+) -> Result<RecordBatch> {
+    if omitted_columns.is_empty() {
+        return Ok(batch);
+    }
+    let batch_schema = batch.schema();
+    let fields = batch_schema
+        .fields()
+        .iter()
+        .map(|field| {
+            if !omitted_columns.contains(field.name().as_str()) {
+                return field.as_ref().clone();
+            }
+            let mut metadata = field.metadata().clone();
+            metadata.insert(
+                LIX_INSERT_COLUMN_OMITTED_METADATA_KEY.to_string(),
+                "true".to_string(),
+            );
+            field.as_ref().clone().with_metadata(metadata)
+        })
+        .collect::<Vec<_>>();
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        batch_schema.metadata().clone(),
+    ));
+    Ok(RecordBatch::try_new(schema, batch.columns().to_vec())?)
 }
 
 pub(crate) fn scalar_is_binary_or_null(value: &ScalarValue) -> bool {

--- a/packages/engine/tests/sql.rs
+++ b/packages/engine/tests/sql.rs
@@ -98,6 +98,7 @@ mod sql {
     mod entity_view;
     mod errors;
     mod history_conformance;
+    mod information_schema;
     mod lix_branch;
     mod lix_change;
     mod lix_commit;

--- a/packages/engine/tests/sql/information_schema.rs
+++ b/packages/engine/tests/sql/information_schema.rs
@@ -1,0 +1,1915 @@
+use lix_engine::{LixError, Value};
+
+use super::assert_rows_eq;
+
+simulation_test!(
+    information_schema_exposes_executable_lix_column_contract,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                   lix_json('{\"x-lix-key\":\"engine_column_contract\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"x-lix-default\":\"lix_uuid_v7()\"},\"title\":{\"type\":\"string\"},\"note\":{\"type\":\"string\"},\"count\":{\"type\":\"integer\"},\"ratio\":{\"type\":\"number\"},\"active\":{\"type\":\"boolean\"},\"metadata\":{\"type\":\"object\"}},\"required\":[\"id\",\"title\",\"count\",\"ratio\",\"active\",\"metadata\"],\"additionalProperties\":false}'),\
+                   false,\
+                   false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                   lix_json('{\"x-lix-key\":\"engine_no_pk_contract\",\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},\"required\":[\"name\"],\"additionalProperties\":false}'),\
+                   false,\
+                   false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("no-primary-key schema insert should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                   lix_json('{\"x-lix-key\":\"columns\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"table_name\":{\"type\":\"string\"}},\"required\":[\"id\",\"table_name\"],\"additionalProperties\":false}'),\
+                   false,\
+                   false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("schema colliding with an information-schema table name should register");
+
+        let information_schema_self_contract = session
+            .execute(
+                "SELECT is_nullable, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_schema = 'information_schema' \
+                   AND table_name = 'columns' \
+                   AND column_name = 'table_name'",
+                &[],
+            )
+            .await
+            .expect("information schema should retain its own column contract");
+        assert_rows_eq(
+            information_schema_self_contract,
+            vec![vec![
+                Value::Text("NO".to_string()),
+                Value::Text("READ_ONLY".to_string()),
+            ]],
+        );
+
+        let read_only_entity_contract = session
+            .execute(
+                "SELECT table_name, column_name, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name IN ('lix_commit', 'lix_file_descriptor') \
+                   AND column_name = 'id' \
+                 ORDER BY table_name",
+                &[],
+            )
+            .await
+            .expect("read-only generated entity surfaces should introspect");
+        assert_rows_eq(
+            read_only_entity_contract,
+            vec![
+                vec![
+                    Value::Text("lix_commit".to_string()),
+                    Value::Text("id".to_string()),
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text("lix_file_descriptor".to_string()),
+                    Value::Text("id".to_string()),
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+            ],
+        );
+
+        let result = session
+            .execute(
+                "SELECT column_name, data_type, is_nullable, column_default, \
+                        lix_value_kind, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name = 'engine_column_contract' \
+                   AND column_name IN ('active', 'count', 'id', 'metadata', 'note', 'ratio', 'title') \
+                 ORDER BY column_name",
+                &[],
+            )
+            .await
+            .expect("information schema query should succeed");
+
+        assert_rows_eq(
+            result,
+            vec![
+                vec![
+                    Value::Text("active".to_string()),
+                    Value::Text("BOOLEAN".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Null,
+                    Value::Text("REQUIRED".to_string()),
+                ],
+                vec![
+                    Value::Text("count".to_string()),
+                    Value::Text("BIGINT".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Null,
+                    Value::Text("REQUIRED".to_string()),
+                ],
+                vec![
+                    Value::Text("id".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("lix_uuid_v7()".to_string()),
+                    Value::Null,
+                    Value::Text("DEFAULT".to_string()),
+                ],
+                vec![
+                    Value::Text("metadata".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("JSON".to_string()),
+                    Value::Text("REQUIRED".to_string()),
+                ],
+                vec![
+                    Value::Text("note".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("YES".to_string()),
+                    Value::Null,
+                    Value::Null,
+                    Value::Text("OPTIONAL".to_string()),
+                ],
+                vec![
+                    Value::Text("ratio".to_string()),
+                    Value::Text("DOUBLE PRECISION".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Null,
+                    Value::Text("REQUIRED".to_string()),
+                ],
+                vec![
+                    Value::Text("title".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Null,
+                    Value::Text("REQUIRED".to_string()),
+                ],
+            ],
+        );
+
+        let file_contract = session
+            .execute(
+                "SELECT column_name, data_type, is_nullable, column_default, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name = 'lix_file' \
+                   AND column_name IN ('data', 'id') \
+                 ORDER BY column_name",
+                &[],
+            )
+            .await
+            .expect("file contract query should succeed");
+        assert_rows_eq(
+            file_contract,
+            vec![
+                vec![
+                    Value::Text("data".to_string()),
+                    Value::Text("BYTEA".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("X''".to_string()),
+                    Value::Text("DEFAULT".to_string()),
+                ],
+                vec![
+                    Value::Text("id".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("lix_uuid_v7()".to_string()),
+                    Value::Text("DEFAULT".to_string()),
+                ],
+            ],
+        );
+
+        let by_branch_contract = session
+            .execute(
+                "SELECT table_name, is_nullable, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name IN (\
+                   'engine_column_contract_by_branch', \
+                   'lix_directory_by_branch', \
+                   'lix_file_by_branch'\
+                 ) \
+                   AND column_name = 'lixcol_branch_id' \
+                 ORDER BY table_name",
+                &[],
+            )
+            .await
+            .expect("by-branch contract query should succeed");
+        assert_rows_eq(
+            by_branch_contract,
+            vec![
+                vec![
+                    Value::Text("engine_column_contract_by_branch".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("REQUIRED".to_string()),
+                ],
+                vec![
+                    Value::Text("lix_directory_by_branch".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("REQUIRED".to_string()),
+                ],
+                vec![
+                    Value::Text("lix_file_by_branch".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("REQUIRED".to_string()),
+                ],
+            ],
+        );
+
+        let identity_contract = session
+            .execute(
+                "SELECT table_name, column_name, is_nullable, column_default, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE (\
+                   table_name = 'engine_column_contract' \
+                   AND column_name IN (\
+                     'lixcol_change_id', 'lixcol_commit_id', 'lixcol_created_at', \
+                     'lixcol_entity_pk', 'lixcol_global', 'lixcol_schema_key', \
+                     'lixcol_untracked', 'lixcol_updated_at'\
+                   )\
+                 ) OR (\
+                   table_name = 'engine_no_pk_contract' \
+                   AND column_name = 'lixcol_entity_pk'\
+                 ) \
+                 ORDER BY table_name, column_name",
+                &[],
+            )
+            .await
+            .expect("entity system-column contract query should succeed");
+        assert_rows_eq(
+            identity_contract,
+            vec![
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_change_id".to_string()),
+                    Value::Text("YES".to_string()),
+                    Value::Null,
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_commit_id".to_string()),
+                    Value::Text("YES".to_string()),
+                    Value::Null,
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_created_at".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_entity_pk".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("CONDITIONAL".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_global".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("FALSE".to_string()),
+                    Value::Text("DEFAULT".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_schema_key".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_untracked".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("FALSE".to_string()),
+                    Value::Text("DEFAULT".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_column_contract".to_string()),
+                    Value::Text("lixcol_updated_at".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text("engine_no_pk_contract".to_string()),
+                    Value::Text("lixcol_entity_pk".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("REQUIRED".to_string()),
+                ],
+            ],
+        );
+
+        let filesystem_system_contract = session
+            .execute(
+                "SELECT table_name, column_name, is_nullable, column_default, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name IN ('lix_file', 'lix_directory') \
+                   AND column_name IN (\
+                     'lixcol_created_at', 'lixcol_global', \
+                     'lixcol_untracked', 'lixcol_updated_at'\
+                   ) \
+                 ORDER BY table_name, column_name",
+                &[],
+            )
+            .await
+            .expect("filesystem system-column contract query should succeed");
+        let mut expected_filesystem_system_contract = Vec::new();
+        for table_name in ["lix_directory", "lix_file"] {
+            expected_filesystem_system_contract.extend([
+                vec![
+                    Value::Text(table_name.to_string()),
+                    Value::Text("lixcol_created_at".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text(table_name.to_string()),
+                    Value::Text("lixcol_global".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("FALSE".to_string()),
+                    Value::Text("DEFAULT".to_string()),
+                ],
+                vec![
+                    Value::Text(table_name.to_string()),
+                    Value::Text("lixcol_untracked".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("FALSE".to_string()),
+                    Value::Text("DEFAULT".to_string()),
+                ],
+                vec![
+                    Value::Text(table_name.to_string()),
+                    Value::Text("lixcol_updated_at".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+            ]);
+        }
+        assert_rows_eq(
+            filesystem_system_contract,
+            expected_filesystem_system_contract,
+        );
+
+        let raw_state_contract = session
+            .execute(
+                "SELECT column_name, is_nullable, column_default, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name = 'lix_state' \
+                 ORDER BY column_name",
+                &[],
+            )
+            .await
+            .expect("raw state contract query should succeed");
+        let expected_raw_state_contract = [
+            ("change_id", "YES", None, "READ_ONLY"),
+            ("commit_id", "YES", None, "READ_ONLY"),
+            ("created_at", "NO", None, "READ_ONLY"),
+            ("entity_pk", "NO", None, "REQUIRED"),
+            ("file_id", "YES", None, "OPTIONAL"),
+            ("global", "NO", Some("FALSE"), "DEFAULT"),
+            ("metadata", "YES", None, "OPTIONAL"),
+            ("schema_key", "NO", None, "REQUIRED"),
+            ("snapshot_content", "YES", None, "OPTIONAL"),
+            ("untracked", "NO", Some("FALSE"), "DEFAULT"),
+            ("updated_at", "NO", None, "READ_ONLY"),
+        ]
+        .into_iter()
+        .map(
+            |(column_name, is_nullable, column_default, insert_policy)| {
+                vec![
+                    Value::Text(column_name.to_string()),
+                    Value::Text(is_nullable.to_string()),
+                    column_default.map_or(Value::Null, |value| Value::Text(value.to_string())),
+                    Value::Text(insert_policy.to_string()),
+                ]
+            },
+        )
+        .collect();
+        assert_rows_eq(raw_state_contract, expected_raw_state_contract);
+
+        let raw_state_branch_contract = session
+            .execute(
+                "SELECT column_name, is_nullable, column_default, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name = 'lix_state_by_branch' \
+                   AND column_name IN ('branch_id', 'global') \
+                 ORDER BY column_name",
+                &[],
+            )
+            .await
+            .expect("raw state branch contract query should succeed");
+        assert_rows_eq(
+            raw_state_branch_contract,
+            vec![
+                vec![
+                    Value::Text("branch_id".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("CONDITIONAL".to_string()),
+                ],
+                vec![
+                    Value::Text("global".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
+                    Value::Text("CONDITIONAL".to_string()),
+                ],
+            ],
+        );
+
+        let history_contract = session
+            .execute(
+                "SELECT column_name, is_nullable, lix_insert_policy \
+                 FROM information_schema.columns \
+                 WHERE table_name = 'engine_column_contract_history' \
+                   AND column_name IN ('id', 'title') \
+                 ORDER BY column_name",
+                &[],
+            )
+            .await
+            .expect("entity history nullability contract query should succeed");
+        assert_rows_eq(
+            history_contract,
+            vec![
+                vec![
+                    Value::Text("id".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+                vec![
+                    Value::Text("title".to_string()),
+                    Value::Text("YES".to_string()),
+                    Value::Text("READ_ONLY".to_string()),
+                ],
+            ],
+        );
+    }
+);
+
+simulation_test!(
+    advertised_lix_types_work_in_select_insert_and_update,
+    |sim| async move {
+        #[derive(Clone, Debug)]
+        struct CastContract {
+            table_name: String,
+            column_name: String,
+            data_type: String,
+            value_kind: Option<String>,
+        }
+
+        fn values_for_contract(contract: &CastContract) -> (Value, Value, Value, Value, Value) {
+            match (
+                contract.column_name.as_str(),
+                contract.value_kind.as_deref(),
+            ) {
+                ("text_value", None) => (
+                    Value::Integer(101),
+                    Value::Text("101".to_string()),
+                    Value::Text("101".to_string()),
+                    Value::Integer(202),
+                    Value::Text("202".to_string()),
+                ),
+                ("integer_value", None) => (
+                    Value::Text("41".to_string()),
+                    Value::Integer(41),
+                    Value::Integer(41),
+                    Value::Text("42".to_string()),
+                    Value::Integer(42),
+                ),
+                ("number_value", None) => (
+                    Value::Text("1.25".to_string()),
+                    Value::Real(1.25),
+                    Value::Real(1.25),
+                    Value::Text("2.5".to_string()),
+                    Value::Real(2.5),
+                ),
+                ("boolean_value", None) => (
+                    Value::Text("true".to_string()),
+                    Value::Boolean(true),
+                    Value::Boolean(true),
+                    Value::Text("false".to_string()),
+                    Value::Boolean(false),
+                ),
+                ("json_value", Some("JSON")) => (
+                    Value::Text("{\"phase\":\"insert\"}".to_string()),
+                    Value::Text("{\"phase\":\"insert\"}".to_string()),
+                    Value::Json(serde_json::json!({"phase": "insert"})),
+                    Value::Text("{\"phase\":\"update\"}".to_string()),
+                    Value::Json(serde_json::json!({"phase": "update"})),
+                ),
+                ("data", None) => (
+                    Value::Text("before".to_string()),
+                    Value::Blob(b"before".to_vec().into()),
+                    Value::Blob(b"before".to_vec().into()),
+                    Value::Text("after".to_string()),
+                    Value::Blob(b"after".to_vec().into()),
+                ),
+                _ => panic!("unexpected advertised cast contract: {contract:?}"),
+            }
+        }
+
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                   lix_json('{\"x-lix-key\":\"engine_scalar_cast_contract\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"x-lix-default\":\"lix_uuid_v7()\"},\"text_value\":{\"type\":\"string\"},\"integer_value\":{\"type\":\"integer\"},\"number_value\":{\"type\":\"number\"},\"boolean_value\":{\"type\":\"boolean\"},\"json_value\":{\"type\":\"object\"}},\"required\":[\"id\",\"text_value\",\"integer_value\",\"number_value\",\"boolean_value\",\"json_value\"],\"additionalProperties\":false}'),\
+                   false,\
+                   false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered scalar cast schema should succeed");
+
+        let contract_rows = session
+            .execute(
+                "SELECT table_name, column_name, data_type, lix_value_kind \
+                 FROM information_schema.columns \
+                 WHERE (\
+                   table_name = 'engine_scalar_cast_contract' \
+                   AND column_name IN (\
+                     'text_value', 'integer_value', 'number_value', \
+                     'boolean_value', 'json_value'\
+                   )\
+                 ) OR (table_name = 'lix_file' AND column_name = 'data') \
+                 ORDER BY table_name, column_name",
+                &[],
+            )
+            .await
+            .expect("advertised cast contract query should succeed");
+        let contracts = contract_rows
+            .rows()
+            .iter()
+            .map(|row| {
+                let [
+                    Value::Text(table_name),
+                    Value::Text(column_name),
+                    Value::Text(data_type),
+                    value_kind,
+                ] = row.values()
+                else {
+                    panic!("unexpected information_schema cast row: {:?}", row.values());
+                };
+                let value_kind = match value_kind {
+                    Value::Null => None,
+                    Value::Text(value) => Some(value.clone()),
+                    other => panic!("unexpected lix_value_kind: {other:?}"),
+                };
+                CastContract {
+                    table_name: table_name.clone(),
+                    column_name: column_name.clone(),
+                    data_type: data_type.clone(),
+                    value_kind,
+                }
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(contracts.len(), 6, "expected five entity types plus BYTEA");
+
+        for contract in &contracts {
+            let expected_type = match contract.column_name.as_str() {
+                "text_value" | "json_value" => "TEXT",
+                "integer_value" => "BIGINT",
+                "number_value" => "DOUBLE PRECISION",
+                "boolean_value" => "BOOLEAN",
+                "data" => "BYTEA",
+                other => panic!("unexpected contract column {other}"),
+            };
+            assert_eq!(contract.data_type, expected_type);
+            assert_eq!(
+                contract.value_kind.as_deref(),
+                (contract.column_name == "json_value").then_some("JSON")
+            );
+
+            let (insert_param, select_expected, _, _, _) = values_for_contract(contract);
+            let select_cast = session
+                .execute(
+                    &format!("SELECT CAST($1 AS {}) AS cast_value", contract.data_type),
+                    &[insert_param],
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    panic!("SELECT cast should follow {contract:?}: {error:?}")
+                });
+            assert_rows_eq(select_cast, vec![vec![select_expected]]);
+        }
+
+        let entity_contracts = contracts
+            .iter()
+            .filter(|contract| contract.table_name == "engine_scalar_cast_contract")
+            .collect::<Vec<_>>();
+        let entity_columns = entity_contracts
+            .iter()
+            .map(|contract| contract.column_name.clone())
+            .collect::<Vec<_>>();
+        let insert_params = entity_contracts
+            .iter()
+            .map(|contract| values_for_contract(contract).0)
+            .collect::<Vec<_>>();
+        let insert_casts = entity_contracts
+            .iter()
+            .enumerate()
+            .map(|(index, contract)| format!("CAST(${} AS {})", index + 1, contract.data_type))
+            .collect::<Vec<_>>();
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO engine_scalar_cast_contract ({}) VALUES ({})",
+                    entity_columns.join(", "),
+                    insert_casts.join(", ")
+                ),
+                &insert_params,
+            )
+            .await
+            .expect("all advertised entity casts should work in a bound INSERT");
+
+        let inserted = session
+            .execute(
+                &format!(
+                    "SELECT {} FROM engine_scalar_cast_contract",
+                    entity_columns.join(", ")
+                ),
+                &[],
+            )
+            .await
+            .expect("inserted scalar cast row should be readable");
+        assert_rows_eq(
+            inserted,
+            vec![
+                entity_contracts
+                    .iter()
+                    .map(|contract| values_for_contract(contract).2)
+                    .collect(),
+            ],
+        );
+
+        let update_params = entity_contracts
+            .iter()
+            .map(|contract| values_for_contract(contract).3)
+            .collect::<Vec<_>>();
+        let update_casts = entity_contracts
+            .iter()
+            .enumerate()
+            .map(|(index, contract)| {
+                format!(
+                    "{} = CAST(${} AS {})",
+                    contract.column_name,
+                    index + 1,
+                    contract.data_type
+                )
+            })
+            .collect::<Vec<_>>();
+        session
+            .execute(
+                &format!(
+                    "UPDATE engine_scalar_cast_contract SET {}",
+                    update_casts.join(", ")
+                ),
+                &update_params,
+            )
+            .await
+            .expect("all advertised entity casts should work in a bound UPDATE");
+        let updated = session
+            .execute(
+                &format!(
+                    "SELECT {} FROM engine_scalar_cast_contract",
+                    entity_columns.join(", ")
+                ),
+                &[],
+            )
+            .await
+            .expect("updated scalar cast row should be readable");
+        assert_rows_eq(
+            updated,
+            vec![
+                entity_contracts
+                    .iter()
+                    .map(|contract| values_for_contract(contract).4)
+                    .collect(),
+            ],
+        );
+
+        let bytea_contract = contracts
+            .iter()
+            .find(|contract| contract.table_name == "lix_file")
+            .expect("lix_file.data BYTEA contract should exist");
+        let (file_insert_param, _, _, file_update_param, file_update_expected) =
+            values_for_contract(bytea_contract);
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (path, data) \
+                     VALUES ('/contract.bin', CAST($1 AS {}))",
+                    bytea_contract.data_type
+                ),
+                &[file_insert_param],
+            )
+            .await
+            .expect("advertised BYTEA should work in a bound INSERT");
+        session
+            .execute(
+                &format!(
+                    "UPDATE lix_file SET data = CAST($1 AS {}) \
+                     WHERE path = '/contract.bin'",
+                    bytea_contract.data_type
+                ),
+                &[file_update_param],
+            )
+            .await
+            .expect("advertised BYTEA should work in a bound UPDATE");
+        let file = session
+            .execute(
+                "SELECT data FROM lix_file WHERE path = '/contract.bin'",
+                &[],
+            )
+            .await
+            .expect("file read should succeed");
+        assert_rows_eq(file, vec![vec![file_update_expected]]);
+
+        for sql in [
+            "SELECT CAST(1 AS INTEGER)",
+            "SELECT CAST(CAST('2026-01-01' AS DATE) AS TEXT)",
+            "SELECT CAST(CAST('12.50' AS DECIMAL(10, 2)) AS TEXT)",
+            "SELECT CAST(CAST('2026-01-01T00:00:00' AS TIMESTAMP) AS TEXT)",
+            "SELECT TRY_CAST('not-an-integer' AS INTEGER)",
+        ] {
+            session.execute(sql, &[]).await.unwrap_or_else(|error| {
+                panic!("DataFusion read-expression cast should remain available: {error:?}")
+            });
+        }
+
+        let binary_select_error = session
+            .execute("SELECT CAST('legacy' AS BINARY)", &[])
+            .await
+            .expect_err("retired BINARY spelling must not be accepted by SELECT");
+        assert_eq!(binary_select_error.code, LixError::CODE_DIALECT_UNSUPPORTED);
+
+        for (unsupported, column_name, value_sql, table_name) in [
+            (
+                "VARCHAR",
+                "text_value",
+                "'legacy'",
+                "engine_scalar_cast_contract",
+            ),
+            (
+                "INT64",
+                "integer_value",
+                "'7'",
+                "engine_scalar_cast_contract",
+            ),
+            (
+                "FLOAT64",
+                "number_value",
+                "'1.5'",
+                "engine_scalar_cast_contract",
+            ),
+            (
+                "BOOL",
+                "boolean_value",
+                "'true'",
+                "engine_scalar_cast_contract",
+            ),
+            ("BINARY", "data", "'legacy'", "lix_file"),
+        ] {
+            let write_error = session
+                .execute(
+                    &format!(
+                        "UPDATE {table_name} SET {column_name} = \
+                         CAST({value_sql} AS {unsupported})"
+                    ),
+                    &[],
+                )
+                .await
+                .expect_err("unsupported cast spelling should not be accepted by bound UPDATE");
+            assert_eq!(write_error.code, LixError::CODE_UNSUPPORTED_SQL);
+        }
+
+        let binary_insert_error = session
+            .execute(
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/legacy-binary.bin', CAST('legacy' AS BINARY))",
+                &[],
+            )
+            .await
+            .expect_err("BINARY must not be accepted by bound INSERT");
+        assert_eq!(binary_insert_error.code, LixError::CODE_UNSUPPORTED_SQL);
+    }
+);
+
+simulation_test!(
+    defaulted_columns_distinguish_omission_from_explicit_null,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute("INSERT INTO lix_file (path) VALUES ('/generated.txt')", &[])
+            .await
+            .expect("omitted file id should generate");
+        session
+            .execute(
+                "INSERT INTO lix_directory (path) VALUES ('/generated/')",
+                &[],
+            )
+            .await
+            .expect("omitted directory id should generate");
+        session
+            .execute(
+                "INSERT INTO lix_file (path) \
+                 SELECT '/query-generated.txt' \
+                 FROM information_schema.tables \
+                 WHERE table_name = 'lix_file'",
+                &[],
+            )
+            .await
+            .expect("query-backed file insert should see information_schema and default id/data");
+        session
+            .execute(
+                "INSERT INTO lix_directory (path) \
+                 SELECT '/query-generated/' \
+                 FROM information_schema.tables \
+                 WHERE table_name = 'lix_directory'",
+                &[],
+            )
+            .await
+            .expect("query-backed directory insert should see information_schema and default id");
+        session
+            .execute(
+                "INSERT INTO lix_file (path) VALUES ('/upsert-generated.txt') \
+                 ON CONFLICT (path) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect("upsert with an omitted file id should generate");
+        session
+            .execute(
+                "UPDATE lix_file SET data = X'6F6C64' WHERE path = '/generated.txt'",
+                &[],
+            )
+            .await
+            .expect("seed file contents should update");
+        session
+            .execute(
+                "INSERT INTO lix_file (path) VALUES ('/generated.txt') \
+                 ON CONFLICT (path) DO UPDATE SET data = excluded.data",
+                &[],
+            )
+            .await
+            .expect("excluded.data should materialize its advertised empty default");
+        let defaulted_upsert = session
+            .execute(
+                "SELECT data FROM lix_file WHERE path = '/generated.txt'",
+                &[],
+            )
+            .await
+            .expect("defaulted upsert file should be readable");
+        assert_rows_eq(defaulted_upsert, vec![vec![Value::Blob(Vec::new().into())]]);
+
+        session
+            .execute(
+                "INSERT INTO lix_file (path) VALUES ('/excluded-file-id.txt')",
+                &[],
+            )
+            .await
+            .expect("file id default seed should insert");
+        let file_before = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/excluded-file-id.txt'",
+                &[],
+            )
+            .await
+            .expect("seed file id should be readable");
+        let [Value::Text(file_id)] = file_before.rows()[0].values() else {
+            panic!("expected seed file id");
+        };
+        let file_id = file_id.clone();
+        session
+            .execute(
+                "INSERT INTO lix_file (path) VALUES ('/excluded-file-id.txt') \
+                 ON CONFLICT (path) DO UPDATE SET name = excluded.id",
+                &[],
+            )
+            .await
+            .expect("excluded.id should materialize the file UUID default");
+        let file_after = session
+            .execute(
+                "SELECT name FROM lix_file WHERE id = $1",
+                &[Value::Text(file_id.clone())],
+            )
+            .await
+            .expect("renamed file should remain readable by durable id");
+        let [Value::Text(file_name)] = file_after.rows()[0].values() else {
+            panic!("expected materialized file id as name");
+        };
+        assert!(!file_name.is_empty());
+        assert_ne!(file_name, &file_id);
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (path) VALUES ('/excluded-directory-id/')",
+                &[],
+            )
+            .await
+            .expect("directory id default seed should insert");
+        let directory_before = session
+            .execute(
+                "SELECT id FROM lix_directory WHERE path = '/excluded-directory-id/'",
+                &[],
+            )
+            .await
+            .expect("seed directory id should be readable");
+        let [Value::Text(directory_id)] = directory_before.rows()[0].values() else {
+            panic!("expected seed directory id");
+        };
+        let directory_id = directory_id.clone();
+        session
+            .execute(
+                "INSERT INTO lix_directory (path) VALUES ('/excluded-directory-id/') \
+                 ON CONFLICT (path) DO UPDATE SET name = excluded.id",
+                &[],
+            )
+            .await
+            .expect("excluded.id should materialize the directory UUID default");
+        let directory_after = session
+            .execute(
+                "SELECT name FROM lix_directory WHERE id = $1",
+                &[Value::Text(directory_id.clone())],
+            )
+            .await
+            .expect("renamed directory should remain readable by durable id");
+        let [Value::Text(directory_name)] = directory_after.rows()[0].values() else {
+            panic!("expected materialized directory id as name");
+        };
+        assert!(!directory_name.is_empty());
+        assert_ne!(directory_name, &directory_id);
+
+        session
+            .execute(
+                "INSERT INTO lix_branch (id, name, hidden) \
+                 VALUES ('excluded-default-branch', 'before', true)",
+                &[],
+            )
+            .await
+            .expect("branch default seed should insert");
+        let active_head = session
+            .execute("SELECT lix_active_branch_commit_id()", &[])
+            .await
+            .expect("active head default should resolve");
+        let [Value::Text(active_head)] = active_head.rows()[0].values() else {
+            panic!("expected active branch head");
+        };
+        let active_head = active_head.clone();
+        session
+            .execute(
+                "INSERT INTO lix_branch (id, name) \
+                 VALUES ('excluded-default-branch', 'after') \
+                 ON CONFLICT (id) DO UPDATE \
+                 SET name = excluded.name, \
+                     hidden = excluded.hidden, \
+                     commit_id = excluded.commit_id",
+                &[],
+            )
+            .await
+            .expect("excluded branch columns should materialize advertised defaults");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT name, hidden, commit_id FROM lix_branch \
+                     WHERE id = 'excluded-default-branch'",
+                    &[],
+                )
+                .await
+                .expect("defaulted branch should be readable"),
+            vec![vec![
+                Value::Text("after".to_string()),
+                Value::Boolean(false),
+                Value::Text(active_head),
+            ]],
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_state (\
+                   entity_pk, schema_key, snapshot_content, global, untracked\
+                 ) \
+                 VALUES (\
+                   lix_json('[\"excluded-default-state\"]'), \
+                   'lix_key_value', \
+                   lix_json('{\"key\":\"excluded-default-state\",\"value\":\"before\"}'), \
+                   true, \
+                   true\
+                 )",
+                &[],
+            )
+            .await
+            .expect("generic state default seed should insert");
+        session
+            .execute(
+                "INSERT INTO lix_state (entity_pk, schema_key, snapshot_content) \
+                 VALUES (\
+                   lix_json('[\"excluded-default-state\"]'), \
+                   'lix_key_value', \
+                   lix_json('{\"key\":\"excluded-default-state\",\"value\":\"after\"}')\
+                 ) \
+                 ON CONFLICT (entity_pk, schema_key, file_id) DO UPDATE \
+                 SET global = excluded.global, untracked = excluded.untracked",
+                &[],
+            )
+            .await
+            .expect("excluded state booleans should materialize advertised defaults");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT global, untracked FROM lix_state \
+                     WHERE schema_key = 'lix_key_value' \
+                       AND entity_pk = lix_json('[\"excluded-default-state\"]')",
+                    &[],
+                )
+                .await
+                .expect("defaulted state booleans should be readable"),
+            vec![vec![Value::Boolean(false), Value::Boolean(false)]],
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                   lix_json('{\"x-lix-key\":\"engine_default_identity_contract\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"x-lix-default\":\"lix_uuid_v7()\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"],\"additionalProperties\":false}'),\
+                   false,\
+                   false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+        session
+            .execute(
+                "INSERT INTO engine_default_identity_contract (name) VALUES ('generated')",
+                &[],
+            )
+            .await
+            .expect("omitted typed-entity primary key should generate");
+
+        let generated = session
+            .execute(
+                "SELECT id FROM engine_default_identity_contract WHERE name = 'generated'",
+                &[],
+            )
+            .await
+            .expect("generated typed entity should be readable");
+        let [Value::Text(id)] = generated.rows()[0].values() else {
+            panic!("expected generated text identity");
+        };
+        assert!(!id.is_empty(), "generated identity should not be empty");
+
+        let query_generated_file = session
+            .execute(
+                "SELECT id, data FROM lix_file WHERE path = '/query-generated.txt'",
+                &[],
+            )
+            .await
+            .expect("query-backed file should be readable");
+        let [Value::Text(file_id), Value::Blob(data)] = query_generated_file.rows()[0].values()
+        else {
+            panic!("expected generated file id and binary data");
+        };
+        assert!(!file_id.is_empty(), "query-backed file id should generate");
+        assert!(data.is_empty(), "omitted file data should default to empty");
+
+        let query_generated_directory = session
+            .execute(
+                "SELECT id FROM lix_directory WHERE path = '/query-generated/'",
+                &[],
+            )
+            .await
+            .expect("query-backed directory should be readable");
+        let [Value::Text(directory_id)] = query_generated_directory.rows()[0].values() else {
+            panic!("expected generated directory id");
+        };
+        assert!(
+            !directory_id.is_empty(),
+            "query-backed directory id should generate"
+        );
+
+        for (sql, expected_code) in [
+            (
+                "INSERT INTO lix_file (id, path) VALUES (NULL, '/null-id.txt')",
+                LixError::CODE_TYPE_MISMATCH,
+            ),
+            (
+                "INSERT INTO lix_file (id, path) VALUES (NULL, '/upsert-null-id.txt') \
+                 ON CONFLICT (path) DO NOTHING",
+                LixError::CODE_TYPE_MISMATCH,
+            ),
+            (
+                "INSERT INTO lix_file (id, path) VALUES (CAST(NULL AS TEXT), '/generated.txt') \
+                 ON CONFLICT (path) DO NOTHING",
+                LixError::CODE_TYPE_MISMATCH,
+            ),
+            (
+                "INSERT INTO lix_file (path, data) \
+                 VALUES ('/generated.txt', CAST(NULL AS BYTEA)) \
+                 ON CONFLICT (path) DO NOTHING",
+                LixError::CODE_TYPE_MISMATCH,
+            ),
+            (
+                "INSERT INTO lix_directory (id, path) VALUES (NULL, '/null-id/')",
+                LixError::CODE_TYPE_MISMATCH,
+            ),
+            (
+                "INSERT INTO engine_default_identity_contract (id, name) VALUES (NULL, 'explicit-null')",
+                LixError::CODE_SCHEMA_VALIDATION,
+            ),
+            (
+                "INSERT INTO lix_directory (id, path) \
+                 SELECT NULL, '/query-null-id/' \
+                 FROM information_schema.tables \
+                 WHERE table_name = 'lix_directory'",
+                LixError::CODE_TYPE_MISMATCH,
+            ),
+            (
+                "INSERT INTO lix_file (path, data) \
+                 SELECT '/query-null-data.txt', NULL \
+                 FROM information_schema.tables \
+                 WHERE table_name = 'lix_file'",
+                LixError::CODE_TYPE_MISMATCH,
+            ),
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("explicit NULL must not trigger a column default");
+            assert_eq!(error.code, expected_code);
+        }
+
+        for sql in [
+            "INSERT INTO lix_branch (id, name, hidden) \
+             VALUES ('null-hidden-branch', 'Null hidden', NULL)",
+            "INSERT INTO lix_branch (id, name, commit_id) \
+             VALUES ('null-commit-branch', 'Null commit', NULL)",
+            "INSERT INTO lix_file (path, lixcol_global) \
+             VALUES ('/null-global-file.txt', NULL)",
+            "INSERT INTO lix_file (path, lixcol_untracked) \
+             VALUES ('/null-untracked-file.txt', NULL)",
+            "INSERT INTO lix_directory (path, lixcol_global) \
+             VALUES ('/null-global-directory/', NULL)",
+            "INSERT INTO lix_directory (path, lixcol_untracked) \
+             VALUES ('/null-untracked-directory/', NULL)",
+            "INSERT INTO lix_state (entity_pk, schema_key, snapshot_content, global) \
+             VALUES (\
+               lix_json('[\"null-global-state\"]'), \
+               'lix_key_value', \
+               lix_json('{\"key\":\"null-global-state\",\"value\":null}'), \
+               NULL\
+             )",
+            "INSERT INTO lix_state (entity_pk, schema_key, snapshot_content, untracked) \
+             VALUES (\
+               lix_json('[\"null-untracked-state\"]'), \
+               'lix_key_value', \
+               lix_json('{\"key\":\"null-untracked-state\",\"value\":null}'), \
+               NULL\
+             )",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("explicit NULL must not trigger a boolean or branch default");
+            assert!(
+                error.code == LixError::CODE_TYPE_MISMATCH
+                    || error.code == LixError::CODE_UNSUPPORTED_SQL,
+                "unexpected explicit-NULL error for {sql}: {error:?}"
+            );
+        }
+    }
+);
+
+simulation_test!(
+    typed_entity_upsert_materializes_omitted_defaults_in_excluded,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                   lix_json('{\"x-lix-key\":\"engine_excluded_typed_default\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"x-lix-default\":\"lix_uuid_v7()\"},\"status\":{\"type\":\"string\",\"default\":\"fresh\"},\"mirror\":{\"type\":\"string\"},\"identity_copy\":{\"type\":\"array\"}},\"required\":[\"id\",\"status\"],\"additionalProperties\":false}'),\
+                   false,\
+                   false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+        session
+            .execute(
+                "INSERT INTO engine_excluded_typed_default (id, status, mirror) \
+                 VALUES ('same', 'old', 'old')",
+                &[],
+            )
+            .await
+            .expect("seed insert should succeed");
+        session
+            .execute(
+                "INSERT INTO engine_excluded_typed_default (id) VALUES ('same') \
+                 ON CONFLICT (id) DO UPDATE \
+                 SET mirror = excluded.status, \
+                     identity_copy = excluded.lixcol_entity_pk",
+                &[],
+            )
+            .await
+            .expect("typed entity upsert should succeed");
+
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT mirror, identity_copy \
+                     FROM engine_excluded_typed_default WHERE id = 'same'",
+                    &[],
+                )
+                .await
+                .expect("updated row should be readable"),
+            vec![vec![
+                Value::Text("fresh".to_string()),
+                Value::Json(serde_json::json!(["same"])),
+            ]],
+        );
+
+        session
+            .execute(
+                "INSERT INTO engine_excluded_typed_default (status) VALUES ('generated') \
+                 ON CONFLICT (id) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect("typed upsert should materialize a defaulted primary key");
+        let generated = session
+            .execute(
+                "SELECT id FROM engine_excluded_typed_default WHERE status = 'generated'",
+                &[],
+            )
+            .await
+            .expect("generated upsert row should be readable");
+        let [Value::Text(id)] = generated.rows()[0].values() else {
+            panic!("expected generated typed-upsert identity");
+        };
+        assert!(!id.is_empty());
+
+        let mismatched_identity = session
+            .execute(
+                "INSERT INTO engine_excluded_typed_default \
+                 (id, status, lixcol_entity_pk) \
+                 VALUES ('different', 'corrupted', lix_json('[\"same\"]')) \
+                 ON CONFLICT (id) DO UPDATE SET status = excluded.status",
+                &[],
+            )
+            .await
+            .expect_err("opaque and public typed identities must agree before conflict routing");
+        assert_eq!(mismatched_identity.code, LixError::CODE_SCHEMA_VALIDATION);
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT status FROM engine_excluded_typed_default WHERE id = 'same'",
+                    &[],
+                )
+                .await
+                .expect("mismatched upsert must leave the existing row unchanged"),
+            vec![vec![Value::Text("old".to_string())]],
+        );
+
+        for column_name in ["lixcol_global", "lixcol_untracked"] {
+            let error = session
+                .execute(
+                    &format!(
+                        "INSERT INTO engine_excluded_typed_default \
+                         (id, status, {column_name}) VALUES ('null-{column_name}', 'x', NULL)"
+                    ),
+                    &[],
+                )
+                .await
+                .expect_err("explicit NULL must not trigger a typed system-column default");
+            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
+        }
+
+        for sql in [
+            "INSERT INTO engine_excluded_typed_default (id, status) \
+             VALUES ('unsupported-returning-insert', 'x') RETURNING id",
+            "UPDATE engine_excluded_typed_default SET status = 'changed' \
+             WHERE id = 'same' RETURNING id",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("unsupported entity RETURNING must not be silently ignored");
+            assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL, "{sql}");
+            assert!(error.message.contains("RETURNING"), "{error:?}");
+        }
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT id FROM engine_excluded_typed_default \
+                     WHERE id = 'unsupported-returning-insert'",
+                    &[],
+                )
+                .await
+                .expect("rejected INSERT RETURNING must not write"),
+            vec![],
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT status FROM engine_excluded_typed_default WHERE id = 'same'",
+                    &[],
+                )
+                .await
+                .expect("rejected UPDATE RETURNING must not write"),
+            vec![vec![Value::Text("old".to_string())]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_state_by_branch_scope_is_materialized_before_conflict_routing,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        for sql in [
+            "INSERT INTO lix_state_by_branch \
+             (entity_pk, schema_key, snapshot_content, branch_id) VALUES \
+             (lix_json('[\"null-branch-insert\"]'), 'lix_key_value', lix_json('{\"key\":\"null-branch-insert\",\"value\":\"invalid\"}'), $1)",
+            "INSERT INTO lix_state_by_branch \
+             (entity_pk, schema_key, snapshot_content, branch_id) VALUES \
+             (lix_json('[\"null-branch-upsert\"]'), 'lix_key_value', lix_json('{\"key\":\"null-branch-upsert\",\"value\":\"invalid\"}'), $1) \
+             ON CONFLICT (entity_pk, schema_key, file_id, branch_id) DO NOTHING",
+        ] {
+            let error = session
+                .execute(sql, &[Value::Null])
+                .await
+                .expect_err("NULL INSERT branch parameters must not become empty-scope no-ops");
+            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH, "{sql}");
+            assert!(error.message.contains("branch-id"), "{error:?}");
+        }
+
+        session
+            .execute(
+                "INSERT INTO lix_state_by_branch \
+                 (entity_pk, schema_key, file_id, snapshot_content, branch_id) VALUES \
+                 (lix_json('[\"nothing-branch\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"nothing-branch\",\"value\":\"old\"}'), 'global'), \
+                 (lix_json('[\"update-branch\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"update-branch\",\"value\":\"old\"}'), 'global')",
+                &[],
+            )
+            .await
+            .expect("branch-id spelling should seed global rows");
+        session
+            .execute(
+                "INSERT INTO lix_state_by_branch \
+                 (entity_pk, schema_key, file_id, snapshot_content, global) VALUES \
+                 (lix_json('[\"nothing-global\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"nothing-global\",\"value\":\"old\"}'), true), \
+                 (lix_json('[\"update-global\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"update-global\",\"value\":\"old\"}'), true)",
+                &[],
+            )
+            .await
+            .expect("global spelling should seed rows with a derived global branch id");
+
+        let do_nothing = session
+            .execute(
+                "INSERT INTO lix_state_by_branch \
+                 (entity_pk, schema_key, file_id, snapshot_content, global) VALUES \
+                 (lix_json('[\"nothing-branch\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"nothing-branch\",\"value\":\"ignored\"}'), true) \
+                 ON CONFLICT (entity_pk, schema_key, file_id, branch_id) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect("global spelling should match branch-spelled conflict identity");
+        assert_eq!(do_nothing.rows_affected(), 0);
+        let do_nothing = session
+            .execute(
+                "INSERT INTO lix_state_by_branch \
+                 (entity_pk, schema_key, file_id, snapshot_content, branch_id) VALUES \
+                 (lix_json('[\"nothing-global\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"nothing-global\",\"value\":\"ignored\"}'), 'global') \
+                 ON CONFLICT (entity_pk, schema_key, file_id, branch_id) DO NOTHING",
+                &[],
+            )
+            .await
+            .expect("branch spelling should match global-spelled conflict identity");
+        assert_eq!(do_nothing.rows_affected(), 0);
+
+        let do_update = session
+            .execute(
+                "INSERT INTO lix_state_by_branch \
+                 (entity_pk, schema_key, file_id, snapshot_content, global) VALUES \
+                 (lix_json('[\"update-branch\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"update-branch\",\"value\":\"new\"}'), true) \
+                 ON CONFLICT (entity_pk, schema_key, file_id, branch_id) \
+                 DO UPDATE SET snapshot_content = excluded.snapshot_content",
+                &[],
+            )
+            .await
+            .expect("global spelling should update branch-spelled conflict identity");
+        assert_eq!(do_update.rows_affected(), 1);
+        let do_update = session
+            .execute(
+                "INSERT INTO lix_state_by_branch \
+                 (entity_pk, schema_key, file_id, snapshot_content, branch_id) VALUES \
+                 (lix_json('[\"update-global\"]'), 'lix_key_value', NULL, lix_json('{\"key\":\"update-global\",\"value\":\"new\"}'), 'global') \
+                 ON CONFLICT (entity_pk, schema_key, file_id, branch_id) \
+                 DO UPDATE SET snapshot_content = excluded.snapshot_content",
+                &[],
+            )
+            .await
+            .expect("branch spelling should update global-spelled conflict identity");
+        assert_eq!(do_update.rows_affected(), 1);
+
+        for (id, expected_value) in [
+            ("nothing-branch", "old"),
+            ("nothing-global", "old"),
+            ("update-branch", "new"),
+            ("update-global", "new"),
+        ] {
+            assert_rows_eq(
+                session
+                    .execute(
+                        &format!(
+                            "SELECT snapshot_content, branch_id, global \
+                             FROM lix_state_by_branch \
+                             WHERE entity_pk = lix_json('[\"{id}\"]') \
+                               AND schema_key = 'lix_key_value' \
+                               AND branch_id = 'global'"
+                        ),
+                        &[],
+                    )
+                    .await
+                    .expect("global conflict result should be readable"),
+                vec![vec![
+                    Value::Json(serde_json::json!({
+                        "key": id,
+                        "value": expected_value,
+                    })),
+                    Value::Text("global".to_string()),
+                    Value::Boolean(true),
+                ]],
+            );
+        }
+    }
+);
+
+simulation_test!(
+    required_nullable_columns_separate_read_and_insert_contracts,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) \
+                 VALUES (lix_json('{\"x-lix-key\":\"engine_required_nullable_contract\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"payload\":{\"type\":[\"object\",\"null\"]}},\"required\":[\"id\",\"payload\"],\"additionalProperties\":false}'))",
+                &[],
+            )
+            .await
+            .expect("required nullable schema should register");
+
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT is_nullable, lix_insert_policy \
+                     FROM information_schema.columns \
+                     WHERE table_name = 'engine_required_nullable_contract' \
+                       AND column_name = 'payload'",
+                    &[],
+                )
+                .await
+                .expect("required nullable column should introspect"),
+            vec![vec![
+                Value::Text("YES".to_string()),
+                Value::Text("REQUIRED".to_string()),
+            ]],
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT is_nullable, lix_insert_policy \
+                     FROM information_schema.columns \
+                     WHERE table_name = 'lix_label_assignment' \
+                       AND column_name = 'target_file_id'",
+                    &[],
+                )
+                .await
+                .expect("built-in required nullable column should introspect"),
+            vec![vec![
+                Value::Text("YES".to_string()),
+                Value::Text("REQUIRED".to_string()),
+            ]],
+        );
+
+        let omission_error = session
+            .execute(
+                "INSERT INTO engine_required_nullable_contract (id) VALUES ('omitted')",
+                &[],
+            )
+            .await
+            .expect_err("required nullable column must not be omittable");
+        assert!(
+            omission_error.message.contains("payload"),
+            "{omission_error:?}"
+        );
+
+        session
+            .execute(
+                "INSERT INTO engine_required_nullable_contract (id, payload) \
+                 VALUES ('explicit-null', lix_json('null'))",
+                &[],
+            )
+            .await
+            .expect("required nullable column should accept explicit JSON null");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT payload FROM engine_required_nullable_contract \
+                     WHERE id = 'explicit-null'",
+                    &[],
+                )
+                .await
+                .expect("typed JSON null should read as SQL NULL"),
+            vec![vec![Value::Null]],
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "DELETE FROM engine_required_nullable_contract \
+                     WHERE id = 'explicit-null' \
+                     RETURNING payload, lix_json('null')",
+                    &[],
+                )
+                .await
+                .expect("DELETE RETURNING should match SELECT null semantics"),
+            vec![vec![Value::Null, Value::Json(serde_json::Value::Null)]],
+        );
+    }
+);
+
+simulation_test!(
+    typed_bigint_projection_is_lossless_or_explicit,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) \
+                 VALUES (lix_json('{\"x-lix-key\":\"engine_bigint_contract\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"count\":{\"type\":\"integer\"},\"ratio\":{\"type\":\"number\"}},\"required\":[\"id\",\"count\"],\"additionalProperties\":false}'))",
+                &[],
+            )
+            .await
+            .expect("integer schema should register");
+        session
+            .execute(
+                "INSERT INTO lix_state (entity_pk, schema_key, snapshot_content) \
+                 VALUES (\
+                   lix_json('[\"integral-real\"]'),\
+                   'engine_bigint_contract',\
+                   lix_json('{\"id\":\"integral-real\",\"count\":1.0}')\
+                 )",
+                &[],
+            )
+            .await
+            .expect("raw state should accept a mathematically integral JSON real");
+
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT count FROM engine_bigint_contract \
+                     WHERE id = 'integral-real'",
+                    &[],
+                )
+                .await
+                .expect("integral JSON real should project through BIGINT"),
+            vec![vec![Value::Integer(1)]],
+        );
+        assert_rows_eq(
+            session
+                .execute("SELECT id FROM engine_bigint_contract WHERE count = 1", &[])
+                .await
+                .expect("integral JSON real should participate in BIGINT filter pushdown"),
+            vec![vec![Value::Text("integral-real".to_string())]],
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT id FROM engine_bigint_contract WHERE count = 1.0",
+                    &[],
+                )
+                .await
+                .expect("real literal comparison should retain DataFusion coercion semantics"),
+            vec![vec![Value::Text("integral-real".to_string())]],
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT count FROM engine_bigint_contract_history \
+                     WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+                       AND lixcol_entity_pk = lix_json('[\"integral-real\"]')",
+                    &[],
+                )
+                .await
+                .expect("integral JSON real should project through typed history BIGINT"),
+            vec![vec![Value::Integer(1)]],
+        );
+
+        let updated = session
+            .execute(
+                "UPDATE engine_bigint_contract SET ratio = 1 \
+                 WHERE count = 1.0",
+                &[],
+            )
+            .await
+            .expect("BIGINT predicates should normalize an integral real literal");
+        assert_eq!(updated.rows_affected(), 1);
+        let updated = session
+            .execute(
+                "UPDATE engine_bigint_contract SET ratio = 2.5 \
+                 WHERE 1 = ratio",
+                &[],
+            )
+            .await
+            .expect("DOUBLE predicates should normalize an integer literal symmetrically");
+        assert_eq!(updated.rows_affected(), 1);
+        let updated = session
+            .execute(
+                "UPDATE engine_bigint_contract SET ratio = 3 \
+                 WHERE count IN (1.0)",
+                &[],
+            )
+            .await
+            .expect("bound IN predicates should use the same numeric normalization");
+        assert_eq!(updated.rows_affected(), 1);
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT ratio FROM engine_bigint_contract \
+                     WHERE id = 'integral-real'",
+                    &[],
+                )
+                .await
+                .expect("an integer JSON spelling should project through DOUBLE PRECISION"),
+            vec![vec![Value::Real(3.0)]],
+        );
+
+        for sql in [
+            "INSERT INTO engine_bigint_contract (id, count) \
+             VALUES ('below-min-insert', -9223372036854775809)",
+            "UPDATE engine_bigint_contract SET count = -9223372036854775809 \
+             WHERE id = 'integral-real'",
+            "UPDATE engine_bigint_contract SET ratio = 9 \
+             WHERE count = -9223372036854775809",
+            "UPDATE engine_bigint_contract SET ratio = 9 \
+             WHERE count = -9223372036854775809.0",
+            "UPDATE engine_bigint_contract SET ratio = 9 \
+             WHERE count IN (-9223372036854775809e0)",
+            "INSERT INTO engine_bigint_contract (id, count) \
+             VALUES ('above-max-insert', 9223372036854775808)",
+            "INSERT INTO engine_bigint_contract (id, count) \
+             VALUES ('below-min-real-insert', -9223372036854775809.0)",
+            "UPDATE engine_bigint_contract SET count = -9223372036854775809e0 \
+             WHERE id = 'integral-real'",
+            "INSERT INTO engine_bigint_contract (id, count) \
+             VALUES ('rounded-fraction-insert', 9007199254740992.5)",
+            "INSERT INTO engine_bigint_contract (id, count) \
+             VALUES ('underflow-insert', 1e-400)",
+            "UPDATE engine_bigint_contract SET count = 9007199254740992.5 \
+             WHERE id = 'integral-real'",
+            "UPDATE engine_bigint_contract SET ratio = 9 \
+             WHERE count = 9007199254740992.5",
+            "UPDATE engine_bigint_contract SET ratio = 9 \
+             WHERE count IN (1e-400)",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("inexact SQL numeric literals must never round into BIGINT");
+            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH, "{sql}");
+            assert!(error.message.contains("count"), "{error:?}");
+            assert!(error.message.contains("BIGINT"), "{error:?}");
+        }
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT count, ratio FROM engine_bigint_contract \
+                     WHERE id = 'integral-real'",
+                    &[],
+                )
+                .await
+                .expect("rejected numeric writes and predicates must not mutate the row"),
+            vec![vec![Value::Integer(1), Value::Real(3.0)]],
+        );
+
+        session
+            .execute(
+                "INSERT INTO engine_bigint_contract (id, count) VALUES \
+                 ('max-real-spelling', 9223372036854775807.0), \
+                 ('min-exponent-spelling', -9223372036854775808e0)",
+                &[],
+            )
+            .await
+            .expect("exact in-range real and exponent spellings should normalize without rounding");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT count FROM engine_bigint_contract \
+                     WHERE id IN ('max-real-spelling', 'min-exponent-spelling') \
+                     ORDER BY id",
+                    &[],
+                )
+                .await
+                .expect("exact BIGINT boundary spellings should remain lossless"),
+            vec![
+                vec![Value::Integer(i64::MAX)],
+                vec![Value::Integer(i64::MIN)],
+            ],
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_state (entity_pk, schema_key, snapshot_content) \
+                 VALUES (\
+                   lix_json('[\"delete-integral-real\"]'),\
+                   'engine_bigint_contract',\
+                   lix_json('{\"id\":\"delete-integral-real\",\"count\":2.0,\"ratio\":1}')\
+                 )",
+                &[],
+            )
+            .await
+            .expect("raw integral-real delete fixture should insert");
+        let deleted = session
+            .execute(
+                "DELETE FROM engine_bigint_contract \
+                 WHERE count = 2 RETURNING count, ratio",
+                &[],
+            )
+            .await
+            .expect("DELETE predicates and RETURNING should apply the typed numeric contract");
+        assert_eq!(deleted.rows_affected(), 1);
+        assert_rows_eq(deleted, vec![vec![Value::Integer(2), Value::Real(1.0)]]);
+
+        session
+            .execute(
+                "INSERT INTO lix_state (entity_pk, schema_key, snapshot_content) \
+                 VALUES (\
+                   lix_json('[\"out-of-range\"]'),\
+                   'engine_bigint_contract',\
+                   lix_json('{\"id\":\"out-of-range\",\"count\":9223372036854775808}')\
+                 )",
+                &[],
+            )
+            .await
+            .expect("raw interoperability write should preserve a valid JSON-Schema integer");
+
+        for sql in [
+            "SELECT count FROM engine_bigint_contract WHERE id = 'out-of-range'",
+            "SELECT id FROM engine_bigint_contract WHERE count = 1",
+            "SELECT id FROM engine_bigint_contract WHERE count = 1.0",
+            "SELECT count FROM engine_bigint_contract_history \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+               AND lixcol_entity_pk = lix_json('[\"out-of-range\"]')",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("typed BIGINT reads must reject values outside the i64 range");
+            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH, "{sql}");
+            assert!(
+                error.message.contains("engine_bigint_contract"),
+                "{error:?}"
+            );
+            assert!(error.message.contains("count"), "{error:?}");
+            assert!(error.message.contains("BIGINT"), "{error:?}");
+        }
+
+        let update_error = session
+            .execute(
+                "UPDATE engine_bigint_contract SET ratio = 4 \
+                 WHERE count = 1",
+                &[],
+            )
+            .await
+            .expect_err("bound numeric predicates must reject an out-of-BIGINT stored value");
+        assert_eq!(update_error.code, LixError::CODE_TYPE_MISMATCH);
+        assert!(update_error.message.contains("count"), "{update_error:?}");
+        assert!(update_error.message.contains("BIGINT"), "{update_error:?}");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT ratio FROM engine_bigint_contract \
+                     WHERE id = 'integral-real'",
+                    &[],
+                )
+                .await
+                .expect("failed bound UPDATE must not stage earlier candidate mutations"),
+            vec![vec![Value::Real(3.0)]],
+        );
+
+        let delete_error = session
+            .execute(
+                "DELETE FROM engine_bigint_contract \
+                 WHERE id = 'out-of-range' RETURNING count",
+                &[],
+            )
+            .await
+            .expect_err("DELETE RETURNING must reject an out-of-BIGINT stored value");
+        assert_eq!(delete_error.code, LixError::CODE_TYPE_MISMATCH);
+        assert!(delete_error.message.contains("count"), "{delete_error:?}");
+        assert!(delete_error.message.contains("BIGINT"), "{delete_error:?}");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT entity_pk FROM lix_state \
+                     WHERE schema_key = 'engine_bigint_contract' \
+                       AND entity_pk = lix_json('[\"out-of-range\"]')",
+                    &[],
+                )
+                .await
+                .expect("failed DELETE RETURNING must leave raw state untouched"),
+            vec![vec![Value::Json(serde_json::json!(["out-of-range"]))]],
+        );
+
+        let non_integral = session
+            .execute(
+                "INSERT INTO lix_state (entity_pk, schema_key, snapshot_content) \
+                 VALUES (\
+                   lix_json('[\"non-integral\"]'),\
+                   'engine_bigint_contract',\
+                   lix_json('{\"id\":\"non-integral\",\"count\":1.5}')\
+                 )",
+                &[],
+            )
+            .await
+            .expect_err("schema validation should reject a non-integral raw value");
+        assert_eq!(non_integral.code, LixError::CODE_SCHEMA_VALIDATION);
+    }
+);

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -1077,7 +1077,7 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO lix_file (id, path, data) \
-                 VALUES ('cast-binary-file', $1, CAST($2 AS BINARY))",
+                 VALUES ('cast-binary-file', $1, CAST($2 AS BYTEA))",
                 &[
                     Value::Text("/cast-binary.txt".to_string()),
                     Value::Text("inserted".to_string()),
@@ -1088,7 +1088,7 @@ simulation_test!(
 
         session
             .execute(
-                "UPDATE lix_file SET data = CAST($1 AS BINARY) \
+                "UPDATE lix_file SET data = CAST($1 AS BYTEA) \
                  WHERE id = 'cast-binary-file'",
                 &[Value::Text("updated".to_string())],
             )
@@ -2707,7 +2707,7 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO lix_file (id, path, data, lixcol_global) \
-                 VALUES ('global-shared-file', '/shared/a.txt', CAST('a' AS BINARY), true)",
+                 VALUES ('global-shared-file', '/shared/a.txt', CAST('a' AS BYTEA), true)",
                 &[],
             )
             .await
@@ -2748,7 +2748,7 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO lix_file (id, path, data) \
-                 VALUES ('file-readme', '/scratch/readme.md', CAST('hello' AS BINARY))",
+                 VALUES ('file-readme', '/scratch/readme.md', CAST('hello' AS BYTEA))",
                 &[],
             )
             .await
@@ -2815,7 +2815,7 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO lix_file (id, path, data, lixcol_untracked) \
-                 VALUES ('file-draft', '/docs/draft.md', CAST('draft' AS BINARY), true)",
+                 VALUES ('file-draft', '/docs/draft.md', CAST('draft' AS BYTEA), true)",
                 &[],
             )
             .await


### PR DESCRIPTION
## What

Make `information_schema.columns` the executable public contract for Lix SQL instead of exposing raw Arrow/DataFusion internals.

- report canonical public types (`TEXT`, `BYTEA`, `BIGINT`, `DOUBLE PRECISION`, `BOOLEAN`)
- mark JSON-backed text with `lix_value_kind = 'JSON'`
- represent read nullability, insert requiredness, and omission/default behavior independently
- expose insert omission through `column_default` and `lix_insert_policy`
- derive introspection, filter binding, and write binding from the same public catalog
- keep the custom information schema available in read and write sessions, scoped by catalog/schema

## Breaking changes

- retire `BINARY` in favor of `BYTEA` across reads and writes
- defaulted filesystem/entity IDs may be omitted, but explicit `NULL` is rejected
- explicit file `data = NULL` is rejected through direct and query-backed inserts and matching `ON CONFLICT` paths; omission still creates an empty file
- apply defaults and scope-derived identity before conflict routing and `excluded.*` construction, then derive/validate primary keys from the resulting row
- advertise required-but-nullable properties as nullable on read and required on insert
- advertise `lix_state_by_branch.global` as `CONDITIONAL`: global scope materializes both `branch_id = 'global'` and `global = true` before conflict matching
- reject NULL branch-id parameters for by-branch `INSERT VALUES` and upserts instead of silently turning them into zero-row writes; NULL UPDATE/DELETE predicates remain no-match
- advertise typed read-only entity surfaces as read-only and preserve their targeted migration hints
- reject unsupported `INSERT ... RETURNING` and `UPDATE ... RETURNING` before mutation; `DELETE ... RETURNING` remains supported and matches `SELECT` semantics for SQL NULL versus JSON null

The five advertised scalar names are covered across `SELECT`, bound `INSERT`, bound `UPDATE`, filters, and supported `RETURNING` paths. `BIGINT` coercion is exact: mathematically integral decimal and exponent spellings in the signed 64-bit range are accepted, while non-integral and out-of-range spellings are rejected from the raw literal rather than rounded through `f64`. SQL numeric literals remain distinct from JSON values. Read expressions retain DataFusion's wider cast dialect (`DATE`, `INTEGER`, `DECIMAL`, `TIMESTAMP`, `TRY_CAST`, etc.); this does not narrow query expressions.

History identity is reconstructed for tombstones, including nested and composite primary keys. Every guaranteed primary-key root is therefore advertised non-null. The catalog also uses the current explicit history vocabulary and composed filesystem provenance (`lixcol_as_of_commit_id`, `lixcol_change_created_at`, `lixcol_is_deleted`, and `lixcol_source_changes`).

## Validation

- `cargo test -p lix_engine --lib`: 1184 passed, 6 ignored
- `cargo test -p lix_engine --test sql`: 599 passed
- focused information-schema, history-conformance, defaults/identity/RETURNING, numeric-boundary, required-nullable, global-scope conflict-routing, NULL branch-parameter, and read-only-surface regressions
- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- repeated independent adversarial review before and after rebasing onto current `main`; every finding fixed before this push