### PR TITLE
fix!(sql): make filesystem history DAG-correct

### DIFF
--- a/.changenotes/fix-filesystem-history-dag-reconstruction.md
+++ b/.changenotes/fix-filesystem-history-dag-reconstruction.md
@@ -1,0 +1,17 @@
+---
+type: minor
+---
+
+Fixed `lix_file_history` and `lix_directory_history` reconstruction across commit DAGs.
+
+Composed history rows are now identified by the requested start commit, observed commit, and logical entity. Equal-depth sibling revisions are preserved, while descriptor, blob, direct-directory, plugin-owner, registry, and plugin state is reconstructed from the observed commit's immutable state root instead of inferred from traversal depth.
+
+Plugin-backed file history now follows the durable per-file owner used by live `lix_file`. Plugin upgrades and uninstalls create projection revisions for files owned by the changed plugin, overlapping plugin globs do not reassign existing files, unavailable historical owners return `LIX_PLUGIN_UNAVAILABLE` when `data` is projected, and plugin-state tombstones remain in composed provenance.
+
+Exact public `id` predicates are routed through observed-state descriptor, blob, owner, and plugin-state reads, avoiding a second full observed-root materialization. Commit-provenance traversal and unfiltered history remain bulk operations.
+
+The composed histories now expose `lixcol_source_changes`, a non-null JSON array ordered by change ID. Each element mirrors the stable `lix_change` payload fields: `id`, `entity_pk`, `schema_key`, `file_id`, `snapshot_content`, `metadata`, `created_at`, and `origin_key`. Multiple source changes in one commit produce one logical revision with every source in this array.
+
+This is a breaking SQL catalog change. The misleading singular `lixcol_schema_key`, `lixcol_file_id`, `lixcol_snapshot_content`, `lixcol_change_id`, `lixcol_origin_key`, and `lixcol_metadata` columns were removed from the composed filesystem histories. Inspect the structured `lixcol_source_changes` objects, or join their `id` fields to `lix_change`, when raw provenance is required.
+
+Recursive propagation of an ancestor-directory rename, move, or deletion to every descendant file revision is intentionally not part of this change. This history surface currently emits directory projection events only for a file's directly referenced directory; full ancestor propagation remains follow-up work.

--- a/packages/engine/src/filesystem/read.rs
+++ b/packages/engine/src/filesystem/read.rs
@@ -140,6 +140,7 @@ impl FilesystemIndex {
         Ok(Self { entries_by_path })
     }
 
+    #[cfg(test)]
     pub(crate) fn file_entries(&self) -> impl Iterator<Item = (&str, &FilesystemFileEntry)> {
         self.entries_by_path
             .iter()

--- a/packages/engine/src/plugin/archive.rs
+++ b/packages/engine/src/plugin/archive.rs
@@ -9,7 +9,9 @@ use crate::LixError;
 use crate::binary_cas::BlobHash;
 use crate::schema::{schema_key_from_definition, validate_lix_schema_definition};
 
-use super::{InstalledPlugin, InstalledPluginMetadata, PluginManifest, parse_plugin_manifest_json};
+#[cfg(test)]
+use super::InstalledPluginMetadata;
+use super::{InstalledPlugin, PluginManifest, parse_plugin_manifest_json};
 
 /// Fully validated plugin package data needed by the install transaction.
 ///
@@ -155,6 +157,7 @@ pub(crate) fn load_installed_plugin_from_archive_bytes(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn load_installed_plugin_metadata_from_archive_bytes(
     plugin_key: &str,
     archive_path: &str,

--- a/packages/engine/src/plugin/manifest.rs
+++ b/packages/engine/src/plugin/manifest.rs
@@ -99,46 +99,7 @@ pub fn parse_plugin_manifest_json(raw: &str) -> Result<ValidatedPluginManifest, 
     })
 }
 
-pub fn select_best_glob_match<'a, T, C: Copy + PartialEq>(
-    path: &str,
-    file_content_type: Option<C>,
-    candidates: &'a [T],
-    glob: impl Fn(&T) -> &str,
-    required_content_type: impl Fn(&T) -> Option<C>,
-) -> Option<&'a T> {
-    let mut selected: Option<&T> = None;
-    let mut selected_rank: Option<(u8, i32)> = None;
-
-    for candidate in candidates {
-        let pattern = glob(candidate);
-        if !glob_matches_path(pattern, path) {
-            continue;
-        }
-        if let (Some(actual_type), Some(required_type)) =
-            (file_content_type, required_content_type(candidate))
-        {
-            if actual_type != required_type {
-                continue;
-            }
-        }
-
-        let rank = glob_specificity_rank(pattern);
-        match selected_rank {
-            None => {
-                selected = Some(candidate);
-                selected_rank = Some(rank);
-            }
-            Some(existing_rank) if rank > existing_rank => {
-                selected = Some(candidate);
-                selected_rank = Some(rank);
-            }
-            _ => {}
-        }
-    }
-
-    selected
-}
-
+#[cfg(test)]
 pub fn glob_matches_path(glob: &str, path: &str) -> bool {
     if glob.is_empty() || path.is_empty() {
         return false;
@@ -171,25 +132,7 @@ fn validate_plugin_manifest_json(manifest: &JsonValue) -> Result<(), LixError> {
     Ok(())
 }
 
-fn glob_specificity_rank(glob: &str) -> (u8, i32) {
-    if is_catch_all_glob(glob) {
-        return (0, i32::MIN);
-    }
-    (1, glob_specificity_score(glob))
-}
-
-fn glob_specificity_score(glob: &str) -> i32 {
-    let mut literal_chars = 0i32;
-    let mut wildcard_chars = 0i32;
-    for ch in glob.chars() {
-        match ch {
-            '*' | '?' | '[' | ']' | '{' | '}' => wildcard_chars += 1,
-            _ => literal_chars += 1,
-        }
-    }
-    literal_chars - wildcard_chars
-}
-
+#[cfg(test)]
 fn is_catch_all_glob(glob: &str) -> bool {
     glob == "*" || glob == "**/*" || glob == "**"
 }

--- a/packages/engine/src/plugin/materializer.rs
+++ b/packages/engine/src/plugin/materializer.rs
@@ -71,20 +71,6 @@ pub(crate) async fn render_plugin_state_with_component_instance(
         .await
 }
 
-pub(crate) async fn render_materialized_plugin_file(
-    host: &impl PluginComponentHost,
-    plugin: &InstalledPlugin,
-    active_state: &[MaterializedLiveStateRow],
-) -> Result<Option<Vec<u8>>, LixError> {
-    // A matching plugin is not enough: raw empty files also have no blob ref.
-    // Durable plugin-owned state is the signal that the file was materialized.
-    if active_state.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(render_plugin_state(host, plugin, active_state).await?))
-}
-
 pub(crate) fn retain_plugin_state_rows(
     plugin: &InstalledPlugin,
     rows: Vec<MaterializedLiveStateRow>,

--- a/packages/engine/src/plugin/mod.rs
+++ b/packages/engine/src/plugin/mod.rs
@@ -13,8 +13,7 @@ mod registry;
 mod storage;
 
 pub(crate) use archive::{
-    ParsedPluginArchive, load_installed_plugin_from_archive_bytes,
-    load_installed_plugin_metadata_from_archive_bytes, parse_plugin_archive_for_install,
+    ParsedPluginArchive, load_installed_plugin_from_archive_bytes, parse_plugin_archive_for_install,
 };
 pub(crate) use component::{
     CachedPluginComponent, PluginComponentHost, PluginRuntimeHost, load_or_init_plugin_component,
@@ -22,11 +21,10 @@ pub(crate) use component::{
 pub(crate) use install::{PluginArchiveInstallPlan, plugin_install_plan_from_archive_path};
 pub(crate) use manifest::{
     PluginContentType, PluginManifest, PluginRuntime, parse_plugin_manifest_json,
-    select_best_glob_match,
 };
 pub(crate) use materializer::{
     PluginDetectedChange, detect_changes_with_component_instance,
-    plugin_state_live_state_projection, render_materialized_plugin_file,
+    plugin_state_live_state_projection, render_plugin_state,
     render_plugin_state_with_component_instance, retain_plugin_state_rows,
     retain_plugin_state_rows_for_schema_keys,
 };

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -20,11 +20,11 @@ use crate::live_state::MaterializedLiveStateRow;
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
 use crate::{GLOBAL_BRANCH_ID, LixError};
 
-use super::InstalledPlugin;
 use super::manifest::{
     PluginContentType, PluginManifest, PluginRuntime, parse_plugin_manifest_json,
 };
 use super::storage::{plugin_storage_archive_file_id, plugin_storage_archive_path};
+use super::{InstalledPlugin, InstalledPluginMetadata};
 
 pub(crate) const PLUGIN_REGISTRY_KEY: &str = "lix_plugin_registry_v1";
 pub(crate) const PLUGIN_OWNER_KEY: &str = "lix_plugin_owner_v1";
@@ -127,6 +127,17 @@ impl PluginRegistryEntry {
 
     pub(crate) fn archive_blob_hash(&self) -> &str {
         &self.archive_blob_hash
+    }
+
+    pub(crate) fn to_installed_plugin_metadata(&self) -> InstalledPluginMetadata {
+        InstalledPluginMetadata {
+            key: self.key.clone(),
+            archive_path: self.archive_path.clone(),
+            archive_blob_hash: self.archive_blob_hash.clone(),
+            path_glob: self.path_glob.clone(),
+            content_type: self.content_type,
+            schema_keys: self.schema_keys.clone(),
+        }
     }
 
     pub(crate) fn wasm_blob_hash(&self) -> &str {
@@ -480,7 +491,15 @@ impl PluginFileOwner {
             return Ok(None);
         }
         let snapshot = parse_snapshot_content(row, "plugin owner")?;
-        let value = decode_key_value_snapshot(&snapshot, PLUGIN_OWNER_KEY)?;
+        Self::from_snapshot(file_id, &snapshot).map(Some)
+    }
+
+    pub(crate) fn from_snapshot(
+        file_id: impl Into<String>,
+        snapshot: &JsonValue,
+    ) -> Result<Self, LixError> {
+        let file_id = file_id.into();
+        let value = decode_key_value_snapshot(snapshot, PLUGIN_OWNER_KEY)?;
         let owner_value: PluginFileOwnerValue =
             serde_json::from_value(value.clone()).map_err(|error| {
                 invalid_registry(format!(
@@ -493,11 +512,7 @@ impl PluginFileOwner {
                 owner_value.version
             )));
         }
-        Ok(Some(Self::new(
-            file_id,
-            owner_value.plugin_key,
-            owner_value.schema_keys,
-        )?))
+        Self::new(file_id, owner_value.plugin_key, owner_value.schema_keys)
     }
 
     pub(crate) fn write_row(&self, branch_id: &str) -> Result<TransactionWriteRow, LixError> {

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -579,6 +579,7 @@ where
 
     fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore> {
         HistoryQuerySource {
+            store: self.read_store.clone(),
             json_reader: JsonStoreContext::new().reader(self.read_store.clone()),
         }
     }

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -18,10 +18,8 @@ use crate::sql2::catalog::{
     schema_exposed_as_entity_surface,
 };
 use crate::sql2::history_route::{
-    HISTORY_COL_CHANGE_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
-    HISTORY_COL_FILE_ID, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
-    HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
-    HISTORY_COL_START_COMMIT_ID,
+    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
+    HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_SOURCE_CHANGES, HISTORY_COL_START_COMMIT_ID,
 };
 #[cfg(test)]
 use crate::sql2::result_metadata::json_field;
@@ -381,12 +379,7 @@ fn history_filesystem_schema(include_data: bool) -> SchemaRef {
     };
     fields.extend([
         json_field(HISTORY_COL_ENTITY_PK, false),
-        Field::new(HISTORY_COL_SCHEMA_KEY, DataType::Utf8, false),
-        Field::new(HISTORY_COL_FILE_ID, DataType::Utf8, true),
-        json_field(HISTORY_COL_SNAPSHOT_CONTENT, true),
-        Field::new(HISTORY_COL_CHANGE_ID, DataType::Utf8, false),
-        Field::new(HISTORY_COL_ORIGIN_KEY, DataType::Utf8, true),
-        json_field(HISTORY_COL_METADATA, true),
+        json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
         Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),
@@ -555,12 +548,7 @@ fn file_history_columns() -> Vec<PublicColumn> {
         "name",
         "data",
         HISTORY_COL_ENTITY_PK,
-        HISTORY_COL_SCHEMA_KEY,
-        HISTORY_COL_FILE_ID,
-        HISTORY_COL_SNAPSHOT_CONTENT,
-        HISTORY_COL_CHANGE_ID,
-        HISTORY_COL_ORIGIN_KEY,
-        HISTORY_COL_METADATA,
+        HISTORY_COL_SOURCE_CHANGES,
         HISTORY_COL_OBSERVED_COMMIT_ID,
         HISTORY_COL_COMMIT_CREATED_AT,
         HISTORY_COL_START_COMMIT_ID,
@@ -575,12 +563,7 @@ fn directory_history_columns() -> Vec<PublicColumn> {
         "parent_id",
         "name",
         HISTORY_COL_ENTITY_PK,
-        HISTORY_COL_SCHEMA_KEY,
-        HISTORY_COL_FILE_ID,
-        HISTORY_COL_SNAPSHOT_CONTENT,
-        HISTORY_COL_CHANGE_ID,
-        HISTORY_COL_ORIGIN_KEY,
-        HISTORY_COL_METADATA,
+        HISTORY_COL_SOURCE_CHANGES,
         HISTORY_COL_OBSERVED_COMMIT_ID,
         HISTORY_COL_COMMIT_CREATED_AT,
         HISTORY_COL_START_COMMIT_ID,

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -33,6 +33,7 @@ pub(crate) type SqlJsonReader<S> = JsonStoreReader<S>;
 
 #[derive(Clone)]
 pub(crate) struct HistoryQuerySource<S> {
+    pub(crate) store: S,
     pub(crate) json_reader: JsonStoreReader<S>,
 }
 

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1906,6 +1906,7 @@ mod tests {
             let storage = StorageAdapter::new(Memory::new());
             let read_scope = SharedStorageAdapterRead::new(test_read_scope(&storage));
             HistoryQuerySource {
+                store: read_scope.clone(),
                 json_reader: JsonStoreContext::new().reader(read_scope),
             }
         }

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -149,11 +149,78 @@ pub(crate) const HISTORY_COL_FILE_ID: &str = "lixcol_file_id";
 pub(crate) const HISTORY_COL_SNAPSHOT_CONTENT: &str = "lixcol_snapshot_content";
 pub(crate) const HISTORY_COL_METADATA: &str = "lixcol_metadata";
 pub(crate) const HISTORY_COL_CHANGE_ID: &str = "lixcol_change_id";
+pub(crate) const HISTORY_COL_SOURCE_CHANGES: &str = "lixcol_source_changes";
 pub(crate) const HISTORY_COL_ORIGIN_KEY: &str = "lixcol_origin_key";
 pub(crate) const HISTORY_COL_OBSERVED_COMMIT_ID: &str = "lixcol_observed_commit_id";
 pub(crate) const HISTORY_COL_COMMIT_CREATED_AT: &str = "lixcol_commit_created_at";
 pub(crate) const HISTORY_COL_START_COMMIT_ID: &str = "lixcol_start_commit_id";
 pub(crate) const HISTORY_COL_DEPTH: &str = "lixcol_depth";
+
+/// Serializes the deterministic provenance set for one composed history row.
+///
+/// The array is sorted by change id by the composed provider. Each object
+/// deliberately mirrors `lix_change` so callers can join or inspect raw
+/// provenance without pretending that one source change owns a composed row.
+pub(crate) fn serialize_history_source_changes(
+    changes: &[MaterializedChange],
+    surface_name: &str,
+) -> Result<String, LixError> {
+    let mut ordered_changes = changes.iter().collect::<Vec<_>>();
+    ordered_changes.sort_by(|left, right| left.id.cmp(&right.id));
+    let source_changes = ordered_changes
+        .into_iter()
+        .map(|change| {
+            let entity_pk =
+                serde_json::from_str::<serde_json::Value>(&change.entity_pk.as_json_array_text()?)
+                    .map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!("{surface_name} source entity_pk is invalid JSON: {error}"),
+                        )
+                    })?;
+            let snapshot_content = parse_optional_source_json(
+                change.snapshot_content.as_deref(),
+                surface_name,
+                "snapshot_content",
+            )?;
+            let metadata =
+                parse_optional_source_json(change.metadata.as_deref(), surface_name, "metadata")?;
+            Ok(serde_json::json!({
+                "id": change.id,
+                "entity_pk": entity_pk,
+                "schema_key": change.schema_key,
+                "file_id": change.file_id,
+                "snapshot_content": snapshot_content,
+                "metadata": metadata,
+                "created_at": change.created_at,
+                "origin_key": change.origin_key,
+            }))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    serde_json::to_string(&source_changes).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to serialize {surface_name} source changes: {error}"),
+        )
+    })
+}
+
+fn parse_optional_source_json(
+    value: Option<&str>,
+    surface_name: &str,
+    field: &str,
+) -> Result<Option<serde_json::Value>, LixError> {
+    value
+        .map(|value| {
+            serde_json::from_str(value).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("{surface_name} source {field} is invalid JSON: {error}"),
+                )
+            })
+        })
+        .transpose()
+}
 
 pub(crate) struct HistoryViewDescriptor<'a> {
     pub(crate) view_name: &'a str,
@@ -197,21 +264,6 @@ impl HistoryMetadataProjection {
     fn commit_created_at(self) -> bool {
         self.commit_created_at
     }
-}
-
-/// Shaped history views expose delete events as tombstone rows.
-///
-/// If the current event is the descriptor tombstone itself, the provider must
-/// use that tombstone row instead of looking through to an earlier live
-/// descriptor. This keeps one contract across typed entity, file, directory,
-/// and state history: `snapshot_content IS NULL` means projected user/domain
-/// columns are NULL while metadata columns still identify the event.
-pub(crate) fn history_descriptor_event_matches(
-    descriptor_entry: &HistoryEntry,
-    event_depth: u32,
-    event_change_id: &str,
-) -> bool {
-    descriptor_entry.depth == event_depth && descriptor_entry.change.id == event_change_id
 }
 
 pub(crate) fn parse_history_filter(expr: &Expr, column_style: HistoryColumnStyle) -> Option<()> {

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(test)]
 use std::future::Future;
 use std::sync::Arc;
 
@@ -13,7 +14,9 @@ use tokio::sync::Mutex;
 
 use crate::LixError;
 use crate::commit_graph::CommitGraphReader;
-use crate::serialize_row_metadata;
+use crate::tracked_state::{
+    MaterializedTrackedStateRow, TrackedStateContext, TrackedStateFilter, TrackedStateScanRequest,
+};
 
 use crate::sql2::SqlHistoryQuerySource;
 use crate::sql2::WriteAccess;
@@ -21,12 +24,11 @@ use crate::sql2::change_materialization::MaterializedChange;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
 use crate::sql2::history_route::{
-    HISTORY_COL_CHANGE_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
-    HISTORY_COL_FILE_ID, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
-    HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
-    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection,
-    HistoryRoute, HistoryViewDescriptor, history_descriptor_event_matches, load_history_entries,
-    parse_history_filter,
+    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
+    HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_SOURCE_CHANGES, HISTORY_COL_START_COMMIT_ID,
+    HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
+    HistoryViewDescriptor, load_history_entries, parse_history_filter,
+    serialize_history_source_changes,
 };
 use crate::sql2::providers::filesystem_history_path::{
     HistoryDirectoryPathRecord, resolve_history_directory_path,
@@ -171,7 +173,6 @@ struct DirectoryHistoryOutputRow {
     path: Option<String>,
     parent_id: Option<String>,
     name: Option<String>,
-    descriptor_change: MaterializedChange,
     event: DirectoryHistoryEvent,
 }
 
@@ -180,7 +181,7 @@ struct DirectoryHistoryEvent {
     directory_id: String,
     start_commit_id: String,
     depth: u32,
-    change: MaterializedChange,
+    source_changes: Vec<MaterializedChange>,
     observed_commit_id: String,
     commit_created_at: String,
 }
@@ -202,42 +203,50 @@ where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     let event_route = route.traversal_only();
-    let context_route = route.starts_only();
-    let (event_entries, context_entries) =
-        load_directory_history_entry_sets(&event_route, &context_route, move |route| {
-            let commit_graph = Arc::clone(&commit_graph);
-            let json_reader = query_source.json_reader.clone();
-            async move {
-                load_history_entries(
-                    HistoryViewDescriptor {
-                        view_name: "lix_directory_history",
-                        start_commit_column: HISTORY_COL_START_COMMIT_ID,
-                    },
-                    commit_graph,
-                    json_reader,
-                    &route,
-                    vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
-                    metadata_projection,
-                )
-                .await
-            }
-        })
-        .await?;
+    let event_entries = load_history_entries(
+        HistoryViewDescriptor {
+            view_name: "lix_directory_history",
+            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+        },
+        commit_graph,
+        query_source.json_reader.clone(),
+        &event_route,
+        vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+        metadata_projection,
+    )
+    .await?;
     let event_descriptors = parse_directory_history_records(&event_entries)?;
-    let descriptors = parse_directory_history_records(&context_entries)?;
+    let events = grouped_directory_history_events(&event_descriptors);
+    let observed_commit_ids = events
+        .iter()
+        .map(|event| event.observed_commit_id.clone())
+        .collect::<BTreeSet<_>>();
+    let observed_states =
+        load_directory_history_observed_states(query_source, observed_commit_ids).await?;
     let mut output = Vec::new();
 
-    for descriptor in &event_descriptors {
-        let event = directory_history_event_from_entry(&descriptor.id, &descriptor.entry);
-        let Some(visible_descriptor) = nearest_directory_descriptor(&descriptors, &event) else {
+    for event in events {
+        let Some(descriptors) = observed_states.get(&event.observed_commit_id) else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "lix_directory_history did not load observed commit '{}'",
+                    event.observed_commit_id
+                ),
+            ));
+        };
+        let Some(visible_descriptor) = descriptors
+            .iter()
+            .find(|descriptor| descriptor.id == event.directory_id)
+        else {
             continue;
         };
         let path = if visible_descriptor.name.is_some() {
             resolve_history_directory_path(
                 &visible_descriptor.id,
-                &event.start_commit_id,
-                event.depth,
-                &descriptors,
+                &event.observed_commit_id,
+                0,
+                descriptors,
                 &mut BTreeMap::new(),
                 &mut BTreeSet::new(),
             )
@@ -257,7 +266,6 @@ where
             path,
             parent_id: visible_descriptor.parent_id.clone(),
             name: visible_descriptor.name.clone(),
-            descriptor_change: visible_descriptor.entry.change.clone(),
             event,
         });
     }
@@ -281,11 +289,11 @@ where
                     .observed_commit_id
                     .cmp(&right.event.observed_commit_id),
             )
-            .then(left.event.change.id.cmp(&right.event.change.id))
     });
     Ok(output)
 }
 
+#[cfg(test)]
 async fn load_directory_history_entry_sets<Load, LoadFuture>(
     event_route: &HistoryRoute,
     context_route: &HistoryRoute,
@@ -302,6 +310,66 @@ where
         load(context_route.clone()).await?
     };
     Ok((event_entries, context_entries))
+}
+
+async fn load_directory_history_observed_states<S>(
+    query_source: SqlHistoryQuerySource<S>,
+    observed_commit_ids: BTreeSet<String>,
+) -> Result<BTreeMap<String, Vec<DirectoryHistoryRecord>>, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    // Equal-depth commits can be siblings. Resolve the directory projection
+    // from the observed commit's root so no sibling descriptor can leak into
+    // the row merely because it has the same traversal depth.
+    let mut reader = TrackedStateContext::new().reader(query_source.store);
+    let mut states = BTreeMap::new();
+    for observed_commit_id in observed_commit_ids {
+        let rows = reader
+            .scan_rows_at_commit(
+                &observed_commit_id,
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
+                        schema_keys: vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+                        include_tombstones: true,
+                        ..TrackedStateFilter::default()
+                    },
+                    ..TrackedStateScanRequest::default()
+                },
+            )
+            .await?;
+        let entries = rows
+            .into_iter()
+            .map(|row| directory_history_entry_from_observed_state(row, &observed_commit_id))
+            .collect::<Vec<_>>();
+        states.insert(
+            observed_commit_id,
+            parse_directory_history_records(&entries)?,
+        );
+    }
+    Ok(states)
+}
+
+fn directory_history_entry_from_observed_state(
+    row: MaterializedTrackedStateRow,
+    observed_commit_id: &str,
+) -> HistoryEntry {
+    HistoryEntry {
+        change: MaterializedChange {
+            id: row.change_id.to_string(),
+            entity_pk: row.entity_pk,
+            schema_key: row.schema_key,
+            file_id: row.file_id,
+            snapshot_content: row.snapshot_content,
+            metadata: row.metadata,
+            created_at: row.updated_at.clone(),
+            origin_key: None,
+        },
+        observed_commit_id: observed_commit_id.to_string(),
+        commit_created_at: row.updated_at,
+        start_commit_id: observed_commit_id.to_string(),
+        depth: 0,
+    }
 }
 
 fn parse_directory_history_records(
@@ -336,6 +404,52 @@ fn parse_directory_history_records(
         .collect()
 }
 
+fn grouped_directory_history_events(
+    descriptors: &[DirectoryHistoryRecord],
+) -> Vec<DirectoryHistoryEvent> {
+    let mut grouped = BTreeMap::<(String, String, String), DirectoryHistoryEvent>::new();
+    for descriptor in descriptors {
+        let mut event = directory_history_event_from_entry(&descriptor.id, &descriptor.entry);
+        let key = (
+            event.directory_id.clone(),
+            event.start_commit_id.clone(),
+            event.observed_commit_id.clone(),
+        );
+        match grouped.entry(key) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(event);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                let grouped_event = entry.get_mut();
+                debug_assert_eq!(grouped_event.depth, event.depth);
+                // When commit metadata is not projected, history loading uses
+                // each source change's timestamp as an intentionally unused
+                // fallback. Those timestamps may differ within one commit.
+                grouped_event
+                    .source_changes
+                    .append(&mut event.source_changes);
+            }
+        }
+    }
+    let mut events = grouped.into_values().collect::<Vec<_>>();
+    for event in &mut events {
+        event
+            .source_changes
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        event
+            .source_changes
+            .dedup_by(|left, right| left.id == right.id);
+    }
+    events.sort_by(|left, right| {
+        left.directory_id
+            .cmp(&right.directory_id)
+            .then(left.start_commit_id.cmp(&right.start_commit_id))
+            .then(left.depth.cmp(&right.depth))
+            .then(left.observed_commit_id.cmp(&right.observed_commit_id))
+    });
+    events
+}
+
 fn directory_history_event_from_entry(
     directory_id: &str,
     entry: &HistoryEntry,
@@ -344,32 +458,10 @@ fn directory_history_event_from_entry(
         directory_id: directory_id.to_string(),
         start_commit_id: entry.start_commit_id.clone(),
         depth: entry.depth,
-        change: entry.change.clone(),
+        source_changes: vec![entry.change.clone()],
         observed_commit_id: entry.observed_commit_id.clone(),
         commit_created_at: entry.commit_created_at.clone(),
     }
-}
-
-fn nearest_directory_descriptor<'a>(
-    descriptors: &'a [DirectoryHistoryRecord],
-    event: &DirectoryHistoryEvent,
-) -> Option<&'a DirectoryHistoryRecord> {
-    descriptors
-        .iter()
-        .filter(|descriptor| {
-            let exact_descriptor_event =
-                history_descriptor_event_matches(&descriptor.entry, event.depth, &event.change.id);
-            (exact_descriptor_event || descriptor.name.is_some())
-                && descriptor.id == event.directory_id
-                && descriptor.entry.start_commit_id == event.start_commit_id
-                && descriptor.entry.depth >= event.depth
-        })
-        .min_by(|left, right| {
-            left.entry
-                .depth
-                .cmp(&right.entry.depth)
-                .then(left.entry.change.id.cmp(&right.entry.change.id))
-        })
 }
 
 static LIX_DIRECTORY_HISTORY_COLS: ColumnTable<DirectoryHistoryOutputRow> = ColumnTable {
@@ -383,29 +475,10 @@ static LIX_DIRECTORY_HISTORY_COLS: ColumnTable<DirectoryHistoryOutputRow> = Colu
             Col::Utf8Fallible(|row| entity_pk_json_array(&row.entity_pk).map(Some)),
         ),
         (
-            HISTORY_COL_SCHEMA_KEY,
-            Col::Utf8(|_row| Some(DIRECTORY_DESCRIPTOR_SCHEMA_KEY)),
-        ),
-        (HISTORY_COL_FILE_ID, Col::Utf8(|_row| None)),
-        (
-            HISTORY_COL_CHANGE_ID,
-            Col::Utf8(|row| Some(row.event.change.id.as_str())),
-        ),
-        (
-            HISTORY_COL_ORIGIN_KEY,
-            Col::Utf8(|row| row.event.change.origin_key.as_deref()),
-        ),
-        (
-            HISTORY_COL_SNAPSHOT_CONTENT,
-            Col::Utf8(|row| row.descriptor_change.snapshot_content.as_deref()),
-        ),
-        (
-            HISTORY_COL_METADATA,
-            Col::Utf8Owned(|row| {
-                row.descriptor_change
-                    .metadata
-                    .as_deref()
-                    .map(serialize_row_metadata)
+            HISTORY_COL_SOURCE_CHANGES,
+            Col::Utf8Fallible(|row| {
+                serialize_history_source_changes(&row.event.source_changes, "lix_directory_history")
+                    .map(Some)
             }),
         ),
         (
@@ -450,12 +523,7 @@ pub(super) fn lix_directory_history_schema() -> SchemaRef {
         Field::new("parent_id", DataType::Utf8, true),
         Field::new("name", DataType::Utf8, true),
         json_field(HISTORY_COL_ENTITY_PK, false),
-        Field::new(HISTORY_COL_SCHEMA_KEY, DataType::Utf8, false),
-        Field::new(HISTORY_COL_FILE_ID, DataType::Utf8, true),
-        json_field(HISTORY_COL_SNAPSHOT_CONTENT, true),
-        Field::new(HISTORY_COL_CHANGE_ID, DataType::Utf8, false),
-        Field::new(HISTORY_COL_ORIGIN_KEY, DataType::Utf8, true),
-        json_field(HISTORY_COL_METADATA, true),
+        json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
         Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -12,33 +12,34 @@ use datafusion::logical_expr::{BinaryExpr, Expr, Operator, TableProviderFilterPu
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
-use crate::GLOBAL_BRANCH_ID;
-use crate::LixError;
+use crate::NullableKeyFilter;
 use crate::binary_cas::{BlobDataReader, BlobHash};
+use crate::changelog::CommitId;
 use crate::commit_graph::CommitGraphReader;
 use crate::common::compose_file_path;
-use crate::filesystem::FilesystemIndex;
+use crate::entity_pk::EntityPk;
 use crate::live_state::MaterializedLiveStateRow;
 use crate::plugin::{
-    InstalledPlugin, InstalledPluginMetadata, PluginContentType, PluginRuntimeHost,
-    load_installed_plugin_from_archive_bytes, load_installed_plugin_metadata_from_archive_bytes,
-    plugin_key_from_archive_path, render_materialized_plugin_file, retain_plugin_state_rows,
-    select_best_glob_match,
+    InstalledPlugin, InstalledPluginMetadata, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY,
+    PluginFileOwner, PluginRegistry, PluginRuntimeHost, load_installed_plugin_from_archive_bytes,
+    render_plugin_state, retain_plugin_state_rows,
 };
-use crate::schema::is_seed_schema_key;
-use crate::serialize_row_metadata;
+use crate::tracked_state::{
+    MaterializedTrackedStateRow, TrackedStateContext, TrackedStateFilter, TrackedStateReadColumns,
+    TrackedStateScanRequest, TrackedStateStoreReader,
+};
+use crate::{GLOBAL_BRANCH_ID, LixError};
 
 use crate::sql2::SqlHistoryQuerySource;
 use crate::sql2::WriteAccess;
 use crate::sql2::change_materialization::MaterializedChange;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
 use crate::sql2::history_route::{
-    HISTORY_COL_CHANGE_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
-    HISTORY_COL_FILE_ID, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
-    HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
-    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection,
-    HistoryRoute, HistoryViewDescriptor, history_descriptor_event_matches, load_history_entries,
-    parse_history_filter,
+    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
+    HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_SOURCE_CHANGES, HISTORY_COL_START_COMMIT_ID,
+    HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
+    HistoryViewDescriptor, load_history_entries, parse_history_filter,
+    serialize_history_source_changes,
 };
 use crate::sql2::providers::filesystem_history_path::{
     HistoryDirectoryPathRecord, resolve_history_directory_path,
@@ -53,7 +54,7 @@ use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table,
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 const BLOB_REF_SCHEMA_KEY: &str = "lix_binary_blob_ref";
-const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
+const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 
 pub(super) async fn register_lix_file_history_surface<S>(
     session: &datafusion::prelude::SessionContext,
@@ -246,12 +247,18 @@ struct FileHistoryPluginStateRecord {
 }
 
 #[derive(Debug, Clone)]
+struct FileHistoryPluginOwnerRecord {
+    file_id: String,
+    owner: Option<PluginFileOwner>,
+    entry: HistoryEntry,
+}
+
+#[derive(Debug, Clone)]
 struct FileHistoryEvent {
     file_id: String,
     start_commit_id: String,
     depth: u32,
-    priority: u8,
-    change: MaterializedChange,
+    source_changes: Vec<MaterializedChange>,
     observed_commit_id: String,
     commit_created_at: String,
 }
@@ -264,7 +271,6 @@ struct FileHistoryOutputRow {
     directory_id: Option<String>,
     name: Option<String>,
     data: Option<Vec<u8>>,
-    descriptor_change: MaterializedChange,
     event: FileHistoryEvent,
 }
 
@@ -453,8 +459,22 @@ struct FileHistoryFilesystemContext {
     event_directories: Vec<FileHistoryDirectoryRecord>,
     event_blobs: Vec<FileHistoryBlobRecord>,
     descriptors: Vec<FileHistoryDescriptorRecord>,
+}
+
+struct FileHistoryObservedState {
+    descriptors: Vec<FileHistoryDescriptorRecord>,
     directories: Vec<FileHistoryDirectoryRecord>,
     blobs: Vec<FileHistoryBlobRecord>,
+    plugin_state: Vec<FileHistoryPluginStateRecord>,
+    plugin_owners: Vec<FileHistoryPluginOwnerRecord>,
+    plugin_registry: PluginRegistry,
+}
+
+struct FileHistoryPluginDiscovery {
+    schema_keys: Vec<String>,
+    registries_by_commit: BTreeMap<String, PluginRegistry>,
+    parent_commit_ids_by_commit: BTreeMap<String, Vec<String>>,
+    registry_events: Vec<HistoryEntry>,
 }
 
 async fn load_file_history_rows<S>(
@@ -482,29 +502,6 @@ where
 
     let event_route = route.traversal_only();
     let context_route = route.starts_only();
-    // Plugins can materialize file history from state rather than a blob. A
-    // plugin install always registers at least one non-seed schema, so retain
-    // the complete filesystem traversal whenever reachable history contains
-    // one. The common no-plugin workspace can safely narrow descriptor/blob
-    // history to the exact public file IDs while retaining all directories for
-    // historical path and rename reconstruction.
-    let lookup_ids = if let Some(lookup_ids) = lookup_ids {
-        match history_contains_non_seed_registered_schema(
-            Arc::clone(&commit_graph),
-            query_source.clone(),
-            &context_route,
-        )
-        .await
-        {
-            Ok(false) => Some(lookup_ids),
-            // If this proof cannot be completed, preserve the established
-            // complete traversal rather than introducing a new query error or
-            // risking skipped plugin materialization.
-            Ok(true) | Err(_) => None,
-        }
-    } else {
-        None
-    };
     let filesystem_context = load_file_history_filesystem_context(
         Arc::clone(&commit_graph),
         query_source.clone(),
@@ -514,61 +511,108 @@ where
         metadata_projection,
     )
     .await?;
-    let mut installed_plugins_cache = BTreeMap::<(String, u32, String), InstalledPlugin>::new();
-    let mut installed_plugin_metadata_cache =
-        BTreeMap::<(String, u32), Vec<InstalledPluginMetadata>>::new();
-    let events = file_history_events(
+    let mut installed_plugins_cache = BTreeMap::<(String, String), InstalledPlugin>::new();
+    let filesystem_events = file_history_events(
         &filesystem_context.event_descriptors,
         &filesystem_context.event_directories,
         &filesystem_context.event_blobs,
         &filesystem_context.descriptors,
     );
-    let (mut event_plugin_state, plugin_state) = if lookup_ids.is_some() {
-        (Vec::new(), Vec::new())
-    } else {
-        let plugin_schema_keys = discover_file_history_plugin_schema_keys(
-            blob_reader,
-            &mut installed_plugin_metadata_cache,
-            &filesystem_context,
-            &events,
-            public_predicate,
-        )
-        .await?;
-        if plugin_schema_keys.is_empty() {
-            (Vec::new(), Vec::new())
-        } else {
-            load_file_history_plugin_state(
-                commit_graph,
-                query_source,
-                &event_route,
-                &context_route,
-                plugin_schema_keys,
-                metadata_projection,
-            )
-            .await?
-        }
-    };
-    retain_matching_plugin_events(
-        &mut event_plugin_state,
-        &filesystem_context.descriptors,
-        &filesystem_context.directories,
-        public_predicate,
-    );
-    cache_installed_plugins_for_plugin_state_depths(
-        blob_reader,
-        &mut installed_plugin_metadata_cache,
-        &filesystem_context,
-        &event_plugin_state,
+    let plugin_discovery = discover_file_history_plugins(
+        Arc::clone(&commit_graph),
+        query_source.clone(),
+        &event_route,
+        &context_route,
+        metadata_projection,
     )
     .await?;
-    let plugin_events = file_history_plugin_events(
-        &installed_plugin_metadata_cache,
+    let plugin_schema_keys = plugin_discovery.schema_keys.clone();
+    let event_plugin_state = if plugin_schema_keys.is_empty() {
+        Vec::new()
+    } else {
+        let (events, _) = load_file_history_plugin_state(
+            Arc::clone(&commit_graph),
+            query_source.clone(),
+            &event_route,
+            &context_route,
+            plugin_schema_keys.clone(),
+            lookup_ids,
+            metadata_projection,
+        )
+        .await?;
+        events
+    };
+    let event_plugin_owners = load_file_history_plugin_owner_events(
+        Arc::clone(&commit_graph),
+        query_source.clone(),
+        &event_route,
+        lookup_ids,
+        metadata_projection,
+    )
+    .await?;
+    // Ownership replacement and deletion can tombstone the prior owner's
+    // plugin state in the same commit. The exact observed root contains only
+    // the new owner (or its tombstone), so retain direct-parent roots as the
+    // ownership evidence for those cleanup changes.
+    let owner_change_parent_commit_ids = event_plugin_owners.iter().flat_map(|record| {
+        plugin_discovery
+            .parent_commit_ids_by_commit
+            .get(&record.entry.observed_commit_id)
+            .into_iter()
+            .flatten()
+            .cloned()
+    });
+    let observed_commit_ids = filesystem_events
+        .iter()
+        .map(|event| event.observed_commit_id.clone())
+        .chain(
+            event_plugin_state
+                .iter()
+                .map(|record| record.entry.observed_commit_id.clone()),
+        )
+        .chain(
+            event_plugin_owners
+                .iter()
+                .map(|record| record.entry.observed_commit_id.clone()),
+        )
+        .chain(
+            plugin_discovery
+                .registry_events
+                .iter()
+                .map(|entry| entry.observed_commit_id.clone()),
+        )
+        .chain(owner_change_parent_commit_ids)
+        .collect::<BTreeSet<_>>();
+    let observed_states = load_file_history_observed_states(
+        query_source,
+        observed_commit_ids,
+        plugin_schema_keys,
+        lookup_ids,
+    )
+    .await?;
+    let plugin_state_events = file_history_plugin_events(
         &event_plugin_state,
-        &filesystem_context.descriptors,
-        &filesystem_context.directories,
+        &event_plugin_owners,
+        &observed_states,
+        &plugin_discovery.parent_commit_ids_by_commit,
     );
-    let events = sorted_deduped_file_history_events(events.into_iter().chain(plugin_events));
-    let prepared = prepare_file_history_rows(&filesystem_context, events, route, public_predicate)?;
+    let plugin_owner_events = event_plugin_owners
+        .iter()
+        .map(|record| file_history_event_from_entry(record.file_id.clone(), &record.entry));
+    let plugin_registry_events = file_history_plugin_registry_events(
+        &plugin_discovery.registry_events,
+        &observed_states,
+        &plugin_discovery.registries_by_commit,
+        &plugin_discovery.parent_commit_ids_by_commit,
+    )?;
+    let events = sorted_grouped_file_history_events(
+        filesystem_events
+            .into_iter()
+            .chain(plugin_state_events)
+            .chain(plugin_owner_events)
+            .chain(plugin_registry_events),
+    );
+    let prepared = prepare_file_history_rows(&observed_states, events, route, public_predicate)?;
     let blob_bytes = if needs_data {
         load_file_history_blob_bytes(blob_reader, &prepared).await?
     } else {
@@ -586,8 +630,7 @@ where
                             &plugin_host,
                             blob_reader,
                             &mut installed_plugins_cache,
-                            &installed_plugin_metadata_cache,
-                            &plugin_state,
+                            &observed_states,
                             &prepared_row.descriptor,
                             &prepared_row.event,
                             path,
@@ -609,7 +652,6 @@ where
             directory_id: prepared_row.descriptor.directory_id.clone(),
             name: prepared_row.descriptor.name.clone(),
             data,
-            descriptor_change: prepared_row.descriptor.entry.change.clone(),
             event: prepared_row.event,
         });
     }
@@ -624,25 +666,38 @@ where
                     .observed_commit_id
                     .cmp(&right.event.observed_commit_id),
             )
-            .then(left.event.change.id.cmp(&right.event.change.id))
     });
     Ok(output)
 }
 
 fn prepare_file_history_rows(
-    filesystem_context: &FileHistoryFilesystemContext,
+    observed_states: &BTreeMap<String, FileHistoryObservedState>,
     events: Vec<FileHistoryEvent>,
     route: &HistoryRoute,
     public_predicate: &FileHistoryPublicPredicate,
 ) -> Result<Vec<PreparedFileHistoryRow>, LixError> {
     let mut prepared = Vec::new();
     for event in events {
-        let Some(descriptor) = nearest_file_descriptor(&filesystem_context.descriptors, &event)
+        let Some(state) = observed_states.get(&event.observed_commit_id) else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "lix_file_history did not load observed commit '{}'",
+                    event.observed_commit_id
+                ),
+            ));
+        };
+        let Some(descriptor) = state
+            .descriptors
+            .iter()
+            .find(|descriptor| descriptor.id == event.file_id)
         else {
             continue;
         };
-        let path =
-            resolve_file_history_path(descriptor, &filesystem_context.directories, event.depth);
+        if !file_history_event_affects_observed_file(&event, descriptor) {
+            continue;
+        }
+        let path = resolve_file_history_path(descriptor, &state.directories, 0);
         let id = tombstone_identity_column_value(
             "id",
             &descriptor.id,
@@ -666,7 +721,10 @@ fn prepare_file_history_rows(
             id,
             path,
             descriptor: descriptor.clone(),
-            blob_hash: nearest_blob_ref(&filesystem_context.blobs, &event)
+            blob_hash: state
+                .blobs
+                .iter()
+                .find(|blob| blob.file_id == event.file_id)
                 .and_then(|blob| blob.blob_hash.clone()),
             event,
         });
@@ -748,38 +806,314 @@ where
         event_directories: parse_file_history_directories(&event_entries)?,
         event_blobs: parse_file_history_blobs(&event_entries)?,
         descriptors: parse_file_history_descriptors(&context_entries)?,
-        directories: parse_file_history_directories(&context_entries)?,
-        blobs: parse_file_history_blobs(&context_entries)?,
     })
 }
 
-async fn history_contains_non_seed_registered_schema<S>(
-    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+async fn load_file_history_observed_states<S>(
     query_source: SqlHistoryQuerySource<S>,
-    route: &HistoryRoute,
-) -> Result<bool, LixError>
+    observed_commit_ids: BTreeSet<String>,
+    plugin_schema_keys: Vec<String>,
+    lookup_ids: Option<&FileHistoryLookupIds>,
+) -> Result<BTreeMap<String, FileHistoryObservedState>, LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
-    let entries = load_history_entries(
-        HistoryViewDescriptor {
-            view_name: "lix_file_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
-        },
-        commit_graph,
-        query_source.json_reader,
-        route,
-        vec![REGISTERED_SCHEMA_KEY.to_string()],
-        HistoryMetadataProjection::default(),
+    // Traversal depth is only a distance from the requested start commit. In a
+    // DAG, an equal-depth row may belong to a sibling and must not shape this
+    // revision. Commit roots are the canonical state as of each observed
+    // commit, so use them directly instead of inferring ancestry from depth.
+    let mut reader = TrackedStateContext::new().reader(query_source.store);
+    let mut states = BTreeMap::new();
+    for observed_commit_id in observed_commit_ids {
+        let state = load_file_history_observed_state(
+            &mut reader,
+            &observed_commit_id,
+            &plugin_schema_keys,
+            lookup_ids,
+        )
+        .await?;
+        states.insert(observed_commit_id, state);
+    }
+    Ok(states)
+}
+
+async fn load_file_history_observed_state<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    observed_commit_id: &str,
+    plugin_schema_keys: &[String],
+    lookup_ids: Option<&FileHistoryLookupIds>,
+) -> Result<FileHistoryObservedState, LixError>
+where
+    S: StorageAdapterRead,
+{
+    let plugin_registry =
+        load_plugin_registry_at_observed_commit(reader, observed_commit_id).await?;
+    let plugin_owner_entries = load_file_history_plugin_owner_entries_at_observed_commit(
+        reader,
+        observed_commit_id,
+        lookup_ids,
     )
     .await?;
-    Ok(entries.iter().any(|entry| {
-        entry
-            .change
-            .entity_pk
-            .as_single_string_owned()
-            .map_or(true, |schema_key| !is_seed_schema_key(&schema_key))
-    }))
+    let entries = if let Some(lookup_ids) = lookup_ids {
+        load_selected_file_history_observed_entries(
+            reader,
+            observed_commit_id,
+            plugin_schema_keys,
+            lookup_ids,
+        )
+        .await?
+    } else {
+        let mut schema_keys = file_history_filesystem_schema_keys();
+        schema_keys.extend(plugin_schema_keys.iter().cloned());
+        scan_file_history_observed_entries(
+            reader,
+            observed_commit_id,
+            TrackedStateFilter {
+                schema_keys,
+                include_tombstones: true,
+                ..TrackedStateFilter::default()
+            },
+        )
+        .await?
+    };
+    Ok(FileHistoryObservedState {
+        descriptors: parse_file_history_descriptors(&entries)?,
+        directories: parse_file_history_directories(&entries)?,
+        blobs: parse_file_history_blobs(&entries)?,
+        plugin_state: parse_file_history_plugin_state(&entries),
+        plugin_owners: parse_file_history_plugin_owners(&plugin_owner_entries)?,
+        plugin_registry,
+    })
+}
+
+async fn load_file_history_plugin_owner_entries_at_observed_commit<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    observed_commit_id: &str,
+    lookup_ids: Option<&FileHistoryLookupIds>,
+) -> Result<Vec<HistoryEntry>, LixError>
+where
+    S: StorageAdapterRead,
+{
+    scan_file_history_observed_entries(
+        reader,
+        observed_commit_id,
+        TrackedStateFilter {
+            schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
+            entity_pks: vec![EntityPk::single(PLUGIN_OWNER_KEY)],
+            file_ids: lookup_ids
+                .map(|lookup_ids| {
+                    lookup_ids
+                        .0
+                        .iter()
+                        .cloned()
+                        .map(NullableKeyFilter::Value)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            include_tombstones: true,
+        },
+    )
+    .await
+}
+
+async fn load_selected_file_history_observed_entries<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    observed_commit_id: &str,
+    plugin_schema_keys: &[String],
+    lookup_ids: &FileHistoryLookupIds,
+) -> Result<Vec<HistoryEntry>, LixError>
+where
+    S: StorageAdapterRead,
+{
+    let entity_pks = lookup_ids
+        .0
+        .iter()
+        .map(EntityPk::single)
+        .collect::<Vec<_>>();
+    let file_ids = selected_file_id_filters(lookup_ids);
+    let mut entries = scan_file_history_observed_entries(
+        reader,
+        observed_commit_id,
+        TrackedStateFilter {
+            schema_keys: vec![
+                FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                BLOB_REF_SCHEMA_KEY.to_string(),
+            ],
+            entity_pks,
+            file_ids: file_ids.clone(),
+            include_tombstones: true,
+        },
+    )
+    .await?;
+    let descriptors = parse_file_history_descriptors(&entries)?;
+    entries.extend(
+        load_file_history_ancestor_directory_entries(
+            reader,
+            observed_commit_id,
+            &descriptors,
+            file_ids.clone(),
+        )
+        .await?,
+    );
+    if !plugin_schema_keys.is_empty() {
+        entries.extend(
+            scan_file_history_observed_entries(
+                reader,
+                observed_commit_id,
+                TrackedStateFilter {
+                    schema_keys: plugin_schema_keys.to_vec(),
+                    file_ids,
+                    include_tombstones: true,
+                    ..TrackedStateFilter::default()
+                },
+            )
+            .await?,
+        );
+    }
+    Ok(entries)
+}
+
+fn selected_file_id_filters(lookup_ids: &FileHistoryLookupIds) -> Vec<NullableKeyFilter<String>> {
+    std::iter::once(NullableKeyFilter::Null)
+        .chain(lookup_ids.0.iter().cloned().map(NullableKeyFilter::Value))
+        .collect()
+}
+
+async fn load_file_history_ancestor_directory_entries<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    observed_commit_id: &str,
+    descriptors: &[FileHistoryDescriptorRecord],
+    file_ids: Vec<NullableKeyFilter<String>>,
+) -> Result<Vec<HistoryEntry>, LixError>
+where
+    S: StorageAdapterRead,
+{
+    let mut pending = descriptors
+        .iter()
+        .filter_map(|descriptor| descriptor.directory_id.clone())
+        .collect::<BTreeSet<_>>();
+    let mut requested = BTreeSet::new();
+    let mut entries = Vec::new();
+    while !pending.is_empty() {
+        let ids = std::mem::take(&mut pending)
+            .into_iter()
+            .filter(|id| requested.insert(id.clone()))
+            .collect::<Vec<_>>();
+        if ids.is_empty() {
+            break;
+        }
+        let loaded = scan_file_history_observed_entries(
+            reader,
+            observed_commit_id,
+            TrackedStateFilter {
+                schema_keys: vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+                entity_pks: ids.iter().map(EntityPk::single).collect(),
+                file_ids: file_ids.clone(),
+                include_tombstones: true,
+            },
+        )
+        .await?;
+        let directories = parse_file_history_directories(&loaded)?;
+        pending.extend(
+            directories
+                .iter()
+                .filter_map(|directory| directory.parent_id.clone())
+                .filter(|id| !requested.contains(id)),
+        );
+        entries.extend(loaded);
+    }
+    Ok(entries)
+}
+
+async fn scan_file_history_observed_entries<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    observed_commit_id: &str,
+    filter: TrackedStateFilter,
+) -> Result<Vec<HistoryEntry>, LixError>
+where
+    S: StorageAdapterRead,
+{
+    Ok(reader
+        .scan_rows_at_commit(
+            observed_commit_id,
+            &TrackedStateScanRequest {
+                filter,
+                read_columns: TrackedStateReadColumns {
+                    columns: vec!["snapshot_content".to_string(), "metadata".to_string()],
+                },
+                ..TrackedStateScanRequest::default()
+            },
+        )
+        .await?
+        .into_iter()
+        .map(|row| history_entry_from_observed_state(row, observed_commit_id))
+        .collect())
+}
+
+async fn load_plugin_registry_at_observed_commit<S>(
+    reader: &mut TrackedStateStoreReader<S>,
+    observed_commit_id: &str,
+) -> Result<PluginRegistry, LixError>
+where
+    S: StorageAdapterRead,
+{
+    let mut rows = reader
+        .scan_rows_at_commit(
+            observed_commit_id,
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
+                    entity_pks: vec![EntityPk::single(PLUGIN_REGISTRY_KEY)],
+                    file_ids: vec![NullableKeyFilter::Null],
+                    include_tombstones: true,
+                },
+                read_columns: TrackedStateReadColumns {
+                    columns: vec!["snapshot_content".to_string()],
+                },
+                ..TrackedStateScanRequest::default()
+            },
+        )
+        .await?;
+    let row = rows.pop();
+    let snapshot = row
+        .and_then(|row| (!row.deleted).then_some(row.snapshot_content))
+        .flatten()
+        .map(|snapshot| {
+            serde_json::from_str::<serde_json::Value>(&snapshot).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "lix_file_history plugin registry snapshot is invalid JSON at observed commit '{observed_commit_id}': {error}"
+                    ),
+                )
+            })
+        })
+        .transpose()?;
+    PluginRegistry::from_optional_snapshot(snapshot.as_ref())
+}
+
+fn history_entry_from_observed_state(
+    row: MaterializedTrackedStateRow,
+    observed_commit_id: &str,
+) -> HistoryEntry {
+    HistoryEntry {
+        change: MaterializedChange {
+            id: row.change_id.to_string(),
+            entity_pk: row.entity_pk,
+            schema_key: row.schema_key,
+            file_id: row.file_id,
+            snapshot_content: row.snapshot_content,
+            metadata: row.metadata,
+            created_at: row.updated_at.clone(),
+            // Origin is event provenance, not reconstructed state. Source
+            // changes retain it; commit-root rows intentionally do not.
+            origin_key: None,
+        },
+        observed_commit_id: observed_commit_id.to_string(),
+        commit_created_at: row.updated_at,
+        start_commit_id: observed_commit_id.to_string(),
+        depth: 0,
+    }
 }
 
 async fn load_file_history_filesystem_entries<S>(
@@ -857,6 +1191,7 @@ async fn load_file_history_plugin_state<S>(
     event_route: &HistoryRoute,
     context_route: &HistoryRoute,
     plugin_schema_keys: Vec<String>,
+    lookup_ids: Option<&FileHistoryLookupIds>,
     metadata_projection: HistoryMetadataProjection,
 ) -> Result<
     (
@@ -868,8 +1203,10 @@ async fn load_file_history_plugin_state<S>(
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
+    let event_route = file_history_plugin_route(event_route, lookup_ids);
+    let context_route = file_history_plugin_route(context_route, lookup_ids);
     let (event_entries, context_entries) =
-        load_file_history_entry_sets(event_route, context_route, move |route| {
+        load_file_history_entry_sets(&event_route, &context_route, move |route| {
             let commit_graph = Arc::clone(&commit_graph);
             let json_reader = query_source.json_reader.clone();
             let schema_keys = plugin_schema_keys.clone();
@@ -893,6 +1230,44 @@ where
         parse_file_history_plugin_state(&event_entries),
         parse_file_history_plugin_state(&context_entries),
     ))
+}
+
+async fn load_file_history_plugin_owner_events<S>(
+    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+    query_source: SqlHistoryQuerySource<S>,
+    event_route: &HistoryRoute,
+    lookup_ids: Option<&FileHistoryLookupIds>,
+    metadata_projection: HistoryMetadataProjection,
+) -> Result<Vec<FileHistoryPluginOwnerRecord>, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    let mut owner_route = file_history_plugin_route(event_route, lookup_ids);
+    owner_route.entity_pks = vec![EntityPk::single(PLUGIN_OWNER_KEY).as_json_array_text()?];
+    let entries = load_history_entries(
+        HistoryViewDescriptor {
+            view_name: "lix_file_history",
+            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+        },
+        commit_graph,
+        query_source.json_reader,
+        &owner_route,
+        vec![KEY_VALUE_SCHEMA_KEY.to_string()],
+        metadata_projection,
+    )
+    .await?;
+    parse_file_history_plugin_owners(&entries)
+}
+
+fn file_history_plugin_route(
+    route: &HistoryRoute,
+    lookup_ids: Option<&FileHistoryLookupIds>,
+) -> HistoryRoute {
+    let mut route = route.clone();
+    if let Some(lookup_ids) = lookup_ids {
+        route.file_ids = lookup_ids.0.iter().cloned().collect();
+    }
+    route
 }
 
 async fn load_file_history_entry_sets<Load, LoadFuture>(
@@ -949,7 +1324,6 @@ fn file_history_events(
         candidates.push(file_history_event_from_entry(
             descriptor.id.clone(),
             &descriptor.entry,
-            1,
         ));
     }
     for directory in event_directories {
@@ -960,7 +1334,6 @@ fn file_history_events(
                 candidates.push(file_history_event_from_entry(
                     file_id.clone(),
                     &directory.entry,
-                    2,
                 ));
             }
         }
@@ -972,209 +1345,286 @@ fn file_history_events(
             candidates.push(file_history_event_from_entry(
                 blob.file_id.clone(),
                 &blob.entry,
-                3,
             ));
         }
     }
-    sorted_deduped_file_history_events(candidates)
+    sorted_grouped_file_history_events(candidates)
 }
 
-fn sorted_deduped_file_history_events<I>(events: I) -> Vec<FileHistoryEvent>
+fn sorted_grouped_file_history_events<I>(events: I) -> Vec<FileHistoryEvent>
 where
     I: IntoIterator<Item = FileHistoryEvent>,
 {
-    let mut candidates = events.into_iter().collect::<Vec<_>>();
-    candidates.sort_by(|left, right| {
+    let mut grouped = BTreeMap::<(String, String, String), FileHistoryEvent>::new();
+    for mut event in events {
+        let key = (
+            event.file_id.clone(),
+            event.start_commit_id.clone(),
+            event.observed_commit_id.clone(),
+        );
+        match grouped.entry(key) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(event);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                let grouped_event = entry.get_mut();
+                debug_assert_eq!(grouped_event.depth, event.depth);
+                // When commit metadata is not projected, history loading uses
+                // each source change's timestamp as an intentionally unused
+                // fallback. Those timestamps may differ within one commit.
+                grouped_event
+                    .source_changes
+                    .append(&mut event.source_changes);
+            }
+        }
+    }
+    let mut events = grouped.into_values().collect::<Vec<_>>();
+    for event in &mut events {
+        event
+            .source_changes
+            .sort_by(|left, right| left.id.cmp(&right.id));
+        event
+            .source_changes
+            .dedup_by(|left, right| left.id == right.id);
+    }
+    events.sort_by(|left, right| {
         left.file_id
             .cmp(&right.file_id)
             .then(left.start_commit_id.cmp(&right.start_commit_id))
             .then(left.depth.cmp(&right.depth))
-            .then(left.priority.cmp(&right.priority))
-            .then(left.change.id.cmp(&right.change.id))
+            .then(left.observed_commit_id.cmp(&right.observed_commit_id))
     });
-    candidates.dedup_by(|left, right| {
-        left.file_id == right.file_id
-            && left.start_commit_id == right.start_commit_id
-            && left.depth == right.depth
-    });
-    candidates
+    events
 }
 
-async fn discover_file_history_plugin_schema_keys(
-    blob_reader: &Arc<dyn BlobDataReader>,
-    installed_plugin_metadata_cache: &mut BTreeMap<(String, u32), Vec<InstalledPluginMetadata>>,
-    filesystem_context: &FileHistoryFilesystemContext,
-    events: &[FileHistoryEvent],
-    public_predicate: &FileHistoryPublicPredicate,
-) -> Result<Vec<String>, LixError> {
-    let mut depths = BTreeSet::<(String, u32)>::new();
-    for event in events {
-        depths.insert((event.start_commit_id.clone(), event.depth));
+async fn discover_file_history_plugins<S>(
+    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+    query_source: SqlHistoryQuerySource<S>,
+    event_route: &HistoryRoute,
+    context_route: &HistoryRoute,
+    metadata_projection: HistoryMetadataProjection,
+) -> Result<FileHistoryPluginDiscovery, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    // The durable registry snapshot is already the complete plugin set at its
+    // observed commit. Read that exact root identity for every reachable commit
+    // instead of inventing a filesystem state from `(start, depth)`, which
+    // conflates equal-depth siblings in a DAG.
+    let mut observed_commit_ids = BTreeSet::new();
+    let mut parent_commit_ids_by_commit = BTreeMap::new();
+    for start_commit_id in &context_route.start_commit_ids {
+        let start_commit_id = CommitId::parse_lix(start_commit_id, "history start_commit_id")?;
+        let reachable = commit_graph
+            .lock()
+            .await
+            .reachable_commits(&start_commit_id)
+            .await?;
+        for reachable in reachable {
+            let observed_commit_id = reachable.commit.commit_id.to_string();
+            parent_commit_ids_by_commit.insert(
+                observed_commit_id.clone(),
+                reachable
+                    .commit
+                    .parent_commit_ids
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            );
+            observed_commit_ids.insert(observed_commit_id);
+        }
     }
-    collect_record_depths(&filesystem_context.descriptors, &mut depths);
-    collect_record_depths(&filesystem_context.directories, &mut depths);
-    collect_record_depths(&filesystem_context.blobs, &mut depths);
-
+    let mut reader = TrackedStateContext::new().reader(query_source.store.clone());
     let mut schema_keys = BTreeSet::new();
-    for (start_commit_id, depth) in depths {
-        let paths = file_identity_paths_at_history_depth(
-            &filesystem_context.descriptors,
-            &filesystem_context.directories,
-            &start_commit_id,
-            depth,
-        )
-        .into_iter()
-        .filter_map(|(id, path)| public_predicate.matches(&id, Some(&path)).then_some(path))
-        .collect::<Vec<_>>();
-        if paths.is_empty() {
-            continue;
-        }
-        let plugins = installed_plugins_at_history_depth(
-            blob_reader,
-            installed_plugin_metadata_cache,
-            &filesystem_context.descriptors,
-            &filesystem_context.directories,
-            &filesystem_context.blobs,
-            &start_commit_id,
-            depth,
-        )
-        .await?;
-        for plugin in plugins {
-            if paths.iter().any(|path| {
-                select_plugin_metadata_for_path(plugins, path)
-                    .is_some_and(|candidate| candidate.key == plugin.key)
-            }) {
-                schema_keys.extend(plugin.schema_keys.iter().cloned());
-            }
-        }
+    let mut registries_by_commit = BTreeMap::new();
+    for observed_commit_id in observed_commit_ids {
+        let registry =
+            load_plugin_registry_at_observed_commit(&mut reader, &observed_commit_id).await?;
+        schema_keys.extend(
+            registry
+                .plugins()
+                .iter()
+                .flat_map(|plugin| plugin.schema_keys().iter().cloned()),
+        );
+        registries_by_commit.insert(observed_commit_id, registry);
     }
 
-    Ok(schema_keys.into_iter().collect())
+    let mut registry_route = event_route.clone();
+    registry_route.entity_pks = vec![EntityPk::single(PLUGIN_REGISTRY_KEY).as_json_array_text()?];
+    let registry_events = load_history_entries(
+        HistoryViewDescriptor {
+            view_name: "lix_file_history",
+            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+        },
+        commit_graph,
+        query_source.json_reader,
+        &registry_route,
+        vec![KEY_VALUE_SCHEMA_KEY.to_string()],
+        metadata_projection,
+    )
+    .await?;
+
+    Ok(FileHistoryPluginDiscovery {
+        schema_keys: schema_keys.into_iter().collect(),
+        registries_by_commit,
+        parent_commit_ids_by_commit,
+        registry_events,
+    })
 }
 
-fn file_identity_paths_at_history_depth(
-    descriptors: &[FileHistoryDescriptorRecord],
-    directories: &[FileHistoryDirectoryRecord],
-    start_commit_id: &str,
-    depth: u32,
-) -> Vec<(String, String)> {
-    let file_ids = descriptors
+fn file_history_plugin_events(
+    event_plugin_state: &[FileHistoryPluginStateRecord],
+    event_plugin_owners: &[FileHistoryPluginOwnerRecord],
+    observed_states: &BTreeMap<String, FileHistoryObservedState>,
+    parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
+) -> Vec<FileHistoryEvent> {
+    let owner_changes = event_plugin_owners
         .iter()
-        .filter(|record| record.entry.start_commit_id == start_commit_id)
-        .map(|record| record.id.clone())
+        .map(|record| {
+            (
+                record.entry.observed_commit_id.as_str(),
+                record.file_id.as_str(),
+            )
+        })
         .collect::<BTreeSet<_>>();
-    file_ids
-        .into_iter()
-        .filter_map(|file_id| {
-            let descriptor = nearest_history_record(
-                descriptors.iter().filter(|record| {
-                    record.id == file_id && record.entry.start_commit_id == start_commit_id
-                }),
-                depth,
-            )?;
-            let path = resolve_file_history_path(descriptor, directories, depth)?;
-            Some((file_id, path))
+
+    event_plugin_state
+        .iter()
+        .filter(|plugin_state| {
+            let observed_commit_id = plugin_state.entry.observed_commit_id.as_str();
+            let schema_key = plugin_state.entry.change.schema_key.as_str();
+            let live_owner_matches = observed_states
+                .get(observed_commit_id)
+                .and_then(|state| {
+                    live_file_history_plugin_owner(state, &plugin_state.file_id)
+                        .map(|owner| (state, owner))
+                })
+                .is_some_and(|(state, owner)| {
+                    file_history_owner_schema_keys(state, owner)
+                        .iter()
+                        .any(|owner_schema_key| owner_schema_key == schema_key)
+                });
+            if live_owner_matches {
+                return true;
+            }
+
+            // A non-owner live row cannot change the public file projection.
+            // A tombstone remains relevant only when this commit also changes
+            // the durable owner and a direct parent proves that the schema was
+            // part of the prior owner's rendering contract. This covers owner
+            // deletion, A -> B replacement, and same-key contract updates.
+            if plugin_state.entry.change.snapshot_content.is_some()
+                || !owner_changes.contains(&(observed_commit_id, plugin_state.file_id.as_str()))
+            {
+                return false;
+            }
+            parent_commit_ids_by_commit
+                .get(observed_commit_id)
+                .into_iter()
+                .flatten()
+                .any(|parent_commit_id| {
+                    observed_states
+                        .get(parent_commit_id)
+                        .and_then(|state| {
+                            live_file_history_plugin_owner(state, &plugin_state.file_id)
+                                .map(|owner| (state, owner))
+                        })
+                        .is_some_and(|(_state, owner)| {
+                            owner
+                                .schema_keys()
+                                .iter()
+                                .any(|owner_schema_key| owner_schema_key == schema_key)
+                        })
+                })
+        })
+        .map(|plugin_state| {
+            file_history_event_from_entry(plugin_state.file_id.clone(), &plugin_state.entry)
         })
         .collect()
 }
 
-fn collect_record_depths<T>(records: &[T], depths: &mut BTreeSet<(String, u32)>)
-where
-    T: FileHistoryRecord,
-{
-    depths.extend(
-        records
-            .iter()
-            .map(|record| (record.entry().start_commit_id.clone(), record.entry().depth)),
-    );
+fn live_file_history_plugin_owner<'a>(
+    state: &'a FileHistoryObservedState,
+    file_id: &str,
+) -> Option<&'a PluginFileOwner> {
+    state
+        .plugin_owners
+        .iter()
+        .find(|record| record.file_id == file_id)
+        .and_then(|record| record.owner.as_ref())
 }
 
-async fn cache_installed_plugins_for_plugin_state_depths(
-    blob_reader: &Arc<dyn BlobDataReader>,
-    installed_plugin_metadata_cache: &mut BTreeMap<(String, u32), Vec<InstalledPluginMetadata>>,
-    filesystem_context: &FileHistoryFilesystemContext,
-    event_plugin_state: &[FileHistoryPluginStateRecord],
-) -> Result<(), LixError> {
-    let mut depths = BTreeSet::<(String, u32)>::new();
-    for record in event_plugin_state {
-        depths.insert((record.entry.start_commit_id.clone(), record.entry.depth));
-    }
-    for (start_commit_id, depth) in depths {
-        installed_plugins_at_history_depth(
-            blob_reader,
-            installed_plugin_metadata_cache,
-            &filesystem_context.descriptors,
-            &filesystem_context.directories,
-            &filesystem_context.blobs,
-            &start_commit_id,
-            depth,
-        )
-        .await?;
-    }
-    Ok(())
+fn file_history_owner_schema_keys<'a>(
+    state: &'a FileHistoryObservedState,
+    owner: &'a PluginFileOwner,
+) -> &'a [String] {
+    state
+        .plugin_registry
+        .get(owner.plugin_key())
+        .map(crate::plugin::PluginRegistryEntry::schema_keys)
+        .unwrap_or_else(|| owner.schema_keys())
 }
 
-fn file_history_plugin_events(
-    installed_plugin_metadata_cache: &BTreeMap<(String, u32), Vec<InstalledPluginMetadata>>,
-    event_plugin_state: &[FileHistoryPluginStateRecord],
-    descriptors: &[FileHistoryDescriptorRecord],
-    directories: &[FileHistoryDirectoryRecord],
-) -> Vec<FileHistoryEvent> {
+fn file_history_plugin_registry_events(
+    registry_events: &[HistoryEntry],
+    observed_states: &BTreeMap<String, FileHistoryObservedState>,
+    registries_by_commit: &BTreeMap<String, PluginRegistry>,
+    parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
+) -> Result<Vec<FileHistoryEvent>, LixError> {
     let mut events = Vec::new();
-    for plugin_state in event_plugin_state {
-        let event =
-            file_history_event_from_entry(plugin_state.file_id.clone(), &plugin_state.entry, 4);
-        let Some(descriptor) = nearest_file_descriptor(descriptors, &event) else {
-            continue;
-        };
-        let Some(path) = resolve_file_history_path(descriptor, directories, event.depth) else {
-            continue;
-        };
-        let plugins = installed_plugin_metadata_cache
-            .get(&(event.start_commit_id.clone(), event.depth))
+    for registry_event in registry_events {
+        let observed_commit_id = &registry_event.observed_commit_id;
+        let state = observed_states.get(observed_commit_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("lix_file_history did not load observed commit '{observed_commit_id}'"),
+            )
+        })?;
+        let registry = registries_by_commit.get(observed_commit_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "lix_file_history did not load plugin registry at observed commit '{observed_commit_id}'"
+                ),
+            )
+        })?;
+        let parent_commit_ids = parent_commit_ids_by_commit
+            .get(observed_commit_id)
             .map(Vec::as_slice)
-            .unwrap_or(&[]);
-        let Some(plugin) = select_plugin_metadata_for_path(plugins, &path) else {
-            continue;
-        };
-        if plugin
-            .schema_keys
+            .unwrap_or_default();
+        for owner_record in state
+            .plugin_owners
             .iter()
-            .any(|schema_key| schema_key == &plugin_state.entry.change.schema_key)
+            .filter(|record| record.owner.is_some())
         {
-            events.push(event);
+            let owner = owner_record
+                .owner
+                .as_ref()
+                .expect("filtered plugin owner should exist");
+            let current_entry = registry.get(owner.plugin_key());
+            let owner_contract_changed = parent_commit_ids.iter().any(|parent_commit_id| {
+                registries_by_commit
+                    .get(parent_commit_id)
+                    .and_then(|parent| parent.get(owner.plugin_key()))
+                    != current_entry
+            });
+            if owner_contract_changed {
+                events.push(file_history_event_from_entry(
+                    owner_record.file_id.clone(),
+                    registry_event,
+                ));
+            }
         }
     }
-    events
+    Ok(events)
 }
 
-fn retain_matching_plugin_events(
-    plugin_state: &mut Vec<FileHistoryPluginStateRecord>,
-    descriptors: &[FileHistoryDescriptorRecord],
-    directories: &[FileHistoryDirectoryRecord],
-    public_predicate: &FileHistoryPublicPredicate,
-) {
-    plugin_state.retain(|record| {
-        let event = file_history_event_from_entry(record.file_id.clone(), &record.entry, 4);
-        let Some(descriptor) = nearest_file_descriptor(descriptors, &event) else {
-            return false;
-        };
-        let path = resolve_file_history_path(descriptor, directories, event.depth);
-        public_predicate.matches(&descriptor.id, path.as_deref())
-    });
-}
-
-fn file_history_event_from_entry(
-    file_id: String,
-    entry: &HistoryEntry,
-    priority: u8,
-) -> FileHistoryEvent {
+fn file_history_event_from_entry(file_id: String, entry: &HistoryEntry) -> FileHistoryEvent {
     FileHistoryEvent {
         file_id,
         start_commit_id: entry.start_commit_id.clone(),
         depth: entry.depth,
-        priority,
-        change: entry.change.clone(),
+        source_changes: vec![entry.change.clone()],
         observed_commit_id: entry.observed_commit_id.clone(),
         commit_created_at: entry.commit_created_at.clone(),
     }
@@ -1294,44 +1744,86 @@ fn parse_file_history_plugin_state(entries: &[HistoryEntry]) -> Vec<FileHistoryP
         .collect()
 }
 
-fn nearest_file_descriptor<'a>(
-    descriptors: &'a [FileHistoryDescriptorRecord],
-    event: &FileHistoryEvent,
-) -> Option<&'a FileHistoryDescriptorRecord> {
-    descriptors
+fn parse_file_history_plugin_owners(
+    entries: &[HistoryEntry],
+) -> Result<Vec<FileHistoryPluginOwnerRecord>, LixError> {
+    entries
         .iter()
-        .filter(|descriptor| {
-            let exact_descriptor_event =
-                history_descriptor_event_matches(&descriptor.entry, event.depth, &event.change.id);
-            (exact_descriptor_event || descriptor.name.is_some())
-                && descriptor.id == event.file_id
-                && descriptor.entry.start_commit_id == event.start_commit_id
-                && descriptor.entry.depth >= event.depth
+        .filter(|entry| {
+            entry.change.schema_key == KEY_VALUE_SCHEMA_KEY
+                && entry.change.entity_pk.as_single_string().ok() == Some(PLUGIN_OWNER_KEY)
         })
-        .min_by(|left, right| {
-            left.entry
-                .depth
-                .cmp(&right.entry.depth)
-                .then(left.entry.change.id.cmp(&right.entry.change.id))
+        .map(|entry| {
+            let file_id = entry.change.file_id.clone().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "lix_file_history plugin owner row is missing file_id",
+                )
+            })?;
+            let owner = entry
+                .change
+                .snapshot_content
+                .as_deref()
+                .map(|snapshot| {
+                    serde_json::from_str::<serde_json::Value>(snapshot)
+                        .map_err(|error| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "lix_file_history plugin owner snapshot is invalid JSON for file '{file_id}': {error}"
+                                ),
+                            )
+                        })
+                        .and_then(|snapshot| PluginFileOwner::from_snapshot(&file_id, &snapshot))
+                })
+                .transpose()?;
+            Ok(FileHistoryPluginOwnerRecord {
+                file_id,
+                owner,
+                entry: entry.clone(),
+            })
         })
+        .collect()
 }
 
-fn nearest_blob_ref<'a>(
-    blobs: &'a [FileHistoryBlobRecord],
+fn file_history_event_affects_observed_file(
     event: &FileHistoryEvent,
-) -> Option<&'a FileHistoryBlobRecord> {
-    blobs
+    descriptor: &FileHistoryDescriptorRecord,
+) -> bool {
+    event
+        .source_changes
         .iter()
-        .filter(|blob| {
-            blob.file_id == event.file_id
-                && blob.entry.start_commit_id == event.start_commit_id
-                && blob.entry.depth >= event.depth
-        })
-        .min_by(|left, right| {
-            left.entry
-                .depth
-                .cmp(&right.entry.depth)
-                .then(left.entry.change.id.cmp(&right.entry.change.id))
+        .any(|change| match change.schema_key.as_str() {
+            FILE_DESCRIPTOR_SCHEMA_KEY | BLOB_REF_SCHEMA_KEY => {
+                change
+                    .file_id
+                    .as_deref()
+                    .is_some_and(|file_id| file_id == descriptor.id)
+                    || change
+                        .entity_pk
+                        .as_single_string_owned()
+                        .is_ok_and(|entity_id| entity_id == descriptor.id)
+            }
+            DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
+                descriptor
+                    .directory_id
+                    .as_deref()
+                    .is_some_and(|directory_id| {
+                        change
+                            .entity_pk
+                            .as_single_string_owned()
+                            .is_ok_and(|entity_id| entity_id == directory_id)
+                    })
+            }
+            KEY_VALUE_SCHEMA_KEY
+                if change.entity_pk.as_single_string().ok() == Some(PLUGIN_REGISTRY_KEY) =>
+            {
+                event.file_id == descriptor.id
+            }
+            _ => change
+                .file_id
+                .as_deref()
+                .is_some_and(|file_id| file_id == descriptor.id),
         })
 }
 
@@ -1358,129 +1850,89 @@ fn resolve_file_history_path(
 async fn render_plugin_file_history_data(
     plugin_host: &PluginRuntimeHost,
     blob_reader: &Arc<dyn BlobDataReader>,
-    installed_plugins_cache: &mut BTreeMap<(String, u32, String), InstalledPlugin>,
-    installed_plugin_metadata_cache: &BTreeMap<(String, u32), Vec<InstalledPluginMetadata>>,
-    plugin_state: &[FileHistoryPluginStateRecord],
+    installed_plugins_cache: &mut BTreeMap<(String, String), InstalledPlugin>,
+    observed_states: &BTreeMap<String, FileHistoryObservedState>,
     descriptor: &FileHistoryDescriptorRecord,
     event: &FileHistoryEvent,
     path: &str,
 ) -> Result<Option<Vec<u8>>, LixError> {
-    let plugins = installed_plugin_metadata_cache
-        .get(&(event.start_commit_id.clone(), event.depth))
-        .map(Vec::as_slice)
-        .unwrap_or(&[]);
-    let Some(plugin_metadata) = select_plugin_metadata_for_path(plugins, path) else {
+    let Some(state) = observed_states.get(&event.observed_commit_id) else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "lix_file_history did not load observed commit '{}'",
+                event.observed_commit_id
+            ),
+        ));
+    };
+    let Some(owner) = live_file_history_plugin_owner(state, &descriptor.id) else {
         return Ok(None);
     };
-    let plugin = installed_plugin_at_history_depth(
+    let Some(plugin_entry) = state.plugin_registry.get(owner.plugin_key()) else {
+        return Err(plugin_history_unavailable_error(
+            descriptor, event, path, owner,
+        ));
+    };
+    let catalog = plugin_host.compiled_plugin_catalog(&state.plugin_registry)?;
+    if !catalog.matches_plugin(owner.plugin_key(), path) {
+        return Ok(None);
+    }
+    let plugin_metadata = plugin_entry.to_installed_plugin_metadata();
+    let plugin = installed_plugin_at_observed_commit(
         blob_reader,
         installed_plugins_cache,
-        plugin_metadata,
-        &event.start_commit_id,
-        event.depth,
+        &plugin_metadata,
+        &event.observed_commit_id,
     )
     .await?;
-    let rows = plugin_state_live_rows_at_depth(plugin_state, plugin, descriptor, event);
+    let rows = plugin_state_live_rows_at_observed_commit(&state.plugin_state, plugin, descriptor);
     let active_state = retain_plugin_state_rows(plugin, rows);
-    render_materialized_plugin_file(plugin_host, plugin, &active_state).await
+    Ok(Some(
+        render_plugin_state(plugin_host, plugin, &active_state).await?,
+    ))
 }
 
-fn select_plugin_metadata_for_path<'a>(
-    plugins: &'a [InstalledPluginMetadata],
+fn plugin_history_unavailable_error(
+    descriptor: &FileHistoryDescriptorRecord,
+    event: &FileHistoryEvent,
     path: &str,
-) -> Option<&'a InstalledPluginMetadata> {
-    select_best_glob_match(
-        path,
-        None::<PluginContentType>,
-        plugins,
-        |plugin| plugin.path_glob.as_str(),
-        |plugin| plugin.content_type,
+    owner: &PluginFileOwner,
+) -> LixError {
+    LixError::new(
+        LixError::CODE_PLUGIN_UNAVAILABLE,
+        format!(
+            "file '{path}' requires unavailable plugin '{}'",
+            owner.plugin_key()
+        ),
     )
+    .with_hint(format!(
+        "Add a valid .lixplugin archive for '{}' to /.lix/plugins/ to render the file again.",
+        owner.plugin_key()
+    ))
+    .with_details(serde_json::json!({
+        "file_id": descriptor.id,
+        "path": path,
+        "plugin_key": owner.plugin_key(),
+        "observed_commit_id": event.observed_commit_id,
+    }))
 }
 
-async fn installed_plugins_at_history_depth<'a>(
+async fn installed_plugin_at_observed_commit<'a>(
     blob_reader: &Arc<dyn BlobDataReader>,
-    installed_plugin_metadata_cache: &'a mut BTreeMap<(String, u32), Vec<InstalledPluginMetadata>>,
-    descriptors: &[FileHistoryDescriptorRecord],
-    directories: &[FileHistoryDirectoryRecord],
-    blobs: &[FileHistoryBlobRecord],
-    start_commit_id: &str,
-    depth: u32,
-) -> Result<&'a [InstalledPluginMetadata], LixError> {
-    let key = (start_commit_id.to_string(), depth);
-    if !installed_plugin_metadata_cache.contains_key(&key) {
-        let rows = filesystem_live_rows_at_history_depth(
-            descriptors,
-            directories,
-            blobs,
-            start_commit_id,
-            depth,
-        );
-        let filesystem = FilesystemIndex::from_live_rows(rows)?;
-        let plugins =
-            load_installed_plugin_metadata_from_filesystem(&filesystem, blob_reader.as_ref())
-                .await?;
-        installed_plugin_metadata_cache.insert(key.clone(), plugins);
-    }
-    Ok(installed_plugin_metadata_cache
-        .get(&key)
-        .map(Vec::as_slice)
-        .unwrap_or(&[]))
-}
-
-async fn load_installed_plugin_metadata_from_filesystem(
-    filesystem: &FilesystemIndex,
-    blob_reader: &dyn BlobDataReader,
-) -> Result<Vec<InstalledPluginMetadata>, LixError> {
-    let mut plugins = Vec::new();
-    for (path, file) in filesystem.file_entries() {
-        let Some(plugin_key) = plugin_key_from_archive_path(path) else {
-            continue;
-        };
-        let Some(blob_hash) = file.blob_hash.as_deref() else {
-            continue;
-        };
-        let Ok(hash) = BlobHash::from_hex(blob_hash) else {
-            continue;
-        };
-        let mut batch = blob_reader.load_bytes_many(&[hash]).await?.into_vec();
-        let Some(archive_bytes) = batch.pop().flatten() else {
-            continue;
-        };
-        let Ok(plugin) = load_installed_plugin_metadata_from_archive_bytes(
-            &plugin_key,
-            path,
-            blob_hash,
-            &archive_bytes,
-        ) else {
-            continue;
-        };
-        plugins.push(plugin);
-    }
-    Ok(plugins)
-}
-
-async fn installed_plugin_at_history_depth<'a>(
-    blob_reader: &Arc<dyn BlobDataReader>,
-    installed_plugins_cache: &'a mut BTreeMap<(String, u32, String), InstalledPlugin>,
+    installed_plugins_cache: &'a mut BTreeMap<(String, String), InstalledPlugin>,
     plugin_metadata: &InstalledPluginMetadata,
-    start_commit_id: &str,
-    depth: u32,
+    observed_commit_id: &str,
 ) -> Result<&'a InstalledPlugin, LixError> {
-    let cache_key = (
-        start_commit_id.to_string(),
-        depth,
-        plugin_metadata.key.clone(),
-    );
+    let cache_key = (observed_commit_id.to_string(), plugin_metadata.key.clone());
     if !installed_plugins_cache.contains_key(&cache_key) {
         let Some(plugin) =
-            load_installed_plugin_at_history_depth(blob_reader, plugin_metadata).await?
+            load_installed_plugin_for_observed_commit(blob_reader, plugin_metadata).await?
         else {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!(
-                    "installed plugin archive '{}' is unavailable at history depth {}",
-                    plugin_metadata.key, depth
+                    "installed plugin archive '{}' is unavailable at observed commit '{}'",
+                    plugin_metadata.key, observed_commit_id
                 ),
             ));
         };
@@ -1491,7 +1943,7 @@ async fn installed_plugin_at_history_depth<'a>(
         .expect("plugin should be cached after load"))
 }
 
-async fn load_installed_plugin_at_history_depth(
+async fn load_installed_plugin_for_observed_commit(
     blob_reader: &Arc<dyn BlobDataReader>,
     plugin_metadata: &InstalledPluginMetadata,
 ) -> Result<Option<InstalledPlugin>, LixError> {
@@ -1507,155 +1959,20 @@ async fn load_installed_plugin_at_history_depth(
     )?))
 }
 
-fn filesystem_live_rows_at_history_depth(
-    descriptors: &[FileHistoryDescriptorRecord],
-    directories: &[FileHistoryDirectoryRecord],
-    blobs: &[FileHistoryBlobRecord],
-    start_commit_id: &str,
-    depth: u32,
-) -> Vec<MaterializedLiveStateRow> {
-    let mut rows = Vec::new();
-    let mut descriptor_ids = descriptors
-        .iter()
-        .filter(|record| record.entry.start_commit_id == start_commit_id)
-        .map(|record| record.id.clone())
-        .collect::<BTreeSet<_>>();
-    for descriptor_id in std::mem::take(&mut descriptor_ids) {
-        if let Some(record) = nearest_history_record(
-            descriptors.iter().filter(|record| {
-                record.id == descriptor_id && record.entry.start_commit_id == start_commit_id
-            }),
-            depth,
-        ) {
-            rows.push(history_entry_to_live_row(&record.entry));
-        }
-    }
-
-    let mut directory_ids = directories
-        .iter()
-        .filter(|record| record.entry.start_commit_id == start_commit_id)
-        .map(|record| record.id.clone())
-        .collect::<BTreeSet<_>>();
-    for directory_id in std::mem::take(&mut directory_ids) {
-        if let Some(record) = nearest_history_record(
-            directories.iter().filter(|record| {
-                record.id == directory_id && record.entry.start_commit_id == start_commit_id
-            }),
-            depth,
-        ) {
-            rows.push(history_entry_to_live_row(&record.entry));
-        }
-    }
-
-    let mut blob_file_ids = blobs
-        .iter()
-        .filter(|record| record.entry.start_commit_id == start_commit_id)
-        .map(|record| record.file_id.clone())
-        .collect::<BTreeSet<_>>();
-    for file_id in std::mem::take(&mut blob_file_ids) {
-        if let Some(record) = nearest_history_record(
-            blobs.iter().filter(|record| {
-                record.file_id == file_id && record.entry.start_commit_id == start_commit_id
-            }),
-            depth,
-        ) {
-            rows.push(history_entry_to_live_row(&record.entry));
-        }
-    }
-
-    rows
-}
-
-fn plugin_state_live_rows_at_depth(
+fn plugin_state_live_rows_at_observed_commit(
     plugin_state: &[FileHistoryPluginStateRecord],
     plugin: &InstalledPlugin,
     descriptor: &FileHistoryDescriptorRecord,
-    event: &FileHistoryEvent,
 ) -> Vec<MaterializedLiveStateRow> {
     let plugin_schema_keys = plugin.schema_keys.iter().collect::<BTreeSet<_>>();
-    let mut identities = plugin_state
+    plugin_state
         .iter()
         .filter(|record| {
             record.file_id == descriptor.id
-                && record.entry.start_commit_id == event.start_commit_id
                 && plugin_schema_keys.contains(&record.entry.change.schema_key)
         })
-        .map(|record| {
-            (
-                record.entry.change.schema_key.clone(),
-                record
-                    .entry
-                    .change
-                    .entity_pk
-                    .as_json_array_text()
-                    .unwrap_or_default(),
-            )
-        })
-        .collect::<BTreeSet<_>>();
-
-    let mut rows = Vec::new();
-    for (schema_key, entity_pk) in std::mem::take(&mut identities) {
-        if let Some(record) = nearest_history_record(
-            plugin_state.iter().filter(|record| {
-                record.file_id == descriptor.id
-                    && record.entry.start_commit_id == event.start_commit_id
-                    && record.entry.change.schema_key == schema_key
-                    && record
-                        .entry
-                        .change
-                        .entity_pk
-                        .as_json_array_text()
-                        .is_ok_and(|candidate| candidate == entity_pk)
-            }),
-            event.depth,
-        ) {
-            rows.push(history_entry_to_live_row(&record.entry));
-        }
-    }
-    rows
-}
-
-trait FileHistoryRecord {
-    fn entry(&self) -> &HistoryEntry;
-}
-
-impl FileHistoryRecord for FileHistoryDescriptorRecord {
-    fn entry(&self) -> &HistoryEntry {
-        &self.entry
-    }
-}
-
-impl FileHistoryRecord for FileHistoryDirectoryRecord {
-    fn entry(&self) -> &HistoryEntry {
-        &self.entry
-    }
-}
-
-impl FileHistoryRecord for FileHistoryBlobRecord {
-    fn entry(&self) -> &HistoryEntry {
-        &self.entry
-    }
-}
-
-impl FileHistoryRecord for FileHistoryPluginStateRecord {
-    fn entry(&self) -> &HistoryEntry {
-        &self.entry
-    }
-}
-
-fn nearest_history_record<'a, T, I>(records: I, depth: u32) -> Option<&'a T>
-where
-    T: FileHistoryRecord + 'a,
-    I: Iterator<Item = &'a T>,
-{
-    records
-        .filter(|record| record.entry().depth >= depth)
-        .min_by(|left, right| {
-            left.entry()
-                .depth
-                .cmp(&right.entry().depth)
-                .then(left.entry().change.id.cmp(&right.entry().change.id))
-        })
+        .map(|record| history_entry_to_live_row(&record.entry))
+        .collect()
 }
 
 fn history_entry_to_live_row(entry: &HistoryEntry) -> MaterializedLiveStateRow {
@@ -1688,32 +2005,10 @@ static LIX_FILE_HISTORY_COLS: ColumnTable<FileHistoryOutputRow> = ColumnTable {
             Col::Utf8Fallible(|row| entity_pk_json_array(&row.entity_pk).map(Some)),
         ),
         (
-            HISTORY_COL_SCHEMA_KEY,
-            Col::Utf8(|_| Some(FILE_DESCRIPTOR_SCHEMA_KEY)),
-        ),
-        (
-            HISTORY_COL_FILE_ID,
-            Col::Utf8(|row| Some(row.entity_pk.as_str())),
-        ),
-        (
-            HISTORY_COL_CHANGE_ID,
-            Col::Utf8(|row| Some(row.event.change.id.as_str())),
-        ),
-        (
-            HISTORY_COL_ORIGIN_KEY,
-            Col::Utf8(|row| row.event.change.origin_key.as_deref()),
-        ),
-        (
-            HISTORY_COL_SNAPSHOT_CONTENT,
-            Col::Utf8(|row| row.descriptor_change.snapshot_content.as_deref()),
-        ),
-        (
-            HISTORY_COL_METADATA,
-            Col::Utf8Owned(|row| {
-                row.descriptor_change
-                    .metadata
-                    .as_deref()
-                    .map(serialize_row_metadata)
+            HISTORY_COL_SOURCE_CHANGES,
+            Col::Utf8Fallible(|row| {
+                serialize_history_source_changes(&row.event.source_changes, "lix_file_history")
+                    .map(Some)
             }),
         ),
         (
@@ -1759,12 +2054,7 @@ pub(super) fn lix_file_history_schema() -> SchemaRef {
         Field::new("name", DataType::Utf8, true),
         Field::new("data", DataType::LargeBinary, true),
         json_field(HISTORY_COL_ENTITY_PK, false),
-        Field::new(HISTORY_COL_SCHEMA_KEY, DataType::Utf8, false),
-        Field::new(HISTORY_COL_FILE_ID, DataType::Utf8, true),
-        json_field(HISTORY_COL_SNAPSHOT_CONTENT, true),
-        Field::new(HISTORY_COL_CHANGE_ID, DataType::Utf8, false),
-        Field::new(HISTORY_COL_ORIGIN_KEY, DataType::Utf8, true),
-        json_field(HISTORY_COL_METADATA, true),
+        json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
         Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),
@@ -1791,14 +2081,20 @@ mod tests {
     use crate::LixError;
     use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobHash};
     use crate::entity_pk::EntityPk;
+    use crate::plugin::{
+        PluginFileOwner, PluginRegistryEntry, PluginRegistryEntryInput, PluginRuntime,
+        plugin_storage_archive_file_id, plugin_storage_archive_path,
+    };
     use crate::sql2::change_materialization::MaterializedChange;
     use crate::sql2::history_route::HistoryEntry;
 
     use super::{
         FileHistoryBlobRecord, FileHistoryDescriptorRecord, FileHistoryFilesystemContext,
-        FileHistoryLookupIds, FileHistoryPublicPredicate, HistoryRoute, PreparedFileHistoryRow,
-        file_history_descriptor_blob_route, file_history_event_from_entry,
-        load_file_history_blob_bytes, load_file_history_entry_sets, prepare_file_history_rows,
+        FileHistoryLookupIds, FileHistoryObservedState, FileHistoryPluginOwnerRecord,
+        FileHistoryPluginStateRecord, FileHistoryPublicPredicate, HistoryRoute, PluginRegistry,
+        PreparedFileHistoryRow, file_history_descriptor_blob_route, file_history_event_from_entry,
+        file_history_plugin_events, load_file_history_blob_bytes, load_file_history_entry_sets,
+        prepare_file_history_rows, sorted_grouped_file_history_events,
     };
 
     fn history_entry(file_id: &str, depth: u32, snapshot_content: Option<String>) -> HistoryEntry {
@@ -1855,11 +2151,108 @@ mod tests {
         FileHistoryFilesystemContext {
             event_descriptors: descriptors.clone(),
             event_directories: Vec::new(),
-            event_blobs: blobs.clone(),
+            event_blobs: blobs,
             descriptors,
-            directories: Vec::new(),
-            blobs,
         }
+    }
+
+    fn observed_states(
+        context: &FileHistoryFilesystemContext,
+    ) -> BTreeMap<String, FileHistoryObservedState> {
+        BTreeMap::from([(
+            "commit-0".to_string(),
+            FileHistoryObservedState {
+                descriptors: context.descriptors.clone(),
+                directories: context.event_directories.clone(),
+                blobs: context.event_blobs.clone(),
+                plugin_state: Vec::new(),
+                plugin_owners: Vec::new(),
+                plugin_registry: PluginRegistry::empty(),
+            },
+        )])
+    }
+
+    fn plugin_owner_record(
+        file_id: &str,
+        owner: PluginFileOwner,
+        observed_commit_id: &str,
+    ) -> FileHistoryPluginOwnerRecord {
+        let snapshot_content = owner
+            .to_snapshot()
+            .expect("test owner should serialize")
+            .to_string();
+        let mut entry = history_entry(file_id, 0, Some(snapshot_content));
+        entry.observed_commit_id = observed_commit_id.to_string();
+        entry.change.id = format!("owner-{file_id}-{observed_commit_id}");
+        entry.change.entity_pk = EntityPk::single(super::PLUGIN_OWNER_KEY);
+        entry.change.schema_key = super::KEY_VALUE_SCHEMA_KEY.to_string();
+        FileHistoryPluginOwnerRecord {
+            file_id: file_id.to_string(),
+            owner: Some(owner),
+            entry,
+        }
+    }
+
+    fn plugin_state_tombstone(
+        file_id: &str,
+        schema_key: &str,
+        observed_commit_id: &str,
+    ) -> FileHistoryPluginStateRecord {
+        let mut entry = history_entry(file_id, 0, None);
+        entry.observed_commit_id = observed_commit_id.to_string();
+        entry.change.id = format!("plugin-state-{schema_key}-{observed_commit_id}");
+        entry.change.entity_pk = EntityPk::single("plugin-state");
+        entry.change.schema_key = schema_key.to_string();
+        FileHistoryPluginStateRecord {
+            file_id: file_id.to_string(),
+            entry,
+        }
+    }
+
+    fn plugin_observed_state(
+        owner_record: FileHistoryPluginOwnerRecord,
+    ) -> FileHistoryObservedState {
+        FileHistoryObservedState {
+            descriptors: Vec::new(),
+            directories: Vec::new(),
+            blobs: Vec::new(),
+            plugin_state: Vec::new(),
+            plugin_owners: vec![owner_record],
+            plugin_registry: PluginRegistry::empty(),
+        }
+    }
+
+    fn plugin_registry(plugin_key: &str, schema_keys: &[&str]) -> PluginRegistry {
+        let wasm = b"test wasm";
+        let manifest_json = serde_json::json!({
+            "api_version": "0.1.0",
+            "entry": "plugin.wasm",
+            "key": plugin_key,
+            "match": { "path_glob": "*.plugin-test" },
+            "runtime": "wasm-component-v1",
+            "schemas": ["schema/plugin.json"],
+        })
+        .to_string();
+        let entry = PluginRegistryEntry::new(PluginRegistryEntryInput {
+            key: plugin_key.to_string(),
+            runtime: PluginRuntime::WasmComponentV1,
+            api_version: "0.1.0".to_string(),
+            path_glob: "*.plugin-test".to_string(),
+            content_type: None,
+            entry: "plugin.wasm".to_string(),
+            schema_keys: schema_keys
+                .iter()
+                .map(|schema_key| (*schema_key).to_string())
+                .collect(),
+            manifest_json,
+            archive_file_id: plugin_storage_archive_file_id(plugin_key),
+            archive_path: plugin_storage_archive_path(plugin_key),
+            archive_blob_hash: BlobHash::from_content(format!("archive-{plugin_key}").as_bytes())
+                .to_hex(),
+            wasm_blob_hash: BlobHash::from_content(wasm).to_hex(),
+        })
+        .expect("test plugin registry entry should be valid");
+        PluginRegistry::new(vec![entry]).expect("test plugin registry should be valid")
     }
 
     fn eq_filter(column_name: &str, value: &str) -> Expr {
@@ -1921,7 +2314,7 @@ mod tests {
         let events = [&live_a, &live_b, &tombstone]
             .into_iter()
             .map(|descriptor| {
-                file_history_event_from_entry(descriptor.id.clone(), &descriptor.entry, 1)
+                file_history_event_from_entry(descriptor.id.clone(), &descriptor.entry)
             })
             .collect::<Vec<_>>();
         let context = filesystem_context(
@@ -1934,7 +2327,7 @@ mod tests {
 
         let id_predicate = FileHistoryPublicPredicate::from_filters(&[eq_filter("id", "file-a")]);
         let by_id = prepare_file_history_rows(
-            &context,
+            &observed_states(&context),
             events.clone(),
             &HistoryRoute::default(),
             &id_predicate,
@@ -1946,7 +2339,7 @@ mod tests {
         let path_predicate =
             FileHistoryPublicPredicate::from_filters(&[eq_filter("path", "/b.md")]);
         let by_path = prepare_file_history_rows(
-            &context,
+            &observed_states(&context),
             events.clone(),
             &HistoryRoute::default(),
             &path_predicate,
@@ -1958,7 +2351,7 @@ mod tests {
         let tombstone_predicate =
             FileHistoryPublicPredicate::from_filters(&[eq_filter("id", "file-deleted")]);
         let deleted = prepare_file_history_rows(
-            &context,
+            &observed_states(&context),
             events,
             &HistoryRoute::default(),
             &tombstone_predicate,
@@ -1987,6 +2380,158 @@ mod tests {
                 .matches("file-a", Some("/a.md")),
             "a guaranteed public conjunct remains safe for early pruning"
         );
+    }
+
+    #[test]
+    fn equal_depth_sibling_revisions_are_not_deduplicated() {
+        let mut left = history_entry("file-a", 1, None);
+        left.observed_commit_id = "commit-left".to_string();
+        left.change.id = "change-left".to_string();
+        let mut right = history_entry("file-a", 1, None);
+        right.observed_commit_id = "commit-right".to_string();
+        right.change.id = "change-right".to_string();
+
+        let events = sorted_grouped_file_history_events([
+            file_history_event_from_entry("file-a".to_string(), &left),
+            file_history_event_from_entry("file-a".to_string(), &right),
+        ]);
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.observed_commit_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["commit-left", "commit-right"]
+        );
+    }
+
+    #[test]
+    fn same_commit_sources_form_one_logical_revision() {
+        let descriptor = history_entry("file-a", 0, None);
+        let mut blob = descriptor.clone();
+        blob.change.id = "change-file-a-blob".to_string();
+        blob.change.schema_key = super::BLOB_REF_SCHEMA_KEY.to_string();
+
+        let events = sorted_grouped_file_history_events([
+            file_history_event_from_entry("file-a".to_string(), &descriptor),
+            file_history_event_from_entry("file-a".to_string(), &blob),
+        ]);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source_changes.len(), 2);
+        assert_eq!(
+            events[0]
+                .source_changes
+                .iter()
+                .map(|change| change.schema_key.as_str())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                super::BLOB_REF_SCHEMA_KEY,
+                super::FILE_DESCRIPTOR_SCHEMA_KEY,
+            ])
+        );
+    }
+
+    #[test]
+    fn owner_replacement_retains_prior_owner_state_tombstones() {
+        let file_id = "plugin-file";
+        let parent_commit_id = "commit-parent";
+        let replacement_commit_id = "commit-replacement";
+        let parent_owner = plugin_owner_record(
+            file_id,
+            PluginFileOwner::new(file_id, "plugin-a", vec!["plugin_a_state".to_string()]).unwrap(),
+            parent_commit_id,
+        );
+        let replacement_owner = plugin_owner_record(
+            file_id,
+            PluginFileOwner::new(file_id, "plugin-b", vec!["plugin_b_state".to_string()]).unwrap(),
+            replacement_commit_id,
+        );
+        let old_state_tombstone =
+            plugin_state_tombstone(file_id, "plugin_a_state", replacement_commit_id);
+        let observed_states = BTreeMap::from([
+            (
+                parent_commit_id.to_string(),
+                plugin_observed_state(parent_owner),
+            ),
+            (
+                replacement_commit_id.to_string(),
+                plugin_observed_state(replacement_owner.clone()),
+            ),
+        ]);
+        let parents = BTreeMap::from([(
+            replacement_commit_id.to_string(),
+            vec![parent_commit_id.to_string()],
+        )]);
+
+        assert!(
+            file_history_plugin_events(
+                std::slice::from_ref(&old_state_tombstone),
+                &[],
+                &observed_states,
+                &parents,
+            )
+            .is_empty(),
+            "a prior-owner tombstone needs a durable owner change in the same commit"
+        );
+        let events = file_history_plugin_events(
+            &[old_state_tombstone],
+            &[replacement_owner],
+            &observed_states,
+            &parents,
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source_changes[0].schema_key, "plugin_a_state");
+    }
+
+    #[test]
+    fn owner_contract_update_retains_removed_schema_tombstones() {
+        let file_id = "plugin-file";
+        let parent_commit_id = "commit-parent";
+        let update_commit_id = "commit-contract-update";
+        let parent_owner = plugin_owner_record(
+            file_id,
+            PluginFileOwner::new(
+                file_id,
+                "plugin-a",
+                vec![
+                    "plugin_a_removed".to_string(),
+                    "plugin_a_retained".to_string(),
+                ],
+            )
+            .unwrap(),
+            parent_commit_id,
+        );
+        let updated_owner = plugin_owner_record(
+            file_id,
+            PluginFileOwner::new(file_id, "plugin-a", vec!["plugin_a_retained".to_string()])
+                .unwrap(),
+            update_commit_id,
+        );
+        let removed_schema_tombstone =
+            plugin_state_tombstone(file_id, "plugin_a_removed", update_commit_id);
+        let mut parent_state = plugin_observed_state(parent_owner);
+        parent_state.plugin_registry = plugin_registry("plugin-a", &["plugin_a_retained"]);
+        let mut updated_state = plugin_observed_state(updated_owner.clone());
+        updated_state.plugin_registry = plugin_registry("plugin-a", &["plugin_a_retained"]);
+        let observed_states = BTreeMap::from([
+            (parent_commit_id.to_string(), parent_state),
+            (update_commit_id.to_string(), updated_state),
+        ]);
+        let parents = BTreeMap::from([(
+            update_commit_id.to_string(),
+            vec![parent_commit_id.to_string()],
+        )]);
+
+        let events = file_history_plugin_events(
+            &[removed_schema_tombstone],
+            &[updated_owner],
+            &observed_states,
+            &parents,
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source_changes[0].schema_key, "plugin_a_removed");
     }
 
     #[test]
@@ -2058,7 +2603,7 @@ mod tests {
         let present_hash = BlobHash::from_content(b"present");
         let missing_hash = BlobHash::from_content(b"missing");
         let descriptor = descriptor("file-a", Some("a.md"), 0);
-        let event = file_history_event_from_entry("file-a".to_string(), &descriptor.entry, 1);
+        let event = file_history_event_from_entry("file-a".to_string(), &descriptor.entry);
         let row = |id: &str, hash: BlobHash| PreparedFileHistoryRow {
             id: id.to_string(),
             path: Some(format!("/{id}.md")),
@@ -2097,7 +2642,7 @@ mod tests {
     #[tokio::test]
     async fn blob_hydration_rejects_malformed_batch_lengths() {
         let descriptor = descriptor("file-a", Some("a.md"), 0);
-        let event = file_history_event_from_entry("file-a".to_string(), &descriptor.entry, 1);
+        let event = file_history_event_from_entry("file-a".to_string(), &descriptor.entry);
         let row = |id: &str, hash: BlobHash| PreparedFileHistoryRow {
             id: id.to_string(),
             path: Some(format!("/{id}.md")),
@@ -2137,7 +2682,7 @@ mod tests {
         let events = descriptors
             .iter()
             .map(|descriptor| {
-                file_history_event_from_entry(descriptor.id.clone(), &descriptor.entry, 1)
+                file_history_event_from_entry(descriptor.id.clone(), &descriptor.entry)
             })
             .collect::<Vec<_>>();
         let context = filesystem_context(
@@ -2148,7 +2693,7 @@ mod tests {
             ],
         );
         let rows = prepare_file_history_rows(
-            &context,
+            &observed_states(&context),
             events,
             &HistoryRoute::default(),
             &FileHistoryPublicPredicate::All,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -992,8 +992,10 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
+        let read_scope = SharedStorageAdapterRead::new(read_scope);
         HistoryQuerySource {
-            json_reader: JsonStoreContext::new().reader(SharedStorageAdapterRead::new(read_scope)),
+            store: read_scope.clone(),
+            json_reader: JsonStoreContext::new().reader(read_scope),
         }
     }
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1868,6 +1868,7 @@ where
 
     fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore> {
         HistoryQuerySource {
+            store: self.read_store.clone(),
             json_reader: crate::json_store::JsonStoreContext::new().reader(self.read_store.clone()),
         }
     }

--- a/packages/engine/tests/sql/history_conformance.rs
+++ b/packages/engine/tests/sql/history_conformance.rs
@@ -57,6 +57,38 @@ simulation_test!(
         .collect::<Vec<_>>();
 
         assert_eq!(rows, expected);
+
+        let provenance_columns = select_rows(
+            &session,
+            "SELECT table_name, column_name \
+             FROM information_schema.columns \
+             WHERE table_name IN ('lix_file_history', 'lix_directory_history') \
+               AND column_name IN (\
+                 'lixcol_source_changes',\
+                 'lixcol_schema_key',\
+                 'lixcol_file_id',\
+                 'lixcol_snapshot_content',\
+                 'lixcol_change_id',\
+                 'lixcol_origin_key',\
+                 'lixcol_metadata'\
+               ) \
+             ORDER BY table_name, column_name",
+        )
+        .await;
+        assert_eq!(
+            provenance_columns,
+            vec![
+                vec![
+                    Value::Text("lix_directory_history".to_string()),
+                    Value::Text("lixcol_source_changes".to_string()),
+                ],
+                vec![
+                    Value::Text("lix_file_history".to_string()),
+                    Value::Text("lixcol_source_changes".to_string()),
+                ],
+            ],
+            "composed histories expose aggregate provenance without singular aliases"
+        );
     }
 );
 
@@ -96,7 +128,7 @@ simulation_test!(
              ) \
                AND (\
                  column_name IN ('path', 'directory_id', 'parent_id', 'name', 'data', 'id', 'count', 'active', 'meta') \
-                 OR column_name = 'lixcol_snapshot_content'\
+                 OR column_name IN ('lixcol_snapshot_content', 'lixcol_source_changes')\
                ) \
              ORDER BY table_name, column_name",
         )
@@ -113,14 +145,14 @@ simulation_test!(
             ),
             ("engine_history_contract_schema_history", "meta", "YES"),
             ("lix_directory_history", "id", "NO"),
-            ("lix_directory_history", "lixcol_snapshot_content", "YES"),
+            ("lix_directory_history", "lixcol_source_changes", "NO"),
             ("lix_directory_history", "name", "YES"),
             ("lix_directory_history", "parent_id", "YES"),
             ("lix_directory_history", "path", "YES"),
             ("lix_file_history", "data", "YES"),
             ("lix_file_history", "directory_id", "YES"),
             ("lix_file_history", "id", "NO"),
-            ("lix_file_history", "lixcol_snapshot_content", "YES"),
+            ("lix_file_history", "lixcol_source_changes", "NO"),
             ("lix_file_history", "name", "YES"),
             ("lix_file_history", "path", "YES"),
         ]
@@ -405,7 +437,7 @@ simulation_test!(
 
         let file_rows = select_rows(
             &session,
-            "SELECT id, path, name, data, lixcol_entity_pk, lixcol_file_id, lixcol_snapshot_content, lixcol_depth \
+            "SELECT id, path, name, data, lixcol_entity_pk, lixcol_depth \
              FROM lix_file_history \
              WHERE lixcol_start_commit_id = lix_active_branch_commit_id() \
                AND id = 'history-conformance-file' \
@@ -420,8 +452,6 @@ simulation_test!(
                 Value::Null,
                 Value::Null,
                 Value::Json(serde_json::json!(["history-conformance-file"])),
-                Value::Text("history-conformance-file".to_string()),
-                Value::Null,
                 Value::Integer(0),
             ]]
         );
@@ -478,7 +508,7 @@ simulation_test!(
 
         let directory_rows = select_rows(
             &session,
-            "SELECT id, path, parent_id, name, lixcol_entity_pk, lixcol_snapshot_content, lixcol_depth \
+            "SELECT id, path, parent_id, name, lixcol_entity_pk, lixcol_depth \
              FROM lix_directory_history \
              WHERE lixcol_start_commit_id = lix_active_branch_commit_id() \
                AND id = 'history-conformance-dir' \
@@ -493,7 +523,6 @@ simulation_test!(
                 Value::Null,
                 Value::Null,
                 Value::Json(serde_json::json!(["history-conformance-dir"])),
-                Value::Null,
                 Value::Integer(0),
             ]]
         );

--- a/packages/engine/tests/sql/lix_directory_history.rs
+++ b/packages/engine/tests/sql/lix_directory_history.rs
@@ -1,4 +1,4 @@
-use lix_engine::Value;
+use lix_engine::{CreateBranchOptions, MergeBranchOptions, Value};
 use serde_json::json;
 
 use super::assert_rows_eq;
@@ -81,10 +81,10 @@ simulation_test!(
             ],
         );
 
-        let snapshot_result = session
+        let source_changes_result = session
             .execute(
                 &format!(
-                    "SELECT lixcol_snapshot_content \
+                    "SELECT lixcol_source_changes \
                      FROM lix_directory_history \
                      WHERE lixcol_start_commit_id = '{second_commit_id}' \
                        AND id = 'history-dir-guides' \
@@ -93,15 +93,44 @@ simulation_test!(
                 &[],
             )
             .await
-            .expect("directory history descriptor snapshot should be selectable");
-        let snapshot = snapshot_result.rows()[0]
-            .get::<Value>("lixcol_snapshot_content")
-            .expect("snapshot_content should be present");
-        let Value::Json(snapshot) = snapshot else {
-            panic!("snapshot_content should be semantic JSON, got {snapshot:?}");
+            .expect("directory history source changes should be selectable");
+        let source_changes = source_changes_result.rows()[0]
+            .get::<Value>("lixcol_source_changes")
+            .expect("source_changes should be present");
+        let Value::Json(source_changes) = source_changes else {
+            panic!("source_changes should be semantic JSON, got {source_changes:?}");
         };
-        assert_eq!(snapshot["parent_id"], json!("history-dir-docs"));
-        assert_eq!(snapshot["name"], json!("guides"));
+        assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            source_changes[0]["schema_key"],
+            json!("lix_directory_descriptor")
+        );
+        assert_eq!(
+            source_changes[0]["snapshot_content"]["parent_id"],
+            json!("history-dir-docs")
+        );
+        assert_eq!(
+            source_changes[0]["snapshot_content"]["name"],
+            json!("guides")
+        );
+        assert_eq!(
+            source_changes[0]
+                .as_object()
+                .unwrap()
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                "created_at",
+                "entity_pk",
+                "file_id",
+                "id",
+                "metadata",
+                "origin_key",
+                "schema_key",
+                "snapshot_content",
+            ]
+        );
     }
 );
 
@@ -134,6 +163,116 @@ simulation_test!(
                 .is_some_and(|hint| hint.contains("WHERE lixcol_start_commit_id")),
             "unexpected error: {error}"
         );
+    }
+);
+
+simulation_test!(
+    lix_directory_history_preserves_equal_depth_siblings_in_a_diamond,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_directory (id, path) VALUES ('diamond-dir', '/before/')",
+            &[],
+        )
+        .await
+        .expect("base directory should insert");
+        main.create_branch(CreateBranchOptions {
+            id: Some("diamond-dir-draft".to_string()),
+            name: "Diamond directory draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft branch should be created");
+        let draft = sim.wrap_session(
+            engine
+                .open_session("diamond-dir-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "UPDATE lix_directory SET name = 'same' WHERE id = 'diamond-dir'",
+            &[],
+        )
+        .await
+        .expect("main rename should succeed");
+        let main_sibling = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("main sibling should load")
+            .expect("main sibling should exist");
+        draft
+            .execute(
+                "UPDATE lix_directory SET name = 'same' WHERE id = 'diamond-dir'",
+                &[],
+            )
+            .await
+            .expect("draft rename should succeed");
+        let draft_sibling = engine
+            .load_branch_head_commit_id("diamond-dir-draft")
+            .await
+            .expect("draft sibling should load")
+            .expect("draft sibling should exist");
+        let receipt = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "diamond-dir-draft".to_string(),
+            })
+            .await
+            .expect("convergent sibling renames should merge");
+        let merge_commit_id = receipt
+            .created_merge_commit_id
+            .expect("convergent sibling renames should create an empty merge commit");
+
+        let rows = main
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_observed_commit_id, lixcol_depth \
+                     FROM lix_directory_history \
+                     WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                       AND id = 'diamond-dir' \
+                       AND lixcol_depth = 1 \
+                     ORDER BY lixcol_observed_commit_id"
+                ),
+                &[],
+            )
+            .await
+            .expect("diamond directory history should load");
+
+        assert_eq!(rows.len(), 2, "both equal-depth sibling revisions survive");
+        let mut observed = rows
+            .rows()
+            .iter()
+            .map(|row| {
+                assert_eq!(
+                    row.get::<Value>("path").expect("path should decode"),
+                    Value::Text("/same/".to_string())
+                );
+                assert_eq!(
+                    row.get::<Value>("lixcol_depth")
+                        .expect("history depth should decode"),
+                    Value::Integer(1)
+                );
+                match row
+                    .get::<Value>("lixcol_observed_commit_id")
+                    .expect("observed commit should exist")
+                {
+                    Value::Text(commit_id) => commit_id,
+                    value => panic!("observed commit should be text, got {value:?}"),
+                }
+            })
+            .collect::<Vec<_>>();
+        observed.sort();
+        let mut expected = vec![main_sibling, draft_sibling];
+        expected.sort();
+        assert_eq!(observed, expected);
     }
 );
 
@@ -182,7 +321,7 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-					"SELECT id, path, name, lixcol_snapshot_content, lixcol_schema_key, lixcol_start_commit_id, lixcol_depth \
+					"SELECT id, path, name, lixcol_source_changes, lixcol_start_commit_id, lixcol_depth \
 	                 FROM lix_directory_history \
 	                 WHERE lixcol_start_commit_id = '{delete_commit_id}' \
 	                   AND lixcol_entity_pk IN (lix_json('[\"history-delete-docs\"]'), lix_json('[\"history-delete-guides\"]')) \
@@ -194,28 +333,34 @@ simulation_test!(
             .await
             .expect("directory delete history read should succeed");
 
-        assert_rows_eq(
-            result,
-            vec![
-                vec![
-                    Value::Text("history-delete-docs".to_string()),
+        assert_eq!(result.len(), 2);
+        for (row, expected_id) in result
+            .rows()
+            .iter()
+            .zip(["history-delete-docs", "history-delete-guides"])
+        {
+            assert_eq!(
+                &row.values()[..3],
+                &[
+                    Value::Text(expected_id.to_string()),
                     Value::Null,
                     Value::Null,
-                    Value::Null,
-                    Value::Text("lix_directory_descriptor".to_string()),
-                    Value::Text(delete_commit_id.clone()),
-                    Value::Integer(0),
-                ],
-                vec![
-                    Value::Text("history-delete-guides".to_string()),
-                    Value::Null,
-                    Value::Null,
-                    Value::Null,
-                    Value::Text("lix_directory_descriptor".to_string()),
-                    Value::Text(delete_commit_id),
-                    Value::Integer(0),
-                ],
-            ],
-        );
+                ]
+            );
+            let Value::Json(source_changes) = &row.values()[3] else {
+                panic!("delete source changes should be JSON");
+            };
+            assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
+            assert_eq!(
+                source_changes[0]["schema_key"],
+                json!("lix_directory_descriptor")
+            );
+            assert_eq!(
+                source_changes[0]["snapshot_content"],
+                serde_json::Value::Null
+            );
+            assert_eq!(row.values()[4], Value::Text(delete_commit_id.clone()));
+            assert_eq!(row.values()[5], Value::Integer(0));
+        }
     }
 );

--- a/packages/engine/tests/sql/lix_file_history.rs
+++ b/packages/engine/tests/sql/lix_file_history.rs
@@ -1,5 +1,6 @@
 use std::io::{Cursor, Write};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use lix_engine::Value;
@@ -7,10 +8,228 @@ use lix_engine::wasm::{
     WasmComponentInstance, WasmLimits, WasmPluginDetectedChange, WasmPluginEntityState,
     WasmPluginFile, WasmRuntime,
 };
-use lix_engine::{Engine, LixError, Memory};
+use lix_engine::{
+    CreateBranchOptions, Engine, GetManyResult, GetOptions, Key, KeyRange, LixError, Memory,
+    MemoryRead, MemoryWrite, MergeBranchOptions, ReadOptions, ScanChunk, ScanOptions, SpaceId,
+    Storage, StorageError, StorageRead, WriteOptions,
+};
 use serde_json::json;
 
 use super::assert_rows_eq;
+
+#[derive(Clone, Default)]
+struct CountingStorage {
+    inner: Memory,
+    get_many_requested_keys: Arc<AtomicU64>,
+    scan_calls: Arc<AtomicU64>,
+    scanned_rows: Arc<AtomicU64>,
+}
+
+struct CountingRead {
+    inner: MemoryRead,
+    get_many_requested_keys: Arc<AtomicU64>,
+    scan_calls: Arc<AtomicU64>,
+    scanned_rows: Arc<AtomicU64>,
+}
+
+impl CountingStorage {
+    fn reset_counters(&self) {
+        self.get_many_requested_keys.store(0, Ordering::Relaxed);
+        self.scan_calls.store(0, Ordering::Relaxed);
+        self.scanned_rows.store(0, Ordering::Relaxed);
+    }
+
+    fn counters(&self) -> (u64, u64, u64) {
+        (
+            self.get_many_requested_keys.load(Ordering::Relaxed),
+            self.scan_calls.load(Ordering::Relaxed),
+            self.scanned_rows.load(Ordering::Relaxed),
+        )
+    }
+}
+
+impl Storage for CountingStorage {
+    type Read<'a>
+        = CountingRead
+    where
+        Self: 'a;
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        Ok(CountingRead {
+            inner: self.inner.begin_read(options).await?,
+            get_many_requested_keys: Arc::clone(&self.get_many_requested_keys),
+            scan_calls: Arc::clone(&self.scan_calls),
+            scanned_rows: Arc::clone(&self.scanned_rows),
+        })
+    }
+
+    async fn begin_write(&self, options: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(options).await
+    }
+}
+
+impl StorageRead for CountingRead {
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        options: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        self.get_many_requested_keys
+            .fetch_add(keys.len() as u64, Ordering::Relaxed);
+        self.inner.get_many(space, keys, options).await
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        options: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        let chunk = self.inner.scan(space, range, options).await?;
+        self.scan_calls.fetch_add(1, Ordering::Relaxed);
+        self.scanned_rows
+            .fetch_add(chunk.entries.len() as u64, Ordering::Relaxed);
+        Ok(chunk)
+    }
+}
+
+#[tokio::test]
+async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state() {
+    const UNRELATED_FILE_COUNT: usize = 64;
+    const UNRELATED_DIRECTORY_COUNT: usize = 32;
+    const UNRELATED_PLUGIN_FILE_COUNT: usize = 16;
+    // Event provenance still walks the commit's change refs. The observed-root
+    // reconstruction must not load the unrelated descriptor/blob/directory,
+    // plugin-state, or durable-owner rows a second time.
+    const MAX_REQUESTED_KEYS: u64 = 416;
+    const MAX_SCAN_CALLS: u64 = 128;
+    const MAX_SCANNED_ROWS: u64 = 512;
+
+    let storage = CountingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine =
+        Engine::new_with_wasm_runtime(storage.clone(), Arc::new(HistoryRenderPluginRuntime))
+            .await
+            .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let unrelated_values = (0..UNRELATED_FILE_COUNT)
+        .map(|index| {
+            format!("('unrelated-history-{index:03}', '/unrelated-history-{index:03}.txt', X'78')")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!("INSERT INTO lix_file (id, path, data) VALUES {unrelated_values}"),
+            &[],
+        )
+        .await
+        .expect("unrelated files should insert in one commit");
+    let unrelated_directories = (0..UNRELATED_DIRECTORY_COUNT)
+        .map(|index| {
+            format!("('unrelated-directory-{index:03}', '/unrelated-directory-{index:03}/')")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!("INSERT INTO lix_directory (id, path) VALUES {unrelated_directories}"),
+            &[],
+        )
+        .await
+        .expect("unrelated directories should insert in one commit");
+    session
+        .execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_history_render.lixplugin".to_string()),
+                Value::Blob(history_render_plugin_archive().into()),
+            ],
+        )
+        .await
+        .expect("performance fixture plugin should install");
+    let unrelated_plugin_files = (0..UNRELATED_PLUGIN_FILE_COUNT)
+        .map(|index| {
+            format!(
+                "('unrelated-plugin-{index:03}', '/unrelated-plugin-{index:03}.history-render', X'78')"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!("INSERT INTO lix_file (id, path, data) VALUES {unrelated_plugin_files}"),
+            &[],
+        )
+        .await
+        .expect("unrelated plugin-owned files should insert in one commit");
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, data) \
+             VALUES ('history-point-target', '/history-point-target.txt', X'746172676574')",
+            &[],
+        )
+        .await
+        .expect("target file should insert in its own commit");
+    let commit_id_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("target commit head should load");
+    let [Value::Text(commit_id)] = commit_id_rows.rows()[0].values() else {
+        panic!(
+            "expected active branch commit id row, got {:?}",
+            commit_id_rows.rows()[0].values()
+        );
+    };
+
+    storage.reset_counters();
+    let result = session
+        .execute(
+            &format!(
+                "SELECT id, path \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'history-point-target'"
+            ),
+            &[],
+        )
+        .await
+        .expect("point-routed file history should load");
+
+    assert_rows_eq(
+        result,
+        vec![vec![
+            Value::Text("history-point-target".to_string()),
+            Value::Text("/history-point-target.txt".to_string()),
+        ]],
+    );
+    let (requested_keys, scan_calls, scanned_rows) = storage.counters();
+    assert!(
+        requested_keys <= MAX_REQUESTED_KEYS,
+        "point-routed history requested {requested_keys} storage keys with \
+         {UNRELATED_FILE_COUNT} unrelated files, {UNRELATED_DIRECTORY_COUNT} directories, and \
+         {UNRELATED_PLUGIN_FILE_COUNT} plugin-owned files; expected at most {MAX_REQUESTED_KEYS}"
+    );
+    assert!(
+        scan_calls <= MAX_SCAN_CALLS && scanned_rows <= MAX_SCANNED_ROWS,
+        "point-routed history performed {scan_calls} scans returning {scanned_rows} rows; \
+         expected at most {MAX_SCAN_CALLS} scans and {MAX_SCANNED_ROWS} rows"
+    );
+
+    session.close().await.expect("session should close");
+}
 
 simulation_test!(
     lix_file_history_reads_path_and_data_from_commit_graph,
@@ -94,10 +313,10 @@ simulation_test!(
             ],
         );
 
-        let snapshot_result = session
+        let source_changes_result = session
             .execute(
                 &format!(
-                    "SELECT lixcol_snapshot_content \
+                    "SELECT lixcol_source_changes \
                      FROM lix_file_history \
                      WHERE lixcol_start_commit_id = '{second_commit_id}' \
                        AND id = 'history-file' \
@@ -106,14 +325,22 @@ simulation_test!(
                 &[],
             )
             .await
-            .expect("file history descriptor snapshot should be selectable");
-        let snapshot = snapshot_result.rows()[0]
-            .get::<Value>("lixcol_snapshot_content")
-            .expect("snapshot_content should be present");
-        let Value::Json(snapshot) = snapshot else {
-            panic!("snapshot_content should be semantic JSON, got {snapshot:?}");
+            .expect("file history source changes should be selectable");
+        let source_changes = source_changes_result.rows()[0]
+            .get::<Value>("lixcol_source_changes")
+            .expect("source_changes should be present");
+        let Value::Json(source_changes) = source_changes else {
+            panic!("source_changes should be semantic JSON, got {source_changes:?}");
         };
-        assert_eq!(snapshot["name"], json!("readme-renamed.md"));
+        assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            source_changes[0]["schema_key"],
+            json!("lix_file_descriptor")
+        );
+        assert_eq!(
+            source_changes[0]["snapshot_content"]["name"],
+            json!("readme-renamed.md")
+        );
 
         let result = session
             .execute(
@@ -177,6 +404,129 @@ simulation_test!(
                 Value::Blob(Vec::new().into()),
             ]],
         );
+    }
+);
+
+simulation_test!(
+    lix_file_history_preserves_equal_depth_siblings_in_a_diamond,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_file (id, path, data) \
+             VALUES ('diamond-file', '/before.md', X'62617365')",
+            &[],
+        )
+        .await
+        .expect("base file should insert");
+        main.create_branch(CreateBranchOptions {
+            id: Some("diamond-draft".to_string()),
+            name: "Diamond draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft branch should be created");
+        let draft = sim.wrap_session(
+            engine
+                .open_session("diamond-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "UPDATE lix_file SET path = '/same.md' WHERE id = 'diamond-file'",
+            &[],
+        )
+        .await
+        .expect("main path update should succeed");
+        let main_sibling = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("main sibling should load")
+            .expect("main sibling should exist");
+        draft
+            .execute(
+                "UPDATE lix_file SET path = '/same.md' WHERE id = 'diamond-file'",
+                &[],
+            )
+            .await
+            .expect("draft path update should succeed");
+        let draft_sibling = engine
+            .load_branch_head_commit_id("diamond-draft")
+            .await
+            .expect("draft sibling should load")
+            .expect("draft sibling should exist");
+
+        let receipt = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "diamond-draft".to_string(),
+            })
+            .await
+            .expect("convergent sibling updates should merge");
+        let merge_commit_id = receipt
+            .created_merge_commit_id
+            .expect("convergent sibling updates should create an empty merge commit");
+
+        let result = main
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_observed_commit_id, lixcol_depth, lixcol_source_changes \
+                     FROM lix_file_history \
+                     WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                       AND id = 'diamond-file' \
+                       AND lixcol_depth = 1 \
+                     ORDER BY lixcol_observed_commit_id"
+                ),
+                &[],
+            )
+            .await
+            .expect("diamond history should load");
+
+        assert_eq!(
+            result.len(),
+            2,
+            "both equal-depth sibling revisions survive"
+        );
+        let mut observed = result
+            .rows()
+            .iter()
+            .map(|row| {
+                assert_eq!(
+                    row.get::<Value>("path").expect("path should decode"),
+                    Value::Text("/same.md".to_string())
+                );
+                assert_eq!(
+                    row.get::<Value>("lixcol_depth")
+                        .expect("history depth should decode"),
+                    Value::Integer(1)
+                );
+                let source_changes = row
+                    .get::<Value>("lixcol_source_changes")
+                    .expect("source changes should exist");
+                let Value::Json(source_changes) = source_changes else {
+                    panic!("source changes should be JSON, got {source_changes:?}");
+                };
+                assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
+                match row
+                    .get::<Value>("lixcol_observed_commit_id")
+                    .expect("observed commit should exist")
+                {
+                    Value::Text(commit_id) => commit_id,
+                    value => panic!("observed commit should be text, got {value:?}"),
+                }
+            })
+            .collect::<Vec<_>>();
+        observed.sort();
+        let mut expected = vec![main_sibling, draft_sibling];
+        expected.sort();
+        assert_eq!(observed, expected);
     }
 );
 
@@ -485,6 +835,445 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
     session.close().await.expect("session should close");
 }
 
+#[tokio::test]
+async fn lix_file_history_uses_each_siblings_observed_plugin_registry() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new_with_wasm_runtime(storage, Arc::new(HistoryRenderPluginRuntime))
+        .await
+        .expect("engine should open with plugin runtime");
+    let main = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    main.execute(
+        "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+        &[
+            Value::Text("/.lix/plugins/plugin_history_render.lixplugin".to_string()),
+            Value::Blob(history_render_plugin_archive().into()),
+        ],
+    )
+    .await
+    .expect("plugin archive write should install plugin");
+    main.create_branch(CreateBranchOptions {
+        id: Some("plugin-history-sibling".to_string()),
+        name: "Plugin history sibling".to_string(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("plugin history sibling should be created");
+    let sibling = engine
+        .open_session("plugin-history-sibling")
+        .await
+        .expect("plugin history sibling should open");
+
+    main.execute(
+        "DELETE FROM lix_file \
+         WHERE path = '/.lix/plugins/plugin_history_render.lixplugin'",
+        &[],
+    )
+    .await
+    .expect("main sibling should uninstall the plugin");
+    sibling
+        .execute(
+            "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+            &[
+                Value::Text("plugin-sibling-note".to_string()),
+                Value::Text("/note.history-render".to_string()),
+                Value::Blob(b"sibling".to_vec().into()),
+            ],
+        )
+        .await
+        .expect("other sibling should materialize a plugin file");
+    let sibling_commit_id = engine
+        .load_branch_head_commit_id("plugin-history-sibling")
+        .await
+        .expect("plugin sibling head should load")
+        .expect("plugin sibling head should exist");
+
+    let receipt = main
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: "plugin-history-sibling".to_string(),
+        })
+        .await
+        .expect("independent plugin uninstall and file insert should merge");
+    let merge_commit_id = receipt
+        .created_merge_commit_id
+        .expect("sibling merge should create a merge commit");
+
+    let result = main
+        .execute(
+            &format!(
+                "SELECT data, lixcol_observed_commit_id, lixcol_source_changes \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                   AND path = '/note.history-render' \
+                   AND lixcol_depth = 1"
+            ),
+            &[],
+        )
+        .await
+        .expect("plugin-backed sibling history should load from its observed registry");
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result.rows()[0]
+            .get::<Value>("data")
+            .expect("rendered data should decode"),
+        Value::Blob(b"rendered:sibling-a|sibling-b".to_vec().into())
+    );
+    assert_eq!(
+        result.rows()[0]
+            .get::<Value>("lixcol_observed_commit_id")
+            .expect("observed commit should decode"),
+        Value::Text(sibling_commit_id)
+    );
+    let Value::Json(source_changes) = result.rows()[0]
+        .get::<Value>("lixcol_source_changes")
+        .expect("source changes should decode")
+    else {
+        panic!("source changes should be JSON");
+    };
+    assert!(
+        source_changes.as_array().is_some_and(|changes| changes
+            .iter()
+            .any(|change| change["schema_key"] == json!("plugin_history_note"))),
+        "the plugin state changes from the sibling commit must remain provenance"
+    );
+
+    sibling.close().await.expect("sibling should close");
+    main.close().await.expect("main should close");
+}
+
+#[tokio::test]
+async fn lix_file_history_projects_owned_file_plugin_lifecycle_without_glob_reassignment() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new_with_wasm_runtime(storage, Arc::new(HistoryRenderPluginRuntime))
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    session
+        .execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_history_render.lixplugin".to_string()),
+                Value::Blob(history_render_plugin_archive().into()),
+            ],
+        )
+        .await
+        .expect("initial plugin should install");
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+            &[
+                Value::Text("plugin-lifecycle-note".to_string()),
+                Value::Text("/note.history-render".to_string()),
+                Value::Blob(b"owned".to_vec().into()),
+            ],
+        )
+        .await
+        .expect("plugin-owned file should insert");
+
+    session
+        .execute(
+            "UPDATE lix_file SET data = $1 \
+             WHERE path = '/.lix/plugins/plugin_history_render.lixplugin'",
+            &[Value::Blob(history_render_plugin_upgrade_archive().into())],
+        )
+        .await
+        .expect("plugin should upgrade without rewriting the owned file");
+    let upgrade_commit_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("upgrade commit should load");
+    let [Value::Text(upgrade_commit_id)] = upgrade_commit_rows.rows()[0].values() else {
+        panic!("upgrade commit id should be text");
+    };
+
+    let upgraded = session
+        .execute(
+            &format!(
+                "SELECT data, lixcol_source_changes \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{upgrade_commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'plugin-lifecycle-note'"
+            ),
+            &[],
+        )
+        .await
+        .expect("plugin upgrade should project an owned-file revision");
+    assert_eq!(upgraded.len(), 1);
+    assert_eq!(
+        upgraded.rows()[0].get::<Value>("data").unwrap(),
+        Value::Blob(b"upgraded:owned-a|owned-b".to_vec().into())
+    );
+    let Value::Json(upgrade_sources) = upgraded.rows()[0]
+        .get::<Value>("lixcol_source_changes")
+        .unwrap()
+    else {
+        panic!("upgrade source changes should be JSON");
+    };
+    assert!(
+        upgrade_sources.as_array().is_some_and(|sources| {
+            sources.iter().any(|source| {
+                source["schema_key"] == json!("lix_key_value")
+                    && source["entity_pk"] == json!(["lix_plugin_registry_v1"])
+            })
+        }),
+        "the registry upgrade must be the owned-file projection source"
+    );
+
+    session
+        .execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_history_overlap.lixplugin".to_string()),
+                Value::Blob(history_overlap_plugin_archive().into()),
+            ],
+        )
+        .await
+        .expect("overlapping plugin should install");
+    let overlap_commit_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("overlap commit should load");
+    let [Value::Text(overlap_commit_id)] = overlap_commit_rows.rows()[0].values() else {
+        panic!("overlap commit id should be text");
+    };
+    let overlap_history = session
+        .execute(
+            &format!(
+                "SELECT id \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{overlap_commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'plugin-lifecycle-note'"
+            ),
+            &[],
+        )
+        .await
+        .expect("unrelated overlapping install should not project an owned-file revision");
+    assert_rows_eq(overlap_history, Vec::<Vec<Value>>::new());
+    let still_owned = session
+        .execute(
+            "SELECT data FROM lix_file WHERE id = 'plugin-lifecycle-note'",
+            &[],
+        )
+        .await
+        .expect("overlapping plugin must not steal the durable owner");
+    assert_rows_eq(
+        still_owned,
+        vec![vec![Value::Blob(
+            b"upgraded:owned-a|owned-b".to_vec().into(),
+        )]],
+    );
+
+    session
+        .execute(
+            "INSERT INTO plugin_history_overlap_note \
+             (id, value, lixcol_file_id, lixcol_global, lixcol_untracked) \
+             VALUES ('overlap-sidecar', 'noise', 'plugin-lifecycle-note', false, false)",
+            &[],
+        )
+        .await
+        .expect("non-owner plugin state should remain independently writable");
+    let non_owner_state_commit_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("non-owner plugin state commit should load");
+    let [Value::Text(non_owner_state_commit_id)] = non_owner_state_commit_rows.rows()[0].values()
+    else {
+        panic!("non-owner plugin state commit id should be text");
+    };
+    let non_owner_state_history = session
+        .execute(
+            &format!(
+                "SELECT id \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{non_owner_state_commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'plugin-lifecycle-note'"
+            ),
+            &[],
+        )
+        .await
+        .expect("non-owner plugin state should not revise the owned file projection");
+    assert_rows_eq(non_owner_state_history, Vec::<Vec<Value>>::new());
+    let still_owned_after_non_owner_write = session
+        .execute(
+            "SELECT data FROM lix_file WHERE id = 'plugin-lifecycle-note'",
+            &[],
+        )
+        .await
+        .expect("non-owner plugin state must not affect the durable owner's rendering");
+    assert_rows_eq(
+        still_owned_after_non_owner_write,
+        vec![vec![Value::Blob(
+            b"upgraded:owned-a|owned-b".to_vec().into(),
+        )]],
+    );
+
+    session
+        .execute(
+            "DELETE FROM lix_file \
+             WHERE path = '/.lix/plugins/plugin_history_render.lixplugin'",
+            &[],
+        )
+        .await
+        .expect("owning plugin should uninstall");
+    let uninstall_commit_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("uninstall commit should load");
+    let [Value::Text(uninstall_commit_id)] = uninstall_commit_rows.rows()[0].values() else {
+        panic!("uninstall commit id should be text");
+    };
+    let unavailable_projection = session
+        .execute(
+            &format!(
+                "SELECT id, lixcol_source_changes \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{uninstall_commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'plugin-lifecycle-note'"
+            ),
+            &[],
+        )
+        .await
+        .expect("uninstall should remain queryable when data is not projected");
+    assert_eq!(unavailable_projection.len(), 1);
+    let history_error = session
+        .execute(
+            &format!(
+                "SELECT data \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{uninstall_commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'plugin-lifecycle-note'"
+            ),
+            &[],
+        )
+        .await
+        .expect_err("unavailable historical owner must not silently render or reassign");
+    assert_eq!(history_error.code, LixError::CODE_PLUGIN_UNAVAILABLE);
+    let live_error = session
+        .execute(
+            "SELECT data FROM lix_file WHERE id = 'plugin-lifecycle-note'",
+            &[],
+        )
+        .await
+        .expect_err("live file should use the same unavailable-owner contract");
+    assert_eq!(live_error.code, LixError::CODE_PLUGIN_UNAVAILABLE);
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn lix_file_history_keeps_plugin_state_tombstones_in_deleted_file_provenance() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new_with_wasm_runtime(storage, Arc::new(HistoryRenderPluginRuntime))
+        .await
+        .expect("engine should open with plugin runtime");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    session
+        .execute(
+            "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_history_render.lixplugin".to_string()),
+                Value::Blob(history_render_plugin_archive().into()),
+            ],
+        )
+        .await
+        .expect("plugin should install");
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, data) VALUES ($1, $2, $3)",
+            &[
+                Value::Text("plugin-deleted-note".to_string()),
+                Value::Text("/deleted.history-render".to_string()),
+                Value::Blob(b"deleted".to_vec().into()),
+            ],
+        )
+        .await
+        .expect("plugin-owned file should insert");
+    session
+        .execute("DELETE FROM lix_file WHERE id = 'plugin-deleted-note'", &[])
+        .await
+        .expect("plugin-owned file should delete");
+    let delete_commit_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("delete commit should load");
+    let [Value::Text(delete_commit_id)] = delete_commit_rows.rows()[0].values() else {
+        panic!("delete commit id should be text");
+    };
+
+    let result = session
+        .execute(
+            &format!(
+                "SELECT path, data, lixcol_source_changes \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{delete_commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'plugin-deleted-note'"
+            ),
+            &[],
+        )
+        .await
+        .expect("deleted plugin-file provenance should remain queryable");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.rows()[0].get::<Value>("path").unwrap(), Value::Null);
+    assert_eq!(result.rows()[0].get::<Value>("data").unwrap(), Value::Null);
+    let Value::Json(sources) = result.rows()[0]
+        .get::<Value>("lixcol_source_changes")
+        .unwrap()
+    else {
+        panic!("delete source changes should be JSON");
+    };
+    let sources = sources
+        .as_array()
+        .expect("delete source changes should be an array");
+    let plugin_tombstones = sources
+        .iter()
+        .filter(|source| source["schema_key"] == json!("plugin_history_note"))
+        .collect::<Vec<_>>();
+    assert_eq!(plugin_tombstones.len(), 2);
+    assert!(
+        plugin_tombstones
+            .iter()
+            .all(|source| source["snapshot_content"].is_null()),
+        "plugin entity tombstones must remain in composed provenance"
+    );
+    assert!(
+        sources.iter().any(|source| {
+            source["schema_key"] == json!("lix_key_value")
+                && source["entity_pk"] == json!(["lix_plugin_owner_v1"])
+                && source["snapshot_content"].is_null()
+        }),
+        "durable owner tombstone must remain in composed provenance"
+    );
+
+    session.close().await.expect("session should close");
+}
+
 simulation_test!(
     lix_file_history_requires_start_commit_id,
     |sim| async move {
@@ -580,16 +1369,25 @@ simulation_test!(
 
 struct HistoryRenderPluginRuntime;
 
-struct HistoryRenderPluginComponent;
+struct HistoryRenderPluginComponent {
+    prefix: &'static str,
+}
 
 #[async_trait]
 impl WasmRuntime for HistoryRenderPluginRuntime {
     async fn init_component(
         &self,
-        _bytes: Vec<u8>,
+        bytes: Vec<u8>,
         _limits: WasmLimits,
     ) -> Result<Arc<dyn WasmComponentInstance>, LixError> {
-        Ok(Arc::new(HistoryRenderPluginComponent))
+        let prefix = if bytes.ends_with(b"upgrade") {
+            "upgraded"
+        } else if bytes.ends_with(b"overlap") {
+            "overlap"
+        } else {
+            "rendered"
+        };
+        Ok(Arc::new(HistoryRenderPluginComponent { prefix }))
     }
 }
 
@@ -631,48 +1429,82 @@ impl WasmComponentInstance for HistoryRenderPluginComponent {
             })
             .collect::<Vec<_>>();
         values.sort();
-        Ok(format!("rendered:{}", values.join("|")).into_bytes())
+        Ok(format!("{}:{}", self.prefix, values.join("|")).into_bytes())
     }
 }
 
 fn history_render_plugin_archive() -> Vec<u8> {
-    const MANIFEST_JSON: &[u8] = br#"{
-        "key": "plugin_history_render",
+    history_plugin_archive(
+        "plugin_history_render",
+        "*.history-render",
+        "plugin_history_note",
+        b"",
+    )
+}
+
+fn history_render_plugin_upgrade_archive() -> Vec<u8> {
+    history_plugin_archive(
+        "plugin_history_render",
+        "*.history-render",
+        "plugin_history_note",
+        b"upgrade",
+    )
+}
+
+fn history_overlap_plugin_archive() -> Vec<u8> {
+    history_plugin_archive(
+        "plugin_history_overlap",
+        "note.history-render",
+        "plugin_history_overlap_note",
+        b"overlap",
+    )
+}
+
+fn history_plugin_archive(
+    plugin_key: &str,
+    path_glob: &str,
+    schema_key: &str,
+    wasm_marker: &[u8],
+) -> Vec<u8> {
+    let manifest_json = serde_json::to_vec(&json!({
+        "key": plugin_key,
         "runtime": "wasm-component-v1",
         "api_version": "0.1.0",
-        "match": { "path_glob": "*.history-render" },
+        "match": { "path_glob": path_glob },
         "entry": "plugin.wasm",
-        "schemas": ["schema/plugin_history_note.json"]
-    }"#;
-    const SCHEMA_JSON: &[u8] = br#"{
-        "x-lix-key": "plugin_history_note",
+        "schemas": [format!("schema/{schema_key}.json")],
+    }))
+    .expect("plugin manifest fixture should serialize");
+    let schema_json = serde_json::to_vec(&json!({
+        "x-lix-key": schema_key,
         "x-lix-primary-key": ["/id"],
         "type": "object",
         "properties": {
             "id": { "type": "string" },
-            "value": { "type": "string" }
+            "value": { "type": "string" },
         },
         "required": ["id", "value"],
-        "additionalProperties": false
-    }"#;
-    const WASM_HEADER: &[u8] = b"\0asm\x01\0\0\0";
-
+        "additionalProperties": false,
+    }))
+    .expect("plugin schema fixture should serialize");
+    let mut wasm = b"\0asm\x01\0\0\0".to_vec();
+    wasm.extend_from_slice(wasm_marker);
     let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
     let options =
         zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
     for (path, bytes) in [
-        ("manifest.json", MANIFEST_JSON),
-        ("schema/plugin_history_note.json", SCHEMA_JSON),
-        ("plugin.wasm", WASM_HEADER),
+        ("manifest.json".to_string(), manifest_json),
+        (format!("schema/{schema_key}.json"), schema_json),
+        ("plugin.wasm".to_string(), wasm),
     ] {
         writer.start_file(path, options).unwrap();
-        writer.write_all(bytes).unwrap();
+        writer.write_all(&bytes).unwrap();
     }
     writer.finish().unwrap().into_inner()
 }
 
 simulation_test!(
-    lix_file_history_exposes_file_descriptor_schema_key,
+    lix_file_history_aggregates_composed_source_changes,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -686,7 +1518,7 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO lix_file (id, path, data) \
-                 VALUES ('history-file-blob-filter', '/docs/blob-filter.txt', X'626C6F62')",
+                 VALUES ('history-file-blob-filter', '/blob-filter.txt', X'626C6F62')",
                 &[],
             )
             .await
@@ -708,41 +1540,83 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, path, data, lixcol_schema_key \
+                    "SELECT id, path, data, lixcol_source_changes \
                      FROM lix_file_history \
                      WHERE lixcol_start_commit_id = '{commit_id}' \
-                       AND lixcol_schema_key = 'lix_file_descriptor' \
                        AND id = 'history-file-blob-filter' \
-                       AND lixcol_depth = 0"
+                     ORDER BY lixcol_depth"
                 ),
                 &[],
             )
             .await
-            .expect("file-descriptor-filtered file history read should succeed");
+            .expect("file history read should succeed");
 
-        assert_rows_eq(
-            result,
-            vec![vec![
+        assert_eq!(result.len(), 2);
+        let latest = result.rows()[0].values();
+        assert_eq!(
+            &latest[..3],
+            &[
                 Value::Text("history-file-blob-filter".to_string()),
-                Value::Text("/docs/blob-filter.txt".to_string()),
+                Value::Text("/blob-filter.txt".to_string()),
                 Value::Blob(b"blob2".to_vec().into()),
-                Value::Text("lix_file_descriptor".to_string()),
-            ]],
+            ]
+        );
+        let Value::Json(latest_sources) = &latest[3] else {
+            panic!("latest source changes should be JSON, got {:?}", latest[3]);
+        };
+        assert_eq!(latest_sources.as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            latest_sources[0]["schema_key"],
+            json!("lix_binary_blob_ref")
         );
 
-        let blob_schema_result = session
-            .execute(
-                &format!(
-                    "SELECT id \
-                     FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
-                       AND lixcol_schema_key = 'lix_binary_blob_ref' \
-                       AND id = 'history-file-blob-filter'"
-                ),
-                &[],
-            )
-            .await
-            .expect("blob-ref-filtered file history read should succeed");
-        assert_rows_eq(blob_schema_result, Vec::<Vec<Value>>::new());
+        let Value::Json(initial_sources) = &result.rows()[1].values()[3] else {
+            panic!(
+                "initial source changes should be JSON, got {:?}",
+                result.rows()[1].values()[3]
+            );
+        };
+        assert_eq!(initial_sources.as_array().map(Vec::len), Some(2));
+        let source_schema_keys = initial_sources
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|source| source["schema_key"].as_str().unwrap())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            source_schema_keys,
+            std::collections::BTreeSet::from(["lix_binary_blob_ref", "lix_file_descriptor",])
+        );
+        let source_ids = initial_sources
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|source| source["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert!(
+            source_ids.windows(2).all(|ids| ids[0] <= ids[1]),
+            "source changes must be ordered by change id: {source_ids:?}"
+        );
+        for source in initial_sources.as_array().unwrap() {
+            assert_eq!(
+                source
+                    .as_object()
+                    .unwrap()
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                vec![
+                    "created_at",
+                    "entity_pk",
+                    "file_id",
+                    "id",
+                    "metadata",
+                    "origin_key",
+                    "schema_key",
+                    "snapshot_content",
+                ],
+                "source change objects must mirror the stable lix_change field set"
+            );
+        }
     }
 );

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -400,15 +400,16 @@ test("execute originKey is exposed on change and history surfaces without metada
 	const insertedHeadCommitId = await activeHeadCommitId(lix);
 	expect(get(inserted, "origin_key")).toBe("test-origin");
 	expect(get(inserted, "lixcol_metadata")).toEqual(metadata);
-	expect(
-		get(
-			await lix.execute(
-				"SELECT lixcol_origin_key FROM lix_file_history WHERE id = $1 AND lixcol_start_commit_id = $2",
-				[fileId, insertedHeadCommitId],
-			),
-			"lixcol_origin_key",
+	const fileHistorySources = get(
+		await lix.execute(
+			"SELECT lixcol_source_changes FROM lix_file_history WHERE id = $1 AND lixcol_start_commit_id = $2",
+			[fileId, insertedHeadCommitId],
 		),
-	).toBe("test-origin");
+		"lixcol_source_changes",
+	) as Array<{ origin_key: string | null }>;
+	expect(fileHistorySources.map((source) => source.origin_key)).toContain(
+		"test-origin",
+	);
 	expect(
 		get(
 			await lix.execute(


### PR DESCRIPTION
## Why

`lix_file_history` and `lix_directory_history` reconstructed revisions by depth. In a commit DAG, equal-depth siblings are different observations, so depth-based deduplication could drop valid rows or combine event provenance from one sibling with descriptor/blob/plugin state from another.

## Hard cut

- Reconstruct each composed filesystem revision through the exact observed commit's ancestry.
- Preserve equal-depth siblings in diamond histories.
- Aggregate all same-commit inputs into structured `lixcol_source_changes`.
- Remove misleading singular composed provenance columns; typed/raw descriptor history remains the source for singular provenance.
- Persist plugin ownership per observed commit, so history does not re-glob files through the current registry.
- Project plugin upgrade, replacement, uninstall, overlap, and contract-shrink cleanup with ancestry-correct tombstone provenance.
- Reject non-owner plugin state when composing a file revision.

Ancestor-directory propagation is intentionally the dependent #719 layer.

## Validation

- Original full SQL integration suite: 564/564 passed.
- Original full library suite: 1,153 passed, 6 ignored.
- Independent focused review: 25/25 file-history SQL cases and 2/2 owner-transition units passed.
- CI-equivalent engine Clippy with `-D warnings`: passed.
- JS typecheck, Rust formatting, and `git diff --check`: passed.
- Rebased onto latest `main` (`13639daf`, including #706 and #716–#718); the only semantic adaptation was the new immutable `Blob`/`Bytes` test representation. Engine code compiled locally. GitHub's full CI is now the authoritative post-rebase gate.

Regression coverage includes diamond DAGs, equal-depth sibling edits, same-commit descriptor/blob/plugin changes, durable plugin ownership transitions, uninstall/replacement/contract shrink, tombstone provenance, and a bounded-I/O point lookup.