### PR TITLE
perf(storage): compress binary CAS chunks

### DIFF
--- a/.changenotes/compress-binary-cas-chunks.md
+++ b/.changenotes/compress-binary-cas-chunks.md
@@ -1,0 +1,10 @@
+---
+type: minor
+---
+
+Native binary CAS chunks now use zstd level 1 when compression saves at least
+128 bytes and 12.5%, with a raw fallback for small or high-entropy content.
+Browser/WASM writers keep raw chunks to avoid a slower, lower-ratio encoder.
+
+All runtimes can decode both codecs. Chunk hashes and deduplication remain
+based on the uncompressed bytes.

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,4 +1,5 @@
 const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
+pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct BinaryCasChunking {
@@ -13,7 +14,7 @@ impl BinaryCasChunking {
         Self {
             min_chunk_bytes: 256 * 1024,
             avg_chunk_bytes: 1024 * 1024,
-            max_chunk_bytes: 4096 * 1024,
+            max_chunk_bytes: MAX_BINARY_CAS_CHUNK_BYTES,
             single_chunk_fast_path_max_bytes: SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
         }
     }
@@ -66,7 +67,7 @@ mod tests {
 
         assert_eq!(chunking.min_chunk_bytes, 256 * 1024);
         assert_eq!(chunking.avg_chunk_bytes, 1024 * 1024);
-        assert_eq!(chunking.max_chunk_bytes, 4096 * 1024);
+        assert_eq!(chunking.max_chunk_bytes, MAX_BINARY_CAS_CHUNK_BYTES);
         assert_eq!(chunking.single_chunk_fast_path_max_bytes, 64 * 1024);
     }
 

--- a/packages/engine/src/binary_cas/codec.rs
+++ b/packages/engine/src/binary_cas/codec.rs
@@ -9,6 +9,7 @@ const HASH_BYTES: usize = 32;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
 pub(crate) enum BinaryChunkCodec {
     Raw,
+    Zstd,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
@@ -210,12 +211,15 @@ mod tests {
     #[test]
     fn chunk_roundtrips_payload_as_remaining_bytes() {
         let payload = b"hello payload";
-        let encoded = encode_binary_cas_chunk(BinaryChunkCodec::Raw, payload.len() as u64, payload);
-        assert_eq!(encoded.len(), CHUNK_STORAGE_OVERHEAD_BYTES + payload.len());
-        let (codec, uncompressed_len, decoded_payload) = decode_binary_cas_chunk(&encoded).unwrap();
-        assert_eq!(codec, BinaryChunkCodec::Raw);
-        assert_eq!(uncompressed_len, payload.len() as u64);
-        assert_eq!(decoded_payload, payload);
+        for codec in [BinaryChunkCodec::Raw, BinaryChunkCodec::Zstd] {
+            let encoded = encode_binary_cas_chunk(codec, payload.len() as u64, payload);
+            assert_eq!(encoded.len(), CHUNK_STORAGE_OVERHEAD_BYTES + payload.len());
+            let (decoded_codec, uncompressed_len, decoded_payload) =
+                decode_binary_cas_chunk(&encoded).unwrap();
+            assert_eq!(decoded_codec, codec);
+            assert_eq!(uncompressed_len, payload.len() as u64);
+            assert_eq!(decoded_payload, payload);
+        }
     }
 
     #[test]

--- a/packages/engine/src/binary_cas/compression.rs
+++ b/packages/engine/src/binary_cas/compression.rs
@@ -1,0 +1,187 @@
+use std::borrow::Cow;
+
+use crate::LixError;
+#[cfg(not(target_family = "wasm"))]
+use crate::compression::compress_zstd_level_1;
+use crate::compression::decompress_zstd;
+
+use super::codec::BinaryChunkCodec;
+use super::types::BlobHash;
+
+#[cfg(not(target_family = "wasm"))]
+const ZSTD_MIN_CHUNK_BYTES: usize = 512;
+#[cfg(not(target_family = "wasm"))]
+const MIN_ZSTD_SAVINGS_BYTES: usize = 128;
+// At 2 MiB, zstd-1 costs roughly 1 ms more than the storage layer's LZ4.
+// Requiring 12.5% relative savings amortizes that CPU by avoiding marginal
+// frames while the absolute floor protects sub-KiB chunks.
+#[cfg(not(target_family = "wasm"))]
+const MIN_ZSTD_SAVINGS_DIVISOR: usize = 8;
+
+#[derive(Debug)]
+pub(super) struct EncodedChunkPayload<'a> {
+    pub(super) codec: BinaryChunkCodec,
+    pub(super) data: Cow<'a, [u8]>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub(super) fn encode_chunk_payload(
+    chunk_hash: BlobHash,
+    chunk_data: &[u8],
+) -> Result<EncodedChunkPayload<'_>, LixError> {
+    if chunk_data.len() < ZSTD_MIN_CHUNK_BYTES {
+        return Ok(raw_payload(chunk_data));
+    }
+
+    let compressed = compress_zstd_level_1(chunk_data).map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS chunk '{}' compression failed: {error}",
+                chunk_hash.to_hex()
+            ),
+        )
+    })?;
+    if !compression_is_worthwhile(chunk_data.len(), compressed.len()) {
+        return Ok(raw_payload(chunk_data));
+    }
+
+    Ok(EncodedChunkPayload {
+        codec: BinaryChunkCodec::Zstd,
+        data: Cow::Owned(compressed),
+    })
+}
+
+#[cfg(target_family = "wasm")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "keep the native and WASM binary CAS write paths identical"
+)]
+pub(super) fn encode_chunk_payload(
+    _chunk_hash: BlobHash,
+    chunk_data: &[u8],
+) -> Result<EncodedChunkPayload<'_>, LixError> {
+    // ruzstd's only implemented encoder is substantially slower and produces
+    // frames close to SlateDB's existing LZ4 output for representative plugin
+    // binaries. Keep browser writes raw, while retaining Zstd decode support so
+    // databases written by native/server runtimes remain portable.
+    Ok(raw_payload(chunk_data))
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn compression_is_worthwhile(uncompressed_len: usize, compressed_len: usize) -> bool {
+    let minimum_savings =
+        MIN_ZSTD_SAVINGS_BYTES.max(uncompressed_len.div_ceil(MIN_ZSTD_SAVINGS_DIVISOR));
+    uncompressed_len.saturating_sub(compressed_len) >= minimum_savings
+}
+
+pub(super) fn decode_zstd_chunk(
+    chunk_hash: BlobHash,
+    compressed_payload: &[u8],
+    uncompressed_len: usize,
+) -> Result<Vec<u8>, LixError> {
+    let decoded = decompress_zstd(compressed_payload, uncompressed_len).map_err(|error| {
+        LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS chunk '{}' decompression failed: {error}",
+                chunk_hash.to_hex()
+            ),
+        )
+    })?;
+    if decoded.len() != uncompressed_len {
+        return Err(LixError::new(
+            LixError::CODE_UNKNOWN,
+            format!(
+                "binary CAS chunk '{}' decoded to {} bytes, expected {}",
+                chunk_hash.to_hex(),
+                decoded.len(),
+                uncompressed_len
+            ),
+        ));
+    }
+    Ok(decoded)
+}
+
+fn raw_payload(chunk_data: &[u8]) -> EncodedChunkPayload<'_> {
+    EncodedChunkPayload {
+        codec: BinaryChunkCodec::Raw,
+        data: Cow::Borrowed(chunk_data),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deterministic_high_entropy_bytes(len: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(len);
+        let mut counter = 0u64;
+        while out.len() < len {
+            out.extend_from_slice(blake3::hash(&counter.to_le_bytes()).as_bytes());
+            counter += 1;
+        }
+        out.truncate(len);
+        out
+    }
+
+    #[test]
+    #[cfg(not(target_family = "wasm"))]
+    fn compresses_repetitive_chunks_and_roundtrips() {
+        let data = b"component-section:function-signature\n".repeat(4096);
+        let chunk_hash = BlobHash::from_content(&data);
+
+        let encoded = encode_chunk_payload(chunk_hash, &data).expect("chunk should encode");
+
+        assert_eq!(encoded.codec, BinaryChunkCodec::Zstd);
+        assert!(encoded.data.len() < data.len() / 4);
+        assert_eq!(
+            decode_zstd_chunk(chunk_hash, &encoded.data, data.len()).expect("chunk should decode"),
+            data
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_family = "wasm"))]
+    fn keeps_small_and_high_entropy_chunks_raw() {
+        let small = vec![b'a'; ZSTD_MIN_CHUNK_BYTES - 1];
+        let small_hash = BlobHash::from_content(&small);
+        let high_entropy = deterministic_high_entropy_bytes(32 * 1024);
+        let high_entropy_hash = BlobHash::from_content(&high_entropy);
+
+        let small_encoded =
+            encode_chunk_payload(small_hash, &small).expect("small chunk should encode");
+        let high_entropy_encoded = encode_chunk_payload(high_entropy_hash, &high_entropy)
+            .expect("high-entropy chunk should encode");
+
+        assert_eq!(small_encoded.codec, BinaryChunkCodec::Raw);
+        assert_eq!(small_encoded.data.as_ref(), small);
+        assert_eq!(high_entropy_encoded.codec, BinaryChunkCodec::Raw);
+        assert_eq!(high_entropy_encoded.data.as_ref(), high_entropy);
+    }
+
+    #[test]
+    #[cfg(not(target_family = "wasm"))]
+    fn savings_policy_enforces_absolute_and_relative_floors() {
+        assert!(!compression_is_worthwhile(512, 385));
+        assert!(compression_is_worthwhile(512, 384));
+        assert!(!compression_is_worthwhile(4096, 3585));
+        assert!(compression_is_worthwhile(4096, 3584));
+    }
+
+    #[test]
+    #[cfg(not(target_family = "wasm"))]
+    fn rejects_truncated_zstd_payload() {
+        let data = b"compressible binary CAS bytes".repeat(4096);
+        let chunk_hash = BlobHash::from_content(&data);
+        let encoded = encode_chunk_payload(chunk_hash, &data).expect("chunk should encode");
+        assert_eq!(encoded.codec, BinaryChunkCodec::Zstd);
+        let mut corrupted = encoded.data.into_owned();
+        corrupted.truncate(corrupted.len() / 2);
+
+        let error = decode_zstd_chunk(chunk_hash, &corrupted, data.len())
+            .expect_err("truncated zstd should fail");
+
+        assert!(error.message.contains("decompression failed"));
+    }
+}

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -1,12 +1,13 @@
 #![allow(clippy::cast_sign_loss)]
 
 use crate::LixError;
-use crate::binary_cas::chunking::fastcdc_chunk_ranges_with_chunking;
+use crate::binary_cas::chunking::{MAX_BINARY_CAS_CHUNK_BYTES, fastcdc_chunk_ranges_with_chunking};
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
     decode_binary_cas_manifest_chunk, encode_binary_cas_chunk, encode_binary_cas_manifest,
     encode_binary_cas_manifest_chunk,
 };
+use crate::binary_cas::compression::{decode_zstd_chunk, encode_chunk_payload};
 use crate::binary_cas::{
     BinaryCasChunking, BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch,
     BlobWriteReceipt,
@@ -20,6 +21,7 @@ use crate::storage_adapter::{
 };
 use bytes::Bytes;
 use futures_util::{StreamExt, stream};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use web_time::Instant;
 
@@ -173,6 +175,22 @@ pub(crate) fn stage_chunk(
         key(chunk_key(chunk_hash)),
         value(encode_binary_cas_chunk(codec, uncompressed_len, payload)),
     );
+}
+
+fn stage_content_chunk(
+    writes: &mut StorageWriteSet,
+    chunk_hash: BlobHash,
+    chunk_data: &[u8],
+) -> Result<(), LixError> {
+    let encoded = encode_chunk_payload(chunk_hash, chunk_data)?;
+    stage_chunk(
+        writes,
+        chunk_hash,
+        encoded.codec,
+        chunk_data.len() as u64,
+        &encoded.data,
+    );
+    Ok(())
 }
 
 #[cfg(test)]
@@ -465,7 +483,7 @@ fn assemble_blob_bytes(
             )?;
             if cfg!(debug_assertions)
                 && *chunk_hash != metadata.hash
-                && BlobHash::from_content(chunk) != metadata.hash
+                && BlobHash::from_content(&chunk) != metadata.hash
             {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
@@ -475,7 +493,7 @@ fn assemble_blob_bytes(
                     ),
                 ));
             }
-            chunk.to_vec()
+            chunk.into_owned()
         }
         BlobLayout::Chunked { chunk_count } => {
             let Some(manifest_chunks) = chunked_manifest else {
@@ -509,7 +527,7 @@ fn assemble_blob_bytes(
                     chunk_hash,
                     expected_chunk_size,
                 )?;
-                out.extend_from_slice(chunk);
+                out.extend_from_slice(&chunk);
             }
             if out.len() != expected_blob_size {
                 return Err(LixError::new(
@@ -542,7 +560,7 @@ fn decode_chunk_from_map(
     blob_hash: BlobHash,
     chunk_hash: BlobHash,
     expected_chunk_size: usize,
-) -> Result<&[u8], LixError> {
+) -> Result<Cow<'_, [u8]>, LixError> {
     let Some(Some(chunk_bytes)) = chunk_rows_by_hash.get(&chunk_hash) else {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
@@ -561,8 +579,21 @@ fn decode_and_verify_chunk(
     expected_chunk_size: usize,
     blob_hash: BlobHash,
     chunk_hash: BlobHash,
-) -> Result<&[u8], LixError> {
+) -> Result<Cow<'_, [u8]>, LixError> {
     let (codec, uncompressed_len, chunk_payload) = decode_binary_cas_chunk(chunk_bytes)?;
+    if expected_chunk_size > MAX_BINARY_CAS_CHUNK_BYTES
+        || uncompressed_len > MAX_BINARY_CAS_CHUNK_BYTES as u64
+    {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!(
+                "binary CAS chunk '{}' for blob '{}' exceeds the {} byte format maximum",
+                chunk_hash.to_hex(),
+                blob_hash.to_hex(),
+                MAX_BINARY_CAS_CHUNK_BYTES
+            ),
+        ));
+    }
     if uncompressed_len != expected_chunk_size as u64 {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
@@ -575,8 +606,15 @@ fn decode_and_verify_chunk(
             ),
         ));
     }
-    let BinaryChunkCodec::Raw = codec;
-    if chunk_payload.len() != expected_chunk_size {
+    let decoded = match codec {
+        BinaryChunkCodec::Raw => Cow::Borrowed(chunk_payload),
+        BinaryChunkCodec::Zstd => Cow::Owned(decode_zstd_chunk(
+            chunk_hash,
+            chunk_payload,
+            expected_chunk_size,
+        )?),
+    };
+    if decoded.len() != expected_chunk_size {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!(
@@ -584,11 +622,15 @@ fn decode_and_verify_chunk(
                 chunk_hash.to_hex(),
                 blob_hash.to_hex(),
                 expected_chunk_size,
-                chunk_payload.len()
+                decoded.len()
             ),
         ));
     }
-    if cfg!(debug_assertions) && BlobHash::from_content(chunk_payload) != chunk_hash {
+    // Native zstd level 1 does not enable frame checksums. Always authenticate
+    // decoded compressed bytes against the CAS key, including in release builds.
+    if (matches!(codec, BinaryChunkCodec::Zstd) || cfg!(debug_assertions))
+        && BlobHash::from_content(&decoded) != chunk_hash
+    {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!(
@@ -598,7 +640,7 @@ fn decode_and_verify_chunk(
             ),
         ));
     }
-    Ok(chunk_payload)
+    Ok(decoded)
 }
 
 pub(in crate::binary_cas) async fn stage_blob_write_skipping_existing_chunks<S>(
@@ -720,13 +762,7 @@ fn stage_prepared_blob_write(
                 },
             );
             if should_stage_chunk(chunk_hash)? {
-                stage_chunk(
-                    writes,
-                    chunk_hash,
-                    BinaryChunkCodec::Raw,
-                    bytes.len() as u64,
-                    bytes,
-                );
+                stage_content_chunk(writes, chunk_hash, bytes)?;
             }
         }
         BlobLayout::Chunked { chunk_count } => {
@@ -743,13 +779,7 @@ fn stage_prepared_blob_write(
                 let chunk_data = &bytes[chunk.start..chunk.end];
                 let chunk_hash = chunk.hash;
                 if should_stage_chunk(chunk_hash)? {
-                    stage_chunk(
-                        writes,
-                        chunk_hash,
-                        BinaryChunkCodec::Raw,
-                        chunk_data.len() as u64,
-                        chunk_data,
-                    );
+                    stage_content_chunk(writes, chunk_hash, chunk_data)?;
                 }
 
                 stage_manifest_chunk(
@@ -915,6 +945,18 @@ mod tests {
             .map(|index| (index % 251) as u8)
             .collect::<Vec<_>>()
     }
+
+    fn deterministic_high_entropy_bytes(len: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(len);
+        let mut counter = 0u64;
+        while out.len() < len {
+            out.extend_from_slice(blake3::hash(&counter.to_le_bytes()).as_bytes());
+            counter += 1;
+        }
+        out.truncate(len);
+        out
+    }
+
     use crate::binary_cas::BinaryCasContext;
     use crate::binary_cas::BlobPayload;
     use crate::storage_adapter::StorageAdapter;
@@ -1503,6 +1545,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn public_kv_api_compresses_repetitive_single_chunk_blob() {
+        let storage = StorageAdapter::new(Memory::new());
+        let data = b"component-section:function-signature\n".repeat(1024);
+        let blob_hash = BlobHash::from_content(&data);
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_bytes(&storage, &mut writes, &data).await;
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("blob write should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let stored = load_chunk(&store, blob_hash)
+            .await
+            .expect("chunk should load")
+            .expect("chunk should exist");
+        assert_eq!(stored.codec, BinaryChunkCodec::Zstd);
+        assert_eq!(stored.uncompressed_len, data.len() as u64);
+        assert!(stored.data.len() < data.len() / 4);
+
+        assert_eq!(
+            load_bytes_many(&store, &[blob_hash])
+                .await
+                .expect("blob should load")
+                .into_vec(),
+            vec![Some(data)]
+        );
+    }
+
+    #[tokio::test]
+    async fn public_kv_api_keeps_high_entropy_single_chunk_raw() {
+        let storage = StorageAdapter::new(Memory::new());
+        let data = deterministic_high_entropy_bytes(32 * 1024);
+        let blob_hash = BlobHash::from_content(&data);
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_bytes(&storage, &mut writes, &data).await;
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("blob write should commit");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let stored = load_chunk(&store, blob_hash)
+            .await
+            .expect("chunk should load")
+            .expect("chunk should exist");
+        assert_eq!(stored.codec, BinaryChunkCodec::Raw);
+        assert_eq!(stored.uncompressed_len, data.len() as u64);
+        assert_eq!(stored.data, data);
+    }
+
+    #[tokio::test]
     async fn existing_chunk_aware_writer_skips_persisted_chunk_payloads() {
         let storage = StorageAdapter::new(Memory::new());
         let data = b"hello chunked kv cas";
@@ -1758,6 +1864,92 @@ mod tests {
                 .message
                 .contains("failed content-address verification")
         );
+    }
+
+    #[tokio::test]
+    async fn read_rejects_truncated_zstd_chunk() {
+        let storage = StorageAdapter::new(Memory::new());
+        let data = b"compressible binary CAS bytes".repeat(4096);
+        let blob_hash = BlobHash::from_content(&data);
+
+        {
+            let mut writes = storage.new_write_set();
+            stage_test_bytes(&storage, &mut writes, &data).await;
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("blob write should commit");
+        }
+
+        let encoded = encode_chunk_payload(blob_hash, &data).expect("chunk should encode");
+        assert_eq!(encoded.codec, BinaryChunkCodec::Zstd);
+        let mut corrupted = encoded.data.into_owned();
+        corrupted.truncate(corrupted.len() / 2);
+        {
+            let mut writes = storage.new_write_set();
+            writes.put(
+                BINARY_CAS_CHUNK_SPACE,
+                key(chunk_key(blob_hash)),
+                value(encode_binary_cas_chunk(
+                    BinaryChunkCodec::Zstd,
+                    data.len() as u64,
+                    &corrupted,
+                )),
+            );
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("corrupt chunk should overwrite");
+        }
+
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let error = load_bytes_many(&store, &[blob_hash])
+            .await
+            .expect_err("corrupt chunk should be rejected");
+        assert!(error.message.contains("decompression failed"));
+    }
+
+    #[test]
+    fn decode_rejects_same_length_valid_zstd_frame_for_wrong_hash() {
+        let expected = vec![b'a'; 128 * 1024];
+        let substituted = vec![b'b'; expected.len()];
+        assert_eq!(expected.len(), substituted.len());
+        let expected_hash = BlobHash::from_content(&expected);
+        let substituted_hash = BlobHash::from_content(&substituted);
+        let encoded = encode_chunk_payload(substituted_hash, &substituted)
+            .expect("substituted chunk should encode");
+        assert_eq!(encoded.codec, BinaryChunkCodec::Zstd);
+        let row =
+            encode_binary_cas_chunk(BinaryChunkCodec::Zstd, expected.len() as u64, &encoded.data);
+
+        let error = decode_and_verify_chunk(&row, expected.len(), expected_hash, expected_hash)
+            .expect_err("valid zstd frame for different bytes should be rejected");
+
+        assert!(
+            error
+                .message
+                .contains("failed content-address verification")
+        );
+    }
+
+    #[test]
+    fn decode_rejects_chunks_above_the_format_maximum_before_decompression() {
+        let data = b"valid compressed content".repeat(4096);
+        let chunk_hash = BlobHash::from_content(&data);
+        let encoded = encode_chunk_payload(chunk_hash, &data).expect("chunk should encode");
+        assert_eq!(encoded.codec, BinaryChunkCodec::Zstd);
+        let oversized_len = MAX_BINARY_CAS_CHUNK_BYTES + 1;
+        let row =
+            encode_binary_cas_chunk(BinaryChunkCodec::Zstd, oversized_len as u64, &encoded.data);
+
+        let error = decode_and_verify_chunk(&row, oversized_len, chunk_hash, chunk_hash)
+            .expect_err("oversized chunk metadata should be rejected");
+
+        assert!(error.message.contains("exceeds"));
+        assert!(error.message.contains("format maximum"));
     }
 
     #[tokio::test]

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -1,5 +1,6 @@
 mod chunking;
 mod codec;
+mod compression;
 mod context;
 pub(crate) mod kv;
 pub(crate) mod metrics;

--- a/packages/engine/src/compression.rs
+++ b/packages/engine/src/compression.rs
@@ -1,0 +1,172 @@
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn compress_zstd_level_1(data: &[u8]) -> Result<Vec<u8>, String> {
+    zstd::bulk::compress(data, 1).map_err(|error| error.to_string())
+}
+
+#[cfg(target_family = "wasm")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "keep the native and WASM compression APIs identical"
+)]
+pub(crate) fn compress_zstd_level_1(data: &[u8]) -> Result<Vec<u8>, String> {
+    Ok(ruzstd::encoding::compress_to_vec(
+        data,
+        ruzstd::encoding::CompressionLevel::Fastest,
+    ))
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn decompress_zstd(
+    compressed_payload: &[u8],
+    uncompressed_len: usize,
+) -> Result<Vec<u8>, String> {
+    zstd::bulk::decompress(compressed_payload, uncompressed_len).map_err(|error| error.to_string())
+}
+
+#[cfg(target_family = "wasm")]
+pub(crate) fn decompress_zstd(
+    compressed_payload: &[u8],
+    uncompressed_len: usize,
+) -> Result<Vec<u8>, String> {
+    use std::io::Read as _;
+
+    validate_zstd_frame_limits(compressed_payload, uncompressed_len)?;
+    let decoder = ruzstd::decoding::StreamingDecoder::new(compressed_payload)
+        .map_err(|error| error.to_string())?;
+    let output_limit = u64::try_from(uncompressed_len)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let mut limited = decoder.take(output_limit);
+    let mut output = Vec::new();
+    limited
+        .read_to_end(&mut output)
+        .map_err(|error| error.to_string())?;
+    Ok(output)
+}
+
+#[cfg(any(test, target_family = "wasm"))]
+fn validate_zstd_frame_limits(
+    compressed_payload: &[u8],
+    uncompressed_len: usize,
+) -> Result<(), String> {
+    const MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
+    const MAX_BLOCK_BYTES: u64 = 128 * 1024;
+
+    if compressed_payload.get(..MAGIC.len()) != Some(MAGIC.as_slice()) {
+        return Err("invalid zstd frame magic".to_string());
+    }
+    let descriptor = *compressed_payload
+        .get(MAGIC.len())
+        .ok_or_else(|| "truncated zstd frame descriptor".to_string())?;
+    if descriptor & 0x18 != 0 {
+        return Err("invalid zstd frame descriptor".to_string());
+    }
+
+    let single_segment = descriptor & 0x20 != 0;
+    let mut cursor = MAGIC.len() + 1;
+    let window_size = if single_segment {
+        None
+    } else {
+        let window_descriptor = *compressed_payload
+            .get(cursor)
+            .ok_or_else(|| "truncated zstd window descriptor".to_string())?;
+        cursor += 1;
+        let exponent = window_descriptor >> 3;
+        let mantissa = window_descriptor & 0x07;
+        let window_base = 1_u64 << (10 + u32::from(exponent));
+        Some(window_base + (window_base / 8) * u64::from(mantissa))
+    };
+
+    let dictionary_id_bytes = match descriptor & 0x03 {
+        0 => 0,
+        1 => 1,
+        2 => 2,
+        3 => 4,
+        _ => unreachable!(),
+    };
+    cursor = cursor
+        .checked_add(dictionary_id_bytes)
+        .ok_or_else(|| "zstd frame header length overflow".to_string())?;
+
+    let frame_content_size_bytes = match descriptor >> 6 {
+        0 if single_segment => 1,
+        0 => 0,
+        1 => 2,
+        2 => 4,
+        3 => 8,
+        _ => unreachable!(),
+    };
+    let frame_content_size = if frame_content_size_bytes == 0 {
+        None
+    } else {
+        let end = cursor
+            .checked_add(frame_content_size_bytes)
+            .ok_or_else(|| "zstd frame header length overflow".to_string())?;
+        let encoded = compressed_payload
+            .get(cursor..end)
+            .ok_or_else(|| "truncated zstd frame content size".to_string())?;
+        let mut bytes = [0_u8; 8];
+        bytes[..encoded.len()].copy_from_slice(encoded);
+        let mut decoded = u64::from_le_bytes(bytes);
+        if frame_content_size_bytes == 2 {
+            decoded += 256;
+        }
+        Some(decoded)
+    };
+
+    let expected = u64::try_from(uncompressed_len).unwrap_or(u64::MAX);
+    if let Some(frame_content_size) = frame_content_size
+        && frame_content_size != expected
+    {
+        return Err(format!(
+            "zstd frame content size {frame_content_size} does not match expected {expected}"
+        ));
+    }
+    let window_size = window_size.or(frame_content_size).unwrap_or_default();
+    let maximum_window_size = expected.max(MAX_BLOCK_BYTES);
+    if window_size > maximum_window_size {
+        return Err(format!(
+            "zstd frame window size {window_size} exceeds limit {maximum_window_size}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writer_zstd_frames_fit_the_wasm_decoder_limits() {
+        for size in [512, 128 * 1024, 4 * 1024 * 1024] {
+            let data = vec![b'a'; size];
+            let compressed = compress_zstd_level_1(&data).expect("test frame should compress");
+
+            validate_zstd_frame_limits(&compressed, data.len())
+                .expect("writer frame should fit the WASM decoder limits");
+        }
+    }
+
+    #[test]
+    fn wasm_rejects_zstd_frames_with_oversized_history_windows() {
+        let mut frame = vec![0x28, 0xb5, 0x2f, 0xfd, 0x00];
+        frame.push(14 << 3); // 16 MiB window.
+
+        let error = validate_zstd_frame_limits(&frame, 4 * 1024 * 1024)
+            .expect_err("oversized zstd window should fail before decoder allocation");
+
+        assert!(error.contains("window size"));
+        assert!(error.contains("exceeds limit"));
+    }
+
+    #[test]
+    fn wasm_rejects_zstd_frames_with_wrong_content_size() {
+        let frame = [0x28, 0xb5, 0x2f, 0xfd, 0x20, 5];
+
+        let error = validate_zstd_frame_limits(&frame, 4)
+            .expect_err("mismatched zstd content size should fail");
+
+        assert!(error.contains("content size 5"));
+        assert!(error.contains("expected 4"));
+    }
+}

--- a/packages/engine/src/json_store/compression.rs
+++ b/packages/engine/src/json_store/compression.rs
@@ -1,8 +1,8 @@
 use crate::LixError;
+use crate::compression::{compress_zstd_level_1, decompress_zstd};
 
-#[cfg(not(target_family = "wasm"))]
 pub(crate) fn compress_json_payload(json_data: &[u8]) -> Result<Vec<u8>, LixError> {
-    zstd::bulk::compress(json_data, 1).map_err(|error| LixError {
+    compress_zstd_level_1(json_data).map_err(|error| LixError {
         code: "LIX_ERROR_UNKNOWN".to_string(),
         message: format!("json compression failed: {error}"),
         hint: None,
@@ -10,56 +10,17 @@ pub(crate) fn compress_json_payload(json_data: &[u8]) -> Result<Vec<u8>, LixErro
     })
 }
 
-#[cfg(target_family = "wasm")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "keep the native and WASM compression APIs identical"
-)]
-pub(crate) fn compress_json_payload(json_data: &[u8]) -> Result<Vec<u8>, LixError> {
-    Ok(ruzstd::encoding::compress_to_vec(
-        json_data,
-        ruzstd::encoding::CompressionLevel::Fastest,
-    ))
-}
-
-#[cfg(not(target_family = "wasm"))]
 pub(crate) fn decode_json_zstd_payload(
     compressed_payload: &[u8],
     uncompressed_len: usize,
     hash_hex: &str,
 ) -> Result<Vec<u8>, LixError> {
-    zstd::bulk::decompress(compressed_payload, uncompressed_len).map_err(|error| LixError {
+    decompress_zstd(compressed_payload, uncompressed_len).map_err(|error| LixError {
         code: "LIX_ERROR_UNKNOWN".to_string(),
         message: format!("json decompression failed for ref '{hash_hex}': {error}"),
         hint: None,
         details: None,
     })
-}
-
-#[cfg(target_family = "wasm")]
-pub(crate) fn decode_json_zstd_payload(
-    compressed_payload: &[u8],
-    _uncompressed_len: usize,
-    _hash_hex: &str,
-) -> Result<Vec<u8>, LixError> {
-    use std::io::Read as _;
-
-    let mut decoder =
-        ruzstd::decoding::StreamingDecoder::new(compressed_payload).map_err(|error| LixError {
-            code: "LIX_ERROR_UNKNOWN".to_string(),
-            message: format!("json decompression failed: {error}"),
-            hint: None,
-            details: None,
-        })?;
-
-    let mut output = Vec::new();
-    decoder.read_to_end(&mut output).map_err(|error| LixError {
-        code: "LIX_ERROR_UNKNOWN".to_string(),
-        message: format!("json decompression failed: {error}"),
-        hint: None,
-        details: None,
-    })?;
-    Ok(output)
 }
 
 #[cfg(test)]

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod cel;
 pub mod changelog;
 pub(crate) mod commit_graph;
 mod common;
+pub(crate) mod compression;
 pub(crate) mod domain;
 pub mod engine;
 pub(crate) mod entity_pk;


### PR DESCRIPTION
## Summary

- encode native/server binary CAS chunks with zstd level 1 only when they save at least 128 bytes and 12.5%
- keep small and high-entropy chunks raw
- keep chunk hashes and deduplication over uncompressed content
- decode Raw and Zstd on native and WASM; WASM writers intentionally keep Raw
- share the bounded native/WASM zstd decode helper with the JSON store

This is a clean codec change, not a migration or compatibility shim. Raw remains the adaptive fallback. Current code reads both codecs; older binaries will not understand newly written Zstd rows.

## End-to-end storage profiling

Representative input: a real 2,071,182-byte CSV plugin WASM, written through Engine → binary CAS → SlateDB using the versioned LZ4 layout from #704.

| Metric | Raw CAS + SlateDB LZ4 | Selective zstd CAS | Change |
| --- | ---: | ---: | ---: |
| Physical database bytes | 1,020,528–1,020,550 B | 721,467–721,490 B | **-29.3%** |
| CAS chunk payload bytes | 2,071,182 B | 716,925 B | **-65.4%** |

Seven alternating fresh-database A/B pairs measured a median +5.688 ms (+22.7%) on this uncommon first plugin write.

A 100-round codec probe isolates the trade-off:

| Codec | Encode time | Output |
| --- | ---: | ---: |
| LZ4 | 3.035 ms | 1,017,882 B |
| zstd level 1 | 4.203 ms | 716,918 B |

That is ~1.17 ms additional codec CPU for 29.6% fewer bytes than LZ4. The selective threshold avoids paying it for marginal frames. This follows the established lightweight/adaptive compression pattern documented by [RocksDB](https://github.com/facebook/rocksdb/wiki/Compression) and uses [Zstandard](https://facebook.github.io/zstd/index.html)'s fast level 1.

## WASM policy

A wasm32/Node probe on the current 2,134,363-byte CSV plugin measured the only implemented ruzstd encoder at 33.6 ms and 1,009,513 bytes—about 8× native encode time, with output close to the existing SlateDB LZ4 result. Higher ruzstd levels are unimplemented.

Therefore WASM writes Raw instead of overpaying for little physical gain. It still reads native Zstd rows: the same probe measured 13.392 ms for WASM decode plus required BLAKE3 verification. Because CAS deduplication is by uncompressed hash, the first writer fixes a chunk's representation; a WASM-first Raw chunk is not opportunistically rewritten later.

## Bounds and integrity

- each declared and expected chunk size is capped at the fixed 4 MiB format maximum before decompression
- compressed chunks are BLAKE3-verified in release builds because level-1 frames do not carry a checksum
- WASM parses the standard frame header before constructing ruzstd, bounding its advertised history window and emitted output
- truncated frames, oversized metadata, and valid same-length frames containing the wrong bytes are rejected
- Raw decoding remains zero-copy through `Cow`

## Validation

- change-fragment validation
- `cargo fmt --all -- --check`
- `git diff --check`
- 30 binary CAS tests
- 8 shared/binary/JSON compression tests
- optimized release-mode content-substitution rejection test
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- production `npm run build:wasm`
- independent storage/correctness review plus post-fix frame-parser and cross-target review
