### PR TITLE
refactor!(sql): establish one explicit history vocabulary

### DIFF
--- a/.changenotes/establish-explicit-sql-history-vocabulary.md
+++ b/.changenotes/establish-explicit-sql-history-vocabulary.md
@@ -1,0 +1,11 @@
+---
+type: minor
+---
+
+Lix SQL history surfaces now use one explicit, prefixed vocabulary.
+
+Every public history surface exposes `lixcol_entity_pk`, `lixcol_observed_commit_id`, `lixcol_commit_created_at`, `lixcol_as_of_commit_id`, `lixcol_depth`, and `lixcol_is_deleted`. The ambiguous `start_commit_id` and `lixcol_start_commit_id` spellings, along with all bare generic-history column names, were removed without aliases.
+
+Raw state and typed entity histories expose singular provenance through `lixcol_change_id`, `lixcol_change_created_at`, and `lixcol_origin_key`. Commit time is loaded from the observed commit and no longer silently falls back to change time.
+
+Composed `lix_file_history` and `lix_directory_history` rows expose `lixcol_source_changes` instead of singular change, schema, origin, snapshot, and metadata columns. The non-null JSON array is ordered by change ID and contains `id`, `entity_pk`, `schema_key`, `file_id`, `snapshot_content`, `metadata`, `created_at`, and `origin_key` for each source change.

--- a/docs/history.md
+++ b/docs/history.md
@@ -9,7 +9,7 @@ Lix gives you three SQL surfaces for history. Pick the one that matches the ques
 | Surface | What you ask it |
 | --- | --- |
 | `lix_change` | "Which canonical changes exist?" Tracked history plus the latest compactable untracked change for each current identity. |
-| `lix_state_history` | "What did this version see?" State walked back from a commit, with `depth` for time-travel. |
+| `lix_state_history` | "What did this version see?" State walked back from a commit, with `lixcol_depth` for time-travel. |
 | `<schema>_by_version` | "What's in this version right now?" Current rows in each version. Documented in [Versions & Merging](./versions.md). |
 
 Versions don't filter `lix_change` directly; commit membership lives in the commit graph. Tracked changes are retained by commits. Untracked changes are real change rows too, but a later mutation of the same current identity compacts the superseded untracked change. To scope retained history to a version, use `lix_state_history` with the version's `commit_id`.
@@ -41,21 +41,21 @@ ORDER BY created_at;
 
 ## `lix_state_history` columns
 
-| Column               | What it is                                                                              |
-| -------------------- | --------------------------------------------------------------------------------------- |
-| `entity_pk`          | JSON array of the row's primary-key values, in `x-lix-primary-key` order.                |
-| `schema_key`         | Which schema.                                                                           |
-| `file_id`            | The file the row belongs to, or `null`.                                                 |
-| `snapshot_content`   | JSON snapshot at this depth.                                                            |
-| `metadata`           | JSON metadata.                                                                          |
-| `schema_version`     | Schema contract version.                                                                |
-| `change_id`          | The `lix_change.id` that produced this state.                                           |
-| `observed_commit_id` | The commit where this state was recorded.                                               |
-| `commit_created_at`  | When the commit was created.                                                            |
-| `start_commit_id`    | The commit the walk started from (typically the version's tip, `lix_version.commit_id`). |
-| `depth`              | `0` = current state at `start_commit_id`. Higher values walk back through history.       |
-
-`schema_version` here is engine metadata on history/state projections. It is not a schema authoring field; do not put `x-lix-version` in registered schemas.
+| Column                     | What it is                                                                                     |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| `lixcol_entity_pk`         | JSON array of the row's primary-key values, in `x-lix-primary-key` order.                       |
+| `lixcol_schema_key`        | Which schema.                                                                                  |
+| `lixcol_file_id`           | The file the row belongs to, or `null`.                                                        |
+| `lixcol_snapshot_content`  | JSON snapshot at this revision, or `null` for a tombstone.                                     |
+| `lixcol_metadata`          | JSON metadata.                                                                                 |
+| `lixcol_change_id`         | The `lix_change.id` that produced this state.                                                  |
+| `lixcol_change_created_at` | When that source change was created.                                                           |
+| `lixcol_origin_key`        | Optional origin key attached to the source change.                                             |
+| `lixcol_observed_commit_id`| The commit where this state was recorded.                                                      |
+| `lixcol_commit_created_at` | When that commit was created. This never falls back to the change timestamp.                    |
+| `lixcol_as_of_commit_id`   | The commit anchoring the walk (typically the active branch tip).                                |
+| `lixcol_depth`             | `0` = revision at the anchor. Higher values walk back through reachable history.                |
+| `lixcol_is_deleted`        | `true` when this revision is a tombstone.                                                      |
 
 ## Recipes
 
@@ -92,14 +92,15 @@ WHERE lixcol_version_id = $1;
 ### What did this version see, walked back through history
 
 ```sql
-SELECT entity_pk, schema_key, snapshot_content, depth, observed_commit_id
+SELECT lixcol_entity_pk, lixcol_schema_key, lixcol_snapshot_content,
+       lixcol_depth, lixcol_observed_commit_id, lixcol_is_deleted
 FROM lix_state_history
-WHERE start_commit_id = lix_active_version_commit_id()
-  AND depth >= 0
-ORDER BY depth, schema_key, entity_pk;
+WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()
+  AND lixcol_depth >= 0
+ORDER BY lixcol_depth, lixcol_schema_key, lixcol_entity_pk;
 ```
 
-`depth = 0` is the current state of that version. Higher depths walk back through earlier commits. Filter by `schema_key` or `entity_pk` to narrow.
+`lixcol_depth = 0` is the current state of that version. Higher depths walk back through earlier commits. Filter by `lixcol_schema_key` or `lixcol_entity_pk` to narrow.
 
 For filesystem history, `lix_file_history` and `lix_directory_history` expose
 logical projection revisions. A directory change is visible in every

--- a/docs/lix-for-ai-agents.md
+++ b/docs/lix-for-ai-agents.md
@@ -44,11 +44,12 @@ if (preview.conflicts.length === 0) {
 The point of routing agent writes through Lix is that you can ask SQL what the agent did:
 
 ```sql
-SELECT entity_pk, schema_key, snapshot_content, depth, observed_commit_id
+SELECT lixcol_entity_pk, lixcol_schema_key, lixcol_snapshot_content,
+       lixcol_depth, lixcol_observed_commit_id, lixcol_is_deleted
 FROM lix_state_history
-WHERE start_commit_id = lix_active_version_commit_id()
-  AND depth >= 0
-ORDER BY depth, schema_key, entity_pk;
+WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()
+  AND lixcol_depth >= 0
+ORDER BY lixcol_depth, lixcol_schema_key, lixcol_entity_pk;
 ```
 
 This is the data your review UI renders. See [Change History](./history.md) for more recipes (per-entity history, who-changed-what, diffs between versions).

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -127,7 +127,7 @@ If a schema author truly needs a breaking change, they mint a new `x-lix-key` (e
 - **Constraints (`x-lix-primary-key`, `x-lix-unique`, `x-lix-foreign-keys`).** Frozen. You can reorder list elements cosmetically (Lix normalizes the comparison), but you can't add, remove, or modify a constraint. Primary-key column order is semantic and cannot be reordered.
 - **Top-level keywords** like `type`, `examples`, `patternProperties`. Frozen.
 - **Nested object schemas.** A property whose `type` is `object` is frozen as a unit: you cannot add subproperties to it. Recursive schema evolution is intentionally a later, explicit feature.
-- **`x-lix-version`.** Rejected if present on either side. The `schema_version` columns you may see on state/history SQL surfaces are engine metadata, not a schema authoring field.
+- **`x-lix-version`.** Rejected if present on either side. The `schema_version` column you may see on current state SQL surfaces is engine metadata, not a schema authoring field.
 
 ### What to do when you really need a breaking change
 

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -30,16 +30,16 @@ Returns the active branch id of the current SQL session. Branch-pinned clients t
 
 Returns the commit id at the tip of the **currently active** branch, as resolved when the SQL statement was planned.
 
-History surfaces (`lix_state_history`, `<schema>_history`, `lix_file_history`, `lix_directory_history`) require a literal or bound-parameter equality on `start_commit_id` (or `lixcol_start_commit_id`). A correlated subquery against `lix_branch` is rejected by the planner. `lix_active_branch_commit_id()` is the canonical way to scope history to the active branch in a single statement:
+History surfaces (`lix_state_history`, `<schema>_history`, `lix_file_history`, `lix_directory_history`) require a literal or bound-parameter equality on `lixcol_as_of_commit_id`. A correlated subquery against `lix_branch` is rejected by the planner. `lix_active_branch_commit_id()` is the canonical way to scope history to the active branch in a single statement:
 
 ```sql
 -- Walk one entity's history from the active branch's tip
-SELECT depth, observed_commit_id, snapshot_content
+SELECT lixcol_depth, lixcol_observed_commit_id, lixcol_snapshot_content
 FROM lix_state_history
-WHERE schema_key = 'task'
-  AND lix_json_get_text(entity_pk, 0) = 't1'
-  AND start_commit_id = lix_active_branch_commit_id()
-ORDER BY depth;
+WHERE lixcol_schema_key = 'task'
+  AND lix_json_get_text(lixcol_entity_pk, 0) = 't1'
+  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
+ORDER BY lixcol_depth;
 ```
 
 For an arbitrary branch, resolve the commit id with one query and pass it as a parameter:
@@ -52,12 +52,12 @@ const { rows } = await lix.execute(
 const commitId = rows[0].value("commit_id").asText();
 
 await lix.execute(
-  `SELECT depth, snapshot_content
+  `SELECT lixcol_depth, lixcol_snapshot_content
      FROM lix_state_history
-    WHERE start_commit_id = $1
-      AND schema_key = $2
-      AND lix_json_get_text(entity_pk, 0) = $3
-    ORDER BY depth`,
+    WHERE lixcol_as_of_commit_id = $1
+      AND lixcol_schema_key = $2
+      AND lix_json_get_text(lixcol_entity_pk, 0) = $3
+    ORDER BY lixcol_depth`,
   [commitId, "task", "t1"],
 );
 ```

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -40,9 +40,9 @@ Common columns (`lix_state` and `lix_state_by_version`): `entity_pk` (JSON array
 
 Every canonical current row has a `change_id`, including rows written with `lixcol_untracked = true`. Untracked current rows have no `commit_id`; tracked rows reference the commit that retained their change. Deleting an untracked row physically removes its flat current-index entry and standalone ChangeRecord; no untracked tombstone is retained. Valid writes reject tracked and untracked rows with the same canonical identity.
 
-`lix_state_history` shares `entity_pk` (JSON array of primary-key values), `schema_key`, `file_id`, `snapshot_content`, `metadata`, `schema_version`, `change_id`, and instead of `commit_id` exposes `start_commit_id`, `observed_commit_id`, `commit_created_at`, and `depth` (commit-graph distance from `start_commit_id`; `0` is the freshest observation, higher values walk back, and intermediate commits that didn't touch the entity are skipped).
+`lix_state_history` uses the same prefixed history vocabulary as every other history surface: `lixcol_entity_pk`, `lixcol_observed_commit_id`, `lixcol_commit_created_at`, `lixcol_as_of_commit_id`, `lixcol_depth`, and `lixcol_is_deleted`. Because it exposes one canonical change per row, it also provides singular provenance through `lixcol_change_id`, `lixcol_change_created_at`, and `lixcol_origin_key`, plus `lixcol_schema_key`, `lixcol_file_id`, `lixcol_snapshot_content`, and `lixcol_metadata`.
 
-> **History queries require a literal filter on `start_commit_id`.** A correlated subquery against `lix_version` is rejected by the planner. Use `lix_active_version_commit_id()` for the active version, or resolve the commit id with one query and pass it as a parameter. See [`lix_active_version_commit_id()`](./sql-functions.md#lix_active_version_commit_id).
+> **History queries require a literal filter on `lixcol_as_of_commit_id`.** A correlated subquery against `lix_branch` is rejected by the planner. Use `lix_active_branch_commit_id()` for the active branch, or resolve the commit id with one query and pass it as a parameter. See [`lix_active_branch_commit_id()`](./sql-functions.md#lix_active_branch_commit_id).
 
 ```sql
 -- Every entity in the active version, raw JSON
@@ -56,12 +56,12 @@ WHERE schema_key = 'task'
   AND version_id IN ($a, $b);
 
 -- Walk history of one entity from a version's tip
-SELECT depth, observed_commit_id, snapshot_content
+SELECT lixcol_depth, lixcol_observed_commit_id, lixcol_snapshot_content
 FROM lix_state_history
-WHERE schema_key = 'task'
-  AND lix_json_get_text(entity_pk, 0) = 't1'
-  AND start_commit_id = lix_active_version_commit_id()
-ORDER BY depth;
+WHERE lixcol_schema_key = 'task'
+  AND lix_json_get_text(lixcol_entity_pk, 0) = 't1'
+  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
+ORDER BY lixcol_depth;
 ```
 
 ## Per-entity sugar
@@ -78,9 +78,9 @@ Per-entity surfaces project user columns directly (`id`, `title`, `done`, …) p
 
 - `<schema>` (active): `lixcol_change_id`, `lixcol_commit_id`, `lixcol_created_at`, `lixcol_updated_at`, plus bookkeeping. **No `lixcol_version_id`**; the active surface is implicitly the active version.
 - `<schema>_by_version`: adds `lixcol_version_id`. INSERT/UPDATE require it.
-- `<schema>_history`: `lixcol_start_commit_id`, `lixcol_observed_commit_id`, `lixcol_depth`, `lixcol_snapshot_content`, `lixcol_change_id` (no `lixcol_commit_id` here; commits in history are addressed via `lixcol_observed_commit_id`).
+- `<schema>_history`: the common history columns plus `lixcol_snapshot_content`, `lixcol_change_id`, `lixcol_change_created_at`, and `lixcol_origin_key` (no `lixcol_commit_id`; revisions are anchored by `lixcol_as_of_commit_id` and observed at `lixcol_observed_commit_id`).
 
-Note the prefix asymmetry between grains: state surfaces use **bare** column names (`start_commit_id`, `depth`, `observed_commit_id`); per-entity, file, and directory surfaces wear `lixcol_` on the same columns.
+There are no bare history aliases. The `lixcol_` prefix and `lixcol_as_of_commit_id` spelling are identical across raw, typed, file, and directory history.
 
 ```sql
 -- Current rows of one schema, typed columns
@@ -95,7 +95,7 @@ WHERE id = 't1' AND lixcol_version_id IN ($a, $b);
 SELECT lixcol_depth, title, done
 FROM task_history
 WHERE id = 't1'
-  AND lixcol_start_commit_id = lix_active_version_commit_id()
+  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
 ORDER BY lixcol_depth;
 ```
 
@@ -111,7 +111,7 @@ When you need the typed columns, reach for the per-entity sugar. When you're que
 | `lix_file_by_version` | Read or write files across versions. |
 | `lix_file_history` | Walk previous versions of a file's bytes through the commit graph. |
 
-User columns: `id`, `path`, `directory_id`, `name`, `data`. System columns are `lixcol_*` (`lixcol_version_id` on `_by_version`; `lixcol_start_commit_id`, `lixcol_depth`, `lixcol_observed_commit_id` on `_history`).
+User columns: `id`, `path`, `directory_id`, `name`, `data`. File history adds the common history columns and `lixcol_source_changes`, a deterministic JSON array of the canonical changes that caused the composed file revision. It deliberately has no singular `lixcol_change_id`, `lixcol_schema_key`, or `lixcol_origin_key`.
 
 `lix_file_history` records changes to the composed file projection, not only
 changes to the file descriptor or bytes. Renaming, moving, deleting, or
@@ -137,7 +137,7 @@ WHERE path = '/orders.xlsx' AND lixcol_version_id IN ($a, $b);
 SELECT lixcol_depth, lixcol_observed_commit_id, data
 FROM lix_file_history
 WHERE path = '/orders.xlsx'
-  AND lixcol_start_commit_id = lix_active_version_commit_id()
+  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
 ORDER BY lixcol_depth;
 ```
 
@@ -153,7 +153,7 @@ Same shape as files, minus the `data` column.
 | `lix_directory_by_version` | Cross-version directory reads/writes. |
 | `lix_directory_history` | Directory history walked through commits. |
 
-User columns: `id`, `path`, `parent_id`, `name`. Same `lixcol_*` system columns as files. Directory paths must end with a trailing slash (`/data/`, not `/data`).
+User columns: `id`, `path`, `parent_id`, `name`. Directory history uses the same common history columns and structured `lixcol_source_changes` provenance as file history. Directory paths must end with a trailing slash (`/data/`, not `/data`).
 
 Directory history uses the same composed-projection rule: an ancestor rename,
 move, deletion, or restoration creates a revision for each descendant
@@ -192,13 +192,17 @@ Per-version history goes through the commit graph, not `lix_change` directly. Se
 
 ## Naming conventions
 
-| Surface family | System column prefix | Version column |
+| Surface family | System column prefix | Branch column |
 | :-- | :-- | :-- |
-| `lix_state*` | bare (no prefix) | `version_id` |
-| `<schema>*`, `lix_file*`, `lix_directory*` | `lixcol_*` | `lixcol_version_id` |
+| `lix_state`, `lix_state_by_branch` | bare (no prefix) | `branch_id` |
+| `lix_state_history` | `lixcol_*` | (none; anchor with `lixcol_as_of_commit_id`) |
+| `<schema>*`, `lix_file*`, `lix_directory*` | `lixcol_*` | `lixcol_branch_id` |
 | `lix_change` | bare | (none, global) |
 
-State surfaces are projection-friendly raw views. Per-entity, file, and directory surfaces wear `lixcol_*` to keep your user columns (`id`, `title`, `path`, …) cleanly separated from Lix bookkeeping.
+Current and cross-branch state surfaces are projection-friendly raw views with
+bare bookkeeping names. History, per-entity, file, and directory surfaces wear
+`lixcol_*` to keep user columns (`id`, `title`, `path`, …) cleanly separated
+from Lix bookkeeping.
 
 ## Composition recap
 

--- a/docs/what-is-lix.md
+++ b/docs/what-is-lix.md
@@ -61,11 +61,11 @@ Lix stores changes as data, not snapshots. One immutable journal across every en
 
 ```sql
 -- What does this version see right now?
-SELECT entity_pk, schema_key, snapshot_content
+SELECT lixcol_entity_pk, lixcol_schema_key, lixcol_snapshot_content
 FROM lix_state_history
-WHERE start_commit_id = lix_active_version_commit_id()
-  AND depth = 0
-ORDER BY schema_key, entity_pk;
+WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()
+  AND lixcol_depth = 0
+ORDER BY lixcol_schema_key, lixcol_entity_pk;
 ```
 
 Whether the entity is a spreadsheet cell, a document clause, a CAD part, or an application row, the surface is the same. Diffs, undo, audit, blame, and attribution are all SQL. See [Change History](./history.md).

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2726,7 +2726,7 @@ mod tests {
         session
             .execute(
                 "SELECT COUNT(*) AS rows FROM lix_key_value_history \
-                 WHERE lixcol_start_commit_id = lix_active_branch_commit_id()",
+                 WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()",
                 &[],
             )
             .await

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -6,10 +6,10 @@ use serde_json::Value as JsonValue;
 
 use crate::LixError;
 use crate::sql2::history_route::{
-    HISTORY_COL_CHANGE_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
-    HISTORY_COL_FILE_ID, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
+    HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT, HISTORY_COL_CHANGE_ID,
+    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK, HISTORY_COL_FILE_ID,
+    HISTORY_COL_IS_DELETED, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
     HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
-    HISTORY_COL_START_COMMIT_ID,
 };
 use crate::sql2::result_metadata::{json_field, mark_json_field};
 
@@ -150,11 +150,13 @@ pub(crate) fn entity_system_fields(shape: EntitySurfaceShape) -> Vec<Field> {
             json_field(HISTORY_COL_SNAPSHOT_CONTENT, true),
             json_field(HISTORY_COL_METADATA, true),
             Field::new(HISTORY_COL_CHANGE_ID, DataType::Utf8, false),
+            Field::new(HISTORY_COL_CHANGE_CREATED_AT, DataType::Utf8, false),
             Field::new(HISTORY_COL_ORIGIN_KEY, DataType::Utf8, true),
             Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
             Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
-            Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),
+            Field::new(HISTORY_COL_AS_OF_COMMIT_ID, DataType::Utf8, false),
             Field::new(HISTORY_COL_DEPTH, DataType::Int64, false),
+            Field::new(HISTORY_COL_IS_DELETED, DataType::Boolean, false),
         ];
     }
 

--- a/packages/engine/src/sql2/catalog/registry.rs
+++ b/packages/engine/src/sql2/catalog/registry.rs
@@ -18,8 +18,11 @@ use crate::sql2::catalog::{
     schema_exposed_as_entity_surface,
 };
 use crate::sql2::history_route::{
-    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
-    HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_SOURCE_CHANGES, HISTORY_COL_START_COMMIT_ID,
+    HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT, HISTORY_COL_CHANGE_ID,
+    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK, HISTORY_COL_FILE_ID,
+    HISTORY_COL_IS_DELETED, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
+    HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
+    HISTORY_COL_SOURCE_CHANGES,
 };
 #[cfg(test)]
 use crate::sql2::result_metadata::json_field;
@@ -124,17 +127,19 @@ impl PublicCatalog {
                 json_field("snapshot_content", true),
             ])),
             PublicSurfaceKind::History => Arc::new(Schema::new(vec![
-                json_field("entity_pk", false),
-                Field::new("schema_key", DataType::Utf8, false),
-                Field::new("file_id", DataType::Utf8, true),
-                json_field("snapshot_content", true),
-                json_field("metadata", true),
-                Field::new("change_id", DataType::Utf8, false),
-                Field::new("origin_key", DataType::Utf8, true),
-                Field::new("observed_commit_id", DataType::Utf8, false),
-                Field::new("commit_created_at", DataType::Utf8, false),
-                Field::new("start_commit_id", DataType::Utf8, false),
-                Field::new("depth", DataType::Int64, false),
+                json_field(HISTORY_COL_ENTITY_PK, false),
+                Field::new(HISTORY_COL_SCHEMA_KEY, DataType::Utf8, false),
+                Field::new(HISTORY_COL_FILE_ID, DataType::Utf8, true),
+                json_field(HISTORY_COL_SNAPSHOT_CONTENT, true),
+                json_field(HISTORY_COL_METADATA, true),
+                Field::new(HISTORY_COL_CHANGE_ID, DataType::Utf8, false),
+                Field::new(HISTORY_COL_CHANGE_CREATED_AT, DataType::Utf8, false),
+                Field::new(HISTORY_COL_ORIGIN_KEY, DataType::Utf8, true),
+                Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
+                Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
+                Field::new(HISTORY_COL_AS_OF_COMMIT_ID, DataType::Utf8, false),
+                Field::new(HISTORY_COL_DEPTH, DataType::Int64, false),
+                Field::new(HISTORY_COL_IS_DELETED, DataType::Boolean, false),
             ])),
             PublicSurfaceKind::FileHistory => history_filesystem_schema(true),
             PublicSurfaceKind::DirectoryHistory => history_filesystem_schema(false),
@@ -382,8 +387,9 @@ fn history_filesystem_schema(include_data: bool) -> SchemaRef {
         json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
-        Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),
+        Field::new(HISTORY_COL_AS_OF_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_DEPTH, DataType::Int64, false),
+        Field::new(HISTORY_COL_IS_DELETED, DataType::Boolean, false),
     ]);
     Arc::new(Schema::new(fields))
 }
@@ -526,17 +532,19 @@ fn entity_system_columns(variant: EntitySurfaceShape) -> Vec<PublicColumn> {
 
 fn state_history_columns() -> Vec<PublicColumn> {
     public_columns([
-        "entity_pk",
-        "schema_key",
-        "file_id",
-        "snapshot_content",
-        "metadata",
-        "change_id",
-        "origin_key",
-        "observed_commit_id",
-        "commit_created_at",
-        "start_commit_id",
-        "depth",
+        HISTORY_COL_ENTITY_PK,
+        HISTORY_COL_SCHEMA_KEY,
+        HISTORY_COL_FILE_ID,
+        HISTORY_COL_SNAPSHOT_CONTENT,
+        HISTORY_COL_METADATA,
+        HISTORY_COL_CHANGE_ID,
+        HISTORY_COL_CHANGE_CREATED_AT,
+        HISTORY_COL_ORIGIN_KEY,
+        HISTORY_COL_OBSERVED_COMMIT_ID,
+        HISTORY_COL_COMMIT_CREATED_AT,
+        HISTORY_COL_AS_OF_COMMIT_ID,
+        HISTORY_COL_DEPTH,
+        HISTORY_COL_IS_DELETED,
     ])
 }
 
@@ -551,8 +559,9 @@ fn file_history_columns() -> Vec<PublicColumn> {
         HISTORY_COL_SOURCE_CHANGES,
         HISTORY_COL_OBSERVED_COMMIT_ID,
         HISTORY_COL_COMMIT_CREATED_AT,
-        HISTORY_COL_START_COMMIT_ID,
+        HISTORY_COL_AS_OF_COMMIT_ID,
         HISTORY_COL_DEPTH,
+        HISTORY_COL_IS_DELETED,
     ])
 }
 
@@ -566,7 +575,8 @@ fn directory_history_columns() -> Vec<PublicColumn> {
         HISTORY_COL_SOURCE_CHANGES,
         HISTORY_COL_OBSERVED_COMMIT_ID,
         HISTORY_COL_COMMIT_CREATED_AT,
-        HISTORY_COL_START_COMMIT_ID,
+        HISTORY_COL_AS_OF_COMMIT_ID,
         HISTORY_COL_DEPTH,
+        HISTORY_COL_IS_DELETED,
     ])
 }

--- a/packages/engine/src/sql2/error.rs
+++ b/packages/engine/src/sql2/error.rs
@@ -79,7 +79,7 @@ fn classify_datafusion_error(error: &DataFusionError) -> LixError {
             .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...");
     }
 
-    if lower.contains("requires start_commit_id")
+    if lower.contains("requires a lixcol_as_of_commit_id filter")
         || lower.contains("history filter")
         || lower.contains("history table")
     {

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2948,12 +2948,12 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT entity_pk, snapshot_content, metadata, depth, start_commit_id \
+                    "SELECT lixcol_entity_pk, lixcol_snapshot_content, lixcol_metadata, lixcol_depth, lixcol_as_of_commit_id \
 	             FROM lix_state_history \
-	             WHERE schema_key = 'test_state_schema' \
-	               AND entity_pk = lix_json('[\"entity-history\"]') \
-	               AND start_commit_id = '{head_commit_id}' \
-	               AND depth >= 0"
+	             WHERE lixcol_schema_key = 'test_state_schema' \
+	               AND lixcol_entity_pk = lix_json('[\"entity-history\"]') \
+	               AND lixcol_as_of_commit_id = '{head_commit_id}' \
+	               AND lixcol_depth >= 0"
                 ),
                 &[],
             )
@@ -2964,11 +2964,11 @@ mod tests {
         assert_eq!(
             columns,
             vec![
-                "entity_pk",
-                "snapshot_content",
-                "metadata",
-                "depth",
-                "start_commit_id"
+                "lixcol_entity_pk",
+                "lixcol_snapshot_content",
+                "lixcol_metadata",
+                "lixcol_depth",
+                "lixcol_as_of_commit_id"
             ]
         );
         assert_eq!(rows.len(), 1);
@@ -2987,9 +2987,9 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT value, count, lixcol_entity_pk, lixcol_start_commit_id, lixcol_depth \
+                    "SELECT value, count, lixcol_entity_pk, lixcol_as_of_commit_id, lixcol_depth \
 	             FROM test_state_schema_history \
-	             WHERE lixcol_start_commit_id = '{head_commit_id}' \
+	             WHERE lixcol_as_of_commit_id = '{head_commit_id}' \
 	               AND lixcol_entity_pk = lix_json('[\"entity-history\"]')"
                 ),
                 &[],
@@ -3004,7 +3004,7 @@ mod tests {
                 "value",
                 "count",
                 "lixcol_entity_pk",
-                "lixcol_start_commit_id",
+                "lixcol_as_of_commit_id",
                 "lixcol_depth",
             ]
         );
@@ -3024,9 +3024,9 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, parent_id, name, path, lixcol_start_commit_id, lixcol_depth \
+                    "SELECT id, parent_id, name, path, lixcol_as_of_commit_id, lixcol_depth \
              FROM lix_directory_history \
-             WHERE id = 'dir-docs' AND lixcol_start_commit_id = '{head_commit_id}'"
+             WHERE id = 'dir-docs' AND lixcol_as_of_commit_id = '{head_commit_id}'"
                 ),
                 &[],
             )
@@ -3045,7 +3045,7 @@ mod tests {
                 "parent_id",
                 "name",
                 "path",
-                "lixcol_start_commit_id",
+                "lixcol_as_of_commit_id",
                 "lixcol_depth",
             ]
         );
@@ -3063,7 +3063,7 @@ mod tests {
                     "SELECT id \
              FROM lix_directory_history \
              WHERE name = 'docs' \
-               AND lixcol_start_commit_id = '{head_commit_id}'"
+               AND lixcol_as_of_commit_id = '{head_commit_id}'"
                 ),
                 &[],
             )
@@ -3084,10 +3084,10 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, path, data, lixcol_start_commit_id, lixcol_depth \
+                    "SELECT id, path, data, lixcol_as_of_commit_id, lixcol_depth \
              FROM lix_file_history \
              WHERE id = 'file-a' \
-               AND lixcol_start_commit_id = '{head_commit_id}' \
+               AND lixcol_as_of_commit_id = '{head_commit_id}' \
                AND data IS NOT NULL \
              ORDER BY lixcol_depth",
                 ),
@@ -3107,7 +3107,7 @@ mod tests {
                 "id",
                 "path",
                 "data",
-                "lixcol_start_commit_id",
+                "lixcol_as_of_commit_id",
                 "lixcol_depth",
             ]
         );
@@ -3124,7 +3124,7 @@ mod tests {
                     "SELECT id \
              FROM lix_file_history \
              WHERE path = '/docs/readme.md' \
-               AND lixcol_start_commit_id = '{head_commit_id}'"
+               AND lixcol_as_of_commit_id = '{head_commit_id}'"
                 ),
                 &[],
             )

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -19,11 +19,11 @@ use crate::storage_adapter::StorageAdapterRead;
 /// Shared routing state for commit-shaped history SQL surfaces.
 ///
 /// History providers differ in how they shape rows, but they should not drift
-/// in how they interpret filters such as `start_commit_id IN (...)`, entity
+/// in how they interpret filters such as `lixcol_as_of_commit_id IN (...)`, entity
 /// filters, or depth ranges.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct HistoryRoute {
-    pub(crate) start_commit_ids: Vec<String>,
+    pub(crate) as_of_commit_ids: Vec<String>,
     pub(crate) entity_pks: Vec<String>,
     pub(crate) schema_keys: Vec<String>,
     pub(crate) file_ids: Vec<String>,
@@ -33,10 +33,10 @@ pub(crate) struct HistoryRoute {
 }
 
 impl HistoryRoute {
-    pub(crate) fn from_filters(filters: &[Expr], column_style: HistoryColumnStyle) -> Self {
+    pub(crate) fn from_filters(filters: &[Expr]) -> Self {
         let mut route = Self::default();
         for filter in filters {
-            apply_history_filter(filter, &mut route, column_style);
+            apply_history_filter(filter, &mut route);
         }
         route
     }
@@ -50,7 +50,7 @@ impl HistoryRoute {
     /// not against the canonical event row.
     pub(crate) fn traversal_only(&self) -> Self {
         Self {
-            start_commit_ids: self.start_commit_ids.clone(),
+            as_of_commit_ids: self.as_of_commit_ids.clone(),
             min_depth: self.min_depth,
             max_depth: self.max_depth,
             contradictory: self.contradictory,
@@ -58,14 +58,14 @@ impl HistoryRoute {
         }
     }
 
-    /// Returns only the explicit history starts.
+    /// Returns only the explicit history anchors.
     ///
     /// Shaped history providers use this for context loading: path/data shaping
     /// often needs ancestor descriptor rows even when the event route is
     /// restricted to a specific depth.
-    pub(crate) fn starts_only(&self) -> Self {
+    pub(crate) fn anchors_only(&self) -> Self {
         Self {
-            start_commit_ids: self.start_commit_ids.clone(),
+            as_of_commit_ids: self.as_of_commit_ids.clone(),
             contradictory: self.contradictory,
             ..Self::default()
         }
@@ -138,8 +138,8 @@ impl HistoryRoute {
 pub(crate) struct HistoryEntry {
     pub(crate) change: MaterializedChange,
     pub(crate) observed_commit_id: String,
-    pub(crate) commit_created_at: String,
-    pub(crate) start_commit_id: String,
+    pub(crate) commit_created_at: Option<String>,
+    pub(crate) as_of_commit_id: String,
     pub(crate) depth: u32,
 }
 
@@ -149,18 +149,20 @@ pub(crate) const HISTORY_COL_FILE_ID: &str = "lixcol_file_id";
 pub(crate) const HISTORY_COL_SNAPSHOT_CONTENT: &str = "lixcol_snapshot_content";
 pub(crate) const HISTORY_COL_METADATA: &str = "lixcol_metadata";
 pub(crate) const HISTORY_COL_CHANGE_ID: &str = "lixcol_change_id";
+pub(crate) const HISTORY_COL_CHANGE_CREATED_AT: &str = "lixcol_change_created_at";
 pub(crate) const HISTORY_COL_SOURCE_CHANGES: &str = "lixcol_source_changes";
 pub(crate) const HISTORY_COL_ORIGIN_KEY: &str = "lixcol_origin_key";
 pub(crate) const HISTORY_COL_OBSERVED_COMMIT_ID: &str = "lixcol_observed_commit_id";
 pub(crate) const HISTORY_COL_COMMIT_CREATED_AT: &str = "lixcol_commit_created_at";
-pub(crate) const HISTORY_COL_START_COMMIT_ID: &str = "lixcol_start_commit_id";
+pub(crate) const HISTORY_COL_AS_OF_COMMIT_ID: &str = "lixcol_as_of_commit_id";
 pub(crate) const HISTORY_COL_DEPTH: &str = "lixcol_depth";
+pub(crate) const HISTORY_COL_IS_DELETED: &str = "lixcol_is_deleted";
 
 /// Serializes the deterministic provenance set for one composed history row.
 ///
-/// The array is sorted by change id by the composed provider. Each object
-/// deliberately mirrors `lix_change` so callers can join or inspect raw
-/// provenance without pretending that one source change owns a composed row.
+/// Each object mirrors the public `lix_change` fields. Composed history uses
+/// an array because one logical revision can be caused by multiple source
+/// changes in the same commit.
 pub(crate) fn serialize_history_source_changes(
     changes: &[MaterializedChange],
     surface_name: &str,
@@ -224,13 +226,7 @@ fn parse_optional_source_json(
 
 pub(crate) struct HistoryViewDescriptor<'a> {
     pub(crate) view_name: &'a str,
-    pub(crate) start_commit_column: &'a str,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum HistoryColumnStyle {
-    Bare,
-    Prefixed,
+    pub(crate) as_of_commit_column: &'a str,
 }
 
 /// Commit metadata that a history scan must materialize for its projected
@@ -241,15 +237,8 @@ pub(crate) struct HistoryMetadataProjection {
 }
 
 impl HistoryMetadataProjection {
-    pub(crate) fn from_scan(
-        projected_schema: &SchemaRef,
-        filters: &[Expr],
-        column_style: HistoryColumnStyle,
-    ) -> Self {
-        let column_name = match column_style {
-            HistoryColumnStyle::Bare => "commit_created_at",
-            HistoryColumnStyle::Prefixed => HISTORY_COL_COMMIT_CREATED_AT,
-        };
+    pub(crate) fn from_scan(projected_schema: &SchemaRef, filters: &[Expr]) -> Self {
+        let column_name = HISTORY_COL_COMMIT_CREATED_AT;
         let commit_created_at = projected_schema.field_with_name(column_name).is_ok()
             || filters.iter().any(|filter| {
                 filter
@@ -266,8 +255,8 @@ impl HistoryMetadataProjection {
     }
 }
 
-pub(crate) fn parse_history_filter(expr: &Expr, column_style: HistoryColumnStyle) -> Option<()> {
-    parse_history_filter_terms(expr, column_style).map(|_| ())
+pub(crate) fn parse_history_filter(expr: &Expr) -> Option<()> {
+    parse_history_filter_terms(expr).map(|_| ())
 }
 
 pub(crate) fn commit_graph_history_request(
@@ -307,17 +296,17 @@ where
     if route.is_contradictory() {
         return Ok(Vec::new());
     }
-    if route.start_commit_ids.is_empty() {
+    if route.as_of_commit_ids.is_empty() {
         return Err(LixError::new(
             LixError::CODE_HISTORY_FILTER_REQUIRED,
             format!(
                 "{} requires a {} filter",
-                descriptor.view_name, descriptor.start_commit_column
+                descriptor.view_name, descriptor.as_of_commit_column
             ),
         )
         .with_hint(format!(
             "Use WHERE {} = lix_active_branch_commit_id() to inspect {} from the active branch head.",
-            descriptor.start_commit_column, descriptor.view_name
+            descriptor.as_of_commit_column, descriptor.view_name
         )));
     }
     let Some(request) = commit_graph_history_request(route, schema_keys) else {
@@ -325,15 +314,16 @@ where
     };
 
     let mut rows = Vec::new();
-    for start_commit_id in &route.start_commit_ids {
-        let start_commit_id = CommitId::parse_lix(start_commit_id, "history start_commit_id")?;
+    for as_of_commit_id in &route.as_of_commit_ids {
+        let as_of_commit_id =
+            CommitId::parse_lix(as_of_commit_id, "history lixcol_as_of_commit_id")?;
         let (entries, reachable_commits) = {
             let mut guard = commit_graph.lock().await;
             let entries = guard
-                .change_history_from_commit(&start_commit_id, &request)
+                .change_history_from_commit(&as_of_commit_id, &request)
                 .await?;
             let reachable_commits = if metadata_projection.commit_created_at {
-                guard.reachable_commits(&start_commit_id).await?
+                guard.reachable_commits(&as_of_commit_id).await?
             } else {
                 Vec::new()
             };
@@ -351,14 +341,29 @@ where
 
         for entry in entries {
             let change = materialize_located_history_change(&mut json_reader, entry.change).await?;
+            let commit_created_at = if metadata_projection.commit_created_at {
+                Some(
+                    commit_created_at_by_id
+                        .get(&entry.observed_commit_id)
+                        .cloned()
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "history commit '{}' is missing its commit timestamp",
+                                    entry.observed_commit_id
+                                ),
+                            )
+                        })?,
+                )
+            } else {
+                None
+            };
             rows.push(HistoryEntry {
-                commit_created_at: commit_created_at_by_id
-                    .get(&entry.observed_commit_id)
-                    .cloned()
-                    .unwrap_or_else(|| change.created_at.clone()),
+                commit_created_at,
                 change,
                 observed_commit_id: entry.observed_commit_id.to_string(),
-                start_commit_id: entry.start_commit_id.to_string(),
+                as_of_commit_id: entry.start_commit_id.to_string(),
                 depth: entry.depth,
             });
         }
@@ -391,55 +396,41 @@ fn effective_schema_keys(
     }
 }
 
-fn parse_history_filter_terms(
-    expr: &Expr,
-    column_style: HistoryColumnStyle,
-) -> Option<Vec<HistoryFilterTerm>> {
+fn parse_history_filter_terms(expr: &Expr) -> Option<Vec<HistoryFilterTerm>> {
     match expr {
         Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
-            let mut terms = parse_history_filter_terms(&binary_expr.left, column_style)?;
-            terms.extend(parse_history_filter_terms(
-                &binary_expr.right,
-                column_style,
-            )?);
+            let mut terms = parse_history_filter_terms(&binary_expr.left)?;
+            terms.extend(parse_history_filter_terms(&binary_expr.right)?);
             Some(terms)
         }
         Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
-            parse_history_disjunction(binary_expr, column_style)
+            parse_history_disjunction(binary_expr)
         }
         Expr::BinaryExpr(binary_expr) => {
-            parse_history_binary_filter(binary_expr, column_style).map(|term| vec![term])
+            parse_history_binary_filter(binary_expr).map(|term| vec![term])
         }
-        Expr::InList(in_list) => {
-            parse_history_in_list_filter(in_list, column_style).map(|term| vec![term])
-        }
+        Expr::InList(in_list) => parse_history_in_list_filter(in_list).map(|term| vec![term]),
         _ => None,
     }
 }
 
-fn collect_history_route_terms(
-    expr: &Expr,
-    column_style: HistoryColumnStyle,
-) -> Vec<HistoryFilterTerm> {
+fn collect_history_route_terms(expr: &Expr) -> Vec<HistoryFilterTerm> {
     match expr {
         Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
-            let mut terms = collect_history_route_terms(&binary_expr.left, column_style);
-            terms.extend(collect_history_route_terms(
-                &binary_expr.right,
-                column_style,
-            ));
+            let mut terms = collect_history_route_terms(&binary_expr.left);
+            terms.extend(collect_history_route_terms(&binary_expr.right));
             terms
         }
         // OR filters are only safe to route when the entire disjunction is a
         // supported history predicate. Partially routing one side would change
         // SQL semantics before DataFusion can apply the residual filter.
         Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
-            parse_history_disjunction(binary_expr, column_style).unwrap_or_default()
+            parse_history_disjunction(binary_expr).unwrap_or_default()
         }
-        Expr::BinaryExpr(binary_expr) => parse_history_binary_filter(binary_expr, column_style)
+        Expr::BinaryExpr(binary_expr) => parse_history_binary_filter(binary_expr)
             .map(|term| vec![term])
             .unwrap_or_default(),
-        Expr::InList(in_list) => parse_history_in_list_filter(in_list, column_style)
+        Expr::InList(in_list) => parse_history_in_list_filter(in_list)
             .map(|term| vec![term])
             .unwrap_or_default(),
         _ => Vec::new(),
@@ -448,10 +439,9 @@ fn collect_history_route_terms(
 
 fn parse_history_disjunction(
     binary_expr: &datafusion::logical_expr::BinaryExpr,
-    column_style: HistoryColumnStyle,
 ) -> Option<Vec<HistoryFilterTerm>> {
-    let left = parse_history_filter_terms(&binary_expr.left, column_style)?;
-    let right = parse_history_filter_terms(&binary_expr.right, column_style)?;
+    let left = parse_history_filter_terms(&binary_expr.left)?;
+    let right = parse_history_filter_terms(&binary_expr.right)?;
     let [left] = left.as_slice() else {
         return None;
     };
@@ -463,7 +453,7 @@ fn parse_history_disjunction(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum HistoryFilterTerm {
-    StartCommitIds(Vec<String>),
+    AsOfCommitIds(Vec<String>),
     EntityPks(Vec<String>),
     SchemaKeys(Vec<String>),
     FileIds(Vec<String>),
@@ -477,9 +467,9 @@ fn merge_history_disjunction_terms(
     right: HistoryFilterTerm,
 ) -> Option<HistoryFilterTerm> {
     match (left, right) {
-        (HistoryFilterTerm::StartCommitIds(mut left), HistoryFilterTerm::StartCommitIds(right)) => {
+        (HistoryFilterTerm::AsOfCommitIds(mut left), HistoryFilterTerm::AsOfCommitIds(right)) => {
             extend_unique(&mut left, right);
-            Some(HistoryFilterTerm::StartCommitIds(left))
+            Some(HistoryFilterTerm::AsOfCommitIds(left))
         }
         (HistoryFilterTerm::EntityPks(mut left), HistoryFilterTerm::EntityPks(right)) => {
             extend_unique(&mut left, right);
@@ -499,20 +489,19 @@ fn merge_history_disjunction_terms(
 
 fn parse_history_binary_filter(
     binary_expr: &datafusion::logical_expr::BinaryExpr,
-    column_style: HistoryColumnStyle,
 ) -> Option<HistoryFilterTerm> {
     let Expr::Column(column) = &*binary_expr.left else {
         return None;
     };
-    let column_name = canonical_history_column_name(column.name.as_str(), column_style)?;
+    let column_name = canonical_history_column_name(column.name.as_str())?;
     let right = &*binary_expr.right;
     match (column_name, &binary_expr.op, right) {
         (
-            "start_commit_id" | "schema_key" | "file_id",
+            "as_of_commit_id" | "schema_key" | "file_id",
             Operator::Eq,
             Expr::Literal(ScalarValue::Utf8(Some(value)), _),
         ) => Some(match column_name {
-            "start_commit_id" => HistoryFilterTerm::StartCommitIds(vec![value.clone()]),
+            "as_of_commit_id" => HistoryFilterTerm::AsOfCommitIds(vec![value.clone()]),
             "schema_key" => HistoryFilterTerm::SchemaKeys(vec![value.clone()]),
             "file_id" => HistoryFilterTerm::FileIds(vec![value.clone()]),
             _ => unreachable!(),
@@ -539,10 +528,7 @@ fn parse_history_binary_filter(
     }
 }
 
-fn parse_history_in_list_filter(
-    in_list: &InList,
-    column_style: HistoryColumnStyle,
-) -> Option<HistoryFilterTerm> {
+fn parse_history_in_list_filter(in_list: &InList) -> Option<HistoryFilterTerm> {
     if in_list.negated {
         return None;
     }
@@ -550,7 +536,7 @@ fn parse_history_in_list_filter(
     let Expr::Column(column) = in_list.expr.as_ref() else {
         return None;
     };
-    let column_name = canonical_history_column_name(column.name.as_str(), column_style)?;
+    let column_name = canonical_history_column_name(column.name.as_str())?;
     let values = in_list
         .list
         .iter()
@@ -561,7 +547,7 @@ fn parse_history_in_list_filter(
     }
 
     match column_name {
-        "start_commit_id" => Some(HistoryFilterTerm::StartCommitIds(values)),
+        "as_of_commit_id" => Some(HistoryFilterTerm::AsOfCommitIds(values)),
         "entity_pk" => canonical_entity_pk_values(values).map(HistoryFilterTerm::EntityPks),
         "schema_key" => Some(HistoryFilterTerm::SchemaKeys(values)),
         "file_id" => Some(HistoryFilterTerm::FileIds(values)),
@@ -569,12 +555,12 @@ fn parse_history_in_list_filter(
     }
 }
 
-fn apply_history_filter(expr: &Expr, route: &mut HistoryRoute, column_style: HistoryColumnStyle) {
-    for term in collect_history_route_terms(expr, column_style) {
+fn apply_history_filter(expr: &Expr, route: &mut HistoryRoute) {
+    for term in collect_history_route_terms(expr) {
         match term {
-            HistoryFilterTerm::StartCommitIds(values) => {
+            HistoryFilterTerm::AsOfCommitIds(values) => {
                 route.contradictory |=
-                    apply_conjunctive_values_filter(&mut route.start_commit_ids, values);
+                    apply_conjunctive_values_filter(&mut route.as_of_commit_ids, values);
             }
             HistoryFilterTerm::EntityPks(values) => {
                 route.contradictory |=
@@ -630,19 +616,13 @@ fn canonical_entity_pk_value(value: &str) -> Option<String> {
         .ok()
 }
 
-fn canonical_history_column_name(name: &str, column_style: HistoryColumnStyle) -> Option<&str> {
-    match (column_style, name) {
-        (HistoryColumnStyle::Bare, "start_commit_id")
-        | (HistoryColumnStyle::Prefixed, "lixcol_start_commit_id") => Some("start_commit_id"),
-        (HistoryColumnStyle::Bare, "entity_pk")
-        | (HistoryColumnStyle::Prefixed, "lixcol_entity_pk") => Some("entity_pk"),
-        (HistoryColumnStyle::Bare, "schema_key")
-        | (HistoryColumnStyle::Prefixed, "lixcol_schema_key") => Some("schema_key"),
-        (HistoryColumnStyle::Bare, "file_id")
-        | (HistoryColumnStyle::Prefixed, "lixcol_file_id") => Some("file_id"),
-        (HistoryColumnStyle::Bare, "depth") | (HistoryColumnStyle::Prefixed, "lixcol_depth") => {
-            Some("depth")
-        }
+fn canonical_history_column_name(name: &str) -> Option<&str> {
+    match name {
+        HISTORY_COL_AS_OF_COMMIT_ID => Some("as_of_commit_id"),
+        HISTORY_COL_ENTITY_PK => Some("entity_pk"),
+        HISTORY_COL_SCHEMA_KEY => Some("schema_key"),
+        HISTORY_COL_FILE_ID => Some("file_id"),
+        HISTORY_COL_DEPTH => Some("depth"),
         _ => None,
     }
 }
@@ -703,14 +683,15 @@ mod tests {
     };
 
     use super::{
-        HistoryColumnStyle, HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor,
-        load_history_entries, parse_history_filter,
+        HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH,
+        HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor, load_history_entries,
+        parse_history_filter,
     };
 
     #[test]
     fn route_extraction_keeps_supported_terms_from_mixed_and_filter() {
         let filter = and(
-            eq(col("start_commit_id"), str_lit("commit-1")),
+            eq(col(HISTORY_COL_AS_OF_COMMIT_ID), str_lit("commit-1")),
             Expr::Like(Like::new(
                 false,
                 Box::new(col("path")),
@@ -721,18 +702,18 @@ mod tests {
         );
 
         assert!(
-            parse_history_filter(&filter, HistoryColumnStyle::Bare).is_none(),
+            parse_history_filter(&filter).is_none(),
             "mixed filters must not be advertised as exact pushdown"
         );
 
-        let route = HistoryRoute::from_filters(&[filter], HistoryColumnStyle::Bare);
-        assert_eq!(route.start_commit_ids, vec!["commit-1".to_string()]);
+        let route = HistoryRoute::from_filters(&[filter]);
+        assert_eq!(route.as_of_commit_ids, vec!["commit-1".to_string()]);
     }
 
     #[test]
     fn route_extraction_does_not_partially_route_mixed_or_filter() {
         let filter = or(
-            eq(col("start_commit_id"), str_lit("commit-1")),
+            eq(col(HISTORY_COL_AS_OF_COMMIT_ID), str_lit("commit-1")),
             Expr::Like(Like::new(
                 false,
                 Box::new(col("path")),
@@ -742,51 +723,57 @@ mod tests {
             )),
         );
 
-        let route = HistoryRoute::from_filters(&[filter], HistoryColumnStyle::Bare);
+        let route = HistoryRoute::from_filters(&[filter]);
         assert!(
-            route.start_commit_ids.is_empty(),
+            route.as_of_commit_ids.is_empty(),
             "partial OR pushdown would change SQL semantics"
         );
     }
 
     #[test]
+    fn routing_rejects_retired_history_column_names() {
+        for retired in [
+            "start_commit_id",
+            "lixcol_start_commit_id",
+            "entity_pk",
+            "depth",
+        ] {
+            let filter = eq(col(retired), str_lit("value"));
+            assert!(
+                parse_history_filter(&filter).is_none(),
+                "retired column '{retired}' must not route"
+            );
+            assert!(
+                HistoryRoute::from_filters(&[filter])
+                    .as_of_commit_ids
+                    .is_empty()
+            );
+        }
+    }
+
+    #[test]
     fn commit_metadata_projection_tracks_projection_and_filters() {
         let unrelated_schema = Arc::new(Schema::new(vec![Field::new(
-            "depth",
+            HISTORY_COL_DEPTH,
             DataType::Int64,
             false,
         )]));
-        assert!(
-            !HistoryMetadataProjection::from_scan(
-                &unrelated_schema,
-                &[],
-                HistoryColumnStyle::Bare,
-            )
-            .commit_created_at()
-        );
+        assert!(!HistoryMetadataProjection::from_scan(&unrelated_schema, &[]).commit_created_at());
 
         let projected_schema = Arc::new(Schema::new(vec![Field::new(
-            "lixcol_commit_created_at",
+            HISTORY_COL_COMMIT_CREATED_AT,
             DataType::Utf8,
             false,
         )]));
-        assert!(
-            HistoryMetadataProjection::from_scan(
-                &projected_schema,
-                &[],
-                HistoryColumnStyle::Prefixed,
-            )
-            .commit_created_at()
-        );
+        assert!(HistoryMetadataProjection::from_scan(&projected_schema, &[]).commit_created_at());
 
-        let residual_filter = eq(col("commit_created_at"), str_lit("2026-07-12T00:00:00Z"));
+        let residual_filter = eq(
+            col(HISTORY_COL_COMMIT_CREATED_AT),
+            str_lit("2026-07-12T00:00:00Z"),
+        );
         assert!(
-            HistoryMetadataProjection::from_scan(
-                &unrelated_schema,
-                &[residual_filter],
-                HistoryColumnStyle::Bare,
-            )
-            .commit_created_at()
+            HistoryMetadataProjection::from_scan(&unrelated_schema, &[residual_filter])
+                .commit_created_at()
         );
     }
 
@@ -797,12 +784,12 @@ mod tests {
         let rows = load_history_entries(
             HistoryViewDescriptor {
                 view_name: "test_history",
-                start_commit_column: "start_commit_id",
+                as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
             },
             test_commit_graph(Arc::clone(&reachable_calls), start_commit_id),
             empty_json_reader().await,
             &HistoryRoute {
-                start_commit_ids: vec![start_commit_id.to_string()],
+                as_of_commit_ids: vec![start_commit_id.to_string()],
                 ..HistoryRoute::default()
             },
             vec!["message".to_string()],
@@ -813,6 +800,7 @@ mod tests {
 
         assert_eq!(reachable_calls.load(Ordering::SeqCst), 0);
         assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].commit_created_at, None);
     }
 
     #[tokio::test]
@@ -820,35 +808,74 @@ mod tests {
         let reachable_calls = Arc::new(AtomicUsize::new(0));
         let start_commit_id = CommitId::for_test_label("start");
         let metadata_schema = Arc::new(Schema::new(vec![Field::new(
-            "commit_created_at",
+            HISTORY_COL_COMMIT_CREATED_AT,
             DataType::Utf8,
             false,
         )]));
         let rows = load_history_entries(
             HistoryViewDescriptor {
                 view_name: "test_history",
-                start_commit_column: "start_commit_id",
+                as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
             },
             test_commit_graph(Arc::clone(&reachable_calls), start_commit_id),
             empty_json_reader().await,
             &HistoryRoute {
-                start_commit_ids: vec![start_commit_id.to_string()],
+                as_of_commit_ids: vec![start_commit_id.to_string()],
                 ..HistoryRoute::default()
             },
             vec!["message".to_string()],
-            HistoryMetadataProjection::from_scan(&metadata_schema, &[], HistoryColumnStyle::Bare),
+            HistoryMetadataProjection::from_scan(&metadata_schema, &[]),
         )
         .await
         .expect("history load should enrich commit metadata");
 
         assert_eq!(reachable_calls.load(Ordering::SeqCst), 1);
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].commit_created_at, commit_timestamp().to_string());
+        assert_eq!(
+            rows[0].commit_created_at,
+            Some(commit_timestamp().to_string())
+        );
+        assert_eq!(rows[0].change.created_at, event_timestamp().to_string());
+    }
+
+    #[tokio::test]
+    async fn history_loader_does_not_substitute_change_time_for_missing_commit_time() {
+        let reachable_calls = Arc::new(AtomicUsize::new(0));
+        let as_of_commit_id = CommitId::for_test_label("start");
+        let metadata_schema = Arc::new(Schema::new(vec![Field::new(
+            HISTORY_COL_COMMIT_CREATED_AT,
+            DataType::Utf8,
+            false,
+        )]));
+        let error = load_history_entries(
+            HistoryViewDescriptor {
+                view_name: "test_history",
+                as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
+            },
+            Arc::new(Mutex::new(Box::new(CountingCommitGraphReader {
+                reachable_calls,
+                start_commit_id: as_of_commit_id,
+                include_reachable_commit: false,
+            }))),
+            empty_json_reader().await,
+            &HistoryRoute {
+                as_of_commit_ids: vec![as_of_commit_id.to_string()],
+                ..HistoryRoute::default()
+            },
+            vec!["message".to_string()],
+            HistoryMetadataProjection::from_scan(&metadata_schema, &[]),
+        )
+        .await
+        .expect_err("missing commit metadata must be an explicit error");
+
+        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+        assert!(error.message.contains("missing its commit timestamp"));
     }
 
     struct CountingCommitGraphReader {
         reachable_calls: Arc<AtomicUsize>,
         start_commit_id: CommitId,
+        include_reachable_commit: bool,
     }
 
     #[async_trait::async_trait]
@@ -865,6 +892,9 @@ mod tests {
             _head_commit_id: &CommitId,
         ) -> Result<Vec<ReachableCommitGraphCommit>, LixError> {
             self.reachable_calls.fetch_add(1, Ordering::SeqCst);
+            if !self.include_reachable_commit {
+                return Ok(Vec::new());
+            }
             let change = test_change("commit-change", commit_timestamp());
             Ok(vec![ReachableCommitGraphCommit {
                 commit: CommitGraphCommit {
@@ -900,6 +930,7 @@ mod tests {
         Arc::new(Mutex::new(Box::new(CountingCommitGraphReader {
             reachable_calls,
             start_commit_id,
+            include_reachable_commit: true,
         })))
     }
 

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -24,9 +24,9 @@ use crate::sql2::change_materialization::MaterializedChange;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
 use crate::sql2::history_route::{
-    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
-    HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_SOURCE_CHANGES, HISTORY_COL_START_COMMIT_ID,
-    HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
+    HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH,
+    HISTORY_COL_ENTITY_PK, HISTORY_COL_IS_DELETED, HISTORY_COL_OBSERVED_COMMIT_ID,
+    HISTORY_COL_SOURCE_CHANGES, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
     HistoryViewDescriptor, load_history_entries, parse_history_filter,
     serialize_history_source_changes,
 };
@@ -89,7 +89,7 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        if parse_history_filter(filter, HistoryColumnStyle::Prefixed).is_some() {
+        if parse_history_filter(filter).is_some() {
             TableProviderFilterPushDown::Exact
         } else {
             TableProviderFilterPushDown::Unsupported
@@ -104,9 +104,8 @@ where
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
         let schema = projected_schema(&self.schema, projection);
-        let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Prefixed);
-        let metadata_projection =
-            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
+        let route = HistoryRoute::from_filters(filters);
+        let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
@@ -174,17 +173,18 @@ struct DirectoryHistoryOutputRow {
     path: Option<String>,
     parent_id: Option<String>,
     name: Option<String>,
+    is_deleted: bool,
     event: DirectoryHistoryEvent,
 }
 
 #[derive(Debug, Clone)]
 struct DirectoryHistoryEvent {
     directory_id: String,
-    start_commit_id: String,
+    as_of_commit_id: String,
     depth: u32,
     source_changes: Vec<MaterializedChange>,
     observed_commit_id: String,
-    commit_created_at: String,
+    commit_created_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -207,7 +207,7 @@ where
     let event_entries = load_history_entries(
         HistoryViewDescriptor {
             view_name: "lix_directory_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         Arc::clone(&commit_graph),
         query_source.json_reader.clone(),
@@ -218,7 +218,7 @@ where
     .await?;
     let event_descriptors = parse_directory_history_records(&event_entries)?;
     let parent_commit_ids_by_commit =
-        load_history_commit_parents(&commit_graph, &event_route.start_commit_ids).await?;
+        load_history_commit_parents(&commit_graph, &event_route.as_of_commit_ids).await?;
     let mut observed_commit_ids = event_descriptors
         .iter()
         .map(|record| record.entry.observed_commit_id.clone())
@@ -284,6 +284,7 @@ where
             path,
             parent_id: visible_descriptor.parent_id.clone(),
             name: visible_descriptor.name.clone(),
+            is_deleted: visible_descriptor.name.is_none(),
             event,
         });
     }
@@ -300,12 +301,19 @@ where
     output.sort_by(|left, right| {
         left.entity_pk
             .cmp(&right.entity_pk)
-            .then(left.event.start_commit_id.cmp(&right.event.start_commit_id))
+            .then(left.event.as_of_commit_id.cmp(&right.event.as_of_commit_id))
             .then(left.event.depth.cmp(&right.event.depth))
             .then(
                 left.event
                     .observed_commit_id
                     .cmp(&right.event.observed_commit_id),
+            )
+            .then(
+                left.event
+                    .source_changes
+                    .first()
+                    .map(|change| &change.id)
+                    .cmp(&right.event.source_changes.first().map(|change| &change.id)),
             )
     });
     Ok(output)
@@ -384,8 +392,8 @@ fn directory_history_entry_from_observed_state(
             origin_key: None,
         },
         observed_commit_id: observed_commit_id.to_string(),
-        commit_created_at: row.updated_at,
-        start_commit_id: observed_commit_id.to_string(),
+        commit_created_at: Some(row.updated_at),
+        as_of_commit_id: observed_commit_id.to_string(),
         depth: 0,
     }
 }
@@ -461,7 +469,7 @@ fn grouped_directory_history_events(
                 directory_history_event_from_entry(&affected_directory_id, &descriptor.entry);
             let key = (
                 event.directory_id.clone(),
-                event.start_commit_id.clone(),
+                event.as_of_commit_id.clone(),
                 event.observed_commit_id.clone(),
             );
             match grouped.entry(key) {
@@ -471,9 +479,6 @@ fn grouped_directory_history_events(
                 std::collections::btree_map::Entry::Occupied(mut entry) => {
                     let grouped_event = entry.get_mut();
                     debug_assert_eq!(grouped_event.depth, event.depth);
-                    // When commit metadata is not projected, history loading uses
-                    // each source change's timestamp as an intentionally unused
-                    // fallback. Those timestamps may differ within one commit.
                     grouped_event
                         .source_changes
                         .append(&mut event.source_changes);
@@ -493,7 +498,7 @@ fn grouped_directory_history_events(
     events.sort_by(|left, right| {
         left.directory_id
             .cmp(&right.directory_id)
-            .then(left.start_commit_id.cmp(&right.start_commit_id))
+            .then(left.as_of_commit_id.cmp(&right.as_of_commit_id))
             .then(left.depth.cmp(&right.depth))
             .then(left.observed_commit_id.cmp(&right.observed_commit_id))
     });
@@ -506,7 +511,7 @@ fn directory_history_event_from_entry(
 ) -> DirectoryHistoryEvent {
     DirectoryHistoryEvent {
         directory_id: directory_id.to_string(),
-        start_commit_id: entry.start_commit_id.clone(),
+        as_of_commit_id: entry.as_of_commit_id.clone(),
         depth: entry.depth,
         source_changes: vec![entry.change.clone()],
         observed_commit_id: entry.observed_commit_id.clone(),
@@ -537,15 +542,19 @@ static LIX_DIRECTORY_HISTORY_COLS: ColumnTable<DirectoryHistoryOutputRow> = Colu
         ),
         (
             HISTORY_COL_COMMIT_CREATED_AT,
-            Col::Utf8(|row| Some(row.event.commit_created_at.as_str())),
+            Col::Utf8(|row| row.event.commit_created_at.as_deref()),
         ),
         (
-            HISTORY_COL_START_COMMIT_ID,
-            Col::Utf8(|row| Some(row.event.start_commit_id.as_str())),
+            HISTORY_COL_AS_OF_COMMIT_ID,
+            Col::Utf8(|row| Some(row.event.as_of_commit_id.as_str())),
         ),
         (
             HISTORY_COL_DEPTH,
             Col::I64(|row| Some(i64::from(row.event.depth))),
+        ),
+        (
+            HISTORY_COL_IS_DELETED,
+            Col::Bool(|row| Some(row.is_deleted)),
         ),
     ],
 };
@@ -576,8 +585,9 @@ pub(super) fn lix_directory_history_schema() -> SchemaRef {
         json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
-        Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),
+        Field::new(HISTORY_COL_AS_OF_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_DEPTH, DataType::Int64, false),
+        Field::new(HISTORY_COL_IS_DELETED, DataType::Boolean, false),
     ]))
 }
 
@@ -591,11 +601,11 @@ mod tests {
     #[tokio::test]
     async fn identical_event_and_context_routes_load_history_once() {
         let route = HistoryRoute {
-            start_commit_ids: vec!["cid-start".to_string()],
+            as_of_commit_ids: vec!["cid-start".to_string()],
             ..HistoryRoute::default()
         };
         let event_route = route.traversal_only();
-        let context_route = route.starts_only();
+        let context_route = route.anchors_only();
         assert_eq!(event_route, context_route);
 
         let loads = Arc::new(AtomicUsize::new(0));
@@ -616,12 +626,12 @@ mod tests {
     #[tokio::test]
     async fn differing_depth_routes_load_history_twice() {
         let route = HistoryRoute {
-            start_commit_ids: vec!["cid-start".to_string()],
+            as_of_commit_ids: vec!["cid-start".to_string()],
             max_depth: Some(3),
             ..HistoryRoute::default()
         };
         let event_route = route.traversal_only();
-        let context_route = route.starts_only();
+        let context_route = route.anchors_only();
         assert_ne!(event_route, context_route);
 
         let loads = Arc::new(AtomicUsize::new(0));

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -25,8 +25,9 @@ use crate::sql2::catalog::{
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
 use crate::sql2::history_route::{
-    HISTORY_COL_START_COMMIT_ID, HistoryColumnStyle, HistoryMetadataProjection, HistoryRoute,
-    HistoryViewDescriptor, load_history_entries, parse_history_filter,
+    HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT, HISTORY_COL_IS_DELETED,
+    HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor, load_history_entries,
+    parse_history_filter,
 };
 use crate::sql2::providers::entity::{
     entity_f64_value, entity_i64_value, entity_json_text_value, parse_snapshot,
@@ -91,7 +92,7 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        if parse_history_filter(filter, HistoryColumnStyle::Prefixed).is_some() {
+        if parse_history_filter(filter).is_some() {
             TableProviderFilterPushDown::Exact
         } else {
             TableProviderFilterPushDown::Unsupported
@@ -105,10 +106,9 @@ where
         limit: Option<usize>,
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
-        let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Prefixed);
+        let route = HistoryRoute::from_filters(filters);
         let schema = projected_schema(&self.schema, projection);
-        let metadata_projection =
-            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
+        let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
@@ -143,8 +143,8 @@ where
 struct EntityHistoryRow {
     change: MaterializedChange,
     observed_commit_id: String,
-    commit_created_at: String,
-    start_commit_id: String,
+    commit_created_at: Option<String>,
+    as_of_commit_id: String,
     depth: u32,
 }
 
@@ -163,7 +163,7 @@ where
     let entries = load_history_entries(
         HistoryViewDescriptor {
             view_name: history_view_name.as_str(),
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
         query_source.json_reader,
@@ -178,7 +178,7 @@ where
             change: entry.change,
             observed_commit_id: entry.observed_commit_id,
             commit_created_at: entry.commit_created_at,
-            start_commit_id: entry.start_commit_id,
+            as_of_commit_id: entry.as_of_commit_id,
             depth: entry.depth,
         })
         .collect::<Vec<_>>();
@@ -226,6 +226,10 @@ static ENTITY_HISTORY_SYSTEM_COLS: ColumnTable<EntityHistoryRow> = ColumnTable {
             Col::Utf8(|row| Some(row.change.id.as_str())),
         ),
         (
+            HISTORY_COL_CHANGE_CREATED_AT,
+            Col::Utf8(|row| Some(row.change.created_at.as_str())),
+        ),
+        (
             "lixcol_origin_key",
             Col::Utf8(|row| row.change.origin_key.as_deref()),
         ),
@@ -235,13 +239,17 @@ static ENTITY_HISTORY_SYSTEM_COLS: ColumnTable<EntityHistoryRow> = ColumnTable {
         ),
         (
             "lixcol_commit_created_at",
-            Col::Utf8(|row| Some(row.commit_created_at.as_str())),
+            Col::Utf8(|row| row.commit_created_at.as_deref()),
         ),
         (
-            "lixcol_start_commit_id",
-            Col::Utf8(|row| Some(row.start_commit_id.as_str())),
+            HISTORY_COL_AS_OF_COMMIT_ID,
+            Col::Utf8(|row| Some(row.as_of_commit_id.as_str())),
         ),
         ("lixcol_depth", Col::I64(|row| Some(i64::from(row.depth)))),
+        (
+            HISTORY_COL_IS_DELETED,
+            Col::Bool(|row| Some(row.change.snapshot_content.is_none())),
+        ),
     ],
 };
 

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -34,9 +34,9 @@ use crate::sql2::WriteAccess;
 use crate::sql2::change_materialization::MaterializedChange;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
 use crate::sql2::history_route::{
-    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK,
-    HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_SOURCE_CHANGES, HISTORY_COL_START_COMMIT_ID,
-    HistoryColumnStyle, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
+    HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH,
+    HISTORY_COL_ENTITY_PK, HISTORY_COL_IS_DELETED, HISTORY_COL_OBSERVED_COMMIT_ID,
+    HISTORY_COL_SOURCE_CHANGES, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
     HistoryViewDescriptor, load_history_entries, parse_history_filter,
     serialize_history_source_changes,
 };
@@ -83,7 +83,7 @@ where
 /// SQL spec for `lix_file_history`.
 ///
 /// The reachability-aware file history surface: rows are reconstructed by
-/// walking the commit graph from the routed start commits, resolving the
+/// walking the commit graph from the routed anchor commits, resolving the
 /// nearest descriptor/blob/directory events per file.
 struct LixFileHistorySpec<S> {
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
@@ -111,7 +111,7 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        if parse_history_filter(filter, HistoryColumnStyle::Prefixed).is_some()
+        if parse_history_filter(filter).is_some()
             || FileHistoryPublicPredicate::parse_exact(filter).is_some()
         {
             TableProviderFilterPushDown::Exact
@@ -142,9 +142,8 @@ where
                     .eq_ignore_ascii_case("data")
             })
         });
-        let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Prefixed);
-        let metadata_projection =
-            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Prefixed);
+        let route = HistoryRoute::from_filters(filters);
+        let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         let public_predicate = FileHistoryPublicPredicate::from_filters(filters);
         let lookup_ids = FileHistoryLookupIds::from_public_predicate(&public_predicate);
         Ok(PlannedScan {
@@ -256,11 +255,11 @@ struct FileHistoryPluginOwnerRecord {
 #[derive(Debug, Clone)]
 struct FileHistoryEvent {
     file_id: String,
-    start_commit_id: String,
+    as_of_commit_id: String,
     depth: u32,
     source_changes: Vec<MaterializedChange>,
     observed_commit_id: String,
-    commit_created_at: String,
+    commit_created_at: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -271,6 +270,7 @@ struct FileHistoryOutputRow {
     directory_id: Option<String>,
     name: Option<String>,
     data: Option<Vec<u8>>,
+    is_deleted: bool,
     event: FileHistoryEvent,
 }
 
@@ -544,7 +544,7 @@ where
     }
 
     let event_route = route.traversal_only();
-    let context_route = route.starts_only();
+    let context_route = route.anchors_only();
     let filesystem_context = load_file_history_filesystem_context(
         Arc::clone(&commit_graph),
         query_source.clone(),
@@ -556,7 +556,7 @@ where
     .await?;
     let mut installed_plugins_cache = BTreeMap::<(String, String), InstalledPlugin>::new();
     let parent_commit_ids_by_commit =
-        load_history_commit_parents(&commit_graph, &context_route.start_commit_ids).await?;
+        load_history_commit_parents(&commit_graph, &context_route.as_of_commit_ids).await?;
     let plugin_discovery = discover_file_history_plugins(
         Arc::clone(&commit_graph),
         query_source.clone(),
@@ -722,6 +722,7 @@ where
             directory_id: prepared_row.descriptor.directory_id.clone(),
             name: prepared_row.descriptor.name.clone(),
             data,
+            is_deleted: prepared_row.descriptor.name.is_none(),
             event: prepared_row.event,
         });
     }
@@ -729,7 +730,7 @@ where
     output.sort_by(|left, right| {
         left.entity_pk
             .cmp(&right.entity_pk)
-            .then(left.event.start_commit_id.cmp(&right.event.start_commit_id))
+            .then(left.event.as_of_commit_id.cmp(&right.event.as_of_commit_id))
             .then(left.event.depth.cmp(&right.event.depth))
             .then(
                 left.event
@@ -1192,8 +1193,8 @@ fn history_entry_from_observed_state(
             origin_key: None,
         },
         observed_commit_id: observed_commit_id.to_string(),
-        commit_created_at: row.updated_at,
-        start_commit_id: observed_commit_id.to_string(),
+        commit_created_at: Some(row.updated_at),
+        as_of_commit_id: observed_commit_id.to_string(),
         depth: 0,
     }
 }
@@ -1212,7 +1213,7 @@ where
         return load_history_entries(
             HistoryViewDescriptor {
                 view_name: "lix_file_history",
-                start_commit_column: HISTORY_COL_START_COMMIT_ID,
+                as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
             },
             commit_graph,
             query_source.json_reader,
@@ -1227,7 +1228,7 @@ where
     let mut entries = load_history_entries(
         HistoryViewDescriptor {
             view_name: "lix_file_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         Arc::clone(&commit_graph),
         query_source.json_reader.clone(),
@@ -1245,7 +1246,7 @@ where
     let directories = load_history_entries(
         HistoryViewDescriptor {
             view_name: "lix_file_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
         query_source.json_reader,
@@ -1296,7 +1297,7 @@ where
                 load_history_entries(
                     HistoryViewDescriptor {
                         view_name: "lix_file_history",
-                        start_commit_column: HISTORY_COL_START_COMMIT_ID,
+                        as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
                     },
                     commit_graph,
                     json_reader,
@@ -1329,7 +1330,7 @@ where
     let entries = load_history_entries(
         HistoryViewDescriptor {
             view_name: "lix_file_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
         query_source.json_reader,
@@ -1386,14 +1387,14 @@ fn file_history_events(
     observed_states: &BTreeMap<String, FileHistoryObservedState>,
     parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
 ) -> Vec<FileHistoryEvent> {
-    let mut descriptor_ids_by_start = BTreeSet::<(String, String)>::new();
+    let mut descriptor_ids_by_as_of = BTreeSet::<(String, String)>::new();
 
     for descriptor in context_descriptors {
         let key = (
             descriptor.id.clone(),
-            descriptor.entry.start_commit_id.clone(),
+            descriptor.entry.as_of_commit_id.clone(),
         );
-        descriptor_ids_by_start.insert(key);
+        descriptor_ids_by_as_of.insert(key);
     }
 
     let mut candidates = Vec::new();
@@ -1431,8 +1432,8 @@ fn file_history_events(
         }
     }
     for blob in event_blobs {
-        if descriptor_ids_by_start
-            .contains(&(blob.file_id.clone(), blob.entry.start_commit_id.clone()))
+        if descriptor_ids_by_as_of
+            .contains(&(blob.file_id.clone(), blob.entry.as_of_commit_id.clone()))
         {
             candidates.push(file_history_event_from_entry(
                 blob.file_id.clone(),
@@ -1451,7 +1452,7 @@ where
     for mut event in events {
         let key = (
             event.file_id.clone(),
-            event.start_commit_id.clone(),
+            event.as_of_commit_id.clone(),
             event.observed_commit_id.clone(),
         );
         match grouped.entry(key) {
@@ -1461,9 +1462,6 @@ where
             std::collections::btree_map::Entry::Occupied(mut entry) => {
                 let grouped_event = entry.get_mut();
                 debug_assert_eq!(grouped_event.depth, event.depth);
-                // When commit metadata is not projected, history loading uses
-                // each source change's timestamp as an intentionally unused
-                // fallback. Those timestamps may differ within one commit.
                 grouped_event
                     .source_changes
                     .append(&mut event.source_changes);
@@ -1482,7 +1480,7 @@ where
     events.sort_by(|left, right| {
         left.file_id
             .cmp(&right.file_id)
-            .then(left.start_commit_id.cmp(&right.start_commit_id))
+            .then(left.as_of_commit_id.cmp(&right.as_of_commit_id))
             .then(left.depth.cmp(&right.depth))
             .then(left.observed_commit_id.cmp(&right.observed_commit_id))
     });
@@ -1501,7 +1499,7 @@ where
 {
     // The durable registry snapshot is already the complete plugin set at its
     // observed commit. Read that exact root identity for every reachable commit
-    // instead of inventing a filesystem state from `(start, depth)`, which
+    // instead of inventing a filesystem state from `(anchor, depth)`, which
     // conflates equal-depth siblings in a DAG.
     let observed_commit_ids = parent_commit_ids_by_commit
         .keys()
@@ -1527,7 +1525,7 @@ where
     let registry_events = load_history_entries(
         HistoryViewDescriptor {
             view_name: "lix_file_history",
-            start_commit_column: HISTORY_COL_START_COMMIT_ID,
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
         query_source.json_reader,
@@ -1695,7 +1693,7 @@ fn file_history_plugin_registry_events(
 fn file_history_event_from_entry(file_id: String, entry: &HistoryEntry) -> FileHistoryEvent {
     FileHistoryEvent {
         file_id,
-        start_commit_id: entry.start_commit_id.clone(),
+        as_of_commit_id: entry.as_of_commit_id.clone(),
         depth: entry.depth,
         source_changes: vec![entry.change.clone()],
         observed_commit_id: entry.observed_commit_id.clone(),
@@ -1914,7 +1912,7 @@ fn resolve_file_history_path(
     };
     let directory_path = resolve_history_directory_path(
         directory_id,
-        &descriptor.entry.start_commit_id,
+        &descriptor.entry.as_of_commit_id,
         target_depth,
         directories,
         &mut BTreeMap::new(),
@@ -2093,15 +2091,19 @@ static LIX_FILE_HISTORY_COLS: ColumnTable<FileHistoryOutputRow> = ColumnTable {
         ),
         (
             HISTORY_COL_COMMIT_CREATED_AT,
-            Col::Utf8(|row| Some(row.event.commit_created_at.as_str())),
+            Col::Utf8(|row| row.event.commit_created_at.as_deref()),
         ),
         (
-            HISTORY_COL_START_COMMIT_ID,
-            Col::Utf8(|row| Some(row.event.start_commit_id.as_str())),
+            HISTORY_COL_AS_OF_COMMIT_ID,
+            Col::Utf8(|row| Some(row.event.as_of_commit_id.as_str())),
         ),
         (
             HISTORY_COL_DEPTH,
             Col::I64(|row| Some(i64::from(row.event.depth))),
+        ),
+        (
+            HISTORY_COL_IS_DELETED,
+            Col::Bool(|row| Some(row.is_deleted)),
         ),
     ],
 };
@@ -2133,8 +2135,9 @@ pub(super) fn lix_file_history_schema() -> SchemaRef {
         json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
-        Field::new(HISTORY_COL_START_COMMIT_ID, DataType::Utf8, false),
+        Field::new(HISTORY_COL_AS_OF_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_DEPTH, DataType::Int64, false),
+        Field::new(HISTORY_COL_IS_DELETED, DataType::Boolean, false),
     ]))
 }
 
@@ -2187,8 +2190,8 @@ mod tests {
                 origin_key: None,
             },
             observed_commit_id: format!("commit-{depth}"),
-            commit_created_at: "2026-01-01T00:00:00Z".to_string(),
-            start_commit_id: "start".to_string(),
+            commit_created_at: Some("2026-01-01T00:00:00Z".to_string()),
+            as_of_commit_id: "start".to_string(),
             depth,
         }
     }
@@ -2711,7 +2714,7 @@ mod tests {
             .expect("literal public ID IN filter should be routable");
         let route = file_history_descriptor_blob_route(
             &HistoryRoute {
-                start_commit_ids: vec!["commit-start".to_string()],
+                as_of_commit_ids: vec!["commit-start".to_string()],
                 ..HistoryRoute::default()
             },
             &ids,
@@ -2722,7 +2725,7 @@ mod tests {
             route.entity_pks,
             vec![r#"["file-a"]"#.to_string(), r#"["file-b"]"#.to_string()]
         );
-        assert_eq!(route.start_commit_ids, vec!["commit-start".to_string()]);
+        assert_eq!(route.as_of_commit_ids, vec!["commit-start".to_string()]);
     }
 
     #[test]
@@ -2889,12 +2892,12 @@ mod tests {
     #[tokio::test]
     async fn identical_event_and_context_routes_load_history_once() {
         let route = HistoryRoute {
-            start_commit_ids: vec!["cid-start".to_string()],
+            as_of_commit_ids: vec!["cid-start".to_string()],
             file_ids: vec!["file-a".to_string()],
             ..HistoryRoute::default()
         };
         let event_route = route.traversal_only();
-        let context_route = route.starts_only();
+        let context_route = route.anchors_only();
         assert_eq!(event_route, context_route);
 
         let loads = Arc::new(AtomicUsize::new(0));
@@ -2915,12 +2918,12 @@ mod tests {
     #[tokio::test]
     async fn differing_depth_routes_load_history_twice() {
         let route = HistoryRoute {
-            start_commit_ids: vec!["cid-start".to_string()],
+            as_of_commit_ids: vec!["cid-start".to_string()],
             max_depth: Some(3),
             ..HistoryRoute::default()
         };
         let event_route = route.traversal_only();
-        let context_route = route.starts_only();
+        let context_route = route.anchors_only();
         assert_ne!(event_route, context_route);
 
         let loads = Arc::new(AtomicUsize::new(0));

--- a/packages/engine/src/sql2/providers/filesystem_history_path.rs
+++ b/packages/engine/src/sql2/providers/filesystem_history_path.rs
@@ -83,7 +83,7 @@ impl HistoryDirectoryTree {
 }
 
 /// Loads direct-parent edges for every commit reachable from the requested
-/// history starts.
+/// history anchors.
 ///
 /// Ancestor deletion and move-out events need both sides of the revision:
 /// descendants may no longer be linked to the changed directory in the
@@ -91,13 +91,14 @@ impl HistoryDirectoryTree {
 /// isolation; no depth-based predecessor is inferred.
 pub(super) async fn load_history_commit_parents(
     commit_graph: &Arc<Mutex<Box<dyn CommitGraphReader>>>,
-    start_commit_ids: &[String],
+    as_of_commit_ids: &[String],
 ) -> Result<BTreeMap<String, Vec<String>>, LixError> {
     let mut parents_by_commit = BTreeMap::new();
     let mut commit_graph = commit_graph.lock().await;
-    for start_commit_id in start_commit_ids {
-        let start_commit_id = CommitId::parse_lix(start_commit_id, "history start_commit_id")?;
-        for reachable in commit_graph.reachable_commits(&start_commit_id).await? {
+    for as_of_commit_id in as_of_commit_ids {
+        let as_of_commit_id =
+            CommitId::parse_lix(as_of_commit_id, "history lixcol_as_of_commit_id")?;
+        for reachable in commit_graph.reachable_commits(&as_of_commit_id).await? {
             parents_by_commit.insert(
                 reachable.commit.commit_id.to_string(),
                 reachable
@@ -114,7 +115,7 @@ pub(super) async fn load_history_commit_parents(
 
 pub(super) fn resolve_history_directory_path<R: HistoryDirectoryPathRecord>(
     directory_id: &str,
-    start_commit_id: &str,
+    as_of_commit_id: &str,
     target_depth: u32,
     directories: &[R],
     cache: &mut BTreeMap<String, Option<String>>,
@@ -134,7 +135,7 @@ pub(super) fn resolve_history_directory_path<R: HistoryDirectoryPathRecord>(
             let entry = directory.entry();
             directory.name().is_some()
                 && directory.id() == directory_id
-                && entry.start_commit_id == start_commit_id
+                && entry.as_of_commit_id == as_of_commit_id
                 && entry.depth >= target_depth
         })
         .min_by(|left, right| {
@@ -151,7 +152,7 @@ pub(super) fn resolve_history_directory_path<R: HistoryDirectoryPathRecord>(
         Some(parent_id) => {
             let parent_path = resolve_history_directory_path(
                 parent_id,
-                start_commit_id,
+                as_of_commit_id,
                 target_depth,
                 directories,
                 cache,

--- a/packages/engine/src/sql2/providers/history.rs
+++ b/packages/engine/src/sql2/providers/history.rs
@@ -16,8 +16,12 @@ use crate::sql2::SqlHistoryQuerySource;
 use crate::sql2::WriteAccess;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_route::{
-    HistoryColumnStyle, HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor,
-    load_history_entries, parse_history_filter,
+    HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT, HISTORY_COL_CHANGE_ID,
+    HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH, HISTORY_COL_ENTITY_PK, HISTORY_COL_FILE_ID,
+    HISTORY_COL_IS_DELETED, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
+    HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
+    HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor, load_history_entries,
+    parse_history_filter,
 };
 use crate::sql2::result_metadata::json_field;
 use crate::storage_adapter::StorageAdapterRead;
@@ -48,7 +52,7 @@ where
 /// SQL spec for `lix_state_history`.
 ///
 /// The reachability-aware history surface over canonical state changes: rows
-/// are loaded by walking the commit graph from the routed start commits.
+/// are loaded by walking the commit graph from the routed anchor commits.
 struct StateHistorySpec<S> {
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
@@ -73,7 +77,7 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        if parse_history_filter(filter, HistoryColumnStyle::Bare).is_some() {
+        if parse_history_filter(filter).is_some() {
             TableProviderFilterPushDown::Exact
         } else {
             TableProviderFilterPushDown::Unsupported
@@ -88,9 +92,8 @@ where
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
         let schema = projected_schema(&lix_state_history_schema(), projection);
-        let route = HistoryRoute::from_filters(filters, HistoryColumnStyle::Bare);
-        let metadata_projection =
-            HistoryMetadataProjection::from_scan(&schema, filters, HistoryColumnStyle::Bare);
+        let route = HistoryRoute::from_filters(filters);
+        let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
@@ -131,17 +134,19 @@ where
 
 pub(super) fn lix_state_history_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
-        json_field("entity_pk", false),
-        Field::new("schema_key", DataType::Utf8, false),
-        Field::new("file_id", DataType::Utf8, true),
-        json_field("snapshot_content", true),
-        json_field("metadata", true),
-        Field::new("change_id", DataType::Utf8, false),
-        Field::new("origin_key", DataType::Utf8, true),
-        Field::new("observed_commit_id", DataType::Utf8, false),
-        Field::new("commit_created_at", DataType::Utf8, false),
-        Field::new("start_commit_id", DataType::Utf8, false),
-        Field::new("depth", DataType::Int64, false),
+        json_field(HISTORY_COL_ENTITY_PK, false),
+        Field::new(HISTORY_COL_SCHEMA_KEY, DataType::Utf8, false),
+        Field::new(HISTORY_COL_FILE_ID, DataType::Utf8, true),
+        json_field(HISTORY_COL_SNAPSHOT_CONTENT, true),
+        json_field(HISTORY_COL_METADATA, true),
+        Field::new(HISTORY_COL_CHANGE_ID, DataType::Utf8, false),
+        Field::new(HISTORY_COL_CHANGE_CREATED_AT, DataType::Utf8, false),
+        Field::new(HISTORY_COL_ORIGIN_KEY, DataType::Utf8, true),
+        Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
+        Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
+        Field::new(HISTORY_COL_AS_OF_COMMIT_ID, DataType::Utf8, false),
+        Field::new(HISTORY_COL_DEPTH, DataType::Int64, false),
+        Field::new(HISTORY_COL_IS_DELETED, DataType::Boolean, false),
     ]))
 }
 
@@ -164,41 +169,63 @@ struct StateHistorySqlRow {
     snapshot_content: Option<String>,
     metadata: Option<String>,
     change_id: String,
+    change_created_at: String,
     origin_key: Option<String>,
     observed_commit_id: String,
-    commit_created_at: String,
-    start_commit_id: String,
+    commit_created_at: Option<String>,
+    as_of_commit_id: String,
     depth: i64,
+    is_deleted: bool,
 }
 
 static LIX_STATE_HISTORY_COLS: ColumnTable<StateHistorySqlRow> = ColumnTable {
     columns: &[
-        ("entity_pk", Col::Utf8(|row| Some(row.entity_pk.as_str()))),
-        ("schema_key", Col::Utf8(|row| Some(row.schema_key.as_str()))),
-        ("file_id", Col::Utf8(|row| row.file_id.as_deref())),
         (
-            "snapshot_content",
+            HISTORY_COL_ENTITY_PK,
+            Col::Utf8(|row| Some(row.entity_pk.as_str())),
+        ),
+        (
+            HISTORY_COL_SCHEMA_KEY,
+            Col::Utf8(|row| Some(row.schema_key.as_str())),
+        ),
+        (HISTORY_COL_FILE_ID, Col::Utf8(|row| row.file_id.as_deref())),
+        (
+            HISTORY_COL_SNAPSHOT_CONTENT,
             Col::Utf8(|row| row.snapshot_content.as_deref()),
         ),
         (
-            "metadata",
+            HISTORY_COL_METADATA,
             Col::Utf8Owned(|row| row.metadata.as_deref().map(serialize_row_metadata)),
         ),
-        ("change_id", Col::Utf8(|row| Some(row.change_id.as_str()))),
-        ("origin_key", Col::Utf8(|row| row.origin_key.as_deref())),
         (
-            "observed_commit_id",
+            HISTORY_COL_CHANGE_ID,
+            Col::Utf8(|row| Some(row.change_id.as_str())),
+        ),
+        (
+            HISTORY_COL_CHANGE_CREATED_AT,
+            Col::Utf8(|row| Some(row.change_created_at.as_str())),
+        ),
+        (
+            HISTORY_COL_ORIGIN_KEY,
+            Col::Utf8(|row| row.origin_key.as_deref()),
+        ),
+        (
+            HISTORY_COL_OBSERVED_COMMIT_ID,
             Col::Utf8(|row| Some(row.observed_commit_id.as_str())),
         ),
         (
-            "commit_created_at",
-            Col::Utf8(|row| Some(row.commit_created_at.as_str())),
+            HISTORY_COL_COMMIT_CREATED_AT,
+            Col::Utf8(|row| row.commit_created_at.as_deref()),
         ),
         (
-            "start_commit_id",
-            Col::Utf8(|row| Some(row.start_commit_id.as_str())),
+            HISTORY_COL_AS_OF_COMMIT_ID,
+            Col::Utf8(|row| Some(row.as_of_commit_id.as_str())),
         ),
-        ("depth", Col::I64(|row| Some(row.depth))),
+        (HISTORY_COL_DEPTH, Col::I64(|row| Some(row.depth))),
+        (
+            HISTORY_COL_IS_DELETED,
+            Col::Bool(|row| Some(row.is_deleted)),
+        ),
     ],
 };
 
@@ -227,7 +254,7 @@ where
     let entries = load_history_entries(
         HistoryViewDescriptor {
             view_name: "lix_state_history",
-            start_commit_column: "start_commit_id",
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
         query_source.json_reader,
@@ -243,13 +270,15 @@ where
                 entity_pk: entry.change.entity_pk.as_json_array_text()?,
                 schema_key: entry.change.schema_key,
                 file_id: entry.change.file_id,
+                is_deleted: entry.change.snapshot_content.is_none(),
                 snapshot_content: entry.change.snapshot_content,
                 metadata: entry.change.metadata,
                 change_id: entry.change.id,
+                change_created_at: entry.change.created_at,
                 origin_key: entry.change.origin_key,
                 observed_commit_id: entry.observed_commit_id,
                 commit_created_at: entry.commit_created_at,
-                start_commit_id: entry.start_commit_id,
+                as_of_commit_id: entry.as_of_commit_id,
                 depth: i64::from(entry.depth),
             })
         })

--- a/packages/engine/tests/branching.rs
+++ b/packages/engine/tests/branching.rs
@@ -949,11 +949,11 @@ simulation_test!(
 
         let history = main
             .execute(
-                "SELECT snapshot_content \
+                "SELECT lixcol_snapshot_content \
 	             FROM lix_state_history \
-	             WHERE start_commit_id = lix_active_branch_commit_id() \
-	               AND entity_pk = lix_json('[\"merge-select-change\"]') \
-	             ORDER BY depth",
+	             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+	               AND lixcol_entity_pk = lix_json('[\"merge-select-change\"]') \
+	             ORDER BY lixcol_depth",
                 &[],
             )
             .await

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -974,10 +974,10 @@ async fn non_empty_plugin_overwrite_does_not_stage_blob_ref_tombstone() {
     let blob_ref_history = session
         .execute(
             &format!(
-                "SELECT entity_pk FROM lix_state_history \
-                 WHERE start_commit_id = '{commit_id}' \
-                   AND schema_key = 'lix_binary_blob_ref' \
-                   AND entity_pk = lix_json('[\"{file_id}\"]')"
+                "SELECT lixcol_entity_pk FROM lix_state_history \
+                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
+                   AND lixcol_schema_key = 'lix_binary_blob_ref' \
+                   AND lixcol_entity_pk = lix_json('[\"{file_id}\"]')"
             ),
             &[],
         )

--- a/packages/engine/tests/sql/entity_history.rs
+++ b/packages/engine/tests/sql/entity_history.rs
@@ -62,9 +62,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, count, active, meta, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_start_commit_id, lixcol_depth \
+                    "SELECT id, count, active, meta, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_as_of_commit_id, lixcol_is_deleted, lixcol_depth \
                      FROM engine_history_schema_history \
-                     WHERE lixcol_start_commit_id = '{second_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
                        AND lixcol_entity_pk = lix_json('[\"history-entity\"]') \
                      ORDER BY lixcol_depth"
                 ),
@@ -84,6 +84,7 @@ simulation_test!(
                     Value::Json(json!(["history-entity"])),
                     Value::Text(second_commit_id.clone()),
                     Value::Text(second_commit_id.clone()),
+                    Value::Boolean(false),
                     Value::Integer(0),
                 ],
                 vec![
@@ -94,6 +95,7 @@ simulation_test!(
                     Value::Json(json!(["history-entity"])),
                     Value::Text(first_commit_id),
                     Value::Text(second_commit_id),
+                    Value::Boolean(false),
                     Value::Integer(1),
                 ],
             ],
@@ -102,7 +104,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    entity_history_requires_lixcol_start_commit_id,
+    entity_history_requires_lixcol_as_of_commit_id,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -129,7 +131,7 @@ simulation_test!(
         let error = session
             .execute("SELECT id FROM engine_history_error_schema_history", &[])
             .await
-            .expect_err("typed history queries must provide start commit");
+            .expect_err("typed history queries must provide an as-of commit");
 
         assert_eq!(
             error.code,
@@ -138,20 +140,20 @@ simulation_test!(
         assert!(
             error
                 .to_string()
-                .contains("requires a lixcol_start_commit_id filter"),
+                .contains("requires a lixcol_as_of_commit_id filter"),
             "unexpected error: {error}"
         );
         assert!(
             error
                 .hint()
-                .is_some_and(|hint| hint.contains("WHERE lixcol_start_commit_id")),
+                .is_some_and(|hint| hint.contains("WHERE lixcol_as_of_commit_id")),
             "unexpected error: {error}"
         );
     }
 );
 
 simulation_test!(
-    entity_history_rejects_bare_start_commit_id_filter,
+    entity_history_rejects_retired_anchor_names,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -175,20 +177,24 @@ simulation_test!(
             .await
             .expect("registered schema insert should succeed");
 
-        let error = session
-            .execute(
-                "SELECT id \
-                 FROM engine_history_bare_error_schema_history \
-                 WHERE start_commit_id = lix_active_branch_commit_id()",
-                &[],
-            )
-            .await
-            .expect_err("typed history should only expose lixcol_start_commit_id");
+        for retired in ["start_commit_id", "lixcol_start_commit_id"] {
+            let error = session
+                .execute(
+                    &format!(
+                        "SELECT id \
+                         FROM engine_history_bare_error_schema_history \
+                         WHERE {retired} = lix_active_branch_commit_id()"
+                    ),
+                    &[],
+                )
+                .await
+                .expect_err("retired history anchor must fail");
 
-        assert_eq!(error.code, lix_engine::LixError::CODE_COLUMN_NOT_FOUND);
-        assert!(
-            error.to_string().contains("start_commit_id"),
-            "unexpected error: {error}"
-        );
+            assert_eq!(error.code, lix_engine::LixError::CODE_COLUMN_NOT_FOUND);
+            assert!(
+                error.to_string().contains(retired),
+                "unexpected error: {error}"
+            );
+        }
     }
 );

--- a/packages/engine/tests/sql/history_conformance.rs
+++ b/packages/engine/tests/sql/history_conformance.rs
@@ -128,7 +128,7 @@ simulation_test!(
              ) \
                AND (\
                  column_name IN ('path', 'directory_id', 'parent_id', 'name', 'data', 'id', 'count', 'active', 'meta') \
-                 OR column_name IN ('lixcol_snapshot_content', 'lixcol_source_changes')\
+                 OR column_name IN ('lixcol_snapshot_content', 'lixcol_is_deleted', 'lixcol_source_changes')\
                ) \
              ORDER BY table_name, column_name",
         )
@@ -140,11 +140,17 @@ simulation_test!(
             ("engine_history_contract_schema_history", "id", "YES"),
             (
                 "engine_history_contract_schema_history",
+                "lixcol_is_deleted",
+                "NO",
+            ),
+            (
+                "engine_history_contract_schema_history",
                 "lixcol_snapshot_content",
                 "YES",
             ),
             ("engine_history_contract_schema_history", "meta", "YES"),
             ("lix_directory_history", "id", "NO"),
+            ("lix_directory_history", "lixcol_is_deleted", "NO"),
             ("lix_directory_history", "lixcol_source_changes", "NO"),
             ("lix_directory_history", "name", "YES"),
             ("lix_directory_history", "parent_id", "YES"),
@@ -152,6 +158,7 @@ simulation_test!(
             ("lix_file_history", "data", "YES"),
             ("lix_file_history", "directory_id", "YES"),
             ("lix_file_history", "id", "NO"),
+            ("lix_file_history", "lixcol_is_deleted", "NO"),
             ("lix_file_history", "lixcol_source_changes", "NO"),
             ("lix_file_history", "name", "YES"),
             ("lix_file_history", "path", "YES"),
@@ -226,7 +233,7 @@ simulation_test!(
             &session,
             "SELECT id, value, lixcol_entity_pk, lixcol_snapshot_content, lixcol_depth \
              FROM engine_history_conformance_history \
-             WHERE lixcol_start_commit_id = lix_active_branch_commit_id() \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
                AND lixcol_entity_pk = lix_json('[\"history-conformance-entity\"]') \
              ORDER BY lixcol_depth",
         )
@@ -245,12 +252,12 @@ simulation_test!(
 
         let state_rows = select_rows(
             &session,
-            "SELECT snapshot_content, depth \
+            "SELECT lixcol_snapshot_content, lixcol_depth \
              FROM lix_state_history \
-             WHERE start_commit_id = lix_active_branch_commit_id() \
-               AND schema_key = 'engine_history_conformance' \
-               AND entity_pk = lix_json('[\"history-conformance-entity\"]') \
-               AND snapshot_content IS NULL",
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+               AND lixcol_schema_key = 'engine_history_conformance' \
+               AND lixcol_entity_pk = lix_json('[\"history-conformance-entity\"]') \
+               AND lixcol_snapshot_content IS NULL",
         )
         .await;
         assert_eq!(state_rows, vec![vec![Value::Null, Value::Integer(0)]]);
@@ -289,7 +296,7 @@ simulation_test!(
             &session,
             "SELECT key, value, lixcol_entity_pk, lixcol_snapshot_content, lixcol_depth \
              FROM lix_key_value_history \
-             WHERE lixcol_start_commit_id = lix_active_branch_commit_id() \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
                AND key = 'history-pk-backfill' \
              ORDER BY lixcol_depth",
         )
@@ -367,7 +374,7 @@ simulation_test!(
             &session,
             "SELECT namespace, id, value, lixcol_snapshot_content, lixcol_depth \
              FROM engine_history_composite_pk_history \
-             WHERE lixcol_start_commit_id = lix_active_branch_commit_id() \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
                AND namespace = 'messages' \
                AND id = '7' \
              ORDER BY lixcol_depth",
@@ -437,9 +444,9 @@ simulation_test!(
 
         let file_rows = select_rows(
             &session,
-            "SELECT id, path, name, data, lixcol_entity_pk, lixcol_depth \
+            "SELECT id, path, name, data, lixcol_entity_pk, lixcol_is_deleted, lixcol_depth \
              FROM lix_file_history \
-             WHERE lixcol_start_commit_id = lix_active_branch_commit_id() \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
                AND id = 'history-conformance-file' \
                AND lixcol_depth = 0",
         )
@@ -452,18 +459,19 @@ simulation_test!(
                 Value::Null,
                 Value::Null,
                 Value::Json(serde_json::json!(["history-conformance-file"])),
+                Value::Boolean(true),
                 Value::Integer(0),
             ]]
         );
 
         let state_rows = select_rows(
             &session,
-            "SELECT snapshot_content, depth \
+            "SELECT lixcol_snapshot_content, lixcol_depth \
              FROM lix_state_history \
-             WHERE start_commit_id = lix_active_branch_commit_id() \
-               AND schema_key = 'lix_file_descriptor' \
-               AND entity_pk = lix_json('[\"history-conformance-file\"]') \
-               AND snapshot_content IS NULL",
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+               AND lixcol_schema_key = 'lix_file_descriptor' \
+               AND lixcol_entity_pk = lix_json('[\"history-conformance-file\"]') \
+               AND lixcol_snapshot_content IS NULL",
         )
         .await;
         assert_eq!(state_rows, vec![vec![Value::Null, Value::Integer(0)]]);
@@ -508,9 +516,9 @@ simulation_test!(
 
         let directory_rows = select_rows(
             &session,
-            "SELECT id, path, parent_id, name, lixcol_entity_pk, lixcol_depth \
+            "SELECT id, path, parent_id, name, lixcol_entity_pk, lixcol_is_deleted, lixcol_depth \
              FROM lix_directory_history \
-             WHERE lixcol_start_commit_id = lix_active_branch_commit_id() \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
                AND id = 'history-conformance-dir' \
                AND lixcol_depth = 0",
         )
@@ -523,18 +531,19 @@ simulation_test!(
                 Value::Null,
                 Value::Null,
                 Value::Json(serde_json::json!(["history-conformance-dir"])),
+                Value::Boolean(true),
                 Value::Integer(0),
             ]]
         );
 
         let state_rows = select_rows(
             &session,
-            "SELECT snapshot_content, depth \
+            "SELECT lixcol_snapshot_content, lixcol_depth \
              FROM lix_state_history \
-             WHERE start_commit_id = lix_active_branch_commit_id() \
-               AND schema_key = 'lix_directory_descriptor' \
-               AND entity_pk = lix_json('[\"history-conformance-dir\"]') \
-               AND snapshot_content IS NULL",
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+               AND lixcol_schema_key = 'lix_directory_descriptor' \
+               AND lixcol_entity_pk = lix_json('[\"history-conformance-dir\"]') \
+               AND lixcol_snapshot_content IS NULL",
         )
         .await;
         assert_eq!(state_rows, vec![vec![Value::Null, Value::Integer(0)]]);

--- a/packages/engine/tests/sql/lix_directory_history.rs
+++ b/packages/engine/tests/sql/lix_directory_history.rs
@@ -50,9 +50,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, path, parent_id, name, lixcol_start_commit_id, lixcol_depth \
+                    "SELECT id, path, parent_id, name, lixcol_as_of_commit_id, lixcol_depth \
                      FROM lix_directory_history \
-                     WHERE lixcol_start_commit_id = '{second_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
                        AND id IN ('history-dir-docs', 'history-dir-guides') \
                      ORDER BY lixcol_depth, id"
                 ),
@@ -88,7 +88,7 @@ simulation_test!(
                 &format!(
                     "SELECT lixcol_source_changes \
                      FROM lix_directory_history \
-                     WHERE lixcol_start_commit_id = '{second_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
                        AND id = 'history-dir-guides' \
                        AND lixcol_depth = 0"
                 ),
@@ -137,7 +137,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_directory_history_requires_start_commit_id,
+    lix_directory_history_requires_as_of_commit_id,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -151,18 +151,18 @@ simulation_test!(
         let error = session
             .execute("SELECT id FROM lix_directory_history", &[])
             .await
-            .expect_err("directory history queries must provide start commit");
+            .expect_err("directory history queries must provide an as-of commit");
 
         assert!(
             error
                 .to_string()
-                .contains("requires a lixcol_start_commit_id filter"),
+                .contains("requires a lixcol_as_of_commit_id filter"),
             "unexpected error: {error}"
         );
         assert!(
             error
                 .hint()
-                .is_some_and(|hint| hint.contains("WHERE lixcol_start_commit_id")),
+                .is_some_and(|hint| hint.contains("WHERE lixcol_as_of_commit_id")),
             "unexpected error: {error}"
         );
     }
@@ -238,7 +238,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_observed_commit_id, lixcol_depth \
                      FROM lix_directory_history \
-                     WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{merge_commit_id}' \
                        AND id = 'diamond-dir' \
                        AND lixcol_depth = 1 \
                      ORDER BY lixcol_observed_commit_id"
@@ -323,9 +323,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-					"SELECT id, path, name, lixcol_source_changes, lixcol_start_commit_id, lixcol_depth \
+					"SELECT id, path, name, lixcol_is_deleted, lixcol_source_changes, lixcol_as_of_commit_id, lixcol_depth \
 	                 FROM lix_directory_history \
-	                 WHERE lixcol_start_commit_id = '{delete_commit_id}' \
+	                 WHERE lixcol_as_of_commit_id = '{delete_commit_id}' \
 	                   AND lixcol_entity_pk IN (lix_json('[\"history-delete-docs\"]'), lix_json('[\"history-delete-guides\"]')) \
 	                   AND lixcol_depth = 0 \
 	                 ORDER BY lixcol_entity_pk"
@@ -342,14 +342,15 @@ simulation_test!(
             .zip(["history-delete-docs", "history-delete-guides"])
         {
             assert_eq!(
-                &row.values()[..3],
+                &row.values()[..4],
                 &[
                     Value::Text(expected_id.to_string()),
                     Value::Null,
                     Value::Null,
+                    Value::Boolean(true),
                 ]
             );
-            let Value::Json(source_changes) = &row.values()[3] else {
+            let Value::Json(source_changes) = &row.values()[4] else {
                 panic!("delete source changes should be JSON");
             };
             let source_changes = source_changes
@@ -371,8 +372,8 @@ simulation_test!(
                 })
                 .collect::<BTreeSet<_>>();
             assert_eq!(actual_source_ids, expected_source_ids);
-            assert_eq!(row.values()[4], Value::Text(delete_commit_id.clone()));
-            assert_eq!(row.values()[5], Value::Integer(0));
+            assert_eq!(row.values()[5], Value::Text(delete_commit_id.clone()));
+            assert_eq!(row.values()[6], Value::Integer(0));
         }
     }
 );

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -2569,11 +2569,11 @@ async fn file_descriptor_event_count(
     session
         .execute(
             &format!(
-                "SELECT entity_pk FROM lix_state_history \
-                 WHERE start_commit_id = '{commit_id}' \
-                   AND depth = 0 \
-                   AND schema_key = 'lix_file_descriptor' \
-                   AND entity_pk = lix_json('[\"{file_id}\"]')"
+                "SELECT lixcol_entity_pk FROM lix_state_history \
+                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND lixcol_schema_key = 'lix_file_descriptor' \
+                   AND lixcol_entity_pk = lix_json('[\"{file_id}\"]')"
             ),
             &[],
         )
@@ -2619,11 +2619,11 @@ simulation_test!(
         let blob_ref_history = session
             .execute(
                 &format!(
-                    "SELECT entity_pk \
+                    "SELECT lixcol_entity_pk \
                      FROM lix_state_history \
-                     WHERE start_commit_id = '{commit_id}' \
-                       AND schema_key = 'lix_binary_blob_ref' \
-                       AND entity_pk = lix_json('[\"already-empty-file\"]')"
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
+                       AND lixcol_schema_key = 'lix_binary_blob_ref' \
+                       AND lixcol_entity_pk = lix_json('[\"already-empty-file\"]')"
                 ),
                 &[],
             )

--- a/packages/engine/tests/sql/lix_file_history.rs
+++ b/packages/engine/tests/sql/lix_file_history.rs
@@ -200,7 +200,7 @@ async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state(
             &format!(
                 "SELECT id, path \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'history-point-target'"
             ),
@@ -300,7 +300,7 @@ async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() 
             &format!(
                 "SELECT path, lixcol_source_changes \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'bounded-file'"
             ),
@@ -387,7 +387,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_source_changes \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{rename_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{rename_commit_id}' \
                        AND lixcol_depth = 0 \
                        AND id = 'projection-file'"
                 ),
@@ -414,7 +414,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_source_changes \
                      FROM lix_directory_history \
-                     WHERE lixcol_start_commit_id = '{rename_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{rename_commit_id}' \
                        AND lixcol_depth = 0 \
                        AND id = 'projection-guides'"
                 ),
@@ -447,7 +447,7 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT path FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{move_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{move_commit_id}' \
                        AND lixcol_depth = 0 \
                        AND id = 'projection-file'"
                 ),
@@ -534,7 +534,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_source_changes \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
                        AND lixcol_depth = 0 \
                        AND id = 'grouped-file'"
                 ),
@@ -569,7 +569,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_source_changes \
                      FROM lix_directory_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
                        AND lixcol_depth = 0 \
                        AND id = 'grouped-child'"
                 ),
@@ -667,7 +667,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_observed_commit_id \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{merge_commit_id}' \
                        AND lixcol_depth = 1 \
                        AND id = 'ancestor-sibling-file' \
                      ORDER BY lixcol_observed_commit_id"
@@ -742,7 +742,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_source_changes \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{delete_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{delete_commit_id}' \
                        AND lixcol_depth = 0 \
                        AND id = 'restore-file'"
                 ),
@@ -805,7 +805,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, data, lixcol_source_changes \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{restore_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{restore_commit_id}' \
                        AND lixcol_depth = 0 \
                        AND id = 'restore-file'"
                 ),
@@ -887,9 +887,9 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT id, path, name, data, lixcol_start_commit_id, lixcol_depth \
+                "SELECT id, path, name, data, lixcol_as_of_commit_id, lixcol_depth \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = $1 \
+                 WHERE lixcol_as_of_commit_id = $1 \
                    AND id = $2 \
                    AND path LIKE $3 \
                  ORDER BY lixcol_depth",
@@ -929,7 +929,7 @@ simulation_test!(
                 &format!(
                     "SELECT lixcol_source_changes \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{second_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
                        AND id = 'history-file' \
                        AND lixcol_depth = 0"
                 ),
@@ -958,13 +958,13 @@ simulation_test!(
                 &format!(
                     "SELECT id \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{first_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{first_commit_id}' \
                        AND path LIKE '/missing/%'"
                 ),
                 &[],
             )
             .await
-            .expect("file history should route start commit and leave path LIKE as residual");
+            .expect("file history should route the as-of commit and leave path LIKE as residual");
         assert_rows_eq(result, Vec::<Vec<Value>>::new());
     }
 );
@@ -999,7 +999,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, data \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
                        AND path = '/empty-history.txt' \
                        AND lixcol_depth = 0"
                 ),
@@ -1090,7 +1090,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, lixcol_observed_commit_id, lixcol_depth, lixcol_source_changes \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{merge_commit_id}' \
                        AND id = 'diamond-file' \
                        AND lixcol_depth = 1 \
                      ORDER BY lixcol_observed_commit_id"
@@ -1170,7 +1170,7 @@ simulation_test!(lix_file_history_reads_bound_id_in_list, |sim| async move {
         .execute(
             "SELECT id, path, data \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = $1 \
+                 WHERE lixcol_as_of_commit_id = $1 \
                    AND id IN ($2, $3) \
                  ORDER BY id",
             &[
@@ -1238,7 +1238,7 @@ simulation_test!(
                 &format!(
                     "SELECT id, path, lixcol_depth \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
                      ORDER BY lixcol_depth \
                      LIMIT 1"
                 ),
@@ -1291,7 +1291,7 @@ simulation_test!(
                 &format!(
                     "SELECT id, path, data \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
                        AND path LIKE '/target/%' \
                      LIMIT 1"
                 ),
@@ -1393,7 +1393,7 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
             &format!(
                 "SELECT path, data, lixcol_depth \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
                    AND id = '{file_id}' \
                  ORDER BY lixcol_depth \
                  LIMIT 2"
@@ -1427,7 +1427,7 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
             &format!(
                 "SELECT data, lixcol_depth \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{commit_id}' \
                    AND id = '{file_id}' \
                    AND lixcol_depth = 1"
             ),
@@ -1520,7 +1520,7 @@ async fn lix_file_history_uses_each_siblings_observed_plugin_registry() {
             &format!(
                 "SELECT data, lixcol_observed_commit_id, lixcol_source_changes \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{merge_commit_id}' \
                    AND path = '/note.history-render' \
                    AND lixcol_depth = 1"
             ),
@@ -1616,7 +1616,7 @@ async fn lix_file_history_projects_owned_file_plugin_lifecycle_without_glob_reas
             &format!(
                 "SELECT data, lixcol_source_changes \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{upgrade_commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{upgrade_commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'plugin-lifecycle-note'"
             ),
@@ -1667,7 +1667,7 @@ async fn lix_file_history_projects_owned_file_plugin_lifecycle_without_glob_reas
             &format!(
                 "SELECT id \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{overlap_commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{overlap_commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'plugin-lifecycle-note'"
             ),
@@ -1712,7 +1712,7 @@ async fn lix_file_history_projects_owned_file_plugin_lifecycle_without_glob_reas
             &format!(
                 "SELECT id \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{non_owner_state_commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{non_owner_state_commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'plugin-lifecycle-note'"
             ),
@@ -1755,7 +1755,7 @@ async fn lix_file_history_projects_owned_file_plugin_lifecycle_without_glob_reas
             &format!(
                 "SELECT id, lixcol_source_changes \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{uninstall_commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{uninstall_commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'plugin-lifecycle-note'"
             ),
@@ -1769,7 +1769,7 @@ async fn lix_file_history_projects_owned_file_plugin_lifecycle_without_glob_reas
             &format!(
                 "SELECT data \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{uninstall_commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{uninstall_commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'plugin-lifecycle-note'"
             ),
@@ -1842,7 +1842,7 @@ async fn lix_file_history_keeps_plugin_state_tombstones_in_deleted_file_provenan
             &format!(
                 "SELECT path, data, lixcol_source_changes \
                  FROM lix_file_history \
-                 WHERE lixcol_start_commit_id = '{delete_commit_id}' \
+                 WHERE lixcol_as_of_commit_id = '{delete_commit_id}' \
                    AND lixcol_depth = 0 \
                    AND id = 'plugin-deleted-note'"
             ),
@@ -1886,7 +1886,7 @@ async fn lix_file_history_keeps_plugin_state_tombstones_in_deleted_file_provenan
 }
 
 simulation_test!(
-    lix_file_history_requires_start_commit_id,
+    lix_file_history_requires_as_of_commit_id,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -1900,18 +1900,18 @@ simulation_test!(
         let error = session
             .execute("SELECT id FROM lix_file_history", &[])
             .await
-            .expect_err("file history queries must provide start commit");
+            .expect_err("file history queries must provide an as-of commit");
 
         assert!(
             error
                 .to_string()
-                .contains("requires a lixcol_start_commit_id filter"),
+                .contains("requires a lixcol_as_of_commit_id filter"),
             "unexpected error: {error}"
         );
         assert!(
             error
                 .hint()
-                .is_some_and(|hint| hint.contains("WHERE lixcol_start_commit_id")),
+                .is_some_and(|hint| hint.contains("WHERE lixcol_as_of_commit_id")),
             "unexpected error: {error}"
         );
     }
@@ -1958,7 +1958,7 @@ simulation_test!(
                 &format!(
                     "SELECT path, data, lixcol_depth \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
                        AND id = 'ordinary-history-file' \
                      ORDER BY lixcol_depth"
                 ),
@@ -2153,7 +2153,7 @@ simulation_test!(
                 &format!(
                     "SELECT id, path, data, lixcol_source_changes \
                      FROM lix_file_history \
-                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{commit_id}' \
                        AND id = 'history-file-blob-filter' \
                      ORDER BY lixcol_depth"
                 ),
@@ -2228,6 +2228,27 @@ simulation_test!(
                 ],
                 "source change objects must mirror the stable lix_change field set"
             );
+        }
+
+        for retired in [
+            "lixcol_change_id",
+            "lixcol_schema_key",
+            "lixcol_origin_key",
+            "lixcol_snapshot_content",
+            "lixcol_metadata",
+        ] {
+            let error = session
+                .execute(
+                    &format!(
+                        "SELECT {retired} \
+                         FROM lix_file_history \
+                         WHERE lixcol_as_of_commit_id = '{commit_id}'"
+                    ),
+                    &[],
+                )
+                .await
+                .expect_err("composed history singular provenance must fail");
+            assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
         }
     }
 );

--- a/packages/engine/tests/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/sql/lix_registered_schema.rs
@@ -424,9 +424,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT value, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_start_commit_id, lixcol_depth \
+                    "SELECT value, lixcol_entity_pk, lixcol_observed_commit_id, lixcol_as_of_commit_id, lixcol_depth \
                      FROM lix_registered_schema_history \
-                     WHERE lixcol_start_commit_id = '{second_commit_id}' \
+                     WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
                        AND lixcol_entity_pk = lix_json('[\"engine_schema_update_history\"]') \
                      ORDER BY lixcol_depth"
                 ),

--- a/packages/engine/tests/sql/lix_state_history.rs
+++ b/packages/engine/tests/sql/lix_state_history.rs
@@ -2,7 +2,7 @@ use lix_engine::Value;
 use serde_json::json;
 
 simulation_test!(
-    lix_state_history_requires_start_commit_id,
+    lix_state_history_requires_as_of_commit_id,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -22,14 +22,14 @@ simulation_test!(
             .expect("tracked write should succeed");
 
         let error = session
-            .execute("SELECT entity_pk FROM lix_state_history", &[])
+            .execute("SELECT lixcol_entity_pk FROM lix_state_history", &[])
             .await
-            .expect_err("history queries must provide start_commit_id");
+            .expect_err("history queries must provide lixcol_as_of_commit_id");
 
         assert!(
             error
                 .to_string()
-                .contains("requires a start_commit_id filter")
+                .contains("requires a lixcol_as_of_commit_id filter")
         );
         assert_eq!(
             error.code,
@@ -66,7 +66,7 @@ simulation_test!(
 
         let rows = select_history_rows(
             &session,
-            "SELECT entity_pk FROM lix_state_history WHERE start_commit_id = lix_active_branch_commit_id()",
+            "SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()",
         )
         .await;
 
@@ -79,7 +79,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_state_history_rejects_prefixed_start_commit_id_filter,
+    lix_state_history_rejects_retired_anchor_names,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -98,21 +98,64 @@ simulation_test!(
             .await
             .expect("tracked write should succeed");
 
-        let error = session
-            .execute(
-                "SELECT entity_pk \
-                 FROM lix_state_history \
-                 WHERE lixcol_start_commit_id = lix_active_branch_commit_id()",
-                &[],
-            )
-            .await
-            .expect_err("lix_state_history should only expose bare start_commit_id");
+        for retired in ["start_commit_id", "lixcol_start_commit_id"] {
+            let error = session
+                .execute(
+                    &format!(
+                        "SELECT lixcol_entity_pk \
+                         FROM lix_state_history \
+                         WHERE {retired} = lix_active_branch_commit_id()"
+                    ),
+                    &[],
+                )
+                .await
+                .expect_err("retired history anchor must fail");
 
-        assert_eq!(error.code, lix_engine::LixError::CODE_COLUMN_NOT_FOUND);
-        assert!(
-            error.to_string().contains("lixcol_start_commit_id"),
-            "unexpected error: {error}"
+            assert_eq!(error.code, lix_engine::LixError::CODE_COLUMN_NOT_FOUND);
+            assert!(
+                error.to_string().contains(retired),
+                "unexpected error: {error}"
+            );
+        }
+    }
+);
+
+simulation_test!(
+    lix_state_history_rejects_bare_system_column_names,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
         );
+
+        for retired in [
+            "entity_pk",
+            "schema_key",
+            "observed_commit_id",
+            "commit_created_at",
+            "depth",
+        ] {
+            let error = session
+                .execute(
+                    &format!(
+                        "SELECT {retired} \
+                         FROM lix_state_history \
+                         WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()"
+                    ),
+                    &[],
+                )
+                .await
+                .expect_err("bare history system columns must fail");
+            assert_eq!(error.code, lix_engine::LixError::CODE_COLUMN_NOT_FOUND);
+            assert!(
+                error.to_string().contains(retired),
+                "unexpected error: {error}"
+            );
+        }
     }
 );
 
@@ -173,11 +216,11 @@ simulation_test!(
         let first_history = select_history_rows(
             &session,
             &format!(
-                "SELECT start_commit_id, depth, snapshot_content, change_id, observed_commit_id, commit_created_at \
+                "SELECT lixcol_as_of_commit_id, lixcol_depth, lixcol_snapshot_content, lixcol_change_id, lixcol_observed_commit_id, lixcol_commit_created_at, lixcol_change_created_at, lixcol_is_deleted \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{first_commit_id}' \
-                   AND entity_pk = lix_json('[\"history-explicit\"]') \
-                 ORDER BY depth"
+                 WHERE lixcol_as_of_commit_id = '{first_commit_id}' \
+                   AND lixcol_entity_pk = lix_json('[\"history-explicit\"]') \
+                 ORDER BY lixcol_depth"
             ),
         )
         .await;
@@ -191,29 +234,34 @@ simulation_test!(
             "historical commit should be queryable after later commits"
         );
         let Value::Text(first_change_id) = &first_history[0][3] else {
-            panic!("change_id should be text");
+            panic!("lixcol_change_id should be text");
         };
         let Value::Text(first_row_commit_id) = &first_history[0][4] else {
-            panic!("observed_commit_id should be text");
+            panic!("lixcol_observed_commit_id should be text");
         };
         let Value::Text(first_commit_created_at) = &first_history[0][5] else {
-            panic!("commit_created_at should be text");
+            panic!("lixcol_commit_created_at should be text");
+        };
+        let Value::Text(first_change_created_at) = &first_history[0][6] else {
+            panic!("lixcol_change_created_at should be text");
         };
         assert!(!first_change_id.is_empty());
         assert_eq!(first_row_commit_id, &first_commit_id);
         assert!(
             !first_commit_created_at.is_empty(),
-            "commit_created_at should be populated"
+            "lixcol_commit_created_at should be populated"
         );
+        assert!(!first_change_created_at.is_empty());
+        assert_eq!(first_history[0][7], Value::Boolean(false));
 
         let second_history = select_history_rows(
             &session,
             &format!(
-                "SELECT depth, snapshot_content \
+                "SELECT lixcol_depth, lixcol_snapshot_content, lixcol_is_deleted \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{second_commit_id}' \
-                   AND entity_pk = lix_json('[\"history-explicit\"]') \
-                 ORDER BY depth"
+                 WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
+                   AND lixcol_entity_pk = lix_json('[\"history-explicit\"]') \
+                 ORDER BY lixcol_depth"
             ),
         )
         .await;
@@ -223,31 +271,33 @@ simulation_test!(
                 vec![
                     Value::Integer(0),
                     Value::Json(json!({"key": "history-explicit", "value": "two"})),
+                    Value::Boolean(false),
                 ],
                 vec![
                     Value::Integer(1),
                     Value::Json(json!({"key": "history-explicit", "value": "one"})),
+                    Value::Boolean(false),
                 ],
             ],
-            "depth 0 is the start commit and parent changes appear at depth > 0"
+            "lixcol_depth 0 is the as-of commit and parent changes appear at lixcol_depth > 0"
         );
 
         let tombstone_history = select_history_rows(
             &session,
             &format!(
-                "SELECT depth, snapshot_content \
+                "SELECT lixcol_depth, lixcol_snapshot_content, lixcol_is_deleted \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{third_commit_id}' \
-                   AND entity_pk = lix_json('[\"history-explicit\"]') \
-                   AND depth = 0 \
-                   AND snapshot_content IS NULL"
+                 WHERE lixcol_as_of_commit_id = '{third_commit_id}' \
+                   AND lixcol_entity_pk = lix_json('[\"history-explicit\"]') \
+                   AND lixcol_depth = 0 \
+                   AND lixcol_snapshot_content IS NULL"
             ),
         )
         .await;
         assert_eq!(
             tombstone_history,
-            vec![vec![Value::Integer(0), Value::Null]],
-            "tombstone changes should be visible as NULL snapshot_content"
+            vec![vec![Value::Integer(0), Value::Null, Value::Boolean(true)]],
+            "tombstone changes should be visible as NULL lixcol_snapshot_content"
         );
     }
 );
@@ -294,15 +344,15 @@ simulation_test!(
         let rows = select_history_rows(
             &session,
             &format!(
-                "SELECT entity_pk, schema_key, file_id, depth \
+                "SELECT lixcol_entity_pk, lixcol_schema_key, lixcol_file_id, lixcol_depth \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{second_commit_id}' \
-                   AND schema_key = 'lix_binary_blob_ref' \
-                   AND entity_pk = lix_json('[\"history-file-a\"]') \
-                   AND file_id = 'history-file-a' \
-                   AND depth >= 0 \
-                   AND depth <= 1 \
-                 ORDER BY depth"
+                 WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
+                   AND lixcol_schema_key = 'lix_binary_blob_ref' \
+                   AND lixcol_entity_pk = lix_json('[\"history-file-a\"]') \
+                   AND lixcol_file_id = 'history-file-a' \
+                   AND lixcol_depth >= 0 \
+                   AND lixcol_depth <= 1 \
+                 ORDER BY lixcol_depth"
             ),
         )
         .await;
@@ -322,45 +372,45 @@ simulation_test!(
                     Value::Integer(1),
                 ],
             ],
-            "schema_key, entity_pk, file_id, and depth range filters should route through the provider"
+            "lixcol_schema_key, lixcol_entity_pk, lixcol_file_id, and lixcol_depth range filters should route through the provider"
         );
 
         let parent_only_rows = select_history_rows(
             &session,
             &format!(
-                "SELECT start_commit_id, depth \
+                "SELECT lixcol_as_of_commit_id, lixcol_depth \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{second_commit_id}' \
-                   AND schema_key = 'lix_binary_blob_ref' \
-                   AND entity_pk = lix_json('[\"history-file-a\"]') \
-                   AND file_id = 'history-file-a' \
-                   AND depth > 0 \
-                   AND depth < 2"
+                 WHERE lixcol_as_of_commit_id = '{second_commit_id}' \
+                   AND lixcol_schema_key = 'lix_binary_blob_ref' \
+                   AND lixcol_entity_pk = lix_json('[\"history-file-a\"]') \
+                   AND lixcol_file_id = 'history-file-a' \
+                   AND lixcol_depth > 0 \
+                   AND lixcol_depth < 2"
             ),
         )
         .await;
         assert_eq!(
             parent_only_rows,
             vec![vec![Value::Text(second_commit_id), Value::Integer(1)]],
-            "strict depth ranges should keep only matching parent rows"
+            "strict lixcol_depth ranges should keep only matching parent rows"
         );
 
         let historical_start_rows = select_history_rows(
             &session,
             &format!(
-                "SELECT start_commit_id, depth \
+                "SELECT lixcol_as_of_commit_id, lixcol_depth \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{first_commit_id}' \
-                   AND schema_key = 'lix_binary_blob_ref' \
-                   AND entity_pk = lix_json('[\"history-file-a\"]') \
-                   AND file_id = 'history-file-a'"
+                 WHERE lixcol_as_of_commit_id = '{first_commit_id}' \
+                   AND lixcol_schema_key = 'lix_binary_blob_ref' \
+                   AND lixcol_entity_pk = lix_json('[\"history-file-a\"]') \
+                   AND lixcol_file_id = 'history-file-a'"
             ),
         )
         .await;
         assert_eq!(
             historical_start_rows,
             vec![vec![Value::Text(first_commit_id), Value::Integer(0)]],
-            "file_id filtering should also work for historical non-head starts"
+            "lixcol_file_id filtering should also work for historical non-head starts"
         );
     }
 );
@@ -415,12 +465,12 @@ simulation_test!(
         let tombstone_rows = select_history_rows(
             &session,
             &format!(
-                "SELECT observed_commit_id, depth, snapshot_content \
+                "SELECT lixcol_observed_commit_id, lixcol_depth, lixcol_snapshot_content \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{later_commit_id}' \
-                   AND entity_pk = lix_json('[\"history-ancestor-tombstone\"]') \
-                   AND snapshot_content IS NULL \
-                 ORDER BY depth"
+                 WHERE lixcol_as_of_commit_id = '{later_commit_id}' \
+                   AND lixcol_entity_pk = lix_json('[\"history-ancestor-tombstone\"]') \
+                   AND lixcol_snapshot_content IS NULL \
+                 ORDER BY lixcol_depth"
             ),
         )
         .await;
@@ -431,13 +481,13 @@ simulation_test!(
                 Value::Integer(1),
                 Value::Null,
             ]],
-            "a tombstone from the parent commit should appear at ancestor depth"
+            "a tombstone from the parent commit should appear at ancestor lixcol_depth"
         );
     }
 );
 
 simulation_test!(
-    lix_state_history_supports_multiple_start_commit_filters,
+    lix_state_history_supports_multiple_as_of_commit_filters,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -477,12 +527,12 @@ simulation_test!(
         let in_rows = select_history_rows(
             &session,
             &format!(
-                "SELECT start_commit_id, depth, snapshot_content \
+                "SELECT lixcol_as_of_commit_id, lixcol_depth, lixcol_snapshot_content \
                  FROM lix_state_history \
-                 WHERE start_commit_id IN ('{first_commit_id}', '{second_commit_id}') \
-                   AND entity_pk = lix_json('[\"history-multi-start\"]') \
-                   AND depth = 0 \
-                 ORDER BY start_commit_id"
+                 WHERE lixcol_as_of_commit_id IN ('{first_commit_id}', '{second_commit_id}') \
+                   AND lixcol_entity_pk = lix_json('[\"history-multi-start\"]') \
+                   AND lixcol_depth = 0 \
+                 ORDER BY lixcol_as_of_commit_id"
             ),
         )
         .await;
@@ -500,19 +550,19 @@ simulation_test!(
                     Value::Json(json!({"key": "history-multi-start", "value": "two"})),
                 ],
             ],
-            "IN should allow multiple explicit history starts"
+            "IN should allow multiple explicit history anchors"
         );
 
         let or_rows = select_history_rows(
             &session,
             &format!(
-                "SELECT start_commit_id \
+                "SELECT lixcol_as_of_commit_id \
                  FROM lix_state_history \
-                 WHERE (start_commit_id = '{first_commit_id}' \
-                        OR start_commit_id = '{second_commit_id}') \
-                   AND entity_pk = lix_json('[\"history-multi-start\"]') \
-                   AND depth = 0 \
-                 ORDER BY start_commit_id"
+                 WHERE (lixcol_as_of_commit_id = '{first_commit_id}' \
+                        OR lixcol_as_of_commit_id = '{second_commit_id}') \
+                   AND lixcol_entity_pk = lix_json('[\"history-multi-start\"]') \
+                   AND lixcol_depth = 0 \
+                 ORDER BY lixcol_as_of_commit_id"
             ),
         )
         .await;
@@ -522,7 +572,7 @@ simulation_test!(
                 vec![Value::Text(first_commit_id)],
                 vec![Value::Text(second_commit_id)],
             ],
-            "OR should also allow multiple explicit history starts"
+            "OR should also allow multiple explicit history anchors"
         );
     }
 );
@@ -562,11 +612,11 @@ simulation_test!(
         let narrowed_rows = select_history_rows(
             &session,
             &format!(
-                "SELECT entity_pk \
+                "SELECT lixcol_entity_pk \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{head_commit_id}' \
-                   AND entity_pk IN (lix_json('[\"history-and-a\"]'), lix_json('[\"history-and-b\"]')) \
-                   AND entity_pk = lix_json('[\"history-and-a\"]')"
+                 WHERE lixcol_as_of_commit_id = '{head_commit_id}' \
+                   AND lixcol_entity_pk IN (lix_json('[\"history-and-a\"]'), lix_json('[\"history-and-b\"]')) \
+                   AND lixcol_entity_pk = lix_json('[\"history-and-a\"]')"
             ),
         )
         .await;
@@ -579,11 +629,11 @@ simulation_test!(
         let contradictory_rows = select_history_rows(
             &session,
             &format!(
-                "SELECT entity_pk \
+                "SELECT lixcol_entity_pk \
                  FROM lix_state_history \
-                 WHERE start_commit_id = '{head_commit_id}' \
-                   AND entity_pk = lix_json('[\"history-and-a\"]') \
-                   AND entity_pk = lix_json('[\"history-and-b\"]')"
+                 WHERE lixcol_as_of_commit_id = '{head_commit_id}' \
+                   AND lixcol_entity_pk = lix_json('[\"history-and-a\"]') \
+                   AND lixcol_entity_pk = lix_json('[\"history-and-b\"]')"
             ),
         )
         .await;

--- a/packages/engine/tests/sql/metadata.rs
+++ b/packages/engine/tests/sql/metadata.rs
@@ -644,17 +644,17 @@ simulation_test!(
             session
                 .execute(
                     &format!(
-                        "SELECT metadata \
+                        "SELECT lixcol_metadata \
                          FROM lix_state_history \
-                         WHERE start_commit_id = '{commit_id}' \
-                           AND entity_pk = lix_json('[\"metadata-valid-object\"]') \
-                           AND schema_key = 'lix_key_value'"
+                         WHERE lixcol_as_of_commit_id = '{commit_id}' \
+                           AND lixcol_entity_pk = lix_json('[\"metadata-valid-object\"]') \
+                           AND lixcol_schema_key = 'lix_key_value'"
                     ),
                     &[],
                 )
                 .await
                 .expect("lix_state_history metadata should read"),
-            "metadata",
+            "lixcol_metadata",
             &expected,
         );
     }

--- a/packages/engine/tests/sql/untracked_change_ledger.rs
+++ b/packages/engine/tests/sql/untracked_change_ledger.rs
@@ -420,11 +420,11 @@ simulation_test!(
         let tracked_history = session
             .execute(
                 &format!(
-                    "SELECT change_id FROM lix_state_history \
-                     WHERE start_commit_id = '{mixed_head}' \
-                       AND schema_key = 'lix_key_value' \
-                       AND lix_json_get_text(entity_pk, 0) = 'untracked-ledger-tx-tracked' \
-                       AND depth = 0"
+                    "SELECT lixcol_change_id FROM lix_state_history \
+                     WHERE lixcol_as_of_commit_id = '{mixed_head}' \
+                       AND lixcol_schema_key = 'lix_key_value' \
+                       AND lix_json_get_text(lixcol_entity_pk, 0) = 'untracked-ledger-tx-tracked' \
+                       AND lixcol_depth = 0"
                 ),
                 &[],
             )
@@ -434,10 +434,10 @@ simulation_test!(
         let untracked_history = session
             .execute(
                 &format!(
-                    "SELECT change_id FROM lix_state_history \
-                     WHERE start_commit_id = '{mixed_head}' \
-                       AND schema_key = 'lix_key_value' \
-                       AND lix_json_get_text(entity_pk, 0) = 'untracked-ledger-tx-untracked'"
+                    "SELECT lixcol_change_id FROM lix_state_history \
+                     WHERE lixcol_as_of_commit_id = '{mixed_head}' \
+                       AND lixcol_schema_key = 'lix_key_value' \
+                       AND lix_json_get_text(lixcol_entity_pk, 0) = 'untracked-ledger-tx-untracked'"
                 ),
                 &[],
             )

--- a/packages/engine/tests/transaction.rs
+++ b/packages/engine/tests/transaction.rs
@@ -266,9 +266,9 @@ async fn transaction_read_can_query_history_surfaces() {
         .expect("transaction should begin");
     let result = tx
         .execute(
-            "SELECT entity_pk FROM lix_state_history \
-             WHERE start_commit_id = lix_active_branch_commit_id() \
-             AND schema_key = 'lix_key_value'",
+            "SELECT lixcol_entity_pk FROM lix_state_history \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+             AND lixcol_schema_key = 'lix_key_value'",
             &[],
         )
         .await

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -402,7 +402,7 @@ test("execute originKey is exposed on change and history surfaces without metada
 	expect(get(inserted, "lixcol_metadata")).toEqual(metadata);
 	const fileHistorySources = get(
 		await lix.execute(
-			"SELECT lixcol_source_changes FROM lix_file_history WHERE id = $1 AND lixcol_start_commit_id = $2",
+			"SELECT lixcol_source_changes FROM lix_file_history WHERE id = $1 AND lixcol_as_of_commit_id = $2",
 			[fileId, insertedHeadCommitId],
 		),
 		"lixcol_source_changes",
@@ -413,10 +413,10 @@ test("execute originKey is exposed on change and history surfaces without metada
 	expect(
 		get(
 			await lix.execute(
-				"SELECT origin_key FROM lix_state_history WHERE change_id = $1 AND start_commit_id = $2",
+				"SELECT lixcol_origin_key FROM lix_state_history WHERE lixcol_change_id = $1 AND lixcol_as_of_commit_id = $2",
 				[get(inserted, "lixcol_change_id"), insertedHeadCommitId],
 			),
-			"origin_key",
+			"lixcol_origin_key",
 		),
 	).toBe("test-origin");
 
@@ -441,10 +441,10 @@ test("execute originKey is exposed on change and history surfaces without metada
 	expect(
 		get(
 			await lix.execute(
-				"SELECT origin_key FROM lix_state_history WHERE change_id = $1 AND start_commit_id = $2",
+				"SELECT lixcol_origin_key FROM lix_state_history WHERE lixcol_change_id = $1 AND lixcol_as_of_commit_id = $2",
 				[get(txStamped, "lixcol_change_id"), txHeadCommitId],
 			),
-			"origin_key",
+			"lixcol_origin_key",
 		),
 	).toBe("tx-origin");
 	expect(get(txStamped, "lixcol_metadata")).toEqual(metadata);
@@ -1222,7 +1222,7 @@ test("beginTransaction preserves handle after failed statement", async () => {
 		["failed-tx-task", "Before failure", false, JSON.stringify({ batch: 1 })],
 	);
 	await expect(
-		tx.execute("SELECT entity_pk FROM lix_state_history"),
+		tx.execute("SELECT lixcol_entity_pk FROM lix_state_history"),
 	).rejects.toMatchObject({
 		code: "LIX_HISTORY_FILTER_REQUIRED",
 	});
@@ -1251,7 +1251,7 @@ test("beginTransaction can continue after failed statement", async () => {
 		],
 	);
 	await expect(
-		tx.execute("SELECT entity_pk FROM lix_state_history"),
+		tx.execute("SELECT lixcol_entity_pk FROM lix_state_history"),
 	).rejects.toMatchObject({
 		code: "LIX_HISTORY_FILTER_REQUIRED",
 	});
@@ -1384,7 +1384,7 @@ test("engine errors cross the native boundary", async () => {
 	const lix = await openLix();
 
 	try {
-		await lix.execute("SELECT entity_pk FROM lix_state_history");
+		await lix.execute("SELECT lixcol_entity_pk FROM lix_state_history");
 		throw new Error("expected history query to fail");
 	} catch (error) {
 		expect(error).toMatchObject({
@@ -1818,14 +1818,14 @@ test("lix_state_history snapshot_content preserves JSON null for binary file row
 	);
 
 	const result = await lix.execute(
-		"SELECT schema_key, snapshot_content \
+		"SELECT lixcol_schema_key, lixcol_snapshot_content \
 		 FROM lix_state_history \
-		 WHERE start_commit_id = lix_active_branch_commit_id()",
+		 WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()",
 	);
 	const directoryRow = result.rows.find(
-		(row) => row.get("schema_key") === "lix_directory_descriptor",
+		(row) => row.get("lixcol_schema_key") === "lix_directory_descriptor",
 	);
-	expect(directoryRow?.get("snapshot_content")).toMatchObject({
+	expect(directoryRow?.get("lixcol_snapshot_content")).toMatchObject({
 		parent_id: null,
 	});
 

--- a/packages/js-sdk/tests/memory-storage-contract.ts
+++ b/packages/js-sdk/tests/memory-storage-contract.ts
@@ -63,7 +63,7 @@ export function registerMemoryStorageContract({
 					details: { operation: "execute", parameter_index: 1 },
 				});
 				await expect(
-					lix.execute("SELECT entity_pk FROM lix_state_history"),
+					lix.execute("SELECT lixcol_entity_pk FROM lix_state_history"),
 				).rejects.toMatchObject({
 					name: "LixError",
 					code: "LIX_HISTORY_FILTER_REQUIRED",
@@ -174,7 +174,7 @@ export function registerMemoryStorageContract({
 							sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
 							params: ["batch-rolled-back", "before failure"],
 						},
-						{ sql: "SELECT entity_pk FROM lix_state_history" },
+						{ sql: "SELECT lixcol_entity_pk FROM lix_state_history" },
 						{
 							sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
 							params: ["batch-not-run", "after failure"],

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -359,7 +359,7 @@ async fn execute_batch_is_atomic_and_returns_ordered_results() {
                 ],
             },
             ExecuteBatchStatement {
-                sql: "SELECT entity_pk FROM lix_state_history".to_string(),
+                sql: "SELECT lixcol_entity_pk FROM lix_state_history".to_string(),
                 params: Vec::new(),
             },
         ])


### PR DESCRIPTION
## Dependency

This draft is stacked on #711 because composed `lixcol_source_changes` is only truthful after the DAG-correct same-commit aggregation in that PR. Once #711 lands, this PR should be retargeted to `main`.

## Why

History currently mixes bare and `lixcol_`-prefixed metadata and calls the query anchor a “start” commit, which agents repeatedly confuse with the commit where an entity first appeared. Composed filesystem rows also cannot honestly expose one singular source change.

## Hard cut

Every public history surface now uses one common vocabulary:

- `lixcol_entity_pk`
- `lixcol_observed_commit_id`
- `lixcol_commit_created_at`
- `lixcol_as_of_commit_id`
- `lixcol_depth`
- `lixcol_is_deleted`

Raw/typed entity history additionally exposes singular provenance, including `lixcol_change_id`, `lixcol_change_created_at`, `lixcol_schema_key`, and `lixcol_origin_key`.

Composed `lix_file_history` and `lix_directory_history` expose only the structured `lixcol_source_changes` provenance array—no misleading singular source fields.

All bare compatibility names and `lixcol_start_commit_id` are removed. Missing observed-commit timestamps are explicit internal errors; commit time never silently falls back to change time.

Docs, errors, routing, information-schema contracts, SDK queries, and SQL regressions use the same names.

## Validation

On the exact #711 stack before the final unrelated storage-only base rebase:

- Full SQL suite: 566/566 passed.
- Full library suite: 1,159 passed, 6 ignored.
- Focused history SQL: 81/81 passed.
- History-route units: 7/7 passed.
- CI-equivalent engine Clippy with warnings denied: passed.
- Formatting and diff checks: passed.

After rebasing both layers onto current `main` (`f2e1e1bc`), `cargo check -p lix_engine --all-targets`, formatting, and diff checks pass.