### PR TITLE
fix!(sql): make history identity routing complete

### DIFF
--- a/.changenotes/complete-history-identity-routing.md
+++ b/.changenotes/complete-history-identity-routing.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Typed SQL history now routes exact public primary-key predicates in declared `x-lix-primary-key` order and keeps primary-key columns non-null on deletion rows, including nested identity roots.
+
+The relation-blind `LIX_HISTORY_NON_IDENTITY_FILTER` notice has been removed. File and directory history filters retain ordinary SQL row semantics: filtering by a historical path returns revisions with that path, while filtering by immutable identity returns the entity lineage.

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -97,6 +97,17 @@ WHERE id = 't1'
 ORDER BY lixcol_depth;
 ```
 
+Typed history preserves every declared primary-key root on deletion rows, including nested JSON roots. For a composite key, constrain every public key column for an exact entity lookup; Lix encodes the identity in the schema's `x-lix-primary-key` order, regardless of predicate order:
+
+```sql
+SELECT lixcol_depth, value
+FROM localized_message_history
+WHERE key = 'welcome'
+  AND locale = 'en'
+  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
+ORDER BY lixcol_depth;
+```
+
 When you need the typed columns, reach for the per-entity sugar. When you're querying across schemas, drop down to `lix_state*`. Same data either way.
 
 ## Files
@@ -137,6 +148,8 @@ FROM lix_file_history
 WHERE path = '/orders.xlsx'
 ORDER BY lixcol_depth;
 ```
+
+`path` has ordinary SQL row semantics on history: this query returns only revisions whose path was `/orders.xlsx`. Filter by immutable `id` when you want the complete lineage across renames and moves.
 
 In JavaScript, pass a `Uint8Array` or `ArrayBuffer` for `$1`. Read `data` with `row.value("data").asBytes()`.
 

--- a/packages/engine/src/sql2/catalog/entity_surface.rs
+++ b/packages/engine/src/sql2/catalog/entity_surface.rs
@@ -120,6 +120,15 @@ pub(crate) fn entity_surface_schema(
     spec: &EntitySurfaceSpec,
     shape: EntitySurfaceShape,
 ) -> SchemaRef {
+    let history_identity_roots = if shape == EntitySurfaceShape::History {
+        spec.primary_key_paths
+            .iter()
+            .filter_map(|path| path.first())
+            .cloned()
+            .collect::<BTreeSet<_>>()
+    } else {
+        BTreeSet::new()
+    };
     let mut fields = spec
         .columns
         .iter()
@@ -127,7 +136,7 @@ pub(crate) fn entity_surface_schema(
             let field = Field::new(
                 &column.name,
                 arrow_data_type_for_entity_column_type(column.column_type),
-                true,
+                !history_identity_roots.contains(&column.name),
             );
             if column.column_type == EntityColumnType::Json {
                 mark_json_field(field)
@@ -296,5 +305,66 @@ fn collect_entity_type_kinds<'a>(schema: &'a JsonValue, out: &mut BTreeSet<&'a s
                 collect_entity_type_kinds(branch, out);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{
+        EntitySurfaceShape, derive_entity_surface_spec_from_schema, entity_surface_schema,
+    };
+
+    #[test]
+    fn history_identity_roots_are_non_null_even_for_nested_keys() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "localized_document",
+            "x-lix-primary-key": ["/identity/tenant", "/identity/id", "/locale"],
+            "type": "object",
+            "properties": {
+                "identity": {
+                    "type": "object",
+                    "properties": {
+                        "tenant": { "type": "string" },
+                        "id": { "type": "string" }
+                    },
+                    "required": ["tenant", "id"]
+                },
+                "locale": { "type": "string" },
+                "body": { "type": "string" }
+            },
+            "required": ["identity", "locale", "body"]
+        }))
+        .expect("schema should derive");
+
+        let history = entity_surface_schema(&spec, EntitySurfaceShape::History);
+        assert!(
+            !history
+                .field_with_name("identity")
+                .expect("nested identity root")
+                .is_nullable()
+        );
+        assert!(
+            !history
+                .field_with_name("locale")
+                .expect("top-level identity")
+                .is_nullable()
+        );
+        assert!(
+            history
+                .field_with_name("body")
+                .expect("payload")
+                .is_nullable()
+        );
+
+        let active = entity_surface_schema(&spec, EntitySurfaceShape::Active);
+        assert!(
+            active
+                .field_with_name("identity")
+                .expect("active identity input")
+                .is_nullable(),
+            "write surfaces keep omission/default input semantics"
+        );
     }
 }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -142,12 +142,11 @@ async fn create_logical_plan_in_session_from_parsed(
     validate_json_predicates_in_logical_plan(&plan)?;
     validate_history_anchor_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
-    let notices = history_filter_notices(&plan);
 
     Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
         session: session.session.clone(),
         plan,
-        notices,
+        notices: Vec::new(),
         json_predicate_params,
     }))
 }
@@ -180,12 +179,11 @@ async fn create_transaction_read_logical_plan_from_parsed(
     validate_json_predicates_in_logical_plan(&plan)?;
     validate_history_anchor_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
-    let notices = history_filter_notices(&plan);
 
     Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
         session,
         plan,
-        notices,
+        notices: Vec::new(),
         json_predicate_params,
     }))
 }
@@ -2130,125 +2128,6 @@ pub(crate) fn query_result_from_batches(
     })
 }
 
-fn history_filter_notices(plan: &LogicalPlan) -> Vec<LixNotice> {
-    let mut observations = Vec::new();
-    collect_notice_observations(plan, &Vec::new(), &mut observations);
-
-    let mut notices = Vec::new();
-    let mut emitted_codes = HashSet::<String>::new();
-    for observation in observations {
-        for rule in HISTORY_NOTICE_RULES {
-            if observation.table_name != rule.table_name {
-                continue;
-            }
-            if !observation.references_any(rule.payload_columns)
-                || observation.references_any(rule.identity_columns)
-            {
-                continue;
-            }
-
-            let code = format!("LIX_HISTORY_NON_IDENTITY_FILTER:{}", rule.table_name);
-            if emitted_codes.insert(code) {
-                notices.push(history_non_identity_filter_notice(rule.table_name));
-            }
-        }
-    }
-    notices
-}
-
-#[derive(Debug)]
-struct NoticeObservation {
-    table_name: String,
-    filter_columns: HashSet<String>,
-}
-
-impl NoticeObservation {
-    fn references_any(&self, columns: &[&str]) -> bool {
-        columns
-            .iter()
-            .any(|column| self.filter_columns.contains(*column))
-    }
-}
-
-struct HistoryNoticeRule {
-    table_name: &'static str,
-    payload_columns: &'static [&'static str],
-    identity_columns: &'static [&'static str],
-}
-
-const HISTORY_NOTICE_RULES: &[HistoryNoticeRule] = &[
-    HistoryNoticeRule {
-        table_name: "lix_file_history",
-        payload_columns: &["path", "directory_id", "name", "data"],
-        identity_columns: &["id", "lixcol_entity_pk"],
-    },
-    HistoryNoticeRule {
-        table_name: "lix_directory_history",
-        payload_columns: &["path", "parent_id", "name"],
-        identity_columns: &["id", "lixcol_entity_pk"],
-    },
-];
-
-fn collect_notice_observations(
-    plan: &LogicalPlan,
-    active_filter_columns: &Vec<HashSet<String>>,
-    observations: &mut Vec<NoticeObservation>,
-) {
-    match plan {
-        LogicalPlan::Filter(filter) => {
-            let mut next_filters = active_filter_columns.clone();
-            next_filters.push(expr_column_names(&filter.predicate));
-            collect_notice_observations(&filter.input, &next_filters, observations);
-        }
-        LogicalPlan::TableScan(scan) => {
-            let mut filter_columns = HashSet::new();
-            for columns in active_filter_columns {
-                filter_columns.extend(columns.iter().cloned());
-            }
-            for filter in &scan.filters {
-                filter_columns.extend(expr_column_names(filter));
-            }
-            if !filter_columns.is_empty() {
-                observations.push(NoticeObservation {
-                    table_name: table_reference_name(&scan.table_name),
-                    filter_columns,
-                });
-            }
-        }
-        other => {
-            for input in other.inputs() {
-                collect_notice_observations(input, active_filter_columns, observations);
-            }
-        }
-    }
-}
-
-fn expr_column_names(expr: &Expr) -> HashSet<String> {
-    expr.column_refs()
-        .iter()
-        .map(|column| column.name.clone())
-        .collect()
-}
-
-fn table_reference_name(table: &datafusion::common::TableReference) -> String {
-    match table {
-        datafusion::common::TableReference::Bare { table } => table.to_string(),
-        datafusion::common::TableReference::Partial { table, .. } => table.to_string(),
-        datafusion::common::TableReference::Full { table, .. } => table.to_string(),
-    }
-}
-
-fn history_non_identity_filter_notice(view_name: &str) -> LixNotice {
-    LixNotice {
-        code: "LIX_HISTORY_NON_IDENTITY_FILTER".to_string(),
-        message: format!("{view_name} was filtered without an identity predicate."),
-        hint: Some(
-            "Filter by id or lixcol_entity_pk to include tombstones and renamed history."
-                .to_string(),
-        ),
-    }
-}
-
 fn scalar_value_to_lix_value(value: ScalarValue, field: Option<&Field>) -> Result<Value, LixError> {
     match value {
         ScalarValue::Null => Ok(Value::Null),
@@ -3683,11 +3562,10 @@ mod tests {
                 &[],
             )
             .await
-            .expect("sql2 execute should attach notices to name-filtered directory history reads");
-        assert_eq!(name_filtered_result.notices().len(), 1);
-        assert_eq!(
-            name_filtered_result.notices()[0].code,
-            "LIX_HISTORY_NON_IDENTITY_FILTER"
+            .expect("name-filtered directory history should execute");
+        assert!(
+            name_filtered_result.notices().is_empty(),
+            "ordinary SQL predicates should not emit identity heuristics"
         );
     }
 
@@ -3744,11 +3622,10 @@ mod tests {
                 &[],
             )
             .await
-            .expect("sql2 execute should attach notices to path-filtered file history reads");
-        assert_eq!(path_filtered_result.notices().len(), 1);
-        assert_eq!(
-            path_filtered_result.notices()[0].code,
-            "LIX_HISTORY_NON_IDENTITY_FILTER"
+            .expect("path-filtered file history should execute");
+        assert!(
+            path_filtered_result.notices().is_empty(),
+            "ordinary SQL predicates should not emit identity heuristics"
         );
     }
 

--- a/packages/engine/src/sql2/history_projection.rs
+++ b/packages/engine/src/sql2/history_projection.rs
@@ -37,20 +37,127 @@ fn primary_key_tombstone_value(
     entity_pk: &str,
     primary_key_paths: &[Vec<String>],
 ) -> Result<Option<JsonValue>, LixError> {
-    let Some(part_index) = primary_key_paths
+    if !primary_key_paths
         .iter()
-        .position(|path| path.as_slice() == [column_name])
-    else {
+        .any(|path| path.first().is_some_and(|root| root == column_name))
+    {
         return Ok(None);
-    };
+    }
 
     let identity = EntityPk::from_json_array_text(entity_pk).map_err(|error| {
         LixError::unknown(format!(
             "failed to decode history tombstone entity primary key: {error}"
         ))
     })?;
-    Ok(identity
-        .parts
-        .get(part_index)
-        .map(|part| JsonValue::String(part.clone())))
+    if identity.parts.len() != primary_key_paths.len() {
+        return Err(LixError::unknown(format!(
+            "history tombstone entity primary key has {} part(s), but its schema declares {} primary-key path(s)",
+            identity.parts.len(),
+            primary_key_paths.len()
+        )));
+    }
+
+    let mut projected = JsonValue::Null;
+    for (path, part) in primary_key_paths.iter().zip(&identity.parts) {
+        let Some((root, nested_path)) = path.split_first() else {
+            return Err(LixError::unknown(
+                "history tombstone schema contains an empty primary-key path",
+            ));
+        };
+        if root != column_name {
+            continue;
+        }
+        insert_tombstone_identity_part(
+            &mut projected,
+            nested_path,
+            JsonValue::String(part.clone()),
+        )?;
+    }
+    Ok(Some(projected))
+}
+
+fn insert_tombstone_identity_part(
+    target: &mut JsonValue,
+    path: &[String],
+    value: JsonValue,
+) -> Result<(), LixError> {
+    let Some((segment, remaining)) = path.split_first() else {
+        if !target.is_null() && target != &value {
+            return Err(LixError::unknown(
+                "history tombstone schema has conflicting primary-key paths",
+            ));
+        }
+        *target = value;
+        return Ok(());
+    };
+
+    if target.is_null() {
+        *target = JsonValue::Object(serde_json::Map::new());
+    }
+    let object = target.as_object_mut().ok_or_else(|| {
+        LixError::unknown("history tombstone schema has conflicting primary-key paths")
+    })?;
+    insert_tombstone_identity_part(
+        object.entry(segment.clone()).or_insert(JsonValue::Null),
+        remaining,
+        value,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{HistoryIdentityProjection, tombstone_identity_column_value};
+
+    #[test]
+    fn reconstructs_nested_composite_identity_roots_for_tombstones() {
+        let primary_key_paths = vec![
+            vec!["identity".to_string(), "tenant".to_string()],
+            vec![
+                "identity".to_string(),
+                "document".to_string(),
+                "id".to_string(),
+            ],
+            vec!["locale".to_string()],
+        ];
+
+        let identity = tombstone_identity_column_value(
+            "identity",
+            r#"["acme","welcome","en"]"#,
+            HistoryIdentityProjection::PrimaryKeyPaths(&primary_key_paths),
+        )
+        .expect("nested tombstone identity should project");
+        let locale = tombstone_identity_column_value(
+            "locale",
+            r#"["acme","welcome","en"]"#,
+            HistoryIdentityProjection::PrimaryKeyPaths(&primary_key_paths),
+        )
+        .expect("top-level tombstone identity should project");
+
+        assert_eq!(
+            identity,
+            Some(json!({
+                "tenant": "acme",
+                "document": { "id": "welcome" }
+            }))
+        );
+        assert_eq!(locale, Some(json!("en")));
+    }
+
+    #[test]
+    fn rejects_identity_arity_that_does_not_match_the_schema() {
+        let error = tombstone_identity_column_value(
+            "id",
+            r#"["one","two"]"#,
+            HistoryIdentityProjection::PrimaryKeyPaths(&[vec!["id".to_string()]]),
+        )
+        .expect_err("mismatched identity arity should fail");
+
+        assert!(
+            error
+                .message
+                .contains("2 part(s), but its schema declares 1")
+        );
+    }
 }

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -101,6 +101,10 @@ impl HistoryRoute {
             || self.max_depth.is_some_and(|depth| depth < 0)
     }
 
+    pub(crate) fn constrain_entity_pks(&mut self, entity_pks: Vec<String>) {
+        self.contradictory |= apply_conjunctive_values_filter(&mut self.entity_pks, entity_pks);
+    }
+
     /// Checks filters that refer to the row exposed by a shaped history surface.
     pub(crate) fn matches_surface_row(
         &self,

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -537,23 +537,25 @@ fn entity_delete_stage_rows_from_batch(
         .collect()
 }
 
-fn entity_pks_from_primary_key_filters(
+pub(super) fn entity_pks_from_primary_key_filters(
     spec: &EntitySurfaceSpec,
     filters: &[Expr],
 ) -> Result<Option<Vec<EntityPk>>> {
     let analyzer = EntityPrimaryKeyFilterAnalyzer::new(spec);
-    let mut entity_pks: Option<BTreeSet<EntityPk>> = None;
+    let mut constraint: Option<EntityPkConstraint> = None;
     for filter in filters {
-        let Some(filter_ids) = analyzer.analyze(filter)? else {
+        let Some(filter_constraint) = analyzer.analyze_conjunctive_constraint(filter)? else {
             continue;
         };
-        entity_pks = Some(match entity_pks {
-            Some(existing_ids) => existing_ids.intersection(&filter_ids).cloned().collect(),
-            None => filter_ids,
+        constraint = Some(match constraint {
+            Some(existing) => existing.intersect(filter_constraint, &analyzer.primary_key_columns),
+            None => filter_constraint,
         });
     }
 
-    Ok(entity_pks.map(|ids| ids.into_iter().collect()))
+    Ok(constraint
+        .and_then(|constraint| constraint.into_entity_pks(&analyzer.primary_key_columns))
+        .map(|ids| ids.into_iter().collect()))
 }
 
 fn apply_exact_entity_pk_filters(
@@ -597,7 +599,7 @@ fn apply_exact_branch_id_filter(
     }
 }
 
-struct EntityPrimaryKeyFilterAnalyzer<'a> {
+pub(super) struct EntityPrimaryKeyFilterAnalyzer<'a> {
     primary_key_columns: Vec<&'a str>,
 }
 
@@ -689,14 +691,19 @@ fn branch_id_from_column_literal_filter(column_expr: &Expr, literal_expr: &Expr)
 }
 
 impl<'a> EntityPrimaryKeyFilterAnalyzer<'a> {
-    fn new(spec: &'a EntitySurfaceSpec) -> Self {
+    pub(super) fn new(spec: &'a EntitySurfaceSpec) -> Self {
         Self {
             primary_key_columns: string_primary_key_columns(spec),
         }
     }
 
-    fn supports(&self, expr: &Expr) -> bool {
+    pub(super) fn supports(&self, expr: &Expr) -> bool {
         self.analyze(expr)
+            .is_ok_and(|constraint| constraint.is_some())
+    }
+
+    pub(super) fn contains_routable_conjunct(&self, expr: &Expr) -> bool {
+        self.analyze_conjunctive_constraint(expr)
             .is_ok_and(|constraint| constraint.is_some())
     }
 
@@ -708,6 +715,30 @@ impl<'a> EntityPrimaryKeyFilterAnalyzer<'a> {
             return Ok(None);
         };
         Ok(constraint.into_entity_pks(&self.primary_key_columns))
+    }
+
+    /// Extracts identity constraints that are guaranteed conjuncts while
+    /// refusing to partially route a disjunction. This lets DataFusion pass
+    /// separately planned composite-key terms without turning a payload
+    /// predicate into identity semantics.
+    fn analyze_conjunctive_constraint(&self, expr: &Expr) -> Result<Option<EntityPkConstraint>> {
+        if self.primary_key_columns.is_empty() {
+            return Ok(None);
+        }
+        let Expr::BinaryExpr(binary_expr) = expr else {
+            return self.analyze_constraint(expr);
+        };
+        if binary_expr.op != Operator::And {
+            return self.analyze_constraint(expr);
+        }
+
+        let left = self.analyze_conjunctive_constraint(&binary_expr.left)?;
+        let right = self.analyze_conjunctive_constraint(&binary_expr.right)?;
+        Ok(match (left, right) {
+            (Some(left), Some(right)) => Some(left.intersect(right, &self.primary_key_columns)),
+            (Some(constraint), None) | (None, Some(constraint)) => Some(constraint),
+            (None, None) => None,
+        })
     }
 
     fn analyze_constraint(&self, expr: &Expr) -> Result<Option<EntityPkConstraint>> {
@@ -1142,6 +1173,9 @@ fn identity_matches_parts(
     parts: &BTreeMap<String, BTreeSet<String>>,
 ) -> bool {
     let identity_parts = identity.parts.as_slice();
+    if identity_parts.len() != primary_key_columns.len() {
+        return false;
+    }
     primary_key_columns
         .iter()
         .zip(identity_parts.iter())
@@ -1879,6 +1913,37 @@ mod tests {
         assert_eq!(
             entity_pks,
             vec![crate::entity_pk::EntityPk::single("entity-a")]
+        );
+    }
+
+    #[test]
+    fn split_composite_primary_key_filters_use_declared_path_order() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "localized_message",
+            "x-lix-primary-key": ["/locale", "/key"],
+            "type": "object",
+            "properties": {
+                "key": { "type": "string" },
+                "locale": { "type": "string" },
+                "body": { "type": "string" }
+            },
+            "required": ["key", "locale", "body"]
+        }))
+        .expect("schema should derive");
+        // SQL predicate order is deliberately the reverse of the schema's
+        // primary-key order.
+        let filters = vec![eq_filter("key", "welcome"), eq_filter("locale", "en")];
+
+        let entity_pks = super::entity_pks_from_primary_key_filters(&spec, &filters)
+            .expect("composite primary-key filters should analyze")
+            .expect("all composite parts should produce an exact identity");
+
+        assert_eq!(
+            entity_pks,
+            vec![
+                crate::entity_pk::EntityPk::tuple(vec!["en".to_string(), "welcome".to_string(),])
+                    .expect("test identity should be valid")
+            ]
         );
     }
 

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -35,6 +35,7 @@ use crate::sql2::providers::entity::{
 use crate::storage_adapter::StorageAdapterRead;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
+use super::entity::{EntityPrimaryKeyFilterAnalyzer, entity_pks_from_primary_key_filters};
 use super::spec::{PlannedScan, TableSpec, projected_schema, register_spec_table, row_source};
 
 pub(super) fn register_entity_history_surface<S>(
@@ -96,8 +97,13 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        if parse_history_filter(filter).is_some() {
+        let identity_analyzer = EntityPrimaryKeyFilterAnalyzer::new(&self.spec);
+        if parse_history_filter(filter).is_some() || identity_analyzer.supports(filter) {
             TableProviderFilterPushDown::Exact
+        } else if identity_analyzer.contains_routable_conjunct(filter) {
+            // Keep DataFusion's residual evaluation for mixed predicates while
+            // still receiving exact identity conjuncts for commit-graph routing.
+            TableProviderFilterPushDown::Inexact
         } else {
             TableProviderFilterPushDown::Unsupported
         }
@@ -114,7 +120,7 @@ where
         limit: Option<usize>,
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
-        let mut route = HistoryRoute::from_filters(filters);
+        let mut route = entity_history_route_from_filters(&self.spec, filters)?;
         route.default_to_as_of_commit_id(&self.query_source.default_as_of_commit_id);
         let schema = projected_schema(&self.schema, projection);
         let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
@@ -146,6 +152,22 @@ where
             ),
         })
     }
+}
+
+fn entity_history_route_from_filters(
+    spec: &EntitySurfaceSpec,
+    filters: &[Expr],
+) -> Result<HistoryRoute> {
+    let mut route = HistoryRoute::from_filters(filters);
+    if let Some(entity_pks) = entity_pks_from_primary_key_filters(spec, filters)? {
+        let entity_pks = entity_pks
+            .into_iter()
+            .map(|entity_pk| entity_pk.as_json_array_text())
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(lix_error_to_datafusion_error)?;
+        route.constrain_entity_pks(entity_pks);
+    }
+    Ok(route)
 }
 
 #[derive(Debug, Clone)]
@@ -374,4 +396,91 @@ fn entity_history_column_value(
         HistoryIdentityProjection::PrimaryKeyPaths(&spec.primary_key_paths),
     )
     .map_err(|error| DataFusionError::Execution(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::common::{Column, ScalarValue};
+    use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
+    use serde_json::json;
+
+    use crate::sql2::catalog::derive_entity_surface_spec_from_schema;
+
+    use super::entity_history_route_from_filters;
+
+    #[test]
+    fn public_composite_key_filters_route_in_schema_order() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "localized_message",
+            "x-lix-primary-key": ["/locale", "/key"],
+            "type": "object",
+            "properties": {
+                "key": { "type": "string" },
+                "locale": { "type": "string" },
+                "body": { "type": "string" }
+            },
+            "required": ["key", "locale", "body"]
+        }))
+        .expect("schema should derive");
+        let filters = vec![
+            eq("lixcol_as_of_commit_id", "commit-head"),
+            // Deliberately reverse the declared primary-key path order.
+            eq("key", "welcome"),
+            eq("locale", "en"),
+        ];
+
+        let route = entity_history_route_from_filters(&spec, &filters)
+            .expect("history route should derive");
+
+        assert_eq!(route.as_of_commit_ids, vec!["commit-head"]);
+        assert_eq!(route.entity_pks, vec![r#"["en","welcome"]"#]);
+        assert!(!route.is_contradictory());
+    }
+
+    #[test]
+    fn public_and_opaque_identity_filters_intersect() {
+        let spec = derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "localized_message",
+            "x-lix-primary-key": ["/locale", "/key"],
+            "type": "object",
+            "properties": {
+                "key": { "type": "string" },
+                "locale": { "type": "string" }
+            },
+            "required": ["key", "locale"]
+        }))
+        .expect("schema should derive");
+        let filters = vec![
+            eq("key", "welcome"),
+            eq("locale", "en"),
+            eq("lixcol_entity_pk", r#"["fr","welcome"]"#),
+        ];
+
+        let route = entity_history_route_from_filters(&spec, &filters)
+            .expect("history route should derive");
+
+        assert!(route.is_contradictory());
+
+        let wrong_arity_route = entity_history_route_from_filters(
+            &spec,
+            &[
+                eq("key", "welcome"),
+                eq("locale", "en"),
+                eq("lixcol_entity_pk", r#"["en"]"#),
+            ],
+        )
+        .expect("wrong-arity identity should produce a route");
+        assert!(wrong_arity_route.is_contradictory());
+    }
+
+    fn eq(column: &str, value: &str) -> Expr {
+        Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(Expr::Column(Column::from_name(column))),
+            Operator::Eq,
+            Box::new(Expr::Literal(
+                ScalarValue::Utf8(Some(value.to_string())),
+                None,
+            )),
+        ))
+    }
 }

--- a/packages/engine/tests/sql/history_conformance.rs
+++ b/packages/engine/tests/sql/history_conformance.rs
@@ -108,7 +108,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
                  VALUES (\
-                 lix_json('{\"x-lix-key\":\"engine_history_contract_schema\",\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"count\":{\"type\":\"integer\"},\"active\":{\"type\":\"boolean\"},\"meta\":{\"type\":\"object\"}},\"required\":[\"id\",\"count\",\"active\",\"meta\"],\"additionalProperties\":false}'),\
+                 lix_json('{\"x-lix-key\":\"engine_history_contract_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"count\":{\"type\":\"integer\"},\"active\":{\"type\":\"boolean\"},\"meta\":{\"type\":\"object\"}},\"required\":[\"id\",\"count\",\"active\",\"meta\"],\"additionalProperties\":false}'),\
                  false,\
                  false\
                  )",
@@ -137,7 +137,7 @@ simulation_test!(
         let expected = vec![
             ("engine_history_contract_schema_history", "active", "YES"),
             ("engine_history_contract_schema_history", "count", "YES"),
-            ("engine_history_contract_schema_history", "id", "YES"),
+            ("engine_history_contract_schema_history", "id", "NO"),
             (
                 "engine_history_contract_schema_history",
                 "lixcol_is_deleted",
@@ -404,6 +404,102 @@ simulation_test!(
                 ],
             ]
         );
+    }
+);
+
+simulation_test!(
+    typed_entity_history_reconstructs_nested_primary_key_roots_on_tombstones,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"engine_history_nested_pk\",\"x-lix-primary-key\":[\"/identity/tenant\",\"/identity/id\"],\"type\":\"object\",\"properties\":{\"identity\":{\"type\":\"object\",\"properties\":{\"tenant\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"}},\"required\":[\"tenant\",\"id\"],\"additionalProperties\":false},\"value\":{\"type\":\"string\"}},\"required\":[\"identity\",\"value\"],\"additionalProperties\":false}'),\
+                 false,\
+                 false\
+                 )",
+                &[],
+            )
+            .await
+            .expect("registered schema insert should succeed");
+
+        session
+            .execute(
+                "INSERT INTO engine_history_nested_pk \
+                 (identity, value, lixcol_untracked) \
+                 VALUES (lix_json('{\"tenant\":\"acme\",\"id\":\"7\"}'), 'one', false)",
+                &[],
+            )
+            .await
+            .expect("nested-key entity insert should succeed");
+        session
+            .execute(
+                "DELETE FROM engine_history_nested_pk \
+                 WHERE lixcol_entity_pk = lix_json('[\"acme\",\"7\"]')",
+                &[],
+            )
+            .await
+            .expect("nested-key entity delete should succeed");
+
+        let rows = select_rows(
+            &session,
+            "SELECT identity, value, lixcol_snapshot_content, lixcol_depth \
+             FROM engine_history_nested_pk_history \
+             WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+               AND lix_json_get_text(identity, 'tenant') = 'acme' \
+               AND lix_json_get_text(identity, 'id') = '7' \
+             ORDER BY lixcol_depth",
+        )
+        .await;
+
+        assert_eq!(
+            rows,
+            vec![
+                vec![
+                    Value::Json(serde_json::json!({
+                        "tenant": "acme",
+                        "id": "7"
+                    })),
+                    Value::Null,
+                    Value::Null,
+                    Value::Integer(0),
+                ],
+                vec![
+                    Value::Json(serde_json::json!({
+                        "tenant": "acme",
+                        "id": "7"
+                    })),
+                    Value::Text("one".to_string()),
+                    Value::Json(serde_json::json!({
+                        "identity": {
+                            "tenant": "acme",
+                            "id": "7"
+                        },
+                        "value": "one"
+                    })),
+                    Value::Integer(1),
+                ],
+            ]
+        );
+
+        let nullability = select_rows(
+            &session,
+            "SELECT is_nullable \
+             FROM information_schema.columns \
+             WHERE table_name = 'engine_history_nested_pk_history' \
+               AND column_name = 'identity'",
+        )
+        .await;
+        assert_eq!(nullability, vec![vec![Value::Text("NO".to_string())]]);
     }
 );
 

--- a/packages/engine/tests/sql/lix_file_history.rs
+++ b/packages/engine/tests/sql/lix_file_history.rs
@@ -901,6 +901,10 @@ simulation_test!(
             )
             .await
             .expect("file history read should succeed");
+        assert!(
+            result.notices().is_empty(),
+            "ordinary path predicates should not emit identity heuristics"
+        );
 
         assert_rows_eq(
             result,
@@ -922,6 +926,26 @@ simulation_test!(
                     Value::Integer(1),
                 ],
             ],
+        );
+
+        let old_path_result = session
+            .execute(
+                "SELECT id, path, lixcol_depth \
+                 FROM lix_file_history \
+                 WHERE lixcol_as_of_commit_id = $1 \
+                   AND path = '/docs/guides/readme.md' \
+                 ORDER BY lixcol_depth",
+                &[Value::Text(second_commit_id.clone())],
+            )
+            .await
+            .expect("historical path predicate should execute");
+        assert_rows_eq(
+            old_path_result,
+            vec![vec![
+                Value::Text("history-file".to_string()),
+                Value::Text("/docs/guides/readme.md".to_string()),
+                Value::Integer(1),
+            ]],
         );
 
         let source_changes_result = session
@@ -1138,6 +1162,73 @@ simulation_test!(
         let mut expected = vec![main_sibling, draft_sibling];
         expected.sort();
         assert_eq!(observed, expected);
+    }
+);
+
+simulation_test!(
+    joined_history_filters_keep_relation_local_sql_semantics,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) \
+                 VALUES ('history-join-dir', '/joined/')",
+                &[],
+            )
+            .await
+            .expect("directory insert should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('history-join-file', '/joined/old.txt', X'6F6E65')",
+                &[],
+            )
+            .await
+            .expect("file insert should succeed");
+        session
+            .execute(
+                "UPDATE lix_file \
+                 SET path = '/joined/new.txt' \
+                 WHERE id = 'history-join-file'",
+                &[],
+            )
+            .await
+            .expect("file rename should succeed");
+
+        let result = session
+            .execute(
+                "SELECT file.id, file.path, directory.id \
+                 FROM lix_file_history AS file \
+                 JOIN lix_directory_history AS directory \
+                   ON file.directory_id = directory.id \
+                 WHERE file.lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+                   AND directory.lixcol_as_of_commit_id = lix_active_branch_commit_id() \
+                   AND file.path = '/joined/old.txt'",
+                &[],
+            )
+            .await
+            .expect("joined history query should succeed");
+
+        assert!(
+            result.notices().is_empty(),
+            "join predicates must not be attributed to unrelated history relations"
+        );
+        assert_rows_eq(
+            result,
+            vec![vec![
+                Value::Text("history-join-file".to_string()),
+                Value::Text("/joined/old.txt".to_string()),
+                Value::Text("history-join-dir".to_string()),
+            ]],
+        );
     }
 );
 


### PR DESCRIPTION
## Why

Typed history exposed public primary-key columns but did not consistently use them to constrain commit-graph reconstruction. Composite keys could depend on SQL predicate order, nested-key tombstones lost their public identity shape, and the `LIX_HISTORY_NON_IDENTITY_FILTER` notice guessed across relations in joins.

## Hard cut

- Route exact typed-history public primary-key predicates through the commit graph.
- Assemble ordered composite identities in declared `x-lix-primary-key` order, independent of predicate order.
- Intersect public identity predicates with `lixcol_entity_pk` constraints and detect contradictions, including wrong arity.
- Reconstruct nested primary-key roots on tombstones and mark guaranteed identity projections non-null.
- Remove the relation-blind `LIX_HISTORY_NON_IDENTITY_FILTER` heuristic and its notice machinery.
- Preserve ordinary SQL semantics: `WHERE path = ...` selects revision rows that had that path; it never resolves a path and returns the entity's full lineage. Use immutable identity for lineage.
- Keep provider-local routing relation-safe in joins; mixed predicates retain DataFusion residual evaluation.

## Validation

- Entity and entity-history routing units: 18/18 passed.
- Nested tombstone projection units: 2/2 passed.
- Typed history conformance: 8/8 passed in both simulation modes.
- Historical path row semantics: 2/2 passed.
- Joined relation-local history semantics: 2/2 passed.
- Formatting and diff checks passed.
- Rebased onto #715 head `160008a96860c03db8c0769a3519b1e7b74c1a5d`.
- Full GitHub CI is running on head `eac1b17771436518b8dec62733a24d21e0be2175`.