### PR TITLE
feat!(sql): default history to the pinned active head

### DIFF
--- a/.changenotes/default-history-to-active-head.md
+++ b/.changenotes/default-history-to-active-head.md
@@ -1,0 +1,14 @@
+---
+type: minor
+---
+
+History SQL surfaces now default to the active branch head pinned for the
+statement or coherent read batch. Queries no longer need a
+`lixcol_as_of_commit_id = lix_active_branch_commit_id()` predicate for the common
+case.
+
+The obsolete `LIX_HISTORY_FILTER_REQUIRED` error code is retired.
+
+Exact equality and non-empty `IN` predicates on the history anchor still
+override the default for time travel. Other anchor predicates now fail
+explicitly instead of silently traversing from the active head.

--- a/.changenotes/default-history-to-active-head.md
+++ b/.changenotes/default-history-to-active-head.md
@@ -12,3 +12,5 @@ The obsolete `LIX_HISTORY_FILTER_REQUIRED` error code is retired.
 Exact equality and non-empty `IN` predicates on the history anchor still
 override the default for time travel. Other anchor predicates now fail
 explicitly instead of silently traversing from the active head.
+Validation follows the resolved history relation through aliases, subqueries,
+and joins; an unrelated table column with the same name is not an anchor.

--- a/docs/history.md
+++ b/docs/history.md
@@ -95,12 +95,17 @@ WHERE lixcol_version_id = $1;
 SELECT lixcol_entity_pk, lixcol_schema_key, lixcol_snapshot_content,
        lixcol_depth, lixcol_observed_commit_id, lixcol_is_deleted
 FROM lix_state_history
-WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()
-  AND lixcol_depth >= 0
+WHERE lixcol_depth >= 0
 ORDER BY lixcol_depth, lixcol_schema_key, lixcol_entity_pk;
 ```
 
 `lixcol_depth = 0` is the current state of that version. Higher depths walk back through earlier commits. Filter by `lixcol_schema_key` or `lixcol_entity_pk` to narrow.
+
+History starts at the active branch head pinned for the statement or coherent
+read batch. Use exact equality or a non-empty `IN` predicate on
+`lixcol_as_of_commit_id` for time travel. Ranges, `LIKE`, `NOT IN`, expressions
+around the anchor, and mixed `OR` conditions are rejected instead of silently
+falling back to the pinned head.
 
 For filesystem history, `lix_file_history` and `lix_directory_history` expose
 logical projection revisions. A directory change is visible in every

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -11,7 +11,7 @@ Lix's DataFusion-backed engine registers a small set of scalar functions for use
 | Function | Returns | Use for |
 | :-- | :-- | :-- |
 | `lix_active_branch_id()` | text | Reading the current SQL session's active branch id. |
-| `lix_active_branch_commit_id()` | text | Scoping `_history` queries to the active branch head. |
+| `lix_active_branch_commit_id()` | text | Reading the active branch head pinned for this SQL statement. |
 | `lix_json(text)` | JSON | Parse a JSON string parameter into a JSON-typed value. |
 | `lix_json_get(json, path...)` | JSON | Project a value out of a JSON column, preserving JSON type. |
 | `lix_json_get_text(json, path...)` | text | Project a value out of a JSON column as plain text. |
@@ -30,7 +30,7 @@ Returns the active branch id of the current SQL session. Branch-pinned clients t
 
 Returns the commit id at the tip of the **currently active** branch, as resolved when the SQL statement was planned.
 
-History surfaces (`lix_state_history`, `<schema>_history`, `lix_file_history`, `lix_directory_history`) require a literal or bound-parameter equality on `lixcol_as_of_commit_id`. A correlated subquery against `lix_branch` is rejected by the planner. `lix_active_branch_commit_id()` is the canonical way to scope history to the active branch in a single statement:
+History surfaces (`lix_state_history`, `<schema>_history`, `lix_file_history`, `lix_directory_history`) use that same pinned active-branch head by default. No anchor predicate is needed for the common case:
 
 ```sql
 -- Walk one entity's history from the active branch's tip
@@ -38,11 +38,13 @@ SELECT lixcol_depth, lixcol_observed_commit_id, lixcol_snapshot_content
 FROM lix_state_history
 WHERE lixcol_schema_key = 'task'
   AND lix_json_get_text(lixcol_entity_pk, 0) = 't1'
-  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
 ORDER BY lixcol_depth;
 ```
 
-For an arbitrary branch, resolve the commit id with one query and pass it as a parameter:
+For time travel, override the default with exact equality or a non-empty `IN`
+predicate on `lixcol_as_of_commit_id`. Other anchor predicates are rejected
+instead of falling back to the active head. For an arbitrary branch, resolve
+the commit id with one query and pass it as a parameter:
 
 ```ts
 const { rows } = await lix.execute(

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -42,7 +42,7 @@ Every canonical current row has a `change_id`, including rows written with `lixc
 
 `lix_state_history` uses the same prefixed history vocabulary as every other history surface: `lixcol_entity_pk`, `lixcol_observed_commit_id`, `lixcol_commit_created_at`, `lixcol_as_of_commit_id`, `lixcol_depth`, and `lixcol_is_deleted`. Because it exposes one canonical change per row, it also provides singular provenance through `lixcol_change_id`, `lixcol_change_created_at`, and `lixcol_origin_key`, plus `lixcol_schema_key`, `lixcol_file_id`, `lixcol_snapshot_content`, and `lixcol_metadata`.
 
-> **History queries require a literal filter on `lixcol_as_of_commit_id`.** A correlated subquery against `lix_branch` is rejected by the planner. Use `lix_active_branch_commit_id()` for the active branch, or resolve the commit id with one query and pass it as a parameter. See [`lix_active_branch_commit_id()`](./sql-functions.md#lix_active_branch_commit_id).
+> **History starts at the pinned active branch head by default.** Add exact `lixcol_as_of_commit_id = ...` or non-empty `lixcol_as_of_commit_id IN (...)` only for time travel. Other anchor predicates are rejected instead of silently using the default.
 
 ```sql
 -- Every entity in the active version, raw JSON
@@ -60,7 +60,6 @@ SELECT lixcol_depth, lixcol_observed_commit_id, lixcol_snapshot_content
 FROM lix_state_history
 WHERE lixcol_schema_key = 'task'
   AND lix_json_get_text(lixcol_entity_pk, 0) = 't1'
-  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
 ORDER BY lixcol_depth;
 ```
 
@@ -95,7 +94,6 @@ WHERE id = 't1' AND lixcol_version_id IN ($a, $b);
 SELECT lixcol_depth, title, done
 FROM task_history
 WHERE id = 't1'
-  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
 ORDER BY lixcol_depth;
 ```
 
@@ -137,7 +135,6 @@ WHERE path = '/orders.xlsx' AND lixcol_version_id IN ($a, $b);
 SELECT lixcol_depth, lixcol_observed_commit_id, data
 FROM lix_file_history
 WHERE path = '/orders.xlsx'
-  AND lixcol_as_of_commit_id = lix_active_branch_commit_id()
 ORDER BY lixcol_depth;
 ```
 

--- a/packages/engine/src/common/error.rs
+++ b/packages/engine/src/common/error.rs
@@ -72,9 +72,6 @@ impl LixError {
     /// A SQL write targeted a read-only internal/component surface.
     pub const CODE_READ_ONLY: &'static str = "LIX_ERROR_READ_ONLY";
 
-    /// A history table was queried without an explicit commit/branch range.
-    pub const CODE_HISTORY_FILTER_REQUIRED: &'static str = "LIX_HISTORY_FILTER_REQUIRED";
-
     /// SQL syntax is valid, but the feature is intentionally outside the Lix
     /// SQL surface.
     pub const CODE_UNSUPPORTED_SQL: &'static str = "LIX_UNSUPPORTED_SQL";

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -577,10 +577,14 @@ where
         reader
     }
 
-    fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore> {
+    fn history_query_source(
+        &self,
+        default_as_of_commit_id: String,
+    ) -> SqlHistoryQuerySource<Self::ReadStore> {
         HistoryQuerySource {
             store: self.read_store.clone(),
             json_reader: JsonStoreContext::new().reader(self.read_store.clone()),
+            default_as_of_commit_id,
         }
     }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2616,10 +2616,16 @@ mod tests {
             .rows()[0]
             .get::<String>("commit_id")
             .expect("commit id should be text");
-        let statements: [(&str, &[Value]); 2] = [
+        let statements: [(&str, &[Value]); 3] = [
             ("SELECT 'first' AS label", &[]),
             (
                 "SELECT key, value FROM lix_key_value WHERE key = 'batch-read'",
+                &[],
+            ),
+            (
+                "SELECT DISTINCT lixcol_as_of_commit_id \
+                 FROM lix_key_value_history \
+                 WHERE key = 'batch-read'",
                 &[],
             ),
         ];
@@ -2632,7 +2638,7 @@ mod tests {
         assert_eq!(batch.active_branch_id, active_branch_id);
         assert_eq!(batch.active_branch_commit_id, active_branch_commit_id);
         assert_eq!(batch.storage_mutation_revision, storage_mutation_revision);
-        assert_eq!(batch.results.len(), 2);
+        assert_eq!(batch.results.len(), 3);
         assert_eq!(
             batch.results[0].rows()[0].get::<String>("label").unwrap(),
             "first"
@@ -2642,6 +2648,12 @@ mod tests {
         assert_eq!(
             row.get::<serde_json::Value>("value").unwrap(),
             serde_json::json!("value")
+        );
+        assert_eq!(
+            batch.results[2].rows()[0]
+                .get::<String>("lixcol_as_of_commit_id")
+                .unwrap(),
+            batch.active_branch_commit_id
         );
     }
 
@@ -2724,11 +2736,7 @@ mod tests {
         );
 
         session
-            .execute(
-                "SELECT COUNT(*) AS rows FROM lix_key_value_history \
-                 WHERE lixcol_as_of_commit_id = lix_active_branch_commit_id()",
-                &[],
-            )
+            .execute("SELECT COUNT(*) AS rows FROM lix_key_value_history", &[])
             .await
             .expect("fixed history surface should execute");
         assert_eq!(

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -29,12 +29,17 @@ use super::{PublicCatalog, SessionFileViews};
 
 pub(crate) type SqlChangelogQuerySource<S> = ChangelogQuerySource<S>;
 pub(crate) type SqlHistoryQuerySource<S> = HistoryQuerySource<S>;
-pub(crate) type SqlJsonReader<S> = JsonStoreReader<S>;
 
 #[derive(Clone)]
 pub(crate) struct HistoryQuerySource<S> {
     pub(crate) store: S,
     pub(crate) json_reader: JsonStoreReader<S>,
+    /// Active-branch head pinned by the SQL session that owns this provider.
+    ///
+    /// History scans use this commit when the query does not provide an
+    /// explicit time-travel anchor. Keeping it beside the snapshot-scoped JSON
+    /// reader prevents a later branch-head lookup from mixing snapshots.
+    pub(crate) default_as_of_commit_id: String,
 }
 
 #[derive(Clone)]
@@ -62,7 +67,10 @@ pub(crate) trait SqlExecutionContext {
         Arc::new(UncachedFilesystemPathIndexReader::new(self.live_state()))
     }
     fn functions(&self) -> FunctionProviderHandle;
-    fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore>;
+    fn history_query_source(
+        &self,
+        default_as_of_commit_id: String,
+    ) -> SqlHistoryQuerySource<Self::ReadStore>;
     fn changelog_query_source(&self) -> SqlChangelogQuerySource<Self::ReadStore>;
     fn commit_graph(&self) -> Box<dyn CommitGraphReader>;
     fn branch_ref(&self) -> Arc<dyn BranchRefReader>;

--- a/packages/engine/src/sql2/error.rs
+++ b/packages/engine/src/sql2/error.rs
@@ -79,14 +79,6 @@ fn classify_datafusion_error(error: &DataFusionError) -> LixError {
             .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...");
     }
 
-    if lower.contains("requires a lixcol_as_of_commit_id filter")
-        || lower.contains("history filter")
-        || lower.contains("history table")
-    {
-        return LixError::new(LixError::CODE_HISTORY_FILTER_REQUIRED, message)
-            .with_hint("Add a commit/branch range predicate before querying history tables.");
-    }
-
     if lower.contains("table not found")
         || (lower.contains("table") && lower.contains("not found"))
         || lower.contains("no table named")

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -29,6 +29,7 @@ use crate::sql2::bind::write::{BoundInsertValues, BoundReturning, FileWriteSurfa
 use crate::sql2::bind::write::{
     BoundWriteInput, BoundWriteOp, BoundWriteTarget, DirectoryWriteSurface,
 };
+use crate::sql2::history_route::validate_history_anchor_filter_shape;
 use crate::sql2::plan::LogicalWritePlan;
 use crate::sql2::plan::branch_scope::BranchScope;
 use crate::sql2::plan::predicate::BoundPredicate;
@@ -138,6 +139,7 @@ async fn create_logical_plan_in_session_from_parsed(
     let plan = create_logical_plan_from_statement(&session.session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
+    validate_history_anchor_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
     let notices = history_filter_notices(&plan);
 
@@ -175,6 +177,7 @@ async fn create_transaction_read_logical_plan_from_parsed(
     let plan = create_logical_plan_from_statement(&session, statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
+    validate_history_anchor_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
     let notices = history_filter_notices(&plan);
 
@@ -250,6 +253,43 @@ fn json_predicate_params_in_logical_plan(plan: &LogicalPlan) -> BTreeSet<usize> 
         params.extend(json_predicate_params_in_logical_plan(input));
     }
     params
+}
+
+fn validate_history_anchor_predicates_in_logical_plan(plan: &LogicalPlan) -> Result<(), LixError> {
+    fn visit(plan: &LogicalPlan, inherited_filters: &[Expr]) -> Result<(), LixError> {
+        match plan {
+            LogicalPlan::Filter(filter) => {
+                let mut filters = inherited_filters.to_vec();
+                filters.push(filter.predicate.clone());
+                visit(&filter.input, &filters)
+            }
+            LogicalPlan::TableScan(scan) => {
+                let table_name = table_reference_name(&scan.table_name);
+                if !table_name.ends_with("_history") {
+                    return Ok(());
+                }
+                if scan
+                    .source
+                    .schema()
+                    .field_with_name("lixcol_as_of_commit_id")
+                    .is_ok()
+                {
+                    for filter in inherited_filters.iter().chain(&scan.filters) {
+                        validate_history_anchor_filter_shape(filter)?;
+                    }
+                }
+                Ok(())
+            }
+            other => {
+                for input in other.inputs() {
+                    visit(input, inherited_filters)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    visit(plan, &[])
 }
 
 async fn execute_logical_plan(
@@ -1902,12 +1942,16 @@ mod tests {
             Arc::clone(&self.blob_reader)
         }
 
-        fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore> {
+        fn history_query_source(
+            &self,
+            default_as_of_commit_id: String,
+        ) -> SqlHistoryQuerySource<Self::ReadStore> {
             let storage = StorageAdapter::new(Memory::new());
             let read_scope = SharedStorageAdapterRead::new(test_read_scope(&storage));
             HistoryQuerySource {
                 store: read_scope.clone(),
                 json_reader: JsonStoreContext::new().reader(read_scope),
+                default_as_of_commit_id,
             }
         }
 

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -11,7 +11,8 @@
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::metadata::{FieldMetadata, ScalarAndMetadata};
-use datafusion::common::{Column, DFSchema, ParamValues, ScalarValue};
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::common::{Column, DFSchema, DFSchemaRef, JoinType, ParamValues, ScalarValue};
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::expr::{BinaryExpr, Cast, InList, Like, ScalarFunction};
 use datafusion::logical_expr::registry::FunctionRegistry;
@@ -29,7 +30,7 @@ use crate::sql2::bind::write::{BoundInsertValues, BoundReturning, FileWriteSurfa
 use crate::sql2::bind::write::{
     BoundWriteInput, BoundWriteOp, BoundWriteTarget, DirectoryWriteSurface,
 };
-use crate::sql2::history_route::validate_history_anchor_filter_shape;
+use crate::sql2::history_route::invalid_history_anchor_error;
 use crate::sql2::plan::LogicalWritePlan;
 use crate::sql2::plan::branch_scope::BranchScope;
 use crate::sql2::plan::predicate::BoundPredicate;
@@ -255,41 +256,611 @@ fn json_predicate_params_in_logical_plan(plan: &LogicalPlan) -> BTreeSet<usize> 
     params
 }
 
-fn validate_history_anchor_predicates_in_logical_plan(plan: &LogicalPlan) -> Result<(), LixError> {
-    fn visit(plan: &LogicalPlan, inherited_filters: &[Expr]) -> Result<(), LixError> {
-        match plan {
-            LogicalPlan::Filter(filter) => {
-                let mut filters = inherited_filters.to_vec();
-                filters.push(filter.predicate.clone());
-                visit(&filter.input, &filters)
-            }
-            LogicalPlan::TableScan(scan) => {
-                let table_name = table_reference_name(&scan.table_name);
-                if !table_name.ends_with("_history") {
-                    return Ok(());
-                }
-                if scan
-                    .source
-                    .schema()
-                    .field_with_name("lixcol_as_of_commit_id")
-                    .is_ok()
-                {
-                    for filter in inherited_filters.iter().chain(&scan.filters) {
-                        validate_history_anchor_filter_shape(filter)?;
-                    }
-                }
-                Ok(())
-            }
-            other => {
-                for input in other.inputs() {
-                    visit(input, inherited_filters)?;
-                }
-                Ok(())
-            }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HistoryAnchorLineage {
+    Direct,
+    Derived,
+}
+
+#[derive(Clone, Debug)]
+struct HistoryAnchorScope {
+    schema: DFSchemaRef,
+    columns: Vec<Option<HistoryAnchorLineage>>,
+}
+
+impl HistoryAnchorScope {
+    fn empty(schema: DFSchemaRef) -> Self {
+        Self {
+            columns: vec![None; schema.fields().len()],
+            schema,
         }
     }
 
-    visit(plan, &[])
+    fn resolve(&self, column: &Column) -> Option<(usize, HistoryAnchorLineage)> {
+        let index = self.schema.maybe_index_of_column(column)?;
+        self.columns
+            .get(index)
+            .copied()
+            .flatten()
+            .map(|lineage| (index, lineage))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HistoryAnchorLocation {
+    Local,
+    Outer,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedHistoryAnchor {
+    location: HistoryAnchorLocation,
+    scope_index: usize,
+    column_index: usize,
+    lineage: HistoryAnchorLineage,
+    column_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HistoryAnchorKey {
+    scope_index: usize,
+    column_index: usize,
+}
+
+struct HistoryAnchorResolver<'a> {
+    local: &'a [HistoryAnchorScope],
+    outer: &'a [HistoryAnchorScope],
+}
+
+impl HistoryAnchorResolver<'_> {
+    fn resolve_local(&self, column: &Column) -> Option<ResolvedHistoryAnchor> {
+        Self::resolve(column, self.local, HistoryAnchorLocation::Local)
+    }
+
+    fn resolve_outer(&self, column: &Column) -> Option<ResolvedHistoryAnchor> {
+        Self::resolve(column, self.outer, HistoryAnchorLocation::Outer)
+    }
+
+    fn resolve(
+        column: &Column,
+        scopes: &[HistoryAnchorScope],
+        location: HistoryAnchorLocation,
+    ) -> Option<ResolvedHistoryAnchor> {
+        let mut schema_matches = scopes
+            .iter()
+            .enumerate()
+            .filter_map(|(scope_index, scope)| {
+                scope
+                    .schema
+                    .maybe_index_of_column(column)
+                    .map(|column_index| (scope_index, column_index, scope))
+            });
+        let first = schema_matches.next()?;
+        // An unqualified same-named column across multiple inputs is not enough
+        // to identify the history relation. DataFusion normally qualifies these
+        // references; keeping ambiguity non-history avoids relation-blind false
+        // positives if an extension plan does not.
+        if schema_matches.next().is_some() {
+            return None;
+        }
+        let lineage = first.2.columns.get(first.1).copied().flatten()?;
+        Some(ResolvedHistoryAnchor {
+            location,
+            scope_index: first.0,
+            column_index: first.1,
+            lineage,
+            column_name: column.name.clone(),
+        })
+    }
+}
+
+fn history_anchor_references(
+    expr: &Expr,
+    resolver: &HistoryAnchorResolver<'_>,
+) -> Vec<ResolvedHistoryAnchor> {
+    let mut references = expr
+        .column_refs()
+        .into_iter()
+        .filter_map(|column| resolver.resolve_local(column))
+        .collect::<Vec<_>>();
+    expr.apply(|nested| {
+        if let Expr::OuterReferenceColumn(_, column) = nested {
+            if let Some(reference) = resolver.resolve_outer(column) {
+                references.push(reference);
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .expect("history anchor expression traversal is infallible");
+    references
+}
+
+fn direct_history_anchor_reference(
+    expr: &Expr,
+    resolver: &HistoryAnchorResolver<'_>,
+) -> Option<ResolvedHistoryAnchor> {
+    match expr {
+        Expr::Alias(alias) => direct_history_anchor_reference(&alias.expr, resolver),
+        Expr::Column(column) => resolver.resolve_local(column),
+        Expr::OuterReferenceColumn(_, column) => resolver.resolve_outer(column),
+        _ => None,
+    }
+}
+
+fn routable_history_anchor_value_shape(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Literal(ScalarValue::Utf8(Some(_)), _) | Expr::Placeholder(_)
+    ) || matches!(
+        expr,
+        Expr::ScalarFunction(function)
+            if function.name() == "lix_active_branch_commit_id" && function.args.is_empty()
+    )
+}
+
+fn exact_history_anchor_equality_key(
+    binary: &BinaryExpr,
+    resolver: &HistoryAnchorResolver<'_>,
+) -> Option<HistoryAnchorKey> {
+    for (anchor, value) in [
+        (binary.left.as_ref(), binary.right.as_ref()),
+        (binary.right.as_ref(), binary.left.as_ref()),
+    ] {
+        let Some(reference) = direct_history_anchor_reference(anchor, resolver) else {
+            continue;
+        };
+        if reference.location == HistoryAnchorLocation::Local
+            && reference.lineage == HistoryAnchorLineage::Direct
+            && history_anchor_references(value, resolver).is_empty()
+            && routable_history_anchor_value_shape(value)
+        {
+            return Some(HistoryAnchorKey {
+                scope_index: reference.scope_index,
+                column_index: reference.column_index,
+            });
+        }
+    }
+    None
+}
+
+fn exact_history_anchor_term_key(
+    expr: &Expr,
+    resolver: &HistoryAnchorResolver<'_>,
+) -> Option<HistoryAnchorKey> {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::Eq => {
+            exact_history_anchor_equality_key(binary, resolver)
+        }
+        Expr::BinaryExpr(binary) if binary.op == Operator::Or => {
+            let left = exact_history_anchor_term_key(&binary.left, resolver)?;
+            let right = exact_history_anchor_term_key(&binary.right, resolver)?;
+            (left == right).then_some(left)
+        }
+        Expr::InList(in_list) if !in_list.negated && !in_list.list.is_empty() => {
+            let reference = direct_history_anchor_reference(&in_list.expr, resolver)?;
+            (reference.location == HistoryAnchorLocation::Local
+                && reference.lineage == HistoryAnchorLineage::Direct
+                && in_list.list.iter().all(routable_history_anchor_value_shape))
+            .then_some(HistoryAnchorKey {
+                scope_index: reference.scope_index,
+                column_index: reference.column_index,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn history_anchor_predicate_shape_is_exact(
+    expr: &Expr,
+    resolver: &HistoryAnchorResolver<'_>,
+) -> bool {
+    if history_anchor_references(expr, resolver).is_empty() {
+        return true;
+    }
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+            history_anchor_predicate_shape_is_exact(&binary.left, resolver)
+                && history_anchor_predicate_shape_is_exact(&binary.right, resolver)
+        }
+        Expr::BinaryExpr(binary) if binary.op == Operator::Or => {
+            exact_history_anchor_term_key(expr, resolver).is_some()
+        }
+        Expr::BinaryExpr(binary) if binary.op == Operator::Eq => {
+            exact_history_anchor_equality_key(binary, resolver).is_some()
+        }
+        Expr::InList(_) => exact_history_anchor_term_key(expr, resolver).is_some(),
+        _ => false,
+    }
+}
+
+fn validate_history_anchor_predicate(
+    expr: &Expr,
+    resolver: &HistoryAnchorResolver<'_>,
+) -> Result<(), LixError> {
+    let references = history_anchor_references(expr, resolver);
+    if references.is_empty() || history_anchor_predicate_shape_is_exact(expr, resolver) {
+        return Ok(());
+    }
+    Err(invalid_history_anchor_error(
+        &references[0].column_name,
+        None,
+    ))
+}
+
+fn join_on_history_anchor_side_is_pushable(join_type: JoinType, scope_index: usize) -> bool {
+    let (left, right) = match join_type {
+        JoinType::Inner | JoinType::LeftSemi | JoinType::RightSemi => (true, true),
+        JoinType::Left | JoinType::LeftAnti | JoinType::LeftMark => (false, true),
+        JoinType::Right | JoinType::RightAnti | JoinType::RightMark => (true, false),
+        JoinType::Full => (false, false),
+    };
+    match scope_index {
+        0 => left,
+        1 => right,
+        _ => false,
+    }
+}
+
+fn validate_history_anchor_join_predicate(
+    expr: &Expr,
+    resolver: &HistoryAnchorResolver<'_>,
+    join_type: JoinType,
+) -> Result<(), LixError> {
+    validate_history_anchor_predicate(expr, resolver)?;
+    let unpushable = history_anchor_references(expr, resolver)
+        .into_iter()
+        .find(|reference| {
+            reference.location == HistoryAnchorLocation::Local
+                && !join_on_history_anchor_side_is_pushable(join_type, reference.scope_index)
+        });
+    let Some(reference) = unpushable else {
+        return Ok(());
+    };
+    Err(invalid_history_anchor_error(&reference.column_name, None))
+}
+
+fn validate_embedded_history_anchor_predicates(
+    expr: &Expr,
+    resolver: &HistoryAnchorResolver<'_>,
+) -> Result<(), LixError> {
+    let mut result = Ok(());
+    expr.apply(|nested| {
+        let predicate = match nested {
+            Expr::AggregateFunction(function) => function.params.filter.as_deref(),
+            Expr::WindowFunction(function) => function.params.filter.as_deref(),
+            _ => None,
+        };
+        if let Some(predicate) = predicate {
+            if let Some(reference) = history_anchor_references(predicate, resolver).first() {
+                result = Err(invalid_history_anchor_error(&reference.column_name, None));
+                return Ok(TreeNodeRecursion::Stop);
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .expect("embedded history anchor predicate traversal is infallible");
+    result
+}
+
+fn projected_history_anchor_scope(
+    schema: DFSchemaRef,
+    expressions: &[Expr],
+    inputs: &[HistoryAnchorScope],
+    outer: &[HistoryAnchorScope],
+) -> HistoryAnchorScope {
+    let resolver = HistoryAnchorResolver {
+        local: inputs,
+        outer,
+    };
+    let mut output = HistoryAnchorScope::empty(schema);
+    for (index, expression) in expressions.iter().enumerate() {
+        let has_local_reference = history_anchor_references(expression, &resolver)
+            .into_iter()
+            .any(|reference| reference.location == HistoryAnchorLocation::Local);
+        if !has_local_reference {
+            continue;
+        }
+        let lineage = direct_history_anchor_reference(expression, &resolver)
+            .filter(|reference| reference.location == HistoryAnchorLocation::Local)
+            .map_or(HistoryAnchorLineage::Derived, |reference| reference.lineage);
+        if let Some(column) = output.columns.get_mut(index) {
+            *column = Some(lineage);
+        }
+    }
+    output
+}
+
+fn positional_history_anchor_scope(
+    schema: DFSchemaRef,
+    input: &HistoryAnchorScope,
+) -> HistoryAnchorScope {
+    let mut output = HistoryAnchorScope::empty(schema);
+    for (target, source) in output.columns.iter_mut().zip(&input.columns) {
+        *target = *source;
+    }
+    output
+}
+
+fn unroutable_history_anchor_scope(
+    schema: DFSchemaRef,
+    input: &HistoryAnchorScope,
+) -> HistoryAnchorScope {
+    let mut output = positional_history_anchor_scope(schema, input);
+    for lineage in output.columns.iter_mut().flatten() {
+        *lineage = HistoryAnchorLineage::Derived;
+    }
+    output
+}
+
+fn merged_history_anchor_scope(
+    schema: DFSchemaRef,
+    inputs: &[HistoryAnchorScope],
+) -> HistoryAnchorScope {
+    let mut output = HistoryAnchorScope::empty(schema);
+    for index in 0..output.columns.len() {
+        let column = Column::from(output.schema.qualified_field(index));
+        let mut matches = inputs.iter().filter_map(|input| input.resolve(&column));
+        let first = matches.next();
+        if matches.next().is_none() {
+            output.columns[index] = first.map(|(_, lineage)| lineage);
+        }
+    }
+    output
+}
+
+fn validate_history_anchor_subqueries(
+    expr: &Expr,
+    local: &[HistoryAnchorScope],
+    outer: &[HistoryAnchorScope],
+) -> Result<(), LixError> {
+    let nested_outer = local.iter().chain(outer).cloned().collect::<Vec<_>>();
+    let mut result = Ok(());
+    expr.apply(|nested| {
+        let subquery = match nested {
+            Expr::Exists(exists) => Some(exists.subquery.subquery.as_ref()),
+            Expr::InSubquery(in_subquery) => Some(in_subquery.subquery.subquery.as_ref()),
+            Expr::SetComparison(comparison) => Some(comparison.subquery.subquery.as_ref()),
+            Expr::ScalarSubquery(subquery) => Some(subquery.subquery.as_ref()),
+            _ => None,
+        };
+        if let Some(subquery) = subquery {
+            result = visit_history_anchor_plan(subquery, &nested_outer).map(|_| ());
+            if result.is_err() {
+                return Ok(TreeNodeRecursion::Stop);
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .expect("history anchor subquery traversal is infallible");
+    result
+}
+
+fn visit_history_anchor_plan(
+    plan: &LogicalPlan,
+    outer: &[HistoryAnchorScope],
+) -> Result<HistoryAnchorScope, LixError> {
+    match plan {
+        LogicalPlan::TableScan(scan) => {
+            let Some(anchor_column) =
+                crate::sql2::providers::history_anchor_column(scan.source.as_ref())
+            else {
+                return Ok(HistoryAnchorScope::empty(scan.projected_schema.clone()));
+            };
+            let source_schema = std::sync::Arc::new(
+                DFSchema::try_from_qualified_schema(
+                    scan.table_name.clone(),
+                    scan.source.schema().as_ref(),
+                )
+                .map_err(datafusion_error_to_lix_error)?,
+            );
+            let mut source_scope = HistoryAnchorScope::empty(source_schema);
+            if let Some(index) = source_scope
+                .schema
+                .index_of_column_by_name(Some(&scan.table_name), anchor_column)
+            {
+                source_scope.columns[index] = Some(HistoryAnchorLineage::Direct);
+            }
+            let local = std::slice::from_ref(&source_scope);
+            let resolver = HistoryAnchorResolver { local, outer };
+            for filter in &scan.filters {
+                validate_history_anchor_subqueries(filter, local, outer)?;
+                validate_history_anchor_predicate(filter, &resolver)?;
+            }
+
+            let mut output = HistoryAnchorScope::empty(scan.projected_schema.clone());
+            if let Some(index) = output
+                .schema
+                .index_of_column_by_name(Some(&scan.table_name), anchor_column)
+            {
+                output.columns[index] = Some(HistoryAnchorLineage::Direct);
+            }
+            Ok(output)
+        }
+        LogicalPlan::Filter(filter) => {
+            let input = visit_history_anchor_plan(&filter.input, outer)?;
+            let local = std::slice::from_ref(&input);
+            validate_history_anchor_subqueries(&filter.predicate, local, outer)?;
+            validate_history_anchor_predicate(
+                &filter.predicate,
+                &HistoryAnchorResolver { local, outer },
+            )?;
+            Ok(positional_history_anchor_scope(
+                plan.schema().clone(),
+                &input,
+            ))
+        }
+        LogicalPlan::Projection(projection) => {
+            let input = visit_history_anchor_plan(&projection.input, outer)?;
+            let local = std::slice::from_ref(&input);
+            for expression in &projection.expr {
+                validate_history_anchor_subqueries(expression, local, outer)?;
+                validate_embedded_history_anchor_predicates(
+                    expression,
+                    &HistoryAnchorResolver { local, outer },
+                )?;
+            }
+            Ok(projected_history_anchor_scope(
+                projection.schema.clone(),
+                &projection.expr,
+                local,
+                outer,
+            ))
+        }
+        LogicalPlan::Aggregate(aggregate) => {
+            let input = visit_history_anchor_plan(&aggregate.input, outer)?;
+            let local = std::slice::from_ref(&input);
+            let expressions = aggregate
+                .group_expr
+                .iter()
+                .chain(&aggregate.aggr_expr)
+                .cloned()
+                .collect::<Vec<_>>();
+            for expression in &expressions {
+                validate_history_anchor_subqueries(expression, local, outer)?;
+                validate_embedded_history_anchor_predicates(
+                    expression,
+                    &HistoryAnchorResolver { local, outer },
+                )?;
+            }
+            let projected = projected_history_anchor_scope(
+                aggregate.schema.clone(),
+                &expressions,
+                local,
+                outer,
+            );
+            Ok(unroutable_history_anchor_scope(
+                aggregate.schema.clone(),
+                &projected,
+            ))
+        }
+        LogicalPlan::Window(window) => {
+            let input = visit_history_anchor_plan(&window.input, outer)?;
+            let local = std::slice::from_ref(&input);
+            for expression in &window.window_expr {
+                validate_history_anchor_subqueries(expression, local, outer)?;
+                validate_embedded_history_anchor_predicates(
+                    expression,
+                    &HistoryAnchorResolver { local, outer },
+                )?;
+            }
+            let mut output = positional_history_anchor_scope(window.schema.clone(), &input);
+            let input_width = input.schema.fields().len();
+            for (index, expression) in window.window_expr.iter().enumerate() {
+                if history_anchor_references(expression, &HistoryAnchorResolver { local, outer })
+                    .into_iter()
+                    .any(|reference| reference.location == HistoryAnchorLocation::Local)
+                {
+                    if let Some(column) = output.columns.get_mut(input_width + index) {
+                        *column = Some(HistoryAnchorLineage::Derived);
+                    }
+                }
+            }
+            Ok(unroutable_history_anchor_scope(
+                window.schema.clone(),
+                &output,
+            ))
+        }
+        LogicalPlan::Join(join) => {
+            let left = visit_history_anchor_plan(&join.left, outer)?;
+            let right = visit_history_anchor_plan(&join.right, outer)?;
+            let local = [left, right];
+            let resolver = HistoryAnchorResolver {
+                local: &local,
+                outer,
+            };
+            for (left, right) in &join.on {
+                let predicate = Expr::BinaryExpr(BinaryExpr::new(
+                    Box::new(left.clone()),
+                    Operator::Eq,
+                    Box::new(right.clone()),
+                ));
+                validate_history_anchor_subqueries(&predicate, &local, outer)?;
+                validate_history_anchor_join_predicate(&predicate, &resolver, join.join_type)?;
+            }
+            if let Some(filter) = &join.filter {
+                validate_history_anchor_subqueries(filter, &local, outer)?;
+                validate_history_anchor_join_predicate(filter, &resolver, join.join_type)?;
+            }
+            Ok(merged_history_anchor_scope(join.schema.clone(), &local))
+        }
+        LogicalPlan::SubqueryAlias(alias) => {
+            let input = visit_history_anchor_plan(&alias.input, outer)?;
+            Ok(positional_history_anchor_scope(
+                alias.schema.clone(),
+                &input,
+            ))
+        }
+        LogicalPlan::Limit(limit) => {
+            let input = visit_history_anchor_plan(&limit.input, outer)?;
+            for expression in plan.expressions() {
+                validate_history_anchor_subqueries(
+                    &expression,
+                    std::slice::from_ref(&input),
+                    outer,
+                )?;
+            }
+            Ok(unroutable_history_anchor_scope(
+                plan.schema().clone(),
+                &input,
+            ))
+        }
+        LogicalPlan::Union(union) => {
+            let inputs = union
+                .inputs
+                .iter()
+                .map(|input| visit_history_anchor_plan(input, outer))
+                .collect::<Result<Vec<_>, _>>()?;
+            let mut output = HistoryAnchorScope::empty(union.schema.clone());
+            for index in 0..output.columns.len() {
+                let lineages = inputs
+                    .iter()
+                    .filter_map(|input| input.columns.get(index).copied().flatten())
+                    .collect::<Vec<_>>();
+                if !lineages.is_empty() {
+                    output.columns[index] = Some(
+                        if lineages
+                            .iter()
+                            .all(|lineage| *lineage == HistoryAnchorLineage::Direct)
+                        {
+                            HistoryAnchorLineage::Direct
+                        } else {
+                            HistoryAnchorLineage::Derived
+                        },
+                    );
+                }
+            }
+            Ok(output)
+        }
+        other => {
+            let inputs = other
+                .inputs()
+                .into_iter()
+                .map(|input| visit_history_anchor_plan(input, outer))
+                .collect::<Result<Vec<_>, _>>()?;
+            for expression in other.expressions() {
+                validate_history_anchor_subqueries(&expression, &inputs, outer)?;
+                validate_embedded_history_anchor_predicates(
+                    &expression,
+                    &HistoryAnchorResolver {
+                        local: &inputs,
+                        outer,
+                    },
+                )?;
+            }
+            if inputs.len() == 1 {
+                Ok(positional_history_anchor_scope(
+                    other.schema().clone(),
+                    &inputs[0],
+                ))
+            } else {
+                Ok(merged_history_anchor_scope(other.schema().clone(), &inputs))
+            }
+        }
+    }
+}
+
+fn validate_history_anchor_predicates_in_logical_plan(plan: &LogicalPlan) -> Result<(), LixError> {
+    visit_history_anchor_plan(plan, &[]).map(|_| ())
 }
 
 async fn execute_logical_plan(

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -295,21 +295,6 @@ pub(crate) fn validate_history_anchor_filter(expr: &Expr) -> Result<(), LixError
     ))
 }
 
-/// Planning-time counterpart to [`validate_history_anchor_filter`].
-///
-/// Logical plans still contain bound placeholders before DataFusion prepares
-/// the physical scan, so this validates the exact routing *shape* while the
-/// provider-level validation later verifies the resolved commit-id values.
-pub(crate) fn validate_history_anchor_filter_shape(expr: &Expr) -> Result<(), LixError> {
-    if history_anchor_filter_shape_is_exact(expr) {
-        return Ok(());
-    }
-    Err(invalid_history_anchor_error(
-        HISTORY_COL_AS_OF_COMMIT_ID,
-        None,
-    ))
-}
-
 pub(crate) fn commit_graph_history_request(
     route: &HistoryRoute,
     schema_keys: Vec<String>,
@@ -430,7 +415,7 @@ pub(crate) fn invalid_history_anchor_error(
     LixError::new(
         LixError::CODE_UNSUPPORTED_SQL,
         format!(
-            "{surface}history anchor '{as_of_commit_column}' only supports exact equality or non-empty IN predicates"
+            "{surface}history anchor '{as_of_commit_column}' only supports exact equality or non-empty IN predicates that resolve directly to a history scan"
         ),
     )
     .with_hint(format!(
@@ -619,71 +604,6 @@ fn history_anchor_filter_is_exact(expr: &Expr) -> bool {
         ),
         _ => false,
     }
-}
-
-fn history_anchor_filter_shape_is_exact(expr: &Expr) -> bool {
-    if !history_filter_references_anchor(expr) {
-        return true;
-    }
-    match expr {
-        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
-            history_anchor_filter_shape_is_exact(&binary_expr.left)
-                && history_anchor_filter_shape_is_exact(&binary_expr.right)
-        }
-        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
-            exact_anchor_disjunction_shape(expr)
-        }
-        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Eq => {
-            exact_anchor_equality_shape(binary_expr)
-        }
-        Expr::InList(in_list) => {
-            !in_list.negated
-                && !in_list.list.is_empty()
-                && matches!(
-                    in_list.expr.as_ref(),
-                    Expr::Column(column)
-                        if canonical_history_column_name(column.name.as_str())
-                            == Some("as_of_commit_id")
-                )
-                && in_list.list.iter().all(routable_anchor_value_shape)
-        }
-        _ => false,
-    }
-}
-
-fn exact_anchor_disjunction_shape(expr: &Expr) -> bool {
-    match expr {
-        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
-            exact_anchor_disjunction_shape(&binary_expr.left)
-                && exact_anchor_disjunction_shape(&binary_expr.right)
-        }
-        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Eq => {
-            exact_anchor_equality_shape(binary_expr)
-        }
-        Expr::InList(_) => history_anchor_filter_shape_is_exact(expr),
-        _ => false,
-    }
-}
-
-fn exact_anchor_equality_shape(binary_expr: &datafusion::logical_expr::BinaryExpr) -> bool {
-    match (&*binary_expr.left, &*binary_expr.right) {
-        (Expr::Column(column), value) | (value, Expr::Column(column)) => {
-            canonical_history_column_name(column.name.as_str()) == Some("as_of_commit_id")
-                && routable_anchor_value_shape(value)
-        }
-        _ => false,
-    }
-}
-
-fn routable_anchor_value_shape(expr: &Expr) -> bool {
-    matches!(
-        expr,
-        Expr::Literal(ScalarValue::Utf8(Some(_)), _) | Expr::Placeholder(_)
-    ) || matches!(
-        expr,
-        Expr::ScalarFunction(function)
-            if function.name() == "lix_active_branch_commit_id" && function.args.is_empty()
-    )
 }
 
 fn history_filter_references_anchor(expr: &Expr) -> bool {

--- a/packages/engine/src/sql2/history_route.rs
+++ b/packages/engine/src/sql2/history_route.rs
@@ -12,7 +12,7 @@ use crate::changelog::CommitId;
 use crate::commit_graph::{CommitGraphChangeHistoryRequest, CommitGraphReader};
 use crate::entity_pk::EntityPk;
 
-use super::SqlJsonReader;
+use super::SqlHistoryQuerySource;
 use crate::sql2::change_materialization::{MaterializedChange, materialize_located_history_change};
 use crate::storage_adapter::StorageAdapterRead;
 
@@ -29,6 +29,11 @@ pub(crate) struct HistoryRoute {
     pub(crate) file_ids: Vec<String>,
     pub(crate) min_depth: Option<i64>,
     pub(crate) max_depth: Option<i64>,
+    /// An anchor column appeared in a predicate that cannot be routed exactly.
+    ///
+    /// This must be rejected rather than treated as an anchor-free query,
+    /// because anchor-free queries default to the pinned active head.
+    pub(crate) invalid_as_of_commit_filter: bool,
     pub(crate) contradictory: bool,
 }
 
@@ -36,9 +41,22 @@ impl HistoryRoute {
     pub(crate) fn from_filters(filters: &[Expr]) -> Self {
         let mut route = Self::default();
         for filter in filters {
+            route.invalid_as_of_commit_filter |= !history_anchor_filter_is_exact(filter);
             apply_history_filter(filter, &mut route);
         }
         route
+    }
+
+    /// Materializes the session-pinned head when no explicit time-travel
+    /// anchor was routed.
+    ///
+    /// Filesystem history consumers inspect the route before loading rows to
+    /// resolve commit parents and ancestor projection changes, so the default
+    /// must be visible on the route itself rather than only inside the loader.
+    pub(crate) fn default_to_as_of_commit_id(&mut self, commit_id: &str) {
+        if self.as_of_commit_ids.is_empty() && !self.invalid_as_of_commit_filter {
+            self.as_of_commit_ids.push(commit_id.to_string());
+        }
     }
 
     /// Returns the part of the route that is safe to apply before a shaped
@@ -53,6 +71,7 @@ impl HistoryRoute {
             as_of_commit_ids: self.as_of_commit_ids.clone(),
             min_depth: self.min_depth,
             max_depth: self.max_depth,
+            invalid_as_of_commit_filter: self.invalid_as_of_commit_filter,
             contradictory: self.contradictory,
             ..Self::default()
         }
@@ -66,6 +85,7 @@ impl HistoryRoute {
     pub(crate) fn anchors_only(&self) -> Self {
         Self {
             as_of_commit_ids: self.as_of_commit_ids.clone(),
+            invalid_as_of_commit_filter: self.invalid_as_of_commit_filter,
             contradictory: self.contradictory,
             ..Self::default()
         }
@@ -259,6 +279,37 @@ pub(crate) fn parse_history_filter(expr: &Expr) -> Option<()> {
     parse_history_filter_terms(expr).map(|_| ())
 }
 
+/// Rejects an anchor predicate unless every occurrence can be routed exactly.
+///
+/// Without this validation an unsupported predicate could be left for
+/// DataFusion as a residual filter while the provider silently defaulted its
+/// traversal to the active head. That would make a time-travel query inspect
+/// the wrong commit before the residual predicate removed the rows.
+pub(crate) fn validate_history_anchor_filter(expr: &Expr) -> Result<(), LixError> {
+    if history_anchor_filter_is_exact(expr) {
+        return Ok(());
+    }
+    Err(invalid_history_anchor_error(
+        HISTORY_COL_AS_OF_COMMIT_ID,
+        None,
+    ))
+}
+
+/// Planning-time counterpart to [`validate_history_anchor_filter`].
+///
+/// Logical plans still contain bound placeholders before DataFusion prepares
+/// the physical scan, so this validates the exact routing *shape* while the
+/// provider-level validation later verifies the resolved commit-id values.
+pub(crate) fn validate_history_anchor_filter_shape(expr: &Expr) -> Result<(), LixError> {
+    if history_anchor_filter_shape_is_exact(expr) {
+        return Ok(());
+    }
+    Err(invalid_history_anchor_error(
+        HISTORY_COL_AS_OF_COMMIT_ID,
+        None,
+    ))
+}
+
 pub(crate) fn commit_graph_history_request(
     route: &HistoryRoute,
     schema_keys: Vec<String>,
@@ -285,7 +336,7 @@ pub(crate) fn commit_graph_history_request(
 pub(crate) async fn load_history_entries<S>(
     descriptor: HistoryViewDescriptor<'_>,
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
-    mut json_reader: SqlJsonReader<S>,
+    query_source: SqlHistoryQuerySource<S>,
     route: &HistoryRoute,
     schema_keys: Vec<String>,
     metadata_projection: HistoryMetadataProjection,
@@ -293,28 +344,27 @@ pub(crate) async fn load_history_entries<S>(
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
+    if route.invalid_as_of_commit_filter {
+        return Err(invalid_history_anchor_error(
+            descriptor.as_of_commit_column,
+            Some(descriptor.view_name),
+        ));
+    }
     if route.is_contradictory() {
         return Ok(Vec::new());
-    }
-    if route.as_of_commit_ids.is_empty() {
-        return Err(LixError::new(
-            LixError::CODE_HISTORY_FILTER_REQUIRED,
-            format!(
-                "{} requires a {} filter",
-                descriptor.view_name, descriptor.as_of_commit_column
-            ),
-        )
-        .with_hint(format!(
-            "Use WHERE {} = lix_active_branch_commit_id() to inspect {} from the active branch head.",
-            descriptor.as_of_commit_column, descriptor.view_name
-        )));
     }
     let Some(request) = commit_graph_history_request(route, schema_keys) else {
         return Ok(Vec::new());
     };
+    let as_of_commit_ids = if route.as_of_commit_ids.is_empty() {
+        std::slice::from_ref(&query_source.default_as_of_commit_id)
+    } else {
+        route.as_of_commit_ids.as_slice()
+    };
+    let mut json_reader = query_source.json_reader;
 
     let mut rows = Vec::new();
-    for as_of_commit_id in &route.as_of_commit_ids {
+    for as_of_commit_id in as_of_commit_ids {
         let as_of_commit_id =
             CommitId::parse_lix(as_of_commit_id, "history lixcol_as_of_commit_id")?;
         let (entries, reachable_commits) = {
@@ -370,6 +420,22 @@ where
     }
 
     Ok(rows)
+}
+
+pub(crate) fn invalid_history_anchor_error(
+    as_of_commit_column: &str,
+    view_name: Option<&str>,
+) -> LixError {
+    let surface = view_name.map_or_else(String::new, |view_name| format!("{view_name}: "));
+    LixError::new(
+        LixError::CODE_UNSUPPORTED_SQL,
+        format!(
+            "{surface}history anchor '{as_of_commit_column}' only supports exact equality or non-empty IN predicates"
+        ),
+    )
+    .with_hint(format!(
+        "Omit {as_of_commit_column} to use the pinned active branch head, or use WHERE {as_of_commit_column} = $1 (or {as_of_commit_column} IN ($1, $2)) for time travel."
+    ))
 }
 
 fn effective_schema_keys(
@@ -490,11 +556,12 @@ fn merge_history_disjunction_terms(
 fn parse_history_binary_filter(
     binary_expr: &datafusion::logical_expr::BinaryExpr,
 ) -> Option<HistoryFilterTerm> {
-    let Expr::Column(column) = &*binary_expr.left else {
-        return None;
+    let (column, right) = match (&*binary_expr.left, &binary_expr.op, &*binary_expr.right) {
+        (Expr::Column(column), _, right) => (column, right),
+        (left, Operator::Eq, Expr::Column(column)) => (column, left),
+        _ => return None,
     };
     let column_name = canonical_history_column_name(column.name.as_str())?;
-    let right = &*binary_expr.right;
     match (column_name, &binary_expr.op, right) {
         (
             "as_of_commit_id" | "schema_key" | "file_id",
@@ -526,6 +593,103 @@ fn parse_history_binary_filter(
         }
         _ => None,
     }
+}
+
+fn history_anchor_filter_is_exact(expr: &Expr) -> bool {
+    if !history_filter_references_anchor(expr) {
+        return true;
+    }
+
+    match expr {
+        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
+            history_anchor_filter_is_exact(&binary_expr.left)
+                && history_anchor_filter_is_exact(&binary_expr.right)
+        }
+        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => matches!(
+            parse_history_disjunction(binary_expr).as_deref(),
+            Some([HistoryFilterTerm::AsOfCommitIds(_)])
+        ),
+        Expr::BinaryExpr(binary_expr) => matches!(
+            parse_history_binary_filter(binary_expr),
+            Some(HistoryFilterTerm::AsOfCommitIds(_))
+        ),
+        Expr::InList(in_list) => matches!(
+            parse_history_in_list_filter(in_list),
+            Some(HistoryFilterTerm::AsOfCommitIds(_))
+        ),
+        _ => false,
+    }
+}
+
+fn history_anchor_filter_shape_is_exact(expr: &Expr) -> bool {
+    if !history_filter_references_anchor(expr) {
+        return true;
+    }
+    match expr {
+        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
+            history_anchor_filter_shape_is_exact(&binary_expr.left)
+                && history_anchor_filter_shape_is_exact(&binary_expr.right)
+        }
+        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
+            exact_anchor_disjunction_shape(expr)
+        }
+        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Eq => {
+            exact_anchor_equality_shape(binary_expr)
+        }
+        Expr::InList(in_list) => {
+            !in_list.negated
+                && !in_list.list.is_empty()
+                && matches!(
+                    in_list.expr.as_ref(),
+                    Expr::Column(column)
+                        if canonical_history_column_name(column.name.as_str())
+                            == Some("as_of_commit_id")
+                )
+                && in_list.list.iter().all(routable_anchor_value_shape)
+        }
+        _ => false,
+    }
+}
+
+fn exact_anchor_disjunction_shape(expr: &Expr) -> bool {
+    match expr {
+        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
+            exact_anchor_disjunction_shape(&binary_expr.left)
+                && exact_anchor_disjunction_shape(&binary_expr.right)
+        }
+        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Eq => {
+            exact_anchor_equality_shape(binary_expr)
+        }
+        Expr::InList(_) => history_anchor_filter_shape_is_exact(expr),
+        _ => false,
+    }
+}
+
+fn exact_anchor_equality_shape(binary_expr: &datafusion::logical_expr::BinaryExpr) -> bool {
+    match (&*binary_expr.left, &*binary_expr.right) {
+        (Expr::Column(column), value) | (value, Expr::Column(column)) => {
+            canonical_history_column_name(column.name.as_str()) == Some("as_of_commit_id")
+                && routable_anchor_value_shape(value)
+        }
+        _ => false,
+    }
+}
+
+fn routable_anchor_value_shape(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Literal(ScalarValue::Utf8(Some(_)), _) | Expr::Placeholder(_)
+    ) || matches!(
+        expr,
+        Expr::ScalarFunction(function)
+            if function.name() == "lix_active_branch_commit_id" && function.args.is_empty()
+    )
+}
+
+fn history_filter_references_anchor(expr: &Expr) -> bool {
+    expr.column_refs().iter().any(|column| {
+        canonical_history_column_name(column.name.as_str()) == Some("as_of_commit_id")
+    })
 }
 
 fn parse_history_in_list_filter(in_list: &InList) -> Option<HistoryFilterTerm> {
@@ -678,6 +842,7 @@ mod tests {
     };
     use crate::entity_pk::EntityPk;
     use crate::json_store::{JsonSlot, JsonStoreContext};
+    use crate::sql2::HistoryQuerySource;
     use crate::storage_adapter::{
         Memory, MemoryRead, SharedStorageAdapterRead, StorageAdapter, StorageReadOptions,
     };
@@ -778,7 +943,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn history_loader_skips_unprojected_commit_metadata_walk() {
+    async fn history_loader_defaults_to_pinned_head_without_metadata_walk() {
         let reachable_calls = Arc::new(AtomicUsize::new(0));
         let start_commit_id = CommitId::for_test_label("start");
         let rows = load_history_entries(
@@ -787,11 +952,8 @@ mod tests {
                 as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
             },
             test_commit_graph(Arc::clone(&reachable_calls), start_commit_id),
-            empty_json_reader().await,
-            &HistoryRoute {
-                as_of_commit_ids: vec![start_commit_id.to_string()],
-                ..HistoryRoute::default()
-            },
+            empty_history_query_source(start_commit_id).await,
+            &HistoryRoute::default(),
             vec!["message".to_string()],
             HistoryMetadataProjection::default(),
         )
@@ -818,7 +980,7 @@ mod tests {
                 as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
             },
             test_commit_graph(Arc::clone(&reachable_calls), start_commit_id),
-            empty_json_reader().await,
+            empty_history_query_source(start_commit_id).await,
             &HistoryRoute {
                 as_of_commit_ids: vec![start_commit_id.to_string()],
                 ..HistoryRoute::default()
@@ -857,7 +1019,7 @@ mod tests {
                 start_commit_id: as_of_commit_id,
                 include_reachable_commit: false,
             }))),
-            empty_json_reader().await,
+            empty_history_query_source(as_of_commit_id).await,
             &HistoryRoute {
                 as_of_commit_ids: vec![as_of_commit_id.to_string()],
                 ..HistoryRoute::default()
@@ -955,14 +1117,20 @@ mod tests {
         crate::common::LixTimestamp::expect_parse("commit timestamp", "2026-07-12T00:00:00Z")
     }
 
-    async fn empty_json_reader() -> crate::sql2::SqlJsonReader<SharedStorageAdapterRead<MemoryRead>>
-    {
+    async fn empty_history_query_source(
+        default_as_of_commit_id: CommitId,
+    ) -> HistoryQuerySource<SharedStorageAdapterRead<MemoryRead>> {
         let storage = StorageAdapter::new(Memory::new());
         let read_scope = storage
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        JsonStoreContext::new().reader(SharedStorageAdapterRead::new(read_scope))
+        let read_scope = SharedStorageAdapterRead::new(read_scope);
+        HistoryQuerySource {
+            store: read_scope.clone(),
+            json_reader: JsonStoreContext::new().reader(read_scope),
+            default_as_of_commit_id: default_as_of_commit_id.to_string(),
+        }
     }
 
     fn and(left: Expr, right: Expr) -> Expr {

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -35,7 +35,7 @@ pub(crate) use bind::{
 pub(crate) use catalog::PublicCatalog;
 pub(crate) use context::{
     ChangelogQuerySource, HistoryQuerySource, SqlChangelogQuerySource, SqlExecutionContext,
-    SqlHistoryQuerySource, SqlJsonReader, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,
+    SqlHistoryQuerySource, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,
     WriteContextBranchRefReader, WriteContextLiveStateReader,
 };
 pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -84,6 +84,10 @@ where
         Arc::clone(&self.schema)
     }
 
+    fn history_anchor_column(&self) -> Option<&'static str> {
+        Some(HISTORY_COL_AS_OF_COMMIT_ID)
+    }
+
     fn table_type(&self) -> TableType {
         TableType::View
     }

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -28,7 +28,7 @@ use crate::sql2::history_route::{
     HISTORY_COL_ENTITY_PK, HISTORY_COL_IS_DELETED, HISTORY_COL_OBSERVED_COMMIT_ID,
     HISTORY_COL_SOURCE_CHANGES, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
     HistoryViewDescriptor, load_history_entries, parse_history_filter,
-    serialize_history_source_changes,
+    serialize_history_source_changes, validate_history_anchor_filter,
 };
 use crate::sql2::providers::filesystem_history_path::{
     HistoryDirectoryPathRecord, HistoryDirectoryTree, load_history_commit_parents,
@@ -96,6 +96,10 @@ where
         }
     }
 
+    fn validate_filter_pushdown(&self, filter: &Expr) -> Result<()> {
+        validate_history_anchor_filter(filter).map_err(lix_error_to_datafusion_error)
+    }
+
     async fn plan_scan(
         &self,
         projection: Option<&Vec<usize>>,
@@ -104,7 +108,8 @@ where
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
         let schema = projected_schema(&self.schema, projection);
-        let route = HistoryRoute::from_filters(filters);
+        let mut route = HistoryRoute::from_filters(filters);
+        route.default_to_as_of_commit_id(&self.query_source.default_as_of_commit_id);
         let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
@@ -210,7 +215,7 @@ where
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         Arc::clone(&commit_graph),
-        query_source.json_reader.clone(),
+        query_source.clone(),
         &event_route,
         vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
         metadata_projection,

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -87,6 +87,10 @@ where
         Arc::clone(&self.schema)
     }
 
+    fn history_anchor_column(&self) -> Option<&'static str> {
+        Some(HISTORY_COL_AS_OF_COMMIT_ID)
+    }
+
     fn table_type(&self) -> TableType {
         TableType::View
     }

--- a/packages/engine/src/sql2/providers/entity_history.rs
+++ b/packages/engine/src/sql2/providers/entity_history.rs
@@ -27,7 +27,7 @@ use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_ident
 use crate::sql2::history_route::{
     HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT, HISTORY_COL_IS_DELETED,
     HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor, load_history_entries,
-    parse_history_filter,
+    parse_history_filter, validate_history_anchor_filter,
 };
 use crate::sql2::providers::entity::{
     entity_f64_value, entity_i64_value, entity_json_text_value, parse_snapshot,
@@ -99,6 +99,10 @@ where
         }
     }
 
+    fn validate_filter_pushdown(&self, filter: &Expr) -> Result<()> {
+        validate_history_anchor_filter(filter).map_err(lix_error_to_datafusion_error)
+    }
+
     async fn plan_scan(
         &self,
         projection: Option<&Vec<usize>>,
@@ -106,7 +110,8 @@ where
         limit: Option<usize>,
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
-        let route = HistoryRoute::from_filters(filters);
+        let mut route = HistoryRoute::from_filters(filters);
+        route.default_to_as_of_commit_id(&self.query_source.default_as_of_commit_id);
         let schema = projected_schema(&self.schema, projection);
         let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         Ok(PlannedScan {
@@ -166,7 +171,7 @@ where
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
-        query_source.json_reader,
+        query_source,
         route,
         vec![spec.schema_key.clone()],
         metadata_projection,

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -106,6 +106,10 @@ where
         lix_file_history_schema()
     }
 
+    fn history_anchor_column(&self) -> Option<&'static str> {
+        Some(HISTORY_COL_AS_OF_COMMIT_ID)
+    }
+
     fn table_type(&self) -> TableType {
         TableType::View
     }

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -38,7 +38,7 @@ use crate::sql2::history_route::{
     HISTORY_COL_ENTITY_PK, HISTORY_COL_IS_DELETED, HISTORY_COL_OBSERVED_COMMIT_ID,
     HISTORY_COL_SOURCE_CHANGES, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
     HistoryViewDescriptor, load_history_entries, parse_history_filter,
-    serialize_history_source_changes,
+    serialize_history_source_changes, validate_history_anchor_filter,
 };
 use crate::sql2::providers::filesystem_history_path::{
     HistoryDirectoryPathRecord, HistoryDirectoryTree, load_history_commit_parents,
@@ -124,6 +124,10 @@ where
         }
     }
 
+    fn validate_filter_pushdown(&self, filter: &Expr) -> Result<()> {
+        validate_history_anchor_filter(filter).map_err(lix_error_to_datafusion_error)
+    }
+
     async fn plan_scan(
         &self,
         projection: Option<&Vec<usize>>,
@@ -142,7 +146,8 @@ where
                     .eq_ignore_ascii_case("data")
             })
         });
-        let route = HistoryRoute::from_filters(filters);
+        let mut route = HistoryRoute::from_filters(filters);
+        route.default_to_as_of_commit_id(&self.query_source.default_as_of_commit_id);
         let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         let public_predicate = FileHistoryPublicPredicate::from_filters(filters);
         let lookup_ids = FileHistoryLookupIds::from_public_predicate(&public_predicate);
@@ -1216,7 +1221,7 @@ where
                 as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
             },
             commit_graph,
-            query_source.json_reader,
+            query_source,
             route,
             file_history_filesystem_schema_keys(),
             metadata_projection,
@@ -1231,7 +1236,7 @@ where
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         Arc::clone(&commit_graph),
-        query_source.json_reader.clone(),
+        query_source.clone(),
         &descriptor_and_blob_route,
         vec![
             FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
@@ -1249,7 +1254,7 @@ where
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
-        query_source.json_reader,
+        query_source,
         route,
         vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
         metadata_projection,
@@ -1291,7 +1296,7 @@ where
     let (event_entries, context_entries) =
         load_file_history_entry_sets(&event_route, &context_route, move |route| {
             let commit_graph = Arc::clone(&commit_graph);
-            let json_reader = query_source.json_reader.clone();
+            let query_source = query_source.clone();
             let schema_keys = plugin_schema_keys.clone();
             async move {
                 load_history_entries(
@@ -1300,7 +1305,7 @@ where
                         as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
                     },
                     commit_graph,
-                    json_reader,
+                    query_source,
                     &route,
                     schema_keys,
                     metadata_projection,
@@ -1333,7 +1338,7 @@ where
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
-        query_source.json_reader,
+        query_source,
         &owner_route,
         vec![KEY_VALUE_SCHEMA_KEY.to_string()],
         metadata_projection,
@@ -1528,7 +1533,7 @@ where
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
-        query_source.json_reader,
+        query_source,
         &registry_route,
         vec![KEY_VALUE_SCHEMA_KEY.to_string()],
         metadata_projection,

--- a/packages/engine/src/sql2/providers/history.rs
+++ b/packages/engine/src/sql2/providers/history.rs
@@ -72,6 +72,10 @@ where
         lix_state_history_schema()
     }
 
+    fn history_anchor_column(&self) -> Option<&'static str> {
+        Some(HISTORY_COL_AS_OF_COMMIT_ID)
+    }
+
     fn table_type(&self) -> TableType {
         TableType::View
     }

--- a/packages/engine/src/sql2/providers/history.rs
+++ b/packages/engine/src/sql2/providers/history.rs
@@ -21,7 +21,7 @@ use crate::sql2::history_route::{
     HISTORY_COL_IS_DELETED, HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID,
     HISTORY_COL_ORIGIN_KEY, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SNAPSHOT_CONTENT,
     HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor, load_history_entries,
-    parse_history_filter,
+    parse_history_filter, validate_history_anchor_filter,
 };
 use crate::sql2::result_metadata::json_field;
 use crate::storage_adapter::StorageAdapterRead;
@@ -84,6 +84,10 @@ where
         }
     }
 
+    fn validate_filter_pushdown(&self, filter: &Expr) -> Result<()> {
+        validate_history_anchor_filter(filter).map_err(lix_error_to_datafusion_error)
+    }
+
     async fn plan_scan(
         &self,
         projection: Option<&Vec<usize>>,
@@ -92,7 +96,8 @@ where
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
         let schema = projected_schema(&lix_state_history_schema(), projection);
-        let route = HistoryRoute::from_filters(filters);
+        let mut route = HistoryRoute::from_filters(filters);
+        route.default_to_as_of_commit_id(&self.query_source.default_as_of_commit_id);
         let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
@@ -257,7 +262,7 @@ where
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
         commit_graph,
-        query_source.json_reader,
+        query_source,
         route,
         Vec::new(),
         metadata_projection,

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -30,6 +30,8 @@ use crate::sql2::session::SqlWriteSessionOptions;
 use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
 use datafusion::catalog::TableProvider;
+use datafusion::datasource::DefaultTableSource;
+use datafusion::logical_expr::TableSource;
 
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
@@ -38,6 +40,15 @@ pub(crate) use file::{
 };
 pub(crate) use spec::DmlReturning;
 pub(crate) use upsert::{UpsertAction, excluded_field_name};
+
+pub(crate) fn history_anchor_column(source: &dyn TableSource) -> Option<&'static str> {
+    let source = source.as_any().downcast_ref::<DefaultTableSource>()?;
+    let provider = source
+        .table_provider
+        .as_any()
+        .downcast_ref::<spec::SpecTableProvider>()?;
+    provider.history_anchor_column()
+}
 
 /// Execute an `INSERT ... ON CONFLICT` against a registered table provider.
 /// The four builtin writable surfaces are all [`spec::SpecTableProvider`]s.

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -113,6 +113,7 @@ pub(crate) async fn register_read<C>(
     session: &SessionContext,
     ctx: &C,
     branch_ref: Arc<dyn BranchRefReader>,
+    active_branch_commit_id: Option<String>,
     selection: &ProviderSelection,
 ) -> Result<(), LixError>
 where
@@ -132,6 +133,7 @@ where
         session,
         ctx,
         branch_ref,
+        active_branch_commit_id,
         catalog,
         ReadProviderScope::All,
         selection,
@@ -263,6 +265,7 @@ async fn register_read_from_catalog<C>(
     session: &SessionContext,
     ctx: &C,
     branch_ref: Arc<dyn BranchRefReader>,
+    active_branch_commit_id: Option<String>,
     catalog: &PublicCatalog,
     scope: ReadProviderScope,
     selection: &ProviderSelection,
@@ -281,7 +284,18 @@ where
                     | PublicSurfaceKind::EntityHistory { .. }
             )
     });
-    let history_query_source = needs_history_query_source.then(|| ctx.history_query_source());
+    let history_query_source = if needs_history_query_source {
+        let active_branch_commit_id = active_branch_commit_id.ok_or_else(|| {
+            LixError::branch_not_found(
+                ctx.active_branch_id(),
+                "register SQL history providers",
+                "active branch",
+            )
+        })?;
+        Some(ctx.history_query_source(active_branch_commit_id))
+    } else {
+        None
+    };
     let history_query_source_for_provider = || {
         history_query_source.clone().ok_or_else(|| {
             LixError::new(
@@ -457,6 +471,7 @@ pub(crate) async fn register_transaction<C>(
     session: &SessionContext,
     read_ctx: &C,
     read_branch_ref: Arc<dyn BranchRefReader>,
+    active_branch_commit_id: Option<String>,
     write_ctx: SqlWriteContext,
     write_branch_ref: Arc<dyn BranchRefReader>,
     options: SqlWriteSessionOptions,
@@ -473,6 +488,7 @@ where
         session,
         read_ctx,
         read_branch_ref,
+        active_branch_commit_id,
         &catalog,
         ReadProviderScope::ReadOnly,
         selection,
@@ -996,6 +1012,7 @@ mod tests {
         HistoryQuerySource {
             store: read_scope.clone(),
             json_reader: JsonStoreContext::new().reader(read_scope),
+            default_as_of_commit_id: CommitId::for_test_label("history-default").to_string(),
         }
     }
 

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -214,6 +214,15 @@ pub(super) trait TableSpec: Send + Sync + 'static {
         TableProviderFilterPushDown::Unsupported
     }
 
+    /// Rejects filters that would be unsafe to leave as residual expressions.
+    ///
+    /// Most providers accept every well-typed filter and keep the default.
+    /// History providers use this hook to prevent an unrouteable time-travel
+    /// anchor from being mistaken for an anchor-free active-head query.
+    fn validate_filter_pushdown(&self, _filter: &Expr) -> Result<()> {
+        Ok(())
+    }
+
     /// `props` are the session's execution properties, for specs that compile
     /// pushed-down filters to physical expressions at plan time.
     async fn plan_scan(
@@ -438,10 +447,13 @@ impl TableProvider for SpecTableProvider {
         &self,
         filters: &[&Expr],
     ) -> Result<Vec<TableProviderFilterPushDown>> {
-        Ok(filters
+        filters
             .iter()
-            .map(|filter| self.spec.filter_pushdown(filter))
-            .collect())
+            .map(|filter| {
+                self.spec.validate_filter_pushdown(filter)?;
+                Ok(self.spec.filter_pushdown(filter))
+            })
+            .collect()
     }
 
     async fn scan(

--- a/packages/engine/src/sql2/providers/spec.rs
+++ b/packages/engine/src/sql2/providers/spec.rs
@@ -205,6 +205,14 @@ pub(super) trait TableSpec: Send + Sync + 'static {
 
     fn schema(&self) -> SchemaRef;
 
+    /// Public column that routes a history scan to an explicit commit.
+    ///
+    /// This is provider identity, not a name heuristic: ordinary entity
+    /// schemas may legitimately expose a property with the same name.
+    fn history_anchor_column(&self) -> Option<&'static str> {
+        None
+    }
+
     /// How the surface introspects in `information_schema.tables`.
     fn table_type(&self) -> TableType {
         TableType::Base
@@ -337,6 +345,10 @@ impl SpecTableProvider {
             spec,
             write_access,
         }
+    }
+
+    pub(super) fn history_anchor_column(&self) -> Option<&'static str> {
+        self.spec.history_anchor_column()
     }
 
     #[cfg(test)]

--- a/packages/engine/src/sql2/session.rs
+++ b/packages/engine/src/sql2/session.rs
@@ -67,10 +67,17 @@ where
         &session,
         ctx.functions(),
         Some(ctx.active_branch_id().to_string()),
-        active_branch_commit_id,
+        active_branch_commit_id.clone(),
     );
     let provider_selection = providers::read_provider_selection(&session, statements);
-    providers::register_read(&session, ctx, branch_ref, &provider_selection).await?;
+    providers::register_read(
+        &session,
+        ctx,
+        branch_ref,
+        active_branch_commit_id,
+        &provider_selection,
+    )
+    .await?;
 
     Ok(session)
 }
@@ -94,7 +101,7 @@ where
         &session,
         read_ctx.functions(),
         Some(read_ctx.active_branch_id().to_string()),
-        active_branch_commit_id,
+        active_branch_commit_id.clone(),
     );
     let write_ctx = SqlWriteContext::new(write_ctx);
     let write_branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(
@@ -106,6 +113,7 @@ where
         &session,
         read_ctx,
         read_branch_ref,
+        active_branch_commit_id,
         write_ctx,
         write_branch_ref,
         SqlWriteSessionOptions::default(),

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1866,10 +1866,14 @@ where
         self.functions.clone()
     }
 
-    fn history_query_source(&self) -> SqlHistoryQuerySource<Self::ReadStore> {
+    fn history_query_source(
+        &self,
+        default_as_of_commit_id: String,
+    ) -> SqlHistoryQuerySource<Self::ReadStore> {
         HistoryQuerySource {
             store: self.read_store.clone(),
             json_reader: crate::json_store::JsonStoreContext::new().reader(self.read_store.clone()),
+            default_as_of_commit_id,
         }
     }
 

--- a/packages/engine/tests/sql/entity_history.rs
+++ b/packages/engine/tests/sql/entity_history.rs
@@ -103,19 +103,17 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    entity_history_requires_lixcol_as_of_commit_id,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_workspace_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
+simulation_test!(entity_history_defaults_to_active_head, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("main session should open"),
+        &engine,
+    );
 
-        session
+    session
             .execute(
                 "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
                  VALUES (\
@@ -128,29 +126,40 @@ simulation_test!(
             .await
             .expect("registered schema insert should succeed");
 
-        let error = session
-            .execute("SELECT id FROM engine_history_error_schema_history", &[])
-            .await
-            .expect_err("typed history queries must provide an as-of commit");
+    session
+        .execute(
+            "INSERT INTO engine_history_error_schema \
+                 (lixcol_entity_pk, id, lixcol_untracked) \
+                 VALUES (lix_json('[\"history-default\"]'), 'history-default', false)",
+            &[],
+        )
+        .await
+        .expect("entity insert should succeed");
+    let active_head = engine
+        .load_branch_head_commit_id(sim.main_branch_id())
+        .await
+        .expect("active head should load")
+        .expect("active head should exist");
 
-        assert_eq!(
-            error.code,
-            lix_engine::LixError::CODE_HISTORY_FILTER_REQUIRED
-        );
-        assert!(
-            error
-                .to_string()
-                .contains("requires a lixcol_as_of_commit_id filter"),
-            "unexpected error: {error}"
-        );
-        assert!(
-            error
-                .hint()
-                .is_some_and(|hint| hint.contains("WHERE lixcol_as_of_commit_id")),
-            "unexpected error: {error}"
-        );
-    }
-);
+    let result = session
+        .execute(
+            "SELECT id, lixcol_as_of_commit_id, lixcol_depth \
+                 FROM engine_history_error_schema_history \
+                 WHERE id = 'history-default'",
+            &[],
+        )
+        .await
+        .expect("typed history should default to the active head");
+
+    assert_rows_eq(
+        result,
+        vec![vec![
+            Value::Text("history-default".to_string()),
+            Value::Text(active_head),
+            Value::Integer(0),
+        ]],
+    );
+});
 
 simulation_test!(
     entity_history_rejects_retired_anchor_names,

--- a/packages/engine/tests/sql/lix_directory_history.rs
+++ b/packages/engine/tests/sql/lix_directory_history.rs
@@ -137,7 +137,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_directory_history_requires_as_of_commit_id,
+    lix_directory_history_defaults_to_active_head,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -148,22 +148,37 @@ simulation_test!(
             &engine,
         );
 
-        let error = session
-            .execute("SELECT id FROM lix_directory_history", &[])
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) \
+                 VALUES ('history-default-dir', '/history-default/')",
+                &[],
+            )
             .await
-            .expect_err("directory history queries must provide an as-of commit");
+            .expect("directory insert should succeed");
+        let active_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("active head should load")
+            .expect("active head should exist");
 
-        assert!(
-            error
-                .to_string()
-                .contains("requires a lixcol_as_of_commit_id filter"),
-            "unexpected error: {error}"
-        );
-        assert!(
-            error
-                .hint()
-                .is_some_and(|hint| hint.contains("WHERE lixcol_as_of_commit_id")),
-            "unexpected error: {error}"
+        let result = session
+            .execute(
+                "SELECT id, lixcol_as_of_commit_id, lixcol_depth \
+                 FROM lix_directory_history \
+                 WHERE id = 'history-default-dir'",
+                &[],
+            )
+            .await
+            .expect("directory history should default to the active head");
+
+        assert_rows_eq(
+            result,
+            vec![vec![
+                Value::Text("history-default-dir".to_string()),
+                Value::Text(active_head),
+                Value::Integer(0),
+            ]],
         );
     }
 );

--- a/packages/engine/tests/sql/lix_file_history.rs
+++ b/packages/engine/tests/sql/lix_file_history.rs
@@ -1885,37 +1885,49 @@ async fn lix_file_history_keeps_plugin_state_tombstones_in_deleted_file_provenan
     session.close().await.expect("session should close");
 }
 
-simulation_test!(
-    lix_file_history_requires_as_of_commit_id,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_workspace_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        let error = session
-            .execute("SELECT id FROM lix_file_history", &[])
+simulation_test!(lix_file_history_defaults_to_active_head, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine
+            .open_workspace_session()
             .await
-            .expect_err("file history queries must provide an as-of commit");
+            .expect("main session should open"),
+        &engine,
+    );
 
-        assert!(
-            error
-                .to_string()
-                .contains("requires a lixcol_as_of_commit_id filter"),
-            "unexpected error: {error}"
-        );
-        assert!(
-            error
-                .hint()
-                .is_some_and(|hint| hint.contains("WHERE lixcol_as_of_commit_id")),
-            "unexpected error: {error}"
-        );
-    }
-);
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('history-default-file', '/history-default.txt', X'64656661756C74')",
+            &[],
+        )
+        .await
+        .expect("file insert should succeed");
+    let active_head = engine
+        .load_branch_head_commit_id(sim.main_branch_id())
+        .await
+        .expect("active head should load")
+        .expect("active head should exist");
+
+    let result = session
+        .execute(
+            "SELECT id, lixcol_as_of_commit_id, lixcol_depth \
+                 FROM lix_file_history \
+                 WHERE id = 'history-default-file'",
+            &[],
+        )
+        .await
+        .expect("file history should default to the active head");
+
+    assert_rows_eq(
+        result,
+        vec![vec![
+            Value::Text("history-default-file".to_string()),
+            Value::Text(active_head),
+            Value::Integer(0),
+        ]],
+    );
+});
 
 simulation_test!(
     lix_file_history_ignores_unrelated_file_scoped_state_events,

--- a/packages/engine/tests/sql/lix_state_history.rs
+++ b/packages/engine/tests/sql/lix_state_history.rs
@@ -2,7 +2,7 @@ use lix_engine::Value;
 use serde_json::json;
 
 simulation_test!(
-    lix_state_history_requires_as_of_commit_id,
+    lix_state_history_defaults_to_pinned_active_head,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -21,25 +21,295 @@ simulation_test!(
             .await
             .expect("tracked write should succeed");
 
-        let error = session
-            .execute("SELECT lixcol_entity_pk FROM lix_state_history", &[])
+        let result = session
+            .execute(
+                "SELECT lixcol_entity_pk, lixcol_as_of_commit_id \
+                 FROM lix_state_history \
+                 WHERE lixcol_entity_pk = lix_json('[\"history-start-required\"]')",
+                &[],
+            )
             .await
-            .expect_err("history queries must provide lixcol_as_of_commit_id");
-
-        assert!(
-            error
-                .to_string()
-                .contains("requires a lixcol_as_of_commit_id filter")
-        );
+            .expect("anchor-free history should use the pinned active head");
+        let active_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("active head should load")
+            .expect("active branch should have a head");
         assert_eq!(
-            error.code,
-            lix_engine::LixError::CODE_HISTORY_FILTER_REQUIRED
+            result
+                .rows()
+                .iter()
+                .map(|row| {
+                    (
+                        row.get::<Value>("lixcol_entity_pk")
+                            .expect("lixcol_entity_pk"),
+                        row.get::<Value>("lixcol_as_of_commit_id")
+                            .expect("lixcol_as_of_commit_id"),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![(
+                Value::Json(json!(["history-start-required"])),
+                Value::Text(active_head),
+            )]
         );
-        assert!(
-            error
-                .hint()
-                .is_some_and(|hint| hint.contains("lix_active_branch_commit_id()")),
-            "expected active-branch-head hint: {error}"
+    }
+);
+
+simulation_test!(
+    lix_state_history_routes_exact_anchor_from_join_predicate,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('history-join-anchor', 'one')",
+                &[],
+            )
+            .await
+            .expect("initial tracked write should succeed");
+        let first_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("first head should load")
+            .expect("first head should exist");
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'two' WHERE key = 'history-join-anchor'",
+                &[],
+            )
+            .await
+            .expect("second tracked write should succeed");
+
+        let result = session
+            .execute(
+                &format!(
+                    "SELECT h.lixcol_as_of_commit_id \
+                     FROM lix_state_history AS h \
+                     JOIN lix_state AS active \
+                       ON h.lixcol_entity_pk = active.entity_pk \
+                      AND h.lixcol_schema_key = active.schema_key \
+                      AND h.lixcol_as_of_commit_id = '{first_commit_id}' \
+                     WHERE h.lixcol_entity_pk = lix_json('[\"history-join-anchor\"]')"
+                ),
+                &[],
+            )
+            .await
+            .expect("an exact join anchor should route to the requested history root");
+
+        assert_eq!(
+            result
+                .rows()
+                .iter()
+                .map(|row| row
+                    .get::<Value>("lixcol_as_of_commit_id")
+                    .expect("lixcol_as_of_commit_id"))
+                .collect::<Vec<_>>(),
+            vec![Value::Text(first_commit_id.clone())]
+        );
+
+        let nullable_side = session
+            .execute(
+                &format!(
+                    "SELECT h.lixcol_as_of_commit_id, h.lixcol_snapshot_content \
+                     FROM lix_branch AS b \
+                     LEFT JOIN lix_state_history AS h \
+                       ON h.lixcol_as_of_commit_id = '{first_commit_id}' \
+                      AND h.lixcol_entity_pk = lix_json('[\"history-join-anchor\"]') \
+                     WHERE b.id = 'global'"
+                ),
+                &[],
+            )
+            .await
+            .expect("an exact anchor on the nullable join side should route");
+        assert_eq!(
+            nullable_side
+                .rows()
+                .iter()
+                .map(|row| row.values().to_vec())
+                .collect::<Vec<_>>(),
+            vec![vec![
+                Value::Text(first_commit_id.clone()),
+                Value::Json(json!({"key": "history-join-anchor", "value": "one"})),
+            ]]
+        );
+
+        let right_nullable_side = session
+            .execute(
+                &format!(
+                    "SELECT h.lixcol_as_of_commit_id, h.lixcol_snapshot_content \
+                     FROM lix_state_history AS h \
+                     RIGHT JOIN lix_branch AS b \
+                       ON h.lixcol_as_of_commit_id = '{first_commit_id}' \
+                      AND h.lixcol_entity_pk = lix_json('[\"history-join-anchor\"]') \
+                     WHERE b.id = 'global'"
+                ),
+                &[],
+            )
+            .await
+            .expect("an exact anchor on the nullable side of a right join should route");
+        assert_eq!(
+            right_nullable_side
+                .rows()
+                .iter()
+                .map(|row| row.values().to_vec())
+                .collect::<Vec<_>>(),
+            vec![vec![
+                Value::Text(first_commit_id.clone()),
+                Value::Json(json!({"key": "history-join-anchor", "value": "one"})),
+            ]]
+        );
+
+        let semi_join = session
+            .execute(
+                &format!(
+                    "SELECT h.lixcol_as_of_commit_id, h.lixcol_snapshot_content \
+                     FROM lix_state_history AS h \
+                     LEFT SEMI JOIN lix_branch AS b \
+                       ON h.lixcol_as_of_commit_id = '{first_commit_id}' \
+                     WHERE h.lixcol_entity_pk = lix_json('[\"history-join-anchor\"]')"
+                ),
+                &[],
+            )
+            .await
+            .expect("an exact semi-join anchor should route");
+        assert_eq!(
+            semi_join
+                .rows()
+                .iter()
+                .map(|row| row.values().to_vec())
+                .collect::<Vec<_>>(),
+            vec![vec![
+                Value::Text(first_commit_id.clone()),
+                Value::Json(json!({"key": "history-join-anchor", "value": "one"})),
+            ]]
+        );
+
+        let projected = session
+            .execute(
+                &format!(
+                    "SELECT projected.anchor AS lixcol_as_of_commit_id \
+                     FROM (\
+                       SELECT lixcol_entity_pk, lixcol_as_of_commit_id AS anchor \
+                       FROM lix_state_history\
+                     ) AS projected \
+                     WHERE projected.anchor = '{first_commit_id}' \
+                       AND projected.lixcol_entity_pk = lix_json('[\"history-join-anchor\"]')"
+                ),
+                &[],
+            )
+            .await
+            .expect("an exact anchor should route through a direct projection alias");
+        assert_eq!(
+            projected
+                .rows()
+                .iter()
+                .map(|row| row
+                    .get::<Value>("lixcol_as_of_commit_id")
+                    .expect("lixcol_as_of_commit_id"))
+                .collect::<Vec<_>>(),
+            vec![Value::Text(first_commit_id)]
+        );
+    }
+);
+
+simulation_test!(
+    history_surfaces_reject_unrouteable_anchor_predicates,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        for sql in [
+            "SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+            "SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id NOT IN ('cid_invalid')",
+            "SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id = 'cid_invalid' OR lixcol_schema_key = 'lix_key_value'",
+            "SELECT h.lixcol_entity_pk FROM lix_state_history AS h JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = b.commit_id",
+            "SELECT h.lixcol_entity_pk FROM lix_state_history AS h JOIN lix_branch AS b ON h.lixcol_as_of_commit_id > b.commit_id",
+            "SELECT h.lixcol_entity_pk FROM lix_state_history AS h LEFT JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = 'cid_invalid'",
+            "SELECT h.lixcol_entity_pk FROM lix_branch AS b RIGHT JOIN lix_state_history AS h ON h.lixcol_as_of_commit_id = 'cid_invalid'",
+            "SELECT h.lixcol_entity_pk FROM lix_state_history AS h FULL JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = 'cid_invalid'",
+            "SELECT h.lixcol_entity_pk FROM lix_state_history AS h LEFT ANTI JOIN lix_branch AS b ON h.lixcol_as_of_commit_id = 'cid_invalid'",
+            "SELECT h.lixcol_entity_pk FROM lix_branch AS b RIGHT ANTI JOIN lix_state_history AS h ON h.lixcol_as_of_commit_id = 'cid_invalid'",
+            "SELECT projected.lixcol_entity_pk FROM (SELECT lixcol_entity_pk, lixcol_as_of_commit_id AS anchor FROM lix_state_history) AS projected WHERE projected.anchor > 'cid_invalid'",
+            "SELECT limited.lixcol_entity_pk FROM (SELECT lixcol_entity_pk, lixcol_as_of_commit_id AS anchor FROM lix_state_history LIMIT 1) AS limited WHERE limited.anchor = 'cid_invalid'",
+            "SELECT key FROM lix_key_value_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+            "SELECT id FROM lix_file_history WHERE lixcol_as_of_commit_id LIKE 'cid_%'",
+            "SELECT id FROM lix_directory_history WHERE lixcol_as_of_commit_id IS NULL",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("unrouteable history anchors must not fall back to the active head");
+            assert_eq!(error.code, lix_engine::LixError::CODE_UNSUPPORTED_SQL);
+            assert!(
+                error.to_string().contains("only supports exact equality"),
+                "unexpected error: {error}"
+            );
+            assert!(
+                error
+                    .hint()
+                    .is_some_and(|hint| hint.contains("pinned active branch head")),
+                "unexpected hint: {error:?}"
+            );
+        }
+    }
+);
+
+simulation_test!(
+    unrelated_same_named_column_does_not_validate_as_history_anchor,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('collision', 'value')",
+                &[],
+            )
+            .await
+            .expect("history row should insert");
+
+        let result = session
+            .execute(
+                "SELECT ordinary.lixcol_as_of_commit_id \
+                 FROM (SELECT 'ordinary' AS lixcol_as_of_commit_id) AS ordinary \
+                 CROSS JOIN lix_state_history AS history \
+                 WHERE ordinary.lixcol_as_of_commit_id > 'a' \
+                   AND history.lixcol_entity_pk = lix_json('[\"collision\"]') \
+                 LIMIT 1",
+                &[],
+            )
+            .await
+            .expect("ordinary same-named predicate must not be treated as a history anchor");
+
+        assert_eq!(
+            result
+                .rows()
+                .iter()
+                .map(|row| row
+                    .get::<Value>("lixcol_as_of_commit_id")
+                    .expect("lixcol_as_of_commit_id"))
+                .collect::<Vec<_>>(),
+            vec![Value::Text("ordinary".to_string())]
         );
     }
 );
@@ -253,6 +523,28 @@ simulation_test!(
         );
         assert!(!first_change_created_at.is_empty());
         assert_eq!(first_history[0][7], Value::Boolean(false));
+
+        let reversed_parameter = session
+            .execute(
+                "SELECT lixcol_as_of_commit_id, lixcol_snapshot_content \
+                 FROM lix_state_history \
+                 WHERE $1 = lixcol_as_of_commit_id \
+                   AND lixcol_entity_pk = lix_json('[\"history-explicit\"]')",
+                &[Value::Text(first_commit_id.clone())],
+            )
+            .await
+            .expect("a reversed parameter equality should route the history anchor");
+        assert_eq!(
+            reversed_parameter
+                .rows()
+                .iter()
+                .map(|row| row.values().to_vec())
+                .collect::<Vec<_>>(),
+            vec![vec![
+                Value::Text(first_commit_id.clone()),
+                Value::Json(json!({"key": "history-explicit", "value": "one"})),
+            ]]
+        );
 
         let second_history = select_history_rows(
             &session,

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -1222,9 +1222,11 @@ test("beginTransaction preserves handle after failed statement", async () => {
 		["failed-tx-task", "Before failure", false, JSON.stringify({ batch: 1 })],
 	);
 	await expect(
-		tx.execute("SELECT lixcol_entity_pk FROM lix_state_history"),
+		tx.execute(
+			"SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+		),
 	).rejects.toMatchObject({
-		code: "LIX_HISTORY_FILTER_REQUIRED",
+		code: "LIX_UNSUPPORTED_SQL",
 	});
 	await tx.rollback();
 
@@ -1251,9 +1253,11 @@ test("beginTransaction can continue after failed statement", async () => {
 		],
 	);
 	await expect(
-		tx.execute("SELECT lixcol_entity_pk FROM lix_state_history"),
+		tx.execute(
+			"SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+		),
 	).rejects.toMatchObject({
-		code: "LIX_HISTORY_FILTER_REQUIRED",
+		code: "LIX_UNSUPPORTED_SQL",
 	});
 	await tx.execute(
 		"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, lix_json($4))",
@@ -1384,16 +1388,16 @@ test("engine errors cross the native boundary", async () => {
 	const lix = await openLix();
 
 	try {
-		await lix.execute("SELECT lixcol_entity_pk FROM lix_state_history");
+		await lix.execute(
+			"SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+		);
 		throw new Error("expected history query to fail");
 	} catch (error) {
 		expect(error).toMatchObject({
 			name: "LixError",
-			code: "LIX_HISTORY_FILTER_REQUIRED",
+			code: "LIX_UNSUPPORTED_SQL",
 		});
-		expect((error as { hint?: string }).hint).toContain(
-			"lix_active_branch_commit_id()",
-		);
+		expect((error as { hint?: string }).hint).toContain("pinned active branch head");
 	}
 
 	await lix.close();

--- a/packages/js-sdk/tests/memory-storage-contract.ts
+++ b/packages/js-sdk/tests/memory-storage-contract.ts
@@ -61,14 +61,16 @@ export function registerMemoryStorageContract({
 					name: "LixError",
 					code: "LIX_INVALID_PARAM",
 					details: { operation: "execute", parameter_index: 1 },
-				});
-				await expect(
-					lix.execute("SELECT lixcol_entity_pk FROM lix_state_history"),
-				).rejects.toMatchObject({
-					name: "LixError",
-					code: "LIX_HISTORY_FILTER_REQUIRED",
-					hint: expect.stringContaining("lix_active_branch_commit_id()"),
-				});
+					});
+					await expect(
+						lix.execute(
+							"SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+						),
+					).rejects.toMatchObject({
+						name: "LixError",
+						code: "LIX_UNSUPPORTED_SQL",
+						hint: expect.stringContaining("pinned active branch head"),
+					});
 			} finally {
 				await lix.close();
 			}
@@ -174,17 +176,19 @@ export function registerMemoryStorageContract({
 							sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
 							params: ["batch-rolled-back", "before failure"],
 						},
-						{ sql: "SELECT lixcol_entity_pk FROM lix_state_history" },
+						{
+							sql: "SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id > 'cid_invalid'",
+						},
 						{
 							sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
 							params: ["batch-not-run", "after failure"],
 						},
 					]),
-				).rejects.toMatchObject({
-					name: "LixError",
-					code: "LIX_HISTORY_FILTER_REQUIRED",
-					details: { statementIndex: 1 },
-				});
+					).rejects.toMatchObject({
+						name: "LixError",
+						code: "LIX_UNSUPPORTED_SQL",
+						details: { statementIndex: 1 },
+					});
 				const rolledBack = await lix.execute(
 					"SELECT key FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key",
 					["batch-rolled-back", "batch-not-run"],

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -359,13 +359,15 @@ async fn execute_batch_is_atomic_and_returns_ordered_results() {
                 ],
             },
             ExecuteBatchStatement {
-                sql: "SELECT lixcol_entity_pk FROM lix_state_history".to_string(),
+                sql:
+                    "SELECT lixcol_entity_pk FROM lix_state_history WHERE lixcol_as_of_commit_id > 'cid_invalid'"
+                        .to_string(),
                 params: Vec::new(),
             },
         ])
         .await
         .expect_err("middle batch statement should fail");
-    assert_eq!(error.code, LixError::CODE_HISTORY_FILTER_REQUIRED);
+    assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
     assert!(
         error
             .details


### PR DESCRIPTION
## Why

Agents repeatedly spend an extra query discovering the active commit before every history read. The SQL session already pins the active branch head for coherent reads, so requiring an explicit history anchor adds friction without adding consistency.

## Hard cut

- An anchor-free history scan uses the active branch head already pinned by the SQL session/transaction.
- Exact equality (including reversed equality), non-empty `IN`, and exact equality disjunctions override the default for time travel.
- Any mention of `lixcol_as_of_commit_id` that cannot be routed exactly is rejected instead of silently defaulting and applying a residual filter.
- Validation identifies anchors by provider/relation identity, not by column name, then carries lineage through qualified plans, aliases, projections, subqueries, and joins.
- Exact literal/parameter/UDF anchors in `JOIN ... ON` are accepted only when they route the history provider; column-to-column, range, derived, optimizer-barrier, and unsafe preserved-side outer/anti anchors reject with `LIX_UNSUPPORTED_SQL`.
- Same-named ordinary application columns are unaffected.
- A coherent read batch uses the same pinned head across all statements.
- `LIX_HISTORY_FILTER_REQUIRED` is retired; SDK rollback/error tests use intentionally unsafe anchor predicates and preserve their transaction assertions.

## Validation

- Final stacked history integration: 30/30 passed in both simulation modes.
- Typed/file/directory default-head regressions: 6/6 passed.
- Pinned-head loader unit regression: passed.
- Exact older-commit JOIN, reversed-placeholder, projection alias, semi-join, nullable outer-side, and preserved-side rejection regressions passed.
- Native JS and Rust SDK error/transaction regressions passed before the final rebase.
- Formatting and diff checks passed.
- Full GitHub CI is running on head `160008a96860c03db8c0769a3519b1e7b74c1a5d`.