### PR TITLE
perf(storage): use 2 MiB SlateDB cache parts

### DIFF
--- a/.changenotes/use-two-mib-cache-parts.md
+++ b/.changenotes/use-two-mib-cache-parts.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+Reduced cold point-read cache fill and disk usage by aligning SlateDB disk-cache
+parts with the two-MiB scan read-ahead window.

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -42,7 +42,7 @@ const SCAN_BATCH_ROWS: usize = 1024;
 const SCAN_READ_AHEAD_BYTES: usize = 2 * 1024 * 1024;
 const SCAN_MAX_FETCH_TASKS: usize = 16;
 const SCAN_CACHE_BLOCKS: bool = true;
-const OBJECT_STORE_CACHE_PART_SIZE_BYTES: usize = 4 * 1024 * 1024;
+const OBJECT_STORE_CACHE_PART_SIZE_BYTES: usize = 2 * 1024 * 1024;
 
 #[derive(Debug)]
 pub struct SlateDBFactory {
@@ -1036,6 +1036,11 @@ mod tests {
             slatedb_settings().compression_codec,
             Some(CompressionCodec::Lz4)
         );
+    }
+
+    #[test]
+    fn disk_cache_parts_match_scan_read_ahead() {
+        assert_eq!(OBJECT_STORE_CACHE_PART_SIZE_BYTES, SCAN_READ_AHEAD_BYTES);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reduce SlateDB disk-cache parts from 4 MiB to 2 MiB
- align cache fills with Lix's 2 MiB scan read-ahead window
- retain the existing scan concurrency and cache behavior

## Evidence

Using the real Lix SlateDB adapter with a 4.29 MB LZ4 SST, a fresh cache, and 32 evenly distributed point reads:

| | 4 MiB parts | 2 MiB parts | Change |
|---|---:|---:|---:|
| p50 | 8.844 ms | 6.401 ms | **-27.6%** |
| p95 | 9.615 ms | 7.298 ms | **-24.1%** |
| fetched bytes | 4,294,897 | 2,197,745 | **-48.8%** |
| cache footprint | baseline | 51.1% | **-48.9%** |

Full scans fetched the same payload bytes and remained latency-neutral; range requests increased from 24 to 25 (+4.2%). Hot point reads and cached reopen were neutral.

The cold point-read result uses the on-demand cache behavior in #706. This PR intentionally targets `main` independently: it is safe to merge in either order, while the point-read benefit becomes active once #706 lands.

## Validation

- `cargo test -p lix_slatedb_storage disk_cache_parts_match_scan_read_ahead`
- `cargo clippy -p lix_slatedb_storage --all-targets -- -D warnings`
- `node scripts/validate-changes.mjs`
