### PR TITLE
perf(engine): make blob values immutable

### DIFF
--- a/.changenotes/use-immutable-blob-values.md
+++ b/.changenotes/use-immutable-blob-values.md
@@ -1,0 +1,11 @@
+---
+type: minor
+---
+
+Changed Rust `Value::Blob` payloads from `Vec<u8>` to a new immutable `Blob`
+type backed by `bytes::Bytes`.
+
+Blob values now clone in constant time and share their payload across query
+parameters, exact `lix_file` writes, transaction staging, CAS encoding, and
+result fan-out. Rust callers must convert owned vectors with `.into()` when
+constructing blob values.

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -959,7 +959,7 @@ fn build_replay_commit_statements(
             .map(|row| {
                 params.push(Value::Text(row.id.clone()));
                 params.push(Value::Text(row.path.clone()));
-                params.push(Value::Blob(row.data.clone()));
+                params.push(Value::Blob(row.data.clone().into()));
                 "(?, ?, ?)"
             })
             .collect::<Vec<_>>()
@@ -972,14 +972,17 @@ fn build_replay_commit_statements(
         if stable_file_id(&row.path) == row.id {
             statements.push(SqlStatement {
                 sql: "UPDATE lix_file SET data = ? WHERE id = ?".to_string(),
-                params: vec![Value::Blob(row.data.clone()), Value::Text(row.id.clone())],
+                params: vec![
+                    Value::Blob(row.data.clone().into()),
+                    Value::Text(row.id.clone()),
+                ],
             });
         } else {
             statements.push(SqlStatement {
                 sql: "UPDATE lix_file SET path = ?, data = ? WHERE id = ?".to_string(),
                 params: vec![
                     Value::Text(row.path.clone()),
-                    Value::Blob(row.data.clone()),
+                    Value::Blob(row.data.clone().into()),
                     Value::Text(row.id.clone()),
                 ],
             });
@@ -1505,7 +1508,7 @@ mod tests {
             SqlStatement {
                 sql: "UPDATE lix_file SET data = ? WHERE id = ?".to_string(),
                 params: vec![
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                     Value::Text("file-id".to_string()),
                 ],
             },
@@ -1539,7 +1542,7 @@ mod tests {
         assert_eq!(
             statements[0].params,
             vec![
-                Value::Blob(b"hello".to_vec()),
+                Value::Blob(b"hello".to_vec().into()),
                 Value::Text("/src/main.ts".to_string())
             ]
         );
@@ -1568,7 +1571,7 @@ mod tests {
             statements[0].params,
             vec![
                 Value::Text("/src/new.ts".to_string()),
-                Value::Blob(b"hello".to_vec()),
+                Value::Blob(b"hello".to_vec().into()),
                 Value::Text("/src/old.ts".to_string())
             ]
         );

--- a/packages/cli/src/commands/sql/execute.rs
+++ b/packages/cli/src/commands/sql/execute.rs
@@ -154,7 +154,7 @@ fn parse_object_param(
                     "invalid --params value at index {index}: $blob is not valid base64: {error}"
                 ))
             })?;
-        return Ok(Value::Blob(bytes));
+        return Ok(Value::Blob(bytes.into()));
     }
 
     Err(CliError::msg(format!(
@@ -189,7 +189,7 @@ mod tests {
                 Value::Integer(7),
                 Value::Real(2.5),
                 Value::Text("hello".to_string()),
-                Value::Blob(vec![0x68, 0x69]),
+                Value::Blob(vec![0x68, 0x69].into()),
             ]
         );
     }

--- a/packages/cli/src/output/mod.rs
+++ b/packages/cli/src/output/mod.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn value_to_json_uses_blob_tagged_shape() {
-        let value = Value::Blob(vec![0x01, 0x02, 0x03]);
+        let value = Value::Blob(vec![0x01, 0x02, 0x03].into());
         let json = value_to_json(&value);
         assert_eq!(
             json,
@@ -149,7 +149,7 @@ mod tests {
             vec!["n".to_string(), "payload".to_string()],
             vec![
                 vec![Value::Integer(1), Value::Text("a".to_string())],
-                vec![Value::Integer(2), Value::Blob(vec![0x01, 0x02])],
+                vec![Value::Integer(2), Value::Blob(vec![0x01, 0x02].into())],
             ],
         );
 

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -100,7 +100,7 @@ blake3 = "1"
 fastcdc = "3"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 base64 = "0.22"
-bytes = "1"
+bytes = { version = "1", features = ["serde"] }
 zip = { version = "8", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 [dev-dependencies]

--- a/packages/engine/benches/large_blob_updates.rs
+++ b/packages/engine/benches/large_blob_updates.rs
@@ -304,7 +304,10 @@ where
             .session
             .execute(
                 UPSERT_SQL,
-                &[Value::Text(prepared.path), Value::Blob(prepared.data)],
+                &[
+                    Value::Text(prepared.path),
+                    Value::Blob(prepared.data.into()),
+                ],
             )
             .await
             .expect("write large benchmark blob");

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -730,7 +730,7 @@ impl UploadBenchFixture {
                  lixcol_metadata = excluded.lixcol_metadata",
                 &[
                     Value::Text(self.upload_path.clone()),
-                    Value::Blob(upload_file_bytes(version)),
+                    Value::Blob(upload_file_bytes(version).into()),
                     upload_file_metadata(version),
                 ],
             )
@@ -749,7 +749,7 @@ impl UploadBenchFixture {
                  lixcol_metadata = excluded.lixcol_metadata",
                 &[
                     Value::Text(self.upload_path.clone()),
-                    Value::Blob(upload_file_bytes(version)),
+                    Value::Blob(upload_file_bytes(version).into()),
                     file_metadata(),
                 ],
             )
@@ -770,9 +770,9 @@ impl UploadBenchFixture {
             .execute(
                 "UPDATE lix_file SET data = $1 WHERE id = $2 AND data = $3",
                 &[
-                    Value::Blob(upload_file_bytes(version)),
+                    Value::Blob(upload_file_bytes(version).into()),
                     Value::Text(self.file_id.clone()),
-                    Value::Blob(expected),
+                    Value::Blob(expected.into()),
                 ],
             )
             .await
@@ -792,7 +792,7 @@ impl UploadBenchFixture {
             .execute(
                 "UPDATE lix_file SET data = $1 WHERE id = $2",
                 &[
-                    Value::Blob(upload_file_bytes(version)),
+                    Value::Blob(upload_file_bytes(version).into()),
                     Value::Text(self.file_id.clone()),
                 ],
             )
@@ -811,7 +811,7 @@ impl UploadBenchFixture {
                 .wrapping_mul(self.upload_batch_paths.len() as u64)
                 .wrapping_add(file_index as u64);
             params.push(Value::Text(path.clone()));
-            params.push(Value::Blob(upload_file_bytes(file_version)));
+            params.push(Value::Blob(upload_file_bytes(file_version).into()));
             params.push(upload_file_metadata(file_version));
         }
         let result = self
@@ -833,7 +833,7 @@ impl UploadBenchFixture {
                  lixcol_metadata = excluded.lixcol_metadata",
                 &[
                     Value::Text(path),
-                    Value::Blob(upload_file_bytes(version)),
+                    Value::Blob(upload_file_bytes(version).into()),
                     upload_file_metadata(version),
                 ],
             )
@@ -1334,7 +1334,7 @@ async fn seed_files(session: &SessionContext<SlateDB>) {
                 row_index * 3 + 3
             ));
             params.push(Value::Text(file_path(file_index)));
-            params.push(Value::Blob(file_bytes(file_index)));
+            params.push(Value::Blob(file_bytes(file_index).into()));
             params.push(file_metadata());
         }
 

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -33,12 +33,13 @@ impl BlobHash {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlobPayload {
-    bytes: Vec<u8>,
+    bytes: crate::Blob,
     hash: Option<BlobHash>,
 }
 
 impl BlobPayload {
-    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
+    pub(crate) fn from_bytes(bytes: impl Into<crate::Blob>) -> Self {
+        let bytes = bytes.into();
         let hash = (!bytes.is_empty()).then(|| BlobHash::from_content(&bytes));
         Self { bytes, hash }
     }

--- a/packages/engine/src/common/mod.rs
+++ b/packages/engine/src/common/mod.rs
@@ -16,5 +16,5 @@ pub(crate) use metadata::{
     parse_row_metadata, parse_row_metadata_value, serialize_row_metadata, validate_row_metadata,
 };
 pub(crate) use timestamp::LixTimestamp;
-pub use types::{LixNotice, NullableKeyFilter, SqlQueryResult, Value};
+pub use types::{Blob, LixNotice, NullableKeyFilter, SqlQueryResult, Value};
 pub use wire::{WireQueryResult, WireValue};

--- a/packages/engine/src/common/types.rs
+++ b/packages/engine/src/common/types.rs
@@ -1,5 +1,68 @@
 use std::ops::Deref;
 
+/// Immutable, cheaply cloned binary SQL value.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct Blob(bytes::Bytes);
+
+impl Blob {
+    pub fn from_static(bytes: &'static [u8]) -> Self {
+        Self(bytes::Bytes::from_static(bytes))
+    }
+
+    pub fn into_bytes(self) -> bytes::Bytes {
+        self.0
+    }
+
+    pub fn as_bytes(&self) -> &bytes::Bytes {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for Blob {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes.into())
+    }
+}
+
+impl From<&[u8]> for Blob {
+    fn from(bytes: &[u8]) -> Self {
+        Self(bytes::Bytes::copy_from_slice(bytes))
+    }
+}
+
+impl From<bytes::Bytes> for Blob {
+    fn from(bytes: bytes::Bytes) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Blob> for bytes::Bytes {
+    fn from(blob: Blob) -> Self {
+        blob.0
+    }
+}
+
+impl AsRef<[u8]> for Blob {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl PartialEq<[u8]> for Blob {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_ref() == other
+    }
+}
+
+impl Deref for Blob {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Value {
     Null,
@@ -8,7 +71,7 @@ pub enum Value {
     Real(f64),
     Text(String),
     Json(serde_json::Value),
-    Blob(Vec<u8>),
+    Blob(Blob),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -67,4 +130,22 @@ pub struct LixNotice {
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Value;
+
+    #[test]
+    fn cloning_blob_values_shares_the_payload() {
+        let value = Value::Blob(vec![7; 1024 * 1024].into());
+        let cloned = value.clone();
+        let Value::Blob(original) = value else {
+            unreachable!("constructed a blob value");
+        };
+        let Value::Blob(cloned) = cloned else {
+            unreachable!("cloned a blob value");
+        };
+        assert_eq!(original.as_ptr(), cloned.as_ptr());
+    }
 }

--- a/packages/engine/src/common/wire.rs
+++ b/packages/engine/src/common/wire.rs
@@ -80,7 +80,7 @@ impl WireValue {
                         hint: None,
                         details: None,
                     })?;
-                Ok(Value::Blob(decoded))
+                Ok(Value::Blob(decoded.into()))
             }
         }
     }
@@ -135,7 +135,7 @@ mod tests {
             Value::Real(1.5),
             Value::Text("hello".to_string()),
             Value::Json(json!({"hello": "world"})),
-            Value::Blob(vec![1, 2, 3]),
+            Value::Blob(vec![1, 2, 3].into()),
         ];
 
         for value in original {
@@ -154,7 +154,7 @@ mod tests {
                 vec![
                     Value::Integer(1),
                     Value::Text("a".to_string()),
-                    Value::Blob(vec![0x41, 0x42]),
+                    Value::Blob(vec![0x41, 0x42].into()),
                 ],
                 vec![Value::Null, Value::Boolean(false), Value::Real(2.5)],
             ],

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -887,7 +887,7 @@ pub(crate) fn plan_parsed_file_path_write_with_resolvers(
     resolvers: &mut BTreeMap<String, DirectoryPathResolver>,
     parsed: LixPath,
     id: Option<String>,
-    data: Option<Vec<u8>>,
+    data: Option<crate::Blob>,
     context: FilesystemRowContext,
     generate_directory_id: &mut dyn FnMut() -> String,
 ) -> Result<FilesystemWritePlan, LixError> {
@@ -909,7 +909,7 @@ fn plan_parsed_file_path_write_with_fallback(
     fallback: Option<&DirectoryPathResolver>,
     parsed: LixPath,
     id: Option<String>,
-    data: Option<Vec<u8>>,
+    data: Option<crate::Blob>,
     context: FilesystemRowContext,
     generate_directory_id: &mut dyn FnMut() -> String,
 ) -> Result<FilesystemWritePlan, LixError> {
@@ -1627,7 +1627,7 @@ mod tests {
                 resolvers,
                 parsed,
                 id,
-                data,
+                data.map(Into::into),
                 context,
                 generate_directory_id,
             )

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -63,8 +63,8 @@ pub use schema::{
 };
 
 pub use common::LixError;
+pub use common::{Blob, LixNotice, NullableKeyFilter, SqlQueryResult, Value};
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, EntityPk, FileId};
-pub use common::{LixNotice, NullableKeyFilter, SqlQueryResult, Value};
 pub use common::{WireQueryResult, WireValue};
 pub(crate) use common::{parse_row_metadata, parse_row_metadata_value, serialize_row_metadata};
 pub use engine::{Engine, EngineOptions};

--- a/packages/engine/src/observe_coordinator.rs
+++ b/packages/engine/src/observe_coordinator.rs
@@ -49,7 +49,7 @@ enum ObserveParamKey {
     Real(u64),
     Text(String),
     Json(String),
-    Blob(Vec<u8>),
+    Blob(crate::Blob),
 }
 
 impl ObserveParamKey {
@@ -337,7 +337,7 @@ mod tests {
     fn blob_result(byte: u8) -> ExecuteResult {
         ExecuteResult::from_rows(
             vec!["data".to_string()],
-            vec![vec![Value::Blob(vec![byte; 1024])]],
+            vec![vec![Value::Blob(vec![byte; 1024].into())]],
         )
     }
 

--- a/packages/engine/src/observe_coordinator/performance_tests.rs
+++ b/packages/engine/src/observe_coordinator/performance_tests.rs
@@ -9,7 +9,10 @@ fn sized_blob_result(size: usize, changed: bool) -> ExecuteResult {
     if changed {
         bytes[size / 2] = 1;
     }
-    ExecuteResult::from_rows(vec!["data".to_string()], vec![vec![Value::Blob(bytes)]])
+    ExecuteResult::from_rows(
+        vec!["data".to_string()],
+        vec![vec![Value::Blob(bytes.into())]],
+    )
 }
 
 #[test]

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -14,7 +14,7 @@ use crate::storage_adapter::{
 };
 use crate::telemetry::TelemetrySpanKind;
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
-use crate::{LixError, LixNotice, SqlQueryResult, Value};
+use crate::{Blob, LixError, LixNotice, SqlQueryResult, Value};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use datafusion::sql::sqlparser::ast::{
     BinaryOperator, Expr, GroupByExpr, Ident, LimitClause, OrderByKind, Query, Select,
@@ -323,9 +323,24 @@ impl TryFromValue for serde_json::Value {
 impl TryFromValue for Vec<u8> {
     fn try_from_value(value: &Value) -> Result<Self, LixError> {
         match value {
+            Value::Blob(value) => Ok(value.to_vec()),
+            other => Err(value_type_error("blob", other)),
+        }
+    }
+}
+
+impl TryFromValue for Blob {
+    fn try_from_value(value: &Value) -> Result<Self, LixError> {
+        match value {
             Value::Blob(value) => Ok(value.clone()),
             other => Err(value_type_error("blob", other)),
         }
+    }
+}
+
+impl TryFromValue for bytes::Bytes {
+    fn try_from_value(value: &Value) -> Result<Self, LixError> {
+        Blob::try_from_value(value).map(Blob::into_bytes)
     }
 }
 
@@ -2433,9 +2448,9 @@ mod tests {
                 "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4)",
                 &[
                     Value::Text("/b.txt".to_string()),
-                    Value::Blob(b"bravo".to_vec()),
+                    Value::Blob(b"bravo".to_vec().into()),
                     Value::Text("/a.txt".to_string()),
-                    Value::Blob(b"alpha".to_vec()),
+                    Value::Blob(b"alpha".to_vec().into()),
                 ],
             )
             .await
@@ -2458,12 +2473,12 @@ mod tests {
         assert_eq!(result.rows()[0].get::<String>("path").unwrap(), "/a.txt");
         assert_eq!(
             result.rows()[0].value("data").unwrap(),
-            &Value::Blob(b"alpha".to_vec())
+            &Value::Blob(b"alpha".to_vec().into())
         );
         assert_eq!(result.rows()[1].get::<String>("path").unwrap(), "/b.txt");
         assert_eq!(
             result.rows()[1].value("data").unwrap(),
-            &Value::Blob(b"bravo".to_vec())
+            &Value::Blob(b"bravo".to_vec().into())
         );
     }
 
@@ -2475,11 +2490,11 @@ mod tests {
                 "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4), ($5, $6)",
                 &[
                     Value::Text("/a.txt".to_string()),
-                    Value::Blob(b"alpha".to_vec()),
+                    Value::Blob(b"alpha".to_vec().into()),
                     Value::Text("/b.txt".to_string()),
-                    Value::Blob(b"bravo".to_vec()),
+                    Value::Blob(b"bravo".to_vec().into()),
                     Value::Text("/c.txt".to_string()),
-                    Value::Blob(b"charlie".to_vec()),
+                    Value::Blob(b"charlie".to_vec().into()),
                 ],
             )
             .await
@@ -2499,14 +2514,14 @@ mod tests {
             result.rows()[0].values(),
             &[
                 Value::Text("/c.txt".to_string()),
-                Value::Blob(b"charlie".to_vec()),
+                Value::Blob(b"charlie".to_vec().into()),
             ]
         );
         assert_eq!(
             result.rows()[1].values(),
             &[
                 Value::Text("/b.txt".to_string()),
-                Value::Blob(b"bravo".to_vec()),
+                Value::Blob(b"bravo".to_vec().into()),
             ]
         );
     }
@@ -2531,7 +2546,7 @@ mod tests {
     fn execute_result_clone_shares_immutable_backing() {
         let result = ExecuteResult::from_rows(
             vec!["data".to_string()],
-            vec![vec![Value::Blob(vec![b'x'; 1024 * 1024])]],
+            vec![vec![Value::Blob(vec![b'x'; 1024 * 1024].into())]],
         );
         let cloned = result.clone();
 

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -402,9 +402,9 @@ fn eval_fast_file_blob(
     expr: &BoundExpr,
     params: &[Value],
     column: &str,
-) -> Result<Vec<u8>, LixError> {
+) -> Result<crate::Blob, LixError> {
     match expr {
-        BoundExpr::Literal(BoundLiteral::Blob(value)) => Ok(value.clone()),
+        BoundExpr::Literal(BoundLiteral::Blob(value)) => Ok(value.clone().into()),
         BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
             Some(Value::Blob(value)) => Ok(value.clone()),
             Some(_) => Err(LixError::new(
@@ -737,7 +737,9 @@ fn entity_returning_value(
     active_branch_commit_id: Option<&CommitId>,
 ) -> Result<Value, LixError> {
     match expr {
-        BoundExpr::Literal(BoundLiteral::Blob(value)) => return Ok(Value::Blob(value.clone())),
+        BoundExpr::Literal(BoundLiteral::Blob(value)) => {
+            return Ok(Value::Blob(value.clone().into()));
+        }
         BoundExpr::Param(param)
             if params
                 .get(param.index.saturating_sub(1))

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -1475,7 +1475,7 @@ fn scalar_value_from_lix_value(value: &Value) -> ScalarAndMetadata {
             ScalarValue::Utf8(Some(value.to_string())),
             Some(json_field_metadata()),
         ),
-        Value::Blob(value) => ScalarValue::LargeBinary(Some(value.clone())).into(),
+        Value::Blob(value) => ScalarValue::LargeBinary(Some(value.to_vec())).into(),
     }
 }
 
@@ -1673,7 +1673,7 @@ fn scalar_value_to_lix_value(value: ScalarValue, field: Option<&Field>) -> Resul
             Ok(Value::Null)
         }
         ScalarValue::Binary(Some(value)) | ScalarValue::LargeBinary(Some(value)) => {
-            Ok(Value::Blob(value))
+            Ok(Value::Blob(value.into()))
         }
         ScalarValue::Binary(None) | ScalarValue::LargeBinary(None) => Ok(Value::Null),
         other => Ok(Value::Text(other.to_string())),
@@ -3113,7 +3113,7 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0][0], Value::Text("file-a".to_string()));
         assert_eq!(rows[0][1], Value::Text("/docs/readme.md".to_string()));
-        assert_eq!(rows[0][2], Value::Blob(b"hello".to_vec()));
+        assert_eq!(rows[0][2], Value::Blob(b"hello".to_vec().into()));
         assert_eq!(rows[0][3], Value::Text(head_commit_id.clone()));
         assert!(matches!(rows[0][4], Value::Integer(_)));
 
@@ -4872,9 +4872,9 @@ mod tests {
             "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4)",
             &[
                 Value::Text("/multi/param-a.md".to_string()),
-                Value::Blob(b"param-a".to_vec()),
+                Value::Blob(b"param-a".to_vec().into()),
                 Value::Text("/multi/param-b.md".to_string()),
-                Value::Blob(b"param-b".to_vec()),
+                Value::Blob(b"param-b".to_vec().into()),
             ],
             WriteExecutorMode::ForceFast,
         )
@@ -4898,10 +4898,10 @@ mod tests {
              VALUES ($1, $2, $3), ($4, $5, $6)",
             &[
                 Value::Text("/multi/param-a.md".to_string()),
-                Value::Blob(b"param-a".to_vec()),
+                Value::Blob(b"param-a".to_vec().into()),
                 Value::Json(json!({"source": "json-param"})),
                 Value::Text("/multi/param-b.md".to_string()),
-                Value::Blob(b"param-b".to_vec()),
+                Value::Blob(b"param-b".to_vec().into()),
                 Value::Text(r#"{"source":"text-param"}"#.to_string()),
             ],
             WriteExecutorMode::ForceFast,
@@ -4957,7 +4957,7 @@ mod tests {
                    lixcol_metadata = excluded.lixcol_metadata";
         let params = [
             Value::Text("/docs/existing.md".to_string()),
-            Value::Blob(b"updated".to_vec()),
+            Value::Blob(b"updated".to_vec().into()),
             Value::Json(json!({"source": "upload"})),
         ];
 
@@ -5023,7 +5023,7 @@ mod tests {
             "INSERT INTO lix_file (path, data, lixcol_metadata) VALUES ($1, $2, $3)",
             &[
                 Value::Text("/invalid.md".to_string()),
-                Value::Blob(b"data".to_vec()),
+                Value::Blob(b"data".to_vec().into()),
                 Value::Json(json!(["not", "an", "object"])),
             ],
             WriteExecutorMode::ForceFast,
@@ -5254,7 +5254,7 @@ mod tests {
             "INSERT INTO lix_file (path, data) VALUES ($1, $2), ($3, $4)",
             &[
                 Value::Text("/ok.md".to_string()),
-                Value::Blob(b"ok".to_vec()),
+                Value::Blob(b"ok".to_vec().into()),
                 Value::Text("/bad.md".to_string()),
                 Value::Text("not a blob".to_string()),
             ],
@@ -5448,9 +5448,9 @@ mod tests {
             &mut ctx,
             "UPDATE lix_file SET data = $1 WHERE id = $2 AND data = $3",
             &[
-                Value::Blob(b"new".to_vec()),
+                Value::Blob(b"new".to_vec().into()),
                 Value::Text("file-readme".to_string()),
-                Value::Blob(b"old".to_vec()),
+                Value::Blob(b"old".to_vec().into()),
             ],
             WriteExecutorMode::Auto,
         )
@@ -5603,7 +5603,7 @@ mod tests {
             &mut ctx,
             "UPDATE lix_file SET data = $1 WHERE id = $2",
             &[
-                Value::Blob(b"parameterized".to_vec()),
+                Value::Blob(b"parameterized".to_vec().into()),
                 Value::Text("file-readme".to_string()),
             ],
             WriteExecutorMode::ForceFast,
@@ -5635,7 +5635,7 @@ mod tests {
         let rows = vec![live_file_row("file-readme", "branch-a", None, "readme.md")];
         let (mut fast_ctx, fast_staged, fast_scans) = counting_write_context(rows);
         let sql = "UPDATE lix_file SET data = $1 WHERE id = $2";
-        let params = [Value::Blob(b"parameterized".to_vec()), Value::Null];
+        let params = [Value::Blob(b"parameterized".to_vec().into()), Value::Null];
 
         let (fast_result, fast_path) =
             execute_write_sql_trace(&mut fast_ctx, sql, &params, WriteExecutorMode::ForceFast)
@@ -7055,7 +7055,7 @@ mod tests {
                     Value::Text("/docs/readme.md".to_string())
                 );
                 assert_eq!(result.rows[0][1], Value::Text("readme.md".to_string()));
-                assert_eq!(result.rows[0][2], Value::Blob(vec![0x41, 0x42]));
+                assert_eq!(result.rows[0][2], Value::Blob(vec![0x41, 0x42].into()));
                 assert_eq!(result.rows[0][3], Value::Text("branch-a".to_string()));
             })
         });
@@ -7086,7 +7086,7 @@ mod tests {
                     Value::Text("/docs/readme.md".to_string())
                 );
                 assert_eq!(result.rows[0][1], Value::Text("readme.md".to_string()));
-                assert_eq!(result.rows[0][2], Value::Blob(vec![0x41, 0x42]));
+                assert_eq!(result.rows[0][2], Value::Blob(vec![0x41, 0x42].into()));
             })
         });
     }

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1899,7 +1899,7 @@ pub(crate) enum FastLixFilePathWriteConflict {
 
 pub(crate) async fn execute_fast_lix_file_path_writes(
     ctx: &mut dyn SqlWriteExecutionContext,
-    writes: Vec<(String, Vec<u8>, Option<TransactionJson>)>,
+    writes: Vec<(String, crate::Blob, Option<TransactionJson>)>,
     conflict: FastLixFilePathWriteConflict,
 ) -> Result<Option<u64>, LixError> {
     if writes.is_empty() {
@@ -2282,7 +2282,7 @@ async fn load_exact_existing_blob_keys(
 pub(crate) async fn execute_fast_lix_file_data_update_by_id(
     ctx: &mut dyn SqlWriteExecutionContext,
     file_id: Option<String>,
-    data: Vec<u8>,
+    data: crate::Blob,
 ) -> Result<u64, LixError> {
     let active_branch_id = ctx.active_branch_id().to_string();
     ctx.load_branch_head(&active_branch_id)
@@ -2363,12 +2363,12 @@ pub(crate) async fn execute_fast_lix_file_data_update_by_id(
 
 struct FastLixFilePathWrite {
     parsed: ParsedFileWritePath,
-    data: Vec<u8>,
+    data: crate::Blob,
     metadata: Option<TransactionJson>,
 }
 
 fn parse_fast_lix_file_path_writes(
-    writes: Vec<(String, Vec<u8>, Option<TransactionJson>)>,
+    writes: Vec<(String, crate::Blob, Option<TransactionJson>)>,
 ) -> std::result::Result<Vec<FastLixFilePathWrite>, LixError> {
     writes
         .into_iter()
@@ -3038,7 +3038,7 @@ fn lix_file_stage_from_batch_with_options_and_path_resolvers(
                 path_resolvers,
                 parsed_path,
                 Some(file_id.clone()),
-                data,
+                data.map(Into::into),
                 context,
                 generate_directory_id,
             )
@@ -3156,7 +3156,7 @@ fn stage_lix_file_data_insert_write(
     file_id: String,
     path: Option<String>,
     filename: Option<String>,
-    data: Vec<u8>,
+    data: impl Into<crate::Blob>,
     context: FilesystemRowContext,
     origin: Option<TransactionWriteOrigin>,
 ) -> Result<()> {
@@ -3181,7 +3181,7 @@ fn stage_lix_file_data_update_write(
     file_id: String,
     path: Option<String>,
     filename: Option<String>,
-    data: Vec<u8>,
+    data: impl Into<crate::Blob>,
     context: FilesystemRowContext,
     has_blob_ref: bool,
     origin: Option<TransactionWriteOrigin>,
@@ -3962,7 +3962,7 @@ async fn exact_path_data_rows_from_prepared(
         };
         rows.push(vec![
             Value::Text(path),
-            data.map_or(Value::Null, Value::Blob),
+            data.map_or(Value::Null, |data| Value::Blob(data.into())),
         ]);
     }
 
@@ -10043,7 +10043,7 @@ mod tests {
         let count = super::execute_fast_lix_file_data_update_by_id(
             &mut write_context,
             Some("file-readme".to_string()),
-            b"new".to_vec(),
+            b"new".to_vec().into(),
         )
         .await
         .expect("fast data update should stage");
@@ -10097,7 +10097,7 @@ mod tests {
             &mut write_context,
             vec![(
                 "/readme.md".to_string(),
-                b"new".to_vec(),
+                b"new".to_vec().into(),
                 Some(TransactionJson::from_value_for_test(
                     serde_json::json!({"source": "upload"}),
                 )),
@@ -10159,8 +10159,8 @@ mod tests {
         let outcome = super::execute_fast_lix_file_path_writes(
             &mut write_context,
             vec![
-                ("/readme.md".to_string(), b"updated".to_vec(), None),
-                ("/new.md".to_string(), b"new".to_vec(), None),
+                ("/readme.md".to_string(), b"updated".to_vec().into(), None),
+                ("/new.md".to_string(), b"new".to_vec().into(), None),
             ],
             super::FastLixFilePathWriteConflict::UpdateData,
         )
@@ -10195,7 +10195,11 @@ mod tests {
 
         let outcome = super::execute_fast_lix_file_path_writes(
             &mut write_context,
-            vec![("/new/nested/file.md".to_string(), b"new".to_vec(), None)],
+            vec![(
+                "/new/nested/file.md".to_string(),
+                b"new".to_vec().into(),
+                None,
+            )],
             super::FastLixFilePathWriteConflict::UpdateDataAndMetadata,
         )
         .await
@@ -10233,8 +10237,8 @@ mod tests {
         let error = super::execute_fast_lix_file_path_writes(
             &mut write_context,
             vec![
-                ("/duplicate.md".to_string(), b"first".to_vec(), None),
-                ("/duplicate.md".to_string(), b"second".to_vec(), None),
+                ("/duplicate.md".to_string(), b"first".to_vec().into(), None),
+                ("/duplicate.md".to_string(), b"second".to_vec().into(), None),
             ],
             super::FastLixFilePathWriteConflict::UpdateData,
         )
@@ -10260,7 +10264,7 @@ mod tests {
 
         let error = super::execute_fast_lix_file_path_writes(
             &mut write_context,
-            vec![("/docs".to_string(), b"file".to_vec(), None)],
+            vec![("/docs".to_string(), b"file".to_vec().into(), None)],
             super::FastLixFilePathWriteConflict::UpdateData,
         )
         .await
@@ -10314,8 +10318,12 @@ mod tests {
         let outcome = super::execute_fast_lix_file_path_writes(
             &mut write_context,
             vec![
-                ("/local.md".to_string(), b"new-local".to_vec(), None),
-                ("/global.md".to_string(), b"new-global".to_vec(), None),
+                ("/local.md".to_string(), b"new-local".to_vec().into(), None),
+                (
+                    "/global.md".to_string(),
+                    b"new-global".to_vec().into(),
+                    None,
+                ),
             ],
             super::FastLixFilePathWriteConflict::UpdateData,
         )
@@ -10362,7 +10370,7 @@ mod tests {
 
         let outcome = super::execute_fast_lix_file_path_writes(
             &mut write_context,
-            vec![("/readme.md".to_string(), Vec::new(), None)],
+            vec![("/readme.md".to_string(), Vec::new().into(), None)],
             super::FastLixFilePathWriteConflict::UpdateData,
         )
         .await
@@ -10408,7 +10416,7 @@ mod tests {
 
         let outcome = super::execute_fast_lix_file_path_writes(
             &mut write_context,
-            vec![("/shared.md".to_string(), b"new".to_vec(), None)],
+            vec![("/shared.md".to_string(), b"new".to_vec().into(), None)],
             super::FastLixFilePathWriteConflict::UpdateDataAndMetadata,
         )
         .await

--- a/packages/engine/src/sql2/test_support/differential.rs
+++ b/packages/engine/src/sql2/test_support/differential.rs
@@ -350,7 +350,7 @@ mod tests {
                     Value::Json(value)
                 }
                 DifferentialParam::Text(value) => Value::Text((*value).to_string()),
-                DifferentialParam::Blob(value) => Value::Blob((*value).to_vec()),
+                DifferentialParam::Blob(value) => Value::Blob((*value).to_vec().into()),
             })
             .collect()
     }

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -203,7 +203,7 @@ impl TransactionFileData {
         branch_id: String,
         global: bool,
         untracked: bool,
-        data: Vec<u8>,
+        data: impl Into<crate::Blob>,
     ) -> Self {
         Self {
             file_id,
@@ -223,7 +223,7 @@ impl TransactionFileData {
         self
     }
 
-    pub(crate) fn add_auxiliary_payload(&mut self, data: Vec<u8>) {
+    pub(crate) fn add_auxiliary_payload(&mut self, data: impl Into<crate::Blob>) {
         self.auxiliary_payloads.push(BlobPayload::from_bytes(data));
     }
 

--- a/packages/engine/tests/correlated_live_state_perf.rs
+++ b/packages/engine/tests/correlated_live_state_perf.rs
@@ -554,7 +554,7 @@ async fn measure_update(
     for iteration in 0..warmups {
         let data = update_data(iteration);
         let result = session
-            .execute(update_sql, &[Value::Blob(data.clone())])
+            .execute(update_sql, &[Value::Blob(data.clone().into())])
             .await
             .expect("update warmup should succeed");
         assert_eq!(
@@ -570,7 +570,7 @@ async fn measure_update(
         let before = storage.stats();
         let started = Instant::now();
         let result = session
-            .execute(update_sql, &[Value::Blob(data.clone())])
+            .execute(update_sql, &[Value::Blob(data.clone().into())])
             .await
             .expect("timed update should succeed");
         let duration_ns = elapsed_ns(started);

--- a/packages/engine/tests/exact_file_read_benchmark.rs
+++ b/packages/engine/tests/exact_file_read_benchmark.rs
@@ -61,7 +61,7 @@ where
                 &[
                     Value::Text(file_id.to_string()),
                     Value::Text(path.to_string()),
-                    Value::Blob(bytes),
+                    Value::Blob(bytes.into()),
                 ],
             )
             .await

--- a/packages/engine/tests/execute_result_allocations.rs
+++ b/packages/engine/tests/execute_result_allocations.rs
@@ -94,7 +94,7 @@ fn execute_result_construction_and_clone_allocations() {
     for size_mib in [1_usize, 10] {
         let size_bytes = size_mib * 1024 * 1024;
         let columns = vec!["data".to_string()];
-        let rows = vec![vec![Value::Blob(vec![b'x'; size_bytes])]];
+        let rows = vec![vec![Value::Blob(vec![b'x'; size_bytes].into())]];
         let (result, construction) =
             measure_allocations(|| ExecuteResult::from_rows(columns, rows));
         let probe = result.clone();

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -343,7 +343,10 @@ async fn sql_plugin_archive_plain_insert_reuses_deterministic_file_id() {
     let error = session
         .execute(
             "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
-            &[Value::Text(path.to_string()), Value::Blob(archive.clone())],
+            &[
+                Value::Text(path.to_string()),
+                Value::Blob(archive.clone().into()),
+            ],
         )
         .await
         .expect_err("plain plugin archive insert should reject duplicate archive id");
@@ -402,7 +405,7 @@ async fn explicit_transaction_install_is_visible_to_later_plugin_write() {
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
         &[
             Value::Text("/.lix/plugins/plugin_sentinel.lixplugin".to_string()),
-            Value::Blob(sentinel_plugin_archive()),
+            Value::Blob(sentinel_plugin_archive().into()),
         ],
     )
     .await
@@ -411,7 +414,7 @@ async fn explicit_transaction_install_is_visible_to_later_plugin_write() {
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
         &[
             Value::Text("/same-transaction.sentinel".to_string()),
-            Value::Blob(b"hello".to_vec()),
+            Value::Blob(b"hello".to_vec().into()),
         ],
     )
     .await
@@ -450,7 +453,7 @@ async fn sql_update_path_to_plugin_storage_rejects_plugin_archive_rename() {
             "UPDATE lix_file SET path = $1, data = $2 WHERE path = $3",
             &[
                 Value::Text("/.lix/plugins/plugin_sentinel.lixplugin".to_string()),
-                Value::Blob(sentinel_plugin_archive()),
+                Value::Blob(sentinel_plugin_archive().into()),
                 Value::Text("/normal.txt".to_string()),
             ],
         )
@@ -825,7 +828,7 @@ async fn empty_regular_file_does_not_render_through_later_installed_plugin() {
         .await
         .expect("lix_file data read should succeed");
     assert_eq!(files.len(), 1);
-    assert_eq!(files.rows()[0].values(), &[Value::Blob(Vec::new())]);
+    assert_eq!(files.rows()[0].values(), &[Value::Blob(Vec::new().into())]);
     assert_eq!(runtime.render_calls.load(Ordering::SeqCst), 0);
 
     session.close().await.expect("session should close");
@@ -1338,7 +1341,7 @@ async fn lixray_batch_read_acknowledges_only_delivered_plugin_state() {
         delivered.rows()[0].values(),
         &[
             Value::Text("/shared.keyed".to_string()),
-            Value::Blob(b"root=0\nseen=S\n".to_vec()),
+            Value::Blob(b"root=0\nseen=S\n".to_vec().into()),
         ]
     );
 
@@ -1385,7 +1388,7 @@ async fn late_file_data_read_acknowledges_only_delivered_plugin_state() {
         delivered.rows()[0].values(),
         &[
             Value::Text("/shared.keyed".to_string()),
-            Value::Blob(b"root=0\nseen=S\n".to_vec()),
+            Value::Blob(b"root=0\nseen=S\n".to_vec().into()),
         ]
     );
 
@@ -1440,7 +1443,7 @@ async fn observe_point_read_acknowledges_delivered_plugin_state_per_session() {
         .expect("initial observation should be delivered");
     assert_eq!(
         initial.rows.rows()[0].values(),
-        &[Value::Blob(b"a=0\nb=0\n".to_vec())]
+        &[Value::Blob(b"a=0\nb=0\n".to_vec().into())]
     );
 
     write_file(&session_a, "/shared.keyed", b"a=A\nb=0\n".to_vec())
@@ -1524,7 +1527,7 @@ async fn observe_late_subscriber_acknowledges_fresh_plugin_incarnation_after_unc
         .expect("late initial snapshot should be delivered");
     assert_eq!(
         late_initial.rows.rows()[0].values(),
-        &[Value::Blob(b"a=0\n".to_vec())]
+        &[Value::Blob(b"a=0\n".to_vec().into())]
     );
 
     write_file(&session_a, "/shared.keyed", b"a=0\nb=remote\n".to_vec())
@@ -1742,10 +1745,10 @@ async fn multi_value_file_upsert_reconciles_each_plugin_file() {
                  data = excluded.data, lixcol_metadata = excluded.lixcol_metadata";
     let params = [
         Value::Text("/nested/first.sentinel".to_string()),
-        Value::Blob(b"first".to_vec()),
+        Value::Blob(b"first".to_vec().into()),
         Value::Json(json!({"size": 5})),
         Value::Text("/nested/second.sentinel".to_string()),
-        Value::Blob(b"second".to_vec()),
+        Value::Blob(b"second".to_vec().into()),
         Value::Json(json!({"size": 6})),
     ];
     session
@@ -2149,7 +2152,7 @@ where
         .execute_sql(
             "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
              ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-            &[Value::Text(path.to_string()), Value::Blob(data)],
+            &[Value::Text(path.to_string()), Value::Blob(data.into())],
         )
         .await?;
     Ok(())
@@ -2169,7 +2172,7 @@ where
         return Ok(None);
     };
     match row.values() {
-        [Value::Blob(data)] => Ok(Some(data.clone())),
+        [Value::Blob(data)] => Ok(Some(data.to_vec())),
         [Value::Null] => Ok(Some(Vec::new())),
         other => panic!("expected one blob data column, got {other:?}"),
     }

--- a/packages/engine/tests/plugin_registry_perf.rs
+++ b/packages/engine/tests/plugin_registry_perf.rs
@@ -576,7 +576,7 @@ async fn install_benchmark_plugin(
             "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
             &[
                 Value::Text("/.lix/plugins/plugin_perf.lixplugin".to_string()),
-                Value::Blob(benchmark_plugin_archive(path_glob, wasm_bytes)),
+                Value::Blob(benchmark_plugin_archive(path_glob, wasm_bytes).into()),
             ],
         )
         .await;
@@ -608,7 +608,7 @@ async fn execute_update(
     payload: Vec<u8>,
     expected_rows: usize,
 ) -> Duration {
-    let params = [Value::Blob(payload)];
+    let params = [Value::Blob(payload.into())];
     let started = Instant::now();
     let result = session.execute(sql, &params).await;
     let elapsed = started.elapsed();
@@ -638,7 +638,7 @@ async fn execute_read_render(
     for row in result.rows() {
         assert_eq!(
             row.values(),
-            &[Value::Blob(BENCH_RENDERED_BYTES.to_vec())],
+            &[Value::Blob(BENCH_RENDERED_BYTES.to_vec().into())],
             "timed rendered read must return deterministic component bytes"
         );
     }

--- a/packages/engine/tests/sql/delete_returning.rs
+++ b/packages/engine/tests/sql/delete_returning.rs
@@ -64,7 +64,7 @@ simulation_test!(
             deleted_file,
             vec![vec![
                 Value::Text("returning-file".to_string()),
-                Value::Blob(b"before".to_vec()),
+                Value::Blob(b"before".to_vec().into()),
             ]],
         );
 

--- a/packages/engine/tests/sql/errors.rs
+++ b/packages/engine/tests/sql/errors.rs
@@ -316,7 +316,7 @@ simulation_test!(
         );
 
         let error = session
-            .execute("SELECT length($1)", &[Value::Blob(vec![0xff])])
+            .execute("SELECT length($1)", &[Value::Blob(vec![0xff].into())])
             .await
             .expect_err("non-UTF-8 blob should fail as text");
 
@@ -349,7 +349,7 @@ simulation_test!(
         let error = session
             .execute(
                 "INSERT INTO lix_key_value (key, value) VALUES ('blob-value', $1)",
-                &[Value::Blob(vec![1, 2, 3, 255, 0, 128])],
+                &[Value::Blob(vec![1, 2, 3, 255, 0, 128].into())],
             )
             .await
             .expect_err("blob entity insert should fail cleanly");

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -62,7 +62,7 @@ simulation_test!(
             .execute("SELECT data FROM lix_file WHERE id = 'guarded-file'", &[])
             .await
             .expect("guarded file read should succeed");
-        assert_rows_eq(content, vec![vec![Value::Blob(b"after".to_vec())]]);
+        assert_rows_eq(content, vec![vec![Value::Blob(b"after".to_vec().into())]]);
     }
 );
 
@@ -187,7 +187,7 @@ simulation_test!(
             )
             .await
             .expect("updated file should be readable");
-        assert_rows_eq(content, vec![vec![Value::Blob(b"after".to_vec())]]);
+        assert_rows_eq(content, vec![vec![Value::Blob(b"after".to_vec().into())]]);
 
         let unicode_search = session
             .execute(
@@ -664,7 +664,7 @@ simulation_test!(
             &[
                 Value::Text("file-readme".to_string()),
                 Value::Text("/docs/guides/readme.md".to_string()),
-                Value::Blob(b"hello".to_vec()),
+                Value::Blob(b"hello".to_vec().into()),
                 Value::Text("lix_file_descriptor".to_string()),
             ]
         );
@@ -806,7 +806,7 @@ simulation_test!(
         assert!(!id.is_empty(), "defaulted file id should be non-empty");
         assert_eq!(path, "/docs/readme.md");
         assert_eq!(name, "readme.md");
-        assert_eq!(data, b"");
+        assert_eq!(data.as_ref(), b"");
 
         let null_result = session
             .execute(
@@ -857,7 +857,7 @@ simulation_test!(
         };
         assert!(!id.is_empty(), "defaulted file id should be non-empty");
         assert_eq!(path, "/docs/readme.md");
-        assert_eq!(data, b"hello");
+        assert_eq!(data.as_ref(), b"hello");
     }
 );
 
@@ -1102,7 +1102,7 @@ simulation_test!(
             )
             .await
             .expect("cast file read should succeed");
-        assert_rows_eq(result, vec![vec![Value::Blob(b"updated".to_vec())]]);
+        assert_rows_eq(result, vec![vec![Value::Blob(b"updated".to_vec().into())]]);
     }
 );
 
@@ -1124,7 +1124,7 @@ simulation_test!(
                 &[
                     Value::Text("anonymous-param-file".to_string()),
                     Value::Text("/anonymous-param.bin".to_string()),
-                    Value::Blob(b"anonymous".to_vec()),
+                    Value::Blob(b"anonymous".to_vec().into()),
                 ],
             )
             .await
@@ -1142,7 +1142,7 @@ simulation_test!(
             result,
             vec![vec![
                 Value::Text("/anonymous-param.bin".to_string()),
-                Value::Blob(b"anonymous".to_vec()),
+                Value::Blob(b"anonymous".to_vec().into()),
             ]],
         );
     }
@@ -1203,7 +1203,7 @@ simulation_test!(lix_file_insert_accepts_empty_blob_data, |sim| async move {
         .await
         .expect("file read should succeed");
     assert_eq!(result.len(), 1);
-    assert_eq!(result.rows()[0].values(), &[Value::Blob(Vec::new())]);
+    assert_eq!(result.rows()[0].values(), &[Value::Blob(Vec::new().into())]);
 
     let blob_ref_result = session
         .execute(
@@ -1233,7 +1233,7 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO lix_file (path, data) VALUES ('/x.bin', $1)",
-                &[Value::Blob(vec![1])],
+                &[Value::Blob(vec![1].into())],
             )
             .await
             .expect("first file path insert should succeed");
@@ -1241,7 +1241,7 @@ simulation_test!(
         let error = session
             .execute(
                 "INSERT INTO lix_file (path, data) VALUES ('/x.bin', $1)",
-                &[Value::Blob(vec![2])],
+                &[Value::Blob(vec![2].into())],
             )
             .await
             .expect_err("duplicate file path insert should be rejected");
@@ -1664,7 +1664,10 @@ simulation_test!(
             let error = session
                 .execute(
                     "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
-                    &[Value::Text(path.to_string()), Value::Blob(Vec::new())],
+                    &[
+                        Value::Text(path.to_string()),
+                        Value::Blob(Vec::new().into()),
+                    ],
                 )
                 .await
                 .expect_err("file path insert should reject dot segments");
@@ -1729,7 +1732,7 @@ simulation_test!(
         };
         assert!(!id.is_empty(), "defaulted file id should be non-empty");
         assert_eq!(path, "/docs/readme.md");
-        assert_eq!(data, b"hello");
+        assert_eq!(data.as_ref(), b"hello");
     }
 );
 
@@ -1780,7 +1783,7 @@ simulation_test!(lix_file_path_update_preserves_data, |sim| async move {
         &[
             Value::Text("file-readme".to_string()),
             Value::Text("/docs/readme-renamed.md".to_string()),
-            Value::Blob(b"hello".to_vec()),
+            Value::Blob(b"hello".to_vec().into()),
         ]
     );
 
@@ -1888,7 +1891,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("file-target".to_string()),
                 Value::Text("/archive/renamed.md".to_string()),
-                Value::Blob(b"target".to_vec()),
+                Value::Blob(b"target".to_vec().into()),
             ]],
         );
 
@@ -1903,7 +1906,7 @@ simulation_test!(
             unrelated,
             vec![vec![
                 Value::Text("/docs/other.md".to_string()),
-                Value::Blob(b"other".to_vec()),
+                Value::Blob(b"other".to_vec().into()),
             ]],
         );
     }
@@ -2046,11 +2049,11 @@ simulation_test!(
             vec![
                 vec![
                     Value::Text("/.lix/app_data/atelier/extensions/demo/a.js".to_string()),
-                    Value::Blob(b"a".to_vec()),
+                    Value::Blob(b"a".to_vec().into()),
                 ],
                 vec![
                     Value::Text("/.lix/app_data/atelier/extensions/demo/b.js".to_string()),
-                    Value::Blob(b"b".to_vec()),
+                    Value::Blob(b"b".to_vec().into()),
                 ],
             ],
         );
@@ -2159,7 +2162,10 @@ simulation_test!(
             .await
             .expect("file read should succeed");
         assert_eq!(result.len(), 1);
-        assert_eq!(result.rows()[0].values(), &[Value::Blob(b"hello".to_vec())]);
+        assert_eq!(
+            result.rows()[0].values(),
+            &[Value::Blob(b"hello".to_vec().into())]
+        );
     }
 );
 
@@ -2228,23 +2234,23 @@ simulation_test!(
             vec![
                 vec![
                     Value::Text("update-bool-file".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                 ],
                 vec![
                     Value::Text("update-float-file".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                 ],
                 vec![
                     Value::Text("update-int-file".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                 ],
                 vec![
                     Value::Text("update-text-file".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                 ],
                 vec![
                     Value::Text("update-text-function-file".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                 ],
             ],
         );
@@ -2302,11 +2308,11 @@ simulation_test!(
             vec![
                 vec![
                     Value::Text("update-int-param-file".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                 ],
                 vec![
                     Value::Text("update-text-param-file".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                 ],
             ],
         );
@@ -2349,7 +2355,7 @@ simulation_test!(lix_file_update_accepts_empty_blob_data, |sim| async move {
         .await
         .expect("file read should succeed");
     assert_eq!(result.len(), 1);
-    assert_eq!(result.rows()[0].values(), &[Value::Blob(Vec::new())]);
+    assert_eq!(result.rows()[0].values(), &[Value::Blob(Vec::new().into())]);
 
     let blob_ref_result = session
         .execute(
@@ -2387,7 +2393,7 @@ simulation_test!(
                 upsert,
                 &[
                     Value::Text("/equal-metadata.bin".to_string()),
-                    Value::Blob(b"before".to_vec()),
+                    Value::Blob(b"before".to_vec().into()),
                     Value::Json(metadata.clone()),
                 ],
             )
@@ -2409,7 +2415,7 @@ simulation_test!(
                 upsert,
                 &[
                     Value::Text("/equal-metadata.bin".to_string()),
-                    Value::Blob(b"after".to_vec()),
+                    Value::Blob(b"after".to_vec().into()),
                     Value::Json(metadata.clone()),
                 ],
             )
@@ -2431,7 +2437,7 @@ simulation_test!(
             .expect("updated file should load");
         assert_eq!(
             current.rows()[0].values(),
-            &[Value::Blob(b"after".to_vec()), Value::Json(metadata),]
+            &[Value::Blob(b"after".to_vec().into()), Value::Json(metadata),]
         );
         assert_eq!(
             file_descriptor_event_count(&session, &commit_id, file_id).await,
@@ -2461,7 +2467,7 @@ simulation_test!(
                 upsert,
                 &[
                     Value::Text("/changed-metadata.bin".to_string()),
-                    Value::Blob(b"one".to_vec()),
+                    Value::Blob(b"one".to_vec().into()),
                     Value::Json(json!({"version": 1})),
                 ],
             )
@@ -2483,7 +2489,7 @@ simulation_test!(
                 upsert,
                 &[
                     Value::Text("/changed-metadata.bin".to_string()),
-                    Value::Blob(b"two".to_vec()),
+                    Value::Blob(b"two".to_vec().into()),
                     Value::Json(json!({"version": 2})),
                 ],
             )
@@ -2504,7 +2510,7 @@ simulation_test!(
                 upsert,
                 &[
                     Value::Text("/changed-metadata.bin".to_string()),
-                    Value::Blob(b"three".to_vec()),
+                    Value::Blob(b"three".to_vec().into()),
                     Value::Null,
                 ],
             )
@@ -2525,7 +2531,7 @@ simulation_test!(
                 upsert,
                 &[
                     Value::Text("/changed-metadata.bin".to_string()),
-                    Value::Blob(b"four".to_vec()),
+                    Value::Blob(b"four".to_vec().into()),
                     Value::Null,
                 ],
             )
@@ -2550,7 +2556,7 @@ simulation_test!(
             .expect("null-metadata file should load");
         assert_eq!(
             current.rows()[0].values(),
-            &[Value::Blob(b"four".to_vec()), Value::Null]
+            &[Value::Blob(b"four".to_vec().into()), Value::Null]
         );
     }
 );
@@ -2781,7 +2787,7 @@ simulation_test!(
                 Value::Text("file-readme".to_string()),
                 Value::Text("/scratch/readme.md".to_string()),
                 Value::Text("dir-scratch".to_string()),
-                Value::Blob(b"hello".to_vec()),
+                Value::Blob(b"hello".to_vec().into()),
             ]],
         );
     }
@@ -2898,7 +2904,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("file-upsert".to_string()),
                 Value::Text("/docs/upsert.md".to_string()),
-                Value::Blob(b"new".to_vec()),
+                Value::Blob(b"new".to_vec().into()),
             ]],
         );
     }
@@ -2948,7 +2954,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("file-nothing".to_string()),
                 Value::Text("/docs/nothing.md".to_string()),
-                Value::Blob(b"keep".to_vec()),
+                Value::Blob(b"keep".to_vec().into()),
             ]],
         );
     }
@@ -2989,7 +2995,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("file-fresh".to_string()),
                 Value::Text("/docs/fresh.md".to_string()),
-                Value::Blob(b"new".to_vec()),
+                Value::Blob(b"new".to_vec().into()),
             ]],
         );
     }
@@ -3029,7 +3035,7 @@ simulation_test!(
             read,
             vec![vec![
                 Value::Text("/docs/path-fresh.md".to_string()),
-                Value::Blob(b"new".to_vec()),
+                Value::Blob(b"new".to_vec().into()),
             ]],
         );
     }
@@ -3079,7 +3085,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("file-path-upsert".to_string()),
                 Value::Text("/docs/path-upsert.md".to_string()),
-                Value::Blob(b"new".to_vec()),
+                Value::Blob(b"new".to_vec().into()),
             ]],
         );
 
@@ -3156,7 +3162,7 @@ simulation_test!(
             read,
             vec![vec![
                 Value::Text("file-branch-path-upsert".to_string()),
-                Value::Blob(b"new".to_vec()),
+                Value::Blob(b"new".to_vec().into()),
             ]],
         );
     }
@@ -3300,7 +3306,7 @@ simulation_test!(
             read,
             vec![vec![
                 Value::Text("file-global-path-upsert".to_string()),
-                Value::Blob(b"new".to_vec()),
+                Value::Blob(b"new".to_vec().into()),
                 Value::Boolean(true),
                 Value::Text("global".to_string()),
             ]],
@@ -3401,7 +3407,7 @@ simulation_test!(
             first_read,
             vec![vec![
                 Value::Text("transaction-target".to_string()),
-                Value::Blob(b"after".to_vec()),
+                Value::Blob(b"after".to_vec().into()),
             ]],
         );
 
@@ -3420,7 +3426,10 @@ simulation_test!(
             )
             .await
             .expect("repeated transaction path lookup should succeed");
-        assert_rows_eq(repeated_read, vec![vec![Value::Blob(b"again".to_vec())]]);
+        assert_rows_eq(
+            repeated_read,
+            vec![vec![Value::Blob(b"again".to_vec().into())]],
+        );
 
         let error = transaction
             .execute(
@@ -3443,7 +3452,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("transaction-target".to_string()),
                 Value::Text("/docs/target.md".to_string()),
-                Value::Blob(b"again".to_vec()),
+                Value::Blob(b"again".to_vec().into()),
             ]],
         );
 
@@ -3463,7 +3472,7 @@ simulation_test!(
             rolled_back,
             vec![vec![
                 Value::Text("transaction-target".to_string()),
-                Value::Blob(b"before".to_vec()),
+                Value::Blob(b"before".to_vec().into()),
             ]],
         );
         let anchor = session

--- a/packages/engine/tests/sql/lix_file_history.rs
+++ b/packages/engine/tests/sql/lix_file_history.rs
@@ -79,7 +79,7 @@ simulation_test!(
                     Value::Text("history-file".to_string()),
                     Value::Text("/docs/readme-renamed.md".to_string()),
                     Value::Text("readme-renamed.md".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                     Value::Text(second_commit_id.clone()),
                     Value::Integer(0),
                 ],
@@ -87,7 +87,7 @@ simulation_test!(
                     Value::Text("history-file".to_string()),
                     Value::Text("/docs/guides/readme.md".to_string()),
                     Value::Text("readme.md".to_string()),
-                    Value::Blob(b"hello".to_vec()),
+                    Value::Blob(b"hello".to_vec().into()),
                     Value::Text(second_commit_id.clone()),
                     Value::Integer(1),
                 ],
@@ -174,7 +174,7 @@ simulation_test!(
             result,
             vec![vec![
                 Value::Text("/empty-history.txt".to_string()),
-                Value::Blob(Vec::new()),
+                Value::Blob(Vec::new().into()),
             ]],
         );
     }
@@ -227,12 +227,12 @@ simulation_test!(lix_file_history_reads_bound_id_in_list, |sim| async move {
             vec![
                 Value::Text("history-in-a".to_string()),
                 Value::Text("/history/in-a.txt".to_string()),
-                Value::Blob(b"a".to_vec()),
+                Value::Blob(b"a".to_vec().into()),
             ],
             vec![
                 Value::Text("history-in-b".to_string()),
                 Value::Text("/history/in-b.txt".to_string()),
-                Value::Blob(b"b".to_vec()),
+                Value::Blob(b"b".to_vec().into()),
             ],
         ],
     );
@@ -344,7 +344,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("zzz-history-target".to_string()),
                 Value::Text("/target/three.txt".to_string()),
-                Value::Blob(b"three".to_vec()),
+                Value::Blob(b"three".to_vec().into()),
             ]],
         );
     }
@@ -369,7 +369,7 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
             "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
             &[
                 Value::Text("/.lix/plugins/plugin_history_render.lixplugin".to_string()),
-                Value::Blob(history_render_plugin_archive()),
+                Value::Blob(history_render_plugin_archive().into()),
             ],
         )
         .await
@@ -379,7 +379,7 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
             "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
             &[
                 Value::Text("/note.history-render".to_string()),
-                Value::Blob(b"first".to_vec()),
+                Value::Blob(b"first".to_vec().into()),
             ],
         )
         .await
@@ -388,7 +388,7 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
         .execute(
             "UPDATE lix_file SET data = $1 WHERE path = $2",
             &[
-                Value::Blob(b"second".to_vec()),
+                Value::Blob(b"second".to_vec().into()),
                 Value::Text("/note.history-render".to_string()),
             ],
         )
@@ -447,12 +447,12 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
         vec![
             vec![
                 Value::Text("/note.history-render".to_string()),
-                Value::Blob(b"rendered:second-a|second-b".to_vec()),
+                Value::Blob(b"rendered:second-a|second-b".to_vec().into()),
                 Value::Integer(1),
             ],
             vec![
                 Value::Text("/note.history-render".to_string()),
-                Value::Blob(b"rendered:first-a|first-b".to_vec()),
+                Value::Blob(b"rendered:first-a|first-b".to_vec().into()),
                 Value::Integer(2),
             ],
         ],
@@ -477,7 +477,7 @@ async fn lix_file_history_renders_plugin_state_at_each_depth() {
     assert_rows_eq(
         depth_filtered,
         vec![vec![
-            Value::Blob(b"rendered:second-a|second-b".to_vec()),
+            Value::Blob(b"rendered:second-a|second-b".to_vec().into()),
             Value::Integer(1),
         ]],
     );
@@ -571,7 +571,7 @@ simulation_test!(
             result,
             vec![vec![
                 Value::Text("/ordinary-history.txt".to_string()),
-                Value::Blob(b"hello".to_vec()),
+                Value::Blob(b"hello".to_vec().into()),
                 Value::Integer(1),
             ]],
         );
@@ -725,7 +725,7 @@ simulation_test!(
             vec![vec![
                 Value::Text("history-file-blob-filter".to_string()),
                 Value::Text("/docs/blob-filter.txt".to_string()),
-                Value::Blob(b"blob2".to_vec()),
+                Value::Blob(b"blob2".to_vec().into()),
                 Value::Text("lix_file_descriptor".to_string()),
             ]],
         );

--- a/packages/engine/tests/sql/read_only.rs
+++ b/packages/engine/tests/sql/read_only.rs
@@ -213,7 +213,10 @@ simulation_test!(read_only_binary_blob_ref_rejects_writes, |sim| async move {
         .execute("SELECT data FROM lix_file WHERE id = 'file-with-data'", &[])
         .await
         .expect("file data should still be readable");
-    assert_eq!(data.rows()[0].values(), &[Value::Blob(vec![0x41, 0x42])]);
+    assert_eq!(
+        data.rows()[0].values(),
+        &[Value::Blob(vec![0x41, 0x42].into())]
+    );
 });
 
 simulation_test!(
@@ -381,7 +384,7 @@ simulation_test!(
                 &[
                     Value::Text("fresh-snapshot-file".to_string()),
                     Value::Text("/fresh-snapshot.txt".to_string()),
-                    Value::Blob(b"fresh".to_vec()),
+                    Value::Blob(b"fresh".to_vec().into()),
                 ],
             )
             .await
@@ -391,7 +394,10 @@ simulation_test!(
             .execute(select_sql, &params)
             .await
             .expect("repeated syntax should use a fresh provider snapshot");
-        assert_eq!(after.rows()[0].values(), &[Value::Blob(b"fresh".to_vec())]);
+        assert_eq!(
+            after.rows()[0].values(),
+            &[Value::Blob(b"fresh".to_vec().into())]
+        );
     }
 );
 

--- a/packages/engine/tests/support/simulation_test/engine/simulation.rs
+++ b/packages/engine/tests/support/simulation_test/engine/simulation.rs
@@ -243,7 +243,7 @@ impl SimFs {
             .execute(
                 "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
                  ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-                &[Value::Text(path.to_string()), Value::Blob(data)],
+                &[Value::Text(path.to_string()), Value::Blob(data.into())],
             )
             .await
             .map(|_| ());

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -1754,7 +1754,7 @@ impl TryFrom<LixValue> for Value {
                         "blob value must include bytes",
                     )
                 })?;
-                Ok(Self::Blob(bytes.to_vec()))
+                Ok(Self::Blob(bytes.to_vec().into()))
             }
             other => Err(LixError::new(
                 LixError::CODE_INVALID_PARAM,
@@ -1810,7 +1810,7 @@ impl TryFrom<&Value> for LixValue {
             Value::Blob(value) => Ok(Self {
                 kind: "blob".to_string(),
                 value: None,
-                blob: Some(Buffer::from(value.clone())),
+                blob: Some(Buffer::from(value.to_vec())),
             }),
         }
     }

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -669,7 +669,7 @@ impl TryFrom<LixValueDto> for Value {
             "json" => Ok(Self::Json(value.value.unwrap_or(serde_json::Value::Null))),
             "blob" => value
                 .blob
-                .map(|bytes| Self::Blob(bytes.into_vec()))
+                .map(|bytes| Self::Blob(bytes.into_vec().into()))
                 .ok_or_else(|| invalid_param("blob value must include bytes")),
             other => Err(invalid_param(format!("unsupported LixValue kind: {other}"))),
         }
@@ -690,7 +690,7 @@ impl TryFrom<&Value> for LixValueDto {
             Value::Real(_) => return Err(invalid_param("cannot encode non-finite real value")),
             Value::Text(value) => ("text", Some(serde_json::json!(value)), None),
             Value::Json(value) => ("json", Some(value.clone()), None),
-            Value::Blob(value) => ("blob", None, Some(ByteBuf::from(value.clone()))),
+            Value::Blob(value) => ("blob", None, Some(ByteBuf::from(value.to_vec()))),
         };
         Ok(Self {
             kind: kind.to_string(),

--- a/packages/rs-sdk-tests/benches/e2e.rs
+++ b/packages/rs-sdk-tests/benches/e2e.rs
@@ -392,7 +392,7 @@ impl BenchLix {
         self.execute(
             "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
              ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-            &[Value::Text(path.to_string()), Value::Blob(data)],
+            &[Value::Text(path.to_string()), Value::Blob(data.into())],
         )
         .await?;
         Ok(())
@@ -533,7 +533,7 @@ where
          ON CONFLICT (path) DO UPDATE SET data = excluded.data",
         &[
             Value::Text(format!("/.lix/plugins/{key}.lixplugin")),
-            Value::Blob(archive.to_vec()),
+            Value::Blob(archive.to_vec().into()),
         ],
     )
     .await?;

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -107,7 +107,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
         files.rows()[0].values(),
         &[
             Value::Text("/people.csv".to_string()),
-            Value::Blob(updated_csv.clone())
+            Value::Blob(updated_csv.clone().into())
         ]
     );
 
@@ -121,7 +121,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
     assert_eq!(files_by_id.len(), 1);
     assert_eq!(
         files_by_id.rows()[0].values(),
-        &[Value::Blob(updated_csv.clone())]
+        &[Value::Blob(updated_csv.clone().into())]
     );
 
     let file_changes_before_empty = file_changes(&lix, &file_id).await;
@@ -143,7 +143,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
     assert_eq!(files_empty_by_id.len(), 1);
     assert_eq!(
         files_empty_by_id.rows()[0].values(),
-        &[Value::Blob(empty_csv)]
+        &[Value::Blob(empty_csv.into())]
     );
     let empty_changes = file_changes(&lix, &file_id)
         .await
@@ -161,7 +161,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
         &[
             Value::Text("/sql-people.csv".to_string()),
-            Value::Blob(sql_csv.clone()),
+            Value::Blob(sql_csv.clone().into()),
         ],
     )
     .await
@@ -202,7 +202,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
     lix.execute(
         "UPDATE lix_file SET data = $1 WHERE path = $2",
         &[
-            Value::Blob(sql_updated_csv.clone()),
+            Value::Blob(sql_updated_csv.clone().into()),
             Value::Text("/sql-people.csv".to_string()),
         ],
     )
@@ -240,9 +240,9 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
     lix.execute(
         "UPDATE lix_file SET data = $1 WHERE path = $2 AND data = $3",
         &[
-            Value::Blob(sql_predicate_updated_csv.clone()),
+            Value::Blob(sql_predicate_updated_csv.clone().into()),
             Value::Text("/sql-people.csv".to_string()),
-            Value::Blob(sql_updated_csv.clone()),
+            Value::Blob(sql_updated_csv.clone().into()),
         ],
     )
     .await
@@ -279,7 +279,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
         &[
             Value::Text("/sql-empty.csv".to_string()),
-            Value::Blob(sql_empty_target),
+            Value::Blob(sql_empty_target.into()),
         ],
     )
     .await
@@ -298,7 +298,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
     lix.execute(
         "UPDATE lix_file SET data = $1 WHERE path = $2",
         &[
-            Value::Blob(sql_empty_bytes.clone()),
+            Value::Blob(sql_empty_bytes.clone().into()),
             Value::Text("/sql-empty.csv".to_string()),
         ],
     )
@@ -324,7 +324,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
         &[
             Value::Text("/sql-rename.csv".to_string()),
-            Value::Blob(sql_rename_csv.clone()),
+            Value::Blob(sql_rename_csv.clone().into()),
         ],
     )
     .await
@@ -364,7 +364,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
     assert_eq!(renamed_files.len(), 1);
     assert_eq!(
         renamed_files.rows()[0].values(),
-        &[Value::Blob(sql_rename_csv.clone())]
+        &[Value::Blob(sql_rename_csv.clone().into())]
     );
     let active_plugin_rows_after_rename = lix
         .execute(
@@ -391,7 +391,7 @@ async fn rs_sdk_installs_built_csv_plugin_archive_and_uses_schema() {
         "DELETE FROM lix_file WHERE path = $1 AND data = $2",
         &[
             Value::Text("/sql-people.csv".to_string()),
-            Value::Blob(sql_predicate_updated_csv),
+            Value::Blob(sql_predicate_updated_csv.into()),
         ],
     )
     .await
@@ -458,7 +458,7 @@ async fn transaction_lix_file_data_uses_session_plugin_runtime() {
         .unwrap();
 
     assert_eq!(files.len(), 1);
-    assert_eq!(files.rows()[0].values(), &[Value::Blob(csv)]);
+    assert_eq!(files.rows()[0].values(), &[Value::Blob(csv.into())]);
 
     tx.rollback().await.unwrap();
     lix.close().await.unwrap();
@@ -571,7 +571,7 @@ where
     lix.execute(
         "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
          ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-        &[Value::Text(path.to_string()), Value::Blob(data)],
+        &[Value::Text(path.to_string()), Value::Blob(data.into())],
     )
     .await?;
     Ok(())

--- a/packages/rs-sdk/benches/profile_merge_10k.rs
+++ b/packages/rs-sdk/benches/profile_merge_10k.rs
@@ -111,7 +111,7 @@ async fn write_file(lix: &lix_sdk::Lix<SQLite>, path: &str, data: Vec<u8>) {
     lix.execute(
         "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
          ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-        &[Value::Text(path.to_string()), Value::Blob(data)],
+        &[Value::Text(path.to_string()), Value::Blob(data.into())],
     )
     .await
     .unwrap();

--- a/packages/rs-sdk/src/filesystem.rs
+++ b/packages/rs-sdk/src/filesystem.rs
@@ -1011,7 +1011,7 @@ where
             let mut params = Vec::with_capacity(chunk.len() * 2);
             for (path, data) in chunk {
                 params.push(Value::Text((*path).to_string()));
-                params.push(Value::Blob((*data).to_vec()));
+                params.push(Value::Blob((*data).to_vec().into()));
             }
             self.session.execute(&sql, &params).await?;
             start = end;
@@ -2551,7 +2551,7 @@ mod tests {
             .execute(
                 "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
              ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-                &[Value::Text(path.to_string()), Value::Blob(data)],
+                &[Value::Text(path.to_string()), Value::Blob(data.into())],
             )
             .await?;
         Ok(())
@@ -3010,7 +3010,7 @@ mod tests {
             "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
             &[
                 Value::Text("/.lix/app_data/test.bin".to_string()),
-                Value::Blob(b"plugin".to_vec()),
+                Value::Blob(b"plugin".to_vec().into()),
             ],
         )
         .await

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -400,7 +400,10 @@ async fn transaction_lix_file_data_reads_staged_file_bytes() {
 
     tx.execute(
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
-        &[Value::Text(path.clone()), Value::Blob(original.clone())],
+        &[
+            Value::Text(path.clone()),
+            Value::Blob(original.clone().into()),
+        ],
     )
     .await
     .unwrap();
@@ -408,14 +411,17 @@ async fn transaction_lix_file_data_reads_staged_file_bytes() {
     let selected = tx
         .execute(
             "SELECT data FROM lix_file WHERE path = $1 AND data = $2",
-            &[Value::Text(path.clone()), Value::Blob(original.clone())],
+            &[
+                Value::Text(path.clone()),
+                Value::Blob(original.clone().into()),
+            ],
         )
         .await
         .unwrap();
     assert_eq!(selected.len(), 1);
     assert_eq!(
         selected.rows()[0].values(),
-        &[Value::Blob(original.clone())]
+        &[Value::Blob(original.clone().into())]
     );
 
     let updated = b"updated bytes before commit".to_vec();
@@ -423,9 +429,9 @@ async fn transaction_lix_file_data_reads_staged_file_bytes() {
         .execute(
             "UPDATE lix_file SET data = $1 WHERE path = $2 AND data = $3",
             &[
-                Value::Blob(updated.clone()),
+                Value::Blob(updated.clone().into()),
                 Value::Text(path.clone()),
-                Value::Blob(original),
+                Value::Blob(original.into()),
             ],
         )
         .await
@@ -435,20 +441,23 @@ async fn transaction_lix_file_data_reads_staged_file_bytes() {
     let after_update = tx
         .execute(
             "SELECT data FROM lix_file WHERE path = $1 AND data = $2",
-            &[Value::Text(path.clone()), Value::Blob(updated.clone())],
+            &[
+                Value::Text(path.clone()),
+                Value::Blob(updated.clone().into()),
+            ],
         )
         .await
         .unwrap();
     assert_eq!(after_update.len(), 1);
     assert_eq!(
         after_update.rows()[0].values(),
-        &[Value::Blob(updated.clone())]
+        &[Value::Blob(updated.clone().into())]
     );
 
     let delete = tx
         .execute(
             "DELETE FROM lix_file WHERE path = $1 AND data = $2",
-            &[Value::Text(path.clone()), Value::Blob(updated)],
+            &[Value::Text(path.clone()), Value::Blob(updated.into())],
         )
         .await
         .unwrap();
@@ -747,7 +756,7 @@ where
     lix.execute(
         "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
          ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-        &[Value::Text(path.to_string()), Value::Blob(data)],
+        &[Value::Text(path.to_string()), Value::Blob(data.into())],
     )
     .await?;
     Ok(())
@@ -949,7 +958,7 @@ async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
         &[
             Value::Text("/sql.txt".to_string()),
-            Value::Blob(b"sql".to_vec()),
+            Value::Blob(b"sql".to_vec().into()),
         ],
     )
     .await
@@ -959,7 +968,7 @@ async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
     lix.execute(
         "UPDATE lix_file SET data = $1 WHERE path = $2",
         &[
-            Value::Blob(b"updated".to_vec()),
+            Value::Blob(b"updated".to_vec().into()),
             Value::Text("/sql.txt".to_string()),
         ],
     )
@@ -972,7 +981,7 @@ async fn filesystem_materializes_sdk_sql_and_transaction_writes() {
         "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
         &[
             Value::Text("/tx.txt".to_string()),
-            Value::Blob(b"tx".to_vec()),
+            Value::Blob(b"tx".to_vec().into()),
         ],
     )
     .await
@@ -1095,7 +1104,7 @@ async fn filesystem_materializes_untracked_sdk_sql_writes() {
         &[
             Value::Text("file-untracked".to_string()),
             Value::Text("/untracked.txt".to_string()),
-            Value::Blob(b"untracked".to_vec()),
+            Value::Blob(b"untracked".to_vec().into()),
         ],
     )
     .await

--- a/packages/rs-sdk/tests/sqlite.rs
+++ b/packages/rs-sdk/tests/sqlite.rs
@@ -174,7 +174,7 @@ where
     lix.execute(
         "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
          ON CONFLICT (path) DO UPDATE SET data = excluded.data",
-        &[Value::Text(path.to_string()), Value::Blob(data)],
+        &[Value::Text(path.to_string()), Value::Blob(data.into())],
     )
     .await?;
     Ok(())

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -1434,7 +1434,7 @@ fn decode_request_params(
                     cache_candidate_bytes_remaining,
                     cache_candidates,
                 );
-                values.push(Value::Blob(reconstructed));
+                values.push(Value::Blob(reconstructed.into()));
             }
         }
     }
@@ -2017,7 +2017,7 @@ fn single_blob_splice(
     }
     let WireValue::Blob {
         base64: insert_base64,
-    } = WireValue::try_from_engine(&Value::Blob(insert.to_vec()))?
+    } = WireValue::try_from_engine(&Value::Blob(insert.to_vec().into()))?
     else {
         unreachable!("blob wire conversion must return a blob")
     };
@@ -2322,8 +2322,8 @@ mod tests {
     }
 
     fn wire_blob_json(bytes: &[u8]) -> JsonValue {
-        let value =
-            WireValue::try_from_engine(&Value::Blob(bytes.to_vec())).expect("blob should encode");
+        let value = WireValue::try_from_engine(&Value::Blob(bytes.to_vec().into()))
+            .expect("blob should encode");
         serde_json::to_value(value).expect("wire blob should serialize")
     }
 
@@ -3058,7 +3058,7 @@ mod tests {
     async fn default_body_limit_accepts_blobs_larger_than_axums_two_megabyte_default() {
         let app = app().await;
         let (session_id, _) = new_session(&app.router).await;
-        let blob = WireValue::try_from_engine(&Value::Blob(vec![0x41; 2 * 1024 * 1024]))
+        let blob = WireValue::try_from_engine(&Value::Blob(vec![0x41; 2 * 1024 * 1024].into()))
             .expect("large blob should encode");
         let response = request(
             &app.router,
@@ -3254,7 +3254,7 @@ mod tests {
             mutation_sequence: sequence,
             rows: ExecuteResult::from_rows(
                 vec!["data".to_string()],
-                vec![vec![Value::Blob(bytes)]],
+                vec![vec![Value::Blob(bytes.into())]],
             ),
         }
     }


### PR DESCRIPTION
## Summary

- replace the Rust `Value::Blob(Vec<u8>)` API with an immutable `Blob(Bytes)` newtype
- carry shared blob storage through query parameters, observe keys, exact `lix_file` writes, transaction staging, and CAS payloads
- keep explicit owned-vector copies only at Arrow, N-API, and WASM boundaries that require them
- intentionally break Rust construction APIs; JS `Uint8Array` and the JSON/base64 wire format are unchanged

## Evidence

Warmed 2/4/8 MiB high-entropy `lix_file` writes showed the following allocation-churn reduction after removing the parameter-vector and fast-write payload clones:

| payload | direct engine | HTTP end-to-end |
|---:|---:|---:|
| 2 MiB | **-46.6%** | **-30.3%** |
| 4 MiB | **-54.8%** | **-32.8%** |
| 8 MiB | **-60.1%** | **-34.9%** |

A 100-clone microbenchmark took 16.65/25.36/33.94 ms with `Vec<u8>` and 0.004–0.008 ms with the immutable blob representation. The deterministic allocation test also reports zero allocations and zero payload bytes copied when cloning 1 MiB and 10 MiB results.

This follows the immutable, reference-counted buffer model used by `bytes`, Arrow, and other analytical/storage engines: ownership is transferred once at ingress and clones share the backing allocation.

## Breaking API

Rust callers now construct blobs with an explicit conversion:

```rust
Value::Blob(bytes.into())
```

`Blob::from_static`, `AsRef<[u8]>`, `Deref<Target = [u8]>`, `Blob::into_bytes`, and `TryFromValue` implementations for `Blob`, `Bytes`, and `Vec<u8>` cover the common read paths.

This does not change the physical Lix storage format, CAS hashes, compression, protocol encoding, or JS value shape, so no stored-data migration is required.

## Validation

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-targets`
- blob clone-sharing, wire round-trip, and `ExecuteResult` backing tests
- ignored deterministic allocation diagnostic at 1 MiB and 10 MiB
- `node scripts/validate-changes.mjs`
