### PR TITLE
fix!(sql): propagate ancestor directory history

### DIFF
--- a/.changenotes/fix-filesystem-history-dag-reconstruction.md
+++ b/.changenotes/fix-filesystem-history-dag-reconstruction.md
@@ -13,5 +13,3 @@ Exact public `id` predicates are routed through observed-state descriptor, blob,
 The composed histories now expose `lixcol_source_changes`, a non-null JSON array ordered by change ID. Each element mirrors the stable `lix_change` payload fields: `id`, `entity_pk`, `schema_key`, `file_id`, `snapshot_content`, `metadata`, `created_at`, and `origin_key`. Multiple source changes in one commit produce one logical revision with every source in this array.
 
 This is a breaking SQL catalog change. The misleading singular `lixcol_schema_key`, `lixcol_file_id`, `lixcol_snapshot_content`, `lixcol_change_id`, `lixcol_origin_key`, and `lixcol_metadata` columns were removed from the composed filesystem histories. Inspect the structured `lixcol_source_changes` objects, or join their `id` fields to `lix_change`, when raw provenance is required.
-
-Recursive propagation of an ancestor-directory rename, move, or deletion to every descendant file revision is intentionally not part of this change. This history surface currently emits directory projection events only for a file's directly referenced directory; full ancestor propagation remains follow-up work.

--- a/.changenotes/propagate-ancestor-directory-history.md
+++ b/.changenotes/propagate-ancestor-directory-history.md
@@ -1,0 +1,19 @@
+---
+type: patch
+---
+
+Fixed `lix_file_history` and `lix_directory_history` so changes to an ancestor
+directory produce revisions for every affected descendant.
+
+Ancestor renames, subtree moves, deletions, and restorations now revise the
+composed `path` of nested files and directories without changing their stable
+`id`. Each revision is reconstructed from the exact observed commit and its
+direct-parent roots, preserving distinct sibling revisions in a commit DAG.
+
+`lixcol_source_changes` now includes every same-commit ancestor descriptor that
+shaped the descendant projection. Recursive deletion rows retain both the
+descendant's direct tombstone and the tombstones of its deleted ancestors.
+
+Exact `id` queries keep observed and direct-parent reconstruction scoped to the
+selected file and its ancestor chain instead of rescanning unrelated filesystem
+state.

--- a/docs/history.md
+++ b/docs/history.md
@@ -101,6 +101,15 @@ ORDER BY depth, schema_key, entity_pk;
 
 `depth = 0` is the current state of that version. Higher depths walk back through earlier commits. Filter by `schema_key` or `entity_pk` to narrow.
 
+For filesystem history, `lix_file_history` and `lix_directory_history` expose
+logical projection revisions. A directory change is visible in every
+descendant whose composed path depends on that directory, even when the
+descendant's own descriptor did not change. Rows keep immutable file or
+directory identity and list all same-commit causes in
+`lixcol_source_changes`. Deletions use the exact direct-parent roots to retain
+ancestor tombstones in descendant provenance; merge siblings are never inferred
+from depth.
+
 ### Diff one entity between two versions
 
 ```sql

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -113,6 +113,13 @@ When you need the typed columns, reach for the per-entity sugar. When you're que
 
 User columns: `id`, `path`, `directory_id`, `name`, `data`. System columns are `lixcol_*` (`lixcol_version_id` on `_by_version`; `lixcol_start_commit_id`, `lixcol_depth`, `lixcol_observed_commit_id` on `_history`).
 
+`lix_file_history` records changes to the composed file projection, not only
+changes to the file descriptor or bytes. Renaming, moving, deleting, or
+restoring any ancestor directory creates a revision for every affected
+descendant file. The file `id` remains stable while `path` reflects the exact
+observed commit. `lixcol_source_changes` contains the descriptor, blob, plugin,
+and ancestor-directory changes combined into that logical revision.
+
 ```sql
 -- Write a file into the active version
 INSERT INTO lix_file (path, data)
@@ -147,6 +154,11 @@ Same shape as files, minus the `data` column.
 | `lix_directory_history` | Directory history walked through commits. |
 
 User columns: `id`, `path`, `parent_id`, `name`. Same `lixcol_*` system columns as files. Directory paths must end with a trailing slash (`/data/`, not `/data`).
+
+Directory history uses the same composed-projection rule: an ancestor rename,
+move, deletion, or restoration creates a revision for each descendant
+directory whose `path` changed. Recursive deletion provenance includes both a
+descendant's own tombstone and the tombstones of deleted ancestors.
 
 Inserting a `lix_file` at `/a/b/c.txt` auto-creates `lix_directory` rows for `/a/` and `/a/b/` if they don't already exist; you only need to insert directories explicitly when you want them to exist before any file does.
 

--- a/packages/engine/src/sql2/providers/directory_history.rs
+++ b/packages/engine/src/sql2/providers/directory_history.rs
@@ -31,7 +31,8 @@ use crate::sql2::history_route::{
     serialize_history_source_changes,
 };
 use crate::sql2::providers::filesystem_history_path::{
-    HistoryDirectoryPathRecord, resolve_history_directory_path,
+    HistoryDirectoryPathRecord, HistoryDirectoryTree, load_history_commit_parents,
+    resolve_history_directory_path,
 };
 use crate::sql2::result_metadata::json_field;
 use crate::storage_adapter::StorageAdapterRead;
@@ -208,7 +209,7 @@ where
             view_name: "lix_directory_history",
             start_commit_column: HISTORY_COL_START_COMMIT_ID,
         },
-        commit_graph,
+        Arc::clone(&commit_graph),
         query_source.json_reader.clone(),
         &event_route,
         vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
@@ -216,13 +217,30 @@ where
     )
     .await?;
     let event_descriptors = parse_directory_history_records(&event_entries)?;
-    let events = grouped_directory_history_events(&event_descriptors);
-    let observed_commit_ids = events
+    let parent_commit_ids_by_commit =
+        load_history_commit_parents(&commit_graph, &event_route.start_commit_ids).await?;
+    let mut observed_commit_ids = event_descriptors
         .iter()
-        .map(|event| event.observed_commit_id.clone())
+        .map(|record| record.entry.observed_commit_id.clone())
         .collect::<BTreeSet<_>>();
+    let direct_parent_commit_ids = observed_commit_ids
+        .iter()
+        .flat_map(|observed_commit_id| {
+            parent_commit_ids_by_commit
+                .get(observed_commit_id)
+                .into_iter()
+                .flatten()
+                .cloned()
+        })
+        .collect::<Vec<_>>();
+    observed_commit_ids.extend(direct_parent_commit_ids);
     let observed_states =
         load_directory_history_observed_states(query_source, observed_commit_ids).await?;
+    let events = grouped_directory_history_events(
+        &event_descriptors,
+        &observed_states,
+        &parent_commit_ids_by_commit,
+    );
     let mut output = Vec::new();
 
     for event in events {
@@ -406,28 +424,60 @@ fn parse_directory_history_records(
 
 fn grouped_directory_history_events(
     descriptors: &[DirectoryHistoryRecord],
+    observed_states: &BTreeMap<String, Vec<DirectoryHistoryRecord>>,
+    parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
 ) -> Vec<DirectoryHistoryEvent> {
     let mut grouped = BTreeMap::<(String, String, String), DirectoryHistoryEvent>::new();
+    let directory_trees = observed_states
+        .iter()
+        .map(|(commit_id, state)| {
+            (
+                commit_id.as_str(),
+                HistoryDirectoryTree::from_records(state),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
     for descriptor in descriptors {
-        let mut event = directory_history_event_from_entry(&descriptor.id, &descriptor.entry);
-        let key = (
-            event.directory_id.clone(),
-            event.start_commit_id.clone(),
-            event.observed_commit_id.clone(),
+        let state_commit_ids = std::iter::once(descriptor.entry.observed_commit_id.as_str()).chain(
+            parent_commit_ids_by_commit
+                .get(&descriptor.entry.observed_commit_id)
+                .into_iter()
+                .flatten()
+                .map(String::as_str),
         );
-        match grouped.entry(key) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert(event);
+        let mut affected_directory_ids = BTreeSet::from([descriptor.id.clone()]);
+        for state_commit_id in state_commit_ids {
+            if observed_states.contains_key(state_commit_id) {
+                affected_directory_ids.extend(
+                    directory_trees
+                        .get(state_commit_id)
+                        .expect("every observed directory state should have a directory tree")
+                        .descendants_including(&descriptor.id),
+                );
             }
-            std::collections::btree_map::Entry::Occupied(mut entry) => {
-                let grouped_event = entry.get_mut();
-                debug_assert_eq!(grouped_event.depth, event.depth);
-                // When commit metadata is not projected, history loading uses
-                // each source change's timestamp as an intentionally unused
-                // fallback. Those timestamps may differ within one commit.
-                grouped_event
-                    .source_changes
-                    .append(&mut event.source_changes);
+        }
+        for affected_directory_id in affected_directory_ids {
+            let mut event =
+                directory_history_event_from_entry(&affected_directory_id, &descriptor.entry);
+            let key = (
+                event.directory_id.clone(),
+                event.start_commit_id.clone(),
+                event.observed_commit_id.clone(),
+            );
+            match grouped.entry(key) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(event);
+                }
+                std::collections::btree_map::Entry::Occupied(mut entry) => {
+                    let grouped_event = entry.get_mut();
+                    debug_assert_eq!(grouped_event.depth, event.depth);
+                    // When commit metadata is not projected, history loading uses
+                    // each source change's timestamp as an intentionally unused
+                    // fallback. Those timestamps may differ within one commit.
+                    grouped_event
+                        .source_changes
+                        .append(&mut event.source_changes);
+                }
             }
         }
     }

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -14,7 +14,6 @@ use tokio::sync::Mutex;
 
 use crate::NullableKeyFilter;
 use crate::binary_cas::{BlobDataReader, BlobHash};
-use crate::changelog::CommitId;
 use crate::commit_graph::CommitGraphReader;
 use crate::common::compose_file_path;
 use crate::entity_pk::EntityPk;
@@ -42,7 +41,8 @@ use crate::sql2::history_route::{
     serialize_history_source_changes,
 };
 use crate::sql2::providers::filesystem_history_path::{
-    HistoryDirectoryPathRecord, resolve_history_directory_path,
+    HistoryDirectoryPathRecord, HistoryDirectoryTree, load_history_commit_parents,
+    resolve_history_directory_path,
 };
 use crate::sql2::result_metadata::json_field;
 use crate::storage_adapter::StorageAdapterRead;
@@ -211,7 +211,7 @@ struct FileHistoryDescriptorRecord {
 struct FileHistoryDirectoryRecord {
     id: String,
     parent_id: Option<String>,
-    name: String,
+    name: Option<String>,
     entry: HistoryEntry,
 }
 
@@ -225,7 +225,7 @@ impl HistoryDirectoryPathRecord for FileHistoryDirectoryRecord {
     }
 
     fn name(&self) -> Option<&str> {
-        Some(&self.name)
+        self.name.as_deref()
     }
 
     fn entry(&self) -> &HistoryEntry {
@@ -470,6 +470,49 @@ struct FileHistoryObservedState {
     plugin_registry: PluginRegistry,
 }
 
+struct FileHistoryDirectoryIndex {
+    tree: HistoryDirectoryTree,
+    file_ids_by_directory: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl FileHistoryDirectoryIndex {
+    fn from_state(state: &FileHistoryObservedState) -> Self {
+        let mut file_ids_by_directory = BTreeMap::<String, BTreeSet<String>>::new();
+        for descriptor in &state.descriptors {
+            if let Some(directory_id) = &descriptor.directory_id {
+                file_ids_by_directory
+                    .entry(directory_id.clone())
+                    .or_default()
+                    .insert(descriptor.id.clone());
+            }
+        }
+        Self {
+            tree: HistoryDirectoryTree::from_records(&state.directories),
+            file_ids_by_directory,
+        }
+    }
+
+    fn affected_file_ids(&self, changed_directory_id: &str) -> BTreeSet<String> {
+        let mut file_ids = BTreeSet::new();
+        self.visit_affected_file_buckets(changed_directory_id, |bucket| {
+            file_ids.extend(bucket.iter().cloned());
+        });
+        file_ids
+    }
+
+    fn visit_affected_file_buckets(
+        &self,
+        changed_directory_id: &str,
+        mut visit: impl FnMut(&BTreeSet<String>),
+    ) {
+        for directory_id in self.tree.descendants_including(changed_directory_id) {
+            if let Some(bucket) = self.file_ids_by_directory.get(&directory_id) {
+                visit(bucket);
+            }
+        }
+    }
+}
+
 struct FileHistoryPluginDiscovery {
     schema_keys: Vec<String>,
     registries_by_commit: BTreeMap<String, PluginRegistry>,
@@ -512,17 +555,13 @@ where
     )
     .await?;
     let mut installed_plugins_cache = BTreeMap::<(String, String), InstalledPlugin>::new();
-    let filesystem_events = file_history_events(
-        &filesystem_context.event_descriptors,
-        &filesystem_context.event_directories,
-        &filesystem_context.event_blobs,
-        &filesystem_context.descriptors,
-    );
+    let parent_commit_ids_by_commit =
+        load_history_commit_parents(&commit_graph, &context_route.start_commit_ids).await?;
     let plugin_discovery = discover_file_history_plugins(
         Arc::clone(&commit_graph),
         query_source.clone(),
         &event_route,
-        &context_route,
+        &parent_commit_ids_by_commit,
         metadata_projection,
     )
     .await?;
@@ -554,17 +593,22 @@ where
     // plugin state in the same commit. The exact observed root contains only
     // the new owner (or its tombstone), so retain direct-parent roots as the
     // ownership evidence for those cleanup changes.
-    let owner_change_parent_commit_ids = event_plugin_owners.iter().flat_map(|record| {
-        plugin_discovery
-            .parent_commit_ids_by_commit
-            .get(&record.entry.observed_commit_id)
-            .into_iter()
-            .flatten()
-            .cloned()
-    });
-    let observed_commit_ids = filesystem_events
+    let mut observed_commit_ids = filesystem_context
+        .event_descriptors
         .iter()
-        .map(|event| event.observed_commit_id.clone())
+        .map(|record| record.entry.observed_commit_id.clone())
+        .chain(
+            filesystem_context
+                .event_directories
+                .iter()
+                .map(|record| record.entry.observed_commit_id.clone()),
+        )
+        .chain(
+            filesystem_context
+                .event_blobs
+                .iter()
+                .map(|record| record.entry.observed_commit_id.clone()),
+        )
         .chain(
             event_plugin_state
                 .iter()
@@ -581,8 +625,26 @@ where
                 .iter()
                 .map(|entry| entry.observed_commit_id.clone()),
         )
-        .chain(owner_change_parent_commit_ids)
         .collect::<BTreeSet<_>>();
+    let parent_evidence_commit_ids = filesystem_context
+        .event_directories
+        .iter()
+        .map(|record| record.entry.observed_commit_id.as_str())
+        .chain(
+            event_plugin_owners
+                .iter()
+                .map(|record| record.entry.observed_commit_id.as_str()),
+        );
+    let direct_parent_commit_ids = parent_evidence_commit_ids
+        .flat_map(|observed_commit_id| {
+            parent_commit_ids_by_commit
+                .get(observed_commit_id)
+                .into_iter()
+                .flatten()
+                .cloned()
+        })
+        .collect::<Vec<_>>();
+    observed_commit_ids.extend(direct_parent_commit_ids);
     let observed_states = load_file_history_observed_states(
         query_source,
         observed_commit_ids,
@@ -590,6 +652,14 @@ where
         lookup_ids,
     )
     .await?;
+    let filesystem_events = file_history_events(
+        &filesystem_context.event_descriptors,
+        &filesystem_context.event_directories,
+        &filesystem_context.event_blobs,
+        &filesystem_context.descriptors,
+        &observed_states,
+        &parent_commit_ids_by_commit,
+    );
     let plugin_state_events = file_history_plugin_events(
         &event_plugin_state,
         &event_plugin_owners,
@@ -676,6 +746,15 @@ fn prepare_file_history_rows(
     route: &HistoryRoute,
     public_predicate: &FileHistoryPublicPredicate,
 ) -> Result<Vec<PreparedFileHistoryRow>, LixError> {
+    let directory_indexes = observed_states
+        .iter()
+        .map(|(commit_id, state)| {
+            (
+                commit_id.as_str(),
+                FileHistoryDirectoryIndex::from_state(state),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
     let mut prepared = Vec::new();
     for event in events {
         let Some(state) = observed_states.get(&event.observed_commit_id) else {
@@ -694,7 +773,10 @@ fn prepare_file_history_rows(
         else {
             continue;
         };
-        if !file_history_event_affects_observed_file(&event, descriptor) {
+        let directory_index = directory_indexes
+            .get(event.observed_commit_id.as_str())
+            .expect("every observed file state should have a directory index");
+        if !file_history_event_affects_observed_file(&event, descriptor, &directory_index.tree) {
             continue;
         }
         let path = resolve_file_history_path(descriptor, &state.directories, 0);
@@ -1301,25 +1383,29 @@ fn file_history_events(
     event_directories: &[FileHistoryDirectoryRecord],
     event_blobs: &[FileHistoryBlobRecord],
     context_descriptors: &[FileHistoryDescriptorRecord],
+    observed_states: &BTreeMap<String, FileHistoryObservedState>,
+    parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
 ) -> Vec<FileHistoryEvent> {
     let mut descriptor_ids_by_start = BTreeSet::<(String, String)>::new();
-    let mut directory_ids_by_file_start = BTreeMap::<(String, String), BTreeSet<String>>::new();
 
     for descriptor in context_descriptors {
         let key = (
             descriptor.id.clone(),
             descriptor.entry.start_commit_id.clone(),
         );
-        descriptor_ids_by_start.insert(key.clone());
-        if let Some(directory_id) = &descriptor.directory_id {
-            directory_ids_by_file_start
-                .entry(key)
-                .or_default()
-                .insert(directory_id.clone());
-        }
+        descriptor_ids_by_start.insert(key);
     }
 
     let mut candidates = Vec::new();
+    let directory_indexes = observed_states
+        .iter()
+        .map(|(commit_id, state)| {
+            (
+                commit_id.as_str(),
+                FileHistoryDirectoryIndex::from_state(state),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
     for descriptor in event_descriptors {
         candidates.push(file_history_event_from_entry(
             descriptor.id.clone(),
@@ -1327,15 +1413,21 @@ fn file_history_events(
         ));
     }
     for directory in event_directories {
-        for ((file_id, start_commit_id), directory_ids) in &directory_ids_by_file_start {
-            if start_commit_id == &directory.entry.start_commit_id
-                && directory_ids.contains(&directory.id)
-            {
-                candidates.push(file_history_event_from_entry(
-                    file_id.clone(),
-                    &directory.entry,
-                ));
+        let state_commit_ids = std::iter::once(directory.entry.observed_commit_id.as_str()).chain(
+            parent_commit_ids_by_commit
+                .get(&directory.entry.observed_commit_id)
+                .into_iter()
+                .flatten()
+                .map(String::as_str),
+        );
+        let mut affected_file_ids = BTreeSet::new();
+        for state_commit_id in state_commit_ids {
+            if let Some(directory_index) = directory_indexes.get(state_commit_id) {
+                affected_file_ids.extend(directory_index.affected_file_ids(&directory.id));
             }
+        }
+        for file_id in affected_file_ids {
+            candidates.push(file_history_event_from_entry(file_id, &directory.entry));
         }
     }
     for blob in event_blobs {
@@ -1401,7 +1493,7 @@ async fn discover_file_history_plugins<S>(
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
     event_route: &HistoryRoute,
-    context_route: &HistoryRoute,
+    parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
     metadata_projection: HistoryMetadataProjection,
 ) -> Result<FileHistoryPluginDiscovery, LixError>
 where
@@ -1411,29 +1503,10 @@ where
     // observed commit. Read that exact root identity for every reachable commit
     // instead of inventing a filesystem state from `(start, depth)`, which
     // conflates equal-depth siblings in a DAG.
-    let mut observed_commit_ids = BTreeSet::new();
-    let mut parent_commit_ids_by_commit = BTreeMap::new();
-    for start_commit_id in &context_route.start_commit_ids {
-        let start_commit_id = CommitId::parse_lix(start_commit_id, "history start_commit_id")?;
-        let reachable = commit_graph
-            .lock()
-            .await
-            .reachable_commits(&start_commit_id)
-            .await?;
-        for reachable in reachable {
-            let observed_commit_id = reachable.commit.commit_id.to_string();
-            parent_commit_ids_by_commit.insert(
-                observed_commit_id.clone(),
-                reachable
-                    .commit
-                    .parent_commit_ids
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect(),
-            );
-            observed_commit_ids.insert(observed_commit_id);
-        }
-    }
+    let observed_commit_ids = parent_commit_ids_by_commit
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
     let mut reader = TrackedStateContext::new().reader(query_source.store.clone());
     let mut schema_keys = BTreeSet::new();
     let mut registries_by_commit = BTreeMap::new();
@@ -1467,7 +1540,7 @@ where
     Ok(FileHistoryPluginDiscovery {
         schema_keys: schema_keys.into_iter().collect(),
         registries_by_commit,
-        parent_commit_ids_by_commit,
+        parent_commit_ids_by_commit: parent_commit_ids_by_commit.clone(),
         registry_events,
     })
 }
@@ -1668,12 +1741,16 @@ fn parse_file_history_directories(
     entries
         .iter()
         .filter(|entry| entry.change.schema_key == DIRECTORY_DESCRIPTOR_SCHEMA_KEY)
-        .filter_map(|entry| {
-            let snapshot_content = entry.change.snapshot_content.clone()?;
-            Some((entry, snapshot_content))
-        })
-        .map(|(entry, snapshot_content)| {
-            let snapshot: DirectoryDescriptorSnapshot = serde_json::from_str(&snapshot_content)
+        .map(|entry| {
+            let Some(snapshot_content) = entry.change.snapshot_content.as_deref() else {
+                return Ok(FileHistoryDirectoryRecord {
+                    id: entry.change.entity_pk.as_single_string_owned()?,
+                    parent_id: None,
+                    name: None,
+                    entry: entry.clone(),
+                });
+            };
+            let snapshot: DirectoryDescriptorSnapshot = serde_json::from_str(snapshot_content)
                 .map_err(|error| {
                     LixError::new(
                         "LIX_ERROR_UNKNOWN",
@@ -1683,7 +1760,7 @@ fn parse_file_history_directories(
             Ok(FileHistoryDirectoryRecord {
                 id: snapshot.id,
                 parent_id: snapshot.parent_id,
-                name: snapshot.name,
+                name: Some(snapshot.name),
                 entry: entry.clone(),
             })
         })
@@ -1789,6 +1866,7 @@ fn parse_file_history_plugin_owners(
 fn file_history_event_affects_observed_file(
     event: &FileHistoryEvent,
     descriptor: &FileHistoryDescriptorRecord,
+    directory_tree: &HistoryDirectoryTree,
 ) -> bool {
     event
         .source_changes
@@ -1805,15 +1883,13 @@ fn file_history_event_affects_observed_file(
                         .is_ok_and(|entity_id| entity_id == descriptor.id)
             }
             DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
-                descriptor
-                    .directory_id
-                    .as_deref()
-                    .is_some_and(|directory_id| {
-                        change
-                            .entity_pk
-                            .as_single_string_owned()
-                            .is_ok_and(|entity_id| entity_id == directory_id)
-                    })
+                let Ok(changed_directory_id) = change.entity_pk.as_single_string_owned() else {
+                    return false;
+                };
+                let Some(directory_id) = descriptor.directory_id.as_deref() else {
+                    return false;
+                };
+                directory_tree.has_ancestor_including(directory_id, &changed_directory_id)
             }
             KEY_VALUE_SCHEMA_KEY
                 if change.entity_pk.as_single_string().ok() == Some(PLUGIN_REGISTRY_KEY) =>
@@ -2089,10 +2165,11 @@ mod tests {
     use crate::sql2::history_route::HistoryEntry;
 
     use super::{
-        FileHistoryBlobRecord, FileHistoryDescriptorRecord, FileHistoryFilesystemContext,
-        FileHistoryLookupIds, FileHistoryObservedState, FileHistoryPluginOwnerRecord,
-        FileHistoryPluginStateRecord, FileHistoryPublicPredicate, HistoryRoute, PluginRegistry,
-        PreparedFileHistoryRow, file_history_descriptor_blob_route, file_history_event_from_entry,
+        FileHistoryBlobRecord, FileHistoryDescriptorRecord, FileHistoryDirectoryIndex,
+        FileHistoryDirectoryRecord, FileHistoryFilesystemContext, FileHistoryLookupIds,
+        FileHistoryObservedState, FileHistoryPluginOwnerRecord, FileHistoryPluginStateRecord,
+        FileHistoryPublicPredicate, HistoryRoute, PluginRegistry, PreparedFileHistoryRow,
+        file_history_descriptor_blob_route, file_history_event_from_entry, file_history_events,
         file_history_plugin_events, load_file_history_blob_bytes, load_file_history_entry_sets,
         prepare_file_history_rows, sorted_grouped_file_history_events,
     };
@@ -2130,6 +2207,41 @@ mod tests {
             directory_id: None,
             name: name.map(str::to_string),
             entry: history_entry(file_id, depth, snapshot),
+        }
+    }
+
+    fn descriptor_in_directory(file_id: &str, directory_id: &str) -> FileHistoryDescriptorRecord {
+        let mut descriptor = descriptor(file_id, Some("file.txt"), 0);
+        descriptor.directory_id = Some(directory_id.to_string());
+        descriptor.entry.change.snapshot_content = Some(
+            serde_json::json!({
+                "id": file_id,
+                "directory_id": directory_id,
+                "name": "file.txt",
+            })
+            .to_string(),
+        );
+        descriptor
+    }
+
+    fn directory_record(directory_id: &str) -> FileHistoryDirectoryRecord {
+        let mut entry = history_entry(directory_id, 0, None);
+        entry.change.id = format!("change-{directory_id}");
+        entry.change.schema_key = super::DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string();
+        entry.change.file_id = None;
+        entry.change.snapshot_content = Some(
+            serde_json::json!({
+                "id": directory_id,
+                "parent_id": null,
+                "name": directory_id,
+            })
+            .to_string(),
+        );
+        FileHistoryDirectoryRecord {
+            id: directory_id.to_string(),
+            parent_id: None,
+            name: Some(directory_id.to_string()),
+            entry,
         }
     }
 
@@ -2431,6 +2543,63 @@ mod tests {
                 super::FILE_DESCRIPTOR_SCHEMA_KEY,
             ])
         );
+    }
+
+    #[test]
+    fn unfiltered_sibling_directory_fanout_uses_directory_file_buckets() {
+        const SIBLING_COUNT: usize = 512;
+
+        let directories = (0..SIBLING_COUNT)
+            .map(|index| directory_record(&format!("directory-{index:04}")))
+            .collect::<Vec<_>>();
+        let descriptors = (0..SIBLING_COUNT)
+            .map(|index| {
+                descriptor_in_directory(
+                    &format!("file-{index:04}"),
+                    &format!("directory-{index:04}"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let observed_state = FileHistoryObservedState {
+            descriptors: descriptors.clone(),
+            directories: directories.clone(),
+            blobs: Vec::new(),
+            plugin_state: Vec::new(),
+            plugin_owners: Vec::new(),
+            plugin_registry: PluginRegistry::empty(),
+        };
+        let directory_index = FileHistoryDirectoryIndex::from_state(&observed_state);
+        let observed_states = BTreeMap::from([("commit-0".to_string(), observed_state)]);
+
+        let events = file_history_events(
+            &[],
+            &directories,
+            &[],
+            &descriptors,
+            &observed_states,
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(events.len(), SIBLING_COUNT);
+        for (index, event) in events.iter().enumerate() {
+            assert_eq!(event.file_id, format!("file-{index:04}"));
+            assert_eq!(event.source_changes.len(), 1);
+            assert_eq!(
+                event.source_changes[0].entity_pk,
+                EntityPk::single(format!("directory-{index:04}"))
+            );
+        }
+
+        let mut visited_buckets = 0;
+        let mut visited_file_candidates = 0;
+        for directory in &directories {
+            directory_index.visit_affected_file_buckets(&directory.id, |bucket| {
+                visited_buckets += 1;
+                visited_file_candidates += bucket.len();
+            });
+        }
+        assert_eq!(visited_buckets, SIBLING_COUNT);
+        assert_eq!(visited_file_candidates, SIBLING_COUNT);
     }
 
     #[test]

--- a/packages/engine/src/sql2/providers/filesystem_history_path.rs
+++ b/packages/engine/src/sql2/providers/filesystem_history_path.rs
@@ -1,5 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
+use tokio::sync::Mutex;
+
+use crate::LixError;
+use crate::changelog::CommitId;
+use crate::commit_graph::CommitGraphReader;
 use crate::common::compose_directory_path;
 use crate::sql2::history_route::HistoryEntry;
 
@@ -8,6 +14,102 @@ pub(super) trait HistoryDirectoryPathRecord {
     fn parent_id(&self) -> Option<&str>;
     fn name(&self) -> Option<&str>;
     fn entry(&self) -> &HistoryEntry;
+}
+
+/// Immutable child index for one exact observed filesystem state.
+///
+/// Composed file and directory history use this to fan a directory descriptor
+/// change out to every descendant whose public path depends on it. The index is
+/// built from an observed commit root, so equal-depth sibling commits never
+/// share ancestry.
+#[derive(Debug, Default)]
+pub(super) struct HistoryDirectoryTree {
+    children_by_parent: BTreeMap<String, BTreeSet<String>>,
+    parent_by_directory: BTreeMap<String, String>,
+}
+
+impl HistoryDirectoryTree {
+    pub(super) fn from_records<R: HistoryDirectoryPathRecord>(directories: &[R]) -> Self {
+        let mut children_by_parent = BTreeMap::<String, BTreeSet<String>>::new();
+        let mut parent_by_directory = BTreeMap::new();
+        for directory in directories {
+            if let Some(parent_id) = directory.parent_id() {
+                children_by_parent
+                    .entry(parent_id.to_string())
+                    .or_default()
+                    .insert(directory.id().to_string());
+                parent_by_directory.insert(directory.id().to_string(), parent_id.to_string());
+            }
+        }
+        Self {
+            children_by_parent,
+            parent_by_directory,
+        }
+    }
+
+    /// Returns the changed directory and every directory below it.
+    ///
+    /// Including the root is useful for files directly owned by the changed
+    /// directory. A visited set makes corrupt cycles terminate deterministically
+    /// instead of multiplying history rows.
+    pub(super) fn descendants_including(&self, directory_id: &str) -> BTreeSet<String> {
+        let mut descendants = BTreeSet::new();
+        let mut pending = vec![directory_id.to_string()];
+        while let Some(candidate) = pending.pop() {
+            if !descendants.insert(candidate.clone()) {
+                continue;
+            }
+            if let Some(children) = self.children_by_parent.get(&candidate) {
+                pending.extend(children.iter().rev().cloned());
+            }
+        }
+        descendants
+    }
+
+    pub(super) fn has_ancestor_including(&self, directory_id: &str, ancestor_id: &str) -> bool {
+        let mut current = Some(directory_id);
+        let mut visited = BTreeSet::new();
+        while let Some(candidate) = current {
+            if candidate == ancestor_id {
+                return true;
+            }
+            if !visited.insert(candidate) {
+                return false;
+            }
+            current = self.parent_by_directory.get(candidate).map(String::as_str);
+        }
+        false
+    }
+}
+
+/// Loads direct-parent edges for every commit reachable from the requested
+/// history starts.
+///
+/// Ancestor deletion and move-out events need both sides of the revision:
+/// descendants may no longer be linked to the changed directory in the
+/// observed root. Direct-parent roots are sufficient and preserve DAG
+/// isolation; no depth-based predecessor is inferred.
+pub(super) async fn load_history_commit_parents(
+    commit_graph: &Arc<Mutex<Box<dyn CommitGraphReader>>>,
+    start_commit_ids: &[String],
+) -> Result<BTreeMap<String, Vec<String>>, LixError> {
+    let mut parents_by_commit = BTreeMap::new();
+    let mut commit_graph = commit_graph.lock().await;
+    for start_commit_id in start_commit_ids {
+        let start_commit_id = CommitId::parse_lix(start_commit_id, "history start_commit_id")?;
+        for reachable in commit_graph.reachable_commits(&start_commit_id).await? {
+            parents_by_commit.insert(
+                reachable.commit.commit_id.to_string(),
+                reachable
+                    .commit
+                    .parent_commit_ids
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            );
+        }
+    }
+    Ok(parents_by_commit)
 }
 
 pub(super) fn resolve_history_directory_path<R: HistoryDirectoryPathRecord>(

--- a/packages/engine/tests/sql/lix_directory_history.rs
+++ b/packages/engine/tests/sql/lix_directory_history.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use lix_engine::{CreateBranchOptions, MergeBranchOptions, Value};
 use serde_json::json;
 
@@ -350,15 +352,25 @@ simulation_test!(
             let Value::Json(source_changes) = &row.values()[3] else {
                 panic!("delete source changes should be JSON");
             };
-            assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
-            assert_eq!(
-                source_changes[0]["schema_key"],
-                json!("lix_directory_descriptor")
-            );
-            assert_eq!(
-                source_changes[0]["snapshot_content"],
-                serde_json::Value::Null
-            );
+            let source_changes = source_changes
+                .as_array()
+                .expect("delete source changes should be an array");
+            let expected_source_ids = if expected_id == "history-delete-docs" {
+                BTreeSet::from(["history-delete-docs"])
+            } else {
+                BTreeSet::from(["history-delete-docs", "history-delete-guides"])
+            };
+            let actual_source_ids = source_changes
+                .iter()
+                .map(|source| {
+                    assert_eq!(source["schema_key"], json!("lix_directory_descriptor"));
+                    assert_eq!(source["snapshot_content"], serde_json::Value::Null);
+                    source["entity_pk"][0]
+                        .as_str()
+                        .expect("directory source identity should be text")
+                })
+                .collect::<BTreeSet<_>>();
+            assert_eq!(actual_source_ids, expected_source_ids);
             assert_eq!(row.values()[4], Value::Text(delete_commit_id.clone()));
             assert_eq!(row.values()[5], Value::Integer(0));
         }

--- a/packages/engine/tests/sql/lix_file_history.rs
+++ b/packages/engine/tests/sql/lix_file_history.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::io::{Cursor, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -230,6 +231,616 @@ async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state(
 
     session.close().await.expect("session should close");
 }
+
+#[tokio::test]
+async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() {
+    const UNRELATED_DIRECTORY_COUNT: usize = 256;
+    const MAX_REQUESTED_KEYS: u64 = 400;
+    const MAX_SCAN_CALLS: u64 = 48;
+    const MAX_SCANNED_ROWS: u64 = 48;
+
+    let storage = CountingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let unrelated_directories = (0..UNRELATED_DIRECTORY_COUNT)
+        .map(|index| format!("('ancestor-noise-{index:03}', '/ancestor-noise-{index:03}/')"))
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!("INSERT INTO lix_directory (id, path) VALUES {unrelated_directories}"),
+            &[],
+        )
+        .await
+        .expect("unrelated directories should insert");
+    session
+        .execute(
+            "INSERT INTO lix_directory (id, path) VALUES \
+             ('bounded-root', '/bounded/'), \
+             ('bounded-child', '/bounded/child/')",
+            &[],
+        )
+        .await
+        .expect("target ancestors should insert");
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, data) \
+             VALUES ('bounded-file', '/bounded/child/target.txt', X'78')",
+            &[],
+        )
+        .await
+        .expect("target file should insert");
+    session
+        .execute(
+            "UPDATE lix_directory SET name = 'renamed' WHERE id = 'bounded-root'",
+            &[],
+        )
+        .await
+        .expect("target ancestor should rename");
+    let commit_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("renamed head should load");
+    let [Value::Text(commit_id)] = commit_rows.rows()[0].values() else {
+        panic!("renamed head should be text");
+    };
+
+    storage.reset_counters();
+    let result = session
+        .execute(
+            &format!(
+                "SELECT path, lixcol_source_changes \
+                 FROM lix_file_history \
+                 WHERE lixcol_start_commit_id = '{commit_id}' \
+                   AND lixcol_depth = 0 \
+                   AND id = 'bounded-file'"
+            ),
+            &[],
+        )
+        .await
+        .expect("ancestor-projected point history should load");
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result.rows()[0].get::<Value>("path").unwrap(),
+        Value::Text("/renamed/child/target.txt".to_string())
+    );
+    let Value::Json(sources) = result.rows()[0]
+        .get::<Value>("lixcol_source_changes")
+        .unwrap()
+    else {
+        panic!("ancestor source changes should be JSON");
+    };
+    assert_eq!(sources[0]["entity_pk"], json!(["bounded-root"]));
+
+    let (requested_keys, scan_calls, scanned_rows) = storage.counters();
+    assert!(
+        requested_keys <= MAX_REQUESTED_KEYS,
+        "ancestor point history requested {requested_keys} keys with \
+         {UNRELATED_DIRECTORY_COUNT} unrelated directories; expected at most {MAX_REQUESTED_KEYS}"
+    );
+    assert!(
+        scan_calls <= MAX_SCAN_CALLS && scanned_rows <= MAX_SCANNED_ROWS,
+        "ancestor point history performed {scan_calls} scans returning {scanned_rows} rows; \
+         expected at most {MAX_SCAN_CALLS} scans and {MAX_SCANNED_ROWS} rows"
+    );
+
+    session.close().await.expect("session should close");
+}
+
+simulation_test!(
+    lix_filesystem_history_propagates_nested_ancestor_rename_and_move,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) VALUES \
+                 ('projection-root', '/workspace/'), \
+                 ('projection-docs', '/workspace/docs/'), \
+                 ('projection-guides', '/workspace/docs/guides/'), \
+                 ('projection-destination', '/destination/')",
+                &[],
+            )
+            .await
+            .expect("nested projection directories should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('projection-file', '/workspace/docs/guides/readme.md', X'78')",
+                &[],
+            )
+            .await
+            .expect("nested projection file should insert");
+
+        session
+            .execute(
+                "UPDATE lix_directory SET name = 'archive' WHERE id = 'projection-root'",
+                &[],
+            )
+            .await
+            .expect("ancestor rename should succeed");
+        let rename_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("rename head should load")
+            .expect("rename head should exist");
+
+        let renamed_file = session
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_source_changes \
+                     FROM lix_file_history \
+                     WHERE lixcol_start_commit_id = '{rename_commit_id}' \
+                       AND lixcol_depth = 0 \
+                       AND id = 'projection-file'"
+                ),
+                &[],
+            )
+            .await
+            .expect("renamed descendant file history should load");
+        assert_eq!(renamed_file.len(), 1);
+        assert_eq!(
+            renamed_file.rows()[0].get::<Value>("path").unwrap(),
+            Value::Text("/archive/docs/guides/readme.md".to_string())
+        );
+        let Value::Json(rename_sources) = renamed_file.rows()[0]
+            .get::<Value>("lixcol_source_changes")
+            .unwrap()
+        else {
+            panic!("rename sources should be JSON");
+        };
+        assert_eq!(rename_sources.as_array().map(Vec::len), Some(1));
+        assert_eq!(rename_sources[0]["entity_pk"], json!(["projection-root"]));
+
+        let renamed_directory = session
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_source_changes \
+                     FROM lix_directory_history \
+                     WHERE lixcol_start_commit_id = '{rename_commit_id}' \
+                       AND lixcol_depth = 0 \
+                       AND id = 'projection-guides'"
+                ),
+                &[],
+            )
+            .await
+            .expect("renamed descendant directory history should load");
+        assert_eq!(renamed_directory.len(), 1);
+        assert_eq!(
+            renamed_directory.rows()[0].get::<Value>("path").unwrap(),
+            Value::Text("/archive/docs/guides/".to_string())
+        );
+
+        session
+            .execute(
+                "UPDATE lix_directory \
+                 SET path = '/destination/archive/' \
+                 WHERE id = 'projection-root'",
+                &[],
+            )
+            .await
+            .expect("ancestor subtree move should succeed");
+        let move_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("move head should load")
+            .expect("move head should exist");
+
+        let moved = session
+            .execute(
+                &format!(
+                    "SELECT path FROM lix_file_history \
+                     WHERE lixcol_start_commit_id = '{move_commit_id}' \
+                       AND lixcol_depth = 0 \
+                       AND id = 'projection-file'"
+                ),
+                &[],
+            )
+            .await
+            .expect("moved descendant file history should load");
+        assert_rows_eq(
+            moved,
+            vec![vec![Value::Text(
+                "/destination/archive/docs/guides/readme.md".to_string(),
+            )]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_filesystem_history_groups_same_commit_ancestor_sources,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) VALUES \
+                 ('grouped-root', '/grouped/'), \
+                 ('grouped-child', '/grouped/child/')",
+                &[],
+            )
+            .await
+            .expect("grouped directories should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('grouped-file', '/grouped/child/file.txt', X'78')",
+                &[],
+            )
+            .await
+            .expect("grouped file should insert");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("grouped transaction should begin");
+        transaction
+            .execute(
+                "UPDATE lix_directory SET name = 'renamed-root' WHERE id = 'grouped-root'",
+                &[],
+            )
+            .await
+            .expect("root rename should stage");
+        transaction
+            .execute(
+                "UPDATE lix_directory SET name = 'renamed-child' WHERE id = 'grouped-child'",
+                &[],
+            )
+            .await
+            .expect("child rename should stage");
+        transaction
+            .execute(
+                "UPDATE lix_file SET name = 'renamed.txt' WHERE id = 'grouped-file'",
+                &[],
+            )
+            .await
+            .expect("file rename should stage");
+        transaction
+            .commit()
+            .await
+            .expect("grouped transaction should commit");
+        let commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("grouped head should load")
+            .expect("grouped head should exist");
+
+        let file_row = session
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_source_changes \
+                     FROM lix_file_history \
+                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                       AND lixcol_depth = 0 \
+                       AND id = 'grouped-file'"
+                ),
+                &[],
+            )
+            .await
+            .expect("grouped file history should load");
+        assert_eq!(file_row.len(), 1);
+        assert_eq!(
+            file_row.rows()[0].get::<Value>("path").unwrap(),
+            Value::Text("/renamed-root/renamed-child/renamed.txt".to_string())
+        );
+        let Value::Json(file_sources) = file_row.rows()[0]
+            .get::<Value>("lixcol_source_changes")
+            .unwrap()
+        else {
+            panic!("grouped file sources should be JSON");
+        };
+        let source_ids = file_sources
+            .as_array()
+            .expect("grouped file sources should be an array")
+            .iter()
+            .map(|source| source["entity_pk"][0].as_str().unwrap())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            source_ids,
+            BTreeSet::from(["grouped-root", "grouped-child", "grouped-file"])
+        );
+
+        let directory_row = session
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_source_changes \
+                     FROM lix_directory_history \
+                     WHERE lixcol_start_commit_id = '{commit_id}' \
+                       AND lixcol_depth = 0 \
+                       AND id = 'grouped-child'"
+                ),
+                &[],
+            )
+            .await
+            .expect("grouped directory history should load");
+        assert_eq!(directory_row.len(), 1);
+        let Value::Json(directory_sources) = directory_row.rows()[0]
+            .get::<Value>("lixcol_source_changes")
+            .unwrap()
+        else {
+            panic!("grouped directory sources should be JSON");
+        };
+        assert_eq!(directory_sources.as_array().map(Vec::len), Some(2));
+    }
+);
+
+simulation_test!(
+    lix_filesystem_history_preserves_ancestor_sibling_revisions,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_directory (id, path) VALUES \
+             ('ancestor-sibling-root', '/before/'), \
+             ('ancestor-sibling-child', '/before/child/')",
+            &[],
+        )
+        .await
+        .expect("sibling directories should insert");
+        main.execute(
+            "INSERT INTO lix_file (id, path, data) \
+             VALUES ('ancestor-sibling-file', '/before/child/file.txt', X'78')",
+            &[],
+        )
+        .await
+        .expect("sibling file should insert");
+        main.create_branch(CreateBranchOptions {
+            id: Some("ancestor-sibling-draft".to_string()),
+            name: "Ancestor sibling draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("sibling branch should create");
+        let draft = sim.wrap_session(
+            engine
+                .open_session("ancestor-sibling-draft")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "UPDATE lix_directory SET name = 'same' WHERE id = 'ancestor-sibling-root'",
+            &[],
+        )
+        .await
+        .expect("main ancestor rename should succeed");
+        let main_sibling = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("main sibling should load")
+            .expect("main sibling should exist");
+        draft
+            .execute(
+                "UPDATE lix_directory SET name = 'same' WHERE id = 'ancestor-sibling-root'",
+                &[],
+            )
+            .await
+            .expect("draft ancestor rename should succeed");
+        let draft_sibling = engine
+            .load_branch_head_commit_id("ancestor-sibling-draft")
+            .await
+            .expect("draft sibling should load")
+            .expect("draft sibling should exist");
+        let receipt = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "ancestor-sibling-draft".to_string(),
+            })
+            .await
+            .expect("convergent ancestor renames should merge");
+        let merge_commit_id = receipt
+            .created_merge_commit_id
+            .expect("convergent ancestor renames should create a merge commit");
+
+        let rows = main
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_observed_commit_id \
+                     FROM lix_file_history \
+                     WHERE lixcol_start_commit_id = '{merge_commit_id}' \
+                       AND lixcol_depth = 1 \
+                       AND id = 'ancestor-sibling-file' \
+                     ORDER BY lixcol_observed_commit_id"
+                ),
+                &[],
+            )
+            .await
+            .expect("sibling descendant history should load");
+        assert_eq!(rows.len(), 2);
+        let mut actual_commits = rows
+            .rows()
+            .iter()
+            .map(|row| {
+                assert_eq!(
+                    row.get::<Value>("path").unwrap(),
+                    Value::Text("/same/child/file.txt".to_string())
+                );
+                match row.get::<Value>("lixcol_observed_commit_id").unwrap() {
+                    Value::Text(commit_id) => commit_id,
+                    value => panic!("observed commit should be text, got {value:?}"),
+                }
+            })
+            .collect::<Vec<_>>();
+        actual_commits.sort();
+        let mut expected_commits = vec![main_sibling, draft_sibling];
+        expected_commits.sort();
+        assert_eq!(actual_commits, expected_commits);
+    }
+);
+
+simulation_test!(
+    lix_filesystem_history_attributes_recursive_delete_and_restore_to_ancestors,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) VALUES \
+                 ('restore-root', '/restore/'), \
+                 ('restore-child', '/restore/child/')",
+                &[],
+            )
+            .await
+            .expect("restore directories should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('restore-file', '/restore/child/file.txt', X'78')",
+                &[],
+            )
+            .await
+            .expect("restore file should insert");
+        session
+            .execute("DELETE FROM lix_directory WHERE id = 'restore-root'", &[])
+            .await
+            .expect("recursive delete should succeed");
+        let delete_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("delete head should load")
+            .expect("delete head should exist");
+
+        let deleted = session
+            .execute(
+                &format!(
+                    "SELECT path, lixcol_source_changes \
+                     FROM lix_file_history \
+                     WHERE lixcol_start_commit_id = '{delete_commit_id}' \
+                       AND lixcol_depth = 0 \
+                       AND id = 'restore-file'"
+                ),
+                &[],
+            )
+            .await
+            .expect("deleted descendant file history should load");
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(deleted.rows()[0].get::<Value>("path").unwrap(), Value::Null);
+        let Value::Json(delete_sources) = deleted.rows()[0]
+            .get::<Value>("lixcol_source_changes")
+            .unwrap()
+        else {
+            panic!("delete sources should be JSON");
+        };
+        let deleted_directory_ids = delete_sources
+            .as_array()
+            .expect("delete sources should be an array")
+            .iter()
+            .filter(|source| source["schema_key"] == json!("lix_directory_descriptor"))
+            .map(|source| source["entity_pk"][0].as_str().unwrap())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            deleted_directory_ids,
+            BTreeSet::from(["restore-root", "restore-child"])
+        );
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("restore transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_directory (id, path) VALUES \
+                 ('restore-root', '/restored/'), \
+                 ('restore-child', '/restored/child/')",
+                &[],
+            )
+            .await
+            .expect("directories should restore");
+        transaction
+            .execute(
+                "INSERT INTO lix_file (id, path, data) \
+                 VALUES ('restore-file', '/restored/child/file.txt', X'79')",
+                &[],
+            )
+            .await
+            .expect("file should restore");
+        transaction
+            .commit()
+            .await
+            .expect("restore transaction should commit");
+        let restore_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("restore head should load")
+            .expect("restore head should exist");
+        let restored = session
+            .execute(
+                &format!(
+                    "SELECT path, data, lixcol_source_changes \
+                     FROM lix_file_history \
+                     WHERE lixcol_start_commit_id = '{restore_commit_id}' \
+                       AND lixcol_depth = 0 \
+                       AND id = 'restore-file'"
+                ),
+                &[],
+            )
+            .await
+            .expect("restored descendant file history should load");
+        assert_eq!(restored.len(), 1);
+        assert_eq!(
+            restored.rows()[0].get::<Value>("path").unwrap(),
+            Value::Text("/restored/child/file.txt".to_string())
+        );
+        assert_eq!(
+            restored.rows()[0].get::<Value>("data").unwrap(),
+            Value::Blob(b"y".to_vec().into())
+        );
+        let Value::Json(restore_sources) = restored.rows()[0]
+            .get::<Value>("lixcol_source_changes")
+            .unwrap()
+        else {
+            panic!("restore sources should be JSON");
+        };
+        let restored_directory_ids = restore_sources
+            .as_array()
+            .expect("restore sources should be an array")
+            .iter()
+            .filter(|source| source["schema_key"] == json!("lix_directory_descriptor"))
+            .map(|source| source["entity_pk"][0].as_str().unwrap())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            restored_directory_ids,
+            BTreeSet::from(["restore-root", "restore-child"])
+        );
+    }
+);
 
 simulation_test!(
     lix_file_history_reads_path_and_data_from_commit_graph,
@@ -1582,10 +2193,10 @@ simulation_test!(
             .unwrap()
             .iter()
             .map(|source| source["schema_key"].as_str().unwrap())
-            .collect::<std::collections::BTreeSet<_>>();
+            .collect::<BTreeSet<_>>();
         assert_eq!(
             source_schema_keys,
-            std::collections::BTreeSet::from(["lix_binary_blob_ref", "lix_file_descriptor",])
+            BTreeSet::from(["lix_binary_blob_ref", "lix_file_descriptor",])
         );
         let source_ids = initial_sources
             .as_array()


### PR DESCRIPTION
## Why

A file or nested directory depends on every directory above it for its public path and visibility. Previously, composed history only indexed the direct `directory_id`, so renaming, moving, or deleting `/a` could fail to create a revision for `/a/b/file.txt`.

## Hard cut

- Treat an ancestor directory rename, move, and deletion as a projection change for every affected descendant file and directory.
- Reconstruct descendant membership from the exact observed commit root plus its exact direct-parent roots; never infer a predecessor by depth.
- Preserve DAG isolation for equal-depth sibling commits.
- Aggregate ancestor and direct descendant changes that happen in the same commit into the existing structured source-change provenance.
- Preserve ancestor provenance for recursive deletion even when the public delete also emits descendant tombstones.
- Keep exact-ID reads scoped and bounded with per-commit parent/child indexes.
- Cache a per-observed-state directory→file index, so bulk directory commits visit only affected buckets instead of scanning every file per directory event.

## Validation

- Full SQL suite: 573/573 passed.
- Full library suite: 1,169 passed; 6 ignored on the original implementation.
- File-history units after the scaling fix: 13/13 passed.
- New nested rename/move/delete/restore/sibling/same-commit regressions: 8/8 passed.
- Point-lookup performance regressions: 2/2 passed.
- Unfiltered 512-sibling fanout regression proves 512 bucket/file probes rather than 512².
- Engine all-targets Clippy with warnings denied: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Rebasing onto the latest #711/main stack required only the immutable `Blob`/`Bytes` test adaptation; GitHub CI is the post-rebase gate.

This PR is stacked on #711, which supplies the DAG-correct `(as_of_commit_id, observed_commit_id, entity_id)` reconstruction and structured source provenance used here.