### PR TITLE
Skip redundant v2 rendering for uncontended writes

### DIFF
--- a/experiments/plugin-api-v2/engine-bench/README.md
+++ b/experiments/plugin-api-v2/engine-bench/README.md
@@ -54,9 +54,10 @@ Every measured Component v2 edit (CSV or the JSON v2 arm) resets and prints the
 engine's aggregate transition counters as `plugin_v2_counters`. The harness
 fails the run unless the warm single-row or single-property edit materializes
 no full semantic state, requests and returns fewer than 64 change payloads,
-persists exactly one semantic change, hits both the private actor and shared
-renderer documents once, and performs no full document reparse, full renderer
-invocation, or filesystem-sync full render. These are work invariants in
+persists exactly one semantic change, hits the private actor document once,
+skips the shared renderer for an uncontended current-base edit, and performs
+no full document reparse, full renderer invocation, or filesystem-sync full
+render. These are work invariants in
 addition to the latency gate; a faster sample cannot hide a regression to
 document-sized work. CSV additionally retains its stricter 64 MiB efficiency
 invariant inside the production sandbox. The JSON paired diagnostic checks

--- a/experiments/plugin-api-v2/engine-bench/json_paired_gate.py
+++ b/experiments/plugin-api-v2/engine-bench/json_paired_gate.py
@@ -38,6 +38,7 @@ ZERO_COUNTERS = (
     "host_full_diff_bytes_compared",
     "host_full_content_classification_bytes",
     "full_state_semantic_rows_materialized",
+    "shared_renderer_cache_hits",
     "full_document_reparses",
     "full_renderer_invocations",
     "filesystem_sync_full_renders",
@@ -45,7 +46,6 @@ ZERO_COUNTERS = (
 ONE_COUNTERS = (
     "durable_semantic_changes",
     "private_document_cache_hits",
-    "shared_renderer_cache_hits",
 )
 
 

--- a/experiments/plugin-api-v2/engine-bench/test_json_paired_gate.py
+++ b/experiments/plugin-api-v2/engine-bench/test_json_paired_gate.py
@@ -30,7 +30,7 @@ def counter_row(round_index: int) -> dict:
         "returned_change_payloads": 1,
         "durable_semantic_changes": 1,
         "private_document_cache_hits": 1,
-        "shared_renderer_cache_hits": 1,
+        "shared_renderer_cache_hits": 0,
         "full_document_reparses": 0,
         "full_renderer_invocations": 0,
         "filesystem_sync_full_renders": 0,

--- a/experiments/plugin-api-v2/engine-bench/test_run_json_paired.py
+++ b/experiments/plugin-api-v2/engine-bench/test_run_json_paired.py
@@ -120,7 +120,7 @@ class JsonPairedRunnerTests(unittest.TestCase):
             "full_state_semantic_rows_materialized=0 "
             "change_payload_requests=1 returned_change_payloads=1 "
             "durable_semantic_changes=1 private_document_cache_hits=1 "
-            "shared_renderer_cache_hits=1 full_document_reparses=0 "
+            "shared_renderer_cache_hits=0 full_document_reparses=0 "
             "full_renderer_invocations=0 filesystem_sync_full_renders=0\n"
         )
         rows = runner.parse_v2_counters(counter, 1)
@@ -177,7 +177,7 @@ elif mode == "edit":
                 "full_state_semantic_rows_materialized=0 "
                 "change_payload_requests=1 returned_change_payloads=1 "
                 "durable_semantic_changes=1 private_document_cache_hits=1 "
-                "shared_renderer_cache_hits=1 full_document_reparses=0 "
+                "shared_renderer_cache_hits=0 full_document_reparses=0 "
                 "full_renderer_invocations=0 "
                 "filesystem_sync_full_renders=0"
             )

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -2001,7 +2001,6 @@ where
                         write.splice_provenance(),
                         limits,
                     )?;
-                    let expected_delta = built_splices.edits.clone();
                     let host_full_diff_bytes_compared = built_splices.full_diff_bytes_compared;
                     let observed_source = ArcByteSource::new(Arc::clone(&observed_bytes));
                     let submitted_source = ArcByteSource::new(Arc::clone(&submitted_bytes));
@@ -2046,73 +2045,93 @@ where
                         return Err(lease.handle_guest_call_error(error));
                     }
 
-                    // Detection happened against the session's observed
-                    // document (which may now be historical). Apply its sparse
-                    // merge-resolved delta to the actor's current accepted
-                    // document so concurrent different-row edits compose and
-                    // same-row edits obey transaction commit order.
                     let changes = detected_transition.changes;
                     let detection_document = detected_transition.document;
-                    if let Err(error) = lease.actor_mut().drop_document(detection_document).await {
-                        return Err(lease.handle_guest_call_error(error));
-                    }
-                    let current_document = lease.accepted_document();
-                    let current_bytes = lease.accepted_bytes();
-                    let change_source = match VecEntityChangeSource::new(changes.clone(), limits) {
-                        Ok(source) => source,
-                        Err(error) => return Err(lease.handle_guest_call_error(error)),
-                    };
-                    let activated_entities = match VecEntitySource::empty(limits) {
-                        Ok(source) => source,
-                        Err(error) => return Err(lease.handle_guest_call_error(error)),
-                    };
-                    let current_entities = match VecEntitySource::empty(limits) {
-                        Ok(source) => source,
-                        Err(error) => return Err(lease.handle_guest_call_error(error)),
-                    };
-                    let renderer_input =
-                        match lease.actor_mut().fork_document(current_document).await {
-                            Ok(document) => document,
+                    let mut counters = detected_transition.counters;
+                    let (successor_document, materialized_bytes) = if observation_is_current {
+                        // The actor lease serializes this file and the durable
+                        // root still equals the acknowledged observation. The
+                        // validated file successor is therefore already the
+                        // exact merge result; rendering the same sparse change
+                        // onto the same base would only repeat guest work.
+                        (detection_document, Arc::clone(&submitted_bytes))
+                    } else {
+                        // Detection happened against a historical session
+                        // document. Apply its sparse merge-resolved delta to
+                        // the actor's current accepted document so concurrent
+                        // different-entity edits compose and same-entity edits
+                        // obey transaction commit order.
+                        if let Err(error) =
+                            lease.actor_mut().drop_document(detection_document).await
+                        {
+                            return Err(lease.handle_guest_call_error(error));
+                        }
+                        let current_document = lease.accepted_document();
+                        let current_bytes = lease.accepted_bytes();
+                        let change_source =
+                            match VecEntityChangeSource::new(changes.clone(), limits) {
+                                Ok(source) => source,
+                                Err(error) => {
+                                    return Err(lease.handle_guest_call_error(error));
+                                }
+                            };
+                        let activated_entities = match VecEntitySource::empty(limits) {
+                            Ok(source) => source,
                             Err(error) => return Err(lease.handle_guest_call_error(error)),
                         };
-                    let renderer_transition = match lease
-                        .actor_mut()
-                        .entities_changed(
-                            renderer_input,
+                        let current_entities = match VecEntitySource::empty(limits) {
+                            Ok(source) => source,
+                            Err(error) => return Err(lease.handle_guest_call_error(error)),
+                        };
+                        let renderer_input =
+                            match lease.actor_mut().fork_document(current_document).await {
+                                Ok(document) => document,
+                                Err(error) => return Err(lease.handle_guest_call_error(error)),
+                            };
+                        let renderer_transition = match lease
+                            .actor_mut()
+                            .entities_changed(
+                                renderer_input,
+                                limits,
+                                WasmEntityUpdate {
+                                    before_descriptor,
+                                    after_descriptor,
+                                    before: Arc::new(ArcByteSource::new(Arc::clone(
+                                        &current_bytes,
+                                    ))),
+                                    changes: Box::new(change_source),
+                                    activated_entities: Box::new(activated_entities),
+                                    current_entities: Box::new(current_entities),
+                                },
+                            )
+                            .await
+                        {
+                            Ok(transition) => transition,
+                            Err(error) => return Err(lease.handle_guest_call_error(error)),
+                        };
+                        let rendered_transition = match drain_entity_transition_edits(
+                            lease.actor_mut(),
+                            renderer_transition,
+                            &current_bytes,
+                            None,
+                            None,
                             limits,
-                            WasmEntityUpdate {
-                                before_descriptor,
-                                after_descriptor,
-                                before: Arc::new(ArcByteSource::new(Arc::clone(&current_bytes))),
-                                changes: Box::new(change_source),
-                                activated_entities: Box::new(activated_entities),
-                                current_entities: Box::new(current_entities),
-                            },
                         )
                         .await
-                    {
-                        Ok(transition) => transition,
-                        Err(error) => return Err(lease.handle_guest_call_error(error)),
+                        {
+                            Ok(transition) => transition,
+                            Err(error) => return Err(lease.handle_guest_call_error(error)),
+                        };
+                        if let Err(error) = lease.actor_mut().drop_document(renderer_input).await {
+                            return Err(lease.handle_guest_call_error(error));
+                        }
+                        counters.accumulate(rendered_transition.counters);
+                        counters.shared_renderer_cache_hits = 1;
+                        (
+                            rendered_transition.document,
+                            Arc::clone(&rendered_transition.bytes),
+                        )
                     };
-                    let rendered_transition = match drain_entity_transition_edits(
-                        lease.actor_mut(),
-                        renderer_transition,
-                        &current_bytes,
-                        observation_is_current.then(|| Arc::clone(&submitted_bytes)),
-                        observation_is_current.then_some(expected_delta.as_slice()),
-                        limits,
-                    )
-                    .await
-                    {
-                        Ok(transition) => transition,
-                        Err(error) => return Err(lease.handle_guest_call_error(error)),
-                    };
-                    if let Err(error) = lease.actor_mut().drop_document(renderer_input).await {
-                        return Err(lease.handle_guest_call_error(error));
-                    }
-
-                    let mut counters = detected_transition.counters;
-                    counters.accumulate(rendered_transition.counters);
                     counters.host_full_diff_bytes_compared = host_full_diff_bytes_compared;
                     counters.host_full_content_classification_bytes =
                         full_content_classification_bytes
@@ -2120,13 +2139,11 @@ where
                             .copied()
                             .unwrap_or(0);
                     counters.private_document_cache_hits = 1;
-                    counters.shared_renderer_cache_hits = 1;
                     counters.durable_semantic_changes =
                         u64::try_from(changes.entity_change_count()).unwrap_or(u64::MAX);
                     self.plugin_host.record_v2_transition_counters(counters);
-                    let materialized_bytes = Arc::clone(&rendered_transition.bytes);
                     lease.complete_guest_call(
-                        rendered_transition.document,
+                        successor_document,
                         Arc::clone(&materialized_bytes),
                         materialization_version.clone(),
                     )?;

--- a/packages/rs-sdk/benches/profile_plugin_large_file.rs
+++ b/packages/rs-sdk/benches/profile_plugin_large_file.rs
@@ -1060,8 +1060,8 @@ fn assert_warm_single_entity_edit_counters(
         "warm v2 edit round {round} must use exactly one private actor document"
     );
     assert_eq!(
-        counters.shared_renderer_cache_hits, 1,
-        "warm v2 edit round {round} must use exactly one cached renderer document"
+        counters.shared_renderer_cache_hits, 0,
+        "uncontended warm v2 edit round {round} redundantly invoked the shared renderer"
     );
     assert_eq!(
         counters.full_document_reparses, 0,

--- a/perf-results/plugin-api-v2/json-v2-pareto-stack-2026-07-23.md
+++ b/perf-results/plugin-api-v2/json-v2-pareto-stack-2026-07-23.md
@@ -1,0 +1,57 @@
+# JSON v2 Pareto stack — 2026-07-23
+
+This report records the benchmark gate for each independently reviewable layer
+of the recursive JSON v2 optimization stack. Results use the production
+Component v2 runtime and RocksDB filesystem backend with an exact 10,000,000
+byte JSON document containing 220,000 editable leaf properties.
+
+## Layer 1: uncontended successor adoption
+
+The engine can adopt the already validated `file-changed` successor when the
+actor lease and durable semantic root prove that the acknowledged observation
+is current. A stale observation still takes the renderer path so concurrent
+changes compose.
+
+The latency comparison pooled two runs in opposite baseline/candidate order.
+Both used sparse splice provenance, 4 warmups in the second run, and 36 measured
+samples per shape in total.
+
+| Shape | Metric | Recursive v2 baseline | Candidate | Change |
+| --- | ---: | ---: | ---: | ---: |
+| flat | edit p50 | 64.566 ms | 65.118 ms | +0.9% |
+| flat | edit p95 | 70.659 ms | 77.184 ms | +9.2% |
+| nested | edit p50 | 68.789 ms | 70.520 ms | +2.5% |
+| nested | edit p95 | 75.460 ms | 76.277 ms | +1.1% |
+
+The flat candidate p95 contains a single 89.182 ms scheduler/storage outlier;
+its next-highest sample is 77.184 ms. End-to-end edit latency remains dominated
+by the durable RocksDB transaction, so latency is treated as neutral rather
+than as evidence for this layer.
+
+The deterministic hot-path work counters improve on every measured edit:
+
+| Shape | Metric | Recursive v2 baseline | Candidate | Change |
+| --- | ---: | ---: | ---: | ---: |
+| flat | packet pages / records | 2 / 2 | 1 / 1 | -50% / -50% |
+| flat | component imports | 1 | 0 | -100% |
+| flat | component boundary bytes | 458 B | 204 B | -55.5% |
+| nested | packet pages / records | 2 / 2 | 1 / 1 | -50% / -50% |
+| nested | component imports | 1 | 0 | -100% |
+| nested | component boundary bytes | 622 B | 286 B | -54.0% |
+
+All rounds retained one durable semantic change and zero source reads, full
+semantic materializations, full reparses, full renderer invocations, and
+filesystem-sync full renders. Guest high-water memory was unchanged, as
+expected for a warm-path-only change.
+
+Example command (run once per shape and binary):
+
+```sh
+LIX_PROFILE_FORMAT=json \
+LIX_PROFILE_JSON_API=v2 \
+LIX_PROFILE_JSON_SHAPE=nested \
+LIX_PROFILE_SPLICE_PROVENANCE=1 \
+LIX_PROFILE_WARMUPS=4 \
+LIX_PROFILE_ROUNDS=21 \
+profile_plugin_large_file rocksdb-fs edit <fixture-dir>
+```


### PR DESCRIPTION
## Summary

First optimization stacked on #720.

When the actor lease and durable semantic root prove that an acknowledged
observation is current, the engine now adopts the already validated
`file-changed` successor directly. It no longer sends the same sparse change
back through `entities-changed` to reproduce identical bytes.

Stale observations retain the renderer path, so concurrent edits still
compose against the accepted document.

## Benchmark decision

Production RocksDB filesystem, exact 10,000,000-byte JSON, 220,000 leaves,
sparse splice provenance:

| Deterministic work | Baseline | Candidate |
| --- | ---: | ---: |
| packet pages / records | 2 / 2 | 1 / 1 |
| component imports | 1 | 0 |
| flat boundary bytes | 458 B | 204 B |
| nested boundary bytes | 622 B | 286 B |

This cuts packets and records by 50%, component imports by 100%, and boundary
traffic by 54–56%. Across 36 measurements per shape, end-to-end RocksDB
latency remained storage-bound and effectively neutral; the report does not
claim a latency win.

All rounds retained one durable semantic change and zero source reads, full
semantic materializations, full reparses, full renderer invocations, and
filesystem full renders.

## Authorship

No public WIT, packet contract, or plugin implementation changes. The existing
N=10 v2 AX result therefore remains the applicable authoring baseline.

## Validation

- `cargo check -p lix_engine --lib`
- `cargo test -p plugin_json_incremental_v2 --lib`
- engine benchmark gate Python tests
- flat and nested production RocksDB benchmark
- `cargo fmt --all -- --check`
- `git diff --check`

Full samples and interpretation are retained in
`perf-results/plugin-api-v2/json-v2-pareto-stack-2026-07-23.md`.
