### PR TITLE
perf(engine): expose CRUD phase spans

### DIFF
--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
+use tracing::Instrument as _;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobDataReader};
@@ -327,6 +328,10 @@ where
             Some(
                 Arc::clone(&self.collaboration_write_gate)
                     .lock_owned()
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.collaboration_gate_wait"
+                    ))
                     .await,
             )
         } else {
@@ -482,13 +487,23 @@ where
             Arc::clone(&self.sql_planning_cache),
             self.file_views.clone(),
         )
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.transaction_open"
+        ))
         .await?;
         self.ensure_open()?;
         let mut transaction = opened.transaction;
         transaction.attach_commit_boundary(self.transaction_commit_boundary());
         let runtime_functions = opened.runtime_functions;
 
-        match f(&mut transaction).await {
+        match f(&mut transaction)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_plan_and_stage"
+            ))
+            .await
+        {
             Ok(value) => {
                 self.ensure_open()?;
                 let outcome = transaction.commit(&runtime_functions).await?;

--- a/packages/engine/src/storage_adapter/context.rs
+++ b/packages/engine/src/storage_adapter/context.rs
@@ -1,6 +1,7 @@
 use std::ops::Bound;
 
 use bytes::Bytes;
+use tracing::Instrument as _;
 
 use crate::storage::{
     CommitResult, CoreProjection, GetOptions, Key, KeyRange, Memory, Prefix, ProjectedValue,
@@ -89,21 +90,33 @@ where
         let mut write = self
             .storage
             .begin_write(opts)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.storage_writer_wait"
+            ))
             .await
             .map_err(StorageWriteSetError::Storage)?;
-        let stats = match write_set.lower_into(&mut write).await {
+        let lowered = async {
+            let stats = write_set.lower_into(&mut write).await?;
+            if stats.staged_puts > 0 || stats.staged_deletes > 0 {
+                stage_mutation_revision(&mut write)
+                    .await
+                    .map_err(StorageWriteSetError::Storage)?;
+            }
+            Ok::<_, StorageWriteSetError>(stats)
+        }
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.storage_lowering"
+        ))
+        .await;
+        let stats = match lowered {
             Ok(stats) => stats,
             Err(error) => {
                 let _ = write.rollback().await;
                 return Err(error);
             }
         };
-        if stats.staged_puts > 0 || stats.staged_deletes > 0 {
-            if let Err(error) = stage_mutation_revision(&mut write).await {
-                let _ = write.rollback().await;
-                return Err(StorageWriteSetError::Storage(error));
-            }
-        }
         Ok(PreparedStorageCommit { write, stats })
     }
 
@@ -206,7 +219,14 @@ where
     StorageImpl: Storage + 'a,
 {
     pub async fn commit(self) -> Result<(CommitResult, StorageWriteSetStats), StorageError> {
-        let result = self.write.commit().await?;
+        let result = self
+            .write
+            .commit()
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.storage_commit_accepted_visible"
+            ))
+            .await?;
         Ok((result, self.stats))
     }
 

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -25,6 +25,7 @@ use crate::tracked_state::{TrackedStateContext, TrackedStateDeltaRef};
 use crate::transaction::staging::{PreparedStateRowIdentity, PreparedWriteSet};
 use crate::transaction::types::{PreparedStateRow, StagedCommitChangeRef, StagedCommitChangeRefs};
 use std::collections::{BTreeMap, BTreeSet};
+use tracing::Instrument as _;
 
 type RowIndex = usize;
 
@@ -82,6 +83,10 @@ pub(crate) async fn commit_prepared_writes(
         branch_ctx,
         &*read,
     )
+    .instrument(tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.materialization.finalize_commit_rows"
+    ))
     .await?;
     let commit_rows = finalized.commit_rows;
     let branch_heads = finalized.branch_heads;
@@ -119,6 +124,10 @@ pub(crate) async fn commit_prepared_writes(
         &engine_rows,
         &insert_identities,
     )
+    .instrument(tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.materialization.flat_current_rows"
+    ))
     .await?;
 
     let staged_commits = stage_changelog_commits(
@@ -130,6 +139,10 @@ pub(crate) async fn commit_prepared_writes(
         &row_index.tracked_row_indices_by_commit,
         &commit_rows,
     )
+    .instrument(tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.materialization.changelog"
+    ))
     .await?;
 
     stage_state_json_payloads(&mut json_writer, &mut writes, &state_rows)?;
@@ -142,6 +155,10 @@ pub(crate) async fn commit_prepared_writes(
         tracked_roots,
         staged_commits,
     )
+    .instrument(tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.materialization.tracked_roots"
+    ))
     .await?;
     if filesystem_view_changed {
         stage_path_index_revision(&mut writes);

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -15,6 +15,7 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use serde_json::Value as JsonValue;
+use tracing::Instrument as _;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobHash};
@@ -381,6 +382,10 @@ where
         check_commit_boundary(commit_boundary.as_ref())?;
         transaction
             .validate_prepared_writes_by_branch(&prepared_writes)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_validation"
+            ))
             .await?;
         let filesystem_delta_rows = if prepared_writes
             .state_rows
@@ -421,6 +426,10 @@ where
             &mut read,
             prepared_writes,
         )
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.transaction_materialization"
+        ))
         .await
         {
             Ok(writes) => writes,

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -10,6 +10,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value as JsonValue;
+use tracing::Instrument as _;
 
 use crate::LixError;
 use crate::branch::{BRANCH_DESCRIPTOR_SCHEMA_KEY, BRANCH_REF_SCHEMA_KEY};
@@ -200,7 +201,12 @@ pub(crate) async fn validate_prepared_writes(
     let constraint_rows = input.staged_writes.constraint_rows().collect::<Vec<_>>();
     let pending_file_descriptors = PendingFileDescriptorIndex::from_rows(&constraint_rows);
     let pending_schema_domains = PendingSchemaDomains::from_staged_rows(&staged_rows)?;
-    validate_registered_schema_identity_is_canonical(&input, &staged_rows).await?;
+    validate_registered_schema_identity_is_canonical(&input, &staged_rows)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.registered_schema_identity"
+        ))
+        .await?;
     let mut pending_constraints = PendingConstraintIndexes::default();
     let mut validated_constraint_rows =
         BTreeMap::<DomainRowIdentity, ValidatedRowContent<'_>>::new();
@@ -232,6 +238,10 @@ pub(crate) async fn validate_prepared_writes(
         if let Some(snapshot) = snapshot {
             file_owner_validator
                 .validate(&input, &pending_file_descriptors, row)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.validation.file_owner"
+                ))
                 .await?;
             validate_primary_key_identity(row, schema_plan, snapshot)?;
             pending_constraints.remember_foreign_key_references(row, schema_plan, snapshot)?;
@@ -245,16 +255,54 @@ pub(crate) async fn validate_prepared_writes(
     validate_pending_delete_restrictions(input.schema_catalog, &pending_constraints)?;
     let unresolved_foreign_keys =
         validate_committed_foreign_keys(&input, &pending_constraints, &unresolved_foreign_keys)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.validation.committed_foreign_keys"
+            ))
             .await?;
     reject_unresolved_foreign_keys(&unresolved_foreign_keys)?;
     validate_committed_delete_restrictions(&input, input.schema_catalog, &pending_constraints)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.delete_restrictions"
+        ))
         .await?;
-    validate_file_descriptor_delete_restrictions(&input, &pending_constraints).await?;
-    validate_branch_ref_delete_restrictions(&input, &pending_constraints).await?;
-    validate_committed_insert_identities(&input, &pending_constraints).await?;
-    validate_committed_unique_constraints(&input, &pending_constraints).await?;
-    validate_directory_descriptor_parent_graph(&input, &staged_rows, &constraint_rows).await?;
-    validate_filesystem_namespace(&input, &staged_rows).await?;
+    validate_file_descriptor_delete_restrictions(&input, &pending_constraints)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.file_delete_restrictions"
+        ))
+        .await?;
+    validate_branch_ref_delete_restrictions(&input, &pending_constraints)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.branch_ref_delete_restrictions"
+        ))
+        .await?;
+    validate_committed_insert_identities(&input, &pending_constraints)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.insert_identities"
+        ))
+        .await?;
+    validate_committed_unique_constraints(&input, &pending_constraints)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.unique_constraints"
+        ))
+        .await?;
+    validate_directory_descriptor_parent_graph(&input, &staged_rows, &constraint_rows)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.directory_parent_graph"
+        ))
+        .await?;
+    validate_filesystem_namespace(&input, &staged_rows)
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.validation.filesystem_namespace"
+        ))
+        .await?;
     Ok(())
 }
 


### PR DESCRIPTION
Stack 1/4.

## Why

A 1,000–5,000-commit end-to-end CRUD profile needed phase accounting inside the engine. The dominant write time was invisible at the server boundary, so this adds close-event spans around the session gate, transaction open/planning, validation and its subphases, materialization, storage-writer wait, lowering, and visible acceptance.

## Scope

- instrumentation only; no SQL2 optimization or persistence behavior change
- span close events remain opt-in at the `lix-server` layer
- fields are phase durations and bounded metadata, not payload contents

## Validation

- rebased onto current `origin/main` (`5eac714f`)
- full `lix_engine` library suite: 1,188 passed, 6 ignored
- formatting and diff checks pass

The next PR uses these measurements to remove redundant filesystem validation work.