### PR TITLE
perf(engine): trust serialized filesystem planner validation

### DIFF
--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -339,7 +339,7 @@ where
         };
         let write_access = SessionWriteAccess {
             _write_lease: write_lease,
-            _collaboration_write_guard: collaboration_write_guard,
+            collaboration_write_guard,
         };
         self.ensure_open()?;
         Ok(write_access)
@@ -550,12 +550,12 @@ where
 
 pub(super) struct SessionWriteAccess {
     _write_lease: SessionWriteLease,
-    _collaboration_write_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+    collaboration_write_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
 }
 
 impl SessionWriteAccess {
     fn serializes_collaboration_writes(&self) -> bool {
-        self._collaboration_write_guard.is_some()
+        self.collaboration_write_guard.is_some()
     }
 }
 

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -312,9 +312,9 @@ where
     ) -> Result<SessionWriteAccess, LixError> {
         let write_lease = self.begin_explicit_session_write_lease()?;
         // Explicit transactions can remain open across arbitrary application
-        // awaits. Serializing them for their entire lifetime would allow one
-        // client to block every engine writer indefinitely. The collaboration
-        // MVP serializes bounded implicit statements and execute batches.
+        // awaits, so the common non-deterministic path only serializes their
+        // commit. Deterministic transactions add the collaboration guard before
+        // taking the runtime guard to preserve the global lock order.
         self.begin_session_write_access_with_lease(write_lease, false)
             .await
     }
@@ -554,8 +554,25 @@ pub(super) struct SessionWriteAccess {
 }
 
 impl SessionWriteAccess {
-    fn serializes_collaboration_writes(&self) -> bool {
+    pub(super) fn serializes_collaboration_writes(&self) -> bool {
         self.collaboration_write_guard.is_some()
+    }
+
+    pub(super) async fn serialize_collaboration_writes(
+        &mut self,
+        collaboration_write_gate: &Arc<tokio::sync::Mutex<()>>,
+    ) {
+        if self.collaboration_write_guard.is_none() {
+            self.collaboration_write_guard = Some(
+                Arc::clone(collaboration_write_gate)
+                    .lock_owned()
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.collaboration_gate_wait"
+                    ))
+                    .await,
+            );
+        }
     }
 }
 

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -470,6 +470,7 @@ where
             &'tx mut Transaction<StorageImpl>,
         ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
     {
+        let planner_validation_is_serialized = write_access.serializes_collaboration_writes();
         let _deterministic_runtime_guard = if self.deterministic_mode_enabled().await? {
             Some(self.lock_deterministic_runtime().await)
         } else {
@@ -495,6 +496,9 @@ where
         self.ensure_open()?;
         let mut transaction = opened.transaction;
         transaction.attach_commit_boundary(self.transaction_commit_boundary());
+        if planner_validation_is_serialized {
+            transaction.trust_serialized_filesystem_planner();
+        }
         let runtime_functions = opened.runtime_functions;
 
         match f(&mut transaction)
@@ -547,6 +551,12 @@ where
 pub(super) struct SessionWriteAccess {
     _write_lease: SessionWriteLease,
     _collaboration_write_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
+impl SessionWriteAccess {
+    fn serializes_collaboration_writes(&self) -> bool {
+        self._collaboration_write_guard.is_some()
+    }
 }
 
 pub(super) fn closed_error() -> LixError {
@@ -862,6 +872,38 @@ mod tests {
             .await
             .expect("transaction commit should succeed");
         assert!(!session.commit_in_progress_for_test());
+    }
+
+    #[tokio::test]
+    async fn explicit_transaction_commit_waits_for_collaboration_write_gate() {
+        let session = open_session().await;
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("transaction should begin");
+        transaction
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('serialized-commit', 'value')",
+                &[],
+            )
+            .await
+            .expect("transaction write should stage");
+
+        let collaboration_guard = std::sync::Arc::clone(&session.collaboration_write_gate)
+            .lock_owned()
+            .await;
+        let mut commit = Box::pin(transaction.commit());
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(
+            matches!(commit.as_mut().poll(&mut cx), Poll::Pending),
+            "explicit commit should wait behind a bounded collaboration write"
+        );
+
+        drop(collaboration_guard);
+        tokio::time::timeout(TEST_WAIT_TIMEOUT, commit)
+            .await
+            .expect("commit should resume after collaboration gate release")
+            .expect("explicit transaction commit should succeed");
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -28,6 +28,7 @@ pub struct SessionTransaction<StorageImpl: Storage = Memory> {
     pub(super) sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     _deterministic_runtime_guard: Option<DeterministicRuntimeGuard>,
     write_access: Option<SessionWriteAccess>,
+    collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
     pub(super) telemetry: Option<Arc<dyn TelemetrySink>>,
 }
 
@@ -76,6 +77,7 @@ where
             sql_planning_cache: Arc::clone(&self.sql_planning_cache),
             _deterministic_runtime_guard: deterministic_runtime_guard,
             write_access: Some(write_access),
+            collaboration_write_gate: Arc::clone(&self.collaboration_write_gate),
             telemetry: self.telemetry.clone(),
         })
     }
@@ -101,6 +103,12 @@ where
     }
 
     pub async fn commit(mut self) -> Result<(), LixError> {
+        // Explicit transactions may remain open across application awaits, so
+        // they do not hold the collaboration gate while planning. Serialize
+        // their commit-time revalidation and persistence with bounded writes.
+        let _collaboration_write_guard = Arc::clone(&self.collaboration_write_gate)
+            .lock_owned()
+            .await;
         let operation_guard = self.begin_session_commit_operation()?;
         let transaction = self
             .transaction

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -38,8 +38,16 @@ where
 {
     pub async fn begin_transaction(&self) -> Result<SessionTransaction<StorageImpl>, LixError> {
         self.ensure_open()?;
-        let write_access = self.begin_explicit_session_write_access().await?;
+        let mut write_access = self.begin_explicit_session_write_access().await?;
         let deterministic_runtime_guard = if self.deterministic_mode_enabled().await? {
+            // Bounded durable-runtime writes take the collaboration gate before
+            // the deterministic-runtime gate. Keep that order for explicit
+            // transactions as well, then retain both guards for their lifetime
+            // so commit cannot deadlock with a bounded writer holding one gate
+            // while waiting for the other.
+            write_access
+                .serialize_collaboration_writes(&self.collaboration_write_gate)
+                .await;
             Some(self.lock_deterministic_runtime().await)
         } else {
             None
@@ -106,9 +114,21 @@ where
         // Explicit transactions may remain open across application awaits, so
         // they do not hold the collaboration gate while planning. Serialize
         // their commit-time revalidation and persistence with bounded writes.
-        let _collaboration_write_guard = Arc::clone(&self.collaboration_write_gate)
-            .lock_owned()
-            .await;
+        // Deterministic transactions already retain this gate to preserve the
+        // global lock order with their deterministic-runtime guard.
+        let _collaboration_write_guard = if self
+            .write_access
+            .as_ref()
+            .is_some_and(SessionWriteAccess::serializes_collaboration_writes)
+        {
+            None
+        } else {
+            Some(
+                Arc::clone(&self.collaboration_write_gate)
+                    .lock_owned()
+                    .await,
+            )
+        };
         let operation_guard = self.begin_session_commit_operation()?;
         let transaction = self
             .transaction

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -151,6 +151,7 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     storage: StorageAdapter<StorageImpl>,
     functions: FunctionProviderHandle,
     commit_boundary: Option<TransactionCommitBoundary>,
+    trust_filesystem_planner: bool,
     origin_key: Option<String>,
     session_file_views: SessionFileViews,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
@@ -352,6 +353,7 @@ where
                 storage,
                 functions,
                 commit_boundary: None,
+                trust_filesystem_planner: false,
                 origin_key: None,
                 session_file_views,
                 pending_file_view_mutations: BTreeMap::new(),
@@ -471,6 +473,10 @@ where
 
     pub(crate) fn attach_commit_boundary(&mut self, boundary: TransactionCommitBoundary) {
         self.commit_boundary = Some(boundary);
+    }
+
+    pub(crate) fn trust_serialized_filesystem_planner(&mut self) {
+        self.trust_filesystem_planner = true;
     }
 
     /// Rolls back the storage transaction.
@@ -1597,12 +1603,15 @@ where
                 .schema_resolver
                 .catalog_for_validation(&live_state, scope)
                 .await?;
-            validate_prepared_writes(TransactionValidationInput::new(
+            let mut validation_input = TransactionValidationInput::new(
                 &branch_prepared_writes,
                 schema_catalog,
                 &live_state,
-            ))
-            .await?;
+            );
+            if self.trust_filesystem_planner {
+                validation_input = validation_input.with_trusted_filesystem_planner();
+            }
+            validate_prepared_writes(validation_input).await?;
         }
         Ok(())
     }

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -61,6 +61,7 @@ pub(crate) struct TransactionValidationInput<'a> {
     staged_writes: &'a PreparedWriteValidationSet<'a>,
     schema_catalog: &'a CatalogSnapshot,
     live_state: &'a dyn LiveStateReader,
+    trust_filesystem_planner: bool,
 }
 
 impl<'a> TransactionValidationInput<'a> {
@@ -73,7 +74,16 @@ impl<'a> TransactionValidationInput<'a> {
             staged_writes,
             schema_catalog,
             live_state,
+            trust_filesystem_planner: false,
         }
+    }
+
+    /// Trust namespace checks performed while a serialized, bounded write
+    /// statement was planned. Explicit transactions retain commit-time
+    /// validation because their planner snapshot can become stale.
+    pub(crate) fn with_trusted_filesystem_planner(mut self) -> Self {
+        self.trust_filesystem_planner = true;
+        self
     }
 
     #[cfg(test)]
@@ -639,6 +649,17 @@ async fn filesystem_namespace_domain_changed(
     {
         return Ok(false);
     }
+    // Bounded filesystem writes are serialized from planning through commit.
+    // Their transaction-visible namespace resolver already rejects duplicate
+    // paths and cross-kind collisions. TransactionWriteOrigin is crate-private,
+    // so an exact origin/row match can identify those planner-owned inserts.
+    if input.trust_filesystem_planner
+        && descriptor_rows
+            .iter()
+            .all(|row| filesystem_planner_validated_insert(row))
+    {
+        return Ok(false);
+    }
     if descriptor_rows.len() > 1 {
         return Ok(true);
     }
@@ -675,6 +696,43 @@ async fn filesystem_namespace_domain_changed(
         return Ok(true);
     };
     Ok(committed_occupant != filesystem_namespace_occupant_from_staged_row(row, snapshot)?)
+}
+
+fn filesystem_planner_validated_insert(row: &PreparedValidationRow<'_>) -> bool {
+    if row.snapshot_json().is_none() {
+        return false;
+    }
+    let Some(origin) = row.origin() else {
+        return false;
+    };
+    if origin.operation != TransactionWriteOperation::Insert {
+        return false;
+    }
+    let surface_matches_schema = match row.schema_key() {
+        FILE_DESCRIPTOR_SCHEMA_KEY => {
+            matches!(origin.surface.as_str(), "lix_file" | "lix_file_by_branch")
+        }
+        DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
+            matches!(
+                origin.surface.as_str(),
+                "lix_directory" | "lix_directory_by_branch"
+            )
+        }
+        _ => false,
+    };
+    if !surface_matches_schema {
+        return false;
+    }
+    let Some(primary_key) = origin.primary_key.as_ref() else {
+        return false;
+    };
+    primary_key.columns.len() == 1
+        && primary_key.columns[0] == "id"
+        && primary_key.values.len() == 1
+        && row
+            .entity_pk()
+            .as_single_string()
+            .is_ok_and(|entity_pk| primary_key.values[0] == entity_pk)
 }
 
 fn staged_filesystem_namespace_domains(
@@ -2906,7 +2964,7 @@ mod tests {
     use super::*;
     use crate::live_state::{LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow};
     use crate::schema::{schema_key_from_definition, seed_schema_definition};
-    use crate::transaction::types::{StageJson, TransactionJson};
+    use crate::transaction::types::{LogicalPrimaryKey, StageJson, TransactionJson};
 
     struct EmptyLiveStateReader;
 
@@ -3030,6 +3088,7 @@ mod tests {
 
     async fn filesystem_namespace_validation_scan_count_for_test(
         staged_writes: PreparedWriteSet,
+        trust_filesystem_planner: bool,
     ) -> Result<usize, LixError> {
         let validation_set = staged_writes.validation_set_for_tests();
         let staged_rows = validation_set.rows().collect::<Vec<_>>();
@@ -3041,9 +3100,23 @@ mod tests {
             rows: Vec::new(),
             scan_count: AtomicUsize::new(0),
         };
-        let input = TransactionValidationInput::new(&validation_set, &catalog, &live_state);
+        let mut input = TransactionValidationInput::new(&validation_set, &catalog, &live_state);
+        if trust_filesystem_planner {
+            input = input.with_trusted_filesystem_planner();
+        }
         validate_filesystem_namespace(&input, &staged_rows).await?;
         Ok(live_state.scan_count.load(Ordering::Relaxed))
+    }
+
+    fn filesystem_insert_origin(surface: &str, entity_id: &str) -> TransactionWriteOrigin {
+        TransactionWriteOrigin {
+            surface: surface.to_string(),
+            operation: TransactionWriteOperation::Insert,
+            primary_key: Some(LogicalPrimaryKey {
+                columns: vec!["id".to_string()],
+                values: vec![entity_id.to_string()],
+            }),
+        }
     }
 
     fn catalog_from_transaction_input<'a>(
@@ -3491,7 +3564,7 @@ mod tests {
             ..empty_staged_write_set()
         };
         assert_eq!(
-            filesystem_namespace_validation_scan_count_for_test(delete_write)
+            filesystem_namespace_validation_scan_count_for_test(delete_write, false)
                 .await
                 .expect("descriptor deletion should validate"),
             0,
@@ -3503,7 +3576,7 @@ mod tests {
             ..empty_staged_write_set()
         };
         assert_eq!(
-            filesystem_namespace_validation_scan_count_for_test(mixed_write)
+            filesystem_namespace_validation_scan_count_for_test(mixed_write, false)
                 .await
                 .expect("mixed namespace mutation should validate"),
             1,
@@ -3512,25 +3585,90 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn filesystem_namespace_inserts_do_not_add_a_point_read_before_full_validation() {
-        let mut logical_insert = staged_file_descriptor_row("logical-insert", "branch-a");
-        logical_insert.origin = Some(TransactionWriteOrigin {
+    async fn filesystem_planner_inserts_skip_redundant_namespace_scan() {
+        for (surface, schema_key) in [
+            ("lix_file", FILE_DESCRIPTOR_SCHEMA_KEY),
+            ("lix_file_by_branch", FILE_DESCRIPTOR_SCHEMA_KEY),
+            ("lix_directory", DIRECTORY_DESCRIPTOR_SCHEMA_KEY),
+            ("lix_directory_by_branch", DIRECTORY_DESCRIPTOR_SCHEMA_KEY),
+        ] {
+            let mut logical_insert = if schema_key == FILE_DESCRIPTOR_SCHEMA_KEY {
+                staged_file_descriptor_row(surface, "branch-a")
+            } else {
+                directory_descriptor_row(surface, None, surface, "branch-a")
+            };
+            logical_insert.origin = Some(filesystem_insert_origin(surface, surface));
+            let untrusted_transaction_write = PreparedWriteSet {
+                state_rows: vec![logical_insert.clone()],
+                ..empty_staged_write_set()
+            };
+            assert_eq!(
+                filesystem_namespace_validation_scan_count_for_test(
+                    untrusted_transaction_write,
+                    false,
+                )
+                .await
+                .expect("explicit transaction insert should succeed"),
+                1,
+                "{surface} must be revalidated when planning was not serialized"
+            );
+            let logical_write = PreparedWriteSet {
+                state_rows: vec![logical_insert],
+                ..empty_staged_write_set()
+            };
+            assert_eq!(
+                filesystem_namespace_validation_scan_count_for_test(logical_write, true)
+                    .await
+                    .expect("planner-validated insert should succeed"),
+                0,
+                "{surface} already validated the transaction-visible namespace"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn filesystem_planner_certificate_must_match_final_descriptor() {
+        let mut wrong_surface = staged_file_descriptor_row("wrong-surface", "branch-a");
+        wrong_surface.origin = Some(filesystem_insert_origin("lix_directory", "wrong-surface"));
+        let mut missing_key = staged_file_descriptor_row("missing-key", "branch-a");
+        missing_key.origin = Some(TransactionWriteOrigin {
             surface: "lix_file".to_string(),
             operation: TransactionWriteOperation::Insert,
             primary_key: None,
         });
-        let logical_write = PreparedWriteSet {
-            state_rows: vec![logical_insert],
-            ..empty_staged_write_set()
-        };
-        assert_eq!(
-            filesystem_namespace_validation_scan_count_for_test(logical_write)
-                .await
-                .expect("logical insert validation should succeed"),
-            1,
-            "logical inserts should perform only the complete namespace scan"
-        );
+        let mut wrong_key = staged_file_descriptor_row("wrong-key", "branch-a");
+        wrong_key.origin = Some(filesystem_insert_origin("lix_file", "different-id"));
+        let mut update = staged_file_descriptor_row("update", "branch-a");
+        update.origin = Some(TransactionWriteOrigin {
+            operation: TransactionWriteOperation::Update,
+            ..filesystem_insert_origin("lix_file", "update")
+        });
+        let mut near_match = staged_file_descriptor_row("near-match", "branch-a");
+        near_match.origin = Some(filesystem_insert_origin("lix_file_internal", "near-match"));
 
+        for (row, scenario) in [
+            (wrong_surface, "wrong schema/surface pair"),
+            (missing_key, "missing logical primary key"),
+            (wrong_key, "logical primary key mismatch"),
+            (update, "non-insert operation"),
+            (near_match, "near-match surface"),
+        ] {
+            let staged_writes = PreparedWriteSet {
+                state_rows: vec![row],
+                ..empty_staged_write_set()
+            };
+            assert!(
+                filesystem_namespace_validation_scan_count_for_test(staged_writes, true)
+                    .await
+                    .unwrap_or_else(|error| panic!("{scenario}: {error}"))
+                    >= 1,
+                "{scenario} must retain commit-time namespace validation"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_and_mixed_descriptor_inserts_keep_namespace_scan() {
         let explicit_insert = staged_file_descriptor_row("explicit-insert", "branch-a");
         let mut explicit_write = PreparedWriteSet {
             state_rows: vec![explicit_insert.clone()],
@@ -3538,11 +3676,25 @@ mod tests {
         };
         explicit_write.remember_insert_identity_for_tests(&explicit_insert);
         assert_eq!(
-            filesystem_namespace_validation_scan_count_for_test(explicit_write)
+            filesystem_namespace_validation_scan_count_for_test(explicit_write, true)
                 .await
                 .expect("explicit insert validation should succeed"),
             1,
-            "explicit inserts should perform only the complete namespace scan"
+            "direct descriptor inserts have no trusted planner certificate"
+        );
+
+        let mut logical_insert = staged_file_descriptor_row("logical-insert", "branch-a");
+        logical_insert.origin = Some(filesystem_insert_origin("lix_file", "logical-insert"));
+        let mixed_write = PreparedWriteSet {
+            state_rows: vec![logical_insert, explicit_insert],
+            ..empty_staged_write_set()
+        };
+        assert_eq!(
+            filesystem_namespace_validation_scan_count_for_test(mixed_write, true)
+                .await
+                .expect("mixed insert validation should succeed"),
+            1,
+            "one untrusted descriptor keeps validation for the whole domain"
         );
     }
 
@@ -3602,11 +3754,6 @@ mod tests {
         inserted.snapshot = Some(test_stage_json(
             r#"{"id":"file-new","directory_id":null,"name":"occupied"}"#,
         ));
-        inserted.origin = Some(TransactionWriteOrigin {
-            surface: "lix_file".to_string(),
-            operation: TransactionWriteOperation::Insert,
-            primary_key: None,
-        });
         let staged_writes = PreparedWriteSet {
             state_rows: vec![inserted],
             ..empty_staged_write_set()


### PR DESCRIPTION
Stack 3/4, on top of #725.

## Outcome

At an exact 1,000-file / 1,000-total-commit start state, five counterbalanced end-to-end `lix-server -> protocol -> Lix -> SlateDB` pairs measured:

| Operation | Baseline median | Candidate median | Median change | Median paired change |
| --- | ---: | ---: | ---: | ---: |
| Create 4 KiB | 181.252 ms | 118.463 ms | **34.6% faster** | **29.7% faster** |
| Delete 1 KiB | 75.034 ms | 51.860 ms | **30.9% faster** | **30.9% faster** |

Each pair used physical clones of one gracefully closed template, a fresh server process, five asserted unrelated precondition reads, a one-second settle outside timing, and exactly one timed mutation. Cold first-operation medians improved 17.2% CREATE and 18.4% DELETE; object-store/background variance dominates that profile, so it is not promoted as the >20% claim.

## Hard cut with a narrow certificate

The engine skips the redundant namespace scan only when a bounded implicit/autocommit write is still under the per-engine collaboration gate and the exact trusted origin, schema, operation, and primary key match a filesystem-planner insertion. Raw `lix_state` writes, mixed batches, unmatched origins, implicit parent creation, and long-lived explicit transactions keep conservative commit-time validation.

Explicit transaction commits serialize revalidation with that same collaboration gate. Deterministic explicit transactions acquire the collaboration and runtime gates in one global order and retain them through commit; this avoids the lock inversion found by the first full CI run.

## Validation

- full all-feature `lix_engine` library suite: 1,185 passed, 6 ignored
- all 27 engine simulations pass, including both deterministic lock-order variants that previously timed out
- all-feature engine lib/test clippy passes with `-D warnings`
- targeted negative tests cover wrong origin, schema, operation, and primary key
- SQL2 was not changed

Raw end-to-end samples and reproduction details are in the stacked Lixray harness PR.