### PR TITLE
perf(engine)!: inline small binary CAS blobs

### DIFF
--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -70,6 +70,12 @@ path = "benches/large_blob_updates.rs"
 harness = false
 required-features = ["storage-benches", "slatedb"]
 
+[[bench]]
+name = "small_blob_cas"
+path = "benches/small_blob_cas.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
 [dependencies]
 ahash = "0.8"
 async-trait = "0.1"

--- a/packages/engine/benches/small_blob_cas.rs
+++ b/packages/engine/benches/small_blob_cas.rs
@@ -1,0 +1,341 @@
+use std::fmt::{self, Display, Formatter};
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use lix_engine::storage_adapter::StorageAdapter;
+use lix_engine::storage_bench::{
+    binary_cas_write_accounting, layout_accounting, read_binary_cas_for_bench,
+    reset_binary_cas_write_accounting, write_binary_cas_for_bench,
+};
+use lix_engine::{ReadOptions, Storage};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+use tempfile::TempDir;
+
+const BACKENDS: &[Backend] = &[Backend::Rocks, Backend::Slate];
+const SIZES: &[usize] = &[4 << 10, 32 << 10];
+const OPERATIONS: &[Operation] = &[
+    Operation::UniqueWrite,
+    Operation::DedupeWrite,
+    Operation::HotRead,
+];
+const DEFAULT_WARMUPS: usize = 20;
+const DEFAULT_SAMPLES: usize = 200;
+
+#[derive(Clone, Copy, Debug)]
+enum Backend {
+    Rocks,
+    Slate,
+}
+
+impl Display for Backend {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Rocks => formatter.write_str("rocksdb"),
+            Self::Slate => formatter.write_str("slatedb"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Operation {
+    UniqueWrite,
+    DedupeWrite,
+    HotRead,
+}
+
+impl Display for Operation {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UniqueWrite => formatter.write_str("unique_write"),
+            Self::DedupeWrite => formatter.write_str("dedupe_write"),
+            Self::HotRead => formatter.write_str("hot_read"),
+        }
+    }
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create small blob benchmark runtime");
+    runtime.block_on(run());
+}
+
+async fn run() {
+    let warmups = env_usize("LIX_SMALL_BLOB_WARMUPS", DEFAULT_WARMUPS);
+    let samples = env_usize("LIX_SMALL_BLOB_SAMPLES", DEFAULT_SAMPLES).max(1);
+
+    for &backend in BACKENDS {
+        if !selected("LIX_SMALL_BLOB_BACKENDS", &backend.to_string()) {
+            continue;
+        }
+        for &size in SIZES {
+            if !selected("LIX_SMALL_BLOB_SIZES_KIB", &(size >> 10).to_string()) {
+                continue;
+            }
+            for &operation in OPERATIONS {
+                if !selected("LIX_SMALL_BLOB_OPERATIONS", &operation.to_string()) {
+                    continue;
+                }
+                run_case(backend, size, operation, warmups, samples).await;
+            }
+        }
+    }
+}
+
+async fn run_case(
+    backend: Backend,
+    size: usize,
+    operation: Operation,
+    warmups: usize,
+    samples: usize,
+) {
+    let mut fixture = Fixture::new(backend, size, operation).await;
+    for _ in 0..warmups {
+        fixture.run_once().await;
+    }
+
+    reset_binary_cas_write_accounting();
+    let mut timings = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let prepared = fixture.prepare();
+        let started = Instant::now();
+        black_box(fixture.execute(prepared).await);
+        timings.push(started.elapsed());
+    }
+    let accounting = binary_cas_write_accounting();
+    let layout = fixture.layout().await;
+    timings.sort_unstable();
+
+    println!(
+        "small_blob_cas,backend={backend},operation={operation},size_bytes={size},\
+         warmups={warmups},samples={samples},p50_us={},p95_us={},mean_us={},\
+         chunk_lookups={},chunk_lookup_batches={},chunk_lookup_hits={},\
+         chunk_lookup_misses={},chunk_lookup_us={},manifest_rows={},\
+         manifest_value_bytes={},manifest_chunk_rows={},payload_rows={},\
+         payload_value_bytes={},presence_rows={}",
+        duration_us(percentile(&timings, 50, 100)),
+        duration_us(percentile(&timings, 95, 100)),
+        duration_us(timings.iter().sum::<Duration>() / samples as u32),
+        accounting.chunk_lookup_count,
+        accounting.chunk_lookup_batch_count,
+        accounting.chunk_lookup_hit_count,
+        accounting.chunk_lookup_miss_count,
+        accounting.chunk_lookup_elapsed_ns / 1_000,
+        layout.manifest_rows,
+        layout.manifest_value_bytes,
+        layout.manifest_chunk_rows,
+        layout.payload_rows,
+        layout.payload_value_bytes,
+        layout.presence_rows,
+    );
+}
+
+fn duration_us(duration: Duration) -> u128 {
+    duration.as_micros()
+}
+
+fn percentile(sorted: &[Duration], numerator: usize, denominator: usize) -> Duration {
+    let rank = sorted.len().saturating_mul(numerator).div_ceil(denominator);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn selected(variable: &str, candidate: &str) -> bool {
+    std::env::var(variable).map_or(true, |selection| {
+        selection
+            .split(',')
+            .map(str::trim)
+            .any(|value| value == candidate)
+    })
+}
+
+struct PreparedOperation {
+    bytes: Option<Vec<u8>>,
+    expected_hash: Option<String>,
+}
+
+struct BackendFixture<S: Storage> {
+    storage: StorageAdapter<S>,
+    _temp_dir: TempDir,
+    size: usize,
+    operation: Operation,
+    version: u64,
+    stable_bytes: Vec<u8>,
+    stable_hash: String,
+}
+
+impl<S> BackendFixture<S>
+where
+    S: Storage,
+{
+    async fn create(storage: S, temp_dir: TempDir, size: usize, operation: Operation) -> Self {
+        let storage = StorageAdapter::new(storage);
+        let stable_bytes = deterministic_bytes(size, 0x5a17);
+        let stable_hash = write_binary_cas_for_bench(&storage, &stable_bytes)
+            .await
+            .expect("seed small blob benchmark");
+        Self {
+            storage,
+            _temp_dir: temp_dir,
+            size,
+            operation,
+            version: 1,
+            stable_bytes,
+            stable_hash,
+        }
+    }
+
+    fn prepare(&mut self) -> PreparedOperation {
+        let version = self.version;
+        self.version += 1;
+        match self.operation {
+            Operation::UniqueWrite => PreparedOperation {
+                bytes: Some(deterministic_bytes(self.size, version)),
+                expected_hash: None,
+            },
+            Operation::DedupeWrite => PreparedOperation {
+                bytes: Some(self.stable_bytes.clone()),
+                expected_hash: Some(self.stable_hash.clone()),
+            },
+            Operation::HotRead => PreparedOperation {
+                bytes: None,
+                expected_hash: Some(self.stable_hash.clone()),
+            },
+        }
+    }
+
+    async fn execute(&self, prepared: PreparedOperation) -> usize {
+        match prepared.bytes {
+            Some(bytes) => {
+                let hash = write_binary_cas_for_bench(&self.storage, &bytes)
+                    .await
+                    .expect("write benchmark blob");
+                if let Some(expected_hash) = prepared.expected_hash {
+                    assert_eq!(hash, expected_hash);
+                }
+                bytes.len()
+            }
+            None => {
+                let hash = prepared
+                    .expected_hash
+                    .expect("read benchmark operation should have a hash");
+                let bytes = read_binary_cas_for_bench(&self.storage, &hash)
+                    .await
+                    .expect("read benchmark blob")
+                    .expect("benchmark blob should exist");
+                assert_eq!(bytes, self.stable_bytes);
+                bytes.len()
+            }
+        }
+    }
+
+    async fn layout(&self) -> Layout {
+        let read = self
+            .storage
+            .begin_read(ReadOptions::default())
+            .await
+            .expect("open layout accounting read");
+        let spaces = layout_accounting(&read).await;
+        Layout {
+            manifest_rows: rows(&spaces, "binary_cas.manifest"),
+            manifest_value_bytes: value_bytes(&spaces, "binary_cas.manifest"),
+            manifest_chunk_rows: rows(&spaces, "binary_cas.manifest_chunk"),
+            payload_rows: rows(&spaces, "binary_cas.chunk"),
+            payload_value_bytes: value_bytes(&spaces, "binary_cas.chunk"),
+            presence_rows: rows(&spaces, "binary_cas.chunk_presence"),
+        }
+    }
+}
+
+enum Fixture {
+    Rocks(BackendFixture<RocksDB>),
+    Slate(BackendFixture<SlateDB>),
+}
+
+impl Fixture {
+    async fn new(backend: Backend, size: usize, operation: Operation) -> Self {
+        let temp_dir = tempfile::tempdir().expect("create small blob benchmark directory");
+        let database_path = temp_dir.path().join("database");
+        match backend {
+            Backend::Rocks => {
+                let storage = RocksDB::open(&database_path).expect("open benchmark RocksDB");
+                Self::Rocks(BackendFixture::create(storage, temp_dir, size, operation).await)
+            }
+            Backend::Slate => {
+                let storage = SlateDB::open(&database_path).expect("open benchmark SlateDB");
+                Self::Slate(BackendFixture::create(storage, temp_dir, size, operation).await)
+            }
+        }
+    }
+
+    fn prepare(&mut self) -> PreparedOperation {
+        match self {
+            Self::Rocks(fixture) => fixture.prepare(),
+            Self::Slate(fixture) => fixture.prepare(),
+        }
+    }
+
+    async fn execute(&self, prepared: PreparedOperation) -> usize {
+        match self {
+            Self::Rocks(fixture) => fixture.execute(prepared).await,
+            Self::Slate(fixture) => fixture.execute(prepared).await,
+        }
+    }
+
+    async fn run_once(&mut self) {
+        let prepared = self.prepare();
+        black_box(self.execute(prepared).await);
+    }
+
+    async fn layout(&self) -> Layout {
+        match self {
+            Self::Rocks(fixture) => fixture.layout().await,
+            Self::Slate(fixture) => fixture.layout().await,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Layout {
+    manifest_rows: u64,
+    manifest_value_bytes: u64,
+    manifest_chunk_rows: u64,
+    payload_rows: u64,
+    payload_value_bytes: u64,
+    presence_rows: u64,
+}
+
+fn rows(spaces: &[lix_engine::storage_bench::StorageLayoutAccounting], name: &str) -> u64 {
+    spaces
+        .iter()
+        .find(|space| space.space == name)
+        .map_or(0, |space| space.rows)
+}
+
+fn value_bytes(spaces: &[lix_engine::storage_bench::StorageLayoutAccounting], name: &str) -> u64 {
+    spaces
+        .iter()
+        .find(|space| space.space == name)
+        .map_or(0, |space| space.value_bytes)
+}
+
+fn deterministic_bytes(len: usize, seed: u64) -> Vec<u8> {
+    let mut bytes = vec![0; len];
+    let mut state = seed ^ 0xd1b5_4a32_d192_ed03;
+    for chunk in bytes.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let generated = state.to_le_bytes();
+        chunk.copy_from_slice(&generated[..chunk.len()]);
+    }
+    bytes
+}

--- a/packages/engine/benches/small_blob_cas.rs
+++ b/packages/engine/benches/small_blob_cas.rs
@@ -107,6 +107,8 @@ async fn run_case(
     let accounting = binary_cas_write_accounting();
     let layout = fixture.layout().await;
     timings.sort_unstable();
+    let sample_count = u32::try_from(samples).expect("benchmark sample count should fit in u32");
+    let mean = timings.iter().sum::<Duration>() / sample_count;
 
     println!(
         "small_blob_cas,backend={backend},operation={operation},size_bytes={size},\
@@ -118,10 +120,10 @@ async fn run_case(
          payload_value_bytes={},presence_rows={}",
         percentile(&timings, 50, 100).as_nanos(),
         percentile(&timings, 95, 100).as_nanos(),
-        (timings.iter().sum::<Duration>() / samples as u32).as_nanos(),
+        mean.as_nanos(),
         duration_us(percentile(&timings, 50, 100)),
         duration_us(percentile(&timings, 95, 100)),
-        duration_us(timings.iter().sum::<Duration>() / samples as u32),
+        duration_us(mean),
         accounting.chunk_lookup_count,
         accounting.chunk_lookup_batch_count,
         accounting.chunk_lookup_hit_count,

--- a/packages/engine/benches/small_blob_cas.rs
+++ b/packages/engine/benches/small_blob_cas.rs
@@ -110,11 +110,15 @@ async fn run_case(
 
     println!(
         "small_blob_cas,backend={backend},operation={operation},size_bytes={size},\
-         warmups={warmups},samples={samples},p50_us={},p95_us={},mean_us={},\
+         warmups={warmups},samples={samples},p50_ns={},p95_ns={},mean_ns={},\
+         p50_us={},p95_us={},mean_us={},\
          chunk_lookups={},chunk_lookup_batches={},chunk_lookup_hits={},\
          chunk_lookup_misses={},chunk_lookup_us={},manifest_rows={},\
          manifest_value_bytes={},manifest_chunk_rows={},payload_rows={},\
          payload_value_bytes={},presence_rows={}",
+        percentile(&timings, 50, 100).as_nanos(),
+        percentile(&timings, 95, 100).as_nanos(),
+        (timings.iter().sum::<Duration>() / samples as u32).as_nanos(),
         duration_us(percentile(&timings, 50, 100)),
         duration_us(percentile(&timings, 95, 100)),
         duration_us(timings.iter().sum::<Duration>() / samples as u32),

--- a/packages/engine/benches/small_blob_cas.rs
+++ b/packages/engine/benches/small_blob_cas.rs
@@ -186,6 +186,11 @@ where
         let stable_hash = write_binary_cas_for_bench(&storage, &stable_bytes)
             .await
             .expect("seed small blob benchmark");
+        let stored_bytes = read_binary_cas_for_bench(&storage, &stable_hash)
+            .await
+            .expect("validate benchmark blob")
+            .expect("seeded benchmark blob should exist");
+        assert_eq!(stored_bytes, stable_bytes);
         Self {
             storage,
             _temp_dir: temp_dir,
@@ -235,7 +240,6 @@ where
                     .await
                     .expect("read benchmark blob")
                     .expect("benchmark blob should exist");
-                assert_eq!(bytes, self.stable_bytes);
                 bytes.len()
             }
         }

--- a/packages/engine/benches/small_blob_cas_results.md
+++ b/packages/engine/benches/small_blob_cas_results.md
@@ -1,0 +1,87 @@
+# Small Binary CAS Optimization Log
+
+## Inline manifests through 32 KiB
+
+Date: 2026-07-23
+
+This entry compares the former three-row small-blob layout with an inline
+manifest. It measures the production binary CAS API directly through
+`StorageAdapter`; it is not a `lix-server` end-to-end benchmark.
+
+The cutoff is deliberately 32 KiB. That is the largest measured payload, and
+the RocksDB benefit decreases as payload size grows. Blobs from 32 KiB + 1
+through 64 KiB retain the existing single-chunk fast path.
+
+### Method
+
+- Backends: RocksDB and SlateDB.
+- Payloads: deterministic high-entropy 4 KiB and 32 KiB byte strings.
+- Operations: a new-content write, a repeat-same-content write, and a hot read.
+- Seven counterbalanced baseline/candidate process pairs per exact case.
+- Each process used a fresh temporary database, 300 warmups, and 3,000 timed
+  samples.
+- Values below are the median per-run p50. Improvement is the median of the
+  seven paired percentage changes, so it need not equal the percentage
+  calculated from the two independently reported medians.
+- Host: 16-vCPU AMD EPYC-Genoa KVM guest, Linux x86-64.
+- Write baseline tree: the nanosecond benchmark commit immediately before the
+  inline-layout change.
+- Write baseline executable SHA-256:
+  `3e24f816521361da3a07c0d3c51cbf658b8e195d7de700ba3d7b61f5e73acb69`.
+- Write candidate executable SHA-256:
+  `85c0583c6a7a2fdca7a25fa7d9a1ddd32d898f98bcc5f87ed47c6755a33b06b2`.
+- Read baseline tree: that same pre-inline benchmark with this log commit's
+  fixture-only byte validation applied.
+- Read baseline executable SHA-256:
+  `ca6ecfe0008ed0446273ca65e0a74d88cae9797215d3fc5dfb55ee89dec412f3`.
+- Read candidate executable SHA-256:
+  `156b82974cb2293dde870f027155d1c70c8620ce9ae8a46d425b45acf44b3d53`.
+- The read fixture validates the seeded bytes once before warmup; the timed
+  operation includes storage read, decode, allocation, and destruction, but
+  excludes the full-byte correctness comparison.
+- Combined raw-result SHA-256:
+  `d76a7a73b0690e81443d064ea2ef25fac033cc3f04f710b812fd56f6c11e4f3b`.
+
+Run one exact case with:
+
+```sh
+LIX_SMALL_BLOB_BACKENDS=slatedb \
+LIX_SMALL_BLOB_SIZES_KIB=4 \
+LIX_SMALL_BLOB_OPERATIONS=unique_write \
+LIX_SMALL_BLOB_WARMUPS=300 \
+LIX_SMALL_BLOB_SAMPLES=3000 \
+cargo bench -p lix_engine --features storage-benches,slatedb \
+  --bench small_blob_cas
+```
+
+### Results
+
+| Backend | Size | Operation | Baseline p50 | Inline p50 | Paired improvement |
+| ------- | ---: | --------- | -----------: | ---------: | -----------------: |
+| RocksDB | 4 KiB | New-content write | 20,570 ns | 17,030 ns | +17.2% |
+| RocksDB | 4 KiB | Repeat write | 6,690 ns | 16,740 ns | -150.4% |
+| RocksDB | 4 KiB | Hot read | 5,820 ns | 3,880 ns | +33.0% |
+| RocksDB | 32 KiB | New-content write | 79,341 ns | 75,670 ns | +4.9% |
+| RocksDB | 32 KiB | Repeat write | 9,260 ns | 75,000 ns | -713.8% |
+| RocksDB | 32 KiB | Hot read | 9,930 ns | 4,070 ns | +58.5% |
+| SlateDB | 4 KiB | New-content write | 155,429 ns | 78,749 ns | +36.3% |
+| SlateDB | 4 KiB | Repeat write | 154,759 ns | 114,730 ns | +29.7% |
+| SlateDB | 4 KiB | Hot read | 138,420 ns | 81,760 ns | +33.9% |
+| SlateDB | 32 KiB | New-content write | 170,299 ns | 120,779 ns | +32.6% |
+| SlateDB | 32 KiB | Repeat write | 177,149 ns | 168,110 ns | +7.4% |
+| SlateDB | 32 KiB | Hot read | 141,179 ns | 89,940 ns | +27.8% |
+
+The layout changes a unique small blob from three logical rows to one, its key
+bytes from 108 to 36, its write-time presence lookup from one to zero, and its
+read point phases from two to one. Logical value bytes are nearly flat: 4,140
+to 4,106 bytes at 4 KiB and 32,815 to 32,780 bytes at 32 KiB. Physical
+SST/WAL bytes were not measured.
+
+### Tradeoff
+
+RocksDB repeat-same-content writes regress because the old layout probes the
+presence row and rewrites only the small manifest, while the inline layout
+rewrites the whole value. This change is justified only when new or changed
+file content plus reads represent the dominant path. If repeat writes of
+identical content are common, do not treat this optimization as a net win
+without a representative workload measurement.

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,4 +1,4 @@
-const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
+pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,3 +1,4 @@
+pub(super) const INLINE_BINARY_CAS_MAX_BYTES: usize = 32 * 1024;
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
 

--- a/packages/engine/src/binary_cas/codec.rs
+++ b/packages/engine/src/binary_cas/codec.rs
@@ -25,6 +25,12 @@ pub(crate) enum BinaryCasManifest {
         size_bytes: u64,
         chunk_count: u32,
     },
+    Inline {
+        size_bytes: u64,
+        codec: BinaryChunkCodec,
+        #[musli(bytes)]
+        payload: Vec<u8>,
+    },
 }
 
 #[derive(Encode, Decode)]
@@ -43,12 +49,24 @@ struct BinaryCasChunkRef<'a> {
     payload: &'a [u8],
 }
 
+#[derive(Encode)]
+enum InlineBinaryCasManifestRef<'a> {
+    #[musli(Binary, name = 3)]
+    Inline {
+        size_bytes: u64,
+        codec: BinaryChunkCodec,
+        #[musli(bytes)]
+        payload: &'a [u8],
+    },
+}
+
 impl BinaryCasManifest {
     pub(crate) fn size_bytes(&self) -> u64 {
         match self {
             Self::Empty { size_bytes }
             | Self::SingleChunk { size_bytes, .. }
-            | Self::Chunked { size_bytes, .. } => *size_bytes,
+            | Self::Chunked { size_bytes, .. }
+            | Self::Inline { size_bytes, .. } => *size_bytes,
         }
     }
 }
@@ -91,6 +109,22 @@ pub(crate) fn encode_binary_cas_manifest(manifest: &BinaryCasManifest) -> Vec<u8
 
 pub(crate) fn decode_binary_cas_manifest(bytes: &[u8]) -> Result<BinaryCasManifest, LixError> {
     storage_codec::decode("binary CAS manifest", bytes)
+}
+
+pub(crate) fn encode_inline_binary_cas_manifest(
+    size_bytes: u64,
+    codec: BinaryChunkCodec,
+    payload: &[u8],
+) -> Vec<u8> {
+    storage_codec::encode(
+        "inline binary CAS manifest",
+        &InlineBinaryCasManifestRef::Inline {
+            size_bytes,
+            codec,
+            payload,
+        },
+    )
+    .expect("inline binary CAS manifest storage encoding should not fail")
 }
 
 pub(crate) fn encode_binary_cas_manifest_chunk(
@@ -164,6 +198,7 @@ mod tests {
     const EMPTY_MANIFEST_STORAGE_BYTES: usize = 4;
     const SINGLE_CHUNK_MANIFEST_STORAGE_BYTES: usize = 38;
     const CHUNKED_MANIFEST_STORAGE_BYTES: usize = 6;
+    const INLINE_MANIFEST_STORAGE_OVERHEAD_BYTES: usize = 8;
     const MANIFEST_CHUNK_STORAGE_BYTES: usize = 35;
     const CHUNK_STORAGE_OVERHEAD_BYTES: usize = 3;
 
@@ -195,6 +230,25 @@ mod tests {
             assert_eq!(encoded.len(), expected_len);
             assert_eq!(decode_binary_cas_manifest(&encoded).unwrap(), manifest);
         }
+    }
+
+    #[test]
+    fn inline_manifest_roundtrips_borrowed_payload_bytes() {
+        let manifest = BinaryCasManifest::Inline {
+            size_bytes: 5,
+            codec: BinaryChunkCodec::Raw,
+            payload: b"hello".to_vec(),
+        };
+
+        let encoded =
+            encode_inline_binary_cas_manifest(5, BinaryChunkCodec::Raw, b"hello".as_slice());
+
+        assert_eq!(encoded, encode_binary_cas_manifest(&manifest));
+        assert_eq!(
+            encoded.len(),
+            b"hello".len() + INLINE_MANIFEST_STORAGE_OVERHEAD_BYTES
+        );
+        assert_eq!(decode_binary_cas_manifest(&encoded).unwrap(), manifest);
     }
 
     #[test]

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -354,8 +354,7 @@ pub(crate) async fn load_bytes_many(
             continue;
         };
         match &metadata.layout {
-            BlobLayout::Empty => {}
-            BlobLayout::Inline => {}
+            BlobLayout::Empty | BlobLayout::Inline => {}
             BlobLayout::SingleChunk { chunk_hash } => {
                 if seen_chunks.insert(*chunk_hash) {
                     requested_chunks.push(*chunk_hash);
@@ -866,8 +865,7 @@ async fn missing_chunk_hashes(
 ) -> Result<HashSet<BlobHash>, LixError> {
     let mut candidates = Vec::<(BlobHash, StorageKey)>::new();
     match &plan.layout {
-        BlobLayout::Empty => {}
-        BlobLayout::Inline => {}
+        BlobLayout::Empty | BlobLayout::Inline => {}
         BlobLayout::SingleChunk { chunk_hash } => {
             collect_chunk_lookup_candidate(*chunk_hash, transaction_chunk_keys, &mut candidates);
         }

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -2,8 +2,7 @@
 
 use crate::LixError;
 use crate::binary_cas::chunking::{
-    MAX_BINARY_CAS_CHUNK_BYTES, SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
-    fastcdc_chunk_ranges_with_chunking,
+    INLINE_BINARY_CAS_MAX_BYTES, MAX_BINARY_CAS_CHUNK_BYTES, fastcdc_chunk_ranges_with_chunking,
 };
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
@@ -729,7 +728,7 @@ fn prepare_blob_write(
     }
     let (chunk_ranges, layout) = if bytes.is_empty() {
         (Vec::new(), BlobLayout::Empty)
-    } else if bytes.len() <= SINGLE_CHUNK_FAST_PATH_MAX_BYTES {
+    } else if bytes.len() <= INLINE_BINARY_CAS_MAX_BYTES {
         (Vec::new(), BlobLayout::Inline)
     } else {
         let chunk_ranges = fastcdc_chunk_ranges_with_chunking(bytes, chunking);
@@ -959,7 +958,7 @@ fn metadata_from_manifest(
             codec,
             payload,
         } => {
-            if size_bytes == 0 || size_bytes > SINGLE_CHUNK_FAST_PATH_MAX_BYTES as u64 {
+            if size_bytes == 0 || size_bytes > INLINE_BINARY_CAS_MAX_BYTES as u64 {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
@@ -1584,9 +1583,9 @@ mod tests {
     }
 
     #[test]
-    fn inline_layout_stops_at_the_64kib_boundary() {
-        let at_boundary = vec![b'a'; SINGLE_CHUNK_FAST_PATH_MAX_BYTES];
-        let above_boundary = vec![b'a'; SINGLE_CHUNK_FAST_PATH_MAX_BYTES + 1];
+    fn inline_layout_stops_at_the_32kib_boundary() {
+        let at_boundary = vec![b'a'; INLINE_BINARY_CAS_MAX_BYTES];
+        let above_boundary = vec![b'a'; INLINE_BINARY_CAS_MAX_BYTES + 1];
 
         let inline = prepare_blob_write(BinaryCasChunking::default(), &at_boundary, None)
             .expect("boundary blob should plan");
@@ -1595,14 +1594,14 @@ mod tests {
 
         assert_eq!(inline.layout, BlobLayout::Inline);
         assert!(inline.chunk_ranges.is_empty());
-        assert!(!matches!(out_of_line.layout, BlobLayout::Inline));
-        assert!(!out_of_line.chunk_ranges.is_empty());
+        assert!(matches!(out_of_line.layout, BlobLayout::SingleChunk { .. }));
+        assert_eq!(out_of_line.chunk_ranges, vec![(0, above_boundary.len())]);
     }
 
     #[test]
     fn inline_manifest_rejects_sizes_outside_the_format_boundary() {
         let hash = BlobHash::from_content(b"invalid inline");
-        for size_bytes in [0, SINGLE_CHUNK_FAST_PATH_MAX_BYTES as u64 + 1] {
+        for size_bytes in [0, INLINE_BINARY_CAS_MAX_BYTES as u64 + 1] {
             let error = metadata_from_manifest(
                 hash,
                 BinaryCasManifest::Inline {
@@ -1671,7 +1670,7 @@ mod tests {
     #[tokio::test]
     async fn public_kv_api_compresses_repetitive_inline_blob() {
         let storage = StorageAdapter::new(Memory::new());
-        let data = b"component-section:function-signature\n".repeat(1024);
+        let data = b"component-section:function-signature\n".repeat(512);
         let blob_hash = BlobHash::from_content(&data);
 
         {

--- a/packages/engine/src/binary_cas/kv.rs
+++ b/packages/engine/src/binary_cas/kv.rs
@@ -1,16 +1,19 @@
 #![allow(clippy::cast_sign_loss)]
 
 use crate::LixError;
-use crate::binary_cas::chunking::{MAX_BINARY_CAS_CHUNK_BYTES, fastcdc_chunk_ranges_with_chunking};
+use crate::binary_cas::chunking::{
+    MAX_BINARY_CAS_CHUNK_BYTES, SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
+    fastcdc_chunk_ranges_with_chunking,
+};
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, decode_binary_cas_chunk, decode_binary_cas_manifest,
     decode_binary_cas_manifest_chunk, encode_binary_cas_chunk, encode_binary_cas_manifest,
-    encode_binary_cas_manifest_chunk,
+    encode_binary_cas_manifest_chunk, encode_inline_binary_cas_manifest,
 };
 use crate::binary_cas::compression::{decode_zstd_chunk, encode_chunk_payload};
 use crate::binary_cas::{
     BinaryCasChunking, BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch,
-    BlobWriteReceipt,
+    BlobWriteReceipt, InlineBlob,
 };
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageSpace, StorageWriteSet,
@@ -353,6 +356,7 @@ pub(crate) async fn load_bytes_many(
         };
         match &metadata.layout {
             BlobLayout::Empty => {}
+            BlobLayout::Inline => {}
             BlobLayout::SingleChunk { chunk_hash } => {
                 if seen_chunks.insert(*chunk_hash) {
                     requested_chunks.push(*chunk_hash);
@@ -392,10 +396,11 @@ pub(crate) async fn load_bytes_many(
         .map(|metadata| {
             metadata
                 .map(|metadata| {
+                    let hash = metadata.hash;
                     assemble_blob_bytes(
-                        &metadata,
+                        metadata,
                         &chunk_rows_by_hash,
-                        chunked_manifests_by_hash.get(&metadata.hash),
+                        chunked_manifests_by_hash.get(&hash),
                     )
                 })
                 .transpose()
@@ -456,7 +461,7 @@ fn full_value(value: StorageProjectedValue) -> Option<Bytes> {
 }
 
 fn assemble_blob_bytes(
-    metadata: &BlobMetadata,
+    mut metadata: BlobMetadata,
     chunk_rows_by_hash: &HashMap<BlobHash, Option<Bytes>>,
     chunked_manifest: Option<&Vec<KvBlobManifestChunk>>,
 ) -> Result<Vec<u8>, LixError> {
@@ -473,6 +478,26 @@ fn assemble_blob_bytes(
                 ));
             }
             Vec::new()
+        }
+        BlobLayout::Inline => {
+            let inline_blob = metadata.inline_blob.take().ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS inline blob '{}' is missing its encoded bytes",
+                        metadata.hash.to_hex()
+                    ),
+                )
+            })?;
+            decode_and_verify_payload(
+                inline_blob.codec,
+                metadata.size_bytes,
+                Cow::Owned(inline_blob.payload),
+                expected_blob_size,
+                metadata.hash,
+                metadata.hash,
+            )?
+            .into_owned()
         }
         BlobLayout::SingleChunk { chunk_hash } => {
             let chunk = decode_chunk_from_map(
@@ -581,6 +606,24 @@ fn decode_and_verify_chunk(
     chunk_hash: BlobHash,
 ) -> Result<Cow<'_, [u8]>, LixError> {
     let (codec, uncompressed_len, chunk_payload) = decode_binary_cas_chunk(chunk_bytes)?;
+    decode_and_verify_payload(
+        codec,
+        uncompressed_len,
+        Cow::Borrowed(chunk_payload),
+        expected_chunk_size,
+        blob_hash,
+        chunk_hash,
+    )
+}
+
+fn decode_and_verify_payload(
+    codec: BinaryChunkCodec,
+    uncompressed_len: u64,
+    chunk_payload: Cow<'_, [u8]>,
+    expected_chunk_size: usize,
+    blob_hash: BlobHash,
+    chunk_hash: BlobHash,
+) -> Result<Cow<'_, [u8]>, LixError> {
     if expected_chunk_size > MAX_BINARY_CAS_CHUNK_BYTES
         || uncompressed_len > MAX_BINARY_CAS_CHUNK_BYTES as u64
     {
@@ -607,10 +650,10 @@ fn decode_and_verify_chunk(
         ));
     }
     let decoded = match codec {
-        BinaryChunkCodec::Raw => Cow::Borrowed(chunk_payload),
+        BinaryChunkCodec::Raw => chunk_payload,
         BinaryChunkCodec::Zstd => Cow::Owned(decode_zstd_chunk(
             chunk_hash,
-            chunk_payload,
+            &chunk_payload,
             expected_chunk_size,
         )?),
     };
@@ -684,24 +727,31 @@ fn prepare_blob_write(
             "binary CAS blob hash does not match blob contents".to_string(),
         ));
     }
-    let chunk_ranges = fastcdc_chunk_ranges_with_chunking(bytes, chunking);
-    let layout = match chunk_ranges.as_slice() {
-        [] => BlobLayout::Empty,
-        [(start, end)] => BlobLayout::SingleChunk {
-            chunk_hash: if *start == 0 && *end == bytes.len() {
-                blob_hash
-            } else {
-                BlobHash::from_content(&bytes[*start..*end])
+    let (chunk_ranges, layout) = if bytes.is_empty() {
+        (Vec::new(), BlobLayout::Empty)
+    } else if bytes.len() <= SINGLE_CHUNK_FAST_PATH_MAX_BYTES {
+        (Vec::new(), BlobLayout::Inline)
+    } else {
+        let chunk_ranges = fastcdc_chunk_ranges_with_chunking(bytes, chunking);
+        let layout = match chunk_ranges.as_slice() {
+            [] => unreachable!("non-empty blobs always have at least one chunk"),
+            [(start, end)] => BlobLayout::SingleChunk {
+                chunk_hash: if *start == 0 && *end == bytes.len() {
+                    blob_hash
+                } else {
+                    BlobHash::from_content(&bytes[*start..*end])
+                },
             },
-        },
-        _ => BlobLayout::Chunked {
-            chunk_count: u32::try_from(chunk_ranges.len()).map_err(|_| {
-                LixError::new(
-                    "LIX_ERROR_UNKNOWN",
-                    "binary CAS blob has too many chunks for manifest".to_string(),
-                )
-            })?,
-        },
+            _ => BlobLayout::Chunked {
+                chunk_count: u32::try_from(chunk_ranges.len()).map_err(|_| {
+                    LixError::new(
+                        "LIX_ERROR_UNKNOWN",
+                        "binary CAS blob has too many chunks for manifest".to_string(),
+                    )
+                })?,
+            },
+        };
+        (chunk_ranges, layout)
     };
     let receipt = BlobWriteReceipt {
         hash: blob_hash,
@@ -749,6 +799,18 @@ fn stage_prepared_blob_write(
                 writes,
                 plan.blob_hash,
                 &BinaryCasManifest::Empty { size_bytes: 0 },
+            );
+        }
+        BlobLayout::Inline => {
+            let encoded = encode_chunk_payload(plan.blob_hash, bytes)?;
+            writes.put(
+                BINARY_CAS_MANIFEST_SPACE,
+                key(manifest_key(plan.blob_hash)),
+                value(encode_inline_binary_cas_manifest(
+                    bytes.len() as u64,
+                    encoded.codec,
+                    &encoded.data,
+                )),
             );
         }
         BlobLayout::SingleChunk { chunk_hash } => {
@@ -806,6 +868,7 @@ async fn missing_chunk_hashes(
     let mut candidates = Vec::<(BlobHash, StorageKey)>::new();
     match &plan.layout {
         BlobLayout::Empty => {}
+        BlobLayout::Inline => {}
         BlobLayout::SingleChunk { chunk_hash } => {
             collect_chunk_lookup_candidate(*chunk_hash, transaction_chunk_keys, &mut candidates);
         }
@@ -878,7 +941,7 @@ fn metadata_from_manifest(
     manifest: BinaryCasManifest,
 ) -> Result<BlobMetadata, LixError> {
     let size_bytes = manifest.size_bytes();
-    let layout = match manifest {
+    let (layout, inline_blob) = match manifest {
         BinaryCasManifest::Empty { size_bytes } => {
             if size_bytes != 0 {
                 return Err(LixError::new(
@@ -889,17 +952,39 @@ fn metadata_from_manifest(
                     ),
                 ));
             }
-            BlobLayout::Empty
+            (BlobLayout::Empty, None)
         }
-        BinaryCasManifest::SingleChunk { chunk_hash, .. } => BlobLayout::SingleChunk {
-            chunk_hash: BlobHash::from_bytes(chunk_hash),
-        },
-        BinaryCasManifest::Chunked { chunk_count, .. } => BlobLayout::Chunked { chunk_count },
+        BinaryCasManifest::Inline {
+            size_bytes,
+            codec,
+            payload,
+        } => {
+            if size_bytes == 0 || size_bytes > SINGLE_CHUNK_FAST_PATH_MAX_BYTES as u64 {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS inline blob '{}' has invalid size {size_bytes}",
+                        hash.to_hex()
+                    ),
+                ));
+            }
+            (BlobLayout::Inline, Some(InlineBlob { codec, payload }))
+        }
+        BinaryCasManifest::SingleChunk { chunk_hash, .. } => (
+            BlobLayout::SingleChunk {
+                chunk_hash: BlobHash::from_bytes(chunk_hash),
+            },
+            None,
+        ),
+        BinaryCasManifest::Chunked { chunk_count, .. } => {
+            (BlobLayout::Chunked { chunk_count }, None)
+        }
     };
     Ok(BlobMetadata {
         hash,
         size_bytes,
         layout,
+        inline_blob,
     })
 }
 
@@ -974,6 +1059,7 @@ mod tests {
         max_active_manifest_scans: AtomicUsize,
         manifest_scan_calls: AtomicUsize,
         chunk_get_many_calls: AtomicUsize,
+        presence_get_many_calls: AtomicUsize,
         chunk_keys_requested: AtomicUsize,
         completed_manifest_hashes: Mutex<Vec<BlobHash>>,
     }
@@ -989,6 +1075,7 @@ mod tests {
                 max_active_manifest_scans: AtomicUsize::new(0),
                 manifest_scan_calls: AtomicUsize::new(0),
                 chunk_get_many_calls: AtomicUsize::new(0),
+                presence_get_many_calls: AtomicUsize::new(0),
                 chunk_keys_requested: AtomicUsize::new(0),
                 completed_manifest_hashes: Mutex::new(Vec::new()),
             }
@@ -1018,6 +1105,9 @@ mod tests {
                 self.chunk_get_many_calls.fetch_add(1, Ordering::Relaxed);
                 self.chunk_keys_requested
                     .fetch_add(keys.len(), Ordering::Relaxed);
+            }
+            if space == BINARY_CAS_CHUNK_PRESENCE_SPACE.id {
+                self.presence_get_many_calls.fetch_add(1, Ordering::Relaxed);
             }
             self.inner.get_many(space, keys, opts).await
         }
@@ -1493,6 +1583,39 @@ mod tests {
         assert!(second < later);
     }
 
+    #[test]
+    fn inline_layout_stops_at_the_64kib_boundary() {
+        let at_boundary = vec![b'a'; SINGLE_CHUNK_FAST_PATH_MAX_BYTES];
+        let above_boundary = vec![b'a'; SINGLE_CHUNK_FAST_PATH_MAX_BYTES + 1];
+
+        let inline = prepare_blob_write(BinaryCasChunking::default(), &at_boundary, None)
+            .expect("boundary blob should plan");
+        let out_of_line = prepare_blob_write(BinaryCasChunking::default(), &above_boundary, None)
+            .expect("above-boundary blob should plan");
+
+        assert_eq!(inline.layout, BlobLayout::Inline);
+        assert!(inline.chunk_ranges.is_empty());
+        assert!(!matches!(out_of_line.layout, BlobLayout::Inline));
+        assert!(!out_of_line.chunk_ranges.is_empty());
+    }
+
+    #[test]
+    fn inline_manifest_rejects_sizes_outside_the_format_boundary() {
+        let hash = BlobHash::from_content(b"invalid inline");
+        for size_bytes in [0, SINGLE_CHUNK_FAST_PATH_MAX_BYTES as u64 + 1] {
+            let error = metadata_from_manifest(
+                hash,
+                BinaryCasManifest::Inline {
+                    size_bytes,
+                    codec: BinaryChunkCodec::Raw,
+                    payload: Vec::new(),
+                },
+            )
+            .expect_err("invalid inline size should be rejected");
+            assert!(error.message.contains("invalid size"));
+        }
+    }
+
     #[tokio::test]
     async fn public_kv_api_roundtrips_blob_bytes() {
         let storage = StorageAdapter::new(Memory::new());
@@ -1527,9 +1650,10 @@ mod tests {
             load_manifest(&store, blob_hash)
                 .await
                 .expect("manifest should load"),
-            Some(BinaryCasManifest::SingleChunk {
+            Some(BinaryCasManifest::Inline {
                 size_bytes: data.len() as u64,
-                chunk_hash: BlobHash::from_content(data).into_bytes(),
+                codec: BinaryChunkCodec::Raw,
+                payload: data.to_vec(),
             })
         );
         let store = storage
@@ -1539,13 +1663,13 @@ mod tests {
         assert_eq!(
             scan_manifest_chunks(&store, blob_hash)
                 .await
-                .expect("single-chunk blob should not spill manifest chunks"),
+                .expect("inline blob should not spill manifest chunks"),
             Vec::<KvBlobManifestChunk>::new()
         );
     }
 
     #[tokio::test]
-    async fn public_kv_api_compresses_repetitive_single_chunk_blob() {
+    async fn public_kv_api_compresses_repetitive_inline_blob() {
         let storage = StorageAdapter::new(Memory::new());
         let data = b"component-section:function-signature\n".repeat(1024);
         let blob_hash = BlobHash::from_content(&data);
@@ -1563,13 +1687,21 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let stored = load_chunk(&store, blob_hash)
+        let stored = load_manifest(&store, blob_hash)
             .await
-            .expect("chunk should load")
-            .expect("chunk should exist");
-        assert_eq!(stored.codec, BinaryChunkCodec::Zstd);
-        assert_eq!(stored.uncompressed_len, data.len() as u64);
-        assert!(stored.data.len() < data.len() / 4);
+            .expect("manifest should load")
+            .expect("manifest should exist");
+        let BinaryCasManifest::Inline {
+            size_bytes,
+            codec,
+            payload,
+        } = stored
+        else {
+            panic!("small blob should be inline");
+        };
+        assert_eq!(codec, BinaryChunkCodec::Zstd);
+        assert_eq!(size_bytes, data.len() as u64);
+        assert!(payload.len() < data.len() / 4);
 
         assert_eq!(
             load_bytes_many(&store, &[blob_hash])
@@ -1581,7 +1713,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn public_kv_api_keeps_high_entropy_single_chunk_raw() {
+    async fn public_kv_api_keeps_high_entropy_inline_blob_raw() {
         let storage = StorageAdapter::new(Memory::new());
         let data = deterministic_high_entropy_bytes(32 * 1024);
         let blob_hash = BlobHash::from_content(&data);
@@ -1599,17 +1731,22 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let stored = load_chunk(&store, blob_hash)
+        let stored = load_manifest(&store, blob_hash)
             .await
-            .expect("chunk should load")
-            .expect("chunk should exist");
-        assert_eq!(stored.codec, BinaryChunkCodec::Raw);
-        assert_eq!(stored.uncompressed_len, data.len() as u64);
-        assert_eq!(stored.data, data);
+            .expect("manifest should load")
+            .expect("manifest should exist");
+        assert_eq!(
+            stored,
+            BinaryCasManifest::Inline {
+                size_bytes: data.len() as u64,
+                codec: BinaryChunkCodec::Raw,
+                payload: data,
+            }
+        );
     }
 
     #[tokio::test]
-    async fn existing_chunk_aware_writer_skips_persisted_chunk_payloads() {
+    async fn inline_writer_stages_one_row_without_chunk_presence_reads() {
         let storage = StorageAdapter::new(Memory::new());
         let data = b"hello chunked kv cas";
         let payload = BlobPayload::from_bytes(data.to_vec());
@@ -1618,7 +1755,7 @@ mod tests {
         {
             let mut writes = storage.new_write_set();
             stage_test_payload(&storage, &mut writes, &payload).await;
-            assert_eq!(writes.stats().staged_puts, 3);
+            assert_eq!(writes.stats().staged_puts, 1);
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
@@ -1637,11 +1774,22 @@ mod tests {
             )
             .await
             .expect("chunk presence marker should load"),
-            Some(Vec::new())
+            None
         );
+        assert_eq!(
+            get_one(
+                &store,
+                BINARY_CAS_CHUNK_SPACE,
+                chunk_key(BlobHash::from_content(data)),
+            )
+            .await
+            .expect("chunk row lookup should succeed"),
+            None
+        );
+        let counted = DelayedManifestScanRead::new(store, Duration::ZERO);
         let mut writes = storage.new_write_set();
         let mut writer =
-            BinaryCasContext::new().writer_skipping_existing_chunks(&store, &mut writes);
+            BinaryCasContext::new().writer_skipping_existing_chunks(&counted, &mut writes);
         writer
             .stage_payload(&payload)
             .await
@@ -1650,7 +1798,12 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             1,
-            "a persisted marker should make the repeat write stage only its manifest"
+            "an inline repeat write should deterministically replace one manifest"
+        );
+        assert_eq!(
+            counted.presence_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "inline blobs must not probe the out-of-line chunk presence space"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -1661,12 +1814,18 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
+        let counted = DelayedManifestScanRead::new(store, Duration::ZERO);
         assert_eq!(
-            load_bytes_many(&store, &[blob_hash])
+            load_bytes_many(&counted, &[blob_hash])
                 .await
                 .expect("blob should load")
                 .into_vec(),
             vec![Some(data.to_vec())]
+        );
+        assert_eq!(
+            counted.chunk_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "inline blob reads must finish from the manifest point read"
         );
     }
 
@@ -1812,9 +1971,10 @@ mod tests {
             load_manifest(&store, blob_hash)
                 .await
                 .expect("manifest should load"),
-            Some(BinaryCasManifest::SingleChunk {
+            Some(BinaryCasManifest::Inline {
                 size_bytes: data.len() as u64,
-                chunk_hash: blob_hash.into_bytes(),
+                codec: BinaryChunkCodec::Raw,
+                payload: data.to_vec(),
             })
         );
     }
@@ -1838,18 +1998,18 @@ mod tests {
         {
             let mut writes = storage.new_write_set();
             writes.put(
-                BINARY_CAS_CHUNK_SPACE,
-                key(chunk_key(blob_hash)),
-                value(encode_binary_cas_chunk(
-                    BinaryChunkCodec::Raw,
+                BINARY_CAS_MANIFEST_SPACE,
+                key(manifest_key(blob_hash)),
+                value(encode_inline_binary_cas_manifest(
                     corrupted.len() as u64,
+                    BinaryChunkCodec::Raw,
                     corrupted,
                 )),
             );
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
-                .expect("corrupt chunk should overwrite");
+                .expect("corrupt manifest should overwrite");
         }
 
         let store = storage
@@ -1867,9 +2027,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_rejects_truncated_zstd_chunk() {
+    async fn read_rejects_truncated_zstd_inline_payload() {
         let storage = StorageAdapter::new(Memory::new());
-        let data = b"compressible binary CAS bytes".repeat(4096);
+        let data = b"compressible binary CAS bytes".repeat(1024);
         let blob_hash = BlobHash::from_content(&data);
 
         {
@@ -1888,18 +2048,18 @@ mod tests {
         {
             let mut writes = storage.new_write_set();
             writes.put(
-                BINARY_CAS_CHUNK_SPACE,
-                key(chunk_key(blob_hash)),
-                value(encode_binary_cas_chunk(
-                    BinaryChunkCodec::Zstd,
+                BINARY_CAS_MANIFEST_SPACE,
+                key(manifest_key(blob_hash)),
+                value(encode_inline_binary_cas_manifest(
                     data.len() as u64,
+                    BinaryChunkCodec::Zstd,
                     &corrupted,
                 )),
             );
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
                 .await
-                .expect("corrupt chunk should overwrite");
+                .expect("corrupt inline manifest should overwrite");
         }
 
         let store = storage

--- a/packages/engine/src/binary_cas/mod.rs
+++ b/packages/engine/src/binary_cas/mod.rs
@@ -12,5 +12,5 @@ pub(crate) use chunking::BinaryCasChunking;
 pub(crate) use context::{BinaryCasContext, BlobDataReader};
 pub(crate) use types::{
     BlobBytesBatch, BlobHash, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobPayload,
-    BlobWriteReceipt,
+    BlobWriteReceipt, InlineBlob,
 };

--- a/packages/engine/src/binary_cas/stats.rs
+++ b/packages/engine/src/binary_cas/stats.rs
@@ -15,6 +15,7 @@ use crate::storage_adapter::{
 pub(crate) struct BinaryCasStorageStats {
     pub manifest_rows: u64,
     pub empty_blob_rows: u64,
+    pub inline_blob_rows: u64,
     pub single_chunk_blob_rows: u64,
     pub chunked_blob_rows: u64,
     pub manifest_chunk_rows: u64,
@@ -47,6 +48,7 @@ where
             stats.logical_blob_bytes += manifest.size_bytes();
             match manifest {
                 BinaryCasManifest::Empty { .. } => stats.empty_blob_rows += 1,
+                BinaryCasManifest::Inline { .. } => stats.inline_blob_rows += 1,
                 BinaryCasManifest::SingleChunk { .. } => {
                     stats.single_chunk_blob_rows += 1;
                     stats.total_chunk_refs += 1;
@@ -139,6 +141,18 @@ mod tests {
             &BinaryCasManifest::Empty { size_bytes: 0 },
         );
 
+        let inline = b"inline";
+        let inline_hash = BlobHash::from_content(inline);
+        stage_manifest(
+            &mut writes,
+            inline_hash,
+            &BinaryCasManifest::Inline {
+                size_bytes: inline.len() as u64,
+                codec: BinaryChunkCodec::Raw,
+                payload: inline.to_vec(),
+            },
+        );
+
         let single_hash = BlobHash::from_content(b"single blob");
         let single_chunk_hash = BlobHash::from_content(b"single");
         stage_manifest(
@@ -204,15 +218,16 @@ mod tests {
         assert_eq!(
             stats,
             BinaryCasStorageStats {
-                manifest_rows: 3,
+                manifest_rows: 4,
                 empty_blob_rows: 1,
+                inline_blob_rows: 1,
                 single_chunk_blob_rows: 1,
                 chunked_blob_rows: 1,
                 manifest_chunk_rows: 2,
                 chunk_presence_rows: 3,
                 chunk_rows: 3,
                 total_chunk_refs: 3,
-                logical_blob_bytes: 14,
+                logical_blob_bytes: 20,
             }
         );
     }

--- a/packages/engine/src/binary_cas/types.rs
+++ b/packages/engine/src/binary_cas/types.rs
@@ -64,8 +64,15 @@ impl BlobPayload {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BlobLayout {
     Empty,
+    Inline,
     SingleChunk { chunk_hash: BlobHash },
     Chunked { chunk_count: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InlineBlob {
+    pub(crate) codec: BinaryChunkCodec,
+    pub(crate) payload: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,6 +80,7 @@ pub(crate) struct BlobMetadata {
     pub(crate) hash: BlobHash,
     pub(crate) size_bytes: u64,
     pub(crate) layout: BlobLayout,
+    pub(crate) inline_blob: Option<InlineBlob>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -7,6 +7,7 @@ use crate::storage_adapter::{
     ScanPlan, StorageAdapterRead, StorageCoreProjection, StoragePrefix, StorageProjectedValue,
     StorageScanOptions, StorageWriteOptions, StorageWriteSet, StorageWriteSetError,
 };
+use crate::{ReadOptions, WriteOptions};
 
 static TRANSACTION_ROWS_STAGED: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_UNTRACKED_ROWS: AtomicU64 = AtomicU64::new(0);
@@ -52,13 +53,15 @@ pub async fn write_binary_cas_for_bench<StorageImpl>(
 where
     StorageImpl: Storage,
 {
-    let read = storage.begin_read(Default::default()).await?;
+    let read = storage.begin_read(ReadOptions::default()).await?;
     let mut writes = storage.new_write_set();
     let receipt = crate::binary_cas::BinaryCasContext::new()
         .writer_skipping_existing_chunks(&read, &mut writes)
         .stage_payload(&crate::binary_cas::BlobPayload::from_bytes(bytes.to_vec()))
         .await?;
-    storage.commit_write_set(writes, Default::default()).await?;
+    storage
+        .commit_write_set(writes, WriteOptions::default())
+        .await?;
     Ok(receipt.hash.to_hex())
 }
 
@@ -71,7 +74,7 @@ pub async fn read_binary_cas_for_bench<StorageImpl>(
 where
     StorageImpl: Storage,
 {
-    let read = storage.begin_read(Default::default()).await?;
+    let read = storage.begin_read(ReadOptions::default()).await?;
     let hash = crate::binary_cas::BlobHash::from_hex(hash_hex)?;
     let mut entries = crate::binary_cas::BinaryCasContext::new()
         .reader(read)

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -41,6 +41,46 @@ pub fn binary_cas_write_accounting() -> BinaryCasWriteAccounting {
     }
 }
 
+/// Writes one payload through the production binary CAS and commits the
+/// resulting canonical write set. This is intentionally available only to
+/// storage benchmarks so they can isolate CAS layout costs from SQL planning,
+/// validation, tracked state, and changelog work.
+pub async fn write_binary_cas_for_bench<StorageImpl>(
+    storage: &crate::storage_adapter::StorageAdapter<StorageImpl>,
+    bytes: &[u8],
+) -> Result<String, crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    let read = storage.begin_read(Default::default()).await?;
+    let mut writes = storage.new_write_set();
+    let receipt = crate::binary_cas::BinaryCasContext::new()
+        .writer_skipping_existing_chunks(&read, &mut writes)
+        .stage_payload(&crate::binary_cas::BlobPayload::from_bytes(bytes.to_vec()))
+        .await?;
+    storage.commit_write_set(writes, Default::default()).await?;
+    Ok(receipt.hash.to_hex())
+}
+
+/// Reads one payload through the production binary CAS. See
+/// [`write_binary_cas_for_bench`] for why this feature-gated helper exists.
+pub async fn read_binary_cas_for_bench<StorageImpl>(
+    storage: &crate::storage_adapter::StorageAdapter<StorageImpl>,
+    hash_hex: &str,
+) -> Result<Option<Vec<u8>>, crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    let read = storage.begin_read(Default::default()).await?;
+    let hash = crate::binary_cas::BlobHash::from_hex(hash_hex)?;
+    let mut entries = crate::binary_cas::BinaryCasContext::new()
+        .reader(read)
+        .load_bytes_many(&[hash])
+        .await?
+        .into_vec();
+    Ok(entries.pop().flatten())
+}
+
 pub(crate) fn record_transaction_rows_staged(count: usize) {
     TRANSACTION_ROWS_STAGED.fetch_add(count as u64, Ordering::Relaxed);
 }


### PR DESCRIPTION
Stack 4/4, on top of #726.

## Hard cut

Non-empty binary CAS payloads through the largest measured boundary, 32 KiB, are stored directly in a versioned inline manifest. The existing 64 KiB one-chunk fast path remains for 32 KiB + 1 through 64 KiB, and genuinely chunked blobs are unchanged. This is a coordinated storage-format cut: old binaries do not accept the new inline tag.

A unique small blob changes from 3 logical rows to 1, key bytes from 108 to 36, the pre-write presence-read phase from 1 to 0, and blob-read point phases from 2 to 1. Compression and end-to-end hash verification remain.

## Controlled dual-backend results

Seven counterbalanced process/database pairs per case, each with 300 warmups and 3,000 samples; values are median paired p50 change:

| Backend | Size | New-content write | Hot read | Repeat-identical write |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 4 KiB | 17.2% faster | **33.0% faster** | **150.4% slower** |
| RocksDB | 32 KiB | 4.9% faster | **58.5% faster** | **713.8% slower** |
| SlateDB | 4 KiB | **36.3% faster** | **33.9% faster** | **29.7% faster** |
| SlateDB | 32 KiB | **32.6% faster** | **27.8% faster** | 7.4% faster |

This is deliberately scoped to the production SlateDB changed-content/read-heavy 90% path. RocksDB repeat-identical writes regress because the old layout can prove the payload present and rewrite only a tiny manifest, while inline rewrites the whole value. If identical repeat writes are common, this is not a net win.

The checked-in benchmark log documents exact p50 values, binary hashes, host, command, raw-matrix SHA, and logical accounting. It explicitly makes no physical SST/WAL reduction claim.

## Validation

- current-main full `lix_engine` library suite: 1,188 passed, 6 ignored
- focused binary CAS suite: 37 passed
- isolated RocksDB adapter suite: 5 passed
- isolated SlateDB adapter suite: 12 passed
- strict benchmark clippy and formatting pass

Raw matrix SHA-256: `d76a7a73b0690e81443d064ea2ef25fac033cc3f04f710b812fd56f6c11e4f3b`.