### PR TITLE
perf: index commit derived change ids

### DIFF
--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -19,8 +19,11 @@ use super::codec::{
     encode_commit_change_ref_chunk, encode_commit_record,
 };
 use super::store::{
-    CHANGE_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, change_id_from_key, change_key,
-    commit_change_ref_chunk_key, commit_change_ref_chunk_prefix, commit_id_from_key, commit_key,
+    CHANGE_SPACE, COMMIT_CHANGE_ID_INDEX_FORMAT_VALUE, COMMIT_CHANGE_ID_SPACE,
+    COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, change_id_from_key, change_key,
+    commit_change_id_index_format_key, commit_change_id_index_format_value, commit_change_id_key,
+    commit_change_id_value, commit_change_ref_chunk_key, commit_change_ref_chunk_prefix,
+    commit_id_from_key, commit_key,
 };
 use crate::changelog::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeScanBatch, ChangeScanRequest,
@@ -329,11 +332,24 @@ where
     S: ChangelogStorageRead + Send + ?Sized,
 {
     async fn stage_append(&mut self, append: ChangelogAppend) -> Result<(), LixError> {
-        self.validate_append(&append).await?;
+        let stage_commit_change_id_index_format = self.validate_append(&append).await?;
+
+        if stage_commit_change_id_index_format {
+            self.writes.put(
+                COMMIT_CHANGE_ID_SPACE,
+                commit_change_id_index_format_key(),
+                commit_change_id_index_format_value(),
+            );
+        }
 
         self.writes
             .reserve_space(CHANGE_SPACE, append.changes.len(), 0);
+        self.writes
+            .reserve_space(COMMIT_SPACE, append.commits.len(), 0);
+        self.writes
+            .reserve_space(COMMIT_CHANGE_ID_SPACE, append.commits.len(), 0);
         self.staged_changes.reserve(append.changes.len());
+        self.staged_commits.reserve(append.commits.len());
 
         for change in append.changes {
             self.writes.put(
@@ -345,11 +361,21 @@ where
         }
 
         let chunks = chunk_commit_change_refs(append.commit_change_refs);
+        self.writes.reserve_space(
+            COMMIT_CHANGE_REF_CHUNK_SPACE,
+            chunks.values().map(Vec::len).sum(),
+            0,
+        );
         for commit in append.commits {
             self.writes.put(
                 COMMIT_SPACE,
                 commit_key(commit.commit_id),
                 encode_commit_record(&commit)?,
+            );
+            self.writes.put(
+                COMMIT_CHANGE_ID_SPACE,
+                commit_change_id_key(commit.change_id),
+                commit_change_id_value(commit.commit_id),
             );
             self.staged_commits.insert(commit.commit_id, commit);
         }
@@ -399,7 +425,7 @@ impl<S> ChangelogStoreWriter<'_, S>
 where
     S: ChangelogStorageRead + Send + ?Sized,
 {
-    async fn validate_append(&mut self, append: &ChangelogAppend) -> Result<(), LixError> {
+    async fn validate_append(&mut self, append: &ChangelogAppend) -> Result<bool, LixError> {
         validate_unique(
             append.commits.iter().map(|commit| commit.commit_id),
             "commit_id",
@@ -451,7 +477,8 @@ where
         self.reject_existing_commits(&append_commit_ids).await?;
         self.reject_existing_changes(append_changes.keys().copied())
             .await?;
-        self.reject_commit_change_id_collisions(append, &append_changes)
+        let stage_commit_change_id_index_format = self
+            .reject_commit_change_id_collisions(append, &append_changes)
             .await?;
         self.validate_parent_commits(append, &append_commit_ids)
             .await?;
@@ -479,24 +506,40 @@ where
             self.validate_change_refs(refs, &append_changes).await?;
         }
 
-        Ok(())
+        Ok(stage_commit_change_id_index_format)
     }
 
     async fn reject_commit_change_id_collisions(
         &mut self,
         append: &ChangelogAppend,
         append_changes: &HashMap<ChangeId, &ChangeRecord>,
-    ) -> Result<(), LixError> {
+    ) -> Result<bool, LixError> {
         if append.commits.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
-        for commit in &append.commits {
-            if append_changes.contains_key(&commit.change_id)
-                || self.change_exists(&commit.change_id).await?
+        let commit_change_ids = append
+            .commits
+            .iter()
+            .map(|commit| commit.change_id)
+            .collect::<Vec<_>>();
+        let change_keys = commit_change_ids
+            .iter()
+            .map(|change_id| change_key(*change_id))
+            .collect::<Vec<_>>();
+        let existing_changes = get_many(self.store, CHANGE_SPACE, change_keys).await?;
+        for ((commit, change_id), existing_change) in append
+            .commits
+            .iter()
+            .zip(commit_change_ids.iter())
+            .zip(existing_changes)
+        {
+            if append_changes.contains_key(change_id)
+                || existing_change.is_some()
+                || self.staged_changes.contains_key(change_id)
                 || self
                     .staged_commits
                     .values()
-                    .any(|staged| staged.change_id == commit.change_id)
+                    .any(|staged| staged.change_id == *change_id)
             {
                 return Err(LixError::unknown(format!(
                     "changelog commit '{}' derived change_id '{}' collides with an existing change id",
@@ -504,38 +547,58 @@ where
                 )));
             }
         }
-        let mut start_after = None::<String>;
-        loop {
-            let batch = scan_commits_from_store(
-                self.store,
-                CommitScanRequest {
-                    start_after: start_after.as_deref(),
-                    limit: Some(SCAN_PAGE_LIMIT),
-                    projection: CommitProjection::Record,
-                },
-            )
-            .await?;
-            for entry in batch.entries {
-                let CommitLoadEntry::Record(record) = entry else {
-                    continue;
-                };
-                if append
-                    .commits
-                    .iter()
-                    .any(|commit| commit.change_id == record.change_id)
-                {
-                    return Err(LixError::unknown(format!(
-                        "changelog commit derived change_id '{}' already exists",
-                        record.change_id
-                    )));
-                }
+        let index_format_key = commit_change_id_index_format_key();
+        let index_format_is_staged = self
+            .writes
+            .contains_put(COMMIT_CHANGE_ID_SPACE, &index_format_key);
+        let mut index_keys = Vec::with_capacity(commit_change_ids.len() + 1);
+        index_keys.push(index_format_key);
+        index_keys.extend(
+            commit_change_ids
+                .iter()
+                .map(|change_id| commit_change_id_key(*change_id)),
+        );
+        let mut index_values = get_many(self.store, COMMIT_CHANGE_ID_SPACE, index_keys)
+            .await?
+            .into_iter();
+        let stored_format = index_values
+            .next()
+            .expect("commit change-id index format key was requested");
+        let stage_commit_change_id_index_format = match stored_format {
+            Some(value) if value.as_slice() == COMMIT_CHANGE_ID_INDEX_FORMAT_VALUE => false,
+            Some(_) => {
+                return Err(LixError::unknown(
+                    "changelog commit_change_id index has an unsupported format; recreate the repository",
+                ));
             }
-            let Some(next) = batch.next_start_after else {
-                break;
-            };
-            start_after = Some(next.to_string());
+            None if index_format_is_staged => false,
+            None => {
+                let existing_commits = self
+                    .store
+                    .changelog_scan(
+                        COMMIT_SPACE,
+                        Vec::new(),
+                        None,
+                        1,
+                        StorageCoreProjection::KeyOnly,
+                    )
+                    .await?;
+                if !existing_commits.keys.is_empty() {
+                    return Err(LixError::unknown(
+                        "changelog commit_change_id index is missing for an existing repository; recreate the repository before appending commits",
+                    ));
+                }
+                true
+            }
+        };
+        for (change_id, existing_commit) in commit_change_ids.iter().zip(index_values) {
+            if existing_commit.is_some() {
+                return Err(LixError::unknown(format!(
+                    "changelog commit derived change_id '{change_id}' already exists"
+                )));
+            }
         }
-        Ok(())
+        Ok(stage_commit_change_id_index_format)
     }
 
     async fn reject_existing_commits(
@@ -672,15 +735,6 @@ where
             }
         }
         Ok(out)
-    }
-
-    async fn change_exists(&mut self, change_id: &ChangeId) -> Result<bool, LixError> {
-        if self.staged_changes.contains_key(change_id) {
-            return Ok(true);
-        }
-        Ok(get_one(self.store, CHANGE_SPACE, change_key(*change_id))
-            .await?
-            .is_some())
     }
 }
 
@@ -946,18 +1000,6 @@ fn empty_gc_plan(roots: &[GcRoot]) -> GcPlan {
     }
 }
 
-async fn get_one(
-    store: &mut (impl ChangelogStorageRead + ?Sized),
-    space: StorageSpace,
-    key: Vec<u8>,
-) -> Result<Option<Vec<u8>>, LixError> {
-    Ok(get_many(store, space, vec![key])
-        .await?
-        .into_iter()
-        .next()
-        .flatten())
-}
-
 async fn get_many(
     store: &mut (impl ChangelogStorageRead + ?Sized),
     space: StorageSpace,
@@ -1040,11 +1082,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use async_trait::async_trait;
+
     use crate::changelog::test_support::{changelog_test_context, test_append, test_change_record};
     use crate::changelog::{
         ChangeId, ChangeLoadRequest, ChangeRecord, ChangeScanRequest, ChangelogAppend,
         ChangelogReader, ChangelogWriter, CommitId, CommitLoadEntry, CommitLoadRequest,
-        CommitProjection, CommitScanRequest,
+        CommitProjection, CommitRecord, CommitScanRequest,
     };
     use crate::entity_pk::EntityPk;
 
@@ -1076,6 +1120,67 @@ mod tests {
         let mut ids = labels.into_iter().map(change_id).collect::<Vec<_>>();
         ids.sort();
         ids
+    }
+
+    fn append_with_commit_count(label: &str, count: usize) -> ChangelogAppend {
+        let mut append = ChangelogAppend::default();
+        for index in 0..count {
+            let commit_id = CommitId::for_test_label(&format!("{label}-commit-{index}"));
+            let change_id = ChangeId::for_test_label(&format!("{label}-change-{index}"));
+            append.changes.push(ChangeRecord {
+                change_id,
+                entity_pk: EntityPk::single(format!("{label}-entity-{index}")),
+                ..test_change_record()
+            });
+            append.commits.push(CommitRecord {
+                format_version: 1,
+                commit_id,
+                parent_commit_ids: Vec::new(),
+                change_id: ChangeId::for_test_label(&format!("{label}-commit-change-{index}")),
+                author_account_ids: Vec::new(),
+                created_at: ts("2026-05-20T00:00:00Z"),
+            });
+            append.commit_change_refs.push(CommitChangeRefSet {
+                commit_id,
+                entries: vec![change_id],
+            });
+        }
+        append
+    }
+
+    struct CommitScanCountingRead<'a, R: ?Sized> {
+        inner: &'a mut R,
+        commit_scan_calls: usize,
+    }
+
+    #[async_trait]
+    impl<R> ChangelogStorageRead for CommitScanCountingRead<'_, R>
+    where
+        R: ChangelogStorageRead + Send + ?Sized,
+    {
+        async fn changelog_get_many(
+            &mut self,
+            space: StorageSpace,
+            keys: Vec<Vec<u8>>,
+        ) -> Result<Vec<Option<Vec<u8>>>, LixError> {
+            self.inner.changelog_get_many(space, keys).await
+        }
+
+        async fn changelog_scan(
+            &mut self,
+            space: StorageSpace,
+            prefix: Vec<u8>,
+            after: Option<Vec<u8>>,
+            limit: usize,
+            projection: StorageCoreProjection,
+        ) -> Result<ChangelogScanPage, LixError> {
+            if space.id == COMMIT_SPACE.id {
+                self.commit_scan_calls += 1;
+            }
+            self.inner
+                .changelog_scan(space, prefix, after, limit, projection)
+                .await
+        }
     }
 
     #[test]
@@ -1129,14 +1234,32 @@ mod tests {
             writer.stage_append(append).await.unwrap();
         }
         let stats = writes.apply(&mut *transaction).await.unwrap();
-        assert_eq!(stats.staged_puts, 3);
+        assert_eq!(stats.staged_puts, 5);
         transaction.commit().await.unwrap();
 
         let mut read = storage.begin_read_transaction().await.unwrap();
+        let commit_id = CommitId::for_test_label("commit-1");
+        let commit_change_id = ChangeId::for_test_label("commit-row-change-1");
+        assert_eq!(
+            get_many(
+                &mut *read,
+                COMMIT_CHANGE_ID_SPACE,
+                vec![
+                    commit_change_id_index_format_key(),
+                    commit_change_id_key(commit_change_id),
+                ],
+            )
+            .await
+            .unwrap(),
+            vec![
+                Some(commit_change_id_index_format_value()),
+                Some(commit_change_id_value(commit_id)),
+            ]
+        );
         let mut reader = context.reader(&mut *read);
         let commits = reader
             .load_commits(CommitLoadRequest {
-                commit_ids: &[CommitId::for_test_label("commit-1")],
+                commit_ids: &[commit_id],
                 projection: CommitProjection::Full,
             })
             .await
@@ -1353,6 +1476,160 @@ mod tests {
                 .contains("collides with an existing change id"),
             "{error:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn stage_append_rejects_commit_change_id_colliding_with_persisted_commit() {
+        let (context, storage) = changelog_test_context();
+        let first = test_append();
+        let duplicate_change_id = first.commits[0].change_id;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(first).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut duplicate = test_append();
+        let duplicate_commit_id = CommitId::for_test_label("duplicate-commit");
+        let duplicate_change_record_id = ChangeId::for_test_label("duplicate-change-record");
+        duplicate.commits[0].commit_id = duplicate_commit_id;
+        duplicate.commits[0].change_id = duplicate_change_id;
+        duplicate.changes[0].change_id = duplicate_change_record_id;
+        duplicate.commit_change_refs[0].commit_id = duplicate_commit_id;
+        duplicate.commit_change_refs[0].entries[0] = duplicate_change_record_id;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(duplicate).await.unwrap_err()
+        };
+        assert!(error.message.contains("derived change_id"), "{error:?}");
+        assert!(error.message.contains("already exists"), "{error:?}");
+    }
+
+    #[tokio::test]
+    async fn stage_append_rejects_commit_change_id_staged_in_same_write_set() {
+        let (context, storage) = changelog_test_context();
+        let first = test_append();
+        let duplicate_change_id = first.commits[0].change_id;
+
+        let mut duplicate = test_append();
+        let duplicate_commit_id = CommitId::for_test_label("same-write-set-duplicate-commit");
+        let duplicate_change_record_id =
+            ChangeId::for_test_label("same-write-set-duplicate-change");
+        duplicate.commits[0].commit_id = duplicate_commit_id;
+        duplicate.commits[0].change_id = duplicate_change_id;
+        duplicate.changes[0].change_id = duplicate_change_record_id;
+        duplicate.commit_change_refs[0].commit_id = duplicate_commit_id;
+        duplicate.commit_change_refs[0].entries[0] = duplicate_change_record_id;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(first).await.unwrap();
+            writer.stage_append(duplicate).await.unwrap_err()
+        };
+        assert!(
+            error
+                .message
+                .contains("collides with an existing change id"),
+            "{error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage_append_initializes_index_once_across_writers_in_one_write_set() {
+        let (context, storage) = changelog_test_context();
+        let first = append_with_commit_count("first-writer", 1);
+        let second = append_with_commit_count("second-writer", 1);
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(first).await.unwrap();
+        }
+        {
+            let mut writer = ChangelogContext::new().writer(&mut *transaction, &mut writes);
+            writer.stage_append(second).await.unwrap();
+        }
+        let stats = writes.apply(&mut *transaction).await.unwrap();
+        assert_eq!(stats.staged_puts, 9);
+        transaction.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stage_append_rejects_legacy_commit_layout_without_reverse_index() {
+        let (context, storage) = changelog_test_context();
+        let legacy_commit = test_append().commits.remove(0);
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut legacy_writes = StorageWriteSet::new();
+        legacy_writes.put(
+            COMMIT_SPACE,
+            commit_key(legacy_commit.commit_id),
+            encode_commit_record(&legacy_commit).unwrap(),
+        );
+        legacy_writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut append = test_append();
+        let commit_id = CommitId::for_test_label("post-legacy-commit");
+        let change_id = ChangeId::for_test_label("post-legacy-change");
+        append.commits[0].commit_id = commit_id;
+        append.commits[0].change_id = ChangeId::for_test_label("post-legacy-commit-change");
+        append.changes[0].change_id = change_id;
+        append.commit_change_refs[0].commit_id = commit_id;
+        append.commit_change_refs[0].entries[0] = change_id;
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let error = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(append).await.unwrap_err()
+        };
+        assert!(
+            error
+                .message
+                .contains("index is missing for an existing repository"),
+            "{error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stage_append_with_large_history_does_not_scan_commits_after_index_initialization() {
+        let (context, storage) = changelog_test_context();
+        let history = append_with_commit_count("history", 1_000);
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(history).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let mut counting_read = CommitScanCountingRead {
+            inner: &mut *transaction,
+            commit_scan_calls: 0,
+        };
+        {
+            let mut writer = context.writer(&mut counting_read, &mut writes);
+            writer
+                .stage_append(append_with_commit_count("next", 1))
+                .await
+                .unwrap();
+        }
+        assert_eq!(counting_read.commit_scan_calls, 0);
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -21,7 +21,9 @@ pub(crate) use materialization::{
     ChangeRecordProjection, MaterializedChangeIdentity, MaterializedChangePayload,
     load_change_records, materialize_change_payloads,
 };
-pub(crate) use store::{CHANGE_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, change_key};
+pub(crate) use store::{
+    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, change_key,
+};
 pub(crate) use store::{ChangelogReader, ChangelogWriter};
 pub(crate) use types::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeRecordView, ChangeScanBatch,

--- a/packages/engine/src/changelog/store.rs
+++ b/packages/engine/src/changelog/store.rs
@@ -12,6 +12,13 @@ use async_trait::async_trait;
 pub(crate) const COMMIT_NAMESPACE: &str = "changelog.commit";
 pub(crate) const CHANGE_NAMESPACE: &str = "changelog.change";
 pub(crate) const COMMIT_CHANGE_REF_CHUNK_NAMESPACE: &str = "changelog.commit_change_ref_chunk";
+pub(crate) const COMMIT_CHANGE_ID_NAMESPACE: &str = "changelog.commit_change_id";
+
+// Commit-derived change-id keys are always exactly 16 raw UUID bytes. This
+// non-UUID key therefore cannot collide with an identity key in the same
+// space, while keeping the format check in the hot index point-read batch.
+pub(crate) const COMMIT_CHANGE_ID_INDEX_FORMAT_KEY: &[u8] = b"format-v1";
+pub(crate) const COMMIT_CHANGE_ID_INDEX_FORMAT_VALUE: &[u8] = b"1";
 
 pub(crate) const COMMIT_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0006_0001), COMMIT_NAMESPACE);
@@ -21,6 +28,12 @@ pub(crate) const COMMIT_CHANGE_REF_CHUNK_SPACE: StorageSpace = StorageSpace::new
     StorageSpaceId(0x0006_0003),
     COMMIT_CHANGE_REF_CHUNK_NAMESPACE,
 );
+/// Immutable reverse lookup from a commit-derived change id to its commit id.
+///
+/// The changelog write path uses this to enforce the globally unique
+/// `CommitRecord::change_id` invariant without scanning every commit record.
+pub(crate) const COMMIT_CHANGE_ID_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0006_0004), COMMIT_CHANGE_ID_NAMESPACE);
 
 // Identity keys are the raw 16 UUID bytes. UUIDv7's big-endian byte order
 // matches the lexicographic order of its lowercase hyphenated text, so range
@@ -32,6 +45,22 @@ pub(crate) fn commit_key(commit_id: CommitId) -> Vec<u8> {
 
 pub(crate) fn change_key(change_id: ChangeId) -> Vec<u8> {
     change_id.as_uuid().as_bytes().to_vec()
+}
+
+pub(crate) fn commit_change_id_key(change_id: ChangeId) -> Vec<u8> {
+    change_key(change_id)
+}
+
+pub(crate) fn commit_change_id_value(commit_id: CommitId) -> Vec<u8> {
+    commit_key(commit_id)
+}
+
+pub(crate) fn commit_change_id_index_format_key() -> Vec<u8> {
+    COMMIT_CHANGE_ID_INDEX_FORMAT_KEY.to_vec()
+}
+
+pub(crate) fn commit_change_id_index_format_value() -> Vec<u8> {
+    COMMIT_CHANGE_ID_INDEX_FORMAT_VALUE.to_vec()
 }
 
 pub(crate) fn commit_change_ref_chunk_prefix(commit_id: CommitId) -> Vec<u8> {
@@ -118,6 +147,7 @@ mod tests {
             COMMIT_CHANGE_REF_CHUNK_NAMESPACE,
             "changelog.commit_change_ref_chunk"
         );
+        assert_eq!(COMMIT_CHANGE_ID_NAMESPACE, "changelog.commit_change_id");
     }
 
     #[test]
@@ -133,6 +163,27 @@ mod tests {
             change_id.as_uuid().as_bytes().to_vec()
         );
         assert_eq!(commit_key(commit_id).len(), 16);
+    }
+
+    #[test]
+    fn commit_change_id_index_uses_raw_identity_bytes() {
+        let commit_id = CommitId::for_test_label("commit-1");
+        let change_id = ChangeId::for_test_label("commit-change-1");
+        assert_eq!(commit_change_id_key(change_id), change_key(change_id));
+        assert_eq!(commit_change_id_value(commit_id), commit_key(commit_id));
+        assert_eq!(commit_change_id_key(change_id).len(), 16);
+        assert_eq!(commit_change_id_value(commit_id).len(), 16);
+    }
+
+    #[test]
+    fn commit_change_id_index_format_key_cannot_collide_with_identity_keys() {
+        let change_id = ChangeId::for_test_label("commit-change-1");
+        assert_ne!(commit_change_id_index_format_key(), change_key(change_id));
+        assert_ne!(
+            commit_change_id_index_format_key().len(),
+            change_key(change_id).len()
+        );
+        assert_eq!(commit_change_id_index_format_value(), b"1");
     }
 
     #[test]

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -203,6 +203,18 @@ impl StorageWriteSet {
         group.deletes.reserve(expected_deletes);
     }
 
+    /// Returns whether this write set already stages a put for an exact
+    /// `(space, key)` pair.
+    ///
+    /// Domain writers use this only for transaction-scoped format markers;
+    /// normal data rows must remain unique and are validated by [`Self::validate`].
+    pub(crate) fn contains_put(&self, space: StorageSpace, key: &[u8]) -> bool {
+        self.group_index
+            .get(&space.id)
+            .and_then(|index| self.groups.get(*index))
+            .is_some_and(|group| group.puts.iter().any(|put| put.key.0.as_ref() == key))
+    }
+
     pub fn extend(&mut self, other: Self) {
         for group in other.groups {
             let space = group.space;

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -181,6 +181,7 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::changelog::COMMIT_SPACE,
         crate::changelog::CHANGE_SPACE,
         crate::changelog::COMMIT_CHANGE_REF_CHUNK_SPACE,
+        crate::changelog::COMMIT_CHANGE_ID_SPACE,
     ]
 }
 

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -322,7 +322,9 @@ mod tests {
         BINARY_CAS_CHUNK_PRESENCE_SPACE, BINARY_CAS_CHUNK_SPACE, BINARY_CAS_MANIFEST_CHUNK_SPACE,
         BINARY_CAS_MANIFEST_SPACE,
     };
-    use crate::changelog::{CHANGE_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, CommitId};
+    use crate::changelog::{
+        CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, CommitId,
+    };
     use crate::json_store::store::JSON_SPACE;
     use crate::live_state::LIVE_STATE_INDEX_ROW_SPACE;
     use crate::tracked_state::types::{
@@ -348,6 +350,7 @@ mod tests {
             COMMIT_SPACE,
             CHANGE_SPACE,
             COMMIT_CHANGE_REF_CHUNK_SPACE,
+            COMMIT_CHANGE_ID_SPACE,
         ];
         let mut seen = BTreeMap::new();
         for space in spaces {


### PR DESCRIPTION
## What

Replaces the append-time full scan of immutable changelog commits with an immutable `commit_change_id -> commit_id` reverse index. The mapping is staged in the same atomic write set as its commit.

## Root cause

Every append scanned all historical commit records to reject a duplicate derived change id. At 5,000 commits that was five paged scans, roughly 5,000 rows and 215 KB of decoded values per operation.

## Result

Native 31-sample A/B at 5,000 commits:

- RocksDB unique append p50: 4,536 us -> 14 us
- SlateDB unique append p50: 4,066 us -> 376 us
- no historical COMMIT scans in the candidate; batched point reads remain

End-to-end Lixray/SlateDB with the deterministic mixed 1,000-file corpus and fresh closed-store clones:

- 5,000-commit delete: 66.29 ms -> 47.70 ms median, 28.20% median paired improvement across five counterbalanced pairs
- 5,000-commit update: 58.53 ms -> 35.42 ms median, 36.52% median paired improvement across three pairs
- 1,000-commit update: 7.37% median paired improvement; the design deliberately pays off as history grows

## Storage and compatibility

The index adds one raw 16-byte key to 16-byte value mapping per commit (36 logical bytes including the storage-space prefix), plus one format marker. This is an intentional hard cut: an existing commit store without the index is rejected for new appends rather than silently falling back to a history scan.

## Scope and validation

No SQLite workload or SQL2 code is touched. The benchmark covers RocksDB and SlateDB only.

- `cargo fmt --check`
- `cargo test -p lix_engine changelog:: --lib` (37 passed)
- storage-space uniqueness test
- `cargo check -p lix_engine --features storage-benches,slatedb --bench changelog_history_append`
- independent code review: no blocking findings