### PR TITLE
perf(changelog): make garbage collection scans linear

### DIFF
--- a/.changenotes/linear-changelog-garbage-collection.md
+++ b/.changenotes/linear-changelog-garbage-collection.md
@@ -1,0 +1,9 @@
+---
+type: patch
+---
+
+Improved Lix garbage-collection planning by scanning changelog records in
+ordered batches instead of reopening the storage backend once per commit.
+
+This keeps checkpoint cleanup practical for repositories with long automatic
+commit histories, especially on remote LSM-backed storage.

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -8,7 +8,7 @@
     clippy::unused_self
 )]
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 
 use async_trait::async_trait;
@@ -31,9 +31,8 @@ use crate::changelog::{
     CommitId, CommitLoadBatch, CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitRecord,
     CommitScanBatch, CommitScanRequest,
 };
-#[cfg(feature = "storage-benches")]
 use crate::changelog::{GcPlan, GcRoot};
-use crate::json_store::JsonSlot;
+use crate::json_store::{JsonRef, JsonSlot, JsonStoreContext};
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapter, StorageAdapterRead, StorageCoreProjection,
@@ -175,9 +174,8 @@ impl<S> ChangelogReader for ChangelogStoreReader<S>
 where
     S: ChangelogStorageRead + Send,
 {
-    #[cfg(feature = "storage-benches")]
     async fn plan_gc(&mut self, roots: &[GcRoot]) -> Result<GcPlan, LixError> {
-        Ok(empty_gc_plan(roots))
+        plan_gc_from_store(&mut self.store, roots).await
     }
 
     async fn load_commits(
@@ -214,9 +212,9 @@ impl<S> ChangelogReader for ChangelogStoreWriter<'_, S>
 where
     S: ChangelogStorageRead + Send + ?Sized,
 {
-    #[cfg(feature = "storage-benches")]
     async fn plan_gc(&mut self, roots: &[GcRoot]) -> Result<GcPlan, LixError> {
-        Ok(empty_gc_plan(roots))
+        self.ensure_gc_has_no_staged_mutations()?;
+        plan_gc_from_store(self.store, roots).await
     }
 
     async fn load_commits(
@@ -332,6 +330,7 @@ where
     S: ChangelogStorageRead + Send + ?Sized,
 {
     async fn stage_append(&mut self, append: ChangelogAppend) -> Result<(), LixError> {
+        self.ensure_changelog_mutation_is_allowed()?;
         let stage_commit_change_id_index_format = self.validate_append(&append).await?;
 
         if stage_commit_change_id_index_format {
@@ -399,6 +398,7 @@ where
         &mut self,
         change_ids: &[ChangeId],
     ) -> Result<(), LixError> {
+        self.ensure_changelog_mutation_is_allowed()?;
         let change_ids = change_ids.iter().copied().collect::<HashSet<_>>();
         for change_id in &change_ids {
             if self.staged_changes.contains_key(change_id) {
@@ -415,9 +415,13 @@ where
         Ok(())
     }
 
-    #[cfg(feature = "storage-benches")]
+    #[allow(dead_code)] // Activated by the checkpoint GC integration.
     async fn collect_garbage(&mut self, roots: &[GcRoot]) -> Result<GcPlan, LixError> {
-        Ok(empty_gc_plan(roots))
+        self.ensure_gc_has_no_staged_mutations()?;
+        let plan = plan_gc_from_store(self.store, roots).await?;
+        stage_gc_sweep(self.writes, &plan);
+        self.writes.seal_changelog_gc();
+        Ok(plan)
     }
 }
 
@@ -425,6 +429,42 @@ impl<S> ChangelogStoreWriter<'_, S>
 where
     S: ChangelogStorageRead + Send + ?Sized,
 {
+    fn ensure_changelog_mutation_is_allowed(&self) -> Result<(), LixError> {
+        if !self.writes.changelog_gc_is_sealed() {
+            return Ok(());
+        }
+        Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "cannot stage changelog mutations after garbage collection in the same transaction",
+        ))
+    }
+
+    fn ensure_gc_has_no_staged_mutations(&self) -> Result<(), LixError> {
+        if self.writes.changelog_gc_is_sealed() {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "changelog garbage collection may run only once per transaction",
+            ));
+        }
+        let has_staged_changelog_mutations = !self.staged_commits.is_empty()
+            || !self.staged_changes.is_empty()
+            || !self.staged_change_deletes.is_empty()
+            || !self.staged_commit_change_ref_chunks.is_empty()
+            || self.writes.has_mutations_in_space(COMMIT_SPACE)
+            || self.writes.has_mutations_in_space(COMMIT_CHANGE_ID_SPACE)
+            || self.writes.has_mutations_in_space(CHANGE_SPACE)
+            || self
+                .writes
+                .has_mutations_in_space(COMMIT_CHANGE_REF_CHUNK_SPACE);
+        if !has_staged_changelog_mutations {
+            return Ok(());
+        }
+        Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "changelog garbage collection must run in a transaction with a fresh changelog write set",
+        ))
+    }
+
     async fn validate_append(&mut self, append: &ChangelogAppend) -> Result<bool, LixError> {
         validate_unique(
             append.commits.iter().map(|commit| commit.commit_id),
@@ -992,12 +1032,297 @@ where
     Ok(())
 }
 
-#[cfg(feature = "storage-benches")]
-fn empty_gc_plan(roots: &[GcRoot]) -> GcPlan {
-    GcPlan {
-        roots: roots.to_vec(),
-        ..GcPlan::default()
+async fn plan_gc_from_store(
+    store: &mut (impl ChangelogStorageRead + ?Sized),
+    roots: &[GcRoot],
+) -> Result<GcPlan, LixError> {
+    let commits = scan_all_commits_for_gc(store).await?;
+    let changes = scan_all_changes_for_gc(store).await?;
+
+    let mut live_commits = BTreeSet::new();
+    let mut live_changes = roots
+        .iter()
+        .filter_map(|root| match root {
+            GcRoot::StandaloneChange(change_id) => Some(*change_id),
+            GcRoot::BranchHead(_) => None,
+        })
+        .collect::<BTreeSet<_>>();
+    let mut pending = roots
+        .iter()
+        .filter_map(|root| match root {
+            GcRoot::BranchHead(commit_id) => Some(*commit_id),
+            GcRoot::StandaloneChange(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    while let Some(commit_id) = pending.pop() {
+        if !live_commits.insert(commit_id) {
+            continue;
+        }
+        let Some((record, chunks)) = commits.get(&commit_id) else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("garbage-collection root references missing commit '{commit_id}'"),
+            ));
+        };
+        pending.extend(record.parent_commit_ids.iter().copied());
+        live_changes.extend(
+            chunks
+                .iter()
+                .flat_map(|chunk| chunk.entries.iter().copied()),
+        );
     }
+
+    let mut live_payloads = BTreeSet::<[u8; 32]>::new();
+    for change_id in &live_changes {
+        let Some(change) = changes.get(change_id) else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("garbage collection found live reference to missing change '{change_id}'"),
+            ));
+        };
+        for slot in [&change.snapshot, &change.metadata] {
+            if let JsonSlot::Ref(json_ref) = slot {
+                live_payloads.insert(*json_ref.as_hash_array());
+            }
+        }
+    }
+
+    let sweep_commits = commits
+        .keys()
+        .filter(|commit_id| !live_commits.contains(commit_id))
+        .copied()
+        .collect::<Vec<_>>();
+    let sweep_commit_change_ids = sweep_commits
+        .iter()
+        .map(|commit_id| {
+            commits
+                .get(commit_id)
+                .expect("sweep commit id came from the commit map")
+                .0
+                .change_id
+        })
+        .collect::<Vec<_>>();
+    let sweep_commit_change_ref_chunks = sweep_commits
+        .iter()
+        .flat_map(|commit_id| {
+            commits
+                .get(commit_id)
+                .into_iter()
+                .flat_map(|(_, chunks)| (0..chunks.len()).map(|chunk_no| (*commit_id, chunk_no)))
+        })
+        .map(|(commit_id, chunk_no)| {
+            u32::try_from(chunk_no)
+                .map(|chunk_no| (commit_id, chunk_no))
+                .map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "commit '{commit_id}' has more change-ref chunks than GC can address"
+                        ),
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let sweep_changes = changes
+        .keys()
+        .filter(|change_id| !live_changes.contains(change_id))
+        .copied()
+        .collect::<Vec<_>>();
+    let garbage_payloads = sweep_changes
+        .iter()
+        .flat_map(|change_id| {
+            let change = changes
+                .get(change_id)
+                .expect("sweep change id came from the change map");
+            [&change.snapshot, &change.metadata]
+                .into_iter()
+                .filter_map(|slot| match slot {
+                    JsonSlot::Ref(json_ref) => Some(*json_ref.as_hash_array()),
+                    JsonSlot::None | JsonSlot::Inline(_) => None,
+                })
+        })
+        .collect::<BTreeSet<_>>();
+    // This collector reclaims payloads made unreachable by the changes it is
+    // sweeping. A repository-wide JSON inventory is both
+    // unnecessary for that proof and prohibitively expensive on remote LSM
+    // stores. Never-referenced legacy/orphan payloads are deliberately left
+    // to an explicit offline repair pass.
+    let sweep_json_payloads = garbage_payloads
+        .difference(&live_payloads)
+        .copied()
+        .map(JsonRef::from_hash_bytes)
+        .collect::<Vec<_>>();
+
+    Ok(GcPlan {
+        roots: roots.to_vec(),
+        live: crate::changelog::GcLiveSet {
+            commits: live_commits.into_iter().collect(),
+            changes: live_changes.into_iter().collect(),
+            payloads: live_payloads
+                .into_iter()
+                .map(JsonRef::from_hash_bytes)
+                .collect(),
+        },
+        sweep: crate::changelog::GcSweepSet {
+            commits: sweep_commits,
+            commit_change_ids: sweep_commit_change_ids,
+            changes: sweep_changes,
+            commit_change_ref_chunks: sweep_commit_change_ref_chunks,
+            json_payloads: sweep_json_payloads,
+        },
+        repair: crate::changelog::GcRepairSet::default(),
+    })
+}
+
+async fn scan_all_commits_for_gc(
+    store: &mut (impl ChangelogStorageRead + ?Sized),
+) -> Result<BTreeMap<CommitId, (CommitRecord, Vec<CommitChangeRefChunk>)>, LixError> {
+    let mut commits = BTreeMap::new();
+    let mut after = None;
+    loop {
+        let page = store
+            .changelog_scan(
+                COMMIT_SPACE,
+                Vec::new(),
+                after,
+                SCAN_PAGE_LIMIT,
+                StorageCoreProjection::FullValue,
+            )
+            .await?;
+        for (key, value) in page.keys.iter().zip(page.values.iter()) {
+            let record: CommitRecord = storage_codec::decode("commit record", value)?;
+            if key.as_slice() != commit_key(record.commit_id).as_slice() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "GC commit scan key does not match decoded commit_id '{}'",
+                        record.commit_id
+                    ),
+                ));
+            }
+            let commit_id = record.commit_id;
+            if commits.insert(commit_id, (record, Vec::new())).is_some() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("GC commit scan returned duplicate commit '{commit_id}'"),
+                ));
+            }
+        }
+        let Some(resume_after) = page.resume_after else {
+            break;
+        };
+        after = Some(resume_after);
+    }
+
+    // Change-ref chunks are globally ordered by (commit_id, chunk_no). Scan
+    // the space once and group in memory instead of reopening a prefix scan
+    // for every commit. This keeps backend calls O(pages), not O(commits).
+    let mut after = None;
+    loop {
+        let page = store
+            .changelog_scan(
+                COMMIT_CHANGE_REF_CHUNK_SPACE,
+                Vec::new(),
+                after,
+                SCAN_PAGE_LIMIT,
+                StorageCoreProjection::FullValue,
+            )
+            .await?;
+        for (key, value) in page.keys.iter().zip(page.values.iter()) {
+            if key.len() != 20 {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "GC found a commit change-ref chunk with a non-20-byte key",
+                ));
+            }
+            let commit_id = commit_id_from_key(&key[..16])?;
+            let chunk_no = u32::from_be_bytes(
+                key[16..]
+                    .try_into()
+                    .expect("commit change-ref chunk suffix length checked"),
+            );
+            let Some((_, chunks)) = commits.get_mut(&commit_id) else {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("GC found change-ref chunk for missing commit '{commit_id}'"),
+                ));
+            };
+            let expected_chunk_no = u32::try_from(chunks.len()).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("commit '{commit_id}' has too many change-ref chunks"),
+                )
+            })?;
+            if chunk_no != expected_chunk_no {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "commit '{commit_id}' change-ref chunks are not contiguous: expected {expected_chunk_no}, found {chunk_no}"
+                    ),
+                ));
+            }
+            chunks.push(decode_commit_change_ref_chunk(value, commit_id)?);
+        }
+        let Some(resume_after) = page.resume_after else {
+            break;
+        };
+        after = Some(resume_after);
+    }
+    if let Some((commit_id, _)) = commits.iter().find(|(_, (_, chunks))| chunks.is_empty()) {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("commit '{commit_id}' has no change-ref chunk"),
+        ));
+    }
+    Ok(commits)
+}
+
+async fn scan_all_changes_for_gc(
+    store: &mut (impl ChangelogStorageRead + ?Sized),
+) -> Result<BTreeMap<ChangeId, ChangeRecord>, LixError> {
+    let mut changes = BTreeMap::new();
+    let mut start_after = None::<String>;
+    loop {
+        let batch = scan_changes_from_store(
+            store,
+            ChangeScanRequest {
+                start_after: start_after.as_deref(),
+                limit: Some(SCAN_PAGE_LIMIT),
+            },
+        )
+        .await?;
+        for change in batch.entries {
+            changes.insert(change.change_id, change);
+        }
+        let Some(next) = batch.next_start_after else {
+            break;
+        };
+        start_after = Some(next.to_string());
+    }
+    Ok(changes)
+}
+
+#[allow(dead_code)] // Activated by the checkpoint GC integration.
+fn stage_gc_sweep(writes: &mut StorageWriteSet, plan: &GcPlan) {
+    for (commit_id, chunk_no) in &plan.sweep.commit_change_ref_chunks {
+        writes.delete(
+            COMMIT_CHANGE_REF_CHUNK_SPACE,
+            commit_change_ref_chunk_key(*commit_id, *chunk_no),
+        );
+    }
+    for commit_id in &plan.sweep.commits {
+        writes.delete(COMMIT_SPACE, commit_key(*commit_id));
+    }
+    for change_id in &plan.sweep.commit_change_ids {
+        writes.delete(COMMIT_CHANGE_ID_SPACE, commit_change_id_key(*change_id));
+    }
+    for change_id in &plan.sweep.changes {
+        writes.delete(CHANGE_SPACE, change_key(*change_id));
+    }
+    JsonStoreContext::new()
+        .writer()
+        .stage_delete_refs(writes, plan.sweep.json_payloads.iter().copied());
 }
 
 async fn get_many(
@@ -1084,13 +1409,16 @@ where
 mod tests {
     use async_trait::async_trait;
 
-    use crate::changelog::test_support::{changelog_test_context, test_append, test_change_record};
+    use crate::changelog::test_support::{
+        changelog_test_context, test_append, test_change_record, test_commit_record,
+    };
     use crate::changelog::{
         ChangeId, ChangeLoadRequest, ChangeRecord, ChangeScanRequest, ChangelogAppend,
-        ChangelogReader, ChangelogWriter, CommitId, CommitLoadEntry, CommitLoadRequest,
-        CommitProjection, CommitRecord, CommitScanRequest,
+        ChangelogReader, ChangelogWriter, CommitChangeRefSet, CommitId, CommitLoadEntry,
+        CommitLoadRequest, CommitProjection, CommitRecord, CommitScanRequest,
     };
     use crate::entity_pk::EntityPk;
+    use crate::json_store::JsonRef;
 
     use super::*;
 
@@ -1181,6 +1509,40 @@ mod tests {
                 .changelog_scan(space, prefix, after, limit, projection)
                 .await
         }
+    }
+
+    fn gc_append(
+        commit_label: &str,
+        parent_label: Option<&str>,
+        snapshot: JsonSlot,
+    ) -> (ChangelogAppend, CommitId, ChangeId) {
+        let commit_id = CommitId::for_test_label(commit_label);
+        let change_id = ChangeId::for_test_label(&format!("{commit_label}-change"));
+        let mut commit = test_commit_record();
+        commit.commit_id = commit_id;
+        commit.change_id = ChangeId::for_test_label(&format!("{commit_label}-row-change"));
+        commit.parent_commit_ids = parent_label
+            .into_iter()
+            .map(CommitId::for_test_label)
+            .collect();
+
+        let mut change = test_change_record();
+        change.change_id = change_id;
+        change.entity_pk = EntityPk::single(format!("{commit_label}-entity"));
+        change.snapshot = snapshot;
+
+        (
+            ChangelogAppend {
+                commits: vec![commit],
+                changes: vec![change],
+                commit_change_refs: vec![CommitChangeRefSet {
+                    commit_id,
+                    entries: vec![change_id],
+                }],
+            },
+            commit_id,
+            change_id,
+        )
     }
 
     #[test]
@@ -1294,6 +1656,264 @@ mod tests {
             .unwrap();
         assert_eq!(changes.entries[0].as_ref().unwrap().schema_key, "message");
         assert!(changes.entries[1].is_none());
+    }
+
+    #[tokio::test]
+    async fn garbage_collection_marks_parents_and_standalone_changes_then_sweeps_dead_records() {
+        let (context, storage) = changelog_test_context();
+        let shared_payload = JsonRef::for_content(b"shared payload");
+        let dead_payload = JsonRef::for_content(b"dead payload");
+        let (first, first_commit, first_change) =
+            gc_append("gc-first", None, JsonSlot::Ref(shared_payload));
+        let (head, head_commit, head_change) =
+            gc_append("gc-head", Some("gc-first"), JsonSlot::Ref(shared_payload));
+        let (dead, dead_commit, dead_change) =
+            gc_append("gc-dead", None, JsonSlot::Ref(dead_payload));
+        let standalone_change = ChangeId::for_test_label("gc-standalone");
+        let standalone = ChangeRecord {
+            change_id: standalone_change,
+            entity_pk: EntityPk::single("gc-standalone-entity"),
+            ..test_change_record()
+        };
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(first).await.unwrap();
+            writer.stage_append(head).await.unwrap();
+            writer.stage_append(dead).await.unwrap();
+            writer
+                .stage_append(ChangelogAppend {
+                    changes: vec![standalone],
+                    ..ChangelogAppend::default()
+                })
+                .await
+                .unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let roots = [
+            GcRoot::BranchHead(head_commit),
+            GcRoot::StandaloneChange(standalone_change),
+        ];
+        let mut read = storage.begin_read_transaction().await.unwrap();
+        let plan = context.reader(&mut *read).plan_gc(&roots).await.unwrap();
+        assert!(plan.live.commits.contains(&first_commit));
+        assert!(plan.live.commits.contains(&head_commit));
+        assert!(plan.live.changes.contains(&first_change));
+        assert!(plan.live.changes.contains(&head_change));
+        assert!(plan.live.changes.contains(&standalone_change));
+        assert_eq!(plan.sweep.commits, vec![dead_commit]);
+        assert_eq!(
+            plan.sweep.commit_change_ids,
+            vec![ChangeId::for_test_label("gc-dead-row-change")]
+        );
+        assert_eq!(plan.sweep.changes, vec![dead_change]);
+        assert_eq!(plan.sweep.json_payloads, vec![dead_payload]);
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        let collected = {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.collect_garbage(&roots).await.unwrap()
+        };
+        assert_eq!(collected, plan);
+        let stats = writes.apply(&mut *transaction).await.unwrap();
+        assert_eq!(stats.staged_deletes, 5);
+        transaction.commit().await.unwrap();
+
+        let mut read = storage.begin_read_transaction().await.unwrap();
+        assert_eq!(
+            get_many(
+                &mut *read,
+                COMMIT_CHANGE_ID_SPACE,
+                vec![commit_change_id_key(ChangeId::for_test_label(
+                    "gc-dead-row-change"
+                ))],
+            )
+            .await
+            .unwrap(),
+            vec![None]
+        );
+        let mut reader = context.reader(&mut *read);
+        let commits = reader
+            .load_commits(CommitLoadRequest {
+                commit_ids: &[first_commit, head_commit, dead_commit],
+                projection: CommitProjection::Record,
+            })
+            .await
+            .unwrap();
+        assert!(commits.entries[0].is_some());
+        assert!(commits.entries[1].is_some());
+        assert!(commits.entries[2].is_none());
+        let changes = reader
+            .load_changes(ChangeLoadRequest {
+                change_ids: &[first_change, head_change, dead_change, standalone_change],
+            })
+            .await
+            .unwrap();
+        assert!(changes.entries[0].is_some());
+        assert!(changes.entries[1].is_some());
+        assert!(changes.entries[2].is_none());
+        assert!(changes.entries[3].is_some());
+    }
+
+    #[tokio::test]
+    async fn garbage_collection_keeps_empty_root_commits_addressable() {
+        let (context, storage) = changelog_test_context();
+        let commit_id = CommitId::for_test_label("gc-empty");
+        let mut commit = test_commit_record();
+        commit.commit_id = commit_id;
+        commit.change_id = ChangeId::for_test_label("gc-empty-row-change");
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .stage_append(ChangelogAppend {
+                    commits: vec![commit],
+                    changes: Vec::new(),
+                    commit_change_refs: vec![CommitChangeRefSet {
+                        commit_id,
+                        entries: Vec::new(),
+                    }],
+                })
+                .await
+                .unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut read = storage.begin_read_transaction().await.unwrap();
+        let plan = context
+            .reader(&mut *read)
+            .plan_gc(&[GcRoot::BranchHead(commit_id)])
+            .await
+            .unwrap();
+        assert_eq!(plan.live.commits, vec![commit_id]);
+        assert!(plan.live.changes.is_empty());
+        assert!(plan.sweep.commits.is_empty());
+        assert!(plan.sweep.commit_change_ref_chunks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn garbage_collection_scans_commit_change_and_chunk_page_boundaries() {
+        let (context, storage) = changelog_test_context();
+        let count = SCAN_PAGE_LIMIT + 1;
+        let mut append = ChangelogAppend::default();
+        let mut parent = None;
+        for index in 0..count {
+            let commit_id = CommitId::for_test_label(&format!("gc-page-commit-{index:05}"));
+            let change_id = ChangeId::for_test_label(&format!("gc-page-change-{index:05}"));
+            let mut commit = test_commit_record();
+            commit.commit_id = commit_id;
+            commit.change_id = ChangeId::for_test_label(&format!("gc-page-row-{index:05}"));
+            commit.parent_commit_ids = parent.into_iter().collect();
+            append.commits.push(commit);
+
+            let mut change = test_change_record();
+            change.change_id = change_id;
+            change.entity_pk = EntityPk::single(format!("gc-page-entity-{index:05}"));
+            append.changes.push(change);
+            append.commit_change_refs.push(CommitChangeRefSet {
+                commit_id,
+                entries: vec![change_id],
+            });
+            parent = Some(commit_id);
+        }
+        let head = parent.expect("page-boundary fixture must have a head");
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(append).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let mut read = storage.begin_read_transaction().await.unwrap();
+        let plan = context
+            .reader(&mut *read)
+            .plan_gc(&[GcRoot::BranchHead(head)])
+            .await
+            .unwrap();
+        assert_eq!(plan.live.commits.len(), count);
+        assert_eq!(plan.live.changes.len(), count);
+        assert!(plan.sweep.commits.is_empty());
+        assert!(plan.sweep.changes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn garbage_collection_requires_a_fresh_changelog_lane_and_seals_it_afterward() {
+        let (context, storage) = changelog_test_context();
+        let (root, root_commit, _) = gc_append("gc-sealed-root", None, JsonSlot::None);
+
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(root).await.unwrap();
+        }
+        writes.apply(&mut *transaction).await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let (child, _, _) = gc_append("gc-sealed-child", Some("gc-sealed-root"), JsonSlot::None);
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer
+                .collect_garbage(&[GcRoot::BranchHead(root_commit)])
+                .await
+                .unwrap();
+        }
+        let error = {
+            let mut second_writer = context.writer(&mut *transaction, &mut writes);
+            second_writer.stage_append(child).await.unwrap_err()
+        };
+        assert!(
+            error.message.contains("after garbage collection"),
+            "{error:?}"
+        );
+
+        let (carried_child, _, _) = gc_append(
+            "gc-sealed-carried-child",
+            Some("gc-sealed-root"),
+            JsonSlot::None,
+        );
+        let mut combined_writes = StorageWriteSet::new();
+        combined_writes.extend(writes);
+        let error = {
+            let mut second_writer = context.writer(&mut *transaction, &mut combined_writes);
+            second_writer.stage_append(carried_child).await.unwrap_err()
+        };
+        assert!(
+            error.message.contains("after garbage collection"),
+            "{error:?}"
+        );
+
+        let (child, _, _) = gc_append("gc-fresh-child", Some("gc-sealed-root"), JsonSlot::None);
+        let mut transaction = storage.begin_write_transaction().await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        {
+            let mut writer = context.writer(&mut *transaction, &mut writes);
+            writer.stage_append(child).await.unwrap();
+        }
+        let error = {
+            let mut second_writer = context.writer(&mut *transaction, &mut writes);
+            second_writer
+                .collect_garbage(&[GcRoot::BranchHead(root_commit)])
+                .await
+                .unwrap_err()
+        };
+        assert!(
+            error.message.contains("fresh changelog write set"),
+            "{error:?}"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -25,11 +25,12 @@ pub(crate) use store::{
     CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, change_key,
 };
 pub(crate) use store::{ChangelogReader, ChangelogWriter};
+#[cfg(feature = "storage-benches")]
+pub(crate) use types::RebuildIndexStats;
 pub(crate) use types::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeRecordView, ChangeScanBatch,
     ChangeScanRequest, ChangelogAppend, CommitChangeRefChunk, CommitChangeRefSet, CommitId,
     CommitLoadBatch, CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitRecord,
     CommitScanBatch, CommitScanRequest, commit_row_snapshot_json,
 };
-#[cfg(feature = "storage-benches")]
-pub(crate) use types::{GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, RebuildIndexStats};
+pub(crate) use types::{GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet};

--- a/packages/engine/src/changelog/store.rs
+++ b/packages/engine/src/changelog/store.rs
@@ -3,7 +3,6 @@ use super::types::{
     ChangelogAppend, CommitId, CommitLoadBatch, CommitLoadRequest, CommitScanBatch,
     CommitScanRequest,
 };
-#[cfg(feature = "storage-benches")]
 use super::types::{GcPlan, GcRoot};
 use crate::common::LixError;
 use crate::storage_adapter::{StorageSpace, StorageSpaceId};
@@ -92,7 +91,7 @@ fn uuid_from_key(key: &[u8], kind: &str) -> Result<uuid::Uuid, LixError> {
 
 #[async_trait]
 pub(crate) trait ChangelogReader {
-    #[cfg(feature = "storage-benches")]
+    #[allow(dead_code)] // Exercised directly by the storage-bench feature.
     async fn plan_gc(&mut self, roots: &[GcRoot]) -> Result<GcPlan, LixError>;
 
     async fn load_commits(
@@ -131,7 +130,7 @@ pub(crate) trait ChangelogWriter {
         change_ids: &[ChangeId],
     ) -> Result<(), LixError>;
 
-    #[cfg(feature = "storage-benches")]
+    #[allow(dead_code)] // Activated by the checkpoint GC integration.
     async fn collect_garbage(&mut self, roots: &[GcRoot]) -> Result<GcPlan, LixError>;
 }
 

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -461,13 +461,13 @@ pub(crate) struct RebuildIndexStats {
     pub(crate) unchanged: usize,
 }
 
-#[cfg(feature = "storage-benches")]
+#[allow(dead_code)] // Activated by the checkpoint GC integration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum GcRoot {
     BranchHead(CommitId),
+    StandaloneChange(ChangeId),
 }
 
-#[cfg(feature = "storage-benches")]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct GcLiveSet {
     pub(crate) commits: Vec<CommitId>,
@@ -475,20 +475,18 @@ pub(crate) struct GcLiveSet {
     pub(crate) payloads: Vec<JsonRef>,
 }
 
-#[cfg(feature = "storage-benches")]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct GcSweepSet {
     pub(crate) commits: Vec<CommitId>,
+    pub(crate) commit_change_ids: Vec<ChangeId>,
     pub(crate) changes: Vec<ChangeId>,
     pub(crate) commit_change_ref_chunks: Vec<(CommitId, u32)>,
     pub(crate) json_payloads: Vec<JsonRef>,
 }
 
-#[cfg(feature = "storage-benches")]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct GcRepairSet {}
 
-#[cfg(feature = "storage-benches")]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct GcPlan {
     pub(crate) roots: Vec<GcRoot>,

--- a/packages/engine/src/json_store/context.rs
+++ b/packages/engine/src/json_store/context.rs
@@ -117,4 +117,19 @@ impl JsonStoreWriter {
 
         Ok(order)
     }
+
+    #[allow(dead_code)] // Activated by the checkpoint GC integration.
+    #[expect(clippy::unused_self)]
+    pub(crate) fn stage_delete_refs(
+        &self,
+        writes: &mut StorageWriteSet,
+        refs: impl IntoIterator<Item = JsonRef>,
+    ) {
+        for json_ref in refs {
+            writes.delete(
+                store::JSON_SPACE,
+                StorageKey(Bytes::copy_from_slice(json_ref.as_hash_bytes())),
+            );
+        }
+    }
 }

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -74,6 +74,11 @@ pub struct StorageWriteSet {
     groups: Vec<StorageWriteGroup>,
     group_index: HashMap<SpaceId, usize, FastHashBuilder>,
     stats: StorageWriteSetStats,
+    // Domain stores can seal a write lane after planning a destructive sweep.
+    // The flag carries no storage representation; it only prevents a later
+    // domain writer sharing this canonical write set from invalidating the
+    // sweep's reachability proof before commit.
+    changelog_gc_sealed: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -116,6 +121,7 @@ impl StorageWriteSet {
                 FastHashBuilder::with_seeds(0, 0, 0, 0),
             ),
             stats: StorageWriteSetStats::default(),
+            changelog_gc_sealed: false,
         }
     }
 
@@ -216,6 +222,7 @@ impl StorageWriteSet {
     }
 
     pub fn extend(&mut self, other: Self) {
+        self.changelog_gc_sealed |= other.changelog_gc_sealed;
         for group in other.groups {
             let space = group.space;
             let conflicting_declarations = group.conflicting_declarations;
@@ -235,6 +242,22 @@ impl StorageWriteSet {
 
     pub fn stats(&self) -> StorageWriteSetStats {
         self.stats
+    }
+
+    pub(crate) fn has_mutations_in_space(&self, space: StorageSpace) -> bool {
+        self.group_index
+            .get(&space.id)
+            .and_then(|index| self.groups.get(*index))
+            .is_some_and(|group| !group.puts.is_empty() || !group.deletes.is_empty())
+    }
+
+    pub(crate) fn changelog_gc_is_sealed(&self) -> bool {
+        self.changelog_gc_sealed
+    }
+
+    #[allow(dead_code)] // Activated by the checkpoint GC integration.
+    pub(crate) fn seal_changelog_gc(&mut self) {
+        self.changelog_gc_sealed = true;
     }
 
     /// Validates the canonical write-set contract.
@@ -431,6 +454,7 @@ impl Default for StorageWriteSet {
             groups: Vec::new(),
             group_index: HashMap::with_hasher(FastHashBuilder::with_seeds(0, 0, 0, 0)),
             stats: StorageWriteSetStats::default(),
+            changelog_gc_sealed: false,
         }
     }
 }


### PR DESCRIPTION
## What changed

Makes changelog garbage-collection planning a bounded sequence of global scans rather than an N+1 walk over commits and change-reference chunks.

- Scans commit records, change-ref chunks, and change records once in pages, then derives reachability in memory.
- Keeps the commit-to-canonical-change index consistent when sweeping commits.
- Adds a write-set seal: no changelog mutation may be added after GC has proved reachability. A new transaction lane is required instead.
- Limits JSON deletion candidates to references proved dead by the changelog sweep. Legacy/unreferenced payload repair remains an explicit offline maintenance concern.

## Why

Checkpoint GC needs foreground work that grows linearly with retained metadata, not with repeated point scans. This generic lower-layer change is intentionally separate from checkpoint policy and UI work.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --lib changelog::context::tests --quiet`
- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- `git diff --check`

The tests cover page boundaries, commit-index cleanup, live/dead JSON protection, and all same-/shared-/extended-write-set lifecycle fences.