### PR TITLE
perf(protocol): add native binary file upsert

### DIFF
--- a/.changenotes/native-binary-file-upsert.md
+++ b/.changenotes/native-binary-file-upsert.md
@@ -1,0 +1,10 @@
+---
+type: minor
+---
+
+Added a native binary file-upsert route for remote Lix clients.
+
+`POST /lix/v1/file/upsert` accepts an `application/octet-stream` file body and
+uses Lix's existing transactional file-write path without JSON base64 encoding
+or SQL planning. Clients can discover the capability in the handshake response
+as `binaryFileUpsert`.

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -404,6 +404,12 @@ enum ExecuteBatchExecution {
     Transaction(Vec<datafusion::sql::parser::Statement>),
 }
 
+// Keep the rare legacy-topology fallback semantically identical to the public
+// `lix_file` upsert. The native route stays on the allocation-light direct
+// path for normal workspaces and only plans SQL when that helper declines.
+const NATIVE_FILE_UPSERT_SQL: &str = "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
+    ON CONFLICT (path) DO UPDATE SET data = excluded.data";
+
 impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -428,6 +434,56 @@ where
     ) -> Result<ExecuteResult, LixError> {
         self.execute_with_kind(sql, params, options, "execute")
             .await
+    }
+
+    /// Upserts one file's bytes by its full logical path without constructing
+    /// a SQL parser or DataFusion plan for normal filesystem layouts.
+    ///
+    /// This is the structured file-transfer path. It deliberately delegates
+    /// planning and staging to the existing filesystem fast-write helper, so
+    /// plugin reconciliation, transactional visibility, and commit behavior
+    /// remain identical to the corresponding `lix_file` upsert.
+    pub async fn upsert_file_data(&self, path: String, data: Blob) -> Result<u64, LixError> {
+        self.ensure_open()?;
+        // Preserve the public filesystem path contract before entering a
+        // write transaction. The lower-level fast helper maps this validation
+        // through DataFusion for SQL callers; this native surface should keep
+        // its specific path errors intact.
+        crate::common::LixPath::try_from_file_path(&path)?;
+        let write_access = self.begin_session_write_access().await?;
+        let sql_planning_cache = Arc::clone(&self.sql_planning_cache);
+        self.with_write_transaction_reserved(write_access, |transaction| {
+            Box::pin(async move {
+                // `Blob` is reference-counted. Retaining a copy lets the rare
+                // general-write fallback reuse the same payload without a
+                // second allocation or a second transaction.
+                let fast_path = sql2::execute_fast_lix_file_path_writes(
+                    transaction,
+                    vec![(path.clone(), data.clone(), None)],
+                    sql2::FastLixFilePathWriteConflict::UpdateData,
+                )
+                .await?;
+                if let Some(count) = fast_path {
+                    return Ok(count);
+                }
+
+                // The fast helper declines pre-existing cross-scope path
+                // collisions before staging anything. The general provider
+                // handles those valid legacy layouts, so keep this request in
+                // the same transaction and use its public upsert semantics.
+                let statement = sql_planning_cache.parse_statement(NATIVE_FILE_UPSERT_SQL)?;
+                let plan = transaction
+                    .prepare_sql_write_logical_plan(NATIVE_FILE_UPSERT_SQL, &statement)?;
+                sql2::execute_write_logical_plan_result(
+                    transaction,
+                    plan,
+                    &[Value::Text(path), Value::Blob(data)],
+                )
+                .await
+                .map(|result| result.rows_affected)
+            })
+        })
+        .await
     }
 
     pub(crate) async fn execute_for_observe(

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -63,7 +63,8 @@ pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::SqlPlanningCache;
 pub(crate) use providers::{
-    ExactLixFileReadColumn, ExactLixFileReadSelector, execute_exact_lix_file_batch_read,
-    execute_exact_lix_file_read,
+    ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
+    execute_exact_lix_file_batch_read, execute_exact_lix_file_read,
+    execute_fast_lix_file_path_writes,
 };
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/engine/tests/native_file_upsert_storage.rs
+++ b/packages/engine/tests/native_file_upsert_storage.rs
@@ -1,0 +1,167 @@
+//! Storage-backend coverage for the structured native file-write surface.
+
+use lix_engine::{Engine, SessionContext, Storage, Value};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+
+#[tokio::test]
+async fn native_file_upsert_works_with_rocksdb() {
+    let temp_dir = tempfile::tempdir().expect("create RocksDB temp directory");
+    let storage =
+        RocksDB::open(temp_dir.path().join("native-file-upsert")).expect("open RocksDB storage");
+    assert_native_file_upsert(storage).await;
+}
+
+#[tokio::test]
+async fn native_file_upsert_works_with_slatedb() {
+    let temp_dir = tempfile::tempdir().expect("create SlateDB temp directory");
+    let storage =
+        SlateDB::open(temp_dir.path().join("native-file-upsert")).expect("open SlateDB storage");
+    assert_native_file_upsert(storage).await;
+}
+
+async fn assert_native_file_upsert<S>(storage: S)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize storage");
+    let engine = Engine::new(storage).await.expect("open engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace session");
+
+    assert_eq!(
+        session
+            .upsert_file_data(
+                "/native/deep/payload.bin".to_string(),
+                b"first".to_vec().into()
+            )
+            .await
+            .expect("create through native file upsert"),
+        1
+    );
+    assert_file_data(&session, "/native/deep/payload.bin", b"first").await;
+
+    assert_eq!(
+        session
+            .upsert_file_data(
+                "/native/deep/payload.bin".to_string(),
+                b"second".to_vec().into()
+            )
+            .await
+            .expect("update through native file upsert"),
+        1
+    );
+    assert_file_data(&session, "/native/deep/payload.bin", b"second").await;
+
+    // Empty content is a present empty file. For an existing blob-backed file,
+    // the fast helper also stages the matching blob-reference tombstone.
+    assert_eq!(
+        session
+            .upsert_file_data("/native/deep/payload.bin".to_string(), Vec::new().into())
+            .await
+            .expect("empty native file upsert"),
+        1
+    );
+    assert_file_data(&session, "/native/deep/payload.bin", b"").await;
+
+    // A global file can have a branch-local overlay at the same logical path.
+    // The direct filesystem index deliberately declines that topology so SQL
+    // can select the visible active-branch row. The native surface must make
+    // the same selection instead of rejecting a valid existing workspace.
+    let active_branch_id = session
+        .active_branch_id()
+        .await
+        .expect("active branch should resolve");
+    session
+        .execute(
+            "INSERT INTO lix_file_by_branch \
+             (id, path, data, lixcol_global, lixcol_branch_id) \
+             VALUES ($1, $2, $3, true, 'global')",
+            &[
+                Value::Text("native-overlap".to_string()),
+                Value::Text("/native/overlap.bin".to_string()),
+                Value::Blob(b"g".to_vec().into()),
+            ],
+        )
+        .await
+        .expect("global overlap fixture should insert");
+    session
+        .execute(
+            "INSERT INTO lix_file_by_branch \
+             (id, path, data, lixcol_branch_id) \
+             VALUES ($1, $2, $3, $4)",
+            &[
+                Value::Text("native-overlap".to_string()),
+                Value::Text("/native/overlap.bin".to_string()),
+                Value::Blob(b"l".to_vec().into()),
+                Value::Text(active_branch_id.clone()),
+            ],
+        )
+        .await
+        .expect("active overlap fixture should insert");
+
+    assert_eq!(
+        session
+            .upsert_file_data(
+                "/native/overlap.bin".to_string(),
+                b"updated".to_vec().into()
+            )
+            .await
+            .expect("native upsert should fall back for global/local overlap"),
+        1
+    );
+    assert_file_data_by_branch(&session, "native-overlap", &active_branch_id, b"updated").await;
+    assert_file_data_by_branch(&session, "native-overlap", "global", b"g").await;
+}
+
+async fn assert_file_data<S>(session: &SessionContext<S>, path: &str, expected: &[u8])
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(
+            "SELECT data FROM lix_file WHERE path = $1",
+            &[Value::Text(path.to_string())],
+        )
+        .await
+        .expect("read native upserted file");
+    let actual = result
+        .rows()
+        .first()
+        .expect("native upserted file should remain visible")
+        .get::<Vec<u8>>("data")
+        .expect("file data should decode");
+    assert_eq!(actual, expected);
+}
+
+async fn assert_file_data_by_branch<S>(
+    session: &SessionContext<S>,
+    id: &str,
+    branch_id: &str,
+    expected: &[u8],
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(
+            "SELECT data FROM lix_file_by_branch \
+             WHERE id = $1 AND lixcol_branch_id = $2",
+            &[
+                Value::Text(id.to_string()),
+                Value::Text(branch_id.to_string()),
+            ],
+        )
+        .await
+        .expect("read native upserted file by branch");
+    let actual = result
+        .rows()
+        .first()
+        .expect("native upserted file should remain visible by branch")
+        .get::<Vec<u8>>("data")
+        .expect("file data should decode");
+    assert_eq!(actual, expected);
+}

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -29,7 +29,7 @@ pub use lix_engine::wasm::{
     WasmPluginFile, WasmRuntime,
 };
 pub use lix_engine::{
-    CommitResult, CoreProjection, CreateBranchOptions, CreateBranchReceipt,
+    Blob, CommitResult, CoreProjection, CreateBranchOptions, CreateBranchReceipt,
     CreateBranchReceipt as CreateBranchResult, ExecuteBatchStatement, ExecuteOptions,
     ExecuteResult, GetManyResult, GetOptions, Key, KeyRange, LixError, LixNotice,
     MAX_SCAN_PAGE_ROWS, Memory, MemoryRead, MemoryWrite, MergeBranchOptions, MergeBranchOutcome,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -1,7 +1,7 @@
 use lix_engine::telemetry::TelemetrySink;
 use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
-    CreateBranchOptions, CreateBranchReceipt, Engine, EngineOptions, ExecuteBatchStatement,
+    Blob, CreateBranchOptions, CreateBranchReceipt, Engine, EngineOptions, ExecuteBatchStatement,
     ExecuteOptions, ExecuteResult, LixError, Memory, MergeBranchOptions, MergeBranchPreview,
     MergeBranchPreviewOptions, MergeBranchReceipt, ObserveEvents, SessionContext, Storage,
     SwitchBranchOptions, SwitchBranchReceipt, Value,
@@ -192,6 +192,21 @@ where
     ) -> Result<ExecuteResult, LixError> {
         self.session
             .execute_with_options(sql, params, options)
+            .await
+    }
+
+    /// Upserts one file's bytes by full logical path without parsing SQL.
+    ///
+    /// This structured path is intended for file transfer clients. It uses the
+    /// engine's filesystem fast-write path and retains normal plugin and
+    /// transaction behavior.
+    pub async fn upsert_file_data(
+        &self,
+        path: impl Into<String>,
+        data: impl Into<Blob>,
+    ) -> Result<u64, LixError> {
+        self.session
+            .upsert_file_data(path.into(), data.into())
             .await
     }
 

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -45,6 +45,49 @@ async fn rs_sdk_telemetry_is_explicit_and_redacts_sql_literals() {
 }
 
 #[tokio::test]
+async fn rs_sdk_native_file_upsert_creates_updates_and_keeps_empty_file() {
+    let lix = open_lix(OpenLixOptions::default()).await.expect("open Lix");
+
+    assert_eq!(
+        lix.upsert_file_data("/native/file.bin", b"first".as_slice())
+            .await
+            .expect("create native file"),
+        1
+    );
+    assert_eq!(
+        lix.upsert_file_data("/native/file.bin", b"second".as_slice())
+            .await
+            .expect("update native file"),
+        1
+    );
+    assert_eq!(
+        read_file(&lix, "/native/file.bin")
+            .await
+            .expect("read native file"),
+        Some(b"second".to_vec())
+    );
+
+    assert_eq!(
+        lix.upsert_file_data("/native/file.bin", Vec::<u8>::new())
+            .await
+            .expect("write empty native file"),
+        1
+    );
+    assert_eq!(
+        read_file(&lix, "/native/file.bin")
+            .await
+            .expect("read empty native file"),
+        Some(Vec::new())
+    );
+
+    let error = lix
+        .upsert_file_data("relative.bin", b"invalid".as_slice())
+        .await
+        .expect_err("relative native file path should be rejected");
+    assert_eq!(error.code, "LIX_ERROR_PATH_MISSING_LEADING_SLASH");
+}
+
+#[tokio::test]
 async fn rs_sdk_open_register_write_query_branch_and_merge_flow() {
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
     let main_branch_id = lix.active_branch_id().await.unwrap();

--- a/packages/server-protocol/README.md
+++ b/packages/server-protocol/README.md
@@ -64,3 +64,26 @@ mapping, and multiplexed observations. Host-specific routes such as
 authentication, health checks, and compare-and-swap filesystem mutations stay
 outside it. Session identifiers are opaque capabilities: hosts should not log
 or persist them.
+
+## Binary file upsert
+
+Clients that explicitly want file **upsert** semantics can check for
+`capabilities.binaryFileUpsert === true` in the handshake response and send a
+protected request to:
+
+```text
+POST /lix/v1/file/upsert?path=<percent-encoded-absolute-file-path>
+Lix-Session-Id: <session-id>
+Content-Type: application/octet-stream
+```
+
+The body is the raw file bytes, including an empty body for a present empty
+file. The endpoint creates a missing file or replaces an existing file's data,
+uses the normal transactional filesystem write path, and returns the standard
+`ExecuteResponse` envelope with `rowsAffected: 1`. It has the same configured
+request-body ceiling as JSON protocol requests.
+
+This is intentionally a structured file-transfer operation, not a transparent
+replacement for arbitrary SQL `UPDATE`: callers choose its upsert behavior
+explicitly. The path must be a percent-encoded absolute Lix file path (for
+example, `%2Fassets%2Freport.pdf`).

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -3,6 +3,7 @@
 
 use axum::{
     Extension, Json, Router,
+    body::Bytes,
     extract::{DefaultBodyLimit, Query, Request, State},
     http::{HeaderMap, StatusCode, header::CACHE_CONTROL},
     middleware::{self, Next},
@@ -585,6 +586,7 @@ where
         let protected = Router::new()
             .route("/lix/v1/execute", post(execute::<S>))
             .route("/lix/v1/execute-batch", post(execute_batch::<S>))
+            .route("/lix/v1/file/upsert", post(upsert_file_data::<S>))
             .route("/lix/v1/branch/create", post(create_branch::<S>))
             .route("/lix/v1/branch/switch", post(switch_branch::<S>))
             .route("/lix/v1/observe", post(observe::<S>))
@@ -973,6 +975,7 @@ where
             session_id: lease.session_id.clone(),
             capabilities: ProtocolCapabilities {
                 request_blob_splice: true,
+                binary_file_upsert: true,
             },
         }),
     ))
@@ -1063,6 +1066,28 @@ where
             .map(ExecuteResponse::try_from)
             .collect::<Result<Vec<_>, _>>()?,
     ))
+}
+
+/// Upserts one file from an octet-stream body.
+///
+/// This intentionally covers only the dominant file-transfer shape. It keeps
+/// the normal execute response envelope, but avoids JSON base64 expansion and
+/// decoding for the file payload itself.
+async fn upsert_file_data<S>(
+    Extension(lease): Extension<SessionLease<S>>,
+    Query(request): Query<BinaryFileUpdateRequest>,
+    body: Bytes,
+) -> Result<Json<ExecuteResponse>, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let path = required_non_empty(request.path, "path")?;
+    let result = lease
+        .run(move |lix| async move { lix.upsert_file_data(path, body).await })
+        .await?;
+    Ok(Json(ExecuteResponse::try_from(
+        ExecuteResult::from_rows_affected(result),
+    )?))
 }
 
 async fn create_branch<S>(
@@ -1701,6 +1726,7 @@ struct HandshakeResponse {
 #[serde(rename_all = "camelCase")]
 struct ProtocolCapabilities {
     request_blob_splice: bool,
+    binary_file_upsert: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1713,6 +1739,11 @@ struct ExecuteRequest {
     options: ExecuteOptionsRequest,
     #[serde(default)]
     cache_blobs: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct BinaryFileUpdateRequest {
+    path: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -2384,6 +2415,7 @@ mod tests {
         let (session_id, first) = new_session(&app.router).await;
         assert_eq!(first["protocolVersion"], PROTOCOL_VERSION);
         assert_eq!(first["capabilities"]["requestBlobSplice"], true);
+        assert_eq!(first["capabilities"]["binaryFileUpsert"], true);
         assert_eq!(session_id.len(), SESSION_TOKEN_HEX_LEN);
         assert!(
             session_id
@@ -2440,6 +2472,181 @@ mod tests {
         .await;
         assert_eq!(gone.status(), StatusCode::GONE);
         assert_eq!(error_code(gone).await, "LIX_ERROR_PROTOCOL_SESSION_GONE");
+    }
+
+    #[tokio::test]
+    async fn binary_file_upsert_accepts_raw_bytes_and_preserves_execute_response_shape() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let inserted = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                "params": [
+                    { "kind": "text", "value": "/payload.bin" },
+                    { "kind": "blob", "base64": "b2xk" }
+                ]
+            })),
+        )
+        .await;
+        assert_eq!(inserted.status(), StatusCode::OK);
+
+        let payload = vec![0, 1, 2, 3, 255];
+        let response = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::from(payload.clone()))
+                    .expect("binary file upsert request"),
+            )
+            .await
+            .expect("binary file upsert response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = response_json(response).await;
+        assert_eq!(response["rowsAffected"], 1);
+        assert_eq!(response["columns"], json!([]));
+        assert_eq!(response["rows"], json!([]));
+
+        let selected = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/payload.bin" }]
+            })),
+        )
+        .await;
+        assert_eq!(selected.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(selected).await["rows"][0][0],
+            wire_blob_json(&payload)
+        );
+
+        // An empty body is a real empty file, not an absent request payload.
+        // The filesystem fast path tombstones a prior blob reference when
+        // appropriate and leaves the file itself visible.
+        let emptied = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::empty())
+                    .expect("empty binary file upsert request"),
+            )
+            .await
+            .expect("empty binary file upsert response");
+        assert_eq!(emptied.status(), StatusCode::OK);
+        assert_eq!(response_json(emptied).await["rowsAffected"], 1);
+
+        let empty_selected = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/payload.bin" }]
+            })),
+        )
+        .await;
+        assert_eq!(empty_selected.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(empty_selected).await["rows"][0][0],
+            wire_blob_json(&[])
+        );
+
+        let created_payload = vec![4, 5, 6];
+        let created = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Fcreated.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::from(created_payload.clone()))
+                    .expect("binary file create request"),
+            )
+            .await
+            .expect("binary file create response");
+        assert_eq!(created.status(), StatusCode::OK);
+        assert_eq!(response_json(created).await["rowsAffected"], 1);
+
+        let created_selected = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/created.bin" }]
+            })),
+        )
+        .await;
+        assert_eq!(created_selected.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(created_selected).await["rows"][0][0],
+            wire_blob_json(&created_payload)
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_file_upsert_requires_a_live_session_and_valid_path() {
+        let app = app().await;
+        let missing_session = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Fpayload.bin")
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::from(vec![1_u8]))
+                    .expect("missing session request"),
+            )
+            .await
+            .expect("missing session response");
+        assert_eq!(missing_session.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_code(missing_session).await,
+            "LIX_ERROR_PROTOCOL_SESSION_REQUIRED"
+        );
+
+        let (session_id, _) = new_session(&app.router).await;
+        let invalid_path = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=relative.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::from(vec![1_u8]))
+                    .expect("invalid path request"),
+            )
+            .await
+            .expect("invalid path response");
+        assert_eq!(invalid_path.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_code(invalid_path).await,
+            "LIX_ERROR_PATH_MISSING_LEADING_SLASH"
+        );
     }
 
     #[tokio::test]
@@ -3097,6 +3304,32 @@ mod tests {
             })),
         )
         .await;
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn configured_body_limit_rejects_oversized_binary_file_upsert() {
+        let app = app_with_options(ProtocolServerOptions {
+            max_request_body_bytes: 1_024,
+            ..ProtocolServerOptions::default()
+        })
+        .await;
+        let (session_id, _) = new_session(&app.router).await;
+        let response = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Foversized.bin")
+                    .header(SESSION_ID_HEADER, session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::from(vec![0_u8; 2_048]))
+                    .expect("oversized binary file upsert request"),
+            )
+            .await
+            .expect("oversized binary file upsert response");
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }


### PR DESCRIPTION
## Summary
- add a capability-gated `POST /lix/v1/file/upsert` endpoint that accepts raw `application/octet-stream` bytes with explicit file upsert semantics
- expose the same structured operation through the Rust SDK and preserve the existing transactional filesystem fast-write path
- document the protocol contract, request cap, and release note; add protocol, SDK, and SlateDB/RocksDB storage coverage

## Performance evidence
On fresh SlateDB-backed 5,000-file / 5,000-commit mixed-corpus workspaces, using matched SQL `INSERT ... ON CONFLICT(path) DO UPDATE` controls, a 2 MiB binary upsert had a 46.6% median paired end-to-end latency reduction (85.4 ms -> 46.2 ms) and 25.0% fewer request bytes (2,796,399 -> 2,097,152).

This is intentionally an opt-in large-binary-transfer path, not a general SQL rewrite: a representative mixed small-write hot distribution regressed, and matched native-vs-SQL-upsert storage timings are near parity on both SlateDB and RocksDB.

## Validation
- `node scripts/validate-changes.mjs`
- `cargo fmt --all --check`
- `cargo clippy -p lix_engine -p lix_sdk -p lix_server_protocol --all-targets --all-features -- -D warnings`
- `cargo test -p lix_server_protocol -- --nocapture` (42 passed)
- `cargo test -p lix_sdk rs_sdk_native_file_upsert -- --nocapture`
- `cargo test -p lix_engine --test native_file_upsert_storage -- --nocapture` (SlateDB + RocksDB)