### PR TITLE
Add atomic native file upsert batches

### DIFF
--- a/.changenotes/add-binary-file-upsert-batches.md
+++ b/.changenotes/add-binary-file-upsert-batches.md
@@ -1,0 +1,9 @@
+---
+type: minor
+---
+
+Added atomic binary batches for ordinary file upserts through the Lix engine,
+Rust SDK, and server protocol.
+
+Clients can send up to 1,024 raw file payloads in one request and receive one
+commit with the standard execution response.

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -65,6 +65,12 @@ harness = false
 required-features = ["slatedb"]
 
 [[bench]]
+name = "native_file_upsert_component"
+path = "benches/native_file_upsert_component.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "large_blob_updates"
 path = "benches/large_blob_updates.rs"
 harness = false

--- a/packages/engine/benches/native_file_upsert_component.rs
+++ b/packages/engine/benches/native_file_upsert_component.rs
@@ -1,0 +1,1153 @@
+//! Direct native file-upsert component benchmark for the normal filesystem
+//! layout. This deliberately excludes SQL parsing, server framing, and
+//! metadata changes: it isolates the cost of ten commits versus one commit
+//! for the same ten file writes.
+//!
+//! The benchmark builds one immutable, closed source database per backend and
+//! configuration. Every sample copies that source before opening it, so all
+//! timed operations start from the same file and commit cardinality without
+//! paying the 5k-history setup cost repeatedly.
+//!
+//! Environment variables:
+//! - `LIX_NATIVE_FILE_COMPONENT_FILE_COUNT` (default: 5000)
+//! - `LIX_NATIVE_FILE_COMPONENT_HISTORY_COMMITS` (default: 5000)
+//! - `LIX_NATIVE_FILE_COMPONENT_PAIRS` (default/minimum: 30)
+//! - `LIX_NATIVE_FILE_COMPONENT_SEED_BATCH_SIZE` (default: 1000)
+//! - `LIX_NATIVE_FILE_COMPONENT_BACKENDS` (default: `rocksdb,slatedb`)
+
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use lix_engine::{Blob, Engine, SessionContext, Storage};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+use tempfile::TempDir;
+
+const DEFAULT_FILE_COUNT: usize = 5_000;
+const DEFAULT_HISTORY_COMMITS: usize = 5_000;
+const DEFAULT_PAIRS: usize = 30;
+const DEFAULT_SEED_BATCH_SIZE: usize = 1_000;
+const MEASURED_FILE_COUNT: usize = 10;
+const TEXT_FILE_BYTES: usize = 4 * 1024;
+const PDF_FILE_BYTES: usize = 64 * 1024;
+const PNG_FILE_BYTES: usize = 32 * 1024;
+const BINARY_FILE_BYTES: usize = 256 * 1024;
+// Coprime with the 100 and 500 tiles used by the 1k and 5k corpus screens.
+const PREFERRED_TILE_PERMUTATION_STRIDE: usize = 37;
+// A two-sided 99% Student-t critical value with 29 degrees of freedom. Keeping
+// this value for more than thirty pairs is conservative.
+const T_99_TWO_SIDED_DF_29: f64 = 2.756;
+
+const FILE_KINDS: [FileKind; MEASURED_FILE_COUNT] = [
+    FileKind::new("json", "json"),
+    FileKind::new("csv", "csv"),
+    FileKind::new("markdown", "md"),
+    FileKind::new("text", "txt"),
+    FileKind::new("xml", "xml"),
+    FileKind::new("yaml", "yaml"),
+    FileKind::new("pdf", "pdf"),
+    FileKind::new("png", "png"),
+    FileKind::new("binary", "bin"),
+    FileKind::new("logs", "log"),
+];
+
+#[derive(Clone, Copy)]
+struct FileKind {
+    directory: &'static str,
+    extension: &'static str,
+}
+
+impl FileKind {
+    const fn new(directory: &'static str, extension: &'static str) -> Self {
+        Self {
+            directory,
+            extension,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Backend {
+    RocksDb,
+    SlateDb,
+}
+
+impl Backend {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::RocksDb => "rocksdb",
+            Self::SlateDb => "slatedb",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    TenSingles,
+    OneBatch,
+}
+
+impl Operation {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::TenSingles => "10_native_single_upserts",
+            Self::OneBatch => "1_native_10_entry_batch",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Config {
+    file_count: usize,
+    history_commits: usize,
+    pairs: usize,
+    seed_batch_size: usize,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        let file_count = env_usize("LIX_NATIVE_FILE_COMPONENT_FILE_COUNT", DEFAULT_FILE_COUNT);
+        let history_commits = env_usize(
+            "LIX_NATIVE_FILE_COMPONENT_HISTORY_COMMITS",
+            DEFAULT_HISTORY_COMMITS,
+        );
+        let pairs = env_usize("LIX_NATIVE_FILE_COMPONENT_PAIRS", DEFAULT_PAIRS);
+        let seed_batch_size = env_usize(
+            "LIX_NATIVE_FILE_COMPONENT_SEED_BATCH_SIZE",
+            DEFAULT_SEED_BATCH_SIZE,
+        );
+
+        assert!(
+            file_count >= MEASURED_FILE_COUNT * 2 && file_count.is_multiple_of(MEASURED_FILE_COUNT),
+            "LIX_NATIVE_FILE_COMPONENT_FILE_COUNT must be a multiple of {MEASURED_FILE_COUNT} and at least {}",
+            MEASURED_FILE_COUNT * 2
+        );
+        assert!(
+            history_commits >= 2,
+            "LIX_NATIVE_FILE_COMPONENT_HISTORY_COMMITS must leave one commit for per-clone warmup"
+        );
+        assert!(
+            pairs >= DEFAULT_PAIRS,
+            "LIX_NATIVE_FILE_COMPONENT_PAIRS must be at least {DEFAULT_PAIRS} for a 99% CI"
+        );
+        assert!(
+            seed_batch_size > 0,
+            "LIX_NATIVE_FILE_COMPONENT_SEED_BATCH_SIZE must be greater than zero"
+        );
+
+        Self {
+            file_count,
+            history_commits,
+            pairs,
+            seed_batch_size: seed_batch_size.min(file_count),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MixedFileTile {
+    tile: usize,
+    index_base: usize,
+    payload_seed: u64,
+}
+
+impl MixedFileTile {
+    const fn index_end_exclusive(self) -> usize {
+        self.index_base + MEASURED_FILE_COUNT
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TileSelection {
+    warmup: MixedFileTile,
+    timed: MixedFileTile,
+    permutation_stride: usize,
+    timed_offset: usize,
+}
+
+struct Seed {
+    backend: Backend,
+    // The source database must outlive every clone. It stays closed after
+    // creation, which makes copying RocksDB's WAL/SST set and SlateDB's local
+    // object-store tree safe.
+    _root: TempDir,
+    source_path: PathBuf,
+    main_branch_id: String,
+    source_commit_count: usize,
+    source_usage: DiskUsage,
+    next_clone: AtomicU64,
+}
+
+impl Seed {
+    async fn create(backend: Backend, config: &Config) -> Self {
+        let root = tempfile::tempdir().expect("create native component benchmark root");
+        let source_path = root.path().join("source");
+        let main_branch_id = match backend {
+            Backend::RocksDb => {
+                let storage = RocksDB::open(&source_path).expect("open native component RocksDB");
+                let branch_id = seed_repository(storage.clone(), config).await;
+                storage
+                    .flush()
+                    .expect("flush native component RocksDB source");
+                branch_id
+            }
+            Backend::SlateDb => {
+                let storage = SlateDB::open(&source_path).expect("open native component SlateDB");
+                let branch_id = seed_repository(storage.clone(), config).await;
+                storage
+                    .flush()
+                    .await
+                    .expect("flush native component SlateDB source");
+                branch_id
+            }
+        };
+
+        // Each match arm above drops its last storage handle before this
+        // recursive copy source is ever used. SlateDB's worker Drop closes the
+        // DB synchronously; RocksDB's weak open registry no longer owns a DB.
+        let source_usage = disk_usage(&source_path).expect("account native component source");
+        Self {
+            backend,
+            _root: root,
+            source_path,
+            main_branch_id,
+            source_commit_count: config.history_commits - 1,
+            source_usage,
+            next_clone: AtomicU64::new(0),
+        }
+    }
+
+    async fn fork(&self) -> Fixture {
+        let clone_number = self.next_clone.fetch_add(1, Ordering::Relaxed);
+        let clone_dir = tempfile::tempdir_in(self._root.path())
+            .expect("create native component benchmark clone directory");
+        let database_path = clone_dir.path().join(format!("database-{clone_number:04}"));
+        copy_directory(&self.source_path, &database_path)
+            .expect("copy closed native component benchmark source");
+
+        match self.backend {
+            Backend::RocksDb => {
+                let storage =
+                    RocksDB::open(&database_path).expect("open copied native component RocksDB");
+                Fixture::RocksDb(
+                    open_fixture(
+                        storage,
+                        self.main_branch_id.clone(),
+                        clone_dir,
+                        database_path,
+                    )
+                    .await,
+                )
+            }
+            Backend::SlateDb => {
+                let storage =
+                    SlateDB::open(&database_path).expect("open copied native component SlateDB");
+                Fixture::SlateDb(
+                    open_fixture(
+                        storage,
+                        self.main_branch_id.clone(),
+                        clone_dir,
+                        database_path,
+                    )
+                    .await,
+                )
+            }
+        }
+    }
+}
+
+struct ComponentFixture<S: Storage> {
+    // Keep storage before the TempDir in declaration order: SessionContext and
+    // storage drop before the clone directory is removed.
+    session: SessionContext<S>,
+    storage: S,
+    database_path: PathBuf,
+    _clone_dir: TempDir,
+}
+
+impl<S> ComponentFixture<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    async fn native_batch(&self, writes: Vec<(String, Blob)>) -> u64 {
+        self.session
+            .upsert_file_data_batch(writes)
+            .await
+            .expect("native component batch upsert")
+    }
+
+    async fn native_sequential(&self, writes: Vec<(String, Blob)>) -> u64 {
+        let mut rows_affected = 0;
+        for (path, data) in writes {
+            rows_affected += self
+                .session
+                .upsert_file_data(path, data)
+                .await
+                .expect("native component sequential upsert");
+        }
+        rows_affected
+    }
+
+    async fn visible_commit_count(&self) -> usize {
+        count_rows(&self.session, "SELECT COUNT(*) AS count FROM lix_commit").await
+    }
+
+    async fn visible_file_count(&self) -> usize {
+        count_rows(&self.session, "SELECT COUNT(*) AS count FROM lix_file").await
+    }
+
+    fn disk_usage(&self) -> DiskUsage {
+        disk_usage(&self.database_path).expect("account native component clone")
+    }
+}
+
+enum Fixture {
+    RocksDb(ComponentFixture<RocksDB>),
+    SlateDb(ComponentFixture<SlateDB>),
+}
+
+impl Fixture {
+    async fn native_batch(&self, writes: Vec<(String, Blob)>) -> u64 {
+        match self {
+            Self::RocksDb(fixture) => fixture.native_batch(writes).await,
+            Self::SlateDb(fixture) => fixture.native_batch(writes).await,
+        }
+    }
+
+    async fn native_sequential(&self, writes: Vec<(String, Blob)>) -> u64 {
+        match self {
+            Self::RocksDb(fixture) => fixture.native_sequential(writes).await,
+            Self::SlateDb(fixture) => fixture.native_sequential(writes).await,
+        }
+    }
+
+    async fn visible_commit_count(&self) -> usize {
+        match self {
+            Self::RocksDb(fixture) => fixture.visible_commit_count().await,
+            Self::SlateDb(fixture) => fixture.visible_commit_count().await,
+        }
+    }
+
+    async fn visible_file_count(&self) -> usize {
+        match self {
+            Self::RocksDb(fixture) => fixture.visible_file_count().await,
+            Self::SlateDb(fixture) => fixture.visible_file_count().await,
+        }
+    }
+
+    async fn flush(&self) {
+        match self {
+            Self::RocksDb(fixture) => fixture
+                .storage
+                .flush()
+                .expect("flush native component RocksDB clone"),
+            Self::SlateDb(fixture) => fixture
+                .storage
+                .flush()
+                .await
+                .expect("flush native component SlateDB clone"),
+        }
+    }
+
+    fn disk_usage(&self) -> DiskUsage {
+        match self {
+            Self::RocksDb(fixture) => fixture.disk_usage(),
+            Self::SlateDb(fixture) => fixture.disk_usage(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, serde::Serialize)]
+struct DiskUsage {
+    total_bytes: u64,
+    sst_bytes: u64,
+    log_bytes: u64,
+    manifest_bytes: u64,
+    options_bytes: u64,
+    other_bytes: u64,
+    file_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+struct DiskDelta {
+    total_bytes: i64,
+    sst_bytes: i64,
+    log_bytes: i64,
+    manifest_bytes: i64,
+    options_bytes: i64,
+    other_bytes: i64,
+    file_count: i64,
+}
+
+impl DiskUsage {
+    fn delta_from(self, before: Self) -> DiskDelta {
+        DiskDelta {
+            total_bytes: signed_delta(self.total_bytes, before.total_bytes),
+            sst_bytes: signed_delta(self.sst_bytes, before.sst_bytes),
+            log_bytes: signed_delta(self.log_bytes, before.log_bytes),
+            manifest_bytes: signed_delta(self.manifest_bytes, before.manifest_bytes),
+            options_bytes: signed_delta(self.options_bytes, before.options_bytes),
+            other_bytes: signed_delta(self.other_bytes, before.other_bytes),
+            file_count: signed_delta(self.file_count, before.file_count),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Sample {
+    accepted_ns: u64,
+    flush_ns: u64,
+    flush_complete_ns: u64,
+    storage_before: DiskUsage,
+    storage_after: DiskUsage,
+}
+
+impl Sample {
+    fn storage_delta(&self) -> DiskDelta {
+        self.storage_after.delta_from(self.storage_before)
+    }
+}
+
+struct PairResult {
+    sequential: Sample,
+    batch: Sample,
+}
+
+fn main() {
+    let config = Config::from_env();
+    let backends = selected_backends();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create native component benchmark runtime");
+
+    runtime.block_on(async {
+        for backend in backends {
+            run_backend(backend, &config).await;
+        }
+    });
+}
+
+async fn run_backend(backend: Backend, config: &Config) {
+    let seed = Seed::create(backend, config).await;
+    println!(
+        "{}",
+        serde_json::json!({
+            "benchmark": "native_file_upsert_component",
+            "event": "source_seed",
+            "backend": backend.label(),
+            "file_count": config.file_count,
+            "history_commits_at_measurement_start": config.history_commits,
+            "source_commit_count_before_clone_warmup": seed.source_commit_count,
+            "seed_batch_size": config.seed_batch_size,
+            "measured_batch_bytes": measured_batch_bytes(),
+            "source_storage": seed.source_usage,
+        })
+    );
+
+    let mut pairs = Vec::with_capacity(config.pairs);
+    for pair_index in 0..config.pairs {
+        let sequential_first = pair_index % 2 == 0;
+        let (sequential, batch) = if sequential_first {
+            (
+                run_sample(
+                    &seed,
+                    config,
+                    pair_index,
+                    sequential_first,
+                    Operation::TenSingles,
+                )
+                .await,
+                run_sample(
+                    &seed,
+                    config,
+                    pair_index,
+                    sequential_first,
+                    Operation::OneBatch,
+                )
+                .await,
+            )
+        } else {
+            let batch = run_sample(
+                &seed,
+                config,
+                pair_index,
+                sequential_first,
+                Operation::OneBatch,
+            )
+            .await;
+            let sequential = run_sample(
+                &seed,
+                config,
+                pair_index,
+                sequential_first,
+                Operation::TenSingles,
+            )
+            .await;
+            (sequential, batch)
+        };
+        pairs.push(PairResult { sequential, batch });
+    }
+
+    print_summary(backend, config, &pairs);
+}
+
+async fn run_sample(
+    seed: &Seed,
+    config: &Config,
+    pair_index: usize,
+    sequential_first: bool,
+    operation: Operation,
+) -> Sample {
+    let fixture = seed.fork().await;
+
+    // This is an intentionally direct, parser-free warmup. The source starts
+    // at history - 1 so this one commit leaves the timed request at exactly the
+    // configured history depth on every clone.
+    let selection = selected_tiles(config, pair_index);
+    let warmup_tile = selection.warmup;
+    let timed_tile = selection.timed;
+    let warmup_rows = fixture.native_batch(tile_entries(warmup_tile)).await;
+    assert_eq!(warmup_rows, MEASURED_FILE_COUNT as u64);
+    // Drain the warmup before establishing the storage baseline. Otherwise
+    // its WAL/SST publication would be incorrectly attributed to the timed
+    // operation's storage delta.
+    fixture.flush().await;
+
+    let storage_before = fixture.disk_usage();
+    // Prepare corpus paths and bytes before the timer. No SQL, framing,
+    // metadata construction, or input allocation is inside the timed region.
+    let writes = tile_entries(timed_tile);
+    let accepted_started = Instant::now();
+    let rows_affected = match operation {
+        Operation::TenSingles => fixture.native_sequential(writes).await,
+        Operation::OneBatch => fixture.native_batch(writes).await,
+    };
+    let accepted_ns = duration_ns(accepted_started.elapsed());
+    assert_eq!(rows_affected, MEASURED_FILE_COUNT as u64);
+    black_box(rows_affected);
+
+    // Flush-complete latency is reported separately from accepted latency. It
+    // covers this backend's explicit flush completion, not a claim about crash
+    // durability under every deployment configuration.
+    let flush_started = Instant::now();
+    fixture.flush().await;
+    let flush_ns = duration_ns(flush_started.elapsed());
+    let storage_after = fixture.disk_usage();
+    let flush_complete_ns = accepted_ns
+        .checked_add(flush_ns)
+        .expect("accepted and flush benchmark durations must fit u64 nanoseconds");
+
+    let sample = Sample {
+        accepted_ns,
+        flush_ns,
+        flush_complete_ns,
+        storage_before,
+        storage_after,
+    };
+    let storage_delta = sample.storage_delta();
+
+    // Validate the clone only after timing and disk accounting. The known
+    // direct-write cardinality proves that its warmed timed operation began at
+    // the configured history depth without preheating metadata before timing.
+    let expected_commit_count = config
+        .history_commits
+        .checked_add(match operation {
+            Operation::TenSingles => MEASURED_FILE_COUNT,
+            Operation::OneBatch => 1,
+        })
+        .expect("post-timing commit count must fit usize");
+    let post_timing_commit_count = fixture.visible_commit_count().await;
+    let post_timing_file_count = fixture.visible_file_count().await;
+    assert_eq!(
+        post_timing_commit_count, expected_commit_count,
+        "every clone must preserve the configured history plus its known direct-write count"
+    );
+    assert_eq!(
+        post_timing_file_count, config.file_count,
+        "timed upserts must not alter the mixed corpus file count"
+    );
+    drop(fixture);
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "benchmark": "native_file_upsert_component",
+            "event": "sample",
+            "backend": seed.backend.label(),
+            "pair": pair_index,
+            "order": if sequential_first { "sequential_then_batch" } else { "batch_then_sequential" },
+            "operation": operation.label(),
+            "file_count": config.file_count,
+            "history_commits_at_start": config.history_commits,
+            "measured_batch_bytes": measured_batch_bytes(),
+            "tile_permutation_stride": selection.permutation_stride,
+            "timed_tile_offset": selection.timed_offset,
+            "warmup_tile": warmup_tile.tile,
+            "warmup_index_base": warmup_tile.index_base,
+            "warmup_index_end_exclusive": warmup_tile.index_end_exclusive(),
+            "warmup_payload_seed": warmup_tile.payload_seed,
+            "timed_tile": timed_tile.tile,
+            "timed_index_base": timed_tile.index_base,
+            "timed_index_end_exclusive": timed_tile.index_end_exclusive(),
+            "timed_payload_seed": timed_tile.payload_seed,
+            "accepted_ns": sample.accepted_ns,
+            "flush_ns": sample.flush_ns,
+            "flush_complete_ns": sample.flush_complete_ns,
+            "post_timing_commit_count": post_timing_commit_count,
+            "post_timing_file_count": post_timing_file_count,
+            "post_timing_state_verified": true,
+            "storage_before": sample.storage_before,
+            "storage_after": sample.storage_after,
+            "storage_delta": storage_delta,
+        })
+    );
+    sample
+}
+
+fn print_summary(backend: Backend, config: &Config, pairs: &[PairResult]) {
+    let mut sequential_accepted = pairs
+        .iter()
+        .map(|pair| pair.sequential.accepted_ns)
+        .collect::<Vec<_>>();
+    let mut batch_accepted = pairs
+        .iter()
+        .map(|pair| pair.batch.accepted_ns)
+        .collect::<Vec<_>>();
+    let mut sequential_flush = pairs
+        .iter()
+        .map(|pair| pair.sequential.flush_ns)
+        .collect::<Vec<_>>();
+    let mut batch_flush = pairs
+        .iter()
+        .map(|pair| pair.batch.flush_ns)
+        .collect::<Vec<_>>();
+    let mut sequential_flush_complete = pairs
+        .iter()
+        .map(|pair| pair.sequential.flush_complete_ns)
+        .collect::<Vec<_>>();
+    let mut batch_flush_complete = pairs
+        .iter()
+        .map(|pair| pair.batch.flush_complete_ns)
+        .collect::<Vec<_>>();
+    let mut sequential_storage_delta = pairs
+        .iter()
+        .map(|pair| pair.sequential.storage_delta().total_bytes)
+        .collect::<Vec<_>>();
+    let mut batch_storage_delta = pairs
+        .iter()
+        .map(|pair| pair.batch.storage_delta().total_bytes)
+        .collect::<Vec<_>>();
+
+    let accepted_speedup = paired_speedup(pairs, |sample| sample.accepted_ns);
+    let flush_complete_speedup = paired_speedup(pairs, |sample| sample.flush_complete_ns);
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "benchmark": "native_file_upsert_component",
+            "event": "summary",
+            "backend": backend.label(),
+            "file_count": config.file_count,
+            "history_commits_at_start": config.history_commits,
+            "pairs": pairs.len(),
+            "confidence_level": 0.99,
+            "comparison": "10 direct native single-file commits / 1 direct native ten-file batch commit",
+            "sequential_accepted_p50_ns": percentile(&mut sequential_accepted, 50),
+            "sequential_accepted_p95_ns": percentile(&mut sequential_accepted, 95),
+            "sequential_accepted_mean_ns": mean_u64(&sequential_accepted),
+            "batch_accepted_p50_ns": percentile(&mut batch_accepted, 50),
+            "batch_accepted_p95_ns": percentile(&mut batch_accepted, 95),
+            "batch_accepted_mean_ns": mean_u64(&batch_accepted),
+            "sequential_flush_p50_ns": percentile(&mut sequential_flush, 50),
+            "batch_flush_p50_ns": percentile(&mut batch_flush, 50),
+            "sequential_flush_complete_p50_ns": percentile(&mut sequential_flush_complete, 50),
+            "sequential_flush_complete_p95_ns": percentile(&mut sequential_flush_complete, 95),
+            "sequential_flush_complete_mean_ns": mean_u64(&sequential_flush_complete),
+            "batch_flush_complete_p50_ns": percentile(&mut batch_flush_complete, 50),
+            "batch_flush_complete_p95_ns": percentile(&mut batch_flush_complete, 95),
+            "batch_flush_complete_mean_ns": mean_u64(&batch_flush_complete),
+            "sequential_median_storage_total_delta_bytes": median_i64(&mut sequential_storage_delta),
+            "batch_median_storage_total_delta_bytes": median_i64(&mut batch_storage_delta),
+            "accepted_paired_geometric_mean_speedup": accepted_speedup.geometric_mean,
+            "accepted_paired_99_lower_speedup": accepted_speedup.lower_99,
+            "accepted_paired_99_upper_speedup": accepted_speedup.upper_99,
+            "accepted_paired_99_lower_latency_reduction_percent": (1.0 - 1.0 / accepted_speedup.lower_99) * 100.0,
+            "accepted_qualifies_more_than_20_percent": accepted_speedup.lower_99 > 1.25,
+            "flush_complete_definition": "accepted_ns + post_operation_flush_ns; not a crash-durability claim",
+            "flush_complete_paired_geometric_mean_speedup": flush_complete_speedup.geometric_mean,
+            "flush_complete_paired_99_lower_speedup": flush_complete_speedup.lower_99,
+            "flush_complete_paired_99_upper_speedup": flush_complete_speedup.upper_99,
+            "flush_complete_paired_99_lower_latency_reduction_percent": (1.0 - 1.0 / flush_complete_speedup.lower_99) * 100.0,
+            "flush_complete_qualifies_more_than_20_percent": flush_complete_speedup.lower_99 > 1.25,
+            "qualifies_more_than_20_percent": flush_complete_speedup.lower_99 > 1.25,
+        })
+    );
+}
+
+struct PairedSpeedup {
+    geometric_mean: f64,
+    lower_99: f64,
+    upper_99: f64,
+}
+
+fn paired_speedup(pairs: &[PairResult], value: impl Fn(&Sample) -> u64) -> PairedSpeedup {
+    let log_speedups = pairs
+        .iter()
+        .map(|pair| {
+            let sequential = value(&pair.sequential).max(1) as f64;
+            let batch = value(&pair.batch).max(1) as f64;
+            (sequential / batch).ln()
+        })
+        .collect::<Vec<_>>();
+    let mean_log_speedup = mean(&log_speedups);
+    let standard_error =
+        sample_standard_deviation(&log_speedups) / (log_speedups.len() as f64).sqrt();
+    PairedSpeedup {
+        geometric_mean: mean_log_speedup.exp(),
+        lower_99: (mean_log_speedup - T_99_TWO_SIDED_DF_29 * standard_error).exp(),
+        upper_99: (mean_log_speedup + T_99_TWO_SIDED_DF_29 * standard_error).exp(),
+    }
+}
+
+async fn seed_repository<S>(storage: S, config: &Config) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let init = Engine::initialize(storage.clone())
+        .await
+        .expect("initialize native component source repository");
+    let engine = Engine::new(storage)
+        .await
+        .expect("open native component source engine");
+    let session = engine
+        .open_session(init.main_branch_id.clone())
+        .await
+        .expect("open native component source session");
+
+    seed_files(&session, config).await;
+    assert_eq!(
+        count_rows(&session, "SELECT COUNT(*) AS count FROM lix_file").await,
+        config.file_count,
+        "the source corpus must contain the requested number of files"
+    );
+
+    // The per-clone direct batch warmup supplies the final commit so the timed
+    // operation starts at exactly `history_commits` rather than history + 1.
+    let target_before_clone_warmup = config.history_commits - 1;
+    let mut commit_count = count_rows(&session, "SELECT COUNT(*) AS count FROM lix_commit").await;
+    assert!(
+        commit_count <= target_before_clone_warmup,
+        "history target {target_before_clone_warmup} is too small for {} seed commits",
+        commit_count
+    );
+
+    while commit_count < target_before_clone_warmup {
+        // Rotate normal-sized writes across the mixed corpus. A one-byte
+        // history anchor would understate the changelog/blob layout and skew
+        // the later 5k-history component screen toward a pathological case.
+        let file_index = commit_count % config.file_count;
+        let rows_affected = session
+            .upsert_file_data(
+                corpus_path(file_index),
+                Blob::from(corpus_payload(file_index, commit_count as u64)),
+            )
+            .await
+            .expect("append direct native mixed-corpus history commit");
+        assert_eq!(rows_affected, 1);
+        commit_count += 1;
+    }
+
+    assert_eq!(
+        count_rows(&session, "SELECT COUNT(*) AS count FROM lix_commit").await,
+        target_before_clone_warmup,
+        "source history must match the configured pre-warmup commit count"
+    );
+    init.main_branch_id
+}
+
+async fn seed_files<S>(session: &SessionContext<S>, config: &Config)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    for chunk_start in (0..config.file_count).step_by(config.seed_batch_size) {
+        let chunk_end = (chunk_start + config.seed_batch_size).min(config.file_count);
+        let writes = (chunk_start..chunk_end)
+            .map(|file_index| {
+                (
+                    corpus_path(file_index),
+                    Blob::from(corpus_payload(file_index, 0)),
+                )
+            })
+            .collect::<Vec<_>>();
+        let rows_affected = session
+            .upsert_file_data_batch(writes)
+            .await
+            .expect("seed direct native file batch");
+        assert_eq!(rows_affected, (chunk_end - chunk_start) as u64);
+    }
+}
+
+async fn open_fixture<S>(
+    storage: S,
+    main_branch_id: String,
+    clone_dir: TempDir,
+    database_path: PathBuf,
+) -> ComponentFixture<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open native component clone engine");
+    let session = engine
+        .open_session(main_branch_id)
+        .await
+        .expect("open native component clone session");
+    ComponentFixture {
+        session,
+        storage,
+        database_path,
+        _clone_dir: clone_dir,
+    }
+}
+
+async fn count_rows<S>(session: &SessionContext<S>, sql: &str) -> usize
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(sql, &[])
+        .await
+        .expect("count benchmark rows");
+    let row = result
+        .rows()
+        .first()
+        .expect("count benchmark query should return a row");
+    let count = row.get::<i64>("count").expect("decode benchmark row count");
+    usize::try_from(count).expect("benchmark row count must be non-negative")
+}
+
+fn selected_tiles(config: &Config, pair_index: usize) -> TileSelection {
+    let tile_count = config.file_count / MEASURED_FILE_COUNT;
+    let permutation_stride = coprime_tile_stride(tile_count);
+    let warmup_tile = pair_index.wrapping_mul(permutation_stride) % tile_count;
+    // Split the paired sets across the corpus while retaining a deterministic
+    // one-of-each-type tile. For 100 and 500 tiles this gives 30 samples broad
+    // coverage rather than a prefix-only walk.
+    let timed_offset = (tile_count / 2).max(1);
+    let timed_tile = (warmup_tile + timed_offset) % tile_count;
+    assert_ne!(
+        warmup_tile, timed_tile,
+        "configured corpus must leave a timed mixed tile disjoint from warmup"
+    );
+
+    TileSelection {
+        warmup: MixedFileTile {
+            tile: warmup_tile,
+            index_base: warmup_tile * MEASURED_FILE_COUNT,
+            payload_seed: (pair_index as u64).wrapping_mul(2).wrapping_add(1),
+        },
+        timed: MixedFileTile {
+            tile: timed_tile,
+            index_base: timed_tile * MEASURED_FILE_COUNT,
+            payload_seed: (pair_index as u64).wrapping_mul(2).wrapping_add(2),
+        },
+        permutation_stride,
+        timed_offset,
+    }
+}
+
+fn coprime_tile_stride(tile_count: usize) -> usize {
+    assert!(
+        tile_count >= 2,
+        "tile selection needs warmup and timed tiles"
+    );
+    let mut stride = PREFERRED_TILE_PERMUTATION_STRIDE % tile_count;
+    if stride == 0 {
+        stride = tile_count - 1;
+    }
+    while greatest_common_divisor(stride, tile_count) != 1 {
+        stride -= 1;
+    }
+    stride
+}
+
+fn greatest_common_divisor(mut left: usize, mut right: usize) -> usize {
+    while right != 0 {
+        let remainder = left % right;
+        left = right;
+        right = remainder;
+    }
+    left
+}
+
+fn tile_entries(tile: MixedFileTile) -> Vec<(String, Blob)> {
+    (tile.index_base..tile.index_end_exclusive())
+        .map(|file_index| {
+            (
+                corpus_path(file_index),
+                Blob::from(corpus_payload(file_index, tile.payload_seed)),
+            )
+        })
+        .collect()
+}
+
+fn corpus_path(file_index: usize) -> String {
+    let kind = FILE_KINDS[file_index % FILE_KINDS.len()];
+    format!(
+        "/corpus/{}/file-{file_index:05}.{}",
+        kind.directory, kind.extension
+    )
+}
+
+fn corpus_payload(file_index: usize, version: u64) -> Vec<u8> {
+    let kind = FILE_KINDS[file_index % FILE_KINDS.len()];
+    let payload_bytes = corpus_payload_bytes(file_index);
+    match kind.extension {
+        "pdf" => binary_payload(
+            payload_bytes,
+            b"%PDF-1.7\n%lix-native-benchmark\n",
+            file_index,
+            version,
+        ),
+        "png" => binary_payload(
+            payload_bytes,
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR",
+            file_index,
+            version,
+        ),
+        "bin" => binary_payload(payload_bytes, b"LIX\x00BINARY\x01", file_index, version),
+        "json" => text_payload(
+            payload_bytes,
+            &format!(
+                "{{\"kind\":\"json\",\"file\":{file_index},\"version\":{version},\"payload\":\""
+            ),
+            "xYz0123456789",
+            "\"}\n",
+        ),
+        "csv" => text_payload(
+            payload_bytes,
+            &format!("file,version,value\n{file_index},{version},"),
+            "csv-value-0123456789,",
+            "\n",
+        ),
+        "md" => text_payload(
+            payload_bytes,
+            &format!("# Benchmark {file_index}\n\nversion: {version}\n\n"),
+            "lix native batch markdown content ",
+            "\n",
+        ),
+        "txt" => text_payload(
+            payload_bytes,
+            &format!("file={file_index} version={version}\n"),
+            "plain-text-content-0123456789 ",
+            "\n",
+        ),
+        "xml" => text_payload(
+            payload_bytes,
+            &format!("<file id=\"{file_index}\" version=\"{version}\">"),
+            "xml-content-0123456789",
+            "</file>\n",
+        ),
+        "yaml" => text_payload(
+            payload_bytes,
+            &format!("file: {file_index}\nversion: {version}\nvalue: "),
+            "yaml-content-0123456789",
+            "\n",
+        ),
+        "log" => text_payload(
+            payload_bytes,
+            &format!("INFO file={file_index} version={version} message="),
+            "native-upsert-log-0123456789 ",
+            "\n",
+        ),
+        extension => panic!("unsupported benchmark extension {extension}"),
+    }
+}
+
+fn corpus_payload_bytes(file_index: usize) -> usize {
+    match FILE_KINDS[file_index % FILE_KINDS.len()].extension {
+        "pdf" => PDF_FILE_BYTES,
+        "png" => PNG_FILE_BYTES,
+        "bin" => BINARY_FILE_BYTES,
+        _ => TEXT_FILE_BYTES,
+    }
+}
+
+fn measured_batch_bytes() -> usize {
+    (0..MEASURED_FILE_COUNT).map(corpus_payload_bytes).sum()
+}
+
+fn text_payload(target_bytes: usize, prefix: &str, repeated: &str, suffix: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(target_bytes);
+    bytes.extend_from_slice(prefix.as_bytes());
+    while bytes.len() + suffix.len() < target_bytes {
+        bytes.extend_from_slice(repeated.as_bytes());
+    }
+    bytes.truncate(target_bytes.saturating_sub(suffix.len()));
+    bytes.extend_from_slice(suffix.as_bytes());
+    bytes
+}
+
+fn binary_payload(target_bytes: usize, prefix: &[u8], file_index: usize, version: u64) -> Vec<u8> {
+    let mut bytes = vec![0; target_bytes];
+    let prefix_len = prefix.len().min(bytes.len());
+    bytes[..prefix_len].copy_from_slice(&prefix[..prefix_len]);
+    let mut state = (file_index as u64)
+        .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        .wrapping_add(version)
+        .wrapping_add(0xd1b5_4a32_d192_ed03);
+    for byte in &mut bytes[prefix_len..] {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        *byte = state as u8;
+    }
+    bytes
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_directory(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(source_path, destination_path)?;
+        } else {
+            return Err(std::io::Error::other(format!(
+                "unsupported source entry {} while copying benchmark database",
+                source_path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn disk_usage(path: &Path) -> std::io::Result<DiskUsage> {
+    let mut usage = DiskUsage::default();
+    accumulate_disk_usage(path, &mut usage)?;
+    Ok(usage)
+}
+
+fn accumulate_disk_usage(path: &Path, usage: &mut DiskUsage) -> std::io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            accumulate_disk_usage(&entry.path(), usage)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let bytes = entry.metadata()?.len();
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        usage.total_bytes += bytes;
+        usage.file_count += 1;
+        if file_name.ends_with(".sst") {
+            usage.sst_bytes += bytes;
+        } else if file_name.ends_with(".log") || file_name.starts_with("LOG") {
+            usage.log_bytes += bytes;
+        } else if file_name.starts_with("MANIFEST") {
+            usage.manifest_bytes += bytes;
+        } else if file_name.starts_with("OPTIONS") {
+            usage.options_bytes += bytes;
+        } else {
+            usage.other_bytes += bytes;
+        }
+    }
+    Ok(())
+}
+
+fn selected_backends() -> Vec<Backend> {
+    let requested = std::env::var("LIX_NATIVE_FILE_COMPONENT_BACKENDS")
+        .unwrap_or_else(|_| "rocksdb,slatedb".to_string());
+    let mut selected = Vec::new();
+    for value in requested
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let backend = match value {
+            "rocksdb" => Backend::RocksDb,
+            "slatedb" => Backend::SlateDb,
+            other => panic!(
+                "unsupported LIX_NATIVE_FILE_COMPONENT_BACKENDS value {other:?}; expected rocksdb or slatedb"
+            ),
+        };
+        if !selected.contains(&backend) {
+            selected.push(backend);
+        }
+    }
+    assert!(
+        !selected.is_empty(),
+        "LIX_NATIVE_FILE_COMPONENT_BACKENDS must select at least one backend"
+    );
+    selected
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<usize>()
+            .unwrap_or_else(|error| panic!("parse {name}={value:?} as usize: {error}")),
+        Err(_) => default,
+    }
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).expect("benchmark duration must fit u64 nanoseconds")
+}
+
+fn signed_delta(after: u64, before: u64) -> i64 {
+    let after = i128::from(after);
+    let before = i128::from(before);
+    i64::try_from(after - before).expect("benchmark storage delta must fit i64")
+}
+
+fn percentile(values: &mut [u64], percentile: usize) -> u64 {
+    assert!(!values.is_empty(), "benchmark percentile requires samples");
+    values.sort_unstable();
+    let rank = values.len().saturating_mul(percentile).div_ceil(100);
+    values[rank.saturating_sub(1).min(values.len() - 1)]
+}
+
+fn median_i64(values: &mut [i64]) -> i64 {
+    assert!(!values.is_empty(), "benchmark median requires samples");
+    values.sort_unstable();
+    values[(values.len() - 1) / 2]
+}
+
+fn mean(values: &[f64]) -> f64 {
+    assert!(!values.is_empty(), "benchmark mean requires samples");
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+fn mean_u64(values: &[u64]) -> f64 {
+    assert!(!values.is_empty(), "benchmark mean requires samples");
+    values.iter().map(|value| *value as f64).sum::<f64>() / values.len() as f64
+}
+
+fn sample_standard_deviation(values: &[f64]) -> f64 {
+    assert!(
+        values.len() > 1,
+        "benchmark standard deviation requires multiple samples"
+    );
+    let mean = mean(values);
+    let variance = values
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / (values.len() - 1) as f64;
+    variance.sqrt()
+}

--- a/packages/engine/benches/native_file_upsert_component.rs
+++ b/packages/engine/benches/native_file_upsert_component.rs
@@ -173,7 +173,7 @@ struct Seed {
     // The source database must outlive every clone. It stays closed after
     // creation, which makes copying RocksDB's WAL/SST set and SlateDB's local
     // object-store tree safe.
-    _root: TempDir,
+    root: TempDir,
     source_path: PathBuf,
     main_branch_id: String,
     source_commit_count: usize,
@@ -211,7 +211,7 @@ impl Seed {
         let source_usage = disk_usage(&source_path).expect("account native component source");
         Self {
             backend,
-            _root: root,
+            root,
             source_path,
             main_branch_id,
             source_commit_count: config.history_commits - 1,
@@ -222,7 +222,7 @@ impl Seed {
 
     async fn fork(&self) -> Fixture {
         let clone_number = self.next_clone.fetch_add(1, Ordering::Relaxed);
-        let clone_dir = tempfile::tempdir_in(self._root.path())
+        let clone_dir = tempfile::tempdir_in(self.root.path())
             .expect("create native component benchmark clone directory");
         let database_path = clone_dir.path().join(format!("database-{clone_number:04}"));
         copy_directory(&self.source_path, &database_path)
@@ -698,18 +698,22 @@ fn paired_speedup(pairs: &[PairResult], value: impl Fn(&Sample) -> u64) -> Paire
     let log_speedups = pairs
         .iter()
         .map(|pair| {
-            let sequential = value(&pair.sequential).max(1) as f64;
-            let batch = value(&pair.batch).max(1) as f64;
+            let sequential = exact_f64_from_u64(value(&pair.sequential).max(1));
+            let batch = exact_f64_from_u64(value(&pair.batch).max(1));
             (sequential / batch).ln()
         })
         .collect::<Vec<_>>();
     let mean_log_speedup = mean(&log_speedups);
     let standard_error =
-        sample_standard_deviation(&log_speedups) / (log_speedups.len() as f64).sqrt();
+        sample_standard_deviation(&log_speedups) / exact_f64_from_usize(log_speedups.len()).sqrt();
     PairedSpeedup {
         geometric_mean: mean_log_speedup.exp(),
-        lower_99: (mean_log_speedup - T_99_TWO_SIDED_DF_29 * standard_error).exp(),
-        upper_99: (mean_log_speedup + T_99_TWO_SIDED_DF_29 * standard_error).exp(),
+        lower_99: T_99_TWO_SIDED_DF_29
+            .mul_add(-standard_error, mean_log_speedup)
+            .exp(),
+        upper_99: T_99_TWO_SIDED_DF_29
+            .mul_add(standard_error, mean_log_speedup)
+            .exp(),
     }
 }
 
@@ -741,8 +745,7 @@ where
     let mut commit_count = count_rows(&session, "SELECT COUNT(*) AS count FROM lix_commit").await;
     assert!(
         commit_count <= target_before_clone_warmup,
-        "history target {target_before_clone_warmup} is too small for {} seed commits",
-        commit_count
+        "history target {target_before_clone_warmup} is too small for {commit_count} seed commits"
     );
 
     while commit_count < target_before_clone_warmup {
@@ -1005,7 +1008,7 @@ fn binary_payload(target_bytes: usize, prefix: &[u8], file_index: usize, version
         state ^= state << 13;
         state ^= state >> 7;
         state ^= state << 17;
-        *byte = state as u8;
+        *byte = state.to_le_bytes()[0];
     }
     bytes
 }
@@ -1097,12 +1100,11 @@ fn selected_backends() -> Vec<Backend> {
 }
 
 fn env_usize(name: &str, default: usize) -> usize {
-    match std::env::var(name) {
-        Ok(value) => value
+    std::env::var(name).map_or(default, |value| {
+        value
             .parse::<usize>()
-            .unwrap_or_else(|error| panic!("parse {name}={value:?} as usize: {error}")),
-        Err(_) => default,
-    }
+            .unwrap_or_else(|error| panic!("parse {name}={value:?} as usize: {error}"))
+    })
 }
 
 fn duration_ns(duration: Duration) -> u64 {
@@ -1130,12 +1132,16 @@ fn median_i64(values: &mut [i64]) -> i64 {
 
 fn mean(values: &[f64]) -> f64 {
     assert!(!values.is_empty(), "benchmark mean requires samples");
-    values.iter().sum::<f64>() / values.len() as f64
+    values.iter().sum::<f64>() / exact_f64_from_usize(values.len())
 }
 
 fn mean_u64(values: &[u64]) -> f64 {
     assert!(!values.is_empty(), "benchmark mean requires samples");
-    values.iter().map(|value| *value as f64).sum::<f64>() / values.len() as f64
+    values
+        .iter()
+        .map(|value| exact_f64_from_u64(*value))
+        .sum::<f64>()
+        / exact_f64_from_usize(values.len())
 }
 
 fn sample_standard_deviation(values: &[f64]) -> f64 {
@@ -1148,6 +1154,23 @@ fn sample_standard_deviation(values: &[f64]) -> f64 {
         .iter()
         .map(|value| (value - mean).powi(2))
         .sum::<f64>()
-        / (values.len() - 1) as f64;
+        / exact_f64_from_usize(values.len() - 1);
     variance.sqrt()
+}
+
+fn exact_f64_from_usize(value: usize) -> f64 {
+    exact_f64_from_u64(u64::try_from(value).expect("benchmark count must fit u64"))
+}
+
+fn exact_f64_from_u64(value: u64) -> f64 {
+    // All benchmark values must remain exactly representable so confidence
+    // interval math cannot silently lose nanosecond/count precision.
+    assert!(
+        value <= (1_u64 << f64::MANTISSA_DIGITS),
+        "benchmark value {value} exceeds f64's exact integer range"
+    );
+    #[allow(clippy::cast_precision_loss)]
+    {
+        value as f64
+    }
 }

--- a/packages/engine/benches/slatedb_file_api.rs
+++ b/packages/engine/benches/slatedb_file_api.rs
@@ -20,7 +20,7 @@ use lix_engine::storage_adapter::StorageAdapter;
 use lix_engine::transaction::bench::{
     BenchTransactionFixture, BenchTransactionRow, BenchWriteAccounting,
 };
-use lix_engine::{Engine, SessionContext, Storage, Value};
+use lix_engine::{Blob, Engine, SessionContext, Storage, Value};
 use lix_slatedb_storage::{SlateDB, SlateDBCacheOptions, SlateDBObjectStoreOptions};
 use object_store::memory::InMemory;
 use object_store::path::Path;
@@ -58,6 +58,7 @@ fn slatedb_file_api_benches(c: &mut Criterion) {
         .build()
         .expect("create tokio runtime for slatedb_file_api benchmarks");
     maybe_print_write_accounting(&runtime);
+    maybe_print_native_batch_write_accounting(&runtime);
     #[cfg(feature = "storage-benches")]
     maybe_print_singleton_write_accounting(&runtime);
     let mut group = c.benchmark_group("slatedb_file_api_warm_cache");
@@ -394,6 +395,55 @@ fn maybe_print_write_accounting(runtime: &tokio::runtime::Runtime) {
         println!(
             "slatedb-object-write path={path} put_calls={} put_bytes={}",
             path_stats.put_calls, path_stats.put_bytes,
+        );
+    }
+}
+
+fn maybe_print_native_batch_write_accounting(runtime: &tokio::runtime::Runtime) {
+    if std::env::var_os("LIX_SLATEDB_NATIVE_BATCH_ACCOUNTING").is_none() {
+        return;
+    }
+
+    for operation in ["10_native_single_upserts", "1_native_10_entry_batch"] {
+        let fixture = runtime.block_on(UploadBenchFixture::seeded(Duration::ZERO));
+        // Prime the identical direct path outside the accounting interval so
+        // accepted and flush figures describe steady-state writes, not engine
+        // open or first-index population.
+        black_box(
+            runtime.block_on(fixture.native_upsert_one_batch(fixture.next_native_upsert_entries())),
+        );
+        runtime
+            .block_on(fixture.storage.flush())
+            .expect("flush native batch accounting warmup");
+        fixture.object_store.reset_write_stats();
+
+        let entries = fixture.next_native_upsert_entries();
+        let accepted_started = Instant::now();
+        let rows_affected = match operation {
+            "10_native_single_upserts" => {
+                runtime.block_on(fixture.native_upsert_ten_sequential(entries))
+            }
+            "1_native_10_entry_batch" => runtime.block_on(fixture.native_upsert_one_batch(entries)),
+            _ => unreachable!("native batch accounting operation is fixed"),
+        };
+        let accepted = accepted_started.elapsed();
+        let flush_started = Instant::now();
+        runtime
+            .block_on(fixture.storage.flush())
+            .expect("flush native batch accounting write");
+        let flush = flush_started.elapsed();
+        let stats = fixture.object_store.write_stats();
+        let wal = stats.wal_totals();
+        println!(
+            "slatedb-native-batch-accounting operation={operation} seed_files={} seed_batch_size={} rows_affected={rows_affected} accepted_ns={} flush_ns={} put_calls={} put_bytes={} wal_put_calls={} wal_put_bytes={}",
+            seed_file_count(),
+            seed_upload_batch_size(),
+            accepted.as_nanos(),
+            flush.as_nanos(),
+            stats.put_calls,
+            stats.put_bytes,
+            wal.put_calls,
+            wal.put_bytes,
         );
     }
 }
@@ -820,6 +870,43 @@ impl UploadBenchFixture {
             .await
             .expect("overwrite benchmark file batch");
         result.rows_affected()
+    }
+
+    fn next_native_upsert_entries(&self) -> Vec<(String, Blob)> {
+        let version = self.next_upload_version.fetch_add(1, Ordering::Relaxed);
+        self.upload_batch_paths
+            .iter()
+            .enumerate()
+            .map(|(index, path)| {
+                let file_version = version
+                    .wrapping_mul(LIXRAY_UPLOAD_BATCH_FILES as u64)
+                    .wrapping_add(index as u64);
+                (path.clone(), Blob::from(upload_file_bytes(file_version)))
+            })
+            .collect()
+    }
+
+    async fn native_upsert_ten_sequential(&self, entries: Vec<(String, Blob)>) -> u64 {
+        let mut rows_affected = 0;
+        for (path, data) in entries {
+            rows_affected += self
+                .session
+                .upsert_file_data(path, data)
+                .await
+                .expect("native sequential file upsert");
+        }
+        assert_eq!(rows_affected, LIXRAY_UPLOAD_BATCH_FILES as u64);
+        rows_affected
+    }
+
+    async fn native_upsert_one_batch(&self, entries: Vec<(String, Blob)>) -> u64 {
+        let rows_affected = self
+            .session
+            .upsert_file_data_batch(entries)
+            .await
+            .expect("native batch file upsert");
+        assert_eq!(rows_affected, LIXRAY_UPLOAD_BATCH_FILES as u64);
+        rows_affected
     }
 
     async fn upload_new_file(&self) -> u64 {
@@ -1449,7 +1536,6 @@ struct ObjectStorePathWriteStats {
 }
 
 impl ObjectStoreWriteStats {
-    #[cfg(feature = "storage-benches")]
     fn wal_totals(&self) -> ObjectStorePathWriteStats {
         self.by_path
             .iter()

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -404,11 +404,47 @@ enum ExecuteBatchExecution {
     Transaction(Vec<datafusion::sql::parser::Statement>),
 }
 
-// Keep the rare legacy-topology fallback semantically identical to the public
-// `lix_file` upsert. The native route stays on the allocation-light direct
-// path for normal workspaces and only plans SQL when that helper declines.
+// Keep the single-file legacy-topology fallback semantically identical to the
+// public `lix_file` upsert. Batch writes intentionally stay direct-only.
 const NATIVE_FILE_UPSERT_SQL: &str = "INSERT INTO lix_file (path, data) VALUES ($1, $2) \
     ON CONFLICT (path) DO UPDATE SET data = excluded.data";
+
+fn validate_native_file_upsert_batch(writes: &[(String, Blob)]) -> Result<(), LixError> {
+    if writes.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_INVALID_PARAM,
+            "upsert_file_data_batch requires at least one file",
+        )
+        .with_details(serde_json::json!({
+            "operation": "upsertFileDataBatch",
+            "argument": "writes",
+            "expected": "non-empty array",
+        })));
+    }
+
+    let mut paths = BTreeSet::new();
+    for (path, _) in writes {
+        // Preserve the public filesystem path contract before entering a
+        // write transaction. The lower-level fast helper maps this validation
+        // through DataFusion for SQL callers; this native surface should keep
+        // its specific path errors intact.
+        crate::common::LixPath::try_from_file_path(path)?;
+        if !paths.insert(path.as_str()) {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                format!("upsert_file_data_batch contains duplicate path '{path}'"),
+            )
+            .with_details(serde_json::json!({
+                "operation": "upsertFileDataBatch",
+                "argument": "writes",
+                "path": path,
+                "expected": "unique file paths",
+            })));
+        }
+    }
+
+    Ok(())
+}
 
 impl<StorageImpl> SessionContext<StorageImpl>
 where
@@ -439,10 +475,9 @@ where
     /// Upserts one file's bytes by its full logical path without constructing
     /// a SQL parser or DataFusion plan for normal filesystem layouts.
     ///
-    /// This is the structured file-transfer path. It deliberately delegates
-    /// planning and staging to the existing filesystem fast-write helper, so
-    /// plugin reconciliation, transactional visibility, and commit behavior
-    /// remain identical to the corresponding `lix_file` upsert.
+    /// This stays separate from the batch API so the established one-file
+    /// transfer path does not pay for batch-vector allocation or duplicate
+    /// validation.
     pub async fn upsert_file_data(&self, path: String, data: Blob) -> Result<u64, LixError> {
         self.ensure_open()?;
         // Preserve the public filesystem path contract before entering a
@@ -481,6 +516,45 @@ where
                 )
                 .await
                 .map(|result| result.rows_affected)
+            })
+        })
+        .await
+    }
+
+    /// Upserts a non-empty batch of file bytes in one transaction.
+    ///
+    /// Paths are validated and required to be unique before a transaction is
+    /// opened. This is deliberately a direct filesystem write: if the path
+    /// index cannot route an exceptional layout unambiguously, the batch is
+    /// rejected instead of copying the complete payload into a SQL fallback.
+    pub async fn upsert_file_data_batch(
+        &self,
+        writes: Vec<(String, Blob)>,
+    ) -> Result<u64, LixError> {
+        self.ensure_open()?;
+        validate_native_file_upsert_batch(&writes)?;
+        let write_access = self.begin_session_write_access().await?;
+        self.with_write_transaction_reserved(write_access, |transaction| {
+            Box::pin(async move {
+                sql2::execute_fast_lix_file_path_writes(
+                    transaction,
+                    writes
+                        .into_iter()
+                        .map(|(path, data)| (path, data, None))
+                        .collect(),
+                    sql2::FastLixFilePathWriteConflict::UpdateData,
+                )
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_CONSTRAINT_VIOLATION,
+                        "upsert_file_data_batch requires a filesystem layout that its direct path index can route unambiguously",
+                    )
+                    .with_details(serde_json::json!({
+                        "operation": "upsertFileDataBatch",
+                        "expected": "a filesystem layout that the direct path index can route unambiguously",
+                    }))
+                })
             })
         })
         .await

--- a/packages/engine/tests/native_file_upsert_storage.rs
+++ b/packages/engine/tests/native_file_upsert_storage.rs
@@ -1,6 +1,6 @@
 //! Storage-backend coverage for the structured native file-write surface.
 
-use lix_engine::{Engine, SessionContext, Storage, Value};
+use lix_engine::{Blob, Engine, LixError, SessionContext, Storage, Value};
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::SlateDB;
 
@@ -68,10 +68,77 @@ where
     );
     assert_file_data(&session, "/native/deep/payload.bin", b"").await;
 
+    let fast_batch_parent = active_branch_commit_id(&session).await;
+    assert_eq!(
+        session
+            .upsert_file_data_batch(file_writes(&[
+                ("/native/deep/payload.bin", b"batch-update"),
+                ("/native/batch/one.bin", b"one"),
+                ("/native/batch/two.bin", b"two"),
+                ("/native/batch/empty.bin", b""),
+            ]))
+            .await
+            .expect("create a native file batch"),
+        4
+    );
+    assert_active_branch_head_parent(&session, &fast_batch_parent).await;
+    assert_file_data(&session, "/native/deep/payload.bin", b"batch-update").await;
+    assert_file_data(&session, "/native/batch/one.bin", b"one").await;
+    assert_file_data(&session, "/native/batch/two.bin", b"two").await;
+    assert_file_data(&session, "/native/batch/empty.bin", b"").await;
+
+    let fast_batch_update_parent = active_branch_commit_id(&session).await;
+    assert_eq!(
+        session
+            .upsert_file_data_batch(file_writes(&[
+                ("/native/batch/one.bin", b"updated-one"),
+                ("/native/batch/two.bin", b""),
+                ("/native/batch/empty.bin", b"updated-empty"),
+            ]))
+            .await
+            .expect("update a native file batch"),
+        3
+    );
+    assert_active_branch_head_parent(&session, &fast_batch_update_parent).await;
+    assert_file_data(&session, "/native/batch/one.bin", b"updated-one").await;
+    assert_file_data(&session, "/native/batch/two.bin", b"").await;
+    assert_file_data(&session, "/native/batch/empty.bin", b"updated-empty").await;
+
+    let head_before_prevalidation_errors = active_branch_commit_id(&session).await;
+    let empty_error = session
+        .upsert_file_data_batch(Vec::new())
+        .await
+        .expect_err("empty native file batches should be rejected");
+    assert_eq!(empty_error.code, LixError::CODE_INVALID_PARAM);
+
+    let duplicate_error = session
+        .upsert_file_data_batch(file_writes(&[
+            ("/native/batch/duplicate.bin", b"first"),
+            ("/native/batch/duplicate.bin", b"second"),
+        ]))
+        .await
+        .expect_err("duplicate paths should be rejected before the batch writes");
+    assert_eq!(duplicate_error.code, LixError::CODE_INVALID_PARAM);
+    assert_file_missing(&session, "/native/batch/duplicate.bin").await;
+
+    let path_error = session
+        .upsert_file_data_batch(file_writes(&[
+            ("/native/batch/must-not-write.bin", b"first"),
+            ("relative.bin", b"invalid"),
+        ]))
+        .await
+        .expect_err("an invalid path should reject the complete batch before it writes");
+    assert_eq!(path_error.code, "LIX_ERROR_PATH_MISSING_LEADING_SLASH");
+    assert_file_missing(&session, "/native/batch/must-not-write.bin").await;
+    assert_eq!(
+        active_branch_commit_id(&session).await,
+        head_before_prevalidation_errors,
+        "prevalidation failures must not create a partial batch commit"
+    );
+
     // A global file can have a branch-local overlay at the same logical path.
-    // The direct filesystem index deliberately declines that topology so SQL
-    // can select the visible active-branch row. The native surface must make
-    // the same selection instead of rejecting a valid existing workspace.
+    // The exact path index selects the active overlay directly, without a
+    // general SQL fallback.
     let active_branch_id = session
         .active_branch_id()
         .await
@@ -104,18 +171,90 @@ where
         .await
         .expect("active overlap fixture should insert");
 
+    let overlay_batch_parent = active_branch_commit_id(&session).await;
     assert_eq!(
         session
-            .upsert_file_data(
-                "/native/overlap.bin".to_string(),
-                b"updated".to_vec().into()
-            )
+            .upsert_file_data_batch(file_writes(&[
+                ("/native/overlap.bin", b"updated"),
+                ("/native/batch/overlay-companion.bin", b"companion"),
+            ]))
             .await
-            .expect("native upsert should fall back for global/local overlap"),
-        1
+            .expect("direct batch should update the active overlay"),
+        2
     );
+    assert_active_branch_head_parent(&session, &overlay_batch_parent).await;
     assert_file_data_by_branch(&session, "native-overlap", &active_branch_id, b"updated").await;
     assert_file_data_by_branch(&session, "native-overlap", "global", b"g").await;
+    assert_file_data(
+        &session,
+        "/native/batch/overlay-companion.bin",
+        b"companion",
+    )
+    .await;
+}
+
+fn file_writes(files: &[(&str, &[u8])]) -> Vec<(String, Blob)> {
+    files
+        .iter()
+        .map(|(path, data)| ((*path).to_string(), (*data).to_vec().into()))
+        .collect()
+}
+
+async fn active_branch_commit_id<S>(session: &SessionContext<S>) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("read active branch commit id")
+        .rows()
+        .first()
+        .expect("active branch commit id should have one row")
+        .get::<String>("commit_id")
+        .expect("active branch commit id should decode")
+}
+
+async fn assert_active_branch_head_parent<S>(session: &SessionContext<S>, expected_parent: &str)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let head = active_branch_commit_id(session).await;
+    let result = session
+        .execute(
+            "SELECT parent_id FROM lix_commit_edge WHERE child_id = $1",
+            &[Value::Text(head)],
+        )
+        .await
+        .expect("read active branch commit edge");
+    assert_eq!(
+        result.rows().len(),
+        1,
+        "a native file batch should create exactly one single-parent commit"
+    );
+    assert_eq!(
+        result.rows()[0]
+            .get::<String>("parent_id")
+            .expect("active branch parent id should decode"),
+        expected_parent
+    );
+}
+
+async fn assert_file_missing<S>(session: &SessionContext<S>, path: &str)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(
+            "SELECT data FROM lix_file WHERE path = $1",
+            &[Value::Text(path.to_string())],
+        )
+        .await
+        .expect("read native file absence");
+    assert!(
+        result.rows().is_empty(),
+        "file '{path}' should not be visible after an atomic batch failure"
+    );
 }
 
 async fn assert_file_data<S>(session: &SessionContext<S>, path: &str, expected: &[u8])

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -210,6 +210,19 @@ where
             .await
     }
 
+    /// Upserts a non-empty batch of files atomically without parsing SQL for
+    /// normal filesystem layouts.
+    ///
+    /// Each item is a full logical file path and its bytes. Paths must be
+    /// unique within the batch. This direct-only API rejects exceptional
+    /// layouts that its path index cannot route unambiguously.
+    pub async fn upsert_file_data_batch(
+        &self,
+        writes: Vec<(String, Blob)>,
+    ) -> Result<u64, LixError> {
+        self.session.upsert_file_data_batch(writes).await
+    }
+
     /// Executes statements sequentially against one atomic snapshot.
     /// Pure reads share one read snapshot; batches containing writes retain
     /// transactional read-after-write and rollback semantics.

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -1,7 +1,8 @@
 use lix_sdk::{
-    CallbackTelemetrySink, CompletedTelemetrySpan, CreateBranchOptions, ExecuteBatchStatement, Lix,
-    LixError, Memory, MergeBranchOptions, MergeBranchOutcome, OpenLixOptions, Storage,
-    SwitchBranchOptions, TelemetryValue, Value, open_lix, open_lix_with_telemetry,
+    Blob, CallbackTelemetrySink, CompletedTelemetrySpan, CreateBranchOptions,
+    ExecuteBatchStatement, Lix, LixError, Memory, MergeBranchOptions, MergeBranchOutcome,
+    OpenLixOptions, Storage, SwitchBranchOptions, TelemetryValue, Value, open_lix,
+    open_lix_with_telemetry,
 };
 #[cfg(feature = "local_filesystem")]
 use lix_sdk::{LocalFilesystem, LocalFilesystemOpenOptions, open_lix_with_storage};
@@ -85,6 +86,163 @@ async fn rs_sdk_native_file_upsert_creates_updates_and_keeps_empty_file() {
         .await
         .expect_err("relative native file path should be rejected");
     assert_eq!(error.code, "LIX_ERROR_PATH_MISSING_LEADING_SLASH");
+}
+
+#[tokio::test]
+async fn rs_sdk_native_file_upsert_batch_is_atomic_and_updates_active_overlays() {
+    let lix = open_lix(OpenLixOptions::default()).await.expect("open Lix");
+
+    lix.upsert_file_data("/native/batch/one.bin", b"before".as_slice())
+        .await
+        .expect("seed native file batch update");
+    let fast_batch_parent = active_branch_commit_id(&lix).await;
+    assert_eq!(
+        lix.upsert_file_data_batch(native_file_writes(&[
+            ("/native/batch/one.bin", b"one"),
+            ("/native/batch/two.bin", b"two"),
+            ("/native/batch/empty.bin", b""),
+        ]))
+        .await
+        .expect("create native file batch"),
+        3
+    );
+    assert_active_branch_head_parent(&lix, &fast_batch_parent).await;
+    assert_eq!(
+        read_file(&lix, "/native/batch/one.bin").await.unwrap(),
+        Some(b"one".to_vec())
+    );
+    assert_eq!(
+        read_file(&lix, "/native/batch/two.bin").await.unwrap(),
+        Some(b"two".to_vec())
+    );
+    assert_eq!(
+        read_file(&lix, "/native/batch/empty.bin").await.unwrap(),
+        Some(Vec::new())
+    );
+
+    let fast_batch_update_parent = active_branch_commit_id(&lix).await;
+    assert_eq!(
+        lix.upsert_file_data_batch(native_file_writes(&[
+            ("/native/batch/one.bin", b"updated-one"),
+            ("/native/batch/two.bin", b""),
+            ("/native/batch/empty.bin", b"updated-empty"),
+        ]))
+        .await
+        .expect("update native file batch"),
+        3
+    );
+    assert_active_branch_head_parent(&lix, &fast_batch_update_parent).await;
+    assert_eq!(
+        read_file(&lix, "/native/batch/one.bin").await.unwrap(),
+        Some(b"updated-one".to_vec())
+    );
+    assert_eq!(
+        read_file(&lix, "/native/batch/two.bin").await.unwrap(),
+        Some(Vec::new())
+    );
+    assert_eq!(
+        read_file(&lix, "/native/batch/empty.bin").await.unwrap(),
+        Some(b"updated-empty".to_vec())
+    );
+
+    let head_before_prevalidation_errors = active_branch_commit_id(&lix).await;
+    let empty_error = lix
+        .upsert_file_data_batch(Vec::new())
+        .await
+        .expect_err("empty native file batch should be rejected");
+    assert_eq!(empty_error.code, LixError::CODE_INVALID_PARAM);
+
+    let duplicate_error = lix
+        .upsert_file_data_batch(native_file_writes(&[
+            ("/native/batch/duplicate.bin", b"first"),
+            ("/native/batch/duplicate.bin", b"second"),
+        ]))
+        .await
+        .expect_err("duplicate native file batch path should be rejected");
+    assert_eq!(duplicate_error.code, LixError::CODE_INVALID_PARAM);
+    assert_eq!(
+        read_file(&lix, "/native/batch/duplicate.bin")
+            .await
+            .unwrap(),
+        None
+    );
+
+    let path_error = lix
+        .upsert_file_data_batch(native_file_writes(&[
+            ("/native/batch/must-not-write.bin", b"first"),
+            ("relative.bin", b"invalid"),
+        ]))
+        .await
+        .expect_err("invalid file path should reject the complete batch");
+    assert_eq!(path_error.code, "LIX_ERROR_PATH_MISSING_LEADING_SLASH");
+    assert_eq!(
+        read_file(&lix, "/native/batch/must-not-write.bin")
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        active_branch_commit_id(&lix).await,
+        head_before_prevalidation_errors,
+        "prevalidation failures must not create a partial batch commit"
+    );
+
+    let active_branch_id = lix.active_branch_id().await.expect("resolve active branch");
+    lix.execute(
+        "INSERT INTO lix_file_by_branch \
+         (id, path, data, lixcol_global, lixcol_branch_id) \
+         VALUES ($1, $2, $3, true, 'global')",
+        &[
+            Value::Text("sdk-native-overlap".to_string()),
+            Value::Text("/native/overlap.bin".to_string()),
+            Value::Blob(b"g".to_vec().into()),
+        ],
+    )
+    .await
+    .expect("insert global overlap fixture");
+    lix.execute(
+        "INSERT INTO lix_file_by_branch \
+         (id, path, data, lixcol_branch_id) \
+         VALUES ($1, $2, $3, $4)",
+        &[
+            Value::Text("sdk-native-overlap".to_string()),
+            Value::Text("/native/overlap.bin".to_string()),
+            Value::Blob(b"l".to_vec().into()),
+            Value::Text(active_branch_id.clone()),
+        ],
+    )
+    .await
+    .expect("insert active overlap fixture");
+
+    let overlay_batch_parent = active_branch_commit_id(&lix).await;
+    assert_eq!(
+        lix.upsert_file_data_batch(native_file_writes(&[
+            ("/native/overlap.bin", b"updated"),
+            ("/native/batch/overlay-companion.bin", b"companion"),
+        ]))
+        .await
+        .expect("native file batch should update the active overlay"),
+        2
+    );
+    assert_active_branch_head_parent(&lix, &overlay_batch_parent).await;
+    assert_eq!(
+        read_file_by_branch(&lix, "sdk-native-overlap", &active_branch_id)
+            .await
+            .unwrap(),
+        Some(b"updated".to_vec())
+    );
+    assert_eq!(
+        read_file_by_branch(&lix, "sdk-native-overlap", "global")
+            .await
+            .unwrap(),
+        Some(b"g".to_vec())
+    );
+    assert_eq!(
+        read_file(&lix, "/native/batch/overlay-companion.bin")
+            .await
+            .unwrap(),
+        Some(b"companion".to_vec())
+    );
 }
 
 #[tokio::test]
@@ -780,6 +938,78 @@ where
         .execute(
             "SELECT data FROM lix_file WHERE path = $1",
             &[Value::Text(path.to_string())],
+        )
+        .await?;
+    result
+        .rows()
+        .first()
+        .map(|row| row.get::<Vec<u8>>("data"))
+        .transpose()
+}
+
+fn native_file_writes(files: &[(&str, &[u8])]) -> Vec<(String, Blob)> {
+    files
+        .iter()
+        .map(|(path, data)| ((*path).to_string(), (*data).to_vec().into()))
+        .collect()
+}
+
+async fn active_branch_commit_id<StorageImpl>(lix: &Lix<StorageImpl>) -> String
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("read active branch commit id")
+        .rows()
+        .first()
+        .expect("active branch commit id should have one row")
+        .get::<String>("commit_id")
+        .expect("active branch commit id should decode")
+}
+
+async fn assert_active_branch_head_parent<StorageImpl>(
+    lix: &Lix<StorageImpl>,
+    expected_parent: &str,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let head = active_branch_commit_id(lix).await;
+    let result = lix
+        .execute(
+            "SELECT parent_id FROM lix_commit_edge WHERE child_id = $1",
+            &[Value::Text(head)],
+        )
+        .await
+        .expect("read active branch commit edge");
+    assert_eq!(
+        result.rows().len(),
+        1,
+        "a native file batch should create exactly one single-parent commit"
+    );
+    assert_eq!(
+        result.rows()[0]
+            .get::<String>("parent_id")
+            .expect("active branch parent id should decode"),
+        expected_parent
+    );
+}
+
+async fn read_file_by_branch<StorageImpl>(
+    lix: &Lix<StorageImpl>,
+    id: &str,
+    branch_id: &str,
+) -> Result<Option<Vec<u8>>, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let result = lix
+        .execute(
+            "SELECT data FROM lix_file_by_branch WHERE id = $1 AND lixcol_branch_id = $2",
+            &[
+                Value::Text(id.to_string()),
+                Value::Text(branch_id.to_string()),
+            ],
         )
         .await?;
     result

--- a/packages/server-protocol/README.md
+++ b/packages/server-protocol/README.md
@@ -87,3 +87,34 @@ This is intentionally a structured file-transfer operation, not a transparent
 replacement for arbitrary SQL `UPDATE`: callers choose its upsert behavior
 explicitly. The path must be a percent-encoded absolute Lix file path (for
 example, `%2Fassets%2Freport.pdf`).
+
+## Binary file upsert batch
+
+Clients that need one atomic commit for several ordinary file upserts can
+check `capabilities.binaryFileUpsertBatch === true` and send:
+
+```text
+POST /lix/v1/file/upsert-batch
+Lix-Session-Id: <session-id>
+Content-Type: application/octet-stream
+```
+
+The body is a deterministic big-endian frame:
+
+```text
+u32 entry_count
+repeat entry_count times:
+  u32 UTF-8 path byte length
+  u32 raw data byte length
+  path bytes
+  data bytes
+```
+
+`entry_count` must be between 1 and 1,024; paths must be unique, valid UTF-8,
+and consume the complete frame. Empty file data is valid. The server keeps data
+as slices of the request body rather than making a second payload copy. A valid
+request stages all entries in one transaction and returns the standard
+`ExecuteResponse` with `rowsAffected` equal to the entry count; any validation
+or engine error commits none of the entries. Larger client batches should be
+split into frames of at most 1,024 files. The configured request-body ceiling
+is the same as for the rest of the protocol.

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -14,15 +14,16 @@ use axum::{
     routing::{delete, get, post},
 };
 use lix_sdk::{
-    CreateBranchOptions, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, Lix, LixError,
+    Blob, CreateBranchOptions, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, Lix, LixError,
     ObserveEvent, ObserveEvents, Storage, SwitchBranchOptions, Value, WireValue,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     convert::Infallible,
     future::Future,
+    mem::size_of,
     sync::{
         Arc, Mutex, Once,
         atomic::{AtomicUsize, Ordering},
@@ -57,6 +58,11 @@ pub const DEFAULT_SESSION_IDLE_TIMEOUT: Duration = Duration::from_mins(30);
 /// so 64 MiB carries the engine's 32 MiB maximum plugin archive with room for
 /// the SQL envelope and also covers ordinary larger document blobs.
 pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
+/// Largest number of file entries accepted by one native batch request.
+///
+/// Keeping this bounded makes the fast path predictable for the normal bulk
+/// upload shape while keeping one request from monopolizing a session.
+const MAX_BINARY_FILE_UPSERT_BATCH_ENTRIES: usize = 1024;
 const MIN_COMPRESSION_BODY_BYTES: u16 = 32 * 1024;
 /// Maximum number of queries multiplexed onto one observation stream.
 pub const MAX_MULTIPLEX_SUBSCRIPTIONS: usize = 32;
@@ -587,6 +593,10 @@ where
             .route("/lix/v1/execute", post(execute::<S>))
             .route("/lix/v1/execute-batch", post(execute_batch::<S>))
             .route("/lix/v1/file/upsert", post(upsert_file_data::<S>))
+            .route(
+                "/lix/v1/file/upsert-batch",
+                post(upsert_file_data_batch::<S>),
+            )
             .route("/lix/v1/branch/create", post(create_branch::<S>))
             .route("/lix/v1/branch/switch", post(switch_branch::<S>))
             .route("/lix/v1/observe", post(observe::<S>))
@@ -976,6 +986,7 @@ where
             capabilities: ProtocolCapabilities {
                 request_blob_splice: true,
                 binary_file_upsert: true,
+                binary_file_upsert_batch: true,
             },
         }),
     ))
@@ -1088,6 +1099,156 @@ where
     Ok(Json(ExecuteResponse::try_from(
         ExecuteResult::from_rows_affected(result),
     )?))
+}
+
+/// Upserts a bounded batch of files from one deterministic octet-stream frame.
+///
+/// The frame is `u32be entry_count`, followed by one `u32be path_length`,
+/// `u32be data_length`, UTF-8 path, and raw data sequence per entry. Data
+/// payloads remain `Bytes` slices through the SDK boundary; only paths need a
+/// `String` allocation.
+async fn upsert_file_data_batch<S>(
+    Extension(lease): Extension<SessionLease<S>>,
+    body: Bytes,
+) -> Result<Json<ExecuteResponse>, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let writes = parse_binary_file_upsert_batch(body)?;
+    let result = lease
+        .run(move |lix| async move { lix.upsert_file_data_batch(writes).await })
+        .await?;
+    Ok(Json(ExecuteResponse::try_from(
+        ExecuteResult::from_rows_affected(result),
+    )?))
+}
+
+fn parse_binary_file_upsert_batch(body: Bytes) -> Result<Vec<(String, Blob)>, ApiError> {
+    let mut offset = 0;
+    let count = usize::try_from(read_binary_file_upsert_batch_u32(
+        &body,
+        &mut offset,
+        "entry count",
+    )?)
+    .map_err(|_| ApiError::bad_request("batch frame entry count does not fit this platform"))?;
+    if count == 0 {
+        return Err(ApiError::bad_request(
+            "batch frame must contain at least one file entry",
+        ));
+    }
+    if count > MAX_BINARY_FILE_UPSERT_BATCH_ENTRIES {
+        return Err(ApiError::bad_request(format!(
+            "batch frame has {count} file entries; maximum is {MAX_BINARY_FILE_UPSERT_BATCH_ENTRIES}",
+        )));
+    }
+
+    let mut writes = Vec::with_capacity(count);
+    let mut paths = HashSet::with_capacity(count);
+    for entry_index in 0..count {
+        let path_length = usize::try_from(read_binary_file_upsert_batch_u32(
+            &body,
+            &mut offset,
+            "path length",
+        )?)
+        .map_err(|_| {
+            ApiError::bad_request(format!(
+                "batch frame path length for entry {entry_index} does not fit this platform",
+            ))
+        })?;
+        let data_length = usize::try_from(read_binary_file_upsert_batch_u32(
+            &body,
+            &mut offset,
+            "data length",
+        )?)
+        .map_err(|_| {
+            ApiError::bad_request(format!(
+                "batch frame data length for entry {entry_index} does not fit this platform",
+            ))
+        })?;
+        let path_range = take_binary_file_upsert_batch_range(
+            &body,
+            &mut offset,
+            path_length,
+            "path",
+            entry_index,
+        )?;
+        let path = std::str::from_utf8(&body[path_range])
+            .map_err(|_| {
+                ApiError::bad_request(format!(
+                    "batch frame path for entry {entry_index} must be valid UTF-8",
+                ))
+            })?
+            .to_owned();
+        // Reject duplicate entries as a malformed frame before opening an
+        // engine transaction. Payload bytes remain zero-copy; only bounded
+        // path metadata is cloned for this protocol-level validation.
+        if !paths.insert(path.clone()) {
+            return Err(ApiError::bad_request(format!(
+                "batch frame contains duplicate path for entry {entry_index}",
+            )));
+        }
+        let data_range = take_binary_file_upsert_batch_range(
+            &body,
+            &mut offset,
+            data_length,
+            "data",
+            entry_index,
+        )?;
+        // `Bytes::slice` preserves the request allocation. Do not replace it
+        // with `to_vec`: large file bodies are intentionally forwarded as
+        // shared immutable Blob storage.
+        writes.push((path, Blob::from(body.slice(data_range))));
+    }
+
+    if offset != body.len() {
+        return Err(ApiError::bad_request(
+            "batch frame contains trailing bytes after its declared entries",
+        ));
+    }
+    Ok(writes)
+}
+
+fn read_binary_file_upsert_batch_u32(
+    body: &Bytes,
+    offset: &mut usize,
+    field: &str,
+) -> Result<u32, ApiError> {
+    let end = offset.checked_add(size_of::<u32>()).ok_or_else(|| {
+        ApiError::bad_request(format!("batch frame offset overflow while reading {field}"))
+    })?;
+    let bytes: [u8; size_of::<u32>()] = body
+        .get(*offset..end)
+        .ok_or_else(|| {
+            ApiError::bad_request(format!("batch frame is truncated while reading {field}"))
+        })?
+        .try_into()
+        .map_err(|_| {
+            ApiError::bad_request(format!("batch frame is truncated while reading {field}"))
+        })?;
+    *offset = end;
+    Ok(u32::from_be_bytes(bytes))
+}
+
+fn take_binary_file_upsert_batch_range(
+    body: &Bytes,
+    offset: &mut usize,
+    length: usize,
+    field: &str,
+    entry_index: usize,
+) -> Result<std::ops::Range<usize>, ApiError> {
+    let start = *offset;
+    let end = start.checked_add(length).ok_or_else(|| {
+        ApiError::bad_request(format!(
+            "batch frame {field} length for entry {entry_index} overflows its offset",
+        ))
+    })?;
+    if end > body.len() {
+        return Err(ApiError::bad_request(format!(
+            "batch frame is truncated while reading {field} for entry {entry_index}",
+        )));
+    }
+    *offset = end;
+    Ok(start..end)
 }
 
 async fn create_branch<S>(
@@ -1727,6 +1888,7 @@ struct HandshakeResponse {
 struct ProtocolCapabilities {
     request_blob_splice: bool,
     binary_file_upsert: bool,
+    binary_file_upsert_batch: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2409,6 +2571,52 @@ mod tests {
             .to_string()
     }
 
+    fn binary_file_upsert_batch_body(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(
+            &u32::try_from(entries.len())
+                .expect("test batch entry count should fit the wire format")
+                .to_be_bytes(),
+        );
+        for (path, data) in entries {
+            body.extend_from_slice(
+                &u32::try_from(path.len())
+                    .expect("test batch path should fit the wire format")
+                    .to_be_bytes(),
+            );
+            body.extend_from_slice(
+                &u32::try_from(data.len())
+                    .expect("test batch data should fit the wire format")
+                    .to_be_bytes(),
+            );
+            body.extend_from_slice(path.as_bytes());
+            body.extend_from_slice(data);
+        }
+        body
+    }
+
+    async fn binary_file_upsert_batch_request(
+        app: &Router,
+        session_id: Option<&str>,
+        body: Vec<u8>,
+    ) -> Response {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/lix/v1/file/upsert-batch")
+            .header(axum::http::header::CONTENT_TYPE, "application/octet-stream");
+        if let Some(session_id) = session_id {
+            builder = builder.header(SESSION_ID_HEADER, session_id);
+        }
+        app.clone()
+            .oneshot(
+                builder
+                    .body(Body::from(body))
+                    .expect("binary batch request"),
+            )
+            .await
+            .expect("binary batch response")
+    }
+
     #[tokio::test]
     async fn handshake_issues_and_resumes_a_256_bit_server_session() {
         let app = app().await;
@@ -2416,6 +2624,7 @@ mod tests {
         assert_eq!(first["protocolVersion"], PROTOCOL_VERSION);
         assert_eq!(first["capabilities"]["requestBlobSplice"], true);
         assert_eq!(first["capabilities"]["binaryFileUpsert"], true);
+        assert_eq!(first["capabilities"]["binaryFileUpsertBatch"], true);
         assert_eq!(session_id.len(), SESSION_TOKEN_HEX_LEN);
         assert!(
             session_id
@@ -2647,6 +2856,206 @@ mod tests {
             error_code(invalid_path).await,
             "LIX_ERROR_PATH_MISSING_LEADING_SLASH"
         );
+    }
+
+    #[tokio::test]
+    async fn binary_file_upsert_batch_accepts_raw_frames_and_preserves_execute_response_shape() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let seeded = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_file (path, data) VALUES ($1, $2)",
+                "params": [
+                    { "kind": "text", "value": "/batch/updated.bin" },
+                    { "kind": "blob", "base64": "b2xk" }
+                ]
+            })),
+        )
+        .await;
+        assert_eq!(seeded.status(), StatusCode::OK);
+
+        let response = binary_file_upsert_batch_request(
+            &app.router,
+            Some(&session_id),
+            binary_file_upsert_batch_body(&[
+                ("/batch/updated.bin", b"updated"),
+                ("/batch/created.bin", b"created"),
+                ("/batch/empty.bin", b""),
+            ]),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = response_json(response).await;
+        assert_eq!(response["rowsAffected"], 3);
+        assert_eq!(response["columns"], json!([]));
+        assert_eq!(response["rows"], json!([]));
+
+        for (path, expected) in [
+            ("/batch/updated.bin", &b"updated"[..]),
+            ("/batch/created.bin", &b"created"[..]),
+            ("/batch/empty.bin", &b""[..]),
+        ] {
+            let selected = request(
+                &app.router,
+                "POST",
+                "/lix/v1/execute",
+                Some(&session_id),
+                Some(json!({
+                    "sql": "SELECT data FROM lix_file WHERE path = $1",
+                    "params": [{ "kind": "text", "value": path }]
+                })),
+            )
+            .await;
+            assert_eq!(selected.status(), StatusCode::OK);
+            assert_eq!(
+                response_json(selected).await["rows"][0][0],
+                wire_blob_json(expected)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn binary_file_upsert_batch_requires_a_live_session_and_preserves_engine_path_errors() {
+        let app = app().await;
+        let missing_session = binary_file_upsert_batch_request(
+            &app.router,
+            None,
+            binary_file_upsert_batch_body(&[("/batch/missing-session.bin", b"payload")]),
+        )
+        .await;
+        assert_eq!(missing_session.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_code(missing_session).await,
+            "LIX_ERROR_PROTOCOL_SESSION_REQUIRED"
+        );
+
+        let (session_id, _) = new_session(&app.router).await;
+        let invalid_path = binary_file_upsert_batch_request(
+            &app.router,
+            Some(&session_id),
+            binary_file_upsert_batch_body(&[
+                ("/batch/must-not-write.bin", b"first"),
+                ("relative.bin", b"invalid"),
+            ]),
+        )
+        .await;
+        assert_eq!(invalid_path.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_code(invalid_path).await,
+            "LIX_ERROR_PATH_MISSING_LEADING_SLASH"
+        );
+
+        let selected = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/batch/must-not-write.bin" }]
+            })),
+        )
+        .await;
+        assert_eq!(selected.status(), StatusCode::OK);
+        assert!(
+            response_json(selected).await["rows"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_file_upsert_batch_rejects_malformed_trailing_and_duplicate_frames() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+
+        let malformed = binary_file_upsert_batch_request(
+            &app.router,
+            Some(&session_id),
+            vec![0, 0, 0, 1, 0, 0],
+        )
+        .await;
+        assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(malformed).await, "LIX_INVALID_ARGUMENT");
+
+        let mut trailing = binary_file_upsert_batch_body(&[("/batch/trailing.bin", b"payload")]);
+        trailing.push(0);
+        let trailing =
+            binary_file_upsert_batch_request(&app.router, Some(&session_id), trailing).await;
+        assert_eq!(trailing.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(trailing).await, "LIX_INVALID_ARGUMENT");
+
+        let duplicate = binary_file_upsert_batch_request(
+            &app.router,
+            Some(&session_id),
+            binary_file_upsert_batch_body(&[
+                ("/batch/duplicate.bin", b"first"),
+                ("/batch/duplicate.bin", b"second"),
+            ]),
+        )
+        .await;
+        assert_eq!(duplicate.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(duplicate).await, "LIX_INVALID_ARGUMENT");
+
+        let duplicate_selected = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT data FROM lix_file WHERE path = $1",
+                "params": [{ "kind": "text", "value": "/batch/duplicate.bin" }]
+            })),
+        )
+        .await;
+        assert_eq!(duplicate_selected.status(), StatusCode::OK);
+        assert!(
+            response_json(duplicate_selected).await["rows"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+
+        let empty = binary_file_upsert_batch_request(
+            &app.router,
+            Some(&session_id),
+            0_u32.to_be_bytes().to_vec(),
+        )
+        .await;
+        assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(empty).await, "LIX_INVALID_ARGUMENT");
+
+        let over_limit = binary_file_upsert_batch_request(
+            &app.router,
+            Some(&session_id),
+            u32::try_from(MAX_BINARY_FILE_UPSERT_BATCH_ENTRIES + 1)
+                .expect("test entry count should fit the wire format")
+                .to_be_bytes()
+                .to_vec(),
+        )
+        .await;
+        assert_eq!(over_limit.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(over_limit).await, "LIX_INVALID_ARGUMENT");
+    }
+
+    #[test]
+    fn binary_file_upsert_batch_parser_slices_payload_bytes_without_copying_them() {
+        let path = "/batch/slice.bin";
+        let payload = b"payload";
+        let data_offset = size_of::<u32>() * 3 + path.len();
+        let body = Bytes::from(binary_file_upsert_batch_body(&[(path, payload)]));
+        let expected_data_pointer = body[data_offset..].as_ptr();
+
+        let writes = parse_binary_file_upsert_batch(body).expect("valid batch frame");
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].0, path);
+        assert_eq!(writes[0].1.as_ref(), payload);
+        assert_eq!(writes[0].1.as_bytes().as_ptr(), expected_data_pointer);
     }
 
     #[tokio::test]
@@ -3330,6 +3739,25 @@ mod tests {
             )
             .await
             .expect("oversized binary file upsert response");
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn configured_body_limit_rejects_oversized_binary_file_upsert_batch() {
+        let app = app_with_options(ProtocolServerOptions {
+            max_request_body_bytes: 1_024,
+            ..ProtocolServerOptions::default()
+        })
+        .await;
+        let (session_id, _) = new_session(&app.router).await;
+        let oversized = vec![0_u8; 2_048];
+        let response = binary_file_upsert_batch_request(
+            &app.router,
+            Some(&session_id),
+            binary_file_upsert_batch_body(&[("/batch/oversized.bin", &oversized)]),
+        )
+        .await;
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }


### PR DESCRIPTION
## Summary

Adds an atomic binary `POST /lix/v1/file/upsert-batch` path for the common
multi-file update case.

- Frames up to 1,024 distinct `{path, bytes}` entries as u32-length-prefixed
  bytes, parsing payloads as zero-copy `Bytes` slices at the server boundary.
- Routes the batch through one reserved engine write transaction and one Lix
  commit, while preserving normal active-branch/global-overlay semantics.
- Exposes matching engine and Rust SDK batch APIs, plus protocol capability
  negotiation and strict malformed/duplicate-frame rejection.
- Adds a reproducible mixed-corpus benchmark for both RocksDB and SlateDB.

This is deliberately a hard cut for ambiguous legacy direct-storage layouts:
the new batch API returns a constraint error instead of allocating copies for
a rare SQL fallback. Existing one-file upserts retain their current fallback.

## Why

The happy-path workload is a logical edit across several files. Previously it
paid SQL/protocol work and a commit for every file. Batching keeps the existing
storage layout but removes that repeated commit, metadata, and object-store
flush overhead.

## Measurements

### Engine/storage component screen

30 counterbalanced AB/BA paired samples per backend from byte-copied closed
mixed-corpus sources. Timed work is ten one-file commits versus one ten-file
batch; `flush-complete` means accepted time plus the benchmark's flush wait,
not a crash-durability claim. No SQLite results are used.

| Corpus / history | RocksDB conservative reduction | SlateDB conservative reduction |
| --- | ---: | ---: |
| 1k files / 5k commits | 45.4% | 77.9% |
| 5k files / 5k commits | 42.7% | 71.2% |

At 5k files, the conservative flush-complete reduction stays stable across
history depth: RocksDB 43.2% / 45.0% / 42.7% and SlateDB 77.1% / 75.0% /
71.2% at 100 / 1k / 5k commits respectively.

### Full-stack SlateDB confirmation

The candidate `lix-server -> Lix -> SlateDB -> MinIO` stack was exercised over
HTTP using a local protocol client. Each arm used five independently mirrored,
closed templates, one fresh server process per sample, five unrelated
precondition reads, and a one-second post-open settle. The logical operation is
the same 412 KiB mixed update (4 JSON, 3 CSV, 2 PDF, and 1 binary file).

| Corpus / history | Ten native singles p50 | One batch p50 | Median reduction | 99% paired lower-bound reduction |
| --- | ---: | ---: | ---: | ---: |
| 1k files / 5k commits | 130.512 ms | 46.977 ms | 64.0% | 51.0% |
| 5k files / 5k commits | 120.465 ms | 48.631 ms | 59.6% | 53.9% |

The full-stack storage increment is modestly lower rather than the primary
win: median 834,450 -> 781,528 bytes (-6.3%) at 1k files and 854,843 ->
814,046 bytes (-4.8%) at 5k files. Server `VmHWM` at 5k files was effectively
unchanged (127.3 MiB singles vs 127.4 MiB batch), so this PR claims no memory
improvement.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix_engine --test native_file_upsert_storage -- --nocapture`
  (RocksDB and SlateDB)
- `cargo test -p lix_sdk rs_sdk_native_file_upsert -- --nocapture`
- `cargo test -p lix_server_protocol -- --nocapture` (47 passed, 2 manual
  diagnostics ignored)
- Docker end-to-end protocol smoke and the isolated full-stack matrix above
