### PR TITLE
feat: add native raw file reads

### DIFF
--- a/.changenotes/native-binary-file-read.md
+++ b/.changenotes/native-binary-file-read.md
@@ -1,0 +1,10 @@
+---
+type: minor
+---
+
+Added a native binary file-read route for remote Lix clients.
+
+`GET /lix/v1/file` returns raw file bytes without SQL planning or JSON/base64
+encoding. Clients can discover the capability in the handshake response as
+`binaryFileRead`; `Lix-File-Found` distinguishes a missing file from a present
+empty file.

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -71,6 +71,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "native_file_read_component"
+path = "benches/native_file_read_component.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "large_blob_updates"
 path = "benches/large_blob_updates.rs"
 harness = false

--- a/packages/engine/benches/native_file_read_component.rs
+++ b/packages/engine/benches/native_file_read_component.rs
@@ -1,0 +1,1242 @@
+//! Direct native-file-read component benchmark.
+//!
+//! This compares the normal exact SQL read (`SELECT data FROM lix_file WHERE
+//! path = $1`) with [`SessionContext::read_file_data`]. Both arms return a
+//! `Blob` before the timer stops: the comparison therefore includes SQL result
+//! materialization and extraction, but deliberately excludes HTTP framing and
+//! JSON/Base64 serialization, which belong to the end-to-end benchmark.
+//!
+//! Each sample copies a closed, immutable source database before opening it.
+//! That keeps every SQL/native pair at the same file and history cardinality
+//! without charging corpus/history construction to the timed read. A direct
+//! warmup uses a *different* path in the same payload class and the same arm
+//! as the timed request.
+//!
+//! The default is a diagnostic matrix. For a qualification run use at least
+//! thirty pairs, for example:
+//!
+//! ```text
+//! LIX_NATIVE_FILE_READ_COMPONENT_FILE_COUNTS=1000,5000 \
+//! LIX_NATIVE_FILE_READ_COMPONENT_HISTORY_COMMITS=100,1000,5000 \
+//! LIX_NATIVE_FILE_READ_COMPONENT_PAIRS=30 \
+//! cargo bench -p lix_engine --bench native_file_read_component \
+//!   --features storage-benches,slatedb
+//! ```
+//!
+//! Environment variables:
+//! - `LIX_NATIVE_FILE_READ_COMPONENT_FILE_COUNTS` (default: `1000,5000`)
+//! - `LIX_NATIVE_FILE_READ_COMPONENT_HISTORY_COMMITS` (default: `100,1000,5000`)
+//! - `LIX_NATIVE_FILE_READ_COMPONENT_PAIRS` (default: `3`, diagnostic)
+//! - `LIX_NATIVE_FILE_READ_COMPONENT_SEED_BATCH_SIZE` (default: `1000`)
+//! - `LIX_NATIVE_FILE_READ_COMPONENT_BACKENDS` (default: `rocksdb,slatedb`)
+
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use lix_engine::{Blob, Engine, ExecuteResult, SessionContext, Storage, Value};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+use tempfile::TempDir;
+
+const DEFAULT_FILE_COUNTS: &[usize] = &[1_000, 5_000];
+const DEFAULT_HISTORY_COMMITS: &[usize] = &[100, 1_000, 5_000];
+const DEFAULT_PAIRS: usize = 3;
+const QUALIFICATION_PAIRS: usize = 30;
+const DEFAULT_SEED_BATCH_SIZE: usize = 1_000;
+const TARGETS_PER_CLASS: usize = 2;
+const NORMAL_TEXT_FILE_BYTES: usize = 4 * 1024;
+const NORMAL_PDF_FILE_BYTES: usize = 8 * 1024;
+const NORMAL_PNG_FILE_BYTES: usize = 16 * 1024;
+const NORMAL_BINARY_FILE_BYTES: usize = 8 * 1024;
+
+const FILE_KINDS: [FileKind; 10] = [
+    FileKind::new("json", "json"),
+    FileKind::new("csv", "csv"),
+    FileKind::new("markdown", "md"),
+    FileKind::new("text", "txt"),
+    FileKind::new("xml", "xml"),
+    FileKind::new("yaml", "yaml"),
+    FileKind::new("pdf", "pdf"),
+    FileKind::new("png", "png"),
+    FileKind::new("binary", "bin"),
+    FileKind::new("logs", "log"),
+];
+
+const READ_CLASSES: [ReadClass; 3] = [
+    ReadClass::new("json_4k", 0, 4 * 1024),
+    ReadClass::new("pdf_32k", 6, 32 * 1024),
+    ReadClass::new("binary_256k", 8, 256 * 1024),
+];
+
+#[derive(Clone, Copy)]
+struct FileKind {
+    directory: &'static str,
+    extension: &'static str,
+}
+
+impl FileKind {
+    const fn new(directory: &'static str, extension: &'static str) -> Self {
+        Self {
+            directory,
+            extension,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ReadClass {
+    label: &'static str,
+    file_kind_index: usize,
+    payload_bytes: usize,
+}
+
+impl ReadClass {
+    const fn new(label: &'static str, file_kind_index: usize, payload_bytes: usize) -> Self {
+        Self {
+            label,
+            file_kind_index,
+            payload_bytes,
+        }
+    }
+
+    const fn kind(self) -> FileKind {
+        FILE_KINDS[self.file_kind_index]
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Backend {
+    RocksDb,
+    SlateDb,
+}
+
+impl Backend {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::RocksDb => "rocksdb",
+            Self::SlateDb => "slatedb",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    SqlExact,
+    Native,
+}
+
+impl Operation {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::SqlExact => "sql_exact_lix_file_read",
+            Self::Native => "native_file_read_data",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Config {
+    file_counts: Vec<usize>,
+    history_commits: Vec<usize>,
+    pairs: usize,
+    seed_batch_size: usize,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        let file_counts = env_usize_list(
+            "LIX_NATIVE_FILE_READ_COMPONENT_FILE_COUNTS",
+            DEFAULT_FILE_COUNTS,
+        );
+        let history_commits = env_usize_list(
+            "LIX_NATIVE_FILE_READ_COMPONENT_HISTORY_COMMITS",
+            DEFAULT_HISTORY_COMMITS,
+        );
+        let pairs = env_usize("LIX_NATIVE_FILE_READ_COMPONENT_PAIRS", DEFAULT_PAIRS);
+        let seed_batch_size = env_usize(
+            "LIX_NATIVE_FILE_READ_COMPONENT_SEED_BATCH_SIZE",
+            DEFAULT_SEED_BATCH_SIZE,
+        );
+
+        assert!(
+            file_counts
+                .iter()
+                .all(|file_count| *file_count >= target_file_count() + FILE_KINDS.len()),
+            "LIX_NATIVE_FILE_READ_COMPONENT_FILE_COUNTS values must be at least {}",
+            target_file_count() + FILE_KINDS.len()
+        );
+        assert!(
+            history_commits.iter().all(|history| *history >= 2),
+            "LIX_NATIVE_FILE_READ_COMPONENT_HISTORY_COMMITS values must be at least 2"
+        );
+        assert!(
+            pairs >= 2,
+            "LIX_NATIVE_FILE_READ_COMPONENT_PAIRS must be at least 2 for a paired confidence interval"
+        );
+        assert!(
+            seed_batch_size > 0,
+            "LIX_NATIVE_FILE_READ_COMPONENT_SEED_BATCH_SIZE must be greater than zero"
+        );
+
+        Self {
+            file_counts,
+            history_commits,
+            pairs,
+            seed_batch_size,
+        }
+    }
+}
+
+struct Seed {
+    backend: Backend,
+    // The source must remain alive while its copies are created. It is closed
+    // after seeding, so both RocksDB and SlateDB copies start from a complete,
+    // immutable source tree rather than an open database.
+    root: TempDir,
+    source_path: PathBuf,
+    main_branch_id: String,
+    source_commit_count: usize,
+    source_usage: DiskUsage,
+    next_clone: AtomicU64,
+}
+
+impl Seed {
+    async fn create(
+        backend: Backend,
+        file_count: usize,
+        history_commits: usize,
+        seed_batch_size: usize,
+    ) -> Self {
+        let root = tempfile::tempdir().expect("create native read component benchmark root");
+        let source_path = root.path().join("source");
+        let main_branch_id = match backend {
+            Backend::RocksDb => {
+                let storage =
+                    RocksDB::open(&source_path).expect("open native read component RocksDB");
+                let branch_id = seed_repository(
+                    storage.clone(),
+                    file_count,
+                    history_commits,
+                    seed_batch_size,
+                )
+                .await;
+                storage
+                    .flush()
+                    .expect("flush native read component RocksDB source");
+                branch_id
+            }
+            Backend::SlateDb => {
+                let storage =
+                    SlateDB::open(&source_path).expect("open native read component SlateDB");
+                let branch_id = seed_repository(
+                    storage.clone(),
+                    file_count,
+                    history_commits,
+                    seed_batch_size,
+                )
+                .await;
+                storage
+                    .flush()
+                    .await
+                    .expect("flush native read component SlateDB source");
+                branch_id
+            }
+        };
+        let source_usage = disk_usage(&source_path).expect("account native read component source");
+
+        Self {
+            backend,
+            root,
+            source_path,
+            main_branch_id,
+            source_commit_count: history_commits,
+            source_usage,
+            next_clone: AtomicU64::new(0),
+        }
+    }
+
+    async fn fork(&self) -> Fixture {
+        let clone_number = self.next_clone.fetch_add(1, Ordering::Relaxed);
+        let clone_dir = tempfile::tempdir_in(self.root.path())
+            .expect("create native read component benchmark clone directory");
+        let database_path = clone_dir.path().join(format!("database-{clone_number:04}"));
+        copy_directory(&self.source_path, &database_path)
+            .expect("copy closed native read component source");
+
+        match self.backend {
+            Backend::RocksDb => {
+                let storage = RocksDB::open(&database_path)
+                    .expect("open copied native read component RocksDB");
+                Fixture::RocksDb(
+                    open_fixture(
+                        storage,
+                        self.main_branch_id.clone(),
+                        clone_dir,
+                        database_path,
+                    )
+                    .await,
+                )
+            }
+            Backend::SlateDb => {
+                let storage = SlateDB::open(&database_path)
+                    .expect("open copied native read component SlateDB");
+                Fixture::SlateDb(
+                    open_fixture(
+                        storage,
+                        self.main_branch_id.clone(),
+                        clone_dir,
+                        database_path,
+                    )
+                    .await,
+                )
+            }
+        }
+    }
+}
+
+struct ComponentFixture<S: Storage> {
+    // Keep storage before TempDir in declaration order so it closes before the
+    // clone directory is removed.
+    session: SessionContext<S>,
+    _storage: S,
+    database_path: PathBuf,
+    _clone_dir: TempDir,
+}
+
+impl<S> ComponentFixture<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    async fn sql_exact_read(&self, path: String) -> Blob {
+        let result = self
+            .session
+            .execute(
+                "SELECT data FROM lix_file WHERE path = $1",
+                &[Value::Text(path)],
+            )
+            .await
+            .expect("execute exact SQL file read");
+        blob_from_exact_sql(result)
+    }
+
+    async fn native_read(&self, path: String) -> Blob {
+        self.session
+            .read_file_data(path)
+            .await
+            .expect("execute native file read")
+            .expect("seeded timed file must exist")
+    }
+
+    async fn visible_commit_count(&self) -> usize {
+        count_rows(&self.session, "SELECT COUNT(*) AS count FROM lix_commit").await
+    }
+
+    async fn visible_file_count(&self) -> usize {
+        count_rows(&self.session, "SELECT COUNT(*) AS count FROM lix_file").await
+    }
+
+    fn disk_usage(&self) -> DiskUsage {
+        disk_usage(&self.database_path).expect("account native read component clone")
+    }
+}
+
+enum Fixture {
+    RocksDb(ComponentFixture<RocksDB>),
+    SlateDb(ComponentFixture<SlateDB>),
+}
+
+impl Fixture {
+    async fn read(&self, operation: Operation, path: String) -> Blob {
+        match (self, operation) {
+            (Self::RocksDb(fixture), Operation::SqlExact) => fixture.sql_exact_read(path).await,
+            (Self::RocksDb(fixture), Operation::Native) => fixture.native_read(path).await,
+            (Self::SlateDb(fixture), Operation::SqlExact) => fixture.sql_exact_read(path).await,
+            (Self::SlateDb(fixture), Operation::Native) => fixture.native_read(path).await,
+        }
+    }
+
+    async fn visible_commit_count(&self) -> usize {
+        match self {
+            Self::RocksDb(fixture) => fixture.visible_commit_count().await,
+            Self::SlateDb(fixture) => fixture.visible_commit_count().await,
+        }
+    }
+
+    async fn visible_file_count(&self) -> usize {
+        match self {
+            Self::RocksDb(fixture) => fixture.visible_file_count().await,
+            Self::SlateDb(fixture) => fixture.visible_file_count().await,
+        }
+    }
+
+    fn disk_usage(&self) -> DiskUsage {
+        match self {
+            Self::RocksDb(fixture) => fixture.disk_usage(),
+            Self::SlateDb(fixture) => fixture.disk_usage(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, serde::Serialize)]
+struct DiskUsage {
+    total_bytes: u64,
+    sst_bytes: u64,
+    log_bytes: u64,
+    manifest_bytes: u64,
+    options_bytes: u64,
+    other_bytes: u64,
+    file_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+struct DiskDelta {
+    total_bytes: i64,
+    sst_bytes: i64,
+    log_bytes: i64,
+    manifest_bytes: i64,
+    options_bytes: i64,
+    other_bytes: i64,
+    file_count: i64,
+}
+
+impl DiskUsage {
+    fn delta_from(self, before: Self) -> DiskDelta {
+        DiskDelta {
+            total_bytes: signed_delta(self.total_bytes, before.total_bytes),
+            sst_bytes: signed_delta(self.sst_bytes, before.sst_bytes),
+            log_bytes: signed_delta(self.log_bytes, before.log_bytes),
+            manifest_bytes: signed_delta(self.manifest_bytes, before.manifest_bytes),
+            options_bytes: signed_delta(self.options_bytes, before.options_bytes),
+            other_bytes: signed_delta(self.other_bytes, before.other_bytes),
+            file_count: signed_delta(self.file_count, before.file_count),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ReadSelection {
+    class: ReadClass,
+    warmup_slot: usize,
+    timed_slot: usize,
+}
+
+impl ReadSelection {
+    fn warmup_path(self) -> String {
+        target_path(self.class, self.warmup_slot)
+    }
+
+    fn timed_path(self) -> String {
+        target_path(self.class, self.timed_slot)
+    }
+
+    fn expected_hash(self) -> String {
+        blake3::hash(&target_payload(self.class, self.timed_slot))
+            .to_hex()
+            .to_string()
+    }
+}
+
+struct Sample {
+    read_ns: u64,
+    output_bytes: usize,
+    output_hash: String,
+    storage_before: DiskUsage,
+    storage_after: DiskUsage,
+    rss_before_bytes: Option<u64>,
+    rss_after_bytes: Option<u64>,
+}
+
+impl Sample {
+    fn storage_delta(&self) -> DiskDelta {
+        self.storage_after.delta_from(self.storage_before)
+    }
+}
+
+struct PairResult {
+    sql: Sample,
+    native: Sample,
+}
+
+fn main() {
+    let config = Config::from_env();
+    let backends = selected_backends();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create native read component benchmark runtime");
+
+    runtime.block_on(async {
+        for backend in backends {
+            for &file_count in &config.file_counts {
+                for &history_commits in &config.history_commits {
+                    run_configuration(backend, &config, file_count, history_commits).await;
+                }
+            }
+        }
+    });
+}
+
+async fn run_configuration(
+    backend: Backend,
+    config: &Config,
+    file_count: usize,
+    history_commits: usize,
+) {
+    let seed = Seed::create(backend, file_count, history_commits, config.seed_batch_size).await;
+    println!(
+        "{}",
+        serde_json::json!({
+            "benchmark": "native_file_read_component",
+            "event": "source_seed",
+            "backend": backend.label(),
+            "file_count": file_count,
+            "history_commits_at_measurement_start": history_commits,
+            "source_commit_count": seed.source_commit_count,
+            "seed_batch_size": config.seed_batch_size,
+            "pairs": config.pairs,
+            "source_clone_per_sample": true,
+            "timing_boundary": "from SQL/native invocation through an extracted usable Blob",
+            "warmup_policy": "same arm and payload class, distinct path, excluded from timer",
+            "read_classes": read_classes_json(),
+            "source_storage": seed.source_usage,
+        })
+    );
+
+    for (class_index, class) in READ_CLASSES.iter().copied().enumerate() {
+        let mut pairs = Vec::with_capacity(config.pairs);
+        for pair_index in 0..config.pairs {
+            let sql_first = (pair_index + class_index).is_multiple_of(2);
+            let selection = selected_targets(class, pair_index);
+            let (sql, native) = if sql_first {
+                (
+                    run_sample(
+                        &seed,
+                        file_count,
+                        history_commits,
+                        pair_index,
+                        sql_first,
+                        selection,
+                        Operation::SqlExact,
+                    )
+                    .await,
+                    run_sample(
+                        &seed,
+                        file_count,
+                        history_commits,
+                        pair_index,
+                        sql_first,
+                        selection,
+                        Operation::Native,
+                    )
+                    .await,
+                )
+            } else {
+                let native = run_sample(
+                    &seed,
+                    file_count,
+                    history_commits,
+                    pair_index,
+                    sql_first,
+                    selection,
+                    Operation::Native,
+                )
+                .await;
+                let sql = run_sample(
+                    &seed,
+                    file_count,
+                    history_commits,
+                    pair_index,
+                    sql_first,
+                    selection,
+                    Operation::SqlExact,
+                )
+                .await;
+                (sql, native)
+            };
+            pairs.push(PairResult { sql, native });
+        }
+        print_summary(backend, file_count, history_commits, class, &pairs);
+    }
+}
+
+async fn run_sample(
+    seed: &Seed,
+    file_count: usize,
+    history_commits: usize,
+    pair_index: usize,
+    sql_first: bool,
+    selection: ReadSelection,
+    operation: Operation,
+) -> Sample {
+    let fixture = seed.fork().await;
+    let warmup_path = selection.warmup_path();
+    let timed_path = selection.timed_path();
+
+    // Warm the exact route and the same payload class, but never the path
+    // timed below. This remains outside both timing and disk baselines.
+    let warmup = fixture.read(operation, warmup_path.clone()).await;
+    assert_eq!(warmup.len(), selection.class.payload_bytes);
+    black_box(warmup);
+
+    let storage_before = fixture.disk_usage();
+    let rss_before_bytes = process_resident_bytes();
+    let started = Instant::now();
+    // Both arms receive an owned path and finish at the same usable `Blob`
+    // boundary. SQL result decoding is consequently not deferred outside its
+    // timer while native data handling is inside its timer.
+    let data = fixture.read(operation, timed_path.clone()).await;
+    let read_ns = duration_ns(started.elapsed());
+    let data = black_box(data);
+    let output_bytes = data.len();
+    let output_hash = blake3::hash(data.as_ref()).to_hex().to_string();
+    assert_eq!(output_bytes, selection.class.payload_bytes);
+    assert_eq!(output_hash, selection.expected_hash());
+    drop(data);
+    let rss_after_bytes = process_resident_bytes();
+    let storage_after = fixture.disk_usage();
+
+    // Read samples must not create commits, files, or storage-layout changes.
+    let post_timing_commit_count = fixture.visible_commit_count().await;
+    let post_timing_file_count = fixture.visible_file_count().await;
+    assert_eq!(post_timing_commit_count, history_commits);
+    assert_eq!(post_timing_file_count, file_count);
+    drop(fixture);
+
+    let sample = Sample {
+        read_ns,
+        output_bytes,
+        output_hash,
+        storage_before,
+        storage_after,
+        rss_before_bytes,
+        rss_after_bytes,
+    };
+    println!(
+        "{}",
+        serde_json::json!({
+            "benchmark": "native_file_read_component",
+            "event": "sample",
+            "backend": seed.backend.label(),
+            "pair": pair_index,
+            "order": if sql_first { "sql_then_native" } else { "native_then_sql" },
+            "operation": operation.label(),
+            "file_count": file_count,
+            "history_commits_at_start": history_commits,
+            "read_class": selection.class.label,
+            "payload_bytes": selection.class.payload_bytes,
+            "warmup_path": warmup_path,
+            "timed_path": timed_path,
+            "warmup_and_timed_paths_disjoint": selection.warmup_slot != selection.timed_slot,
+            "timing_boundary": "from SQL/native invocation through an extracted usable Blob",
+            "read_ns": sample.read_ns,
+            "output_bytes": sample.output_bytes,
+            "output_blake3": &sample.output_hash,
+            "post_timing_commit_count": post_timing_commit_count,
+            "post_timing_file_count": post_timing_file_count,
+            "post_timing_state_verified": true,
+            "storage_before": sample.storage_before,
+            "storage_after": sample.storage_after,
+            "storage_delta": sample.storage_delta(),
+            "process_rss_before_bytes": sample.rss_before_bytes,
+            "process_rss_after_bytes": sample.rss_after_bytes,
+        })
+    );
+    sample
+}
+
+fn print_summary(
+    backend: Backend,
+    file_count: usize,
+    history_commits: usize,
+    class: ReadClass,
+    pairs: &[PairResult],
+) {
+    let mut sql = pairs
+        .iter()
+        .map(|pair| pair.sql.read_ns)
+        .collect::<Vec<_>>();
+    let mut native = pairs
+        .iter()
+        .map(|pair| pair.native.read_ns)
+        .collect::<Vec<_>>();
+    let mut sql_storage_delta = pairs
+        .iter()
+        .map(|pair| pair.sql.storage_delta().total_bytes)
+        .collect::<Vec<_>>();
+    let mut native_storage_delta = pairs
+        .iter()
+        .map(|pair| pair.native.storage_delta().total_bytes)
+        .collect::<Vec<_>>();
+    let speedup = paired_speedup(pairs);
+    let has_qualification_pair_count = pairs.len() >= QUALIFICATION_PAIRS;
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "benchmark": "native_file_read_component",
+            "event": "summary",
+            "backend": backend.label(),
+            "file_count": file_count,
+            "history_commits_at_start": history_commits,
+            "read_class": class.label,
+            "payload_bytes": class.payload_bytes,
+            "pairs": pairs.len(),
+            "confidence_level": 0.99,
+            "t_critical": speedup.t_critical,
+            "comparison": "SQL exact lix_file read / SessionContext::read_file_data; both end at an extracted usable Blob",
+            "sql_read_p50_ns": percentile(&mut sql, 50),
+            "sql_read_p95_ns": percentile(&mut sql, 95),
+            "sql_read_mean_ns": mean_u64(&sql),
+            "native_read_p50_ns": percentile(&mut native, 50),
+            "native_read_p95_ns": percentile(&mut native, 95),
+            "native_read_mean_ns": mean_u64(&native),
+            "sql_median_storage_total_delta_bytes": median_i64(&mut sql_storage_delta),
+            "native_median_storage_total_delta_bytes": median_i64(&mut native_storage_delta),
+            "paired_geometric_mean_speedup": speedup.geometric_mean,
+            "paired_99_lower_speedup": speedup.lower_99,
+            "paired_99_upper_speedup": speedup.upper_99,
+            "paired_99_lower_latency_reduction_percent": (1.0 - 1.0 / speedup.lower_99) * 100.0,
+            "minimum_pairs_for_robust_qualification": QUALIFICATION_PAIRS,
+            "statistically_robust_99_ci": has_qualification_pair_count,
+            "qualifies_more_than_20_percent": has_qualification_pair_count && speedup.lower_99 > 1.25,
+        })
+    );
+}
+
+struct PairedSpeedup {
+    geometric_mean: f64,
+    lower_99: f64,
+    upper_99: f64,
+    t_critical: f64,
+}
+
+fn paired_speedup(pairs: &[PairResult]) -> PairedSpeedup {
+    let log_speedups = pairs
+        .iter()
+        .map(|pair| {
+            let sql = exact_f64_from_u64(pair.sql.read_ns.max(1));
+            let native = exact_f64_from_u64(pair.native.read_ns.max(1));
+            (sql / native).ln()
+        })
+        .collect::<Vec<_>>();
+    let mean_log_speedup = mean(&log_speedups);
+    let standard_error =
+        sample_standard_deviation(&log_speedups) / exact_f64_from_usize(log_speedups.len()).sqrt();
+    let t_critical = t_99_two_sided_critical(log_speedups.len() - 1);
+    PairedSpeedup {
+        geometric_mean: mean_log_speedup.exp(),
+        lower_99: (-t_critical)
+            .mul_add(standard_error, mean_log_speedup)
+            .exp(),
+        upper_99: t_critical.mul_add(standard_error, mean_log_speedup).exp(),
+        t_critical,
+    }
+}
+
+async fn seed_repository<S>(
+    storage: S,
+    file_count: usize,
+    history_commits: usize,
+    seed_batch_size: usize,
+) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let init = Engine::initialize(storage.clone())
+        .await
+        .expect("initialize native read component source repository");
+    let engine = Engine::new(storage)
+        .await
+        .expect("open native read component source engine");
+    let session = engine
+        .open_session(init.main_branch_id.clone())
+        .await
+        .expect("open native read component source session");
+
+    let entries = seed_entries(file_count);
+    for chunk in entries.chunks(seed_batch_size) {
+        let rows_affected = session
+            .upsert_file_data_batch(chunk.to_vec())
+            .await
+            .expect("seed native read mixed corpus batch");
+        assert_eq!(
+            rows_affected,
+            u64::try_from(chunk.len()).expect("seed rows fit u64")
+        );
+    }
+    assert_eq!(
+        count_rows(&session, "SELECT COUNT(*) AS count FROM lix_file").await,
+        file_count,
+        "source corpus must contain the requested number of files"
+    );
+
+    let mut commit_count = count_rows(&session, "SELECT COUNT(*) AS count FROM lix_commit").await;
+    assert!(
+        commit_count <= history_commits,
+        "history target {history_commits} is too small for {commit_count} initialization and seed commits"
+    );
+    while commit_count < history_commits {
+        let file_index = commit_count % generic_file_count(file_count);
+        let rows_affected = session
+            .upsert_file_data(
+                generic_path(file_index),
+                Blob::from(generic_payload(
+                    file_index,
+                    u64::try_from(commit_count).expect("commit count fits u64"),
+                )),
+            )
+            .await
+            .expect("append mixed-corpus history commit");
+        assert_eq!(rows_affected, 1);
+        commit_count += 1;
+    }
+    assert_eq!(
+        count_rows(&session, "SELECT COUNT(*) AS count FROM lix_commit").await,
+        history_commits,
+        "source history must match the configured measurement depth"
+    );
+    init.main_branch_id
+}
+
+async fn open_fixture<S>(
+    storage: S,
+    main_branch_id: String,
+    clone_dir: TempDir,
+    database_path: PathBuf,
+) -> ComponentFixture<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open native read component clone engine");
+    let session = engine
+        .open_session(main_branch_id)
+        .await
+        .expect("open native read component clone session");
+    ComponentFixture {
+        session,
+        _storage: storage,
+        database_path,
+        _clone_dir: clone_dir,
+    }
+}
+
+async fn count_rows<S>(session: &SessionContext<S>, sql: &str) -> usize
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(sql, &[])
+        .await
+        .expect("count benchmark rows");
+    let row = result
+        .rows()
+        .first()
+        .expect("count benchmark query should return a row");
+    let count = row.get::<i64>("count").expect("decode benchmark row count");
+    usize::try_from(count).expect("benchmark row count must be non-negative")
+}
+
+fn blob_from_exact_sql(result: ExecuteResult) -> Blob {
+    let row = result
+        .rows()
+        .first()
+        .expect("seeded SQL exact read must return a row");
+    row.get::<Blob>("data")
+        .expect("SQL exact read must return a blob data column")
+}
+
+fn selected_targets(class: ReadClass, pair_index: usize) -> ReadSelection {
+    let warmup_slot = pair_index % TARGETS_PER_CLASS;
+    let timed_slot = (warmup_slot + 1) % TARGETS_PER_CLASS;
+    assert_ne!(warmup_slot, timed_slot);
+    ReadSelection {
+        class,
+        warmup_slot,
+        timed_slot,
+    }
+}
+
+fn target_file_count() -> usize {
+    READ_CLASSES.len() * TARGETS_PER_CLASS
+}
+
+fn generic_file_count(file_count: usize) -> usize {
+    file_count
+        .checked_sub(target_file_count())
+        .expect("file count must leave room for target read files")
+}
+
+fn seed_entries(file_count: usize) -> Vec<(String, Blob)> {
+    let mut entries = Vec::with_capacity(file_count);
+    for class in READ_CLASSES {
+        for target_slot in 0..TARGETS_PER_CLASS {
+            entries.push((
+                target_path(class, target_slot),
+                Blob::from(target_payload(class, target_slot)),
+            ));
+        }
+    }
+    for file_index in 0..generic_file_count(file_count) {
+        entries.push((
+            generic_path(file_index),
+            Blob::from(generic_payload(file_index, 0)),
+        ));
+    }
+    assert_eq!(entries.len(), file_count);
+    entries
+}
+
+fn target_path(class: ReadClass, target_slot: usize) -> String {
+    let kind = class.kind();
+    format!(
+        "/component-read/{}/target-{target_slot}.{}",
+        kind.directory, kind.extension
+    )
+}
+
+fn generic_path(file_index: usize) -> String {
+    let kind = FILE_KINDS[file_index % FILE_KINDS.len()];
+    format!(
+        "/corpus/{}/file-{file_index:05}.{}",
+        kind.directory, kind.extension
+    )
+}
+
+fn target_payload(class: ReadClass, target_slot: usize) -> Vec<u8> {
+    payload_for_kind(
+        class.kind(),
+        class.payload_bytes,
+        class.file_kind_index,
+        u64::try_from(target_slot).expect("target slot fits u64"),
+    )
+}
+
+fn generic_payload(file_index: usize, version: u64) -> Vec<u8> {
+    let kind = FILE_KINDS[file_index % FILE_KINDS.len()];
+    payload_for_kind(kind, generic_payload_bytes(kind), file_index, version)
+}
+
+fn generic_payload_bytes(kind: FileKind) -> usize {
+    match kind.extension {
+        "pdf" => NORMAL_PDF_FILE_BYTES,
+        "png" => NORMAL_PNG_FILE_BYTES,
+        "bin" => NORMAL_BINARY_FILE_BYTES,
+        _ => NORMAL_TEXT_FILE_BYTES,
+    }
+}
+
+fn payload_for_kind(
+    kind: FileKind,
+    target_bytes: usize,
+    file_index: usize,
+    version: u64,
+) -> Vec<u8> {
+    match kind.extension {
+        "pdf" => binary_payload(
+            target_bytes,
+            b"%PDF-1.7\n%lix-native-read-benchmark\n",
+            file_index,
+            version,
+        ),
+        "png" => binary_payload(
+            target_bytes,
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR",
+            file_index,
+            version,
+        ),
+        "bin" => binary_payload(target_bytes, b"LIX\x00BINARY\x01", file_index, version),
+        "json" => text_payload(
+            target_bytes,
+            &format!(
+                "{{\"kind\":\"json\",\"file\":{file_index},\"version\":{version},\"payload\":\""
+            ),
+            "xYz0123456789",
+            "\"}\n",
+        ),
+        "csv" => text_payload(
+            target_bytes,
+            &format!("file,version,value\n{file_index},{version},"),
+            "csv-value-0123456789,",
+            "\n",
+        ),
+        "md" => text_payload(
+            target_bytes,
+            &format!("# Benchmark {file_index}\n\nversion: {version}\n\n"),
+            "lix native read markdown content ",
+            "\n",
+        ),
+        "txt" => text_payload(
+            target_bytes,
+            &format!("file={file_index} version={version}\n"),
+            "plain-text-content-0123456789 ",
+            "\n",
+        ),
+        "xml" => text_payload(
+            target_bytes,
+            &format!("<file id=\"{file_index}\" version=\"{version}\">"),
+            "xml-content-0123456789",
+            "</file>\n",
+        ),
+        "yaml" => text_payload(
+            target_bytes,
+            &format!("file: {file_index}\nversion: {version}\nvalue: "),
+            "yaml-content-0123456789",
+            "\n",
+        ),
+        "log" => text_payload(
+            target_bytes,
+            &format!("INFO file={file_index} version={version} message="),
+            "native-read-log-0123456789 ",
+            "\n",
+        ),
+        extension => panic!("unsupported benchmark extension {extension}"),
+    }
+}
+
+fn text_payload(target_bytes: usize, prefix: &str, repeated: &str, suffix: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(target_bytes);
+    bytes.extend_from_slice(prefix.as_bytes());
+    while bytes.len() + suffix.len() < target_bytes {
+        bytes.extend_from_slice(repeated.as_bytes());
+    }
+    bytes.truncate(target_bytes.saturating_sub(suffix.len()));
+    bytes.extend_from_slice(suffix.as_bytes());
+    bytes
+}
+
+fn binary_payload(target_bytes: usize, prefix: &[u8], file_index: usize, version: u64) -> Vec<u8> {
+    let mut bytes = vec![0; target_bytes];
+    let prefix_len = prefix.len().min(bytes.len());
+    bytes[..prefix_len].copy_from_slice(&prefix[..prefix_len]);
+    let mut state = (file_index as u64)
+        .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        .wrapping_add(version)
+        .wrapping_add(0xd1b5_4a32_d192_ed03);
+    for byte in &mut bytes[prefix_len..] {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        *byte = state.to_le_bytes()[0];
+    }
+    bytes
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_directory(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(source_path, destination_path)?;
+        } else {
+            return Err(std::io::Error::other(format!(
+                "unsupported source entry {} while copying benchmark database",
+                source_path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn disk_usage(path: &Path) -> std::io::Result<DiskUsage> {
+    let mut usage = DiskUsage::default();
+    accumulate_disk_usage(path, &mut usage)?;
+    Ok(usage)
+}
+
+fn accumulate_disk_usage(path: &Path, usage: &mut DiskUsage) -> std::io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            accumulate_disk_usage(&entry.path(), usage)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let bytes = entry.metadata()?.len();
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        usage.total_bytes += bytes;
+        usage.file_count += 1;
+        if file_name.ends_with(".sst") {
+            usage.sst_bytes += bytes;
+        } else if file_name.ends_with(".log") || file_name.starts_with("LOG") {
+            usage.log_bytes += bytes;
+        } else if file_name.starts_with("MANIFEST") {
+            usage.manifest_bytes += bytes;
+        } else if file_name.starts_with("OPTIONS") {
+            usage.options_bytes += bytes;
+        } else {
+            usage.other_bytes += bytes;
+        }
+    }
+    Ok(())
+}
+
+fn process_resident_bytes() -> Option<u64> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    let value = status
+        .lines()
+        .find_map(|line| line.strip_prefix("VmRSS:"))?;
+    let kibibytes = value.split_whitespace().next()?.parse::<u64>().ok()?;
+    kibibytes.checked_mul(1024)
+}
+
+fn selected_backends() -> Vec<Backend> {
+    let requested = std::env::var("LIX_NATIVE_FILE_READ_COMPONENT_BACKENDS")
+        .unwrap_or_else(|_| "rocksdb,slatedb".to_string());
+    let mut selected = Vec::new();
+    for value in requested
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let backend = match value {
+            "rocksdb" => Backend::RocksDb,
+            "slatedb" => Backend::SlateDb,
+            other => panic!(
+                "unsupported LIX_NATIVE_FILE_READ_COMPONENT_BACKENDS value {other:?}; expected rocksdb or slatedb"
+            ),
+        };
+        if !selected.contains(&backend) {
+            selected.push(backend);
+        }
+    }
+    assert!(
+        !selected.is_empty(),
+        "LIX_NATIVE_FILE_READ_COMPONENT_BACKENDS must select at least one backend"
+    );
+    selected
+}
+
+fn read_classes_json() -> Vec<serde_json::Value> {
+    READ_CLASSES
+        .iter()
+        .map(|class| {
+            serde_json::json!({
+                "label": class.label,
+                "payload_bytes": class.payload_bytes,
+                "extension": class.kind().extension,
+                "target_paths_per_class": TARGETS_PER_CLASS,
+            })
+        })
+        .collect()
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name).map_or(default, |value| {
+        value
+            .parse::<usize>()
+            .unwrap_or_else(|error| panic!("parse {name}={value:?} as usize: {error}"))
+    })
+}
+
+fn env_usize_list(name: &str, defaults: &[usize]) -> Vec<usize> {
+    let values = std::env::var(name).map_or_else(
+        |_| defaults.to_vec(),
+        |value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(|entry| {
+                    entry.parse::<usize>().unwrap_or_else(|error| {
+                        panic!("parse {name} entry {entry:?} as usize: {error}")
+                    })
+                })
+                .collect::<Vec<_>>()
+        },
+    );
+    assert!(!values.is_empty(), "{name} must contain at least one value");
+    values
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).expect("benchmark duration must fit u64 nanoseconds")
+}
+
+fn signed_delta(after: u64, before: u64) -> i64 {
+    let after = i128::from(after);
+    let before = i128::from(before);
+    i64::try_from(after - before).expect("benchmark storage delta must fit i64")
+}
+
+fn percentile(values: &mut [u64], percentile: usize) -> u64 {
+    assert!(!values.is_empty(), "benchmark percentile requires samples");
+    values.sort_unstable();
+    let rank = values.len().saturating_mul(percentile).div_ceil(100);
+    values[rank.saturating_sub(1).min(values.len() - 1)]
+}
+
+fn median_i64(values: &mut [i64]) -> i64 {
+    assert!(!values.is_empty(), "benchmark median requires samples");
+    values.sort_unstable();
+    values[(values.len() - 1) / 2]
+}
+
+fn mean(values: &[f64]) -> f64 {
+    assert!(!values.is_empty(), "benchmark mean requires samples");
+    values.iter().sum::<f64>() / exact_f64_from_usize(values.len())
+}
+
+fn mean_u64(values: &[u64]) -> f64 {
+    assert!(!values.is_empty(), "benchmark mean requires samples");
+    values
+        .iter()
+        .map(|value| exact_f64_from_u64(*value))
+        .sum::<f64>()
+        / exact_f64_from_usize(values.len())
+}
+
+fn sample_standard_deviation(values: &[f64]) -> f64 {
+    assert!(
+        values.len() > 1,
+        "benchmark standard deviation requires multiple samples"
+    );
+    let mean = mean(values);
+    let variance = values
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / exact_f64_from_usize(values.len() - 1);
+    variance.sqrt()
+}
+
+fn t_99_two_sided_critical(degrees_of_freedom: usize) -> f64 {
+    // Two-sided Student-t critical values for alpha=0.01. Thirty or more
+    // pairs use the df=29 value, intentionally conservative for larger n.
+    const VALUES: [f64; 29] = [
+        63.657, 9.925, 5.841, 4.604, 4.032, 3.707, 3.499, 3.355, 3.250, 3.169, 3.106, 3.055, 3.012,
+        2.977, 2.947, 2.921, 2.898, 2.878, 2.861, 2.845, 2.831, 2.819, 2.807, 2.797, 2.787, 2.779,
+        2.771, 2.763, 2.756,
+    ];
+    assert!(degrees_of_freedom > 0, "paired CI requires two samples");
+    VALUES[degrees_of_freedom.saturating_sub(1).min(28)]
+}
+
+fn exact_f64_from_usize(value: usize) -> f64 {
+    exact_f64_from_u64(u64::try_from(value).expect("benchmark count must fit u64"))
+}
+
+fn exact_f64_from_u64(value: u64) -> f64 {
+    assert!(
+        value <= (1_u64 << f64::MANTISSA_DIGITS),
+        "benchmark value {value} exceeds f64's exact integer range"
+    );
+    #[allow(clippy::cast_precision_loss)]
+    {
+        value as f64
+    }
+}

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -560,6 +560,61 @@ where
         .await
     }
 
+    /// Reads one file's bytes by its full logical path without parsing SQL.
+    ///
+    /// This is the structured file-transfer read path. It uses the same
+    /// active-branch file selection, plugin rendering, and session file-view
+    /// acknowledgement as `SELECT data FROM lix_file WHERE path = $1`, while
+    /// avoiding SQL parsing, planning, and a JSON-shaped result envelope.
+    pub async fn read_file_data(&self, path: String) -> Result<Option<Blob>, LixError> {
+        self.ensure_open()?;
+        // Keep the structured API's path contract aligned with native writes.
+        // SQL remains available for callers that intentionally need broader
+        // `lix_file` predicates or legacy path shapes.
+        crate::common::LixPath::try_from_file_path(&path)?;
+
+        let paths = BTreeSet::from([path]);
+        let _operation_guard = self.begin_waitable_session_operation().await?;
+        let read_scope = self
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await?;
+        let (data, file_view_mutations) = with_static_session_sql_read::<StorageImpl, _, _, _>(
+            read_scope,
+            |read_store| async move {
+                let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+                let live_state: Arc<dyn crate::live_state::LiveStateReader> =
+                    Arc::new(self.live_state.reader(read_store.clone()));
+                let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
+                    Arc::new(self.live_state.reader(read_store.clone()));
+                let branch_ref: Arc<dyn BranchRefReader> =
+                    Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
+                let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
+                    Arc::new(self.binary_cas.reader(read_store));
+                // A raw file download delivers the same bytes as a direct
+                // `lix_file.data` read, so it must acknowledge rendered
+                // plugin state for subsequent collaborative writes.
+                let file_view_collector = sql2::SessionFileViews::default();
+                let result = sql2::execute_exact_lix_file_batch_read(
+                    &active_branch_id,
+                    live_state,
+                    filesystem_path_index,
+                    branch_ref,
+                    blob_reader,
+                    self.plugin_host.clone(),
+                    Some(file_view_collector.clone()),
+                    &paths,
+                )
+                .await?;
+                let data = native_file_data_from_exact_result(result, &paths)?;
+                Ok((data, file_view_collector.plugin_file_mutations()))
+            },
+        )
+        .await?;
+        self.file_views.apply_mutations(file_view_mutations);
+        Ok(data)
+    }
+
     pub(crate) async fn execute_for_observe(
         &self,
         sql: &str,
@@ -1257,6 +1312,54 @@ where
             file_view_mutations,
         ))
     }
+}
+
+fn native_file_data_from_exact_result(
+    result: SqlQueryResult,
+    requested_paths: &BTreeSet<String>,
+) -> Result<Option<Blob>, LixError> {
+    if result.columns.as_slice() != ["path", "data"] {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "native file read returned an unexpected result schema",
+        ));
+    }
+    let mut rows = result.rows.into_iter();
+    let Some(mut row) = rows.next() else {
+        return Ok(None);
+    };
+    if rows.next().is_some() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "native file read returned more than one path",
+        ));
+    }
+    let [Value::Text(path), data] = row.as_mut_slice() else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "native file read returned an invalid row",
+        ));
+    };
+    if !requested_paths.contains(path.as_str()) {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "native file read returned an unrequested path",
+        ));
+    }
+    let data = match std::mem::replace(data, Value::Null) {
+        Value::Blob(data) => data,
+        // A path-only `lix_file` row is a present empty file on the public
+        // surface. Preserve that contract even if a storage layout represents
+        // it as SQL NULL internally.
+        Value::Null => Blob::default(),
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "native file read returned a non-binary data value",
+            ));
+        }
+    };
+    Ok(Some(data))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/packages/engine/tests/fs_api.rs
+++ b/packages/engine/tests/fs_api.rs
@@ -1531,6 +1531,46 @@ async fn plugin_data_used_by_aggregate_does_not_acknowledge_remote_entities() {
 }
 
 #[tokio::test]
+async fn native_file_read_acknowledges_rendered_plugin_entities() {
+    let (_engine, session_a, session_b) = keyed_collaboration_sessions().await;
+    write_file(&session_a, "/shared.keyed", b"root=0\n".to_vec())
+        .await
+        .expect("seed file should write");
+
+    assert_eq!(
+        session_b
+            .read_file_data("/shared.keyed".to_string())
+            .await
+            .expect("initial native plugin file read")
+            .map(|data| data.to_vec()),
+        Some(b"root=0\n".to_vec())
+    );
+
+    write_file(&session_a, "/shared.keyed", b"remote=R\nroot=0\n".to_vec())
+        .await
+        .expect("remote entity should write");
+    assert_eq!(
+        session_b
+            .read_file_data("/shared.keyed".to_string())
+            .await
+            .expect("updated native plugin file read")
+            .map(|data| data.to_vec()),
+        Some(b"remote=R\nroot=0\n".to_vec())
+    );
+
+    // The second native read delivered the remote entity, so a later client
+    // omission intentionally removes it instead of treating it as unseen
+    // concurrent state that must be preserved.
+    write_file(&session_b, "/shared.keyed", b"root=B\n".to_vec())
+        .await
+        .expect("acknowledged client edit should write");
+    assert_eq!(
+        keyed_entity_values(&session_a, "/shared.keyed").await,
+        BTreeMap::from([("root".to_string(), "B".to_string())])
+    );
+}
+
+#[tokio::test]
 async fn plugin_point_read_filtered_by_null_does_not_acknowledge_remote_entities() {
     let (_engine, session_a, session_b) = keyed_collaboration_sessions().await;
     write_file(&session_a, "/shared.keyed", b"root=0\n".to_vec())

--- a/packages/engine/tests/native_file_read_storage.rs
+++ b/packages/engine/tests/native_file_read_storage.rs
@@ -1,0 +1,105 @@
+//! Storage-backend coverage for the structured native file-read surface.
+
+use lix_engine::{Engine, SessionContext, Storage, Value};
+use lix_rocksdb_storage::RocksDB;
+use lix_slatedb_storage::SlateDB;
+
+#[tokio::test]
+async fn native_file_read_works_with_rocksdb() {
+    let temp_dir = tempfile::tempdir().expect("create RocksDB temp directory");
+    let storage =
+        RocksDB::open(temp_dir.path().join("native-file-read")).expect("open RocksDB storage");
+    assert_native_file_read(storage).await;
+}
+
+#[tokio::test]
+async fn native_file_read_works_with_slatedb() {
+    let temp_dir = tempfile::tempdir().expect("create SlateDB temp directory");
+    let storage =
+        SlateDB::open(temp_dir.path().join("native-file-read")).expect("open SlateDB storage");
+    assert_native_file_read(storage).await;
+}
+
+async fn assert_native_file_read<S>(storage: S)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize storage");
+    let engine = Engine::new(storage).await.expect("open engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace session");
+
+    assert_eq!(
+        session
+            .read_file_data("/native/missing.bin".to_string())
+            .await
+            .expect("read missing file"),
+        None
+    );
+
+    session
+        .upsert_file_data(
+            "/native/deep/payload.bin".to_string(),
+            b"payload".to_vec().into(),
+        )
+        .await
+        .expect("create native file");
+    assert_file_data(&session, "/native/deep/payload.bin", Some(b"payload")).await;
+
+    session
+        .upsert_file_data("/native/empty.bin".to_string(), Vec::new().into())
+        .await
+        .expect("create empty native file");
+    assert_file_data(&session, "/native/empty.bin", Some(b"")).await;
+
+    // Exact native reads must keep the established active-branch precedence
+    // when a global file is overlaid by an active branch-local version.
+    let active_branch_id = session
+        .active_branch_id()
+        .await
+        .expect("active branch should resolve");
+    session
+        .execute(
+            "INSERT INTO lix_file_by_branch \
+             (id, path, data, lixcol_global, lixcol_branch_id) \
+             VALUES ($1, $2, $3, true, 'global')",
+            &[
+                Value::Text("native-read-overlap".to_string()),
+                Value::Text("/native/overlap.bin".to_string()),
+                Value::Blob(b"global".to_vec().into()),
+            ],
+        )
+        .await
+        .expect("global overlap fixture should insert");
+    session
+        .execute(
+            "INSERT INTO lix_file_by_branch \
+             (id, path, data, lixcol_branch_id) \
+             VALUES ($1, $2, $3, $4)",
+            &[
+                Value::Text("native-read-overlap".to_string()),
+                Value::Text("/native/overlap.bin".to_string()),
+                Value::Blob(b"local".to_vec().into()),
+                Value::Text(active_branch_id),
+            ],
+        )
+        .await
+        .expect("local overlap fixture should insert");
+    assert_file_data(&session, "/native/overlap.bin", Some(b"local")).await;
+}
+
+async fn assert_file_data<S>(session: &SessionContext<S>, path: &str, expected: Option<&[u8]>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let actual = session
+        .read_file_data(path.to_string())
+        .await
+        .expect("read native file")
+        .map(|data| data.to_vec());
+    assert_eq!(actual.as_deref(), expected);
+}

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -223,6 +223,14 @@ where
         self.session.upsert_file_data_batch(writes).await
     }
 
+    /// Reads one file's bytes by full logical path without parsing SQL.
+    ///
+    /// The returned `None` means the file is absent; `Some` with an empty
+    /// [`Blob`] means a present empty file.
+    pub async fn read_file_data(&self, path: impl Into<String>) -> Result<Option<Blob>, LixError> {
+        self.session.read_file_data(path.into()).await
+    }
+
     /// Executes statements sequentially against one atomic snapshot.
     /// Pure reads share one read snapshot; batches containing writes retain
     /// transactional read-after-write and rollback semantics.

--- a/packages/rs-sdk/tests/e2e.rs
+++ b/packages/rs-sdk/tests/e2e.rs
@@ -246,6 +246,36 @@ async fn rs_sdk_native_file_upsert_batch_is_atomic_and_updates_active_overlays()
 }
 
 #[tokio::test]
+async fn rs_sdk_native_file_read_distinguishes_missing_and_empty_files() {
+    let lix = open_lix(OpenLixOptions::default()).await.expect("open Lix");
+
+    assert_eq!(
+        lix.read_file_data("/native/missing.bin")
+            .await
+            .expect("read missing native file")
+            .map(|data| data.to_vec()),
+        None
+    );
+
+    lix.upsert_file_data("/native/empty.bin", Vec::<u8>::new())
+        .await
+        .expect("create empty native file");
+    assert_eq!(
+        lix.read_file_data("/native/empty.bin")
+            .await
+            .expect("read empty native file")
+            .map(|data| data.to_vec()),
+        Some(Vec::new())
+    );
+
+    let error = lix
+        .read_file_data("relative.bin")
+        .await
+        .expect_err("relative native file path should be rejected");
+    assert_eq!(error.code, "LIX_ERROR_PATH_MISSING_LEADING_SLASH");
+}
+
+#[tokio::test]
 async fn rs_sdk_open_register_write_query_branch_and_merge_flow() {
     let lix = open_lix(OpenLixOptions::default()).await.unwrap();
     let main_branch_id = lix.active_branch_id().await.unwrap();

--- a/packages/server-protocol/README.md
+++ b/packages/server-protocol/README.md
@@ -118,3 +118,21 @@ request stages all entries in one transaction and returns the standard
 or engine error commits none of the entries. Larger client batches should be
 split into frames of at most 1,024 files. The configured request-body ceiling
 is the same as for the rest of the protocol.
+
+## Binary file read
+
+Clients that explicitly want one file's rendered bytes can check for
+`capabilities.binaryFileRead === true` and send a protected request to:
+
+```text
+GET /lix/v1/file?path=<percent-encoded-absolute-file-path>
+Lix-Session-Id: <session-id>
+```
+
+The successful response has `Content-Type: application/octet-stream`,
+`Cache-Control: no-store`, and raw file bytes as its body. It carries
+`Lix-File-Found: true` for a present file (including a present empty file) or
+`Lix-File-Found: false` for a missing file, whose body is empty. This route has
+the same active-branch, plugin rendering, and per-session acknowledgement
+semantics as `SELECT data FROM lix_file WHERE path = $1`; it is not a generic
+SQL read endpoint.

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -5,7 +5,7 @@ use axum::{
     Extension, Json, Router,
     body::Bytes,
     extract::{DefaultBodyLimit, Query, Request, State},
-    http::{HeaderMap, StatusCode, header::CACHE_CONTROL},
+    http::{HeaderMap, HeaderName, StatusCode, header::CACHE_CONTROL},
     middleware::{self, Next},
     response::{
         IntoResponse, Response,
@@ -50,6 +50,9 @@ pub const PROTOCOL_PATH: &str = "/lix/v1";
 pub const PROTOCOL_VERSION: u32 = 1;
 /// Header carrying the opaque server-issued session capability.
 pub const SESSION_ID_HEADER: &str = "lix-session-id";
+/// Header distinguishing a missing file from a present empty file on the raw
+/// binary file-read endpoint.
+pub const FILE_FOUND_HEADER: &str = "lix-file-found";
 /// Default maximum number of live remote sessions for one workspace.
 pub const DEFAULT_MAX_SESSIONS: usize = 64;
 /// Default idle lifetime for a remote session.
@@ -592,6 +595,7 @@ where
         let protected = Router::new()
             .route("/lix/v1/execute", post(execute::<S>))
             .route("/lix/v1/execute-batch", post(execute_batch::<S>))
+            .route("/lix/v1/file", get(read_file_data::<S>))
             .route("/lix/v1/file/upsert", post(upsert_file_data::<S>))
             .route(
                 "/lix/v1/file/upsert-batch",
@@ -987,6 +991,7 @@ where
                 request_blob_splice: true,
                 binary_file_upsert: true,
                 binary_file_upsert_batch: true,
+                binary_file_read: true,
             },
         }),
     ))
@@ -1249,6 +1254,44 @@ fn take_binary_file_upsert_batch_range(
     }
     *offset = end;
     Ok(start..end)
+}
+
+/// Reads one file as a raw octet stream.
+///
+/// `Lix-File-Found: true` distinguishes a present empty file from a missing
+/// file (`false`), whose body is also empty. The response is explicitly
+/// non-cacheable because the session's rendered plugin view is part of the
+/// collaboration protocol.
+async fn read_file_data<S>(
+    Extension(lease): Extension<SessionLease<S>>,
+    Query(request): Query<BinaryFileReadRequest>,
+) -> Result<Response, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let path = required_non_empty(request.path, "path")?;
+    let data = lease
+        .run(move |lix| async move { lix.read_file_data(path).await })
+        .await?;
+    let (found, body) = data.map_or_else(
+        || ("false", Bytes::new()),
+        |data| ("true", data.into_bytes()),
+    );
+    let mut response = Response::new(axum::body::Body::from(body));
+    let headers = response.headers_mut();
+    headers.insert(
+        CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+    headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/octet-stream"),
+    );
+    headers.insert(
+        HeaderName::from_static(FILE_FOUND_HEADER),
+        axum::http::HeaderValue::from_static(found),
+    );
+    Ok(response)
 }
 
 async fn create_branch<S>(
@@ -1885,10 +1928,14 @@ struct HandshakeResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+// These are independently negotiated wire capabilities; grouping them would
+// change the flat handshake response without reducing protocol complexity.
+#[allow(clippy::struct_excessive_bools)]
 struct ProtocolCapabilities {
     request_blob_splice: bool,
     binary_file_upsert: bool,
     binary_file_upsert_batch: bool,
+    binary_file_read: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1905,6 +1952,11 @@ struct ExecuteRequest {
 
 #[derive(Debug, Deserialize)]
 struct BinaryFileUpdateRequest {
+    path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BinaryFileReadRequest {
     path: Option<String>,
 }
 
@@ -2625,6 +2677,7 @@ mod tests {
         assert_eq!(first["capabilities"]["requestBlobSplice"], true);
         assert_eq!(first["capabilities"]["binaryFileUpsert"], true);
         assert_eq!(first["capabilities"]["binaryFileUpsertBatch"], true);
+        assert_eq!(first["capabilities"]["binaryFileRead"], true);
         assert_eq!(session_id.len(), SESSION_TOKEN_HEX_LEN);
         assert!(
             session_id
@@ -2811,6 +2864,172 @@ mod tests {
         assert_eq!(
             response_json(created_selected).await["rows"][0][0],
             wire_blob_json(&created_payload)
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_file_read_returns_raw_bytes_and_distinguishes_empty_and_missing() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let payload = vec![0, 1, 2, 3, 255];
+        let inserted = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::from(payload.clone()))
+                    .expect("binary file seed request"),
+            )
+            .await
+            .expect("binary file seed response");
+        assert_eq!(inserted.status(), StatusCode::OK);
+
+        let response = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/lix/v1/file?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .body(Body::empty())
+                    .expect("binary file read request"),
+            )
+            .await
+            .expect("binary file read response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CACHE_CONTROL),
+            Some(&axum::http::HeaderValue::from_static("no-store"))
+        );
+        assert_eq!(
+            response.headers().get(axum::http::header::CONTENT_TYPE),
+            Some(&axum::http::HeaderValue::from_static(
+                "application/octet-stream"
+            ))
+        );
+        assert_eq!(
+            response.headers().get(FILE_FOUND_HEADER),
+            Some(&axum::http::HeaderValue::from_static("true"))
+        );
+        assert_eq!(
+            response
+                .into_body()
+                .collect()
+                .await
+                .expect("read body")
+                .to_bytes()
+                .as_ref(),
+            payload.as_slice()
+        );
+
+        let emptied = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/file/upsert?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
+                    .body(Body::empty())
+                    .expect("empty binary file update request"),
+            )
+            .await
+            .expect("empty binary file update response");
+        assert_eq!(emptied.status(), StatusCode::OK);
+
+        let empty = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/lix/v1/file?path=%2Fpayload.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .body(Body::empty())
+                    .expect("empty binary file read request"),
+            )
+            .await
+            .expect("empty binary file read response");
+        assert_eq!(empty.status(), StatusCode::OK);
+        assert_eq!(
+            empty.headers().get(FILE_FOUND_HEADER),
+            Some(&axum::http::HeaderValue::from_static("true"))
+        );
+        assert!(
+            empty
+                .into_body()
+                .collect()
+                .await
+                .expect("empty read body")
+                .to_bytes()
+                .is_empty()
+        );
+
+        let missing = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/lix/v1/file?path=%2Fmissing.bin")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .body(Body::empty())
+                    .expect("missing binary file read request"),
+            )
+            .await
+            .expect("missing binary file read response");
+        assert_eq!(missing.status(), StatusCode::OK);
+        assert_eq!(
+            missing.headers().get(FILE_FOUND_HEADER),
+            Some(&axum::http::HeaderValue::from_static("false"))
+        );
+        assert!(
+            missing
+                .into_body()
+                .collect()
+                .await
+                .expect("missing read body")
+                .to_bytes()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_file_read_requires_a_live_session_and_valid_path() {
+        let app = app().await;
+        let missing_session = request(
+            &app.router,
+            "GET",
+            "/lix/v1/file?path=%2Fpayload.bin",
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(missing_session.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_code(missing_session).await,
+            "LIX_ERROR_PROTOCOL_SESSION_REQUIRED"
+        );
+
+        let (session_id, _) = new_session(&app.router).await;
+        let invalid_path = request(
+            &app.router,
+            "GET",
+            "/lix/v1/file?path=relative.bin",
+            Some(&session_id),
+            None,
+        )
+        .await;
+        assert_eq!(invalid_path.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_code(invalid_path).await,
+            "LIX_ERROR_PATH_MISSING_LEADING_SLASH"
         );
     }
 


### PR DESCRIPTION
## What changed

Adds a capability-gated exact file-read path that bypasses SQL parsing and JSON/Base64 transport for the common `GET file by path` workload:

- `SessionContext::read_file_data` and SDK accessors retain active-branch and plugin-render/acknowledgement semantics.
- `GET /lix/v1/file?path=…` returns `application/octet-stream`, `Cache-Control: no-store`, and `Lix-File-Found` to distinguish missing files from present-empty files.
- Handshake advertises `binaryFileRead`; the route remains session-protected.
- The benchmark client’s JSON control decodes Base64 to usable bytes inside its timer, while the raw arm materializes the response body inside its timer; semantic assertions and preconditioning follow the selected route.

## Why

Exact reads currently pay SQL parse/planning plus JSON/Base64 expansion even though the server already has a direct path-index/blob lookup. The raw path removes that framing for the dominant happy path without changing the storage layout.

## End-to-end data

SlateDB Compose, closed 5,000-commit templates, independently cloned workspaces, restart-isolated and counterbalanced pairs, 3 warmups + 30 timed samples/arm, five paired repetitions:

| corpus | 32 KiB JSON p50 | raw p50 | pooled reduction | paired geometric speedup | bootstrap 99% lower speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1,000 files | 9.812 ms | 6.024 ms | 38.6% | 1.656× | 1.553× |
| 5,000 files | 11.365 ms | 7.358 ms | 35.3% | 1.591× | 1.407× |

The same method on 4 KiB JSON reads showed 43.8% minimum paired reduction at 1k files and 27.4% at 5k files (three pairs each). The raw response is 32 KiB versus 42.8 KiB for JSON/Base64. No storage-layout or retained-RSS win is claimed.

## Validation

- `cargo test -p lix_engine --test native_file_read_storage -- --nocapture` (RocksDB + SlateDB)
- `cargo test -p lix_engine --test fs_api -- --nocapture`
- `cargo test -p lix_sdk --test e2e -- --nocapture`
- `cargo test -p lix_server_protocol -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --profile test -p lix_engine -p lix_sdk -p lix_server_protocol --all-targets --all-features -- -D warnings`

A component benchmark covering both RocksDB and SlateDB is being added to this branch next.