### PR TITLE
fix(protocol): cancel abandoned read requests

### DIFF
--- a/.changenotes/cancel-protocol-read-recovery.md
+++ b/.changenotes/cancel-protocol-read-recovery.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Cancelled read-only protocol requests now release their session locks so a
+timed-out workspace can close and recover promptly. Writes and durable runtime
+functions still complete after a client disconnects.

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -70,8 +70,8 @@ pub(crate) use common::{parse_row_metadata, parse_row_metadata_value, serialize_
 pub use engine::{Engine, EngineOptions};
 pub use init::InitReceipt;
 pub use session::{
-    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ObserveEvent,
-    ObserveEvents, Row, RowRef, TryFromValue,
+    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ExecutionDisposition,
+    ObserveEvent, ObserveEvents, Row, RowRef, TryFromValue,
 };
 pub use session::{
     CreateBranchOptions, CreateBranchReceipt, MergeBranchOptions, MergeBranchOutcome,

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -392,6 +392,20 @@ pub struct ExecuteOptions {
     pub origin_key: Option<String>,
 }
 
+/// Whether abandoning an in-flight SQL execution can discard its work.
+///
+/// This is derived from Lix's parsed and bound statement route, rather than
+/// from SQL-text matching. A [`Self::CancellableRead`] has no durable side
+/// effects. [`Self::Durable`] covers writes and read-shaped statements that
+/// invoke a runtime function whose state is persisted after evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionDisposition {
+    /// A pure read that a transport may cancel when its caller disconnects.
+    CancellableRead,
+    /// An operation whose completion must outlive a cancelled transport.
+    Durable,
+}
+
 /// One SQL statement to execute as part of an atomic batch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecuteBatchStatement {
@@ -450,6 +464,43 @@ impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    /// Classifies one SQL execution for a caller that owns its transport
+    /// lifecycle.
+    ///
+    /// The classification is intentionally based on the parsed statement and
+    /// Lix's bound route. It does not use SQL-text heuristics, and callers
+    /// must still execute the statement to receive the normal validation and
+    /// query-planning errors.
+    pub fn execution_disposition(&self, sql: &str) -> Result<ExecutionDisposition, LixError> {
+        let statement = self.sql_planning_cache.parse_statement(sql)?;
+        execution_disposition(&statement)
+    }
+
+    /// Classifies an atomic SQL batch for a caller that owns its transport
+    /// lifecycle.
+    ///
+    /// A batch is cancellable only when every parsed and bound statement is a
+    /// pure read. Any durable statement makes the whole batch durable so its
+    /// atomic transaction can complete after a transport disconnects.
+    pub fn execute_batch_disposition(
+        &self,
+        statements: &[ExecuteBatchStatement],
+    ) -> Result<ExecutionDisposition, LixError> {
+        for (statement_index, statement) in statements.iter().enumerate() {
+            let parsed = self
+                .sql_planning_cache
+                .parse_statement(&statement.sql)
+                .map_err(|error| with_batch_statement_index(error, statement_index))?;
+            if execution_disposition(&parsed)
+                .map_err(|error| with_batch_statement_index(error, statement_index))?
+                == ExecutionDisposition::Durable
+            {
+                return Ok(ExecutionDisposition::Durable);
+            }
+        }
+        Ok(ExecutionDisposition::CancellableRead)
+    }
+
     /// Executes one DataFusion SQL statement against this Lix session.
     ///
     /// The SQL dialect is DataFusion SQL, not SQLite SQL. Positional
@@ -2163,6 +2214,20 @@ fn point_identity_value_is_text(
     }
 }
 
+fn execution_disposition(
+    statement: &datafusion::sql::parser::Statement,
+) -> Result<ExecutionDisposition, LixError> {
+    match sql2::bind_statement_route(statement)? {
+        sql2::BoundStatementRoute::Write => Ok(ExecutionDisposition::Durable),
+        sql2::BoundStatementRoute::Read
+            if sql2::statement_has_durable_runtime_function(statement) =>
+        {
+            Ok(ExecutionDisposition::Durable)
+        }
+        sql2::BoundStatementRoute::Read => Ok(ExecutionDisposition::CancellableRead),
+    }
+}
+
 fn classify_execute_batch(
     statements: &[ExecuteBatchStatement],
     planning_cache: &sql2::SqlPlanningCache<crate::catalog::CatalogFingerprint>,
@@ -2177,11 +2242,9 @@ fn classify_execute_batch(
         let parsed_statement = planning_cache
             .parse_statement(&statement.sql)
             .map_err(|error| with_batch_statement_index(error, statement_index))?;
-        let route = sql2::bind_statement_route(&parsed_statement)
+        let disposition = execution_disposition(&parsed_statement)
             .map_err(|error| with_batch_statement_index(error, statement_index))?;
-        if route == sql2::BoundStatementRoute::Write
-            || sql2::statement_has_durable_runtime_function(&parsed_statement)
-        {
+        if disposition == ExecutionDisposition::Durable {
             is_read_only = false;
         }
         parsed.push(parsed_statement);
@@ -2530,6 +2593,48 @@ mod tests {
             classify_execute_batch(&[batch_statement("SELECT lix_uuid_v7()")], &cache).unwrap(),
             ExecuteBatchExecution::Transaction(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn execution_disposition_uses_the_parsed_bound_statement_route() {
+        let session = open_session().await;
+
+        assert_eq!(
+            session.execution_disposition("SELECT 1").unwrap(),
+            ExecutionDisposition::CancellableRead
+        );
+        assert_eq!(
+            session
+                .execution_disposition("SELECT lix_uuid_v7()")
+                .unwrap(),
+            ExecutionDisposition::Durable
+        );
+        assert_eq!(
+            session
+                .execution_disposition(
+                    "INSERT INTO lix_file (path, data) VALUES ('/disposition.txt', 'data')",
+                )
+                .unwrap(),
+            ExecutionDisposition::Durable
+        );
+        assert_eq!(
+            session
+                .execute_batch_disposition(&[
+                    batch_statement("SELECT 1"),
+                    batch_statement("SELECT * FROM lix_file"),
+                ])
+                .unwrap(),
+            ExecutionDisposition::CancellableRead
+        );
+        assert_eq!(
+            session
+                .execute_batch_disposition(&[
+                    batch_statement("SELECT 1"),
+                    batch_statement("SELECT lix_timestamp()"),
+                ])
+                .unwrap(),
+            ExecutionDisposition::Durable
+        );
     }
 
     #[test]

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -22,8 +22,8 @@ pub use context::SessionContext;
 pub(crate) use context::{SessionMode, WORKSPACE_BRANCH_KEY};
 pub use create_branch::{CreateBranchOptions, CreateBranchReceipt};
 pub use execute::{
-    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, Row, RowRef,
-    TryFromValue,
+    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ExecutionDisposition,
+    Row, RowRef, TryFromValue,
 };
 pub use merge::{
     MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions,

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -31,9 +31,9 @@ pub use lix_engine::wasm::{
 pub use lix_engine::{
     Blob, CommitResult, CoreProjection, CreateBranchOptions, CreateBranchReceipt,
     CreateBranchReceipt as CreateBranchResult, ExecuteBatchStatement, ExecuteOptions,
-    ExecuteResult, GetManyResult, GetOptions, Key, KeyRange, LixError, LixNotice,
-    MAX_SCAN_PAGE_ROWS, Memory, MemoryRead, MemoryWrite, MergeBranchOptions, MergeBranchOutcome,
-    MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
+    ExecuteResult, ExecutionDisposition, GetManyResult, GetOptions, Key, KeyRange, LixError,
+    LixNotice, MAX_SCAN_PAGE_ROWS, Memory, MemoryRead, MemoryWrite, MergeBranchOptions,
+    MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
     MergeBranchReceipt as MergeBranchResult, MergeChangeStats, MergeConflict,
     MergeConflictChangeKind, MergeConflictKind, MergeConflictSide, ObserveEvent, ObserveEvents,
     ProjectedValue, PutBatch, ReadEntry, ReadOptions, Row, ScanChunk, ScanOptions, SpaceId,

--- a/packages/rs-sdk/src/lix.rs
+++ b/packages/rs-sdk/src/lix.rs
@@ -2,9 +2,9 @@ use lix_engine::telemetry::TelemetrySink;
 use lix_engine::wasm::WasmRuntime;
 use lix_engine::{
     Blob, CreateBranchOptions, CreateBranchReceipt, Engine, EngineOptions, ExecuteBatchStatement,
-    ExecuteOptions, ExecuteResult, LixError, Memory, MergeBranchOptions, MergeBranchPreview,
-    MergeBranchPreviewOptions, MergeBranchReceipt, ObserveEvents, SessionContext, Storage,
-    SwitchBranchOptions, SwitchBranchReceipt, Value,
+    ExecuteOptions, ExecuteResult, ExecutionDisposition, LixError, Memory, MergeBranchOptions,
+    MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt, ObserveEvents,
+    SessionContext, Storage, SwitchBranchOptions, SwitchBranchReceipt, Value,
 };
 use std::sync::Arc;
 
@@ -195,6 +195,16 @@ where
             .await
     }
 
+    /// Classifies one SQL execution for a caller that owns its transport
+    /// lifecycle.
+    ///
+    /// The result comes from Lix's parsed and bound statement route. It is
+    /// safe for a transport to abandon [`ExecutionDisposition::CancellableRead`]
+    /// work; [`ExecutionDisposition::Durable`] work must be allowed to finish.
+    pub fn execution_disposition(&self, sql: &str) -> Result<ExecutionDisposition, LixError> {
+        self.session.execution_disposition(sql)
+    }
+
     /// Upserts one file's bytes by full logical path without parsing SQL.
     ///
     /// This structured path is intended for file transfer clients. It uses the
@@ -241,6 +251,15 @@ where
         self.session
             .execute_batch_with_options(statements, options)
             .await
+    }
+
+    /// Classifies an atomic SQL batch for a caller that owns its transport
+    /// lifecycle.
+    pub fn execute_batch_disposition(
+        &self,
+        statements: &[ExecuteBatchStatement],
+    ) -> Result<ExecutionDisposition, LixError> {
+        self.session.execute_batch_disposition(statements)
     }
 
     pub fn observe(

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -14,8 +14,9 @@ use axum::{
     routing::{delete, get, post},
 };
 use lix_sdk::{
-    Blob, CreateBranchOptions, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, Lix, LixError,
-    ObserveEvent, ObserveEvents, Storage, SwitchBranchOptions, Value, WireValue,
+    Blob, CreateBranchOptions, ExecuteBatchStatement, ExecuteOptions, ExecuteResult,
+    ExecutionDisposition, Lix, LixError, ObserveEvent, ObserveEvents, Storage, SwitchBranchOptions,
+    Value, WireValue,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -399,6 +400,108 @@ where
                 format!("join Lix server operation: {error}"),
             )
         })?
+    }
+
+    /// Runs a read whose work can be discarded when the request future is
+    /// dropped. The cancellation sender deliberately lives in the caller
+    /// future: dropping an HTTP timeout's waiter wakes the blocking runtime,
+    /// which drops the session read lock and its operation lease.
+    async fn run_cancellable_read<T, F, Fut>(&self, operation: F) -> Result<T, LixError>
+    where
+        T: Send + 'static,
+        F: FnOnce(Arc<Lix<S>>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, LixError>> + 'static,
+    {
+        let runtime = Handle::try_current().map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("access Lix server runtime: {error}"),
+            )
+        })?;
+        let lix = Arc::clone(&self.record.lix);
+        let operation_lease = self.clone();
+        let (cancel_on_drop, mut cancelled) = tokio::sync::oneshot::channel::<()>();
+        let parent = tracing::Span::current();
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let result = tokio::task::spawn_blocking(move || {
+            let _operation_lease = operation_lease;
+            tracing::dispatcher::with_default(&dispatch, || {
+                parent.in_scope(|| {
+                    runtime.block_on(async move {
+                        tokio::select! {
+                            result = async {
+                                let lix = lix.read().await;
+                                operation(Arc::clone(&lix)).await
+                            } => result,
+                            _ = &mut cancelled => Err(LixError::new(
+                                LixError::CODE_CLOSED,
+                                "Lix read operation was cancelled",
+                            )),
+                        }
+                    })
+                })
+            })
+        })
+        .await
+        .map_err(|error| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("join Lix server operation: {error}"),
+            )
+        })?;
+        drop(cancel_on_drop);
+        result
+    }
+
+    async fn execute(
+        &self,
+        sql: String,
+        params: Vec<Value>,
+        options: ExecuteOptions,
+    ) -> Result<ExecuteResult, LixError> {
+        let disposition = {
+            let lix = self.record.lix.read().await;
+            lix.execution_disposition(&sql)?
+        };
+        match disposition {
+            ExecutionDisposition::CancellableRead => {
+                self.run_cancellable_read(move |lix| async move {
+                    lix.execute_with_options(&sql, &params, options).await
+                })
+                .await
+            }
+            ExecutionDisposition::Durable => {
+                self.run(move |lix| async move {
+                    lix.execute_with_options(&sql, &params, options).await
+                })
+                .await
+            }
+        }
+    }
+
+    async fn execute_batch(
+        &self,
+        statements: Vec<ExecuteBatchStatement>,
+        options: ExecuteOptions,
+    ) -> Result<Vec<ExecuteResult>, LixError> {
+        let disposition = {
+            let lix = self.record.lix.read().await;
+            lix.execute_batch_disposition(&statements)?
+        };
+        match disposition {
+            ExecutionDisposition::CancellableRead => {
+                self.run_cancellable_read(move |lix| async move {
+                    lix.execute_batch_with_options(&statements, options).await
+                })
+                .await
+            }
+            ExecutionDisposition::Durable => {
+                self.run(move |lix| async move {
+                    lix.execute_batch_with_options(&statements, options).await
+                })
+                .await
+            }
+        }
     }
 
     async fn switch_branch(
@@ -1026,9 +1129,7 @@ where
     )?;
     let options = request.options.into();
     let params = decoded.values;
-    let result = lease
-        .run(move |lix| async move { lix.execute_with_options(&sql, &params, options).await })
-        .await?;
+    let result = lease.execute(sql, params, options).await?;
     lease.record.cache_request_blobs(cache_candidates);
     Ok(Json(ExecuteResponse::try_from(result)?))
 }
@@ -1067,9 +1168,7 @@ where
         })
         .collect::<Result<Vec<_>, ApiError>>()?;
     let options = request.options.into();
-    let results = lease
-        .run(move |lix| async move { lix.execute_batch_with_options(&statements, options).await })
-        .await?;
+    let results = lease.execute_batch(statements, options).await?;
     lease.record.cache_request_blobs(cache_candidates);
     Ok(Json(
         results
@@ -2416,6 +2515,80 @@ mod tests {
                 .is_ok()
             {
                 self.first_reads.barrier.wait().await;
+            }
+            self.inner.begin_read(options).await
+        }
+
+        async fn begin_write(
+            &self,
+            options: WriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            self.inner.begin_write(options).await
+        }
+    }
+
+    #[derive(Clone)]
+    struct BlockingReadStorage {
+        inner: Memory,
+        gate: Arc<BlockingReadGate>,
+    }
+
+    struct BlockingReadGate {
+        remaining: AtomicUsize,
+        entered: Notify,
+        release: Notify,
+    }
+
+    impl BlockingReadStorage {
+        fn new() -> Self {
+            Self {
+                inner: Memory::new(),
+                gate: Arc::new(BlockingReadGate {
+                    remaining: AtomicUsize::new(0),
+                    entered: Notify::new(),
+                    release: Notify::new(),
+                }),
+            }
+        }
+
+        fn block_next_read(&self) {
+            assert_eq!(
+                self.gate.remaining.swap(1, Ordering::AcqRel),
+                0,
+                "test read gate must be idle before arming"
+            );
+        }
+
+        async fn wait_for_blocked_read(&self) {
+            self.gate.entered.notified().await;
+        }
+
+        fn release_blocked_read(&self) {
+            self.gate.release.notify_one();
+        }
+    }
+
+    impl Storage for BlockingReadStorage {
+        type Read<'a>
+            = MemoryRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+            if self
+                .gate
+                .remaining
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                self.gate.entered.notify_one();
+                self.gate.release.notified().await;
             }
             self.inner.begin_read(options).await
         }
@@ -4517,7 +4690,73 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancelled_http_future_keeps_its_detached_operation_leased() {
+    async fn cancelled_cancellable_read_releases_session_for_close_and_replacement() {
+        let storage = BlockingReadStorage::new();
+        let root = Arc::new(
+            open_lix(OpenLixOptions::new(storage.clone()))
+                .await
+                .expect("open lix"),
+        );
+        let server = LixProtocolServer::with_options(
+            root,
+            ProtocolServerOptions {
+                max_sessions: 1,
+                session_idle_timeout: Duration::from_mins(1),
+                ..ProtocolServerOptions::default()
+            },
+        )
+        .expect("protocol server");
+        let router = handler(server.clone());
+        let lease = server.create_session(None).await.expect("session lease");
+        let session_id = lease.session_id.clone();
+        drop(lease);
+
+        storage.block_next_read();
+        let read_router = router.clone();
+        let read_session_id = session_id.clone();
+        let operation = tokio::spawn(async move {
+            request(
+                &read_router,
+                "POST",
+                "/lix/v1/execute",
+                Some(&read_session_id),
+                Some(json!({ "sql": "SELECT 1", "params": [] })),
+            )
+            .await
+        });
+        storage.wait_for_blocked_read().await;
+
+        operation.abort();
+        assert!(
+            operation
+                .await
+                .expect_err("outer HTTP-equivalent future was cancelled")
+                .is_cancelled()
+        );
+
+        let close =
+            tokio::time::timeout(Duration::from_secs(1), server.delete_session(&session_id)).await;
+        // Keep a failing regression self-cleaning: if cancellation ever stops
+        // reaching storage, release the blocked read before asserting below.
+        storage.release_blocked_read();
+        close
+            .expect("cancelled read must release the session read lock")
+            .expect("close cancelled read session");
+
+        let (replacement, _) = new_session(&router).await;
+        let retry = request(
+            &router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&replacement),
+            Some(json!({ "sql": "SELECT 1", "params": [] })),
+        )
+        .await;
+        assert_eq!(retry.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn cancelled_durable_operation_keeps_its_detached_operation_leased() {
         let app = app_with_options(ProtocolServerOptions {
             max_sessions: 1,
             session_idle_timeout: Duration::from_mins(1),
@@ -4534,6 +4773,8 @@ mod tests {
         let (finish_sender, finish) = tokio::sync::oneshot::channel();
         let (done_sender, done) = tokio::sync::oneshot::channel();
         let operation = tokio::spawn(async move {
+            // `run` is the durable path used by writes and durable runtime
+            // functions, so caller cancellation must not interrupt it.
             lease
                 .run(move |_lix| async move {
                     started_sender.send(()).expect("signal start");


### PR DESCRIPTION
## Problem

A timed-out read request could leave its detached `spawn_blocking` operation holding the session read lock. Lixray then could not acquire the writer lock required to close and recover the workspace.

## Change

- Classify execution from Lix's parsed/bound statement route: `CancellableRead` or `Durable`.
- Cancel a pure read when its request future is dropped, releasing its lease and session read lock.
- Keep writes and reads with durable runtime functions detached so they complete after a client disconnects.

This is cooperative cancellation: it releases work at async suspension points; it intentionally does not force-stop non-yielding CPU work.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p lix_engine --lib`
- `cargo test -p lix_server_protocol cancelled_ --lib` (3 passed)

The regression blocks a real storage `begin_read`, aborts the `SELECT`, proves session close completes within one second, opens a replacement session, and successfully retries the query. The durable-operation regression remains covered.

Fixes opral/lixray#123.