### PR TITLE
perf: benchmark and optimize tracked CRUD transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,6 +3382,7 @@ version = "0.8.4"
 name = "lix_rocksdb_storage"
 version = "0.8.4"
 dependencies = [
+ "blake3",
  "bytes",
  "lix_engine",
  "rocksdb",
@@ -3455,6 +3456,7 @@ name = "lix_slatedb_storage"
 version = "0.8.4"
 dependencies = [
  "async-trait",
+ "blake3",
  "bytes",
  "futures-util",
  "lix_engine",
@@ -3468,6 +3470,7 @@ dependencies = [
 name = "lix_sqlite_storage"
 version = "0.8.4"
 dependencies = [
+ "blake3",
  "bytes",
  "lix_engine",
  "rusqlite",

--- a/packages/engine/benches/tracked_state_crud/main.rs
+++ b/packages/engine/benches/tracked_state_crud/main.rs
@@ -6,6 +6,7 @@ use criterion::{BatchSize, BenchmarkGroup, Criterion, black_box, criterion_group
 mod accounting;
 mod io_stats;
 mod kv_layout;
+mod raw_sqlite;
 mod sql_session;
 mod storage;
 mod transaction_api;
@@ -26,12 +27,77 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
     accounting::maybe_print_accounting_report(&runtime, &rows[..SMOKE_ROWS]);
 
     for (label, row_count) in [("smoke", SMOKE_ROWS), ("real_workload", REAL_WORKLOAD_ROWS)] {
+        bench_raw_sqlite(c, &rows[..row_count], label);
         for profile in STORAGE_PROFILES {
             bench_kv_layout(c, &runtime, profile, &rows[..row_count], label);
             bench_transaction_api(c, &runtime, profile, &rows[..row_count], label);
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
         }
     }
+}
+
+fn bench_raw_sqlite(c: &mut Criterion, rows: &[WorkloadRow], label: &str) {
+    let mut group = c.benchmark_group(format!("tracked_state_crud/raw_sqlite/{label}"));
+    configure_group(&mut group, rows.len());
+    let rows = rows.to_vec();
+
+    group.bench_function(format!("insert_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::empty_fixture(&rows),
+            |fixture| black_box(fixture.insert_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("read_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.read_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("read_one_by_pk/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.read_one_by_pk()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("read_many_by_pk/{READ_MANY_PK_COUNT}"), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.read_many_by_pk(READ_MANY_PK_COUNT)),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("update_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.update_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("update_one_by_pk/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.update_one_by_pk()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("delete_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.delete_all()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("delete_one_by_pk/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || raw_sqlite::seeded_fixture(&rows),
+            |fixture| black_box(fixture.delete_one_by_pk()),
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
 }
 
 fn bench_kv_layout(

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -2127,3 +2127,45 @@ or slow fallback. Validation includes golden wire bytes, logical-vs-byte
 ordering, prefix-freedom, malformed codec, multi-level routing, canonical
 rebuild, sparse/deep/height-transition diff oracles, and backend accounting
 coverage.
+
+## 2026-07-24 — Standalone SQLite CRUD control
+
+The tracked CRUD scorecard now includes a deliberately non-versioned,
+standalone SQLite control. It stores the same flattened JSON-pointer workload
+in a normal `WITHOUT ROWID` table keyed by `path`, uses one transaction and one
+prepared statement for bulk writes, and materializes the same selected
+`path`/`value` columns for reads. The file-backed connection uses the same WAL,
+`synchronous=NORMAL`, cache, mmap, and checkpoint settings as Lix's SQLite
+storage adapter.
+
+This is not a semantic-equivalence claim: standalone SQLite does not construct
+changes, commits, tracked roots, or live-state projections. It is the requested
+latency floor for measuring how much headroom remains in Lix + RocksDB's normal
+tracked public-SQL path, following the baseline-driven approach described in
+[How Dolt Got as Fast as MySQL](https://www.dolthub.com/blog/2025-12-12-how-dolt-got-as-fast-as-mysql/).
+
+Command:
+
+```sh
+cargo bench -p lix_engine --features storage-benches \
+  --bench tracked_state_crud -- raw_sqlite
+```
+
+Fresh current-main point estimates on the same machine:
+
+| Operation | Standalone SQLite 1k | Lix + RocksDB SQL 1k | Ratio | Standalone SQLite 10k | Lix + RocksDB SQL 10k | Ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| insert all | 1.187 ms | 36.364 ms | 30.6x | 9.600 ms | 265.030 ms | 27.6x |
+| read all | 0.193 ms | 9.697 ms | 50.2x | 1.487 ms | 72.380 ms | 48.7x |
+| read one by PK | 0.031 ms | 2.624 ms | 84.3x | 0.044 ms | 4.846 ms | 109.6x |
+| read 10 by PK | 0.081 ms | 3.010 ms | 37.1x | 0.095 ms | 5.175 ms | 54.4x |
+| update one by PK | 0.026 ms | 7.563 ms | 295.7x | 0.053 ms | 75.691 ms | 1435.6x |
+| delete all | 0.046 ms | 20.500 ms | 444.7x | 0.271 ms | 251.290 ms | 926.9x |
+| delete one by PK | 0.030 ms | 8.919 ms | 301.9x | 0.049 ms | 76.212 ms | 1539.7x |
+
+The tracked transaction layer isolates storage/commit work from SQL planning.
+At 10k rows, its RocksDB point update/delete are 1.470/1.660 ms while public SQL
+is 75.691/76.212 ms. Both public-SQL writes grow about 10x when the table grows
+10x even though the matched identity count stays one. The first follow-up
+profile therefore targets bound public-write candidate selection above the
+tracked transaction and RocksDB layers.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -2212,3 +2212,58 @@ the 10k point-operation gaps fall from 1358.0x to 76.0x for UPDATE and from
 1316.5x to 94.0x for DELETE. The remaining fixed cost is primarily tracked
 commit construction and persistence rather than surface-size-dependent SQL
 candidate selection.
+
+## 2026-07-24 — Validate once and publish tracked snapshots conditionally
+
+The 10k INSERT profile after primary-key routing still placed most of the timed
+path above RocksDB. Row content was validated while staging and then validated
+again at commit; transaction publication also had no atomic condition tying the
+materialized commit to the tracked state observed when the transaction opened.
+
+The design follows the common transaction architecture rather than adding a
+Lix-specific cache:
+
+- [SQLite WAL mode](https://www.sqlite.org/isolation.html) gives readers a
+  stable snapshot and serializes writers.
+- [DuckDB](https://duckdb.org/docs/current/connect/concurrency) and
+  [Turso](https://docs.turso.tech/tursodb/concurrent-writes) use MVCC with
+  optimistic conflict detection for concurrent writes.
+- [Dolt](https://www.dolthub.com/docs/architecture/storage-engine/prolly-tree/)
+  publishes immutable, content-addressed versioned state through a transaction
+  boundary.
+
+Lix now applies the same split. Transaction open captures a revision of the
+normal tracked path. Explicit reads verify it both before and after execution,
+staging verifies it before accepting writes, and commit publishes the new
+tracked revision with a storage-level compare-and-write precondition. The
+precondition is evaluated under each backend's existing writer serialization
+boundary: the Memory commit lock, RocksDB writer gate, SQLite
+`BEGIN IMMEDIATE`, or SlateDB writer gate. A stale transaction therefore cannot
+publish over a newer tracked commit. Untracked writes remain a sidecar: they do
+not advance the tracked revision and do not cause tracked transaction
+conflicts.
+
+Normalization now produces a row-local validation certificate after metadata,
+JSON Schema, and derived-primary-key checks. Commit reuses that certificate and
+only runs transaction-wide validation when the schema has cross-row constraints
+or the row participates in filesystem, branch-ref, or schema-catalog
+invariants. Simple object schemas also receive a conservative compiled accept
+plan for their common required/property/type checks. Unsupported JSON Schema
+keywords fall back to the full validator, and rejected rows always use the full
+validator so public diagnostics are unchanged.
+
+The exact final 10k RocksDB SQL INSERT estimate was 264.89 ms (95% CI
+248.74–284.06 ms), down 5.3% from the 279.780 ms benchmark baseline. Standalone
+SQLite remains 9.600 ms, so the gap moves from 29.1x to 27.6x. The earlier
+fast-plan run measured 258.17 ms; Criterion found no statistically significant
+change between that run and the exact final build (`p = 0.54`). The measured
+point update (4.417 ms), delete-all (286.23 ms), and point delete (4.372 ms)
+changes were also not statistically significant.
+
+The optimized 1 kHz profile contained 9,664 main-thread samples. Inclusive
+samples still concentrate in transaction commit/materialization (2,997,
+31.0%), commit-time validation (1,591, 16.5%), and SQL write staging (about
+1,280–1,660, 13–17%). Within validation, committed insert-identity probing
+accounts for about 1,160 samples (12.0%). RocksDB leaf work is present but is
+not the dominant gap. The next data-driven target is therefore commit/change
+materialization and insert-identity lookup, not a different storage backend.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -2179,3 +2179,36 @@ places 59.3% of whole-process samples under transaction commit, split between
 prepared-write validation (27.4%) and commit construction/persistence (26.6%);
 SQL parsing is 7.6%. This is a real single-transaction path, not twenty version
 commits hidden in the harness.
+
+## 2026-07-24 — Route bound writes by primary key
+
+A 1 kHz Samply profile of the 10k public-SQL point-update benchmark showed
+`scan_entity_candidates` requesting every live row for the entity schema and
+branch. `overlay_scan_rows` then materialized the full surface before the bound
+predicate discarded 9,999 rows. This explains both the gap over the 1.470 ms
+tracked-transaction control and the approximately linear growth from 1k to 10k.
+
+Bound entity UPDATE and DELETE now extract exact string primary keys from safe
+predicate shapes and pass them to `LiveStateScanRequest::filter.entity_pks`.
+Equality, `IN`, complete `OR` branches, guaranteed `AND` conjuncts, parameters,
+and composite primary keys are supported. Partial disjunctions, non-string
+identity columns, nested identity paths, and other uncertain shapes retain the
+existing full scan. Contradictory identity predicates route to an empty scan.
+Candidate rows still pass through the original predicate evaluator, so this is
+candidate pruning rather than a semantic shortcut.
+
+Criterion point estimates:
+
+| Operation | Main 1k | Routed 1k | Change | Main 10k | Routed 10k | Change |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| update one by PK | 7.812 ms | 1.349 ms | -82.7% | 71.596 ms | 4.008 ms | -94.4% |
+| delete one by PK | 7.982 ms | 1.299 ms | -83.7% | 65.166 ms | 4.654 ms | -92.9% |
+
+The routed 10k profile reduced inclusive samples in
+`scan_entity_candidates`/`overlay_scan_rows` from about 17% to 0.75% of the
+whole profiled process, which includes fixture construction. Transaction commit
+is now the dominant remaining path at about 58.9%. Against standalone SQLite,
+the 10k point-operation gaps fall from 1358.0x to 76.0x for UPDATE and from
+1316.5x to 94.0x for DELETE. The remaining fixed cost is primarily tracked
+commit construction and persistence rather than surface-size-dependent SQL
+candidate selection.

--- a/packages/engine/benches/tracked_state_crud/optimization_log.md
+++ b/packages/engine/benches/tracked_state_crud/optimization_log.md
@@ -2136,7 +2136,10 @@ in a normal `WITHOUT ROWID` table keyed by `path`, uses one transaction and one
 prepared statement for bulk writes, and materializes the same selected
 `path`/`value` columns for reads. The file-backed connection uses the same WAL,
 `synchronous=NORMAL`, cache, mmap, and checkpoint settings as Lix's SQLite
-storage adapter.
+storage adapter. The Lix SQL fixture likewise runs all chunked bulk INSERT or
+UPDATE statements through one explicit `SessionTransaction`; transaction
+boundaries therefore match the standalone control instead of measuring one
+version commit per SQL chunk.
 
 This is not a semantic-equivalence claim: standalone SQLite does not construct
 changes, commits, tracked roots, or live-state projections. It is the requested
@@ -2155,17 +2158,24 @@ Fresh current-main point estimates on the same machine:
 
 | Operation | Standalone SQLite 1k | Lix + RocksDB SQL 1k | Ratio | Standalone SQLite 10k | Lix + RocksDB SQL 10k | Ratio |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| insert all | 1.187 ms | 36.364 ms | 30.6x | 9.600 ms | 265.030 ms | 27.6x |
-| read all | 0.193 ms | 9.697 ms | 50.2x | 1.487 ms | 72.380 ms | 48.7x |
-| read one by PK | 0.031 ms | 2.624 ms | 84.3x | 0.044 ms | 4.846 ms | 109.6x |
-| read 10 by PK | 0.081 ms | 3.010 ms | 37.1x | 0.095 ms | 5.175 ms | 54.4x |
-| update one by PK | 0.026 ms | 7.563 ms | 295.7x | 0.053 ms | 75.691 ms | 1435.6x |
-| delete all | 0.046 ms | 20.500 ms | 444.7x | 0.271 ms | 251.290 ms | 926.9x |
-| delete one by PK | 0.030 ms | 8.919 ms | 301.9x | 0.049 ms | 76.212 ms | 1539.7x |
+| insert all | 1.187 ms | 31.543 ms | 26.6x | 9.600 ms | 279.780 ms | 29.1x |
+| read all | 0.193 ms | 11.080 ms | 57.3x | 1.487 ms | 64.506 ms | 43.4x |
+| read one by PK | 0.031 ms | 2.961 ms | 95.1x | 0.044 ms | 5.386 ms | 121.8x |
+| read 10 by PK | 0.081 ms | 3.461 ms | 42.6x | 0.095 ms | 6.153 ms | 64.7x |
+| update one by PK | 0.026 ms | 7.812 ms | 305.4x | 0.053 ms | 71.596 ms | 1358.0x |
+| delete all | 0.046 ms | 18.885 ms | 409.7x | 0.271 ms | 268.760 ms | 991.3x |
+| delete one by PK | 0.030 ms | 7.982 ms | 270.2x | 0.049 ms | 65.166 ms | 1316.5x |
 
 The tracked transaction layer isolates storage/commit work from SQL planning.
 At 10k rows, its RocksDB point update/delete are 1.470/1.660 ms while public SQL
-is 75.691/76.212 ms. Both public-SQL writes grow about 10x when the table grows
-10x even though the matched identity count stays one. The first follow-up
+is 71.596/65.166 ms. Both public-SQL writes still grow about 9x when the table
+grows 10x even though the matched identity count stays one. The first follow-up
 profile therefore targets bound public-write candidate selection above the
 tracked transaction and RocksDB layers.
+
+The corrected transaction boundary also exposed a separate bulk-write lead:
+10k INSERT is 279.780 ms in one explicit Lix transaction. Its 1 kHz profile
+places 59.3% of whole-process samples under transaction commit, split between
+prepared-write validation (27.4%) and commit construction/persistence (26.6%);
+SQL parsing is 7.6%. This is a real single-transaction path, not twenty version
+commits hidden in the harness.

--- a/packages/engine/benches/tracked_state_crud/raw_sqlite.rs
+++ b/packages/engine/benches/tracked_state_crud/raw_sqlite.rs
@@ -1,0 +1,212 @@
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+use crate::workload::WorkloadRow;
+
+pub(crate) struct RawSqliteFixture {
+    connection: Connection,
+    rows: Vec<WorkloadRow>,
+    _dir: TempDir,
+}
+
+pub(crate) fn empty_fixture(rows: &[WorkloadRow]) -> RawSqliteFixture {
+    let dir = tempfile::tempdir().expect("create raw sqlite benchmark directory");
+    let path = dir.path().join("raw.sqlite");
+    let connection = Connection::open(path).expect("open raw sqlite benchmark database");
+    connection.set_prepared_statement_cache_capacity(32);
+    connection
+        .execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA temp_store = MEMORY;
+             PRAGMA cache_size = -20000;
+             PRAGMA mmap_size = 268435456;
+             PRAGMA wal_autocheckpoint = 10000;
+             CREATE TABLE json_pointer (
+                 path TEXT PRIMARY KEY NOT NULL,
+                 value TEXT NOT NULL
+             ) WITHOUT ROWID;",
+        )
+        .expect("initialize raw sqlite benchmark database");
+    RawSqliteFixture {
+        connection,
+        rows: rows.to_vec(),
+        _dir: dir,
+    }
+}
+
+pub(crate) fn seeded_fixture(rows: &[WorkloadRow]) -> RawSqliteFixture {
+    let mut fixture = empty_fixture(rows);
+    fixture.insert_all();
+    fixture
+}
+
+impl RawSqliteFixture {
+    pub(crate) fn insert_all(&mut self) -> usize {
+        let transaction = self
+            .connection
+            .transaction()
+            .expect("begin raw sqlite insert transaction");
+        let mut affected = 0;
+        {
+            let mut statement = transaction
+                .prepare_cached("INSERT INTO json_pointer (path, value) VALUES (?1, ?2)")
+                .expect("prepare raw sqlite insert");
+            for row in &self.rows {
+                affected += statement
+                    .execute(params![row.path, row.value_json])
+                    .expect("insert raw sqlite row");
+            }
+        }
+        transaction
+            .commit()
+            .expect("commit raw sqlite insert transaction");
+        assert_eq!(affected, self.rows.len());
+        affected
+    }
+
+    pub(crate) fn read_all(&self) -> usize {
+        let mut statement = self
+            .connection
+            .prepare_cached("SELECT path, value FROM json_pointer ORDER BY path")
+            .expect("prepare raw sqlite read all");
+        let mut query = statement.query([]).expect("query all raw sqlite rows");
+        let mut count = 0;
+        while let Some(row) = query.next().expect("read next raw sqlite row") {
+            let _: &str = row
+                .get_ref(0)
+                .expect("read raw sqlite path")
+                .as_str()
+                .expect("raw sqlite path must be text");
+            let _: &str = row
+                .get_ref(1)
+                .expect("read raw sqlite value")
+                .as_str()
+                .expect("raw sqlite value must be text");
+            count += 1;
+        }
+        assert_eq!(count, self.rows.len());
+        count
+    }
+
+    pub(crate) fn read_one_by_pk(&self) -> usize {
+        let row = &self.rows[self.rows.len() / 2];
+        let mut statement = self
+            .connection
+            .prepare_cached("SELECT path, value FROM json_pointer WHERE path = ?1")
+            .expect("prepare raw sqlite point read");
+        let mut query = statement
+            .query(params![row.path])
+            .expect("query raw sqlite point row");
+        let result = query
+            .next()
+            .expect("read raw sqlite point row")
+            .expect("raw sqlite point row must exist");
+        let _: &str = result
+            .get_ref(0)
+            .expect("read raw sqlite point path")
+            .as_str()
+            .expect("raw sqlite point path must be text");
+        let _: &str = result
+            .get_ref(1)
+            .expect("read raw sqlite point value")
+            .as_str()
+            .expect("raw sqlite point value must be text");
+        assert!(
+            query
+                .next()
+                .expect("finish raw sqlite point query")
+                .is_none()
+        );
+        1
+    }
+
+    pub(crate) fn read_many_by_pk(&self, count: usize) -> usize {
+        let count = count.min(self.rows.len());
+        let mut statement = self
+            .connection
+            .prepare_cached("SELECT path, value FROM json_pointer WHERE path = ?1")
+            .expect("prepare raw sqlite multi-point read");
+        let mut found = 0;
+        for row in &self.rows[..count] {
+            let mut query = statement
+                .query(params![row.path])
+                .expect("query raw sqlite multi-point row");
+            let result = query
+                .next()
+                .expect("read raw sqlite multi-point row")
+                .expect("raw sqlite multi-point row must exist");
+            let _: &str = result
+                .get_ref(0)
+                .expect("read raw sqlite multi-point path")
+                .as_str()
+                .expect("raw sqlite multi-point path must be text");
+            let _: &str = result
+                .get_ref(1)
+                .expect("read raw sqlite multi-point value")
+                .as_str()
+                .expect("raw sqlite multi-point value must be text");
+            found += 1;
+        }
+        assert_eq!(found, count);
+        found
+    }
+
+    pub(crate) fn update_all(&mut self) -> usize {
+        let transaction = self
+            .connection
+            .transaction()
+            .expect("begin raw sqlite update transaction");
+        let mut affected = 0;
+        {
+            let mut statement = transaction
+                .prepare_cached("UPDATE json_pointer SET value = ?1 WHERE path = ?2")
+                .expect("prepare raw sqlite update");
+            for row in &self.rows {
+                affected += statement
+                    .execute(params![row.updated_value_json, row.path])
+                    .expect("update raw sqlite row");
+            }
+        }
+        transaction
+            .commit()
+            .expect("commit raw sqlite update transaction");
+        assert_eq!(affected, self.rows.len());
+        affected
+    }
+
+    pub(crate) fn update_one_by_pk(&self) -> usize {
+        let row = &self.rows[self.rows.len() / 2];
+        let affected = self
+            .connection
+            .execute(
+                "UPDATE json_pointer SET value = ?1 WHERE path = ?2",
+                params![row.updated_value_json, row.path],
+            )
+            .expect("update one raw sqlite row");
+        assert_eq!(affected, 1);
+        affected
+    }
+
+    pub(crate) fn delete_all(&self) -> usize {
+        let affected = self
+            .connection
+            .execute("DELETE FROM json_pointer", [])
+            .expect("delete all raw sqlite rows");
+        assert_eq!(affected, self.rows.len());
+        affected
+    }
+
+    pub(crate) fn delete_one_by_pk(&self) -> usize {
+        let row = &self.rows[self.rows.len() / 2];
+        let affected = self
+            .connection
+            .execute(
+                "DELETE FROM json_pointer WHERE path = ?1",
+                params![row.path],
+            )
+            .expect("delete one raw sqlite row");
+        assert_eq!(affected, 1);
+        affected
+    }
+}

--- a/packages/engine/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine/benches/tracked_state_crud/sql_session.rs
@@ -107,10 +107,11 @@ where
 {
     #[expect(clippy::cast_possible_truncation)]
     async fn insert_all(&self) -> usize {
-        let mut affected = 0;
-        for sql in &self.insert_sql_chunks {
-            affected += execute(&self.session, sql).await.rows_affected();
-        }
+        let affected = Box::pin(execute_many_in_transaction(
+            &self.session,
+            &self.insert_sql_chunks,
+        ))
+        .await;
         assert_eq!(affected as usize, self.row_count);
         affected as usize
     }
@@ -135,10 +136,11 @@ where
 
     #[expect(clippy::cast_possible_truncation)]
     async fn update_all(&self) -> usize {
-        let mut affected = 0;
-        for sql in &self.update_all_sql_rows {
-            affected += execute(&self.session, sql).await.rows_affected();
-        }
+        let affected = Box::pin(execute_many_in_transaction(
+            &self.session,
+            &self.update_all_sql_rows,
+        ))
+        .await;
         assert_eq!(affected as usize, self.row_count);
         affected as usize
     }
@@ -250,6 +252,32 @@ where
         .execute(sql, &[])
         .await
         .expect("execute tracked-state crud SQL")
+}
+
+async fn execute_many_in_transaction<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    statements: &[String],
+) -> u64
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin tracked-state CRUD transaction");
+    let mut affected = 0;
+    for sql in statements {
+        affected += transaction
+            .execute(sql, &[])
+            .await
+            .expect("execute tracked-state CRUD transaction SQL")
+            .rows_affected();
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit tracked-state CRUD transaction");
+    affected
 }
 
 fn insert_rows_sql(rows: &[WorkloadRow]) -> String {

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -388,6 +388,7 @@ pub(crate) struct SchemaPlan {
     pub(crate) key: SchemaCatalogKey,
     pub(crate) schema: Arc<JsonValue>,
     pub(crate) compiled_schema: JSONSchema,
+    fast_object_validation: Option<FastObjectValidationPlan>,
     pub(crate) defaults: DefaultPlan,
     pub(crate) primary_key: Option<PointerGroup>,
     pub(crate) uniques: Vec<PointerGroup>,
@@ -396,6 +397,12 @@ pub(crate) struct SchemaPlan {
 }
 
 impl SchemaPlan {
+    pub(crate) fn accepts_row_content_fast(&self, value: &JsonValue) -> bool {
+        self.fast_object_validation
+            .as_ref()
+            .is_some_and(|plan| plan.accepts(value))
+    }
+
     fn compile(
         key: SchemaCatalogKey,
         schema: JsonValue,
@@ -403,6 +410,7 @@ impl SchemaPlan {
         schema_index: &BTreeMap<SchemaCatalogKey, &JsonValue>,
     ) -> Result<Self, LixError> {
         let compiled_schema = compile_lix_schema(&schema)?;
+        let fast_object_validation = FastObjectValidationPlan::compile(&schema);
         let defaults = DefaultPlan::from_schema(&schema);
         let primary_key = primary_key_paths(&schema)?;
         let uniques = pointer_groups(&schema, "x-lix-unique")?;
@@ -418,12 +426,174 @@ impl SchemaPlan {
             key,
             schema: Arc::new(schema),
             compiled_schema,
+            fast_object_validation,
             defaults,
             primary_key,
             uniques,
             foreign_keys,
             state_foreign_keys,
         })
+    }
+}
+
+#[derive(Debug)]
+struct FastObjectValidationPlan {
+    properties: BTreeMap<String, FastJsonTypes>,
+    required: Vec<String>,
+    additional_properties: bool,
+}
+
+impl FastObjectValidationPlan {
+    fn compile(schema: &JsonValue) -> Option<Self> {
+        let schema = schema.as_object()?;
+        if schema.get("type")?.as_str()? != "object" {
+            return None;
+        }
+        if schema.keys().any(|key| !fast_object_root_keyword(key)) {
+            return None;
+        }
+        let mut properties = BTreeMap::new();
+        if let Some(property_schemas) = schema.get("properties") {
+            for (name, schema) in property_schemas.as_object()? {
+                properties.insert(name.clone(), FastJsonTypes::compile_property(schema)?);
+            }
+        }
+        let required = if let Some(required) = schema.get("required") {
+            required
+                .as_array()?
+                .iter()
+                .map(|name| name.as_str().map(str::to_string))
+                .collect::<Option<Vec<_>>>()?
+        } else {
+            Vec::new()
+        };
+        let additional_properties = if let Some(value) = schema.get("additionalProperties") {
+            value.as_bool()?
+        } else {
+            true
+        };
+        Some(Self {
+            properties,
+            required,
+            additional_properties,
+        })
+    }
+
+    fn accepts(&self, value: &JsonValue) -> bool {
+        let Some(value) = value.as_object() else {
+            return false;
+        };
+        if self
+            .required
+            .iter()
+            .any(|required| !value.contains_key(required))
+        {
+            return false;
+        }
+        value.iter().all(|(name, value)| {
+            self.properties
+                .get(name)
+                .map_or(self.additional_properties, |types| types.accepts(value))
+        })
+    }
+}
+
+fn fast_object_root_keyword(key: &str) -> bool {
+    matches!(
+        key,
+        "type"
+            | "properties"
+            | "required"
+            | "additionalProperties"
+            | "description"
+            | "examples"
+            | "$schema"
+    ) || key.starts_with("x-lix-")
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FastJsonTypes(u16);
+
+impl FastJsonTypes {
+    const NULL: u16 = 1 << 0;
+    const BOOLEAN: u16 = 1 << 1;
+    const NUMBER: u16 = 1 << 2;
+    const INTEGER: u16 = 1 << 3;
+    const STRING: u16 = 1 << 4;
+    const ARRAY: u16 = 1 << 5;
+    const OBJECT: u16 = 1 << 6;
+    const ANY: Self = Self(
+        Self::NULL
+            | Self::BOOLEAN
+            | Self::NUMBER
+            | Self::INTEGER
+            | Self::STRING
+            | Self::ARRAY
+            | Self::OBJECT,
+    );
+
+    fn compile_property(schema: &JsonValue) -> Option<Self> {
+        let schema = schema.as_object()?;
+        if schema.keys().any(|key| {
+            !matches!(
+                key.as_str(),
+                "type" | "anyOf" | "description" | "examples" | "default" | "x-lix-default"
+            )
+        }) {
+            return None;
+        }
+        match (schema.get("type"), schema.get("anyOf")) {
+            (Some(types), None) => Self::compile_types(types),
+            (None, Some(options)) => {
+                let mut mask = 0;
+                for option in options.as_array()? {
+                    mask |= Self::compile_property(option)?.0;
+                }
+                Some(Self(mask))
+            }
+            (None, None) => Some(Self::ANY),
+            (Some(_), Some(_)) => None,
+        }
+    }
+
+    fn compile_types(types: &JsonValue) -> Option<Self> {
+        let mut mask = 0;
+        if let Some(value) = types.as_str() {
+            mask |= Self::type_bit(value)?;
+        } else {
+            for value in types.as_array()? {
+                mask |= Self::type_bit(value.as_str()?)?;
+            }
+        }
+        Some(Self(mask))
+    }
+
+    fn type_bit(value: &str) -> Option<u16> {
+        Some(match value {
+            "null" => Self::NULL,
+            "boolean" => Self::BOOLEAN,
+            "number" => Self::NUMBER,
+            "integer" => Self::INTEGER,
+            "string" => Self::STRING,
+            "array" => Self::ARRAY,
+            "object" => Self::OBJECT,
+            _ => return None,
+        })
+    }
+
+    fn accepts(self, value: &JsonValue) -> bool {
+        let bit = match value {
+            JsonValue::Null => Self::NULL,
+            JsonValue::Bool(_) => Self::BOOLEAN,
+            JsonValue::Number(number) if number.is_i64() || number.is_u64() => {
+                Self::NUMBER | Self::INTEGER
+            }
+            JsonValue::Number(_) => Self::NUMBER,
+            JsonValue::String(_) => Self::STRING,
+            JsonValue::Array(_) => Self::ARRAY,
+            JsonValue::Object(_) => Self::OBJECT,
+        };
+        self.0 & bit != 0
     }
 }
 
@@ -1022,6 +1192,52 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn fast_object_validation_accepts_key_value_rows_and_rejects_invalid_shapes() {
+        let schema = crate::schema::seed_schema_definition("lix_key_value")
+            .expect("key-value schema should exist");
+        let plan = SchemaPlan::compile(
+            SchemaCatalogKey {
+                schema_key: "lix_key_value".to_string(),
+            },
+            schema.clone(),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect("key-value schema should compile");
+
+        for value in [
+            json!({"key": "a", "value": null}),
+            json!({"key": "a", "value": {"nested": true}}),
+            json!({"key": "a", "value": [1, 2, 3]}),
+        ] {
+            assert!(plan.accepts_row_content_fast(&value));
+            assert!(plan.compiled_schema.is_valid(&value));
+        }
+        for value in [
+            json!({"key": "a"}),
+            json!({"key": 1, "value": null}),
+            json!({"key": "a", "value": null, "extra": true}),
+        ] {
+            assert!(!plan.accepts_row_content_fast(&value));
+            assert!(!plan.compiled_schema.is_valid(&value));
+        }
+    }
+
+    #[test]
+    fn fast_object_validation_declines_unsupported_keywords() {
+        let schema = json!({
+            "x-lix-key": "patterned",
+            "type": "object",
+            "properties": {
+                "id": {"type": "string", "pattern": "^[a-z]+$"}
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        });
+        assert!(FastObjectValidationPlan::compile(&schema).is_none());
+    }
 
     #[test]
     fn catalog_rejects_same_schema_key_from_multiple_domains() {

--- a/packages/engine/src/common/error.rs
+++ b/packages/engine/src/common/error.rs
@@ -83,6 +83,9 @@ impl LixError {
     /// Storage I/O failed.
     pub const CODE_STORAGE_ERROR: &'static str = "LIX_STORAGE_ERROR";
 
+    /// Optimistic transaction publication lost a race with a newer commit.
+    pub const CODE_TRANSACTION_CONFLICT: &'static str = "LIX_TRANSACTION_CONFLICT";
+
     /// An internal engine invariant failed.
     pub const CODE_INTERNAL_ERROR: &'static str = "LIX_INTERNAL_ERROR";
 
@@ -291,13 +294,24 @@ impl LixError {
 
 impl From<crate::storage_adapter::StorageError> for LixError {
     fn from(error: crate::storage_adapter::StorageError) -> Self {
-        Self::new(Self::CODE_STORAGE_ERROR, error.to_string())
+        match error {
+            crate::storage_adapter::StorageError::WriteConflict
+            | crate::storage_adapter::StorageError::PreconditionFailed(_) => Self::new(
+                Self::CODE_TRANSACTION_CONFLICT,
+                "transaction snapshot is stale because tracked state changed before commit",
+            )
+            .with_hint("Retry the transaction against the latest committed state."),
+            error => Self::new(Self::CODE_STORAGE_ERROR, error.to_string()),
+        }
     }
 }
 
 impl From<crate::storage_adapter::StorageWriteSetError> for LixError {
     fn from(error: crate::storage_adapter::StorageWriteSetError) -> Self {
-        Self::new(Self::CODE_STORAGE_ERROR, error.to_string())
+        match error {
+            crate::storage_adapter::StorageWriteSetError::Storage(error) => error.into(),
+            error => Self::new(Self::CODE_STORAGE_ERROR, error.to_string()),
+        }
     }
 }
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1550,8 +1550,7 @@ where
         sql: &str,
         params: &[Value],
     ) -> Result<ExecuteResult, LixError> {
-        self.execute_with_options(sql, params, ExecuteOptions::default())
-            .await
+        Box::pin(self.execute_with_options(sql, params, ExecuteOptions::default())).await
     }
 
     pub async fn execute_with_options(
@@ -1566,9 +1565,24 @@ where
             let _operation_guard = self.begin_session_operation()?;
             let statement = self.sql_planning_cache.parse_statement(sql)?;
             let transaction = self.transaction_mut()?;
-            execute_transaction_statement(transaction, sql, statement, params, options)
-                .await
-                .map_err(|error| normalize_sql_surface_error(error, sql))
+            let is_read = matches!(
+                sql2::bind_statement_route(&statement)?,
+                sql2::BoundStatementRoute::Read
+            );
+            if is_read {
+                transaction.ensure_opening_snapshot_is_current().await?;
+            }
+            let result =
+                execute_transaction_statement(transaction, sql, statement, params, options)
+                    .await
+                    .map_err(|error| normalize_sql_surface_error(error, sql))?;
+            if is_read {
+                // The query opens its own coherent storage read. Checking on both sides
+                // ensures a concurrent tracked commit cannot leak a newer snapshot
+                // through an older explicit transaction.
+                transaction.ensure_opening_snapshot_is_current().await?;
+            }
+            Ok(result)
         };
         let result = match telemetry.as_ref() {
             Some(telemetry) => telemetry.instrument(operation).await,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -5,7 +5,7 @@ use serde_json::Value as JsonValue;
 use crate::changelog::CommitId;
 use crate::common::validate_row_metadata;
 use crate::entity_pk::EntityPk;
-use crate::live_state::{LiveStateFilter, LiveStateScanRequest};
+use crate::live_state::{LiveStateFilter, LiveStateRowFilter, LiveStateScanRequest};
 use crate::sql2::SqlWriteExecutionContext;
 use crate::sql2::bind::expr::{BoundCastType, BoundExpr, BoundLiteral};
 use crate::sql2::bind::write::{
@@ -561,7 +561,7 @@ async fn entity_update(
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
 ) -> Result<u64, LixError> {
-    let candidates = scan_entity_candidates(ctx, plan, spec).await?;
+    let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
     let mut write_rows = Vec::new();
     for candidate in candidates {
         let Some(snapshot) = candidate_snapshot(&candidate)? else {
@@ -636,7 +636,7 @@ async fn entity_delete(
     params: &[Value],
     active_branch_commit_id: Option<&CommitId>,
 ) -> Result<SqlWriteResult, LixError> {
-    let candidates = scan_entity_candidates(ctx, plan, spec).await?;
+    let candidates = scan_entity_candidates(ctx, plan, spec, params).await?;
     let mut write_rows = Vec::new();
     let mut returning_rows = plan.bound.returning.as_ref().map(|_| Vec::new());
     for candidate in candidates {
@@ -1047,9 +1047,10 @@ async fn scan_entity_candidates(
     ctx: &mut dyn SqlWriteExecutionContext,
     plan: &LogicalWritePlan,
     spec: &EntitySurfaceSpec,
+    params: &[Value],
 ) -> Result<Vec<crate::live_state::MaterializedLiveStateRow>, LixError> {
     let branch_ids = scan_branch_ids(&plan.bound.branch_scope)?;
-    let request = LiveStateScanRequest {
+    let mut request = LiveStateScanRequest {
         filter: LiveStateFilter {
             schema_keys: vec![spec.schema_key.clone()],
             branch_ids,
@@ -1058,7 +1059,215 @@ async fn scan_entity_candidates(
         },
         ..LiveStateScanRequest::default()
     };
+    if let Some(entity_pks) =
+        bound_entity_pks_from_primary_key_predicate(spec, &plan.bound.predicate, params)
+    {
+        if entity_pks.is_empty() {
+            request.filter.rows = LiveStateRowFilter::None;
+        }
+        request.filter.entity_pks = entity_pks;
+    }
     ctx.scan_live_state(&request).await
+}
+
+fn bound_entity_pks_from_primary_key_predicate(
+    spec: &EntitySurfaceSpec,
+    predicate: &BoundPredicate,
+    params: &[Value],
+) -> Option<Vec<EntityPk>> {
+    let primary_key_columns = spec
+        .primary_key_paths
+        .iter()
+        .map(|path| {
+            let [column_name] = path.as_slice() else {
+                return None;
+            };
+            spec.visible_column(column_name)
+                .filter(|column| column.column_type == EntityColumnType::String)
+                .map(|column| column.name.as_str())
+        })
+        .collect::<Option<Vec<_>>>()?;
+    if primary_key_columns.is_empty() {
+        return None;
+    }
+    let analyzer = BoundPrimaryKeyAnalyzer {
+        primary_key_columns,
+        params,
+    };
+    analyzer
+        .analyze_conjunctive_constraint(predicate)?
+        .into_entity_pks(&analyzer.primary_key_columns)
+        .map(|entity_pks| entity_pks.into_iter().collect())
+}
+
+struct BoundPrimaryKeyAnalyzer<'a> {
+    primary_key_columns: Vec<&'a str>,
+    params: &'a [Value],
+}
+
+#[derive(Clone)]
+enum BoundPrimaryKeyConstraint {
+    Full(std::collections::BTreeSet<EntityPk>),
+    Parts(std::collections::BTreeMap<String, std::collections::BTreeSet<String>>),
+}
+
+impl BoundPrimaryKeyAnalyzer<'_> {
+    /// Extracts identity constraints that are guaranteed conjuncts. A partial
+    /// disjunction is never routed because doing so could omit matching rows.
+    fn analyze_conjunctive_constraint(
+        &self,
+        predicate: &BoundPredicate,
+    ) -> Option<BoundPrimaryKeyConstraint> {
+        match predicate {
+            BoundPredicate::And(predicates) => {
+                let mut constraint: Option<BoundPrimaryKeyConstraint> = None;
+                for predicate in predicates {
+                    let Some(next) = self.analyze_conjunctive_constraint(predicate) else {
+                        continue;
+                    };
+                    constraint = Some(match constraint {
+                        Some(current) => current.intersect(next, &self.primary_key_columns),
+                        None => next,
+                    });
+                }
+                constraint
+            }
+            BoundPredicate::Or(predicates) => {
+                let mut entity_pks = std::collections::BTreeSet::new();
+                for predicate in predicates {
+                    entity_pks.extend(
+                        self.analyze_conjunctive_constraint(predicate)?
+                            .into_entity_pks(&self.primary_key_columns)?,
+                    );
+                }
+                Some(BoundPrimaryKeyConstraint::Full(entity_pks))
+            }
+            BoundPredicate::Eq(left, right) => self
+                .column_value_constraint(left, right)
+                .or_else(|| self.column_value_constraint(right, left)),
+            BoundPredicate::In { expr, values } => {
+                let BoundExpr::Column(column) = expr else {
+                    return None;
+                };
+                if !self.primary_key_columns.contains(&column.name.as_str()) {
+                    return None;
+                }
+                let values = values
+                    .iter()
+                    .map(|value| bound_primary_key_string(value, self.params))
+                    .collect::<Option<std::collections::BTreeSet<_>>>()?;
+                if values.is_empty() {
+                    return None;
+                }
+                Some(BoundPrimaryKeyConstraint::Parts(
+                    std::collections::BTreeMap::from([(column.name.clone(), values)]),
+                ))
+            }
+            BoundPredicate::True
+            | BoundPredicate::False
+            | BoundPredicate::Like { .. }
+            | BoundPredicate::IsNull(_)
+            | BoundPredicate::IsNotNull(_) => None,
+        }
+    }
+
+    fn column_value_constraint(
+        &self,
+        column_expr: &BoundExpr,
+        value_expr: &BoundExpr,
+    ) -> Option<BoundPrimaryKeyConstraint> {
+        let BoundExpr::Column(column) = column_expr else {
+            return None;
+        };
+        if !self.primary_key_columns.contains(&column.name.as_str()) {
+            return None;
+        }
+        let value = bound_primary_key_string(value_expr, self.params)?;
+        Some(BoundPrimaryKeyConstraint::Parts(
+            std::collections::BTreeMap::from([(
+                column.name.clone(),
+                std::collections::BTreeSet::from([value]),
+            )]),
+        ))
+    }
+}
+
+impl BoundPrimaryKeyConstraint {
+    fn intersect(self, other: Self, primary_key_columns: &[&str]) -> Self {
+        match (self, other) {
+            (Self::Full(left), Self::Full(right)) => {
+                Self::Full(left.intersection(&right).cloned().collect())
+            }
+            (Self::Full(ids), Self::Parts(parts)) | (Self::Parts(parts), Self::Full(ids)) => {
+                Self::Full(
+                    ids.into_iter()
+                        .filter(|identity| {
+                            identity.parts.len() == primary_key_columns.len()
+                                && primary_key_columns
+                                    .iter()
+                                    .enumerate()
+                                    .all(|(index, column)| {
+                                        parts.get(*column).is_none_or(|values| {
+                                            values.contains(&identity.parts[index])
+                                        })
+                                    })
+                        })
+                        .collect(),
+                )
+            }
+            (Self::Parts(mut left), Self::Parts(right)) => {
+                for (column, right_values) in right {
+                    left.entry(column)
+                        .and_modify(|left_values| {
+                            *left_values =
+                                left_values.intersection(&right_values).cloned().collect();
+                        })
+                        .or_insert(right_values);
+                }
+                Self::Parts(left)
+            }
+        }
+    }
+
+    fn into_entity_pks(
+        self,
+        primary_key_columns: &[&str],
+    ) -> Option<std::collections::BTreeSet<EntityPk>> {
+        match self {
+            Self::Full(entity_pks) => Some(entity_pks),
+            Self::Parts(parts) => {
+                let mut combinations = vec![Vec::new()];
+                for column in primary_key_columns {
+                    let values = parts.get(*column)?;
+                    let mut next = Vec::with_capacity(combinations.len() * values.len());
+                    for prefix in &combinations {
+                        for value in values {
+                            let mut combination = prefix.clone();
+                            combination.push(value.clone());
+                            next.push(combination);
+                        }
+                    }
+                    combinations = next;
+                }
+                combinations
+                    .into_iter()
+                    .map(EntityPk::from_parts)
+                    .collect::<Result<std::collections::BTreeSet<_>, _>>()
+                    .ok()
+            }
+        }
+    }
+}
+
+fn bound_primary_key_string(expr: &BoundExpr, params: &[Value]) -> Option<String> {
+    match expr {
+        BoundExpr::Literal(BoundLiteral::Text(value)) => Some(value.clone()),
+        BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
+            Some(Value::Text(value)) => Some(value.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 struct InsertRowLayout {
@@ -2797,5 +3006,132 @@ fn entity_action(op: &BoundWriteOp) -> &'static str {
         BoundWriteOp::Insert => "INSERT into entity surface",
         BoundWriteOp::Update => "UPDATE entity surface",
         BoundWriteOp::Delete => "DELETE from entity surface",
+    }
+}
+
+#[cfg(test)]
+mod primary_key_route_tests {
+    use super::*;
+    use crate::sql2::bind::expr::{BoundColumnRef, BoundParamRef};
+
+    #[test]
+    fn routes_literal_and_parameter_primary_keys() {
+        let analyzer = BoundPrimaryKeyAnalyzer {
+            primary_key_columns: vec!["id"],
+            params: &[Value::Text("from-param".to_string())],
+        };
+        let predicate = BoundPredicate::Or(vec![
+            equals(column("id"), text("literal")),
+            equals(column("id"), BoundExpr::Param(BoundParamRef { index: 1 })),
+        ]);
+
+        assert_eq!(
+            analyzer
+                .analyze_conjunctive_constraint(&predicate)
+                .expect("identity predicate should route")
+                .into_entity_pks(&analyzer.primary_key_columns)
+                .expect("identity predicate should be complete"),
+            std::collections::BTreeSet::from([
+                EntityPk::single("from-param"),
+                EntityPk::single("literal"),
+            ])
+        );
+    }
+
+    #[test]
+    fn routes_guaranteed_conjunct_but_not_partial_disjunction() {
+        let analyzer = BoundPrimaryKeyAnalyzer {
+            primary_key_columns: vec!["id"],
+            params: &[],
+        };
+        let conjunct = BoundPredicate::And(vec![
+            equals(column("id"), text("entity-a")),
+            equals(column("kind"), text("note")),
+        ]);
+        assert_eq!(
+            analyzer
+                .analyze_conjunctive_constraint(&conjunct)
+                .expect("guaranteed identity conjunct should route")
+                .into_entity_pks(&analyzer.primary_key_columns)
+                .expect("identity conjunct should be complete"),
+            std::collections::BTreeSet::from([EntityPk::single("entity-a")])
+        );
+
+        let disjunction = BoundPredicate::Or(vec![
+            equals(column("id"), text("entity-a")),
+            equals(column("kind"), text("note")),
+        ]);
+        assert!(
+            analyzer
+                .analyze_conjunctive_constraint(&disjunction)
+                .is_none(),
+            "a partially routable disjunction must retain the full scan"
+        );
+    }
+
+    #[test]
+    fn routes_composite_primary_key_in_declared_order() {
+        let analyzer = BoundPrimaryKeyAnalyzer {
+            primary_key_columns: vec!["namespace", "id"],
+            params: &[],
+        };
+        let predicate = BoundPredicate::And(vec![
+            BoundPredicate::In {
+                expr: column("id"),
+                values: vec![text("one"), text("two")],
+            },
+            equals(column("namespace"), text("docs")),
+        ]);
+
+        assert_eq!(
+            analyzer
+                .analyze_conjunctive_constraint(&predicate)
+                .expect("composite predicate should route")
+                .into_entity_pks(&analyzer.primary_key_columns)
+                .expect("composite predicate should be complete"),
+            std::collections::BTreeSet::from([
+                EntityPk::from_parts(vec!["docs".to_string(), "one".to_string()])
+                    .expect("valid entity pk"),
+                EntityPk::from_parts(vec!["docs".to_string(), "two".to_string()])
+                    .expect("valid entity pk"),
+            ])
+        );
+    }
+
+    #[test]
+    fn contradictory_primary_key_conjunct_routes_empty() {
+        let analyzer = BoundPrimaryKeyAnalyzer {
+            primary_key_columns: vec!["id"],
+            params: &[],
+        };
+        let predicate = BoundPredicate::And(vec![
+            equals(column("id"), text("one")),
+            equals(column("id"), text("two")),
+        ]);
+
+        assert!(
+            analyzer
+                .analyze_conjunctive_constraint(&predicate)
+                .expect("contradictory identity should still route")
+                .into_entity_pks(&analyzer.primary_key_columns)
+                .expect("identity predicate should be complete")
+                .is_empty()
+        );
+    }
+
+    fn equals(left: BoundExpr, right: BoundExpr) -> BoundPredicate {
+        BoundPredicate::Eq(left, right)
+    }
+
+    fn column(name: &str) -> BoundExpr {
+        BoundExpr::Column(BoundColumnRef {
+            table: "entity".to_string(),
+            column_id: 0,
+            name: name.to_string(),
+        })
+    }
+
+    fn text(value: &str) -> BoundExpr {
+        BoundExpr::Literal(BoundLiteral::Text(value.to_string()))
     }
 }

--- a/packages/engine/src/storage/conformance/baseline.rs
+++ b/packages/engine/src/storage/conformance/baseline.rs
@@ -14,9 +14,9 @@ use crate::storage::conformance::{
     open_storage,
 };
 use crate::storage::{
-    CoreProjection, GetOptions, Key, KeyRange, MAX_SCAN_PAGE_ROWS, ProjectedValue, ReadEntry,
-    ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage, StorageError, StorageRead, StorageWrite,
-    WriteOptions,
+    CoreProjection, GetOptions, Key, KeyRange, MAX_SCAN_PAGE_ROWS, Precondition, ProjectedValue,
+    ReadEntry, ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage, StorageError, StorageRead,
+    StorageWrite, WriteOptions,
 };
 
 pub(crate) async fn register<F>(report: &mut ConformanceReport, factory: &F)
@@ -106,6 +106,10 @@ where
     );
     run!("baseline::commit_is_atomic", commit_is_atomic);
     run!(
+        "baseline::write_precondition_rejects_stale_value",
+        write_precondition_rejects_stale_value
+    );
+    run!(
         "baseline::rollback_discards_staged_mutations",
         rollback_discards_staged_mutations
     );
@@ -125,6 +129,94 @@ where
         "baseline::full_value_preserves_opaque_bytes",
         full_value_preserves_opaque_bytes
     );
+}
+
+async fn write_precondition_rejects_stale_value<F>(factory: &F) -> ConformanceResult
+where
+    F: StorageFactory,
+{
+    let storage = open_storage(factory).await;
+    let test_space = TEST_SPACE;
+    let target = key("target");
+    seed_full_values(&storage, test_space, [("target", "base")]).await?;
+
+    let mut conditional = storage
+        .begin_write(WriteOptions {
+            preconditions: vec![Precondition::KeyValueEquals {
+                space: test_space,
+                key: target.clone(),
+                expected: Bytes::from_static(b"base"),
+            }],
+            ..WriteOptions::default()
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    conditional
+        .put_many(
+            test_space,
+            put_batch([full_put(target.clone(), Bytes::from_static(b"conditional"))]),
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+    conditional
+        .commit()
+        .await
+        .map_err(|error| error.to_string())?;
+
+    let stale_options = WriteOptions {
+        preconditions: vec![Precondition::KeyValueEquals {
+            space: test_space,
+            key: target.clone(),
+            expected: Bytes::from_static(b"conditional"),
+        }],
+        ..WriteOptions::default()
+    };
+    seed_full_values(&storage, test_space, [("target", "winner")]).await?;
+
+    match storage.begin_write(stale_options).await {
+        Err(StorageError::PreconditionFailed(failures)) => {
+            assert_eq!(failures.len(), 1);
+            assert_eq!(failures[0].index, 0);
+        }
+        Err(error) => return Err(error.to_string()),
+        Ok(mut stale) => {
+            stale
+                .put_many(
+                    test_space,
+                    put_batch([full_put(target.clone(), Bytes::from_static(b"stale"))]),
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+            match stale.commit().await {
+                Err(StorageError::PreconditionFailed(failures)) => {
+                    assert_eq!(failures.len(), 1);
+                    assert_eq!(failures[0].index, 0);
+                }
+                Err(error) => return Err(error.to_string()),
+                Ok(_) => panic!("stale conditional write unexpectedly committed"),
+            }
+        }
+    }
+
+    let read = storage
+        .begin_read(ReadOptions::default())
+        .await
+        .map_err(|error| error.to_string())?;
+    let value = read
+        .get_many(
+            test_space,
+            std::slice::from_ref(&target),
+            GetOptions::default(),
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+    assert_eq!(
+        value.values,
+        vec![Some(ProjectedValue::FullValue(Bytes::from_static(
+            b"winner"
+        )))]
+    );
+    Ok(())
 }
 
 async fn get_many_returns_requested_slots<F>(factory: &F) -> ConformanceResult

--- a/packages/engine/src/storage/conformance/failure_tests.rs
+++ b/packages/engine/src/storage/conformance/failure_tests.rs
@@ -13,9 +13,10 @@ use super::{
     ConformanceStatus, StorageFactory, StorageFixture, StorageTestConfig, run_storage_conformance,
 };
 use crate::storage::{
-    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, ProjectedValue,
-    PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage, StorageError,
-    StorageRead, StorageWrite, StoredValue, WriteOptions, WriteStats,
+    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, Precondition,
+    PreconditionFailure, ProjectedValue, PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions,
+    SpaceId, Storage, StorageError, StorageRead, StorageWrite, StoredValue, WriteOptions,
+    WriteStats,
 };
 
 type BrokenMap = BTreeMap<Key, Bytes>;
@@ -69,6 +70,7 @@ struct BrokenWrite {
     mode: BrokenMode,
     parent: Arc<Mutex<BrokenMap>>,
     commit_count: Arc<Mutex<u64>>,
+    preconditions: Vec<Precondition>,
     staged: BrokenMap,
 }
 
@@ -285,13 +287,14 @@ impl Storage for BrokenStorage {
 
     fn begin_write(
         &self,
-        _opts: WriteOptions,
+        opts: WriteOptions,
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
             Ok(BrokenWrite {
                 mode: self.mode,
                 parent: Arc::clone(&self.entries),
                 commit_count: Arc::clone(&self.commit_count),
+                preconditions: opts.preconditions,
                 staged: self.snapshot()?,
             })
         }
@@ -461,11 +464,32 @@ impl StorageWrite for BrokenWrite {
 
     fn commit(self) -> impl Future<Output = Result<CommitResult, StorageError>> + Send {
         async move {
-            *self
+            let mut parent = self
                 .parent
                 .lock()
-                .map_err(|_| StorageError::Io("broken storage lock poisoned".to_string()))? =
-                self.staged;
+                .map_err(|_| StorageError::Io("broken storage lock poisoned".to_string()))?;
+            let failures = self
+                .preconditions
+                .iter()
+                .enumerate()
+                .filter_map(|(index, precondition)| {
+                    let matches = match precondition {
+                        Precondition::KeyValueEquals {
+                            space,
+                            key,
+                            expected,
+                        } => parent
+                            .get(&broken_physical_key(*space, key))
+                            .is_some_and(|value| value == expected),
+                        _ => false,
+                    };
+                    (!matches).then_some(PreconditionFailure { index })
+                })
+                .collect::<Vec<_>>();
+            if !failures.is_empty() {
+                return Err(StorageError::PreconditionFailed(failures));
+            }
+            *parent = self.staged;
             *self.commit_count.lock().map_err(|_| {
                 StorageError::Io("broken storage commit lock poisoned".to_string())
             })? += 1;

--- a/packages/engine/src/storage/conformance/mod.rs
+++ b/packages/engine/src/storage/conformance/mod.rs
@@ -59,6 +59,7 @@ mod tests {
                 "baseline::scan_cursor_drains_multi_chunk_limits",
                 "baseline::scan_range_empty_range_returns_empty_chunk",
                 "baseline::commit_is_atomic",
+                "baseline::write_precondition_rejects_stale_value",
                 "baseline::rollback_discards_staged_mutations",
                 "baseline::rollback_discards_overwrite_and_delete",
                 "baseline::begin_read_pins_coherent_view",

--- a/packages/engine/src/storage/error.rs
+++ b/packages/engine/src/storage/error.rs
@@ -45,6 +45,11 @@ pub enum Precondition {
         key: Key,
         hash: [u8; 32],
     },
+    KeyValueEquals {
+        space: SpaceId,
+        key: Key,
+        expected: Bytes,
+    },
     RangeEmpty {
         space: SpaceId,
         range: KeyRange,

--- a/packages/engine/src/storage/in_memory.rs
+++ b/packages/engine/src/storage/in_memory.rs
@@ -6,9 +6,10 @@ use bytes::Bytes;
 
 use crate::storage::conformance::{StorageFactory, StorageFixture, StorageTestConfig};
 use crate::storage::{
-    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, ProjectedValue,
-    PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage, StorageError,
-    StorageRead, StorageWrite, StoredValue, WriteOptions, WriteStats,
+    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, Precondition,
+    PreconditionFailure, ProjectedValue, PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions,
+    SpaceId, Storage, StorageError, StorageRead, StorageWrite, StoredValue, WriteOptions,
+    WriteStats,
 };
 
 type InMemoryMap = BTreeMap<Key, Bytes>;
@@ -81,6 +82,7 @@ pub struct MemoryRead {
 pub struct MemoryWrite {
     parent: Arc<Mutex<Arc<EntriesState>>>,
     base: Arc<EntriesState>,
+    preconditions: Vec<Precondition>,
     overlay: EntriesOverlay,
     stats: WriteStats,
 }
@@ -310,10 +312,11 @@ impl Storage for Memory {
         })
     }
 
-    async fn begin_write(&self, _opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+    async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
         Ok(MemoryWrite {
             parent: Arc::clone(&self.entries),
             base: self.snapshot()?,
+            preconditions: opts.preconditions,
             overlay: EntriesOverlay::default(),
             stats: WriteStats::default(),
         })
@@ -432,6 +435,7 @@ impl StorageWrite for MemoryWrite {
             .parent
             .lock()
             .map_err(|_| StorageError::Io("in-memory storage lock poisoned".to_string()))?;
+        check_preconditions(&parent, &self.preconditions)?;
         let base = if Arc::ptr_eq(&parent, &self.base) {
             self.base
         } else {
@@ -458,6 +462,54 @@ impl StorageWrite for MemoryWrite {
 
     async fn rollback(self) -> Result<(), StorageError> {
         Ok(())
+    }
+}
+
+fn check_preconditions(
+    entries: &EntriesState,
+    preconditions: &[Precondition],
+) -> Result<(), StorageError> {
+    let failures = preconditions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, precondition)| {
+            let matches = match precondition {
+                Precondition::KeyAbsent { space, key } => {
+                    entries.get(&physical_key(*space, key)).is_none()
+                }
+                Precondition::KeyPresent { space, key } => {
+                    entries.get(&physical_key(*space, key)).is_some()
+                }
+                Precondition::KeyValueHashEquals { space, key, hash } => entries
+                    .get(&physical_key(*space, key))
+                    .is_some_and(|value| blake3::hash(value).as_bytes() == hash),
+                Precondition::KeyValueEquals {
+                    space,
+                    key,
+                    expected,
+                } => entries
+                    .get(&physical_key(*space, key))
+                    .is_some_and(|value| value == expected),
+                Precondition::RangeEmpty { space, range } => collect_range_chunk(
+                    entries,
+                    physical_range(*space, range.clone()),
+                    &ScanOptions {
+                        limit_rows: 1,
+                        projection: CoreProjection::KeyOnly,
+                        resume_after: None,
+                    },
+                )
+                .entries
+                .is_empty(),
+                Precondition::BranchEquals { .. } => false,
+            };
+            (!matches).then_some(PreconditionFailure { index })
+        })
+        .collect::<Vec<_>>();
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(StorageError::PreconditionFailed(failures))
     }
 }
 

--- a/packages/engine/src/storage/types.rs
+++ b/packages/engine/src/storage/types.rs
@@ -2,7 +2,7 @@ use std::ops::Bound;
 
 use bytes::Bytes;
 
-use crate::storage::StorageError;
+use crate::storage::{Precondition, StorageError};
 
 /// Maximum number of owned rows returned by one storage scan page.
 pub const MAX_SCAN_PAGE_ROWS: usize = 1024;
@@ -102,6 +102,9 @@ pub enum ReadConsistency {
 pub struct WriteOptions {
     pub base_snapshot: Option<SnapshotRef>,
     pub idempotency_key: Option<Bytes>,
+    /// Conditions evaluated atomically against the state immediately before
+    /// this write becomes visible.
+    pub preconditions: Vec<Precondition>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/engine/src/storage_adapter/context.rs
+++ b/packages/engine/src/storage_adapter/context.rs
@@ -4,16 +4,16 @@ use bytes::Bytes;
 use tracing::Instrument as _;
 
 use crate::storage::{
-    CommitResult, CoreProjection, GetOptions, Key, KeyRange, Memory, Prefix, ProjectedValue,
-    PutBatch, PutEntry, ReadOptions, Storage, StorageError, StorageWrite, StoredValue,
-    WriteOptions,
+    CommitResult, CoreProjection, GetOptions, Key, KeyRange, Memory, Precondition, Prefix,
+    ProjectedValue, PutBatch, PutEntry, ReadOptions, Storage, StorageError, StorageWrite,
+    StoredValue, WriteOptions,
 };
 use crate::storage_adapter::{
     StorageAdapterRead, StorageAdapterReadScope, StorageSpace, StorageWriteSet,
     StorageWriteSetError, StorageWriteSetStats,
 };
 
-use super::spaces::MUTATION_REVISION_SPACE;
+use super::spaces::{MUTATION_REVISION_SPACE, TRACKED_MUTATION_REVISION_SPACE};
 
 const MUTATION_REVISION_KEY: &[u8] = b"global";
 
@@ -125,6 +125,28 @@ where
         Self::load_mutation_revision_from_read(&StorageAdapterReadScope::new(read)).await
     }
 
+    pub(crate) fn tracked_mutation_revision_precondition(expected: Option<Bytes>) -> Precondition {
+        expected.map_or_else(
+            || Precondition::KeyAbsent {
+                space: TRACKED_MUTATION_REVISION_SPACE.id,
+                key: mutation_revision_key(),
+            },
+            |expected| Precondition::KeyValueEquals {
+                space: TRACKED_MUTATION_REVISION_SPACE.id,
+                key: mutation_revision_key(),
+                expected,
+            },
+        )
+    }
+
+    pub(crate) fn stage_tracked_mutation_revision(write_set: &mut StorageWriteSet) {
+        write_set.put(
+            TRACKED_MUTATION_REVISION_SPACE,
+            mutation_revision_key(),
+            uuid::Uuid::now_v7().as_bytes().as_slice(),
+        );
+    }
+
     pub(crate) async fn load_mutation_revision_from_read<R>(
         read: &R,
     ) -> Result<Option<Bytes>, StorageError>
@@ -149,6 +171,39 @@ where
                 ProjectedValue::FullValue(bytes) => Some(bytes),
                 ProjectedValue::KeyOnly => None,
             }))
+    }
+
+    pub(crate) async fn load_tracked_mutation_revision_from_read<R>(
+        read: &R,
+    ) -> Result<Option<Bytes>, StorageError>
+    where
+        R: StorageAdapterRead + ?Sized,
+    {
+        let values = read
+            .get_many(
+                TRACKED_MUTATION_REVISION_SPACE.id,
+                &[mutation_revision_key()],
+                GetOptions {
+                    projection: CoreProjection::FullValue,
+                },
+            )
+            .await?;
+        Ok(values
+            .values
+            .into_iter()
+            .next()
+            .flatten()
+            .and_then(|value| match value {
+                ProjectedValue::FullValue(bytes) => Some(bytes),
+                ProjectedValue::KeyOnly => None,
+            }))
+    }
+
+    pub(crate) async fn load_tracked_mutation_revision(
+        &self,
+    ) -> Result<Option<Bytes>, StorageError> {
+        let read = self.storage.begin_read(ReadOptions::default()).await?;
+        Self::load_tracked_mutation_revision_from_read(&StorageAdapterReadScope::new(read)).await
     }
 
     pub async fn delete_range(

--- a/packages/engine/src/storage_adapter/spaces.rs
+++ b/packages/engine/src/storage_adapter/spaces.rs
@@ -6,6 +6,8 @@ use crate::storage::{Key, KeyRange, SpaceId, StorageError};
 
 pub(crate) const MUTATION_REVISION_SPACE: StorageSpace =
     StorageSpace::new(SpaceId(0x0007_0001), "observe.mutation_revision");
+pub(crate) const TRACKED_MUTATION_REVISION_SPACE: StorageSpace =
+    StorageSpace::new(SpaceId(0x0007_0004), "transaction.tracked_revision");
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StorageSpace {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use serde_json::Value as JsonValue;
 use tracing::Instrument as _;
@@ -150,6 +151,10 @@ pub(crate) struct Transaction<StorageImpl: Storage = Memory> {
     filesystem_path_index_epoch: Arc<AtomicUsize>,
     storage: StorageAdapter<StorageImpl>,
     functions: FunctionProviderHandle,
+    /// Tracked-state revision observed by the coherent transaction-open read.
+    /// Durable tracked publication must still be based on this revision;
+    /// untracked sidecar writes do not invalidate the snapshot.
+    opening_tracked_mutation_revision: Option<Bytes>,
     commit_boundary: Option<TransactionCommitBoundary>,
     trust_filesystem_planner: bool,
     origin_key: Option<String>,
@@ -280,6 +285,18 @@ impl<StorageImpl> Transaction<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    pub(crate) async fn ensure_opening_snapshot_is_current(&self) -> Result<(), LixError> {
+        let current = self.storage.load_tracked_mutation_revision().await?;
+        if current == self.opening_tracked_mutation_revision {
+            return Ok(());
+        }
+        Err(LixError::new(
+            LixError::CODE_TRANSACTION_CONFLICT,
+            "transaction snapshot is stale because tracked state changed after it opened",
+        )
+        .with_hint("Retry the transaction against the latest committed state."))
+    }
+
     /// Opens an execution-scoped staging area for SQL/provider hooks.
     async fn open(
         mode: &SessionMode,
@@ -315,15 +332,25 @@ where
                     )
                     .await?
             };
+            let opening_tracked_mutation_revision =
+                StorageAdapter::<StorageImpl>::load_tracked_mutation_revision_from_read(&read)
+                    .await?;
             Ok::<_, LixError>((
                 active_branch_id,
                 runtime_functions,
                 functions,
                 schema_catalog,
+                opening_tracked_mutation_revision,
             ))
         }
         .await;
-        let (active_branch_id, runtime_functions, functions, schema_catalog) = match setup_result {
+        let (
+            active_branch_id,
+            runtime_functions,
+            functions,
+            schema_catalog,
+            opening_tracked_mutation_revision,
+        ) = match setup_result {
             Ok(result) => result,
             Err(error) => {
                 return Err(error);
@@ -352,6 +379,7 @@ where
                 filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
                 storage,
                 functions,
+                opening_tracked_mutation_revision,
                 commit_boundary: None,
                 trust_filesystem_planner: false,
                 origin_key: None,
@@ -379,6 +407,9 @@ where
                 return Err(error);
             }
         };
+        let tracked_state_changed = prepared_writes.state_rows.iter().any(|row| !row.untracked)
+            || !prepared_writes.commit_change_refs_by_branch.is_empty()
+            || !prepared_writes.extra_commit_parents_by_branch.is_empty();
         let catalog_revision_changed = prepared_writes_change_catalog(&prepared_writes);
         let _commit_guard = begin_commit_boundary(commit_boundary.as_ref());
         check_commit_boundary(commit_boundary.as_ref())?;
@@ -440,9 +471,20 @@ where
         if catalog_revision_changed {
             stage_catalog_revision(&mut writes);
         }
+        if tracked_state_changed {
+            StorageAdapter::<StorageImpl>::stage_tracked_mutation_revision(&mut writes);
+        }
+        let mut write_options = StorageWriteOptions::default();
+        if tracked_state_changed {
+            write_options.preconditions.push(
+                StorageAdapter::<StorageImpl>::tracked_mutation_revision_precondition(
+                    transaction.opening_tracked_mutation_revision.clone(),
+                ),
+            );
+        }
         let prepared_commit = transaction
             .storage
-            .prepare_write_set(writes, StorageWriteOptions::default())
+            .prepare_write_set(writes, write_options)
             .await?;
         let storage_stats = commit_at_boundary(commit_boundary.as_ref(), || async move {
             let (_commit, stats) = prepared_commit.commit().await?;
@@ -498,6 +540,7 @@ where
         &mut self,
         write: TransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError> {
+        self.ensure_opening_snapshot_is_current().await?;
         require_valid_transaction_write_storage_scopes(&write)?;
         #[cfg(feature = "storage-benches")]
         {
@@ -3248,7 +3291,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn commit_validates_staged_rows_before_persistence() {
+    async fn stage_rows_validates_row_content_before_persistence() {
         let storage = Memory::new();
         let storage = StorageAdapter::new(storage.clone());
         let live_state = Arc::new(live_state_context());
@@ -3273,21 +3316,15 @@ mod tests {
         .await
         .expect("transaction should open");
         let mut transaction = opened.transaction;
-        let runtime_functions = opened.runtime_functions;
 
         let mut invalid_row = key_value_stage_row("invalid-programmatic", "invalid", false);
         invalid_row.snapshot = Some(TransactionJson::from_value_for_test(
             json!({"key": "invalid-programmatic"}),
         ));
-        transaction
+        let error = transaction
             .stage_rows(vec![invalid_row])
             .await
-            .expect("invalid row should still reach commit validation");
-
-        let error = transaction
-            .commit(&runtime_functions)
-            .await
-            .expect_err("validation should reject before persistence");
+            .expect_err("row-local validation should reject while staging");
         assert!(
             error.message.contains("snapshot_content validation failed"),
             "validation error should explain the rejected schema data: {error:?}"
@@ -3311,23 +3348,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn commit_rejects_non_object_metadata_without_sql() {
+    async fn stage_rows_rejects_non_object_metadata_without_sql() {
         let storage = Memory::new();
-        let (live_state, _binary_cas, branch_ref, runtime_functions, mut transaction) =
+        let (live_state, _binary_cas, branch_ref, _runtime_functions, mut transaction) =
             open_test_transaction(&storage).await;
         let storage = StorageAdapter::new(storage);
 
         let mut row = key_value_stage_row("invalid-metadata", "value", false);
         row.metadata = Some(TransactionJson::from_value_for_test(json!("not-an-object")));
-        transaction
+        let error = transaction
             .stage_rows(vec![row])
             .await
-            .expect("row should stage before metadata validation");
-
-        let error = transaction
-            .commit(&runtime_functions)
-            .await
-            .expect_err("non-object metadata should fail commit validation");
+            .expect_err("non-object metadata should fail statement validation");
 
         assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
         assert!(
@@ -3434,9 +3466,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn commit_rejects_snapshot_that_violates_json_schema_without_sql() {
+    async fn stage_rows_rejects_snapshot_that_violates_json_schema_without_sql() {
         let storage = Memory::new();
-        let (live_state, _binary_cas, branch_ref, runtime_functions, mut transaction) =
+        let (live_state, _binary_cas, branch_ref, _runtime_functions, mut transaction) =
             open_test_transaction(&storage).await;
         let storage = StorageAdapter::new(storage);
 
@@ -3444,15 +3476,10 @@ mod tests {
         row.snapshot = Some(TransactionJson::from_value_for_test(
             json!({"key": "schema-mismatch"}),
         ));
-        transaction
+        let error = transaction
             .stage_rows(vec![row])
             .await
-            .expect("row should stage before JSON Schema validation");
-
-        let error = transaction
-            .commit(&runtime_functions)
-            .await
-            .expect_err("JSON Schema mismatch should fail commit validation");
+            .expect_err("JSON Schema mismatch should fail statement validation");
 
         assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
         assert!(

--- a/packages/engine/src/transaction/normalization.rs
+++ b/packages/engine/src/transaction/normalization.rs
@@ -6,7 +6,7 @@ use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::LixError;
 use crate::catalog::{SchemaPlan, SchemaPlanId, TransactionCatalog};
-use crate::common::format_json_pointer;
+use crate::common::{format_json_pointer, validate_row_metadata};
 use crate::domain::Domain;
 use crate::entity_pk::{EntityPk, EntityPkError};
 use crate::functions::FunctionProviderHandle;
@@ -85,6 +85,18 @@ pub(crate) fn normalize_transaction_write_row(
         None
     };
 
+    validate_normalized_row_content(&row, normalized_snapshot.as_ref(), schema_plan)?;
+    let requires_transaction_validation = if normalized_snapshot.is_some() {
+        !schema_plan.uniques.is_empty()
+            || !schema_plan.foreign_keys.is_empty()
+            || !schema_plan.state_foreign_keys.is_empty()
+    } else {
+        schema_catalog
+            .snapshot()
+            .delete_plan_for_key(&row.schema_key)
+            .has_committed_checks()
+    };
+
     if row.schema_key == REGISTERED_SCHEMA_KEY {
         if row.file_id.is_some() {
             return Err(LixError::new(
@@ -106,8 +118,41 @@ pub(crate) fn normalize_transaction_write_row(
         row,
         snapshot: normalized_snapshot,
         schema_plan_id,
-        facts: PreparedRowFacts::default(),
+        facts: PreparedRowFacts {
+            row_content_validated: true,
+            requires_transaction_validation,
+        },
     })
+}
+
+fn validate_normalized_row_content(
+    row: &TransactionWriteRow,
+    snapshot: Option<&TransactionJson>,
+    schema_plan: &SchemaPlan,
+) -> Result<(), LixError> {
+    if let Some(metadata) = row.metadata.as_ref() {
+        validate_row_metadata(
+            metadata.value(),
+            format!("metadata for schema '{}'", row.schema_key),
+        )?;
+    }
+    let Some(snapshot) = snapshot else {
+        return Ok(());
+    };
+    if schema_plan.accepts_row_content_fast(snapshot.value()) {
+        return Ok(());
+    }
+    if let Err(errors) = schema_plan.compiled_schema.validate(snapshot.value()) {
+        return Err(LixError::new(
+            LixError::CODE_SCHEMA_VALIDATION,
+            format!(
+                "snapshot_content validation failed for schema '{}': {}",
+                row.schema_key,
+                crate::schema::format_lix_schema_validation_errors(errors)
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_transaction_write_row_schema_identity(
@@ -666,20 +711,19 @@ mod tests {
             global: false,
             ..base_stage_row()
         };
-        let dotdot = normalize_transaction_write_row(dotdot, &mut catalog, functions())
-            .expect("normalize dotdot file");
-        let dotdot_snapshot = normalized_snapshot(&dotdot);
-        assert_eq!(dotdot_snapshot["name"], "..");
+        let error = normalize_transaction_write_row(dotdot, &mut catalog, functions())
+            .expect_err("schema validation should reject a parent-directory segment");
+        assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
     }
 
     #[test]
-    fn normalization_leaves_structural_filesystem_descriptor_validation_to_schema() {
+    fn normalization_applies_structural_filesystem_descriptor_schema() {
         let mut catalog = catalog_with(vec![
             builtin_schema(FILE_DESCRIPTOR_SCHEMA_KEY),
             builtin_schema(DIRECTORY_DESCRIPTOR_SCHEMA_KEY),
         ]);
 
-        let row = normalize_transaction_write_row(
+        let error = normalize_transaction_write_row(
             TransactionWriteRow {
                 entity_pk: None,
                 schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
@@ -694,9 +738,8 @@ mod tests {
             &mut catalog,
             functions(),
         )
-        .expect("normalization should preserve descriptor names without path validation");
-        let snapshot = normalized_snapshot(&row);
-        assert_eq!(snapshot["name"], "nested/name");
+        .expect_err("schema validation should reject a path in a descriptor name");
+        assert_eq!(error.code, LixError::CODE_SCHEMA_VALIDATION);
     }
 
     #[test]

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -136,6 +136,18 @@ impl<'a> PreparedValidationRow<'a> {
         }
     }
 
+    pub(crate) fn row_content_validated(self) -> bool {
+        match self {
+            Self::State(row) => row.facts.row_content_validated,
+        }
+    }
+
+    pub(crate) fn requires_transaction_validation(self) -> bool {
+        match self {
+            Self::State(row) => row.facts.requires_transaction_validation,
+        }
+    }
+
     pub(crate) fn origin(&self) -> Option<&TransactionWriteOrigin> {
         match self {
             Self::State(row) => row.origin.as_ref(),

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -340,9 +340,16 @@ pub(crate) fn stage_json_from_value(
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct PreparedRowFacts {
-    /// Placeholder for the next cut: row-derived constraint facts will be
-    /// computed once during normalization and consumed by validation.
-    pub(crate) _sealed: (),
+    /// Row-local schema, metadata, and primary-key validation completed
+    /// against `schema_plan_id` during semantic normalization.
+    ///
+    /// Commit validation still owns transaction-wide and committed-state
+    /// constraints. Keeping this certificate on the prepared row prevents the
+    /// immutable JSON payload from being validated a second time at commit.
+    pub(crate) row_content_validated: bool,
+    /// This prepared operation participates in a cross-row constraint that
+    /// requires transaction-wide or committed-state validation.
+    pub(crate) requires_transaction_validation: bool,
 }
 
 /// Prepared state row owned by the transaction write buffer.

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -217,6 +217,15 @@ pub(crate) async fn validate_prepared_writes(
             "lix.perf.validation.registered_schema_identity"
         ))
         .await?;
+    if row_local_certificates_cover_validation(&staged_rows) {
+        validate_committed_insert_identities(&input, None)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.validation.insert_identities"
+            ))
+            .await?;
+        return Ok(());
+    }
     let mut pending_constraints = PendingConstraintIndexes::default();
     let mut validated_constraint_rows =
         BTreeMap::<DomainRowIdentity, ValidatedRowContent<'_>>::new();
@@ -234,8 +243,10 @@ pub(crate) async fn validate_prepared_writes(
     }
     for row in &staged_rows {
         let row = *row;
-        validate_staged_row_shape(row)?;
-        validate_staged_row_metadata(row)?;
+        if !row.row_content_validated() {
+            validate_staged_row_shape(row)?;
+            validate_staged_row_metadata(row)?;
+        }
         let validated = validated_constraint_rows
             .get(&row.domain_row_identity())
             .copied()
@@ -253,7 +264,9 @@ pub(crate) async fn validate_prepared_writes(
                     "lix.perf.validation.file_owner"
                 ))
                 .await?;
-            validate_primary_key_identity(row, schema_plan, snapshot)?;
+            if !row.row_content_validated() {
+                validate_primary_key_identity(row, schema_plan, snapshot)?;
+            }
             pending_constraints.remember_foreign_key_references(row, schema_plan, snapshot)?;
             staged_snapshots.push((row, schema_plan, snapshot));
         } else {
@@ -289,7 +302,7 @@ pub(crate) async fn validate_prepared_writes(
             "lix.perf.validation.branch_ref_delete_restrictions"
         ))
         .await?;
-    validate_committed_insert_identities(&input, &pending_constraints)
+    validate_committed_insert_identities(&input, Some(&pending_constraints))
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.validation.insert_identities"
@@ -314,6 +327,22 @@ pub(crate) async fn validate_prepared_writes(
         ))
         .await?;
     Ok(())
+}
+
+fn row_local_certificates_cover_validation(staged_rows: &[PreparedValidationRow<'_>]) -> bool {
+    !staged_rows.is_empty()
+        && staged_rows.iter().all(|row| {
+            row.row_content_validated()
+                && !row.requires_transaction_validation()
+                && row.file_id().is_none()
+                && !matches!(
+                    row.schema_key(),
+                    REGISTERED_SCHEMA_KEY
+                        | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                        | FILE_DESCRIPTOR_SCHEMA_KEY
+                        | BRANCH_REF_SCHEMA_KEY
+                )
+        })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -1033,13 +1062,15 @@ fn directory_parent_depth_error(scope: &DirectoryDescriptorScope, start_id: &str
 
 async fn validate_committed_insert_identities(
     input: &TransactionValidationInput<'_>,
-    pending_constraints: &PendingConstraintIndexes,
+    pending_constraints: Option<&PendingConstraintIndexes>,
 ) -> Result<(), LixError> {
-    let pending_identity_targets = pending_constraints
-        .identity_targets
-        .iter()
-        .map(|target| target.identity.clone())
-        .collect::<BTreeSet<_>>();
+    let pending_identity_targets = pending_constraints.map(|pending_constraints| {
+        pending_constraints
+            .identity_targets
+            .iter()
+            .map(|target| target.identity.clone())
+            .collect::<BTreeSet<_>>()
+    });
     let mut checks_by_domain_schema =
         BTreeMap::<(Domain, String), Vec<(EntityPk, Option<TransactionWriteOrigin>)>>::new();
     for (identity, untracked, origin) in input.staged_writes.insert_identities() {
@@ -1048,7 +1079,10 @@ async fn validate_committed_insert_identities(
             identity.schema_key().to_string(),
             identity.entity_pk().clone(),
         );
-        if !pending_identity_targets.contains(&pending_identity) {
+        if pending_identity_targets
+            .as_ref()
+            .is_some_and(|targets| !targets.contains(&pending_identity))
+        {
             continue;
         }
         checks_by_domain_schema
@@ -1070,7 +1104,12 @@ async fn validate_committed_insert_identities(
                 .await?;
         let committed_rows_by_entity_pk = committed_rows
             .into_iter()
-            .filter(|row| !row.deleted && !pending_constraints.tombstones_identity(row))
+            .filter(|row| {
+                !row.deleted
+                    && !pending_constraints.is_some_and(|pending_constraints| {
+                        pending_constraints.tombstones_identity(row)
+                    })
+            })
             .map(|row| (row.entity_pk.clone(), row))
             .collect::<BTreeMap<_, _>>();
         for (entity_pk, origin) in checks {
@@ -1421,7 +1460,11 @@ fn validate_row_content<'a>(
 ) -> Result<ValidatedRowContent<'a>, LixError> {
     let schema_plan = schema_plan_for_row(schema_catalog, pending_schema_domains, row)?;
     validate_schema_matches_row(row, schema_plan)?;
-    let snapshot = validate_snapshot_content(row, schema_plan)?;
+    let snapshot = if row.row_content_validated() {
+        row.snapshot_json()
+    } else {
+        validate_snapshot_content(row, schema_plan)?
+    };
     Ok(ValidatedRowContent {
         schema_plan,
         snapshot,

--- a/packages/engine/tests/sql/lix_file.rs
+++ b/packages/engine/tests/sql/lix_file.rs
@@ -3551,7 +3551,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_file_transaction_path_index_cache_observes_other_session_commits,
+    lix_file_transaction_path_index_cache_rejects_stale_other_session_snapshot,
     options = crate::support::simulation_test::engine::SimulationOptions {
         deterministic: false,
     },
@@ -3603,13 +3603,31 @@ simulation_test!(
             .await
             .expect("other session file should commit");
 
-        let visible_after_commit = transaction
+        let error = transaction
             .execute(
                 "SELECT id, path FROM lix_file WHERE path = '/other-session.md'",
                 &[],
             )
             .await
-            .expect("transaction lookup should observe the newer committed path revision");
+            .expect_err("stale transaction lookup should reject the newer committed revision");
+        assert_eq!(error.code, LixError::CODE_TRANSACTION_CONFLICT);
+
+        transaction
+            .rollback()
+            .await
+            .expect("stale transaction rollback should succeed");
+
+        let mut retry = session
+            .begin_transaction()
+            .await
+            .expect("retry transaction should begin");
+        let visible_after_commit = retry
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/other-session.md'",
+                &[],
+            )
+            .await
+            .expect("retry should observe the newer committed path revision");
         assert_rows_eq(
             visible_after_commit,
             vec![vec![
@@ -3618,15 +3636,15 @@ simulation_test!(
             ]],
         );
 
-        transaction
+        retry
             .rollback()
             .await
-            .expect("transaction rollback should succeed");
+            .expect("retry transaction rollback should succeed");
     }
 );
 
 simulation_test!(
-    lix_file_transaction_path_index_cache_observes_merge_reachability_changes,
+    lix_file_transaction_path_index_cache_rejects_stale_merge_snapshot,
     options = crate::support::simulation_test::engine::SimulationOptions {
         deterministic: false,
     },
@@ -3703,13 +3721,31 @@ simulation_test!(
             .expect("merge should succeed");
         assert_eq!(receipt.outcome, MergeBranchOutcome::MergeCommitted);
 
-        let visible_after_merge = transaction
+        let error = transaction
             .execute(
                 "SELECT id, path FROM lix_file WHERE path = '/merged.md'",
                 &[],
             )
             .await
-            .expect("transaction lookup should observe merged reachable descriptors");
+            .expect_err("stale transaction lookup should reject merged reachable descriptors");
+        assert_eq!(error.code, LixError::CODE_TRANSACTION_CONFLICT);
+
+        transaction
+            .rollback()
+            .await
+            .expect("stale transaction rollback should succeed");
+
+        let mut retry = transaction_session
+            .begin_transaction()
+            .await
+            .expect("retry transaction should begin");
+        let visible_after_merge = retry
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/merged.md'",
+                &[],
+            )
+            .await
+            .expect("retry should observe merged reachable descriptors");
         assert_rows_eq(
             visible_after_merge,
             vec![vec![
@@ -3718,9 +3754,9 @@ simulation_test!(
             ]],
         );
 
-        transaction
+        retry
             .rollback()
             .await
-            .expect("transaction rollback should succeed");
+            .expect("retry transaction rollback should succeed");
     }
 );

--- a/packages/engine/tests/transaction.rs
+++ b/packages/engine/tests/transaction.rs
@@ -12,6 +12,124 @@ use lix_engine::storage::{
 
 const TEST_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 
+#[tokio::test]
+async fn stale_transaction_cannot_publish_over_newer_commit() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage)
+        .await
+        .expect("initialized storage should create an engine");
+    let stale_session = engine
+        .open_workspace_session()
+        .await
+        .expect("stale session should open");
+    let winner_session = engine
+        .open_workspace_session()
+        .await
+        .expect("winner session should open");
+
+    let mut stale = stale_session
+        .begin_transaction()
+        .await
+        .expect("stale transaction should begin");
+    stale
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('stale-key', 'stale')",
+            &[],
+        )
+        .await
+        .expect("stale transaction should stage its write");
+
+    winner_session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('winner-key', 'winner')",
+            &[],
+        )
+        .await
+        .expect("newer transaction should commit");
+
+    let read_error = stale
+        .execute("SELECT key FROM lix_key_value", &[])
+        .await
+        .expect_err("stale transaction must not observe a newer snapshot");
+    assert_eq!(read_error.code, "LIX_TRANSACTION_CONFLICT");
+
+    let error = stale
+        .commit()
+        .await
+        .expect_err("stale transaction must not publish");
+    assert_eq!(error.code, "LIX_TRANSACTION_CONFLICT");
+
+    let result = winner_session
+        .execute(
+            "SELECT key FROM lix_key_value \
+             WHERE key IN ('stale-key', 'winner-key') ORDER BY key",
+            &[],
+        )
+        .await
+        .expect("committed state should remain readable");
+    assert_eq!(result.rows().len(), 1);
+    assert_eq!(result.rows()[0].get::<String>("key").unwrap(), "winner-key");
+}
+
+#[tokio::test]
+async fn untracked_sidecar_write_does_not_invalidate_tracked_transaction() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage)
+        .await
+        .expect("initialized storage should create an engine");
+    let tracked_session = engine
+        .open_workspace_session()
+        .await
+        .expect("tracked session should open");
+    let sidecar_session = engine
+        .open_workspace_session()
+        .await
+        .expect("sidecar session should open");
+
+    let mut tracked = tracked_session
+        .begin_transaction()
+        .await
+        .expect("tracked transaction should begin");
+    tracked
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('tracked-key', 'tracked')",
+            &[],
+        )
+        .await
+        .expect("tracked transaction should stage");
+
+    sidecar_session
+        .execute(
+            "INSERT INTO lix_key_value \
+             (key, value, lixcol_global, lixcol_untracked) \
+             VALUES ('sidecar-key', 'sidecar', true, true)",
+            &[],
+        )
+        .await
+        .expect("untracked sidecar write should commit");
+
+    tracked
+        .commit()
+        .await
+        .expect("sidecar mutation must not invalidate tracked publication");
+
+    let result = tracked_session
+        .execute(
+            "SELECT key FROM lix_key_value \
+             WHERE key IN ('tracked-key', 'sidecar-key') ORDER BY key",
+            &[],
+        )
+        .await
+        .expect("both durability lanes should remain readable");
+    assert_eq!(result.rows().len(), 2);
+}
+
 fn wait_until(description: &str, mut condition: impl FnMut() -> bool) {
     let deadline = Instant::now() + TEST_WAIT_TIMEOUT;
     while !condition() {

--- a/packages/rocksdb-storage/Cargo.toml
+++ b/packages/rocksdb-storage/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 lix_engine = { workspace = true }
 
 bytes = "1"
+blake3 = "1"
 rocksdb = { version = "0.24", default-features = false, features = ["bindgen-runtime"] }
 tempfile = "3"
 tokio = { version = "1", features = ["sync"] }

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -12,9 +12,10 @@ use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use bytes::Bytes;
 use lix_engine::storage::{
-    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, ProjectedValue,
-    PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage, StorageError,
-    StorageRead, StorageWrite, StoredValue, WriteOptions, WriteStats,
+    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, Precondition,
+    PreconditionFailure, ProjectedValue, PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions,
+    SpaceId, Storage, StorageError, StorageRead, StorageWrite, StoredValue, WriteOptions,
+    WriteStats,
 };
 use lix_engine::{StorageFactory, StorageFixture, StorageTestConfig};
 use rocksdb::Snapshot;
@@ -153,10 +154,11 @@ impl Storage for RocksDB {
 
     fn begin_write(
         &self,
-        _opts: WriteOptions,
+        opts: WriteOptions,
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
             let writer_permit = self.inner.write_gate.acquire().await;
+            check_preconditions(&self.inner.db, &opts.preconditions)?;
             Ok(RocksDBWrite {
                 inner: Arc::clone(&self.inner),
                 _writer_permit: writer_permit,
@@ -165,6 +167,62 @@ impl Storage for RocksDB {
                 stats: WriteStats::default(),
             })
         }
+    }
+}
+
+fn check_preconditions(db: &DB, preconditions: &[Precondition]) -> Result<(), StorageError> {
+    let mut failures = Vec::new();
+    for (index, precondition) in preconditions.iter().enumerate() {
+        let matches = match precondition {
+            Precondition::KeyAbsent { space, key } => db
+                .get(physical_key(*space, key).0)
+                .map_err(rocksdb_error)?
+                .is_none(),
+            Precondition::KeyPresent { space, key } => db
+                .get(physical_key(*space, key).0)
+                .map_err(rocksdb_error)?
+                .is_some(),
+            Precondition::KeyValueHashEquals { space, key, hash } => db
+                .get(physical_key(*space, key).0)
+                .map_err(rocksdb_error)?
+                .is_some_and(|value| blake3::hash(&value).as_bytes() == hash),
+            Precondition::KeyValueEquals {
+                space,
+                key,
+                expected,
+            } => db
+                .get(physical_key(*space, key).0)
+                .map_err(rocksdb_error)?
+                .is_some_and(|value| value.as_slice() == expected.as_ref()),
+            Precondition::RangeEmpty { space, range } => {
+                let bounds = EncodedBounds::new(physical_range(*space, range.clone()), None);
+                let mut empty = true;
+                for item in db.iterator(IteratorMode::From(&bounds.lower_seek, Direction::Forward))
+                {
+                    let (key, _) = item.map_err(rocksdb_error)?;
+                    if !bounds.after_lower(&key) {
+                        continue;
+                    }
+                    if bounds.before_upper(&key) {
+                        empty = false;
+                    }
+                    break;
+                }
+                empty
+            }
+            Precondition::BranchEquals { ref_key, expected } => db
+                .get(ref_key.0.as_ref())
+                .map_err(rocksdb_error)?
+                .is_some_and(|value| value.as_slice() == expected.as_ref()),
+        };
+        if !matches {
+            failures.push(PreconditionFailure { index });
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(StorageError::PreconditionFailed(failures))
     }
 }
 

--- a/packages/slatedb-storage/Cargo.toml
+++ b/packages/slatedb-storage/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 lix_engine = { workspace = true }
 
 bytes = "1"
+blake3 = "1"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 object_store = { version = "0.14", default-features = false, features = ["fs"] }
 slatedb = { version = "0.14.1", default-features = false, features = ["lz4", "moka"] }

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -15,9 +15,10 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures_util::stream::{self, StreamExt, TryStreamExt};
 use lix_engine::storage::{
-    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, ProjectedValue,
-    PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage, StorageError,
-    StorageRead, StorageWrite, StoredValue, WriteOptions, WriteStats,
+    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, Precondition,
+    PreconditionFailure, ProjectedValue, PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions,
+    SpaceId, Storage, StorageError, StorageRead, StorageWrite, StoredValue, WriteOptions,
+    WriteStats,
 };
 use lix_engine::{StorageFactory, StorageFixture, StorageTestConfig};
 use object_store::ObjectStore;
@@ -214,10 +215,11 @@ impl Storage for SlateDB {
 
     fn begin_write(
         &self,
-        _opts: WriteOptions,
+        opts: WriteOptions,
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
             let writer_permit = self.write_gate.acquire().await;
+            check_preconditions(&self.worker, &opts.preconditions).await?;
             Ok(SlateDBWrite {
                 worker: self.worker.clone(),
                 _writer_permit: writer_permit,
@@ -227,6 +229,77 @@ impl Storage for SlateDB {
             })
         }
     }
+}
+
+async fn check_preconditions(
+    worker: &SlateDBWorker,
+    preconditions: &[Precondition],
+) -> Result<(), StorageError> {
+    if preconditions.is_empty() {
+        return Ok(());
+    }
+    let snapshot = worker
+        .call_read(|db| async move { db.snapshot().await.map_err(slatedb_error) })
+        .await?;
+    let mut failures = Vec::new();
+    for (index, precondition) in preconditions.iter().enumerate() {
+        let matches = match precondition {
+            Precondition::KeyAbsent { space, key } => {
+                snapshot_value(worker, Arc::clone(&snapshot), *space, key)
+                    .await?
+                    .is_none()
+            }
+            Precondition::KeyPresent { space, key } => {
+                snapshot_value(worker, Arc::clone(&snapshot), *space, key)
+                    .await?
+                    .is_some()
+            }
+            Precondition::KeyValueHashEquals { space, key, hash } => {
+                snapshot_value(worker, Arc::clone(&snapshot), *space, key)
+                    .await?
+                    .is_some_and(|value| blake3::hash(&value).as_bytes() == hash)
+            }
+            Precondition::KeyValueEquals {
+                space,
+                key,
+                expected,
+            } => snapshot_value(worker, Arc::clone(&snapshot), *space, key)
+                .await?
+                .is_some_and(|value| value == *expected),
+            Precondition::RangeEmpty { space, range } => {
+                let bounds = EncodedBounds::new(physical_range(*space, range.clone())?, None);
+                let snapshot = Arc::clone(&snapshot);
+                worker
+                    .call_read(move |_db| collect_snapshot_keys(snapshot, bounds))
+                    .await?
+                    .is_empty()
+            }
+            Precondition::BranchEquals { .. } => false,
+        };
+        if !matches {
+            failures.push(PreconditionFailure { index });
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(StorageError::PreconditionFailed(failures))
+    }
+}
+
+async fn snapshot_value(
+    worker: &SlateDBWorker,
+    snapshot: Arc<DbSnapshot>,
+    space: SpaceId,
+    key: &Key,
+) -> Result<Option<Bytes>, StorageError> {
+    let key = physical_key(space, key)?;
+    Ok(worker
+        .call_read(move |_db| get_snapshot_values(snapshot, vec![key]))
+        .await?
+        .into_iter()
+        .next()
+        .flatten())
 }
 
 impl StorageRead for SlateDBRead {

--- a/packages/sqlite-storage/Cargo.toml
+++ b/packages/sqlite-storage/Cargo.toml
@@ -20,5 +20,6 @@ workspace = true
 lix_engine = { workspace = true }
 
 bytes = "1"
+blake3 = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 tempfile = "3"

--- a/packages/sqlite-storage/src/sqlite.rs
+++ b/packages/sqlite-storage/src/sqlite.rs
@@ -11,9 +11,10 @@ use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use lix_engine::storage::{
-    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, ProjectedValue,
-    PutBatch, PutEntry, ReadEntry, ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage,
-    StorageError, StorageRead, StorageWrite, WriteOptions, WriteStats,
+    CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, Precondition,
+    PreconditionFailure, ProjectedValue, PutBatch, PutEntry, ReadEntry, ReadOptions, ScanChunk,
+    ScanOptions, SpaceId, Storage, StorageError, StorageRead, StorageWrite, WriteOptions,
+    WriteStats,
 };
 use lix_engine::{StorageFactory, StorageFixture, StorageTestConfig};
 use rusqlite::types::ValueRef as SqlValueRef;
@@ -199,7 +200,7 @@ impl Storage for SQLite {
 
     fn begin_write(
         &self,
-        _opts: WriteOptions,
+        opts: WriteOptions,
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
             let conn = self
@@ -210,6 +211,10 @@ impl Storage for SQLite {
                 .map(Ok)
                 .unwrap_or_else(|| self.connect())?;
             execute_cached(&conn, "BEGIN IMMEDIATE TRANSACTION")?;
+            if let Err(error) = check_preconditions(&conn, &opts.preconditions) {
+                let _ = execute_cached(&conn, "ROLLBACK");
+                return Err(error);
+            }
             Ok(SQLiteWrite {
                 conn: Some(conn),
                 write_pool: Arc::clone(&self.write_pool),
@@ -217,6 +222,91 @@ impl Storage for SQLite {
             })
         }
     }
+}
+
+fn check_preconditions(
+    conn: &Connection,
+    preconditions: &[Precondition],
+) -> Result<(), StorageError> {
+    let mut failures = Vec::new();
+    for (index, precondition) in preconditions.iter().enumerate() {
+        let matches = match precondition {
+            Precondition::KeyAbsent { space, key } => {
+                precondition_value(conn, *space, key)?.is_none()
+            }
+            Precondition::KeyPresent { space, key } => {
+                precondition_value(conn, *space, key)?.is_some()
+            }
+            Precondition::KeyValueHashEquals { space, key, hash } => {
+                precondition_value(conn, *space, key)?
+                    .is_some_and(|value| blake3::hash(&value).as_bytes() == hash)
+            }
+            Precondition::KeyValueEquals {
+                space,
+                key,
+                expected,
+            } => precondition_value(conn, *space, key)?
+                .is_some_and(|value| value.as_slice() == expected.as_ref()),
+            Precondition::RangeEmpty { space, range } => {
+                precondition_range_is_empty(conn, *space, range)?
+            }
+            Precondition::BranchEquals { .. } => false,
+        };
+        if !matches {
+            failures.push(PreconditionFailure { index });
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(StorageError::PreconditionFailed(failures))
+    }
+}
+
+fn precondition_value(
+    conn: &Connection,
+    space: SpaceId,
+    key: &Key,
+) -> Result<Option<Vec<u8>>, StorageError> {
+    if !space_table_exists(conn, space)? {
+        return Ok(None);
+    }
+    let sql = format!("SELECT value FROM {} WHERE key = ?1", space_table(space));
+    let mut statement = conn.prepare_cached(&sql).map_err(sqlite_error)?;
+    let mut rows = statement
+        .query(params![key.0.as_ref()])
+        .map_err(sqlite_error)?;
+    let Some(row) = rows.next().map_err(sqlite_error)? else {
+        return Ok(None);
+    };
+    Ok(Some(
+        blob_ref(row.get_ref(0).map_err(sqlite_error)?, "value")?.to_vec(),
+    ))
+}
+
+fn precondition_range_is_empty(
+    conn: &Connection,
+    space: SpaceId,
+    range: &KeyRange,
+) -> Result<bool, StorageError> {
+    if !space_table_exists(conn, space)? {
+        return Ok(true);
+    }
+    let mut sql = format!("SELECT 1 FROM {} WHERE 1 = 1", space_table(space));
+    let mut binds: Vec<&[u8]> = Vec::with_capacity(2);
+    push_range_bounds(&mut sql, &mut binds, &range.lower, &range.upper);
+    sql.push_str(" LIMIT 1");
+    let mut statement = conn.prepare_cached(&sql).map_err(sqlite_error)?;
+    for (index, bytes) in binds.iter().enumerate() {
+        statement
+            .raw_bind_parameter(index + 1, *bytes)
+            .map_err(sqlite_error)?;
+    }
+    Ok(statement
+        .raw_query()
+        .next()
+        .map_err(sqlite_error)?
+        .is_none())
 }
 
 impl StorageRead for SQLiteRead {


### PR DESCRIPTION
## Summary

- add standalone SQLite as the non-versioned CRUD latency floor and make bulk Lix SQL use one explicit transaction instead of one commit per 500-row chunk
- route safe bound UPDATE/DELETE predicates by primary key instead of scanning the full live-state surface (merged PR #740)
- validate row-local metadata, JSON Schema, and derived identity once while staging; carry a certificate into commit and retain commit-time validation for cross-row and special engine invariants
- compile a conservative fast accept plan for simple object schemas, with full JSON Schema fallback for unsupported keywords and all rejected rows
- add tracked-state snapshot OCC: explicit reads validate before and after execution, writes validate before staging, and commit atomically compares the opening tracked revision
- implement atomic write preconditions for Memory, SQLite, RocksDB, and SlateDB; untracked sidecar writes intentionally do not advance the tracked revision

## Architecture

This follows the common shape used by SQLite, DuckDB, Turso, and Dolt: a coherent read view, serialized atomic publication, optimistic conflict detection, and immutable/versioned state behind the transaction boundary. A stale explicit transaction now returns `LIX_TRANSACTION_CONFLICT` with a retry hint. A retry observes the newer commit. Invalid row-local data fails at the statement boundary and never enters the transaction overlay.

References and the full measurement history are in `packages/engine/benches/tracked_state_crud/optimization_log.md`.

## Results

On the same 10k flattened JSON-pointer workload:

- standalone SQLite insert: **9.600 ms**
- Lix + RocksDB insert baseline: **279.780 ms**
- exact final Lix + RocksDB insert: **264.89 ms** (95% CI 248.74–284.06 ms), **5.3% faster**, with a remaining **27.6x** gap
- point UPDATE routing: **71.596 ms -> 4.008 ms** (**-94.4%**)
- point DELETE routing: **65.166 ms -> 4.654 ms** (**-92.9%**)

The final profile still concentrates inclusive samples in commit/materialization (31.0%), commit validation (16.5%), and SQL staging (13–17%). Committed insert-identity probing is about 12.0%. RocksDB leaf work is not the dominant remaining gap, so the next target should be commit/change materialization and identity lookup rather than replacing the backend.

Point update/delete and delete-all changes from the validation/OCC changes alone were not statistically significant. The exact final insert run was also statistically unchanged from the earlier 258.17 ms optimized run (`p = 0.54`).

## Correctness

- stale tracked transaction cannot read or publish over a newer tracked commit
- retry transaction sees the newer commit or merge
- untracked sidecar writes do not invalidate a tracked transaction
- matching storage preconditions commit; stale preconditions reject without overwriting the winner
- unsupported JSON Schema shapes retain the full validator and diagnostics
- filesystem, schema-catalog, branch-ref, unique, and foreign-key invariants retain transaction-wide validation

## Verification

- `cargo test -q -p lix_engine` (1,212 unit tests + all integration/SQL/doctest groups; 6 intentional ignores)
- exact-source transaction tests: 16/16
- exact-source stale snapshot simulations: 4/4
- Memory storage conformance
- SQLite, RocksDB, and SlateDB storage conformance: 11/11
- `cargo clippy -p lix_engine -p lix_rocksdb_storage -p lix_sqlite_storage -p lix_slatedb_storage --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- final Criterion 10k Lix + RocksDB insert run
- 1 kHz Samply profile of the optimized 10k insert path