### PR TITLE
Speed up test compilation and CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -42,7 +42,7 @@ debug = true
 inherits = "dev"
 debug = false
 debug-assertions = true
-opt-level = 1
+opt-level = 0
 
 [profile.test.build-override]
 inherits = "dev"
@@ -54,6 +54,7 @@ overflow-checks = true
 [profile.test.package."*"]
 debug = false
 debug-assertions = false
+opt-level = 1
 overflow-checks = false
 [profile.test.package."log"]
 debug-assertions = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,65 @@ jobs:
       - name: Validate change fragments
         run: node scripts/validate-changes.mjs
 
-  test:
-    name: Cargo + JS SDK Test
+  cargo-test:
+    name: Cargo Test
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: set envs
+        run: |
+          grep -v "^#" << "EOF" >> "$GITHUB_ENV"
+          CARGO_TERM_COLOR=always
+          CARGO_INCREMENTAL=0
+          # keep aligned with config.toml
+          CARGO_PROFILE_DEV_DEBUG=0
+          CARGO_PROFILE_TEST_DEBUG=0
+          CARGO_PROFILE_RELEASE_DEBUG=0
+          CARGO_PROFILE_BENCH_DEBUG=0
+          CARGO_NET_RETRY=10
+          RUSTUP_MAX_RETRIES=10
+          GIT_AUTHOR_NAME=github-actions[bot]
+          GIT_COMMITTER_NAME=github-actions[bot]
+          GIT_AUTHOR_EMAIL=41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL=41898282+github-actions[bot]@users.noreply.github.com
+          DEBIAN_FRONTEND=noninteractive
+          BINSTALL_NO_CONFIRM=true
+          EOF
+
+      - name: Install LLVM build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+
+      - name: Restore compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable compiler cache
+        run: |
+          grep -v "^#" << "EOF" >> "$GITHUB_ENV"
+          SCCACHE_GHA_ENABLED=true
+          RUSTC_WRAPPER=sccache
+          EOF
+
+      - name: Lint Rust workspace
+        run: cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
+
+      - name: Compile Rust workspace tests
+        run: cargo test --profile test --workspace --all-features --no-run
+
+      - name: Run Rust workspace tests
+        run: cargo test --profile test --workspace --all-features
+
+  js-sdk-test:
+    name: JS SDK Test
     runs-on: blacksmith-32vcpu-ubuntu-2404
 
     steps:
@@ -68,6 +125,16 @@ jobs:
         with:
           shared-key: ci
 
+      - name: Restore compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable compiler cache
+        run: |
+          grep -v "^#" << "EOF" >> "$GITHUB_ENV"
+          SCCACHE_GHA_ENABLED=true
+          RUSTC_WRAPPER=sccache
+          EOF
+
       - name: Install WebAssembly build target
         run: rustup target add wasm32-unknown-unknown
 
@@ -91,30 +158,13 @@ jobs:
         working-directory: packages/js-sdk
         run: npx playwright install --with-deps chromium
 
-      - name: Lint Rust workspace
-        run: cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
-
-      - name: Compile Rust workspace tests
-        run: cargo test --profile test --workspace --all-features --no-run
-
       - name: Build JS SDK bindings
         working-directory: packages/js-sdk
         run: npm run build
 
-      - name: Run Rust and JS SDK tests in parallel
+      - name: Run JS SDK tests
+        working-directory: packages/js-sdk
         run: |
-          cargo test --profile test --workspace --all-features &
-          cargo_test_pid=$!
-
-          (
-            cd packages/js-sdk
-            npm exec -- vitest run
-            npm run test:browser:built
-            node ./scripts/test-packed-vite.js
-          ) &
-          js_sdk_test_pid=$!
-
-          failed=0
-          wait "$cargo_test_pid" || failed=1
-          wait "$js_sdk_test_pid" || failed=1
-          exit "$failed"
+          npm exec -- vitest run
+          npm run test:browser:built
+          node ./scripts/test-packed-vite.js


### PR DESCRIPTION
## What changed

- compile workspace test targets at `opt-level = 0` while retaining `opt-level = 1` for dependencies
- split the combined Cargo + JS SDK job so Rust and JS validation run on parallel runners
- add sccache's GitHub Actions backend to reuse compiler outputs across CI runs
- preserve the existing full-workspace, all-features Clippy and test coverage

## Why

After #742, execution is cheap but workspace test codegen remains expensive. On PR #742's successful CI run, the combined job took 10m59s:

- Rust lint: 1m56s
- Rust test compilation: 4m35s
- JS SDK bindings: 2m55s
- running Rust and JS tests: 16s

Serializing the independent Rust and JS phases left several minutes on the critical path.

## Measured impact

### Local full-feature engine build

Measured on a 16-core machine:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| compile wall time | 256.5s | 180.5s | -76.0s (-29.6%) |
| peak RSS | 5.54 GB | 3.53 GB | -36.3% |
| integration target | 102.0s | 32.5s | -69.5s (-68.1%) |
| full-feature test runtime | 4.74s | 6.57s | +1.83s |

### End-to-end CI

Compared with PR #742's successful run:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| CI critical path | 10m59s | 6m34s | -4m25s (-40.2%) |
| Rust test compilation | 4m35s | 2m59s | -1m36s (-34.9%) |
| Rust job | serialized in combined job | 6m34s | runs in parallel |
| JS SDK job | serialized in combined job | 5m26s | runs in parallel |

The first sccache-enabled JS run already reported 144 cache hits (26%); later runs can reuse the compiler results populated by this run.

## Validation

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo test --profile test --workspace --all-features --no-run`
- `cargo test --profile test --workspace --all-features`
- full-feature engine tests under both profile settings
- workflow YAML parsed and formatted with Prettier
- PR CI: Cargo Test, JS SDK Test, and Changelog all pass