### PR TITLE
Run Clippy and Rust tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,17 @@ jobs:
       - name: Validate change fragments
         run: node scripts/validate-changes.mjs
 
-  cargo-test:
-    name: Cargo Test
+  cargo:
+    name: Cargo ${{ matrix.name }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Clippy
+            task: clippy
+          - name: Test
+            task: test
 
     steps:
       - name: Checkout repository
@@ -78,12 +86,15 @@ jobs:
           EOF
 
       - name: Lint Rust workspace
+        if: matrix.task == 'clippy'
         run: cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
 
       - name: Compile Rust workspace tests
+        if: matrix.task == 'test'
         run: cargo test --profile test --workspace --all-features --no-run
 
       - name: Run Rust workspace tests
+        if: matrix.task == 'test'
         run: cargo test --profile test --workspace --all-features
 
   js-sdk-test:


### PR DESCRIPTION
## What changed

- turn Cargo validation into a two-entry matrix
- run full-workspace Clippy and full-workspace tests on separate 32-vCPU runners
- preserve the same profiles, features, caches, and test coverage

## Why

After #744, the 6m34s Cargo job was the CI critical path. Its two dominant phases were serialized even though they are independent:

- Clippy: 2m02s
- compile and run tests: 3m13s

## Measured impact

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| CI critical path | 6m34s | 5m28s | -1m06s (-16.8%) |
| Cargo Clippy job | serialized | 3m05s | parallel |
| Cargo Test job | serialized | 3m47s | parallel |
| JS SDK job | 5m26s | 5m28s | new critical path |

## Validation

- workflow YAML parses and passes Prettier formatting
- no command or feature coverage changed
- Cargo Clippy, Cargo Test, JS SDK Test, and Changelog all pass