### PR TITLE
perf: bulk-build sorted tracked roots

### DIFF
--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -282,6 +282,15 @@ impl TrackedStateTree {
         mut mutations: Vec<TrackedStateMutation>,
         commit_id: Option<&str>,
     ) -> Result<TrackedStateApplyResult, LixError> {
+        // The normal bulk tracked-write path already arrives in primary-key
+        // order.  With no parent root there is nothing to merge it with, so
+        // preserve that order directly instead of routing every row through a
+        // BTreeMap merely to sort it again.
+        if base_root.is_none() && mutations_are_strictly_sorted(&mutations) {
+            return self
+                .build_and_stage_sorted_mutations(writes, overlay, mutations, commit_id)
+                .await;
+        }
         if let Some(root_id) = base_root {
             if mutations.len() == 1 {
                 let mutation = mutations.pop().expect("single mutation should exist");
@@ -760,14 +769,10 @@ impl TrackedStateTree {
         writes: &mut StorageWriteSet,
         overlay: &mut storage::TrackedStateChunkOverlay,
         root_id: &TrackedStateRootId,
-        mutations: Vec<TrackedStateMutation>,
+        mut mutations: Vec<TrackedStateMutation>,
         commit_id: Option<&str>,
     ) -> Result<MutationApply<Vec<TrackedStateMutation>>, LixError> {
-        let mut mutation_map = BTreeMap::new();
-        for mutation in mutations {
-            mutation_map.insert(mutation.encoded_key, mutation.encoded_value);
-        }
-        if mutation_map.is_empty() {
+        if mutations.is_empty() {
             return Ok(MutationApply::Fallback(Vec::new()));
         }
 
@@ -775,28 +780,47 @@ impl TrackedStateTree {
             .collect_summary_levels_with_overlay(store, overlay, root_id)
             .await?;
         let Some(leaves) = levels.first() else {
-            return Ok(MutationApply::Fallback(
-                mutation_map
-                    .into_iter()
-                    .map(|(encoded_key, encoded_value)| TrackedStateMutation {
-                        encoded_key,
-                        encoded_value,
-                    })
-                    .collect(),
-            ));
+            return Ok(MutationApply::Fallback(mutations));
         };
 
+        let mutations_are_sorted = mutations_are_strictly_sorted(&mutations);
+        let mut mutation_map = (!mutations_are_sorted).then(|| {
+            std::mem::take(&mut mutations)
+                .into_iter()
+                .map(|mutation| (mutation.encoded_key, mutation.encoded_value))
+                .collect::<BTreeMap<_, _>>()
+        });
         let base_row_count = leaves
             .iter()
             .map(|leaf| leaf.subtree_count as usize)
             .sum::<usize>();
-        let first_mutation_key = mutation_map
-            .keys()
-            .next()
-            .expect("non-empty mutation map should have first key");
+        let first_mutation_key = mutation_map.as_ref().map_or_else(
+            || &mutations[0].encoded_key,
+            |mutations| {
+                mutations
+                    .keys()
+                    .next()
+                    .expect("non-empty mutation map should have first key")
+            },
+        );
         let append_only = leaves
             .last()
             .is_some_and(|leaf| first_mutation_key.as_slice() > leaf.last_key.as_slice());
+        if mutations_are_sorted && !append_only && mutations.len() * 2 > base_row_count {
+            return Ok(MutationApply::Applied(
+                self.rebuild_from_sorted_mutations(
+                    store, writes, overlay, root_id, mutations, commit_id,
+                )
+                .await?,
+            ));
+        }
+
+        let mutation_map = mutation_map.take().unwrap_or_else(|| {
+            mutations
+                .into_iter()
+                .map(|mutation| (mutation.encoded_key, mutation.encoded_value))
+                .collect()
+        });
         if !append_only && mutation_map.len() * 2 > base_row_count {
             return Ok(MutationApply::Fallback(
                 mutation_map
@@ -919,6 +943,73 @@ impl TrackedStateTree {
             self.persist_built_tree(writes, overlay, built, commit_id)
                 .await?,
         ))
+    }
+
+    async fn build_and_stage_sorted_mutations(
+        &self,
+        writes: &mut StorageWriteSet,
+        overlay: &mut storage::TrackedStateChunkOverlay,
+        mutations: Vec<TrackedStateMutation>,
+        commit_id: Option<&str>,
+    ) -> Result<TrackedStateApplyResult, LixError> {
+        let built = self.build_tree_from_entries(
+            mutations
+                .into_iter()
+                .map(|mutation| EncodedLeafEntry {
+                    key: mutation.encoded_key,
+                    value: mutation.encoded_value,
+                })
+                .collect(),
+        )?;
+        self.persist_built_tree(writes, overlay, built, commit_id)
+            .await
+    }
+
+    async fn rebuild_from_sorted_mutations(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        writes: &mut StorageWriteSet,
+        overlay: &mut storage::TrackedStateChunkOverlay,
+        root_id: &TrackedStateRootId,
+        mutations: Vec<TrackedStateMutation>,
+        commit_id: Option<&str>,
+    ) -> Result<TrackedStateApplyResult, LixError> {
+        let base_entries = self
+            .collect_leaf_entries_with_overlay(store, overlay, root_id)
+            .await?;
+        let mut entries = Vec::with_capacity(base_entries.len() + mutations.len());
+        let mut mutations = mutations.into_iter().peekable();
+        for entry in base_entries {
+            while mutations
+                .peek()
+                .is_some_and(|mutation| mutation.encoded_key < entry.key)
+            {
+                let mutation = mutations.next().expect("peeked mutation should exist");
+                entries.push(EncodedLeafEntry {
+                    key: mutation.encoded_key,
+                    value: mutation.encoded_value,
+                });
+            }
+            if mutations
+                .peek()
+                .is_some_and(|mutation| mutation.encoded_key == entry.key)
+            {
+                let mutation = mutations.next().expect("peeked mutation should exist");
+                entries.push(EncodedLeafEntry {
+                    key: mutation.encoded_key,
+                    value: mutation.encoded_value,
+                });
+            } else {
+                entries.push(entry);
+            }
+        }
+        entries.extend(mutations.map(|mutation| EncodedLeafEntry {
+            key: mutation.encoded_key,
+            value: mutation.encoded_value,
+        }));
+        let built = self.build_tree_from_entries(entries)?;
+        self.persist_built_tree(writes, overlay, built, commit_id)
+            .await
     }
 
     #[expect(clippy::cast_possible_truncation)]
@@ -1892,6 +1983,12 @@ struct InternalChunkRefAccumulator<'a> {
     children: Vec<ChildSummaryRef<'a>>,
     first_key_bytes: usize,
     last_key_bytes: usize,
+}
+
+fn mutations_are_strictly_sorted(mutations: &[TrackedStateMutation]) -> bool {
+    mutations
+        .windows(2)
+        .all(|pair| pair[0].encoded_key < pair[1].encoded_key)
 }
 
 fn chunk_leaf_entries(
@@ -3484,7 +3581,9 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let updates = (10..25)
+        // More than half of the parent is replaced, which exercises the
+        // sorted full-rebuild path instead of the sparse chunk patcher.
+        let updates = (10..90)
             .map(|index| {
                 (
                     key("schema", None, &format!("entity-{index:03}")),

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -507,6 +507,59 @@ async fn stage_flat_current_rows(
     let mut writer = current.writer(read, writes);
     let mut compactable_change_ids = BTreeSet::new();
     for branch_id in &branch_ids {
+        let has_tracked_rows = state_rows
+            .iter()
+            .any(|row| row.branch_id == *branch_id && !row.untracked);
+        let has_tracked_insert = state_rows.iter().any(|row| {
+            row.branch_id == *branch_id
+                && !row.untracked
+                && row.snapshot.is_some()
+                && insert_identities
+                    .get(&PreparedStateRowIdentity::from(row))
+                    .is_some_and(|insert| !insert.untracked())
+        });
+        let untracked_state_deltas = state_rows
+            .iter()
+            .filter(|row| row.branch_id == *branch_id && row.untracked)
+            .map(current_delta_from_state_row)
+            .collect::<Result<Vec<_>, _>>()?;
+        let engine_deltas = engine_rows
+            .iter()
+            .filter(|row| row.branch_id == *branch_id)
+            .map(current_delta_from_engine_row)
+            .collect::<Vec<_>>();
+        let new_deltas = untracked_state_deltas
+            .into_iter()
+            .chain(engine_deltas)
+            .collect::<Vec<_>>();
+
+        if !has_tracked_rows {
+            if !new_deltas.is_empty() {
+                compactable_change_ids
+                    .extend(writer.stage_branch_rows(branch_id, new_deltas).await?);
+            }
+            continue;
+        }
+
+        // Tracked rows are served exclusively from immutable commit roots.
+        // On the normal path the branch has no untracked sidecar rows, so a
+        // single range-empty precondition proves there is no durability
+        // collision. Do not construct one mutable-index delta per tracked row
+        // only for the writer to discard it.
+        if !branch_has_local_untracked_rows(&index_reader, branch_id).await? {
+            if has_tracked_insert {
+                preconditions.push(branch_empty_precondition(branch_id)?);
+            }
+            if !new_deltas.is_empty() {
+                compactable_change_ids
+                    .extend(writer.stage_branch_rows(branch_id, new_deltas).await?);
+            }
+            continue;
+        }
+
+        // A populated sidecar is rare. Retain the existing per-row lowering
+        // here so tracked writes can atomically reject collisions and clear a
+        // sidecar row on the internal durability-promotion path.
         let state_deltas = state_rows
             .iter()
             .filter(|row| row.branch_id == *branch_id)
@@ -517,51 +570,37 @@ async fn stage_flat_current_rows(
             .filter(|row| row.branch_id == *branch_id)
             .map(current_delta_from_engine_row)
             .collect::<Vec<_>>();
-        let new_deltas = state_deltas
+        let all_deltas = state_deltas
             .into_iter()
             .chain(engine_deltas)
             .collect::<Vec<_>>();
-
-        if !new_deltas.is_empty() {
-            let absence_guards = state_rows
+        let absence_guards = state_rows
+            .iter()
+            .filter(|row| {
+                row.branch_id == *branch_id
+                    && row.snapshot.is_some()
+                    && insert_identities
+                        .get(&PreparedStateRowIdentity::from(*row))
+                        .is_some_and(|insert| !insert.untracked())
+            })
+            .map(|row| LiveStateIndexRowRequest {
+                branch_id: row.branch_id.clone(),
+                schema_key: row.schema_key.clone(),
+                entity_pk: row.entity_pk.clone(),
+                file_id: row.file_id.clone(),
+            })
+            .collect::<BTreeSet<_>>();
+        preconditions.extend(
+            absence_guards
                 .iter()
-                .filter(|row| {
-                    row.branch_id == *branch_id
-                        && row.snapshot.is_some()
-                        && insert_identities
-                            .get(&PreparedStateRowIdentity::from(*row))
-                            .is_some_and(|insert| !insert.untracked())
-                })
-                .map(|row| LiveStateIndexRowRequest {
-                    branch_id: row.branch_id.clone(),
-                    schema_key: row.schema_key.clone(),
-                    entity_pk: row.entity_pk.clone(),
-                    file_id: row.file_id.clone(),
-                })
-                .collect::<BTreeSet<_>>();
-            let superseded = if absence_guards.is_empty()
-                || !branch_has_local_untracked_rows(&index_reader, branch_id).await?
-            {
-                if !absence_guards.is_empty() {
-                    preconditions.push(branch_empty_precondition(branch_id)?);
-                }
-                let known_absent = absence_guards.iter().cloned().collect::<Vec<_>>();
-                writer
-                    .stage_branch_rows_with_known_absent(branch_id, new_deltas, &known_absent)
-                    .await?
-            } else {
-                preconditions.extend(
-                    absence_guards
-                        .iter()
-                        .map(row_absent_precondition)
-                        .collect::<Result<Vec<_>, _>>()?,
-                );
-                writer
-                    .stage_branch_rows_with_absence_guards(branch_id, new_deltas, &absence_guards)
-                    .await?
-            };
-            compactable_change_ids.extend(superseded);
-        }
+                .map(row_absent_precondition)
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+        compactable_change_ids.extend(
+            writer
+                .stage_branch_rows_with_absence_guards(branch_id, all_deltas, &absence_guards)
+                .await?,
+        );
     }
     if compactable_change_ids.is_empty() {
         return Ok(Vec::new());


### PR DESCRIPTION
## Summary

- build dense, already sorted tracked root mutations directly instead of inserting them into an intermediate `BTreeMap`
- linearly merge a sorted dense mutation stream with its parent root when a full rebuild is cheaper than sparse chunk patching
- stop lowering ordinary tracked writes into the mutable live-state index; tracked rows are served from immutable commit roots
- retain the slow path for populated untracked sidecars, including exact collision guards and durability promotion cleanup

## Root cause

The normal tracked bulk-write path duplicated current-state work. It built one flat-index delta per tracked row even though the flat index deliberately stores only untracked and engine-owned rows; the writer then discarded each tracked delta after constructing a `BTreeMap`. The root builder also rebuilt large sorted batches through another `BTreeMap` before chunking them.

The fast path now preserves prepared primary-key order end to end and performs a linear merge only when dense mutation volume makes a full root rebuild preferable. Unsorted or duplicate mutation streams retain the established last-write-wins fallback.

## Performance

Same 10k tracked insert workload: 20 × 500-row SQL statements inside one explicit transaction, Lix + RocksDB.

- baseline SQL median: **194.1 ms**
- post-change SQL medians across two independent process samples: **164.9–174.7 ms** (**10–15% faster**)
- baseline transaction-API median: **146.6 ms**
- post-change transaction-API medians: **109.0–124.1 ms** (**15–26% faster**)
- standalone SQLite median: **9.21 ms**

The remaining SQL gap is now dominated by SQL planning/staging rather than the commit materializer.

## Correctness

- tracked data remains served from immutable commit roots
- an empty untracked sidecar uses one branch-range-empty precondition
- a populated sidecar retains exact key-absence preconditions and the existing promotion cleanup path
- unsorted and duplicate mutations retain the existing `BTreeMap` fallback; a dense sorted-rebuild regression test compares the resulting root to a canonical rebuild

## Validation

- `cargo test -p lix_engine --features all-simulations` — 1,134 unit/simulation tests, 778 integration tests, 3 doctests
- `cargo test -p lix_engine --features all-simulations tracked_state::tree::tests::batch_update_matches_full_canonical_rebuild`
- tracked 10k CRUD benchmarks for raw SQLite, Lix SQL+RocksDB, and Lix transaction API