### PR TITLE
Run native and browser SDK tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,16 @@ jobs:
         run: cargo test --profile test --workspace --all-features
 
   js-sdk-test:
-    name: JS SDK Test
+    name: JS SDK ${{ matrix.name }} Test
     runs-on: blacksmith-32vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Native
+            runtime: native
+          - name: Browser
+            runtime: browser
 
     steps:
       - name: Checkout repository
@@ -127,6 +135,7 @@ jobs:
           EOF
 
       - name: Install LLVM build dependencies
+        if: matrix.runtime == 'native'
         run: |
           sudo apt-get update
           sudo apt-get install -y llvm-dev libclang-dev clang
@@ -146,10 +155,15 @@ jobs:
           RUSTC_WRAPPER=sccache
           EOF
 
-      - name: Install WebAssembly build target
+      - name: Install plugin build target
+        run: rustup target add wasm32-wasip2
+
+      - name: Install browser WebAssembly build target
+        if: matrix.runtime == 'browser'
         run: rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-bindgen CLI
+        if: matrix.runtime == 'browser'
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-bindgen-cli@0.2.122
@@ -166,16 +180,32 @@ jobs:
         run: npm ci
 
       - name: Install Chromium
+        if: matrix.runtime == 'browser'
         working-directory: packages/js-sdk
         run: npx playwright install --with-deps chromium
 
-      - name: Build JS SDK bindings
-        working-directory: packages/js-sdk
-        run: npm run build
-
-      - name: Run JS SDK tests
+      - name: Build native JS SDK
+        if: matrix.runtime == 'native'
         working-directory: packages/js-sdk
         run: |
-          npm exec -- vitest run
+          npm run clean
+          npm run build:native
+          npm run build:ts
+          npm run build:plugins
+
+      - name: Run native JS SDK tests
+        if: matrix.runtime == 'native'
+        working-directory: packages/js-sdk
+        run: npm exec -- vitest run
+
+      - name: Build browser JS SDK
+        if: matrix.runtime == 'browser'
+        working-directory: packages/js-sdk
+        run: npm run build:browser
+
+      - name: Run browser JS SDK tests
+        if: matrix.runtime == 'browser'
+        working-directory: packages/js-sdk
+        run: |
           npm run test:browser:built
           node ./scripts/test-packed-vite.js


### PR DESCRIPTION
## What changed

- split JS SDK validation into native and browser matrix jobs
- build only native + TypeScript + plugin artifacts for Node tests
- build only WASM + browser + plugin artifacts for browser and packed-Vite tests
- install LLVM only for native builds and Chromium/wasm-bindgen only for browser builds
- preserve all 130 native tests, 23 browser tests, and the packed production smoke test

## Why

After #745, the 5m28s JS SDK job was the CI critical path. Its 3m38s build was overwhelmingly two independent Rust targets that were serialized:

- native binding: 2m49s (77%)
- WASM/browser binding: 45s (21%)
- TypeScript/JCO/plugins: ~4s

## Measured impact

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| CI critical path | 5m28s | 2m32s | -2m56s (-53.7%) |
| JS SDK native | serialized | 1m49s | parallel |
| JS SDK browser | serialized | 2m09s | parallel |
| Cargo Test | 3m47s | 2m32s | new critical path |
| Cargo Clippy | 3m05s | 1m54s | parallel |

Warm sccache contributed to all jobs, while the JS split removed the native/WASM serialization from the critical path.

## Validation

- native subset: 130 tests pass
- browser subset: 23 tests pass
- packed Vite production smoke passes
- workflow YAML passes Prettier formatting
- Cargo Clippy, Cargo Test, JS SDK Native Test, JS SDK Browser Test, and Changelog all pass