### PR TITLE
Remove redundant Rust cache setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm-dev libclang-dev clang
 
-      - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-
       - name: Restore compiler cache
         uses: mozilla-actions/sccache-action@v0.0.10
 


### PR DESCRIPTION
## What changed

- remove `Swatinem/rust-cache` from Cargo Clippy/Test jobs
- retain the shared sccache compiler cache
- leave JS SDK caching unchanged

## Why

The warm Cargo Test baseline spent about 60 seconds restoring a 2.6 GB `target/` cache before a 58-second sccache-backed compile. An intermediate CI experiment disabled target caching, but the cache action still spent 69 seconds computing metadata before reporting no cache; Cargo then downloaded dependencies and compiled in 85 seconds. Removing the overlapping cache action avoids that setup cost while sccache continues serving compiler objects.

## Measured impact

| Job | Before | After | Change |
| --- | ---: | ---: | ---: |
| Cargo Test | 2m32s | 2m03s | -29s (-19.1%) |
| Cargo Clippy | 1m54s | 1m27s | -27s (-23.7%) |

The full run remained green. Browser timing varied independently and is unchanged by this PR.

## Validation

- all 5 CI checks pass
- workflow YAML passes Prettier
- `git diff --check` passes