### PR TITLE
perf: fast-path homogeneous tracked batches

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
@@ -20,8 +20,14 @@ struct BenchRow {
 }
 
 enum ProfileStorage {
-    SQLite(StorageAdapter<SQLite>),
-    RocksDB(StorageAdapter<RocksDB>),
+    SQLite {
+        storage: StorageAdapter<SQLite>,
+        _dir: tempfile::TempDir,
+    },
+    RocksDB {
+        storage: StorageAdapter<RocksDB>,
+        _dir: tempfile::TempDir,
+    },
 }
 
 pub(crate) struct KvFixture {
@@ -160,60 +166,68 @@ impl KvFixture {
 impl ProfileStorage {
     async fn insert_all(&self, rows: &[BenchRow]) -> KvWriteOutcome {
         match self {
-            Self::SQLite(storage) => insert_all_storage(storage, rows).await,
-            Self::RocksDB(storage) => insert_all_storage(storage, rows).await,
+            Self::SQLite { storage, .. } => insert_all_storage(storage, rows).await,
+            Self::RocksDB { storage, .. } => insert_all_storage(storage, rows).await,
         }
     }
 
     async fn update_all(&self, rows: &[BenchRow]) -> KvWriteOutcome {
         match self {
-            Self::SQLite(storage) => update_all_storage(storage, rows).await,
-            Self::RocksDB(storage) => update_all_storage(storage, rows).await,
+            Self::SQLite { storage, .. } => update_all_storage(storage, rows).await,
+            Self::RocksDB { storage, .. } => update_all_storage(storage, rows).await,
         }
     }
 
     async fn delete_all(&self, row_count: usize) -> KvWriteOutcome {
         match self {
-            Self::SQLite(storage) => delete_all_storage(storage, row_count).await,
-            Self::RocksDB(storage) => delete_all_storage(storage, row_count).await,
+            Self::SQLite { storage, .. } => delete_all_storage(storage, row_count).await,
+            Self::RocksDB { storage, .. } => delete_all_storage(storage, row_count).await,
         }
     }
 
     async fn delete_one(&self, row: &BenchRow) -> KvWriteOutcome {
         match self {
-            Self::SQLite(storage) => delete_one_storage(storage, row).await,
-            Self::RocksDB(storage) => delete_one_storage(storage, row).await,
+            Self::SQLite { storage, .. } => delete_one_storage(storage, row).await,
+            Self::RocksDB { storage, .. } => delete_one_storage(storage, row).await,
         }
     }
 
     async fn read_all(&self, expected_rows: usize, projection: StorageCoreProjection) -> usize {
         match self {
-            Self::SQLite(storage) => read_all_storage(storage, expected_rows, projection).await,
-            Self::RocksDB(storage) => read_all_storage(storage, expected_rows, projection).await,
+            Self::SQLite { storage, .. } => {
+                read_all_storage(storage, expected_rows, projection).await
+            }
+            Self::RocksDB { storage, .. } => {
+                read_all_storage(storage, expected_rows, projection).await
+            }
         }
     }
 
     async fn read_points(&self, rows: &[BenchRow]) -> usize {
         match self {
-            Self::SQLite(storage) => read_points_storage(storage, rows).await,
-            Self::RocksDB(storage) => read_points_storage(storage, rows).await,
+            Self::SQLite { storage, .. } => read_points_storage(storage, rows).await,
+            Self::RocksDB { storage, .. } => read_points_storage(storage, rows).await,
         }
     }
 
     async fn layout_accounting(&self) -> Vec<KvLayoutAccounting> {
         match self {
-            Self::SQLite(storage) => layout_accounting_storage(storage).await,
-            Self::RocksDB(storage) => layout_accounting_storage(storage).await,
+            Self::SQLite { storage, .. } => layout_accounting_storage(storage).await,
+            Self::RocksDB { storage, .. } => layout_accounting_storage(storage).await,
         }
     }
 }
 
 fn profile_storage(profile: StorageProfile) -> ProfileStorage {
     match profile.storage() {
-        RawProfileStorage::SQLite(storage) => ProfileStorage::SQLite(StorageAdapter::new(storage)),
-        RawProfileStorage::RocksDB(storage) => {
-            ProfileStorage::RocksDB(StorageAdapter::new(storage))
-        }
+        RawProfileStorage::SQLite { storage, _dir: dir } => ProfileStorage::SQLite {
+            storage: StorageAdapter::new(storage),
+            _dir: dir,
+        },
+        RawProfileStorage::RocksDB { storage, _dir: dir } => ProfileStorage::RocksDB {
+            storage: StorageAdapter::new(storage),
+            _dir: dir,
+        },
     }
 }
 

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -24,16 +24,22 @@ pub(crate) struct GenericSqlFixture<StorageImpl: Storage> {
     update_all_sql_rows: Vec<String>,
     delete_all_sql: String,
     delete_one_by_pk_sql: String,
+    // Keep the storage path alive until after the session/storage is dropped.
+    _dir: tempfile::TempDir,
 }
 
 pub(crate) async fn empty_fixture(profile: StorageProfile, rows: &[WorkloadRow]) -> SqlFixture {
     match profile.storage() {
-        ProfileStorage::SQLite(storage) => {
-            SqlFixture::SQLite(fixture_for_session(prepare_session(storage).await, rows))
-        }
-        ProfileStorage::RocksDB(storage) => {
-            SqlFixture::RocksDB(fixture_for_session(prepare_session(storage).await, rows))
-        }
+        ProfileStorage::SQLite { storage, _dir: dir } => SqlFixture::SQLite(fixture_for_session(
+            prepare_session(storage).await,
+            rows,
+            dir,
+        )),
+        ProfileStorage::RocksDB { storage, _dir: dir } => SqlFixture::RocksDB(fixture_for_session(
+            prepare_session(storage).await,
+            rows,
+            dir,
+        )),
     }
 }
 
@@ -176,6 +182,7 @@ where
 fn fixture_for_session<StorageImpl>(
     session: SessionContext<StorageImpl>,
     rows: &[WorkloadRow],
+    dir: tempfile::TempDir,
 ) -> GenericSqlFixture<StorageImpl>
 where
     StorageImpl: Storage,
@@ -195,6 +202,7 @@ where
             "DELETE FROM json_pointer WHERE path = '{}'",
             sql_string(rows[mid].path.as_str())
         ),
+        _dir: dir,
     }
 }
 

--- a/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/storage.rs
@@ -21,8 +21,8 @@ impl StorageProfile {
 }
 
 pub(crate) enum ProfileStorage {
-    SQLite(SQLite),
-    RocksDB(RocksDB),
+    SQLite { storage: SQLite, _dir: TempDir },
+    RocksDB { storage: RocksDB, _dir: TempDir },
 }
 
 impl StorageProfile {
@@ -30,17 +30,15 @@ impl StorageProfile {
         match self {
             Self::SQLite => {
                 let dir = TempDir::new().expect("create sqlite bench tempdir");
-                ProfileStorage::SQLite(
-                    SQLite::open(dir.keep().join("bench.sqlite"))
-                        .expect("open sqlite bench storage"),
-                )
+                let storage = SQLite::open(dir.path().join("bench.sqlite"))
+                    .expect("open sqlite bench storage");
+                ProfileStorage::SQLite { storage, _dir: dir }
             }
             Self::RocksDB => {
                 let dir = TempDir::new().expect("create rocksdb bench tempdir");
-                ProfileStorage::RocksDB(
-                    RocksDB::open(dir.keep().join("bench.rocksdb"))
-                        .expect("open rocksdb bench storage"),
-                )
+                let storage = RocksDB::open(dir.path().join("bench.rocksdb"))
+                    .expect("open rocksdb bench storage");
+                ProfileStorage::RocksDB { storage, _dir: dir }
             }
         }
     }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/transaction_api.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/transaction_api.rs
@@ -7,8 +7,14 @@ use crate::storage::{ProfileStorage, RocksDB, SQLite, StorageProfile};
 use crate::workload::{WorkloadRow, snapshot_value};
 
 pub(crate) enum TransactionFixture {
-    SQLite(BenchTransactionFixture<SQLite>),
-    RocksDB(BenchTransactionFixture<RocksDB>),
+    SQLite {
+        fixture: BenchTransactionFixture<SQLite>,
+        _dir: tempfile::TempDir,
+    },
+    RocksDB {
+        fixture: BenchTransactionFixture<RocksDB>,
+        _dir: tempfile::TempDir,
+    },
 }
 
 pub(crate) type TransactionWriteAccounting = BenchWriteAccounting;
@@ -20,12 +26,14 @@ pub(crate) async fn empty_fixture(
 ) -> TransactionFixture {
     let rows = bench_rows(rows);
     match profile.storage() {
-        ProfileStorage::SQLite(storage) => TransactionFixture::SQLite(
-            BenchTransactionFixture::new(StorageAdapter::new(storage), rows).await,
-        ),
-        ProfileStorage::RocksDB(storage) => TransactionFixture::RocksDB(
-            BenchTransactionFixture::new(StorageAdapter::new(storage), rows).await,
-        ),
+        ProfileStorage::SQLite { storage, _dir: dir } => TransactionFixture::SQLite {
+            fixture: BenchTransactionFixture::new(StorageAdapter::new(storage), rows).await,
+            _dir: dir,
+        },
+        ProfileStorage::RocksDB { storage, _dir: dir } => TransactionFixture::RocksDB {
+            fixture: BenchTransactionFixture::new(StorageAdapter::new(storage), rows).await,
+            _dir: dir,
+        },
     }
 }
 
@@ -41,106 +49,106 @@ pub(crate) async fn seeded_fixture(
 impl TransactionFixture {
     pub(crate) async fn seed(&mut self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.seed().await,
-            Self::RocksDB(fixture) => fixture.seed().await,
+            Self::SQLite { fixture, .. } => fixture.seed().await,
+            Self::RocksDB { fixture, .. } => fixture.seed().await,
         }
     }
 
     pub(crate) async fn insert_all(&mut self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.insert_all().await,
-            Self::RocksDB(fixture) => fixture.insert_all().await,
+            Self::SQLite { fixture, .. } => fixture.insert_all().await,
+            Self::RocksDB { fixture, .. } => fixture.insert_all().await,
         }
     }
 
     pub(crate) async fn insert_all_accounting(&mut self) -> TransactionWriteAccounting {
         match self {
-            Self::SQLite(fixture) => fixture.insert_all_accounting().await,
-            Self::RocksDB(fixture) => fixture.insert_all_accounting().await,
+            Self::SQLite { fixture, .. } => fixture.insert_all_accounting().await,
+            Self::RocksDB { fixture, .. } => fixture.insert_all_accounting().await,
         }
     }
 
     pub(crate) async fn read_all(&self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.read_all().await,
-            Self::RocksDB(fixture) => fixture.read_all().await,
+            Self::SQLite { fixture, .. } => fixture.read_all().await,
+            Self::RocksDB { fixture, .. } => fixture.read_all().await,
         }
     }
 
     pub(crate) async fn read_many_by_pk(&self, count: usize) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.read_many_by_pk(count).await,
-            Self::RocksDB(fixture) => fixture.read_many_by_pk(count).await,
+            Self::SQLite { fixture, .. } => fixture.read_many_by_pk(count).await,
+            Self::RocksDB { fixture, .. } => fixture.read_many_by_pk(count).await,
         }
     }
 
     pub(crate) async fn read_one_by_pk(&self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.read_one_by_pk().await,
-            Self::RocksDB(fixture) => fixture.read_one_by_pk().await,
+            Self::SQLite { fixture, .. } => fixture.read_one_by_pk().await,
+            Self::RocksDB { fixture, .. } => fixture.read_one_by_pk().await,
         }
     }
 
     pub(crate) async fn update_all(&mut self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.update_all().await,
-            Self::RocksDB(fixture) => fixture.update_all().await,
+            Self::SQLite { fixture, .. } => fixture.update_all().await,
+            Self::RocksDB { fixture, .. } => fixture.update_all().await,
         }
     }
 
     pub(crate) async fn update_all_accounting(&mut self) -> TransactionWriteAccounting {
         match self {
-            Self::SQLite(fixture) => fixture.update_all_accounting().await,
-            Self::RocksDB(fixture) => fixture.update_all_accounting().await,
+            Self::SQLite { fixture, .. } => fixture.update_all_accounting().await,
+            Self::RocksDB { fixture, .. } => fixture.update_all_accounting().await,
         }
     }
 
     pub(crate) async fn update_one_by_pk(&mut self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.update_one_by_pk().await,
-            Self::RocksDB(fixture) => fixture.update_one_by_pk().await,
+            Self::SQLite { fixture, .. } => fixture.update_one_by_pk().await,
+            Self::RocksDB { fixture, .. } => fixture.update_one_by_pk().await,
         }
     }
 
     pub(crate) async fn update_one_by_pk_accounting(&mut self) -> TransactionWriteAccounting {
         match self {
-            Self::SQLite(fixture) => fixture.update_one_by_pk_accounting().await,
-            Self::RocksDB(fixture) => fixture.update_one_by_pk_accounting().await,
+            Self::SQLite { fixture, .. } => fixture.update_one_by_pk_accounting().await,
+            Self::RocksDB { fixture, .. } => fixture.update_one_by_pk_accounting().await,
         }
     }
 
     pub(crate) async fn delete_all(&mut self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.delete_all().await,
-            Self::RocksDB(fixture) => fixture.delete_all().await,
+            Self::SQLite { fixture, .. } => fixture.delete_all().await,
+            Self::RocksDB { fixture, .. } => fixture.delete_all().await,
         }
     }
 
     pub(crate) async fn delete_all_accounting(&mut self) -> TransactionWriteAccounting {
         match self {
-            Self::SQLite(fixture) => fixture.delete_all_accounting().await,
-            Self::RocksDB(fixture) => fixture.delete_all_accounting().await,
+            Self::SQLite { fixture, .. } => fixture.delete_all_accounting().await,
+            Self::RocksDB { fixture, .. } => fixture.delete_all_accounting().await,
         }
     }
 
     pub(crate) async fn delete_one_by_pk(&mut self) -> usize {
         match self {
-            Self::SQLite(fixture) => fixture.delete_one_by_pk().await,
-            Self::RocksDB(fixture) => fixture.delete_one_by_pk().await,
+            Self::SQLite { fixture, .. } => fixture.delete_one_by_pk().await,
+            Self::RocksDB { fixture, .. } => fixture.delete_one_by_pk().await,
         }
     }
 
     pub(crate) async fn delete_one_by_pk_accounting(&mut self) -> TransactionWriteAccounting {
         match self {
-            Self::SQLite(fixture) => fixture.delete_one_by_pk_accounting().await,
-            Self::RocksDB(fixture) => fixture.delete_one_by_pk_accounting().await,
+            Self::SQLite { fixture, .. } => fixture.delete_one_by_pk_accounting().await,
+            Self::RocksDB { fixture, .. } => fixture.delete_one_by_pk_accounting().await,
         }
     }
 
     pub(crate) async fn layout_accounting(&self) -> Vec<TransactionLayoutAccounting> {
         match self {
-            Self::SQLite(fixture) => fixture.layout_accounting().await,
-            Self::RocksDB(fixture) => fixture.layout_accounting().await,
+            Self::SQLite { fixture, .. } => fixture.layout_accounting().await,
+            Self::RocksDB { fixture, .. } => fixture.layout_accounting().await,
         }
     }
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1578,6 +1578,21 @@ where
                 .await?,
         );
         let live_state = self.live_state.reader(&read);
+        if let Some(domain) = homogeneous_row_normalization_domain(&rows) {
+            let functions = self.functions.clone();
+            let catalog = self
+                .schema_resolver
+                .catalog_for_row_normalization(&live_state, &staged, &domain)
+                .await?;
+            return rows
+                .into_iter()
+                .map(|row| {
+                    let normalized =
+                        normalize_transaction_write_row(row, catalog, functions.clone())?;
+                    prepare_state_row(normalized, &functions, self.origin_key.clone())
+                })
+                .collect();
+        }
         let mut rows_by_scope = BTreeMap::<Domain, Vec<(usize, TransactionWriteRow)>>::new();
         for (index, row) in rows.into_iter().enumerate() {
             rows_by_scope
@@ -2270,6 +2285,27 @@ fn prepare_state_row(
         untracked: row.untracked,
         branch_id: row.branch_id,
     })
+}
+
+/// Returns the sole schema-catalog scope for a straightforward statement
+/// batch. The SQL path normally reaches this with one entity schema and one
+/// durability, so it can normalize rows in input order without allocating the
+/// generic scope/reordering maps. Schema registration stays on the generic
+/// path because registrations can change the catalog for later rows.
+fn homogeneous_row_normalization_domain(rows: &[TransactionWriteRow]) -> Option<Domain> {
+    let first = rows.first()?;
+    if first.schema_key == REGISTERED_SCHEMA_KEY {
+        return None;
+    }
+    let branch_id = first.schema_scope_branch_id();
+    let untracked = first.untracked;
+    rows.iter()
+        .all(|row| {
+            row.schema_key != REGISTERED_SCHEMA_KEY
+                && row.untracked == untracked
+                && row.schema_scope_branch_id() == branch_id
+        })
+        .then(|| Domain::schema_catalog(branch_id.to_string(), untracked))
 }
 
 fn parse_prepared_timestamp(column: &str, timestamp: &str) -> Result<LixTimestamp, LixError> {

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -8,6 +8,7 @@
     clippy::unused_self
 )]
 
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 
@@ -568,8 +569,11 @@ impl TransactionWriteBuffer {
         };
         let functions = self.functions.clone();
         let (rows, file_data_writes) = self.state_rows_from_stage_write(write);
-        reject_mixed_durability_rows_in_batch(&rows)?;
-        reject_duplicate_present_rows_in_batch(&rows)?;
+        let identities = rows
+            .iter()
+            .map(PreparedStateRowIdentity::from)
+            .collect::<Vec<_>>();
+        validate_batch_row_identities(&rows, &identities)?;
         let mut guard = self.rows.lock().map_err(|_| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
@@ -595,15 +599,14 @@ impl TransactionWriteBuffer {
                 "failed to acquire transaction staged insert identity lock",
             )
         })?;
-        for row in &rows {
+        for (row, identity) in rows.iter().zip(&identities) {
             if row.global && row.branch_id != GLOBAL_BRANCH_ID {
                 return Err(LixError::new(
                     LixError::CODE_INVALID_PARAM,
                     "global staged rows must use the global branch id",
                 ));
             }
-            let identity = PreparedStateRowIdentity::from(row);
-            let Some(RowSlot::State(index)) = by_identity_guard.get(&identity).copied() else {
+            let Some(RowSlot::State(index)) = by_identity_guard.get(identity).copied() else {
                 continue;
             };
             let Some(previous) = guard.get(index).and_then(Option::as_ref) else {
@@ -613,8 +616,7 @@ impl TransactionWriteBuffer {
                 return Err(mixed_durability_error(row));
             }
         }
-        for mut row in rows {
-            let identity = PreparedStateRowIdentity::from(&row);
+        for (mut row, identity) in rows.into_iter().zip(identities) {
             let is_insert = row_is_insert(mode, &row);
             if is_insert && by_identity_guard.contains_key(&identity) {
                 return Err(duplicate_insert_identity_error(&row));
@@ -933,15 +935,30 @@ impl From<&MaterializedLiveStateRow> for PreparedStateRowIdentity {
     }
 }
 
-fn reject_mixed_durability_rows_in_batch(rows: &[PreparedStateRow]) -> Result<(), LixError> {
-    let mut durability_by_identity = BTreeMap::<PreparedStateRowIdentity, bool>::new();
-    for row in rows {
-        let identity = PreparedStateRowIdentity::from(row);
-        if durability_by_identity
-            .insert(identity, row.untracked)
-            .is_some_and(|untracked| untracked != row.untracked)
-        {
-            return Err(mixed_durability_error(row));
+fn validate_batch_row_identities(
+    rows: &[PreparedStateRow],
+    identities: &[PreparedStateRowIdentity],
+) -> Result<(), LixError> {
+    debug_assert_eq!(rows.len(), identities.len());
+    let mut rows_by_identity =
+        BTreeMap::<&PreparedStateRowIdentity, (bool, Option<&PreparedStateRow>)>::new();
+
+    for (row, identity) in rows.iter().zip(identities) {
+        match rows_by_identity.entry(identity) {
+            Entry::Vacant(entry) => {
+                entry.insert((row.untracked, row.snapshot.as_ref().map(|_| row)));
+            }
+            Entry::Occupied(mut entry) => {
+                let (untracked, pending_present) = entry.get_mut();
+                if *untracked != row.untracked {
+                    return Err(mixed_durability_error(row));
+                }
+                if row.snapshot.is_none() {
+                    *pending_present = None;
+                } else if let Some(previous) = pending_present.replace(row) {
+                    return Err(duplicate_staged_present_row_error(row, previous));
+                }
+            }
         }
     }
     Ok(())
@@ -959,21 +976,6 @@ fn mixed_durability_error(row: &PreparedStateRow) -> LixError {
             row.schema_key, entity_pk, row.branch_id
         ),
     )
-}
-
-fn reject_duplicate_present_rows_in_batch(rows: &[PreparedStateRow]) -> Result<(), LixError> {
-    let mut pending_present_rows = BTreeMap::<PreparedStateRowIdentity, &PreparedStateRow>::new();
-    for row in rows {
-        let identity = PreparedStateRowIdentity::from(row);
-        if row.snapshot.is_none() {
-            pending_present_rows.remove(&identity);
-            continue;
-        }
-        if let Some(previous) = pending_present_rows.insert(identity, row) {
-            return Err(duplicate_staged_present_row_error(row, previous));
-        }
-    }
-    Ok(())
 }
 
 fn duplicate_staged_present_row_error(


### PR DESCRIPTION
## Summary

Speeds up the normal homogeneous tracked-write lane and makes the tracked CRUD benchmark reusable for repeated profiling.

- Normalizes a single schema/durability batch directly in input order instead of building the generic scope/reordering maps.
- Computes each prepared-row identity once, then reuses it for batch validation and staging while preserving duplicate-present and mixed-durability checks.
- Keeps each benchmark fixture's temporary database alive exactly through fixture teardown rather than leaking its RocksDB/SQLite directory per Criterion sample.

## Why

The fresh 10k tracked INSERT baseline was:

| Layer | Median |
| --- | ---: |
| Standalone SQLite | 9.25 ms |
| Raw RocksDB KV | 14.66 ms |
| Lix transaction API | 107.37 ms |
| Lix SQL session | 170.33 ms |

The profiler showed repeated identity cloning and generic row-scope staging in the SQL hot path. The SQL fixture submits 20 homogeneous 500-row statements, so the generic multi-scope path was avoidable.

## Impact

On the same Lix + RocksDB fixture:

- SQL tracked INSERT: **170.33 ms → 153.60 ms** (about **10% faster**).
- Transaction API tracked INSERT: **107.37 ms → 106.21 ms** (small improvement; its single 10k batch already amortizes the removed scope setup).

This is the first incremental cut toward the ≤3× standalone SQLite target (≤27.76 ms). It intentionally leaves the larger transaction-core/changelog materialization rewrite for the next PR.

## Validation

- `cargo check -p lix_engine_benchmarks --benches --features storage-benches`
- `cargo test -p lix_engine --features all-simulations`
  - 1,134 unit/simulation tests passed
  - 786 integration tests passed
  - 3 doctests passed
- Focused Criterion benchmarks for raw SQLite, raw RocksDB KV, transaction API, and SQL session.