### PR TITLE
perf(binary-cas): bound sparse-edit chunk rewrites

### DIFF
--- a/packages/engine/src/binary_cas/chunking.rs
+++ b/packages/engine/src/binary_cas/chunking.rs
@@ -1,6 +1,7 @@
 pub(super) const INLINE_BINARY_CAS_MAX_BYTES: usize = 32 * 1024;
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
+const FASTCDC_WRITE_MAX_CHUNK_BYTES: usize = 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct BinaryCasChunking {
@@ -11,11 +12,11 @@ pub(crate) struct BinaryCasChunking {
 }
 
 impl BinaryCasChunking {
-    pub(crate) const fn fastcdc_1m_v1() -> Self {
+    pub(crate) const fn fastcdc_1m_v2() -> Self {
         Self {
             min_chunk_bytes: 256 * 1024,
             avg_chunk_bytes: 1024 * 1024,
-            max_chunk_bytes: MAX_BINARY_CAS_CHUNK_BYTES,
+            max_chunk_bytes: FASTCDC_WRITE_MAX_CHUNK_BYTES,
             single_chunk_fast_path_max_bytes: SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
         }
     }
@@ -23,7 +24,7 @@ impl BinaryCasChunking {
 
 impl Default for BinaryCasChunking {
     fn default() -> Self {
-        Self::fastcdc_1m_v1()
+        Self::fastcdc_1m_v2()
     }
 }
 
@@ -68,7 +69,7 @@ mod tests {
 
         assert_eq!(chunking.min_chunk_bytes, 256 * 1024);
         assert_eq!(chunking.avg_chunk_bytes, 1024 * 1024);
-        assert_eq!(chunking.max_chunk_bytes, MAX_BINARY_CAS_CHUNK_BYTES);
+        assert_eq!(chunking.max_chunk_bytes, FASTCDC_WRITE_MAX_CHUNK_BYTES);
         assert_eq!(chunking.single_chunk_fast_path_max_bytes, 64 * 1024);
     }
 
@@ -94,6 +95,19 @@ mod tests {
         assert_ne!(
             fastcdc_chunk_ranges_with_chunking(&above_boundary, chunking),
             vec![(0, above_boundary.len())]
+        );
+    }
+
+    #[test]
+    fn multi_megabyte_payloads_cannot_collapse_to_one_rewritten_chunk() {
+        let payload = vec![b'a'; 3_500_000];
+        let ranges = fastcdc_chunk_ranges(&payload);
+
+        assert!(ranges.len() >= 4);
+        assert!(
+            ranges
+                .iter()
+                .all(|(start, end)| end - start <= FASTCDC_WRITE_MAX_CHUNK_BYTES)
         );
     }
 }


### PR DESCRIPTION
## Summary

- cap newly written FastCDC chunks at 1 MiB
- retain the existing 4 MiB decode ceiling, so persisted manifests remain readable
- add a regression proving multi-megabyte low-entropy payloads cannot collapse into one rewritten chunk

## Root cause

The default profile targeted 1 MiB chunks but allowed a 4 MiB maximum. The 3.5 MiB Markdown benchmark therefore collapsed into one chunk. A one-byte edit recompressed and restaged the whole document, consuming about 8.9 ms per edit and defeating content-addressed reuse.

This follows the same bounded-work principle used by scalable storage systems: Sapling avoids O(repository) work through incremental state, DuckDB bounds storage work in blocks and row groups, and LSM systems separate small foreground writes from later compaction.

## Measured impact

Identical 3.5 MiB Markdown corpus, 7,253 paragraphs, 20 deterministic one-byte edits per cohort:

| cohort | Lix byte p50/p95 | Git p50/p95 |
| --- | --- | --- |
| 1 | 45.12 / 49.44 ms | 63.66 / 67.34 ms |
| 2 | 46.35 / 48.38 ms | 61.01 / 64.17 ms |
| 3 | 47.09 / 51.83 ms | 60.69 / 74.69 ms |

Lix is 22-29% faster at p50 and 24-31% faster at p95 in all three cohorts.

Cohort 1 incremental live storage after the identical edit trace:

- Lix: 11.77 MB
- Git before GC: 14.12 MB
- Git after GC: 3.96 MB

## Validation

- cargo test -p lix_engine binary_cas -- --nocapture (38 passed plus relevant integration test)
- cargo test -p lix_engine --features all-simulations (786 passed, 3 ignored)
- engine doc tests (3 passed)
