### PR TITLE
perf: streamline tracked commit materialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm-dev libclang-dev clang
 
-      - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-
       - name: Restore compiler cache
         uses: mozilla-actions/sccache-action@v0.0.10
 

--- a/packages/engine/src/changelog/codec.rs
+++ b/packages/engine/src/changelog/codec.rs
@@ -1,6 +1,7 @@
 use super::types::{
     ChangeId, ChangeRecord, ChangeRecordRef, ChangeRecordView, CommitChangeRefChunk,
     CommitChangeRefChunkWire, CommitChangeRefChunkWireRef, CommitId, CommitRecord,
+    TransactionChangeRecordRef,
 };
 use crate::common::LixError;
 use crate::entity_pk::EntityPk;
@@ -11,20 +12,36 @@ pub(crate) fn encode_commit_record(record: &CommitRecord) -> Result<Vec<u8>, Lix
 }
 
 pub(crate) fn encode_change_record(record: &ChangeRecord) -> Result<Vec<u8>, LixError> {
+    encode_change_record_ref(&ChangeRecordRef {
+        format_version: record.format_version,
+        schema_key: &record.schema_key,
+        entity_pk: &record.entity_pk.parts,
+        file_id: record.file_id.as_deref(),
+        snapshot: record.snapshot.as_ref_slot(),
+        metadata: record.metadata.as_ref_slot(),
+        created_at: record.created_at,
+        origin_key: record.origin_key.as_deref(),
+    })
+}
+
+pub(crate) fn encode_transaction_change_record(
+    record: &TransactionChangeRecordRef<'_>,
+) -> Result<Vec<u8>, LixError> {
+    encode_change_record_ref(&ChangeRecordRef {
+        format_version: record.format_version,
+        schema_key: record.schema_key,
+        entity_pk: &record.entity_pk.parts,
+        file_id: record.file_id,
+        snapshot: record.snapshot,
+        metadata: record.metadata,
+        created_at: record.created_at,
+        origin_key: record.origin_key,
+    })
+}
+
+fn encode_change_record_ref(record: &ChangeRecordRef<'_>) -> Result<Vec<u8>, LixError> {
     // change_id is the storage key; the value intentionally omits it.
-    storage_codec::encode(
-        "change record",
-        &ChangeRecordRef {
-            format_version: record.format_version,
-            schema_key: &record.schema_key,
-            entity_pk: &record.entity_pk.parts,
-            file_id: record.file_id.as_deref(),
-            snapshot: record.snapshot.as_ref_slot(),
-            metadata: record.metadata.as_ref_slot(),
-            created_at: record.created_at,
-            origin_key: record.origin_key.as_deref(),
-        },
-    )
+    storage_codec::encode("change record", record)
 }
 
 pub(crate) fn decode_change_record(
@@ -193,6 +210,20 @@ mod tests {
         let decoded =
             decode_change_record(&encoded, record.change_id).expect("record should decode");
         assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn transaction_change_record_encoding_matches_owned_record() {
+        let record = ChangeRecord {
+            snapshot: JsonSlot::from_json("{\"name\":\"libf\\u00f6\\u4e2d\"}"),
+            metadata: JsonSlot::from_json("{\"k\":1}"),
+            ..full_record()
+        };
+        assert_eq!(
+            encode_transaction_change_record(&TransactionChangeRecordRef::from(&record))
+                .expect("borrowed record should encode"),
+            encode_change_record(&record).expect("owned record should encode"),
+        );
     }
 
     #[test]

--- a/packages/engine/src/changelog/context.rs
+++ b/packages/engine/src/changelog/context.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 
 use super::codec::{
     decode_change_record, decode_commit_change_ref_chunk, encode_change_record,
-    encode_commit_change_ref_chunk, encode_commit_record,
+    encode_commit_change_ref_chunk, encode_commit_record, encode_transaction_change_record,
 };
 use super::store::{
     CHANGE_SPACE, COMMIT_CHANGE_ID_INDEX_FORMAT_VALUE, COMMIT_CHANGE_ID_SPACE,
@@ -29,7 +29,7 @@ use crate::changelog::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeScanBatch, ChangeScanRequest,
     ChangelogAppend, ChangelogReader, ChangelogWriter, CommitChangeRefChunk, CommitChangeRefSet,
     CommitId, CommitLoadBatch, CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitRecord,
-    CommitScanBatch, CommitScanRequest,
+    CommitScanBatch, CommitScanRequest, TransactionChangelogAppend,
 };
 use crate::changelog::{GcPlan, GcRoot};
 use crate::json_store::{JsonRef, JsonSlot, JsonStoreContext};
@@ -370,18 +370,64 @@ impl<S> ChangelogStoreWriter<'_, S>
 where
     S: ChangelogStorageRead + Send + ?Sized,
 {
-    /// Stages an append assembled from already-prepared transaction rows.
+    /// Stages a terminal append assembled from already-prepared transaction rows.
     ///
     /// The transaction owns ID generation, parent selection, and change-ref
-    /// construction. Re-reading all generated UUID keys and rebuilding the
-    /// same relationship indexes here would only revalidate trusted engine
-    /// output. Direct changelog callers continue to use `stage_append`.
+    /// construction. This path has no read-your-writes overlay: its writer is
+    /// dropped immediately after the append, so retaining a second owned copy
+    /// of every row would only add allocation and drop work. Direct changelog
+    /// callers continue to use `stage_append`.
     pub(crate) fn stage_transaction_append(
         &mut self,
-        append: ChangelogAppend,
+        append: TransactionChangelogAppend<'_>,
     ) -> Result<(), LixError> {
         self.ensure_changelog_mutation_is_allowed()?;
-        self.stage_append_records(append, false)
+        let TransactionChangelogAppend {
+            commits,
+            changes,
+            commit_change_refs,
+        } = append;
+        self.writes.reserve_space(CHANGE_SPACE, changes.len(), 0);
+        self.writes.reserve_space(COMMIT_SPACE, commits.len(), 0);
+        self.writes
+            .reserve_space(COMMIT_CHANGE_ID_SPACE, commits.len(), 0);
+
+        for change in changes {
+            self.writes.put(
+                CHANGE_SPACE,
+                change_key(change.change_id),
+                encode_transaction_change_record(&change)?,
+            );
+        }
+
+        let chunks = chunk_commit_change_refs(commit_change_refs);
+        self.writes.reserve_space(
+            COMMIT_CHANGE_REF_CHUNK_SPACE,
+            chunks.values().map(Vec::len).sum(),
+            0,
+        );
+        for commit in commits {
+            self.writes.put(
+                COMMIT_SPACE,
+                commit_key(commit.commit_id),
+                encode_commit_record(&commit)?,
+            );
+            self.writes.put(
+                COMMIT_CHANGE_ID_SPACE,
+                commit_change_id_key(commit.change_id),
+                commit_change_id_value(commit.commit_id),
+            );
+        }
+        for (commit_id, commit_chunks) in chunks {
+            for (chunk_no, chunk) in commit_chunks.iter().enumerate() {
+                self.writes.put(
+                    COMMIT_CHANGE_REF_CHUNK_SPACE,
+                    commit_change_ref_chunk_key(commit_id, chunk_no as u32),
+                    encode_commit_change_ref_chunk(chunk)?,
+                );
+            }
+        }
+        Ok(())
     }
 
     fn stage_append_records(

--- a/packages/engine/src/changelog/mod.rs
+++ b/packages/engine/src/changelog/mod.rs
@@ -14,7 +14,7 @@ mod types;
 
 pub(crate) use codec::{
     decode_change_record, decode_commit_change_ref_chunk, encode_change_record,
-    encode_commit_change_ref_chunk, encode_commit_record,
+    encode_commit_change_ref_chunk, encode_commit_record, encode_transaction_change_record,
 };
 pub(crate) use context::{ChangelogContext, ChangelogStoreReader, ChangelogStoreWriter};
 pub(crate) use materialization::{
@@ -31,6 +31,7 @@ pub(crate) use types::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeRecordView, ChangeScanBatch,
     ChangeScanRequest, ChangelogAppend, CommitChangeRefChunk, CommitChangeRefSet, CommitId,
     CommitLoadBatch, CommitLoadEntry, CommitLoadRequest, CommitProjection, CommitRecord,
-    CommitScanBatch, CommitScanRequest, commit_row_snapshot_json,
+    CommitScanBatch, CommitScanRequest, TransactionChangeRecordRef, TransactionChangelogAppend,
+    commit_row_snapshot_json,
 };
 pub(crate) use types::{GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet};

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -412,6 +412,54 @@ pub(crate) struct ChangeRecordRef<'a> {
     pub(crate) origin_key: Option<&'a str>,
 }
 
+/// Borrowed, already-prepared change record for the terminal transaction
+/// append lane.
+///
+/// Unlike [`ChangeRecord`], this form never owns a second copy of row JSON,
+/// primary-key parts, or schema strings. Transaction materialization has
+/// already assigned identities and validated the facts, so the changelog can
+/// encode these references directly into the final write set.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TransactionChangeRecordRef<'a> {
+    pub(crate) change_id: ChangeId,
+    pub(crate) format_version: u32,
+    pub(crate) schema_key: &'a str,
+    pub(crate) entity_pk: &'a EntityPk,
+    pub(crate) file_id: Option<&'a str>,
+    pub(crate) snapshot: crate::json_store::JsonSlotRef<'a>,
+    pub(crate) metadata: crate::json_store::JsonSlotRef<'a>,
+    pub(crate) created_at: LixTimestamp,
+    pub(crate) origin_key: Option<&'a str>,
+}
+
+impl<'a> From<&'a ChangeRecord> for TransactionChangeRecordRef<'a> {
+    fn from(record: &'a ChangeRecord) -> Self {
+        Self {
+            change_id: record.change_id,
+            format_version: record.format_version,
+            schema_key: &record.schema_key,
+            entity_pk: &record.entity_pk,
+            file_id: record.file_id.as_deref(),
+            snapshot: record.snapshot.as_ref_slot(),
+            metadata: record.metadata.as_ref_slot(),
+            created_at: record.created_at,
+            origin_key: record.origin_key.as_deref(),
+        }
+    }
+}
+
+/// Trusted changelog facts assembled at the transaction commit boundary.
+///
+/// This is deliberately separate from [`ChangelogAppend`]: the generic
+/// writer supports validation and read-your-writes overlays, while this lane
+/// is terminal and encodes prepared transaction facts directly into storage.
+#[derive(Debug)]
+pub(crate) struct TransactionChangelogAppend<'a> {
+    pub(crate) commits: Vec<CommitRecord>,
+    pub(crate) changes: Vec<TransactionChangeRecordRef<'a>>,
+    pub(crate) commit_change_refs: Vec<CommitChangeRefSet>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct ChangeRecordView<'a> {

--- a/packages/engine/src/json_store/types.rs
+++ b/packages/engine/src/json_store/types.rs
@@ -240,16 +240,6 @@ pub(crate) enum JsonSlotRef<'a> {
     Inline(&'a str),
 }
 
-impl JsonSlotRef<'_> {
-    pub(crate) fn to_owned_slot(self) -> JsonSlot {
-        match self {
-            Self::None => JsonSlot::None,
-            Self::Ref(json_ref) => JsonSlot::Ref(*json_ref),
-            Self::Inline(json) => JsonSlot::Inline(json.into()),
-        }
-    }
-}
-
 /// Musli codec for [`JsonSlot`]: tag byte 0/1/2, then the payload.
 pub(crate) mod json_slot_storage {
     use musli::Context;

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -302,17 +302,64 @@ impl StorageWriteSet {
     }
 
     pub async fn lower_into<W>(
-        self,
+        mut self,
         write: &mut W,
     ) -> Result<StorageWriteSetStats, StorageWriteSetError>
     where
         W: StorageWrite,
     {
-        self.validate()?;
-        self.lower_validated_into(write).await
+        self.validate_and_sort()?;
+        self.lower_sorted_into(write).await
     }
 
-    async fn lower_validated_into<W>(
+    /// Validates the owned write set while putting each storage batch in its
+    /// final key order.
+    ///
+    /// The old lowering path first copied every key into a transaction-wide
+    /// hash map solely to find duplicates, then sorted the original vectors
+    /// before sending them to storage. A write group already has exactly one
+    /// storage space, so sorting its owned puts/deletes lets us detect every
+    /// duplicate by adjacent/merge comparison without cloning the keys or
+    /// allocating a second full-workload hash table.
+    fn validate_and_sort(&mut self) -> Result<(), StorageWriteSetError> {
+        for group in &self.groups {
+            if let Some(incoming) = group.conflicting_declarations.first() {
+                return Err(StorageWriteSetError::ConflictingSpaceDeclaration {
+                    id: group.space.id,
+                    existing_name: group.space.name,
+                    incoming_name: incoming.name,
+                });
+            }
+        }
+
+        for group in &mut self.groups {
+            let puts_sorted = group
+                .puts
+                .is_sorted_by(|left, right| left.key.0 <= right.key.0);
+            let deletes_sorted = group.deletes.is_sorted();
+            #[cfg(feature = "storage-benches")]
+            if order_stats_enabled() && !group.puts.is_empty() {
+                eprintln!(
+                    "write-set-order space={} puts={} puts_sorted={puts_sorted} deletes={} deletes_sorted={deletes_sorted}",
+                    group.space.name,
+                    group.puts.len(),
+                    group.deletes.len(),
+                );
+            }
+            if !puts_sorted {
+                group
+                    .puts
+                    .sort_unstable_by(|left, right| left.key.0.cmp(&right.key.0));
+            }
+            if !deletes_sorted {
+                group.deletes.sort_unstable();
+            }
+            validate_sorted_group(group)?;
+        }
+        Ok(())
+    }
+
+    async fn lower_sorted_into<W>(
         self,
         write: &mut W,
     ) -> Result<StorageWriteSetStats, StorageWriteSetError>
@@ -323,7 +370,7 @@ impl StorageWriteSet {
             groups, mut stats, ..
         } = self;
 
-        for mut group in groups {
+        for group in groups {
             #[cfg(feature = "storage-benches")]
             if std::env::var_os("LIX_WRITE_SET_SPACE_STATS").is_some() {
                 let key_bytes = group
@@ -345,34 +392,6 @@ impl StorageWriteSet {
                     key_bytes,
                     value_bytes,
                 );
-            }
-            // Lower each space batch in ascending key order. Hash-keyed
-            // spaces such as json_store produce effectively random insertion
-            // order; sorted batches let B-tree storage implementations write with cursor
-            // locality instead of a fresh seek per key. Most other spaces
-            // already produce key order (BTreeMap
-            // iteration, time-ordered ids), so the common case is a
-            // read-only scan.
-            let puts_sorted = group
-                .puts
-                .is_sorted_by(|left, right| left.key.0 <= right.key.0);
-            let deletes_sorted = group.deletes.is_sorted();
-            #[cfg(feature = "storage-benches")]
-            if order_stats_enabled() && !group.puts.is_empty() {
-                eprintln!(
-                    "write-set-order space={} puts={} puts_sorted={puts_sorted} deletes={} deletes_sorted={deletes_sorted}",
-                    group.space.name,
-                    group.puts.len(),
-                    group.deletes.len(),
-                );
-            }
-            if !puts_sorted {
-                group
-                    .puts
-                    .sort_unstable_by(|left, right| left.key.0.cmp(&right.key.0));
-            }
-            if !deletes_sorted {
-                group.deletes.sort_unstable();
             }
             if !group.puts.is_empty() {
                 stats.put_batches += 1;
@@ -408,12 +427,11 @@ impl StorageWriteSet {
     where
         StorageImpl: Storage,
     {
-        self.validate()?;
         let mut write = storage
             .begin_write(opts)
             .await
             .map_err(StorageWriteSetError::Storage)?;
-        let stats = match self.lower_validated_into(&mut write).await {
+        let stats = match self.lower_into(&mut write).await {
             Ok(stats) => stats,
             Err(error) => {
                 let _ = write.rollback().await;
@@ -446,6 +464,45 @@ impl StorageWriteSet {
         }
         group
     }
+}
+
+fn validate_sorted_group(group: &StorageWriteGroup) -> Result<(), StorageWriteSetError> {
+    if let Some(duplicate) = group
+        .puts
+        .windows(2)
+        .find_map(|pair| (pair[0].key == pair[1].key).then(|| pair[0].key.clone()))
+    {
+        return Err(StorageWriteSetError::DuplicateMutation {
+            space: group.space,
+            key: duplicate,
+        });
+    }
+    if let Some(duplicate) = group
+        .deletes
+        .windows(2)
+        .find_map(|pair| (pair[0] == pair[1]).then(|| pair[0].clone()))
+    {
+        return Err(StorageWriteSetError::DuplicateMutation {
+            space: group.space,
+            key: duplicate,
+        });
+    }
+
+    let mut put_index = 0usize;
+    let mut delete_index = 0usize;
+    while put_index < group.puts.len() && delete_index < group.deletes.len() {
+        match group.puts[put_index].key.cmp(&group.deletes[delete_index]) {
+            std::cmp::Ordering::Less => put_index += 1,
+            std::cmp::Ordering::Greater => delete_index += 1,
+            std::cmp::Ordering::Equal => {
+                return Err(StorageWriteSetError::DuplicateMutation {
+                    space: group.space,
+                    key: group.puts[put_index].key.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 impl Default for StorageWriteSet {

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -31,7 +31,8 @@ use crate::tracked_state::types::{
     TrackedStateKeyRef, TrackedStateMutation, TrackedStateRootId, TrackedStateTreeScanRequest,
 };
 use crate::tracked_state::{
-    MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateScanRequest,
+    MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateRootMutationRef,
+    TrackedStateScanRequest,
 };
 use crate::{LixError, NullableKeyFilter};
 
@@ -1182,6 +1183,121 @@ where
             primary_chunk_puts: result.chunk_count,
         })
     }
+
+    /// Attempts the dense, ordered parent-root merge used by normal bulk
+    /// tracked commits. Sparse and unordered callers stay on the generic
+    /// mutation path, which preserves its latest-write-wins behavior.
+    pub(crate) async fn try_stage_bulk_parent_root_from_ordered_mutations<'a, I>(
+        &mut self,
+        commit_id: &str,
+        parent_commit_id: Option<&str>,
+        mutation_count: usize,
+        first_mutation_key: &[u8],
+        mutations: I,
+    ) -> Result<Option<TrackedStateWriteReport>, LixError>
+    where
+        I: IntoIterator<Item = Result<TrackedStateRootMutationRef<'a>, LixError>>,
+    {
+        let Some(parent_commit_id) = parent_commit_id else {
+            return Ok(None);
+        };
+        let typed_commit_id =
+            CommitId::parse_lix(commit_id, "tracked-state commit root commit_id")?;
+        let typed_parent_commit_id =
+            CommitId::parse_lix(parent_commit_id, "tracked-state parent commit_id")?;
+        let parent_metadata = match self.staged_roots.get(parent_commit_id) {
+            Some(metadata) => metadata.clone(),
+            None => storage::load_commit_root(self.store, parent_commit_id)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        "LIX_ERROR_UNKNOWN",
+                        format!(
+                            "tracked-state parent root for commit '{parent_commit_id}' is missing"
+                        ),
+                    )
+                })?,
+        };
+        let mutation_count_u64 = u64::try_from(mutation_count).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_root changed key count exceeds u64",
+            )
+        })?;
+        // Match the existing full-rebuild threshold, but make the decision
+        // before allocating parent values/mutations. A dense batch is where a
+        // single parent traversal wins decisively over point lookups and patch
+        // construction.
+        if mutation_count < 2 || mutation_count_u64 <= parent_metadata.row_count_estimate / 2 {
+            return Ok(None);
+        }
+        if self
+            .tree
+            .first_key_is_after_root_right_edge(
+                self.store,
+                &self.chunk_overlay,
+                &parent_metadata.root_id,
+                first_mutation_key,
+            )
+            .await?
+        {
+            return Ok(None);
+        }
+
+        let result = self
+            .tree
+            .merge_and_stage_ordered_parent_mutations(
+                self.store,
+                self.writes,
+                &mut self.chunk_overlay,
+                &parent_metadata.root_id,
+                mutations,
+                Some(commit_id),
+            )
+            .await?;
+        let metadata = TrackedStateCommitRoot {
+            commit_id: typed_commit_id,
+            root_id: result.root_id.clone(),
+            parent_roots: vec![TrackedStateCommitRootParent {
+                commit_id: typed_parent_commit_id,
+                root_id: parent_metadata.root_id,
+            }],
+            changed_key_count: mutation_count_u64,
+            row_count_estimate: u64::try_from(result.row_count).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root row count exceeds u64",
+                )
+            })?,
+            tree_height: u32::try_from(result.tree_height).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root tree height exceeds u32",
+                )
+            })?,
+            primary_chunk_count: u64::try_from(result.chunk_count).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root chunk count exceeds u64",
+                )
+            })?,
+            primary_chunk_bytes: u64::try_from(result.chunk_bytes).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit_root chunk bytes exceeds u64",
+                )
+            })?,
+        };
+        storage::stage_commit_root(self.writes, &metadata)?;
+        self.staged_roots.insert(commit_id.to_string(), metadata);
+
+        Ok(Some(TrackedStateWriteReport {
+            commit_id: typed_commit_id,
+            root_id: result.root_id,
+            changed_rows: mutation_count,
+            primary_chunk_puts: result.chunk_count,
+        }))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1397,6 +1513,318 @@ mod tests {
         assert!(metadata.tree_height >= 1);
         assert!(metadata.primary_chunk_count >= 1);
         assert!(metadata.primary_chunk_bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn dense_ordered_parent_merge_is_canonical_and_reads_staged_parent_chunks() {
+        let bulk_storage = StorageAdapter::new(Memory::new());
+        let generic_storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let parent_commit_id = CommitId::for_test_label("dense-parent").to_string();
+        let child_commit_id = CommitId::for_test_label("dense-child").to_string();
+
+        let parent_rows = (0..192)
+            .map(|index| {
+                row(
+                    &format!("entity-{index:03}"),
+                    &format!("change-parent-{index:03}"),
+                    "dense-parent",
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut child_rows = (0..96)
+            .map(|index| {
+                row(
+                    &format!("entity-{index:03}"),
+                    &format!("change-child-{index:03}"),
+                    "dense-child",
+                )
+            })
+            .chain((0..96).map(|index| {
+                row(
+                    &format!("entity-{index:03}-new"),
+                    &format!("change-child-new-{index:03}"),
+                    "dense-child",
+                )
+            }))
+            .collect::<Vec<_>>();
+        child_rows.sort_by(|left, right| left.entity_pk.cmp(&right.entity_pk));
+        for row in &mut child_rows {
+            row.created_at = "2026-02-01T00:00:00Z".to_string();
+            row.updated_at = "2026-03-01T00:00:00Z".to_string();
+        }
+        let first_child_key = encoded_key_from_materialized_row(&child_rows[0]);
+
+        let report = {
+            let read = bulk_storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("bulk read should open");
+            let mut writes = bulk_storage.new_write_set();
+            let mut writer = tracked_state.writer(&read, &mut writes);
+            writer
+                .stage_commit_root(
+                    &parent_commit_id,
+                    None,
+                    parent_rows.iter().map(delta_from_materialized_row),
+                )
+                .await
+                .expect("parent root should stage");
+            let report = writer
+                .try_stage_bulk_parent_root_from_ordered_mutations(
+                    &child_commit_id,
+                    Some(&parent_commit_id),
+                    child_rows.len(),
+                    &first_child_key,
+                    child_rows.iter().map(|row| {
+                        Ok(TrackedStateRootMutationRef {
+                            delta: delta_from_materialized_row(row),
+                            require_absence: false,
+                        })
+                    }),
+                )
+                .await
+                .expect("bulk child root should stage")
+                .expect("dense changed rows should take the dense merge");
+            drop(writer);
+            bulk_storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("bulk roots should commit");
+            report
+        };
+        assert_eq!(report.changed_rows, child_rows.len());
+
+        {
+            let read = generic_storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("generic parent read should open");
+            let mut writes = generic_storage.new_write_set();
+            tracked_state
+                .writer(&read, &mut writes)
+                .stage_commit_root(
+                    &parent_commit_id,
+                    None,
+                    parent_rows.iter().map(delta_from_materialized_row),
+                )
+                .await
+                .expect("generic parent root should stage");
+            generic_storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("generic parent root should commit");
+        }
+        {
+            let read = generic_storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("generic child read should open");
+            let mut writes = generic_storage.new_write_set();
+            tracked_state
+                .writer(&read, &mut writes)
+                .stage_commit_root(
+                    &child_commit_id,
+                    Some(&parent_commit_id),
+                    child_rows.iter().map(delta_from_materialized_row),
+                )
+                .await
+                .expect("generic child root should stage");
+            generic_storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("generic child root should commit");
+        }
+
+        let bulk_read = bulk_storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("bulk result read should open");
+        let bulk_root = storage::load_root(&bulk_read, &child_commit_id)
+            .await
+            .expect("bulk root should load")
+            .expect("bulk child root should exist");
+        let generic_read = generic_storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("generic result read should open");
+        let generic_root = storage::load_root(&generic_read, &child_commit_id)
+            .await
+            .expect("generic root should load")
+            .expect("generic child root should exist");
+        assert_eq!(bulk_root, generic_root, "dense merge must be canonical");
+
+        let entry = TrackedStateTree::new()
+            .get(
+                &bulk_read,
+                &bulk_root,
+                &TrackedStateKey {
+                    schema_key: "test_schema".to_string(),
+                    file_id: None,
+                    entity_pk: EntityPk::single("entity-000"),
+                },
+            )
+            .await
+            .expect("bulk row should load")
+            .expect("bulk row should exist");
+        assert_eq!(
+            entry.created_at(),
+            crate::common::LixTimestamp::expect_parse("created_at", "2026-01-01T00:00:00Z")
+        );
+        assert_eq!(
+            entry.updated_at(),
+            crate::common::LixTimestamp::expect_parse("updated_at", "2026-03-01T00:00:00Z")
+        );
+    }
+
+    #[tokio::test]
+    async fn dense_ordered_parent_merge_preserves_live_insert_absence_guards() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let parent_commit_id = CommitId::for_test_label("dense-guard-parent").to_string();
+        let child_commit_id = CommitId::for_test_label("dense-guard-child").to_string();
+        let parent_rows = [
+            row("entity-a", "change-parent-a", "dense-guard-parent"),
+            row("entity-b", "change-parent-b", "dense-guard-parent"),
+        ];
+        let child_rows = [
+            row("entity-a", "change-child-a", "dense-guard-child"),
+            row("entity-b", "change-child-b", "dense-guard-child"),
+        ];
+        let first_child_key = encoded_key_from_materialized_row(&child_rows[0]);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        writer
+            .stage_commit_root(
+                &parent_commit_id,
+                None,
+                parent_rows.iter().map(delta_from_materialized_row),
+            )
+            .await
+            .expect("parent root should stage");
+        let error = writer
+            .try_stage_bulk_parent_root_from_ordered_mutations(
+                &child_commit_id,
+                Some(&parent_commit_id),
+                child_rows.len(),
+                &first_child_key,
+                child_rows.iter().map(|row| {
+                    Ok(TrackedStateRootMutationRef {
+                        delta: delta_from_materialized_row(row),
+                        require_absence: true,
+                    })
+                }),
+            )
+            .await
+            .expect_err("live parent row must reject INSERT");
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+    }
+
+    #[tokio::test]
+    async fn dense_ordered_parent_merge_allows_tombstone_reinsertion() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let parent_commit_id = CommitId::for_test_label("dense-tombstone-parent").to_string();
+        let child_commit_id = CommitId::for_test_label("dense-tombstone-child").to_string();
+        let parent_rows = [
+            tombstone("entity-a", "change-parent-a", "dense-tombstone-parent"),
+            row("entity-b", "change-parent-b", "dense-tombstone-parent"),
+        ];
+        let child_rows = [
+            row("entity-a", "change-child-a", "dense-tombstone-child"),
+            row("entity-b", "change-child-b", "dense-tombstone-child"),
+        ];
+        let first_child_key = encoded_key_from_materialized_row(&child_rows[0]);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        writer
+            .stage_commit_root(
+                &parent_commit_id,
+                None,
+                parent_rows.iter().map(delta_from_materialized_row),
+            )
+            .await
+            .expect("parent root should stage");
+        assert!(
+            writer
+                .try_stage_bulk_parent_root_from_ordered_mutations(
+                    &child_commit_id,
+                    Some(&parent_commit_id),
+                    child_rows.len(),
+                    &first_child_key,
+                    child_rows.iter().enumerate().map(|(index, row)| {
+                        Ok(TrackedStateRootMutationRef {
+                            delta: delta_from_materialized_row(row),
+                            require_absence: index == 0,
+                        })
+                    }),
+                )
+                .await
+                .expect("tombstone reinsertion should stage")
+                .is_some(),
+            "tombstoned parent rows permit INSERT"
+        );
+    }
+
+    #[tokio::test]
+    async fn dense_ordered_parent_merge_leaves_append_only_batches_to_the_patcher() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let parent_commit_id = CommitId::for_test_label("dense-append-parent").to_string();
+        let child_commit_id = CommitId::for_test_label("dense-append-child").to_string();
+        let parent_rows = [
+            row("entity-a", "change-parent-a", "dense-append-parent"),
+            row("entity-b", "change-parent-b", "dense-append-parent"),
+        ];
+        let child_rows = [
+            row("entity-c", "change-child-c", "dense-append-child"),
+            row("entity-d", "change-child-d", "dense-append-child"),
+        ];
+        let first_child_key = encoded_key_from_materialized_row(&child_rows[0]);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        writer
+            .stage_commit_root(
+                &parent_commit_id,
+                None,
+                parent_rows.iter().map(delta_from_materialized_row),
+            )
+            .await
+            .expect("parent root should stage");
+        assert!(
+            writer
+                .try_stage_bulk_parent_root_from_ordered_mutations(
+                    &child_commit_id,
+                    Some(&parent_commit_id),
+                    child_rows.len(),
+                    &first_child_key,
+                    child_rows.iter().map(|row| {
+                        Ok(TrackedStateRootMutationRef {
+                            delta: delta_from_materialized_row(row),
+                            require_absence: false,
+                        })
+                    }),
+                )
+                .await
+                .expect("append-only route check should succeed")
+                .is_none(),
+            "append-only batches keep the existing chunk-reuse path"
+        );
     }
 
     #[tokio::test]
@@ -3204,5 +3632,26 @@ mod tests {
             change_id: ChangeId::for_test_label(change_id),
             commit_id: CommitId::for_test_label(commit_id),
         }
+    }
+
+    fn delta_from_materialized_row(row: &MaterializedTrackedStateRow) -> TrackedStateDeltaRef<'_> {
+        TrackedStateDeltaRef {
+            schema_key: &row.schema_key,
+            file_id: row.file_id.as_deref(),
+            entity_pk: &row.entity_pk,
+            change_id: row.change_id,
+            commit_id: row.commit_id,
+            deleted: row.snapshot_content.is_none(),
+            created_at: crate::common::LixTimestamp::expect_parse("created_at", &row.created_at),
+            updated_at: crate::common::LixTimestamp::expect_parse("updated_at", &row.updated_at),
+        }
+    }
+
+    fn encoded_key_from_materialized_row(row: &MaterializedTrackedStateRow) -> Vec<u8> {
+        encode_key_ref(TrackedStateKeyRef {
+            schema_key: &row.schema_key,
+            file_id: row.file_id.as_deref(),
+            entity_pk: &row.entity_pk,
+        })
     }
 }

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -10,6 +10,7 @@ mod storage;
 mod tree;
 mod types;
 
+pub(crate) use codec::encode_key_ref;
 pub(crate) use context::{TrackedStateContext, TrackedStateStoreReader};
 pub(crate) use diff::{
     TrackedStateDiff, TrackedStateDiffEntry, TrackedStateDiffIdentity, TrackedStateDiffKind,
@@ -24,11 +25,11 @@ pub(crate) use storage::load_root;
 pub(crate) use storage::stage_delete_commit_root;
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE};
-pub(crate) use types::TrackedStateKey;
 pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateReadColumns,
-    TrackedStateScanRequest,
+    TrackedStateRootMutationRef, TrackedStateScanRequest,
 };
+pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 #[cfg(feature = "storage-benches")]
 pub mod bench {
     pub use super::bench_support::*;

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -23,14 +23,15 @@ use crate::tracked_state::codec::{
     EncodedLeafEntry, EncodedLeafEntryRef, PendingChunkWrite, boundary_trigger,
     child_summary_from_node, decode_key, decode_key_with_trusted_prefix, decode_node,
     decode_node_ref, decode_value, decode_visible_value, encode_internal_node,
-    encode_internal_node_refs, encode_key, encode_leaf_node, encode_leaf_node_refs,
-    encode_schema_file_prefix, encode_schema_key_prefix,
+    encode_internal_node_refs, encode_key, encode_key_ref, encode_leaf_node, encode_leaf_node_refs,
+    encode_schema_file_prefix, encode_schema_key_prefix, encode_value_ref,
 };
 use crate::tracked_state::storage;
 use crate::tracked_state::types::{
-    TRACKED_STATE_HASH_BYTES, TrackedStateApplyResult, TrackedStateIndexValue, TrackedStateKey,
-    TrackedStateMutation, TrackedStateRootId, TrackedStateTreeDiffEntry,
-    TrackedStateTreeScanRequest,
+    TRACKED_STATE_HASH_BYTES, TrackedStateApplyResult, TrackedStateDeltaRef,
+    TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
+    TrackedStateMutation, TrackedStateRootId, TrackedStateRootMutationRef,
+    TrackedStateTreeDiffEntry, TrackedStateTreeScanRequest,
 };
 use crate::{LixError, NullableKeyFilter};
 
@@ -345,6 +346,104 @@ impl TrackedStateTree {
             chunk_count: built.chunks.len(),
             chunk_bytes: built.chunk_bytes,
         })
+    }
+
+    /// Merges a full, primary-key-sorted mutation batch with a parent root in
+    /// one pass and rebuilds canonical chunks directly from that merge.
+    ///
+    /// The normal tracked bulk path used to first point-read every changed key
+    /// for collision/created-at handling, then collect the parent leaves, then
+    /// materialize another complete merged vector. This path keeps only one
+    /// incoming mutation and one output leaf in memory at a time. It also
+    /// reads through `overlay`, so a parent root staged earlier in this write
+    /// set is a valid parent for a child commit.
+    pub(crate) async fn merge_and_stage_ordered_parent_mutations<'a, I>(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        writes: &mut StorageWriteSet,
+        overlay: &mut storage::TrackedStateChunkOverlay,
+        root_id: &TrackedStateRootId,
+        mutations: I,
+        commit_id: Option<&str>,
+    ) -> Result<TrackedStateApplyResult, LixError>
+    where
+        I: IntoIterator<Item = Result<TrackedStateRootMutationRef<'a>, LixError>>,
+    {
+        let mut parent_entries = OrderedLeafCursor::new(*root_id.as_bytes());
+        let mut mutations = mutations.into_iter();
+        let mut next_mutation = next_root_mutation(&mut mutations)?;
+        let mut assembler = OrderedTreeAssembler::new(&self.options);
+
+        let mut next_parent_entry = parent_entries.next(self, store, overlay).await?;
+        while let Some(parent_entry) = next_parent_entry.take() {
+            let Some(mutation) = next_mutation.take() else {
+                assembler.push(parent_entry)?;
+                next_parent_entry = parent_entries.next(self, store, overlay).await?;
+                continue;
+            };
+            match mutation.encoded_key.cmp(&parent_entry.key) {
+                std::cmp::Ordering::Less => {
+                    let created_at = mutation.delta.created_at;
+                    assembler.push(mutation.into_entry(created_at))?;
+                    next_mutation = next_root_mutation(&mut mutations)?;
+                    next_parent_entry = Some(parent_entry);
+                }
+                std::cmp::Ordering::Equal => {
+                    let parent_value = decode_value(&parent_entry.value)?;
+                    if mutation.require_absence && !parent_value.deleted() {
+                        return Err(duplicate_root_insert_error(&mutation.delta));
+                    }
+                    assembler.push(mutation.into_entry(parent_value.created_at()))?;
+                    next_mutation = next_root_mutation(&mut mutations)?;
+                    next_parent_entry = parent_entries.next(self, store, overlay).await?;
+                }
+                std::cmp::Ordering::Greater => {
+                    assembler.push(parent_entry)?;
+                    next_mutation = Some(mutation);
+                    next_parent_entry = parent_entries.next(self, store, overlay).await?;
+                }
+            }
+        }
+
+        while let Some(mutation) = next_mutation {
+            let created_at = mutation.delta.created_at;
+            assembler.push(mutation.into_entry(created_at))?;
+            next_mutation = next_root_mutation(&mut mutations)?;
+        }
+
+        let built = assembler.finish(self)?;
+        self.persist_built_tree(writes, overlay, built, commit_id)
+            .await
+    }
+
+    /// Returns true when every sorted incoming key is strictly beyond the
+    /// parent's right edge. The regular patcher already has a specialized
+    /// append-only path that reuses existing chunks, so dense rebuilding must
+    /// leave that case alone.
+    pub(crate) async fn first_key_is_after_root_right_edge(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        overlay: &storage::TrackedStateChunkOverlay,
+        root_id: &TrackedStateRootId,
+        first_key: &[u8],
+    ) -> Result<bool, LixError> {
+        let mut current = *root_id.as_bytes();
+        loop {
+            match self
+                .load_node_with_overlay(store, overlay, &current)
+                .await?
+            {
+                DecodedNode::Leaf(leaf) => {
+                    return Ok(leaf.last_key().is_some_and(|last_key| first_key > last_key));
+                }
+                DecodedNode::Internal(internal) => {
+                    let Some(child) = internal.children().last() else {
+                        return Ok(false);
+                    };
+                    current = child.child_hash;
+                }
+            }
+        }
     }
 
     async fn apply_single_mutation(
@@ -1910,6 +2009,230 @@ struct BuiltTree {
     row_count: usize,
     tree_height: usize,
     chunk_bytes: usize,
+}
+
+struct PendingRootMutation<'a> {
+    delta: TrackedStateDeltaRef<'a>,
+    require_absence: bool,
+    encoded_key: Vec<u8>,
+}
+
+/// In-order cursor over leaf entries that reads staged chunks before the
+/// durable store. It retains only the internal-node path and one decoded leaf,
+/// so dense commit materialization does not clone a parent root into a
+/// full-workload vector before merging it with the incoming rows.
+struct OrderedLeafCursor {
+    pending_root: Option<[u8; TRACKED_STATE_HASH_BYTES]>,
+    frames: Vec<OrderedLeafCursorFrame>,
+    leaf: Option<DecodedLeafNodeRef>,
+    leaf_entry_index: usize,
+}
+
+struct OrderedLeafCursorFrame {
+    children: Vec<ChildSummary>,
+    next_child_index: usize,
+}
+
+impl OrderedLeafCursor {
+    fn new(root_hash: [u8; TRACKED_STATE_HASH_BYTES]) -> Self {
+        Self {
+            pending_root: Some(root_hash),
+            frames: Vec::new(),
+            leaf: None,
+            leaf_entry_index: 0,
+        }
+    }
+
+    async fn next(
+        &mut self,
+        tree: &TrackedStateTree,
+        store: &(impl StorageAdapterRead + ?Sized),
+        overlay: &storage::TrackedStateChunkOverlay,
+    ) -> Result<Option<EncodedLeafEntry>, LixError> {
+        loop {
+            if let Some(leaf) = self.leaf.as_ref() {
+                if let Some(entry) = leaf.entry(self.leaf_entry_index)? {
+                    self.leaf_entry_index += 1;
+                    return Ok(Some(EncodedLeafEntry {
+                        key: entry.key.to_vec(),
+                        value: entry.value.to_vec(),
+                    }));
+                }
+                self.leaf = None;
+                self.leaf_entry_index = 0;
+            }
+
+            let Some(hash) = self.next_node_hash() else {
+                return Ok(None);
+            };
+            match tree.load_node_with_overlay(store, overlay, &hash).await? {
+                DecodedNode::Leaf(leaf) => self.leaf = Some(leaf),
+                DecodedNode::Internal(internal) => {
+                    self.frames.push(OrderedLeafCursorFrame {
+                        children: internal.into_children(),
+                        next_child_index: 0,
+                    });
+                }
+            }
+        }
+    }
+
+    fn next_node_hash(&mut self) -> Option<[u8; TRACKED_STATE_HASH_BYTES]> {
+        if let Some(root_hash) = self.pending_root.take() {
+            return Some(root_hash);
+        }
+        loop {
+            let frame = self.frames.last_mut()?;
+            if let Some(child) = frame.children.get(frame.next_child_index) {
+                frame.next_child_index += 1;
+                return Some(child.child_hash);
+            }
+            self.frames.pop();
+        }
+    }
+}
+
+impl PendingRootMutation<'_> {
+    fn into_entry(self, created_at: crate::common::LixTimestamp) -> EncodedLeafEntry {
+        let value = TrackedStateIndexValueRef {
+            change_id: self.delta.change_id,
+            commit_id: self.delta.commit_id,
+            deleted: self.delta.deleted,
+            created_at,
+            updated_at: self.delta.updated_at,
+        };
+        EncodedLeafEntry {
+            key: self.encoded_key,
+            value: encode_value_ref(value),
+        }
+    }
+}
+
+fn next_root_mutation<'a, I>(mutations: &mut I) -> Result<Option<PendingRootMutation<'a>>, LixError>
+where
+    I: Iterator<Item = Result<TrackedStateRootMutationRef<'a>, LixError>>,
+{
+    let Some(mutation) = mutations.next().transpose()? else {
+        return Ok(None);
+    };
+    let delta = mutation.delta;
+    Ok(Some(PendingRootMutation {
+        encoded_key: encode_key_ref(TrackedStateKeyRef {
+            schema_key: delta.schema_key,
+            file_id: delta.file_id,
+            entity_pk: delta.entity_pk,
+        }),
+        delta,
+        require_absence: mutation.require_absence,
+    }))
+}
+
+fn duplicate_root_insert_error(delta: &TrackedStateDeltaRef<'_>) -> LixError {
+    let entity_pk = delta
+        .entity_pk
+        .as_json_array_text()
+        .unwrap_or_else(|_| "<invalid entity_pk>".to_string());
+    LixError::new(
+        LixError::CODE_UNIQUE,
+        format!(
+            "primary-key constraint violation on schema '{}': INSERT would duplicate entity_pk '{entity_pk}'",
+            delta.schema_key
+        ),
+    )
+}
+
+struct OrderedTreeAssembler<'a> {
+    options: &'a TrackedStateTreeOptions,
+    current_leaf: LeafChunkAccumulator,
+    leaf_summaries: Vec<ChildSummary>,
+    chunks: BTreeMap<[u8; TRACKED_STATE_HASH_BYTES], PendingChunkWrite>,
+}
+
+impl<'a> OrderedTreeAssembler<'a> {
+    fn new(options: &'a TrackedStateTreeOptions) -> Self {
+        Self {
+            options,
+            current_leaf: LeafChunkAccumulator::default(),
+            leaf_summaries: Vec::new(),
+            chunks: BTreeMap::new(),
+        }
+    }
+
+    fn push(&mut self, entry: EncodedLeafEntry) -> Result<(), LixError> {
+        let previous_key = self
+            .current_leaf
+            .entries
+            .last()
+            .map(|previous| previous.key.as_slice())
+            .or_else(|| {
+                self.leaf_summaries
+                    .last()
+                    .map(|previous| previous.last_key.as_slice())
+            });
+        if previous_key.is_some_and(|previous| previous >= entry.key.as_slice()) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked-state ordered bulk mutation keys must be strictly ascending",
+            ));
+        }
+
+        let item_size = estimate_leaf_boundary_entry_size(entry.key.len());
+        let projected_size = estimate_leaf_boundary_chunk_size(
+            self.current_leaf.entries.len() + 1,
+            self.current_leaf.key_bytes + entry.key.len(),
+        );
+        if !self.current_leaf.entries.is_empty() && projected_size > self.options.max_chunk_bytes {
+            self.flush_leaf();
+        }
+
+        self.current_leaf.key_bytes += entry.key.len();
+        self.current_leaf.entries.push(entry);
+        let current_size = estimate_leaf_boundary_chunk_size(
+            self.current_leaf.entries.len(),
+            self.current_leaf.key_bytes,
+        );
+        if current_size >= self.options.min_chunk_bytes
+            && (current_size >= self.options.max_chunk_bytes
+                || self.current_leaf.entries.last().is_some_and(|entry| {
+                    boundary_trigger(
+                        &entry.key,
+                        0,
+                        current_size,
+                        item_size,
+                        self.options.target_chunk_bytes,
+                    )
+                }))
+        {
+            self.flush_leaf();
+        }
+        Ok(())
+    }
+
+    fn finish(mut self, tree: &TrackedStateTree) -> Result<BuiltTree, LixError> {
+        if !self.current_leaf.entries.is_empty() || self.leaf_summaries.is_empty() {
+            self.flush_leaf();
+        }
+        tree.build_tree_from_leaf_summaries(self.leaf_summaries, self.chunks)
+    }
+
+    fn flush_leaf(&mut self) {
+        let leaf = std::mem::take(&mut self.current_leaf);
+        let subtree_count = leaf.entries.len() as u64;
+        let first_key = leaf
+            .entries
+            .first()
+            .map(|entry| entry.key.clone())
+            .unwrap_or_default();
+        let last_key = leaf
+            .entries
+            .last()
+            .map(|entry| entry.key.clone())
+            .unwrap_or_default();
+        let node = encode_leaf_node(&leaf.entries);
+        let (chunk, summary) = child_summary_from_node(node, first_key, last_key, subtree_count);
+        self.chunks.entry(chunk.hash).or_insert(chunk);
+        self.leaf_summaries.push(summary);
+    }
 }
 
 struct ParentLevelPatch {

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -48,6 +48,18 @@ pub(crate) struct TrackedStateDeltaRef<'a> {
     pub(crate) updated_at: LixTimestamp,
 }
 
+/// One ordered tracked-root mutation with its insert-collision contract.
+///
+/// Bulk commit assembly keeps this zero-copy form until it has compared the
+/// mutation with the parent leaf. That lets the common full-batch path retain
+/// only one incoming key/value at a time instead of a second `Vec` plus a
+/// cloned absence-guard set.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TrackedStateRootMutationRef<'a> {
+    pub(crate) delta: TrackedStateDeltaRef<'a>,
+    pub(crate) require_absence: bool,
+}
+
 /// Value stored in tracked-state commit-root trees.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TrackedStateIndexValue {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -8,8 +8,8 @@ use crate::LixError;
 use crate::binary_cas::BinaryCasContext;
 use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader};
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitChangeRefSet,
-    CommitId, CommitRecord,
+    ChangeId, ChangeRecord, ChangelogContext, ChangelogWriter, CommitChangeRefSet, CommitId,
+    CommitRecord, TransactionChangeRecordRef, TransactionChangelogAppend,
 };
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -21,7 +21,10 @@ use crate::live_state::{
     LiveStateIndexScanRequest, branch_empty_precondition, row_absent_precondition,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
-use crate::tracked_state::{TrackedStateContext, TrackedStateDeltaRef, TrackedStateKey};
+use crate::tracked_state::{
+    TrackedStateContext, TrackedStateDeltaRef, TrackedStateKey, TrackedStateKeyRef,
+    TrackedStateRootMutationRef, encode_key_ref,
+};
 use crate::transaction::staging::{
     PreparedInsertIdentity, PreparedStateRowIdentity, PreparedWriteSet,
 };
@@ -254,7 +257,7 @@ fn index_prepared_rows(rows: &[PreparedStateRow]) -> Result<PreparedRowIndex, Li
 
 #[derive(Clone, Debug)]
 struct StagedChangelogCommit {
-    change_ids: Vec<ChangeId>,
+    change_count: usize,
     selected_change_refs: Vec<StagedCommitChangeRef>,
 }
 
@@ -271,12 +274,12 @@ async fn stage_changelog_commits(
     let changes = state_rows
         .iter()
         .filter(|row| !(row.untracked && row.snapshot.is_none()))
-        .map(change_record_from_state_row)
+        .map(transaction_change_record_from_state_row)
         .chain(
             branch_ref_rows
                 .iter()
                 .filter(|row| row.change.snapshot.is_some())
-                .map(|row| Ok(row.change.clone())),
+                .map(|row| Ok(TransactionChangeRecordRef::from(&row.change))),
         )
         .collect::<Result<Vec<_>, _>>()?;
     let mut commit_change_refs = Vec::with_capacity(commit_rows.len());
@@ -287,8 +290,6 @@ async fn stage_changelog_commits(
             .map(Vec::as_slice)
             .unwrap_or_default();
         let mut refs = Vec::with_capacity(state_row_indices.len());
-        let mut change_ids =
-            Vec::with_capacity(state_row_indices.len() + commit_row.selected_change_refs.len());
         for &row_index in state_row_indices {
             let row = &state_rows[row_index];
             let change_id = row.change_id.as_ref().ok_or_else(|| {
@@ -298,11 +299,9 @@ async fn stage_changelog_commits(
                 )
             })?;
             refs.push(*change_id);
-            change_ids.push(*change_id);
         }
         for change_ref in &commit_row.selected_change_refs {
             refs.push(change_ref.change_id);
-            change_ids.push(change_ref.change_id);
         }
         commits.push(CommitRecord {
             format_version: 1,
@@ -312,6 +311,7 @@ async fn stage_changelog_commits(
             author_account_ids: Vec::new(),
             created_at: commit_row.created_at,
         });
+        let change_count = refs.len();
         commit_change_refs.push(CommitChangeRefSet {
             commit_id: commit_row.commit_id,
             entries: refs,
@@ -319,13 +319,13 @@ async fn stage_changelog_commits(
         staged.insert(
             commit_row.commit_id,
             StagedChangelogCommit {
-                change_ids,
+                change_count,
                 selected_change_refs: commit_row.selected_change_refs.clone(),
             },
         );
     }
 
-    let append = ChangelogAppend {
+    let append = TransactionChangelogAppend {
         commits,
         changes,
         commit_change_refs,
@@ -339,33 +339,31 @@ async fn stage_changelog_commits(
     Ok(staged)
 }
 
-fn change_record_from_state_row(row: &PreparedStateRow) -> Result<ChangeRecord, LixError> {
+fn transaction_change_record_from_state_row(
+    row: &PreparedStateRow,
+) -> Result<TransactionChangeRecordRef<'_>, LixError> {
     let Some(change_id) = row.change_id.as_ref() else {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "staged row is missing change_id before changelog change construction",
         ));
     };
-    Ok(ChangeRecord {
+    Ok(TransactionChangeRecordRef {
         format_version: 2,
         change_id: *change_id,
-        entity_pk: row.entity_pk.clone(),
-        schema_key: row.schema_key.clone(),
-        file_id: row.file_id.clone(),
-        snapshot: row
-            .snapshot
-            .as_ref()
-            .map_or(crate::json_store::JsonSlot::None, |snapshot| {
-                snapshot.slot()
-            }),
-        metadata: row
-            .metadata
-            .as_ref()
-            .map_or(crate::json_store::JsonSlot::None, |metadata| {
-                metadata.slot()
-            }),
+        entity_pk: &row.entity_pk,
+        schema_key: &row.schema_key,
+        file_id: row.file_id.as_deref(),
+        snapshot: row.snapshot.as_ref().map_or(
+            crate::json_store::JsonSlotRef::None,
+            crate::transaction::types::StageJson::slot_ref,
+        ),
+        metadata: row.metadata.as_ref().map_or(
+            crate::json_store::JsonSlotRef::None,
+            crate::transaction::types::StageJson::slot_ref,
+        ),
         created_at: row.updated_at,
-        origin_key: row.origin_key.clone(),
+        origin_key: row.origin_key.as_deref(),
     })
 }
 
@@ -782,16 +780,52 @@ async fn stage_tracked_roots(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
-        if state_row_indices.len() > staged.change_ids.len() {
+        if state_row_indices.len() > staged.change_count {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!(
                     "commit '{}' has {} tracked rows but only {} changelog changes",
                     root.commit_id,
                     state_row_indices.len(),
-                    staged.change_ids.len()
+                    staged.change_count
                 ),
             ));
+        }
+        // Normal entity batches are already in canonical primary-key order.
+        // When they cover a substantial fraction of a parent root, stream the
+        // parent/changes directly into canonical chunks instead of point
+        // reading every key and materializing two more full-workload vectors.
+        if !state_row_indices.is_empty()
+            && staged.selected_change_refs.is_empty()
+            && tracked_state_rows_are_strictly_sorted(state_rows, state_row_indices)
+        {
+            let commit_id_text = root.commit_id.to_string();
+            let parent_commit_id_text = root.parent_commit_id.map(|id| id.to_string());
+            let first_row = &state_rows[state_row_indices[0]];
+            let first_mutation_key = encode_key_ref(TrackedStateKeyRef {
+                schema_key: &first_row.schema_key,
+                file_id: first_row.file_id.as_deref(),
+                entity_pk: &first_row.entity_pk,
+            });
+            if tracked_writer
+                .try_stage_bulk_parent_root_from_ordered_mutations(
+                    &commit_id_text,
+                    parent_commit_id_text.as_deref(),
+                    state_row_indices.len(),
+                    &first_mutation_key,
+                    state_row_indices.iter().map(|&row_index| {
+                        let row = &state_rows[row_index];
+                        Ok(TrackedStateRootMutationRef {
+                            delta: tracked_delta_from_state_row(row)?,
+                            require_absence: tracked_row_requires_absence(row, insert_identities),
+                        })
+                    }),
+                )
+                .await?
+                .is_some()
+            {
+                continue;
+            }
         }
         let deltas = state_row_indices
             .iter()
@@ -882,6 +916,35 @@ async fn stage_tracked_roots(
         ));
     }
     Ok(())
+}
+
+fn tracked_state_rows_are_strictly_sorted(
+    state_rows: &[PreparedStateRow],
+    row_indices: &[RowIndex],
+) -> bool {
+    row_indices.windows(2).all(|pair| {
+        let left = &state_rows[pair[0]];
+        let right = &state_rows[pair[1]];
+        left.schema_key
+            .cmp(&right.schema_key)
+            .then_with(|| left.file_id.cmp(&right.file_id))
+            .then_with(|| left.entity_pk.cmp(&right.entity_pk))
+            .is_lt()
+    })
+}
+
+fn tracked_row_requires_absence(
+    row: &PreparedStateRow,
+    insert_identities: &BTreeMap<PreparedStateRowIdentity, PreparedInsertIdentity>,
+) -> bool {
+    if insert_identities.is_empty() {
+        return false;
+    }
+    row.snapshot.is_some()
+        && !row.untracked
+        && insert_identities
+            .get(&PreparedStateRowIdentity::from(row))
+            .is_some_and(|insert| !insert.untracked())
 }
 
 fn tracked_roots_parent_first(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -79,7 +79,10 @@ use crate::transaction::types::{
     TransactionJson, TransactionWrite, TransactionWriteMode, TransactionWriteOperation,
     TransactionWriteOrigin, TransactionWriteOutcome, TransactionWriteRow, stage_json_from_value,
 };
-use crate::transaction::validation::{TransactionValidationInput, validate_prepared_writes};
+use crate::transaction::validation::{
+    TransactionValidationInput, prepared_tracked_rows_have_row_local_certificates,
+    validate_prepared_writes,
+};
 use crate::wasm::{WasmComponentInstance, WasmPluginFile};
 use crate::{LixError, NullableKeyFilter, SqlQueryResult, Value};
 
@@ -1653,6 +1656,9 @@ where
         &mut self,
         prepared_writes: &PreparedWriteSet,
     ) -> Result<(), LixError> {
+        if prepared_tracked_rows_have_row_local_certificates(&prepared_writes.state_rows) {
+            return Ok(());
+        }
         let validation_index = prepared_writes.validation_index();
         for scope in validation_index.schema_scopes() {
             #[cfg(feature = "storage-benches")]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -317,10 +317,6 @@ impl StageJson {
             crate::json_store::JsonSlotRef::Ref(&self.json_ref)
         }
     }
-
-    pub(crate) fn slot(&self) -> crate::json_store::JsonSlot {
-        self.slot_ref().to_owned_slot()
-    }
 }
 
 #[expect(clippy::unnecessary_wraps)]

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -42,9 +42,9 @@ use crate::transaction::normalization::reject_reserved_schema_namespace;
 use crate::transaction::staging::PreparedWriteSet;
 use crate::transaction::staging::duplicate_insert_identity_message;
 use crate::transaction::staging::{PreparedValidationRow, PreparedWriteValidationSet};
-#[cfg(test)]
-use crate::transaction::types::PreparedStateRow;
-use crate::transaction::types::{TransactionWriteOperation, TransactionWriteOrigin};
+use crate::transaction::types::{
+    PreparedStateRow, TransactionWriteOperation, TransactionWriteOrigin,
+};
 
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
@@ -337,6 +337,30 @@ fn row_local_certificates_cover_validation(staged_rows: &[PreparedValidationRow<
                 && row.file_id().is_none()
                 && !matches!(
                     row.schema_key(),
+                    REGISTERED_SCHEMA_KEY
+                        | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                        | FILE_DESCRIPTOR_SCHEMA_KEY
+                        | BRANCH_REF_SCHEMA_KEY
+                )
+        })
+}
+
+/// Returns whether every prepared row carries the same tracked, row-local
+/// validation certificate that the per-schema validation path recognizes.
+///
+/// Normal tracked entity writes reach commit with this certificate. Checking
+/// it before constructing the validation index avoids allocating one wrapper
+/// and BTreeMap entry per row only to discover every schema scope can skip
+/// validation independently.
+pub(crate) fn prepared_tracked_rows_have_row_local_certificates(rows: &[PreparedStateRow]) -> bool {
+    !rows.is_empty()
+        && rows.iter().all(|row| {
+            row.facts.row_content_validated
+                && !row.facts.requires_transaction_validation
+                && !row.untracked
+                && row.file_id.is_none()
+                && !matches!(
+                    row.schema_key.as_str(),
                     REGISTERED_SCHEMA_KEY
                         | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
                         | FILE_DESCRIPTOR_SCHEMA_KEY
@@ -6756,5 +6780,40 @@ mod tests {
             untracked: false,
             branch_id: crate::GLOBAL_BRANCH_ID.to_string(),
         }
+    }
+
+    #[test]
+    fn prepared_tracked_row_certificates_match_the_commit_skip_contract() {
+        let mut row = staged_row("normal_schema", Some(r#"{"id":"row"}"#.to_string()));
+        row.facts.row_content_validated = true;
+        assert!(prepared_tracked_rows_have_row_local_certificates(
+            std::slice::from_ref(&row)
+        ));
+
+        let mut requires_cross_row_validation = row.clone();
+        requires_cross_row_validation
+            .facts
+            .requires_transaction_validation = true;
+        assert!(!prepared_tracked_rows_have_row_local_certificates(&[
+            requires_cross_row_validation
+        ]));
+
+        let mut untracked = row.clone();
+        untracked.untracked = true;
+        assert!(!prepared_tracked_rows_have_row_local_certificates(&[
+            untracked
+        ]));
+
+        let mut file_scoped = row.clone();
+        file_scoped.file_id = Some("file-a".to_string());
+        assert!(!prepared_tracked_rows_have_row_local_certificates(&[
+            file_scoped
+        ]));
+
+        let mut reserved = row;
+        reserved.schema_key = REGISTERED_SCHEMA_KEY.to_string();
+        assert!(!prepared_tracked_rows_have_row_local_certificates(&[
+            reserved
+        ]));
     }
 }


### PR DESCRIPTION
## Summary

- Stream dense, sorted tracked-root commits through an overlay-aware leaf cursor instead of point-reading every key and materializing full parent and merged vectors.
- Keep the existing append-only chunk-reuse path, while preserving canonical roots, staged-parent visibility, timestamps, tombstone resurrection, and INSERT uniqueness checks.
- Encode terminal transaction changelog rows by reference and lower normal write sets without cloning every key into a global validation map.

## Benchmark result

10k tracked RocksDB transaction CRUD on this host:

- INSERT: 94.4 ms median, 22.3% faster than the previous baseline; standalone SQLite is 9.1 ms (10.4x remaining).
- UPDATE: 114.4 ms median, 10.6% faster than the previous baseline; standalone SQLite is 14.7 ms (7.8x remaining).

The post-change sampling profile moves the dominant remaining CPU to transaction write-buffer identity bookkeeping and repeated JSON preparation; RocksDB's actual write is only about 3.6% of samples.

## Validation

- `cargo test -p lix_engine --features all-simulations`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- Focused Criterion runs for RocksDB and standalone SQLite INSERT/UPDATE at 10k rows.

Stacked on #749.
