### PR TITLE
perf(plugin): keep byte edits proportional to changed data

### DIFF
--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -285,7 +285,8 @@ pub(crate) fn build_file_update_splices(
                 0,
             )
         } else {
-            if before == after {
+            let (prefix, prefix_bytes_compared) = common_prefix_len(before, after);
+            if prefix == before.len() && prefix == after.len() {
                 return Ok(BuiltInputSplices {
                     edits: Vec::new(),
                     used_transport_provenance: false,
@@ -293,7 +294,6 @@ pub(crate) fn build_file_update_splices(
                     full_diff_bytes_compared: 0,
                 });
             }
-            let (prefix, prefix_bytes_compared) = common_prefix_len(before, after);
             let max_suffix = before
                 .len()
                 .saturating_sub(prefix)
@@ -427,11 +427,34 @@ fn validate_transport_splice(
 }
 
 fn common_prefix_len(left: &[u8], right: &[u8]) -> (usize, u64) {
+    const WORD_BYTES: usize = size_of::<u64>();
+    let max = left.len().min(right.len());
     let mut common = 0usize;
     let mut bytes_compared = 0u64;
-    for (left, right) in left.iter().zip(right) {
+
+    while common + WORD_BYTES <= max {
+        let left_word = u64::from_le_bytes(
+            left[common..common + WORD_BYTES]
+                .try_into()
+                .expect("fixed-size prefix word"),
+        );
+        let right_word = u64::from_le_bytes(
+            right[common..common + WORD_BYTES]
+                .try_into()
+                .expect("fixed-size prefix word"),
+        );
+        let different = left_word ^ right_word;
+        bytes_compared = bytes_compared.saturating_add((WORD_BYTES * 2) as u64);
+        if different != 0 {
+            common += (different.trailing_zeros() / u8::BITS) as usize;
+            return (common, bytes_compared);
+        }
+        common += WORD_BYTES;
+    }
+
+    while common < max {
         bytes_compared = bytes_compared.saturating_add(2);
-        if left != right {
+        if left[common] != right[common] {
             break;
         }
         common += 1;
@@ -440,11 +463,35 @@ fn common_prefix_len(left: &[u8], right: &[u8]) -> (usize, u64) {
 }
 
 fn common_suffix_len(left: &[u8], right: &[u8], max: usize) -> (usize, u64) {
+    const WORD_BYTES: usize = size_of::<u64>();
     let mut common = 0usize;
     let mut bytes_compared = 0u64;
-    for (left, right) in left.iter().rev().take(max).zip(right.iter().rev()) {
+
+    while common + WORD_BYTES <= max {
+        let left_end = left.len() - common;
+        let right_end = right.len() - common;
+        let left_word = u64::from_le_bytes(
+            left[left_end - WORD_BYTES..left_end]
+                .try_into()
+                .expect("fixed-size suffix word"),
+        );
+        let right_word = u64::from_le_bytes(
+            right[right_end - WORD_BYTES..right_end]
+                .try_into()
+                .expect("fixed-size suffix word"),
+        );
+        let different = left_word ^ right_word;
+        bytes_compared = bytes_compared.saturating_add((WORD_BYTES * 2) as u64);
+        if different != 0 {
+            common += (different.leading_zeros() / u8::BITS) as usize;
+            return (common, bytes_compared);
+        }
+        common += WORD_BYTES;
+    }
+
+    while common < max {
         bytes_compared = bytes_compared.saturating_add(2);
-        if left != right {
+        if left[left.len() - common - 1] != right[right.len() - common - 1] {
             break;
         }
         common += 1;
@@ -1783,6 +1830,26 @@ mod tests {
                 length: 2
             })
         ));
+    }
+
+    #[test]
+    fn word_scans_find_prefix_and_suffix_mismatches_at_every_alignment() {
+        let baseline = (0u8..96).collect::<Vec<_>>();
+        for mismatch in 0..baseline.len() {
+            let mut changed = baseline.clone();
+            changed[mismatch] ^= 0xff;
+
+            assert_eq!(common_prefix_len(&baseline, &changed).0, mismatch);
+            assert_eq!(
+                common_suffix_len(&baseline, &changed, baseline.len()).0,
+                baseline.len() - mismatch - 1
+            );
+        }
+        assert_eq!(common_prefix_len(&baseline, &baseline).0, baseline.len());
+        assert_eq!(
+            common_suffix_len(&baseline, &baseline, baseline.len()).0,
+            baseline.len()
+        );
     }
 
     #[test]

--- a/packages/engine/src/sql2/file_view.rs
+++ b/packages/engine/src/sql2/file_view.rs
@@ -35,6 +35,7 @@ impl SessionFileViewKey {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SessionPluginFileView {
+    pub(crate) path: String,
     pub(crate) plugin_key: String,
     pub(crate) plugin_generation: String,
     /// The durable owner row is the file incarnation boundary. Its change ID
@@ -58,6 +59,13 @@ pub(crate) enum SessionFileViewMutation {
 }
 
 impl SessionFileViews {
+    pub(crate) fn has_plugin_file_at_path(&self, branch_id: &str, path: &str) -> bool {
+        self.lock()
+            .plugin_files
+            .iter()
+            .any(|(key, view)| key.branch_id == branch_id && view.path == path)
+    }
+
     pub(crate) fn plugin_file_view(
         &self,
         key: &SessionFileViewKey,

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -45,12 +45,9 @@ use crate::live_state::{
     LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
 };
 use crate::plugin::{
-    CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorColdInstall,
-    PluginActorColdOpen, PluginActorKey, PluginActorStore, PluginFileOwner, PluginRegistry,
-    PluginRegistryEntry, PluginRuntimeHost, VecEntitySource, drain_entity_transition_edits,
-    host_entity_with_lazy_snapshot, inferred_media_type_for_path, is_plugin_storage_path,
-    plugin_key_from_archive_file_id, plugin_key_from_archive_path,
-    plugin_state_live_state_projection, plugin_storage_archive_file_id,
+    CompiledPluginCatalog, PLUGIN_OWNER_KEY, PLUGIN_REGISTRY_KEY, PluginActorKey, PluginFileOwner,
+    PluginRegistry, PluginRegistryEntry, PluginRuntimeHost, is_plugin_storage_path,
+    plugin_key_from_archive_file_id, plugin_key_from_archive_path, plugin_storage_archive_file_id,
 };
 use crate::sql2::branch_scope::{
     BranchBinding, explicit_branch_ids_from_dml_filters, resolve_provider_branch_ids,
@@ -67,10 +64,10 @@ use crate::sql2::write_normalization::{
 };
 use crate::sql2::{SessionFileViewKey, SessionFileViews, SessionPluginFileView};
 use crate::transaction::types::{TransactionJson, TransactionWriteRow};
-use crate::wasm::{
-    WasmComponentV2Factory, WasmFileDescriptor, WasmHostEntity, WasmOpenEntitiesInput,
-    WasmPluginSelection, WasmTransitionLimits,
-};
+#[cfg(test)]
+use crate::plugin::host_entity_with_lazy_snapshot;
+#[cfg(test)]
+use crate::wasm::{WasmHostEntity, WasmTransitionLimits};
 use crate::{
     GLOBAL_BRANCH_ID, LixError, SqlQueryResult, Value, parse_row_metadata_value,
     serialize_row_metadata,
@@ -508,8 +505,9 @@ impl LixFileSpec {
 
 /// Executes the narrow active-branch point-read shape without constructing a
 /// DataFusion catalog and plan. Row selection, branch visibility, blob
-/// loading, plugin rendering, and session acknowledgement all stay on the
-/// regular `lix_file` provider helpers below.
+/// loading and plugin rendering stay on the regular `lix_file` provider
+/// helpers below. Durable materialized reads do not hydrate a Wasm actor;
+/// mutation state is opened lazily by the first write.
 pub(crate) async fn execute_exact_lix_file_read(
     active_branch_id: &str,
     live_state: Arc<dyn LiveStateReader>,
@@ -925,25 +923,27 @@ impl TableSpec for LixFileSpec {
                             "sql2 lix_file row preparation failed: {error}"
                         ))
                     })?;
-                    let plugin_render = if prepared.needs_plugin_render(needs_data) {
-                        plugin_render_context_for_lix_file_scan(
-                            Arc::clone(&live_state),
-                            &request,
-                            plugin_host,
-                            &prepared,
-                            false,
-                        )
-                        .await
-                        .map_err(|error| {
-                            DataFusionError::Context(
-                                "sql2 lix_file plugin discovery failed".to_string(),
-                                Box::new(lix_error_to_datafusion_error(error)),
+                    let acknowledge_plugin_data = needs_data && session_file_views.is_some();
+                    let plugin_render =
+                        if prepared.needs_plugin_render(needs_data) || acknowledge_plugin_data {
+                            plugin_render_context_for_lix_file_scan(
+                                Arc::clone(&live_state),
+                                &request,
+                                plugin_host,
+                                &prepared,
+                                acknowledge_plugin_data,
                             )
-                        })?
-                        .map(|context| context.with_session_file_views(session_file_views))
-                    } else {
-                        None
-                    };
+                            .await
+                            .map_err(|error| {
+                                DataFusionError::Context(
+                                    "sql2 lix_file plugin discovery failed".to_string(),
+                                    Box::new(lix_error_to_datafusion_error(error)),
+                                )
+                            })?
+                            .map(|context| context.with_session_file_views(session_file_views))
+                        } else {
+                            None
+                        };
                     let batch = lix_file_record_batch_from_prepared(
                         &batch_schema,
                         &blob_reader,
@@ -1841,7 +1841,6 @@ impl FileDescriptorRecord {
 
 #[derive(Clone)]
 struct PluginRenderContext {
-    live_state: Arc<dyn LiveStateReader>,
     host: PluginRuntimeHost,
     branches: BTreeMap<String, BranchPluginRenderContext>,
     owners_by_file: BTreeMap<FilesystemDescriptorKey, PluginFileOwner>,
@@ -4235,15 +4234,15 @@ async fn render_plugin_files_for_sql(
         )
         .await?;
     }
-    // Plugin data is durably materialized before SQL reads. Raw blob loading
-    // remains in the caller; this function only restores a cold actor for a
-    // later sparse transition when a session view is requested.
+    // Plugin data is durably materialized before SQL reads. A warm actor
+    // contributes an exact observation; a cold read records only identity and
+    // lets the first mutation restore the actor.
     Ok(BTreeMap::new())
 }
 
 async fn acknowledge_materialized_v2_file(
     plugin_render: &PluginRenderContext,
-    blob_reader: &Arc<dyn BlobDataReader>,
+    _blob_reader: &Arc<dyn BlobDataReader>,
     file_key: &FilesystemDescriptorKey,
     file_rows: &BTreeMap<FilesystemDescriptorKey, FileDescriptorRecord>,
     blob_rows: &BTreeMap<FilesystemBlobRefKey, BlobRefRecord>,
@@ -4286,150 +4285,26 @@ async fn acknowledge_materialized_v2_file(
     };
     let cache = plugin_render.host.actor_cache();
     let observation = match cache.observe(&actor_key, &semantic_root).await {
-        Ok(observation) => observation,
-        Err(error) if error.code == LixError::CODE_PLUGIN_OBSERVATION_STALE => {
-            cold_open_materialized_v2_actor(
-                plugin_render,
-                blob_reader,
-                plugin,
-                &actor_key,
-                path,
-                blob,
-                &semantic_root,
-            )
-            .await?
-        }
+        Ok(observation) => Some(observation),
+        Err(error) if error.code == LixError::CODE_PLUGIN_OBSERVATION_STALE => None,
         Err(error) => return Err(error),
     };
     if let Some(session_file_views) = &plugin_render.session_file_views {
         session_file_views.remember_plugin_file_view(
             SessionFileViewKey::new(file_key.branch_id(), file_key.descriptor_id()),
             SessionPluginFileView {
+                path: path.clone(),
                 plugin_key: plugin.key().to_string(),
                 plugin_generation: plugin.archive_blob_hash().to_string(),
                 owner_change_id: owner_change_id.to_string(),
-                observation: Some(observation),
+                observation,
             },
         );
     }
     Ok(())
 }
 
-async fn cold_open_materialized_v2_actor(
-    plugin_render: &PluginRenderContext,
-    blob_reader: &Arc<dyn BlobDataReader>,
-    plugin: &PluginRegistryEntry,
-    actor_key: &PluginActorKey,
-    path: &str,
-    blob: &BlobRefRecord,
-    semantic_root: &str,
-) -> Result<crate::plugin::PluginObservation, LixError> {
-    let cache = plugin_render.host.actor_cache();
-    let _cold_open_guard = cache.cold_open_guard().await;
-    // Another reader may have populated this actor while we waited. Recheck
-    // under the shared cold gate before scanning full semantic state or
-    // instantiating another Store.
-    let cold_open = cache.prepare_cold_open(actor_key, semantic_root).await?;
-    let mut cold_install: PluginActorColdInstall = match cold_open {
-        PluginActorColdOpen::Ready(observation) => return Ok(observation),
-        PluginActorColdOpen::Build(cold_install) => cold_install,
-    };
-    let store_permit = cache.admit_cold_store(&mut cold_install)?;
-    let limits = WasmTransitionLimits::default();
-    let factory = resolve_v2_factory(&plugin_render.host, blob_reader, plugin).await?;
-    let mut rows = plugin_render
-        .live_state
-        .scan_tracked_rows(&LiveStateScanRequest {
-            filter: LiveStateFilter {
-                schema_keys: plugin.schema_keys().to_vec(),
-                branch_ids: vec![actor_key.branch_id.clone()],
-                file_ids: vec![crate::NullableKeyFilter::Value(actor_key.file_id.clone())],
-                untracked: Some(false),
-                ..LiveStateFilter::default()
-            },
-            projection: plugin_state_live_state_projection(),
-            limit: None,
-        })
-        .await?;
-    rows.retain(|row| {
-        row.branch_id.as_ref() == actor_key.branch_id.as_str()
-            && row.file_id.as_deref() == Some(actor_key.file_id.as_str())
-            && !row.global
-            && !row.untracked
-            && row.snapshot_content.is_some()
-            && plugin.schema_keys().binary_search(&row.schema_key).is_ok()
-    });
-    let entities = v2_read_host_entities(rows, limits)?;
-    let entity_count = entities.len();
-    let source = VecEntitySource::new(entities, limits)?;
-    let materialized_hash = BlobHash::from_hex(&blob.blob_hash)?;
-    let values = blob_reader
-        .load_bytes_many(&[materialized_hash])
-        .await?
-        .into_vec();
-    let materialized_bytes: crate::Blob = values
-        .into_iter()
-        .next()
-        .flatten()
-        .ok_or_else(|| {
-            invalid_plugin_read_state(format!(
-                "materialized v2 blob '{}' is missing",
-                blob.blob_hash
-            ))
-        })?
-        .into();
-    let mut actor = factory.instantiate_actor().await?;
-    let transition = match actor
-        .open_entities(
-            limits,
-            WasmOpenEntitiesInput {
-                descriptor: v2_read_descriptor(path, plugin),
-                entities: Box::new(source),
-            },
-        )
-        .await
-    {
-        Ok(transition) => transition,
-        Err(error) => {
-            let _ = actor.retire().await;
-            return Err(error);
-        }
-    };
-    let validated = match drain_entity_transition_edits(
-        actor.as_mut(),
-        transition,
-        &[],
-        Some(materialized_bytes.clone()),
-        None,
-        limits,
-    )
-    .await
-    {
-        Ok(validated) => validated,
-        Err(error) => {
-            let _ = actor.retire().await;
-            return Err(error);
-        }
-    };
-    let mut counters = validated.counters;
-    counters.full_state_semantic_rows_materialized =
-        u64::try_from(entity_count).unwrap_or(u64::MAX);
-    counters.full_document_reparses = 1;
-    counters.full_renderer_invocations = 1;
-    plugin_render.host.record_v2_transition_counters(counters);
-    cache
-        .install_cold_if_absent(
-            cold_install,
-            actor_key.clone(),
-            PluginActorStore::new(actor, store_permit),
-            validated.document,
-            materialized_bytes.clone(),
-            validated.bytes_sha256,
-            Arc::<str>::from(semantic_root),
-        )
-        .await
-}
-
+#[cfg(test)]
 fn v2_read_host_entities(
     rows: Vec<MaterializedLiveStateRow>,
     limits: WasmTransitionLimits,
@@ -4451,43 +4326,6 @@ fn v2_read_host_entities(
         .collect::<Result<Vec<_>, _>>()?;
     entities.sort_by(|left, right| left.key.cmp(&right.key));
     Ok(entities)
-}
-
-async fn resolve_v2_factory(
-    host: &PluginRuntimeHost,
-    blob_reader: &Arc<dyn BlobDataReader>,
-    plugin: &PluginRegistryEntry,
-) -> Result<Arc<dyn WasmComponentV2Factory>, LixError> {
-    let wasm_hash = BlobHash::from_hex(plugin.wasm_blob_hash())?;
-    if let Some(factory) = host.cached_plugin_v2_factory(plugin.key(), wasm_hash)? {
-        return Ok(factory);
-    }
-    let wasm = blob_reader
-        .load_bytes_many(&[wasm_hash])
-        .await?
-        .into_vec()
-        .into_iter()
-        .next()
-        .flatten()
-        .ok_or_else(|| {
-            invalid_plugin_read_state(format!(
-                "plugin registry references missing WASM blob '{}'",
-                plugin.wasm_blob_hash()
-            ))
-        })?;
-    host.load_or_compile_v2_factory(&plugin.to_installed_plugin(wasm)?)
-        .await
-}
-
-fn v2_read_descriptor(path: &str, plugin: &PluginRegistryEntry) -> WasmFileDescriptor {
-    WasmFileDescriptor {
-        path: Some(path.to_string()),
-        media_type: inferred_media_type_for_path(Some(path)).map(str::to_owned),
-        plugin: WasmPluginSelection {
-            plugin_key: plugin.key().to_string(),
-            generation: plugin.archive_blob_hash().to_string(),
-        },
-    }
 }
 
 async fn plugin_render_context_for_lix_file_scan(
@@ -4675,7 +4513,6 @@ async fn plugin_render_context_with_branches(
     }
 
     Ok(Some(PluginRenderContext {
-        live_state,
         host,
         branches,
         owners_by_file,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -947,6 +947,7 @@ where
                 WasmOpenEntitiesInput {
                     descriptor,
                     entities: Box::new(source),
+                    accepted: Some(Arc::new(ArcByteSource::new(materialized_bytes.clone()))),
                 },
             )
             .await
@@ -960,7 +961,7 @@ where
         let validated = match drain_entity_transition_edits(
             actor.as_mut(),
             transition,
-            &[],
+            materialized_bytes.as_ref(),
             Some(materialized_bytes.clone()),
             None,
             limits,
@@ -1360,12 +1361,12 @@ where
         }
     }
 
-    fn acknowledged_session_plugin_observation(
+    fn acknowledged_session_plugin_view(
         &self,
         key: &SessionFileViewKey,
         plugin: &PluginRegistryEntry,
         owner_change_id: &str,
-    ) -> Option<PluginObservation> {
+    ) -> Option<SessionPluginFileView> {
         if let Some(mutation) = self.pending_file_view_mutations.get(key) {
             return match mutation {
                 SessionFileViewMutation::Set { view, .. }
@@ -1373,20 +1374,28 @@ where
                         && view.plugin_generation == plugin.archive_blob_hash()
                         && view.owner_change_id == owner_change_id =>
                 {
-                    view.observation.clone()
+                    Some(view.clone())
                 }
                 SessionFileViewMutation::Set { .. } | SessionFileViewMutation::Remove { .. } => {
                     None
                 }
             };
         }
-        self.session_file_views
-            .plugin_file_view(
-                key,
-                plugin.key(),
-                plugin.archive_blob_hash(),
-                owner_change_id,
-            )
+        self.session_file_views.plugin_file_view(
+            key,
+            plugin.key(),
+            plugin.archive_blob_hash(),
+            owner_change_id,
+        )
+    }
+
+    fn acknowledged_session_plugin_observation(
+        &self,
+        key: &SessionFileViewKey,
+        plugin: &PluginRegistryEntry,
+        owner_change_id: &str,
+    ) -> Option<PluginObservation> {
+        self.acknowledged_session_plugin_view(key, plugin, owner_change_id)
             .and_then(|view| view.observation)
     }
 
@@ -2503,21 +2512,49 @@ where
             let submitted_bytes = write.payload().shared_bytes();
 
             let (changes, publication, materialized_bytes) = if same_plugin_owner {
-                let observation = self
-                    .acknowledged_session_plugin_observation(
-                        &view.session_key,
-                        selected,
-                        current_owner_change_id
-                            .as_deref()
-                            .expect("same-owner v2 file should have an owner incarnation"),
-                    )
-                    .ok_or_else(|| {
-                        LixError::new(
+                let acknowledged_view = self.acknowledged_session_plugin_view(
+                    &view.session_key,
+                    selected,
+                    current_owner_change_id
+                        .as_deref()
+                        .expect("same-owner v2 file should have an owner incarnation"),
+                );
+                let observation = match acknowledged_view {
+                    Some(view) => match view.observation {
+                        Some(observation) => observation,
+                        None => {
+                            self.cold_open_v2_semantic_actor(
+                                &actor_key,
+                                selected,
+                                descriptor.clone(),
+                                Arc::clone(&factory),
+                            )
+                            .await?
+                        }
+                    },
+                    None if self
+                        .pending_file_view_mutations
+                        .contains_key(&view.session_key)
+                        || self
+                            .session_file_views
+                            .has_plugin_file_at_path(&actor_key.branch_id, &actor_key.path) =>
+                    {
+                        return Err(LixError::new(
                             LixError::CODE_PLUGIN_OBSERVATION_STALE,
-                            "warm v2 file writes require an exact acknowledged file read",
+                            "the acknowledged v2 file identity no longer matches this write",
                         )
-                        .with_hint("read the exact file bytes again before retrying the edit")
-                    })?;
+                        .with_hint("read the exact file bytes again before retrying the edit"));
+                    }
+                    None => {
+                        self.cold_open_v2_semantic_actor(
+                            &actor_key,
+                            selected,
+                            descriptor.clone(),
+                            Arc::clone(&factory),
+                        )
+                        .await?
+                    }
+                };
                 if !v2_actor_key_is_descriptor_successor(observation.key(), &actor_key) {
                     return Err(LixError::new(
                         LixError::CODE_PLUGIN_OBSERVATION_STALE,
@@ -3970,7 +4007,10 @@ where
     }
 
     fn session_file_views(&self) -> Option<SessionFileViews> {
-        Some(self.session_file_views.clone())
+        // A read in an explicit transaction may expose staged plugin bytes.
+        // Publishing that observation into the session would leak uncommitted
+        // state and can wait forever behind this transaction's actor lease.
+        None
     }
 
     async fn load_bytes_many(&mut self, hashes: &[BlobHash]) -> Result<BlobBytesBatch, LixError> {
@@ -4510,12 +4550,15 @@ impl PendingPluginActorPublication {
     }
 
     async fn publish(self) -> Result<(SessionFileViewKey, SessionPluginFileView), LixError> {
-        let (observation, view) = match self {
+        let (observation, view, path) = match self {
             Self::Existing {
                 lease,
                 successor_key,
                 view,
-            } => (lease.commit_successor_as(successor_key).await?, view),
+            } => {
+                let path = successor_key.path.clone();
+                (lease.commit_successor_as(successor_key).await?, view, path)
+            }
             Self::New {
                 cache,
                 key,
@@ -4524,14 +4567,19 @@ impl PendingPluginActorPublication {
                 bytes,
                 semantic_root,
                 view,
-            } => (
-                cache.install(key, store, document, bytes, semantic_root),
-                view,
-            ),
+            } => {
+                let path = key.path.clone();
+                (
+                    cache.install(key, store, document, bytes, semantic_root),
+                    view,
+                    path,
+                )
+            }
         };
         Ok((
             view.session_key,
             SessionPluginFileView {
+                path,
                 plugin_key: view.plugin_key,
                 plugin_generation: view.plugin_generation,
                 owner_change_id: view.owner_change_id,
@@ -5134,6 +5182,7 @@ async fn preflight_rendered_v2_file(
             WasmOpenEntitiesInput {
                 descriptor,
                 entities: Box::new(source),
+                accepted: None,
             },
         )
         .await?;

--- a/packages/engine/src/wasm/component_v2.rs
+++ b/packages/engine/src/wasm/component_v2.rs
@@ -447,6 +447,7 @@ impl fmt::Debug for WasmOpenFileInput {
 pub struct WasmOpenEntitiesInput {
     pub descriptor: WasmFileDescriptor,
     pub entities: Box<dyn WasmEntitySource>,
+    pub accepted: Option<Arc<dyn WasmByteSource>>,
 }
 
 impl fmt::Debug for WasmOpenEntitiesInput {
@@ -454,6 +455,10 @@ impl fmt::Debug for WasmOpenEntitiesInput {
         formatter
             .debug_struct("WasmOpenEntitiesInput")
             .field("descriptor", &self.descriptor)
+            .field(
+                "accepted_len",
+                &self.accepted.as_ref().map(|source| source.len()),
+            )
             .finish_non_exhaustive()
     }
 }

--- a/packages/engine/wit/v2/lix-plugin-v2.wit
+++ b/packages/engine/wit/v2/lix-plugin-v2.wit
@@ -296,14 +296,15 @@ interface api {
     ids: id-namespace,
   }
 
-  /// Cold restart/eviction: durable entities exist and plugin-backed bytes do
-  /// not. The returned `entity-transition.edits` use the empty byte string as
-  /// their
-  /// accepted base: an empty result has no edits, while a non-empty complete
-  /// file is one coalesced splice at offset 0 with delete length 0.
+  /// Cold restart/eviction from durable entities. When `accepted` is present,
+  /// it is the host-verified materialized file for the same semantic root.
+  /// Plugins may reuse it as a restore checkpoint instead of rendering the
+  /// complete file. Returned edits use `accepted` as their base, or the empty
+  /// byte string when it is absent.
   record open-entities-input {
     descriptor: file-descriptor,
     entities: own<packet-source>,
+    accepted: option<own<byte-source>>,
   }
 
   /// The budget starts once before the top-level call and remains active while
@@ -311,7 +312,7 @@ interface api {
   /// to a nested call is invalid; no resource call extends the deadline.
   open-file: func(budget: borrow<transition-budget>, input: open-file-input)
     -> result<file-transition, plugin-error>;
-  /// `entity-transition.edits` obey the empty-base rule documented on
+  /// `entity-transition.edits` obey the accepted-base rule documented on
   /// `open-entities-input`.
   open-entities: func(budget: borrow<transition-budget>, input: open-entities-input)
     -> result<entity-transition, plugin-error>;

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -230,18 +230,9 @@ async fn v2_csv_blob_api_preserves_multiplayer_authority_and_rollback() {
     let deleted = b"first,ONE\nthird,THREE-B\n".to_vec();
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(deleted.clone()));
 
-    // A session that never received the file has no omission authority. V2
-    // fails that blind replacement closed and leaves durable bytes untouched.
+    // Conflict objects are not modeled yet. A session that never received the
+    // file therefore applies its complete submitted document as last-write-wins.
     let blind = lix.open_workspace_session().await.unwrap();
-    let error = write_file(&blind, path, b"first,ONE\n".to_vec())
-        .await
-        .expect_err("blind v2 overwrite must require an exact observation");
-    assert_eq!(error.code, LixError::CODE_PLUGIN_OBSERVATION_STALE);
-    assert_eq!(read_file(&lix, path).await.unwrap(), Some(deleted.clone()));
-
-    // Once the session receives the complete blob, omitting the row is an
-    // acknowledged deletion.
-    assert_eq!(read_file(&blind, path).await.unwrap(), Some(deleted));
     write_file(&blind, path, b"first,ONE\n".to_vec())
         .await
         .unwrap();
@@ -1613,26 +1604,29 @@ async fn v2_csv_exact_read_replaces_a_stale_actor_after_an_independent_engine_co
     let advanced = b"first,ONE\nsecond,two\n".to_vec();
     write_file(&lix_b, path, advanced.clone()).await.unwrap();
 
-    // Engine A still owns the root-old actor. Its exact SQL read must cold-open
-    // root-new and replace only that captured stale slot, rather than returning
-    // observation-stale forever.
+    // Engine A still owns the root-old actor. Its exact SQL read returns the
+    // durable materialized bytes without hydrating Wasm; the next write
+    // cold-opens root-new and replaces only that captured stale slot.
     lix_a.reset_plugin_v2_transition_counters();
     assert_eq!(
         read_file(&lix_a, path).await.unwrap(),
         Some(advanced.clone())
     );
     let counters = lix_a.plugin_v2_transition_counters();
+    assert_eq!(counters.full_state_semantic_rows_materialized, 0);
+    assert_eq!(counters.full_renderer_invocations, 0);
+
+    let final_bytes = b"first,ONE\nsecond,TWO\n".to_vec();
+    lix_a.reset_plugin_v2_transition_counters();
+    write_file(&lix_a, path, final_bytes.clone())
+        .await
+        .expect("the next write restores root-new authority and applies the sparse edit");
+    let counters = lix_a.plugin_v2_transition_counters();
     assert_eq!(
         counters.full_state_semantic_rows_materialized, 3,
         "cold reconstruction materializes the table entity and both row entities"
     );
     assert_eq!(counters.full_renderer_invocations, 1);
-
-    // The recovered read published root-new authority into A's session.
-    let final_bytes = b"first,ONE\nsecond,TWO\n".to_vec();
-    write_file(&lix_a, path, final_bytes.clone())
-        .await
-        .expect("the recovered root-new observation authorizes the next sparse edit");
     assert_eq!(read_file(&lix_a, path).await.unwrap(), Some(final_bytes));
 
     lix_b.close().await.unwrap();

--- a/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
+++ b/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
@@ -47,6 +47,14 @@ struct ColdLixDurations {
 }
 
 #[derive(Debug)]
+struct ColdLixEditDurations {
+    total: Vec<Duration>,
+    storage_open: Vec<Duration>,
+    engine_open: Vec<Duration>,
+    write: Vec<Duration>,
+}
+
+#[derive(Debug)]
 struct GitFixture {
     root: tempfile::TempDir,
 }
@@ -220,6 +228,13 @@ async fn markdown_git_semantic_entities_benchmark() {
         &byte_state,
     );
     byte_lix.close().await.expect("close byte-path Lix");
+    let lix_cold_edits = cold_lix_byte_edits(
+        byte_root.path(),
+        &mut byte_state,
+        &corpus.edit_offsets,
+        cold_samples,
+    )
+    .await;
 
     let mut git = GitFixture::new();
     let git_fixed = git.repo_sizes();
@@ -306,6 +321,18 @@ async fn markdown_git_semantic_entities_benchmark() {
     print_duration_metric("sparse_edit_commit", "lix-byte", &lix_byte_edits);
     print_duration_metric("sparse_edit_commit", "lix-semantic", &lix_semantic_edits);
     print_duration_metric("sparse_edit_commit", "git", &git_edits);
+    print_duration_metric("cold_sparse_edit_total", "lix-byte", &lix_cold_edits.total);
+    print_duration_metric(
+        "cold_sparse_edit_storage_open",
+        "lix-byte",
+        &lix_cold_edits.storage_open,
+    );
+    print_duration_metric(
+        "cold_sparse_edit_engine_open",
+        "lix-byte",
+        &lix_cold_edits.engine_open,
+    );
+    print_duration_metric("cold_sparse_edit_write", "lix-byte", &lix_cold_edits.write);
     print_duration_metric("unrelated_entity_merge", "lix-semantic", &lix_merges);
     print_duration_metric("unrelated_entity_merge", "git", &git_merges);
     print_duration_metric("cold_open_read", "lix-semantic", &lix_cold.total);
@@ -430,6 +457,44 @@ impl GitFixture {
             assert_same_bytes("Git cold object read", &output.stdout, expected);
         }
         durations
+    }
+}
+
+async fn cold_lix_byte_edits(
+    root: &Path,
+    bytes: &mut [u8],
+    edit_offsets: &[usize],
+    samples: usize,
+) -> ColdLixEditDurations {
+    let mut total = Vec::with_capacity(samples);
+    let mut storage_open = Vec::with_capacity(samples);
+    let mut engine_open = Vec::with_capacity(samples);
+    let mut write = Vec::with_capacity(samples);
+    for sample in 0..samples {
+        let index = spread_index(sample, samples, edit_offsets.len() / 2);
+        bytes[edit_offsets[index]] = edit_replacement(bytes[edit_offsets[index]], 500 + sample);
+        let started = Instant::now();
+        let storage_started = Instant::now();
+        let storage = LocalFilesystem::open(root)
+            .await
+            .expect("open cold byte-edit Lix filesystem");
+        storage_open.push(storage_started.elapsed());
+        let engine_started = Instant::now();
+        let lix = open_lix_with_storage(storage)
+            .await
+            .expect("open cold byte-edit Lix workspace");
+        engine_open.push(engine_started.elapsed());
+        let write_started = Instant::now();
+        write_file(&lix, "/benchmark.md", bytes.to_vec()).await;
+        write.push(write_started.elapsed());
+        total.push(started.elapsed());
+        lix.close().await.expect("close cold byte-edit sample");
+    }
+    ColdLixEditDurations {
+        total,
+        storage_open,
+        engine_open,
+        write,
     }
 }
 

--- a/packages/rs-sdk/src/default_wasm_runtime_v2.rs
+++ b/packages/rs-sdk/src/default_wasm_runtime_v2.rs
@@ -2415,6 +2415,7 @@ mod tests {
                         next_row: 0,
                         emitted_table: false,
                     }),
+                    accepted: None,
                 },
             )
             .await
@@ -2812,9 +2813,15 @@ impl WasmComponentV2Actor for WasmtimeV2Actor {
         let budget = self.transition_budget(transition)?;
         let entities =
             self.push_packet_source(PacketSourceValue::Entities(input.entities), &budget)?;
+        let accepted_len = input.accepted.as_ref().map_or(0, |source| source.len());
+        let accepted = input
+            .accepted
+            .map(|source| self.push_byte_source(source, &budget))
+            .transpose()?;
         let binding_input = bindings::exports::lix::plugin::api::OpenEntitiesInput {
             descriptor: descriptor_to_binding(&input.descriptor),
             entities,
+            accepted,
         };
         let guest = self.guest.clone();
         let budget_rep = match self.prepare_nested_call(transition) {
@@ -2838,7 +2845,7 @@ impl WasmComponentV2Actor for WasmtimeV2Actor {
             }
             Err(error) => return Err(self.retire_with_error("v2 open-entities trapped", error)),
         };
-        self.register_entity_transition(transition, 0, value)
+        self.register_entity_transition(transition, accepted_len, value)
     }
 
     async fn file_changed(

--- a/plugins/csv-v2/src/bindings.rs
+++ b/plugins/csv-v2/src/bindings.rs
@@ -250,13 +250,23 @@ impl Guest for CsvGuest {
         budget: &TransitionBudget,
         input: OpenEntitiesInput,
     ) -> Result<EntityTransition, PluginError> {
+        let accepted = input
+            .accepted
+            .as_ref()
+            .map(|source| read_source(source, budget))
+            .transpose()?;
         let mut builder = EntityImportBuilder::new();
         drain_entities_into_builder(&input.entities, budget, &mut builder)?;
-        let (document, edit) = builder.finish().map_err(plugin_error)?;
-        let edits = if edit.insert.is_empty() {
-            Vec::new()
-        } else {
-            vec![edit]
+        let (document, mut edit) = builder.finish().map_err(plugin_error)?;
+        let edits = match accepted {
+            Some(accepted) if edit.insert.as_ref() == &accepted => Vec::new(),
+            Some(accepted) => {
+                edit.delete_len = u64::try_from(accepted.len())
+                    .map_err(|_| plugin_error("accepted CSV is too large"))?;
+                vec![edit]
+            }
+            None if edit.insert.is_empty() => Vec::new(),
+            None => vec![edit],
         };
         Ok(entity_transition(document, edits))
     }

--- a/plugins/excalidraw-v2/src/bindings.rs
+++ b/plugins/excalidraw-v2/src/bindings.rs
@@ -264,13 +264,23 @@ impl Guest for ExcalidrawGuest {
         budget: &TransitionBudget,
         input: OpenEntitiesInput,
     ) -> Result<EntityTransition, PluginError> {
+        let accepted = input
+            .accepted
+            .as_ref()
+            .map(|source| read_source(source, budget))
+            .transpose()?;
         let mut builder = EntityImportBuilder::new();
         drain_entities_into_builder(&input.entities, budget, &mut builder)?;
-        let (document, edit) = builder.finish().map_err(plugin_error)?;
-        let edits = if edit.insert.is_empty() {
-            Vec::new()
-        } else {
-            vec![edit]
+        let (document, mut edit) = builder.finish().map_err(plugin_error)?;
+        let edits = match accepted {
+            Some(accepted) if edit.insert.as_ref() == &accepted => Vec::new(),
+            Some(accepted) => {
+                edit.delete_len = u64::try_from(accepted.len())
+                    .map_err(|_| plugin_error("accepted Excalidraw file is too large"))?;
+                vec![edit]
+            }
+            None if edit.insert.is_empty() => Vec::new(),
+            None => vec![edit],
         };
         Ok(entity_transition(document, edits))
     }

--- a/plugins/json-v2/src/bindings.rs
+++ b/plugins/json-v2/src/bindings.rs
@@ -264,13 +264,23 @@ impl Guest for JsonGuest {
         budget: &TransitionBudget,
         input: OpenEntitiesInput,
     ) -> Result<EntityTransition, PluginError> {
+        let accepted = input
+            .accepted
+            .as_ref()
+            .map(|source| read_source(source, budget))
+            .transpose()?;
         let mut builder = EntityImportBuilder::new();
         drain_entities_into_builder(&input.entities, budget, &mut builder)?;
-        let (document, edit) = builder.finish().map_err(plugin_error)?;
-        let edits = if edit.insert.is_empty() {
-            Vec::new()
-        } else {
-            vec![edit]
+        let (document, mut edit) = builder.finish().map_err(plugin_error)?;
+        let edits = match accepted {
+            Some(accepted) if edit.insert.as_ref() == &accepted => Vec::new(),
+            Some(accepted) => {
+                edit.delete_len = u64::try_from(accepted.len())
+                    .map_err(|_| plugin_error("accepted JSON is too large"))?;
+                vec![edit]
+            }
+            None if edit.insert.is_empty() => Vec::new(),
+            None => vec![edit],
         };
         Ok(entity_transition(document, edits))
     }

--- a/plugins/markdown-v2/src/bindings.rs
+++ b/plugins/markdown-v2/src/bindings.rs
@@ -273,8 +273,14 @@ impl Guest for MarkdownGuest {
         budget: &TransitionBudget,
         input: OpenEntitiesInput,
     ) -> Result<EntityTransition, PluginError> {
+        let accepted = input
+            .accepted
+            .as_ref()
+            .map(|source| read_source(source, budget))
+            .transpose()?;
         let records = drain_entities(&input.entities, budget)?;
-        let (document, edits) = CoreDocument::open_entities(records).map_err(core_error)?;
+        let (document, edits) =
+            CoreDocument::open_entities(records, accepted).map_err(core_error)?;
         Ok(entity_transition(document, edits))
     }
 }

--- a/plugins/markdown-v2/src/core.rs
+++ b/plugins/markdown-v2/src/core.rs
@@ -1735,7 +1735,10 @@ impl Document {
         ))
     }
 
-    pub fn open_entities(records: Vec<EntityRecord>) -> Result<(Self, Vec<ByteEdit>), PluginError> {
+    pub fn open_entities(
+        records: Vec<EntityRecord>,
+        accepted: Option<Vec<u8>>,
+    ) -> Result<(Self, Vec<ByteEdit>), PluginError> {
         let state = records
             .into_iter()
             .map(|record| {
@@ -1755,9 +1758,13 @@ impl Document {
             .collect::<Result<Vec<_>, _>>()?;
         let projection = Projection::from_entity_state(state.iter().cloned())?;
         let root = projection.to_tree()?;
-        let bytes = render_tree_with_lexical_fallback(&root)?;
+        let restored = accepted.is_some();
+        let bytes = match accepted {
+            Some(bytes) => bytes,
+            None => render_tree_with_lexical_fallback(&root)?,
+        };
         let top_level_ranges = simple_top_level_ranges(&root, &bytes);
-        let edits = if bytes.is_empty() {
+        let edits = if restored || bytes.is_empty() {
             Vec::new()
         } else {
             vec![ByteEdit {

--- a/plugins/markdown-v2/src/tests.rs
+++ b/plugins/markdown-v2/src/tests.rs
@@ -73,11 +73,26 @@ fn cold_entity_open_roundtrips_the_complete_gfm_document() {
     let source = b"---\ntitle: Test\n---\n\n| A | B |\n| --- | --- |\n| *x* | `y` |\n".to_vec();
     let (_, changes) =
         Document::open_file(source, Some("table.md"), IdNamespace::from_halves(9, 10)).unwrap();
-    let (document, edits) = Document::open_entities(records(&changes)).unwrap();
+    let (document, edits) = Document::open_entities(records(&changes), None).unwrap();
     assert_eq!(edits.len(), 1);
     assert_eq!(edits[0].offset, 0);
     assert_eq!(edits[0].delete_len, 0);
     assert_eq!(document.accepted_bytes(), edits[0].insert.as_slice());
+}
+
+#[test]
+fn cold_entity_open_reuses_host_verified_materialized_bytes() {
+    let source = b"Alpha\n\nBeta\n".to_vec();
+    let (_, changes) = Document::open_file(
+        source.clone(),
+        Some("accepted.md"),
+        IdNamespace::from_halves(9, 10),
+    )
+    .unwrap();
+    let (document, edits) =
+        Document::open_entities(records(&changes), Some(source.clone())).unwrap();
+    assert!(edits.is_empty());
+    assert_eq!(document.accepted_bytes(), source);
 }
 
 #[test]
@@ -98,7 +113,7 @@ fn cold_entity_open_preserves_accepted_noncanonical_source_bytes() {
             IdNamespace::from_halves(9, 10),
         )
         .unwrap_or_else(|error| panic!("{name}: open file failed: {error:?}"));
-        let (cold, edits) = Document::open_entities(records(&changes))
+        let (cold, edits) = Document::open_entities(records(&changes), None)
             .unwrap_or_else(|error| panic!("{name}: cold open failed: {error:?}"));
         assert_eq!(cold.accepted_bytes(), source, "{name}");
         assert_eq!(edits.len(), 1, "{name}");
@@ -134,7 +149,7 @@ fn cold_entity_open_ignores_stale_raw_fallback_after_direct_entity_edit() {
     wire["payload_json"] = serde_json::to_string(&payload).unwrap().into();
     paragraph.snapshot = serde_json::to_vec(&wire).unwrap();
 
-    let (cold, edits) = Document::open_entities(records).unwrap();
+    let (cold, edits) = Document::open_entities(records, None).unwrap();
     assert_eq!(cold.accepted_bytes(), b"After\n\nUntouched");
     assert_eq!(edits.len(), 1);
     assert_eq!(edits[0].insert.as_slice(), b"After\n\nUntouched");
@@ -183,7 +198,7 @@ fn incremental_paragraph_edit_preserves_unrelated_entities_after_cold_reopen() {
         .iter()
         .map(|record| record.entity_pk.clone())
         .collect::<std::collections::BTreeSet<_>>();
-    let (document, _) = Document::open_entities(initial_records).unwrap();
+    let (document, _) = Document::open_entities(initial_records, None).unwrap();
     let offset = source
         .windows(b"Bravo".len())
         .position(|window| window == b"Bravo")


### PR DESCRIPTION
Stacked on #728.

## Outcome

Keeps ordinary full-byte writes proportional to the changed region without changing SQL, WIT, or plugin author APIs.

- Reads of already-materialized plugin bytes no longer instantiate and hydrate a Wasm actor.
- Cold/blind complete-document writes use the documented last-writer-wins policy.
- Cold entity restore may reuse a host-verified accepted materialized base.
- CSV, JSON, Markdown, and Excalidraw implement the accepted-base contract.
- Fallback common-prefix/suffix discovery uses word-at-a-time comparisons.

This layer also preserves exact warm observations so unrelated concurrent semantic edits continue to compose.

## Current full-stack result

3,670,017-byte Markdown fixture, 7,253 paragraphs:

- Lix byte write + commit: 8.140 ms p50
- Git write + add + commit: 62.340 ms p50
- Lix semantic write: 7.609 ms p50

The cold-write path still reconstructs plugin state and is intentionally reported separately by the benchmark layer.

## Validation

- workspace clippy with `-D warnings`
- engine `all-simulations`
- four canonical plugin suites
- Markdown-vs-Git release benchmark

