### PR TITLE
perf: serve tracked heads from durable projection

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -23,6 +23,10 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
         .build()
         .expect("create tokio runtime for tracked_state_crud benchmarks");
     let rows = fixture_rows();
+    if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE").is_some() {
+        profile_operation(&runtime, &rows[..REAL_WORKLOAD_ROWS]);
+        return;
+    }
     io_stats::maybe_print_io_report();
     accounting::maybe_print_accounting_report(&runtime, &rows[..SMOKE_ROWS]);
 
@@ -33,6 +37,160 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
             bench_transaction_api(c, &runtime, profile, &rows[..row_count], label);
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
         }
+    }
+}
+
+/// Reproducible, setup-excluded latency samples for one production transaction
+/// operation. Criterion's CodSpeed-compatible harness intentionally delegates
+/// timing to the runner, while this opt-in mode is useful for local profiling
+/// and before/after investigation. Each sample starts from an independently
+/// seeded RocksDB fixture, matching the benchmark's measurement boundary.
+fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
+    let operation = match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_OP").as_deref() {
+        Ok("insert_all") => TransactionBenchOp::InsertAll,
+        Ok("read_one") => TransactionBenchOp::ReadOneByPk,
+        Ok("read_many") => TransactionBenchOp::ReadManyByPk,
+        Ok("update_all") => TransactionBenchOp::UpdateAll,
+        Ok("update_one") => TransactionBenchOp::UpdateOneByPk,
+        Ok("delete_all") => TransactionBenchOp::DeleteAll,
+        Ok("delete_one") => TransactionBenchOp::DeleteOneByPk,
+        Ok("read_all") | Err(_) => TransactionBenchOp::ReadAll,
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_OP '{other}'; expected insert_all, read_all, read_one, read_many, update_all, update_one, delete_all, or delete_one"
+        ),
+    };
+    let sample_count = std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&count| count > 0)
+        .unwrap_or(15);
+    match std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_LAYER").as_deref() {
+        Ok("kv_layout") => profile_kv_layout_operation(runtime, rows, operation, sample_count),
+        Ok("raw_sqlite") => profile_raw_sqlite_operation(rows, operation, sample_count),
+        Ok("transaction") | Err(_) => {
+            profile_transaction_operation(runtime, rows, operation, sample_count);
+        }
+        Ok(other) => panic!(
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_LAYER '{other}'; expected transaction, kv_layout, or raw_sqlite"
+        ),
+    }
+}
+
+fn profile_transaction_operation(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    operation: TransactionBenchOp,
+    sample_count: usize,
+) {
+    let mut samples = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let mut fixture = if operation.needs_seed() {
+            runtime.block_on(transaction_api::seeded_fixture(
+                StorageProfile::RocksDB,
+                rows,
+            ))
+        } else {
+            runtime.block_on(transaction_api::empty_fixture(
+                StorageProfile::RocksDB,
+                rows,
+            ))
+        };
+        let start = Instant::now();
+        let result = runtime.block_on(operation.run(&mut fixture));
+        samples.push(start.elapsed());
+        black_box(result);
+    }
+    print_profile_samples("transaction/lix_rocksdb", operation, samples);
+}
+
+fn profile_kv_layout_operation(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    operation: TransactionBenchOp,
+    sample_count: usize,
+) {
+    let mut samples = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let mut fixture = if operation.needs_seed() {
+            runtime.block_on(kv_layout::seeded_fixture(StorageProfile::RocksDB, rows))
+        } else {
+            runtime.block_on(kv_layout::empty_fixture(StorageProfile::RocksDB, rows))
+        };
+        let start = Instant::now();
+        let result = runtime.block_on(run_kv_layout_operation(operation, &mut fixture));
+        samples.push(start.elapsed());
+        black_box(result);
+    }
+    print_profile_samples("kv_layout/lix_rocksdb", operation, samples);
+}
+
+async fn run_kv_layout_operation(
+    operation: TransactionBenchOp,
+    fixture: &mut kv_layout::KvFixture,
+) -> usize {
+    match operation {
+        TransactionBenchOp::InsertAll => fixture.insert_all().await,
+        TransactionBenchOp::ReadAll => fixture.read_all().await,
+        TransactionBenchOp::ReadOneByPk => fixture.read_one_by_pk().await,
+        TransactionBenchOp::ReadManyByPk => fixture.read_many_by_pk(READ_MANY_PK_COUNT).await,
+        TransactionBenchOp::UpdateAll => fixture.update_all().await,
+        TransactionBenchOp::UpdateOneByPk => fixture.update_one_by_pk().await,
+        TransactionBenchOp::DeleteAll => fixture.delete_all().await,
+        TransactionBenchOp::DeleteOneByPk => fixture.delete_one_by_pk().await,
+    }
+}
+
+fn profile_raw_sqlite_operation(
+    rows: &[WorkloadRow],
+    operation: TransactionBenchOp,
+    sample_count: usize,
+) {
+    let mut samples = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let mut fixture = if operation.needs_seed() {
+            raw_sqlite::seeded_fixture(rows)
+        } else {
+            raw_sqlite::empty_fixture(rows)
+        };
+        let start = Instant::now();
+        let result = match operation {
+            TransactionBenchOp::InsertAll => fixture.insert_all(),
+            TransactionBenchOp::ReadAll => fixture.read_all(),
+            TransactionBenchOp::ReadOneByPk => fixture.read_one_by_pk(),
+            TransactionBenchOp::ReadManyByPk => fixture.read_many_by_pk(READ_MANY_PK_COUNT),
+            TransactionBenchOp::UpdateAll => fixture.update_all(),
+            TransactionBenchOp::UpdateOneByPk => fixture.update_one_by_pk(),
+            TransactionBenchOp::DeleteAll => fixture.delete_all(),
+            TransactionBenchOp::DeleteOneByPk => fixture.delete_one_by_pk(),
+        };
+        samples.push(start.elapsed());
+        black_box(result);
+    }
+    print_profile_samples("raw_sqlite", operation, samples);
+}
+
+fn print_profile_samples(layer: &str, operation: TransactionBenchOp, mut samples: Vec<Duration>) {
+    samples.sort_unstable();
+    let median = samples[samples.len() / 2];
+    println!(
+        "tracked_state_crud profile: {layer}/{}/{} samples: median={median:?} min={:?} max={:?}",
+        profile_operation_name(operation),
+        samples.len(),
+        samples[0],
+        samples[samples.len() - 1],
+    );
+}
+
+const fn profile_operation_name(operation: TransactionBenchOp) -> &'static str {
+    match operation {
+        TransactionBenchOp::InsertAll => "insert_all",
+        TransactionBenchOp::ReadAll => "read_all",
+        TransactionBenchOp::ReadOneByPk => "read_one",
+        TransactionBenchOp::ReadManyByPk => "read_many",
+        TransactionBenchOp::UpdateAll => "update_all",
+        TransactionBenchOp::UpdateOneByPk => "update_one",
+        TransactionBenchOp::DeleteAll => "delete_all",
+        TransactionBenchOp::DeleteOneByPk => "delete_one",
     }
 }
 
@@ -239,24 +397,17 @@ fn bench_transaction_op(
 ) {
     let rows = rows.to_vec();
     group.bench_function(name, |b| {
-        b.iter_custom(|iterations| {
-            let mut fixtures = Vec::with_capacity(iterations as usize);
-            let mut elapsed = Duration::ZERO;
-            for _ in 0..iterations {
-                let mut fixture = if op.needs_seed() {
+        b.iter_batched_ref(
+            || {
+                if op.needs_seed() {
                     runtime.block_on(transaction_api::seeded_fixture(profile, &rows))
                 } else {
                     runtime.block_on(transaction_api::empty_fixture(profile, &rows))
-                };
-                let start = Instant::now();
-                let rows = runtime.block_on(op.run(&mut fixture));
-                elapsed += start.elapsed();
-                black_box(rows);
-                fixtures.push(fixture);
-            }
-            drop(fixtures);
-            elapsed
-        });
+                }
+            },
+            |fixture| black_box(runtime.block_on(op.run(fixture))),
+            BatchSize::LargeInput,
+        );
     });
 }
 

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -386,7 +386,6 @@ impl TransactionBenchOp {
     }
 }
 
-#[expect(clippy::cast_possible_truncation)]
 fn bench_transaction_op(
     group: &mut BenchmarkGroup<'_, WallTime>,
     runtime: &tokio::runtime::Runtime,

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -13,6 +13,7 @@ use crate::filesystem::{
 use crate::live_state::index::{
     LiveStateIndexContext, LiveStateIndexFilter, LiveStateIndexScanRequest,
 };
+use crate::live_state::tracked_head::TrackedHeadContext;
 use crate::live_state::{
     LiveStateExactBatchRequest, LiveStateReader, LiveStateRowIdentity, LiveStateRowRequest,
     LiveStateScanRequest, MaterializedLiveStateRow, VisibilityBranchScope, VisibilityRequest,
@@ -39,6 +40,7 @@ const COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
 /// identity-to-change index, then both sources are combined for serving.
 pub(crate) struct LiveStateContext {
     tracked_state: TrackedStateContext,
+    tracked_head: TrackedHeadContext,
     live_index: LiveStateIndexContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
@@ -52,6 +54,7 @@ impl LiveStateContext {
     ) -> Self {
         Self {
             tracked_state,
+            tracked_head: TrackedHeadContext::new(),
             live_index,
             commit_graph,
             filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
@@ -66,6 +69,7 @@ impl LiveStateContext {
         LiveStateStoreReader {
             store,
             tracked_state: self.tracked_state.clone(),
+            tracked_head: self.tracked_head,
             live_index: self.live_index.clone(),
             commit_graph: self.commit_graph.clone(),
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
@@ -91,6 +95,7 @@ impl LiveStateContext {
 pub(crate) struct LiveStateStoreReader<S> {
     store: S,
     tracked_state: TrackedStateContext,
+    tracked_head: TrackedHeadContext,
     live_index: LiveStateIndexContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
@@ -108,16 +113,20 @@ where
         let reads_tracked =
             request.filter.untracked != Some(true) && !is_commit_derived_only_request(request);
         let scope = scan_scope(store, &self.live_index, request, reads_tracked).await?;
-        let mut rows = Vec::new();
-        if request.filter.untracked != Some(true) {
-            rows.extend(
-                scan_commit_derived_rows(store, &self.commit_graph, request, &scope).await?,
-            );
-            if !is_commit_derived_only_request(request) {
-                rows.extend(self.scan_tracked_branch_rows(request, &scope).await?);
-            }
-        }
-        if request.filter.untracked != Some(false) && !is_commit_derived_only_request(request) {
+        let commit_derived_rows = if request.filter.untracked != Some(true) {
+            scan_commit_derived_rows(store, &self.commit_graph, request, &scope).await?
+        } else {
+            Vec::new()
+        };
+        let mut tracked_branch_rows =
+            if request.filter.untracked != Some(true) && !is_commit_derived_only_request(request) {
+                self.scan_tracked_branch_rows(request, &scope).await?
+            } else {
+                Vec::new()
+            };
+        let untracked_rows = if request.filter.untracked != Some(false)
+            && !is_commit_derived_only_request(request)
+        {
             let branch_rows = stream::iter(scope.storage_branch_ids.clone())
                 .map(|branch_id| async move {
                     let rows: Vec<_> = self
@@ -133,9 +142,29 @@ where
                 .buffered(BRANCH_READ_CONCURRENCY)
                 .try_collect::<Vec<_>>()
                 .await?;
-            rows.extend(branch_rows.into_iter().flatten());
+            branch_rows.into_iter().flatten().collect()
+        } else {
+            Vec::new()
+        };
+        if commit_derived_rows.is_empty()
+            && untracked_rows.is_empty()
+            && let Some(index) =
+                ordered_unique_branch_row_index(&tracked_branch_rows, &scope.projection_branch_ids)
+        {
+            return Ok(finalize_ordered_unique_rows(
+                std::mem::take(&mut tracked_branch_rows[index].rows),
+                request.filter.include_tombstones,
+                request.limit,
+            ));
         }
-        rows = resolve_visible_rows(
+        let mut rows = commit_derived_rows;
+        rows.extend(
+            tracked_branch_rows
+                .into_iter()
+                .flat_map(|branch_rows| branch_rows.rows),
+        );
+        rows.extend(untracked_rows);
+        Ok(resolve_visible_rows(
             rows,
             Vec::new(),
             &VisibilityRequest {
@@ -145,8 +174,7 @@ where
                 include_tombstones: request.filter.include_tombstones,
                 limit: request.limit,
             },
-        );
-        Ok(rows)
+        ))
     }
 
     pub(crate) async fn load_row(
@@ -273,11 +301,34 @@ where
                                 file_id: identity.file_id.clone(),
                             })
                             .collect::<Vec<_>>();
-                        let rows = self
-                            .tracked_state
-                            .reader(&self.store)
-                            .load_projected_rows_at_commit(&commit_id, &keys, &projection)
-                            .await?;
+                        let rows = if let Some(root_id) =
+                            crate::tracked_state::load_root(&self.store, &commit_id).await?
+                        {
+                            if let Some(rows) = self
+                                .tracked_head
+                                .reader(&self.store)
+                                .load_projected_rows_if_current(
+                                    &branch_id,
+                                    &commit_id,
+                                    &root_id,
+                                    &keys,
+                                    &projection,
+                                )
+                                .await?
+                            {
+                                rows
+                            } else {
+                                self.tracked_state
+                                    .reader(&self.store)
+                                    .load_projected_rows_at_commit(&commit_id, &keys, &projection)
+                                    .await?
+                            }
+                        } else {
+                            self.tracked_state
+                                .reader(&self.store)
+                                .load_projected_rows_at_commit(&commit_id, &keys, &projection)
+                                .await?
+                        };
                         Ok::<_, LixError>((branch_id, identities, rows))
                     }
                 })
@@ -361,10 +412,29 @@ where
         let store = &self.store;
         let reads_tracked = !is_commit_derived_only_request(request);
         let scope = scan_scope(store, &self.live_index, request, reads_tracked).await?;
-        let mut rows = scan_commit_derived_rows(store, &self.commit_graph, request, &scope).await?;
-        if !is_commit_derived_only_request(request) {
-            rows.extend(self.scan_tracked_branch_rows(request, &scope).await?);
+        let commit_derived_rows =
+            scan_commit_derived_rows(store, &self.commit_graph, request, &scope).await?;
+        let mut tracked_branch_rows = if !is_commit_derived_only_request(request) {
+            self.scan_tracked_branch_rows(request, &scope).await?
+        } else {
+            Vec::new()
+        };
+        if commit_derived_rows.is_empty()
+            && let Some(index) =
+                ordered_unique_branch_row_index(&tracked_branch_rows, &scope.projection_branch_ids)
+        {
+            return Ok(finalize_ordered_unique_rows(
+                std::mem::take(&mut tracked_branch_rows[index].rows),
+                request.filter.include_tombstones,
+                request.limit,
+            ));
         }
+        let mut rows = commit_derived_rows;
+        rows.extend(
+            tracked_branch_rows
+                .into_iter()
+                .flat_map(|branch_rows| branch_rows.rows),
+        );
         Ok(resolve_visible_rows(
             rows,
             Vec::new(),
@@ -382,7 +452,7 @@ where
         &self,
         request: &LiveStateScanRequest,
         scope: &LiveStateScanScope,
-    ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+    ) -> Result<Vec<TrackedBranchRows>, LixError> {
         let store = &self.store;
         let tracked_request = tracked_scan_request_from_live(request);
         let branches = scope
@@ -400,21 +470,53 @@ where
                 let tracked_request = tracked_request.clone();
                 async move {
                     let source = tracked_source_from_branch_id(&branch_id);
-                    let rows = self
-                        .tracked_state
-                        .reader(store)
-                        .scan_rows_at_commit(&commit_id, &tracked_request)
-                        .await?
-                        .into_iter()
-                        .map(|row| project_tracked_row(row, &branch_id, source))
-                        .collect::<Vec<_>>();
-                    Ok::<_, LixError>(rows)
+                    let (rows, ordered_unique) = if let Some(root_id) =
+                        crate::tracked_state::load_root(store, &commit_id).await?
+                    {
+                        if let Some(rows) = self
+                            .tracked_head
+                            .reader(store)
+                            .scan_rows_if_current(
+                                &branch_id,
+                                &commit_id,
+                                &root_id,
+                                &tracked_request,
+                            )
+                            .await?
+                        {
+                            (rows, true)
+                        } else {
+                            (
+                                self.tracked_state
+                                    .reader(store)
+                                    .scan_rows_at_commit(&commit_id, &tracked_request)
+                                    .await?,
+                                false,
+                            )
+                        }
+                    } else {
+                        (
+                            self.tracked_state
+                                .reader(store)
+                                .scan_rows_at_commit(&commit_id, &tracked_request)
+                                .await?,
+                            false,
+                        )
+                    };
+                    Ok::<_, LixError>(TrackedBranchRows {
+                        branch_id: branch_id.clone(),
+                        rows: rows
+                            .into_iter()
+                            .map(|row| project_tracked_row(row, &branch_id, source))
+                            .collect(),
+                        ordered_unique,
+                    })
                 }
             })
             .buffered(BRANCH_READ_CONCURRENCY)
             .try_collect::<Vec<_>>()
             .await?;
-        Ok(branch_rows.into_iter().flatten().collect())
+        Ok(branch_rows)
     }
 }
 
@@ -661,6 +763,60 @@ struct LiveStateScanScope {
     branch_commit_ids: BranchCommitIds,
 }
 
+/// Rows read from one durable tracked branch source.
+///
+/// A matching tracked-head projection is storage-key ordered by visible
+/// identity and has one row per identity. Immutable-root fallback rows retain
+/// their existing, more general materialization behavior and therefore never
+/// claim this fast-path contract.
+struct TrackedBranchRows {
+    branch_id: String,
+    rows: Vec<MaterializedLiveStateRow>,
+    ordered_unique: bool,
+}
+
+/// Returns the only nonempty branch candidate when it can be served without
+/// overlay arbitration. Global rows, multiple requested branches, an
+/// immutable-root fallback, and staged/untracked candidates all stay on the
+/// general visibility path.
+fn ordered_unique_branch_row_index(
+    branch_rows: &[TrackedBranchRows],
+    projection_branch_ids: &[String],
+) -> Option<usize> {
+    let [requested_branch_id] = projection_branch_ids else {
+        return None;
+    };
+    let mut candidates = branch_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, branch_rows)| !branch_rows.rows.is_empty());
+    let (index, candidate) = candidates.next()?;
+    if candidates.next().is_some()
+        || !candidate.ordered_unique
+        || candidate.branch_id != *requested_branch_id
+    {
+        return None;
+    }
+    Some(index)
+}
+
+/// Finalizes a table scan whose rows are already ordered and unique for the
+/// sole requested branch. This intentionally does no identity sort or
+/// deduplication; the tracked-head key codec proves both properties.
+fn finalize_ordered_unique_rows(
+    mut rows: Vec<MaterializedLiveStateRow>,
+    include_tombstones: bool,
+    limit: Option<usize>,
+) -> Vec<MaterializedLiveStateRow> {
+    if !include_tombstones {
+        rows.retain(|row| !row.deleted);
+    }
+    if let Some(limit) = limit {
+        rows.truncate(limit);
+    }
+    rows
+}
+
 async fn scan_scope(
     store: &(impl StorageAdapterRead + ?Sized),
     live_index: &LiveStateIndexContext,
@@ -878,6 +1034,58 @@ mod tests {
             LiveStateIndexContext::new(),
             CommitGraphContext::new(),
         )
+    }
+
+    #[test]
+    fn ordered_head_fast_path_requires_one_matching_branch_candidate() {
+        let requested_branch_ids = vec!["branch".to_string()];
+        let branch = TrackedBranchRows {
+            branch_id: "branch".to_string(),
+            rows: vec![tracked_row_at_with_commit(
+                "branch", "branch", None, "branch",
+            )],
+            ordered_unique: true,
+        };
+        assert_eq!(
+            ordered_unique_branch_row_index(&[branch], &requested_branch_ids),
+            Some(0)
+        );
+
+        let branch = TrackedBranchRows {
+            branch_id: "branch".to_string(),
+            rows: vec![tracked_row_at_with_commit(
+                "branch", "branch", None, "branch",
+            )],
+            ordered_unique: true,
+        };
+        let global = TrackedBranchRows {
+            branch_id: GLOBAL_BRANCH_ID.to_string(),
+            rows: vec![tracked_row_at_with_commit(
+                GLOBAL_BRANCH_ID,
+                "global",
+                None,
+                "global",
+            )],
+            ordered_unique: true,
+        };
+        assert_eq!(
+            ordered_unique_branch_row_index(&[branch, global], &requested_branch_ids),
+            None,
+            "a global candidate needs normal overlay arbitration"
+        );
+
+        let immutable_fallback = TrackedBranchRows {
+            branch_id: "branch".to_string(),
+            rows: vec![tracked_row_at_with_commit(
+                "branch", "branch", None, "branch",
+            )],
+            ordered_unique: false,
+        };
+        assert_eq!(
+            ordered_unique_branch_row_index(&[immutable_fallback], &requested_branch_ids),
+            None,
+            "the immutable-root fallback does not make the table ordering promise"
+        );
     }
 
     async fn write_untracked_rows_to_store(

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -1,6 +1,7 @@
 mod context;
 mod index;
 mod reader;
+mod tracked_head;
 mod types;
 pub(crate) mod visibility;
 
@@ -17,6 +18,10 @@ pub(crate) use index::{
 pub(crate) use reader::LiveStateReader;
 #[cfg(test)]
 pub(crate) use reader::load_exact_rows_via_scan_for_test;
+#[allow(unused_imports)]
+pub(crate) use tracked_head::{
+    TRACKED_HEAD_MARKER_SPACE, TRACKED_HEAD_ROW_SPACE, TrackedHeadContext, TrackedHeadDeltaRef,
+};
 #[allow(unused_imports)]
 pub(crate) use types::{
     Bound, LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter,

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -1,0 +1,1444 @@
+//! Materialized serving state for one tracked branch head.
+//!
+//! Commit roots remain the immutable authority for versioned state. This
+//! table is a generation-keyed projection of one branch head which lets the
+//! normal live-state path range scan rows and hydrate JSON directly, without
+//! replaying every row through the changelog. A manifest binds a generation to
+//! both the branch ref's commit and its immutable root. Any mismatch is a
+//! cache miss and callers fall back to the commit root.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use bytes::Bytes;
+
+use crate::LixError;
+use crate::NullableKeyFilter;
+use crate::changelog::{ChangeId, ChangeRecordProjection, CommitId};
+use crate::common::LixTimestamp;
+use crate::entity_pk::EntityPk;
+use crate::json_store::{
+    JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlot, JsonSlotRef, JsonStoreContext,
+};
+use crate::storage_adapter::{
+    PointReadPlan, ScanPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StoragePrefix,
+    StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
+    StorageWriteSet,
+};
+use crate::storage_codec;
+use crate::tracked_state::{
+    MaterializedTrackedStateRow, TrackedStateFilter, TrackedStateKey, TrackedStateRootId,
+    TrackedStateScanRequest,
+};
+
+pub(crate) const TRACKED_HEAD_ROW_NAMESPACE: &str = "live_state.tracked_head_row.v2";
+pub(crate) const TRACKED_HEAD_MARKER_NAMESPACE: &str = "live_state.tracked_head_marker.v2";
+pub(crate) const TRACKED_HEAD_ROW_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_0009), TRACKED_HEAD_ROW_NAMESPACE);
+pub(crate) const TRACKED_HEAD_MARKER_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_000a), TRACKED_HEAD_MARKER_NAMESPACE);
+
+/// Immutable manifest for the currently readable generation of a branch.
+///
+/// A new generation is used after a branch ref moves away from the parent of
+/// a normal commit. Old rows can remain in storage: they are unreachable
+/// without this marker and therefore cannot affect serving reads.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct TrackedHeadMarker {
+    head_commit_id: CommitId,
+    root_id: TrackedStateRootId,
+    generation: CommitId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct HeadIdentity {
+    branch_id: String,
+    generation: CommitId,
+    schema_key: String,
+    entity_pk: EntityPk,
+    #[musli(with = storage_codec::option)]
+    file_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Decode)]
+#[musli(packed)]
+struct HeadValue {
+    change_id: ChangeId,
+    commit_id: CommitId,
+    deleted: bool,
+    created_at: LixTimestamp,
+    updated_at: LixTimestamp,
+    #[musli(with = crate::json_store::json_slot_storage)]
+    snapshot: JsonSlot,
+    #[musli(with = crate::json_store::json_slot_storage)]
+    metadata: JsonSlot,
+}
+
+impl HeadValue {
+    fn as_ref(&self) -> HeadValueRef<'_> {
+        HeadValueRef {
+            change_id: self.change_id,
+            commit_id: self.commit_id,
+            deleted: self.deleted,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            snapshot: self.snapshot.as_ref_slot(),
+            metadata: self.metadata.as_ref_slot(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, musli::Encode)]
+#[musli(packed)]
+struct HeadValueRef<'a> {
+    change_id: ChangeId,
+    commit_id: CommitId,
+    deleted: bool,
+    created_at: LixTimestamp,
+    updated_at: LixTimestamp,
+    #[musli(with = crate::json_store::json_slot_storage_ref)]
+    snapshot: JsonSlotRef<'a>,
+    #[musli(with = crate::json_store::json_slot_storage_ref)]
+    metadata: JsonSlotRef<'a>,
+}
+
+#[derive(Debug, Clone, Copy, musli::Encode)]
+#[musli(packed)]
+struct BranchRef<'a> {
+    branch_id: &'a str,
+}
+
+/// Zero-copy normal tracked mutation staged into a head generation.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TrackedHeadDeltaRef<'a> {
+    pub(crate) schema_key: &'a str,
+    pub(crate) file_id: Option<&'a str>,
+    pub(crate) entity_pk: &'a EntityPk,
+    pub(crate) change_id: ChangeId,
+    pub(crate) commit_id: CommitId,
+    pub(crate) deleted: bool,
+    pub(crate) created_at: LixTimestamp,
+    pub(crate) updated_at: LixTimestamp,
+    pub(crate) snapshot: JsonSlotRef<'a>,
+    pub(crate) metadata: JsonSlotRef<'a>,
+}
+
+impl<'a> TrackedHeadDeltaRef<'a> {
+    fn identity(&self, branch_id: &str, generation: CommitId) -> HeadIdentity {
+        HeadIdentity {
+            branch_id: branch_id.to_string(),
+            generation,
+            schema_key: self.schema_key.to_string(),
+            entity_pk: self.entity_pk.clone(),
+            file_id: self.file_id.map(str::to_string),
+        }
+    }
+
+    fn value_ref(&self, created_at: LixTimestamp) -> HeadValueRef<'a> {
+        HeadValueRef {
+            change_id: self.change_id,
+            commit_id: self.commit_id,
+            deleted: self.deleted,
+            created_at,
+            updated_at: self.updated_at,
+            snapshot: if self.deleted {
+                JsonSlotRef::None
+            } else {
+                self.snapshot
+            },
+            metadata: if self.deleted {
+                JsonSlotRef::None
+            } else {
+                self.metadata
+            },
+        }
+    }
+}
+
+/// Factory for tracked-head readers and writers.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct TrackedHeadContext;
+
+impl TrackedHeadContext {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    #[expect(clippy::unused_self)]
+    pub(crate) fn reader<S>(&self, store: S) -> TrackedHeadStoreReader<S>
+    where
+        S: StorageAdapterRead,
+    {
+        TrackedHeadStoreReader { store }
+    }
+
+    #[expect(clippy::unused_self)]
+    pub(crate) fn writer<'a, S>(
+        &'a self,
+        store: &'a S,
+        writes: &'a mut StorageWriteSet,
+    ) -> TrackedHeadWriter<'a, S>
+    where
+        S: StorageAdapterRead + ?Sized,
+    {
+        TrackedHeadWriter { store, writes }
+    }
+}
+
+/// Direct materializer for the current tracked branch generation.
+pub(crate) struct TrackedHeadStoreReader<S> {
+    store: S,
+}
+
+impl<S> TrackedHeadStoreReader<S>
+where
+    S: StorageAdapterRead,
+{
+    /// Returns `None` when this branch has no projection for the canonical
+    /// branch ref/root pair. That is a cache miss, not empty tracked state.
+    pub(crate) async fn scan_rows_if_current(
+        &self,
+        branch_id: &str,
+        expected_head: &str,
+        expected_root: &TrackedStateRootId,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Option<Vec<MaterializedTrackedStateRow>>, LixError> {
+        let Some(marker) = self
+            .marker_if_current(branch_id, expected_head, expected_root)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let entries = scan_values(
+            &self.store,
+            branch_id,
+            marker.generation,
+            &request.filter,
+            None,
+        )
+        .await?;
+        let projection = ChangeRecordProjection::from_columns(&request.read_columns.columns);
+        let mut rows = materialize_entries(&self.store, entries, projection).await?;
+        if !request.filter.include_tombstones {
+            rows.retain(|row| !row.deleted);
+        }
+        if let Some(limit) = request.limit {
+            rows.truncate(limit);
+        }
+        Ok(Some(rows))
+    }
+
+    /// Like the immutable-root point batch, preserves input cardinality and
+    /// returns tombstones for the visibility layer to resolve.
+    pub(crate) async fn load_projected_rows_if_current(
+        &self,
+        branch_id: &str,
+        expected_head: &str,
+        expected_root: &TrackedStateRootId,
+        keys: &[TrackedStateKey],
+        projection: &ChangeRecordProjection,
+    ) -> Result<Option<Vec<Option<MaterializedTrackedStateRow>>>, LixError> {
+        if keys.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+        let Some(marker) = self
+            .marker_if_current(branch_id, expected_head, expected_root)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let mut output_indices = BTreeMap::<HeadIdentity, Vec<usize>>::new();
+        for (index, key) in keys.iter().enumerate() {
+            output_indices
+                .entry(HeadIdentity {
+                    branch_id: branch_id.to_string(),
+                    generation: marker.generation,
+                    schema_key: key.schema_key.clone(),
+                    entity_pk: key.entity_pk.clone(),
+                    file_id: key.file_id.clone(),
+                })
+                .or_default()
+                .push(index);
+        }
+        let identities = output_indices.keys().cloned().collect::<Vec<_>>();
+        let values = load_values(&self.store, &identities).await?;
+        let entries = identities
+            .into_iter()
+            .zip(values)
+            .filter_map(|(identity, value)| value.map(|value| (identity, value)))
+            .collect();
+        let rows = materialize_entries(&self.store, entries, *projection).await?;
+        let mut output = vec![None; keys.len()];
+        for row in rows {
+            let identity = HeadIdentity {
+                branch_id: branch_id.to_string(),
+                generation: marker.generation,
+                schema_key: row.schema_key.clone(),
+                entity_pk: row.entity_pk.clone(),
+                file_id: row.file_id.clone(),
+            };
+            if let Some(indices) = output_indices.get(&identity) {
+                for &index in indices {
+                    output[index] = Some(row.clone());
+                }
+            }
+        }
+        Ok(Some(output))
+    }
+
+    pub(crate) async fn is_current(
+        &self,
+        branch_id: &str,
+        expected_head: &str,
+        expected_root: &TrackedStateRootId,
+    ) -> Result<bool, LixError> {
+        Ok(self
+            .marker_if_current(branch_id, expected_head, expected_root)
+            .await?
+            .is_some())
+    }
+
+    async fn marker_if_current(
+        &self,
+        branch_id: &str,
+        expected_head: &str,
+        expected_root: &TrackedStateRootId,
+    ) -> Result<Option<TrackedHeadMarker>, LixError> {
+        let expected_head = CommitId::parse_lix(expected_head, "tracked-head expected commit")?;
+        let marker = load_marker(&self.store, branch_id).await?;
+        Ok(marker.filter(|marker| {
+            marker.head_commit_id == expected_head && marker.root_id == *expected_root
+        }))
+    }
+}
+
+/// Writer for an atomic branch-head projection update.
+pub(crate) struct TrackedHeadWriter<'a, S: ?Sized> {
+    store: &'a S,
+    writes: &'a mut StorageWriteSet,
+}
+
+impl<S> TrackedHeadWriter<'_, S>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    /// Incrementally updates a matching parent generation, or creates a fresh
+    /// generation from a caller-provided parent snapshot. The latter is used
+    /// after branch movement and for old repositories which predate this
+    /// serving table.
+    pub(crate) async fn stage_commit(
+        &mut self,
+        branch_id: &str,
+        parent_head: Option<CommitId>,
+        parent_root: Option<&TrackedStateRootId>,
+        new_head: CommitId,
+        new_root: TrackedStateRootId,
+        deltas: &[TrackedHeadDeltaRef<'_>],
+        parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
+    ) -> Result<(), LixError> {
+        let marker = load_marker(self.store, branch_id).await?;
+        let matches_parent = marker.as_ref().is_some_and(|marker| {
+            parent_head.is_some_and(|parent| marker.head_commit_id == parent)
+                && parent_root.is_some_and(|root| marker.root_id == *root)
+        });
+        let generation = if matches_parent {
+            marker
+                .as_ref()
+                .expect("matching tracked-head marker exists")
+                .generation
+        } else {
+            new_head
+        };
+        let delta_identities = deltas
+            .iter()
+            .map(|delta| delta.identity(branch_id, generation))
+            .collect::<BTreeSet<_>>();
+
+        let mut prior = BTreeMap::<HeadIdentity, HeadValue>::new();
+        if matches_parent {
+            let identities = deltas
+                .iter()
+                .map(|delta| delta.identity(branch_id, generation))
+                .collect::<Vec<_>>();
+            let values = load_values(self.store, &identities).await?;
+            for (identity, value) in identities.into_iter().zip(values) {
+                if let Some(value) = value {
+                    prior.insert(identity, value);
+                }
+            }
+        } else if let Some(rows) = parent_rows {
+            self.writes
+                .reserve_space(TRACKED_HEAD_ROW_SPACE, rows.len() + deltas.len(), 0);
+            for row in rows {
+                let identity = HeadIdentity {
+                    branch_id: branch_id.to_string(),
+                    generation,
+                    schema_key: row.schema_key,
+                    entity_pk: row.entity_pk,
+                    file_id: row.file_id,
+                };
+                let value = HeadValue {
+                    change_id: row.change_id,
+                    commit_id: row.commit_id,
+                    deleted: row.deleted,
+                    created_at: LixTimestamp::expect_parse(
+                        "tracked-head parent created_at",
+                        &row.created_at,
+                    ),
+                    updated_at: LixTimestamp::expect_parse(
+                        "tracked-head parent updated_at",
+                        &row.updated_at,
+                    ),
+                    snapshot: row
+                        .snapshot_content
+                        .as_deref()
+                        .map_or(JsonSlot::None, JsonSlot::from_json),
+                    metadata: row
+                        .metadata
+                        .as_deref()
+                        .map_or(JsonSlot::None, JsonSlot::from_json),
+                };
+                // The child delta below owns the final mutation for an
+                // overlapping key. Keep its parent value only to preserve
+                // `created_at`; staging both would violate the write-set's
+                // one-put-per-key invariant.
+                if !delta_identities.contains(&identity) {
+                    stage_put(self.writes, &identity, &value)?;
+                }
+                prior.insert(identity, value);
+            }
+        } else {
+            self.writes
+                .reserve_space(TRACKED_HEAD_ROW_SPACE, deltas.len(), 0);
+        }
+
+        for delta in deltas {
+            let identity = delta.identity(branch_id, generation);
+            let created_at = prior
+                .get(&identity)
+                .map_or(delta.created_at, |previous| previous.created_at);
+            stage_put_ref(self.writes, &identity, &delta.value_ref(created_at))?;
+        }
+        stage_marker(
+            self.writes,
+            branch_id,
+            &TrackedHeadMarker {
+                head_commit_id: new_head,
+                root_id: new_root,
+                generation,
+            },
+        )?;
+        Ok(())
+    }
+}
+
+async fn load_marker(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+) -> Result<Option<TrackedHeadMarker>, LixError> {
+    let key = marker_key(branch_id)?;
+    let result = PointReadPlan::new(TRACKED_HEAD_MARKER_SPACE, &[StorageKey(Bytes::from(key))])
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    result
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .map(decode_marker_value)
+        .transpose()
+}
+
+async fn load_values(
+    store: &(impl StorageAdapterRead + ?Sized),
+    identities: &[HeadIdentity],
+) -> Result<Vec<Option<HeadValue>>, LixError> {
+    if identities.is_empty() {
+        return Ok(Vec::new());
+    }
+    let keys = identities
+        .iter()
+        .map(|identity| StorageKey(Bytes::from(encode_row_key(identity))))
+        .collect::<Vec<_>>();
+    let result = PointReadPlan::new(TRACKED_HEAD_ROW_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    result
+        .value
+        .into_iter()
+        .map(|value| value.map(decode_head_value).transpose())
+        .collect()
+}
+
+async fn scan_values(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    filter: &TrackedStateFilter,
+    limit: Option<usize>,
+) -> Result<Vec<(HeadIdentity, HeadValue)>, LixError> {
+    if let Some(identities) = exact_filter_identities(branch_id, generation, filter) {
+        let values = load_values(store, &identities).await?;
+        return Ok(identities
+            .into_iter()
+            .zip(values)
+            .filter_map(|(identity, value)| value.map(|value| (identity, value)))
+            .take(limit.unwrap_or(usize::MAX))
+            .collect());
+    }
+
+    let mut prefixes = scan_prefixes(branch_id, generation, filter);
+    prefixes.sort();
+    prefixes.dedup();
+    let mut rows = Vec::new();
+    for prefix in prefixes {
+        let plan = ScanPlan::prefix(
+            TRACKED_HEAD_ROW_SPACE,
+            StoragePrefix {
+                bytes: Bytes::from(prefix),
+            },
+        );
+        let mut resume_after = None;
+        loop {
+            let remaining = limit.map(|limit| limit.saturating_sub(rows.len()));
+            if matches!(remaining, Some(0)) {
+                return Ok(rows);
+            }
+            let page = plan
+                .collect(
+                    store,
+                    StorageScanOptions {
+                        resume_after: resume_after.clone(),
+                        limit_rows: remaining
+                            .unwrap_or_else(|| StorageScanOptions::default().limit_rows),
+                        ..StorageScanOptions::default()
+                    },
+                )
+                .await?;
+            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+            for entry in page.value.entries {
+                let identity = decode_row_key(entry.key.0.as_ref())?;
+                if !matches_filter(&identity, filter) {
+                    continue;
+                }
+                rows.push((identity, decode_head_value(entry.value)?));
+                if limit.is_some_and(|limit| rows.len() >= limit) {
+                    return Ok(rows);
+                }
+            }
+            if !page.value.has_more || resume_after.is_none() {
+                break;
+            }
+        }
+    }
+    Ok(rows)
+}
+
+fn exact_filter_identities(
+    branch_id: &str,
+    generation: CommitId,
+    filter: &TrackedStateFilter,
+) -> Option<Vec<HeadIdentity>> {
+    if filter.schema_keys.is_empty()
+        || filter.entity_pks.is_empty()
+        || filter.file_ids.is_empty()
+        || filter
+            .file_ids
+            .iter()
+            .any(|filter| matches!(filter, NullableKeyFilter::Any))
+    {
+        return None;
+    }
+    let mut identities = Vec::with_capacity(
+        filter.schema_keys.len() * filter.entity_pks.len() * filter.file_ids.len(),
+    );
+    for schema_key in &filter.schema_keys {
+        for entity_pk in &filter.entity_pks {
+            for file_id in &filter.file_ids {
+                let file_id = match file_id {
+                    NullableKeyFilter::Null => None,
+                    NullableKeyFilter::Value(value) => Some(value.clone()),
+                    NullableKeyFilter::Any => unreachable!("Any rejected above"),
+                };
+                identities.push(HeadIdentity {
+                    branch_id: branch_id.to_string(),
+                    generation,
+                    schema_key: schema_key.clone(),
+                    entity_pk: entity_pk.clone(),
+                    file_id,
+                });
+            }
+        }
+    }
+    identities.sort();
+    identities.dedup();
+    Some(identities)
+}
+
+fn scan_prefixes(
+    branch_id: &str,
+    generation: CommitId,
+    filter: &TrackedStateFilter,
+) -> Vec<Vec<u8>> {
+    let scope = encode_scope_prefix(branch_id, generation);
+    if filter.schema_keys.is_empty() {
+        return vec![scope];
+    }
+    let mut prefixes = Vec::new();
+    for schema_key in &filter.schema_keys {
+        let mut schema_prefix = scope.clone();
+        write_key_string(&mut schema_prefix, schema_key, KEY_PART_FINAL);
+        if filter.entity_pks.is_empty() {
+            prefixes.push(schema_prefix);
+            continue;
+        }
+        for entity_pk in &filter.entity_pks {
+            let mut entity_prefix = schema_prefix.clone();
+            write_entity_pk(&mut entity_prefix, entity_pk);
+            if filter.file_ids.is_empty()
+                || filter
+                    .file_ids
+                    .iter()
+                    .any(|filter| matches!(filter, NullableKeyFilter::Any))
+            {
+                prefixes.push(entity_prefix);
+                continue;
+            }
+            for file_id in &filter.file_ids {
+                let file_id = match file_id {
+                    NullableKeyFilter::Null => None,
+                    NullableKeyFilter::Value(value) => Some(value.as_str()),
+                    NullableKeyFilter::Any => unreachable!("Any handled above"),
+                };
+                let mut prefix = entity_prefix.clone();
+                write_file_id(&mut prefix, file_id);
+                prefixes.push(prefix);
+            }
+        }
+    }
+    prefixes
+}
+
+fn matches_filter(identity: &HeadIdentity, filter: &TrackedStateFilter) -> bool {
+    (filter.schema_keys.is_empty() || filter.schema_keys.contains(&identity.schema_key))
+        && (filter.entity_pks.is_empty() || filter.entity_pks.contains(&identity.entity_pk))
+        && (filter.file_ids.is_empty()
+            || filter.file_ids.iter().any(|filter| match filter {
+                NullableKeyFilter::Any => true,
+                NullableKeyFilter::Null => identity.file_id.is_none(),
+                NullableKeyFilter::Value(value) => identity.file_id.as_ref() == Some(value),
+            }))
+}
+
+fn stage_marker(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    marker: &TrackedHeadMarker,
+) -> Result<(), LixError> {
+    writes.put(
+        TRACKED_HEAD_MARKER_SPACE,
+        StorageKey(Bytes::from(marker_key(branch_id)?)),
+        StorageValue {
+            bytes: Bytes::from(storage_codec::encode("tracked-head marker", marker)?),
+        },
+    );
+    Ok(())
+}
+
+fn stage_put(
+    writes: &mut StorageWriteSet,
+    identity: &HeadIdentity,
+    value: &HeadValue,
+) -> Result<(), LixError> {
+    stage_put_ref(writes, identity, &value.as_ref())
+}
+
+fn stage_put_ref(
+    writes: &mut StorageWriteSet,
+    identity: &HeadIdentity,
+    value: &HeadValueRef<'_>,
+) -> Result<(), LixError> {
+    writes.put(
+        TRACKED_HEAD_ROW_SPACE,
+        StorageKey(Bytes::from(encode_row_key(identity))),
+        StorageValue {
+            bytes: Bytes::from(storage_codec::encode("tracked-head row", value)?),
+        },
+    );
+    Ok(())
+}
+
+fn marker_key(branch_id: &str) -> Result<Vec<u8>, LixError> {
+    storage_codec::encode("tracked-head marker key", &BranchRef { branch_id })
+}
+
+fn encode_row_key(identity: &HeadIdentity) -> Vec<u8> {
+    let mut out = encode_scope_prefix(&identity.branch_id, identity.generation);
+    write_key_string(&mut out, &identity.schema_key, KEY_PART_FINAL);
+    write_entity_pk(&mut out, &identity.entity_pk);
+    write_file_id(&mut out, identity.file_id.as_deref());
+    out
+}
+
+fn decode_row_key(bytes: &[u8]) -> Result<HeadIdentity, LixError> {
+    let mut offset = 0usize;
+    let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
+    if branch_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error("branch id has an invalid terminator"));
+    }
+    let generation = read_generation(bytes, &mut offset)?;
+    let (schema_key, schema_terminator) = read_key_string(bytes, &mut offset, "schema key")?;
+    if schema_terminator != KEY_PART_FINAL {
+        return Err(key_codec_error("schema key has an invalid terminator"));
+    }
+    let entity_pk = read_entity_pk(bytes, &mut offset)?;
+    let file_id = read_file_id(bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(key_codec_error("has trailing bytes"));
+    }
+    Ok(HeadIdentity {
+        branch_id,
+        generation,
+        schema_key,
+        entity_pk,
+        file_id,
+    })
+}
+
+const KEY_ESCAPE: u8 = 0xff;
+const KEY_PART_FINAL: u8 = 0x00;
+const KEY_PART_MORE: u8 = 0x01;
+const FILE_ID_NONE: u8 = 0x00;
+const FILE_ID_SOME: u8 = 0x01;
+const GENERATION_BYTES: usize = 16;
+
+/// Order-preserving tracked-head key encoding.
+///
+/// The head table is the normal read serving index, so its storage ordering is
+/// also the visible row ordering: `(branch, generation, schema, entity,
+/// file)`. Musli's storage encoding is excellent for values and structural
+/// prefixes, but length-prefixed strings do not preserve lexical order. This
+/// codec retains exact prefix scans while making every table scan already
+/// ordered and duplicate-free for one branch generation.
+fn encode_scope_prefix(branch_id: &str, generation: CommitId) -> Vec<u8> {
+    let mut out = Vec::with_capacity(branch_id.len() + 2 + GENERATION_BYTES);
+    write_key_string(&mut out, branch_id, KEY_PART_FINAL);
+    out.extend_from_slice(generation.as_uuid().as_bytes());
+    out
+}
+
+fn write_entity_pk(out: &mut Vec<u8>, entity_pk: &EntityPk) {
+    debug_assert!(
+        !entity_pk.parts.is_empty(),
+        "tracked-head entity primary keys must be non-empty"
+    );
+    for (index, part) in entity_pk.parts.iter().enumerate() {
+        let terminator = if index + 1 == entity_pk.parts.len() {
+            KEY_PART_FINAL
+        } else {
+            KEY_PART_MORE
+        };
+        write_key_string(out, part, terminator);
+    }
+}
+
+fn write_file_id(out: &mut Vec<u8>, file_id: Option<&str>) {
+    match file_id {
+        None => out.push(FILE_ID_NONE),
+        Some(file_id) => {
+            out.push(FILE_ID_SOME);
+            write_key_string(out, file_id, KEY_PART_FINAL);
+        }
+    }
+}
+
+fn write_key_string(out: &mut Vec<u8>, value: &str, terminator: u8) {
+    for &byte in value.as_bytes() {
+        if byte == KEY_PART_FINAL {
+            out.extend_from_slice(&[KEY_PART_FINAL, KEY_ESCAPE]);
+        } else {
+            out.push(byte);
+        }
+    }
+    out.extend_from_slice(&[KEY_PART_FINAL, terminator]);
+}
+
+fn read_generation(bytes: &[u8], offset: &mut usize) -> Result<CommitId, LixError> {
+    let end = offset
+        .checked_add(GENERATION_BYTES)
+        .ok_or_else(|| key_codec_error("generation offset overflow"))?;
+    let generation = bytes
+        .get(*offset..end)
+        .ok_or_else(|| key_codec_error("is truncated before generation"))?;
+    let mut uuid = [0; GENERATION_BYTES];
+    uuid.copy_from_slice(generation);
+    *offset = end;
+    Ok(CommitId::new(uuid::Uuid::from_bytes(uuid)))
+}
+
+fn read_entity_pk(bytes: &[u8], offset: &mut usize) -> Result<EntityPk, LixError> {
+    let mut parts = Vec::new();
+    loop {
+        let (part, terminator) = read_key_string(bytes, offset, "entity primary key")?;
+        parts.push(part);
+        match terminator {
+            KEY_PART_FINAL => break,
+            KEY_PART_MORE => {}
+            _ => {
+                return Err(key_codec_error(
+                    "entity primary key has an invalid terminator",
+                ));
+            }
+        }
+    }
+    EntityPk::from_parts(parts).map_err(|error| {
+        key_codec_error(&format!("contains an invalid entity primary key: {error}"))
+    })
+}
+
+fn read_file_id(bytes: &[u8], offset: &mut usize) -> Result<Option<String>, LixError> {
+    let tag = *bytes
+        .get(*offset)
+        .ok_or_else(|| key_codec_error("is truncated before file id"))?;
+    *offset += 1;
+    match tag {
+        FILE_ID_NONE => Ok(None),
+        FILE_ID_SOME => {
+            let (file_id, terminator) = read_key_string(bytes, offset, "file id")?;
+            if terminator != KEY_PART_FINAL {
+                return Err(key_codec_error("file id has an invalid terminator"));
+            }
+            Ok(Some(file_id))
+        }
+        _ => Err(key_codec_error("has an invalid file id tag")),
+    }
+}
+
+fn read_key_string(
+    bytes: &[u8],
+    offset: &mut usize,
+    field: &str,
+) -> Result<(String, u8), LixError> {
+    let mut out = Vec::new();
+    loop {
+        let byte = *bytes
+            .get(*offset)
+            .ok_or_else(|| key_codec_error(&format!("is truncated in {field}")))?;
+        *offset += 1;
+        if byte != KEY_PART_FINAL {
+            out.push(byte);
+            continue;
+        }
+        let terminator = *bytes
+            .get(*offset)
+            .ok_or_else(|| key_codec_error(&format!("is truncated after {field}")))?;
+        *offset += 1;
+        if terminator == KEY_ESCAPE {
+            out.push(KEY_PART_FINAL);
+            continue;
+        }
+        let value = String::from_utf8(out).map_err(|error| {
+            key_codec_error(&format!("{field} is not UTF-8: {}", error.utf8_error()))
+        })?;
+        return Ok((value, terminator));
+    }
+}
+
+fn key_codec_error(message: &str) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("invalid tracked-head row key: {message}"),
+    )
+}
+
+fn decode_marker_value(value: StorageProjectedValue) -> Result<TrackedHeadMarker, LixError> {
+    let StorageProjectedValue::FullValue(bytes) = value else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked-head marker read unexpectedly omitted its value",
+        ));
+    };
+    storage_codec::decode("tracked-head marker", &bytes)
+}
+
+fn decode_head_value(value: StorageProjectedValue) -> Result<HeadValue, LixError> {
+    let StorageProjectedValue::FullValue(bytes) = value else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked-head row read unexpectedly omitted its value",
+        ));
+    };
+    storage_codec::decode("tracked-head row", &bytes)
+}
+
+enum MaterializedSlot {
+    None,
+    Inline(Box<str>),
+    Loaded(usize),
+}
+
+async fn materialize_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    entries: Vec<(HeadIdentity, HeadValue)>,
+    projection: ChangeRecordProjection,
+) -> Result<Vec<MaterializedTrackedStateRow>, LixError> {
+    let mut json_refs = Vec::new();
+    let mut plans = Vec::with_capacity(entries.len());
+    for (identity, value) in entries {
+        let HeadValue {
+            change_id,
+            commit_id,
+            deleted,
+            created_at,
+            updated_at,
+            snapshot,
+            metadata,
+        } = value;
+        let snapshot = materialized_slot(
+            !deleted && projection.snapshot_content,
+            snapshot,
+            &mut json_refs,
+        );
+        let metadata = materialized_slot(!deleted && projection.metadata, metadata, &mut json_refs);
+        plans.push((
+            identity, change_id, commit_id, deleted, created_at, updated_at, snapshot, metadata,
+        ));
+    }
+    let mut json_values = if json_refs.is_empty() {
+        Vec::new()
+    } else {
+        JsonStoreContext::new()
+            .load_bytes_many(
+                store,
+                JsonLoadRequestRef {
+                    refs: &json_refs,
+                    scope: JsonReadScopeRef::OutOfBand,
+                },
+            )
+            .await?
+            .into_values()
+    };
+    plans
+        .into_iter()
+        .map(
+            |(
+                identity,
+                change_id,
+                commit_id,
+                deleted,
+                created_at,
+                updated_at,
+                snapshot,
+                metadata,
+            )| {
+                Ok(MaterializedTrackedStateRow {
+                    entity_pk: identity.entity_pk,
+                    schema_key: identity.schema_key,
+                    file_id: identity.file_id,
+                    snapshot_content: materialize_slot(snapshot, &json_refs, &mut json_values)?,
+                    metadata: materialize_slot(metadata, &json_refs, &mut json_values)?,
+                    deleted,
+                    created_at: created_at.to_string(),
+                    updated_at: updated_at.to_string(),
+                    change_id,
+                    commit_id,
+                })
+            },
+        )
+        .collect()
+}
+
+fn materialized_slot(
+    include: bool,
+    slot: JsonSlot,
+    json_refs: &mut Vec<JsonRef>,
+) -> MaterializedSlot {
+    if !include {
+        return MaterializedSlot::None;
+    }
+    match slot {
+        JsonSlot::None => MaterializedSlot::None,
+        JsonSlot::Inline(json) => MaterializedSlot::Inline(json),
+        JsonSlot::Ref(json_ref) => {
+            let index = json_refs.len();
+            json_refs.push(json_ref);
+            MaterializedSlot::Loaded(index)
+        }
+    }
+}
+
+fn materialize_slot(
+    slot: MaterializedSlot,
+    json_refs: &[JsonRef],
+    json_values: &mut [Option<Vec<u8>>],
+) -> Result<Option<String>, LixError> {
+    let index = match slot {
+        MaterializedSlot::None => return Ok(None),
+        MaterializedSlot::Inline(json) => return Ok(Some(json.into_string())),
+        MaterializedSlot::Loaded(index) => index,
+    };
+    let json_ref = json_refs.get(index).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked-head materialization lost JSON ref index",
+        )
+    })?;
+    let bytes = json_values
+        .get_mut(index)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked-head materialization lost JSON value index",
+            )
+        })?
+        .take()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked-head row is missing JSON payload '{}'",
+                    json_ref.to_hex()
+                ),
+            )
+        })?;
+    String::from_utf8(bytes).map(Some).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked-head JSON payload is not UTF-8: {}",
+                error.utf8_error()
+            ),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+
+    fn ts(value: &str) -> LixTimestamp {
+        LixTimestamp::expect_parse("test timestamp", value)
+    }
+
+    fn root(label: &str) -> TrackedStateRootId {
+        TrackedStateRootId::new(*blake3::hash(label.as_bytes()).as_bytes())
+    }
+
+    fn identity(branch_id: &str, generation: CommitId, entity: &str) -> HeadIdentity {
+        HeadIdentity {
+            branch_id: branch_id.to_string(),
+            generation,
+            schema_key: "schema".to_string(),
+            entity_pk: EntityPk::single(entity),
+            file_id: None,
+        }
+    }
+
+    fn head_value(change: &str, commit_id: CommitId) -> HeadValue {
+        HeadValue {
+            change_id: ChangeId::for_test_label(change),
+            commit_id,
+            deleted: false,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+            snapshot: JsonSlot::from_json("{\"value\":true}"),
+            metadata: JsonSlot::None,
+        }
+    }
+
+    #[test]
+    fn row_key_roundtrips_and_preserves_logical_order() {
+        let generation = CommitId::for_test_label("generation");
+        let strings = ["", "\0", "a", "a\0", "a\u{1}", "z", "é"];
+        let mut identities = Vec::new();
+        for schema_key in strings {
+            for entity_first in strings {
+                for entity_pk in [
+                    EntityPk::single(entity_first),
+                    EntityPk::from_parts(vec![entity_first.to_string(), "tail".to_string()])
+                        .expect("tuple entity key should be valid"),
+                ] {
+                    for file_id in [None, Some(""), Some("a"), Some("a\0")] {
+                        identities.push(HeadIdentity {
+                            branch_id: "branch\0name".to_string(),
+                            generation,
+                            schema_key: schema_key.to_string(),
+                            entity_pk: entity_pk.clone(),
+                            file_id: file_id.map(str::to_string),
+                        });
+                    }
+                }
+            }
+        }
+        identities.sort();
+        identities.dedup();
+
+        for identity in &identities {
+            let encoded = encode_row_key(identity);
+            assert_eq!(
+                decode_row_key(&encoded).expect("row key should decode"),
+                *identity
+            );
+        }
+
+        let mut by_encoded = identities
+            .iter()
+            .cloned()
+            .map(|identity| (encode_row_key(&identity), identity))
+            .collect::<Vec<_>>();
+        by_encoded.sort_by(|left, right| left.0.cmp(&right.0));
+        assert_eq!(
+            by_encoded
+                .iter()
+                .map(|(_, identity)| identity)
+                .collect::<Vec<_>>(),
+            identities.iter().collect::<Vec<_>>()
+        );
+        for (index, (encoded, _)) in by_encoded.iter().enumerate() {
+            for (other_index, (other, _)) in by_encoded.iter().enumerate() {
+                if index != other_index {
+                    assert!(
+                        !other.starts_with(encoded),
+                        "complete row key {index} prefixes row key {other_index}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn head_scan_is_logically_ordered_and_unique() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("generation");
+        let head = CommitId::for_test_label("head");
+        let root = root("head");
+        let identities = vec![
+            HeadIdentity {
+                branch_id: "branch".to_string(),
+                generation,
+                schema_key: "schema-z".to_string(),
+                entity_pk: EntityPk::single("entity-a"),
+                file_id: None,
+            },
+            HeadIdentity {
+                branch_id: "branch".to_string(),
+                generation,
+                schema_key: "schema-a".to_string(),
+                entity_pk: EntityPk::single("entity-z"),
+                file_id: Some("file-a".to_string()),
+            },
+            HeadIdentity {
+                branch_id: "branch".to_string(),
+                generation,
+                schema_key: "schema-a".to_string(),
+                entity_pk: EntityPk::single("entity-a"),
+                file_id: None,
+            },
+        ];
+        let mut expected = identities.clone();
+        expected.sort();
+
+        let mut writes = StorageWriteSet::new();
+        for (index, identity) in identities.iter().rev().enumerate() {
+            stage_put(
+                &mut writes,
+                identity,
+                &head_value(&format!("change-{index}"), head),
+            )
+            .expect("stage row");
+        }
+        stage_marker(
+            &mut writes,
+            "branch",
+            &TrackedHeadMarker {
+                head_commit_id: head,
+                root_id: root.clone(),
+                generation,
+            },
+        )
+        .expect("stage marker");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit head table");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open read");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .scan_rows_if_current(
+                "branch",
+                &head.to_string(),
+                &root,
+                &TrackedStateScanRequest::default(),
+            )
+            .await
+            .expect("scan")
+            .expect("marker should match");
+        assert_eq!(rows.len(), expected.len());
+        assert_eq!(
+            rows.into_iter()
+                .map(|row| (row.schema_key, row.entity_pk, row.file_id))
+                .collect::<Vec<_>>(),
+            expected
+                .into_iter()
+                .map(|identity| (identity.schema_key, identity.entity_pk, identity.file_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn marker_gates_generations_and_rows_roundtrip() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("generation");
+        let head = CommitId::for_test_label("head");
+        let identity = identity("branch", generation, "row");
+        let value = HeadValue {
+            change_id: ChangeId::for_test_label("change"),
+            commit_id: head,
+            deleted: false,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:01Z"),
+            snapshot: JsonSlot::from_json("{\"id\":\"row\"}"),
+            metadata: JsonSlot::None,
+        };
+        let root = root("head");
+        let mut writes = StorageWriteSet::new();
+        stage_put(&mut writes, &identity, &value).expect("stage row");
+        stage_marker(
+            &mut writes,
+            "branch",
+            &TrackedHeadMarker {
+                head_commit_id: head,
+                root_id: root.clone(),
+                generation,
+            },
+        )
+        .expect("stage marker");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit table");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open read");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .scan_rows_if_current(
+                "branch",
+                &head.to_string(),
+                &root,
+                &TrackedStateScanRequest::default(),
+            )
+            .await
+            .expect("scan")
+            .expect("matching marker");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].snapshot_content.as_deref(),
+            Some("{\"id\":\"row\"}")
+        );
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open mismatch read");
+        assert!(
+            TrackedHeadContext::new()
+                .reader(read)
+                .scan_rows_if_current(
+                    "branch",
+                    &CommitId::for_test_label("other").to_string(),
+                    &root,
+                    &TrackedStateScanRequest::default(),
+                )
+                .await
+                .expect("scan mismatch")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_commit_preserves_first_created_at() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let entity_pk = EntityPk::single("row");
+        let first_head = CommitId::for_test_label("first-head");
+        let second_head = CommitId::for_test_label("second-head");
+        let first_root = root("first-root");
+        let second_root = root("second-root");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open first read");
+        let mut writes = StorageWriteSet::new();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit(
+                branch_id,
+                None,
+                None,
+                first_head,
+                first_root.clone(),
+                &[TrackedHeadDeltaRef {
+                    schema_key: "schema",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: ChangeId::for_test_label("first-change"),
+                    commit_id: first_head,
+                    deleted: false,
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                    updated_at: ts("2026-01-01T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"value\":1}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                None,
+            )
+            .await
+            .expect("stage first head");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit first head");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open second read");
+        let mut writes = StorageWriteSet::new();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit(
+                branch_id,
+                Some(first_head),
+                Some(&first_root),
+                second_head,
+                second_root.clone(),
+                &[TrackedHeadDeltaRef {
+                    schema_key: "schema",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: ChangeId::for_test_label("second-change"),
+                    commit_id: second_head,
+                    deleted: false,
+                    created_at: ts("2026-01-02T00:00:00Z"),
+                    updated_at: ts("2026-01-02T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"value\":2}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                None,
+            )
+            .await
+            .expect("stage second head");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit second head");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open verify read");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .scan_rows_if_current(
+                branch_id,
+                &second_head.to_string(),
+                &second_root,
+                &TrackedStateScanRequest::default(),
+            )
+            .await
+            .expect("scan second head")
+            .expect("matching marker");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].created_at, "2026-01-01T00:00:00.000Z");
+        assert_eq!(rows[0].updated_at, "2026-01-02T00:00:00.000Z");
+        assert_eq!(rows[0].snapshot_content.as_deref(), Some("{\"value\":2}"));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_overlays_parent_identity_without_duplicate_write() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let entity_pk = EntityPk::single("row");
+        let parent_head = CommitId::for_test_label("parent-head");
+        let child_head = CommitId::for_test_label("child-head");
+        let parent_root = root("parent-root");
+        let child_root = root("child-root");
+        let parent_rows = vec![MaterializedTrackedStateRow {
+            entity_pk: entity_pk.clone(),
+            schema_key: "schema".to_string(),
+            file_id: None,
+            snapshot_content: Some("{\"value\":1}".to_string()),
+            metadata: None,
+            deleted: false,
+            created_at: "2026-01-01T00:00:00.000Z".to_string(),
+            updated_at: "2026-01-01T00:00:00.000Z".to_string(),
+            change_id: ChangeId::for_test_label("parent-change"),
+            commit_id: parent_head,
+        }];
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open read");
+        let mut writes = StorageWriteSet::new();
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit(
+                branch_id,
+                Some(parent_head),
+                Some(&parent_root),
+                child_head,
+                child_root.clone(),
+                &[TrackedHeadDeltaRef {
+                    schema_key: "schema",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: ChangeId::for_test_label("child-change"),
+                    commit_id: child_head,
+                    deleted: false,
+                    created_at: ts("2026-01-02T00:00:00Z"),
+                    updated_at: ts("2026-01-02T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"value\":2}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                Some(parent_rows),
+            )
+            .await
+            .expect("stage bootstrap");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("overlapping bootstrap must commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open verify read");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .scan_rows_if_current(
+                branch_id,
+                &child_head.to_string(),
+                &child_root,
+                &TrackedStateScanRequest::default(),
+            )
+            .await
+            .expect("scan child head")
+            .expect("matching marker");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].change_id, ChangeId::for_test_label("child-change"));
+        assert_eq!(rows[0].created_at, "2026-01-01T00:00:00.000Z");
+        assert_eq!(rows[0].snapshot_content.as_deref(), Some("{\"value\":2}"));
+    }
+}

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -171,6 +171,8 @@ where
 fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
     &[
         crate::live_state::LIVE_STATE_INDEX_ROW_SPACE,
+        crate::live_state::TRACKED_HEAD_ROW_SPACE,
+        crate::live_state::TRACKED_HEAD_MARKER_SPACE,
         crate::json_store::store::JSON_SPACE,
         crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_ROOT_SPACE,

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use storage::stage_delete_commit_root;
 pub(crate) use storage::{TRACKED_STATE_COMMIT_ROOT_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE};
 pub(crate) use types::{
     MaterializedTrackedStateRow, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateReadColumns,
-    TrackedStateRootMutationRef, TrackedStateScanRequest,
+    TrackedStateRootId, TrackedStateRootMutationRef, TrackedStateScanRequest,
 };
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 #[cfg(feature = "storage-benches")]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -18,12 +18,14 @@ use crate::functions::FunctionContext;
 use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
 use crate::live_state::{
     LiveStateIndexContext, LiveStateIndexDeltaRef, LiveStateIndexFilter, LiveStateIndexRowRequest,
-    LiveStateIndexScanRequest, branch_empty_precondition, row_absent_precondition,
+    LiveStateIndexScanRequest, TrackedHeadContext, TrackedHeadDeltaRef, branch_empty_precondition,
+    row_absent_precondition,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{
-    TrackedStateContext, TrackedStateDeltaRef, TrackedStateKey, TrackedStateKeyRef,
-    TrackedStateRootMutationRef, encode_key_ref,
+    TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey,
+    TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
+    TrackedStateScanRequest, encode_key_ref,
 };
 use crate::transaction::staging::{
     PreparedInsertIdentity, PreparedStateRowIdentity, PreparedWriteSet,
@@ -156,18 +158,32 @@ pub(crate) async fn commit_prepared_writes(
 
     stage_state_json_payloads(&mut json_writer, &mut writes, &state_rows)?;
 
-    stage_tracked_roots(
+    let tracked_root_ids = stage_tracked_roots(
         read,
         &mut writes,
         &state_rows,
-        row_index.tracked_row_indices_by_commit,
-        tracked_roots,
-        staged_commits,
+        &row_index.tracked_row_indices_by_commit,
+        &tracked_roots,
+        &staged_commits,
         &insert_identities,
     )
     .instrument(tracing::debug_span!(
         target: "lix_perf",
         "lix.perf.materialization.tracked_roots"
+    ))
+    .await?;
+    stage_tracked_head(
+        read,
+        &mut writes,
+        &state_rows,
+        &row_index.tracked_row_indices_by_commit,
+        &tracked_roots,
+        &staged_commits,
+        &tracked_root_ids,
+    )
+    .instrument(tracing::debug_span!(
+        target: "lix_perf",
+        "lix.perf.materialization.tracked_head"
     ))
     .await?;
     if filesystem_view_changed {
@@ -820,18 +836,161 @@ fn tracked_delta_from_selected_change_ref(
     })
 }
 
+fn tracked_head_delta_from_state_row(
+    row: &PreparedStateRow,
+) -> Result<TrackedHeadDeltaRef<'_>, LixError> {
+    let Some(change_id) = row.change_id else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked staged row is missing change_id before tracked-head staging",
+        ));
+    };
+    let Some(commit_id) = row.commit_id else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked staged row is missing commit_id before tracked-head staging",
+        ));
+    };
+    Ok(TrackedHeadDeltaRef {
+        schema_key: &row.schema_key,
+        file_id: row.file_id.as_deref(),
+        entity_pk: &row.entity_pk,
+        change_id,
+        commit_id,
+        deleted: row.snapshot.is_none(),
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        snapshot: row.snapshot.as_ref().map_or(
+            crate::json_store::JsonSlotRef::None,
+            crate::transaction::types::StageJson::slot_ref,
+        ),
+        metadata: row.metadata.as_ref().map_or(
+            crate::json_store::JsonSlotRef::None,
+            crate::transaction::types::StageJson::slot_ref,
+        ),
+    })
+}
+
+/// Stages the generation-keyed head projection only for normal prepared
+/// rows. Merge/checkpoint selected references stay on the immutable-root
+/// fallback until their next ordinary child commit bootstraps a generation.
+/// This keeps the hot path direct while never publishing an incomplete head.
+async fn stage_tracked_head(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    state_rows: &[PreparedStateRow],
+    tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_roots: &[PendingTrackedRoot],
+    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
+    tracked_root_ids: &BTreeMap<CommitId, crate::tracked_state::TrackedStateRootId>,
+) -> Result<(), LixError> {
+    let tracked_head = TrackedHeadContext::new();
+    let mut writer = tracked_head.writer(read, writes);
+    for root in tracked_roots_parent_first(tracked_roots)? {
+        let Some(new_root) = tracked_root_ids.get(&root.commit_id).cloned() else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked head for commit '{}' has no staged immutable root",
+                    root.commit_id
+                ),
+            ));
+        };
+        let staged = staged_commits.get(&root.commit_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked head for commit '{}' has no staged changelog facts",
+                    root.commit_id
+                ),
+            )
+        })?;
+        if !staged.selected_change_refs.is_empty() {
+            continue;
+        }
+        let state_row_indices = tracked_row_indices_by_commit
+            .get(&root.commit_id)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let deltas = state_row_indices
+            .iter()
+            .map(|&row_index| tracked_head_delta_from_state_row(&state_rows[row_index]))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let parent_root = match root.parent_commit_id {
+            Some(parent_commit_id) => {
+                crate::tracked_state::load_root(read, &parent_commit_id.to_string()).await?
+            }
+            None => None,
+        };
+        // A marker must be bound to both the first parent commit and the
+        // immutable root. A ref move or explicit root rebuild therefore
+        // creates a fresh generation rather than mutating stale state.
+        let parent_is_current = match (root.parent_commit_id, parent_root.as_ref()) {
+            (Some(parent_commit_id), Some(parent_root)) => {
+                tracked_head
+                    .reader(read)
+                    .is_current(&root.branch_id, &parent_commit_id.to_string(), parent_root)
+                    .await?
+            }
+            _ => false,
+        };
+        let parent_rows = if parent_is_current || root.parent_commit_id.is_none() {
+            None
+        } else if let Some(parent_commit_id) = root.parent_commit_id {
+            // A parent staged earlier in this same write set is not visible
+            // through `read`; leave this rare nested path on the root
+            // fallback instead of publishing a partial generation.
+            if parent_root.is_none() {
+                continue;
+            }
+            Some(
+                TrackedStateContext::new()
+                    .reader(read)
+                    .scan_rows_at_commit(
+                        &parent_commit_id.to_string(),
+                        &TrackedStateScanRequest {
+                            filter: TrackedStateFilter {
+                                include_tombstones: true,
+                                ..TrackedStateFilter::default()
+                            },
+                            read_columns: TrackedStateReadColumns::default(),
+                            limit: None,
+                        },
+                    )
+                    .await?,
+            )
+        } else {
+            None
+        };
+        writer
+            .stage_commit(
+                &root.branch_id,
+                root.parent_commit_id,
+                parent_root.as_ref(),
+                root.commit_id,
+                new_root,
+                &deltas,
+                parent_rows,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
 async fn stage_tracked_roots(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     state_rows: &[PreparedStateRow],
-    tracked_row_indices_by_commit: BTreeMap<CommitId, Vec<RowIndex>>,
-    tracked_roots: Vec<PendingTrackedRoot>,
-    staged_commits: BTreeMap<CommitId, StagedChangelogCommit>,
+    tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_roots: &[PendingTrackedRoot],
+    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
     insert_identities: &BTreeMap<PreparedStateRowIdentity, PreparedInsertIdentity>,
-) -> Result<(), LixError> {
+) -> Result<BTreeMap<CommitId, crate::tracked_state::TrackedStateRootId>, LixError> {
     let tracked_state = TrackedStateContext::new();
     let mut tracked_writer = tracked_state.writer(read, writes);
-    for root in tracked_roots_parent_first(&tracked_roots)? {
+    let mut root_ids = BTreeMap::new();
+    for root in tracked_roots_parent_first(tracked_roots)? {
         let staged = staged_commits.get(&root.commit_id).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -872,7 +1031,7 @@ async fn stage_tracked_roots(
                 file_id: first_row.file_id.as_deref(),
                 entity_pk: &first_row.entity_pk,
             });
-            if tracked_writer
+            if let Some(report) = tracked_writer
                 .try_stage_bulk_parent_root_from_ordered_mutations(
                     &commit_id_text,
                     parent_commit_id_text.as_deref(),
@@ -887,8 +1046,8 @@ async fn stage_tracked_roots(
                     }),
                 )
                 .await?
-                .is_some()
             {
+                root_ids.insert(root.commit_id, report.root_id);
                 continue;
             }
         }
@@ -922,7 +1081,7 @@ async fn stage_tracked_roots(
         // also preserves the one-mutation path for ordinary singleton writes.
         let commit_id_text = root.commit_id.to_string();
         let parent_commit_id_text = root.parent_commit_id.map(|id| id.to_string());
-        tracked_writer
+        let report = tracked_writer
             .stage_commit_root_with_absence_guards(
                 &commit_id_text,
                 parent_commit_id_text.as_deref(),
@@ -930,6 +1089,7 @@ async fn stage_tracked_roots(
                 &absence_guards,
             )
             .await?;
+        root_ids.insert(root.commit_id, report.root_id);
     }
     let rooted_commit_ids = tracked_roots
         .iter()
@@ -966,7 +1126,7 @@ async fn stage_tracked_roots(
             .copied()
             .collect::<Vec<_>>();
         if commit_ids.is_empty() {
-            return Ok(());
+            return Ok(root_ids);
         }
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -980,7 +1140,7 @@ async fn stage_tracked_roots(
             ),
         ));
     }
-    Ok(())
+    Ok(root_ids)
 }
 
 fn tracked_state_rows_are_strictly_sorted(
@@ -1107,6 +1267,7 @@ struct PendingBranchHead {
 }
 
 struct PendingTrackedRoot {
+    branch_id: String,
     commit_id: CommitId,
     parent_commit_id: Option<CommitId>,
 }
@@ -1166,6 +1327,7 @@ async fn finalize_commit_rows(
             timestamp,
         });
         tracked_roots.push(PendingTrackedRoot {
+            branch_id,
             commit_id,
             parent_commit_id,
         });
@@ -1202,11 +1364,12 @@ mod tests {
     use crate::live_state::{LiveStateContext, LiveStateRowRequest};
     use crate::live_state::{LiveStateIndexContext, LiveStateIndexRowRequest};
     use crate::storage::{
-        CommitResult, KeyRange, PutBatch, SpaceId, Storage, StorageError, StorageWrite,
+        CommitResult, GetManyResult, GetOptions, Key, KeyRange, PutBatch, ScanChunk, ScanOptions,
+        SpaceId, Storage, StorageError, StorageRead, StorageWrite,
     };
     use crate::storage_adapter::{
-        Memory, MemoryRead, MemoryWrite, StorageAdapter, StorageKey, StorageReadOptions,
-        StorageWriteOptions,
+        Memory, MemoryRead, MemoryWrite, StorageAdapter, StorageAdapterReadScope, StorageKey,
+        StorageReadOptions, StorageWriteOptions,
     };
     use crate::transaction::types::PreparedRowFacts;
     use crate::{GLOBAL_BRANCH_ID, NullableKeyFilter};
@@ -1217,6 +1380,9 @@ mod tests {
 
     const DETERMINISTIC_MODE_KEY: &str = "lix_deterministic_mode";
     const DETERMINISTIC_SEQUENCE_KEY: &str = "lix_deterministic_sequence_number";
+    // `tracked_state::storage` intentionally keeps this internal; this test
+    // observes the durable space rather than reaching through that module.
+    const TRACKED_STATE_TREE_CHUNK_SPACE_ID: SpaceId = SpaceId(0x0004_0001);
 
     fn live_state_context() -> LiveStateContext {
         LiveStateContext::new(
@@ -1224,6 +1390,63 @@ mod tests {
             LiveStateIndexContext::new(),
             crate::commit_graph::CommitGraphContext::new(),
         )
+    }
+
+    #[derive(Default)]
+    struct TrackedHeadReadCounts {
+        marker_get_many_calls: AtomicUsize,
+        row_get_many_calls: AtomicUsize,
+        row_scan_calls: AtomicUsize,
+        tree_chunk_get_many_calls: AtomicUsize,
+        tree_chunk_scan_calls: AtomicUsize,
+    }
+
+    struct CountingTrackedHeadRead {
+        inner: MemoryRead,
+        counts: Arc<TrackedHeadReadCounts>,
+    }
+
+    impl StorageRead for CountingTrackedHeadRead {
+        async fn get_many(
+            &self,
+            space: SpaceId,
+            keys: &[Key],
+            opts: GetOptions,
+        ) -> Result<GetManyResult, StorageError> {
+            if space == crate::live_state::TRACKED_HEAD_MARKER_SPACE.id {
+                self.counts
+                    .marker_get_many_calls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if space == crate::live_state::TRACKED_HEAD_ROW_SPACE.id {
+                self.counts
+                    .row_get_many_calls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if space == TRACKED_STATE_TREE_CHUNK_SPACE_ID {
+                self.counts
+                    .tree_chunk_get_many_calls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            self.inner.get_many(space, keys, opts).await
+        }
+
+        async fn scan(
+            &self,
+            space: SpaceId,
+            range: KeyRange,
+            opts: ScanOptions,
+        ) -> Result<ScanChunk, StorageError> {
+            if space == crate::live_state::TRACKED_HEAD_ROW_SPACE.id {
+                self.counts.row_scan_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            if space == TRACKED_STATE_TREE_CHUNK_SPACE_ID {
+                self.counts
+                    .tree_chunk_scan_calls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            self.inner.scan(space, range, opts).await
+        }
     }
 
     #[test]
@@ -1354,8 +1577,8 @@ mod tests {
         let commit_rows = tracked_reader
             .scan_rows_at_commit(
                 &commit_id_text,
-                &crate::tracked_state::TrackedStateScanRequest {
-                    filter: crate::tracked_state::TrackedStateFilter {
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
                         schema_keys: vec!["lix_commit".to_string()],
                         ..Default::default()
                     },
@@ -1403,6 +1626,366 @@ mod tests {
             .await
             .expect("branch ref load should succeed");
         assert_eq!(loaded_head, Some(record.commit_id));
+    }
+
+    #[tokio::test]
+    async fn normal_tracked_commit_live_reads_select_head_projection() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        let binary_cas = BinaryCasContext::new();
+        let branch_ctx = BranchContext::new();
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("commit read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![tracked_global_row("tracked-head-change")],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    GLOBAL_BRANCH_ID.to_string(),
+                    change_refs(["tracked-head-change"]),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("normal tracked commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("normal tracked commit should persist");
+
+        let counts = Arc::new(TrackedHeadReadCounts::default());
+        let scanned = live_state_context()
+            .reader(StorageAdapterReadScope::new(CountingTrackedHeadRead {
+                inner: memory
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("counted scan read should open"),
+                counts: Arc::clone(&counts),
+            }))
+            .scan_rows(&crate::live_state::LiveStateScanRequest {
+                filter: crate::live_state::LiveStateFilter {
+                    branch_ids: vec![GLOBAL_BRANCH_ID.to_string()],
+                    schema_keys: vec!["test_schema".to_string()],
+                    untracked: Some(false),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .expect("tracked scan should succeed");
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].change_id, Some(change_id("tracked-head-change")));
+        assert!(
+            counts.marker_get_many_calls.load(Ordering::Relaxed) > 0,
+            "the read must validate the head marker before serving tracked rows"
+        );
+        assert!(
+            counts.row_scan_calls.load(Ordering::Relaxed) > 0,
+            "the normal tracked scan must range-scan the head projection"
+        );
+        assert_eq!(
+            counts.tree_chunk_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "a current head projection must avoid immutable-tree chunk reads"
+        );
+        assert_eq!(
+            counts.tree_chunk_scan_calls.load(Ordering::Relaxed),
+            0,
+            "a current head projection must avoid immutable-tree chunk scans"
+        );
+
+        let loaded = live_state_context()
+            .reader(StorageAdapterReadScope::new(CountingTrackedHeadRead {
+                inner: memory
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("counted point read should open"),
+                counts: Arc::clone(&counts),
+            }))
+            .load_row(&live_state_request())
+            .await
+            .expect("tracked point read should succeed")
+            .expect("tracked row should be visible");
+        assert_eq!(loaded.change_id, Some(change_id("tracked-head-change")));
+        assert!(
+            counts.row_get_many_calls.load(Ordering::Relaxed) > 0,
+            "the exact tracked lookup must point-read the head projection"
+        );
+        assert_eq!(
+            counts.tree_chunk_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "neither serving read may fall back to immutable-tree chunks"
+        );
+        assert_eq!(
+            counts.tree_chunk_scan_calls.load(Ordering::Relaxed),
+            0,
+            "neither serving read may scan immutable-tree chunks"
+        );
+    }
+
+    #[tokio::test]
+    async fn normal_head_projections_preserve_global_fallback_branch_override_and_tombstones() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        let binary_cas = BinaryCasContext::new();
+        let branch_ctx = BranchContext::new();
+
+        let mut global_override = tracked_global_row("global-override-change");
+        global_override.commit_id = Some(commit_id("global-head"));
+        let mut global_fallback = tracked_global_row("global-fallback-change");
+        global_fallback.entity_pk = EntityPk::single("entity-2");
+        global_fallback.commit_id = Some(commit_id("global-head"));
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("global commit read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![global_override, global_fallback],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    GLOBAL_BRANCH_ID.to_string(),
+                    change_refs_with(
+                        ["global-override-change", "global-fallback-change"],
+                        "global-head",
+                        "global-head-commit-change",
+                        "global-head-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("global tracked commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("global tracked commit should persist");
+
+        let mut branch_override = tracked_branch_row("branch-a", "branch-override-change");
+        branch_override.commit_id = Some(commit_id("branch-head"));
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch commit read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![branch_override],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["branch-override-change"],
+                        "branch-head",
+                        "branch-head-commit-change",
+                        "branch-head-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("branch tracked commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("branch tracked commit should persist");
+
+        let marker_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("marker read should open");
+        let global_root =
+            crate::tracked_state::load_root(&marker_read, &commit_id_text("global-head"))
+                .await
+                .expect("global root should load")
+                .expect("global root should exist");
+        let branch_root =
+            crate::tracked_state::load_root(&marker_read, &commit_id_text("branch-head"))
+                .await
+                .expect("branch root should load")
+                .expect("branch root should exist");
+        let tracked_head = TrackedHeadContext::new();
+        assert!(
+            tracked_head
+                .reader(&marker_read)
+                .is_current(
+                    GLOBAL_BRANCH_ID,
+                    &commit_id_text("global-head"),
+                    &global_root
+                )
+                .await
+                .expect("global head marker should load"),
+            "the global marker must bind its current branch ref and root"
+        );
+        assert!(
+            tracked_head
+                .reader(&marker_read)
+                .is_current("branch-a", &commit_id_text("branch-head"), &branch_root)
+                .await
+                .expect("branch head marker should load"),
+            "the branch marker must bind its current branch ref and root"
+        );
+
+        let counts = Arc::new(TrackedHeadReadCounts::default());
+        let scanned = live_state_context()
+            .reader(StorageAdapterReadScope::new(CountingTrackedHeadRead {
+                inner: memory
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("counted branch scan read should open"),
+                counts: Arc::clone(&counts),
+            }))
+            .scan_rows(&crate::live_state::LiveStateScanRequest {
+                filter: crate::live_state::LiveStateFilter {
+                    branch_ids: vec!["branch-a".to_string()],
+                    schema_keys: vec!["test_schema".to_string()],
+                    untracked: Some(false),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .expect("branch tracked scan should succeed");
+        assert_eq!(
+            scanned.len(),
+            2,
+            "branch scan should retain global fallback"
+        );
+        let branch_row = scanned
+            .iter()
+            .find(|row| row.entity_pk == EntityPk::single("entity-1"))
+            .expect("branch override should be visible");
+        assert_eq!(
+            branch_row.change_id,
+            Some(change_id("branch-override-change"))
+        );
+        assert_eq!(branch_row.branch_id, "branch-a");
+        assert!(!branch_row.global);
+        let fallback_row = scanned
+            .iter()
+            .find(|row| row.entity_pk == EntityPk::single("entity-2"))
+            .expect("global fallback should be visible");
+        assert_eq!(
+            fallback_row.change_id,
+            Some(change_id("global-fallback-change"))
+        );
+        assert_eq!(fallback_row.branch_id, "branch-a");
+        assert!(fallback_row.global);
+
+        let mut branch_tombstone = tracked_branch_row("branch-a", "branch-tombstone-change");
+        branch_tombstone.entity_pk = EntityPk::single("entity-2");
+        branch_tombstone.snapshot = None;
+        branch_tombstone.commit_id = Some(commit_id("branch-tombstone-head"));
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch tombstone read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![branch_tombstone],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["branch-tombstone-change"],
+                        "branch-tombstone-head",
+                        "branch-tombstone-head-commit-change",
+                        "branch-tombstone-head-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("branch tombstone commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("branch tombstone commit should persist");
+
+        let scanned = live_state_context()
+            .reader(StorageAdapterReadScope::new(CountingTrackedHeadRead {
+                inner: memory
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("counted tombstone scan read should open"),
+                counts: Arc::clone(&counts),
+            }))
+            .scan_rows(&crate::live_state::LiveStateScanRequest {
+                filter: crate::live_state::LiveStateFilter {
+                    branch_ids: vec!["branch-a".to_string()],
+                    schema_keys: vec!["test_schema".to_string()],
+                    untracked: Some(false),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .expect("branch tombstone scan should succeed");
+        assert_eq!(
+            scanned.len(),
+            1,
+            "the branch tombstone must hide the global fallback row"
+        );
+        assert_eq!(scanned[0].entity_pk, EntityPk::single("entity-1"));
+        assert_eq!(
+            scanned[0].change_id,
+            Some(change_id("branch-override-change"))
+        );
+        assert!(
+            counts.marker_get_many_calls.load(Ordering::Relaxed) >= 4,
+            "each branch scan must validate both branch and global head markers"
+        );
+        assert!(
+            counts.row_scan_calls.load(Ordering::Relaxed) >= 4,
+            "each branch scan must range-scan both current head projections"
+        );
+        assert_eq!(
+            counts.tree_chunk_get_many_calls.load(Ordering::Relaxed),
+            0,
+            "current global and branch projections must avoid immutable-tree point reads"
+        );
+        assert_eq!(
+            counts.tree_chunk_scan_calls.load(Ordering::Relaxed),
+            0,
+            "current global and branch projections must avoid immutable-tree scans"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds a durable, generation-keyed tracked-head projection for the normal tracked read path. The immutable commit root remains the authority and every projection marker is bound to both the branch head and root id; a missing, stale, or malformed marker falls back to the existing root reader.

- normal commits incrementally update the current head table, including tombstones and original `created_at` preservation;
- ref moves and legacy heads bootstrap a fresh generation from the immutable parent snapshot;
- the single-branch/no-overlay path uses the table's ordered unique keys directly, avoiding visibility sorting and deduplication;
- scans and exact reads are covered for marker selection, global fallback, branch override, tombstones, and zero immutable-tree reads on a current projection;
- replaces the CodSpeed-compatible transaction benchmark's no-op `iter_custom` use with setup-excluded `iter_batched_ref`, and adds an opt-in manual profiler for raw SQLite, KV layout, and Lix transaction operations.

## Measurement

Clean 10k-operation medians on this machine:

| operation | raw SQLite | Lix + RocksDB |
| --- | ---: | ---: |
| insert all | 8.30 ms | 87.06 ms |
| read all | 1.63 ms | 20.57–22.58 ms |
| read one | 41.99 µs | 264.08 µs |
| update all | 14.10 ms | 138.97 ms |

This establishes the durable serving-index boundary and removes tree reads for a current head, but the data shows that direct head decoding/materialization is still the read bottleneck. The next stacked change will replace the generic `HeadValue -> MaterializedTrackedStateRow -> MaterializedLiveStateRow` chain with one direct wire-row decoder.

## Validation

- `cargo fmt --all -- --check`
- `TMPDIR=/root/projects/lix-hotspots/.tmp-cargo cargo test -p lix_engine --lib` (1169 passed)
- `TMPDIR=/root/projects/lix-hotspots/.tmp-runtime cargo test -p lix_rocksdb_storage` (12 passed)
- `TMPDIR=/root/projects/lix-hotspots/.tmp-cargo cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- `TMPDIR=/root/projects/lix-hotspots/.tmp-cargo cargo bench -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches --no-run`
