### PR TITLE
perf: avoid copies in RocksDB full scans

### DIFF
--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -1577,6 +1577,30 @@ where
         }
     }
 
+    for (case_name, rows) in [
+        ("direct_scan_full_q1000_v32", 1_000),
+        ("direct_scan_full_q10000_v32", 10_000),
+    ] {
+        if should_run(case_name) {
+            let scan_storage = storage_family.seed_points(SpaceId(1), rows, 32);
+            let scan_range = physical_point_scan_range(1);
+            group.throughput(Throughput::Bytes(u64::from(rows) * 32));
+            group.bench_function(case_name, |b| {
+                b.iter(|| {
+                    let read = block_on(scan_storage.begin_read(ReadOptions::default()))
+                        .expect("begin direct small-value full scan read");
+                    let chunk =
+                        block_on(materialize_complete_storage_scan(&read, scan_range.clone()))
+                            .expect("direct small-value full scan");
+                    assert_eq!(chunk.entries.len(), rows as usize);
+                    assert!(!chunk.has_more);
+                    drop(read);
+                    black_box(chunk);
+                });
+            });
+        }
+    }
+
     group.finish();
 }
 
@@ -1952,6 +1976,45 @@ where
     R: StorageRead,
 {
     read.scan(space(1).id, range, opts).await
+}
+
+async fn materialize_complete_storage_scan<R>(
+    read: &R,
+    range: KeyRange,
+) -> Result<ScanChunk, StorageError>
+where
+    R: StorageRead,
+{
+    let mut entries = Vec::new();
+    let mut resume_after = None;
+
+    loop {
+        let chunk = read
+            .scan(
+                space(1).id,
+                range.clone(),
+                ScanOptions {
+                    projection: CoreProjection::FullValue,
+                    resume_after,
+                    ..ScanOptions::default()
+                },
+            )
+            .await?;
+        let has_more = chunk.has_more;
+        resume_after = chunk.entries.last().map(|entry| entry.key.clone());
+        entries.extend(chunk.entries);
+
+        if !has_more {
+            return Ok(ScanChunk {
+                entries,
+                has_more: false,
+            });
+        }
+        assert!(
+            resume_after.is_some(),
+            "scan reported more rows without a resume key"
+        );
+    }
 }
 
 fn checked_write_set_from_mutations(mutations: &[WriteMutation]) -> StorageWriteSet {

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use lix_engine::storage::{
     CommitResult, CoreProjection, GetManyResult, GetOptions, Key, KeyRange, Precondition,
     PreconditionFailure, ProjectedValue, PutBatch, ReadEntry, ReadOptions, ScanChunk, ScanOptions,
@@ -23,7 +23,6 @@ use rocksdb::{BlockBasedOptions, DB, Direction, IteratorMode, Options, WriteBatc
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
-const OWNED_VALUE_MIN_BYTES: usize = 64 * 1024;
 const DEFAULT_BLOB_MIN_SIZE: u64 = 32 * 1024;
 const DEFAULT_BLOB_FILE_SIZE: u64 = 256 * 1024 * 1024;
 const DEFAULT_BLOB_GC_AGE_CUTOFF: f64 = 0.25;
@@ -303,11 +302,10 @@ impl StorageRead for RocksDBRead<'_> {
                 .iterator(IteratorMode::From(&bounds.lower_seek, Direction::Forward))
             {
                 let (encoded_key, value) = item.map_err(rocksdb_error)?;
-                let encoded_key = encoded_key.as_ref();
-                if !bounds.after_lower(encoded_key) {
+                if !bounds.after_lower(encoded_key.as_ref()) {
                     continue;
                 }
-                if !bounds.before_upper(encoded_key) {
+                if !bounds.before_upper(encoded_key.as_ref()) {
                     break;
                 }
                 if entries.len() == opts.page_size() {
@@ -317,7 +315,7 @@ impl StorageRead for RocksDBRead<'_> {
                     });
                 }
                 entries.push(ReadEntry {
-                    key: Key(Bytes::copy_from_slice(&encoded_key[4..])),
+                    key: logical_key_from_physical(encoded_key),
                     value: project_owned_value(value, opts.projection),
                 });
             }
@@ -619,19 +617,70 @@ fn stored_value_bytes(value: StoredValue) -> Bytes {
     value.bytes
 }
 
+/// Reclaims the iterator-owned physical key and removes its four-byte space
+/// prefix without copying its logical-key bytes.
+fn logical_key_from_physical(encoded_key: Box<[u8]>) -> Key {
+    let mut key = Bytes::from(encoded_key);
+    key.advance(4);
+    Key(key)
+}
+
 fn project_owned_value<T>(value: T, projection: CoreProjection) -> ProjectedValue
 where
-    T: AsRef<[u8]>,
     Bytes: From<T>,
 {
     match projection {
         CoreProjection::KeyOnly => ProjectedValue::KeyOnly,
-        CoreProjection::FullValue if value.as_ref().len() >= OWNED_VALUE_MIN_BYTES => {
-            ProjectedValue::FullValue(Bytes::from(value))
-        }
-        CoreProjection::FullValue => {
-            ProjectedValue::FullValue(Bytes::copy_from_slice(value.as_ref()))
-        }
+        // `Snapshot::multi_get` yields Rust-owned `Vec<u8>` values and the
+        // standard iterator yields Rust-owned `Box<[u8]>` values. Retaining
+        // those allocations in `Bytes` avoids a second full value copy.
+        CoreProjection::FullValue => ProjectedValue::FullValue(Bytes::from(value)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CoreProjection, ProjectedValue, logical_key_from_physical, project_owned_value};
+
+    #[test]
+    fn logical_key_reuses_the_physical_key_allocation() {
+        let physical_key: Box<[u8]> = Box::from(&b"\0\0\0\x01logical-key"[..]);
+        let logical_ptr = physical_key.as_ptr().wrapping_add(4);
+
+        let key = logical_key_from_physical(physical_key);
+
+        assert_eq!(key.0.as_ptr(), logical_ptr);
+        assert_eq!(&key.0[..], b"logical-key");
+    }
+
+    #[test]
+    fn full_value_reuses_vec_allocation() {
+        let value = b"small value that used to take the copy path".to_vec();
+        let ptr = value.as_ptr();
+
+        let ProjectedValue::FullValue(value) =
+            project_owned_value(value, CoreProjection::FullValue)
+        else {
+            panic!("full-value projection should return bytes");
+        };
+
+        assert_eq!(value.as_ptr(), ptr);
+        assert_eq!(&value[..], b"small value that used to take the copy path");
+    }
+
+    #[test]
+    fn full_value_reuses_boxed_slice_allocation() {
+        let value: Box<[u8]> = Box::from(&b"iterator value"[..]);
+        let ptr = value.as_ptr();
+
+        let ProjectedValue::FullValue(value) =
+            project_owned_value(value, CoreProjection::FullValue)
+        else {
+            panic!("full-value projection should return bytes");
+        };
+
+        assert_eq!(value.as_ptr(), ptr);
+        assert_eq!(&value[..], b"iterator value");
     }
 }
 


### PR DESCRIPTION
## Summary

Removes avoidable ownership copies from RocksDB full-value scans.

- transfer the iterator-owned physical key into `Bytes` and advance past the space prefix instead of copying the logical key;
- transfer every iterator `Box<[u8]>` and `multi_get` `Vec<u8>` into `Bytes` instead of copying values below 64 KiB;
- add pointer-identity tests for both paths;
- add isolated 1k/10k 32-byte full-scan benchmark cases that drain paged scans and retain the returned rows.

## Measurement

The new 10k / 32-byte direct RocksDB full-scan case measures a 1.933 ms median (157.86 MiB/s) on this machine. There is intentionally no claimed before/after percentage: the benchmark was added with this patch, while the allocation-transfer tests prove the eliminated copies directly.

## Validation

- `cargo fmt --all -- --check`
- `TMPDIR=/root/projects/lix-hotspots/.tmp-runtime cargo test -p lix_rocksdb_storage` (12 passed)
- `TMPDIR=/root/projects/lix-hotspots/.tmp-cargo cargo clippy --profile test -p lix_rocksdb_storage --all-targets --all-features -- -D warnings`
- `TMPDIR=/root/projects/lix-hotspots/.tmp-runtime target/release/deps/storage_v2-5ee7850464dc0ded direct_scan_full_q10000_v32`
