### PR TITLE
perf: retain typed tracked head row fields

### DIFF
--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -308,7 +308,7 @@ fn row_belongs_to_schema_catalog_domain(row: &MaterializedLiveStateRow, domain: 
     row.schema_key == REGISTERED_SCHEMA_KEY
         && row.file_id.is_none()
         && row.snapshot_content.is_some()
-        && row.branch_id == domain.branch_id()
+        && row.branch_id.as_ref() == domain.branch_id()
         && row.untracked == domain.untracked()
         && committed_row_is_exact_branch_scoped(row, domain.branch_id())
 }
@@ -354,6 +354,7 @@ mod tests {
     use super::*;
     use crate::GLOBAL_BRANCH_ID;
     use crate::changelog::ChangeId;
+    use crate::common::LixTimestamp;
     use crate::live_state::LiveStateRowRequest;
 
     #[tokio::test]
@@ -633,7 +634,7 @@ mod tests {
         let context = CatalogContext::new();
         let mut global_only = registered_schema_row("global_only_schema");
         global_only.global = true;
-        global_only.branch_id = "main".to_string();
+        global_only.branch_id = "main".into();
 
         let schemas = context
             .schema_jsons_for_sql_read_planning(
@@ -727,7 +728,11 @@ mod tests {
                 })
                 .filter(|row| {
                     request.filter.branch_ids.is_empty()
-                        || request.filter.branch_ids.contains(&row.branch_id)
+                        || request
+                            .filter
+                            .branch_ids
+                            .iter()
+                            .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref())
                 })
                 .filter(|row| {
                     request
@@ -743,12 +748,13 @@ mod tests {
             &self,
             request: &LiveStateRowRequest,
         ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
+            let request_branch_id = request.branch_id.as_str();
             Ok(self
                 .rows
                 .iter()
                 .find(|row| {
                     row.schema_key == request.schema_key
-                        && row.branch_id == request.branch_id
+                        && row.branch_id.as_ref() == request_branch_id
                         && row.entity_pk == request.entity_pk
                 })
                 .cloned())
@@ -760,15 +766,21 @@ mod tests {
             entity_pk: registered_schema_entity_pk(schema_key),
             file_id: None,
             schema_key: REGISTERED_SCHEMA_KEY.to_string(),
-            branch_id: GLOBAL_BRANCH_ID.to_string(),
+            branch_id: GLOBAL_BRANCH_ID.into(),
             metadata: None,
             deleted: false,
             change_id: Some(ChangeId::for_test_label("change-registered-schema")),
             commit_id: None,
             global: true,
             untracked: true,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse(
+                "registered schema test created_at",
+                "2026-04-23T00:00:00Z",
+            ),
+            updated_at: LixTimestamp::expect_parse(
+                "registered schema test updated_at",
+                "2026-04-23T01:00:00Z",
+            ),
             snapshot_content: Some(
                 json!({
                     "value": {

--- a/packages/engine/src/domain.rs
+++ b/packages/engine/src/domain.rs
@@ -40,7 +40,11 @@ impl Domain {
     }
 
     pub(crate) fn for_live_row(row: &MaterializedLiveStateRow) -> Self {
-        Self::exact_file(row.branch_id.clone(), row.untracked, row.file_id.clone())
+        Self::exact_file(
+            row.branch_id.to_string(),
+            row.untracked,
+            row.file_id.clone(),
+        )
     }
 
     pub(crate) fn schema_catalog_domain(&self) -> Self {
@@ -105,7 +109,7 @@ impl Domain {
     }
 
     pub(crate) fn contains(&self, row: &MaterializedLiveStateRow) -> bool {
-        row.branch_id == self.branch_id
+        row.branch_id.as_ref() == self.branch_id
             && row.untracked == self.untracked
             && committed_row_is_exact_branch_scoped(row, &self.branch_id)
             && match &self.file_scope {
@@ -310,7 +314,8 @@ pub(crate) fn committed_row_is_exact_branch_scoped(
     row: &MaterializedLiveStateRow,
     branch_id: &str,
 ) -> bool {
-    row.branch_id == branch_id && row.global == (row.branch_id == GLOBAL_BRANCH_ID)
+    row.branch_id.as_ref() == branch_id
+        && row.global == (row.branch_id.as_ref() == GLOBAL_BRANCH_ID)
 }
 
 fn nullable_filter_from_option(value: Option<&String>) -> NullableKeyFilter<String> {

--- a/packages/engine/src/filesystem/path_index.rs
+++ b/packages/engine/src/filesystem/path_index.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::LixError;
 use crate::changelog::{ChangeId, CommitId};
-use crate::common::{compose_directory_path, compose_file_path};
+use crate::common::{LixTimestamp, compose_directory_path, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::live_state::{
     LiveStateFilter, LiveStateReader, LiveStateScanRequest, MaterializedLiveStateRow,
@@ -103,13 +103,19 @@ impl FilesystemPathEntry {
             snapshot_content: Some(snapshot_content.to_string()),
             metadata: self.metadata.clone(),
             deleted: false,
-            created_at: self.created_at.clone(),
-            updated_at: self.updated_at.clone(),
+            created_at: LixTimestamp::expect_parse(
+                "filesystem path entry created_at",
+                &self.created_at,
+            ),
+            updated_at: LixTimestamp::expect_parse(
+                "filesystem path entry updated_at",
+                &self.updated_at,
+            ),
             global: self.key.global(),
             change_id: self.change_id,
             commit_id: self.commit_id,
             untracked: self.key.is_untracked(),
-            branch_id: self.key.branch_id().to_string(),
+            branch_id: self.key.branch_id().into(),
         }
     }
 
@@ -280,8 +286,8 @@ impl FilesystemPathIndex {
                             parent_id: snapshot.parent_id,
                             name: snapshot.name,
                             metadata: row.metadata,
-                            created_at: row.created_at,
-                            updated_at: row.updated_at,
+                            created_at: row.created_at.to_string(),
+                            updated_at: row.updated_at.to_string(),
                             change_id: row.change_id,
                             commit_id: row.commit_id,
                         },
@@ -302,8 +308,8 @@ impl FilesystemPathIndex {
                             directory_id: snapshot.directory_id,
                             name: snapshot.name,
                             metadata: row.metadata,
-                            created_at: row.created_at,
-                            updated_at: row.updated_at,
+                            created_at: row.created_at.to_string(),
+                            updated_at: row.updated_at.to_string(),
                             change_id: row.change_id,
                             commit_id: row.commit_id,
                         },
@@ -495,7 +501,11 @@ impl FilesystemPathIndex {
             if !matches!(
                 row.schema_key.as_str(),
                 FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
-            ) || (!row.global && !request.branch_ids.contains(&row.branch_id))
+            ) || (!row.global
+                && !request
+                    .branch_ids
+                    .iter()
+                    .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
             {
                 continue;
             }
@@ -610,8 +620,8 @@ impl FilesystemPathIndex {
             key,
             parent_identity: None,
             metadata: row.metadata.clone(),
-            created_at: row.created_at.clone(),
-            updated_at: row.updated_at.clone(),
+            created_at: row.created_at.to_string(),
+            updated_at: row.updated_at.to_string(),
             change_id: row.change_id,
             commit_id: row.commit_id,
         };
@@ -1403,13 +1413,19 @@ mod tests {
             snapshot_content: Some(snapshot_content),
             metadata: None,
             deleted: false,
-            created_at: "2026-01-01T00:00:00.000Z".to_string(),
-            updated_at: "2026-01-01T00:00:00.000Z".to_string(),
+            created_at: LixTimestamp::expect_parse(
+                "filesystem path index test created_at",
+                "2026-01-01T00:00:00.000Z",
+            ),
+            updated_at: LixTimestamp::expect_parse(
+                "filesystem path index test updated_at",
+                "2026-01-01T00:00:00.000Z",
+            ),
             global,
             change_id: Some(ChangeId::for_test_label(id)),
             commit_id: Some(CommitId::for_test_label(id)),
             untracked: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
         }
     }
 }

--- a/packages/engine/src/filesystem/planner.rs
+++ b/packages/engine/src/filesystem/planner.rs
@@ -100,7 +100,7 @@ impl FilesystemDescriptorKey {
         descriptor_id: impl Into<String>,
     ) -> Self {
         Self {
-            branch_id: row.branch_id.clone(),
+            branch_id: row.branch_id.to_string(),
             global: row.global,
             untracked: row.untracked,
             file_id: row.file_id.clone(),
@@ -1280,7 +1280,7 @@ pub(crate) fn directory_path_resolvers_from_state_rows(
         let storage_branch_id = if row.global {
             GLOBAL_BRANCH_ID
         } else {
-            row.branch_id.as_str()
+            row.branch_id.as_ref()
         };
         let resolver_key = filesystem_storage_scope_key(
             storage_branch_id,
@@ -1557,6 +1557,7 @@ mod tests {
     use crate::GLOBAL_BRANCH_ID;
     use crate::binary_cas::BlobHash;
     use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::filesystem::{FilesystemBlobRefKey, FilesystemDescriptorKey};
     use crate::transaction::types::TransactionJson;
 
@@ -2611,13 +2612,19 @@ mod tests {
             snapshot_content: Some(snapshot_content.to_string()),
             metadata: None,
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global,
             untracked,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse(
+                "filesystem planner test created_at",
+                "2026-04-23T00:00:00Z",
+            ),
+            updated_at: LixTimestamp::expect_parse(
+                "filesystem planner test updated_at",
+                "2026-04-23T01:00:00Z",
+            ),
         }
     }
 }

--- a/packages/engine/src/filesystem/read.rs
+++ b/packages/engine/src/filesystem/read.rs
@@ -26,7 +26,7 @@ impl FilesystemIndex {
 
         for row in rows {
             let scope = RowScope {
-                branch_id: row.branch_id.clone(),
+                branch_id: row.branch_id.to_string(),
                 global: row.global,
                 untracked: row.untracked,
                 file_id: row.file_id.clone(),
@@ -315,6 +315,7 @@ fn filesystem_conflict_error(message: String) -> LixError {
 #[cfg(test)]
 mod tests {
     use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
     use crate::live_state::MaterializedLiveStateRow;
 
@@ -481,13 +482,19 @@ mod tests {
             snapshot_content: Some(snapshot_content.to_string()),
             metadata: None,
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse(
+                "filesystem read test created_at",
+                "2026-04-23T00:00:00Z",
+            ),
+            updated_at: LixTimestamp::expect_parse(
+                "filesystem read test updated_at",
+                "2026-04-23T01:00:00Z",
+            ),
         }
     }
 

--- a/packages/engine/src/filesystem/visibility.rs
+++ b/packages/engine/src/filesystem/visibility.rs
@@ -141,6 +141,7 @@ mod tests {
 
     use crate::LixError;
     use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::filesystem::{FilesystemDescriptorKey, FilesystemRowContext};
     use crate::live_state::MaterializedLiveStateRow;
     use crate::live_state::{LiveStateReader, LiveStateRowRequest, LiveStateScanRequest};
@@ -383,7 +384,11 @@ mod tests {
                     (request.filter.schema_keys.is_empty()
                         || request.filter.schema_keys.contains(&row.schema_key))
                         && (request.filter.branch_ids.is_empty()
-                            || request.filter.branch_ids.contains(&row.branch_id))
+                            || request
+                                .filter
+                                .branch_ids
+                                .iter()
+                                .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
                 })
                 .cloned()
                 .collect())
@@ -421,7 +426,11 @@ mod tests {
                     (request.filter.schema_keys.is_empty()
                         || request.filter.schema_keys.contains(&row.schema_key))
                         && (request.filter.branch_ids.is_empty()
-                            || request.filter.branch_ids.contains(&row.branch_id))
+                            || request
+                                .filter
+                                .branch_ids
+                                .iter()
+                                .any(|branch_id| branch_id.as_str() == row.branch_id.as_ref()))
                 })
                 .cloned()
                 .collect())
@@ -486,13 +495,19 @@ mod tests {
             snapshot_content: snapshot_content.map(ToOwned::to_owned),
             metadata: None,
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse(
+                "filesystem visibility test created_at",
+                "2026-04-23T00:00:00Z",
+            ),
+            updated_at: LixTimestamp::expect_parse(
+                "filesystem visibility test updated_at",
+                "2026-04-23T01:00:00Z",
+            ),
         }
     }
 }

--- a/packages/engine/src/functions/context.rs
+++ b/packages/engine/src/functions/context.rs
@@ -308,7 +308,8 @@ mod tests {
         .expect("sequence row should load")
         .expect("sequence row should exist");
         assert_eq!(
-            row.created_at, "1970-01-01T00:00:00.000Z",
+            row.created_at.to_string(),
+            "1970-01-01T00:00:00.000Z",
             "bookkeeping timestamp must derive from the sequence, not the system clock"
         );
         assert_eq!(row.created_at, row.updated_at);

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -402,8 +402,10 @@ where
                     .get(&branch_identity)
                     .or_else(|| candidates.get(&global_identity))?
                     .clone();
-                if row.branch_id == GLOBAL_BRANCH_ID && requested.branch_id != GLOBAL_BRANCH_ID {
-                    row.branch_id.clone_from(&requested.branch_id);
+                if row.branch_id.as_ref() == GLOBAL_BRANCH_ID
+                    && requested.branch_id != GLOBAL_BRANCH_ID
+                {
+                    row.branch_id = requested.branch_id.clone().into();
                     row.global = true;
                 }
                 if row.deleted && !request.include_tombstones {
@@ -642,7 +644,11 @@ async fn scan_commit_derived_rows(
     rows.retain(|row| {
         (request.filter.entity_pks.is_empty() || request.filter.entity_pks.contains(&row.entity_pk))
             && (request.filter.branch_ids.is_empty()
-                || request.filter.branch_ids.contains(&row.branch_id))
+                || request
+                    .filter
+                    .branch_ids
+                    .iter()
+                    .any(|branch_id| branch_id == row.branch_id.as_ref()))
     });
     Ok(rows)
 }
@@ -700,13 +706,13 @@ fn commit_row(
         snapshot_content: Some(snapshot_content),
         metadata: None,
         deleted: false,
-        created_at: commit.change.created_at.to_string(),
-        updated_at: commit.change.created_at.to_string(),
+        created_at: commit.change.created_at,
+        updated_at: commit.change.created_at,
         global: true,
         change_id: Some(commit.change.id),
         commit_id: Some(commit.commit_id),
         untracked: false,
-        branch_id: branch_id.to_string(),
+        branch_id: branch_id.into(),
     })
 }
 
@@ -737,13 +743,13 @@ fn commit_edge_row(
         snapshot_content: Some(snapshot_content),
         metadata: None,
         deleted: false,
-        created_at: "1970-01-01T00:00:00.000Z".to_string(),
-        updated_at: "1970-01-01T00:00:00.000Z".to_string(),
+        created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+        updated_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
         global: true,
         change_id: None,
         commit_id: Some(edge.child_commit_id),
         untracked: false,
-        branch_id: branch_id.to_string(),
+        branch_id: branch_id.into(),
     })
 }
 
@@ -1003,13 +1009,19 @@ fn project_tracked_row(
         snapshot_content: row.snapshot_content,
         metadata: row.metadata,
         deleted: row.deleted,
-        created_at: row.created_at,
-        updated_at: row.updated_at,
+        created_at: crate::common::LixTimestamp::expect_parse(
+            "tracked-state row created_at",
+            &row.created_at,
+        ),
+        updated_at: crate::common::LixTimestamp::expect_parse(
+            "tracked-state row updated_at",
+            &row.updated_at,
+        ),
         global: source == TrackedRowSource::Global,
         change_id: Some(row.change_id),
         commit_id: Some(row.commit_id),
         untracked: false,
-        branch_id: view_branch_id.to_string(),
+        branch_id: view_branch_id.into(),
     }
 }
 
@@ -1297,7 +1309,7 @@ mod tests {
             if row.schema_key != COMMIT_SCHEMA_KEY {
                 let change = crate::test_support::tracked_change_from_materialized(&materialized)?;
                 stage_json_payloads_from_materialized(writes, json_writer, &materialized)?;
-                current_rows.push((row.branch_id.clone(), materialized.clone()));
+                current_rows.push((row.branch_id.to_string(), materialized.clone()));
                 tracked_rows_by_commit
                     .entry(commit_id_text)
                     .or_default()
@@ -1689,7 +1701,7 @@ mod tests {
             .expect("load should succeed")
             .expect("global row should be visible for requested branch");
 
-        assert_eq!(loaded.branch_id, "branch-a");
+        assert_eq!(loaded.branch_id.as_ref(), "branch-a");
         assert!(loaded.global);
         assert!(!loaded.untracked);
         assert_eq!(
@@ -1745,7 +1757,7 @@ mod tests {
             .await
             .expect("load should succeed")
             .expect("global row should be projected into main");
-        assert_eq!(loaded.branch_id, "main");
+        assert_eq!(loaded.branch_id.as_ref(), "main");
         assert!(loaded.global);
         assert_eq!(
             loaded.snapshot_content.as_deref(),
@@ -1805,7 +1817,7 @@ mod tests {
             .expect("load should succeed")
             .expect("branch row should be visible");
 
-        assert_eq!(loaded.branch_id, "branch-a");
+        assert_eq!(loaded.branch_id.as_ref(), "branch-a");
         assert!(!loaded.untracked);
         assert_eq!(
             loaded.snapshot_content.as_deref(),
@@ -1859,7 +1871,7 @@ mod tests {
             .expect("load should succeed")
             .expect("main row should be visible");
 
-        assert_eq!(loaded.branch_id, "main");
+        assert_eq!(loaded.branch_id.as_ref(), "main");
         assert!(!loaded.global);
         assert_eq!(
             loaded.snapshot_content.as_deref(),
@@ -1913,7 +1925,7 @@ mod tests {
             .expect("scan should succeed");
 
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].branch_id, "branch-a");
+        assert_eq!(rows[0].branch_id.as_ref(), "branch-a");
         assert_eq!(
             rows[0].snapshot_content.as_deref(),
             Some("{\"value\":\"branch-tracked\"}")
@@ -1963,7 +1975,7 @@ mod tests {
             .expect("scan should succeed");
 
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].branch_id, "branch-a");
+        assert_eq!(rows[0].branch_id.as_ref(), "branch-a");
         assert!(rows[0].global);
         assert_eq!(
             rows[0].snapshot_content.as_deref(),
@@ -2065,7 +2077,7 @@ mod tests {
             .await
             .expect("scan should succeed");
         assert_eq!(with_tombstone.len(), 1);
-        assert_eq!(with_tombstone[0].branch_id, "branch-a");
+        assert_eq!(with_tombstone[0].branch_id.as_ref(), "branch-a");
         assert_eq!(with_tombstone[0].snapshot_content, None);
     }
 
@@ -2118,7 +2130,7 @@ mod tests {
             .await
             .expect("scan should succeed");
         assert_eq!(tombstones.len(), 1);
-        assert_eq!(tombstones[0].branch_id, "main");
+        assert_eq!(tombstones[0].branch_id.as_ref(), "main");
         assert!(!tombstones[0].global);
         assert_eq!(tombstones[0].snapshot_content, None);
     }
@@ -2225,7 +2237,7 @@ mod tests {
 
         let fallback = loaded[0].as_ref().expect("global fallback should load");
         assert!(fallback.global);
-        assert_eq!(fallback.branch_id, "branch-a");
+        assert_eq!(fallback.branch_id.as_ref(), "branch-a");
         assert_eq!(
             fallback.snapshot_content.as_deref(),
             Some("{\"value\":\"global-fallback\"}")
@@ -2537,13 +2549,13 @@ mod tests {
             snapshot_content: Some(format!("{{\"value\":\"{value}\"}}")),
             metadata: None,
             deleted: false,
-            created_at: "2026-01-01T00:00:00Z".to_string(),
-            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
             global: branch_id == "global",
             change_id: change_id.map(ChangeId::for_test_label),
             commit_id: Some(commit_id),
             untracked: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
         }
     }
 
@@ -2639,13 +2651,13 @@ mod tests {
             ),
             metadata: None,
             deleted: false,
-            created_at: "2026-01-01T00:00:00Z".to_string(),
-            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
             global: true,
             change_id: Some(ChangeId::for_test_label(&format!("change-{commit_id}"))),
             commit_id: Some(commit_id),
             untracked: false,
-            branch_id: "global".to_string(),
+            branch_id: "global".into(),
         }
     }
 

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -9,6 +9,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use std::sync::Arc;
+
 use bytes::Bytes;
 
 use crate::LixError;
@@ -1225,7 +1227,8 @@ async fn materialize_live_entries(
     projection: ChangeRecordProjection,
     branch_id: &str,
 ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
-    let global = branch_id == crate::GLOBAL_BRANCH_ID;
+    let branch_id = Arc::<str>::from(branch_id);
+    let global = branch_id.as_ref() == crate::GLOBAL_BRANCH_ID;
     let mut json_refs = Vec::new();
     let mut deferred = Vec::new();
     let mut rows = Vec::with_capacity(entries.len());
@@ -1255,13 +1258,13 @@ async fn materialize_live_entries(
             snapshot_content,
             metadata,
             deleted: value.deleted,
-            created_at: value.created_at.to_string(),
-            updated_at: value.updated_at.to_string(),
+            created_at: value.created_at,
+            updated_at: value.updated_at,
             global,
             change_id: Some(value.change_id),
             commit_id: Some(value.commit_id),
             untracked: false,
-            branch_id: branch_id.to_string(),
+            branch_id: Arc::clone(&branch_id),
         });
     }
     if json_refs.is_empty() {
@@ -1469,7 +1472,7 @@ mod tests {
             metadata_only[0].metadata.as_deref(),
             Some(long_metadata.as_str())
         );
-        assert_eq!(metadata_only[0].branch_id, branch_id);
+        assert_eq!(metadata_only[0].branch_id.as_ref(), branch_id);
         assert!(!metadata_only[0].global);
         assert!(!metadata_only[0].untracked);
 
@@ -1648,6 +1651,10 @@ mod tests {
             .expect("scan")
             .expect("marker should match");
         assert_eq!(rows.len(), expected.len());
+        assert!(
+            Arc::ptr_eq(&rows[0].branch_id, &rows[1].branch_id),
+            "one head scan should share its branch allocation across rows"
+        );
         assert_eq!(
             rows.into_iter()
                 .map(|row| (row.schema_key, row.entity_pk, row.file_id))
@@ -1827,8 +1834,8 @@ mod tests {
             .expect("scan second head")
             .expect("matching marker");
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].created_at, "2026-01-01T00:00:00.000Z");
-        assert_eq!(rows[0].updated_at, "2026-01-02T00:00:00.000Z");
+        assert_eq!(rows[0].created_at, ts("2026-01-01T00:00:00Z"));
+        assert_eq!(rows[0].updated_at, ts("2026-01-02T00:00:00Z"));
         assert_eq!(rows[0].snapshot_content.as_deref(), Some("{\"value\":2}"));
     }
 
@@ -1908,7 +1915,7 @@ mod tests {
             rows[0].change_id,
             Some(ChangeId::for_test_label("child-change"))
         );
-        assert_eq!(rows[0].created_at, "2026-01-01T00:00:00.000Z");
+        assert_eq!(rows[0].created_at, ts("2026-01-01T00:00:00Z"));
         assert_eq!(rows[0].snapshot_content.as_deref(), Some("{\"value\":2}"));
     }
 }

--- a/packages/engine/src/live_state/types.rs
+++ b/packages/engine/src/live_state/types.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use crate::changelog::{ChangeId, CommitId};
+use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 use crate::live_state::index::MaterializedLiveStateIndexRow;
 use crate::tracked_state::MaterializedTrackedStateRow;
@@ -8,7 +11,7 @@ use crate::{NullableKeyFilter, Value};
 ///
 /// Unlike provider write rows, live-state rows are fully hydrated facts. Missing
 /// generated fields should be caught before this type is constructed.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MaterializedLiveStateRow {
     pub(crate) entity_pk: EntityPk,
     pub(crate) schema_key: String,
@@ -16,13 +19,13 @@ pub(crate) struct MaterializedLiveStateRow {
     pub(crate) snapshot_content: Option<String>,
     pub(crate) metadata: Option<String>,
     pub(crate) deleted: bool,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: LixTimestamp,
+    pub(crate) updated_at: LixTimestamp,
     pub(crate) global: bool,
     pub(crate) change_id: Option<ChangeId>,
     pub(crate) commit_id: Option<CommitId>,
     pub(crate) untracked: bool,
-    pub(crate) branch_id: String,
+    pub(crate) branch_id: Arc<str>,
 }
 
 impl From<MaterializedLiveStateIndexRow> for MaterializedLiveStateRow {
@@ -35,13 +38,13 @@ impl From<MaterializedLiveStateIndexRow> for MaterializedLiveStateRow {
             snapshot_content: row.snapshot_content,
             metadata: row.metadata,
             deleted: false,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
+            created_at: LixTimestamp::expect_parse("live-state index created_at", &row.created_at),
+            updated_at: LixTimestamp::expect_parse("live-state index updated_at", &row.updated_at),
             global,
             change_id: Some(row.change_id),
             commit_id: None,
             untracked: true,
-            branch_id: row.branch_id,
+            branch_id: row.branch_id.into(),
         }
     }
 }
@@ -76,8 +79,8 @@ impl TryFrom<&MaterializedLiveStateRow> for MaterializedTrackedStateRow {
             snapshot_content: row.snapshot_content.clone(),
             metadata: row.metadata.clone(),
             deleted: row.deleted,
-            created_at: row.created_at.clone(),
-            updated_at: row.updated_at.clone(),
+            created_at: row.created_at.to_string(),
+            updated_at: row.updated_at.to_string(),
             change_id,
             commit_id,
         })
@@ -233,7 +236,7 @@ pub(crate) struct LiveStateRowIdentity {
 impl LiveStateRowIdentity {
     pub(crate) fn from_row(row: &MaterializedLiveStateRow) -> Self {
         Self {
-            branch_id: row.branch_id.clone(),
+            branch_id: row.branch_id.to_string(),
             schema_key: row.schema_key.clone(),
             entity_pk: row.entity_pk.clone(),
             file_id: row.file_id.clone(),

--- a/packages/engine/src/live_state/visibility.rs
+++ b/packages/engine/src/live_state/visibility.rs
@@ -231,7 +231,7 @@ where
             });
             if let Some(mut row) = staged_rows[global_index].clone() {
                 if requested.branch_id != GLOBAL_BRANCH_ID {
-                    row.branch_id.clone_from(&requested.branch_id);
+                    row.branch_id = requested.branch_id.clone().into();
                 }
                 row.global = true;
                 insert_exact_overlay_candidate(&mut winner, OverlayTier::StagedGlobal, row);
@@ -357,7 +357,7 @@ fn can_resolve_uncontested_single_branch_rows(
     staged_rows.is_empty()
         && base_rows
             .iter()
-            .all(|row| !row.global && row.branch_id == *requested_branch_id)
+            .all(|row| !row.global && row.branch_id.as_ref() == requested_branch_id)
 }
 
 /// Resolves candidates which are already scoped to one nonglobal branch.
@@ -417,9 +417,9 @@ fn project_global_rows_into_requested_branches(
     let mut rows_by_identity = BTreeMap::<LiveStateRowIdentity, MaterializedLiveStateRow>::new();
     for requested_branch_id in requested_branch_ids {
         for row in &rows {
-            if row.branch_id == GLOBAL_BRANCH_ID {
+            if row.branch_id.as_ref() == GLOBAL_BRANCH_ID {
                 let mut projected = row.clone();
-                projected.branch_id.clone_from(requested_branch_id);
+                projected.branch_id = requested_branch_id.clone().into();
                 rows_by_identity.insert(LiveStateRowIdentity::from_row(&projected), projected);
             }
         }
@@ -427,7 +427,7 @@ fn project_global_rows_into_requested_branches(
             BTreeMap::<LiveStateRowIdentity, MaterializedLiveStateRow>::new();
         for row in rows
             .iter()
-            .filter(|row| row.branch_id == *requested_branch_id)
+            .filter(|row| row.branch_id.as_ref() == requested_branch_id)
         {
             branch_rows_by_identity.insert(LiveStateRowIdentity::from_row(row), row.clone());
         }
@@ -464,9 +464,14 @@ mod tests {
     use super::*;
     use crate::NullableKeyFilter;
     use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
     use crate::live_state::LiveStateRowRequest;
     use async_trait::async_trait;
+
+    fn test_timestamp() -> LixTimestamp {
+        LixTimestamp::expect_parse("test timestamp", "2026-01-01T00:00:00Z")
+    }
 
     #[test]
     fn expands_requested_branch_with_global_candidates() {
@@ -495,7 +500,7 @@ mod tests {
         );
 
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].branch_id, "branch-a");
+        assert_eq!(rows[0].branch_id.as_ref(), "branch-a");
         assert!(rows[0].global);
         assert_eq!(
             rows[0].snapshot_content.as_deref(),
@@ -527,7 +532,7 @@ mod tests {
         );
 
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].branch_id, "branch-a");
+        assert_eq!(rows[0].branch_id.as_ref(), "branch-a");
         assert!(!rows[0].global);
         assert_eq!(
             rows[0].snapshot_content.as_deref(),
@@ -864,7 +869,7 @@ mod tests {
         );
 
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].branch_id, "branch-a");
+        assert_eq!(rows[0].branch_id.as_ref(), "branch-a");
         assert_eq!(rows[0].snapshot_content, None);
     }
 
@@ -917,7 +922,7 @@ mod tests {
         .expect("overlay scan should succeed");
 
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].branch_id, "staged-branch");
+        assert_eq!(rows[0].branch_id.as_ref(), "staged-branch");
         assert!(rows[0].global);
         assert_eq!(
             rows[0].snapshot_content.as_deref(),
@@ -1088,13 +1093,13 @@ mod tests {
             snapshot_content: Some(format!("{{\"value\":\"{value}\"}}")),
             metadata: None,
             deleted: false,
-            created_at: "2026-01-01T00:00:00Z".to_string(),
-            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            created_at: test_timestamp(),
+            updated_at: test_timestamp(),
             global,
             change_id: change_id.map(ChangeId::for_test_label),
             commit_id: Some(CommitId::for_test_label("commit")),
             untracked: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
         }
     }
 
@@ -1131,8 +1136,11 @@ mod tests {
         request: &LiveStateScanRequest,
     ) -> bool {
         let filter = &request.filter;
-        let branch_matches =
-            filter.branch_ids.is_empty() || filter.branch_ids.contains(&row.branch_id);
+        let branch_matches = filter.branch_ids.is_empty()
+            || filter
+                .branch_ids
+                .iter()
+                .any(|branch_id| branch_id == row.branch_id.as_ref());
         let schema_matches =
             filter.schema_keys.is_empty() || filter.schema_keys.contains(&row.schema_key);
         let entity_matches =

--- a/packages/engine/src/plugin/registry.rs
+++ b/packages/engine/src/plugin/registry.rs
@@ -936,7 +936,7 @@ fn validate_live_state_identity(
         || row.file_id.as_deref() != expected_file_id
         || row.global
         || row.untracked
-        || row.branch_id != branch_id
+        || row.branch_id.as_ref() != branch_id
     {
         return Err(invalid_registry(format!(
             "reserved plugin row '{key}' has invalid tracked branch-local storage identity"

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -997,7 +997,7 @@ fn candidate_matches_insert_identity(
 ) -> bool {
     candidate.entity_pk == *inserted_entity_pk
         && candidate.file_id == insert_row.file_id
-        && candidate.branch_id == insert_row.branch_id
+        && candidate.branch_id.as_ref() == insert_row.branch_id
         && candidate.global == insert_row.global
         && candidate.untracked == insert_row.untracked
 }
@@ -1506,7 +1506,7 @@ fn reject_projected_global_write(
         &plan.bound.target,
         BoundWriteTarget::Entity(EntityWriteSurface::ByBranch { .. })
     );
-    if target_is_by_branch && row.global && row.branch_id != crate::GLOBAL_BRANCH_ID {
+    if target_is_by_branch && row.global && row.branch_id.as_ref() != crate::GLOBAL_BRANCH_ID {
         return Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
             format!(
@@ -1558,7 +1558,7 @@ fn entity_replace_row_from_live(
         branch_id: if row.global {
             crate::GLOBAL_BRANCH_ID.to_string()
         } else {
-            row.branch_id.clone()
+            row.branch_id.to_string()
         },
     })
 }
@@ -2732,10 +2732,10 @@ fn column_eval_value(
             .map(|value| EntityEvalValue::Json(JsonValue::String(value.to_string())))
             .unwrap_or(EntityEvalValue::SqlNull)),
         "lixcol_created_at" => Ok(EntityEvalValue::Json(JsonValue::String(
-            row.created_at.clone(),
+            row.created_at.to_string(),
         ))),
         "lixcol_updated_at" => Ok(EntityEvalValue::Json(JsonValue::String(
-            row.updated_at.clone(),
+            row.updated_at.to_string(),
         ))),
         "lixcol_commit_id" => Ok(row
             .commit_id
@@ -2745,7 +2745,7 @@ fn column_eval_value(
         "lixcol_global" => Ok(EntityEvalValue::Json(JsonValue::Bool(row.global))),
         "lixcol_untracked" => Ok(EntityEvalValue::Json(JsonValue::Bool(row.untracked))),
         "lixcol_branch_id" => Ok(EntityEvalValue::Json(JsonValue::String(
-            row.branch_id.clone(),
+            row.branch_id.to_string(),
         ))),
         _ => Ok(EntityEvalValue::SqlNull),
     }

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2181,6 +2181,7 @@ mod tests {
         CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest, CommitGraphCommit,
         CommitGraphReader, ReachableCommitGraphCommit,
     };
+    use crate::common::LixTimestamp;
     use crate::functions::FunctionProviderHandle;
     use crate::json_store::JsonStoreContext;
     use crate::live_state::{
@@ -2783,7 +2784,11 @@ mod tests {
                     && (request.filter.entity_pks.is_empty()
                         || request.filter.entity_pks.contains(&row.entity_pk))
                     && (request.filter.branch_ids.is_empty()
-                        || request.filter.branch_ids.contains(&row.branch_id))
+                        || request
+                            .filter
+                            .branch_ids
+                            .iter()
+                            .any(|branch_id| branch_id == row.branch_id.as_ref()))
                     && request
                         .filter
                         .untracked
@@ -2919,13 +2924,13 @@ mod tests {
             snapshot_content: Some(format!("{{\"value\":\"{value}\"}}")),
             metadata: Some(json!({ "source": entity_pk }).to_string()),
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 
@@ -2961,13 +2966,13 @@ mod tests {
             ),
             metadata: Some(json!({ "source": entity_pk }).to_string()),
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 
@@ -2991,13 +2996,13 @@ mod tests {
             ),
             metadata: Some(json!({ "source": entity_pk }).to_string()),
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 
@@ -3020,7 +3025,7 @@ mod tests {
             ),
             metadata: Some(json!({ "source": entity_pk }).to_string()),
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!(
                 "change-{entity_pk}-blob"
             ))),
@@ -3029,8 +3034,8 @@ mod tests {
             ))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -965,6 +965,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
+    use crate::common::LixTimestamp;
     use crate::live_state::LiveStateRowRequest;
     use datafusion::common::Column;
 
@@ -1102,13 +1103,19 @@ mod tests {
             ),
             metadata: None,
             deleted: false,
-            created_at: "2026-07-12T00:00:00Z".to_string(),
-            updated_at: "2026-07-12T00:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse(
+                "branch descriptor test created_at",
+                "2026-07-12T00:00:00Z",
+            ),
+            updated_at: LixTimestamp::expect_parse(
+                "branch descriptor test updated_at",
+                "2026-07-12T00:00:00Z",
+            ),
             global: true,
             change_id: None,
             commit_id: None,
             untracked: false,
-            branch_id: GLOBAL_BRANCH_ID.to_string(),
+            branch_id: GLOBAL_BRANCH_ID.into(),
         }
     }
 

--- a/packages/engine/src/sql2/providers/columns.rs
+++ b/packages/engine/src/sql2/providers/columns.rs
@@ -147,8 +147,14 @@ pub(super) static LIVE_STATE_COLS: ColumnTable<MaterializedLiveStateRow> = Colum
             "metadata",
             Col::Utf8Owned(|row| row.metadata.as_deref().map(serialize_row_metadata)),
         ),
-        ("created_at", Col::Utf8(|row| Some(&row.created_at))),
-        ("updated_at", Col::Utf8(|row| Some(&row.updated_at))),
+        (
+            "created_at",
+            Col::Utf8Owned(|row| Some(row.created_at.to_string())),
+        ),
+        (
+            "updated_at",
+            Col::Utf8Owned(|row| Some(row.updated_at.to_string())),
+        ),
         ("global", Col::Bool(|row| Some(row.global))),
         (
             "change_id",
@@ -159,6 +165,6 @@ pub(super) static LIVE_STATE_COLS: ColumnTable<MaterializedLiveStateRow> = Colum
             Col::Utf8Owned(|row| row.commit_id.map(|id| id.to_string())),
         ),
         ("untracked", Col::Bool(|row| Some(row.untracked))),
-        ("branch_id", Col::Utf8(|row| Some(&row.branch_id))),
+        ("branch_id", Col::Utf8(|row| Some(row.branch_id.as_ref()))),
     ],
 };

--- a/packages/engine/src/sql2/providers/directory.rs
+++ b/packages/engine/src/sql2/providers/directory.rs
@@ -1606,8 +1606,8 @@ fn lix_directory_record_batch_from_rendered(
         file_ids.push(directory.live.file_id);
         globals.push(Some(directory.live.global));
         change_ids.push(directory.live.change_id.map(|id| id.to_string()));
-        created_ats.push(directory.live.created_at);
-        updated_ats.push(directory.live.updated_at);
+        created_ats.push(directory.live.created_at.to_string());
+        updated_ats.push(directory.live.updated_at.to_string());
         commit_ids.push(directory.live.commit_id.map(|id| id.to_string()));
         untracked_values.push(Some(directory.live.untracked));
         metadata_values.push(
@@ -1617,7 +1617,7 @@ fn lix_directory_record_batch_from_rendered(
                 .as_deref()
                 .map(serialize_row_metadata),
         );
-        branch_ids.push(Some(directory.live.branch_id));
+        branch_ids.push(Some(directory.live.branch_id.to_string()));
     }
 
     let mut columns = Vec::<ArrayRef>::with_capacity(schema.fields().len());
@@ -1943,6 +1943,7 @@ mod tests {
     use crate::binary_cas::BlobDataReader;
     use crate::branch::{BranchHead, BranchRefReader};
     use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::filesystem::{
         FilesystemPathIndex, FilesystemPathIndexReader, FilesystemPathIndexRequest,
     };
@@ -2225,13 +2226,13 @@ mod tests {
             snapshot_content: Some(snapshot_content.to_string()),
             metadata: Some(json!({"source": "test"}).to_string()),
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1475,6 +1475,7 @@ mod tests {
     use crate::LixError;
     use crate::branch::{BranchHead, BranchRefReader};
     use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::live_state::{
         LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
     };
@@ -1635,13 +1636,13 @@ mod tests {
             ),
             metadata: Some(json!({"source": "test"}).to_string()),
             deleted: false,
-            branch_id: "branch-a".to_string(),
+            branch_id: "branch-a".into(),
             change_id: Some(ChangeId::for_test_label("change-a")),
             commit_id: Some(CommitId::for_test_label("commit-a")),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -3805,12 +3805,12 @@ impl LixFileRecordBatchColumns {
         self.file_ids.push(row.file_id);
         self.globals.push(Some(row.global));
         self.change_ids.push(row.change_id);
-        self.created_ats.push(Some(row.created_at.to_string()));
-        self.updated_ats.push(Some(row.updated_at.to_string()));
+        self.created_ats.push(Some(row.created_at));
+        self.updated_ats.push(Some(row.updated_at));
         self.commit_ids.push(row.commit_id);
         self.untracked_values.push(Some(row.untracked));
         self.metadata_values.push(row.metadata);
-        self.branch_ids.push(Some(row.branch_id.to_string()));
+        self.branch_ids.push(Some(row.branch_id));
     }
 
     fn into_record_batch(self, schema: &SchemaRef) -> Result<RecordBatch, LixError> {
@@ -7656,7 +7656,7 @@ mod tests {
                     branch_ids: request
                         .rows
                         .iter()
-                        .map(|row| row.branch_id.to_string())
+                        .map(|row| row.branch_id.clone())
                         .collect(),
                     schema_keys: request
                         .rows

--- a/packages/engine/src/sql2/providers/file.rs
+++ b/packages/engine/src/sql2/providers/file.rs
@@ -1795,7 +1795,7 @@ struct FileDescriptorRecord {
 impl FileDescriptorRecord {
     fn row_context(&self) -> FilesystemRowContext {
         FilesystemRowContext {
-            branch_id: self.live.branch_id.clone(),
+            branch_id: self.live.branch_id.to_string(),
             global: self.live.global,
             untracked: self.live.untracked,
             file_id: self.live.file_id.clone(),
@@ -2332,7 +2332,7 @@ async fn load_exact_existing_blob_keys(
         .zip(rows)
         .filter_map(|(key, row)| {
             row.filter(|row| {
-                row.branch_id == key.branch_id()
+                row.branch_id.as_ref() == key.branch_id()
                     && row.global == key.global()
                     && row.untracked == key.is_untracked()
             })
@@ -3805,12 +3805,12 @@ impl LixFileRecordBatchColumns {
         self.file_ids.push(row.file_id);
         self.globals.push(Some(row.global));
         self.change_ids.push(row.change_id);
-        self.created_ats.push(Some(row.created_at));
-        self.updated_ats.push(Some(row.updated_at));
+        self.created_ats.push(Some(row.created_at.to_string()));
+        self.updated_ats.push(Some(row.updated_at.to_string()));
         self.commit_ids.push(row.commit_id);
         self.untracked_values.push(Some(row.untracked));
         self.metadata_values.push(row.metadata);
-        self.branch_ids.push(Some(row.branch_id));
+        self.branch_ids.push(Some(row.branch_id.to_string()));
     }
 
     fn into_record_batch(self, schema: &SchemaRef) -> Result<RecordBatch, LixError> {
@@ -3975,12 +3975,12 @@ async fn lix_file_record_batch_from_prepared(
             file_id: live.file_id,
             global: live.global,
             change_id: projected_change_id.map(|id| id.to_string()),
-            created_at: live.created_at,
-            updated_at: live.updated_at,
+            created_at: live.created_at.to_string(),
+            updated_at: live.updated_at.to_string(),
             commit_id: live.commit_id.map(|id| id.to_string()),
             untracked: live.untracked,
             metadata: live.metadata.as_deref().map(serialize_row_metadata),
-            branch_id: live.branch_id,
+            branch_id: live.branch_id.to_string(),
         });
     }
 
@@ -4269,7 +4269,7 @@ async fn render_plugin_files_for_sql(
                     })
                     .await?;
                 rows.retain(|row| {
-                    row.branch_id == branch_id
+                    row.branch_id.as_ref() == branch_id.as_str()
                         && !row.global
                         && !row.untracked
                         && row
@@ -4411,7 +4411,7 @@ async fn load_plugin_render_branches(
                 row.schema_key == "lix_key_value"
                     && row.entity_pk.as_single_string().ok() == Some(PLUGIN_REGISTRY_KEY)
                     && row.file_id.is_none()
-                    && row.branch_id == branch_id
+                    && row.branch_id.as_ref() == branch_id.as_str()
                     && !row.global
                     && !row.untracked
             });
@@ -4499,7 +4499,7 @@ async fn plugin_render_context_with_branches(
             };
             if row.schema_key != "lix_key_value"
                 || row.entity_pk.as_single_string().ok() != Some(PLUGIN_OWNER_KEY)
-                || row.branch_id != branch_id
+                || row.branch_id.as_ref() != branch_id.as_str()
                 || row.global
                 || row.untracked
                 || !file_ids.contains(file_id)
@@ -4570,7 +4570,7 @@ fn plugin_unavailable_error(
         owner.plugin_key()
     ))
     .with_details(serde_json::json!({
-        "branch_id": file.live.branch_id,
+        "branch_id": file.live.branch_id.as_ref(),
         "file_id": file.id,
         "path": path,
         "plugin_key": owner.plugin_key(),
@@ -5751,6 +5751,7 @@ mod tests {
     use crate::binary_cas::{BlobBytesBatch, BlobDataReader, BlobHash};
     use crate::branch::{BranchHead, BranchRefReader};
     use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::filesystem::{
         FilesystemBlobRefKey, FilesystemDescriptorKey, FilesystemPathIndex,
         FilesystemPathIndexReader, FilesystemPathIndexRequest, FilesystemRowContext,
@@ -6534,8 +6535,14 @@ mod tests {
         assert_eq!(string_value("lixcol_file_id"), "remote-file-target");
         assert!(!boolean_value("lixcol_global"));
         assert!(boolean_value("lixcol_untracked"));
-        assert_eq!(string_value("lixcol_created_at"), "2026-04-23T00:00:00Z");
-        assert_eq!(string_value("lixcol_updated_at"), "2026-04-23T01:00:00Z");
+        assert_eq!(
+            string_value("lixcol_created_at"),
+            "2026-04-23T00:00:00.000Z"
+        );
+        assert_eq!(
+            string_value("lixcol_updated_at"),
+            "2026-04-23T01:00:00.000Z"
+        );
         assert_eq!(string_value("lixcol_branch_id"), "branch-b");
         assert_eq!(path_index_requests.load(Ordering::SeqCst), 1);
         assert_eq!(live_state_scans.load(Ordering::SeqCst), 0);
@@ -7489,18 +7496,18 @@ mod tests {
                         .rows
                         .iter()
                         .filter(matches)
-                        .find(|row| row.branch_id == requested.branch_id)
+                        .find(|row| row.branch_id.as_ref() == requested.branch_id.as_str())
                         .or_else(|| {
                             self.rows
                                 .iter()
                                 .filter(matches)
-                                .find(|row| row.branch_id == crate::GLOBAL_BRANCH_ID)
+                                .find(|row| row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID)
                         })?
                         .clone();
-                    if row.branch_id == crate::GLOBAL_BRANCH_ID
+                    if row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID
                         && requested.branch_id != crate::GLOBAL_BRANCH_ID
                     {
-                        row.branch_id.clone_from(&requested.branch_id);
+                        row.branch_id = requested.branch_id.clone().into();
                         row.global = true;
                     }
                     if row.deleted && !request.include_tombstones {
@@ -7649,7 +7656,7 @@ mod tests {
                     branch_ids: request
                         .rows
                         .iter()
-                        .map(|row| row.branch_id.clone())
+                        .map(|row| row.branch_id.to_string())
                         .collect(),
                     schema_keys: request
                         .rows
@@ -7708,18 +7715,18 @@ mod tests {
                         .rows
                         .iter()
                         .filter(exact_match)
-                        .find(|row| row.branch_id == requested.branch_id)
+                        .find(|row| row.branch_id.as_ref() == requested.branch_id.as_str())
                         .or_else(|| {
                             self.rows
                                 .iter()
                                 .filter(exact_match)
-                                .find(|row| row.branch_id == crate::GLOBAL_BRANCH_ID)
+                                .find(|row| row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID)
                         })?
                         .clone();
-                    if row.branch_id == crate::GLOBAL_BRANCH_ID
+                    if row.branch_id.as_ref() == crate::GLOBAL_BRANCH_ID
                         && requested.branch_id != crate::GLOBAL_BRANCH_ID
                     {
-                        row.branch_id.clone_from(&requested.branch_id);
+                        row.branch_id = requested.branch_id.clone().into();
                         row.global = true;
                     }
                     if row.deleted && !request.include_tombstones {
@@ -7829,13 +7836,13 @@ mod tests {
             snapshot_content: Some(snapshot_content.to_string()),
             metadata: None,
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 
@@ -7851,13 +7858,13 @@ mod tests {
             snapshot_content: Some(snapshot_content.to_string()),
             metadata: None,
             deleted: false,
-            branch_id: branch_id.to_string(),
+            branch_id: branch_id.into(),
             change_id: Some(ChangeId::for_test_label(&format!("change-{entity_pk}"))),
             commit_id: Some(CommitId::for_test_label(&format!("commit-{entity_pk}"))),
             global: false,
             untracked: false,
-            created_at: "2026-04-23T00:00:00Z".to_string(),
-            updated_at: "2026-04-23T01:00:00Z".to_string(),
+            created_at: LixTimestamp::expect_parse("test created_at", "2026-04-23T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("test updated_at", "2026-04-23T01:00:00Z"),
         }
     }
 

--- a/packages/engine/src/sql2/providers/file_history.rs
+++ b/packages/engine/src/sql2/providers/file_history.rs
@@ -15,7 +15,7 @@ use tokio::sync::Mutex;
 use crate::NullableKeyFilter;
 use crate::binary_cas::{BlobDataReader, BlobHash};
 use crate::commit_graph::CommitGraphReader;
-use crate::common::compose_file_path;
+use crate::common::{LixTimestamp, compose_file_path};
 use crate::entity_pk::EntityPk;
 use crate::live_state::MaterializedLiveStateRow;
 use crate::plugin::{
@@ -2066,13 +2066,13 @@ fn history_entry_to_live_row(entry: &HistoryEntry) -> MaterializedLiveStateRow {
         snapshot_content: entry.change.snapshot_content.clone(),
         metadata: entry.change.metadata.clone(),
         deleted: entry.change.snapshot_content.is_none(),
-        created_at: entry.change.created_at.clone(),
-        updated_at: entry.change.created_at.clone(),
+        created_at: LixTimestamp::expect_parse("file history created_at", &entry.change.created_at),
+        updated_at: LixTimestamp::expect_parse("file history updated_at", &entry.change.created_at),
         global: false,
         change_id: None,
         commit_id: None,
         untracked: false,
-        branch_id: GLOBAL_BRANCH_ID.to_string(),
+        branch_id: GLOBAL_BRANCH_ID.into(),
     }
 }
 

--- a/packages/engine/src/sql2/test_support/differential.rs
+++ b/packages/engine/src/sql2/test_support/differential.rs
@@ -567,7 +567,7 @@ mod tests {
                     &[
                         entity_pk_value(row),
                         value,
-                        Value::Text(row.branch_id.clone()),
+                        Value::Text(row.branch_id.to_string()),
                         row.metadata
                             .as_deref()
                             .map(serialize_row_metadata)

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1887,7 +1887,7 @@ mod tests {
             branch_row.change_id,
             Some(change_id("branch-override-change"))
         );
-        assert_eq!(branch_row.branch_id, "branch-a");
+        assert_eq!(branch_row.branch_id.as_ref(), "branch-a");
         assert!(!branch_row.global);
         let fallback_row = scanned
             .iter()
@@ -1897,7 +1897,7 @@ mod tests {
             fallback_row.change_id,
             Some(change_id("global-fallback-change"))
         );
-        assert_eq!(fallback_row.branch_id, "branch-a");
+        assert_eq!(fallback_row.branch_id.as_ref(), "branch-a");
         assert!(fallback_row.global);
 
         let mut branch_tombstone = tracked_branch_row("branch-a", "branch-tombstone-change");

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -917,7 +917,7 @@ where
                     continue;
                 };
                 existing_schemas.insert(
-                    (row.branch_id, row.entity_pk),
+                    (row.branch_id.to_string(), row.entity_pk),
                     serde_json::from_str(snapshot).map_err(|error| {
                         LixError::new(
                             LixError::CODE_SCHEMA_DEFINITION,
@@ -985,7 +985,7 @@ where
         let mut registry_rows_by_branch = BTreeMap::<String, MaterializedLiveStateRow>::new();
         for row in registry_rows {
             if registry_rows_by_branch
-                .insert(row.branch_id.clone(), row)
+                .insert(row.branch_id.to_string(), row)
                 .is_some()
             {
                 return Err(LixError::new(
@@ -1131,7 +1131,7 @@ where
         let mut owners = BTreeMap::<PluginFileWriteKey, PluginFileOwner>::new();
         let mut owner_change_ids = BTreeMap::<PluginFileWriteKey, String>::new();
         for row in owner_rows {
-            let branch_id = row.branch_id.clone();
+            let branch_id = row.branch_id.to_string();
             let Some(owner) = PluginFileOwner::from_live_state_row(&row, &branch_id)? else {
                 continue;
             };
@@ -2639,13 +2639,13 @@ fn session_plugin_state_after_changes(
                 snapshot_content: None,
                 metadata: None,
                 deleted: false,
-                created_at: String::new(),
-                updated_at: String::new(),
+                created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+                updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
                 global: false,
                 change_id: None,
                 commit_id: None,
                 untracked: false,
-                branch_id: key.branch_id.clone(),
+                branch_id: key.branch_id.clone().into(),
             });
         row.snapshot_content = Some(snapshot_content);
         row.metadata.clone_from(&change.metadata);
@@ -3303,7 +3303,7 @@ mod tests {
             .expect("untracked row should be visible through live state");
         assert!(live_untracked_row.untracked);
         assert!(live_untracked_row.global);
-        assert_eq!(live_untracked_row.branch_id, GLOBAL_BRANCH_ID);
+        assert_eq!(live_untracked_row.branch_id.as_ref(), GLOBAL_BRANCH_ID);
         assert_eq!(
             live_untracked_row.snapshot_content.as_deref(),
             Some(r#"{"key":"untracked-programmatic","value":"untracked"}"#)
@@ -3383,8 +3383,8 @@ mod tests {
             rows[0].change_id.is_some(),
             "prepared untracked rows must receive a real change id"
         );
-        assert_eq!(rows[0].created_at, "1970-01-01T00:00:00.000Z");
-        assert_eq!(rows[0].updated_at, "2026-04-23T00:00:00.123Z");
+        assert_eq!(rows[0].created_at.to_string(), "1970-01-01T00:00:00.000Z");
+        assert_eq!(rows[0].updated_at.to_string(), "2026-04-23T00:00:00.123Z");
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/schema_resolver.rs
+++ b/packages/engine/src/transaction/schema_resolver.rs
@@ -154,6 +154,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
     use crate::live_state::LiveStateFilter;
 
@@ -285,13 +286,13 @@ mod tests {
             snapshot_content: Some(snapshot_content.to_string()),
             metadata: None,
             deleted: false,
-            created_at: "2026-01-01T00:00:00.000Z".to_string(),
-            updated_at: "2026-01-01T00:00:00.000Z".to_string(),
+            created_at: LixTimestamp::expect_parse("created_at", "2026-01-01T00:00:00.000Z"),
+            updated_at: LixTimestamp::expect_parse("updated_at", "2026-01-01T00:00:00.000Z"),
             global: false,
             change_id: None,
             commit_id: None,
             untracked,
-            branch_id: "main".to_string(),
+            branch_id: "main".into(),
         }
     }
 
@@ -299,7 +300,11 @@ mod tests {
         (request.filter.schema_keys.is_empty()
             || request.filter.schema_keys.contains(&row.schema_key))
             && (request.filter.branch_ids.is_empty()
-                || request.filter.branch_ids.contains(&row.branch_id))
+                || request
+                    .filter
+                    .branch_ids
+                    .iter()
+                    .any(|branch_id| branch_id == row.branch_id.as_ref()))
             && request
                 .filter
                 .untracked

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -1185,7 +1185,7 @@ impl From<&MaterializedLiveStateRow> for PreparedStateRowIdentity {
             schema_key: row.schema_key.clone(),
             entity_pk: row.entity_pk.clone(),
             file_id: row.file_id.clone(),
-            branch_id: row.branch_id.clone(),
+            branch_id: row.branch_id.to_string(),
         }
     }
 }
@@ -2294,7 +2294,7 @@ mod tests {
         assert_eq!(
             rows.iter()
                 .filter(|row| row.entity_pk == EntityPk::single("shared-entity")
-                    && row.branch_id == "global"
+                    && row.branch_id.as_ref() == "global"
                     && row.schema_key == "lix_key_value"
                     && row.file_id.is_none())
                 .count(),

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -384,13 +384,13 @@ impl From<PreparedStateRow> for MaterializedLiveStateRow {
             snapshot_content: row.snapshot.map(|snapshot| snapshot.materialize()),
             metadata: row.metadata.map(|metadata| metadata.materialize()),
             deleted,
-            created_at: row.created_at.to_string(),
-            updated_at: row.updated_at.to_string(),
+            created_at: row.created_at,
+            updated_at: row.updated_at,
             global: row.global,
             change_id: row.change_id,
             commit_id: row.commit_id,
             untracked: row.untracked,
-            branch_id: row.branch_id,
+            branch_id: row.branch_id.into(),
         }
     }
 }
@@ -404,13 +404,13 @@ impl From<&PreparedStateRow> for MaterializedLiveStateRow {
             snapshot_content: row.snapshot.as_ref().map(StageJson::materialize),
             metadata: row.metadata.as_ref().map(StageJson::materialize),
             deleted: row.snapshot.is_none(),
-            created_at: row.created_at.to_string(),
-            updated_at: row.updated_at.to_string(),
+            created_at: row.created_at,
+            updated_at: row.updated_at,
             global: row.global,
             change_id: row.change_id,
             commit_id: row.commit_id,
             untracked: row.untracked,
-            branch_id: row.branch_id.clone(),
+            branch_id: row.branch_id.clone().into(),
         }
     }
 }

--- a/packages/engine/src/transaction/validation.rs
+++ b/packages/engine/src/transaction/validation.rs
@@ -3330,7 +3330,7 @@ mod tests {
                 .chain(test_file_descriptor_rows())
                 .find(|row| {
                     row.schema_key == request.schema_key
-                        && row.branch_id == request.branch_id
+                        && row.branch_id.as_ref() == request.branch_id
                         && row.entity_pk == request.entity_pk
                         && request.file_id.matches(row.file_id.as_ref())
                 }))
@@ -4926,7 +4926,7 @@ mod tests {
             ..empty_staged_write_set()
         };
         let mut projected_overlay_row = committed_unique_row("post-1", "hello-world", "first");
-        projected_overlay_row.branch_id = "branch-a".to_string();
+        projected_overlay_row.branch_id = "branch-a".into();
         projected_overlay_row.global = true;
         let live_state = StaticLiveStateReader {
             rows: vec![projected_overlay_row],
@@ -6406,7 +6406,11 @@ mod tests {
         (request.filter.schema_keys.is_empty()
             || request.filter.schema_keys.contains(&row.schema_key))
             && (request.filter.branch_ids.is_empty()
-                || request.filter.branch_ids.contains(&row.branch_id))
+                || request
+                    .filter
+                    .branch_ids
+                    .iter()
+                    .any(|branch_id| branch_id == row.branch_id.as_ref()))
             && (request.filter.file_ids.is_empty()
                 || request
                     .filter
@@ -6420,7 +6424,7 @@ mod tests {
         request: &LiveStateRowRequest,
     ) -> bool {
         row.schema_key == request.schema_key
-            && row.branch_id == request.branch_id
+            && row.branch_id.as_ref() == request.branch_id
             && row.entity_pk == request.entity_pk
             && request.file_id.matches(row.file_id.as_ref())
     }
@@ -6795,13 +6799,13 @@ mod tests {
             snapshot_content: row.snapshot.as_ref().map(|snapshot| snapshot.materialize()),
             metadata: row.metadata.as_ref().map(|metadata| metadata.materialize()),
             deleted: row.snapshot.is_none(),
-            created_at: row.created_at.to_string(),
-            updated_at: row.updated_at.to_string(),
+            created_at: row.created_at,
+            updated_at: row.updated_at,
             global: row.global,
             change_id: row.change_id,
             commit_id: row.commit_id,
             untracked: row.untracked,
-            branch_id: row.branch_id,
+            branch_id: row.branch_id.into(),
         }
     }
 


### PR DESCRIPTION
## Summary

- keep tracked-head timestamps as packed `LixTimestamp` values until a SQL/export boundary
- share the branch ID allocation across every row from one head scan with `Arc<str>`
- make conversions at filesystem, plugin, SQL, and persistence boundaries explicit

## Why

The direct RocksDB head scan was still formatting both timestamps and cloning the same branch string for every materialized row. Those allocations dominated after the decoder/key fast paths, while RocksDB scanning itself was comparatively small.

## Performance

On the 10k tracked transaction `read_all` hot loop, the parent key-fast-path measured about **8.5–8.8 ms/op**. This change measures **6.39–6.74 ms/op** (median **6.43 ms/op**): roughly a **22%** improvement. The standalone SQLite companion fixture measured **1.51 ms** median, so this is an intermediate stack member rather than the 3× target.

## Validation

- `cargo fmt --all --check`
- `cargo test -p lix_engine --lib` (1,172 passed)
- `cargo clippy -p lix_engine --all-targets --all-features -- -D warnings`
