### PR TITLE
perf: bypass local sidecar scans in tracked commits

### DIFF
--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -269,6 +269,7 @@ where
 {
     let read =
         SharedStorageAdapterRead::new(storage.begin_read(StorageReadOptions::default()).await?);
+    let protocol_read = read.clone();
     let reader = live_state.reader(read);
     let initialized = reader
         .load_row(&LiveStateRowRequest {
@@ -281,7 +282,7 @@ where
         .is_some();
 
     if initialized {
-        return Ok(());
+        return crate::init::assert_repository_protocol(&protocol_read).await;
     }
 
     Err(LixError::new(
@@ -408,5 +409,28 @@ mod tests {
             value,
             Some(StorageProjectedValue::FullValue(predecessor_value))
         );
+    }
+
+    #[tokio::test]
+    async fn initialized_repository_without_protocol_gate_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.delete(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("protocol marker deletion should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("initialized pre-protocol storage must fail closed");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
     }
 }

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -16,16 +16,63 @@ use crate::live_state::{LiveStateIndexContext, LiveStateIndexDeltaRef};
 use crate::schema::{
     registered_schema_entity_pk, schema_key_from_definition, seed_schema_definitions,
 };
-use crate::storage_adapter::SharedStorageAdapterRead;
 use crate::storage_adapter::Storage;
-use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
+use crate::storage_adapter::{PointReadPlan, SharedStorageAdapterRead, StorageAdapterRead};
+use crate::storage_adapter::{
+    StorageAdapter, StorageGetOptions, StorageKey, StorageProjectedValue, StorageSpace,
+    StorageSpaceId, StorageWriteSet,
+};
 use crate::tracked_state::{TrackedStateContext, TrackedStateDeltaRef};
+use bytes::Bytes;
 use serde_json::json;
 
 const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 const LIX_ID_KEY: &str = "lix_id";
 const WORKSPACE_BRANCH_KEY: &str = "lix_workspace_branch_id";
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
+
+/// Repository-wide compatibility gate for physical storage protocols.
+///
+/// The local-sidecar marker changes the meaning of an absent key: it is proof
+/// that a branch has never used the local lane. That proof is only sound for
+/// repositories initialized with this protocol, so opening an earlier store
+/// must fail closed rather than silently shadow tracked state with old flat
+/// rows.
+pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
+pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"local-sidecar.v1";
+
+pub(crate) fn stage_repository_protocol(writes: &mut StorageWriteSet) {
+    writes.put(
+        REPOSITORY_PROTOCOL_SPACE,
+        REPOSITORY_PROTOCOL_KEY,
+        REPOSITORY_PROTOCOL_VALUE,
+    );
+}
+
+pub(crate) async fn assert_repository_protocol(
+    read: &(impl StorageAdapterRead + ?Sized),
+) -> Result<(), LixError> {
+    let values = PointReadPlan::new(
+        REPOSITORY_PROTOCOL_SPACE,
+        &[StorageKey(Bytes::from_static(REPOSITORY_PROTOCOL_KEY))],
+    )
+    .materialize(read, StorageGetOptions::default())
+    .await?;
+    let supported = matches!(
+        values.value.into_iter().next().flatten(),
+        Some(StorageProjectedValue::FullValue(value))
+            if value.as_ref() == REPOSITORY_PROTOCOL_VALUE
+    );
+    if supported {
+        return Ok(());
+    }
+    Err(LixError::new(
+        "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT",
+        "repository uses an unsupported local-sidecar storage protocol; recreate the repository",
+    ))
+}
 
 /// Pure seed plan for initializing an engine repository.
 ///
@@ -270,6 +317,7 @@ where
             .await?;
     }
     crate::catalog::stage_catalog_revision(&mut writes);
+    stage_repository_protocol(&mut writes);
 
     storage
         .commit_write_set(
@@ -333,7 +381,7 @@ fn stage_init_json_payloads(
 }
 
 async fn stage_init_changelog_commit(
-    read: &mut impl crate::storage_adapter::StorageAdapterRead,
+    read: &mut impl StorageAdapterRead,
     writes: &mut StorageWriteSet,
     plan: &InitSeedPlan,
     changes: Vec<ChangeRecord>,

--- a/packages/engine/src/live_state/index/mod.rs
+++ b/packages/engine/src/live_state/index/mod.rs
@@ -6,7 +6,9 @@ mod types;
 pub(crate) use context::{LiveStateIndexContext, LiveStateIndexStoreReader, LiveStateIndexWriter};
 #[allow(unused_imports)]
 pub(crate) use storage::{
-    LIVE_STATE_INDEX_ROW_SPACE, branch_empty_precondition, row_absent_precondition,
+    LIVE_STATE_INDEX_ROW_SPACE, LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE, branch_empty_precondition,
+    load_local_sidecar_branch_token, local_sidecar_branch_precondition, row_absent_precondition,
+    stage_local_sidecar_branch_marker,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/engine/src/live_state/index/storage.rs
+++ b/packages/engine/src/live_state/index/storage.rs
@@ -17,6 +17,21 @@ pub(crate) const LIVE_STATE_INDEX_ROW_NAMESPACE: &str = "live_state.flat_row.v1"
 pub(crate) const LIVE_STATE_INDEX_ROW_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0006), LIVE_STATE_INDEX_ROW_NAMESPACE);
 
+/// A revision token for branch-local mutable sidecars.
+///
+/// Normal tracked branches have an independent durable serving projection. A
+/// token lets their hot commit path prove both that no branch-local sidecar
+/// exists and that one did not change after validation, without opening a
+/// flat-row prefix iterator. Once a branch has used the untracked lane, its
+/// rare tracked promotion path is no longer the normal fast path, even after
+/// its flat rows are later cleaned up or the branch id is reused.
+pub(crate) const LIVE_STATE_LOCAL_SIDECAR_BRANCH_NAMESPACE: &str =
+    "live_state.local_sidecar_branch.v1";
+pub(crate) const LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE: StorageSpace = StorageSpace::new(
+    StorageSpaceId(0x0004_000f),
+    LIVE_STATE_LOCAL_SIDECAR_BRANCH_NAMESPACE,
+);
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(super) struct FlatIdentity {
@@ -48,6 +63,12 @@ pub(super) struct FlatValue {
 #[derive(musli::Encode)]
 #[musli(packed)]
 struct BranchPrefixRef<'a> {
+    branch_id: &'a str,
+}
+
+#[derive(musli::Encode)]
+#[musli(packed)]
+struct SidecarBranchRef<'a> {
     branch_id: &'a str,
 }
 
@@ -308,6 +329,10 @@ fn encode_key(identity: &FlatIdentity) -> Result<Vec<u8>, LixError> {
     storage_codec::encode("flat live-state key", &identity.as_ref())
 }
 
+fn sidecar_branch_key(branch_id: &str) -> Result<Vec<u8>, LixError> {
+    storage_codec::encode("local-sidecar branch key", &SidecarBranchRef { branch_id })
+}
+
 pub(crate) fn branch_empty_precondition(branch_id: &str) -> Result<StoragePrecondition, LixError> {
     let prefix = storage_codec::encode(
         "flat live-state branch prefix",
@@ -319,6 +344,74 @@ pub(crate) fn branch_empty_precondition(branch_id: &str) -> Result<StoragePrecon
             bytes: Bytes::from(prefix),
         }
         .to_range()?,
+    })
+}
+
+/// Rotates the revision token for a non-global mutable sidecar write.
+///
+/// The token is independently generated, rather than reusing an input change
+/// id, so caller-supplied idempotency keys cannot cause an ABA-style false
+/// match. Repeated writes in one transaction use one token per branch, while
+/// a later local transaction necessarily changes the durable value observed by
+/// a concurrent tracked transaction.
+pub(crate) fn stage_local_sidecar_branch_marker(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+) -> Result<(), LixError> {
+    writes.put(
+        LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE,
+        StorageKey(Bytes::from(sidecar_branch_key(branch_id)?)),
+        StorageValue {
+            bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
+        },
+    );
+    Ok(())
+}
+
+/// Returns the branch-local sidecar revision token, when one exists.
+///
+/// This is an exact-key probe, deliberately replacing the historical
+/// branch-wide flat-row scan on normal tracked commits. A present token sends
+/// the rare mixed branch through the existing promotion path and becomes a
+/// compare-and-swap guard for the tracked commit.
+pub(crate) async fn load_local_sidecar_branch_token(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+) -> Result<Option<Bytes>, LixError> {
+    let result = PointReadPlan::new(
+        LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE,
+        &[StorageKey(Bytes::from(sidecar_branch_key(branch_id)?))],
+    )
+    .materialize(store, StorageGetOptions::default())
+    .await?;
+    match result.value.into_iter().next().flatten() {
+        None => Ok(None),
+        Some(StorageProjectedValue::FullValue(value)) => Ok(Some(value)),
+        Some(StorageProjectedValue::KeyOnly) => Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "local-sidecar token read unexpectedly omitted its value",
+        )),
+    }
+}
+
+/// Atomically proves the local-sidecar state observed during tracked commit
+/// staging. This exact-key CAS replaces an empty-prefix scan on every normal
+/// tracked commit and rejects a local write that lands after validation.
+pub(crate) fn local_sidecar_branch_precondition(
+    branch_id: &str,
+    expected: Option<Bytes>,
+) -> Result<StoragePrecondition, LixError> {
+    let key = StorageKey(Bytes::from(sidecar_branch_key(branch_id)?));
+    Ok(match expected {
+        None => StoragePrecondition::KeyAbsent {
+            space: LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE.id,
+            key,
+        },
+        Some(expected) => StoragePrecondition::KeyValueEquals {
+            space: LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE.id,
+            key,
+            expected,
+        },
     })
 }
 

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -9,10 +9,11 @@ pub(crate) mod visibility;
 pub(crate) use context::{LiveStateContext, LiveStateStoreReader};
 #[allow(unused_imports)]
 pub(crate) use index::{
-    LIVE_STATE_INDEX_ROW_SPACE, LiveStateIndexContext, LiveStateIndexDeltaRef,
-    LiveStateIndexFilter, LiveStateIndexRow, LiveStateIndexRowRequest, LiveStateIndexScanRequest,
-    LiveStateIndexStoreReader, LiveStateIndexWriter, MaterializedLiveStateIndexRow,
-    branch_empty_precondition, row_absent_precondition,
+    LIVE_STATE_INDEX_ROW_SPACE, LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE, LiveStateIndexContext,
+    LiveStateIndexDeltaRef, LiveStateIndexFilter, LiveStateIndexRow, LiveStateIndexRowRequest,
+    LiveStateIndexScanRequest, LiveStateIndexStoreReader, LiveStateIndexWriter,
+    MaterializedLiveStateIndexRow, branch_empty_precondition, load_local_sidecar_branch_token,
+    local_sidecar_branch_precondition, row_absent_precondition, stage_local_sidecar_branch_marker,
 };
 #[allow(unused_imports)]
 pub(crate) use reader::LiveStateReader;

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -309,15 +309,18 @@ where
         Ok(Some(output))
     }
 
-    pub(crate) async fn is_current(
+    /// Returns the durable serving generation exactly when the marker is
+    /// bound to `expected_head`. Commit staging passes this value directly to
+    /// the writer so a serial child needs one marker point read, not two.
+    pub(crate) async fn generation_if_current(
         &self,
         branch_id: &str,
         expected_head: &str,
-    ) -> Result<bool, LixError> {
+    ) -> Result<Option<CommitId>, LixError> {
         Ok(self
             .marker_if_current(branch_id, expected_head)
             .await?
-            .is_some())
+            .map(|marker| marker.generation))
     }
 
     async fn marker_if_current(
@@ -348,24 +351,40 @@ where
     pub(crate) async fn stage_commit(
         &mut self,
         branch_id: &str,
-        parent_head: Option<CommitId>,
+        parent_generation: Option<CommitId>,
         new_head: CommitId,
         deltas: &[TrackedHeadDeltaRef<'_>],
         absence_guards: &BTreeSet<TrackedStateKey>,
         parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
     ) -> Result<(), LixError> {
-        let marker = load_marker(self.store, branch_id).await?;
-        let matches_parent = marker.as_ref().is_some_and(|marker| {
-            parent_head.is_some_and(|parent| marker.head_commit_id == parent)
-        });
-        let generation = if matches_parent {
-            marker
-                .as_ref()
-                .expect("matching tracked-head marker exists")
-                .generation
-        } else {
-            new_head
-        };
+        let matches_parent = parent_generation.is_some();
+        let generation = parent_generation.unwrap_or(new_head);
+
+        if matches_parent
+            && absence_guards.is_empty()
+            && let [delta] = deltas
+        {
+            let identity = delta.identity(branch_id, generation);
+            let prior_created_at = load_entry_bytes(self.store, std::slice::from_ref(&identity))
+                .await?
+                .into_iter()
+                .next()
+                .flatten()
+                .map(|value| decode_head_created_at(&value))
+                .transpose()?
+                .unwrap_or(delta.created_at);
+            stage_put_ref(self.writes, &identity, &delta.value_ref(prior_created_at))?;
+            stage_marker(
+                self.writes,
+                branch_id,
+                &TrackedHeadMarker {
+                    head_commit_id: new_head,
+                    generation,
+                },
+            )?;
+            return Ok(());
+        }
+
         let delta_identities = deltas
             .iter()
             .map(|delta| delta.identity(branch_id, generation))
@@ -1095,6 +1114,42 @@ fn full_value_bytes(value: StorageProjectedValue) -> Result<Bytes, LixError> {
         ));
     };
     Ok(bytes)
+}
+
+/// Decodes only the invariant needed by a serial point update. The writer
+/// preserves a row's first `created_at`, but does not need to allocate or
+/// validate its JSON payloads just to do that.
+fn decode_head_created_at(bytes: &[u8]) -> Result<LixTimestamp, LixError> {
+    if bytes.len() < HEAD_VALUE_HEADER_BYTES {
+        return Err(head_value_error("row is shorter than the v3 fixed header"));
+    }
+    if bytes[0] != HEAD_VALUE_VERSION {
+        return Err(head_value_error(&format!(
+            "unsupported row format version {}",
+            bytes[0]
+        )));
+    }
+    let flags = bytes[1];
+    if flags & !HEAD_VALUE_ALLOWED_FLAGS != 0 {
+        return Err(head_value_error("row has unknown v3 flag bits"));
+    }
+    let snapshot_len = usize::try_from(read_u32(&bytes[50..54], "snapshot length")?)
+        .map_err(|_| head_value_error("snapshot length exceeds usize"))?;
+    let metadata_len = usize::try_from(read_u32(&bytes[54..58], "metadata length")?)
+        .map_err(|_| head_value_error("metadata length exceeds usize"))?;
+    let payload_len = snapshot_len
+        .checked_add(metadata_len)
+        .ok_or_else(|| head_value_error("row payload length overflow"))?;
+    let expected_len = HEAD_VALUE_HEADER_BYTES
+        .checked_add(payload_len)
+        .ok_or_else(|| head_value_error("row payload length overflow"))?;
+    if expected_len != bytes.len() {
+        return Err(head_value_error(
+            "row payload lengths do not match the buffer",
+        ));
+    }
+    LixTimestamp::from_packed(read_u64(&bytes[34..42], "created_at")?)
+        .map_err(|error| head_value_error(&format!("invalid created_at: {error}")))
 }
 
 fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
@@ -1834,6 +1889,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incremental_singleton_insert_rejects_existing_live_row() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_id = "branch";
+        let generation = CommitId::for_test_label("first-head");
+        let second_head = CommitId::for_test_label("second-head");
+        let entity_pk = EntityPk::single("row");
+        let identity = identity(branch_id, generation, "row");
+
+        let mut writes = StorageWriteSet::new();
+        stage_put(
+            &mut writes,
+            &identity,
+            &head_value("first-change", generation),
+        )
+        .expect("stage existing live row");
+        stage_marker(
+            &mut writes,
+            branch_id,
+            &TrackedHeadMarker {
+                head_commit_id: generation,
+                generation,
+            },
+        )
+        .expect("stage existing head marker");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("commit existing head");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open singleton insert read");
+        let mut writes = StorageWriteSet::new();
+        let absence_guards = BTreeSet::from([TrackedStateKey {
+            schema_key: "schema".to_string(),
+            entity_pk: entity_pk.clone(),
+            file_id: None,
+        }]);
+        let error = TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_commit(
+                branch_id,
+                Some(generation),
+                second_head,
+                &[TrackedHeadDeltaRef {
+                    schema_key: "schema",
+                    file_id: None,
+                    entity_pk: &entity_pk,
+                    change_id: ChangeId::for_test_label("second-change"),
+                    commit_id: second_head,
+                    deleted: false,
+                    created_at: ts("2026-01-02T00:00:00Z"),
+                    updated_at: ts("2026-01-02T00:00:00Z"),
+                    snapshot: JsonSlotRef::Inline("{\"value\":2}"),
+                    metadata: JsonSlotRef::None,
+                }],
+                &absence_guards,
+                None,
+            )
+            .await
+            .expect_err("singleton INSERT must reject an existing live row");
+        assert_eq!(error.code, LixError::CODE_UNIQUE);
+    }
+
+    #[tokio::test]
     async fn bootstrap_overlays_parent_identity_without_duplicate_write() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";
@@ -1861,7 +1982,7 @@ mod tests {
             .writer(&read, &mut writes)
             .stage_commit(
                 branch_id,
-                Some(parent_head),
+                None,
                 child_head,
                 &[TrackedHeadDeltaRef {
                     schema_key: "schema",

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -170,7 +170,9 @@ where
 
 fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
     &[
+        crate::init::REPOSITORY_PROTOCOL_SPACE,
         crate::live_state::LIVE_STATE_INDEX_ROW_SPACE,
+        crate::live_state::LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE,
         crate::live_state::TRACKED_HEAD_ROW_SPACE,
         crate::live_state::TRACKED_HEAD_MARKER_SPACE,
         crate::json_store::store::JSON_SPACE,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -567,8 +567,12 @@ mod tests {
         CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_CHANGE_REF_CHUNK_SPACE, COMMIT_SPACE, CommitId,
     };
     use crate::gc::{CHECKPOINT_GC_STATE_SPACE, CHECKPOINT_RECOVERY_REF_SPACE};
+    use crate::init::REPOSITORY_PROTOCOL_SPACE;
     use crate::json_store::store::JSON_SPACE;
-    use crate::live_state::LIVE_STATE_INDEX_ROW_SPACE;
+    use crate::live_state::{
+        LIVE_STATE_INDEX_ROW_SPACE, LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE,
+        TRACKED_HEAD_MARKER_SPACE, TRACKED_HEAD_ROW_SPACE,
+    };
     use crate::tracked_state::types::{
         TrackedStateCommitRoot, TrackedStateCommitRootParent, TrackedStateRootId,
     };
@@ -582,7 +586,11 @@ mod tests {
     #[test]
     fn native_storage_space_ids_are_unique_across_owner_layouts() {
         let spaces = [
+            REPOSITORY_PROTOCOL_SPACE,
             LIVE_STATE_INDEX_ROW_SPACE,
+            LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE,
+            TRACKED_HEAD_ROW_SPACE,
+            TRACKED_HEAD_MARKER_SPACE,
             JSON_SPACE,
             TRACKED_STATE_TREE_CHUNK_SPACE,
             TRACKED_STATE_COMMIT_ROOT_SPACE,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -4,6 +4,8 @@
     clippy::unnecessary_wraps
 )]
 
+use bytes::Bytes;
+
 use crate::LixError;
 use crate::binary_cas::BinaryCasContext;
 use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader};
@@ -21,7 +23,8 @@ use crate::json_store::{JsonStoreContext, JsonWritePlacementRef, NormalizedJsonR
 use crate::live_state::{
     LiveStateIndexContext, LiveStateIndexDeltaRef, LiveStateIndexFilter, LiveStateIndexRowRequest,
     LiveStateIndexScanRequest, TrackedHeadContext, TrackedHeadDeltaRef, branch_empty_precondition,
-    row_absent_precondition,
+    load_local_sidecar_branch_token, local_sidecar_branch_precondition, row_absent_precondition,
+    stage_local_sidecar_branch_marker,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{
@@ -556,16 +559,25 @@ async fn stage_flat_current_rows(
     preconditions: &mut Vec<StoragePrecondition>,
 ) -> Result<Vec<ChangeId>, LixError> {
     let index_reader = current.reader(read);
+    let mut branch_ref_sidecar_tokens = BTreeMap::<String, Option<Bytes>>::new();
     for row in state_rows
         .iter()
         .filter(|row| row.untracked && row.schema_key == BRANCH_REF_SCHEMA_KEY)
     {
         let branch_id = row.entity_pk.as_single_string_owned()?;
         let Some(snapshot) = row.snapshot.as_ref() else {
-            if load_current_branch_ref_commit_id(&index_reader, &branch_id)
-                .await?
-                .is_some()
-                && branch_has_local_untracked_rows(&index_reader, &branch_id).await?
+            let existing_commit_id =
+                load_current_branch_ref_commit_id(&index_reader, &branch_id).await?;
+            if existing_commit_id.is_some()
+                && (has_pending_local_sidecar_rows(state_rows, &branch_id)
+                    || guarded_branch_ref_has_local_untracked_rows(
+                        &index_reader,
+                        read,
+                        &branch_id,
+                        &mut branch_ref_sidecar_tokens,
+                        preconditions,
+                    )
+                    .await?)
             {
                 return Err(branch_ref_with_untracked_rows_error(&branch_id, true));
             }
@@ -586,11 +598,31 @@ async fn stage_flat_current_rows(
             continue;
         }
         if existing_commit_id.is_some()
-            && branch_has_local_untracked_rows(&index_reader, &branch_id).await?
+            && (has_pending_local_sidecar_rows(state_rows, &branch_id)
+                || guarded_branch_ref_has_local_untracked_rows(
+                    &index_reader,
+                    read,
+                    &branch_id,
+                    &mut branch_ref_sidecar_tokens,
+                    preconditions,
+                )
+                .await?)
         {
             return Err(branch_ref_with_untracked_rows_error(&branch_id, false));
         }
         ensure_branch_ref_target_exists(read, commit_id).await?;
+    }
+
+    let local_sidecar_branch_ids = state_rows
+        .iter()
+        .filter(|row| row.untracked && row.branch_id != crate::GLOBAL_BRANCH_ID)
+        .map(|row| row.branch_id.as_str())
+        .collect::<BTreeSet<_>>();
+    for branch_id in &local_sidecar_branch_ids {
+        // The token is rotated by every local mutation. A concurrent tracked
+        // write compares the exact value it observed, so it retries rather
+        // than publishing validation against stale sidecar state.
+        stage_local_sidecar_branch_marker(writes, branch_id)?;
     }
 
     let branch_ids = state_rows
@@ -636,10 +668,25 @@ async fn stage_flat_current_rows(
         }
 
         // Tracked rows are served from the durable tracked-head projection.
-        // On the normal path the branch has no untracked sidecar rows, so a
-        // single range-empty precondition proves there is no durability
-        // collision. Do not construct one mutable-index delta per tracked row
-        // only for the writer to discard it.
+        // A branch-local mutable sidecar is explicitly marked when it is
+        // first used. Normal tracked commits therefore need one exact-key
+        // precondition, rather than opening a flat-index prefix iterator on
+        // every write. Global state intentionally keeps the legacy promotion
+        // lane: global untracked rows include engine configuration alongside
+        // tracked state and are not a branch-local sidecar.
+        if *branch_id != crate::GLOBAL_BRANCH_ID {
+            let sidecar_token = load_local_sidecar_branch_token(read, branch_id).await?;
+            let sidecar_is_absent = sidecar_token.is_none();
+            preconditions.push(local_sidecar_branch_precondition(branch_id, sidecar_token)?);
+            if sidecar_is_absent {
+                if !new_deltas.is_empty() {
+                    compactable_change_ids
+                        .extend(writer.stage_branch_rows(branch_id, new_deltas).await?);
+                }
+                continue;
+            }
+        }
+
         if !branch_has_local_untracked_rows(&index_reader, branch_id).await? {
             if has_tracked_insert {
                 preconditions.push(branch_empty_precondition(branch_id)?);
@@ -781,6 +828,39 @@ where
         })
         .await?
         .is_empty())
+}
+
+/// Branch-ref deletion and repointing inspect the sidecar before its pending
+/// rows are staged. Reject a same-transaction collision explicitly rather
+/// than allowing the later flat-index write to invalidate that safety check.
+fn has_pending_local_sidecar_rows(state_rows: &[PreparedStateRow], branch_id: &str) -> bool {
+    branch_id != crate::GLOBAL_BRANCH_ID
+        && state_rows
+            .iter()
+            .any(|row| row.untracked && row.branch_id == branch_id)
+}
+
+/// Reads the branch-local sidecar under the same snapshot as a branch-ref
+/// safety scan and carries its exact revision into the final write. A ref
+/// delete or repoint must retry if a local row appears after that scan.
+async fn guarded_branch_ref_has_local_untracked_rows<S, R>(
+    reader: &crate::live_state::LiveStateIndexStoreReader<S>,
+    read: &R,
+    branch_id: &str,
+    observed_tokens: &mut BTreeMap<String, Option<Bytes>>,
+    preconditions: &mut Vec<StoragePrecondition>,
+) -> Result<bool, LixError>
+where
+    S: StorageAdapterRead,
+    R: StorageAdapterRead + ?Sized,
+{
+    let has_local_rows = branch_has_local_untracked_rows(reader, branch_id).await?;
+    if branch_id != crate::GLOBAL_BRANCH_ID && !observed_tokens.contains_key(branch_id) {
+        let token = load_local_sidecar_branch_token(read, branch_id).await?;
+        preconditions.push(local_sidecar_branch_precondition(branch_id, token.clone())?);
+        observed_tokens.insert(branch_id.to_string(), token);
+    }
+    Ok(has_local_rows)
 }
 
 fn branch_ref_with_untracked_rows_error(branch_id: &str, deletion: bool) -> LixError {
@@ -1009,15 +1089,16 @@ async fn stage_tracked_head(
         // The v4 marker is the durable authority for current state. It is
         // intentionally bound only to the first-parent commit: serial normal
         // commits can append deltas without materializing an immutable root.
-        let parent_is_current = match root.parent_commit_id {
+        let parent_generation = match root.parent_commit_id {
             Some(parent_commit_id) => {
                 tracked_head
                     .reader(read)
-                    .is_current(&root.branch_id, &parent_commit_id.to_string())
+                    .generation_if_current(&root.branch_id, &parent_commit_id.to_string())
                     .await?
             }
-            None => false,
+            None => None,
         };
+        let parent_is_current = parent_generation.is_some();
         let parent_rows = if parent_is_current || root.parent_commit_id.is_none() {
             None
         } else if let Some(parent_commit_id) = root.parent_commit_id {
@@ -1053,7 +1134,7 @@ async fn stage_tracked_head(
         writer
             .stage_commit(
                 &root.branch_id,
-                root.parent_commit_id,
+                parent_generation,
                 root.commit_id,
                 &deltas,
                 &absence_guards,
@@ -1499,8 +1580,10 @@ mod tests {
     #[derive(Default)]
     struct TrackedHeadReadCounts {
         marker_get_many_calls: AtomicUsize,
+        sidecar_marker_get_many_calls: AtomicUsize,
         row_get_many_calls: AtomicUsize,
         row_scan_calls: AtomicUsize,
+        flat_index_scan_calls: AtomicUsize,
         tree_chunk_get_many_calls: AtomicUsize,
         tree_chunk_scan_calls: AtomicUsize,
         commit_root_get_many_calls: AtomicUsize,
@@ -1522,6 +1605,11 @@ mod tests {
             if space == crate::live_state::TRACKED_HEAD_MARKER_SPACE.id {
                 self.counts
                     .marker_get_many_calls
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if space == crate::live_state::LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE.id {
+                self.counts
+                    .sidecar_marker_get_many_calls
                     .fetch_add(1, Ordering::Relaxed);
             }
             if space == crate::live_state::TRACKED_HEAD_ROW_SPACE.id {
@@ -1550,6 +1638,11 @@ mod tests {
         ) -> Result<ScanChunk, StorageError> {
             if space == crate::live_state::TRACKED_HEAD_ROW_SPACE.id {
                 self.counts.row_scan_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            if space == crate::live_state::LIVE_STATE_INDEX_ROW_SPACE.id {
+                self.counts
+                    .flat_index_scan_calls
+                    .fetch_add(1, Ordering::Relaxed);
             }
             if space == TRACKED_STATE_TREE_CHUNK_SPACE_ID {
                 self.counts
@@ -2172,6 +2265,348 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn local_tracked_commit_uses_sidecar_marker_not_flat_index_scan() {
+        let memory = Memory::new();
+        let binary_cas = BinaryCasContext::new();
+        let branch_ctx = BranchContext::new();
+        let counts = Arc::new(TrackedHeadReadCounts::default());
+        let mut read = StorageAdapterReadScope::new(CountingTrackedHeadRead {
+            inner: memory
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("counted commit read should open"),
+            counts: Arc::clone(&counts),
+        });
+
+        let mut row = tracked_branch_row("branch-a", "local-tracked-change");
+        row.commit_id = Some(commit_id("local-tracked-commit"));
+        let (_writes, preconditions) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![row],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["local-tracked-change"],
+                        "local-tracked-commit",
+                        "local-tracked-commit-change",
+                        "local-tracked-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("local tracked commit should stage");
+
+        assert_eq!(
+            counts.flat_index_scan_calls.load(Ordering::Relaxed),
+            0,
+            "normal local tracked staging must not open a flat-sidecar prefix iterator"
+        );
+        assert_eq!(
+            counts.sidecar_marker_get_many_calls.load(Ordering::Relaxed),
+            1,
+            "normal local tracked staging should probe only the sidecar marker"
+        );
+        assert!(preconditions.iter().any(|precondition| {
+            matches!(
+                precondition,
+                StoragePrecondition::KeyAbsent { space, .. }
+                    if *space == crate::live_state::LIVE_STATE_LOCAL_SIDECAR_BRANCH_SPACE.id
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn local_sidecar_write_remains_compatible_with_tracked_head_promotion() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        let binary_cas = BinaryCasContext::new();
+        let branch_ctx = BranchContext::new();
+
+        let mut first_tracked = tracked_branch_row("branch-a", "tracked-first-change");
+        first_tracked.commit_id = Some(commit_id("tracked-first-commit"));
+        let mut first_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("first tracked read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut first_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![first_tracked],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["tracked-first-change"],
+                        "tracked-first-commit",
+                        "tracked-first-commit-change",
+                        "tracked-first-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("first tracked commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("first tracked commit should persist");
+
+        let mut sidecar = tracked_branch_row("branch-a", "sidecar-change");
+        sidecar.untracked = true;
+        sidecar.commit_id = None;
+        let mut sidecar_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("sidecar read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut sidecar_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![sidecar],
+                commit_change_refs_by_branch: BTreeMap::new(),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("local sidecar write should stage after a tracked head");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("local sidecar write should persist after a tracked head");
+        let sidecar_marker_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("sidecar marker read should open");
+        assert!(
+            load_local_sidecar_branch_token(&sidecar_marker_read, "branch-a")
+                .await
+                .expect("sidecar marker should load")
+                .is_some(),
+            "a local sidecar write must durably mark its branch"
+        );
+
+        let counts = Arc::new(TrackedHeadReadCounts::default());
+        let mut second_read = StorageAdapterReadScope::new(CountingTrackedHeadRead {
+            inner: memory
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("second tracked read should open"),
+            counts: Arc::clone(&counts),
+        });
+        let mut second_tracked = tracked_branch_row("branch-a", "tracked-second-change");
+        second_tracked.commit_id = Some(commit_id("tracked-second-commit"));
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut second_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![second_tracked],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["tracked-second-change"],
+                        "tracked-second-commit",
+                        "tracked-second-commit-change",
+                        "tracked-second-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("tracked promotion should stage after a sidecar write");
+        assert!(
+            counts.flat_index_scan_calls.load(Ordering::Relaxed) > 0,
+            "a marked sidecar branch must use the existing promotion path"
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("tracked promotion should persist after a sidecar write");
+
+        let visible = live_state_context()
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("visible read should open"),
+            )
+            .load_row(&LiveStateRowRequest {
+                schema_key: "test_schema".to_string(),
+                branch_id: "branch-a".to_string(),
+                entity_pk: EntityPk::single("entity-1"),
+                file_id: NullableKeyFilter::Null,
+            })
+            .await
+            .expect("tracked promotion should be readable")
+            .expect("tracked row should be visible");
+        assert!(!visible.untracked);
+        assert_eq!(visible.change_id, Some(change_id("tracked-second-change")));
+    }
+
+    #[tokio::test]
+    async fn branch_ref_delete_rejects_pending_local_sidecar_rows() {
+        let storage = StorageAdapter::new(Memory::new());
+        let binary_cas = BinaryCasContext::new();
+        let branch_ctx = BranchContext::new();
+        crate::test_support::seed_branch_head(storage.clone(), "branch-a", "branch-head").await;
+
+        let mut branch_ref_delete = untracked_global_row("delete-branch-ref");
+        branch_ref_delete.entity_pk = EntityPk::single("branch-a");
+        branch_ref_delete.schema_key = BRANCH_REF_SCHEMA_KEY.to_string();
+        branch_ref_delete.snapshot = None;
+
+        let mut pending_local_sidecar = tracked_branch_row("branch-a", "pending-sidecar-row");
+        pending_local_sidecar.untracked = true;
+        pending_local_sidecar.commit_id = None;
+        pending_local_sidecar.global = false;
+
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch-ref delete read should open");
+        let error = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![branch_ref_delete, pending_local_sidecar],
+                commit_change_refs_by_branch: BTreeMap::new(),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect_err("branch-ref delete must reject a pending local sidecar row");
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+    }
+
+    #[tokio::test]
+    async fn serial_local_commit_reads_tracked_head_marker_once() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        let binary_cas = BinaryCasContext::new();
+        let branch_ctx = BranchContext::new();
+
+        let mut first = tracked_branch_row("branch-a", "first-local-change");
+        first.commit_id = Some(commit_id("first-local-commit"));
+        let mut first_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("first commit read should open");
+        let (writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut first_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![first],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["first-local-change"],
+                        "first-local-commit",
+                        "first-local-commit-change",
+                        "first-local-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("first local commit should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("first local commit should persist");
+
+        let counts = Arc::new(TrackedHeadReadCounts::default());
+        let mut second_read = StorageAdapterReadScope::new(CountingTrackedHeadRead {
+            inner: memory
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("second counted read should open"),
+            counts: Arc::clone(&counts),
+        });
+        let mut second = tracked_branch_row("branch-a", "second-local-change");
+        second.commit_id = Some(commit_id("second-local-commit"));
+        let (_writes, _) = commit_prepared_writes(
+            &binary_cas,
+            &branch_ctx,
+            &LiveStateIndexContext::new(),
+            None,
+            &mut second_read,
+            PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![second],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "branch-a".to_string(),
+                    change_refs_with(
+                        ["second-local-change"],
+                        "second-local-commit",
+                        "second-local-commit-change",
+                        "second-local-branch-ref-change",
+                    ),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+        )
+        .await
+        .expect("second local commit should stage");
+
+        assert_eq!(
+            counts.marker_get_many_calls.load(Ordering::Relaxed),
+            1,
+            "serial tracked-head staging must reuse the generation it already read"
+        );
+    }
+
+    #[tokio::test]
     async fn normal_head_projections_preserve_global_fallback_branch_override_and_tombstones() {
         let memory = Memory::new();
         let storage = StorageAdapter::new(memory.clone());
@@ -2263,17 +2698,19 @@ mod tests {
         assert!(
             tracked_head
                 .reader(&marker_read)
-                .is_current(GLOBAL_BRANCH_ID, &commit_id_text("global-head"))
+                .generation_if_current(GLOBAL_BRANCH_ID, &commit_id_text("global-head"))
                 .await
-                .expect("global head marker should load"),
+                .expect("global head marker should load")
+                .is_some(),
             "the global marker must bind its current branch ref"
         );
         assert!(
             tracked_head
                 .reader(&marker_read)
-                .is_current("branch-a", &commit_id_text("branch-head"))
+                .generation_if_current("branch-a", &commit_id_text("branch-head"))
                 .await
-                .expect("branch head marker should load"),
+                .expect("branch head marker should load")
+                .is_some(),
             "the branch marker must bind its current branch ref"
         );
 

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -417,11 +417,27 @@ where
         let tracked_state_changed = prepared_writes.state_rows.iter().any(|row| !row.untracked)
             || !prepared_writes.commit_change_refs_by_branch.is_empty()
             || !prepared_writes.extra_commit_parents_by_branch.is_empty();
+        let has_untracked_state_writes = prepared_writes.state_rows.iter().any(|row| row.untracked);
+        // Untracked rows are a mutable sidecar, but their validation can read
+        // tracked schemas, parents, uniqueness owners, or filesystem state.
+        // Fence that snapshot without rotating the tracked revision: normal
+        // tracked transactions remain independent of sidecar-only commits.
+        let requires_tracked_snapshot_fence = tracked_state_changed || has_untracked_state_writes;
         let catalog_revision_changed = prepared_writes_change_catalog(&prepared_writes);
         let _commit_guard = begin_commit_boundary(commit_boundary.as_ref());
         check_commit_boundary(commit_boundary.as_ref())?;
+        // Validate and materialize from one coherent storage snapshot. The
+        // final write's preconditions then fence every fact validation and
+        // sidecar decision was based on, just like a conventional optimistic
+        // database transaction.
+        let commit_read_storage = transaction.storage.clone();
+        let mut read = SharedStorageAdapterRead::new(
+            commit_read_storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
         transaction
-            .validate_prepared_writes_by_branch(&prepared_writes)
+            .validate_prepared_writes_by_branch(&read, &prepared_writes)
             .instrument(tracing::debug_span!(
                 target: "lix_perf",
                 "lix.perf.transaction_validation"
@@ -447,12 +463,6 @@ where
                 .map(MaterializedLiveStateRow::from)
                 .collect::<Vec<_>>()
         };
-        let mut read = SharedStorageAdapterRead::new(
-            transaction
-                .storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
         let previous_filesystem_revision = if filesystem_delta_rows.is_empty() {
             None
         } else {
@@ -485,7 +495,7 @@ where
         write_options
             .preconditions
             .extend(materialization_preconditions);
-        if tracked_state_changed {
+        if requires_tracked_snapshot_fence {
             write_options.preconditions.push(
                 StorageAdapter::<StorageImpl>::tracked_mutation_revision_precondition(
                     transaction.opening_tracked_mutation_revision.clone(),
@@ -1654,6 +1664,7 @@ where
 
     async fn validate_prepared_writes_by_branch(
         &mut self,
+        read: &(impl StorageAdapterRead + ?Sized),
         prepared_writes: &PreparedWriteSet,
     ) -> Result<(), LixError> {
         if prepared_tracked_rows_have_row_local_certificates(&prepared_writes.state_rows) {
@@ -1669,12 +1680,7 @@ where
             ) {
                 continue;
             }
-            let read = SharedStorageAdapterRead::new(
-                self.storage
-                    .begin_read(StorageReadOptions::default())
-                    .await?,
-            );
-            let live_state = self.live_state.reader(&read);
+            let live_state = self.live_state.reader(read);
             let schema_catalog = self
                 .schema_resolver
                 .catalog_for_validation(&live_state, scope)

--- a/packages/engine/tests/integration/transaction.rs
+++ b/packages/engine/tests/integration/transaction.rs
@@ -3,14 +3,53 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use lix_engine::Engine;
 use lix_engine::storage::{
     CommitResult, GetManyResult, GetOptions, Key, KeyRange, Memory, MemoryRead, MemoryWrite,
     PutBatch, ReadOptions, ScanChunk, ScanOptions, SpaceId, Storage, StorageError, StorageRead,
     StorageWrite, WriteOptions,
 };
+use lix_engine::{CreateBranchOptions, Engine};
 
 const TEST_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
+// Mirrors the private `live_state.local_sidecar_branch.v1` storage space. The
+// integration test deliberately observes this storage-level synchronization
+// point without making it part of the engine's public API.
+const LOCAL_SIDECAR_BRANCH_SPACE: SpaceId = SpaceId(0x0004_000f);
+const SIDECAR_RACE_BRANCH_ID: &str = "sidecar-race";
+
+async fn setup_sidecar_race_branch<StorageImpl>(engine: &Engine<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let setup = engine
+        .open_workspace_session()
+        .await
+        .expect("setup session should open");
+    setup
+        .execute(
+            r#"INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked)
+               VALUES (lix_json('{"x-lix-key":"sidecar_race_parent","x-lix-primary-key":["/id"],"type":"object","properties":{"id":{"type":"string"}},"required":["id"],"additionalProperties":false}'), false, false)"#,
+            &[],
+        )
+        .await
+        .expect("parent schema should register");
+    setup
+        .execute(
+            r#"INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked)
+               VALUES (lix_json('{"x-lix-key":"sidecar_race_child","x-lix-primary-key":["/id"],"x-lix-foreign-keys":[{"properties":["/parent_id"],"references":{"schemaKey":"sidecar_race_parent","properties":["/id"]}}],"type":"object","properties":{"id":{"type":"string"},"parent_id":{"type":"string"}},"required":["id","parent_id"],"additionalProperties":false}'), false, false)"#,
+            &[],
+        )
+        .await
+        .expect("child schema should register");
+    setup
+        .create_branch(CreateBranchOptions {
+            id: Some(SIDECAR_RACE_BRANCH_ID.to_string()),
+            name: "Sidecar race".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("test branch should be created");
+}
 
 #[tokio::test]
 async fn stale_transaction_cannot_publish_over_newer_commit() {
@@ -128,6 +167,175 @@ async fn untracked_sidecar_write_does_not_invalidate_tracked_transaction() {
         .await
         .expect("both durability lanes should remain readable");
     assert_eq!(result.rows().len(), 2);
+}
+
+/// A tracked commit must validate and materialize against one storage snapshot.
+///
+/// The gate stops the tracked delete when it probes the local-sidecar revision.
+/// A second engine then commits an untracked child row. The delete must not
+/// publish using the now-stale validation result, and a fresh retry must see
+/// the child foreign key rather than leaving a dangling reference behind.
+#[tokio::test]
+async fn tracked_commit_retries_when_local_sidecar_changes_after_validation() {
+    let storage = BlockingSidecarReadStorage::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+
+    let setup_engine = Engine::new(storage.clone())
+        .await
+        .expect("initialized storage should create a setup engine");
+    setup_sidecar_race_branch(&setup_engine).await;
+
+    // Separate engine values are deliberate: each engine serializes its own
+    // sessions, while this regression needs to exercise the storage boundary.
+    let tracked_engine = Engine::new(storage.clone())
+        .await
+        .expect("tracked engine should open");
+    let sidecar_engine = Engine::new(storage.clone())
+        .await
+        .expect("sidecar engine should open");
+    let tracked_session = tracked_engine
+        .open_session(SIDECAR_RACE_BRANCH_ID)
+        .await
+        .expect("tracked session should open");
+    let sidecar_session = sidecar_engine
+        .open_session(SIDECAR_RACE_BRANCH_ID)
+        .await
+        .expect("sidecar session should open");
+
+    tracked_session
+        .execute(
+            "INSERT INTO sidecar_race_parent (id) VALUES ('parent-1')",
+            &[],
+        )
+        .await
+        .expect("tracked parent should seed");
+
+    let mut tracked_delete = tracked_session
+        .begin_transaction()
+        .await
+        .expect("tracked delete transaction should begin");
+    tracked_delete
+        .execute("DELETE FROM sidecar_race_parent WHERE id = 'parent-1'", &[])
+        .await
+        .expect("tracked delete should stage");
+
+    let gate = storage.gate();
+    let before_commit = storage.stats();
+    gate.block_next_sidecar_get();
+    let tracked_commit = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move { tracked_delete.commit().await })
+    });
+    gate.wait_until_blocked();
+
+    let while_blocked = storage.stats().delta_since(&before_commit);
+    assert_eq!(
+        while_blocked.read_opened, 1,
+        "validation and materialization must share the one commit snapshot"
+    );
+
+    let sidecar_result = sidecar_session
+        .execute(
+            "INSERT INTO sidecar_race_child (id, parent_id, lixcol_untracked) VALUES ('child-1', 'parent-1', true)",
+            &[],
+        )
+        .await;
+    gate.release();
+    sidecar_result.expect("untracked child should commit while tracked delete is blocked");
+
+    let error = join_thread(tracked_commit, "blocked tracked delete")
+        .expect_err("stale tracked validation must not publish after sidecar mutation");
+    assert_eq!(error.code, "LIX_TRANSACTION_CONFLICT");
+
+    let retry_error = tracked_session
+        .execute("DELETE FROM sidecar_race_parent WHERE id = 'parent-1'", &[])
+        .await
+        .expect_err("fresh delete must observe the committed child foreign key");
+    assert_eq!(retry_error.code, "LIX_ERROR_FOREIGN_KEY");
+}
+
+/// An untracked write may validate a foreign key against tracked state. It must
+/// therefore retry when that tracked state changes before its storage commit.
+#[tokio::test]
+async fn untracked_commit_retries_when_tracked_fk_target_changes_after_validation() {
+    let storage = BlockingCommitStorage::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+
+    let setup_engine = Engine::new(storage.clone())
+        .await
+        .expect("initialized storage should create a setup engine");
+    setup_sidecar_race_branch(&setup_engine).await;
+
+    // Separate engines avoid the per-engine collaboration gate so this test
+    // exercises exactly the storage-level optimistic-concurrency boundary.
+    let tracked_engine = Engine::new(storage.clone())
+        .await
+        .expect("tracked engine should open");
+    let sidecar_engine = Engine::new(storage.clone())
+        .await
+        .expect("sidecar engine should open");
+    let tracked_session = tracked_engine
+        .open_session(SIDECAR_RACE_BRANCH_ID)
+        .await
+        .expect("tracked session should open");
+    let sidecar_session = sidecar_engine
+        .open_session(SIDECAR_RACE_BRANCH_ID)
+        .await
+        .expect("sidecar session should open");
+
+    tracked_session
+        .execute(
+            "INSERT INTO sidecar_race_parent (id) VALUES ('parent-1')",
+            &[],
+        )
+        .await
+        .expect("tracked parent should seed");
+
+    let mut untracked_insert = sidecar_session
+        .begin_transaction()
+        .await
+        .expect("untracked transaction should begin");
+    untracked_insert
+        .execute(
+            "INSERT INTO sidecar_race_child (id, parent_id, lixcol_untracked) VALUES ('child-1', 'parent-1', true)",
+            &[],
+        )
+        .await
+        .expect("untracked child should stage");
+
+    let gate = storage.gate();
+    gate.block_next_write();
+    let untracked_commit = thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        runtime.block_on(async move { untracked_insert.commit().await })
+    });
+    gate.wait_until_blocked();
+
+    let tracked_delete_result = tracked_session
+        .execute("DELETE FROM sidecar_race_parent WHERE id = 'parent-1'", &[])
+        .await;
+    gate.release();
+    tracked_delete_result.expect("tracked delete should commit while untracked write is blocked");
+    let error = join_thread(untracked_commit, "blocked untracked foreign-key insert")
+        .expect_err("untracked write validated against stale tracked state must retry");
+    assert_eq!(error.code, "LIX_TRANSACTION_CONFLICT");
+
+    let retry_error = sidecar_session
+        .execute(
+            "INSERT INTO sidecar_race_child (id, parent_id, lixcol_untracked) VALUES ('child-1', 'parent-1', true)",
+            &[],
+        )
+        .await
+        .expect_err("fresh untracked insert must observe that its tracked FK target was deleted");
+    assert_eq!(retry_error.code, "LIX_ERROR_FOREIGN_KEY");
 }
 
 fn wait_until(description: &str, mut condition: impl FnMut() -> bool) {
@@ -863,6 +1071,12 @@ struct BlockingCommitStorage {
     gate: BlockingBeginWriteGate,
 }
 
+#[derive(Clone)]
+struct BlockingSidecarReadStorage {
+    inner: RecordingStorage,
+    gate: BlockingSidecarReadGate,
+}
+
 impl BlockingBeginWriteStorage {
     fn new() -> Self {
         Self {
@@ -902,6 +1116,23 @@ impl BlockingCommitStorage {
     }
 
     fn gate(&self) -> BlockingBeginWriteGate {
+        self.gate.clone()
+    }
+
+    fn stats(&self) -> TransactionStatsSnapshot {
+        self.inner.stats()
+    }
+}
+
+impl BlockingSidecarReadStorage {
+    fn new() -> Self {
+        Self {
+            inner: RecordingStorage::new(),
+            gate: BlockingSidecarReadGate::new(),
+        }
+    }
+
+    fn gate(&self) -> BlockingSidecarReadGate {
         self.gate.clone()
     }
 
@@ -972,9 +1203,60 @@ impl Storage for BlockingCommitStorage {
     }
 }
 
+impl Storage for BlockingSidecarReadStorage {
+    type Read<'a>
+        = BlockingSidecarRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = RecordingWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        Ok(BlockingSidecarRead {
+            inner: self.inner.begin_read(opts).await?,
+            gate: self.gate.clone(),
+        })
+    }
+
+    async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(opts).await
+    }
+}
+
 struct BlockingCommitWrite {
     inner: RecordingWrite,
     gate: BlockingBeginWriteGate,
+}
+
+struct BlockingSidecarRead {
+    inner: RecordingRead,
+    gate: BlockingSidecarReadGate,
+}
+
+impl StorageRead for BlockingSidecarRead {
+    async fn get_many(
+        &self,
+        space: SpaceId,
+        keys: &[Key],
+        opts: GetOptions,
+    ) -> Result<GetManyResult, StorageError> {
+        if space == LOCAL_SIDECAR_BRANCH_SPACE {
+            self.gate.maybe_block();
+        }
+        self.inner.get_many(space, keys, opts).await
+    }
+
+    async fn scan(
+        &self,
+        space: SpaceId,
+        range: KeyRange,
+        opts: ScanOptions,
+    ) -> Result<ScanChunk, StorageError> {
+        self.inner.scan(space, range, opts).await
+    }
 }
 
 impl StorageWrite for BlockingCommitWrite {
@@ -1078,6 +1360,100 @@ impl BlockingBeginWriteGate {
 
 #[derive(Default)]
 struct BlockingBeginWriteState {
+    block_next: bool,
+    blocked: bool,
+    released: bool,
+}
+
+#[derive(Clone)]
+struct BlockingSidecarReadGate {
+    state: Arc<(Mutex<BlockingSidecarReadState>, Condvar)>,
+}
+
+impl BlockingSidecarReadGate {
+    fn new() -> Self {
+        Self {
+            state: Arc::new((
+                Mutex::new(BlockingSidecarReadState::default()),
+                Condvar::new(),
+            )),
+        }
+    }
+
+    fn block_next_sidecar_get(&self) {
+        let (lock, _) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("sidecar read gate lock should be available");
+        state.block_next = true;
+        state.blocked = false;
+        state.released = false;
+    }
+
+    fn maybe_block(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("sidecar read gate lock should be available");
+        if !state.block_next {
+            return;
+        }
+        state.block_next = false;
+        state.blocked = true;
+        condvar.notify_all();
+        let deadline = Instant::now() + TEST_WAIT_TIMEOUT;
+        while !state.released {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for sidecar read gate release"
+            );
+            let (next_state, wait_result) = condvar
+                .wait_timeout(state, remaining)
+                .expect("sidecar read gate lock should be available after wait");
+            state = next_state;
+            assert!(
+                !wait_result.timed_out() || state.released,
+                "timed out waiting for sidecar read gate release"
+            );
+        }
+    }
+
+    fn wait_until_blocked(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("sidecar read gate lock should be available");
+        let deadline = Instant::now() + TEST_WAIT_TIMEOUT;
+        while !state.blocked {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for sidecar read gate"
+            );
+            let (next_state, wait_result) = condvar
+                .wait_timeout(state, remaining)
+                .expect("sidecar read gate lock should be available after wait");
+            state = next_state;
+            assert!(
+                !wait_result.timed_out() || state.blocked,
+                "timed out waiting for sidecar read gate"
+            );
+        }
+    }
+
+    fn release(&self) {
+        let (lock, condvar) = &*self.state;
+        let mut state = lock
+            .lock()
+            .expect("sidecar read gate lock should be available");
+        state.released = true;
+        condvar.notify_all();
+    }
+}
+
+#[derive(Default)]
+struct BlockingSidecarReadState {
     block_next: bool,
     blocked: bool,
     released: bool,


### PR DESCRIPTION
## Summary
- replace normal tracked-commit flat sidecar scans with an exact branch marker revision/CAS
- validate and materialize from one pinned storage snapshot; fence branch-ref moves and cross-lane writes
- fail closed for pre-marker repository layouts (hard format boundary)
- retain promotion only for branches that actually have local sidecar state

## Why
Normal tracked CRUD should not pay a branch-wide mutable-sidecar scan. The sidecar is rare and must not weaken transactional validation.

## Validation
- `cargo test --profile test -p lix_engine --lib --all-features`
- `cargo test --profile test -p lix_engine --test integration --all-features` (790 passed, 3 ignored)
- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- deterministic two-engine race regressions for tracked↔sidecar FK changes

## Measurement
Current RocksDB tracked `update_one` median: 1.317 ms; standalone SQLite: 37.3 µs. Follow-up work targets transaction-open catalog reads and commit materialization.