### PR TITLE
perf: collapse redundant tracked write reads

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -82,43 +82,47 @@ fn profile_operation(runtime: &tokio::runtime::Runtime, rows: &[WorkloadRow]) {
         Ok("kv_layout") => {
             assert!(
                 hot_repeats.is_none(),
-                "LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS is only available for transaction reads"
+                "LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS is unavailable for the kv_layout layer"
             );
             profile_kv_layout_operation(runtime, rows, operation, sample_count);
         }
         Ok("raw_sqlite") => {
-            assert!(
-                hot_repeats.is_none(),
-                "LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS is only available for transaction reads"
-            );
-            profile_raw_sqlite_operation(rows, operation, sample_count);
+            if let Some(repeats) = hot_repeats {
+                profile_hot_raw_sqlite_operations(rows, operation, repeats);
+            } else {
+                profile_raw_sqlite_operation(rows, operation, sample_count);
+            }
+        }
+        Ok("sql_session") => {
+            if let Some(repeats) = hot_repeats {
+                profile_hot_sql_session_operations(runtime, rows, operation, repeats);
+            } else {
+                profile_sql_session_operation(runtime, rows, operation, sample_count);
+            }
         }
         Ok("transaction") | Err(_) => {
             if let Some(repeats) = hot_repeats {
-                profile_hot_transaction_reads(runtime, rows, operation, repeats);
+                profile_hot_transaction_operations(runtime, rows, operation, repeats);
             } else {
                 profile_transaction_operation(runtime, rows, operation, sample_count);
             }
         }
         Ok(other) => panic!(
-            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_LAYER '{other}'; expected transaction, kv_layout, or raw_sqlite"
+            "unknown LIX_TRACKED_STATE_CRUD_PROFILE_LAYER '{other}'; expected transaction, sql_session, kv_layout, or raw_sqlite"
         ),
     }
 }
 
-/// Keeps one seeded fixture alive for a repeatable, read-only profiling
-/// window. This deliberately trades representative cache behavior for a
-/// trace dominated by the operation itself rather than fixture construction.
-fn profile_hot_transaction_reads(
+/// Keeps one seeded fixture alive for a repeatable profiling window. This
+/// deliberately trades representative cache behavior for a trace dominated
+/// by the operation itself rather than fixture construction.
+fn profile_hot_transaction_operations(
     runtime: &tokio::runtime::Runtime,
     rows: &[WorkloadRow],
     operation: TransactionBenchOp,
     repeats: usize,
 ) {
-    assert!(
-        operation.is_read(),
-        "LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS only supports read_all, read_one, or read_many"
-    );
+    operation.assert_supports_hot_repeats();
     let repeats_u32 =
         u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
     let mut fixture = runtime.block_on(transaction_api::seeded_fixture(
@@ -133,6 +137,55 @@ fn profile_hot_transaction_reads(
     let elapsed = start.elapsed();
     println!(
         "tracked_state_crud hot profile: transaction/lix_rocksdb/{}/{} repeats: total={elapsed:?} per_operation={:?}",
+        profile_operation_name(operation),
+        repeats,
+        elapsed / repeats_u32,
+    );
+    black_box(row_count);
+}
+
+fn profile_hot_sql_session_operations(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    operation: TransactionBenchOp,
+    repeats: usize,
+) {
+    operation.assert_supports_hot_repeats();
+    let repeats_u32 =
+        u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
+    let fixture = runtime.block_on(sql_session::seeded_fixture(StorageProfile::RocksDB, rows));
+    let start = Instant::now();
+    let mut row_count = 0;
+    for _ in 0..repeats {
+        row_count += runtime.block_on(run_sql_session_operation(operation, &fixture));
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "tracked_state_crud hot profile: sql_session/lix_rocksdb/{}/{} repeats: total={elapsed:?} per_operation={:?}",
+        profile_operation_name(operation),
+        repeats,
+        elapsed / repeats_u32,
+    );
+    black_box(row_count);
+}
+
+fn profile_hot_raw_sqlite_operations(
+    rows: &[WorkloadRow],
+    operation: TransactionBenchOp,
+    repeats: usize,
+) {
+    operation.assert_supports_hot_repeats();
+    let repeats_u32 =
+        u32::try_from(repeats).expect("LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS must fit in u32");
+    let mut fixture = raw_sqlite::seeded_fixture(rows);
+    let start = Instant::now();
+    let mut row_count = 0;
+    for _ in 0..repeats {
+        row_count += run_raw_sqlite_operation(operation, &mut fixture);
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "tracked_state_crud hot profile: raw_sqlite/{}/{} repeats: total={elapsed:?} per_operation={:?}",
         profile_operation_name(operation),
         repeats,
         elapsed / repeats_u32,
@@ -217,20 +270,64 @@ fn profile_raw_sqlite_operation(
             raw_sqlite::empty_fixture(rows)
         };
         let start = Instant::now();
-        let result = match operation {
-            TransactionBenchOp::InsertAll => fixture.insert_all(),
-            TransactionBenchOp::ReadAll => fixture.read_all(),
-            TransactionBenchOp::ReadOneByPk => fixture.read_one_by_pk(),
-            TransactionBenchOp::ReadManyByPk => fixture.read_many_by_pk(READ_MANY_PK_COUNT),
-            TransactionBenchOp::UpdateAll => fixture.update_all(),
-            TransactionBenchOp::UpdateOneByPk => fixture.update_one_by_pk(),
-            TransactionBenchOp::DeleteAll => fixture.delete_all(),
-            TransactionBenchOp::DeleteOneByPk => fixture.delete_one_by_pk(),
-        };
+        let result = run_raw_sqlite_operation(operation, &mut fixture);
         samples.push(start.elapsed());
         black_box(result);
     }
     print_profile_samples("raw_sqlite", operation, samples);
+}
+
+fn profile_sql_session_operation(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    operation: TransactionBenchOp,
+    sample_count: usize,
+) {
+    let mut samples = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
+        let fixture = if operation.needs_seed() {
+            runtime.block_on(sql_session::seeded_fixture(StorageProfile::RocksDB, rows))
+        } else {
+            runtime.block_on(sql_session::empty_fixture(StorageProfile::RocksDB, rows))
+        };
+        let start = Instant::now();
+        let result = runtime.block_on(run_sql_session_operation(operation, &fixture));
+        samples.push(start.elapsed());
+        black_box(result);
+    }
+    print_profile_samples("sql_session/lix_rocksdb", operation, samples);
+}
+
+async fn run_sql_session_operation(
+    operation: TransactionBenchOp,
+    fixture: &sql_session::SqlFixture,
+) -> usize {
+    match operation {
+        TransactionBenchOp::InsertAll => fixture.insert_all().await,
+        TransactionBenchOp::ReadAll => fixture.read_all().await,
+        TransactionBenchOp::ReadOneByPk => fixture.read_one_by_pk().await,
+        TransactionBenchOp::ReadManyByPk => fixture.read_many_by_pk().await,
+        TransactionBenchOp::UpdateAll => fixture.update_all().await,
+        TransactionBenchOp::UpdateOneByPk => fixture.update_one_by_pk().await,
+        TransactionBenchOp::DeleteAll => fixture.delete_all().await,
+        TransactionBenchOp::DeleteOneByPk => fixture.delete_one_by_pk().await,
+    }
+}
+
+fn run_raw_sqlite_operation(
+    operation: TransactionBenchOp,
+    fixture: &mut raw_sqlite::RawSqliteFixture,
+) -> usize {
+    match operation {
+        TransactionBenchOp::InsertAll => fixture.insert_all(),
+        TransactionBenchOp::ReadAll => fixture.read_all(),
+        TransactionBenchOp::ReadOneByPk => fixture.read_one_by_pk(),
+        TransactionBenchOp::ReadManyByPk => fixture.read_many_by_pk(READ_MANY_PK_COUNT),
+        TransactionBenchOp::UpdateAll => fixture.update_all(),
+        TransactionBenchOp::UpdateOneByPk => fixture.update_one_by_pk(),
+        TransactionBenchOp::DeleteAll => fixture.delete_all(),
+        TransactionBenchOp::DeleteOneByPk => fixture.delete_one_by_pk(),
+    }
 }
 
 fn print_profile_samples(layer: &str, operation: TransactionBenchOp, mut samples: Vec<Duration>) {
@@ -436,8 +533,18 @@ impl TransactionBenchOp {
         !matches!(self, Self::InsertAll)
     }
 
-    fn is_read(self) -> bool {
-        matches!(self, Self::ReadAll | Self::ReadOneByPk | Self::ReadManyByPk)
+    fn assert_supports_hot_repeats(self) {
+        assert!(
+            matches!(
+                self,
+                Self::ReadAll
+                    | Self::ReadOneByPk
+                    | Self::ReadManyByPk
+                    | Self::UpdateAll
+                    | Self::UpdateOneByPk
+            ),
+            "LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS only supports read_all, read_one, read_many, update_all, or update_one"
+        );
     }
 
     async fn run(self, fixture: &mut transaction_api::TransactionFixture) -> usize {

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -9,6 +9,7 @@ use serde_json::Value as JsonValue;
 use tracing::Instrument as _;
 
 use crate::GLOBAL_BRANCH_ID;
+use crate::LixError;
 use crate::binary_cas::{BinaryCasContext, BlobDataReader};
 use crate::branch::{
     BranchContext, BranchLifecycle, BranchOperation, BranchRefReader, BranchReferenceRole,
@@ -19,7 +20,7 @@ use crate::entity_pk::EntityPk;
 use crate::filesystem::FilesystemPathIndexReader;
 use crate::functions::FunctionProviderHandle;
 use crate::json_store::JsonStoreContext;
-use crate::live_state::{LiveStateContext, LiveStateReader, LiveStateRowRequest};
+use crate::live_state::{LiveStateContext, LiveStateIndexRowRequest, LiveStateReader};
 use crate::observe_coordinator::ObserveCoordinator;
 use crate::observe_invalidation::ObserveInvalidation;
 use crate::plugin::{PluginComponentHost, PluginRuntimeHost};
@@ -33,11 +34,77 @@ use crate::storage_adapter::{SharedStorageAdapterRead, StorageAdapter, StorageAd
 use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
 use crate::transaction::{Transaction, open_transaction};
-use crate::{LixError, NullableKeyFilter};
 
 use super::transaction::{SessionOperationGuard, SessionTransactionManager, SessionWriteLease};
 
 pub(crate) const WORKSPACE_BRANCH_KEY: &str = "lix_workspace_branch_id";
+
+/// Loads the workspace selector from its canonical untracked global index
+/// entry, then verifies that the selected branch still exists in the same
+/// storage snapshot.
+///
+/// The selector is engine-owned mutable state. Routing it through generic
+/// live-state visibility would also probe the immutable tracked head even
+/// though a tracked fallback is not a valid selector representation.
+pub(crate) async fn load_workspace_branch_id_from_index(
+    live_state: &LiveStateContext,
+    branch_ctx: &BranchContext,
+    reader: &(impl StorageAdapterRead + ?Sized),
+) -> Result<String, LixError> {
+    let mut rows = live_state
+        .index()
+        .reader(reader)
+        .load_rows(
+            &[LiveStateIndexRowRequest {
+                schema_key: "lix_key_value".to_string(),
+                branch_id: GLOBAL_BRANCH_ID.to_string(),
+                entity_pk: EntityPk::single(WORKSPACE_BRANCH_KEY),
+                file_id: None,
+            }],
+            &["snapshot_content".to_string()],
+        )
+        .await?;
+    let row = rows.pop().flatten().ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "workspace branch selector is missing lix_key_value:lix_workspace_branch_id",
+        )
+    })?;
+    let snapshot_content = row.snapshot_content.as_deref().ok_or_else(|| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "workspace branch selector is missing snapshot_content",
+        )
+    })?;
+    let snapshot = serde_json::from_str::<JsonValue>(snapshot_content).map_err(|error| {
+        LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!("workspace branch selector snapshot is invalid JSON: {error}"),
+        )
+    })?;
+    let branch_id = snapshot
+        .get("value")
+        .and_then(JsonValue::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "workspace branch selector value must be a non-empty string",
+            )
+        })?
+        .to_string();
+
+    let branch_ref = branch_ctx.ref_reader(reader);
+    BranchLifecycle::new(&branch_ref)
+        .require_existing_ref(
+            &branch_id,
+            BranchOperation::LoadWorkspaceSelector,
+            BranchReferenceRole::WorkspaceSelector,
+        )
+        .await?;
+
+    Ok(branch_id)
+}
 
 #[derive(Clone)]
 pub(crate) enum SessionMode {
@@ -397,56 +464,12 @@ where
     where
         S: StorageAdapterRead + ?Sized,
     {
-        let row = self
-            .live_state
-            .reader(reader)
-            .load_row(&LiveStateRowRequest {
-                schema_key: "lix_key_value".to_string(),
-                branch_id: GLOBAL_BRANCH_ID.to_string(),
-                entity_pk: EntityPk::single(WORKSPACE_BRANCH_KEY),
-                file_id: NullableKeyFilter::Null,
-            })
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    "LIX_ERROR_UNKNOWN",
-                    "workspace branch selector is missing lix_key_value:lix_workspace_branch_id",
-                )
-            })?;
-        let snapshot_content = row.snapshot_content.as_deref().ok_or_else(|| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "workspace branch selector is missing snapshot_content",
-            )
-        })?;
-        let snapshot = serde_json::from_str::<JsonValue>(snapshot_content).map_err(|error| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("workspace branch selector snapshot is invalid JSON: {error}"),
-            )
-        })?;
-        let branch_id = snapshot
-            .get("value")
-            .and_then(JsonValue::as_str)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                LixError::new(
-                    "LIX_ERROR_UNKNOWN",
-                    "workspace branch selector value must be a non-empty string",
-                )
-            })?
-            .to_string();
-
-        let branch_ref = self.branch_ctx.ref_reader(reader);
-        BranchLifecycle::new(&branch_ref)
-            .require_existing_ref(
-                &branch_id,
-                BranchOperation::LoadWorkspaceSelector,
-                BranchReferenceRole::WorkspaceSelector,
-            )
-            .await?;
-
-        Ok(branch_id)
+        load_workspace_branch_id_from_index(
+            self.live_state.as_ref(),
+            self.branch_ctx.as_ref(),
+            reader,
+        )
+        .await
     }
 
     pub(crate) async fn with_write_transaction<T, F>(&self, f: F) -> Result<T, LixError>
@@ -471,11 +494,13 @@ where
         ) -> Pin<Box<dyn Future<Output = Result<T, LixError>> + 'tx>>,
     {
         let planner_validation_is_serialized = write_access.serializes_collaboration_writes();
-        let _deterministic_runtime_guard = if self.deterministic_mode_enabled().await? {
-            Some(self.lock_deterministic_runtime().await)
-        } else {
-            None
-        };
+        // Automatic writes already hold the collaboration gate, so taking the
+        // runtime gate unconditionally cannot reduce their concurrency. It
+        // avoids opening a separate read solely to decide whether
+        // `Transaction::open` should be allowed to prepare deterministic
+        // functions; that coherent opening snapshot remains the source of
+        // truth for the mode.
+        let _deterministic_runtime_guard = self.lock_deterministic_runtime().await;
         let opened = open_transaction(
             &self.mode,
             self.storage.clone(),
@@ -921,6 +946,29 @@ mod tests {
             .await
             .expect("commit should resume after collaboration gate release")
             .expect("explicit transaction commit should succeed");
+    }
+
+    #[tokio::test]
+    async fn automatic_writes_take_the_deterministic_runtime_gate_without_a_mode_precheck() {
+        let session = open_session().await;
+        let deterministic_guard = std::sync::Arc::clone(&session.deterministic_runtime_gate)
+            .lock_owned()
+            .await;
+        let mut write = Box::pin(session.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('automatic-runtime-gate', 'value')",
+            &[],
+        ));
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(
+            matches!(write.as_mut().poll(&mut cx), Poll::Pending),
+            "automatic write should wait for the deterministic runtime gate"
+        );
+
+        drop(deterministic_guard);
+        tokio::time::timeout(TEST_WAIT_TIMEOUT, write)
+            .await
+            .expect("automatic write should resume after runtime gate release")
+            .expect("automatic write should succeed after runtime gate release");
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/mod.rs
+++ b/packages/engine/src/session/mod.rs
@@ -22,7 +22,7 @@ mod transaction;
 
 pub use checkpoint::CreateCheckpointReceipt;
 pub use context::SessionContext;
-pub(crate) use context::{SessionMode, WORKSPACE_BRANCH_KEY};
+pub(crate) use context::{SessionMode, load_workspace_branch_id_from_index};
 pub use create_branch::{CreateBranchOptions, CreateBranchReceipt};
 pub use execute::{
     CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ExecutionDisposition,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -171,7 +171,15 @@ async fn execute_entity_write(
 
     let spec = entity_spec(ctx, schema_key)?;
     validate_bound_write_supported(plan, &spec)?;
-    let active_branch_commit_id = load_active_branch_commit_id(ctx).await?;
+    // Only `lix_active_branch_commit_id()` needs the current branch head.
+    // Normal entity mutations already stage against the transaction's active
+    // branch, so eagerly opening another read here makes the common write
+    // path pay for a value it never observes.
+    let active_branch_commit_id = if plan_references_active_branch_commit_id(plan) {
+        Some(load_active_branch_commit_id(ctx).await?)
+    } else {
+        None
+    };
     let no_op = matches!(plan.bound.branch_scope, BranchScope::Empty)
         || matches!(plan.filters.rows, FilterSet::None);
     match plan.bound.op {
@@ -207,13 +215,180 @@ async fn execute_entity_write(
     }
 }
 
+fn plan_references_active_branch_commit_id(plan: &LogicalWritePlan) -> bool {
+    let input_references_head = match &plan.bound.input {
+        BoundWriteInput::Values(values) => values
+            .rows
+            .iter()
+            .flatten()
+            .any(bound_expr_references_active_branch_commit_id),
+        // Query input does not use this executor today. Keep the old eager
+        // behavior if a future supported shape reaches it without a complete
+        // expression traversal for `BoundRead`.
+        BoundWriteInput::Query { .. } => true,
+        BoundWriteInput::None => false,
+    };
+    input_references_head
+        || bound_predicate_references_active_branch_commit_id(&plan.bound.predicate)
+        || plan
+            .bound
+            .assignments
+            .iter()
+            .any(|assignment| bound_expr_references_active_branch_commit_id(&assignment.value))
+        || plan.bound.conflict.as_ref().is_some_and(|conflict| {
+            conflict
+                .action
+                .assignments()
+                .iter()
+                .any(|assignment| bound_expr_references_active_branch_commit_id(&assignment.value))
+        })
+        || plan.bound.returning.as_ref().is_some_and(|returning| {
+            returning
+                .items
+                .iter()
+                .any(|item| bound_expr_references_active_branch_commit_id(&item.expr))
+        })
+}
+
+fn bound_predicate_references_active_branch_commit_id(predicate: &BoundPredicate) -> bool {
+    match predicate {
+        BoundPredicate::True | BoundPredicate::False => false,
+        BoundPredicate::And(predicates) | BoundPredicate::Or(predicates) => predicates
+            .iter()
+            .any(bound_predicate_references_active_branch_commit_id),
+        BoundPredicate::Eq(left, right) => {
+            bound_expr_references_active_branch_commit_id(left)
+                || bound_expr_references_active_branch_commit_id(right)
+        }
+        BoundPredicate::Like { expr, pattern, .. } => {
+            bound_expr_references_active_branch_commit_id(expr)
+                || bound_expr_references_active_branch_commit_id(pattern)
+        }
+        BoundPredicate::IsNull(expr) | BoundPredicate::IsNotNull(expr) => {
+            bound_expr_references_active_branch_commit_id(expr)
+        }
+        BoundPredicate::In { expr, values } => {
+            bound_expr_references_active_branch_commit_id(expr)
+                || values
+                    .iter()
+                    .any(bound_expr_references_active_branch_commit_id)
+        }
+    }
+}
+
+fn bound_expr_references_active_branch_commit_id(expr: &BoundExpr) -> bool {
+    match expr {
+        BoundExpr::Function { name, args } => {
+            (name == "lix_active_branch_commit_id" && args.is_empty())
+                || args
+                    .iter()
+                    .any(bound_expr_references_active_branch_commit_id)
+        }
+        BoundExpr::Cast { expr, .. } => bound_expr_references_active_branch_commit_id(expr),
+        BoundExpr::Column(_)
+        | BoundExpr::ExcludedColumn(_)
+        | BoundExpr::Param(_)
+        | BoundExpr::Literal(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod active_branch_commit_id_reference_tests {
+    use super::*;
+    use crate::sql2::bind::expr::BoundColumnRef;
+    use crate::sql2::bind::write::{
+        BoundParamMap, BoundWrite, BoundWriteInput, BoundWriteOp, BoundWriteTarget,
+        EntityWriteSurface,
+    };
+    use crate::sql2::plan::branch_scope::BranchScope;
+    use crate::sql2::plan::write::PlannedWriteFilters;
+
+    #[test]
+    fn detects_active_branch_commit_id_in_nested_write_expressions() {
+        let plan = update_plan(
+            BoundPredicate::True,
+            BoundExpr::Function {
+                name: "lix_json".to_string(),
+                args: vec![active_branch_commit_id()],
+            },
+        );
+
+        assert!(plan_references_active_branch_commit_id(&plan));
+    }
+
+    #[test]
+    fn detects_active_branch_commit_id_in_predicates_but_ignores_other_functions() {
+        let plan = update_plan(
+            BoundPredicate::Eq(
+                BoundExpr::Column(BoundColumnRef {
+                    table: "json_pointer".to_string(),
+                    column_id: 0,
+                    name: "value".to_string(),
+                }),
+                active_branch_commit_id(),
+            ),
+            BoundExpr::Function {
+                name: "lix_timestamp".to_string(),
+                args: Vec::new(),
+            },
+        );
+
+        assert!(plan_references_active_branch_commit_id(&plan));
+
+        let no_head_plan = update_plan(
+            BoundPredicate::True,
+            BoundExpr::Function {
+                name: "lix_timestamp".to_string(),
+                args: Vec::new(),
+            },
+        );
+        assert!(!plan_references_active_branch_commit_id(&no_head_plan));
+    }
+
+    fn active_branch_commit_id() -> BoundExpr {
+        BoundExpr::Function {
+            name: "lix_active_branch_commit_id".to_string(),
+            args: Vec::new(),
+        }
+    }
+
+    fn update_plan(predicate: BoundPredicate, assignment_value: BoundExpr) -> LogicalWritePlan {
+        LogicalWritePlan {
+            bound: BoundWrite {
+                target: BoundWriteTarget::Entity(EntityWriteSurface::Base {
+                    schema_key: "json_pointer".to_string(),
+                }),
+                op: BoundWriteOp::Update,
+                input: BoundWriteInput::None,
+                predicate,
+                assignments: vec![BoundAssignment {
+                    column: BoundColumnRef {
+                        table: "json_pointer".to_string(),
+                        column_id: 1,
+                        name: "value".to_string(),
+                    },
+                    value: assignment_value,
+                }],
+                conflict: None,
+                returning: None,
+                params: BoundParamMap::default(),
+                branch_scope: BranchScope::Active {
+                    branch_id: "main".to_string(),
+                },
+            },
+            filters: PlannedWriteFilters {
+                rows: FilterSet::All,
+            },
+        }
+    }
+}
+
 async fn load_active_branch_commit_id(
     ctx: &mut dyn SqlWriteExecutionContext,
-) -> Result<Option<CommitId>, LixError> {
+) -> Result<CommitId, LixError> {
     let active_branch_id = ctx.active_branch_id().to_string();
     ctx.load_branch_head(&active_branch_id)
         .await?
-        .map(Some)
         .ok_or_else(|| {
             LixError::branch_not_found(
                 active_branch_id,

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -3758,7 +3758,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_sql_insert_into_active_entity_rejects_missing_active_head() {
+    async fn execute_sql_insert_into_active_entity_does_not_probe_active_head_during_lowering() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let live_state = Arc::new(DummyLiveStateReader);
         let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
@@ -3776,25 +3776,29 @@ mod tests {
             })],
         };
 
-        let error = execute_write_sql(
+        let result = execute_write_sql(
             &mut ctx,
             "INSERT INTO test_state_schema (lixcol_entity_pk, value) \
              VALUES (lix_json('[\"entity-c\"]'), 'C')",
             &[],
         )
         .await
-        .expect_err("missing active head should fail before staging");
+        .expect("lowering should not probe the active head before commit");
 
-        assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND);
-        assert!(
-            error
-                .message
-                .contains("branch 'missing-branch' was not found")
+        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+        assert_eq!(
+            ctx.staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .len(),
+            1,
+            "the transaction commit boundary owns active-branch validation"
         );
     }
 
     #[tokio::test]
-    async fn execute_sql_noop_active_entity_write_rejects_missing_active_head() {
+    async fn execute_sql_noop_active_entity_write_does_not_probe_active_head() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let live_state = Arc::new(DummyLiveStateReader);
         let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
@@ -3816,19 +3820,20 @@ mod tests {
             "UPDATE test_state_schema SET value = 'D' WHERE false",
             "DELETE FROM test_state_schema WHERE false",
         ] {
-            let error = execute_write_sql(&mut ctx, sql, &[])
+            let result = execute_write_sql(&mut ctx, sql, &[])
                 .await
-                .expect_err("missing active head should fail even for no-op writes");
+                .expect("no-op lowering should not probe the active head");
 
-            assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND, "{sql}");
-            assert!(
-                error
-                    .message
-                    .contains("branch 'missing-branch' was not found"),
-                "{sql}: {}",
-                error.message
-            );
+            assert_eq!(result.rows, vec![vec![Value::Integer(0)]], "{sql}");
         }
+        assert!(
+            ctx.staged_writes
+                .lock()
+                .expect("staged writes lock")
+                .deltas
+                .is_empty(),
+            "no-op writes must not create a staged commit"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -48,11 +48,35 @@ type RowIndex = usize;
 /// stages a canonical changelog fact. Tracked rows additionally become commit
 /// members and update immutable history roots; untracked rows update only the
 /// mutable flat live-state index.
+#[cfg(test)]
 pub(crate) async fn commit_prepared_writes(
     binary_cas: &BinaryCasContext,
     branch_ctx: &BranchContext,
     live_index: &LiveStateIndexContext,
     runtime_functions: Option<&FunctionContext>,
+    read: &mut impl StorageAdapterRead,
+    prepared_writes: PreparedWriteSet,
+) -> Result<(StorageWriteSet, Vec<StoragePrecondition>), LixError> {
+    let commit_parent_heads =
+        resolve_prepared_commit_parent_heads(branch_ctx, &*read, &prepared_writes, false).await?;
+    commit_prepared_writes_with_parent_heads(
+        binary_cas,
+        live_index,
+        runtime_functions,
+        &commit_parent_heads,
+        read,
+        prepared_writes,
+    )
+    .await
+}
+
+/// Materializes a prepared commit with branch heads already resolved from the
+/// caller's coherent commit snapshot.
+pub(crate) async fn commit_prepared_writes_with_parent_heads(
+    binary_cas: &BinaryCasContext,
+    live_index: &LiveStateIndexContext,
+    runtime_functions: Option<&FunctionContext>,
+    commit_parent_heads: &BTreeMap<String, Option<CommitId>>,
     read: &mut impl StorageAdapterRead,
     prepared_writes: PreparedWriteSet,
 ) -> Result<(StorageWriteSet, Vec<StoragePrecondition>), LixError> {
@@ -95,8 +119,7 @@ pub(crate) async fn commit_prepared_writes(
         prepared_writes.commit_change_refs_by_branch,
         prepared_writes.first_commit_parent_override_by_branch,
         prepared_writes.extra_commit_parents_by_branch,
-        branch_ctx,
-        &*read,
+        commit_parent_heads,
     )
     .instrument(tracing::debug_span!(
         target: "lix_perf",
@@ -1448,8 +1471,7 @@ async fn finalize_commit_rows(
     commit_change_refs_by_branch: BTreeMap<String, StagedCommitChangeRefs>,
     first_commit_parent_override_by_branch: BTreeMap<String, CommitId>,
     extra_commit_parents_by_branch: BTreeMap<String, Vec<CommitId>>,
-    branch_ctx: &BranchContext,
-    read: &(impl StorageAdapterRead + ?Sized),
+    commit_parent_heads: &BTreeMap<String, Option<CommitId>>,
 ) -> Result<FinalizedCommitRows, LixError> {
     let mut commit_rows = Vec::new();
     let mut branch_heads = Vec::new();
@@ -1469,10 +1491,16 @@ async fn finalize_commit_rows(
             if let Some(parent) = first_commit_parent_override_by_branch.get(&branch_id) {
                 vec![*parent]
             } else {
-                branch_ctx
-                    .ref_reader(read)
-                    .load_head_commit_id(&branch_id)
-                    .await?
+                commit_parent_heads
+                    .get(&branch_id)
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!("commit parent head was not resolved for branch '{branch_id}'"),
+                        )
+                    })?
+                    .as_ref()
+                    .copied()
                     .into_iter()
                     .collect::<Vec<_>>()
             };
@@ -1512,6 +1540,63 @@ async fn finalize_commit_rows(
         branch_heads,
         tracked_roots,
     })
+}
+
+/// Resolves every branch touched by a prepared commit from the same coherent
+/// read that validation and materialization use. Production callers require
+/// non-global targets to exist; low-level materialization may opt out to
+/// preserve its root-construction primitive.
+pub(crate) async fn resolve_prepared_commit_parent_heads(
+    branch_ctx: &BranchContext,
+    read: &(impl StorageAdapterRead + ?Sized),
+    prepared_writes: &PreparedWriteSet,
+    require_existing_non_global_targets: bool,
+) -> Result<BTreeMap<String, Option<CommitId>>, LixError> {
+    let commit_parent_branch_ids = prepared_writes
+        .commit_change_refs_by_branch
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut required_branch_ids = prepared_writes
+        .state_rows
+        .iter()
+        .map(|row| row.branch_id.clone())
+        .chain(
+            prepared_writes
+                .file_data_writes
+                .iter()
+                .map(|write| write.branch_id.clone()),
+        )
+        .chain(
+            prepared_writes
+                .first_commit_parent_override_by_branch
+                .keys()
+                .cloned(),
+        )
+        .chain(
+            prepared_writes
+                .extra_commit_parents_by_branch
+                .keys()
+                .cloned(),
+        )
+        .collect::<BTreeSet<_>>();
+    required_branch_ids.extend(commit_parent_branch_ids.iter().cloned());
+
+    let branch_ref = branch_ctx.ref_reader(read);
+    let mut parent_heads = BTreeMap::new();
+    for branch_id in required_branch_ids {
+        let head = branch_ref.load_head_commit_id(&branch_id).await?;
+        if require_existing_non_global_targets
+            && branch_id != crate::GLOBAL_BRANCH_ID
+            && head.is_none()
+        {
+            return Err(LixError::branch_not_found(branch_id, "commit", "target"));
+        }
+        if commit_parent_branch_ids.contains(&branch_id) {
+            parent_heads.insert(branch_id, head);
+        }
+    }
+    Ok(parent_heads)
 }
 
 fn merge_parent_commit_ids(mut base: Vec<CommitId>, extra: Vec<CommitId>) -> Vec<CommitId> {
@@ -3415,15 +3500,6 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_commit_rows_parents_global_commit_to_existing_branch_ref() {
-        let storage = StorageAdapter::new(Memory::new());
-        let branch_ctx = BranchContext::new();
-        crate::test_support::seed_branch_head(storage.clone(), GLOBAL_BRANCH_ID, "initial-commit")
-            .await;
-
-        let mut read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
         let rows = finalize_commit_rows(
             BTreeMap::from([(
                 GLOBAL_BRANCH_ID.to_string(),
@@ -3431,8 +3507,10 @@ mod tests {
             )]),
             BTreeMap::new(),
             BTreeMap::new(),
-            &branch_ctx,
-            &mut read,
+            &BTreeMap::from([(
+                GLOBAL_BRANCH_ID.to_string(),
+                Some(CommitId::for_test_label("initial-commit")),
+            )]),
         )
         .await
         .expect("global commit row should finalize");
@@ -3455,12 +3533,6 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_commit_rows_skips_empty_members() {
-        let storage = StorageAdapter::new(Memory::new());
-        let branch_ctx = BranchContext::new();
-        let mut read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
         let rows = finalize_commit_rows(
             BTreeMap::from([(
                 GLOBAL_BRANCH_ID.to_string(),
@@ -3468,8 +3540,7 @@ mod tests {
             )]),
             BTreeMap::new(),
             BTreeMap::new(),
-            &branch_ctx,
-            &mut read,
+            &BTreeMap::new(),
         )
         .await
         .expect("empty change_refs should be ignored");
@@ -3480,22 +3551,14 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_commit_rows_uses_existing_branch_ref_as_parent() {
-        let storage = StorageAdapter::new(Memory::new());
-        let branch_ctx = BranchContext::new();
-        crate::test_support::seed_branch_head(storage.clone(), GLOBAL_BRANCH_ID, "global-before")
-            .await;
-        crate::test_support::seed_branch_head(storage.clone(), "branch-a", "previous-commit").await;
-
-        let mut read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
         let rows = finalize_commit_rows(
             BTreeMap::from([("branch-a".to_string(), change_refs(["change-a"]))]),
             BTreeMap::new(),
             BTreeMap::new(),
-            &branch_ctx,
-            &mut read,
+            &BTreeMap::from([(
+                "branch-a".to_string(),
+                Some(CommitId::for_test_label("previous-commit")),
+            )]),
         )
         .await
         .expect("active-branch commit finalization should resolve parent");
@@ -3509,14 +3572,6 @@ mod tests {
 
     #[tokio::test]
     async fn finalize_commit_rows_appends_extra_merge_parent_after_target_head() {
-        let storage = StorageAdapter::new(Memory::new());
-        let branch_ctx = BranchContext::new();
-        crate::test_support::seed_branch_head(storage.clone(), "branch-a", "target-head").await;
-
-        let mut read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
         let rows = finalize_commit_rows(
             BTreeMap::from([("branch-a".to_string(), change_refs(["change-a"]))]),
             BTreeMap::new(),
@@ -3524,8 +3579,10 @@ mod tests {
                 "branch-a".to_string(),
                 vec![CommitId::for_test_label("source-head")],
             )]),
-            &branch_ctx,
-            &mut read,
+            &BTreeMap::from([(
+                "branch-a".to_string(),
+                Some(CommitId::for_test_label("target-head")),
+            )]),
         )
         .await
         .expect("merge commit finalization should resolve parents");
@@ -3537,6 +3594,68 @@ mod tests {
                 CommitId::for_test_label("source-head")
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn prepared_commit_rejects_missing_non_global_branch_before_materialization() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_ctx = BranchContext::new();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let error = resolve_prepared_commit_parent_heads(
+            &branch_ctx,
+            &read,
+            &PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: vec![tracked_branch_row("missing-branch", "missing-change")],
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    "missing-branch".to_string(),
+                    change_refs(["missing-change"]),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+            true,
+        )
+        .await
+        .expect_err("non-global target must exist when commit materializes");
+
+        assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn prepared_commit_allows_missing_global_root_before_materialization() {
+        let storage = StorageAdapter::new(Memory::new());
+        let branch_ctx = BranchContext::new();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let heads = resolve_prepared_commit_parent_heads(
+            &branch_ctx,
+            &read,
+            &PreparedWriteSet {
+                insert_identities: BTreeMap::new(),
+                state_rows: Vec::new(),
+                commit_change_refs_by_branch: BTreeMap::from([(
+                    GLOBAL_BRANCH_ID.to_string(),
+                    change_refs(["first-global-change"]),
+                )]),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                file_data_writes: Vec::new(),
+            },
+            true,
+        )
+        .await
+        .expect("the root global commit may have no parent branch ref");
+
+        assert_eq!(heads.get(GLOBAL_BRANCH_ID), Some(&None));
     }
 
     fn change_refs<const N: usize>(change_ids: [&str; N]) -> StagedCommitChangeRefs {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -52,7 +52,7 @@ use crate::plugin::{
     is_plugin_storage_path, plugin_install_plan_from_archive_path, plugin_key_from_archive_file_id,
     plugin_state_live_state_projection, retain_plugin_state_rows_for_schema_keys,
 };
-use crate::session::{SessionMode, WORKSPACE_BRANCH_KEY};
+use crate::session::{SessionMode, load_workspace_branch_id_from_index};
 use crate::sql2::{
     ChangelogQuerySource, HistoryQuerySource, SessionFileViewKey, SessionFileViewMutation,
     SessionFileViews, SessionPluginFileView, SqlChangelogQuerySource, SqlExecutionContext,
@@ -445,15 +445,27 @@ where
         let _commit_guard = begin_commit_boundary(commit_boundary.as_ref());
         check_commit_boundary(commit_boundary.as_ref())?;
         // Validate and materialize from one coherent storage snapshot. The
-        // final write's preconditions then fence every fact validation and
-        // sidecar decision was based on, just like a conventional optimistic
-        // database transaction.
+        // final write's tracked-state precondition then fences the tracked
+        // validation decisions this commit was based on, just like a
+        // conventional optimistic database transaction. Branch-reference
+        // movement retains its existing materialization semantics.
         let commit_read_storage = transaction.storage.clone();
         let mut read = SharedStorageAdapterRead::new(
             commit_read_storage
                 .begin_read(StorageReadOptions::default())
                 .await?,
         );
+        // Stage-time branch/snapshot probes are redundant: this coherent
+        // commit read is the only snapshot that can publish, and the durable
+        // revision precondition below fences it. Resolve branch heads here so
+        // validation, parent selection, and persistence agree on one view.
+        let commit_parent_heads = commit::resolve_prepared_commit_parent_heads(
+            transaction.branch_ctx.as_ref(),
+            &read,
+            &prepared_writes,
+            true,
+        )
+        .await?;
         transaction
             .validate_prepared_writes_by_branch(&read, &prepared_writes)
             .instrument(tracing::debug_span!(
@@ -486,23 +498,24 @@ where
         } else {
             load_path_index_revision(&read).await.ok().flatten()
         };
-        let (mut writes, materialization_preconditions) = match commit::commit_prepared_writes(
-            &transaction.binary_cas,
-            transaction.branch_ctx.as_ref(),
-            transaction.live_state.index(),
-            Some(runtime_functions),
-            &mut read,
-            prepared_writes,
-        )
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
-            "lix.perf.transaction_materialization"
-        ))
-        .await
-        {
-            Ok(writes) => writes,
-            Err(error) => return Err(error),
-        };
+        let (mut writes, materialization_preconditions) =
+            match commit::commit_prepared_writes_with_parent_heads(
+                &transaction.binary_cas,
+                transaction.live_state.index(),
+                Some(runtime_functions),
+                &commit_parent_heads,
+                &mut read,
+                prepared_writes,
+            )
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_materialization"
+            ))
+            .await
+            {
+                Ok(writes) => writes,
+                Err(error) => return Err(error),
+            };
         if catalog_revision_changed {
             stage_catalog_revision(&mut writes);
         }
@@ -578,8 +591,20 @@ where
         &mut self,
         write: TransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError> {
-        self.ensure_opening_snapshot_is_current().await?;
+        // Staging is transaction-local. Commit validates and materializes from
+        // one coherent snapshot, then fences that snapshot in the durable
+        // write. Re-checking it for every staged batch only repeats point
+        // reads; it cannot make a stale write publish successfully.
         require_valid_transaction_write_storage_scopes(&write)?;
+        // A normal write targets the branch this transaction already opened
+        // against, so its existence is checked together with the coherent
+        // commit snapshot. Preserve the useful early error for the uncommon
+        // programmatic cross-branch write: normalization cannot meaningfully
+        // resolve a schema from a branch that does not exist.
+        if transaction_write_targets_non_active_branch(&write, &self.active_branch_id) {
+            self.require_existing_transaction_write_branch_ids(&write)
+                .await?;
+        }
         #[cfg(feature = "storage-benches")]
         {
             crate::storage_bench::record_transaction_rows_staged(transaction_write_row_count(
@@ -589,8 +614,6 @@ where
                 transaction_write_untracked_row_count(&write),
             );
         }
-        self.require_existing_transaction_write_branch_ids(&write)
-            .await?;
         let (write, file_view_mutations) = self.reconcile_plugin_write(write).await?;
         require_valid_transaction_write_storage_scopes(&write)?;
         let write = self.prepare_transaction_write(write).await?;
@@ -1732,14 +1755,13 @@ where
         &mut self,
         write: &TransactionWrite,
     ) -> Result<(), LixError> {
-        let branch_ids = transaction_write_branch_ids(write);
         let read = SharedStorageAdapterRead::new(
             self.storage
                 .begin_read(StorageReadOptions::default())
                 .await?,
         );
         let reader = self.branch_ctx.ref_reader(read);
-        for branch_id in branch_ids {
+        for branch_id in transaction_write_branch_ids(write) {
             if branch_id == GLOBAL_BRANCH_ID {
                 continue;
             }
@@ -2813,14 +2835,40 @@ fn plugin_transaction_json(raw: &str, context: &str) -> Result<TransactionJson, 
     TransactionJson::from_value(value, context)
 }
 
-fn transaction_write_branch_ids(write: &TransactionWrite) -> BTreeSet<String> {
+fn transaction_write_targets_non_active_branch(
+    write: &TransactionWrite,
+    active_branch_id: &str,
+) -> bool {
+    let is_non_active_local = |branch_id: &str, global: bool| {
+        !global && branch_id != GLOBAL_BRANCH_ID && branch_id != active_branch_id
+    };
     match write {
-        TransactionWrite::Rows { rows, .. } => transaction_write_row_branch_ids(rows),
+        TransactionWrite::Rows { rows, .. } => rows
+            .iter()
+            .any(|row| is_non_active_local(&row.branch_id, row.global)),
         TransactionWrite::RowsWithFileData {
             rows, file_data, ..
-        } => transaction_write_row_branch_ids(rows)
-            .into_iter()
-            .chain(stage_file_data_branch_ids(file_data))
+        } => {
+            rows.iter()
+                .any(|row| is_non_active_local(&row.branch_id, row.global))
+                || file_data
+                    .iter()
+                    .any(|write| is_non_active_local(&write.branch_id, write.global))
+        }
+    }
+}
+
+fn transaction_write_branch_ids(write: &TransactionWrite) -> BTreeSet<String> {
+    match write {
+        TransactionWrite::Rows { rows, .. } => {
+            rows.iter().map(|row| row.branch_id.clone()).collect()
+        }
+        TransactionWrite::RowsWithFileData {
+            rows, file_data, ..
+        } => rows
+            .iter()
+            .map(|row| row.branch_id.clone())
+            .chain(file_data.iter().map(|write| write.branch_id.clone()))
             .collect(),
     }
 }
@@ -2875,17 +2923,6 @@ fn require_valid_storage_scope(branch_id: &str, global: bool) -> Result<(), LixE
     Ok(())
 }
 
-fn transaction_write_row_branch_ids(rows: &[TransactionWriteRow]) -> BTreeSet<String> {
-    rows.iter().map(|row| row.branch_id.clone()).collect()
-}
-
-fn stage_file_data_branch_ids(file_data: &[TransactionFileData]) -> BTreeSet<String> {
-    file_data
-        .iter()
-        .map(|write| write.branch_id.clone())
-        .collect()
-}
-
 async fn resolve_active_branch_id(
     mode: &SessionMode,
     live_state: &LiveStateContext,
@@ -2894,67 +2931,10 @@ async fn resolve_active_branch_id(
 ) -> Result<String, LixError> {
     match mode {
         SessionMode::Pinned { branch_id } => Ok(branch_id.clone()),
-        SessionMode::Workspace => load_workspace_branch_id(live_state, branch_ctx, read).await,
+        SessionMode::Workspace => {
+            load_workspace_branch_id_from_index(live_state, branch_ctx, read).await
+        }
     }
-}
-
-async fn load_workspace_branch_id(
-    live_state: &LiveStateContext,
-    branch_ctx: &BranchContext,
-    read: &(impl StorageAdapterRead + ?Sized),
-) -> Result<String, LixError> {
-    let row = live_state
-        .reader(read)
-        .load_row(&LiveStateRowRequest {
-            schema_key: "lix_key_value".to_string(),
-            branch_id: GLOBAL_BRANCH_ID.to_string(),
-            entity_pk: EntityPk::single(WORKSPACE_BRANCH_KEY),
-            file_id: NullableKeyFilter::Null,
-        })
-        .await?
-        .ok_or_else(|| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "workspace branch selector is missing lix_key_value:lix_workspace_branch_id",
-            )
-        })?;
-    let snapshot_content = row.snapshot_content.as_deref().ok_or_else(|| {
-        LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            "workspace branch selector is missing snapshot_content",
-        )
-    })?;
-    let snapshot = serde_json::from_str::<JsonValue>(snapshot_content).map_err(|error| {
-        LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            format!("workspace branch selector snapshot is invalid JSON: {error}"),
-        )
-    })?;
-    let branch_id = snapshot
-        .get("value")
-        .and_then(JsonValue::as_str)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "workspace branch selector value must be a non-empty string",
-            )
-        })?
-        .to_string();
-
-    let head = branch_ctx
-        .ref_reader(read)
-        .load_head_commit_id(&branch_id)
-        .await?;
-    if head.is_none() {
-        return Err(LixError::branch_not_found(
-            branch_id,
-            "load_workspace_branch_id",
-            "workspace_selector",
-        ));
-    }
-
-    Ok(branch_id)
 }
 
 #[cfg(test)]
@@ -2999,6 +2979,47 @@ mod tests {
         ] {
             assert!(plugin_owner_needs_write(Some(&current), &desired));
         }
+    }
+
+    #[test]
+    fn active_branch_write_gate_ignores_global_companion_rows_and_files() {
+        let mut active_row = key_value_stage_row("active-row", "value", false);
+        active_row.branch_id = "branch-a".to_string();
+        active_row.global = false;
+        let mut global_row = key_value_stage_row("global-row", "value", false);
+        global_row.branch_id = GLOBAL_BRANCH_ID.to_string();
+        global_row.global = true;
+        let global_file = TransactionFileData::new(
+            "global-file".to_string(),
+            None,
+            None,
+            GLOBAL_BRANCH_ID.to_string(),
+            true,
+            false,
+            Vec::new(),
+        );
+
+        assert!(
+            !transaction_write_targets_non_active_branch(
+                &TransactionWrite::RowsWithFileData {
+                    mode: TransactionWriteMode::Replace,
+                    rows: vec![active_row.clone(), global_row],
+                    file_data: vec![global_file],
+                    count: 1,
+                },
+                "branch-a",
+            ),
+            "normal local writes commonly carry global bookkeeping rows"
+        );
+
+        active_row.branch_id = "branch-b".to_string();
+        assert!(transaction_write_targets_non_active_branch(
+            &TransactionWrite::Rows {
+                mode: TransactionWriteMode::Replace,
+                rows: vec![active_row],
+            },
+            "branch-a",
+        ));
     }
 
     #[tokio::test]

--- a/packages/engine/tests/integration/sql/udfs.rs
+++ b/packages/engine/tests/integration/sql/udfs.rs
@@ -123,3 +123,51 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    lix_active_branch_commit_id_is_available_to_bound_writes,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('active-head-write-seed', 'one')",
+                &[],
+            )
+            .await
+            .expect("tracked write should establish an active head");
+        let expected = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("head should load")
+            .expect("head should exist");
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) \
+                 VALUES ('active-head-write', lix_active_branch_commit_id())",
+                &[],
+            )
+            .await
+            .expect("bound write should evaluate active head UDF");
+
+        let stored = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'active-head-write'",
+                &[],
+            )
+            .await
+            .expect("stored active head should read");
+        assert_eq!(
+            stored.rows()[0].value("value").unwrap(),
+            &Value::Json(json!(expected.clone()))
+        );
+    }
+);

--- a/packages/engine/tests/integration/transaction.rs
+++ b/packages/engine/tests/integration/transaction.rs
@@ -114,6 +114,77 @@ async fn stale_transaction_cannot_publish_over_newer_commit() {
 }
 
 #[tokio::test]
+async fn deferred_active_branch_check_rejects_deleted_branch_at_commit() {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+
+    let setup_engine = Engine::new(storage.clone())
+        .await
+        .expect("initialized storage should create setup engine");
+    let setup_session = setup_engine
+        .open_workspace_session()
+        .await
+        .expect("setup workspace session should open");
+    setup_session
+        .create_branch(CreateBranchOptions {
+            id: Some("deferred-branch".to_string()),
+            name: "Deferred branch".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("local branch should be created");
+
+    // Separate engines share storage but not a collaboration gate, so the
+    // branch can disappear after the transaction opens and before it commits.
+    let branch_engine = Engine::new(storage.clone())
+        .await
+        .expect("branch engine should open");
+    let delete_engine = Engine::new(storage)
+        .await
+        .expect("delete engine should open");
+    let branch_session = branch_engine
+        .open_session("deferred-branch")
+        .await
+        .expect("local branch session should open");
+    let delete_session = delete_engine
+        .open_workspace_session()
+        .await
+        .expect("delete workspace session should open");
+
+    let mut transaction = branch_session
+        .begin_transaction()
+        .await
+        .expect("local transaction should begin");
+    delete_session
+        .execute("DELETE FROM lix_branch WHERE id = 'deferred-branch'", &[])
+        .await
+        .expect("branch delete should commit");
+
+    transaction
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('deferred-branch-key', 'value')",
+            &[],
+        )
+        .await
+        .expect("normal active-branch write should stage without a branch-head probe");
+    let error = transaction
+        .commit()
+        .await
+        .expect_err("commit must reject a branch deleted after transaction open");
+    assert_eq!(error.code, "LIX_BRANCH_NOT_FOUND");
+    assert_eq!(
+        delete_engine
+            .load_branch_head_commit_id("deferred-branch")
+            .await
+            .expect("branch head lookup should succeed"),
+        None,
+        "the failed transaction must not resurrect the deleted branch"
+    );
+}
+
+#[tokio::test]
 async fn untracked_sidecar_write_does_not_invalidate_tracked_transaction() {
     let storage = Memory::new();
     Engine::initialize(storage.clone())


### PR DESCRIPTION
## Summary
- remove duplicate active-head and stage-time snapshot/branch probes from ordinary tracked writes
- resolve branch parents once from the coherent commit snapshot, then reuse those heads for validation and materialization
- read the workspace selector directly from its canonical untracked index entry
- add SQL-session benchmark/profile layers and a raw SQLite peer baseline

## Correctness
- normal writes defer active-branch validation to the coherent commit boundary
- cross-branch programmatic writes retain an early missing-branch error
- a transaction whose branch is deleted after opening fails at commit and cannot resurrect the branch
- `lix_active_branch_commit_id()` still loads the head when a statement references it

## Measurements
Warmed 10k-row tracked SQL-session point update:
- Lix/RocksDB: median 143.647 us/op (20k repetitions); 144.926 us/op (50k)
- standalone SQLite: median 5.310 us/op (20k); 5.348 us/op (50k)
- no material history scaling from 20k to 50k; remaining write gap is about 27x

A separately profiled SQL-session point-read baseline is Lix 1.285 ms vs SQLite 2.563 us, while the direct Transaction API is about 26.4 us. This isolates the next major hotspot to SQL-session setup/planning rather than RocksDB.

## Validation
- `cargo test --profile test -p lix_engine --lib --all-features`
- `cargo test --profile test -p lix_engine --test integration --all-features`
- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`