### PR TITLE
perf: read deterministic runtime state from index

### DIFF
--- a/packages/engine/src/functions/context.rs
+++ b/packages/engine/src/functions/context.rs
@@ -5,6 +5,7 @@ use crate::functions::{
     DeterministicFunctionProvider, DeterministicSequence, FunctionProvider, FunctionProviderHandle,
     SystemFunctionProvider, state,
 };
+#[cfg(test)]
 use crate::live_state::LiveStateReader;
 use crate::storage_adapter::StorageAdapterRead;
 use crate::storage_adapter::StorageWriteSet;
@@ -37,13 +38,15 @@ impl FunctionContext {
     /// If deterministic mode is absent or disabled, the context uses system
     /// functions. If enabled, it starts from the persisted sequence + 1.
     #[expect(trivial_casts)]
-    pub(crate) async fn prepare(live_state: &dyn LiveStateReader) -> Result<Self, LixError> {
-        let mode = state::load_mode(live_state).await?;
+    pub(crate) async fn prepare(
+        read: &(impl StorageAdapterRead + ?Sized),
+    ) -> Result<Self, LixError> {
+        let mode = state::load_mode(read).await?;
         if !mode.enabled {
             return Ok(Self::system_for_function_free_read());
         }
 
-        let sequence = state::load_sequence(live_state).await?;
+        let sequence = state::load_sequence(read).await?;
         // Deterministic mode must produce byte-identical state across runs;
         // bookkeeping rows (sequence persistence) take a timestamp derived
         // from the persisted sequence instead of the system clock, without
@@ -138,15 +141,12 @@ mod tests {
     #[tokio::test]
     async fn prepare_uses_system_functions_when_mode_missing() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
 
-        let context = FunctionContext::prepare(&reader)
+        let context = FunctionContext::prepare(&read)
             .await
             .expect("runtime context should prepare");
 
@@ -161,7 +161,6 @@ mod tests {
     #[tokio::test]
     async fn prepare_starts_deterministic_functions_at_sequence_zero() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
         crate::test_support::seed_global_branch_head(storage.clone()).await;
         write_key_value(
             storage.clone(),
@@ -172,13 +171,11 @@ mod tests {
         )
         .await;
 
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let context = FunctionContext::prepare(&reader)
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let context = FunctionContext::prepare(&read)
             .await
             .expect("runtime context should prepare");
         let functions = context.provider();
@@ -202,7 +199,6 @@ mod tests {
     #[tokio::test]
     async fn prepare_continues_from_persisted_sequence() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
         crate::test_support::seed_global_branch_head(storage.clone()).await;
         write_key_value(
             storage.clone(),
@@ -219,13 +215,11 @@ mod tests {
         )
         .await;
 
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let context = FunctionContext::prepare(&reader)
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let context = FunctionContext::prepare(&read)
             .await
             .expect("runtime context should prepare");
         let functions = context.provider();
@@ -257,13 +251,11 @@ mod tests {
         .await;
 
         let context = {
-            let reader = live_state.reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("read should open"),
-            );
-            FunctionContext::prepare(&reader)
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read should open");
+            FunctionContext::prepare(&read)
                 .await
                 .expect("runtime context should prepare")
         };
@@ -283,20 +275,18 @@ mod tests {
             .await
             .expect("sequence should commit");
 
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let sequence = load_sequence(&reader).await.expect("sequence should load");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let sequence = load_sequence(&read).await.expect("sequence should load");
         assert_eq!(sequence, DeterministicSequence { highest_seen: 0 });
 
         // Deterministic mode must stamp the bookkeeping row from the
         // persisted sequence, never from the system clock; the persisted
         // sequence was empty, so next_sequence is 0 -> epoch.
         let row = LiveStateReader::load_row(
-            &reader,
+            &live_state.reader(&read),
             &crate::live_state::LiveStateRowRequest {
                 schema_key: "lix_key_value".to_string(),
                 branch_id: GLOBAL_BRANCH_ID.to_string(),
@@ -318,14 +308,11 @@ mod tests {
     #[tokio::test]
     async fn persist_if_needed_is_noop_for_system_functions() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let context = FunctionContext::prepare(&reader)
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let context = FunctionContext::prepare(&read)
             .await
             .expect("runtime context should prepare");
 
@@ -340,13 +327,11 @@ mod tests {
             .expect("persist should no-op");
         assert!(writes.is_empty());
 
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let sequence = load_sequence(&reader)
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let sequence = load_sequence(&read)
             .await
             .expect("missing sequence should load");
         assert_eq!(sequence, DeterministicSequence::uninitialized());

--- a/packages/engine/src/functions/mod.rs
+++ b/packages/engine/src/functions/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use types::{DeterministicMode, DeterministicSequence};
 pub(crate) type DeterministicRuntimeGuard = tokio::sync::OwnedMutexGuard<()>;
 
 pub(crate) async fn deterministic_mode_enabled(
-    live_state: &dyn crate::live_state::LiveStateReader,
+    read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
 ) -> Result<bool, crate::LixError> {
-    Ok(state::load_mode(live_state).await?.enabled)
+    Ok(state::load_mode(read).await?.enabled)
 }

--- a/packages/engine/src/functions/state.rs
+++ b/packages/engine/src/functions/state.rs
@@ -2,6 +2,7 @@ use serde_json::Value as JsonValue;
 use std::sync::Arc;
 
 use crate::GLOBAL_BRANCH_ID;
+use crate::LixError;
 use crate::changelog::{
     ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter,
 };
@@ -9,25 +10,29 @@ use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 use crate::functions::{DeterministicMode, DeterministicSequence};
 use crate::json_store::NormalizedJson;
-use crate::live_state::{LiveStateIndexContext, LiveStateIndexDeltaRef, LiveStateIndexRowRequest};
-use crate::live_state::{LiveStateReader, LiveStateRowRequest, MaterializedLiveStateRow};
+use crate::live_state::{
+    LiveStateIndexContext, LiveStateIndexDeltaRef, LiveStateIndexRowRequest,
+    MaterializedLiveStateIndexRow,
+};
 use crate::storage_adapter::StorageAdapterRead;
 use crate::storage_adapter::StorageWriteSet;
-use crate::{LixError, NullableKeyFilter};
 
 pub(crate) const DETERMINISTIC_MODE_KEY: &str = "lix_deterministic_mode";
 pub(crate) const DETERMINISTIC_SEQUENCE_KEY: &str = "lix_deterministic_sequence_number";
 
 const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 
-/// Loads deterministic-mode settings from visible live state.
+/// Loads deterministic-mode settings from the canonical untracked index.
 ///
 /// Missing mode means deterministic execution is disabled. Malformed mode rows
-/// are errors because they would make runtime function behavior ambiguous.
+/// are errors because they would make runtime function behavior ambiguous. This
+/// is engine-owned global state, not branch-visible tracked state, so a generic
+/// live-state lookup would unnecessarily probe the tracked head on every
+/// execution.
 pub(crate) async fn load_mode(
-    live_state: &dyn LiveStateReader,
+    read: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<DeterministicMode, LixError> {
-    let Some(row) = load_key_value_row(live_state, DETERMINISTIC_MODE_KEY).await? else {
+    let Some(row) = load_key_value_row(read, DETERMINISTIC_MODE_KEY).await? else {
         return Ok(DeterministicMode::disabled());
     };
     let value = key_value_payload(&row, DETERMINISTIC_MODE_KEY)?;
@@ -39,9 +44,9 @@ pub(crate) async fn load_mode(
 /// Missing sequence means no deterministic values have been produced yet, so
 /// execution starts at sequence zero.
 pub(crate) async fn load_sequence(
-    live_state: &dyn LiveStateReader,
+    read: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<DeterministicSequence, LixError> {
-    let Some(row) = load_key_value_row(live_state, DETERMINISTIC_SEQUENCE_KEY).await? else {
+    let Some(row) = load_key_value_row(read, DETERMINISTIC_SEQUENCE_KEY).await? else {
         return Ok(DeterministicSequence::uninitialized());
     };
     let value = key_value_payload(&row, DETERMINISTIC_SEQUENCE_KEY)?;
@@ -133,20 +138,24 @@ pub(crate) async fn stage_sequence(
 }
 
 async fn load_key_value_row(
-    live_state: &dyn LiveStateReader,
+    read: &(impl StorageAdapterRead + ?Sized),
     key: &str,
-) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-    live_state
-        .load_row(&LiveStateRowRequest {
+) -> Result<Option<MaterializedLiveStateIndexRow>, LixError> {
+    LiveStateIndexContext::new()
+        .reader(read)
+        .load_row(&LiveStateIndexRowRequest {
             schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
             branch_id: GLOBAL_BRANCH_ID.to_string(),
             entity_pk: EntityPk::single(key),
-            file_id: NullableKeyFilter::Null,
+            file_id: None,
         })
         .await
 }
 
-fn key_value_payload(row: &MaterializedLiveStateRow, key: &str) -> Result<JsonValue, LixError> {
+fn key_value_payload(
+    row: &MaterializedLiveStateIndexRow,
+    key: &str,
+) -> Result<JsonValue, LixError> {
     let snapshot_content = row.snapshot_content.as_deref().ok_or_else(|| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",
@@ -211,6 +220,7 @@ fn parse_sequence_value(value: JsonValue) -> Result<DeterministicSequence, LixEr
 
 #[cfg(test)]
 mod tests {
+    use crate::NullableKeyFilter;
     use crate::live_state::LiveStateIndexContext;
     use crate::live_state::{LiveStateContext, LiveStateRowRequest};
     use crate::storage_adapter::StorageAdapter;
@@ -229,17 +239,12 @@ mod tests {
     #[tokio::test]
     async fn missing_mode_is_disabled() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-
-        let mode = load_mode(&reader)
+        let read = storage
+            .begin_read(StorageReadOptions::default())
             .await
-            .expect("missing mode should decode");
+            .expect("read should open");
+
+        let mode = load_mode(&read).await.expect("missing mode should decode");
 
         assert_eq!(mode, DeterministicMode::disabled());
     }
@@ -247,7 +252,6 @@ mod tests {
     #[tokio::test]
     async fn valid_mode_decodes_flags() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
         crate::test_support::seed_global_branch_head(storage.clone()).await;
         write_test_key_value(
             storage.clone(),
@@ -259,13 +263,11 @@ mod tests {
         )
         .await;
 
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let mode = load_mode(&reader).await.expect("valid mode should decode");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mode = load_mode(&read).await.expect("valid mode should decode");
 
         assert_eq!(
             mode,
@@ -279,15 +281,12 @@ mod tests {
     #[tokio::test]
     async fn missing_sequence_is_uninitialized() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
 
-        let sequence = load_sequence(&reader)
+        let sequence = load_sequence(&read)
             .await
             .expect("missing sequence should decode");
 
@@ -297,7 +296,6 @@ mod tests {
     #[tokio::test]
     async fn valid_sequence_decodes_highest_seen() {
         let storage = StorageAdapter::new(Memory::new());
-        let live_state = live_state_context();
         crate::test_support::seed_global_branch_head(storage.clone()).await;
         write_test_key_value(
             storage.clone(),
@@ -306,13 +304,11 @@ mod tests {
         )
         .await;
 
-        let reader = live_state.reader(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("read should open"),
-        );
-        let sequence = load_sequence(&reader)
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let sequence = load_sequence(&read)
             .await
             .expect("valid sequence should decode");
 

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -32,6 +32,7 @@ pub(crate) trait LiveStateReader: Send + Sync {
         self.scan_rows(&request).await
     }
 
+    #[allow(dead_code)]
     async fn load_row(
         &self,
         request: &LiveStateRowRequest,

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -335,8 +335,7 @@ where
                 .begin_read(StorageReadOptions::default())
                 .await?,
         );
-        let live_state = self.live_state.reader(&read);
-        crate::functions::deterministic_mode_enabled(&live_state).await
+        crate::functions::deterministic_mode_enabled(&read).await
     }
 
     pub(super) async fn lock_deterministic_runtime(

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -1302,7 +1302,7 @@ where
         let live_state: Arc<dyn crate::live_state::LiveStateReader> =
             Arc::new(self.live_state.reader(read_store.clone()));
         let runtime_functions = if has_durable_runtime_function {
-            Some(FunctionContext::prepare(live_state.as_ref()).await?)
+            Some(FunctionContext::prepare(&read_store).await?)
         } else {
             None
         };

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -3272,13 +3272,11 @@ mod tests {
         }
         write_batches.store(0, Ordering::SeqCst);
         let runtime_functions = {
-            let reader = live_state.reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("read should open"),
-            );
-            FunctionContext::prepare(&reader)
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read should open");
+            FunctionContext::prepare(&read)
                 .await
                 .expect("runtime context should prepare")
         };

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -323,10 +323,7 @@ where
             let active_branch_id =
                 resolve_active_branch_id(mode, live_state.as_ref(), branch_ctx.as_ref(), &read)
                     .await?;
-            let runtime_functions = {
-                let runtime_live_state = live_state.reader(&read);
-                FunctionContext::prepare(&runtime_live_state).await?
-            };
+            let runtime_functions = FunctionContext::prepare(&read).await?;
             let functions = runtime_functions.provider();
             let (sql_schema_catalog, tracked_schema_catalog) = {
                 let catalog_revision = load_catalog_revision(&read).await?;


### PR DESCRIPTION
## Summary
- define deterministic mode and sequence as canonical global-untracked index state
- load runtime state directly from the coherent live-state index snapshot instead of generic tracked-state visibility
- preserve malformed-payload validation and conditional sequence loading

## Why
Normal tracked writes were resolving the disabled deterministic-mode setting through generic live-state visibility. That performed branch-head and tracked-head work even though this setting cannot be represented by tracked state. The new direct exact index lookup mirrors the workspace-selector fast path.

## Measurement
Warmed 10k-row RocksDB SQL-session point update (20k repeats):
- before: 143.647 us/op median
- after: 108.830 us/op median across five runs (102.205–109.490 us)
- improvement: about 24.2%

The previous callgrind profile attributed 18.9% inclusive instruction cost to `FunctionContext::prepare`, dominated by this generic mode lookup.

## Validation
- `cargo test --profile test -p lix_engine --lib --all-features`
- `cargo test --profile test -p lix_engine --test integration --all-features`
- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo fmt --check`