### PR TITLE
perf: cache dynamic SQL read catalogs

### DIFF
--- a/packages/engine/src/catalog/context.rs
+++ b/packages/engine/src/catalog/context.rs
@@ -1,4 +1,6 @@
-use std::collections::{BTreeMap, HashMap};
+#[cfg(test)]
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -199,11 +201,12 @@ impl CatalogContext {
         Ok(snapshot)
     }
 
-    /// Loads schema definitions for SQL surface planning at `branch_id`.
+    /// Projects schema definitions for SQL surface-planning cache tests.
     ///
     /// SQL surfaces are a read-planning projection over the active untracked
     /// schema catalog. Validation must use `schema_facts_for_domain` instead so
     /// schema durability remains explicit.
+    #[cfg(test)]
     pub(crate) async fn schema_jsons_for_sql_read_planning<R>(
         &self,
         live_state: &R,
@@ -212,7 +215,6 @@ impl CatalogContext {
     where
         R: LiveStateReader + ?Sized,
     {
-        #[cfg(test)]
         self.sql_read_schema_loads.fetch_add(1, Ordering::Relaxed);
         let facts = self
             .schema_facts_for_domain(live_state, &Domain::schema_catalog(branch_id, true))
@@ -241,7 +243,8 @@ impl CatalogContext {
         self.sql_read_schema_loads.load(Ordering::Relaxed)
     }
 
-    /// Loads schema facts reachable from a row domain.
+    /// Loads schema facts reachable from a row domain for catalog tests.
+    #[cfg(test)]
     pub(crate) async fn schema_facts_for_domain<R>(
         &self,
         live_state: &R,

--- a/packages/engine/src/catalog/revision.rs
+++ b/packages/engine/src/catalog/revision.rs
@@ -313,12 +313,9 @@ mod tests {
 
         register_schema(&session, "branch_rewind_probe", false).await;
         session
-            .execute(
-                "INSERT INTO branch_rewind_probe (id) VALUES ('before-rewind')",
-                &[],
-            )
+            .execute("SELECT COUNT(*) AS rows FROM branch_rewind_probe", &[])
             .await
-            .expect("new surface should warm the registered catalog");
+            .expect("new surface should warm the registered read catalog");
         let schema_head = engine
             .load_branch_head_commit_id(&receipt.main_branch_id)
             .await
@@ -332,12 +329,9 @@ mod tests {
         assert_ne!(rewind_revision, initial_revision);
         assert_ne!(rewind_revision, schema_revision);
         session
-            .execute(
-                "INSERT INTO branch_rewind_probe (id) VALUES ('must-not-bind')",
-                &[],
-            )
+            .execute("SELECT COUNT(*) AS rows FROM branch_rewind_probe", &[])
             .await
-            .expect_err("rewinding the head must hide the newer schema");
+            .expect_err("rewinding the head must hide the newer read surface");
         assert_eq!(
             current_revision(&adapter).await,
             rewind_revision,
@@ -349,13 +343,10 @@ mod tests {
         assert_ne!(restored_revision, rewind_revision);
         assert_ne!(restored_revision, schema_revision);
         let restored = session
-            .execute(
-                "INSERT INTO branch_rewind_probe (id) VALUES ('after-restore')",
-                &[],
-            )
+            .execute("SELECT COUNT(*) AS rows FROM branch_rewind_probe", &[])
             .await
-            .expect("restoring the head must restore the newer schema");
-        assert_eq!(restored.rows_affected(), 1);
+            .expect("restoring the head must restore the newer read surface");
+        assert_eq!(restored.rows()[0].get::<i64>("rows").unwrap(), 0);
     }
 
     #[tokio::test]

--- a/packages/engine/src/catalog/snapshot.rs
+++ b/packages/engine/src/catalog/snapshot.rs
@@ -771,10 +771,12 @@ impl SchemaCatalogFact {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn schema(&self) -> &JsonValue {
         &self.schema
     }
 
+    #[cfg(test)]
     pub(crate) fn catalog_key(&self) -> &SchemaCatalogKey {
         &self.catalog_key
     }

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -14,8 +14,9 @@ use crate::binary_cas::{BinaryCasContext, BlobDataReader};
 use crate::branch::{
     BranchContext, BranchLifecycle, BranchOperation, BranchRefReader, BranchReferenceRole,
 };
-use crate::catalog::{CatalogContext, CatalogFingerprint};
+use crate::catalog::{CatalogContext, CatalogFingerprint, CatalogSnapshot, load_catalog_revision};
 use crate::commit_graph::{CommitGraphContext, CommitGraphReader};
+use crate::domain::Domain;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::FilesystemPathIndexReader;
 use crate::functions::FunctionProviderHandle;
@@ -616,9 +617,27 @@ pub(super) struct SessionSqlExecutionContext<'a, R: crate::storage_adapter::Stor
     pub(super) binary_cas: Arc<BinaryCasContext>,
     pub(super) branch_ctx: Arc<BranchContext>,
     pub(super) catalog_context: Arc<CatalogContext>,
+    pub(super) sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
     pub(super) functions: FunctionProviderHandle,
     pub(super) plugin_host: PluginRuntimeHost,
     pub(super) file_views: Option<SessionFileViews>,
+}
+
+impl<R> SessionSqlExecutionContext<'_, R>
+where
+    R: crate::storage_adapter::StorageRead + 'static,
+{
+    async fn compiled_sql_catalog(&self) -> Result<Arc<CatalogSnapshot>, LixError> {
+        let revision = load_catalog_revision(&self.read_store).await?;
+        let live_state = self.live_state();
+        self.catalog_context
+            .compiled_catalog_for_transaction_open(
+                live_state.as_ref(),
+                &Domain::schema_catalog(self.active_branch_id.to_string(), true),
+                revision.as_ref(),
+            )
+            .await
+    }
 }
 
 #[async_trait]
@@ -679,10 +698,13 @@ where
     }
 
     async fn load_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError> {
-        let live_state = self.live_state();
-        self.catalog_context
-            .schema_jsons_for_sql_read_planning(live_state.as_ref(), self.active_branch_id)
-            .await
+        Ok(self.compiled_sql_catalog().await?.schema_jsons())
+    }
+
+    async fn public_catalog(&self) -> Result<Arc<crate::sql2::PublicCatalog>, LixError> {
+        let catalog = self.compiled_sql_catalog().await?;
+        self.sql_planning_cache
+            .public_catalog(catalog.fingerprint(), || Ok(catalog.schema_jsons()))
     }
 
     fn plugin_host(&self) -> PluginRuntimeHost {

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -947,6 +947,7 @@ where
                     binary_cas: Arc::clone(&self.binary_cas),
                     branch_ctx: Arc::clone(&self.branch_ctx),
                     catalog_context: Arc::clone(&self.catalog_context),
+                    sql_planning_cache: Arc::clone(&self.sql_planning_cache),
                     functions: FunctionProviderHandle::system(),
                     plugin_host: self.plugin_host.clone(),
                     file_views: file_view_collector.clone(),
@@ -1096,6 +1097,7 @@ where
                     binary_cas: Arc::clone(&self.binary_cas),
                     branch_ctx: Arc::clone(&self.branch_ctx),
                     catalog_context: Arc::clone(&self.catalog_context),
+                    sql_planning_cache: Arc::clone(&self.sql_planning_cache),
                     functions: FunctionProviderHandle::system(),
                     plugin_host: self.plugin_host.clone(),
                     file_views: file_view_collector.clone(),
@@ -1323,6 +1325,7 @@ where
             binary_cas: Arc::clone(&self.binary_cas),
             branch_ctx: Arc::clone(&self.branch_ctx),
             catalog_context: Arc::clone(&self.catalog_context),
+            sql_planning_cache: Arc::clone(&self.sql_planning_cache),
             functions: functions.clone(),
             plugin_host: self.plugin_host.clone(),
             file_views: file_view_collector.clone(),
@@ -3062,7 +3065,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_provider_selection_loads_storage_catalog_only_for_dynamic_visibility() {
+    async fn read_provider_selection_reuses_compiled_catalog_for_dynamic_visibility() {
         let session = open_session().await;
         let schema_loads = || {
             session
@@ -3120,8 +3123,8 @@ mod tests {
             .expect("information schema should execute");
         assert_eq!(
             schema_loads(),
-            before + 1,
-            "catalog-wide visibility must load dynamic schemas"
+            before,
+            "catalog-wide visibility must use the revision-keyed catalog instead of rescanning schemas"
         );
 
         let custom_schema = serde_json::json!({
@@ -3148,8 +3151,8 @@ mod tests {
             .expect("custom entity should execute");
         assert_eq!(
             schema_loads(),
-            before_custom_read + 1,
-            "custom entity metadata must load the visible catalog"
+            before_custom_read,
+            "custom entity metadata must use the compiled catalog instead of rescanning schemas"
         );
 
         let before_mixed_join = schema_loads();
@@ -3163,8 +3166,31 @@ mod tests {
             .expect("mixed fixed/custom join should execute");
         assert_eq!(
             schema_loads(),
-            before_mixed_join + 1,
-            "one custom table makes the whole session use the visible catalog"
+            before_mixed_join,
+            "one custom table must keep using the compiled catalog without rescanning schemas"
+        );
+
+        let mut next_schema = custom_schema.clone();
+        next_schema["x-lix-key"] = serde_json::json!("custom_catalog_probe_after_mutation");
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(next_schema.to_string())],
+            )
+            .await
+            .expect("second custom schema should register");
+        let before_changed_catalog_read = schema_loads();
+        session
+            .execute(
+                "SELECT COUNT(*) AS rows FROM custom_catalog_probe_after_mutation",
+                &[],
+            )
+            .await
+            .expect("schema revision must invalidate the cached SQL catalog");
+        assert_eq!(
+            schema_loads(),
+            before_changed_catalog_read,
+            "the next catalog generation must still avoid the uncached schema projection"
         );
     }
 

--- a/packages/engine/src/sql2/context.rs
+++ b/packages/engine/src/sql2/context.rs
@@ -59,7 +59,7 @@ pub(crate) struct ChangelogQuerySource<S> {
 /// the transaction capability instead of flowing through committed read
 /// sources.
 #[async_trait]
-pub(crate) trait SqlExecutionContext {
+pub(crate) trait SqlExecutionContext: Sync {
     type ReadStore: StorageAdapterRead + Clone + Send + Sync + 'static;
 
     fn active_branch_id(&self) -> &str;
@@ -79,6 +79,17 @@ pub(crate) trait SqlExecutionContext {
     /// Loads runtime-defined SQL entity metadata when provider selection could
     /// not be satisfied entirely by compile-time system surfaces.
     async fn load_visible_schemas(&self) -> Result<Vec<JsonValue>, LixError>;
+
+    /// Loads reusable public-surface metadata for this read snapshot.
+    ///
+    /// The default keeps lightweight test/read contexts simple. Session
+    /// contexts override it with their revision-keyed catalog cache; providers
+    /// themselves remain scoped to the current storage snapshot.
+    async fn public_catalog(&self) -> Result<Arc<PublicCatalog>, LixError> {
+        Ok(Arc::new(PublicCatalog::from_visible_schemas(
+            &self.load_visible_schemas().await?,
+        )?))
+    }
 
     fn plugin_host(&self) -> PluginRuntimeHost {
         PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime))

--- a/packages/engine/src/sql2/providers/mod.rs
+++ b/packages/engine/src/sql2/providers/mod.rs
@@ -139,8 +139,8 @@ where
     }
     let dynamic_catalog;
     let catalog = if selection.requires_visible_schemas() {
-        dynamic_catalog = PublicCatalog::from_visible_schemas(&ctx.load_visible_schemas().await?)?;
-        &dynamic_catalog
+        dynamic_catalog = ctx.public_catalog().await?;
+        dynamic_catalog.as_ref()
     } else {
         PublicCatalog::fixed_system()
     };

--- a/packages/engine/tests/integration/code_structure.rs
+++ b/packages/engine/tests/integration/code_structure.rs
@@ -2785,7 +2785,7 @@ fn sql2_read_session_does_not_register_write_surfaces() {
         relative,
         read_registration,
         &[
-            "PublicCatalog::from_visible_schemas",
+            "ctx.public_catalog()",
             "catalog.surfaces()",
             "PublicSurfaceKind::Branch",
             "PublicSurfaceKind::Change",


### PR DESCRIPTION
## Summary

- Reuse revision-keyed compiled metadata for dynamic normal-session SQL reads.
- Build/reuse `PublicCatalog` through the existing bounded SQL planning cache.
- Keep DataFusion sessions, providers, and plans fresh for each pinned snapshot.
- Cover registered-schema mutation plus branch rewind/restore invalidation on the read route.

## Measurement

Warmed 10k-row tracked SQL-session point read, five runs of 10,000 repetitions:

- Before: 1.285 ms/op median
- After: 663.648 µs/op median (651.786–669.225 µs)
- Improvement: 48.4%

Standalone SQLite on the same harness: 2.529 µs/op median. The remaining gap is in tracked-head lookup topology and snapshot-local DataFusion planning, not catalog reconstruction.

## Correctness

The catalog revision and live state are read from the same pinned storage read. The compiled cache key includes catalog domain plus revision; the public-surface cache key includes the catalog fingerprint. Providers remain snapshot-bound.

## Validation

- `cargo fmt --check`
- `cargo check --release -p lix_engine --all-features`
- `cargo clippy --profile test -p lix_engine --all-targets --all-features -- -D warnings`
- `cargo test --profile test -p lix_engine --lib --all-features`
- `cargo test --profile test -p lix_engine --test integration --all-features`