### PR TITLE
bench: align tracked CRUD query shapes

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -627,22 +627,20 @@ fn bench_sql_session(
             BatchSize::LargeInput,
         );
     });
-    if std::env::var_os("LIX_TRACKED_STATE_CRUD_SQL_UPDATE").is_some() {
-        group.bench_function(format!("update_all_rows/{}", row_label(rows.len())), |b| {
-            b.iter_batched_ref(
-                || runtime.block_on(sql_session::seeded_fixture(profile, &rows)),
-                |fixture| black_box(runtime.block_on(fixture.update_all())),
-                BatchSize::LargeInput,
-            );
-        });
-        group.bench_function(format!("update_one_by_pk/{}", row_label(rows.len())), |b| {
-            b.iter_batched_ref(
-                || runtime.block_on(sql_session::seeded_fixture(profile, &rows)),
-                |fixture| black_box(runtime.block_on(fixture.update_one_by_pk())),
-                BatchSize::LargeInput,
-            );
-        });
-    }
+    group.bench_function(format!("update_all_rows/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || runtime.block_on(sql_session::seeded_fixture(profile, &rows)),
+            |fixture| black_box(runtime.block_on(fixture.update_all())),
+            BatchSize::LargeInput,
+        );
+    });
+    group.bench_function(format!("update_one_by_pk/{}", row_label(rows.len())), |b| {
+        b.iter_batched_ref(
+            || runtime.block_on(sql_session::seeded_fixture(profile, &rows)),
+            |fixture| black_box(runtime.block_on(fixture.update_one_by_pk())),
+            BatchSize::LargeInput,
+        );
+    });
     group.bench_function(format!("delete_all_rows/{}", row_label(rows.len())), |b| {
         b.iter_batched_ref(
             || runtime.block_on(sql_session::seeded_fixture(profile, &rows)),

--- a/packages/engine-benchmarks/benches/tracked_state_crud/raw_sqlite.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/raw_sqlite.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, params, params_from_iter};
 use tempfile::TempDir;
 
 use crate::workload::WorkloadRow;
@@ -6,6 +6,8 @@ use crate::workload::WorkloadRow;
 pub(crate) struct RawSqliteFixture {
     connection: Connection,
     rows: Vec<WorkloadRow>,
+    read_many_by_pk_count: usize,
+    read_many_by_pk_sql: String,
     _dir: TempDir,
 }
 
@@ -28,9 +30,12 @@ pub(crate) fn empty_fixture(rows: &[WorkloadRow]) -> RawSqliteFixture {
              ) WITHOUT ROWID;",
         )
         .expect("initialize raw sqlite benchmark database");
+    let read_many_by_pk_count = rows.len().min(crate::READ_MANY_PK_COUNT);
     RawSqliteFixture {
         connection,
         rows: rows.to_vec(),
+        read_many_by_pk_count,
+        read_many_by_pk_sql: select_many_by_pk_sql(read_many_by_pk_count),
         _dir: dir,
     }
 }
@@ -123,19 +128,21 @@ impl RawSqliteFixture {
 
     pub(crate) fn read_many_by_pk(&self, count: usize) -> usize {
         let count = count.min(self.rows.len());
+        assert_eq!(
+            count, self.read_many_by_pk_count,
+            "read-many benchmark must use the fixture's setup-excluded query shape"
+        );
         let mut statement = self
             .connection
-            .prepare_cached("SELECT path, value FROM json_pointer WHERE path = ?1")
+            .prepare_cached(&self.read_many_by_pk_sql)
             .expect("prepare raw sqlite multi-point read");
+        let mut query = statement
+            .query(params_from_iter(
+                self.rows[..count].iter().map(|row| row.path.as_str()),
+            ))
+            .expect("query raw sqlite multi-point rows");
         let mut found = 0;
-        for row in &self.rows[..count] {
-            let mut query = statement
-                .query(params![row.path])
-                .expect("query raw sqlite multi-point row");
-            let result = query
-                .next()
-                .expect("read raw sqlite multi-point row")
-                .expect("raw sqlite multi-point row must exist");
+        while let Some(result) = query.next().expect("read next raw sqlite multi-point row") {
             let _: &str = result
                 .get_ref(0)
                 .expect("read raw sqlite multi-point path")
@@ -209,4 +216,13 @@ impl RawSqliteFixture {
         assert_eq!(affected, 1);
         affected
     }
+}
+
+fn select_many_by_pk_sql(count: usize) -> String {
+    assert!(count > 0, "read-many benchmark requires at least one row");
+    let placeholders = (1..=count)
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("SELECT path, value FROM json_pointer WHERE path IN ({placeholders}) ORDER BY path")
 }


### PR DESCRIPTION
Makes the normal tracked CRUD benchmark compare equivalent SQL shapes.

- Always includes SQL UPDATE operations in the default SQL-session suite.
- Changes standalone SQLite read-many from ten independent point queries to one ordered, bound `IN` query—the same query shape Lix already executes.
- Builds the SQLite SQL template during fixture setup so template construction is outside the timed operation.

This is measurement-only: it does not alter Lix behavior or artificially slow SQLite. It prevents the next performance iterations from comparing different workloads.

Current paired hot read-many baseline after this correction (10k rows, 20k repeats):
- Lix SQL session + RocksDB: 881.23 us/op
- standalone SQLite: 7.19 us/op

Validated with:
- cargo fmt --all -- --check
- cargo check -p lix_engine_benchmarks --features storage-benches --bench tracked_state_crud
- cargo clippy -p lix_engine_benchmarks --features storage-benches --bench tracked_state_crud -- -D warnings
- LIX_TRACKED_STATE_CRUD_PROFILE=1 ... raw_sqlite/read_many (20k hot repeats)
- cargo test -p lix_engine_benchmarks --features storage-benches --bench tracked_state_crud (Criterion smoke matrix)