### PR TITLE
perf: route exact entity reads around DataFusion

### DIFF
--- a/packages/engine/src/sql2/exec/bound_public_read.rs
+++ b/packages/engine/src/sql2/exec/bound_public_read.rs
@@ -1,0 +1,458 @@
+//! Strict native reads for the common public entity primary-key shape.
+//!
+//! Lix keeps the full SQL surface in DataFusion.  This module intentionally
+//! recognizes only a small shape which has a direct, row-oriented execution
+//! equivalent.  A rejected shape is not an error: callers must use the normal
+//! SQL path so that unsupported syntax never receives a partial native
+//! interpretation.
+
+use std::collections::BTreeSet;
+
+use datafusion::sql::parser::Statement as DataFusionStatement;
+use datafusion::sql::sqlparser::ast::{
+    BinaryOperator, Expr, GroupByExpr, OrderByKind, Query, Select, SelectFlavor, SetExpr,
+    Statement as SqlStatement, TableFactor, Value as SqlValue,
+};
+use serde_json::Value as JsonValue;
+
+use crate::entity_pk::EntityPk;
+use crate::live_state::{LiveStateFilter, LiveStateProjection, LiveStateScanRequest};
+use crate::sql2::SqlExecutionContext;
+use crate::sql2::catalog::{EntityColumnType, PublicSurfaceKind};
+use crate::{LixError, SqlQueryResult, Value};
+
+/// Attempts the one public entity read shape that can be evaluated directly
+/// against live state. `None` means the statement belongs to the general SQL
+/// executor.
+pub(crate) async fn try_execute_bound_public_read<C>(
+    ctx: &C,
+    sql: &str,
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Result<Option<SqlQueryResult>, LixError>
+where
+    C: SqlExecutionContext + ?Sized,
+{
+    let Some(shape) = strict_entity_primary_key_read(statement, params) else {
+        return Ok(None);
+    };
+
+    // A native route must retain all public SQL-surface validation. This runs
+    // after structural recognition so normal queries do not pay an additional
+    // validation pass before their existing DataFusion path.
+    crate::sql2::bind_read_statement(sql, statement)?;
+
+    let catalog = ctx.public_catalog().await?;
+    let Some(surface) = catalog.surface(&shape.table_name) else {
+        return Ok(None);
+    };
+    let PublicSurfaceKind::EntityBase { schema_key } = &surface.kind else {
+        return Ok(None);
+    };
+    let Some(spec) = catalog.entity_spec(schema_key) else {
+        return Ok(None);
+    };
+    let Some(primary_key_column) = single_top_level_string_primary_key(spec) else {
+        return Ok(None);
+    };
+    if primary_key_column != shape.primary_key_column
+        || shape.projection.iter().any(|column| {
+            !matches!(
+                spec.visible_column(column).map(|column| column.column_type),
+                Some(EntityColumnType::String | EntityColumnType::Json)
+            )
+        })
+    {
+        return Ok(None);
+    }
+
+    let entity_pks = shape
+        .primary_key_values
+        .into_iter()
+        .map(EntityPk::single)
+        .collect::<Vec<_>>();
+    let mut rows = ctx
+        .live_state()
+        .scan_rows(&LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: vec![schema_key.clone()],
+                entity_pks,
+                branch_ids: vec![ctx.active_branch_id().to_string()],
+                include_tombstones: false,
+                ..LiveStateFilter::default()
+            },
+            projection: LiveStateProjection {
+                columns: vec!["snapshot_content".to_string()],
+            },
+            limit: None,
+        })
+        .await?;
+
+    // The accepted ORDER BY is the complete one-column primary key. Retain
+    // multiple file-backed identities for one logical primary key; `file_id`
+    // is a first-class row identity and must not be collapsed by this route.
+    rows.sort_by(|left, right| left.entity_pk.cmp(&right.entity_pk));
+    let result_rows = rows
+        .iter()
+        .map(|row| materialize_row(spec, &shape.projection, row.snapshot_content.as_deref()))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Some(SqlQueryResult {
+        columns: shape.projection,
+        rows: result_rows,
+        notices: Vec::new(),
+    }))
+}
+
+fn single_top_level_string_primary_key(
+    spec: &crate::sql2::catalog::EntitySurfaceSpec,
+) -> Option<&str> {
+    let [primary_key] = spec.primary_key_paths.as_slice() else {
+        return None;
+    };
+    let [column] = primary_key.as_slice() else {
+        return None;
+    };
+    (spec.visible_column(column)?.column_type == EntityColumnType::String).then_some(column)
+}
+
+fn materialize_row(
+    spec: &crate::sql2::catalog::EntitySurfaceSpec,
+    projection: &[String],
+    snapshot_content: Option<&str>,
+) -> Result<Vec<Value>, LixError> {
+    let snapshot = snapshot_content
+        .map(|content| {
+            serde_json::from_str::<JsonValue>(content).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("sql2 entity provider expected valid snapshot_content JSON: {error}"),
+                )
+            })
+        })
+        .transpose()?;
+    projection
+        .iter()
+        .map(|column| {
+            let spec_column = spec.visible_column(column).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "direct entity read selected unknown column '{}' from schema '{}'",
+                        column, spec.schema_key
+                    ),
+                )
+            })?;
+            let value = snapshot.as_ref().and_then(|snapshot| snapshot.get(column));
+            materialize_value(spec_column.column_type, value)
+        })
+        .collect()
+}
+
+fn materialize_value(
+    column_type: EntityColumnType,
+    value: Option<&JsonValue>,
+) -> Result<Value, LixError> {
+    match (column_type, value) {
+        (_, None | Some(JsonValue::Null)) => Ok(Value::Null),
+        (EntityColumnType::String, Some(JsonValue::String(value))) => {
+            Ok(Value::Text(value.clone()))
+        }
+        (EntityColumnType::String, Some(JsonValue::Bool(value))) => {
+            Ok(Value::Text(value.to_string()))
+        }
+        (EntityColumnType::String, Some(value)) => serde_json::to_string(value)
+            .map(Value::Text)
+            .map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("failed to render string entity value: {error}"),
+                )
+            }),
+        (EntityColumnType::Json, Some(value)) => Ok(Value::Json(value.clone())),
+        // Numeric and boolean direct projection is deliberately left to
+        // DataFusion until this route shares the provider's exact coercion
+        // contracts. The common document CRUD shape uses string/JSON fields.
+        (EntityColumnType::Integer | EntityColumnType::Number | EntityColumnType::Boolean, _) => {
+            Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "direct entity read accepted an unsupported projected column type",
+            ))
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StrictEntityPrimaryKeyRead {
+    table_name: String,
+    projection: Vec<String>,
+    primary_key_column: String,
+    primary_key_values: Vec<String>,
+}
+
+/// Recognizes a single, active entity table with an `IN`/`=` primary-key
+/// predicate and canonical ascending primary-key order. It intentionally does
+/// not inspect catalog metadata: catalog mismatches are handled by the caller
+/// as a safe fallback.
+fn strict_entity_primary_key_read(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<StrictEntityPrimaryKeyRead> {
+    let (query, select, table_name) = strict_single_table_select(statement)?;
+    if query.order_by.is_none()
+        || query.limit_clause.is_some()
+        || query.fetch.is_some()
+        || select.selection.is_none()
+    {
+        return None;
+    }
+    let projection = strict_projection(&select.projection)?;
+    let (primary_key_column, primary_key_values) =
+        strict_primary_key_values(select.selection.as_ref()?, params)?;
+    if !canonical_primary_key_order(query, &primary_key_column) {
+        return None;
+    }
+    Some(StrictEntityPrimaryKeyRead {
+        table_name,
+        projection,
+        primary_key_column,
+        primary_key_values,
+    })
+}
+
+fn strict_single_table_select(
+    statement: &DataFusionStatement,
+) -> Option<(&Query, &Select, String)> {
+    let DataFusionStatement::Statement(statement) = statement else {
+        return None;
+    };
+    let SqlStatement::Query(query) = statement.as_ref() else {
+        return None;
+    };
+    if query.with.is_some()
+        || !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return None;
+    }
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return None;
+    };
+    if select.flavor != SelectFlavor::Standard
+        || select.optimizer_hint.is_some()
+        || select.distinct.is_some()
+        || select.select_modifiers.is_some()
+        || select.top.is_some()
+        || select.exclude.is_some()
+        || select.into.is_some()
+        || !select.lateral_views.is_empty()
+        || select.prewhere.is_some()
+        || !select.connect_by.is_empty()
+        || !group_by_is_empty(&select.group_by)
+        || !select.cluster_by.is_empty()
+        || !select.distribute_by.is_empty()
+        || !select.sort_by.is_empty()
+        || select.having.is_some()
+        || !select.named_window.is_empty()
+        || select.qualify.is_some()
+        || select.value_table_mode.is_some()
+    {
+        return None;
+    }
+    let [from] = select.from.as_slice() else {
+        return None;
+    };
+    if !from.joins.is_empty() {
+        return None;
+    }
+    let TableFactor::Table {
+        name,
+        alias,
+        args,
+        with_hints,
+        version,
+        with_ordinality,
+        partitions,
+        json_path,
+        sample,
+        index_hints,
+        ..
+    } = &from.relation
+    else {
+        return None;
+    };
+    if alias.is_some()
+        || args.is_some()
+        || !with_hints.is_empty()
+        || version.is_some()
+        || *with_ordinality
+        || !partitions.is_empty()
+        || json_path.is_some()
+        || sample.is_some()
+        || !index_hints.is_empty()
+        || name.0.len() != 1
+    {
+        return None;
+    }
+    let table_identifier = name.0.first()?.as_ident()?;
+    if table_identifier.quote_style.is_some() {
+        return None;
+    }
+    Some((query, select, table_identifier.value.to_ascii_lowercase()))
+}
+
+fn strict_projection(
+    projection: &[datafusion::sql::sqlparser::ast::SelectItem],
+) -> Option<Vec<String>> {
+    projection
+        .iter()
+        .map(|item| match item {
+            datafusion::sql::sqlparser::ast::SelectItem::UnnamedExpr(Expr::Identifier(column))
+                if column.quote_style.is_none() =>
+            {
+                Some(column.value.to_ascii_lowercase())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn strict_primary_key_values(expression: &Expr, params: &[Value]) -> Option<(String, Vec<String>)> {
+    let (column, expressions) = match expression {
+        Expr::InList {
+            expr,
+            list,
+            negated: false,
+        } if !list.is_empty() => (strict_identifier(expr)?, list.iter().collect::<Vec<_>>()),
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => match (strict_identifier(left), strict_identifier(right)) {
+            (Some(column), None) => (column, vec![right.as_ref()]),
+            (None, Some(column)) => (column, vec![left.as_ref()]),
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    let mut highest_parameter = 0;
+    let mut values = BTreeSet::new();
+    for expression in expressions {
+        let value = strict_text_value(expression, params, &mut highest_parameter)?;
+        values.insert(value);
+    }
+    (params.len() == highest_parameter).then_some((column, values.into_iter().collect()))
+}
+
+fn strict_text_value(
+    expression: &Expr,
+    params: &[Value],
+    highest_parameter: &mut usize,
+) -> Option<String> {
+    let Expr::Value(value) = expression else {
+        return None;
+    };
+    match &value.value {
+        SqlValue::SingleQuotedString(value) => Some(value.clone()),
+        SqlValue::Placeholder(placeholder) => {
+            let index = placeholder
+                .strip_prefix('$')?
+                .parse::<usize>()
+                .ok()
+                .filter(|index| *index > 0)?;
+            *highest_parameter = (*highest_parameter).max(index);
+            let Value::Text(value) = params.get(index - 1)? else {
+                return None;
+            };
+            Some(value.clone())
+        }
+        _ => None,
+    }
+}
+
+fn canonical_primary_key_order(query: &Query, primary_key_column: &str) -> bool {
+    let Some(order_by) = &query.order_by else {
+        return false;
+    };
+    if order_by.interpolate.is_some() {
+        return false;
+    }
+    let OrderByKind::Expressions(expressions) = &order_by.kind else {
+        return false;
+    };
+    let [order] = expressions.as_slice() else {
+        return false;
+    };
+    order.with_fill.is_none()
+        && order.options.asc != Some(false)
+        && order.options.nulls_first.is_none()
+        && strict_identifier(&order.expr).as_deref() == Some(primary_key_column)
+}
+
+fn strict_identifier(expression: &Expr) -> Option<String> {
+    let Expr::Identifier(identifier) = expression else {
+        return None;
+    };
+    (identifier.quote_style.is_none()).then(|| identifier.value.to_ascii_lowercase())
+}
+
+fn group_by_is_empty(group_by: &GroupByExpr) -> bool {
+    matches!(group_by, GroupByExpr::Expressions(expressions, modifiers)
+        if expressions.is_empty() && modifiers.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(sql: &str) -> DataFusionStatement {
+        crate::sql2::parse_statement(sql).expect("test SQL should parse")
+    }
+
+    #[test]
+    fn recognizes_benchmark_primary_key_read() {
+        let shape = strict_entity_primary_key_read(
+            &parse(
+                "SELECT path, value FROM json_pointer WHERE path IN ('/a', '/b', '/a') ORDER BY path",
+            ),
+            &[],
+        )
+        .expect("benchmark query should use direct route");
+
+        assert_eq!(shape.table_name, "json_pointer");
+        assert_eq!(shape.projection, ["path", "value"]);
+        assert_eq!(shape.primary_key_column, "path");
+        assert_eq!(shape.primary_key_values, ["/a", "/b"]);
+    }
+
+    #[test]
+    fn recognizes_numbered_text_parameters() {
+        let shape = strict_entity_primary_key_read(
+            &parse("SELECT path FROM json_pointer WHERE path IN ($2, $1) ORDER BY path"),
+            &[Value::Text("/a".to_string()), Value::Text("/b".to_string())],
+        )
+        .expect("numbered text params should use direct route");
+
+        assert_eq!(shape.primary_key_values, ["/a", "/b"]);
+    }
+
+    #[test]
+    fn rejects_noncanonical_or_ambiguous_sql() {
+        for sql in [
+            "SELECT path, value FROM json_pointer WHERE path IN ('/a')",
+            "SELECT path, value FROM json_pointer WHERE path IN ('/a') ORDER BY path DESC",
+            "SELECT path, value FROM json_pointer WHERE path IN ('/a') OR value = 'x' ORDER BY path",
+            "SELECT path + 'x' FROM json_pointer WHERE path IN ('/a') ORDER BY path",
+            "SELECT path FROM json_pointer AS p WHERE path IN ('/a') ORDER BY path",
+        ] {
+            assert!(
+                strict_entity_primary_key_read(&parse(sql), &[]).is_none(),
+                "{sql} must fall back"
+            );
+        }
+    }
+}

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -90,6 +90,14 @@ pub(crate) async fn execute_read_statement_from_parsed<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
+    // The route below recognizes only a small, fully understood subset; every
+    // other read continues through the normal DataFusion path unchanged.
+    if let Some(result) =
+        super::bound_public_read::try_execute_bound_public_read(ctx, sql, &statement, params)
+            .await?
+    {
+        return Ok(result);
+    }
     let session = prepare_read_session(ctx, std::slice::from_ref(&statement)).await?;
     execute_read_statement_in_session_from_parsed(&session, sql, statement, params).await
 }
@@ -158,6 +166,12 @@ pub(crate) async fn execute_transaction_read_statement_from_parsed(
     statement: DataFusionStatement,
     params: &[Value],
 ) -> Result<SqlQueryResult, LixError> {
+    if let Some(result) =
+        super::bound_public_read::try_execute_bound_public_read(read_ctx, sql, &statement, params)
+            .await?
+    {
+        return Ok(result);
+    }
     // Same fence as session reads, with the transaction overlay available
     // during planning/execution but not returned to the caller.
     let plan =
@@ -3129,6 +3143,59 @@ mod tests {
             .await
             .expect("sql2 execute should support literal-only queries");
         assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
+    }
+
+    #[tokio::test]
+    async fn native_entity_primary_key_read_materializes_public_result() {
+        let sql = "SELECT id, value FROM test_state_schema \
+                   WHERE id IN ('entity-b', 'entity-a') ORDER BY id";
+        let ctx = DummySqlExecutionContext {
+            active_branch_id: "branch-a",
+            blob_reader: Arc::new(DummyBlobReader),
+            live_state: Arc::new(RowsLiveStateReader {
+                rows: vec![
+                    live_test_state_row("entity-b", "branch-a", "B", false),
+                    live_test_state_row("entity-a", "branch-a", "A", false),
+                ],
+            }),
+            schema_definitions: vec![json!({
+                "x-lix-key": "test_state_schema",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "value": { "type": "string" }
+                },
+                "required": ["id", "value"],
+                "additionalProperties": false
+            })],
+        };
+        let statement = crate::sql2::parse_statement(sql).expect("test SQL should parse");
+
+        let result = super::super::bound_public_read::try_execute_bound_public_read(
+            &ctx,
+            sql,
+            &statement,
+            &[],
+        )
+        .await
+        .expect("native route should execute")
+        .expect("exact public primary-key read should use native route");
+
+        assert_eq!(result.columns, vec!["id", "value"]);
+        assert_eq!(
+            result.rows,
+            vec![
+                vec![
+                    Value::Text("entity-a".to_string()),
+                    Value::Text("A".to_string())
+                ],
+                vec![
+                    Value::Text("entity-b".to_string()),
+                    Value::Text("B".to_string())
+                ],
+            ]
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod bound_public_read;
 pub(crate) mod bound_public_write;
 pub(crate) mod datafusion;
 pub(crate) mod write;


### PR DESCRIPTION
## What changed

Routes exact active-entity primary-key reads directly through `LiveStateReader` instead of constructing a DataFusion session and Arrow result pipeline.

The route is intentionally strict: one unaliased active entity table, direct visible columns, one string primary key, `=` or `IN` values, and canonical ascending primary-key order. Unsupported shapes retain the existing DataFusion path unchanged. The transaction read route uses the same live-state overlay, preserving read-your-writes semantics.

## Why

The tracked CRUD benchmark showed the generic SQL/session path dominated point-read latency. On the comparable hot RocksDB read profile this changes 684.1 us/op to 33.25 us/op (20.6x faster). Standalone SQLite remains 2.66 us/op; the remaining storage-layout gap is addressed separately by the v5 PK-group serving layout.

## Validation

- `cargo test -p lix_engine native_entity_primary_key_read_materializes_public_result --lib`
- `cargo test -p lix_engine bound_public_read --lib`
- `cargo clippy -p lix_engine --features storage-benches -- -D warnings`
- release tracked CRUD hot profile (20,000 reads)
