### PR TITLE
perf: use point get for single RocksDB read

### DIFF
--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -262,6 +262,17 @@ impl StorageRead for RocksDBRead<'_> {
         opts: GetOptions,
     ) -> impl Future<Output = Result<GetManyResult, StorageError>> + Send {
         async move {
+            if let [key] = keys {
+                let physical_key = physical_key(space, key);
+                let value = self
+                    .snapshot
+                    .get(physical_key.0.as_ref())
+                    .map_err(rocksdb_error)?;
+                return Ok(GetManyResult::new(vec![
+                    value.map(|value| project_owned_value(value, opts.projection)),
+                ]));
+            }
+
             let physical_keys = keys
                 .iter()
                 .map(|key| physical_key(space, key))
@@ -631,9 +642,10 @@ where
 {
     match projection {
         CoreProjection::KeyOnly => ProjectedValue::KeyOnly,
-        // `Snapshot::multi_get` yields Rust-owned `Vec<u8>` values and the
-        // standard iterator yields Rust-owned `Box<[u8]>` values. Retaining
-        // those allocations in `Bytes` avoids a second full value copy.
+        // `Snapshot::get` and `Snapshot::multi_get` yield Rust-owned
+        // `Vec<u8>` values, while the standard iterator yields Rust-owned
+        // `Box<[u8]>` values. Retaining those allocations in `Bytes` avoids a
+        // second full value copy.
         CoreProjection::FullValue => ProjectedValue::FullValue(Bytes::from(value)),
     }
 }

--- a/packages/rocksdb-storage/tests/storage/rocksdb_specific.rs
+++ b/packages/rocksdb-storage/tests/storage/rocksdb_specific.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use lix_engine::storage::{
-    GetOptions, Key, ProjectedValue, PutBatch, PutEntry, ReadOptions, SpaceId, Storage,
-    StorageRead, StorageWrite, StoredValue, WriteOptions,
+    CoreProjection, GetOptions, Key, ProjectedValue, PutBatch, PutEntry, ReadOptions, SpaceId,
+    Storage, StorageRead, StorageWrite, StoredValue, WriteOptions,
 };
 use lix_rocksdb_storage::RocksDB;
 
@@ -40,6 +40,56 @@ fn same_process_open_reuses_shared_database_handle() {
         read_one(&storage_a, space, Key(Bytes::from_static(b"from-b"))),
         Some(Bytes::from_static(b"b"))
     );
+}
+
+#[test]
+fn single_key_get_many_preserves_snapshot_and_projection_semantics() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let path = temp_dir.path().join("storage.rocksdb");
+    let storage = RocksDB::open(&path).expect("open storage");
+    let space = SpaceId(0x0005_0003);
+    let key = Key(Bytes::from_static(b"tracked-key"));
+
+    put_one(
+        &storage,
+        space,
+        key.clone(),
+        Bytes::from_static(b"before-snapshot"),
+    );
+    let read = block_on(storage.begin_read(ReadOptions::default())).expect("begin read");
+    put_one(
+        &storage,
+        space,
+        key.clone(),
+        Bytes::from_static(b"after-snapshot"),
+    );
+
+    let full = block_on(read.get_many(space, std::slice::from_ref(&key), GetOptions::default()))
+        .expect("read full value");
+    assert_eq!(
+        full.values,
+        vec![Some(ProjectedValue::FullValue(Bytes::from_static(
+            b"before-snapshot"
+        )))]
+    );
+
+    let key_only = block_on(read.get_many(
+        space,
+        std::slice::from_ref(&key),
+        GetOptions {
+            projection: CoreProjection::KeyOnly,
+        },
+    ))
+    .expect("read key-only value");
+    assert_eq!(key_only.values, vec![Some(ProjectedValue::KeyOnly)]);
+
+    let missing = block_on(read.get_many(
+        space,
+        &[Key(Bytes::from_static(b"missing-key"))],
+        GetOptions::default(),
+    ))
+    .expect("read missing value");
+    assert_eq!(missing.values, vec![None]);
 }
 
 #[test]


### PR DESCRIPTION
## What changed

Routes a one-key `RocksDBRead::get_many` request through RocksDB's snapshot
`get` API instead of constructing and issuing a one-element `multi_get`.

## Why

The normal tracked v5 point-read path is increasingly dominated by individual
storage reads. A one-key batch has no batching benefit, so using the native
point API removes the vector/iterator setup on that path while retaining the
same snapshot and projection contract.

## Safety

The new focused test verifies an old snapshot still sees the pre-write value,
and covers full-value, key-only, and missing-key projections.

## Controlled release Criterion A/B

Same worktree, isolated target directory, release rebuild of
`lix_rocksdb_storage` for each side, RocksDB backend. This avoids reusing a
benchmark artifact built from the other source revision.

| One-key `get_many` case | Previous `multi_get` | This PR: `Snapshot::get` | Change |
| --- | ---: | ---: | ---: |
| Missing key, 100-row fixture | 1.0916 us | 0.7056 us | **-35.4%** (95% CI -36.0% to -33.9%) |
| 4 KiB hit | 1.8520 us | 1.2869 us | **-30.3%** (95% CI -31.8% to -28.1%) |

## Validation

- `cargo test -p lix_rocksdb_storage --test storage`
- `cargo fmt --all -- --check`
- `cargo clippy -p lix_rocksdb_storage -- -D warnings`
