### PR TITLE
perf: add clean tracked entity read lane

### DIFF
--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -17,7 +17,7 @@ use crate::live_state::tracked_head::TrackedHeadContext;
 use crate::live_state::{
     LiveStateExactBatchRequest, LiveStateReader, LiveStateRowIdentity, LiveStateRowRequest,
     LiveStateScanRequest, MaterializedLiveStateRow, VisibilityBranchScope, VisibilityRequest,
-    expanded_branch_ids, resolve_visible_rows,
+    expanded_branch_ids, load_local_sidecar_branch_token, resolve_visible_rows,
 };
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::{
@@ -176,6 +176,95 @@ where
                 limit: request.limit,
             },
         ))
+    }
+
+    /// Serves the strict public entity-PK read shape directly from current v5
+    /// tracked-head groups when all mutable overlays are proven irrelevant.
+    ///
+    /// This is intentionally an all-or-nothing capability. A normal
+    /// `scan_rows` remains the semantic authority whenever an assumption is
+    /// not durable: transaction readers do not override this method, a local
+    /// sidecar marker declines the lane, a matching global sidecar declines
+    /// it, and a missing/stale v5 marker declines it. In each case the caller
+    /// must take the ordinary visible-state path.
+    pub(crate) async fn try_scan_clean_tracked_entity_primary_keys(
+        &self,
+        request: &LiveStateScanRequest,
+    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
+        let Some(_requested_branch_id) = clean_tracked_entity_primary_key_branch(request) else {
+            return Ok(None);
+        };
+
+        // This is the same branch-ref snapshot resolution used by normal
+        // reads. It yields the active branch plus its global fallback source,
+        // without opening the broad tracked or flat scans below.
+        let scope = scan_scope(&self.store, &self.live_index, request, true).await?;
+        if scope.projection_branch_ids.is_empty() {
+            // A missing active branch has no visible rows in the general
+            // path either. Returning an empty successful fast result avoids a
+            // needless fallback while preserving that contract.
+            return Ok(Some(Vec::new()));
+        }
+
+        // The durable marker is a branch-wide proof that a local mutable
+        // sidecar has never participated in this branch's current serving
+        // state. Probe every tracked source (active and global) conservatively
+        // so a present token always uses the fully general visibility path.
+        for branch_id in &scope.storage_branch_ids {
+            if load_local_sidecar_branch_token(&self.store, branch_id)
+                .await?
+                .is_some()
+            {
+                return Ok(None);
+            }
+        }
+
+        // Global state intentionally has no branch-wide sidecar marker: it
+        // also owns engine configuration. A bounded exact-PK probe is enough
+        // here because only rows matching this request could affect its
+        // visible result. It keeps the native lane correct without turning an
+        // ordinary tracked query into a global flat-state scan.
+        if !self
+            .live_index
+            .reader(&self.store)
+            .scan_index_rows(&index_scan_request_from_live(request, GLOBAL_BRANCH_ID))
+            .await?
+            .is_empty()
+        {
+            return Ok(None);
+        }
+
+        let tracked_request = tracked_scan_request_from_live(request);
+        let mut tracked_rows = Vec::new();
+        for branch_id in &scope.storage_branch_ids {
+            let Some(commit_id) = scope.branch_commit_ids.get(branch_id) else {
+                continue;
+            };
+            let Some(rows) = self
+                .tracked_head
+                .reader(&self.store)
+                .scan_live_rows_if_current(branch_id, commit_id, &tracked_request)
+                .await?
+            else {
+                // A head projection is a cache-like serving structure. Do not
+                // infer emptiness from an absent or stale marker; fall back to
+                // the historical tracked-state path instead.
+                return Ok(None);
+            };
+            tracked_rows.extend(rows);
+        }
+
+        Ok(Some(resolve_visible_rows(
+            tracked_rows,
+            Vec::new(),
+            &VisibilityRequest {
+                branch_scope: VisibilityBranchScope::BranchIds {
+                    branch_ids: scope.projection_branch_ids,
+                },
+                include_tombstones: request.filter.include_tombstones,
+                limit: request.limit,
+            },
+        )))
     }
 
     pub(crate) async fn load_row(
@@ -518,6 +607,13 @@ where
         Self::scan_rows(self, request).await
     }
 
+    async fn try_scan_clean_tracked_entity_primary_keys(
+        &self,
+        request: &LiveStateScanRequest,
+    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
+        Self::try_scan_clean_tracked_entity_primary_keys(self, request).await
+    }
+
     async fn load_row(
         &self,
         request: &LiveStateRowRequest,
@@ -744,6 +840,31 @@ fn index_scan_request_from_live(
         projection: request.projection.columns.clone(),
         limit: None,
     }
+}
+
+/// Recognizes the deliberately small request shape backed by a v5 group
+/// point read. The SQL direct route is currently its only caller, but this
+/// guard lives beside the storage implementation so future callers cannot
+/// accidentally skip untracked or visibility semantics with a wider scan.
+fn clean_tracked_entity_primary_key_branch(request: &LiveStateScanRequest) -> Option<&str> {
+    let [branch_id] = request.filter.branch_ids.as_slice() else {
+        return None;
+    };
+    if !matches!(
+        request.filter.rows,
+        crate::live_state::LiveStateRowFilter::All
+    ) || request.filter.schema_keys.len() != 1
+        || request.filter.entity_pks.is_empty()
+        || !request.filter.file_ids.is_empty()
+        || request.filter.untracked.is_some()
+        || !request.filter.constraints.is_empty()
+        || request.filter.include_tombstones
+        || request.limit.is_some()
+        || request_may_include_commit_derived(request)
+    {
+        return None;
+    }
+    Some(branch_id)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -991,7 +1112,9 @@ mod tests {
     use crate::NullableKeyFilter;
     use crate::changelog::{ChangeId, ChangeRecord, ChangelogAppend, CommitId};
     use crate::entity_pk::EntityPk;
-    use crate::json_store::{JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef};
+    use crate::json_store::{
+        JsonRef, JsonSlot, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef,
+    };
     use crate::live_state::index::{LiveStateIndexContext, LiveStateIndexDeltaRef};
     use crate::live_state::{
         LiveStateExactBatchRequest, LiveStateExactRowRequest, LiveStateFilter, LiveStateProjection,
@@ -1124,15 +1247,11 @@ mod tests {
                         snapshot: row
                             .snapshot_content
                             .as_deref()
-                            .map_or(crate::json_store::JsonSlot::None, |snapshot| {
-                                crate::json_store::JsonSlot::from_json(snapshot)
-                            }),
+                            .map_or(JsonSlot::None, JsonSlot::from_json),
                         metadata: row
                             .metadata
                             .as_deref()
-                            .map_or(crate::json_store::JsonSlot::None, |metadata| {
-                                crate::json_store::JsonSlot::from_json(metadata)
-                            }),
+                            .map_or(JsonSlot::None, JsonSlot::from_json),
                         created_at: ts(&row.updated_at),
                         origin_key: None,
                     },
@@ -1367,6 +1486,80 @@ mod tests {
             index_writer.stage_branch_rows(branch_id, deltas).await?;
         }
         Ok(())
+    }
+
+    /// Seeds tracked roots and their matching v5 serving heads in one atomic
+    /// write. Tests which exercise the clean lane must use current markers;
+    /// an ordinary tracked-root fixture intentionally exercises the historical
+    /// fallback instead.
+    async fn write_v5_tracked_heads(
+        storage: &StorageAdapter,
+        heads: &[(&str, &str, &[MaterializedLiveStateRow])],
+    ) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("v5 tracked-head read should open");
+        let mut writes = StorageWriteSet::new();
+        let mut json_writer = JsonStoreContext::new().writer();
+        let rows = heads
+            .iter()
+            .flat_map(|(_, _, rows)| rows.iter().cloned())
+            .collect::<Vec<_>>();
+        stage_materialized_live_rows(&read, &mut writes, &mut json_writer, &rows)
+            .await
+            .expect("v5 tracked roots should stage");
+
+        for &(branch_id, commit_id, rows) in heads {
+            let slots = rows
+                .iter()
+                .map(|row| {
+                    (
+                        row.snapshot_content
+                            .as_deref()
+                            .map_or(JsonSlot::None, JsonSlot::from_json),
+                        row.metadata
+                            .as_deref()
+                            .map_or(JsonSlot::None, JsonSlot::from_json),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let deltas = rows
+                .iter()
+                .zip(&slots)
+                .map(
+                    |(row, (snapshot, metadata))| crate::live_state::TrackedHeadDeltaRef {
+                        schema_key: &row.schema_key,
+                        file_id: row.file_id.as_deref(),
+                        entity_pk: &row.entity_pk,
+                        change_id: row.change_id.expect("tracked fixture needs a change id"),
+                        commit_id: CommitId::for_test_label(commit_id),
+                        deleted: row.deleted,
+                        created_at: row.created_at,
+                        updated_at: row.updated_at,
+                        snapshot: snapshot.as_ref_slot(),
+                        metadata: metadata.as_ref_slot(),
+                    },
+                )
+                .collect::<Vec<_>>();
+            TrackedHeadContext::new()
+                .writer(&read, &mut writes)
+                .stage_commit(
+                    branch_id,
+                    None,
+                    CommitId::for_test_label(commit_id),
+                    &deltas,
+                    &std::collections::BTreeSet::new(),
+                    None,
+                )
+                .await
+                .expect("v5 tracked head should stage");
+        }
+
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("v5 tracked heads should commit");
     }
 
     fn stage_json_payloads_from_materialized(
@@ -2395,6 +2588,226 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn clean_v5_entity_pk_lane_resolves_global_local_and_tombstones() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live_state = live_state_context();
+
+        let mut global_visible = tracked_row_at_with_commit(
+            GLOBAL_BRANCH_ID,
+            "global-visible",
+            Some("global-visible-change"),
+            "clean-global",
+        );
+        global_visible.entity_pk = identity("visible");
+        let mut global_hidden = tracked_row_at_with_commit(
+            GLOBAL_BRANCH_ID,
+            "global-hidden",
+            Some("global-hidden-change"),
+            "clean-global",
+        );
+        global_hidden.entity_pk = identity("hidden");
+        let mut local_visible = tracked_row_at_with_commit(
+            "branch-a",
+            "local-visible",
+            Some("local-visible-change"),
+            "clean-branch",
+        );
+        local_visible.entity_pk = identity("visible");
+        let mut local_tombstone = tombstone_tracked_row_at_with_commit(
+            "branch-a",
+            Some("local-hidden-tombstone"),
+            "clean-branch",
+        );
+        local_tombstone.entity_pk = identity("hidden");
+
+        write_v5_tracked_heads(
+            &storage,
+            &[
+                (
+                    GLOBAL_BRANCH_ID,
+                    "clean-global",
+                    &[global_visible, global_hidden],
+                ),
+                (
+                    "branch-a",
+                    "clean-branch",
+                    &[local_visible, local_tombstone],
+                ),
+            ],
+        )
+        .await;
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch refs read should open");
+        write_untracked_rows_to_store(
+            &storage,
+            &read,
+            &[
+                branch_ref_row(GLOBAL_BRANCH_ID, "clean-global"),
+                branch_ref_row("branch-a", "clean-branch"),
+            ],
+        )
+        .await;
+
+        let rows = live_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("clean v5 read should open"),
+            )
+            .try_scan_clean_tracked_entity_primary_keys(&clean_entity_pk_request(
+                "branch-a",
+                &["visible", "hidden"],
+            ))
+            .await
+            .expect("clean v5 lane should read")
+            .expect("matching v5 heads without sidecars should use clean lane");
+
+        assert_eq!(rows.len(), 1, "local tombstone must hide global fallback");
+        assert_eq!(rows[0].entity_pk, identity("visible"));
+        assert_eq!(
+            rows[0].snapshot_content.as_deref(),
+            Some("{\"value\":\"local-visible\"}")
+        );
+        assert_eq!(rows[0].branch_id.as_ref(), "branch-a");
+        assert!(!rows[0].global);
+        assert!(!rows[0].untracked);
+    }
+
+    #[tokio::test]
+    async fn clean_v5_entity_pk_lane_declines_matching_global_sidecar() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live_state = live_state_context();
+        let global_rows = [tracked_row_at_with_commit(
+            GLOBAL_BRANCH_ID,
+            "tracked-global",
+            Some("tracked-global-change"),
+            "sidecar-global",
+        )];
+        write_v5_tracked_heads(
+            &storage,
+            &[
+                (GLOBAL_BRANCH_ID, "sidecar-global", &global_rows),
+                ("branch-a", "sidecar-branch", &[]),
+            ],
+        )
+        .await;
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch refs read should open");
+        write_untracked_rows_to_store(
+            &storage,
+            &read,
+            &[
+                branch_ref_row(GLOBAL_BRANCH_ID, "sidecar-global"),
+                branch_ref_row("branch-a", "sidecar-branch"),
+                untracked_row("global-sidecar"),
+            ],
+        )
+        .await;
+
+        let request = clean_entity_pk_request("branch-a", &["selected-tab"]);
+        let direct = live_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("clean v5 read should open"),
+            )
+            .try_scan_clean_tracked_entity_primary_keys(&request)
+            .await
+            .expect("clean v5 lane should probe sidecar");
+        assert_eq!(
+            direct, None,
+            "a matching global mutable row must retain ordinary visibility resolution"
+        );
+
+        let rows = live_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("fallback read should open"),
+            )
+            .scan_rows(&request)
+            .await
+            .expect("ordinary visibility path should read sidecar");
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].untracked);
+        assert_eq!(
+            rows[0].snapshot_content.as_deref(),
+            Some("{\"value\":\"global-sidecar\"}")
+        );
+    }
+
+    #[tokio::test]
+    async fn clean_v5_entity_pk_lane_declines_branch_with_sidecar_marker() {
+        let storage = StorageAdapter::new(Memory::new());
+        let live_state = live_state_context();
+        let global_rows = [tracked_row_at_with_commit(
+            GLOBAL_BRANCH_ID,
+            "tracked-global",
+            Some("marker-global-change"),
+            "marker-global",
+        )];
+        let branch_rows = [tracked_row_at_with_commit(
+            "branch-a",
+            "tracked-branch",
+            Some("marker-branch-change"),
+            "marker-branch",
+        )];
+        write_v5_tracked_heads(
+            &storage,
+            &[
+                (GLOBAL_BRANCH_ID, "marker-global", &global_rows),
+                ("branch-a", "marker-branch", &branch_rows),
+            ],
+        )
+        .await;
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch refs read should open");
+        write_untracked_rows_to_store(
+            &storage,
+            &read,
+            &[
+                branch_ref_row(GLOBAL_BRANCH_ID, "marker-global"),
+                branch_ref_row("branch-a", "marker-branch"),
+            ],
+        )
+        .await;
+        let mut writes = StorageWriteSet::new();
+        crate::live_state::stage_local_sidecar_branch_marker(&mut writes, "branch-a")
+            .expect("sidecar marker should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("sidecar marker should commit");
+
+        let direct = live_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("clean v5 read should open"),
+            )
+            .try_scan_clean_tracked_entity_primary_keys(&clean_entity_pk_request(
+                "branch-a",
+                &["selected-tab"],
+            ))
+            .await
+            .expect("clean v5 lane should probe marker");
+        assert_eq!(
+            direct, None,
+            "the monotonic branch-sidecar marker must conservatively reject the clean lane"
+        );
+    }
+
     async fn load_selected_tab(
         live_state: &LiveStateContext,
         storage: &StorageAdapter,
@@ -2461,6 +2874,24 @@ mod tests {
                 ..LiveStateScanRequest::default()
             })
             .await
+    }
+
+    fn clean_entity_pk_request(branch_id: &str, entity_pks: &[&str]) -> LiveStateScanRequest {
+        LiveStateScanRequest {
+            filter: LiveStateFilter {
+                schema_keys: vec!["lix_key_value".to_string()],
+                entity_pks: entity_pks
+                    .iter()
+                    .map(|entity_pk| identity(entity_pk))
+                    .collect(),
+                branch_ids: vec![branch_id.to_string()],
+                ..LiveStateFilter::default()
+            },
+            projection: LiveStateProjection {
+                columns: vec!["snapshot_content".to_string()],
+            },
+            limit: None,
+        }
     }
 
     async fn scan_tracked_root(

--- a/packages/engine/src/live_state/reader.rs
+++ b/packages/engine/src/live_state/reader.rs
@@ -16,6 +16,21 @@ pub(crate) trait LiveStateReader: Send + Sync {
         request: &LiveStateScanRequest,
     ) -> Result<Vec<MaterializedLiveStateRow>, LixError>;
 
+    /// Attempts the narrow, current-head serving lane for an exact set of
+    /// entity primary keys.
+    ///
+    /// `None` is deliberately a normal result: readers with a transaction
+    /// overlay, an untracked sidecar, or no current v5 head projection must
+    /// let the caller use [`Self::scan_rows`] instead. Keeping this capability
+    /// at the live-state boundary means SQL can take the direct path without
+    /// learning about storage layouts or bypassing visibility semantics.
+    async fn try_scan_clean_tracked_entity_primary_keys(
+        &self,
+        _request: &LiveStateScanRequest,
+    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
+        Ok(None)
+    }
+
     /// Scans the immutable tracked head selected by the current branch ref.
     ///
     /// Normal SQL reads use [`Self::scan_rows`] and therefore see exactly one

--- a/packages/engine/src/sql2/exec/bound_public_read.rs
+++ b/packages/engine/src/sql2/exec/bound_public_read.rs
@@ -71,22 +71,28 @@ where
         .into_iter()
         .map(EntityPk::single)
         .collect::<Vec<_>>();
-    let mut rows = ctx
-        .live_state()
-        .scan_rows(&LiveStateScanRequest {
-            filter: LiveStateFilter {
-                schema_keys: vec![schema_key.clone()],
-                entity_pks,
-                branch_ids: vec![ctx.active_branch_id().to_string()],
-                include_tombstones: false,
-                ..LiveStateFilter::default()
-            },
-            projection: LiveStateProjection {
-                columns: vec!["snapshot_content".to_string()],
-            },
-            limit: None,
-        })
-        .await?;
+    let request = LiveStateScanRequest {
+        filter: LiveStateFilter {
+            schema_keys: vec![schema_key.clone()],
+            entity_pks,
+            branch_ids: vec![ctx.active_branch_id().to_string()],
+            include_tombstones: false,
+            ..LiveStateFilter::default()
+        },
+        projection: LiveStateProjection {
+            columns: vec!["snapshot_content".to_string()],
+        },
+        limit: None,
+    };
+    let live_state = ctx.live_state();
+    let mut rows = if let Some(rows) = live_state
+        .try_scan_clean_tracked_entity_primary_keys(&request)
+        .await?
+    {
+        rows
+    } else {
+        live_state.scan_rows(&request).await?
+    };
 
     // The accepted ORDER BY is the complete one-column primary key. Retain
     // multiple file-backed identities for one logical primary key; `file_id`

--- a/packages/engine/src/sql2/exec/datafusion.rs
+++ b/packages/engine/src/sql2/exec/datafusion.rs
@@ -2235,6 +2235,11 @@ mod tests {
         rows: Vec<MaterializedLiveStateRow>,
         scans: Arc<AtomicUsize>,
     }
+    struct CleanRowsLiveStateReader {
+        rows: Vec<MaterializedLiveStateRow>,
+        clean_reads: Arc<AtomicUsize>,
+        scans: Arc<AtomicUsize>,
+    }
     struct DummyCommitGraphReader;
     struct DummyBranchRefReader;
     fn test_read_scope(storage: &StorageAdapter<Memory>) -> StorageAdapterReadScope<MemoryRead> {
@@ -2903,6 +2908,39 @@ mod tests {
     }
 
     #[async_trait]
+    impl LiveStateReader for CleanRowsLiveStateReader {
+        async fn try_scan_clean_tracked_entity_primary_keys(
+            &self,
+            request: &LiveStateScanRequest,
+        ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
+            self.clean_reads.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(filter_live_state_rows(&self.rows, request)))
+        }
+
+        async fn load_exact_rows(
+            &self,
+            request: &crate::live_state::LiveStateExactBatchRequest,
+        ) -> Result<Vec<Option<MaterializedLiveStateRow>>, LixError> {
+            crate::live_state::load_exact_rows_via_scan_for_test(self, request).await
+        }
+
+        async fn scan_rows(
+            &self,
+            request: &LiveStateScanRequest,
+        ) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+            self.scans.fetch_add(1, Ordering::SeqCst);
+            Ok(filter_live_state_rows(&self.rows, request))
+        }
+
+        async fn load_row(
+            &self,
+            _request: &LiveStateRowRequest,
+        ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
+            Ok(None)
+        }
+    }
+
+    #[async_trait]
     impl BlobDataReader for DummyBlobReader {
         async fn load_bytes_many(
             &self,
@@ -3195,6 +3233,68 @@ mod tests {
                     Value::Text("B".to_string())
                 ],
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn native_entity_primary_key_read_uses_clean_live_state_lane_when_available() {
+        let sql = "SELECT id, value FROM test_state_schema \
+                   WHERE id IN ('entity-b', 'entity-a') ORDER BY id";
+        let clean_reads = Arc::new(AtomicUsize::new(0));
+        let scans = Arc::new(AtomicUsize::new(0));
+        let ctx = DummySqlExecutionContext {
+            active_branch_id: "branch-a",
+            blob_reader: Arc::new(DummyBlobReader),
+            live_state: Arc::new(CleanRowsLiveStateReader {
+                rows: vec![
+                    live_test_state_row("entity-b", "branch-a", "B", false),
+                    live_test_state_row("entity-a", "branch-a", "A", false),
+                ],
+                clean_reads: Arc::clone(&clean_reads),
+                scans: Arc::clone(&scans),
+            }),
+            schema_definitions: vec![json!({
+                "x-lix-key": "test_state_schema",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "value": { "type": "string" }
+                },
+                "required": ["id", "value"],
+                "additionalProperties": false
+            })],
+        };
+        let statement = crate::sql2::parse_statement(sql).expect("test SQL should parse");
+
+        let result = super::super::bound_public_read::try_execute_bound_public_read(
+            &ctx,
+            sql,
+            &statement,
+            &[],
+        )
+        .await
+        .expect("native route should execute")
+        .expect("exact public primary-key read should use native route");
+
+        assert_eq!(
+            result.rows,
+            vec![
+                vec![
+                    Value::Text("entity-a".to_string()),
+                    Value::Text("A".to_string())
+                ],
+                vec![
+                    Value::Text("entity-b".to_string()),
+                    Value::Text("B".to_string())
+                ],
+            ]
+        );
+        assert_eq!(clean_reads.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            scans.load(Ordering::SeqCst),
+            0,
+            "a clean-capable reader must not re-enter the generic scan path"
         );
     }
 


### PR DESCRIPTION
## What changed

Adds a narrow clean tracked-state serving lane for the already-native SQL
entity-primary-key read shape. When all of the following are proven from the
same read snapshot, it reads current v5 groups directly and skips the broad
untracked visibility scans:

- the request is a strict active-branch tracked entity-PK read;
- active/global heads have matching v5 markers;
- neither source has a local-sidecar marker; and
- no matching global flat sidecar row exists.

Any uncertainty returns `None` and falls back to the existing general
live-state path. Transaction readers intentionally retain that fallback so
staged overlays stay authoritative.

## Safety

Focused tests cover:

- global/local precedence and a local tombstone hiding the global row;
- a matching global mutable sidecar declining the lane; and
- a branch sidecar marker conservatively declining the lane.

The strict SQL route also has a dispatch test proving it does not re-enter the
generic scan when the capability is available.

## Before / after: release hot SQL PK read

Same host, RocksDB backend, 10k seeded tracked rows, one warmed session, and
only the operation window timed. Both use 100k repeats of the same benchmark
command; values are one-run hot-window means.

| Revision | Read one tracked PK |
| --- | ---: |
| `main` at `135a8c1a` | 30.167 us |
| This PR (`e1dc62c1`) | 28.185 us |

That is **6.6% lower latency** for this PR alone. Against the original
post-v5 pre-#771 baseline (35.704 us), the accumulated v5 + point-get + clean
lane stack is 21.1% lower. Standalone raw SQLite remains 2.696 us, so this is
still about 10.5x slower and deliberately not claimed as parity.

Reproduce:

```text
LIX_TRACKED_STATE_CRUD_PROFILE=1 \
LIX_TRACKED_STATE_CRUD_PROFILE_OP=read_one \
LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session \
LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS=100000 \
cargo bench -p lix_engine_benchmarks --bench tracked_state_crud --features storage-benches
```

## Validation

- `cargo test -p lix_engine clean_v5_entity_pk_lane --lib`
- `cargo test -p lix_engine native_entity_primary_key_read_uses_clean_live_state_lane_when_available --lib`
- `cargo clippy -p lix_engine --features storage-benches -- -D warnings`
