### PR TITLE
bench(plugin-v2): expose transaction phase timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3387,6 +3387,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
  "wasmtime",
  "wasmtime-wasi",
  "zip",

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 sha2 = "0.10"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wasmtime = { version = "45", default-features = false, features = ["component-model", "cranelift", "runtime", "std"] }
 wasmtime-wasi = { version = "45", default-features = false, features = ["p2"] }
 zip = { version = "8", default-features = false }

--- a/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
+++ b/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
@@ -69,6 +69,15 @@ struct GitFixture {
 #[tokio::test]
 #[ignore = "manual steady-state Markdown byte-write profile target"]
 async fn markdown_lix_byte_hotpath_profile() {
+    if std::env::var_os("LIX_MARKDOWN_GIT_TRACE").is_some() {
+        tracing_subscriber::fmt()
+            .with_env_filter("lix_perf=debug")
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_test_writer()
+            .try_init()
+            .expect("initialize one benchmark tracing subscriber");
+    }
+
     let target_bytes = env_usize("LIX_MARKDOWN_GIT_BENCH_BYTES", DEFAULT_TARGET_BYTES);
     let samples = env_usize("LIX_MARKDOWN_GIT_PROFILE_SAMPLES", DEFAULT_PROFILE_SAMPLES);
     assert!(samples > 0);


### PR DESCRIPTION
## Summary

- add opt-in transaction phase tracing to the Markdown hot-path benchmark
- preserve the public SQL and plugin APIs
- make profile attribution repeatable before changing production behavior

## Validation

- Markdown and JSON release benchmark gates
- cargo test -p lix_engine --features all-simulations

Stacked on #773.