### PR TITLE
bench(plugin-v2): split reconciliation timings and cohorts

### DIFF
--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1284,6 +1284,10 @@ where
                     prepared_semantic_rows,
                 } = self
                     .plugin_write_reconciliation(&rows, &mut file_data)
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_reconciliation"
+                    ))
                     .await?;
                 mark_plugin_reconciliation_rows(&mut plugin_rows);
                 for (file_key, version) in &materialization_versions {
@@ -2144,6 +2148,11 @@ where
 
         let mut selected_plugins = BTreeMap::<PluginFileWriteKey, PluginRegistryEntry>::new();
         let mut full_content_classification_bytes = BTreeMap::<PluginFileWriteKey, u64>::new();
+        let selection_span = tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.plugin_selection"
+        );
+        let selection_guard = selection_span.enter();
         for write in file_data.iter() {
             let Some(path) = write.path.as_deref() else {
                 continue;
@@ -2211,6 +2220,7 @@ where
             };
             selected_plugins.insert(file_key, plugin.clone());
         }
+        drop(selection_guard);
 
         let mut state_groups = BTreeMap::<PluginStateGroupKey, PluginStateGroup>::new();
         for (key, owner) in &owners {
@@ -2554,13 +2564,19 @@ where
                 lease.require_accepted_semantic_root(&visible_root)?;
                 let observation_is_current = observation.semantic_root() == visible_root;
                 let observed_bytes = lease.observed_bytes();
-                let built_splices = build_file_update_splices(
-                    &observed_bytes,
-                    lease.observed_bytes_sha256(),
-                    write.data(),
-                    write.splice_provenance(),
-                    limits,
-                )?;
+                let built_splices = tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_splice_discovery"
+                )
+                .in_scope(|| {
+                    build_file_update_splices(
+                        &observed_bytes,
+                        lease.observed_bytes_sha256(),
+                        write.data(),
+                        write.splice_provenance(),
+                        limits,
+                    )
+                })?;
                 let submitted_bytes_sha256 = built_splices.after_sha256;
                 let host_full_diff_bytes_compared = built_splices.full_diff_bytes_compared;
                 let observed_source = ArcByteSource::new(observed_bytes.clone());
@@ -2586,6 +2602,10 @@ where
                             ids,
                         },
                     )
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_file_changed"
+                    ))
                     .await
                 {
                     Ok(transition) => transition,
@@ -2597,6 +2617,10 @@ where
                     &schemas,
                     limits,
                 )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_drain_changes"
+                ))
                 .await
                 {
                     Ok(transition) => transition,
@@ -2610,6 +2634,10 @@ where
                 let mut counters = detected_transition.counters;
                 let changes = match self
                     .suppress_v2_format_only_noops(detected_transition.changes, &file_key)
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_suppress_noops"
+                    ))
                     .await
                 {
                     Ok(changes) => changes,
@@ -2773,6 +2801,10 @@ where
                     &file_key,
                     existing_id_namespace_reservation.as_ref(),
                 )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_id_namespace_rows"
+                ))
                 .await;
             let namespace_rows = match namespace_rows {
                 Ok(rows) => rows,

--- a/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
+++ b/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
@@ -121,16 +121,18 @@ async fn markdown_lix_byte_hotpath_profile() {
 async fn markdown_git_semantic_entities_benchmark() {
     let target_bytes = env_usize("LIX_MARKDOWN_GIT_BENCH_BYTES", DEFAULT_TARGET_BYTES);
     let edit_samples = env_usize("LIX_MARKDOWN_GIT_BENCH_EDIT_SAMPLES", DEFAULT_EDIT_SAMPLES);
+    let semantic_edit_samples =
+        env_usize("LIX_MARKDOWN_GIT_BENCH_SEMANTIC_EDIT_SAMPLES", edit_samples);
     let merge_samples = env_usize(
         "LIX_MARKDOWN_GIT_BENCH_MERGE_SAMPLES",
         DEFAULT_MERGE_SAMPLES,
     );
     let cold_samples = env_usize("LIX_MARKDOWN_GIT_BENCH_COLD_SAMPLES", DEFAULT_COLD_SAMPLES);
-    assert!(edit_samples > 0 && merge_samples > 0 && cold_samples > 0);
+    assert!(edit_samples > 0 && semantic_edit_samples > 0 && merge_samples > 0 && cold_samples > 0);
 
     let corpus = markdown_corpus(target_bytes);
     assert!(
-        corpus.texts.len() > edit_samples + merge_samples * 4,
+        corpus.texts.len() > edit_samples.max(semantic_edit_samples) + merge_samples * 4,
         "benchmark corpus must contain enough unrelated paragraphs"
     );
     let archive = build_markdown_v2_plugin_archive();
@@ -149,10 +151,10 @@ async fn markdown_git_semantic_entities_benchmark() {
     let initial_nodes = markdown_nodes_by_kind(&lix, &file_id, "paragraph").await;
     assert_eq!(initial_nodes.len(), corpus.texts.len());
 
-    let mut lix_semantic_edits = Vec::with_capacity(edit_samples);
+    let mut lix_semantic_edits = Vec::with_capacity(semantic_edit_samples);
     let mut lix_main_state = corpus.bytes.clone();
-    for sample in 0..edit_samples {
-        let index = spread_index(sample, edit_samples, corpus.texts.len() / 2);
+    for sample in 0..semantic_edit_samples {
+        let index = spread_index(sample, semantic_edit_samples, corpus.texts.len() / 2);
         let replacement = edit_replacement(corpus.bytes[corpus.edit_offsets[index]], sample);
         let payload = payload_with_replacement(
             &initial_nodes[index].payload_json,
@@ -293,6 +295,24 @@ async fn markdown_git_semantic_entities_benchmark() {
     )
     .await;
 
+    // Keep the raw Git timing cohort independent from the semantic-history
+    // cohort. This lets hot-byte measurements use a statistically useful
+    // sample count even when semantic edit timings are intentionally bounded.
+    let mut git_timing = GitFixture::new();
+    git_timing.write_worktree(&corpus.bytes);
+    git_timing.commit_all("initial Markdown corpus");
+    let mut git_timing_state = corpus.bytes.clone();
+    let mut git_edits = Vec::with_capacity(edit_samples);
+    for sample in 0..edit_samples {
+        let index = spread_index(sample, edit_samples, corpus.texts.len() / 2);
+        git_timing_state[corpus.edit_offsets[index]] =
+            edit_replacement(corpus.bytes[corpus.edit_offsets[index]], sample);
+        let started = Instant::now();
+        git_timing.write_worktree(&git_timing_state);
+        git_timing.commit_all(&format!("timed edit paragraph {index}"));
+        git_edits.push(started.elapsed());
+    }
+
     let mut git = GitFixture::new();
     let git_fixed = git.repo_sizes();
     let git_import_started = Instant::now();
@@ -301,15 +321,12 @@ async fn markdown_git_semantic_entities_benchmark() {
     let git_import = git_import_started.elapsed();
 
     let mut git_state = corpus.bytes.clone();
-    let mut git_edits = Vec::with_capacity(edit_samples);
-    for sample in 0..edit_samples {
-        let index = spread_index(sample, edit_samples, corpus.texts.len() / 2);
+    for sample in 0..semantic_edit_samples {
+        let index = spread_index(sample, semantic_edit_samples, corpus.texts.len() / 2);
         git_state[corpus.edit_offsets[index]] =
             edit_replacement(corpus.bytes[corpus.edit_offsets[index]], sample);
-        let started = Instant::now();
         git.write_worktree(&git_state);
         git.commit_all(&format!("edit paragraph {index}"));
-        git_edits.push(started.elapsed());
     }
     assert_same_bytes(
         "Git and Lix must match after the identical pre-merge edit trace",
@@ -418,13 +435,14 @@ async fn markdown_git_semantic_entities_benchmark() {
          system=git clean_merges=0 conflicts=1 preserved_edits=0"
     );
     eprintln!(
-        "markdown_git_bench corpus_bytes={} paragraphs={} edit_samples={} merge_samples={} \
+        "markdown_git_bench corpus_bytes={} paragraphs={} edit_samples={} semantic_edit_samples={} merge_samples={} \
          lix_incremental_total_bytes={} lix_incremental_metadata_bytes={} \
          git_live_incremental_total_bytes={} git_live_incremental_metadata_bytes={} \
          git_packed_incremental_total_bytes={} git_packed_incremental_metadata_bytes={}",
         corpus.bytes.len(),
         corpus.texts.len(),
         edit_samples,
+        semantic_edit_samples,
         merge_samples,
         lix_history
             .total_bytes


### PR DESCRIPTION
## Summary

- split plugin selection, splice discovery, guest file_changed, drain, no-op suppression, and ID reservation timings
- keep raw Git/Lix byte timing cohorts independent from bounded semantic-history cohorts
- preserve the public SQL and plugin APIs

## Profile result

Before the final Markdown optimization, plugin reconciliation consumed about 12-13 ms:
- splice discovery: about 2.7 ms
- guest file_changed: about 8.5 ms
- remaining reconciliation stages: below 0.25 ms combined

This identified guest-side full document successor cloning as the dominant controllable CPU cost.

## Validation

- cargo test -p lix_engine --features all-simulations
- release Markdown and JSON benchmark gates

Stacked on the retained materialization PR.