### PR TITLE
perf: move tracked branch heads to direct v6 controls

### DIFF
--- a/packages/engine/src/branch/control.rs
+++ b/packages/engine/src/branch/control.rs
@@ -1,0 +1,354 @@
+//! Durable v6 branch-head control records.
+//!
+//! A branch head is a tiny mutable control-plane record, not a user row.  It
+//! therefore has its own space and exact-byte CAS token.  The current tracked
+//! serving generation lives beside the head so readers can bind a v5 group
+//! marker to the same atomic publication without consulting `lix_branch_ref`
+//! through the mutable live-state index.
+
+use bytes::Bytes;
+
+use crate::LixError;
+use crate::changelog::{ChangeId, CommitId};
+use crate::common::LixTimestamp;
+use crate::storage_adapter::{
+    PointReadPlan, ScanPlan, StorageAdapterRead, StorageGetOptions, StorageKey,
+    StoragePrecondition, StoragePrefix, StorageProjectedValue, StorageScanOptions, StorageSpace,
+    StorageSpaceId, StorageValue, StorageWriteSet,
+};
+use crate::storage_codec;
+
+pub(crate) const BRANCH_HEAD_CONTROL_NAMESPACE: &str = "branch.head_control.v6";
+pub(crate) const BRANCH_HEAD_CONTROL_SPACE: StorageSpace =
+    StorageSpace::new(StorageSpaceId(0x0004_0015), BRANCH_HEAD_CONTROL_NAMESPACE);
+
+/// The one mutable publication record for a branch.
+///
+/// `generation` is the physical v5 tracked-head generation currently serving
+/// `head_commit_id`. Serial normal commits retain it; a rewind, merge fence,
+/// or bootstrap gets a fresh generation and takes the historical fallback
+/// until a complete v5 projection is published.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct BranchHeadControl {
+    pub(crate) head_commit_id: CommitId,
+    pub(crate) generation: CommitId,
+    /// Stable public `lixcol_created_at` for the synthesized branch-ref row.
+    pub(crate) created_at: LixTimestamp,
+    /// Public `lixcol_updated_at` for the last head publication.
+    pub(crate) updated_at: LixTimestamp,
+    /// Public `lixcol_change_id` for the last head publication.
+    pub(crate) ref_change_id: ChangeId,
+}
+
+/// One coherent point-read observation used for both generation selection and
+/// the final exact-byte CAS guard. Keeping the decoded control and original
+/// bytes together prevents a materializer from issuing a second control read
+/// merely to build its publication precondition.
+#[derive(Debug, Clone)]
+pub(crate) struct BranchHeadControlObservation {
+    pub(crate) control: Option<BranchHeadControl>,
+    pub(crate) raw_token: Option<Bytes>,
+}
+
+#[derive(musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct BranchHeadControlKey {
+    branch_id: String,
+}
+
+#[derive(musli::Encode)]
+#[musli(packed)]
+struct BranchHeadControlKeyRef<'a> {
+    branch_id: &'a str,
+}
+
+/// Read-side access for direct branch-head control records.
+pub(crate) struct BranchHeadControlReader<S> {
+    store: S,
+}
+
+impl<S> BranchHeadControlReader<S>
+where
+    S: StorageAdapterRead,
+{
+    pub(crate) async fn load(
+        &self,
+        branch_id: &str,
+    ) -> Result<Option<BranchHeadControl>, LixError> {
+        let mut values = self.load_many(&[branch_id.to_string()]).await?;
+        Ok(values.pop().flatten())
+    }
+
+    /// Preserves request cardinality and order, including duplicates.
+    pub(crate) async fn load_many(
+        &self,
+        branch_ids: &[String],
+    ) -> Result<Vec<Option<BranchHeadControl>>, LixError> {
+        Ok(self
+            .load_observed(branch_ids)
+            .await?
+            .into_iter()
+            .map(|observation| observation.control)
+            .collect())
+    }
+
+    /// One point batch that returns both the decoded control and its opaque
+    /// exact persisted bytes. Publication callers must retain this result
+    /// through their write-set construction rather than reading the control
+    /// again for CAS.
+    pub(crate) async fn load_observed(
+        &self,
+        branch_ids: &[String],
+    ) -> Result<Vec<BranchHeadControlObservation>, LixError> {
+        if branch_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let keys = branch_ids
+            .iter()
+            .map(|branch_id| Ok(StorageKey(Bytes::from(encode_key(branch_id)?))))
+            .collect::<Result<Vec<_>, LixError>>()?;
+        PointReadPlan::new(BRANCH_HEAD_CONTROL_SPACE, &keys)
+            .materialize(&self.store, StorageGetOptions::default())
+            .await?
+            .value
+            .into_iter()
+            .map(|value| match value {
+                None => Ok(BranchHeadControlObservation {
+                    control: None,
+                    raw_token: None,
+                }),
+                Some(StorageProjectedValue::FullValue(bytes)) => {
+                    let control = storage_codec::decode("branch-head control", &bytes)?;
+                    Ok(BranchHeadControlObservation {
+                        control: Some(control),
+                        raw_token: Some(bytes),
+                    })
+                }
+                Some(StorageProjectedValue::KeyOnly) => Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "branch-head control point read unexpectedly omitted its value",
+                )),
+            })
+            .collect()
+    }
+
+    /// Returns every durable branch control in deterministic branch-id order.
+    pub(crate) async fn scan(&self) -> Result<Vec<(String, BranchHeadControl)>, LixError> {
+        let plan = ScanPlan::prefix(
+            BRANCH_HEAD_CONTROL_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        );
+        let mut rows = Vec::new();
+        let mut resume_after = None;
+        loop {
+            let page = plan
+                .collect(
+                    &self.store,
+                    StorageScanOptions {
+                        resume_after: resume_after.clone(),
+                        ..StorageScanOptions::default()
+                    },
+                )
+                .await?;
+            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+            for entry in page.value.entries {
+                let key = storage_codec::decode::<BranchHeadControlKey>(
+                    "branch-head control key",
+                    entry.key.0.as_ref(),
+                )?;
+                let control = decode_projected_value(entry.value)?;
+                rows.push((key.branch_id, control));
+            }
+            if !page.value.has_more || resume_after.is_none() {
+                break;
+            }
+        }
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        Ok(rows)
+    }
+}
+
+/// Storage factory for branch-head controls.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct BranchHeadControlContext;
+
+impl BranchHeadControlContext {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    #[expect(clippy::unused_self)]
+    pub(crate) fn reader<S>(&self, store: S) -> BranchHeadControlReader<S>
+    where
+        S: StorageAdapterRead,
+    {
+        BranchHeadControlReader { store }
+    }
+}
+
+pub(crate) fn stage_branch_head_control(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    control: BranchHeadControl,
+) -> Result<(), LixError> {
+    writes.put(
+        BRANCH_HEAD_CONTROL_SPACE,
+        StorageKey(Bytes::from(encode_key(branch_id)?)),
+        StorageValue {
+            bytes: Bytes::from(storage_codec::encode("branch-head control", &control)?),
+        },
+    );
+    Ok(())
+}
+
+pub(crate) fn stage_delete_branch_head_control(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+) -> Result<(), LixError> {
+    writes.delete(
+        BRANCH_HEAD_CONTROL_SPACE,
+        StorageKey(Bytes::from(encode_key(branch_id)?)),
+    );
+    Ok(())
+}
+
+/// Converts an observed opaque value into the one backend-neutral publication
+/// guard. A missing control is guarded as absent, so concurrent branch
+/// creation cannot both succeed.
+pub(crate) fn branch_head_control_precondition(
+    branch_id: &str,
+    expected: Option<Bytes>,
+) -> Result<StoragePrecondition, LixError> {
+    let key = StorageKey(Bytes::from(encode_key(branch_id)?));
+    Ok(match expected {
+        None => StoragePrecondition::KeyAbsent {
+            space: BRANCH_HEAD_CONTROL_SPACE.id,
+            key,
+        },
+        Some(expected) => StoragePrecondition::KeyValueEquals {
+            space: BRANCH_HEAD_CONTROL_SPACE.id,
+            key,
+            expected,
+        },
+    })
+}
+
+fn encode_key(branch_id: &str) -> Result<Vec<u8>, LixError> {
+    storage_codec::encode(
+        "branch-head control key",
+        &BranchHeadControlKeyRef { branch_id },
+    )
+}
+
+fn decode_projected_value(value: StorageProjectedValue) -> Result<BranchHeadControl, LixError> {
+    let StorageProjectedValue::FullValue(bytes) = value else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "branch-head control read unexpectedly omitted its value",
+        ));
+    };
+    storage_codec::decode("branch-head control", &bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn point_reads_scans_and_exact_byte_cas_controls() {
+        let storage = StorageAdapter::new(Memory::new());
+        let first = BranchHeadControl {
+            head_commit_id: CommitId::for_test_label("first-head"),
+            generation: CommitId::for_test_label("first-generation"),
+            created_at: LixTimestamp::expect_parse("first created_at", "2026-01-01T00:00:00Z"),
+            updated_at: LixTimestamp::expect_parse("first updated_at", "2026-01-01T00:00:00Z"),
+            ref_change_id: ChangeId::for_test_label("first-ref-change"),
+        };
+        let second = BranchHeadControl {
+            head_commit_id: CommitId::for_test_label("second-head"),
+            generation: CommitId::for_test_label("first-generation"),
+            created_at: first.created_at,
+            updated_at: LixTimestamp::expect_parse("second updated_at", "2026-01-02T00:00:00Z"),
+            ref_change_id: ChangeId::for_test_label("second-ref-change"),
+        };
+        let branch_a = "branch-a".to_string();
+        let branch_b = "branch-b".to_string();
+
+        let mut writes = storage.new_write_set();
+        stage_branch_head_control(&mut writes, &branch_b, first)
+            .expect("branch b control should stage");
+        stage_branch_head_control(&mut writes, &branch_a, first)
+            .expect("branch a control should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("controls should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let reader = BranchHeadControlContext::new().reader(read);
+        assert_eq!(
+            reader
+                .load_many(&[branch_b.clone(), branch_a.clone(), branch_a.clone()])
+                .await
+                .expect("point reads should load"),
+            vec![Some(first), Some(first), Some(first)]
+        );
+        assert_eq!(
+            reader.scan().await.expect("scan should load"),
+            vec![(branch_a.clone(), first), (branch_b, first)]
+        );
+        let token = reader
+            .load_observed(std::slice::from_ref(&branch_a))
+            .await
+            .expect("control observation should load")
+            .pop()
+            .and_then(|observation| observation.raw_token)
+            .expect("stored control should have token");
+
+        let mut winner = storage.new_write_set();
+        stage_branch_head_control(&mut winner, &branch_a, second).expect("winner should stage");
+        storage
+            .commit_write_set(
+                winner,
+                StorageWriteOptions {
+                    preconditions: vec![
+                        branch_head_control_precondition(&branch_a, Some(token.clone()))
+                            .expect("winner guard should encode"),
+                    ],
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("winner should commit");
+
+        let mut stale = storage.new_write_set();
+        stage_branch_head_control(&mut stale, &branch_a, first).expect("stale write should stage");
+        let error = storage
+            .commit_write_set(
+                stale,
+                StorageWriteOptions {
+                    preconditions: vec![
+                        branch_head_control_precondition(&branch_a, Some(token))
+                            .expect("stale guard should encode"),
+                    ],
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("stale publish must fail");
+        assert!(matches!(
+            error,
+            crate::storage_adapter::StorageWriteSetError::Storage(
+                crate::storage_adapter::StorageError::PreconditionFailed(_)
+            )
+        ));
+    }
+}

--- a/packages/engine/src/branch/mod.rs
+++ b/packages/engine/src/branch/mod.rs
@@ -1,10 +1,18 @@
 mod context;
+mod control;
 mod lifecycle;
 mod refs;
 mod stage_rows;
 mod types;
 
 pub(crate) use context::BranchContext;
+#[cfg(test)]
+pub(crate) use control::BRANCH_HEAD_CONTROL_SPACE;
+pub(crate) use control::{
+    BranchHeadControl, BranchHeadControlContext, BranchHeadControlObservation,
+    BranchHeadControlReader, branch_head_control_precondition, stage_branch_head_control,
+    stage_delete_branch_head_control,
+};
 pub(crate) use lifecycle::{BranchLifecycle, BranchOperation, BranchReferenceRole};
 pub(crate) use stage_rows::{
     BRANCH_DESCRIPTOR_SCHEMA_KEY, BRANCH_REF_SCHEMA_KEY, branch_descriptor_stage_row,

--- a/packages/engine/src/branch/refs.rs
+++ b/packages/engine/src/branch/refs.rs
@@ -1,21 +1,12 @@
-use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
-use crate::branch::BRANCH_REF_SCHEMA_KEY;
-use crate::branch::{BranchHead, BranchRefReader};
+use crate::branch::{BranchHead, BranchHeadControlContext, BranchRefReader};
 use crate::changelog::CommitId;
-use crate::entity_pk::EntityPk;
-use crate::live_state::{
-    LiveStateIndexContext, LiveStateIndexFilter, LiveStateIndexRowRequest,
-    LiveStateIndexScanRequest, MaterializedLiveStateIndexRow,
-};
 use crate::storage_adapter::StorageAdapterRead;
 
-/// Typed access to moving branch heads stored in live state.
+/// Typed access to moving branch heads stored in the v6 control plane.
 ///
-/// Branch refs are one of the inputs used by live_state visibility, so this
-/// context deliberately bypasses live_state and reads the canonical current
-/// rows directly. That keeps the dependency acyclic:
-/// live_index -> branch_ref -> live_state.
+/// The control record is deliberately below live-state visibility, keeping
+/// the dependency acyclic: `branch-control -> tracked-head -> live-state`.
 pub(super) struct BranchRefContext {}
 
 impl BranchRefContext {
@@ -29,7 +20,9 @@ impl BranchRefContext {
     where
         S: StorageAdapterRead,
     {
-        BranchRefStoreReader { store }
+        BranchRefStoreReader {
+            controls: BranchHeadControlContext::new().reader(store),
+        }
     }
 }
 
@@ -38,7 +31,7 @@ pub(super) struct BranchRefStoreReader<S>
 where
     S: StorageAdapterRead,
 {
-    store: S,
+    controls: crate::branch::BranchHeadControlReader<S>,
 }
 
 impl<S> BranchRefStoreReader<S>
@@ -46,20 +39,14 @@ where
     S: StorageAdapterRead,
 {
     pub(crate) async fn load_head(&self, branch_id: &str) -> Result<Option<BranchHead>, LixError> {
-        let Some(row) = LiveStateIndexContext::new()
-            .reader(&self.store)
-            .load_row(&LiveStateIndexRowRequest {
-                schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
-                branch_id: GLOBAL_BRANCH_ID.to_string(),
-                entity_pk: EntityPk::single(branch_id),
-                file_id: None,
-            })
+        Ok(self
+            .controls
+            .load(branch_id)
             .await?
-        else {
-            return Ok(None);
-        };
-
-        decode_branch_head(branch_id, &row)
+            .map(|control| BranchHead {
+                branch_id: branch_id.to_string(),
+                commit_id: control.head_commit_id,
+            }))
     }
 
     pub(crate) async fn load_head_commit_id(
@@ -70,30 +57,16 @@ where
     }
 
     pub(crate) async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
-        let rows = LiveStateIndexContext::new()
-            .reader(&self.store)
-            .scan_rows(&LiveStateIndexScanRequest {
-                branch_id: GLOBAL_BRANCH_ID.to_string(),
-                filter: LiveStateIndexFilter {
-                    schema_keys: vec![BRANCH_REF_SCHEMA_KEY.to_string()],
-                    ..LiveStateIndexFilter::default()
-                },
-                projection: Vec::new(),
-                limit: None,
-            })
-            .await?;
-        let mut heads = rows
-            .iter()
-            .map(|row| {
-                let branch_id = row.entity_pk.as_single_string_owned()?;
-                decode_branch_head(&branch_id, row)
-            })
-            .collect::<Result<Vec<_>, _>>()?
+        Ok(self
+            .controls
+            .scan()
+            .await?
             .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        heads.sort_by(|left, right| left.branch_id.cmp(&right.branch_id));
-        Ok(heads)
+            .map(|(branch_id, control)| BranchHead {
+                branch_id,
+                commit_id: control.head_commit_id,
+            })
+            .collect())
     }
 }
 
@@ -115,41 +88,11 @@ where
     }
 }
 
-fn decode_branch_head(
-    requested_branch_id: &str,
-    row: &MaterializedLiveStateIndexRow,
-) -> Result<Option<BranchHead>, LixError> {
-    let Some(snapshot_content) = row.snapshot_content.as_deref() else {
-        return Ok(None);
-    };
-    let snapshot =
-        serde_json::from_str::<serde_json::Value>(snapshot_content).map_err(|error| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("engine branch-ref snapshot parse failed: {error}"),
-            )
-        })?;
-    let commit_id = snapshot
-        .get("commit_id")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("branch ref for branch '{requested_branch_id}' is missing commit_id"),
-            )
-        })?;
-    Ok(Some(BranchHead {
-        branch_id: requested_branch_id.to_string(),
-        commit_id: CommitId::parse_lix(commit_id, "branch ref commit_id")?,
-    }))
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::changelog::{
-        ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter,
-    };
-    use crate::live_state::{LiveStateIndexDeltaRef, LiveStateIndexRowRequest};
+    use crate::branch::{BranchHeadControl, stage_branch_head_control};
+    use crate::changelog::{ChangeId, CommitId};
+    use crate::common::LixTimestamp;
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
 
@@ -174,11 +117,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn advance_head_writes_global_current_ref() {
+    async fn advance_head_writes_direct_control() {
         let storage = StorageAdapter::new(Memory::new());
         let branch_ref = BranchRefContext::new();
 
-        stage_branch_head(&storage, "branch-a", "commit-a", "2026-01-01T00:00:00Z")
+        stage_branch_head(&storage, "branch-a", "commit-a")
             .await
             .expect("branch head should advance");
 
@@ -194,24 +137,6 @@ mod tests {
             .expect("branch head should exist");
         assert_eq!(head.branch_id, "branch-a");
         assert_eq!(head.commit_id, "commit-a");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let row = LiveStateIndexContext::new()
-            .reader(read)
-            .load_row(&LiveStateIndexRowRequest {
-                schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
-                branch_id: GLOBAL_BRANCH_ID.to_string(),
-                entity_pk: EntityPk::single("branch-a"),
-                file_id: None,
-            })
-            .await
-            .expect("branch-ref row should load")
-            .expect("branch-ref row should exist");
-        assert_eq!(row.created_at, "2026-01-01T00:00:00.000Z");
-        assert_eq!(row.updated_at, "2026-01-01T00:00:00.000Z");
     }
 
     #[tokio::test]
@@ -219,10 +144,10 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let branch_ref = test_branch_ref();
 
-        stage_branch_head(&storage, "branch-b", "commit-b", "2026-01-01T00:00:00Z")
+        stage_branch_head(&storage, "branch-b", "commit-b")
             .await
             .expect("branch-b should advance");
-        stage_branch_head(&storage, "branch-a", "commit-a", "2026-01-01T00:00:00Z")
+        stage_branch_head(&storage, "branch-a", "commit-a")
             .await
             .expect("branch-a should advance");
 
@@ -259,55 +184,26 @@ mod tests {
         storage: &StorageAdapter,
         branch_id: &str,
         commit_id: &str,
-        timestamp: &str,
     ) -> Result<(), LixError> {
         let commit_id = CommitId::parse_lix(commit_id, "test branch head commit_id")?;
-        let timestamp = crate::common::LixTimestamp::expect_parse("timestamp", timestamp);
-        let entity_pk = EntityPk::single(branch_id);
-        let snapshot = serde_json::json!({
-            "id": branch_id,
-            "commit_id": commit_id,
-        })
-        .to_string();
-        let change_id = ChangeId::for_test_label(&format!("branch-ref-{branch_id}"));
-        let read = storage.begin_read(StorageReadOptions::default()).await?;
         let mut writes = storage.new_write_set();
-        {
-            let mut changelog_read = &read;
-            ChangelogContext::new()
-                .writer(&mut changelog_read, &mut writes)
-                .stage_append(ChangelogAppend {
-                    changes: vec![ChangeRecord {
-                        format_version: 2,
-                        change_id,
-                        schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
-                        entity_pk: entity_pk.clone(),
-                        file_id: None,
-                        snapshot: crate::json_store::JsonSlot::from_json(&snapshot),
-                        metadata: crate::json_store::JsonSlot::None,
-                        created_at: timestamp,
-                        origin_key: None,
-                    }],
-                    ..ChangelogAppend::default()
-                })
-                .await?;
-        }
-        LiveStateIndexContext::new()
-            .writer(&read, &mut writes)
-            .stage_branch_rows(
-                GLOBAL_BRANCH_ID,
-                [LiveStateIndexDeltaRef {
-                    schema_key: BRANCH_REF_SCHEMA_KEY,
-                    file_id: None,
-                    entity_pk: &entity_pk,
-                    change_id,
-                    commit_id: None,
-                    deleted: false,
-                    created_at: timestamp,
-                    updated_at: timestamp,
-                }],
-            )
-            .await?;
+        stage_branch_head_control(
+            &mut writes,
+            branch_id,
+            BranchHeadControl {
+                head_commit_id: commit_id,
+                generation: commit_id,
+                created_at: LixTimestamp::expect_parse(
+                    "test branch ref created_at",
+                    "2026-01-01T00:00:00Z",
+                ),
+                updated_at: LixTimestamp::expect_parse(
+                    "test branch ref updated_at",
+                    "2026-01-01T00:00:00Z",
+                ),
+                ref_change_id: ChangeId::for_test_label("test-branch-ref-change"),
+            },
+        )?;
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await?;

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -10,10 +10,8 @@ use std::time::Instant;
 
 use bytes::Bytes;
 
-use crate::changelog::{
-    ChangeRecordProjection, ChangelogContext, ChangelogWriter, CommitId, GcPlan, GcRoot,
-    materialize_change_payloads,
-};
+use crate::branch::BranchHeadControlContext;
+use crate::changelog::{ChangelogContext, ChangelogWriter, CommitId, GcPlan, GcRoot};
 use crate::live_state::LiveStateIndexContext;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StoragePrefix,
@@ -377,43 +375,24 @@ where
         .reader(store.clone())
         .scan_all_index_rows()
         .await?;
-    let branch_ref_change_ids = flat_rows
-        .iter()
-        .filter(|row| row.schema_key == "lix_branch_ref")
-        .map(|row| row.change_id);
-    let flat_payloads = materialize_change_payloads(
-        &store,
-        branch_ref_change_ids,
-        ChangeRecordProjection::from_columns(&["snapshot_content".to_string()]),
-        "garbage-collection flat live-state root",
-    )
-    .await?;
-
     let mut roots = flat_rows
         .iter()
         .map(|row| GcRoot::StandaloneChange(row.change_id))
         .collect::<Vec<_>>();
-    for row in &flat_rows {
-        if row.schema_key != "lix_branch_ref" {
-            continue;
-        }
-        let payload = flat_payloads.get(&row.change_id).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "garbage collection could not materialize branch-ref change '{}'",
-                    row.change_id
-                ),
-            )
-        })?;
-        let snapshot = parse_snapshot(
-            payload.snapshot_content.as_deref(),
-            "branch ref",
-            row.change_id,
-        )?;
-        let commit_id = required_snapshot_text(&snapshot, "commit_id", "branch ref")?;
-        let commit_id = CommitId::parse_lix(commit_id, "garbage-collection branch head")?;
-        roots.push(GcRoot::BranchHead(commit_id));
+    // v6 branch controls, not their public `lix_branch_ref` projection rows,
+    // are the authoritative GC roots. Explicit lifecycle rows may remain in
+    // flat state for SQL compatibility, but a stale projection must never
+    // keep a superseded commit alive.
+    for (_branch_id, control) in BranchHeadControlContext::new()
+        .reader(store.clone())
+        .scan()
+        .await?
+    {
+        roots.push(GcRoot::BranchHead(control.head_commit_id));
+        // The synthesized public `lix_branch_ref` row exposes this standalone
+        // immutable change id. Keep its currently published ledger fact live
+        // without making the mutable control a flat live-state row again.
+        roots.push(GcRoot::StandaloneChange(control.ref_change_id));
     }
     for recovery in load_recovery_refs(&store).await? {
         roots.push(GcRoot::BranchHead(recovery.recovered_head_commit_id));
@@ -461,46 +440,15 @@ fn elapsed_micros(started: Instant) -> u64 {
     u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX)
 }
 
-fn parse_snapshot(
-    snapshot: Option<&str>,
-    kind: &str,
-    change_id: crate::changelog::ChangeId,
-) -> Result<serde_json::Value, LixError> {
-    let snapshot = snapshot.ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("live {kind} change '{change_id}' has no snapshot"),
-        )
-    })?;
-    serde_json::from_str(snapshot).map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("live {kind} change '{change_id}' has invalid JSON: {error}"),
-        )
-    })
-}
-
-fn required_snapshot_text<'a>(
-    snapshot: &'a serde_json::Value,
-    field: &str,
-    kind: &str,
-) -> Result<&'a str, LixError> {
-    snapshot
-        .get(field)
-        .and_then(serde_json::Value::as_str)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("{kind} snapshot is missing non-empty text field '{field}'"),
-            )
-        })
-}
-
 #[cfg(test)]
 mod tests {
+    use crate::branch::BranchHeadControlContext;
     use crate::changelog::CommitId;
-    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+    use crate::live_state::LiveStateIndexContext;
+    use crate::storage_adapter::{
+        Memory, SharedStorageAdapterRead, StorageAdapter, StorageReadOptions, StorageWriteOptions,
+    };
+    use crate::tracked_state::TrackedStateContext;
 
     use super::{
         CheckpointGcState, CheckpointRecoveryRef, load_checkpoint_gc_state, load_recovery_ref,
@@ -576,6 +524,62 @@ mod tests {
                 .expect("checkpoint GC state should load"),
             expected
         );
+    }
+
+    #[tokio::test]
+    async fn repository_gc_keeps_heads_rooted_only_by_v6_controls() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let live_index = LiveStateIndexContext::new();
+        let receipt = crate::init::initialize(storage.clone(), &tracked_state, &live_index)
+            .await
+            .expect("repository should initialize");
+
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("GC read should open"),
+        );
+        let mut writes = storage.new_write_set();
+        let plan = super::stage_repository_gc(read, &mut writes)
+            .await
+            .expect("GC should plan from direct branch controls");
+        let initial_commit = CommitId::parse_lix(&receipt.initial_commit_id, "initial commit")
+            .expect("initial receipt should contain a commit id");
+        assert!(
+            !plan.changelog.sweep.commits.contains(&initial_commit),
+            "the initial commit must stay live even though init writes no flat lix_branch_ref row"
+        );
+        let controls = BranchHeadControlContext::new()
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("control read should open"),
+            )
+            .scan()
+            .await
+            .expect("v6 controls should scan");
+        assert_eq!(
+            controls.len(),
+            2,
+            "init should publish both direct controls"
+        );
+        for (_branch_id, control) in controls {
+            assert!(
+                plan.changelog.live.changes.contains(&control.ref_change_id),
+                "the control's current public branch-ref ledger change must stay live"
+            );
+            assert!(
+                !plan
+                    .changelog
+                    .sweep
+                    .changes
+                    .contains(&control.ref_change_id),
+                "GC must not sweep a direct control's current public branch-ref ledger change"
+            );
+        }
     }
 
     fn recovery(branch_id: &str, recovered_head: &str, checkpoint: &str) -> CheckpointRecoveryRef {

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -2,7 +2,10 @@
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
-use crate::branch::{BRANCH_DESCRIPTOR_SCHEMA_KEY, BRANCH_REF_SCHEMA_KEY};
+use crate::branch::{
+    BRANCH_DESCRIPTOR_SCHEMA_KEY, BRANCH_REF_SCHEMA_KEY, BranchHeadControl,
+    stage_branch_head_control,
+};
 use crate::changelog::{
     ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitChangeRefSet,
     CommitId, CommitRecord,
@@ -35,14 +38,14 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// The v5 tracked-head group and local-sidecar markers change the meaning of
-/// absent physical keys. Those proofs are only sound for repositories
-/// initialized with this protocol, so opening an older store must fail closed
-/// rather than mixing an old head layout with current visibility rules.
+/// The v6 direct branch-control plane changes the authority for current
+/// branch heads. Those proofs are only sound for repositories initialized
+/// with this protocol, so opening an older store must fail closed rather than
+/// mixing a legacy `lix_branch_ref` row with current visibility rules.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::new(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-head-group.v5";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-direct-plane.v6";
 
 pub(crate) fn stage_repository_protocol(writes: &mut StorageWriteSet) {
     writes.put(
@@ -71,18 +74,20 @@ pub(crate) async fn assert_repository_protocol(
     }
     Err(LixError::new(
         "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT",
-        "repository uses an unsupported tracked-head storage protocol; recreate the repository",
+        "repository uses an unsupported tracked direct-plane storage protocol; recreate the repository",
     ))
 }
 
 /// Pure seed plan for initializing an engine repository.
 ///
-/// Tracked bootstrap facts go to the changelog. Moving refs such as
-/// `lix_branch_ref` are seeded as untracked local state so repository heads
-/// can advance without becoming commit members.
+/// Tracked bootstrap facts go to the changelog. Moving heads are seeded in
+/// the v6 direct control plane and retain a standalone immutable branch-ref
+/// ledger change; only ordinary untracked data enters the flat live-state
+/// sidecar.
 pub(crate) struct InitSeedPlan {
     commit: InitSeedCommit,
     changes: Vec<InitSeedChange>,
+    branch_controls: Vec<InitBranchHeadControl>,
     untracked_rows: Vec<InitSeedLiveRow>,
     pub(crate) receipt: InitReceipt,
 }
@@ -117,6 +122,17 @@ struct InitSeedLiveRow {
     branch_id: String,
 }
 
+/// Initial direct branch controls are planned with the seed so their public
+/// metadata is deterministic and independent of the flat live-state lane.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InitBranchHeadControl {
+    branch_id: String,
+    control: BranchHeadControl,
+    /// Public `lix_change` fact for the control's initial branch-ref
+    /// publication. This deliberately has no flat current-state row.
+    branch_ref_change: InitSeedLiveRow,
+}
+
 /// Values generated while planning the initial repository seed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InitReceipt {
@@ -128,8 +144,9 @@ pub struct InitReceipt {
 
 /// Builds the canonical bootstrap changes for a new engine repository.
 ///
-/// The initial commit tracks durable content rows. Branch refs are moving
-/// pointers and therefore live in untracked local state instead of the commit.
+/// The initial commit tracks durable content rows. Branch heads are moving
+/// pointers and therefore live in direct control records instead of the
+/// changelog or flat current state.
 pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSeedPlan, LixError> {
     let main_branch_id = functions.call_uuid_v7().to_string();
     let lix_id = functions.call_uuid_v7().to_string();
@@ -184,20 +201,43 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
         author_account_ids: Vec::new(),
         created_at: timestamp,
     };
-    let global_branch_ref_row = untracked_row(
+    // Keep one distinct public ref change id per initial branch, matching the
+    // old `lix_branch_ref` current rows without writing those rows into the
+    // normal sidecar plane.
+    let global_branch_ref_change = branch_ref_ledger_change(
         functions.call_uuid_v7(),
-        EntityPk::single(GLOBAL_BRANCH_ID),
-        BRANCH_REF_SCHEMA_KEY,
-        branch_ref_snapshot(GLOBAL_BRANCH_ID, &initial_commit_id)?,
+        GLOBAL_BRANCH_ID,
+        initial_commit_id,
         timestamp,
-    );
-    let main_branch_ref_row = untracked_row(
+    )?;
+    let global_branch_control = InitBranchHeadControl {
+        branch_id: GLOBAL_BRANCH_ID.to_string(),
+        control: BranchHeadControl {
+            head_commit_id: initial_commit_id,
+            generation: initial_commit_id,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: global_branch_ref_change.id,
+        },
+        branch_ref_change: global_branch_ref_change,
+    };
+    let main_branch_ref_change = branch_ref_ledger_change(
         functions.call_uuid_v7(),
-        EntityPk::single(&main_branch_id),
-        BRANCH_REF_SCHEMA_KEY,
-        branch_ref_snapshot(&main_branch_id, &initial_commit_id)?,
+        &main_branch_id,
+        initial_commit_id,
         timestamp,
-    );
+    )?;
+    let main_branch_control = InitBranchHeadControl {
+        branch_id: main_branch_id.clone(),
+        control: BranchHeadControl {
+            head_commit_id: initial_commit_id,
+            generation: initial_commit_id,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: main_branch_ref_change.id,
+        },
+        branch_ref_change: main_branch_ref_change,
+    };
     let workspace_branch_row = untracked_row(
         functions.call_uuid_v7(),
         EntityPk::single(WORKSPACE_BRANCH_KEY),
@@ -217,11 +257,8 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
                 initial_checkpoint_change,
             ])
             .collect(),
-        untracked_rows: vec![
-            global_branch_ref_row,
-            main_branch_ref_row,
-            workspace_branch_row,
-        ],
+        branch_controls: vec![global_branch_control, main_branch_control],
+        untracked_rows: vec![workspace_branch_row],
         receipt: InitReceipt {
             lix_id,
             global_branch_id: GLOBAL_BRANCH_ID.to_string(),
@@ -265,6 +302,11 @@ where
         .iter()
         .map(seed_untracked_change_to_change_record)
         .collect::<Vec<_>>();
+    let branch_ref_ledger_changes = plan
+        .branch_controls
+        .iter()
+        .map(|branch| seed_untracked_change_to_change_record(&branch.branch_ref_change))
+        .collect::<Vec<_>>();
 
     stage_init_json_payloads(&mut writes, &plan)?;
     stage_init_changelog_commit(
@@ -274,6 +316,7 @@ where
         authored_changes
             .iter()
             .chain(&untracked_changes)
+            .chain(&branch_ref_ledger_changes)
             .cloned()
             .collect(),
     )
@@ -319,11 +362,11 @@ where
             .collect::<Vec<_>>();
         let tracked_head = TrackedHeadContext::new();
         let absence_guards = std::collections::BTreeSet::default();
-        for branch_id in [GLOBAL_BRANCH_ID, receipt.main_branch_id.as_str()] {
+        for branch in &plan.branch_controls {
             tracked_head
                 .writer(&read, &mut writes)
                 .stage_commit(
-                    branch_id,
+                    &branch.branch_id,
                     None,
                     plan.commit.id,
                     &head_deltas,
@@ -331,6 +374,7 @@ where
                     None,
                 )
                 .await?;
+            stage_branch_head_control(&mut writes, &branch.branch_id, branch.control)?;
         }
 
         let mut index_writer = live_index.writer(&read, &mut writes);
@@ -410,6 +454,11 @@ fn stage_init_json_payloads(
                     .iter()
                     .map(|row| row.snapshot_content.as_str()),
             )
+            .chain(
+                plan.branch_controls
+                    .iter()
+                    .map(|branch| branch.branch_ref_change.snapshot_content.as_str()),
+            )
             .filter(|snapshot| snapshot.len() > crate::json_store::JSON_INLINE_MAX_BYTES)
             .map(NormalizedJsonRef::new),
     )?;
@@ -464,6 +513,27 @@ fn untracked_row(
     }
 }
 
+/// The direct control owns a branch ref's current visibility, while this
+/// standalone fact preserves the public immutable `lix_change` ledger row.
+/// It intentionally does not enter `LiveStateIndex`.
+fn branch_ref_ledger_change(
+    id: uuid::Uuid,
+    branch_id: &str,
+    commit_id: CommitId,
+    timestamp: LixTimestamp,
+) -> Result<InitSeedLiveRow, LixError> {
+    Ok(InitSeedLiveRow {
+        id: ChangeId::from(id),
+        entity_pk: EntityPk::single(branch_id),
+        schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
+        snapshot_content: branch_ref_snapshot(branch_id, commit_id)?,
+        created_at: timestamp,
+        updated_at: timestamp,
+        global: branch_id == GLOBAL_BRANCH_ID,
+        branch_id: branch_id.to_string(),
+    })
+}
+
 fn canonical_change(
     id: uuid::Uuid,
     entity_pk: EntityPk,
@@ -488,6 +558,13 @@ fn branch_descriptor_snapshot(id: &str, name: &str, hidden: bool) -> Result<Stri
     }))
 }
 
+fn branch_ref_snapshot(branch_id: &str, commit_id: CommitId) -> Result<String, LixError> {
+    encode_snapshot(json!({
+        "id": branch_id,
+        "commit_id": commit_id.to_string(),
+    }))
+}
+
 fn key_value_snapshot(key: &str, value: &str) -> Result<String, LixError> {
     encode_snapshot(json!({
         "key": key,
@@ -504,13 +581,6 @@ fn checkpoint_marker_snapshot(branch_id: &str) -> Result<String, LixError> {
 fn registered_schema_snapshot(schema: &serde_json::Value) -> Result<String, LixError> {
     encode_snapshot(json!({
         "value": schema,
-    }))
-}
-
-fn branch_ref_snapshot(id: &str, commit_id: &CommitId) -> Result<String, LixError> {
-    encode_snapshot(json!({
-        "id": id,
-        "commit_id": commit_id.to_string(),
     }))
 }
 
@@ -539,7 +609,7 @@ mod tests {
         let plan = plan_init_seed(test_functions()).expect("init seed should plan");
 
         assert_eq!(plan.changes.len(), seed_schema_definitions().len() + 4);
-        assert_eq!(plan.untracked_rows.len(), 3);
+        assert_eq!(plan.untracked_rows.len(), 1);
         assert_eq!(plan.receipt.global_branch_id, GLOBAL_BRANCH_ID);
         assert_eq!(plan.receipt.main_branch_id, test_uuid(1));
         assert_eq!(plan.receipt.lix_id, test_uuid(2));
@@ -611,24 +681,28 @@ mod tests {
     }
 
     #[test]
-    fn plan_init_seed_branch_refs_point_to_initial_commit() {
+    fn plan_init_seed_keeps_branch_heads_out_of_untracked_state() {
         let plan = plan_init_seed(test_functions()).expect("init seed should plan");
-        let branch_refs = plan
-            .untracked_rows
-            .iter()
-            .filter(|row| row.schema_key == BRANCH_REF_SCHEMA_KEY)
-            .collect::<Vec<_>>();
-
-        assert_eq!(branch_refs.len(), 2);
+        assert_eq!(plan.untracked_rows.len(), 1);
+        assert!(
+            plan.untracked_rows
+                .iter()
+                .all(|row| row.schema_key != "lix_branch_ref")
+        );
         assert!(
             plan.changes
                 .iter()
-                .all(|change| change.schema_key != BRANCH_REF_SCHEMA_KEY)
+                .all(|change| change.schema_key != "lix_branch_ref")
         );
-        for row in branch_refs {
-            assert_eq!(row.schema_key, BRANCH_REF_SCHEMA_KEY);
-            assert_eq!(row.branch_id, GLOBAL_BRANCH_ID);
-            let snapshot = untracked_snapshot(row);
+        assert_eq!(plan.branch_controls.len(), 2);
+        for branch in &plan.branch_controls {
+            assert_eq!(branch.branch_ref_change.schema_key, BRANCH_REF_SCHEMA_KEY);
+            assert_eq!(branch.control.ref_change_id, branch.branch_ref_change.id);
+            let snapshot = untracked_snapshot(&branch.branch_ref_change);
+            assert_eq!(
+                snapshot.get("id").and_then(JsonValue::as_str),
+                Some(branch.branch_id.as_str())
+            );
             assert_eq!(
                 snapshot.get("commit_id").and_then(JsonValue::as_str),
                 Some(plan.receipt.initial_commit_id.as_str())

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -3,7 +3,7 @@
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::NullableKeyFilter;
-use crate::branch::BRANCH_REF_SCHEMA_KEY;
+use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchHeadControl, BranchHeadControlContext};
 use crate::commit_graph::CommitGraphContext;
 use crate::entity_pk::EntityPk;
 use crate::filesystem::{
@@ -28,7 +28,7 @@ use async_trait::async_trait;
 use futures_util::{StreamExt, TryStreamExt, stream};
 
 const BRANCH_READ_CONCURRENCY: usize = 8;
-type BranchCommitIds = std::collections::BTreeMap<String, String>;
+type BranchHeads = std::collections::BTreeMap<String, BranchHeadControl>;
 
 const COMMIT_SCHEMA_KEY: &str = "lix_commit";
 const COMMIT_EDGE_SCHEMA_KEY: &str = "lix_commit_edge";
@@ -125,7 +125,7 @@ where
             } else {
                 Vec::new()
             };
-        let untracked_rows = if request.filter.untracked != Some(false)
+        let mut untracked_rows = if request.filter.untracked != Some(false)
             && !is_commit_derived_only_request(request)
         {
             let branch_rows = stream::iter(scope.storage_branch_ids.clone())
@@ -136,6 +136,7 @@ where
                         .scan_rows(&index_scan_request_from_live(request, &branch_id))
                         .await?
                         .into_iter()
+                        .filter(|row| row.schema_key != BRANCH_REF_SCHEMA_KEY)
                         .map(MaterializedLiveStateRow::from)
                         .collect();
                     Ok::<_, LixError>(rows)
@@ -147,6 +148,9 @@ where
         } else {
             Vec::new()
         };
+        if request.filter.untracked != Some(false) {
+            untracked_rows.extend(scan_direct_branch_ref_rows(store, request, &scope).await?);
+        }
         if commit_derived_rows.is_empty()
             && untracked_rows.is_empty()
             && let Some(index) =
@@ -214,7 +218,7 @@ where
         if request.rows.iter().any(|row| {
             matches!(
                 row.schema_key.as_str(),
-                COMMIT_SCHEMA_KEY | COMMIT_EDGE_SCHEMA_KEY
+                COMMIT_SCHEMA_KEY | COMMIT_EDGE_SCHEMA_KEY | BRANCH_REF_SCHEMA_KEY
             )
         }) {
             let mut rows = Vec::with_capacity(request.rows.len());
@@ -280,7 +284,7 @@ where
         if request.untracked != Some(true) {
             let mut identities_by_branch = std::collections::BTreeMap::<String, Vec<_>>::new();
             for identity in &storage_identities {
-                if scope.branch_commit_ids.contains_key(&identity.branch_id) {
+                if scope.branch_heads.contains_key(&identity.branch_id) {
                     identities_by_branch
                         .entry(identity.branch_id.clone())
                         .or_default()
@@ -291,7 +295,8 @@ where
                 crate::changelog::ChangeRecordProjection::from_columns(&request.projection.columns);
             let tracked_batches = stream::iter(identities_by_branch)
                 .map(|(branch_id, identities)| {
-                    let commit_id = scope.branch_commit_ids[&branch_id].clone();
+                    let control = scope.branch_heads[&branch_id];
+                    let commit_id = control.head_commit_id.to_string();
                     let projection = projection.clone();
                     async move {
                         let keys = identities
@@ -306,9 +311,9 @@ where
                         let rows = if let Some(rows) = self
                             .tracked_head
                             .reader(&self.store)
-                            .load_projected_live_rows_if_current(
+                            .load_projected_live_rows_if_control_current(
                                 &branch_id,
-                                &commit_id,
+                                control,
                                 &keys,
                                 &projection,
                             )
@@ -458,19 +463,19 @@ where
             .iter()
             .filter_map(|branch_id| {
                 scope
-                    .branch_commit_ids
+                    .branch_heads
                     .get(branch_id)
-                    .map(|commit_id| (branch_id.clone(), commit_id.clone()))
+                    .map(|control| (branch_id.clone(), *control))
             })
             .collect::<Vec<_>>();
         let branch_rows = stream::iter(branches)
-            .map(|(branch_id, commit_id)| {
+            .map(|(branch_id, control)| {
                 let tracked_request = tracked_request.clone();
                 async move {
                     let (rows, ordered_unique) = if let Some(rows) = self
                         .tracked_head
                         .reader(store)
-                        .scan_live_rows_if_current(&branch_id, &commit_id, &tracked_request)
+                        .scan_live_rows_if_control_current(&branch_id, control, &tracked_request)
                         .await?
                     {
                         (rows, true)
@@ -478,7 +483,10 @@ where
                         (
                             self.tracked_state
                                 .reader(store)
-                                .scan_rows_at_commit(&commit_id, &tracked_request)
+                                .scan_rows_at_commit(
+                                    &control.head_commit_id.to_string(),
+                                    &tracked_request,
+                                )
                                 .await?
                                 .into_iter()
                                 .map(|row| {
@@ -611,6 +619,94 @@ async fn scan_commit_derived_rows(
                     .any(|branch_id| branch_id == row.branch_id.as_ref()))
     });
     Ok(rows)
+}
+
+/// Synthesizes the public `lix_branch_ref` metadata entity from authoritative
+/// v6 controls. The old physical flat row is intentionally filtered out at
+/// the caller so SQL/entity consumers keep seeing exactly one current ref per
+/// branch even while a rare lifecycle write retains its legacy projection for
+/// validation and changelog compatibility.
+async fn scan_direct_branch_ref_rows(
+    store: &(impl StorageAdapterRead + ?Sized),
+    request: &LiveStateScanRequest,
+    scope: &LiveStateScanScope,
+) -> Result<Vec<MaterializedLiveStateRow>, LixError> {
+    if !schema_filter_allows(&request.filter.schema_keys, BRANCH_REF_SCHEMA_KEY)
+        || !file_filter_allows_null(&request.filter.file_ids)
+        || !scope
+            .storage_branch_ids
+            .iter()
+            .any(|branch_id| branch_id == GLOBAL_BRANCH_ID)
+    {
+        return Ok(Vec::new());
+    }
+
+    let requested_branch_ids = if request.filter.entity_pks.is_empty() {
+        Vec::new()
+    } else {
+        request
+            .filter
+            .entity_pks
+            .iter()
+            .filter_map(|entity_pk| entity_pk.as_single_string_owned().ok())
+            .collect::<Vec<_>>()
+    };
+    if !request.filter.entity_pks.is_empty()
+        && requested_branch_ids.len() != request.filter.entity_pks.len()
+    {
+        return Ok(Vec::new());
+    }
+    let controls = BranchHeadControlContext::new().reader(store);
+    let entries = if requested_branch_ids.is_empty() {
+        controls.scan().await?
+    } else {
+        controls
+            .load_many(&requested_branch_ids)
+            .await?
+            .into_iter()
+            .zip(requested_branch_ids)
+            .filter_map(|(control, branch_id)| control.map(|control| (branch_id, control)))
+            .collect()
+    };
+    entries
+        .into_iter()
+        .map(|(branch_id, control)| direct_branch_ref_row(&branch_id, control))
+        .collect()
+}
+
+fn direct_branch_ref_row(
+    branch_id: &str,
+    control: BranchHeadControl,
+) -> Result<MaterializedLiveStateRow, LixError> {
+    let snapshot_content = serde_json::to_string(&serde_json::json!({
+        "id": branch_id,
+        "commit_id": control.head_commit_id.to_string(),
+    }))
+    .map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("failed to encode v6 direct branch-ref snapshot: {error}"),
+        )
+    })?;
+    Ok(MaterializedLiveStateRow {
+        entity_pk: EntityPk::single(branch_id),
+        schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
+        file_id: None,
+        snapshot_content: Some(snapshot_content),
+        metadata: None,
+        deleted: false,
+        // These read-only columns are part of every public entity surface.
+        // Preserve the same replacement semantics the old flat current row
+        // had: creation time is stable, while each ref publication gets an
+        // updated timestamp and distinct change id.
+        created_at: control.created_at,
+        updated_at: control.updated_at,
+        global: true,
+        change_id: Some(control.ref_change_id),
+        commit_id: None,
+        untracked: true,
+        branch_id: GLOBAL_BRANCH_ID.into(),
+    })
 }
 
 fn request_may_include_commit_derived(request: &LiveStateScanRequest) -> bool {
@@ -750,7 +846,7 @@ fn index_scan_request_from_live(
 struct LiveStateScanScope {
     storage_branch_ids: Vec<String>,
     projection_branch_ids: Vec<String>,
-    branch_commit_ids: BranchCommitIds,
+    branch_heads: BranchHeads,
 }
 
 /// Rows read from one durable tracked branch source.
@@ -809,46 +905,45 @@ fn finalize_ordered_unique_rows(
 
 async fn scan_scope(
     store: &(impl StorageAdapterRead + ?Sized),
-    live_index: &LiveStateIndexContext,
+    _live_index: &LiveStateIndexContext,
     request: &LiveStateScanRequest,
     resolve_branch_heads: bool,
 ) -> Result<LiveStateScanScope, LixError> {
     if request.filter.branch_ids.is_empty() {
         if resolve_branch_heads {
-            let branch_commit_ids = load_branch_ref_commit_ids(store, live_index, &[]).await?;
+            let branch_heads = load_branch_head_controls(store, &[]).await?;
             return Ok(LiveStateScanScope {
-                storage_branch_ids: branch_commit_ids.keys().cloned().collect(),
+                storage_branch_ids: branch_heads.keys().cloned().collect(),
                 projection_branch_ids: Vec::new(),
-                branch_commit_ids,
+                branch_heads,
             });
         }
         return Ok(LiveStateScanScope {
-            storage_branch_ids: all_branch_ref_ids(store, live_index).await?,
+            storage_branch_ids: all_branch_head_control_ids(store).await?,
             projection_branch_ids: Vec::new(),
-            branch_commit_ids: BranchCommitIds::new(),
+            branch_heads: BranchHeads::new(),
         });
     }
 
     if resolve_branch_heads {
         let candidate_branch_ids = expanded_branch_ids(&request.filter.branch_ids);
-        let branch_commit_ids =
-            load_branch_ref_commit_ids(store, live_index, &candidate_branch_ids).await?;
+        let branch_heads = load_branch_head_controls(store, &candidate_branch_ids).await?;
         let projection_branch_ids = request
             .filter
             .branch_ids
             .iter()
-            .filter(|branch_id| branch_commit_ids.contains_key(*branch_id))
+            .filter(|branch_id| branch_heads.contains_key(*branch_id))
             .cloned()
             .collect::<Vec<_>>();
         let storage_branch_ids = expanded_branch_ids(&projection_branch_ids);
         return Ok(LiveStateScanScope {
             storage_branch_ids,
             projection_branch_ids,
-            branch_commit_ids,
+            branch_heads,
         });
     }
 
-    let existing_branch_ids = load_branch_ref_ids(store, live_index, &request.filter.branch_ids)
+    let existing_branch_ids = load_branch_head_control_ids(store, &request.filter.branch_ids)
         .await?
         .into_iter()
         .collect::<std::collections::BTreeSet<_>>();
@@ -864,83 +959,59 @@ async fn scan_scope(
     Ok(LiveStateScanScope {
         storage_branch_ids,
         projection_branch_ids,
-        branch_commit_ids: BranchCommitIds::new(),
+        branch_heads: BranchHeads::new(),
     })
 }
 
-async fn load_branch_ref_commit_ids(
+/// Loads v6 controls without touching the mutable live-state index. A
+/// nonempty request is point-read; the empty request is the explicit
+/// all-branches scan used only by broad scans.
+async fn load_branch_head_controls(
     store: &(impl StorageAdapterRead + ?Sized),
-    live_index: &LiveStateIndexContext,
     branch_ids: &[String],
-) -> Result<BranchCommitIds, LixError> {
-    let rows = live_index
-        .reader(store)
-        .scan_rows(&LiveStateIndexScanRequest {
-            branch_id: GLOBAL_BRANCH_ID.to_string(),
-            filter: LiveStateIndexFilter {
-                schema_keys: vec![BRANCH_REF_SCHEMA_KEY.to_string()],
-                entity_pks: branch_ids.iter().map(EntityPk::single).collect(),
-                file_ids: vec![NullableKeyFilter::Null],
-            },
-            projection: vec!["snapshot_content".to_string()],
-            limit: None,
-        })
-        .await?;
-    let mut branch_commit_ids = BranchCommitIds::new();
-    for row in rows {
-        let branch_id = row.entity_pk.as_single_string_owned()?;
-        if let Some(commit_id) = parse_branch_ref_commit_id(row.snapshot_content.as_deref())? {
-            branch_commit_ids.insert(branch_id, commit_id);
-        }
+) -> Result<BranchHeads, LixError> {
+    let reader = BranchHeadControlContext::new().reader(store);
+    if branch_ids.is_empty() {
+        return Ok(reader.scan().await?.into_iter().collect());
     }
-    Ok(branch_commit_ids)
+    let controls = reader.load_many(branch_ids).await?;
+    Ok(branch_ids
+        .iter()
+        .cloned()
+        .zip(controls)
+        .filter_map(|(branch_id, control)| control.map(|control| (branch_id, control)))
+        .collect())
 }
 
-async fn all_branch_ref_ids(
+async fn all_branch_head_control_ids(
     store: &(impl StorageAdapterRead + ?Sized),
-    live_index: &LiveStateIndexContext,
 ) -> Result<Vec<String>, LixError> {
-    load_branch_ref_ids(store, live_index, &[]).await
+    Ok(BranchHeadControlContext::new()
+        .reader(store)
+        .scan()
+        .await?
+        .into_iter()
+        .map(|(branch_id, _)| branch_id)
+        .collect())
 }
 
-async fn load_branch_ref_ids(
+async fn load_branch_head_control_ids(
     store: &(impl StorageAdapterRead + ?Sized),
-    live_index: &LiveStateIndexContext,
     branch_ids: &[String],
 ) -> Result<Vec<String>, LixError> {
-    let rows = live_index
+    if branch_ids.is_empty() {
+        return all_branch_head_control_ids(store).await;
+    }
+    let controls = BranchHeadControlContext::new()
         .reader(store)
-        .scan_index_rows(&LiveStateIndexScanRequest {
-            branch_id: GLOBAL_BRANCH_ID.to_string(),
-            filter: LiveStateIndexFilter {
-                schema_keys: vec![BRANCH_REF_SCHEMA_KEY.to_string()],
-                entity_pks: branch_ids.iter().map(EntityPk::single).collect(),
-                file_ids: vec![NullableKeyFilter::Null],
-            },
-            projection: Vec::new(),
-            limit: None,
-        })
+        .load_many(branch_ids)
         .await?;
-    rows.into_iter()
-        .map(|row| row.entity_pk.as_single_string_owned())
-        .collect()
-}
-
-fn parse_branch_ref_commit_id(snapshot_content: Option<&str>) -> Result<Option<String>, LixError> {
-    let Some(snapshot_content) = snapshot_content else {
-        return Ok(None);
-    };
-    let snapshot =
-        serde_json::from_str::<serde_json::Value>(snapshot_content).map_err(|error| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                format!("live_state branch-ref snapshot parse failed: {error}"),
-            )
-        })?;
-    Ok(snapshot
-        .get("commit_id")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string))
+    Ok(branch_ids
+        .iter()
+        .cloned()
+        .zip(controls)
+        .filter_map(|(branch_id, control)| control.map(|_| branch_id))
+        .collect())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1153,6 +1224,44 @@ mod tests {
         .await
         .expect("untracked changes should write");
         drop(changelog_writer);
+
+        // Unit fixtures historically modeled branch heads as flat
+        // `lix_branch_ref` rows. V6 deliberately rejects that physical
+        // authority, so keep the fixture's public row while seeding the
+        // matching direct control used by every production reader.
+        for (row, change) in &changes {
+            if row.schema_key != BRANCH_REF_SCHEMA_KEY || row.deleted {
+                continue;
+            }
+            let branch_id = row
+                .entity_pk
+                .as_single_string_owned()
+                .expect("test branch ref must have one branch id key");
+            let snapshot = row
+                .snapshot_content
+                .as_deref()
+                .expect("test branch ref must have a snapshot");
+            let commit_id = serde_json::from_str::<serde_json::Value>(snapshot)
+                .expect("test branch-ref snapshot should be JSON")
+                .get("commit_id")
+                .and_then(serde_json::Value::as_str)
+                .map(|value| CommitId::parse_lix(value, "test branch-ref commit"))
+                .transpose()
+                .expect("test branch-ref commit should parse")
+                .expect("test branch-ref snapshot should name a commit");
+            crate::branch::stage_branch_head_control(
+                &mut writes,
+                &branch_id,
+                BranchHeadControl {
+                    head_commit_id: commit_id,
+                    generation: commit_id,
+                    created_at: ts(&row.created_at),
+                    updated_at: ts(&row.updated_at),
+                    ref_change_id: change.change_id,
+                },
+            )
+            .expect("test branch-head control should stage");
+        }
 
         let mut rows_by_branch = std::collections::BTreeMap::<&str, Vec<_>>::new();
         for (row, change) in &changes {

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -14,6 +14,7 @@ use bytes::Bytes;
 
 use crate::LixError;
 use crate::NullableKeyFilter;
+use crate::branch::BranchHeadControl;
 use crate::changelog::{ChangeId, ChangeRecordProjection, CommitId};
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -264,15 +265,50 @@ impl<S> TrackedHeadStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    /// v6 control-plane variant of [`Self::scan_live_rows_if_current`].
+    ///
+    /// The direct branch control and the v5 marker are published in one
+    /// storage commit. Requiring both the head and generation to agree makes
+    /// a partially rebuilt or stale group projection a clean historical
+    /// fallback rather than visible current state.
+    pub(crate) async fn scan_live_rows_if_control_current(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
+        self.scan_live_rows_for_marker(
+            branch_id,
+            self.marker_if_control_current(branch_id, control).await?,
+            request,
+        )
+        .await
+    }
+
     /// Returns `None` when this branch has no projection for the canonical
     /// branch ref. That is a cache miss, not empty tracked state.
+    #[cfg(test)]
     pub(crate) async fn scan_live_rows_if_current(
         &self,
         branch_id: &str,
         expected_head: &str,
         request: &TrackedStateScanRequest,
     ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
-        let Some(marker) = self.marker_if_current(branch_id, expected_head).await? else {
+        self.scan_live_rows_for_marker(
+            branch_id,
+            self.marker_if_current(branch_id, expected_head).await?,
+            request,
+        )
+        .await
+    }
+
+    async fn scan_live_rows_for_marker(
+        &self,
+        branch_id: &str,
+        marker: Option<TrackedHeadMarker>,
+        request: &TrackedStateScanRequest,
+    ) -> Result<Option<Vec<MaterializedLiveStateRow>>, LixError> {
+        let Some(marker) = marker else {
             return Ok(None);
         };
         let entries = scan_entries(
@@ -297,6 +333,7 @@ where
 
     /// Like the immutable-root point batch, preserves input cardinality and
     /// returns tombstones for the visibility layer to resolve.
+    #[cfg(test)]
     pub(crate) async fn load_projected_live_rows_if_current(
         &self,
         branch_id: &str,
@@ -304,10 +341,26 @@ where
         keys: &[TrackedStateKey],
         projection: &ChangeRecordProjection,
     ) -> Result<Option<Vec<Option<MaterializedLiveStateRow>>>, LixError> {
+        self.load_projected_live_rows_for_marker(
+            branch_id,
+            self.marker_if_current(branch_id, expected_head).await?,
+            keys,
+            projection,
+        )
+        .await
+    }
+
+    async fn load_projected_live_rows_for_marker(
+        &self,
+        branch_id: &str,
+        marker: Option<TrackedHeadMarker>,
+        keys: &[TrackedStateKey],
+        projection: &ChangeRecordProjection,
+    ) -> Result<Option<Vec<Option<MaterializedLiveStateRow>>>, LixError> {
         if keys.is_empty() {
             return Ok(Some(Vec::new()));
         }
-        let Some(marker) = self.marker_if_current(branch_id, expected_head).await? else {
+        let Some(marker) = marker else {
             return Ok(None);
         };
 
@@ -386,9 +439,28 @@ where
         Ok(Some(output))
     }
 
+    /// v6 control-plane variant of
+    /// [`Self::load_projected_live_rows_if_current`].
+    pub(crate) async fn load_projected_live_rows_if_control_current(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+        keys: &[TrackedStateKey],
+        projection: &ChangeRecordProjection,
+    ) -> Result<Option<Vec<Option<MaterializedLiveStateRow>>>, LixError> {
+        self.load_projected_live_rows_for_marker(
+            branch_id,
+            self.marker_if_control_current(branch_id, control).await?,
+            keys,
+            projection,
+        )
+        .await
+    }
+
     /// Returns the durable serving generation exactly when the marker is
     /// bound to `expected_head`. Commit staging passes this value directly to
     /// the writer so a serial child needs one marker point read, not two.
+    #[cfg(test)]
     pub(crate) async fn generation_if_current(
         &self,
         branch_id: &str,
@@ -400,6 +472,20 @@ where
             .map(|marker| marker.generation))
     }
 
+    /// Returns the durable v5 generation only when it is atomically bound to
+    /// the observed v6 branch control.
+    pub(crate) async fn generation_if_control_current(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+    ) -> Result<Option<CommitId>, LixError> {
+        Ok(self
+            .marker_if_control_current(branch_id, control)
+            .await?
+            .map(|marker| marker.generation))
+    }
+
+    #[cfg(test)]
     async fn marker_if_current(
         &self,
         branch_id: &str,
@@ -408,6 +494,18 @@ where
         let expected_head = CommitId::parse_lix(expected_head, "tracked-head expected commit")?;
         let marker = load_marker(&self.store, branch_id).await?;
         Ok(marker.filter(|marker| marker.head_commit_id == expected_head))
+    }
+
+    async fn marker_if_control_current(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+    ) -> Result<Option<TrackedHeadMarker>, LixError> {
+        let marker = load_marker(&self.store, branch_id).await?;
+        Ok(marker.filter(|marker| {
+            marker.head_commit_id == control.head_commit_id
+                && marker.generation == control.generation
+        }))
     }
 }
 
@@ -433,7 +531,7 @@ where
         deltas: &[TrackedHeadDeltaRef<'_>],
         absence_guards: &BTreeSet<TrackedStateKey>,
         parent_rows: Option<Vec<MaterializedTrackedStateRow>>,
-    ) -> Result<(), LixError> {
+    ) -> Result<CommitId, LixError> {
         let matches_parent = parent_generation.is_some();
         let generation = parent_generation.unwrap_or(new_head);
 
@@ -573,7 +671,7 @@ where
                 generation,
             },
         )?;
-        Ok(())
+        Ok(generation)
     }
 }
 
@@ -1880,6 +1978,7 @@ fn materialize_live_slot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::branch::{BranchHeadControl, stage_branch_head_control};
     use crate::json_store::{JsonWritePlacementRef, NormalizedJsonRef};
     use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
 
@@ -2097,6 +2196,13 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let branch_id = "branch";
         let head = CommitId::for_test_label("head");
+        let control = BranchHeadControl {
+            head_commit_id: head,
+            generation: head,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+            ref_change_id: ChangeId::for_test_label("branch-ref"),
+        };
         let entity_pk = EntityPk::single("row");
         let second_entity_pk = EntityPk::single("row-2");
         let deltas = [
@@ -2159,6 +2265,8 @@ mod tests {
             .stage_commit(branch_id, None, head, &deltas, &BTreeSet::new(), None)
             .await
             .expect("stage grouped head");
+        stage_branch_head_control(&mut writes, branch_id, control)
+            .expect("stage matching v6 control");
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -2311,6 +2419,36 @@ mod tests {
                 .all(|row| row.file_id.as_deref() == Some("file-b"))
         );
 
+        // The v6 control plane only validates the generation marker. Exact
+        // file identity and schema-scoped file-id reads must still route to
+        // the v5 member projection even when every backing group is absent.
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open v6 file-id scan");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .scan_live_rows_if_control_current(
+                branch_id,
+                control,
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
+                        schema_keys: vec!["schema".to_string()],
+                        file_ids: vec![NullableKeyFilter::Value("file-b".to_string())],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("v6 file-id scan should execute")
+            .expect("matching v6 control and marker");
+        assert_eq!(rows.len(), 2);
+        assert!(
+            rows.iter()
+                .all(|row| row.file_id.as_deref() == Some("file-b"))
+        );
+
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -2332,6 +2470,32 @@ mod tests {
             .expect("marker should match");
         assert_eq!(rows.len(), 1);
         let row = rows[0].as_ref().expect("explicit member should resolve");
+        assert_eq!(row.file_id.as_deref(), Some("file-b"));
+        assert_eq!(row.snapshot_content.as_deref(), Some("{\"value\":\"b\"}"));
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open v6 exact file read");
+        let rows = TrackedHeadContext::new()
+            .reader(read)
+            .load_projected_live_rows_if_control_current(
+                branch_id,
+                control,
+                &[TrackedStateKey {
+                    schema_key: "schema".to_string(),
+                    entity_pk: EntityPk::single("row"),
+                    file_id: Some("file-b".to_string()),
+                }],
+                &ChangeRecordProjection::full(),
+            )
+            .await
+            .expect("v6 exact file read should execute")
+            .expect("matching v6 control and marker");
+        assert_eq!(rows.len(), 1);
+        let row = rows[0]
+            .as_ref()
+            .expect("v6 explicit member should resolve without its group");
         assert_eq!(row.file_id.as_deref(), Some("file-b"));
         assert_eq!(row.snapshot_content.as_deref(), Some("{\"value\":\"b\"}"));
     }

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -18,6 +18,8 @@ fn prepare_json_ref(value: &str) -> JsonRef {
 }
 #[cfg(test)]
 use crate::GLOBAL_BRANCH_ID;
+#[cfg(test)]
+use crate::branch::{BranchHeadControl, stage_branch_head_control};
 
 #[cfg(test)]
 pub(crate) const TEST_EMPTY_ROOT_COMMIT_ID: &str = "01920000-0000-7000-8000-000000000001";
@@ -78,6 +80,18 @@ pub(crate) async fn seed_branch_head_with_rows(
     .expect("tracked root should write");
 
     let branch_ref_change_id = test_change_id(&format!("branch-ref-{branch_id}"));
+    stage_branch_head_control(
+        &mut writes,
+        branch_id,
+        BranchHeadControl {
+            head_commit_id: commit_id,
+            generation: commit_id,
+            created_at: test_timestamp(),
+            updated_at: test_timestamp(),
+            ref_change_id: branch_ref_change_id,
+        },
+    )
+    .expect("direct branch-head control should stage");
     let branch_ref_entity_pk = crate::entity_pk::EntityPk::single(branch_id);
     let branch_ref_snapshot = serde_json::json!({
         "id": branch_id,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -8,7 +8,11 @@ use bytes::Bytes;
 
 use crate::LixError;
 use crate::binary_cas::BinaryCasContext;
-use crate::branch::{BRANCH_REF_SCHEMA_KEY, BranchContext, BranchRefReader};
+use crate::branch::{
+    BRANCH_REF_SCHEMA_KEY, BranchContext, BranchHeadControl, BranchHeadControlContext,
+    BranchHeadControlObservation, BranchRefReader, branch_head_control_precondition,
+    stage_branch_head_control, stage_delete_branch_head_control,
+};
 use crate::changelog::{
     ChangeId, ChangeRecord, ChangelogContext, ChangelogReader, ChangelogWriter, CommitChangeRefSet,
     CommitId, CommitLoadRequest as ChangelogCommitLoadRequest,
@@ -127,13 +131,22 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     ))
     .await?;
     let commit_rows = finalized.commit_rows;
-    let branch_heads = finalized.branch_heads;
     let tracked_roots = finalized.tracked_roots;
-    let has_checkpoint_publication = !prepared_writes.checkpoint_publications.is_empty();
-    let mut engine_rows = branch_heads
+    // V6 removes the automatic flat current row for a normal branch-head
+    // advance, but `lix_change` remains an unscoped public ledger. Retain one
+    // tiny direct change fact per published control.
+    let branch_head_changes = tracked_roots
         .iter()
-        .map(branch_ref_current_row)
+        .map(branch_ref_change_record)
         .collect::<Result<Vec<_>, _>>()?;
+    let has_checkpoint_publication = !prepared_writes.checkpoint_publications.is_empty();
+    // v6 publishes automatic tracked heads through one direct control record.
+    // Do not also synthesize a mutable `lix_branch_ref` current row for every
+    // normal commit: `branch_head_changes` above preserves the immutable
+    // public `lix_change` ledger fact. Explicit branch-management writes
+    // retain their legacy row lowering below while control records are the
+    // sole authority readers consult.
+    let mut engine_rows = Vec::new();
     if let Some((highest_seen, timestamp, change_id)) =
         runtime_functions.and_then(FunctionContext::deterministic_sequence_checkpoint)
     {
@@ -148,7 +161,6 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
 
     if state_rows.is_empty()
         && commit_rows.is_empty()
-        && branch_heads.is_empty()
         && engine_rows.is_empty()
         && writes.is_empty()
     {
@@ -174,6 +186,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         read,
         &mut writes,
         &state_rows,
+        &branch_head_changes,
         &engine_rows,
         &compactable_change_ids,
         &row_index.tracked_row_indices_by_commit,
@@ -196,6 +209,9 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
 
     stage_state_json_payloads(&mut json_writer, &mut writes, &state_rows)?;
 
+    let branch_control_observations =
+        observe_branch_head_controls(read, &tracked_roots, &state_rows).await?;
+
     stage_tracked_roots(
         read,
         &mut writes,
@@ -211,7 +227,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         "lix.perf.materialization.tracked_roots"
     ))
     .await?;
-    stage_tracked_head(
+    let normal_branch_controls = stage_tracked_head(
         read,
         &mut writes,
         &state_rows,
@@ -219,11 +235,20 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &tracked_roots,
         &staged_commits,
         &insert_identities,
+        &branch_control_observations,
     )
     .instrument(tracing::debug_span!(
         target: "lix_perf",
         "lix.perf.materialization.tracked_head"
     ))
+    .await?;
+    stage_branch_head_control_publications(
+        &mut writes,
+        &normal_branch_controls,
+        &state_rows,
+        &mut preconditions,
+        &branch_control_observations,
+    )
     .await?;
     if filesystem_view_changed {
         stage_path_index_revision(&mut writes);
@@ -320,6 +345,7 @@ async fn stage_changelog_commits(
     read: &mut impl StorageAdapterRead,
     writes: &mut StorageWriteSet,
     state_rows: &[PreparedStateRow],
+    branch_head_changes: &[ChangeRecord],
     branch_ref_rows: &[EngineCurrentRow],
     compact_change_ids: &[ChangeId],
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
@@ -331,6 +357,11 @@ async fn stage_changelog_commits(
         .iter()
         .filter(|row| !(row.untracked && row.snapshot.is_none()))
         .map(transaction_change_record_from_state_row)
+        .chain(
+            branch_head_changes
+                .iter()
+                .map(|change| Ok(TransactionChangeRecordRef::from(change))),
+        )
         .chain(
             branch_ref_rows
                 .iter()
@@ -499,15 +530,18 @@ struct EngineCurrentRow {
     updated_at: LixTimestamp,
 }
 
-fn branch_ref_current_row(head: &PendingBranchHead) -> Result<EngineCurrentRow, LixError> {
+/// Builds the standalone public ledger fact for an automatic branch-head
+/// advance. The v6 control owns current visibility; this fact keeps the
+/// existing `lix_change` contract without reintroducing a flat current row.
+fn branch_ref_change_record(root: &PendingTrackedRoot) -> Result<ChangeRecord, LixError> {
     let snapshot = serde_json::to_string(&serde_json::json!({
-        "id": head.branch_id,
-        "commit_id": head.commit_id.to_string(),
+        "id": root.branch_id,
+        "commit_id": root.commit_id.to_string(),
     }))
     .map_err(|error| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
-            format!("failed to serialize branch-ref current change: {error}"),
+            format!("failed to serialize direct branch-ref change: {error}"),
         )
     })?;
     if snapshot.len() > crate::json_store::JSON_INLINE_MAX_BYTES {
@@ -520,21 +554,16 @@ fn branch_ref_current_row(head: &PendingBranchHead) -> Result<EngineCurrentRow, 
             ),
         ));
     }
-    Ok(EngineCurrentRow {
-        branch_id: crate::GLOBAL_BRANCH_ID.to_string(),
-        change: ChangeRecord {
-            format_version: 2,
-            change_id: head.change_id,
-            schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
-            entity_pk: EntityPk::single(&head.branch_id),
-            file_id: None,
-            snapshot: crate::json_store::JsonSlot::from_json(&snapshot),
-            metadata: crate::json_store::JsonSlot::None,
-            created_at: head.timestamp,
-            origin_key: None,
-        },
-        created_at: head.timestamp,
-        updated_at: head.timestamp,
+    Ok(ChangeRecord {
+        format_version: 2,
+        change_id: root.ref_change_id,
+        schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
+        entity_pk: EntityPk::single(&root.branch_id),
+        file_id: None,
+        snapshot: crate::json_store::JsonSlot::from_json(&snapshot),
+        metadata: crate::json_store::JsonSlot::None,
+        created_at: root.ref_updated_at,
+        origin_key: None,
     })
 }
 
@@ -638,8 +667,7 @@ async fn stage_flat_current_rows(
     {
         let branch_id = row.entity_pk.as_single_string_owned()?;
         let Some(snapshot) = row.snapshot.as_ref() else {
-            let existing_commit_id =
-                load_current_branch_ref_commit_id(&index_reader, &branch_id).await?;
+            let existing_commit_id = load_current_branch_ref_commit_id(read, &branch_id).await?;
             if existing_commit_id.is_some()
                 && (has_pending_local_sidecar_rows(state_rows, &branch_id)
                     || guarded_branch_ref_has_local_untracked_rows(
@@ -662,8 +690,7 @@ async fn stage_flat_current_rows(
         else {
             continue;
         };
-        let existing_commit_id =
-            load_current_branch_ref_commit_id(&index_reader, &branch_id).await?;
+        let existing_commit_id = load_current_branch_ref_commit_id(read, &branch_id).await?;
         if existing_commit_id.as_deref() == Some(commit_id) {
             // Updating descriptor fields or assigning the current head again
             // must not disturb branch-local live state.
@@ -851,37 +878,15 @@ async fn ensure_branch_ref_target_exists(
     ))
 }
 
-async fn load_current_branch_ref_commit_id<S>(
-    reader: &crate::live_state::LiveStateIndexStoreReader<S>,
+async fn load_current_branch_ref_commit_id(
+    read: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
-) -> Result<Option<String>, LixError>
-where
-    S: StorageAdapterRead,
-{
-    let Some(row) = reader
-        .load_row(&LiveStateIndexRowRequest {
-            branch_id: crate::GLOBAL_BRANCH_ID.to_string(),
-            schema_key: BRANCH_REF_SCHEMA_KEY.to_string(),
-            entity_pk: EntityPk::single(branch_id),
-            file_id: None,
-        })
+) -> Result<Option<String>, LixError> {
+    Ok(BranchHeadControlContext::new()
+        .reader(read)
+        .load(branch_id)
         .await?
-    else {
-        return Ok(None);
-    };
-    let Some(snapshot) = row.snapshot_content.as_deref() else {
-        return Ok(None);
-    };
-    let value = serde_json::from_str::<serde_json::Value>(snapshot).map_err(|error| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("invalid current branch ref for '{branch_id}': {error}"),
-        )
-    })?;
-    Ok(value
-        .get("commit_id")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string))
+        .map(|control| control.head_commit_id.to_string()))
 }
 
 async fn branch_has_local_untracked_rows<S>(
@@ -1122,9 +1127,11 @@ async fn stage_tracked_head(
     tracked_roots: &[PendingTrackedRoot],
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
     insert_identities: &BTreeMap<PreparedStateRowIdentity, PreparedInsertIdentity>,
-) -> Result<(), LixError> {
+    observations: &BTreeMap<String, BranchHeadControlObservation>,
+) -> Result<BTreeMap<String, BranchHeadControl>, LixError> {
     let tracked_head = TrackedHeadContext::new();
     let mut writer = tracked_head.writer(read, writes);
+    let mut controls = BTreeMap::new();
     for root in tracked_roots_parent_first(tracked_roots)? {
         let staged = staged_commits.get(&root.commit_id).ok_or_else(|| {
             LixError::new(
@@ -1135,7 +1142,24 @@ async fn stage_tracked_head(
                 ),
             )
         })?;
+        let parent_control = observations
+            .get(&root.branch_id)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "missing v6 branch-control observation for normal publication branch '{}'",
+                        root.branch_id
+                    ),
+                )
+            })?
+            .control;
         if !staged.selected_change_refs.is_empty() {
+            insert_direct_branch_control(
+                &mut controls,
+                &root.branch_id,
+                normal_branch_head_control(root, parent_control, root.commit_id),
+            )?;
             continue;
         }
         let state_row_indices = tracked_row_indices_by_commit
@@ -1161,14 +1185,16 @@ async fn stage_tracked_head(
         // The v4 marker is the durable authority for current state. It is
         // intentionally bound only to the first-parent commit: serial normal
         // commits can append deltas without materializing an immutable root.
-        let parent_generation = match root.parent_commit_id {
-            Some(parent_commit_id) => {
+        let parent_generation = match (root.parent_commit_id, parent_control) {
+            (Some(parent_commit_id), Some(control))
+                if control.head_commit_id == parent_commit_id =>
+            {
                 tracked_head
                     .reader(read)
-                    .generation_if_current(&root.branch_id, &parent_commit_id.to_string())
+                    .generation_if_control_current(&root.branch_id, control)
                     .await?
             }
-            None => None,
+            _ => None,
         };
         let parent_is_current = parent_generation.is_some();
         let parent_rows = if parent_is_current || root.parent_commit_id.is_none() {
@@ -1182,6 +1208,11 @@ async fn stage_tracked_head(
                 .iter()
                 .any(|candidate| candidate.commit_id == parent_commit_id)
             {
+                insert_direct_branch_control(
+                    &mut controls,
+                    &root.branch_id,
+                    normal_branch_head_control(root, parent_control, root.commit_id),
+                )?;
                 continue;
             }
             Some(
@@ -1203,7 +1234,7 @@ async fn stage_tracked_head(
         } else {
             None
         };
-        writer
+        let generation = writer
             .stage_commit(
                 &root.branch_id,
                 parent_generation,
@@ -1213,8 +1244,218 @@ async fn stage_tracked_head(
                 parent_rows,
             )
             .await?;
+        insert_direct_branch_control(
+            &mut controls,
+            &root.branch_id,
+            normal_branch_head_control(root, parent_control, generation),
+        )?;
+    }
+    Ok(controls)
+}
+
+fn normal_branch_head_control(
+    root: &PendingTrackedRoot,
+    previous: Option<BranchHeadControl>,
+    generation: CommitId,
+) -> BranchHeadControl {
+    BranchHeadControl {
+        head_commit_id: root.commit_id,
+        generation,
+        created_at: previous.map_or(root.ref_updated_at, |control| control.created_at),
+        updated_at: root.ref_updated_at,
+        ref_change_id: root.ref_change_id,
+    }
+}
+
+fn insert_direct_branch_control(
+    controls: &mut BTreeMap<String, BranchHeadControl>,
+    branch_id: &str,
+    control: BranchHeadControl,
+) -> Result<(), LixError> {
+    if controls.insert(branch_id.to_string(), control).is_some() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked direct plane received multiple normal publications for branch '{branch_id}' in one commit"
+            ),
+        ));
     }
     Ok(())
+}
+
+/// Publishes every v6 branch-head control under an exact-byte CAS token.
+///
+/// Normal tracked commits arrive as `normal_controls`, built from the same
+/// parent/generation decision that wrote the v5 group marker. Explicit branch
+/// management still enters the prepared-row pipeline for validation and
+/// changelog compatibility, but its authoritative moving head is lowered
+/// here as well. This deliberately keeps the rare lifecycle lane compatible
+/// while removing automatic `lix_branch_ref` materialization from normal
+/// CRUD commits.
+async fn stage_branch_head_control_publications(
+    writes: &mut StorageWriteSet,
+    normal_controls: &BTreeMap<String, BranchHeadControl>,
+    state_rows: &[PreparedStateRow],
+    preconditions: &mut Vec<StoragePrecondition>,
+    observations: &BTreeMap<String, BranchHeadControlObservation>,
+) -> Result<(), LixError> {
+    let explicit_targets = explicit_branch_head_targets(state_rows)?;
+    let mut publications = normal_controls
+        .iter()
+        .map(|(branch_id, control)| (branch_id.clone(), Some(*control)))
+        .collect::<BTreeMap<String, Option<BranchHeadControl>>>();
+
+    for (branch_id, target) in explicit_targets {
+        if publications.contains_key(&branch_id) {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                format!(
+                    "cannot publish an explicit branch ref and a normal tracked commit for branch '{branch_id}' in one transaction"
+                ),
+            ));
+        }
+        let existing = observations
+            .get(&branch_id)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "missing v6 branch-control observation for explicit publication branch '{branch_id}'"
+                    ),
+                )
+            })?
+            .control;
+        let desired = target
+            .head_commit_id
+            .map(|head_commit_id| BranchHeadControl {
+                head_commit_id,
+                // Repointing to the same head must not invalidate a complete v5
+                // serving generation merely because public ref metadata changed.
+                generation: existing
+                    .filter(|control| control.head_commit_id == head_commit_id)
+                    .map_or(head_commit_id, |control| control.generation),
+                // The flat v5 branch-ref projection preserved creation time on
+                // replacement. The control record owns that same public fact.
+                created_at: existing.map_or(target.created_at, |control| control.created_at),
+                updated_at: target.updated_at,
+                ref_change_id: target.ref_change_id,
+            });
+        publications.insert(branch_id, desired);
+    }
+
+    if publications.is_empty() {
+        return Ok(());
+    }
+    for (branch_id, desired) in &mut publications {
+        let observation = observations.get(branch_id).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "missing v6 branch-control observation for publication branch '{branch_id}'"
+                ),
+            )
+        })?;
+        preconditions.push(branch_head_control_precondition(
+            branch_id,
+            observation.raw_token.clone(),
+        )?);
+        match desired {
+            Some(control) => stage_branch_head_control(writes, branch_id, *control)?,
+            None => stage_delete_branch_head_control(writes, branch_id)?,
+        }
+    }
+    Ok(())
+}
+
+/// Returns explicit public branch-ref targets. `None` is a deletion; `Some`
+/// is a validated commit id. The v6 control record remains the authority, but
+/// retaining these rows in the generic lifecycle lowering means its existing
+/// sidecar and target-existence checks remain in force.
+struct ExplicitBranchHeadTarget {
+    head_commit_id: Option<CommitId>,
+    ref_change_id: ChangeId,
+    created_at: LixTimestamp,
+    updated_at: LixTimestamp,
+}
+
+fn explicit_branch_head_targets(
+    state_rows: &[PreparedStateRow],
+) -> Result<BTreeMap<String, ExplicitBranchHeadTarget>, LixError> {
+    let mut targets = BTreeMap::new();
+    for row in state_rows {
+        if row.schema_key != BRANCH_REF_SCHEMA_KEY || !row.untracked {
+            continue;
+        }
+        let branch_id = row.entity_pk.as_single_string_owned()?;
+        let head_commit_id = row
+            .snapshot
+            .as_ref()
+            .map(|snapshot| {
+                let commit_id = snapshot
+                    .value
+                    .get("commit_id")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INVALID_PARAM,
+                            format!(
+                                "branch ref for branch '{branch_id}' is missing commit_id before v6 publication"
+                            ),
+                        )
+                    })?;
+                CommitId::parse_lix(commit_id, "v6 branch-head control target")
+            })
+            .transpose()?;
+        let ref_change_id = row.change_id.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "explicit branch ref for branch '{branch_id}' is missing its public change id"
+                ),
+            )
+        })?;
+        let target = ExplicitBranchHeadTarget {
+            head_commit_id,
+            ref_change_id,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        };
+        if targets.insert(branch_id.clone(), target).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "transaction contains multiple explicit branch-ref publications for branch '{branch_id}'"
+                ),
+            ));
+        }
+    }
+    Ok(targets)
+}
+
+/// Takes one coherent raw point batch for every control this materialization
+/// can publish. The result is threaded through v5 generation selection and
+/// final CAS staging, so the control plane adds exactly one control batch to
+/// a commit rather than a head lookup plus a second token lookup.
+async fn observe_branch_head_controls(
+    read: &(impl StorageAdapterRead + ?Sized),
+    tracked_roots: &[PendingTrackedRoot],
+    state_rows: &[PreparedStateRow],
+) -> Result<BTreeMap<String, BranchHeadControlObservation>, LixError> {
+    let mut branch_ids = tracked_roots
+        .iter()
+        .map(|root| root.branch_id.clone())
+        .collect::<BTreeSet<_>>();
+    for row in state_rows {
+        if row.schema_key == BRANCH_REF_SCHEMA_KEY && row.untracked {
+            branch_ids.insert(row.entity_pk.as_single_string_owned()?);
+        }
+    }
+    let branch_ids = branch_ids.into_iter().collect::<Vec<_>>();
+    let observations = BranchHeadControlContext::new()
+        .reader(read)
+        .load_observed(&branch_ids)
+        .await?;
+    Ok(branch_ids.into_iter().zip(observations).collect())
 }
 
 async fn stage_tracked_roots(
@@ -1486,11 +1727,11 @@ fn visit_tracked_root_parent_first<'a>(
 /// `commit_rows` are canonical changelog commit facts. tracked_state roots store
 /// serving commit roots keyed by the corresponding commit id.
 ///
-/// `branch_heads` are moving refs. Their changes enter the canonical ledger
-/// without becoming members of the commits they point at.
+/// Moving heads publish through the v6 direct branch-control plane after the
+/// immutable commit facts are staged. They are not synthetic changelog
+/// changes and do not become members of the commits they point at.
 struct FinalizedCommitRows {
     commit_rows: Vec<FinalizedCommitRow>,
-    branch_heads: Vec<PendingBranchHead>,
     tracked_roots: Vec<PendingTrackedRoot>,
 }
 
@@ -1502,17 +1743,13 @@ struct FinalizedCommitRow {
     selected_change_refs: Vec<StagedCommitChangeRef>,
 }
 
-struct PendingBranchHead {
-    branch_id: String,
-    commit_id: CommitId,
-    change_id: ChangeId,
-    timestamp: LixTimestamp,
-}
-
 struct PendingTrackedRoot {
     branch_id: String,
     commit_id: CommitId,
     parent_commit_id: Option<CommitId>,
+    /// Metadata for the public synthesized `lix_branch_ref` row.
+    ref_change_id: ChangeId,
+    ref_updated_at: LixTimestamp,
     requires_root: bool,
 }
 
@@ -1523,7 +1760,6 @@ async fn finalize_commit_rows(
     commit_parent_heads: &BTreeMap<String, Option<CommitId>>,
 ) -> Result<FinalizedCommitRows, LixError> {
     let mut commit_rows = Vec::new();
-    let mut branch_heads = Vec::new();
     let mut tracked_roots = Vec::new();
 
     for (branch_id, change_refs) in commit_change_refs_by_branch {
@@ -1570,23 +1806,18 @@ async fn finalize_commit_rows(
             change_id: commit_change_id,
             selected_change_refs,
         });
-        branch_heads.push(PendingBranchHead {
-            branch_id: branch_id.clone(),
-            commit_id,
-            change_id: branch_ref_change_id,
-            timestamp,
-        });
         tracked_roots.push(PendingTrackedRoot {
             branch_id,
             commit_id,
             parent_commit_id,
+            ref_change_id: branch_ref_change_id,
+            ref_updated_at: timestamp,
             requires_root,
         });
     }
 
     Ok(FinalizedCommitRows {
         commit_rows,
-        branch_heads,
         tracked_roots,
     })
 }
@@ -1790,20 +2021,6 @@ mod tests {
             }
             self.inner.scan(space, range, opts).await
         }
-    }
-
-    #[test]
-    fn branch_ref_current_row_rejects_snapshot_that_cannot_be_inlined() {
-        let error = branch_ref_current_row(&PendingBranchHead {
-            branch_id: "b".repeat(crate::json_store::JSON_INLINE_MAX_BYTES),
-            commit_id: CommitId::for_test_label("long-branch-head"),
-            change_id: ChangeId::for_test_label("long-branch-ref-change"),
-            timestamp: ts("2026-01-01T00:00:00Z"),
-        })
-        .expect_err("oversized engine-authored branch ref should fail clearly");
-
-        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
-        assert!(error.message.contains("branch id is too long"));
     }
 
     #[test]
@@ -2123,7 +2340,7 @@ mod tests {
             matches!(
                 precondition,
                 StoragePrecondition::KeyAbsent { space, .. }
-                    if *space == crate::live_state::LIVE_STATE_INDEX_ROW_SPACE.id
+                    if *space == crate::branch::BRANCH_HEAD_CONTROL_SPACE.id
             )
         }));
 
@@ -2178,16 +2395,16 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("normal branch-ref verification read should open");
-        let row = LiveStateIndexContext::new()
+        let control = BranchHeadControlContext::new()
             .reader(read)
-            .load_index_row(&branch_ref_index_request(GLOBAL_BRANCH_ID))
+            .load(GLOBAL_BRANCH_ID)
             .await
-            .expect("winner engine branch-ref row should load")
-            .expect("winner engine branch-ref row should remain present");
+            .expect("winner direct branch control should load")
+            .expect("winner direct branch control should remain present");
         assert_eq!(
-            row.change_id,
+            control.ref_change_id,
             change_id("winner-normal-branch-ref-change"),
-            "the stale commit must not replace the winner's current ref row"
+            "the stale commit must not replace the winner's public branch-ref metadata"
         );
     }
 
@@ -3239,6 +3456,7 @@ mod tests {
             &[parent_row, child_row],
             &[],
             &[],
+            &[],
             &BTreeMap::from([
                 (CommitId::for_test_label("parent-commit"), vec![0]),
                 (CommitId::for_test_label("child-commit"), vec![1]),
@@ -3775,7 +3993,7 @@ mod tests {
         .expect("global commit row should finalize");
 
         assert_eq!(rows.commit_rows.len(), 1);
-        assert_eq!(rows.branch_heads.len(), 1);
+        assert_eq!(rows.tracked_roots.len(), 1);
         let row = &rows.commit_rows[0];
         assert_eq!(row.commit_id, commit_id("test-uuid-1"));
         assert_eq!(row.change_id, change_id("test-uuid-2"));
@@ -3785,9 +4003,9 @@ mod tests {
             vec![CommitId::for_test_label("initial-commit")]
         );
 
-        let branch_head = &rows.branch_heads[0];
-        assert_eq!(branch_head.branch_id, GLOBAL_BRANCH_ID);
-        assert_eq!(branch_head.commit_id, commit_id("test-uuid-1"));
+        let root = &rows.tracked_roots[0];
+        assert_eq!(root.branch_id, GLOBAL_BRANCH_ID);
+        assert_eq!(root.commit_id, commit_id("test-uuid-1"));
     }
 
     #[tokio::test]
@@ -3805,7 +4023,7 @@ mod tests {
         .expect("empty change_refs should be ignored");
 
         assert!(rows.commit_rows.is_empty());
-        assert!(rows.branch_heads.is_empty());
+        assert!(rows.tracked_roots.is_empty());
     }
 
     #[tokio::test]
@@ -3826,7 +4044,7 @@ mod tests {
             rows.commit_rows[0].parent_commit_ids,
             vec![CommitId::for_test_label("previous-commit")]
         );
-        assert_eq!(rows.branch_heads[0].branch_id, "branch-a");
+        assert_eq!(rows.tracked_roots[0].branch_id, "branch-a");
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -424,6 +424,9 @@ impl From<&PreparedStateRow> for MaterializedLiveStateRow {
 pub(crate) struct StagedCommitChangeRefs {
     pub(crate) commit_id: CommitId,
     pub(crate) commit_change_id: ChangeId,
+    /// Every normal branch-head publication has a distinct public
+    /// `lixcol_change_id`, even though v6 stores the moving ref directly
+    /// rather than as a flat current row.
     pub(crate) branch_ref_change_id: ChangeId,
     pub(crate) created_at: LixTimestamp,
     /// Normal prepared rows are already the authoritative commit-membership

--- a/packages/engine/tests/integration/sql/lix_branch.rs
+++ b/packages/engine/tests/integration/sql/lix_branch.rs
@@ -69,6 +69,88 @@ simulation_test!(
 );
 
 simulation_test!(
+    lix_branch_ref_control_preserves_public_row_metadata,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+        let branch_id = sim.main_branch_id();
+        let before = session
+            .execute(
+                &format!(
+                    "SELECT lixcol_created_at, lixcol_updated_at, lixcol_change_id \
+                     FROM lix_branch_ref WHERE id = '{branch_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("initial ref metadata should be readable");
+        assert_eq!(before.len(), 1);
+        let initial_created_at = before.rows()[0]
+            .get::<String>("lixcol_created_at")
+            .expect("created timestamp should be text");
+        let initial_updated_at = before.rows()[0]
+            .get::<String>("lixcol_updated_at")
+            .expect("updated timestamp should be text");
+        let initial_change_id = before.rows()[0]
+            .get::<String>("lixcol_change_id")
+            .expect("change id should be text");
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) \
+                 VALUES ('branch-ref-public-metadata', 'next-head')",
+                &[],
+            )
+            .await
+            .expect("tracked write should advance the workspace head");
+
+        let after = session
+            .execute(
+                &format!(
+                    "SELECT lixcol_created_at, lixcol_updated_at, lixcol_change_id \
+                     FROM lix_branch_ref WHERE id = '{branch_id}'"
+                ),
+                &[],
+            )
+            .await
+            .expect("advanced ref metadata should be readable");
+        assert_eq!(after.len(), 1);
+        let advanced_created_at = after.rows()[0]
+            .get::<String>("lixcol_created_at")
+            .expect("advanced created timestamp should be text");
+        let advanced_updated_at = after.rows()[0]
+            .get::<String>("lixcol_updated_at")
+            .expect("advanced updated timestamp should be text");
+        let advanced_change_id = after.rows()[0]
+            .get::<String>("lixcol_change_id")
+            .expect("advanced change id should be text");
+
+        assert_eq!(advanced_created_at, initial_created_at);
+        assert_ne!(advanced_updated_at, initial_updated_at);
+        assert_ne!(advanced_change_id, initial_change_id);
+        assert_eq!(
+            count_rows(
+                &session,
+                &format!(
+                    "SELECT COUNT(*) FROM lix_change \
+                     WHERE id = '{advanced_change_id}' \
+                     AND schema_key = 'lix_branch_ref'"
+                ),
+            )
+            .await,
+            1,
+            "the synthesized current ref must retain its immutable public lix_change ledger fact"
+        );
+    }
+);
+
+simulation_test!(
     lix_branch_insert_creates_descriptor_and_ref,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## What changed

Moves the private tracked branch-head publication plane to `tracked-direct-plane.v6`:

- one authoritative `BranchHeadControl` per branch holds the current commit, tracked-head generation, and public branch-ref metadata;
- normal tracked commits publish the v5 group generation and the branch control under one exact-byte CAS fence;
- `lix_branch_ref` is synthesized from that control, while a standalone immutable `lix_change` fact preserves the existing branch-ref ledger contract;
- branch lifecycle writes, initialization, GC roots, and all branch-head readers now use the control plane;
- file-id/member projections remain v5-backed and are explicitly covered when a grouped record is absent.

## Public compatibility

No exported Rust, SQL, or SDK API changes. `lix_branch_ref` metadata and automatic branch-ref entries in `lix_change` retain their public behavior.

This is an intentional physical-storage hard cut: repositories with the former v5 protocol fail closed and must be recreated. The protocol gate changes from `tracked-head-group.v5` to `tracked-direct-plane.v6`.

## Why

Normal tracked commits previously advanced their head through a mutable `lix_branch_ref` row in the generic live-state index. That made normal CRUD pay for a current-state sidecar route even though a branch head is control-plane metadata. The direct control record is the single CAS publication fence and removes that work from the normal tracked path.

## Benchmark (RocksDB Lix, 10k tracked rows)

Fixture setup is excluded. Hot measurements keep one seeded fixture; full scans use alternating main/v6 samples.

| SQL operation | main median | v6 median | change |
| --- | ---: | ---: | ---: |
| `UPDATE … WHERE PK` | 103.826 µs | 80.455 µs | **-22.5%** |
| `UPDATE` all rows in one explicit transaction | 1.462 s | 1.334 s | **-8.8%** |
| `SELECT … WHERE PK` | 30.024 µs | 22.929 µs | **-23.6%** |
| `SELECT … WHERE PK IN (…)` (10 keys) | 151.815 µs | 139.828 µs | **-7.9%** |
| full `SELECT` (10k rows) | 38.178 ms | 38.237 ms | neutral (+0.15%, within noise) |

The full-scan profile remains dominated by unchanged per-row JSON/DataFusion/group decoding and RocksDB iteration; this PR does not add a measurable per-row control-plane cost.

For context, the standalone SQLite hot single-row update baseline is 5.641 µs. This PR is a measured reduction, not a parity claim.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p lix_engine --features storage-benches`
- `cargo clippy -p lix_engine --features storage-benches -- -D warnings`
- `cargo test -p lix_engine --lib`
- `cargo test -p lix_engine --features all-simulations`
- `cargo test -p lix_engine --test integration lix_branch -- --nocapture`
- `cargo test -p lix_rocksdb_storage`
- `cargo test -p lix_sqlite_storage`
- focused public `lix_branch_ref` / `lix_change`, v5 file-id member, and v6 GC-root tests
