### PR TITLE
perf(server): negotiate zstd for remote reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,6 +1084,8 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 tokio = { version = "1", features = ["sync", "rt"] }
-tower-http = { version = "0.6", features = ["compression-gzip", "decompression-gzip"] }
+tower-http = { version = "0.6", features = ["compression-gzip", "compression-zstd", "decompression-gzip"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -724,6 +724,7 @@ where
             .layer(
                 CompressionLayer::new()
                     .gzip(true)
+                    .zstd(true)
                     .quality(CompressionLevel::Precise(2))
                     .compress_when(
                         DefaultPredicate::new().and(SizeAbove::new(MIN_COMPRESSION_BODY_BYTES)),
@@ -2813,6 +2814,21 @@ mod tests {
         serde_json::from_slice(&decoded).expect("compressed json")
     }
 
+    async fn zstd_response_json(response: Response) -> JsonValue {
+        assert_eq!(
+            response.headers().get(axum::http::header::CONTENT_ENCODING),
+            Some(&axum::http::HeaderValue::from_static("zstd"))
+        );
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("compressed body")
+            .to_bytes();
+        let decoded = zstd::stream::decode_all(bytes.as_ref()).expect("decode zstd");
+        serde_json::from_slice(&decoded).expect("compressed json")
+    }
+
     async fn error_code(response: Response) -> String {
         response_json(response).await["error"]["code"]
             .as_str()
@@ -4289,7 +4305,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn large_finite_json_responses_use_gzip_but_sse_does_not() {
+    async fn large_finite_responses_negotiate_compression_but_sse_does_not() {
         let app = app().await;
         let (session_id, _) = new_session(&app.router).await;
         let request_body = json!({
@@ -4315,6 +4331,27 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             gzip_response_json(response).await["rows"][0][0]["value"],
+            "x".repeat(64 * 1024)
+        );
+
+        let response = app
+            .router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/execute")
+                    .header(SESSION_ID_HEADER, &session_id)
+                    .header(axum::http::header::ACCEPT_ENCODING, "zstd")
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(request_body.to_string()))
+                    .expect("zstd response request"),
+            )
+            .await
+            .expect("zstd response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            zstd_response_json(response).await["rows"][0][0]["value"],
             "x".repeat(64 * 1024)
         );
 


### PR DESCRIPTION
## Summary

- enable existing protocol response compression to negotiate zstd in addition to gzip
- preserve gzip fallback and the existing size/content predicate
- add a response-negotiation correctness test; endpoints and response payload semantics are unchanged

This is stacked on #780, whose corrected benchmark keeps profiling reads outside both timed arms and gates both p50 and p95.

## Profile-driven result

The corrected baseline exposed hot 1 MiB transfer/body materialization as the only miss:

- baseline 0 ms warm-memory 1 MiB: 2.15x p50 / 2.24x p95
- zstd 0 ms warm-memory 1 MiB: 1.74x p50 / 1.89x p95
- zstd 10 ms warm-memory 1 MiB: 1.94x p50 / 1.98x p95
- zstd 25 ms warm-memory 1 MiB: 1.82x p50 / 1.88x p95

All other warm-memory operations were at most 1.65x p50 / 1.63x p95. The full 0 ms warm-disk/cold matrix remained 0.99x–1.14x, with identical object-store request totals per arm. The benchmark fully decodes responses inside the timer.

## Validation

- `cargo fmt --all --check`
- `cargo test -p lix_server_protocol --release`
- `cargo clippy -p lix_server_protocol --all-targets -- -D warnings -A clippy::unnecessary-wraps`
- full 0 ms release benchmark matrix (500 warm-memory; 30 warm-disk/cold samples)
- 10 / 25 ms warm-memory matrix (500 samples)
- 10 ms warm-disk request diagnostic (10 samples, equal/lower remote total)