### PR TITLE
bench(plugin): gate Markdown and JSON hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,6 +3385,7 @@ version = "0.8.4"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
+ "lix_rocksdb_storage",
  "lix_sdk",
  "plugin_csv_v2",
  "plugin_excalidraw_v2",
@@ -3395,6 +3396,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
  "wasmtime",
  "wasmtime-wasi",
  "zip",

--- a/packages/engine/src/session/merge/branch.rs
+++ b/packages/engine/src/session/merge/branch.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::{Value as JsonValue, json};
+use tracing::Instrument as _;
 
 use crate::LixError;
 use crate::branch::{BranchLifecycle, BranchOperation, BranchReferenceRole};
@@ -200,7 +201,7 @@ where
                     return Err(LixError::invalid_self_merge(active_branch_id));
                 }
 
-                let (target_head, source_head) = {
+                let (target_head, source_head) = async {
                     let reader = transaction.branch_ref_reader().await;
                     let lifecycle = BranchLifecycle::new(&reader);
                     let target_head = lifecycle
@@ -217,15 +218,25 @@ where
                             BranchReferenceRole::Source,
                         )
                         .await?;
-                    (target_head, source_head)
-                };
+                    Ok::<_, LixError>((target_head, source_head))
+                }
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.merge_branch_refs"
+                ))
+                .await?;
 
-                let merge_base = {
+                let merge_base = async {
                     let mut reader = transaction.commit_graph_reader().await;
-                    reader.merge_base(&target_head, &source_head).await?
-                };
+                    reader.merge_base(&target_head, &source_head).await
+                }
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.merge_base"
+                ))
+                .await?;
                 let base_commit_id = merge_base.commit_id;
-                let analysis = {
+                let analysis = async {
                     let mut reader = transaction.tracked_state_reader().await;
                     analyze(
                         &mut reader,
@@ -235,12 +246,22 @@ where
                             source_commit_id: source_head,
                         },
                     )
-                    .await?
-                };
-                let derived_blob_files = {
+                    .await
+                }
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.merge_analysis"
+                ))
+                .await?;
+                let derived_blob_files = async {
                     let mut reader = transaction.tracked_state_reader().await;
-                    derived_plugin_blob_conflicts(&mut reader, &analysis).await?
-                };
+                    derived_plugin_blob_conflicts(&mut reader, &analysis).await
+                }
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.merge_derived_blob_detection"
+                ))
+                .await?;
 
                 if analysis.outcome == MergeOutcome::AlreadyUpToDate {
                     return Ok(MergeBranchReceipt {
@@ -292,7 +313,7 @@ where
                     )?);
                 }
 
-                let semantic_rows = {
+                let semantic_rows = async {
                     let mut reader = transaction.tracked_state_reader().await;
                     materialized_plugin_merge_rows(
                         &mut reader,
@@ -300,27 +321,42 @@ where
                         &derived_blob_files,
                         &active_branch_id,
                     )
-                    .await?
-                };
+                    .await
+                }
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.merge_materialized_rows"
+                ))
+                .await?;
                 if !semantic_rows.is_empty() {
                     transaction
                         .stage_write(TransactionWrite::Rows {
                             mode: TransactionWriteMode::Replace,
                             rows: semantic_rows,
                         })
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.merge_stage_semantic_rows"
+                        ))
                         .await?;
                 }
-                let selected_changes = merge_plan
-                    .picks
-                    .iter()
-                    .filter(|pick| !pick_is_derived_plugin_state(pick, &derived_blob_files))
-                    .map(selected_change_from_merge_pick)
-                    .collect::<Vec<_>>();
-                let created_merge_commit_id = transaction.stage_merge_commit(
-                    active_branch_id.clone(),
-                    analysis.commits.source_commit_id,
-                    selected_changes,
-                )?;
+                let created_merge_commit_id = tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.merge_stage_commit"
+                )
+                .in_scope(|| {
+                    let selected_changes = merge_plan
+                        .picks
+                        .iter()
+                        .filter(|pick| !pick_is_derived_plugin_state(pick, &derived_blob_files))
+                        .map(selected_change_from_merge_pick)
+                        .collect::<Vec<_>>();
+                    transaction.stage_merge_commit(
+                        active_branch_id.clone(),
+                        analysis.commits.source_commit_id,
+                        selected_changes,
+                    )
+                })?;
                 Ok(MergeBranchReceipt {
                     outcome: MergeBranchOutcome::MergeCommitted,
                     target_branch_id: active_branch_id,
@@ -334,6 +370,10 @@ where
                 })
             })
         })
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.merge_branch_total"
+        ))
         .await
     }
 }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -1281,6 +1281,10 @@ where
                     prepared_semantic_rows,
                 } = self
                     .plugin_write_reconciliation(&rows, &mut file_data)
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_reconciliation"
+                    ))
                     .await?;
                 mark_plugin_reconciliation_rows(&mut plugin_rows);
                 for (file_key, version) in &materialization_versions {
@@ -2152,6 +2156,11 @@ where
 
         let mut selected_plugins = BTreeMap::<PluginFileWriteKey, PluginRegistryEntry>::new();
         let mut full_content_classification_bytes = BTreeMap::<PluginFileWriteKey, u64>::new();
+        let selection_span = tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.plugin_selection"
+        );
+        let selection_guard = selection_span.enter();
         for write in file_data.iter() {
             let Some(path) = write.path.as_deref() else {
                 continue;
@@ -2219,6 +2228,7 @@ where
             };
             selected_plugins.insert(file_key, plugin.clone());
         }
+        drop(selection_guard);
 
         let mut state_groups = BTreeMap::<PluginStateGroupKey, PluginStateGroup>::new();
         for (key, owner) in &owners {
@@ -2591,13 +2601,19 @@ where
                 lease.require_accepted_semantic_root(&visible_root)?;
                 let observation_is_current = observation.semantic_root() == visible_root;
                 let observed_bytes = lease.observed_bytes();
-                let built_splices = build_file_update_splices(
-                    &observed_bytes,
-                    lease.observed_bytes_sha256(),
-                    write.data(),
-                    write.splice_provenance(),
-                    limits,
-                )?;
+                let built_splices = tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_splice_discovery"
+                )
+                .in_scope(|| {
+                    build_file_update_splices(
+                        &observed_bytes,
+                        lease.observed_bytes_sha256(),
+                        write.data(),
+                        write.splice_provenance(),
+                        limits,
+                    )
+                })?;
                 let submitted_bytes_sha256 = built_splices.after_sha256;
                 let host_full_diff_bytes_compared = built_splices.full_diff_bytes_compared;
                 let observed_source = ArcByteSource::new(observed_bytes.clone());
@@ -2623,6 +2639,10 @@ where
                             ids,
                         },
                     )
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_file_changed"
+                    ))
                     .await
                 {
                     Ok(transition) => transition,
@@ -2634,6 +2654,10 @@ where
                     &schemas,
                     limits,
                 )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_drain_changes"
+                ))
                 .await
                 {
                     Ok(transition) => transition,
@@ -2647,6 +2671,10 @@ where
                 let mut counters = detected_transition.counters;
                 let changes = match self
                     .suppress_v2_format_only_noops(detected_transition.changes, &file_key)
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_suppress_noops"
+                    ))
                     .await
                 {
                     Ok(changes) => changes,
@@ -2810,6 +2838,10 @@ where
                     &file_key,
                     existing_id_namespace_reservation.as_ref(),
                 )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_id_namespace_rows"
+                ))
                 .await;
             let namespace_rows = match namespace_rows {
                 Ok(rows) => rows,

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 lix_sdk = { path = "../rs-sdk", version = "0.8.4", default-features = false, features = ["default_wasm_runtime", "local_filesystem", "sqlite"] }
 
 [dev-dependencies]
+lix_rocksdb_storage = { path = "../rocksdb-storage", version = "0.8.4" }
 plugin_csv_v2 = { path = "../../plugins/csv-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_markdown_incremental_v2 = { path = "../../plugins/markdown-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_excalidraw_v2 = { path = "../../plugins/excalidraw-v2", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
@@ -25,6 +26,7 @@ serde_json = "1"
 sha2 = "0.10"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wasmtime = { version = "45", default-features = false, features = ["component-model", "cranelift", "runtime", "std"] }
 wasmtime-wasi = { version = "45", default-features = false, features = ["p2"] }
 zip = { version = "8", default-features = false }

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -1012,6 +1012,192 @@ async fn v2_json_ten_mib_real_wasm_edit_stays_sparse_and_bounded() {
     lix.close().await.expect("workspace should close");
 }
 
+#[tokio::test]
+#[ignore = "10 MiB ordinary public-SQL JSON byte-write benchmark"]
+async fn v2_json_ten_mib_ordinary_sql_byte_edit_benchmark() {
+    const SAMPLES: usize = 7;
+
+    let root = tempfile::tempdir().expect("create JSON benchmark directory");
+    let archive = build_json_v2_plugin_archive();
+    let lix = open_lix_with_filesystem(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json_incremental_v2",
+        &archive,
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+
+    let path = "/ordinary-sql-ten-mib.json";
+    let (mut bytes, edit_offset, _) = json_ten_mib_flat_fixture();
+    write_file(&lix, path, bytes.clone())
+        .await
+        .expect("real JSON v2 Wasm should import the 10 MiB fixture");
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(bytes.clone()),
+        "the initial read must acknowledge the exact materialized base",
+    );
+
+    let mut elapsed_ms = Vec::with_capacity(SAMPLES);
+    for sample in 0..SAMPLES {
+        bytes[edit_offset] = alternate_ascii_hex(bytes[edit_offset]);
+        lix.reset_plugin_v2_transition_counters();
+        let started = Instant::now();
+        write_file(&lix, path, bytes.clone())
+            .await
+            .expect("ordinary SQL full-byte JSON edit should succeed");
+        elapsed_ms.push(started.elapsed().as_secs_f64() * 1_000.0);
+
+        let counters = lix.plugin_v2_transition_counters();
+        assert_eq!(counters.packet_records, 1, "sample {sample}");
+        assert_eq!(counters.durable_semantic_changes, 1, "sample {sample}");
+        assert_eq!(counters.private_document_cache_hits, 1, "sample {sample}");
+        assert_eq!(counters.full_document_reparses, 0, "sample {sample}");
+        assert_eq!(counters.full_renderer_invocations, 0, "sample {sample}");
+        assert!(
+            counters.host_full_diff_bytes_compared >= JSON_TEN_MIB_BYTES as u64,
+            "sample {sample} must exercise the ordinary full-byte fallback",
+        );
+    }
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(bytes),
+        "ordinary SQL JSON edits must remain byte-exact",
+    );
+
+    elapsed_ms.sort_by(f64::total_cmp);
+    let p50_ms = elapsed_ms[elapsed_ms.len() / 2];
+    let p95_index = ((elapsed_ms.len() * 95).div_ceil(100)).saturating_sub(1);
+    let p95_ms = elapsed_ms[p95_index];
+    eprintln!(
+        "v2_json_ordinary_sql_hot_edit bytes={JSON_TEN_MIB_BYTES} samples={SAMPLES} \
+         p50_ms={p50_ms:.3} p95_ms={p95_ms:.3}"
+    );
+
+    lix.close().await.expect("JSON benchmark should close");
+}
+
+#[tokio::test]
+#[ignore = "10 MiB JSON unrelated-entity merge benchmark"]
+async fn v2_json_ten_mib_unrelated_entity_merge_benchmark() {
+    const SAMPLES: usize = 7;
+
+    let archive = build_json_v2_plugin_archive();
+    let lix = open_lix(OpenLixOptions::default())
+        .await
+        .expect("workspace should open with the production Wasmtime runtime");
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json_incremental_v2",
+        &archive,
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+
+    let path = "/merge-ten-mib.json";
+    let (bytes, _, _) = json_ten_mib_flat_fixture();
+    write_file(&lix, path, bytes)
+        .await
+        .expect("real JSON v2 Wasm should import the 10 MiB fixture");
+    let file_id = file_id_at_path(&lix, path).await;
+    let target_branch_id = lix.active_branch_id().await.unwrap();
+    let mut elapsed_ms = Vec::with_capacity(SAMPLES);
+
+    for sample in 0..SAMPLES {
+        let source = lix
+            .create_branch(CreateBranchOptions {
+                id: Some(format!("json-merge-source-{sample}")),
+                name: format!("JSON merge source {sample}"),
+                from_commit_id: None,
+            })
+            .await
+            .unwrap();
+        let target_key = format!("property_{:06}", sample * 2);
+        let source_key = format!("property_{:06}", sample * 2 + 1);
+        let target_value = format!("\"target-{sample}\"");
+        let source_value = format!("\"source-{sample}\"");
+
+        lix.execute(
+            "UPDATE json_object_member SET scalar_json = $1 \
+             WHERE parent_id = 'root' AND key = $2 AND lixcol_file_id = $3",
+            &[
+                Value::Text(target_value.clone()),
+                Value::Text(target_key.clone()),
+                Value::Text(file_id.clone()),
+            ],
+        )
+        .await
+        .expect("target JSON property should update");
+        lix.switch_branch(SwitchBranchOptions {
+            branch_id: source.id.clone(),
+        })
+        .await
+        .unwrap();
+        lix.execute(
+            "UPDATE json_object_member SET scalar_json = $1 \
+             WHERE parent_id = 'root' AND key = $2 AND lixcol_file_id = $3",
+            &[
+                Value::Text(source_value.clone()),
+                Value::Text(source_key.clone()),
+                Value::Text(file_id.clone()),
+            ],
+        )
+        .await
+        .expect("source JSON property should update");
+        lix.switch_branch(SwitchBranchOptions {
+            branch_id: target_branch_id.clone(),
+        })
+        .await
+        .unwrap();
+
+        let started = Instant::now();
+        lix.merge_branch(MergeBranchOptions {
+            source_branch_id: source.id,
+        })
+        .await
+        .expect("unrelated JSON properties should merge cleanly");
+        elapsed_ms.push(started.elapsed().as_secs_f64() * 1_000.0);
+
+        let merged = lix
+            .execute(
+                "SELECT key, scalar_json FROM json_object_member \
+                 WHERE parent_id = 'root' AND key IN ($1, $2) AND lixcol_file_id = $3",
+                &[
+                    Value::Text(target_key),
+                    Value::Text(source_key),
+                    Value::Text(file_id.clone()),
+                ],
+            )
+            .await
+            .expect("merged JSON properties should query");
+        let values = merged
+            .rows()
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<String>("key").unwrap(),
+                    row.get::<String>("scalar_json").unwrap(),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(values.len(), 2);
+        assert!(values.values().any(|value| value == &target_value));
+        assert!(values.values().any(|value| value == &source_value));
+    }
+
+    elapsed_ms.sort_by(f64::total_cmp);
+    let p50_ms = elapsed_ms[elapsed_ms.len() / 2];
+    let p95_index = ((elapsed_ms.len() * 95).div_ceil(100)).saturating_sub(1);
+    let p95_ms = elapsed_ms[p95_index];
+    eprintln!(
+        "v2_json_ten_mib_unrelated_entity_merge bytes={JSON_TEN_MIB_BYTES} samples={SAMPLES} \
+         p50_ms={p50_ms:.3} p95_ms={p95_ms:.3}"
+    );
+
+    lix.close().await.expect("JSON benchmark should close");
+}
+
 #[derive(Debug)]
 struct ColdMaterializedOpenSample {
     elapsed: Duration,

--- a/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
+++ b/packages/rs-sdk-tests/tests/markdown_git_benchmark.rs
@@ -3,9 +3,10 @@
 //! Git is reported both before and after explicit GC; Lix is measured after a
 //! clean close with its normal automatic storage maintenance.
 
+use lix_rocksdb_storage::RocksDB;
 use lix_sdk::{
-    CreateBranchOptions, Lix, LocalFilesystem, MergeBranchOptions, MergeBranchPreviewOptions,
-    Storage, SwitchBranchOptions, Value, open_lix_with_storage,
+    CreateBranchOptions, Lix, MergeBranchOptions, Storage, SwitchBranchOptions, Value,
+    open_lix_with_storage,
 };
 use std::fs;
 use std::io::{Cursor, Write};
@@ -17,6 +18,7 @@ const DEFAULT_TARGET_BYTES: usize = 7 * 1024 * 1024 / 2;
 const DEFAULT_EDIT_SAMPLES: usize = 20;
 const DEFAULT_MERGE_SAMPLES: usize = 7;
 const DEFAULT_COLD_SAMPLES: usize = 5;
+const DEFAULT_PROFILE_SAMPLES: usize = 200;
 const PARAGRAPH_BODY_BYTES: usize = 496;
 
 #[derive(Debug)]
@@ -59,32 +61,85 @@ struct GitFixture {
     root: tempfile::TempDir,
 }
 
+/// CPU-profile target for the ordinary public SQL byte-write path.
+///
+/// This deliberately excludes Git, semantic writes, cold opens, and merges so
+/// a sampled profile is dominated by repeated steady-state Lix edits rather
+/// than fixture construction. The comparison benchmark below remains the
+/// source of user-visible Git versus Lix numbers.
+#[tokio::test]
+#[ignore = "manual steady-state Markdown byte-write profile target"]
+async fn markdown_lix_byte_hotpath_profile() {
+    init_perf_tracing();
+
+    let target_bytes = env_usize("LIX_MARKDOWN_GIT_BENCH_BYTES", DEFAULT_TARGET_BYTES);
+    let samples = env_usize("LIX_MARKDOWN_GIT_PROFILE_SAMPLES", DEFAULT_PROFILE_SAMPLES);
+    assert!(samples > 0);
+
+    let corpus = markdown_corpus(target_bytes);
+    let archive = build_markdown_v2_plugin_archive();
+    let root = tempfile::tempdir().expect("create Markdown profile directory");
+    let lix = open_lix_with_rocksdb(root.path()).await;
+    install_plugin(&lix, "plugin_markdown_incremental_v2", &archive).await;
+    write_file(&lix, "/profile.md", corpus.bytes.clone()).await;
+
+    let mut bytes = corpus.bytes;
+    lix.reset_plugin_v2_transition_counters();
+    let started = Instant::now();
+    for sample in 0..samples {
+        let index = spread_index(sample, samples, corpus.edit_offsets.len() / 2);
+        let offset = corpus.edit_offsets[index];
+        bytes[offset] = edit_replacement(bytes[offset], sample);
+        write_file(&lix, "/profile.md", bytes.clone()).await;
+    }
+    let elapsed = started.elapsed();
+    let counters = lix.plugin_v2_transition_counters();
+    eprintln!(
+        "markdown_lix_hot_profile bytes={} samples={} total_ms={:.3} mean_ms={:.3} counters={counters:?}",
+        bytes.len(),
+        samples,
+        elapsed.as_secs_f64() * 1_000.0,
+        elapsed.as_secs_f64() * 1_000.0 / samples as f64,
+    );
+
+    assert_same_bytes(
+        "profile target must preserve exact Markdown bytes",
+        &read_file(&lix, "/profile.md").await,
+        &bytes,
+    );
+    lix.close().await.expect("close Markdown profile Lix");
+}
+
 #[tokio::test]
 #[ignore = "manual Git versus Lix Markdown benchmark"]
 async fn markdown_git_semantic_entities_benchmark() {
+    init_perf_tracing();
+
     let target_bytes = env_usize("LIX_MARKDOWN_GIT_BENCH_BYTES", DEFAULT_TARGET_BYTES);
     let edit_samples = env_usize("LIX_MARKDOWN_GIT_BENCH_EDIT_SAMPLES", DEFAULT_EDIT_SAMPLES);
+    let semantic_edit_samples =
+        env_usize("LIX_MARKDOWN_GIT_BENCH_SEMANTIC_EDIT_SAMPLES", edit_samples);
     let merge_samples = env_usize(
         "LIX_MARKDOWN_GIT_BENCH_MERGE_SAMPLES",
         DEFAULT_MERGE_SAMPLES,
     );
     let cold_samples = env_usize("LIX_MARKDOWN_GIT_BENCH_COLD_SAMPLES", DEFAULT_COLD_SAMPLES);
-    assert!(edit_samples > 0 && merge_samples > 0 && cold_samples > 0);
+    assert!(edit_samples > 0 && semantic_edit_samples > 0 && merge_samples > 0 && cold_samples > 0);
 
     let corpus = markdown_corpus(target_bytes);
     assert!(
-        corpus.texts.len() > edit_samples + merge_samples * 4,
+        corpus.texts.len() > edit_samples.max(semantic_edit_samples) + merge_samples * 4,
         "benchmark corpus must contain enough unrelated paragraphs"
     );
     let archive = build_markdown_v2_plugin_archive();
 
     let lix_root = tempfile::tempdir().expect("create semantic Lix benchmark directory");
-    let baseline_lix = open_lix_with_filesystem(lix_root.path()).await;
+    let baseline_lix = open_lix_with_rocksdb(lix_root.path()).await;
     install_plugin(&baseline_lix, "plugin_markdown_incremental_v2", &archive).await;
     baseline_lix.close().await.expect("close baseline Lix");
     let lix_fixed = lix_repo_sizes(lix_root.path());
 
-    let lix = open_lix_with_filesystem(lix_root.path()).await;
+    let lix = open_lix_with_rocksdb(lix_root.path()).await;
     let lix_import_started = Instant::now();
     write_file(&lix, "/benchmark.md", corpus.bytes.clone()).await;
     let lix_import = lix_import_started.elapsed();
@@ -92,10 +147,10 @@ async fn markdown_git_semantic_entities_benchmark() {
     let initial_nodes = markdown_nodes_by_kind(&lix, &file_id, "paragraph").await;
     assert_eq!(initial_nodes.len(), corpus.texts.len());
 
-    let mut lix_semantic_edits = Vec::with_capacity(edit_samples);
+    let mut lix_semantic_edits = Vec::with_capacity(semantic_edit_samples);
     let mut lix_main_state = corpus.bytes.clone();
-    for sample in 0..edit_samples {
-        let index = spread_index(sample, edit_samples, corpus.texts.len() / 2);
+    for sample in 0..semantic_edit_samples {
+        let index = spread_index(sample, semantic_edit_samples, corpus.texts.len() / 2);
         let replacement = edit_replacement(corpus.bytes[corpus.edit_offsets[index]], sample);
         let payload = payload_with_replacement(
             &initial_nodes[index].payload_json,
@@ -116,7 +171,7 @@ async fn markdown_git_semantic_entities_benchmark() {
     lix.close().await.expect("close Lix history fixture");
     let lix_history = lix_repo_sizes(lix_root.path());
 
-    let lix = open_lix_with_filesystem(lix_root.path()).await;
+    let lix = open_lix_with_rocksdb(lix_root.path()).await;
     let mut lix_merges = Vec::with_capacity(merge_samples);
     let main_branch_id = lix.active_branch_id().await.expect("resolve main branch");
     for sample in 0..merge_samples {
@@ -176,17 +231,6 @@ async fn markdown_git_semantic_entities_benchmark() {
         .await
         .expect("switch to Lix merge target");
 
-        let preview = lix
-            .merge_branch_preview(MergeBranchPreviewOptions {
-                source_branch_id: source.id.clone(),
-            })
-            .await
-            .expect("preview unrelated Lix Markdown entity merge");
-        assert!(
-            preview.conflicts.is_empty(),
-            "derived materialized blobs must not conflict: {:?}",
-            preview.conflicts
-        );
         let started = Instant::now();
         lix.merge_branch(MergeBranchOptions {
             source_branch_id: source.id,
@@ -199,6 +243,30 @@ async fn markdown_git_semantic_entities_benchmark() {
             200 + sample,
         );
     }
+    let final_nodes = markdown_nodes_by_kind(&lix, &file_id, "paragraph")
+        .await
+        .into_iter()
+        .map(|node| (node.id, node.payload_json))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    for sample in 0..merge_samples {
+        for (side, index, replacement_sample) in [
+            ("target", corpus.texts.len() / 2 + sample * 2, 100 + sample),
+            ("source", corpus.texts.len() - 1 - sample * 2, 200 + sample),
+        ] {
+            let replacement =
+                edit_replacement(corpus.bytes[corpus.edit_offsets[index]], replacement_sample);
+            let expected = payload_with_replacement(
+                &initial_nodes[index].payload_json,
+                &corpus.texts[index],
+                replacement,
+            );
+            let actual = &final_nodes[&initial_nodes[index].id];
+            assert_eq!(
+                actual, &expected,
+                "semantic {side} entity from merge sample {sample} must remain visible"
+            );
+        }
+    }
     let lix_final = read_file(&lix, "/benchmark.md").await;
     assert_same_bytes(
         "semantic merge must materialize both unrelated edits",
@@ -209,7 +277,7 @@ async fn markdown_git_semantic_entities_benchmark() {
     let lix_live = lix_repo_sizes(lix_root.path());
 
     let byte_root = tempfile::tempdir().expect("create byte-path Lix benchmark directory");
-    let byte_lix = open_lix_with_filesystem(byte_root.path()).await;
+    let byte_lix = open_lix_with_rocksdb(byte_root.path()).await;
     install_plugin(&byte_lix, "plugin_markdown_incremental_v2", &archive).await;
     write_file(&byte_lix, "/benchmark.md", corpus.bytes.clone()).await;
     let mut byte_state = corpus.bytes.clone();
@@ -236,6 +304,24 @@ async fn markdown_git_semantic_entities_benchmark() {
     )
     .await;
 
+    // Keep the raw Git timing cohort independent from the semantic-history
+    // cohort. This lets hot-byte measurements use a statistically useful
+    // sample count even when semantic edit timings are intentionally bounded.
+    let mut git_timing = GitFixture::new();
+    git_timing.write_worktree(&corpus.bytes);
+    git_timing.commit_all("initial Markdown corpus");
+    let mut git_timing_state = corpus.bytes.clone();
+    let mut git_edits = Vec::with_capacity(edit_samples);
+    for sample in 0..edit_samples {
+        let index = spread_index(sample, edit_samples, corpus.texts.len() / 2);
+        git_timing_state[corpus.edit_offsets[index]] =
+            edit_replacement(corpus.bytes[corpus.edit_offsets[index]], sample);
+        let started = Instant::now();
+        git_timing.write_worktree(&git_timing_state);
+        git_timing.commit_all(&format!("timed edit paragraph {index}"));
+        git_edits.push(started.elapsed());
+    }
+
     let mut git = GitFixture::new();
     let git_fixed = git.repo_sizes();
     let git_import_started = Instant::now();
@@ -244,15 +330,12 @@ async fn markdown_git_semantic_entities_benchmark() {
     let git_import = git_import_started.elapsed();
 
     let mut git_state = corpus.bytes.clone();
-    let mut git_edits = Vec::with_capacity(edit_samples);
-    for sample in 0..edit_samples {
-        let index = spread_index(sample, edit_samples, corpus.texts.len() / 2);
+    for sample in 0..semantic_edit_samples {
+        let index = spread_index(sample, semantic_edit_samples, corpus.texts.len() / 2);
         git_state[corpus.edit_offsets[index]] =
             edit_replacement(corpus.bytes[corpus.edit_offsets[index]], sample);
-        let started = Instant::now();
         git.write_worktree(&git_state);
         git.commit_all(&format!("edit paragraph {index}"));
-        git_edits.push(started.elapsed());
     }
     assert_same_bytes(
         "Git and Lix must match after the identical pre-merge edit trace",
@@ -361,13 +444,14 @@ async fn markdown_git_semantic_entities_benchmark() {
          system=git clean_merges=0 conflicts=1 preserved_edits=0"
     );
     eprintln!(
-        "markdown_git_bench corpus_bytes={} paragraphs={} edit_samples={} merge_samples={} \
+        "markdown_git_bench corpus_bytes={} paragraphs={} edit_samples={} semantic_edit_samples={} merge_samples={} \
          lix_incremental_total_bytes={} lix_incremental_metadata_bytes={} \
          git_live_incremental_total_bytes={} git_live_incremental_metadata_bytes={} \
          git_packed_incremental_total_bytes={} git_packed_incremental_metadata_bytes={}",
         corpus.bytes.len(),
         corpus.texts.len(),
         edit_samples,
+        semantic_edit_samples,
         merge_samples,
         lix_history
             .total_bytes
@@ -475,9 +559,8 @@ async fn cold_lix_byte_edits(
         bytes[edit_offsets[index]] = edit_replacement(bytes[edit_offsets[index]], 500 + sample);
         let started = Instant::now();
         let storage_started = Instant::now();
-        let storage = LocalFilesystem::open(root)
-            .await
-            .expect("open cold byte-edit Lix filesystem");
+        let storage =
+            RocksDB::open(root.join(".lix")).expect("open cold byte-edit Lix RocksDB storage");
         storage_open.push(storage_started.elapsed());
         let engine_started = Instant::now();
         let lix = open_lix_with_storage(storage)
@@ -506,9 +589,7 @@ async fn cold_lix_reads(root: &Path, expected: &[u8], samples: usize) -> ColdLix
     for _ in 0..samples {
         let started = Instant::now();
         let storage_started = Instant::now();
-        let storage = LocalFilesystem::open(root)
-            .await
-            .expect("open cold Lix filesystem");
+        let storage = RocksDB::open(root.join(".lix")).expect("open cold Lix RocksDB storage");
         storage_open.push(storage_started.elapsed());
         let engine_started = Instant::now();
         let lix = open_lix_with_storage(storage)
@@ -534,7 +615,7 @@ async fn semantic_table_merge_quality(archive: &[u8]) {
     const TABLE: &[u8] = b"| left | right |\n| --- | --- |\n| alpha | beta |\n";
 
     let root = tempfile::tempdir().expect("create Lix semantic quality directory");
-    let lix = open_lix_with_filesystem(root.path()).await;
+    let lix = open_lix_with_rocksdb(root.path()).await;
     install_plugin(&lix, "plugin_markdown_incremental_v2", archive).await;
     write_file(&lix, "/quality.md", TABLE.to_vec()).await;
     let file_id = file_id_at_path(&lix, "/quality.md").await;
@@ -787,25 +868,44 @@ async fn update_markdown_node<StorageImpl>(
 ) where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    let result = lix
-        .execute(
-            "UPDATE markdown_node_v2 SET payload_json = $1 \
-             WHERE id = $2 AND lixcol_file_id = $3",
-            &[
-                Value::Text(payload_json),
-                Value::Text(id.to_owned()),
-                Value::Text(file_id.to_owned()),
-            ],
-        )
-        .await
-        .expect("update Markdown semantic entity");
-    assert_eq!(result.rows_affected(), 1);
+    for attempt in 0..5 {
+        match lix
+            .execute(
+                "UPDATE markdown_node_v2 SET payload_json = $1 \
+                 WHERE id = $2 AND lixcol_file_id = $3",
+                &[
+                    Value::Text(payload_json.clone()),
+                    Value::Text(id.to_owned()),
+                    Value::Text(file_id.to_owned()),
+                ],
+            )
+            .await
+        {
+            Ok(result) => {
+                assert_eq!(result.rows_affected(), 1);
+                return;
+            }
+            Err(error) if error.code == "LIX_TRANSACTION_CONFLICT" && attempt < 4 => {
+                tokio::task::yield_now().await;
+            }
+            Err(error) => panic!("update Markdown semantic entity: {error:?}"),
+        }
+    }
+    unreachable!("bounded Markdown entity update retry loop returns or panics");
 }
 
-async fn open_lix_with_filesystem(path: &Path) -> Lix<LocalFilesystem> {
-    let storage = LocalFilesystem::open(path)
-        .await
-        .expect("open Lix filesystem");
+fn init_perf_tracing() {
+    if std::env::var_os("LIX_MARKDOWN_GIT_TRACE").is_some() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("lix_perf=debug")
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_test_writer()
+            .try_init();
+    }
+}
+
+async fn open_lix_with_rocksdb(path: &Path) -> Lix<RocksDB> {
+    let storage = RocksDB::open(path.join(".lix")).expect("open Lix RocksDB storage");
     open_lix_with_storage(storage)
         .await
         .expect("open Lix workspace")


### PR DESCRIPTION
Stacked on #795.

## Outcome

Checks in unbiased, reproducible RocksDB-backed performance and semantic-quality gates for the canonical v2 stack.

- deterministic 3.5 MiB Markdown corpus
- real 10 MiB recursive JSON fixture
- ordinary public-SQL full-byte writes
- semantic writes and unrelated-entity merges
- warm and cold materialized reads
- phase spans for attribution
- Git CLI comparison with no untimed Lix-only merge warmup

LocalFilesystem watcher/materialization behavior is deliberately excluded; these gates measure engine + plugin + RocksDB.

## Latest release results

Markdown, 3,670,017 bytes and 7,253 paragraphs:

| Operation | Lix p50 | Git p50 |
| --- | ---: | ---: |
| byte write + commit | 8.140 ms | 62.340 ms |
| semantic write + commit | 7.609 ms | n/a |
| unrelated-entity merge | 6.868 ms | 123.419 ms |
| cold materialized/object read | 6.735 ms | 17.191 ms |

Merge quality: Lix preserves both unrelated edits to distinct cells on the same Markdown line; Git conflicts.

JSON, 10,485,760 bytes and 39,870 properties:

- ordinary one-byte write: 12.702 ms p50
- unrelated-property merge: 18.514 ms p50
- warm materialized read: 6.641 ms p50
- reopened materialized read: 6.742 ms p50

Cold Markdown import remains explicitly visible at 4.920 s rather than being hidden from the comparison.
