### PR TITLE
perf(sql): project tracked snapshots directly into Arrow

### DIFF
--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -45,7 +45,7 @@ datafusion = { version = "53.0.0", default-features = false, features = [
 ] }
 musli = { version = "0.0.149", features = ["storage"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 jsonschema = { version = "0.17", default-features = false, features = ["draft202012"] }
 globset = "0.4"
 jiff = { version = "0.2.27", default-features = false, features = ["std"] }

--- a/packages/engine/src/sql2/entity_projection.rs
+++ b/packages/engine/src/sql2/entity_projection.rs
@@ -1,0 +1,545 @@
+//! Projection-aware decoding for entity snapshot JSON.
+//!
+//! Entity SQL reads need only their selected fields. This module is the
+//! private boundary from raw snapshot bytes to Arrow arrays. The current
+//! caller adapts materialized rows; a later tracked-head reader can hand its
+//! v5 JSON bytes to the same boundary directly.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray};
+use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde_json::Value as JsonValue;
+use serde_json::value::RawValue;
+
+use crate::LixError;
+use crate::sql2::catalog::{EntityColumnType, EntitySurfaceSpec};
+use crate::sql2::value_contract::{json_bigint_value, json_double_value};
+
+/// A projection decoder for the general entity provider.
+pub(super) struct EntityProjectionDecoder {
+    schema_key: String,
+    fields: Vec<EntityProjectionField>,
+    slots_by_name: HashMap<String, Vec<usize>>,
+}
+
+#[derive(Clone)]
+struct EntityProjectionField {
+    name: String,
+    column_type: EntityColumnType,
+}
+
+impl EntityProjectionDecoder {
+    /// Builds a decoder for visible entity columns in output order.
+    pub(super) fn new<'a>(
+        spec: &EntitySurfaceSpec,
+        columns: impl IntoIterator<Item = &'a str>,
+    ) -> Result<Self, LixError> {
+        let mut fields = Vec::new();
+        let mut slots_by_name = HashMap::<String, Vec<usize>>::new();
+        for column_name in columns {
+            let column = spec.visible_column(column_name).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "sql2 entity provider '{}' does not expose column '{}'",
+                        spec.schema_key, column_name
+                    ),
+                )
+            })?;
+            let index = fields.len();
+            fields.push(EntityProjectionField {
+                name: column.name.clone(),
+                column_type: column.column_type,
+            });
+            slots_by_name
+                .entry(column.name.clone())
+                .or_default()
+                .push(index);
+        }
+        Ok(Self {
+            schema_key: spec.schema_key.clone(),
+            fields,
+            slots_by_name,
+        })
+    }
+
+    /// Decodes a batch directly into Arrow arrays in constructor field order.
+    pub(super) fn decode_arrow_columns<'a>(
+        &self,
+        snapshots: impl IntoIterator<Item = Option<&'a [u8]>>,
+    ) -> Result<Vec<ArrayRef>, LixError> {
+        let snapshots = snapshots.into_iter();
+        let (capacity, _) = snapshots.size_hint();
+        let mut sink = ArrowProjectionSink {
+            columns: self
+                .fields
+                .iter()
+                .map(|field| EntityProjectionColumn::new(field.column_type, capacity))
+                .collect(),
+        };
+        for snapshot in snapshots {
+            self.decode_into(snapshot, &mut sink)?;
+        }
+        Ok(sink
+            .columns
+            .into_iter()
+            .map(EntityProjectionColumn::into_array)
+            .collect())
+    }
+
+    fn decode_into<S>(&self, snapshot: Option<&[u8]>, sink: &mut S) -> Result<(), LixError>
+    where
+        S: EntityProjectionSink,
+    {
+        let Some(snapshot) = snapshot else {
+            sink.begin_row(self.fields.len());
+            return Ok(());
+        };
+        let mut deserializer = serde_json::Deserializer::from_slice(snapshot);
+        let semantic_error = RawProjectionSeed {
+            decoder: self,
+            sink,
+        }
+        .deserialize(&mut deserializer)
+        .map_err(snapshot_decode_error)?;
+        deserializer.end().map_err(snapshot_decode_error)?;
+        semantic_error.map_or(Ok(()), Err)
+    }
+}
+
+trait EntityProjectionSink {
+    fn begin_row(&mut self, field_count: usize);
+
+    fn project_raw(
+        &mut self,
+        decoder: &EntityProjectionDecoder,
+        indices: &[usize],
+        raw: &RawValue,
+    ) -> Result<(), LixError>;
+}
+
+/// Deserializes only selected top-level object fields. The selected values are
+/// borrowed from the source bytes and consumed immediately by the sink, so a
+/// normal tracked Arrow scan has neither a snapshot JSON DOM nor per-field
+/// raw-value boxes.
+struct RawProjectionSeed<'decoder, 'sink, S> {
+    decoder: &'decoder EntityProjectionDecoder,
+    sink: &'sink mut S,
+}
+
+impl<'de, S> DeserializeSeed<'de> for RawProjectionSeed<'_, '_, S>
+where
+    S: EntityProjectionSink,
+{
+    type Value = Option<LixError>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(RawProjectionVisitor {
+            decoder: self.decoder,
+            sink: self.sink,
+        })
+    }
+}
+
+struct RawProjectionVisitor<'decoder, 'sink, S> {
+    decoder: &'decoder EntityProjectionDecoder,
+    sink: &'sink mut S,
+}
+
+impl<'de, S> Visitor<'de> for RawProjectionVisitor<'_, '_, S>
+where
+    S: EntityProjectionSink,
+{
+    type Value = Option<LixError>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON entity snapshot")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let RawProjectionVisitor { decoder, sink } = self;
+        sink.begin_row(decoder.fields.len());
+        let mut semantic_error = None;
+        while let Some(key) = map.next_key::<Cow<'de, str>>()? {
+            let Some(indices) = decoder.slots_by_name.get(key.as_ref()) else {
+                map.next_value::<IgnoredAny>()?;
+                continue;
+            };
+            let raw = map.next_value::<&RawValue>()?;
+            if semantic_error.is_none() {
+                if let Err(error) = sink.project_raw(decoder, indices, raw) {
+                    semantic_error = Some(error);
+                }
+            }
+        }
+        Ok(semantic_error)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        while seq.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(None)
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+
+    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+
+    fn visit_borrowed_str<E>(self, _value: &'de str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.sink.begin_row(self.decoder.fields.len());
+        Ok(None)
+    }
+}
+
+struct ArrowProjectionSink {
+    columns: Vec<EntityProjectionColumn>,
+}
+
+impl EntityProjectionSink for ArrowProjectionSink {
+    fn begin_row(&mut self, _field_count: usize) {
+        for column in &mut self.columns {
+            column.push_null();
+        }
+    }
+
+    fn project_raw(
+        &mut self,
+        decoder: &EntityProjectionDecoder,
+        indices: &[usize],
+        raw: &RawValue,
+    ) -> Result<(), LixError> {
+        for index in indices {
+            self.columns[*index].replace_last_from_raw(
+                raw,
+                &decoder.fields[*index],
+                &decoder.schema_key,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn parse_json_value(raw: &RawValue) -> Result<JsonValue, LixError> {
+    serde_json::from_str(raw.get()).map_err(snapshot_decode_error)
+}
+
+fn raw_string_text(raw: &RawValue) -> Result<Option<String>, LixError> {
+    let json = raw.get();
+    let trimmed = json.trim();
+    if trimmed == "null" {
+        return Ok(None);
+    }
+    if trimmed == "true" || trimmed == "false" {
+        return Ok(Some(trimmed.to_string()));
+    }
+    if trimmed.starts_with('"') {
+        return serde_json::from_str::<String>(json)
+            .map(Some)
+            .map_err(snapshot_decode_error);
+    }
+    serde_json::from_str::<JsonValue>(json)
+        .and_then(|value| serde_json::to_string(&value))
+        .map(Some)
+        .map_err(snapshot_decode_error)
+}
+
+fn raw_bool(raw: &RawValue) -> Option<bool> {
+    match raw.get().trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn raw_json_text(raw: &RawValue) -> Option<String> {
+    let json = raw.get();
+    if json.trim() == "null" {
+        return None;
+    }
+    Some(json.to_string())
+}
+
+fn snapshot_decode_error(error: serde_json::Error) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("sql2 entity provider expected valid snapshot_content JSON: {error}"),
+    )
+}
+
+enum EntityProjectionColumn {
+    String(Vec<Option<String>>),
+    Json(Vec<Option<String>>),
+    Integer(Vec<Option<i64>>),
+    Number(Vec<Option<f64>>),
+    Boolean(Vec<Option<bool>>),
+}
+
+impl EntityProjectionColumn {
+    fn new(column_type: EntityColumnType, capacity: usize) -> Self {
+        match column_type {
+            EntityColumnType::String => Self::String(Vec::with_capacity(capacity)),
+            EntityColumnType::Json => Self::Json(Vec::with_capacity(capacity)),
+            EntityColumnType::Integer => Self::Integer(Vec::with_capacity(capacity)),
+            EntityColumnType::Number => Self::Number(Vec::with_capacity(capacity)),
+            EntityColumnType::Boolean => Self::Boolean(Vec::with_capacity(capacity)),
+        }
+    }
+
+    fn push_null(&mut self) {
+        match self {
+            Self::String(values) | Self::Json(values) => values.push(None),
+            Self::Integer(values) => values.push(None),
+            Self::Number(values) => values.push(None),
+            Self::Boolean(values) => values.push(None),
+        }
+    }
+
+    fn replace_last_from_raw(
+        &mut self,
+        raw: &RawValue,
+        field: &EntityProjectionField,
+        schema_key: &str,
+    ) -> Result<(), LixError> {
+        match self {
+            Self::String(values) if field.column_type == EntityColumnType::String => {
+                *values
+                    .last_mut()
+                    .expect("projection sink must start the row first") = raw_string_text(raw)?;
+            }
+            Self::Json(values) if field.column_type == EntityColumnType::Json => {
+                *values
+                    .last_mut()
+                    .expect("projection sink must start the row first") = raw_json_text(raw);
+            }
+            Self::Integer(values) if field.column_type == EntityColumnType::Integer => {
+                let value = parse_json_value(raw)?;
+                *values
+                    .last_mut()
+                    .expect("projection sink must start the row first") =
+                    json_bigint_value(Some(&value), schema_key, &field.name)?;
+            }
+            Self::Number(values) if field.column_type == EntityColumnType::Number => {
+                let value = parse_json_value(raw)?;
+                *values
+                    .last_mut()
+                    .expect("projection sink must start the row first") =
+                    json_double_value(Some(&value), schema_key, &field.name)?;
+            }
+            Self::Boolean(values) if field.column_type == EntityColumnType::Boolean => {
+                *values
+                    .last_mut()
+                    .expect("projection sink must start the row first") = raw_bool(raw);
+            }
+            _ => {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "entity snapshot projection produced a value with the wrong SQL type",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn into_array(self) -> ArrayRef {
+        match self {
+            Self::String(values) | Self::Json(values) => Arc::new(StringArray::from(values)),
+            Self::Integer(values) => Arc::new(Int64Array::from(values)),
+            Self::Number(values) => Arc::new(Float64Array::from(values)),
+            Self::Boolean(values) => Arc::new(BooleanArray::from(values)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{Array, BooleanArray, Float64Array, Int64Array, StringArray};
+    use serde_json::json;
+
+    use super::EntityProjectionDecoder;
+    use crate::LixError;
+    use crate::sql2::catalog::derive_entity_surface_spec_from_schema;
+    use crate::transaction::types::TransactionJson;
+
+    fn spec() -> crate::sql2::catalog::EntitySurfaceSpec {
+        derive_entity_surface_spec_from_schema(&json!({
+            "x-lix-key": "projection_test",
+            "x-lix-primary-key": ["/text"],
+            "type": "object",
+            "properties": {
+                "text": { "type": "string" },
+                "json": { "type": "object" },
+                "integer": { "type": "integer" },
+                "number": { "type": "number" },
+                "boolean": { "type": "boolean" },
+                "coerce_bool": { "type": "string" },
+                "coerce_object": { "type": "string" },
+                "null_text": { "type": "string" },
+                "missing": { "type": "string" }
+            }
+        }))
+        .expect("test schema should derive")
+    }
+
+    #[test]
+    #[expect(clippy::float_cmp)]
+    fn decodes_selected_fields_from_canonical_tracked_arrow_projection() {
+        let spec = spec();
+        let decoder = EntityProjectionDecoder::new(
+            &spec,
+            [
+                "text",
+                "json",
+                "integer",
+                "number",
+                "boolean",
+                "coerce_bool",
+                "coerce_object",
+                "null_text",
+                "missing",
+            ],
+        )
+        .expect("decoder should build");
+        let snapshot = TransactionJson::from_value(
+            json!({
+                "text": "line\nquote: \"",
+                "json": {"z": [true, null], "a": "value"},
+                "integer": 7.0,
+                "number": 4.5,
+                "boolean": true,
+                "coerce_bool": false,
+                "coerce_object": {"z": 2, "a": 1},
+                "null_text": null,
+                "ignored": {"nested": [1, 2, 3]}
+            }),
+            "canonical tracked projection test",
+        )
+        .expect("transaction JSON should normalize");
+
+        let arrays = decoder
+            .decode_arrow_columns([Some(snapshot.normalized().as_bytes())])
+            .expect("snapshot should decode");
+        let text = arrays[0]
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("text array");
+        assert_eq!(text.value(0), "line\nquote: \"");
+        let json = arrays[1]
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("JSON array");
+        assert_eq!(json.value(0), r#"{"a":"value","z":[true,null]}"#);
+        let integer = arrays[2]
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("integer array");
+        assert_eq!(integer.value(0), 7);
+        let number = arrays[3]
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("number array");
+        assert_eq!(number.value(0), 4.5);
+        let boolean = arrays[4]
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("boolean array");
+        assert!(boolean.value(0));
+        let coerce_bool = arrays[5]
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("coerced bool array");
+        assert_eq!(coerce_bool.value(0), "false");
+        let coerce_object = arrays[6]
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("coerced object array");
+        assert_eq!(coerce_object.value(0), r#"{"a":1,"z":2}"#);
+        assert!(arrays[7].is_null(0));
+        assert!(arrays[8].is_null(0));
+    }
+
+    #[test]
+    fn reports_the_existing_typed_number_contract_error() {
+        let spec = spec();
+        let decoder = EntityProjectionDecoder::new(&spec, ["integer", "number"])
+            .expect("decoder should build");
+        let snapshot = TransactionJson::from_value(
+            json!({"integer": "7", "number": 4.5}),
+            "typed number projection test",
+        )
+        .expect("transaction JSON should normalize");
+        let error = decoder
+            .decode_arrow_columns([Some(snapshot.normalized().as_bytes())])
+            .expect_err("string must not become a BIGINT");
+        assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
+        assert!(error.message.contains("projection_test"));
+        assert!(error.message.contains("integer"));
+    }
+}

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -5,6 +5,7 @@ mod catalog;
 mod change_materialization;
 mod context;
 mod dml;
+mod entity_projection;
 mod error;
 mod exec;
 mod file_view;

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -1398,15 +1398,16 @@ fn entity_record_batch_from_raw_projection(
         .fields()
         .iter()
         .map(|field| {
-            if let Some(property_name) = field.name().strip_prefix("lixcol_") {
-                entity_system_column_array(property_name, rows)
-            } else {
-                visible_columns.next().ok_or_else(|| {
-                    DataFusionError::Execution(
-                        "entity projection decoder did not return a visible column".to_string(),
-                    )
-                })
-            }
+            field.name().strip_prefix("lixcol_").map_or_else(
+                || {
+                    visible_columns.next().ok_or_else(|| {
+                        DataFusionError::Execution(
+                            "entity projection decoder did not return a visible column".to_string(),
+                        )
+                    })
+                },
+                |property_name| entity_system_column_array(property_name, rows),
+            )
         })
         .collect::<Result<Vec<_>>>()?;
 

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -26,6 +26,7 @@ use crate::sql2::catalog::{
     EntityColumnType, EntitySurfaceShape, EntitySurfaceSpec, PublicCatalog, PublicSurfaceKind,
     entity_surface_schema,
 };
+use crate::sql2::entity_projection::EntityProjectionDecoder;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::read_only::reject_read_only_entity_surface;
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
@@ -320,6 +321,7 @@ impl TableSpec for EntitySpec {
     ) -> Result<PlannedScan> {
         let (schema, request, row_filters) =
             self.plan_scan_parts(projection, filters, limit).await?;
+        let batch_projection = EntityBatchProjection::for_request(&request);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
@@ -330,14 +332,15 @@ impl TableSpec for EntitySpec {
                     schema,
                     request,
                     row_filters,
+                    batch_projection,
                 ),
-                |(spec, live_state, schema, request, row_filters)| async move {
+                |(spec, live_state, schema, request, row_filters, batch_projection)| async move {
                     let mut rows = live_state
                         .scan_rows(&request)
                         .await
                         .map_err(lix_error_to_datafusion_error)?;
                     apply_entity_row_filters(&mut rows, &row_filters)?;
-                    entity_record_batch(&spec, schema, &rows)
+                    entity_record_batch(&spec, schema, &rows, batch_projection)
                 },
             ),
         })
@@ -373,6 +376,7 @@ impl TableSpec for EntitySpec {
             );
         }
         let (schema, request, row_filters) = self.plan_scan_parts(None, filters, None).await?;
+        let batch_projection = EntityBatchProjection::for_request(&request);
         let source = row_source(
             (
                 Arc::clone(&self.spec),
@@ -380,14 +384,15 @@ impl TableSpec for EntitySpec {
                 schema,
                 request,
                 row_filters,
+                batch_projection,
             ),
-            |(spec, live_state, schema, request, row_filters)| async move {
+            |(spec, live_state, schema, request, row_filters, batch_projection)| async move {
                 let mut rows = live_state
                     .scan_rows(&request)
                     .await
                     .map_err(lix_error_to_datafusion_error)?;
                 apply_entity_row_filters(&mut rows, &row_filters)?;
-                entity_record_batch(&spec, schema, &rows)
+                entity_record_batch(&spec, schema, &rows, batch_projection)
             },
         );
         let spec = Arc::clone(&self.spec);
@@ -1298,10 +1303,34 @@ fn projection_column_names(schema: &Schema) -> Vec<String> {
         .collect()
 }
 
+/// Selects the snapshot-to-Arrow implementation once per provider batch.
+///
+/// Exact primary-key scans are latency-sensitive and keep their established
+/// serde-value path. Broad scans are dominated by decoding every snapshot, so
+/// they use the raw projection decoder that visits only selected fields. This
+/// is a physical execution choice; the SQL schema and result contract are the
+/// same in both cases.
+#[derive(Clone, Copy)]
+enum EntityBatchProjection {
+    ParsedSnapshots,
+    RawTrackedProjection,
+}
+
+impl EntityBatchProjection {
+    fn for_request(request: &LiveStateScanRequest) -> Self {
+        if request.filter.entity_pks.is_empty() {
+            Self::RawTrackedProjection
+        } else {
+            Self::ParsedSnapshots
+        }
+    }
+}
+
 fn entity_record_batch(
     spec: &EntitySurfaceSpec,
     schema: SchemaRef,
     rows: &[MaterializedLiveStateRow],
+    projection: EntityBatchProjection,
 ) -> Result<RecordBatch> {
     if schema.fields().is_empty() {
         let options = RecordBatchOptions::new().with_row_count(Some(rows.len()));
@@ -1309,6 +1338,27 @@ fn entity_record_batch(
             .map_err(DataFusionError::from);
     }
 
+    match projection {
+        EntityBatchProjection::ParsedSnapshots => {
+            entity_record_batch_from_snapshots(spec, schema, rows)
+        }
+        EntityBatchProjection::RawTrackedProjection if rows.iter().all(|row| !row.untracked) => {
+            entity_record_batch_from_raw_projection(spec, schema, rows)
+        }
+        // Raw projection depends on the tracked write invariant: compact
+        // TransactionJson bytes with no duplicate-key recovery semantics.
+        // Keep every sidecar/mixed batch on the established parser path.
+        EntityBatchProjection::RawTrackedProjection => {
+            entity_record_batch_from_snapshots(spec, schema, rows)
+        }
+    }
+}
+
+fn entity_record_batch_from_snapshots(
+    spec: &EntitySurfaceSpec,
+    schema: SchemaRef,
+    rows: &[MaterializedLiveStateRow],
+) -> Result<RecordBatch> {
     let snapshots = rows
         .iter()
         .map(|row| parse_snapshot(row.snapshot_content.as_deref()))
@@ -1321,6 +1371,58 @@ fn entity_record_batch(
         .collect::<Result<Vec<_>>>()?;
 
     RecordBatch::try_new(schema, columns).map_err(DataFusionError::from)
+}
+
+fn entity_record_batch_from_raw_projection(
+    spec: &EntitySurfaceSpec,
+    schema: SchemaRef,
+    rows: &[MaterializedLiveStateRow],
+) -> Result<RecordBatch> {
+    let decoder = EntityProjectionDecoder::new(
+        spec,
+        schema.fields().iter().filter_map(|field| {
+            (!field.name().starts_with("lixcol_")).then_some(field.name().as_str())
+        }),
+    )
+    .map_err(entity_projection_error_to_datafusion_error)?;
+    // The tracked write path persists TransactionJson-normalized bytes.
+    // Visibility is resolved by the existing live-state reader first.
+    let mut visible_columns = decoder
+        .decode_arrow_columns(
+            rows.iter()
+                .map(|row| row.snapshot_content.as_deref().map(str::as_bytes)),
+        )
+        .map_err(entity_projection_error_to_datafusion_error)?
+        .into_iter();
+    let columns = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            if let Some(property_name) = field.name().strip_prefix("lixcol_") {
+                entity_system_column_array(property_name, rows)
+            } else {
+                visible_columns.next().ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "entity projection decoder did not return a visible column".to_string(),
+                    )
+                })
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    RecordBatch::try_new(schema, columns).map_err(DataFusionError::from)
+}
+
+/// Keep malformed snapshots and provider-shape failures on the same
+/// DataFusion `Execution` error path as the pre-projection implementation.
+/// Typed value failures already carry a Lix error code and retain that
+/// existing SQL error contract.
+fn entity_projection_error_to_datafusion_error(error: LixError) -> DataFusionError {
+    if error.code == LixError::CODE_INTERNAL_ERROR {
+        DataFusionError::Execution(error.message)
+    } else {
+        lix_error_to_datafusion_error(error)
+    }
 }
 
 #[expect(trivial_casts)]
@@ -1464,6 +1566,7 @@ mod tests {
 
     use async_trait::async_trait;
     use datafusion::arrow::array::{Float64Array, Int64Array};
+    use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::catalog::TableProvider;
     use datafusion::common::{Column, ScalarValue};
     use datafusion::logical_expr::expr::InList;
@@ -1477,7 +1580,8 @@ mod tests {
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
     use crate::live_state::{
-        LiveStateReader, LiveStateRowRequest, LiveStateScanRequest, MaterializedLiveStateRow,
+        LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateRowRequest,
+        LiveStateScanRequest, MaterializedLiveStateRow,
     };
     use crate::sql2::WriteAccess;
     use crate::sql2::catalog::{
@@ -1853,8 +1957,13 @@ mod tests {
         );
         let schema = entity_surface_schema(&spec, EntitySurfaceShape::ByBranch);
 
-        let batch =
-            entity_record_batch(&spec, schema, &[live_row()]).expect("entity batch should build");
+        let batch = entity_record_batch(
+            &spec,
+            schema,
+            &[live_row()],
+            super::EntityBatchProjection::ParsedSnapshots,
+        )
+        .expect("entity batch should build");
 
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(
@@ -1906,6 +2015,250 @@ mod tests {
                 .expect("branch id is string")
                 .value(0),
             "branch-a"
+        );
+    }
+
+    #[test]
+    fn exact_primary_key_batches_keep_the_existing_json_and_scalar_projection_contract() {
+        let spec = Arc::new(
+            derive_entity_surface_spec_from_schema(&json!({
+                "x-lix-key": "project_message",
+                "x-lix-primary-key": ["/body"],
+                "type": "object",
+                "properties": {
+                    "body": { "type": "string" },
+                    "rating": { "type": "number" },
+                    "count": { "type": "integer" },
+                    "enabled": { "type": "boolean" },
+                    "meta": { "type": "object" }
+                }
+            }))
+            .expect("schema should derive entity surface spec"),
+        );
+        let schema = entity_surface_schema(&spec, EntitySurfaceShape::Active);
+        // Deliberately noncanonical nested JSON distinguishes the established
+        // serde-value projection from the broad tracked raw-byte path.
+        let row = MaterializedLiveStateRow {
+            snapshot_content: Some(
+                r#"{"body":"hello","rating":4.5,"count":7,"enabled":true,"meta":{"z":2,"a":1}}"#
+                    .to_string(),
+            ),
+            ..live_row()
+        };
+        let request = LiveStateScanRequest {
+            filter: LiveStateFilter {
+                entity_pks: vec![row.entity_pk.clone()],
+                ..LiveStateFilter::default()
+            },
+            projection: LiveStateProjection::default(),
+            limit: None,
+        };
+        let projection = super::EntityBatchProjection::for_request(&request);
+        assert!(matches!(
+            projection,
+            super::EntityBatchProjection::ParsedSnapshots
+        ));
+
+        let batch = entity_record_batch(&spec, schema, &[row], projection)
+            .expect("exact primary-key batch should build");
+        assert_eq!(
+            batch
+                .column_by_name("meta")
+                .expect("meta column")
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("meta is JSON text")
+                .value(0),
+            r#"{"a":1,"z":2}"#,
+            "exact primary-key reads retain the old parse-and-render JSON semantics"
+        );
+        assert_eq!(
+            batch
+                .column_by_name("count")
+                .expect("count column")
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("count is i64")
+                .value(0),
+            7,
+            "exact primary-key reads retain scalar projection semantics"
+        );
+    }
+
+    #[test]
+    fn untracked_broad_batches_keep_duplicate_key_last_wins_scalar_semantics() {
+        let spec = Arc::new(
+            derive_entity_surface_spec_from_schema(&json!({
+                "x-lix-key": "project_message",
+                "type": "object",
+                "properties": {
+                    "body": { "type": "string" },
+                    "count": { "type": "integer" }
+                }
+            }))
+            .expect("schema should derive entity surface spec"),
+        );
+        let batch = entity_record_batch(
+            &spec,
+            entity_surface_schema(&spec, EntitySurfaceShape::Active),
+            &[MaterializedLiveStateRow {
+                snapshot_content: Some(r#"{"body":"sidecar","count":"bad","count":7}"#.to_string()),
+                untracked: true,
+                ..live_row()
+            }],
+            super::EntityBatchProjection::RawTrackedProjection,
+        )
+        .expect("untracked broad batch must use the established parser path");
+
+        assert_eq!(
+            batch
+                .column_by_name("count")
+                .expect("count column")
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("count is i64")
+                .value(0),
+            7,
+            "the later duplicate value must replace an earlier invalid value"
+        );
+    }
+
+    #[test]
+    fn canonical_tracked_raw_batch_matches_parsed_batch_for_all_system_columns() {
+        let spec = Arc::new(
+            derive_entity_surface_spec_from_schema(&json!({
+                "x-lix-key": "project_message",
+                "x-lix-primary-key": ["/body"],
+                "type": "object",
+                "properties": {
+                    "body": { "type": "string" },
+                    "rating": { "type": "number" },
+                    "count": { "type": "integer" },
+                    "enabled": { "type": "boolean" },
+                    "meta": { "type": "object" }
+                }
+            }))
+            .expect("schema should derive entity surface spec"),
+        );
+        let branch_snapshot = crate::transaction::types::TransactionJson::from_value(
+            json!({
+                "body": "branch-row",
+                "rating": 4.5,
+                "count": 7,
+                "enabled": true,
+                "meta": {"z": 2, "a": 1}
+            }),
+            "canonical branch projection test",
+        )
+        .expect("branch snapshot should normalize");
+        let global_snapshot = crate::transaction::types::TransactionJson::from_value(
+            json!({
+                "body": "global-row",
+                "rating": 1.5,
+                "count": 9,
+                "enabled": false,
+                "meta": {"d": 4, "c": 3}
+            }),
+            "canonical global projection test",
+        )
+        .expect("global snapshot should normalize");
+        let branch_row = MaterializedLiveStateRow {
+            entity_pk: crate::entity_pk::EntityPk::single("branch-row"),
+            file_id: Some("file-branch".to_string()),
+            snapshot_content: Some(branch_snapshot.normalized().to_string()),
+            metadata: Some(r#"{"source":"branch"}"#.to_string()),
+            ..live_row()
+        };
+        let global_row = MaterializedLiveStateRow {
+            entity_pk: crate::entity_pk::EntityPk::single("global-row"),
+            file_id: None,
+            snapshot_content: Some(global_snapshot.normalized().to_string()),
+            metadata: Some(r#"{"source":"global"}"#.to_string()),
+            branch_id: "global".into(),
+            global: true,
+            change_id: Some(ChangeId::for_test_label("change-global")),
+            commit_id: Some(CommitId::for_test_label("commit-global")),
+            ..live_row()
+        };
+        let rows = vec![branch_row, global_row];
+        let schema = entity_surface_schema(&spec, EntitySurfaceShape::ByBranch);
+        let parsed = entity_record_batch(
+            &spec,
+            Arc::clone(&schema),
+            &rows,
+            super::EntityBatchProjection::ParsedSnapshots,
+        )
+        .expect("parsed batch should build");
+        let raw = entity_record_batch(
+            &spec,
+            schema,
+            &rows,
+            super::EntityBatchProjection::RawTrackedProjection,
+        )
+        .expect("raw tracked batch should build");
+
+        for field in [
+            "lixcol_metadata",
+            "lixcol_entity_pk",
+            "lixcol_file_id",
+            "lixcol_branch_id",
+            "lixcol_global",
+            "lixcol_untracked",
+        ] {
+            assert!(
+                raw.schema().field_with_name(field).is_ok(),
+                "missing {field}"
+            );
+        }
+        assert_eq!(raw.schema(), parsed.schema());
+        assert_eq!(record_batch_scalars(&raw), record_batch_scalars(&parsed));
+    }
+
+    fn record_batch_scalars(batch: &RecordBatch) -> Vec<Vec<ScalarValue>> {
+        (0..batch.num_rows())
+            .map(|row_index| {
+                batch
+                    .columns()
+                    .iter()
+                    .map(|array| {
+                        ScalarValue::try_from_array(array.as_ref(), row_index)
+                            .expect("test record batch value should materialize")
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn broad_raw_projection_keeps_invalid_snapshot_errors_on_the_execution_path() {
+        let spec = Arc::new(
+            derive_entity_surface_spec_from_schema(&json!({
+                "x-lix-key": "project_message",
+                "type": "object",
+                "properties": { "body": { "type": "string" } }
+            }))
+            .expect("schema should derive entity surface spec"),
+        );
+        let error = entity_record_batch(
+            &spec,
+            entity_surface_schema(&spec, EntitySurfaceShape::Active),
+            &[MaterializedLiveStateRow {
+                snapshot_content: Some("{not-json".to_string()),
+                ..live_row()
+            }],
+            super::EntityBatchProjection::RawTrackedProjection,
+        )
+        .expect_err("malformed snapshot must fail");
+
+        assert!(matches!(
+            error,
+            datafusion::common::DataFusionError::Execution(_)
+        ));
+        assert!(
+            error
+                .to_string()
+                .contains("sql2 entity provider expected valid snapshot_content JSON"),
+            "unexpected error: {error}"
         );
     }
 

--- a/packages/engine/tests/integration/sql/lix_key_value.rs
+++ b/packages/engine/tests/integration/sql/lix_key_value.rs
@@ -31,6 +31,74 @@ simulation_test!(lix_key_value_roundtrips_arbitrary_json, |sim| async move {
     );
 });
 
+simulation_test!(
+    lix_key_value_persisted_tracked_entity_scan_preserves_canonical_json_through_global_branch_merge,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let global_session = sim.wrap_session(
+            engine
+                .open_session("global")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+
+        // Both writes auto-commit before the read. That forces normal tracked
+        // TransactionJson bytes through the persisted global and active heads,
+        // then through the active branch's global-fallback merge.
+        global_session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_global) \
+                 VALUES ('kv-canonical-persisted-global', \
+                         lix_json('{ \"z\": { \"b\": 2, \"a\": 1 }, \"a\": [3, 2] }'), true)",
+                &[],
+            )
+            .await
+            .expect("tracked global insert should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) \
+                 VALUES ('kv-canonical-persisted-active', \
+                         lix_json('{ \"z\": { \"d\": 4, \"c\": 3 }, \"a\": [5, 4] }'))",
+                &[],
+            )
+            .await
+            .expect("tracked active insert should succeed");
+
+        let result = session
+            // LIKE deliberately routes through the broad EntitySpec scan rather
+            // than the exact-primary-key native executor.
+            .execute(
+                "SELECT key, CONCAT(value, '') AS value_text FROM lix_key_value \
+                 WHERE key LIKE 'kv-canonical-persisted-%' ORDER BY key",
+                &[],
+            )
+            .await
+            .expect("broad tracked entity scan should succeed");
+        assert_eq!(
+            result.rows().iter().map(|row| row.values()).collect::<Vec<_>>(),
+            vec![
+                &[
+                    Value::Text("kv-canonical-persisted-active".to_string()),
+                    Value::Text(r#"{"a":[5,4],"z":{"c":3,"d":4}}"#.to_string()),
+                ],
+                &[
+                    Value::Text("kv-canonical-persisted-global".to_string()),
+                    Value::Text(r#"{"a":[3,2],"z":{"a":1,"b":2}}"#.to_string()),
+                ],
+            ],
+            "persisted tracked JSON stays canonical through global/branch visibility merge"
+        );
+    }
+);
+
 simulation_test!(lix_key_value_duplicate_insert_rejects, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(

--- a/packages/engine/tests/integration/sql/lix_key_value.rs
+++ b/packages/engine/tests/integration/sql/lix_key_value.rs
@@ -83,7 +83,11 @@ simulation_test!(
             .await
             .expect("broad tracked entity scan should succeed");
         assert_eq!(
-            result.rows().iter().map(|row| row.values()).collect::<Vec<_>>(),
+            result
+                .rows()
+                .iter()
+                .map(lix_engine::Row::values)
+                .collect::<Vec<_>>(),
             vec![
                 &[
                     Value::Text("kv-canonical-persisted-active".to_string()),


### PR DESCRIPTION
## What changed

The normal broad tracked entity-read path now decodes only the projected
fields from canonical `TransactionJson` snapshot bytes directly into Arrow
columns. It avoids constructing a `serde_json::Value` DOM for every selected
snapshot before DataFusion evaluates the query.

Exact-PK reads retain the existing parser path. Any batch containing an
untracked/cache row also retains that path, preserving legacy sidecar JSON
semantics while the tracked-only fast path is in place.

## Why

Release profiles identified entity snapshot JSON materialization as the
dominant broad-read cost; RocksDB scanning itself was a small fraction. This
is a generic provider boundary, not a query-shape special case.

## Benchmark evidence

Warmed 10k-row `tracked_state_crud` SQL-session samples, RocksDB backend:

| Operation | `origin/main` median | This PR median | Change |
| --- | ---: | ---: | ---: |
| broad `read_all` | 37.808 ms | 23.094 ms | **-38.9%** |
| exact-PK `read_one` | 22.867 us | 22.955 us | +0.4% (noise; unchanged path) |
| exact-PK `read_many` | 142.051 us | 144.887 us | +2.0% (noise; unchanged path) |

Standalone raw SQLite `read_all` median from the same harness was 1.185 ms.
The remaining gap is intentional context for the next optimization cycle; it
is not claimed as parity.

I also tested a generic Arrow-result converter in the same warmed build and
dropped it: it regressed the broad read by 4.6%, so it is not included here.

## Compatibility

No public Rust, SQL, FFI, SDK, schema, or storage-layout API changed. The
new symbols are private to `sql2`. Focused coverage verifies:

- exact-PK reads retain the established JSON/scalar projection path;
- mixed/untracked batches keep duplicate-key last-wins behavior;
- canonical tracked raw batches match the parsed path for visible and
  `lixcol_*` system columns; and
- persisted global/branch tracked JSON remains canonical through visibility
  merge.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p lix_engine --features storage-benches`
- `cargo clippy -p lix_engine --features storage-benches -- -D warnings`
- `cargo test -p lix_engine --lib` (1207 passed, 6 ignored)
- focused entity-projection, exact-PK, malformed-snapshot, sidecar, and
  persisted global/branch integration tests
