### PR TITLE
perf(plugin): defer transport SHA-256 until needed

### DIFF
--- a/packages/engine/src/plugin/actor.rs
+++ b/packages/engine/src/plugin/actor.rs
@@ -45,7 +45,7 @@ pub(crate) struct PluginObservation {
     actor_nonce: u64,
     revision: u64,
     semantic_root: Arc<str>,
-    bytes_sha256: FileBytesSha256,
+    bytes_sha256: Option<FileBytesSha256>,
 }
 
 impl PluginObservation {
@@ -57,7 +57,7 @@ impl PluginObservation {
         &self.semantic_root
     }
 
-    pub(crate) fn bytes_sha256(&self) -> FileBytesSha256 {
+    pub(crate) fn bytes_sha256(&self) -> Option<FileBytesSha256> {
         self.bytes_sha256
     }
 }
@@ -66,7 +66,7 @@ struct PluginActorAcceptedState {
     store: PluginActorStore,
     document: WasmDocumentHandle,
     bytes: Blob,
-    bytes_sha256: FileBytesSha256,
+    bytes_sha256: Option<FileBytesSha256>,
     semantic_root: Arc<str>,
     history: VecDeque<PluginActorHistoricalState>,
 }
@@ -101,7 +101,7 @@ struct PluginActorHistoricalState {
     revision: u64,
     document: WasmDocumentHandle,
     bytes: Blob,
-    bytes_sha256: FileBytesSha256,
+    bytes_sha256: Option<FileBytesSha256>,
     semantic_root: Arc<str>,
 }
 
@@ -292,7 +292,7 @@ impl PluginActorCache {
         semantic_root: impl Into<Arc<str>>,
     ) -> PluginObservation {
         let semantic_root = semantic_root.into();
-        let bytes_sha256 = FileBytesSha256::compute(&bytes);
+        let bytes_sha256 = Some(FileBytesSha256::compute(&bytes));
         let mut state = self.lock();
         state.clock = state.clock.wrapping_add(1);
         let last_used = state.clock;
@@ -337,10 +337,11 @@ impl PluginActorCache {
         store: PluginActorStore,
         document: WasmDocumentHandle,
         bytes: Blob,
-        bytes_sha256: FileBytesSha256,
+        bytes_sha256: impl Into<Option<FileBytesSha256>>,
         semantic_root: impl Into<Arc<str>>,
     ) -> Result<PluginObservation, LixError> {
         let semantic_root = semantic_root.into();
+        let bytes_sha256 = bytes_sha256.into();
         if cold_install.key != key {
             let mut store = store;
             let _ = store.actor.drop_document(document).await;
@@ -708,7 +709,7 @@ fn plugin_store_resource_limit(capacity: NonZeroUsize) -> LixError {
 struct PluginActorSuccessor {
     document: WasmDocumentHandle,
     bytes: Blob,
-    bytes_sha256: FileBytesSha256,
+    bytes_sha256: Option<FileBytesSha256>,
     semantic_root: Arc<str>,
 }
 
@@ -745,7 +746,7 @@ pub(crate) struct PluginActorLease {
     guard: Option<OwnedMutexGuard<PluginActorAcceptedState>>,
     observed_document: WasmDocumentHandle,
     observed_bytes: Blob,
-    observed_bytes_sha256: FileBytesSha256,
+    observed_bytes_sha256: Option<FileBytesSha256>,
     uncertain_guest_call: bool,
     successor: Option<PluginActorSuccessor>,
 }
@@ -776,7 +777,7 @@ impl PluginActorLease {
     }
 
     #[cfg(test)]
-    pub(crate) fn accepted_bytes_sha256(&self) -> FileBytesSha256 {
+    pub(crate) fn accepted_bytes_sha256(&self) -> Option<FileBytesSha256> {
         self.guard
             .as_deref()
             .expect("actor lease guard exists")
@@ -791,7 +792,7 @@ impl PluginActorLease {
         self.observed_bytes.clone()
     }
 
-    pub(crate) fn observed_bytes_sha256(&self) -> FileBytesSha256 {
+    pub(crate) fn observed_bytes_sha256(&self) -> Option<FileBytesSha256> {
         self.observed_bytes_sha256
     }
 
@@ -890,9 +891,10 @@ impl PluginActorLease {
         mut call: PluginActorPendingCall,
         document: WasmDocumentHandle,
         bytes: Blob,
-        bytes_sha256: FileBytesSha256,
+        bytes_sha256: impl Into<Option<FileBytesSha256>>,
         semantic_root: impl Into<Arc<str>>,
     ) -> Result<(), LixError> {
+        let bytes_sha256 = bytes_sha256.into();
         if !self.uncertain_guest_call || self.successor.is_some() {
             self.slot.retire();
             return Err(LixError::new(
@@ -965,9 +967,10 @@ impl PluginActorLease {
         &mut self,
         document: WasmDocumentHandle,
         bytes: Blob,
-        bytes_sha256: FileBytesSha256,
+        bytes_sha256: impl Into<Option<FileBytesSha256>>,
         semantic_root: impl Into<Arc<str>>,
     ) -> Result<(), LixError> {
+        let bytes_sha256 = bytes_sha256.into();
         if !self.uncertain_guest_call || self.successor.is_some() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -1498,11 +1501,11 @@ mod tests {
         let before_hash = FileBytesSha256::compute(b"before");
         let after_hash = FileBytesSha256::compute(b"after");
         let before = install(&cache, key, 1, b"before", "root-1");
-        assert_eq!(before.bytes_sha256(), before_hash);
+        assert_eq!(before.bytes_sha256(), Some(before_hash));
 
         let mut lease = cache.lease(&before).await.unwrap();
-        assert_eq!(lease.observed_bytes_sha256(), before_hash);
-        assert_eq!(lease.accepted_bytes_sha256(), before_hash);
+        assert_eq!(lease.observed_bytes_sha256(), Some(before_hash));
+        assert_eq!(lease.accepted_bytes_sha256(), Some(before_hash));
         lease.begin_guest_call().unwrap();
         lease
             .complete_guest_call(
@@ -1513,11 +1516,33 @@ mod tests {
             )
             .unwrap();
         let after = lease.commit_successor().await.unwrap();
-        assert_eq!(after.bytes_sha256(), after_hash);
+        assert_eq!(after.bytes_sha256(), Some(after_hash));
 
         let historical = cache.lease_for_transition(&before).await.unwrap();
-        assert_eq!(historical.observed_bytes_sha256(), before_hash);
-        assert_eq!(historical.accepted_bytes_sha256(), after_hash);
+        assert_eq!(historical.observed_bytes_sha256(), Some(before_hash));
+        assert_eq!(historical.accepted_bytes_sha256(), Some(after_hash));
+
+        drop(historical);
+        let mut latest = cache.lease(&after).await.unwrap();
+        latest.begin_guest_call().unwrap();
+        latest
+            .complete_guest_call(
+                WasmDocumentHandle(3),
+                b"later".as_slice().into(),
+                None,
+                Arc::<str>::from("root-3"),
+            )
+            .unwrap();
+        let later = latest.commit_successor().await.unwrap();
+        assert_eq!(later.bytes_sha256(), None);
+        assert_eq!(
+            cache
+                .lease_for_transition(&later)
+                .await
+                .unwrap()
+                .observed_bytes_sha256(),
+            None
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/plugin/incremental.rs
+++ b/packages/engine/src/plugin/incremental.rs
@@ -246,9 +246,12 @@ fn require_framed_record_fits(
 pub(crate) struct BuiltInputSplices {
     pub(crate) edits: Vec<WasmInputSplice>,
     pub(crate) used_transport_provenance: bool,
-    /// Exact identity of `after`, either adopted from verified transport
-    /// provenance or computed by the full-diff fallback.
-    pub(crate) after_sha256: FileBytesSha256,
+    /// Exact identity of `after` when verified transport already supplied it.
+    ///
+    /// Ordinary full-byte SQL writes do not need a protocol SHA-256. Keeping
+    /// this optional avoids hashing a large accepted file solely in case a
+    /// later request happens to carry transport splice provenance.
+    pub(crate) after_sha256: Option<FileBytesSha256>,
     /// Bytes examined only by the bounded host full-diff fallback.
     pub(crate) full_diff_bytes_compared: u64,
 }
@@ -259,15 +262,17 @@ pub(crate) struct BuiltInputSplices {
 /// before/after blobs once to find their maximal common prefix/suffix.
 pub(crate) fn build_file_update_splices(
     before: &[u8],
-    before_sha256: FileBytesSha256,
+    before_sha256: impl Into<Option<FileBytesSha256>>,
     after: &[u8],
     provenance: Option<&RequestBlobSpliceProvenance>,
     limits: WasmTransitionLimits,
 ) -> Result<BuiltInputSplices, LixError> {
     limits.validate()?;
+    let before_sha256 = before_sha256.into();
     let verified_transport = provenance.and_then(|provenance| {
         let provenance_base = FileBytesSha256::from_lower_hex(provenance.base_sha256())?;
         let provenance_result = FileBytesSha256::from_lower_hex(provenance.result_sha256())?;
+        let before_sha256 = before_sha256.unwrap_or_else(|| FileBytesSha256::compute(before));
         (provenance_base == before_sha256
             && provenance.matches_result(after)
             && validate_transport_splice(before, after, provenance).is_ok())
@@ -281,11 +286,15 @@ pub(crate) fn build_file_update_splices(
                 provenance.suffix_bytes(),
                 provenance.insert(),
                 true,
-                result_sha256,
+                Some(result_sha256),
                 0,
             )
         } else {
-            let (prefix, prefix_bytes_compared) = common_prefix_len(before, after);
+            let (prefix, prefix_bytes_compared) = tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.plugin_splice_prefix"
+            )
+            .in_scope(|| common_prefix_len(before, after));
             if prefix == before.len() && prefix == after.len() {
                 return Ok(BuiltInputSplices {
                     edits: Vec::new(),
@@ -298,14 +307,18 @@ pub(crate) fn build_file_update_splices(
                 .len()
                 .saturating_sub(prefix)
                 .min(after.len().saturating_sub(prefix));
-            let (suffix, suffix_bytes_compared) = common_suffix_len(before, after, max_suffix);
+            let (suffix, suffix_bytes_compared) = tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.plugin_splice_suffix"
+            )
+            .in_scope(|| common_suffix_len(before, after, max_suffix));
             let insert_end = after.len() - suffix;
             (
                 prefix,
                 suffix,
                 &after[prefix..insert_end],
                 false,
-                FileBytesSha256::compute(after),
+                None,
                 prefix_bytes_compared.saturating_add(suffix_bytes_compared),
             )
         };
@@ -1035,7 +1048,7 @@ pub(crate) struct ResolvedOutputSplice {
 pub(crate) struct ValidatedEntityTransition {
     pub(crate) document: WasmDocumentHandle,
     pub(crate) bytes: Blob,
-    pub(crate) bytes_sha256: FileBytesSha256,
+    pub(crate) bytes_sha256: Option<FileBytesSha256>,
     #[cfg(test)]
     pub(crate) edits: Vec<ResolvedOutputSplice>,
     pub(crate) counters: WasmTransitionCounters,
@@ -1221,7 +1234,10 @@ async fn drain_entity_transition_edits_inner(
         }
         bytes
     };
-    let bytes_sha256 = FileBytesSha256::compute(&bytes);
+    // Cold-open validation benefits from caching the accepted protocol
+    // digest. A normal semantic render does not: defer that O(file) SHA-256
+    // until a later request actually presents transport splice provenance.
+    let bytes_sha256 = expected.as_ref().map(|_| FileBytesSha256::compute(&bytes));
     let runtime_counters = actor.finish_transition(transition.transition).await?;
     Ok(ValidatedEntityTransition {
         document: transition.document,
@@ -1789,7 +1805,7 @@ mod tests {
         .unwrap();
         assert!(from_transport.used_transport_provenance);
         assert_eq!(from_transport.full_diff_bytes_compared, 0);
-        assert_eq!(from_transport.after_sha256, after_sha256);
+        assert_eq!(from_transport.after_sha256, Some(after_sha256));
         assert_eq!(
             from_transport.edits,
             vec![WasmInputSplice {
@@ -1798,6 +1814,17 @@ mod tests {
                 insert: WasmInputBytes::Inline(b"XY".to_vec()),
             }]
         );
+
+        let lazily_verified_transport = build_file_update_splices(
+            before,
+            None,
+            &after,
+            Some(&provenance),
+            WasmTransitionLimits::default(),
+        )
+        .unwrap();
+        assert!(lazily_verified_transport.used_transport_provenance);
+        assert_eq!(lazily_verified_transport.after_sha256, Some(after_sha256));
 
         let fallback = build_file_update_splices(
             before,
@@ -1809,7 +1836,7 @@ mod tests {
         .unwrap();
         assert!(!fallback.used_transport_provenance);
         assert_eq!(fallback.full_diff_bytes_compared, 12);
-        assert_eq!(fallback.after_sha256, after_sha256);
+        assert_eq!(fallback.after_sha256, None);
         assert_eq!(fallback.edits, from_transport.edits);
 
         let lazy = build_file_update_splices(
@@ -1858,7 +1885,6 @@ mod tests {
         let proof_base = b"uvwxyz";
         let after: Blob = b"uvXYyz".as_slice().into();
         let before_sha256 = FileBytesSha256::compute(before);
-        let after_sha256 = FileBytesSha256::compute(&after);
         let provenance = RequestBlobSpliceProvenance::new_validated_for_test(
             proof_base,
             &after,
@@ -1876,7 +1902,7 @@ mod tests {
         )
         .expect("cross-file provenance is only an optimization miss");
         assert!(!fallback.used_transport_provenance);
-        assert_eq!(fallback.after_sha256, after_sha256);
+        assert_eq!(fallback.after_sha256, None);
     }
 
     #[test]
@@ -1902,7 +1928,7 @@ mod tests {
         .expect("transplanted provenance must fall back safely");
 
         assert!(!fallback.used_transport_provenance);
-        assert_eq!(fallback.after_sha256, FileBytesSha256::compute(&submitted));
+        assert_eq!(fallback.after_sha256, None);
         assert_eq!(
             fallback.edits,
             vec![WasmInputSplice {

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -95,7 +95,13 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     if !prepared_writes.file_data_writes.is_empty() {
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
         for write in &prepared_writes.file_data_writes {
-            blob_writer.stage_payload(write.payload()).await?;
+            blob_writer
+                .stage_payload(write.payload())
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.binary_cas_stage_payload"
+                ))
+                .await?;
             for payload in write.auxiliary_payloads() {
                 blob_writer.stage_payload(payload).await?;
             }

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -2205,10 +2205,9 @@ where
                     None => true,
                     Some(PluginContentType::Text) => {
                         write.splice_provenance().is_some_and(|provenance| {
-                            observation
-                                .bytes_sha256()
-                                .matches_lower_hex(provenance.base_sha256())
-                                && transport_splice_preserves_utf8(write.data(), provenance)
+                            observation.bytes_sha256().is_some_and(|digest| {
+                                digest.matches_lower_hex(provenance.base_sha256())
+                            }) && transport_splice_preserves_utf8(write.data(), provenance)
                         })
                     }
                     Some(PluginContentType::Binary) => false,
@@ -2378,7 +2377,14 @@ where
                 )
             })?;
             let plugin = entry.to_installed_plugin(wasm)?;
-            let factory = self.plugin_host.load_or_compile_v2_factory(&plugin).await?;
+            let factory = self
+                .plugin_host
+                .load_or_compile_v2_factory(&plugin)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.plugin_factory_compile"
+                ))
+                .await?;
             component_v2_factories.insert(key, factory);
         }
 
@@ -2791,7 +2797,13 @@ where
                 )
             } else {
                 let store_permit = self.plugin_host.actor_cache().admit_store()?;
-                let mut actor = factory.instantiate_actor().await?;
+                let mut actor = factory
+                    .instantiate_actor()
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_actor_instantiate"
+                    ))
+                    .await?;
                 let source = ArcByteSource::new(submitted_bytes.clone());
                 let transition = actor
                     .open_file(
@@ -2802,9 +2814,17 @@ where
                             ids,
                         },
                     )
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.plugin_open_file"
+                    ))
                     .await?;
                 let validated =
                     drain_file_transition_changes(actor.as_mut(), transition, &schemas, limits)
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.plugin_open_file_drain"
+                        ))
                         .await?;
                 let changes = validated.changes;
                 let mut counters = validated.counters;
@@ -2854,14 +2874,20 @@ where
                     return Err(error);
                 }
             };
-            let change_rows = plugin_detected_changes_from_v2(&changes).and_then(|detected| {
-                plugin_change_rows(
-                    selected,
-                    detected,
-                    &write.file_id,
-                    &context,
-                    "plugin v2 file transition",
-                )
+            let change_rows = tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.plugin_change_rows"
+            )
+            .in_scope(|| {
+                plugin_detected_changes_from_v2(&changes).and_then(|detected| {
+                    plugin_change_rows(
+                        selected,
+                        detected,
+                        &write.file_id,
+                        &context,
+                        "plugin v2 file transition",
+                    )
+                })
             });
             let change_rows = match change_rows {
                 Ok(rows) => rows,

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -1,3 +1,4 @@
+use lix_rocksdb_storage::RocksDB;
 use lix_sdk::{
     CreateBranchOptions, ExecuteOptions, ExecuteStatementMetadata, Lix, LixError,
     MergeBranchOptions, MergeBranchPreviewOptions, MutationIdentity, RequestBlobSpliceProvenance,
@@ -7,6 +8,7 @@ use lix_sdk::{
 use lix_sdk::{LocalFilesystem, open_lix_with_storage};
 use lix_sdk::{OpenLixOptions, Value, open_lix};
 use sha2::{Digest as _, Sha256};
+use std::hint::black_box;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::sync::Arc;
@@ -849,6 +851,7 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
 #[tokio::test]
 #[ignore = "10 MiB end-to-end Wasm acceptance gate"]
 async fn v2_json_ten_mib_real_wasm_edit_stays_sparse_and_bounded() {
+    init_perf_tracing();
     let archive = build_json_v2_plugin_archive();
     let lix = open_lix(OpenLixOptions::default())
         .await
@@ -1015,11 +1018,12 @@ async fn v2_json_ten_mib_real_wasm_edit_stays_sparse_and_bounded() {
 #[tokio::test]
 #[ignore = "10 MiB ordinary public-SQL JSON byte-write benchmark"]
 async fn v2_json_ten_mib_ordinary_sql_byte_edit_benchmark() {
+    init_perf_tracing();
     const SAMPLES: usize = 7;
 
     let root = tempfile::tempdir().expect("create JSON benchmark directory");
     let archive = build_json_v2_plugin_archive();
-    let lix = open_lix_with_filesystem(root.path()).await;
+    let lix = open_lix_with_rocksdb(root.path()).await;
     install_reference_plugin_in_blank_registry(
         &lix,
         "plugin_json_incremental_v2",
@@ -1081,12 +1085,12 @@ async fn v2_json_ten_mib_ordinary_sql_byte_edit_benchmark() {
 #[tokio::test]
 #[ignore = "10 MiB JSON unrelated-entity merge benchmark"]
 async fn v2_json_ten_mib_unrelated_entity_merge_benchmark() {
+    init_perf_tracing();
     const SAMPLES: usize = 7;
 
+    let root = tempfile::tempdir().expect("create JSON merge benchmark directory");
     let archive = build_json_v2_plugin_archive();
-    let lix = open_lix(OpenLixOptions::default())
-        .await
-        .expect("workspace should open with the production Wasmtime runtime");
+    let lix = open_lix_with_rocksdb(root.path()).await;
     install_reference_plugin_in_blank_registry(
         &lix,
         "plugin_json_incremental_v2",
@@ -1196,6 +1200,107 @@ async fn v2_json_ten_mib_unrelated_entity_merge_benchmark() {
     );
 
     lix.close().await.expect("JSON benchmark should close");
+}
+
+#[tokio::test]
+#[ignore = "10 MiB JSON public-SQL read benchmark on RocksDB"]
+async fn v2_json_ten_mib_rocksdb_read_benchmark() {
+    const WARM_SAMPLES: usize = 20;
+    const COLD_SAMPLES: usize = 7;
+
+    let root = tempfile::tempdir().expect("create JSON read benchmark directory");
+    let archive = build_json_v2_plugin_archive();
+    let lix = open_lix_with_rocksdb(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json_incremental_v2",
+        &archive,
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+
+    let path = "/read-ten-mib.json";
+    let (bytes, _, _) = json_ten_mib_flat_fixture();
+    write_file(&lix, path, bytes.clone())
+        .await
+        .expect("real JSON v2 Wasm should import the 10 MiB fixture");
+
+    for _ in 0..3 {
+        let read = read_file(&lix, path)
+            .await
+            .expect("warm materialized JSON should read")
+            .expect("warm materialized JSON should exist");
+        assert_eq!(read.len(), JSON_TEN_MIB_BYTES);
+        black_box(read);
+    }
+
+    let mut warm_ms = Vec::with_capacity(WARM_SAMPLES);
+    for _ in 0..WARM_SAMPLES {
+        let started = Instant::now();
+        let read = read_file(&lix, path)
+            .await
+            .expect("warm materialized JSON should read")
+            .expect("warm materialized JSON should exist");
+        warm_ms.push(started.elapsed().as_secs_f64() * 1_000.0);
+        assert_eq!(read.len(), JSON_TEN_MIB_BYTES);
+        black_box(read);
+    }
+    lix.close().await.expect("warm JSON benchmark should close");
+
+    let mut cold_total_ms = Vec::with_capacity(COLD_SAMPLES);
+    let mut cold_storage_open_ms = Vec::with_capacity(COLD_SAMPLES);
+    let mut cold_engine_open_ms = Vec::with_capacity(COLD_SAMPLES);
+    let mut cold_read_ms = Vec::with_capacity(COLD_SAMPLES);
+    for _ in 0..COLD_SAMPLES {
+        let total_started = Instant::now();
+        let storage_started = Instant::now();
+        let storage =
+            RocksDB::open(root.path().join(".lix")).expect("reopen JSON benchmark RocksDB");
+        cold_storage_open_ms.push(storage_started.elapsed().as_secs_f64() * 1_000.0);
+
+        let engine_started = Instant::now();
+        let reopened = open_lix_with_storage(storage)
+            .await
+            .expect("reopen JSON benchmark workspace");
+        cold_engine_open_ms.push(engine_started.elapsed().as_secs_f64() * 1_000.0);
+
+        let read_started = Instant::now();
+        let read = read_file(&reopened, path)
+            .await
+            .expect("cold materialized JSON should read")
+            .expect("cold materialized JSON should exist");
+        cold_read_ms.push(read_started.elapsed().as_secs_f64() * 1_000.0);
+        assert_eq!(read, bytes);
+        black_box(&read);
+        reopened
+            .close()
+            .await
+            .expect("cold JSON benchmark should close");
+        cold_total_ms.push(total_started.elapsed().as_secs_f64() * 1_000.0);
+    }
+
+    for samples in [
+        &mut warm_ms,
+        &mut cold_total_ms,
+        &mut cold_storage_open_ms,
+        &mut cold_engine_open_ms,
+        &mut cold_read_ms,
+    ] {
+        samples.sort_by(f64::total_cmp);
+    }
+    eprintln!(
+        "v2_json_ten_mib_rocksdb_read bytes={JSON_TEN_MIB_BYTES} \
+         warm_samples={WARM_SAMPLES} warm_p50_ms={:.3} warm_p95_ms={:.3} \
+         cold_samples={COLD_SAMPLES} cold_total_p50_ms={:.3} \
+         cold_storage_open_p50_ms={:.3} cold_engine_open_p50_ms={:.3} \
+         cold_read_p50_ms={:.3}",
+        p50_ms(&warm_ms),
+        p95_ms(&warm_ms),
+        p50_ms(&cold_total_ms),
+        p50_ms(&cold_storage_open_ms),
+        p50_ms(&cold_engine_open_ms),
+        p50_ms(&cold_read_ms),
+    );
 }
 
 #[derive(Debug)]
@@ -2326,6 +2431,22 @@ async fn open_lix_with_filesystem(path: &Path) -> Lix<LocalFilesystem> {
     open_lix_with_storage(storage).await.unwrap()
 }
 
+async fn open_lix_with_rocksdb(path: &Path) -> Lix<RocksDB> {
+    let storage = RocksDB::open(path.join(".lix")).expect("open Lix RocksDB storage");
+    open_lix_with_storage(storage)
+        .await
+        .expect("open Lix workspace")
+}
+
+fn p50_ms(sorted: &[f64]) -> f64 {
+    sorted[sorted.len() / 2]
+}
+
+fn p95_ms(sorted: &[f64]) -> f64 {
+    let index = ((sorted.len() * 95).div_ceil(100)).saturating_sub(1);
+    sorted[index]
+}
+
 async fn install_plugin<StorageImpl>(
     lix: &Lix<StorageImpl>,
     key: &str,
@@ -2578,6 +2699,16 @@ fn build_json_v2_plugin_archive() -> Vec<u8> {
         writer.write_all(bytes).unwrap();
     }
     writer.finish().unwrap().into_inner()
+}
+
+fn init_perf_tracing() {
+    if std::env::var_os("LIX_PLUGIN_V2_TRACE").is_some() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("lix_perf=debug")
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_test_writer()
+            .try_init();
+    }
 }
 
 const JSON_TEN_MIB_BYTES: usize = 10 * 1024 * 1024;


### PR DESCRIPTION
Stacked on #783.

## Outcome

Defers the transport protocol's SHA-256 digest until a request actually supplies SHA-256 splice provenance.

Lix binary CAS continues to use BLAKE3. SHA-256 remains only where the existing remote splice protocol requires it. This complements main's accelerated remote-splice SHA implementation: main makes required hashing faster; this PR avoids doing it at all when an ordinary SQL or semantic write does not need transport provenance.

- cache digests established by cold hydration or verified provenance
- do not eagerly hash every accepted large-file edit
- retain exact protocol validation when provenance is supplied
- no SQL, WIT, plugin, or transport API changes

## Latest release results

10,485,760-byte JSON fixture:

- ordinary full-SQL one-byte write: 12.702 ms p50
- unrelated-property semantic merge: 18.514 ms p50
- warm materialized read: 6.641 ms p50

3,670,017-byte Markdown fixture:

- Lix byte write: 8.140 ms p50 vs Git 62.340 ms
- Lix semantic merge: 6.868 ms p50 vs Git 123.419 ms
- Lix preserves both unrelated same-line cell edits where Git conflicts

## Validation

- workspace clippy with all targets/features and `-D warnings`
- engine `all-simulations`: 1,282 unit, 758 integration, 3 doctests
- real-Wasm 10 MiB JSON provenance gate
- RocksDB JSON read/write/merge release gates
- RocksDB Markdown-vs-Git performance and merge-quality gate

