### PR TITLE
fix(storage): make commits and observers durable

### DIFF
--- a/packages/engine/src/observe_invalidation.rs
+++ b/packages/engine/src/observe_invalidation.rs
@@ -1,14 +1,13 @@
 #[cfg(not(target_family = "wasm"))]
 use std::sync::Arc;
-#[cfg(not(target_family = "wasm"))]
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
+#[cfg(not(target_family = "wasm"))]
+use tokio::sync::Mutex;
 use tokio::sync::watch;
 
-#[cfg(not(target_family = "wasm"))]
 use crate::LixError;
 #[cfg(not(target_family = "wasm"))]
 use crate::storage_adapter::Storage;
@@ -19,29 +18,47 @@ use crate::storage_adapter::StorageWriteSetStats;
 #[cfg(not(target_family = "wasm"))]
 const EXTERNAL_MUTATION_REVISION_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
+#[derive(Clone, Debug)]
+pub(crate) enum ObserveInvalidationEvent {
+    Generation(u64),
+    TerminalStorageError(LixError),
+}
+
 #[derive(Debug)]
 pub(crate) struct ObserveInvalidation {
     generation: AtomicU64,
-    sender: watch::Sender<u64>,
+    sender: watch::Sender<ObserveInvalidationEvent>,
     #[cfg(not(target_family = "wasm"))]
-    external_watcher_started: AtomicBool,
+    external_watcher_started: Mutex<bool>,
 }
 
 impl ObserveInvalidation {
     pub(crate) fn new() -> Self {
-        let (sender, _) = watch::channel(0);
+        let (sender, _) = watch::channel(ObserveInvalidationEvent::Generation(0));
         Self {
             generation: AtomicU64::new(0),
             sender,
             #[cfg(not(target_family = "wasm"))]
-            external_watcher_started: AtomicBool::new(false),
+            external_watcher_started: Mutex::new(false),
         }
     }
 
     pub(crate) fn bump(&self) -> u64 {
         let next = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
-        self.sender.send_replace(next);
+        self.sender.send_modify(|event| {
+            if !matches!(event, ObserveInvalidationEvent::TerminalStorageError(_)) {
+                *event = ObserveInvalidationEvent::Generation(next);
+            }
+        });
         next
+    }
+
+    fn fail_terminal_storage(&self, error: LixError) {
+        self.sender.send_modify(|event| {
+            if !matches!(event, ObserveInvalidationEvent::TerminalStorageError(_)) {
+                *event = ObserveInvalidationEvent::TerminalStorageError(error);
+            }
+        });
     }
 
     pub(crate) fn bump_if_storage_changed(&self, stats: &StorageWriteSetStats) {
@@ -50,7 +67,7 @@ impl ObserveInvalidation {
         }
     }
 
-    pub(crate) fn subscribe(&self) -> watch::Receiver<u64> {
+    pub(crate) fn subscribe(&self) -> watch::Receiver<ObserveInvalidationEvent> {
         self.sender.subscribe()
     }
 
@@ -62,18 +79,29 @@ impl ObserveInvalidation {
     where
         StorageImpl: Storage + Clone + Send + Sync + 'static,
     {
-        if self
-            .external_watcher_started
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
+        // Keep contenders behind the startup gate until the watcher has read
+        // its baseline. Otherwise they can evaluate an older snapshot that
+        // the watcher treats as already seen; cancellation also releases this
+        // gate so a contender can retry startup.
+        let mut watcher_started = self.external_watcher_started.lock().await;
+        let event = self.sender.borrow().clone();
+        if let ObserveInvalidationEvent::TerminalStorageError(error) = event {
+            return Err(error);
+        }
+        if *watcher_started {
             return Ok(());
         }
         let mut last_seen_revision = match storage.load_mutation_revision().await {
             Ok(revision) => revision,
             Err(error) => {
-                self.external_watcher_started.store(false, Ordering::SeqCst);
-                return Err(error.into());
+                let error: LixError = error.into();
+                if matches!(
+                    error.code.as_str(),
+                    LixError::CODE_STORAGE_FENCED | LixError::CODE_STORAGE_CLOSED
+                ) {
+                    self.fail_terminal_storage(error.clone());
+                }
+                return Err(error);
             }
         };
         let invalidation = Arc::downgrade(self);
@@ -83,8 +111,19 @@ impl ObserveInvalidation {
                 let Some(invalidation) = invalidation.upgrade() else {
                     break;
                 };
-                let Ok(current_revision) = storage.load_mutation_revision().await else {
-                    continue;
+                let current_revision = match storage.load_mutation_revision().await {
+                    Ok(revision) => revision,
+                    Err(error) => {
+                        let error: LixError = error.into();
+                        if matches!(
+                            error.code.as_str(),
+                            LixError::CODE_STORAGE_FENCED | LixError::CODE_STORAGE_CLOSED
+                        ) {
+                            invalidation.fail_terminal_storage(error);
+                            break;
+                        }
+                        continue;
+                    }
                 };
                 if current_revision != last_seen_revision {
                     last_seen_revision = current_revision;
@@ -92,6 +131,178 @@ impl ObserveInvalidation {
                 }
             }
         });
+        *watcher_started = true;
         Ok(())
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use crate::storage::{
+        Memory, MemoryRead, MemoryWrite, ReadOptions, StorageError, WriteOptions,
+    };
+    use crate::storage_adapter::StorageAdapter;
+    use std::sync::atomic::AtomicBool;
+    use tokio::sync::Notify;
+
+    #[derive(Clone)]
+    struct BlockingFirstReadStorage {
+        inner: Memory,
+        first_read: Arc<AtomicBool>,
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    impl BlockingFirstReadStorage {
+        fn new() -> Self {
+            Self {
+                inner: Memory::new(),
+                first_read: Arc::new(AtomicBool::new(true)),
+                entered: Arc::new(Notify::new()),
+                release: Arc::new(Notify::new()),
+            }
+        }
+
+        async fn wait_for_initial_read(&self) {
+            loop {
+                let notified = self.entered.notified();
+                if !self.first_read.load(Ordering::Acquire) {
+                    return;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    impl Storage for BlockingFirstReadStorage {
+        type Read<'a>
+            = MemoryRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+            if self.first_read.swap(false, Ordering::AcqRel) {
+                self.entered.notify_waiters();
+                self.release.notified().await;
+            }
+            self.inner.begin_read(options).await
+        }
+
+        async fn begin_write(
+            &self,
+            options: WriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            self.inner.begin_write(options).await
+        }
+    }
+
+    #[derive(Clone)]
+    struct FencedInitialReadStorage {
+        inner: Memory,
+    }
+
+    impl Storage for FencedInitialReadStorage {
+        type Read<'a>
+            = MemoryRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn begin_read(&self, _options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+            Err(StorageError::Fenced)
+        }
+
+        async fn begin_write(
+            &self,
+            options: WriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            self.inner.begin_write(options).await
+        }
+    }
+
+    #[tokio::test]
+    async fn initial_terminal_watcher_error_is_sticky() {
+        let invalidation = Arc::new(ObserveInvalidation::new());
+        let mut observer = invalidation.subscribe();
+        let storage = FencedInitialReadStorage {
+            inner: Memory::new(),
+        };
+
+        let error = invalidation
+            .ensure_external_watcher(StorageAdapter::new(storage.clone()))
+            .await
+            .expect_err("initial fenced watcher read should fail");
+        assert_eq!(error.code, LixError::CODE_STORAGE_FENCED);
+        observer
+            .changed()
+            .await
+            .expect("initial terminal error should notify observers");
+        assert!(matches!(
+            observer.borrow_and_update().clone(),
+            ObserveInvalidationEvent::TerminalStorageError(error)
+                if error.code == LixError::CODE_STORAGE_FENCED
+        ));
+
+        let retry_error = invalidation
+            .ensure_external_watcher(StorageAdapter::new(storage))
+            .await
+            .expect_err("terminal watcher failure should remain sticky");
+        assert_eq!(retry_error.code, LixError::CODE_STORAGE_FENCED);
+    }
+
+    #[tokio::test]
+    async fn contending_observer_waits_for_cancelled_watcher_start_and_retries() {
+        let invalidation = Arc::new(ObserveInvalidation::new());
+        let storage = BlockingFirstReadStorage::new();
+        let cancelled_start = {
+            let invalidation = Arc::clone(&invalidation);
+            let storage = StorageAdapter::new(storage.clone());
+            tokio::spawn(async move { invalidation.ensure_external_watcher(storage).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), storage.wait_for_initial_read())
+            .await
+            .expect("watcher startup should begin its initial read");
+        let (contender_entered_tx, contender_entered_rx) = tokio::sync::oneshot::channel();
+        let mut contending_start = {
+            let invalidation = Arc::clone(&invalidation);
+            let storage = StorageAdapter::new(storage.clone());
+            tokio::spawn(async move {
+                let _ = contender_entered_tx.send(());
+                invalidation.ensure_external_watcher(storage).await
+            })
+        };
+        contender_entered_rx
+            .await
+            .expect("contending observer task should start");
+        tokio::task::yield_now().await;
+        assert!(
+            !contending_start.is_finished(),
+            "contending observer must wait until the initial watcher startup completes"
+        );
+        cancelled_start.abort();
+        assert!(
+            cancelled_start
+                .await
+                .expect_err("cancelled watcher startup task")
+                .is_cancelled(),
+            "initial watcher startup should be cancelled"
+        );
+        tokio::time::timeout(Duration::from_secs(1), &mut contending_start)
+            .await
+            .expect("contending observer should retry after cancelled startup")
+            .expect("contending observer task should not panic")
+            .expect("contending observer should establish the watcher");
+        assert!(
+            *invalidation.external_watcher_started.lock().await,
+            "contending retry should mark the watcher as started"
+        );
     }
 }

--- a/packages/engine/src/session/observe.rs
+++ b/packages/engine/src/session/observe.rs
@@ -6,6 +6,7 @@ use crate::observe_coordinator::{
     ObserveQueryEvaluation, ObserveQueryKey, ObserveQueryState, ObserveSessionScope,
     ObserveSharedContent,
 };
+use crate::observe_invalidation::ObserveInvalidationEvent;
 use crate::storage_adapter::Memory;
 use crate::storage_adapter::Storage;
 use crate::{ExecuteResult, LixError, Value, sql2};
@@ -47,7 +48,7 @@ where
 {
     session: SessionContext<StorageImpl>,
     query: ObserveQuery,
-    receiver: watch::Receiver<u64>,
+    receiver: watch::Receiver<ObserveInvalidationEvent>,
     sequence: u64,
     last_rows: Option<ExecuteResult>,
     last_shared_content: Option<ObserveSharedContent>,
@@ -127,7 +128,18 @@ where
     }
 
     async fn wait_for_invalidation(&mut self) -> Result<bool, LixError> {
-        Ok(self.receiver.changed().await.is_ok())
+        if self.receiver.changed().await.is_err() {
+            return Ok(false);
+        }
+        self.invalidation_generation().map(|_| true)
+    }
+
+    fn invalidation_generation(&mut self) -> Result<u64, LixError> {
+        let event = self.receiver.borrow_and_update().clone();
+        match event {
+            ObserveInvalidationEvent::Generation(generation) => Ok(generation),
+            ObserveInvalidationEvent::TerminalStorageError(error) => Err(error),
+        }
     }
 
     async fn evaluate_stable_snapshot(
@@ -140,7 +152,7 @@ where
                 .observe_invalidation
                 .ensure_external_watcher(self.session.storage.clone())
                 .await?;
-            let before = *self.receiver.borrow_and_update();
+            let before = self.invalidation_generation()?;
             let rows = self.execute_or_share(before).await;
             drop(operation_guard);
             let rows = match rows {
@@ -151,7 +163,7 @@ where
                 }
                 Err(error) => return Err(error),
             };
-            let after = *self.receiver.borrow_and_update();
+            let after = self.invalidation_generation()?;
             if before == after {
                 return Ok(Some((after, rows)));
             }

--- a/packages/engine/src/sql2/providers/branch.rs
+++ b/packages/engine/src/sql2/providers/branch.rs
@@ -500,7 +500,14 @@ async fn load_branch_rows_scoped(
                 // descriptors being listed. Preserve point-read semantics in
                 // that case while keeping the one-scan fast path for valid
                 // branch-ref state.
-                Err(error) if error.code != LixError::CODE_STORAGE_ERROR => {
+                Err(error)
+                    if !matches!(
+                        error.code.as_str(),
+                        LixError::CODE_STORAGE_ERROR
+                            | LixError::CODE_STORAGE_FENCED
+                            | LixError::CODE_STORAGE_CLOSED
+                    ) =>
+                {
                     load_branch_rows_with_point_lookups(descriptors, branch_ref).await
                 }
                 Err(error) => Err(error),
@@ -1383,34 +1390,37 @@ mod tests {
 
     #[tokio::test]
     async fn batch_head_read_does_not_amplify_storage_errors() {
-        let live_state = Arc::new(RowsLiveStateReader {
-            rows: vec![
-                descriptor_row("branch-a", "Branch A"),
-                descriptor_row("branch-b", "Branch B"),
-                descriptor_row("branch-c", "Branch C"),
-            ],
-        });
-        let branch_ref = Arc::new(CountingBranchRefReader {
-            heads: vec![head("branch-a"), head("branch-b"), head("branch-c")],
-            point_reads: AtomicUsize::new(0),
-            scans: AtomicUsize::new(0),
-            scan_error: Some(LixError::new(
-                LixError::CODE_STORAGE_ERROR,
-                "branch-ref scan failed",
-            )),
-            point_error_branch: None,
-        });
+        for code in [
+            LixError::CODE_STORAGE_ERROR,
+            LixError::CODE_STORAGE_FENCED,
+            LixError::CODE_STORAGE_CLOSED,
+        ] {
+            let live_state = Arc::new(RowsLiveStateReader {
+                rows: vec![
+                    descriptor_row("branch-a", "Branch A"),
+                    descriptor_row("branch-b", "Branch B"),
+                    descriptor_row("branch-c", "Branch C"),
+                ],
+            });
+            let branch_ref = Arc::new(CountingBranchRefReader {
+                heads: vec![head("branch-a"), head("branch-b"), head("branch-c")],
+                point_reads: AtomicUsize::new(0),
+                scans: AtomicUsize::new(0),
+                scan_error: Some(LixError::new(code, "branch-ref scan failed")),
+                point_error_branch: None,
+            });
 
-        let error = load_branch_rows(
-            live_state,
-            branch_ref.clone(),
-            BranchHeadReadStrategy::Batch,
-        )
-        .await
-        .unwrap_err();
+            let error = load_branch_rows(
+                live_state,
+                branch_ref.clone(),
+                BranchHeadReadStrategy::Batch,
+            )
+            .await
+            .unwrap_err();
 
-        assert_eq!(error.code, LixError::CODE_STORAGE_ERROR);
-        assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 1);
-        assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 0);
+            assert_eq!(error.code, code);
+            assert_eq!(branch_ref.scans.load(Ordering::Relaxed), 1);
+            assert_eq!(branch_ref.point_reads.load(Ordering::Relaxed), 0);
+        }
     }
 }

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -2821,6 +2821,8 @@ mod tests {
     struct FencedReadStorage {
         inner: Memory,
         fenced: Arc<AtomicBool>,
+        fenced_read_count: Arc<AtomicUsize>,
+        fenced_read: Arc<Notify>,
     }
 
     impl FencedReadStorage {
@@ -2828,11 +2830,23 @@ mod tests {
             Self {
                 inner: Memory::new(),
                 fenced: Arc::new(AtomicBool::new(false)),
+                fenced_read_count: Arc::new(AtomicUsize::new(0)),
+                fenced_read: Arc::new(Notify::new()),
             }
         }
 
         fn fence_reads(&self) {
             self.fenced.store(true, Ordering::Release);
+        }
+
+        async fn wait_for_fenced_read(&self) {
+            loop {
+                let notified = self.fenced_read.notified();
+                if self.fenced_read_count.load(Ordering::Acquire) != 0 {
+                    return;
+                }
+                notified.await;
+            }
         }
     }
 
@@ -2848,6 +2862,8 @@ mod tests {
 
         async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
             if self.fenced.load(Ordering::Acquire) {
+                self.fenced_read_count.fetch_add(1, Ordering::AcqRel);
+                self.fenced_read.notify_waiters();
                 return Err(StorageError::Fenced);
             }
             self.inner.begin_read(options).await
@@ -3023,6 +3039,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fenced_external_observe_watcher_signals_and_ends_stream() {
+        let storage = FencedReadStorage::new();
+        let root = Arc::new(
+            open_lix(OpenLixOptions::new(storage.clone()))
+                .await
+                .expect("open Lix"),
+        );
+        let server = LixProtocolServer::new(root);
+        let router = handler(server);
+        let (session_id, _) = new_session(&router).await;
+
+        let response = request(
+            &router,
+            "POST",
+            "/lix/v1/observe",
+            Some(&session_id),
+            Some(json!({ "sql": "SELECT 1", "params": [] })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let terminal_signal = terminal_storage_stream_signal(&response)
+            .expect("successful observe response must expose its fence signal");
+        let mut body = response.into_body();
+
+        let initial = tokio::time::timeout(Duration::from_secs(1), body.frame())
+            .await
+            .expect("observe stream should produce its initial frame")
+            .expect("observe stream should contain its initial frame")
+            .expect("observe stream initial frame");
+        let initial = initial
+            .into_data()
+            .expect("observe stream initial frame should contain data");
+        let initial = std::str::from_utf8(&initial).expect("SSE body is UTF-8");
+        assert!(
+            initial.contains("event: next"),
+            "expected initial SSE event, got {initial}"
+        );
+
+        // The initial snapshot has already started the external mutation
+        // watcher. Fencing its next poll must wake the active observation with
+        // the terminal error rather than leave it waiting for invalidation.
+        storage.fence_reads();
+        tokio::time::timeout(Duration::from_secs(1), storage.wait_for_fenced_read())
+            .await
+            .expect("external watcher should observe the fenced storage read");
+
+        let terminal = tokio::time::timeout(Duration::from_secs(1), body.frame())
+            .await
+            .expect("fenced observe watcher should produce its terminal frame")
+            .expect("fenced observe watcher should contain its terminal frame")
+            .expect("fenced observe watcher terminal frame");
+        let terminal = terminal
+            .into_data()
+            .expect("fenced observe watcher terminal frame should contain data");
+        let terminal = std::str::from_utf8(&terminal).expect("SSE body is UTF-8");
+        assert!(
+            terminal.contains("event: error"),
+            "expected SSE error, got {terminal}"
+        );
+        assert!(
+            terminal.contains("\"code\":\"LIX_STORAGE_FENCED\""),
+            "expected fenced storage error, got {terminal}"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), body.frame())
+                .await
+                .expect("fenced observe watcher should finish")
+                .is_none(),
+            "fenced observe watcher should reach EOF"
+        );
+        assert!(
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                terminal_signal.wait_for_terminal_storage(),
+            )
+            .await
+            .expect("fence signal should resolve"),
+            "SSE fence signal should report the terminal storage error"
+        );
+    }
+
+    #[tokio::test]
     async fn fenced_multiplex_observe_aborts_live_sibling_before_next_body_poll() {
         let storage = FailOneBlockedReadStorage::new();
         let root = Arc::new(
@@ -3034,6 +3132,7 @@ mod tests {
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
+        prime_external_observe_watcher(&router, &session_id).await;
         storage.fail_one_and_block_a_sibling();
         let response = request(
             &router,
@@ -3118,6 +3217,7 @@ mod tests {
         let router = handler(server);
         let (session_id, _) = new_session(&router).await;
 
+        prime_external_observe_watcher(&router, &session_id).await;
         storage.fail_one_and_block_a_sibling();
         let response = request(
             &router,
@@ -3156,6 +3256,24 @@ mod tests {
             !signalled.expect("dropping an unpolled response should release its signal"),
             "an unpolled response must not retain a terminal-storage sender"
         );
+    }
+
+    async fn prime_external_observe_watcher(router: &Router, session_id: &str) {
+        let response = request(
+            router,
+            "POST",
+            "/lix/v1/observe",
+            Some(session_id),
+            Some(json!({ "sql": "SELECT 0", "params": [] })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let mut body = response.into_body();
+        tokio::time::timeout(Duration::from_secs(1), body.frame())
+            .await
+            .expect("priming observe should produce an initial frame")
+            .expect("priming observe stream should not end immediately")
+            .expect("priming observe initial frame should be valid");
     }
 
     async fn app() -> TestApp {

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -462,10 +462,13 @@ impl StorageWrite for SlateDBWrite {
                 return Ok(());
             }
 
+            // Snapshot discovery is read-only until both awaits complete and
+            // the overlay is updated below, so a cancelled caller can safely
+            // release this work instead of holding worker shutdown open.
             if self.base.is_none() {
                 self.base = Some(
                     self.worker
-                        .call(|db| async move { db.snapshot().await.map_err(slatedb_error) })
+                        .call_read(|db| async move { db.snapshot().await.map_err(slatedb_error) })
                         .await?,
                 );
             }
@@ -476,7 +479,7 @@ impl StorageWrite for SlateDBWrite {
             );
             let base_keys = self
                 .worker
-                .call(move |_db| collect_snapshot_keys(base, bounds))
+                .call_read(move |_db| collect_snapshot_keys(base, bounds))
                 .await?;
 
             let overlay_keys = self
@@ -530,15 +533,15 @@ impl StorageWrite for SlateDBWrite {
                     db.write_with_options(
                         batch,
                         &SlateDBWriteOptions {
-                            await_durable: false,
+                            await_durable: true,
                             ..SlateDBWriteOptions::default()
                         },
                     )
                     .await
                     .map_err(slatedb_error)?;
-                    // SlateDB owns WAL durability. Returning here makes the
-                    // commit visible immediately while its background flusher
-                    // batches this write with nearby commits.
+                    // The configured SlateDB write contract waits for WAL
+                    // durability, so a successful Lix commit is not merely
+                    // visible in the local write pipeline.
                     Ok(CommitResult {
                         commit_id: None,
                         stats,
@@ -1408,12 +1411,9 @@ mod tests {
         )
         .expect("open newer SlateDB writer");
 
-        // `await_durable: false` intentionally returns after SlateDB accepts
-        // a write into its local pipeline. The newer writer's completed open
-        // fences this one, but its asynchronous manifest poll is what makes
-        // the terminal state observable here. Do not assert that the very
-        // next non-durable commit fails: SlateDB is allowed to acknowledge it
-        // before that poll observes the fence.
+        // A newer writer fences this one asynchronously through SlateDB's
+        // manifest poll. Wait for that terminal state before asserting that a
+        // subsequent commit is rejected.
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
             match block_on(first.begin_read(ReadOptions::default())) {
@@ -1458,7 +1458,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_is_visible_while_background_wal_flush_is_blocked() {
+    fn commit_waits_for_wal_durability_before_success() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let storage = SlateDB::open_object_store_with_options(
             "test-commit-visibility",
@@ -1470,44 +1470,43 @@ mod tests {
         let key = Key(Bytes::from_static(b"visible-before-durable"));
 
         let blocked_write = store.block_next_write();
-        let mut write =
-            block_on(storage.begin_write(WriteOptions::default())).expect("begin visibility write");
-        block_on(write.put_many(
-            space,
-            PutBatch {
-                entries: vec![PutEntry {
-                    key: key.clone(),
-                    value: StoredValue {
-                        bytes: Bytes::from_static(b"value"),
-                    },
-                }],
-            },
-        ))
-        .expect("stage visibility write");
-        block_on(write.commit()).expect("publish visibility value");
-
-        // The request has returned, but SlateDB's first background WAL upload
-        // is still in flight.
+        let (commit_tx, commit_rx) = mpsc::channel();
+        let committer = std::thread::spawn(move || {
+            let mut write = block_on(storage.begin_write(WriteOptions::default()))
+                .expect("begin visibility write");
+            block_on(write.put_many(
+                space,
+                PutBatch {
+                    entries: vec![PutEntry {
+                        key,
+                        value: StoredValue {
+                            bytes: Bytes::from_static(b"value"),
+                        },
+                    }],
+                },
+            ))
+            .expect("stage visibility write");
+            commit_tx
+                .send(block_on(write.commit()))
+                .expect("send commit result");
+        });
         blocked_write.wait_for_entries(1, "SlateDB WAL write");
-
-        let read = block_on(storage.begin_read(ReadOptions::default()))
-            .expect("begin visible in-memory read");
-        let values = block_on(read.get_many(space, &[key], GetOptions::default()))
-            .expect("read visible in-memory value")
-            .values;
         assert_eq!(
-            values,
-            vec![Some(ProjectedValue::FullValue(Bytes::from_static(
-                b"value"
-            )))]
+            commit_rx.recv_timeout(Duration::from_millis(50)),
+            Err(mpsc::RecvTimeoutError::Timeout),
+            "commit must not acknowledge before SlateDB makes its WAL durable"
         );
 
         drop(blocked_write);
-        block_on(storage.flush()).expect("flush visible value");
+        commit_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("commit should finish after WAL durability")
+            .expect("commit visibility value");
+        committer.join().expect("join visibility committer");
     }
 
     #[test]
-    fn explicit_flush_reports_background_durability_failure() {
+    fn commit_reports_wal_durability_failure() {
         let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
         let storage = SlateDB::open_object_store_with_options(
             "test-failed-commit",
@@ -1519,93 +1518,42 @@ mod tests {
         let key = Key(Bytes::from_static(b"rejected"));
 
         let blocked_write = store.block_next_write();
-        let mut write =
-            block_on(storage.begin_write(WriteOptions::default())).expect("begin buffered write");
-        block_on(write.put_many(
-            space,
-            PutBatch {
-                entries: vec![PutEntry {
-                    key,
-                    value: StoredValue {
-                        bytes: Bytes::from_static(b"not-durable"),
-                    },
-                }],
-            },
-        ))
-        .expect("stage buffered write");
-        block_on(write.commit()).expect("publish buffered write");
-
-        blocked_write.wait_for_entries(1, "failing background WAL write");
+        let (commit_tx, commit_rx) = mpsc::channel();
+        let committer = std::thread::spawn(move || {
+            let mut write = block_on(storage.begin_write(WriteOptions::default()))
+                .expect("begin failed commit write");
+            block_on(write.put_many(
+                space,
+                PutBatch {
+                    entries: vec![PutEntry {
+                        key,
+                        value: StoredValue {
+                            bytes: Bytes::from_static(b"not-durable"),
+                        },
+                    }],
+                },
+            ))
+            .expect("stage failed commit write");
+            commit_tx
+                .send(block_on(write.commit()))
+                .expect("send commit result");
+        });
+        blocked_write.wait_for_entries(1, "failing SlateDB WAL write");
+        assert_eq!(
+            commit_rx.recv_timeout(Duration::from_millis(50)),
+            Err(mpsc::RecvTimeoutError::Timeout),
+            "commit must wait for the WAL upload result"
+        );
         store.fail_writes();
         drop(blocked_write);
-        let flush_error = block_on(storage.flush()).expect_err("WAL flush must fail");
-        assert!(
-            matches!(flush_error, StorageError::Io(message) if message.contains("injected write failure")),
-            "flush should preserve the SlateDB write error"
-        );
-    }
-
-    #[test]
-    fn dropping_last_handle_waits_for_background_flush() {
-        let store = Arc::new(BlockingStore::new(Arc::new(InMemory::new())));
-        let db_path = "test-close-background-durability";
-        let space = SpaceId(8);
-        let key = Key(Bytes::from_static(b"background-commit"));
-        let value = Bytes::from_static(b"durable");
-        let storage = SlateDB::open_object_store_with_options(
-            db_path,
-            store.clone(),
-            SlateDBObjectStoreOptions::default(),
-        )
-        .expect("open close-test storage");
-        let mut write =
-            block_on(storage.begin_write(WriteOptions::default())).expect("begin close-test write");
-        block_on(write.put_many(
-            space,
-            PutBatch {
-                entries: vec![PutEntry {
-                    key: key.clone(),
-                    value: StoredValue {
-                        bytes: value.clone(),
-                    },
-                }],
-            },
-        ))
-        .expect("stage close-test value");
-
-        let blocked_write = store.block_next_write();
-        block_on(write.commit()).expect("publish close-test value");
-        blocked_write.wait_for_entries(1, "background commit WAL write");
-
-        let (closed_tx, closed_rx) = mpsc::channel();
-        let closer = std::thread::spawn(move || {
-            drop(storage);
-            let _ = closed_tx.send(());
-        });
-        assert!(
-            matches!(
-                closed_rx.recv_timeout(Duration::from_millis(50)),
-                Err(mpsc::RecvTimeoutError::Timeout)
-            ),
-            "close must wait for the background WAL flush"
-        );
-        drop(blocked_write);
-        closed_rx
+        let commit_error = commit_rx
             .recv_timeout(Duration::from_secs(2))
-            .expect("close should finish after WAL durability");
-        closer.join().expect("join close-test closer");
-
-        let reopened = SlateDB::open_object_store_with_options(
-            db_path,
-            store,
-            SlateDBObjectStoreOptions::default(),
-        )
-        .expect("reopen close-test storage");
-        let read =
-            block_on(reopened.begin_read(ReadOptions::default())).expect("begin close-test read");
-        let result = block_on(read.get_many(space, &[key], GetOptions::default()))
-            .expect("read close-test value");
-        assert_eq!(result.values, vec![Some(ProjectedValue::FullValue(value))]);
+            .expect("failed commit should finish after its WAL upload");
+        assert!(
+            matches!(commit_error, Err(StorageError::Io(message)) if message.contains("injected write failure")),
+            "commit should preserve the SlateDB WAL error"
+        );
+        committer.join().expect("join failed committer");
     }
 
     #[test]

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -188,7 +188,7 @@ async fn cached_slatedb_rebuilds_after_local_cache_is_deleted() {
 }
 
 #[tokio::test]
-async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
+async fn cached_slatedb_reports_write_failure_from_commit() {
     let object_store = Arc::new(InMemory::new());
     let db_path = "cached-slatedb-write-failure";
     let cache_parent = tempfile::tempdir().expect("create SlateDB failure cache parent");
@@ -222,14 +222,9 @@ async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
         .expect("open cached failure-test storage");
         fault_store.fail_writes.store(true, Ordering::Relaxed);
 
-        write_one(&storage, space, rejected_key.clone(), b"not-persisted")
+        let error = write_one(&storage, space, rejected_key.clone(), b"not-persisted")
             .await
-            .expect("commit should accept the visible write");
-
-        let error = storage
-            .flush()
-            .await
-            .expect_err("remote write failure must fail the explicit flush");
+            .expect_err("remote write failure must fail the commit");
         assert!(format!("{error}").contains("not supported"));
     }
 
@@ -247,7 +242,7 @@ async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
     let result = read
         .get_many(space, &[durable_key, rejected_key], GetOptions::default())
         .await
-        .expect("read durable values after failed write");
+        .expect("read durable values after rejected write");
 
     assert_eq!(
         result.values,
@@ -259,7 +254,7 @@ async fn cached_slatedb_reports_failed_flush_after_accepting_write() {
 }
 
 #[tokio::test]
-async fn slatedb_explicit_flush_makes_visible_commit_durable() {
+async fn slatedb_commit_makes_visible_value_durable() {
     let object_store = Arc::new(InMemory::new());
     let counting_store = Arc::new(FaultStore::new(object_store));
     let storage = SlateDB::open_object_store_with_options(
@@ -277,13 +272,12 @@ async fn slatedb_explicit_flush_makes_visible_commit_durable() {
         b"value",
     )
     .await
-    .expect("publish visible value");
+    .expect("commit durable value");
 
-    storage.flush().await.expect("flush visible value");
     assert_eq!(
         counting_store.write_count(),
         1,
-        "the visible commit should require one WAL write"
+        "the durable commit should require one WAL write"
     );
     storage
         .flush()


### PR DESCRIPTION
## Confirmed failures

- The SlateDB adapter explicitly set `await_durable: false`, so Lix could report a successful commit while the WAL upload was still blocked; an upload failure surfaced only on a later flush.
- External observe invalidation swallowed post-start Fenced/Closed errors, leaving SSE observers waiting indefinitely. Its old start flag also let a cancelled/slow baseline read strand or stale concurrent observers.
- Batch branch reads treated the new terminal storage errors as recoverable shape errors and amplified them into point reads.
- `delete_range` ran cancellation-safe discovery reads through the persistent worker path, making dropped callers hold worker shutdown open.

## Fixes

- Commit with SlateDB `await_durable: true`; success now follows the documented WAL durability boundary, and WAL errors are returned by the committing request.
- Make terminal external-watcher failures sticky, wake active observers with the error, and serialize watcher startup through its baseline read.
- Propagate terminal errors without branch-read fallback amplification.
- Mark only the read-only `delete_range` discovery calls as cancellable.

## Validation

- Added regressions for blocked/durable commits, direct WAL failure reporting, observer terminal delivery, cancelled/contended watcher startup, and initial terminal watcher failure.
- `cargo test -p lix_engine -p lix_server_protocol -p lix_slatedb_storage --locked`
- `cargo clippy -p lix_engine -p lix_server_protocol -p lix_slatedb_storage --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`

## Boundary

This does not modify SlateDB or add a Lix retry/journal layer. After the configured SlateDB write returns success, persistence remains SlateDB responsibility under its documented `await_durable` contract.