### PR TITLE
perf(remote): accelerate splice SHA-256

### DIFF
--- a/.changenotes/accelerate-remote-splice-sha256.md
+++ b/.changenotes/accelerate-remote-splice-sha256.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Reduced server CPU time for remote large-blob writes on supported native targets by using the optimized SHA-256 backend for splice verification.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4785,6 +4785,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/packages/server-protocol/Cargo.toml
+++ b/packages/server-protocol/Cargo.toml
@@ -29,6 +29,9 @@ tokio = { version = "1", features = ["sync", "rt"] }
 tower-http = { version = "0.6", features = ["compression-gzip", "compression-zstd", "decompression-gzip"] }
 tracing = "0.1"
 
+[target.'cfg(all(not(target_os = "windows"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+sha2 = { version = "0.10", features = ["asm"] }
+
 [dev-dependencies]
 async-trait = "0.1"
 flate2 = "1"


### PR DESCRIPTION
## Summary

- enable `sha2`'s optimized assembly backend for the remote server protocol on supported non-Windows x86, x86_64, and aarch64 targets
- retain the existing pure-Rust SHA-256 backend on Windows, WebAssembly, and unsupported architectures
- preserve the v1 `baseSha256` / `resultSha256` wire contract unchanged

## Why

Remote blob-splice requests must hash cached and reconstructed blobs as SHA-256 because those digests are part of the public v1 transport protocol. BLAKE3 is faster than the current software SHA-256 implementation, but substituting it would change that contract.

The protocol-compatible option is to enable the optimized SHA-256 backend on targets supported by `sha2-asm`.

## Data

Apple arm64, Rust release build, exact splice reconstruction plus digest/hex encoding used by the server path. The harness used 32-byte middle replacements, `black_box`, warmups, and at least 750 ms per case.

| Reconstructed blob | Current software SHA-256 | Optimized SHA-256 | Reduction |
| ---: | ---: | ---: | ---: |
| 32 KiB | 69.24 µs | 15.42 µs | 77.7% |
| 128 KiB | 570.02 µs | 59.11 µs | 89.6% |
| 512 KiB | 1,518.15 µs | 306.59 µs | 79.8% |
| 1 MiB | 2,144.11 µs | 713.44 µs | 66.7% |
| 2 MiB | 3,876.00 µs | 954.89 µs | 75.4% |

Absolute timings varied with host load, but repeated comparisons remained well beyond the 10% acceptance threshold.

Separate experiments found no viable BLAKE3 change elsewhere:

- browser-compatible BLAKE3 was slower than WebCrypto SHA-256 for the JS remote and plugin-cache paths
- verified git replay improved only 3.5–4.8% in its verification phase and did not improve total runtime

## Portability

The target dependency is positively gated to the architectures supported by `sha2-asm` and excludes Windows. Cargo feature inspection confirms Windows retains default `sha2`, while Linux x86_64 selects `asm`. The `sha2` implementation performs runtime CPU-feature detection and retains a software fallback.

## Validation

- `cargo check -p lix_server_protocol`
- `cargo test -p lix_server_protocol` — 57 passed, 3 ignored
- `cargo clippy -p lix_server_protocol --all-targets --no-deps -- -D warnings`
- independent sub-agent review: approved with no blocking correctness or portability findings
